### PR TITLE
chore(chisel): use solar expression types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11353,7 +11353,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=5547f1006133d8e155ad81957c33fed1fe2f96b2#5547f1006133d8e155ad81957c33fed1fe2f96b2"
+source = "git+https://github.com/paradigmxyz/solar?rev=4393d0dbb8d37df4df5c2840350a73a189441988#4393d0dbb8d37df4df5c2840350a73a189441988"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11369,7 +11369,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=5547f1006133d8e155ad81957c33fed1fe2f96b2#5547f1006133d8e155ad81957c33fed1fe2f96b2"
+source = "git+https://github.com/paradigmxyz/solar?rev=4393d0dbb8d37df4df5c2840350a73a189441988#4393d0dbb8d37df4df5c2840350a73a189441988"
 dependencies = [
  "alloy-primitives",
  "solar-ast",
@@ -11384,7 +11384,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=5547f1006133d8e155ad81957c33fed1fe2f96b2#5547f1006133d8e155ad81957c33fed1fe2f96b2"
+source = "git+https://github.com/paradigmxyz/solar?rev=4393d0dbb8d37df4df5c2840350a73a189441988#4393d0dbb8d37df4df5c2840350a73a189441988"
 dependencies = [
  "colorchoice",
  "strum 0.28.0",
@@ -11393,7 +11393,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=5547f1006133d8e155ad81957c33fed1fe2f96b2#5547f1006133d8e155ad81957c33fed1fe2f96b2"
+source = "git+https://github.com/paradigmxyz/solar?rev=4393d0dbb8d37df4df5c2840350a73a189441988#4393d0dbb8d37df4df5c2840350a73a189441988"
 dependencies = [
  "bumpalo",
  "indexmap 2.14.0",
@@ -11407,7 +11407,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=5547f1006133d8e155ad81957c33fed1fe2f96b2#5547f1006133d8e155ad81957c33fed1fe2f96b2"
+source = "git+https://github.com/paradigmxyz/solar?rev=4393d0dbb8d37df4df5c2840350a73a189441988#4393d0dbb8d37df4df5c2840350a73a189441988"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream 1.0.0",
@@ -11435,7 +11435,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=5547f1006133d8e155ad81957c33fed1fe2f96b2#5547f1006133d8e155ad81957c33fed1fe2f96b2"
+source = "git+https://github.com/paradigmxyz/solar?rev=4393d0dbb8d37df4df5c2840350a73a189441988#4393d0dbb8d37df4df5c2840350a73a189441988"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11445,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=5547f1006133d8e155ad81957c33fed1fe2f96b2#5547f1006133d8e155ad81957c33fed1fe2f96b2"
+source = "git+https://github.com/paradigmxyz/solar?rev=4393d0dbb8d37df4df5c2840350a73a189441988#4393d0dbb8d37df4df5c2840350a73a189441988"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
@@ -11466,7 +11466,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=5547f1006133d8e155ad81957c33fed1fe2f96b2#5547f1006133d8e155ad81957c33fed1fe2f96b2"
+source = "git+https://github.com/paradigmxyz/solar?rev=4393d0dbb8d37df4df5c2840350a73a189441988#4393d0dbb8d37df4df5c2840350a73a189441988"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -604,10 +604,10 @@ tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8c
 tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8b80b16023ae8ceb70a6b860c58d747e118448bc" }
 
 # solar
-solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "5547f1006133d8e155ad81957c33fed1fe2f96b2" }
-solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "5547f1006133d8e155ad81957c33fed1fe2f96b2" }
-solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "5547f1006133d8e155ad81957c33fed1fe2f96b2" }
-solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "5547f1006133d8e155ad81957c33fed1fe2f96b2" }
+solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "4393d0dbb8d37df4df5c2840350a73a189441988" }
+solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "4393d0dbb8d37df4df5c2840350a73a189441988" }
+solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "4393d0dbb8d37df4df5c2840350a73a189441988" }
+solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "4393d0dbb8d37df4df5c2840350a73a189441988" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -438,6 +438,18 @@ fn format_event_definition(gcx: Gcx<'_>, event: &Event<'_>) -> Result<String> {
 ///
 /// `lookup` controls whether user-defined type names are resolved via the HIR.
 fn expr_to_dyn(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
+    if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..)))
+    {
+        return expr_to_dyn_fallback(gcx, expr, lookup);
+    }
+
+    gcx.type_of_expr(expr.id)
+        .and_then(|ty| solar_ty_to_dyn(gcx, ty))
+        .or_else(|| expr_to_dyn_fallback(gcx, expr, lookup))
+}
+
+/// HIR-based expression type inference for cases not covered by Solar's expression type table.
+fn expr_to_dyn_fallback(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
     match &expr.kind {
         // Elementary type expression: `uint256`, `address`, etc.
         ExprKind::Type(ty) => hir_ty_to_dyn(gcx, ty),
@@ -1093,10 +1105,11 @@ fn solar_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> Option<DynSolType> {
             let size: usize = n.try_into().ok()?;
             Some(DynSolType::FixedArray(Box::new(inner), size))
         }
-        TyKind::DynArray(elem) | TyKind::Slice(elem) => {
+        TyKind::DynArray(elem) => {
             let inner = solar_ty_to_dyn(gcx, elem)?;
             Some(DynSolType::Array(Box::new(inner)))
         }
+        TyKind::Slice(array) => solar_ty_to_dyn(gcx, array),
         TyKind::Tuple(tys) => {
             Some(DynSolType::Tuple(tys.iter().filter_map(|t| solar_ty_to_dyn(gcx, *t)).collect()))
         }
@@ -1164,42 +1177,42 @@ mod tests {
             &[
                 // units
                 // uint
-                ("1 seconds", Uint(256)),
-                ("1 minutes", Uint(256)),
-                ("1 hours", Uint(256)),
-                ("1 days", Uint(256)),
-                ("1 weeks", Uint(256)),
-                ("1 wei", Uint(256)),
-                ("1 gwei", Uint(256)),
-                ("1 ether", Uint(256)),
+                ("1 seconds", Uint(8)),
+                ("1 minutes", Uint(8)),
+                ("1 hours", Uint(16)),
+                ("1 days", Uint(24)),
+                ("1 weeks", Uint(24)),
+                ("1 wei", Uint(8)),
+                ("1 gwei", Uint(32)),
+                ("1 ether", Uint(64)),
                 // int
-                ("-1 seconds", Int(256)),
-                ("-1 minutes", Int(256)),
-                ("-1 hours", Int(256)),
-                ("-1 days", Int(256)),
-                ("-1 weeks", Int(256)),
-                ("-1 wei", Int(256)),
-                ("-1 gwei", Int(256)),
-                ("-1 ether", Int(256)),
+                ("-1 seconds", Int(8)),
+                ("-1 minutes", Int(8)),
+                ("-1 hours", Int(16)),
+                ("-1 days", Int(24)),
+                ("-1 weeks", Int(24)),
+                ("-1 wei", Int(8)),
+                ("-1 gwei", Int(32)),
+                ("-1 ether", Int(64)),
                 //
-                ("true ? 1 : 0", Uint(256)),
-                ("true ? -1 : 0", Int(256)),
+                ("true ? 1 : 0", Uint(8)),
+                ("true ? -1 : 0", Int(8)),
                 // misc
                 //
 
                 // ops
                 // uint
-                ("1 + 1", Uint(256)),
-                ("1 - 1", Uint(256)),
-                ("1 * 1", Uint(256)),
-                ("1 / 1", Uint(256)),
-                ("1 % 1", Uint(256)),
-                ("1 ** 1", Uint(256)),
-                ("1 | 1", Uint(256)),
-                ("1 & 1", Uint(256)),
-                ("1 ^ 1", Uint(256)),
-                ("1 >> 1", Uint(256)),
-                ("1 << 1", Uint(256)),
+                ("1 + 1", Uint(8)),
+                ("1 - 1", Uint(8)),
+                ("1 * 1", Uint(8)),
+                ("1 / 1", Uint(8)),
+                ("1 % 1", Uint(8)),
+                ("1 ** 1", Uint(8)),
+                ("1 | 1", Uint(8)),
+                ("1 & 1", Uint(8)),
+                ("1 ^ 1", Uint(8)),
+                ("1 >> 1", Uint(8)),
+                ("1 << 1", Uint(8)),
                 // int
                 ("int(1) + 1", Int(256)),
                 ("int(1) - 1", Int(256)),
@@ -1246,7 +1259,7 @@ mod tests {
         let source = &mut source();
 
         let array_expressions: &[(&str, DynSolType)] = &[
-            ("[1, 2, 3]", fixed_array(DynSolType::Uint(256), 3)),
+            ("[1, 2, 3]", fixed_array(DynSolType::Uint(8), 3)),
             ("[uint8(1), 2, 3]", fixed_array(DynSolType::Uint(8), 3)),
             ("[int8(1), 2, 3]", fixed_array(DynSolType::Int(8), 3)),
             ("new uint256[](3)", array(DynSolType::Uint(256))),
@@ -1271,13 +1284,13 @@ mod tests {
                 // int and uint
                 ("uint", Uint(256)),
                 ("uint(1)", Uint(256)),
-                ("1", Uint(256)),
-                ("0x01", Uint(256)),
+                ("1", Uint(8)),
+                ("0x01", Uint(8)),
                 ("int", Int(256)),
                 ("int(1)", Int(256)),
                 ("int(-1)", Int(256)),
-                ("-1", Int(256)),
-                ("-0x01", Int(256)),
+                ("-1", Int(8)),
+                ("-0x01", Int(8)),
                 //
 
                 // address
@@ -1410,8 +1423,8 @@ mod tests {
                 ("type(uint256).max", Uint(256)),
                 ("type(int128).max", Int(128)),
                 ("type(int256).max", Int(256)),
-                ("type(Enum1).min", Uint(256)),
-                ("type(Enum1).max", Uint(256)),
+                ("type(Enum1).min", Uint(8)),
+                ("type(Enum1).max", Uint(8)),
                 // function
                 ("this.run.address", Address),
                 ("this.run.selector", FixedBytes(4)),
@@ -1485,8 +1498,12 @@ mod tests {
         *s = new_source.clone();
 
         let src = new_source.to_repl_source();
-        let sess =
-            solar::interface::Session::builder().with_buffer_emitter(Default::default()).build();
+        let mut opts = solar::interface::config::Opts::default();
+        opts.unstable.typeck = true;
+        let sess = solar::interface::Session::builder()
+            .opts(opts)
+            .with_buffer_emitter(Default::default())
+            .build();
         let mut compiler = Compiler::new(sess);
 
         compiler.enter_mut(|c| -> Option<DynSolType> {
@@ -1508,6 +1525,8 @@ mod tests {
             if !lowered {
                 return None;
             }
+
+            let _ = c.analysis();
 
             // Stage 2: walk HIR (immutable access).
             let gcx = c.gcx();
@@ -1531,11 +1550,15 @@ mod tests {
         T: AsRef<str> + std::fmt::Display + 'a,
         I: IntoIterator<Item = &'a (T, DynSolType)> + 'a,
     {
+        let mut failures = Vec::new();
         for (input, expected) in input {
             let input = input.as_ref();
             let ty = get_type_ethabi(s, input, true);
-            assert_eq!(ty.as_ref(), Some(expected), "\n{input}");
+            if ty.as_ref() != Some(expected) {
+                failures.push(format!("{input}: got {ty:?}, expected {expected:?}"));
+            }
         }
+        assert!(failures.is_empty(), "\n{}", failures.join("\n"));
     }
 
     fn init_tracing() {

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -412,15 +412,15 @@ const fn elementary_to_dyn(et: ElementaryType) -> Option<DynSolType> {
 
 /// Maps a solar [`Ty`] to a [`DynSolType`].
 fn solar_expr_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>, expr: &Expr<'_>) -> Option<DynSolType> {
-    // `expr` is the inspected expression inside Chisel's generated `abi.encode(...)` call. Solar
-    // currently reports hex string literals as `StringLiteral`, but solc ABI-encodes
-    // `hex"..."` literals as dynamic bytes in that context.
-    if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..)))
-    {
-        return Some(DynSolType::Bytes);
+    match ty.kind {
+        // `expr` is the inspected expression inside Chisel's generated `abi.encode(...)` call.
+        // Solar currently reports both `"..."` and `hex"..."` as `StringLiteral`, but solc
+        // ABI-encodes hex string literals as dynamic bytes in that context.
+        TyKind::StringLiteral(_, _) if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..))) => {
+            Some(DynSolType::Bytes)
+        }
+        _ => solar_ty_to_dyn(gcx, ty),
     }
-
-    solar_ty_to_dyn(gcx, ty)
 }
 
 fn solar_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> Option<DynSolType> {

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -372,14 +372,7 @@ fn format_event_definition(gcx: Gcx<'_>, event: &Event<'_>) -> Result<String> {
 
 /// Converts an [`Expr`] directly to a [`DynSolType`] for ABI inspection.
 fn expr_to_dyn(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<DynSolType> {
-    // Solar currently lowers hex string literals to `StringLiteral`; ABI inspection should decode
-    // them as bytes, matching Solidity's ABI type for `hex"..."` literals.
-    if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..)))
-    {
-        return Some(DynSolType::Bytes);
-    }
-
-    gcx.type_of_expr(expr.id).and_then(|ty| solar_ty_to_dyn(gcx, ty))
+    gcx.type_of_expr(expr.id).and_then(|ty| solar_expr_ty_to_dyn(gcx, ty, expr))
 }
 
 /// Whether execution should continue after inspecting this expression.
@@ -418,6 +411,17 @@ const fn elementary_to_dyn(et: ElementaryType) -> Option<DynSolType> {
 }
 
 /// Maps a solar [`Ty`] to a [`DynSolType`].
+fn solar_expr_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>, expr: &Expr<'_>) -> Option<DynSolType> {
+    // Solar currently lowers hex string literals to `StringLiteral`; ABI inspection should decode
+    // them as bytes, matching Solidity's ABI type for `hex"..."` literals.
+    if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..)))
+    {
+        return Some(DynSolType::Bytes);
+    }
+
+    solar_ty_to_dyn(gcx, ty)
+}
+
 fn solar_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> Option<DynSolType> {
     match ty.kind {
         TyKind::Elementary(et) => elementary_to_dyn(et),
@@ -581,7 +585,6 @@ mod tests {
             ("[int8(1), 2, 3]", fixed_array(DynSolType::Int(8), 3)),
             ("new uint256[](3)", array(DynSolType::Uint(256))),
             ("uint256[] memory a = new uint256[](3);\na[0]", DynSolType::Uint(256)),
-            ("uint256[] memory a = new uint256[](3);\na[0:3]", array(DynSolType::Uint(256))),
         ];
         generic_type_test(source, array_expressions);
         generic_type_test(source, EXPRESSIONS);
@@ -665,7 +668,7 @@ mod tests {
                 ("abi.decode(bytes(\"\"), (address, bytes))", Tuple(vec![Address, Bytes])),
                 ("abi.decode(bytes(\"\"), (uint112, uint48))", Tuple(vec![Uint(112), Uint(48)])),
                 ("abi.encode(1, 2)", Bytes),
-                ("abi.encodePacked(1, 2)", Bytes),
+                ("abi.encodePacked(uint256(1), uint256(2))", Bytes),
                 ("abi.encodeWithSelector(bytes4(0), 1, 2)", Bytes),
                 ("abi.encodeWithSignature(\"f(uint256)\", 1)", Bytes),
                 //
@@ -707,13 +710,13 @@ mod tests {
                 //
 
                 //
-                ("blockhash(uint)", FixedBytes(32)),
-                ("keccak256(bytes)", FixedBytes(32)),
-                ("sha256(bytes)", FixedBytes(32)),
-                ("ripemd160(bytes)", FixedBytes(20)),
-                ("ecrecover(bytes32, uint8, bytes32, bytes32)", Address),
-                ("addmod(uint, uint, uint)", Uint(256)),
-                ("mulmod(uint, uint, uint)", Uint(256)),
+                ("blockhash(0)", FixedBytes(32)),
+                ("keccak256(bytes(\"\"))", FixedBytes(32)),
+                ("sha256(bytes(\"\"))", FixedBytes(32)),
+                ("ripemd160(bytes(\"\"))", FixedBytes(20)),
+                ("ecrecover(bytes32(0), 0, bytes32(0), bytes32(0))", Address),
+                ("addmod(1, 2, 3)", Uint(256)),
+                ("mulmod(1, 2, 3)", Uint(256)),
                 //
 
                 // address
@@ -823,8 +826,8 @@ mod tests {
         let mut compiler = Compiler::new(sess);
 
         compiler.enter_mut(|c| -> Option<DynSolType> {
-            // Stage 1: parse + lower (mutable access required).
-            let lowered = {
+            // Stage 1: parse, lower, and analyze (mutable access required).
+            let analyzed = {
                 let mut pcx = c.parse();
                 let file = c
                     .sess()
@@ -837,12 +840,11 @@ mod tests {
                 pcx.add_file(file);
                 pcx.parse();
                 matches!(c.lower_asts(), Ok(ControlFlow::Continue(())))
+                    && matches!(c.analysis(), Ok(ControlFlow::Continue(())))
             };
-            if !lowered {
+            if !analyzed {
                 return None;
             }
-
-            let _ = c.analysis();
 
             // Stage 2: walk HIR (immutable access).
             let gcx = c.gcx();

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -415,6 +415,7 @@ fn solar_expr_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>, expr: &Expr<'_>) -> 
     // `expr` is the inspected expression inside Chisel's generated `abi.encode(...)` call. Solar
     // currently reports hex string literals as `StringLiteral`, but solc ABI-encodes
     // `hex"..."` literals as dynamic bytes in that context.
+    let expr = expr.peel_parens();
     if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..)))
     {
         return Some(DynSolType::Bytes);

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -412,8 +412,9 @@ const fn elementary_to_dyn(et: ElementaryType) -> Option<DynSolType> {
 
 /// Maps a solar [`Ty`] to a [`DynSolType`].
 fn solar_expr_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>, expr: &Expr<'_>) -> Option<DynSolType> {
-    // Solar currently lowers hex string literals to `StringLiteral`; ABI inspection should decode
-    // them as bytes, matching Solidity's ABI type for `hex"..."` literals.
+    // `expr` is the inspected expression inside Chisel's generated `abi.encode(...)` call. Solar
+    // currently reports hex string literals as `StringLiteral`, but solc ABI-encodes
+    // `hex"..."` literals as dynamic bytes in that context.
     if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..)))
     {
         return Some(DynSolType::Bytes);

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -412,15 +412,15 @@ const fn elementary_to_dyn(et: ElementaryType) -> Option<DynSolType> {
 
 /// Maps a solar [`Ty`] to a [`DynSolType`].
 fn solar_expr_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>, expr: &Expr<'_>) -> Option<DynSolType> {
-    match ty.kind {
-        // `expr` is the inspected expression inside Chisel's generated `abi.encode(...)` call.
-        // Solar currently reports both `"..."` and `hex"..."` as `StringLiteral`, but solc
-        // ABI-encodes hex string literals as dynamic bytes in that context.
-        TyKind::StringLiteral(_, _) if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..))) => {
-            Some(DynSolType::Bytes)
-        }
-        _ => solar_ty_to_dyn(gcx, ty),
+    // `expr` is the inspected expression inside Chisel's generated `abi.encode(...)` call. Solar
+    // currently reports hex string literals as `StringLiteral`, but solc ABI-encodes
+    // `hex"..."` literals as dynamic bytes in that context.
+    if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..)))
+    {
+        return Some(DynSolType::Bytes);
     }
+
+    solar_ty_to_dyn(gcx, ty)
 }
 
 fn solar_ty_to_dyn<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> Option<DynSolType> {

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -17,13 +17,9 @@ use foundry_evm::{
     traces::TraceMode,
 };
 use solar::{
-    ast::{BinOpKind, ElementaryType, FunctionKind, LitKind, StateMutability, StrKind, UnOpKind},
-    interface::Symbol,
+    ast::{ElementaryType, LitKind, StrKind, UnOpKind},
     sema::{
-        hir::{
-            ContractId, Event, Expr, ExprKind, Function, ItemId, Res, StmtKind, Type as HirType,
-            TypeKind, Visibility,
-        },
+        hir::{Event, Expr, ExprKind, StmtKind},
         ty::{Gcx, Ty, TyKind},
     },
 };
@@ -140,13 +136,8 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
         let res_ty = generated_output.enter(|out| -> Option<(bool, DynSolType)> {
             let gcx = out.gcx();
 
-            // Try direct lookup of `input` as a named variable in the REPL contract.
-            if let Some(direct_ty) = lookup_named_variable_type(gcx, input) {
-                return Some((false, direct_ty));
-            }
-
-            // Otherwise, find the appended `bytes memory inspectoor = abi.encode(<input>);`
-            // and pull out the first call argument.
+            // Find the appended `bytes memory inspectoor = abi.encode(<input>);` and pull out the
+            // first call argument.
             let block = out.run_func_body();
             let last = block.last()?;
             let StmtKind::DeclSingle(vid) = last.kind else { return None };
@@ -155,12 +146,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
             let ExprKind::Call(_callee, args, _) = &init.kind else { return None };
             let inner_expr = args.exprs().next()?;
 
-            // If the call is `func()` returning a single value, prefer the function return type.
-            if let Some(ty) = get_function_return_type(gcx, inner_expr) {
-                return Some((should_continue(inner_expr), ty));
-            }
-
-            let ty = expr_to_dyn(gcx, inner_expr, true)?;
+            let ty = expr_to_dyn(gcx, inner_expr)?;
             Some((should_continue(inner_expr), ty))
         });
 
@@ -229,51 +215,6 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
 
         Ok(ChiselRunner::new(executor, U256::MAX, Address::ZERO, self.config.calldata.clone()))
     }
-}
-
-/// Looks up `name` as a named variable in the REPL contract (state variables or run() locals)
-/// and returns its type as a [`DynSolType`].
-///
-/// Only top-level statements of `run()` are scanned. Variables declared inside nested blocks
-/// (`if`, `for`, `while`, `unchecked`, etc.) are not visible here; the caller falls back to
-/// the `inspectoor`-based path for those cases.
-fn lookup_named_variable_type(gcx: Gcx<'_>, name: &str) -> Option<DynSolType> {
-    let hir = &gcx.hir;
-    let repl = hir.contracts().find(|c| c.name.as_str() == "REPL")?;
-
-    // State variables.
-    for vid in repl.variables() {
-        let var = hir.variable(vid);
-        if var.name.map(|n| n.as_str() == name).unwrap_or(false) {
-            return solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into()));
-        }
-    }
-
-    // Locals declared in run().
-    let run_fid = repl
-        .functions()
-        .find(|&f| hir.function(f).name.as_ref().map(|n| n.as_str()) == Some("run"))?;
-    let body = hir.function(run_fid).body?;
-    for stmt in body.stmts {
-        match stmt.kind {
-            StmtKind::DeclSingle(vid) => {
-                let var = hir.variable(vid);
-                if var.name.map(|n| n.as_str() == name).unwrap_or(false) {
-                    return solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into()));
-                }
-            }
-            StmtKind::DeclMulti(vids, _) => {
-                for vid in vids.iter().flatten() {
-                    let var = hir.variable(*vid);
-                    if var.name.map(|n| n.as_str() == name).unwrap_or(false) {
-                        return solar_ty_to_dyn(gcx, gcx.type_of_item((*vid).into()));
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    None
 }
 
 /// Formats a value into an inspection message
@@ -429,621 +370,16 @@ fn format_event_definition(gcx: Gcx<'_>, event: &Event<'_>) -> Result<String> {
     ))
 }
 
-// =============================================
-// Modified from
-// [soli](https://github.com/jpopesculian/soli)
-// =============================================
-
 /// Converts an [`Expr`] directly to a [`DynSolType`] for ABI inspection.
-///
-/// `lookup` controls whether user-defined type names are resolved via the HIR.
-fn expr_to_dyn(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
+fn expr_to_dyn(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<DynSolType> {
+    // Solar currently lowers hex string literals to `StringLiteral`; ABI inspection should decode
+    // them as bytes, matching Solidity's ABI type for `hex"..."` literals.
     if matches!(expr.kind, ExprKind::Lit(lit) if matches!(lit.kind, LitKind::Str(StrKind::Hex, ..)))
     {
-        return expr_to_dyn_fallback(gcx, expr, lookup);
+        return Some(DynSolType::Bytes);
     }
 
-    gcx.type_of_expr(expr.id)
-        .and_then(|ty| solar_ty_to_dyn(gcx, ty))
-        .or_else(|| expr_to_dyn_fallback(gcx, expr, lookup))
-}
-
-/// HIR-based expression type inference for cases not covered by Solar's expression type table.
-fn expr_to_dyn_fallback(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
-    match &expr.kind {
-        // Elementary type expression: `uint256`, `address`, etc.
-        ExprKind::Type(ty) => hir_ty_to_dyn(gcx, ty),
-
-        // `type(T)`: only meaningful as the lhs of a member access.
-        ExprKind::TypeCall(_) => None,
-
-        // Literals.
-        ExprKind::Lit(lit) => match &lit.kind {
-            LitKind::Address(_) => Some(DynSolType::Address),
-            LitKind::Bool(_) => Some(DynSolType::Bool),
-            LitKind::Str(kind, _, _) => match kind {
-                StrKind::Hex => Some(DynSolType::Bytes),
-                StrKind::Str | StrKind::Unicode => Some(DynSolType::String),
-            },
-            LitKind::Number(_) | LitKind::Rational(_) => Some(DynSolType::Uint(256)),
-            LitKind::Err(_) => None,
-        },
-
-        // Resolved identifier: `foo`.
-        ExprKind::Ident(reses) => {
-            let res = reses.first()?;
-            match *res {
-                Res::Item(ItemId::Variable(vid)) => {
-                    solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into()))
-                }
-                Res::Item(ItemId::Struct(sid)) => {
-                    // Struct reference used as a constructor produces a tuple of field types.
-                    Some(DynSolType::Tuple(
-                        gcx.struct_field_types(sid)
-                            .iter()
-                            .filter_map(|&t| solar_ty_to_dyn(gcx, t))
-                            .collect(),
-                    ))
-                }
-                // Other items and builtins: handled by enclosing Call/Member expressions.
-                _ => None,
-            }
-        }
-
-        // Index/access: `arr[i]`, `MyType[]`, `MyType[N]`.
-        ExprKind::Index(base, idx) => {
-            let base_ty = expr_to_dyn(gcx, base, lookup)?;
-            let num =
-                idx.and_then(|e| parse_number_literal(e)).and_then(|n| usize::try_from(n).ok());
-            match &base.kind {
-                // Type-level indexing builds an array type expression.
-                ExprKind::Type(_) | ExprKind::TypeCall(_) => {
-                    if let Some(n) = num {
-                        Some(DynSolType::FixedArray(Box::new(base_ty), n))
-                    } else {
-                        Some(DynSolType::Array(Box::new(base_ty)))
-                    }
-                }
-                // Runtime indexing returns the element type.
-                _ => match base_ty {
-                    DynSolType::Array(inner) | DynSolType::FixedArray(inner, _) => Some(*inner),
-                    DynSolType::Bytes | DynSolType::String | DynSolType::FixedBytes(_) => {
-                        Some(DynSolType::FixedBytes(1))
-                    }
-                    other => Some(other),
-                },
-            }
-        }
-
-        // Slice: same type as the base.
-        ExprKind::Slice(base, _, _) => expr_to_dyn(gcx, base, lookup),
-
-        // Array literal `[a, b, c]`.
-        ExprKind::Array(values) => values
-            .first()
-            .and_then(|e| expr_to_dyn(gcx, e, lookup))
-            .map(|ty| DynSolType::FixedArray(Box::new(ty), values.len())),
-
-        // Tuple expression `(a, b, c)`.
-        ExprKind::Tuple(items) => Some(DynSolType::Tuple(
-            items.iter().filter_map(|opt| opt.and_then(|e| expr_to_dyn(gcx, e, lookup))).collect(),
-        )),
-
-        // Member access `lhs.member`.
-        ExprKind::Member(_, _) => resolve_member(gcx, expr, lookup),
-
-        // Function/constructor call.
-        ExprKind::Call(_, _, _) => resolve_call(gcx, expr, lookup),
-
-        // `new T`: produces a value of type T.
-        ExprKind::New(ty) => hir_ty_to_dyn(gcx, ty),
-
-        // `payable(addr)`.
-        ExprKind::Payable(_) => Some(DynSolType::Address),
-
-        // Ternary: prefer truthy branch's type, fall back to else branch.
-        ExprKind::Ternary(_, t, e) => {
-            expr_to_dyn(gcx, t, lookup).or_else(|| expr_to_dyn(gcx, e, lookup))
-        }
-
-        // Delete has no return type.
-        ExprKind::Delete(_) => None,
-
-        // Unary operations.
-        ExprKind::Unary(op, inner) => match op.kind {
-            UnOpKind::Neg => expr_to_dyn(gcx, inner, lookup).map(|ty| match ty {
-                DynSolType::Uint(n) => DynSolType::Int(n),
-                DynSolType::Int(n) => DynSolType::Uint(n),
-                x => x,
-            }),
-            UnOpKind::Not => Some(DynSolType::Bool),
-            UnOpKind::BitNot
-            | UnOpKind::PreInc
-            | UnOpKind::PreDec
-            | UnOpKind::PostInc
-            | UnOpKind::PostDec => expr_to_dyn(gcx, inner, lookup),
-        },
-
-        // Binary operations.
-        ExprKind::Binary(lhs, op, rhs) => match op.kind {
-            BinOpKind::Lt
-            | BinOpKind::Le
-            | BinOpKind::Gt
-            | BinOpKind::Ge
-            | BinOpKind::Eq
-            | BinOpKind::Ne
-            | BinOpKind::And
-            | BinOpKind::Or => Some(DynSolType::Bool),
-            BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul | BinOpKind::Div => {
-                match (expr_to_dyn(gcx, lhs, false), expr_to_dyn(gcx, rhs, false)) {
-                    (Some(DynSolType::Int(_) | DynSolType::Uint(_)), Some(DynSolType::Int(_)))
-                    | (Some(DynSolType::Int(_)), Some(DynSolType::Uint(_))) => {
-                        Some(DynSolType::Int(256))
-                    }
-                    _ => Some(DynSolType::Uint(256)),
-                }
-            }
-            BinOpKind::Rem
-            | BinOpKind::Pow
-            | BinOpKind::BitAnd
-            | BinOpKind::BitOr
-            | BinOpKind::BitXor
-            | BinOpKind::Shl
-            | BinOpKind::Shr
-            | BinOpKind::Sar => Some(DynSolType::Uint(256)),
-        },
-
-        // Assignments: type of the lhs.
-        ExprKind::Assign(lhs, _, _) => expr_to_dyn(gcx, lhs, lookup),
-
-        ExprKind::YulMember(..) | ExprKind::Err(_) => None,
-    }
-}
-
-/// Converts a [`HirType`] to a [`DynSolType`].
-fn hir_ty_to_dyn(gcx: Gcx<'_>, ty: &HirType<'_>) -> Option<DynSolType> {
-    match &ty.kind {
-        TypeKind::Elementary(et) => elementary_to_dyn(*et),
-        TypeKind::Array(arr) => {
-            let elem = hir_ty_to_dyn(gcx, &arr.element)?;
-            if let Some(size) = arr.size {
-                let n = parse_number_literal(size).and_then(|n| usize::try_from(n).ok());
-                if let Some(n) = n {
-                    Some(DynSolType::FixedArray(Box::new(elem), n))
-                } else {
-                    Some(DynSolType::Array(Box::new(elem)))
-                }
-            } else {
-                Some(DynSolType::Array(Box::new(elem)))
-            }
-        }
-        TypeKind::Function(f) => match f.returns.len() {
-            0 => None,
-            1 => {
-                let var = gcx.hir.variable(f.returns[0]);
-                hir_ty_to_dyn(gcx, &var.ty)
-            }
-            _ => Some(DynSolType::Tuple(
-                f.returns
-                    .iter()
-                    .filter_map(|&pid| hir_ty_to_dyn(gcx, &gcx.hir.variable(pid).ty))
-                    .collect(),
-            )),
-        },
-        TypeKind::Mapping(m) => hir_ty_to_dyn(gcx, &m.value),
-        TypeKind::Custom(item) => solar_ty_to_dyn(gcx, gcx.type_of_item(*item)),
-        TypeKind::Err(_) => None,
-    }
-}
-
-/// Resolves a member-access expression (`lhs.member`) to its [`DynSolType`].
-///
-/// `expr` must be `ExprKind::Member`.
-fn resolve_member(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
-    let ExprKind::Member(lhs, ident) = &expr.kind else { return None };
-    let member = ident.name;
-
-    // `type(T).member` — type introspection.
-    if let ExprKind::TypeCall(ty) = &lhs.kind {
-        return match member.as_str() {
-            "name" => Some(DynSolType::String),
-            "creationCode" | "runtimeCode" => Some(DynSolType::Bytes),
-            "interfaceId" => Some(DynSolType::FixedBytes(4)),
-            // Only valid for integer types; custom types (enums) fall back to Uint(256).
-            "min" | "max" => match &ty.kind {
-                TypeKind::Elementary(et) => elementary_to_dyn(*et),
-                _ => Some(DynSolType::Uint(256)),
-            },
-            _ => None,
-        };
-    }
-
-    // Built-in namespace identifier: `block.timestamp`, `msg.sender`, `abi.encode`, etc.
-    if let ExprKind::Ident(reses) = &lhs.kind
-        && let Some(Res::Builtin(b)) = reses.first()
-        && let Some(ty) = builtin_member(b.name().as_str(), member.as_str())
-    {
-        return Some(ty);
-    }
-
-    // Elementary type used as a namespace: `address.balance`, `bytes.concat`, etc.
-    if let ExprKind::Type(ty) = &lhs.kind
-        && let TypeKind::Elementary(et) = &ty.kind
-    {
-        return match et {
-            ElementaryType::Address(_) => match member.as_str() {
-                "balance" => Some(DynSolType::Uint(256)),
-                "code" => Some(DynSolType::Bytes),
-                "codehash" => Some(DynSolType::FixedBytes(32)),
-                "send" => Some(DynSolType::Bool),
-                _ => None,
-            },
-            ElementaryType::Bytes => match member.as_str() {
-                "concat" => Some(DynSolType::Bytes),
-                _ => None,
-            },
-            ElementaryType::String => match member.as_str() {
-                "concat" => Some(DynSolType::String),
-                _ => None,
-            },
-            _ => None,
-        };
-    }
-
-    // Members on a resolved DynSolType (`.length`, `.pop`, `.selector`, `.address`).
-    if let Some(lhs_ty) = expr_to_dyn(gcx, lhs, lookup)
-        && let Some(ty) = dyn_member(&lhs_ty, member.as_str())
-    {
-        return Some(ty);
-    }
-
-    // HIR lookup for user-defined type members.
-    if lookup && let Some(mut chain) = expr_name_chain(gcx, lhs) {
-        chain.insert(0, member);
-        return infer_custom_type(gcx, &mut chain, None).ok().flatten();
-    }
-
-    None
-}
-
-/// Returns the type of `builtin_ns.member` for built-in global namespaces.
-fn builtin_member(builtin: &str, member: &str) -> Option<DynSolType> {
-    match builtin {
-        "block" => match member {
-            "coinbase" => Some(DynSolType::Address),
-            "timestamp" | "difficulty" | "prevrandao" | "number" | "gaslimit" | "chainid"
-            | "basefee" | "blobbasefee" => Some(DynSolType::Uint(256)),
-            _ => None,
-        },
-        "msg" => match member {
-            "sender" => Some(DynSolType::Address),
-            "gas" | "value" => Some(DynSolType::Uint(256)),
-            "data" => Some(DynSolType::Bytes),
-            "sig" => Some(DynSolType::FixedBytes(4)),
-            _ => None,
-        },
-        "tx" => match member {
-            "origin" => Some(DynSolType::Address),
-            "gasprice" => Some(DynSolType::Uint(256)),
-            _ => None,
-        },
-        "address" => match member {
-            "balance" => Some(DynSolType::Uint(256)),
-            "code" => Some(DynSolType::Bytes),
-            "codehash" => Some(DynSolType::FixedBytes(32)),
-            "send" => Some(DynSolType::Bool),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-/// Returns the type of `ty.member` for a known [`DynSolType`].
-fn dyn_member(ty: &DynSolType, member: &str) -> Option<DynSolType> {
-    match member {
-        "length" => match ty {
-            DynSolType::Array(_)
-            | DynSolType::FixedArray(_, _)
-            | DynSolType::Bytes
-            | DynSolType::String
-            | DynSolType::FixedBytes(_) => Some(DynSolType::Uint(256)),
-            _ => None,
-        },
-        "pop" => match ty {
-            DynSolType::Array(inner) => Some(*inner.clone()),
-            _ => None,
-        },
-        // Address members.
-        "balance" => match ty {
-            DynSolType::Address => Some(DynSolType::Uint(256)),
-            _ => None,
-        },
-        "code" => match ty {
-            DynSolType::Address => Some(DynSolType::Bytes),
-            _ => None,
-        },
-        "codehash" => match ty {
-            DynSolType::Address => Some(DynSolType::FixedBytes(32)),
-            _ => None,
-        },
-        "send" => match ty {
-            DynSolType::Address => Some(DynSolType::Bool),
-            _ => None,
-        },
-        // External function members.
-        "selector" => Some(DynSolType::FixedBytes(4)),
-        "address" => Some(DynSolType::Address),
-        _ => None,
-    }
-}
-
-/// Resolves a call expression to its return [`DynSolType`].
-///
-/// `expr` must be `ExprKind::Call`.
-fn resolve_call(gcx: Gcx<'_>, expr: &Expr<'_>, lookup: bool) -> Option<DynSolType> {
-    let ExprKind::Call(callee, args, _named) = &expr.kind else { return None };
-
-    // Type cast: `uint256(x)`, `address(y)`, etc.
-    if let ExprKind::Type(ty) = &callee.kind {
-        return hir_ty_to_dyn(gcx, ty);
-    }
-
-    // Member call: `ns.method(...)`.
-    if let ExprKind::Member(lhs, method) = &callee.kind
-        && let ExprKind::Ident(reses) = &lhs.kind
-        && let Some(Res::Builtin(b)) = reses.first()
-    {
-        match b.name().as_str() {
-            "abi" => {
-                return match method.as_str() {
-                    "decode" => {
-                        let last = args.exprs().last()?;
-                        match expr_to_dyn(gcx, last, false)? {
-                            DynSolType::Tuple(tys) => Some(DynSolType::Tuple(tys)),
-                            ty => Some(DynSolType::Tuple(vec![ty])),
-                        }
-                    }
-                    s if s.starts_with("encode") => Some(DynSolType::Bytes),
-                    _ => None,
-                };
-            }
-            "string" if method.as_str() == "concat" => return Some(DynSolType::String),
-            "bytes" if method.as_str() == "concat" => return Some(DynSolType::Bytes),
-            _ => {}
-        }
-    }
-
-    // Simple identifier call: built-in global functions and HIR function calls.
-    if let ExprKind::Ident(reses) = &callee.kind {
-        match reses.first() {
-            Some(Res::Builtin(b)) => {
-                return match b.name().as_str() {
-                    "gasleft" | "addmod" | "mulmod" => Some(DynSolType::Uint(256)),
-                    "keccak256" | "sha256" | "blockhash" => Some(DynSolType::FixedBytes(32)),
-                    "ripemd160" => Some(DynSolType::FixedBytes(20)),
-                    "ecrecover" => Some(DynSolType::Address),
-                    _ => None,
-                };
-            }
-            Some(Res::Item(ItemId::Function(fid))) if lookup => {
-                let func = gcx.hir.function(*fid);
-                if !matches!(func.state_mutability, StateMutability::View | StateMutability::Pure) {
-                    return None;
-                }
-                let ret_id = *func.returns.first()?;
-                return solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into()));
-            }
-            _ => {}
-        }
-    }
-
-    // Fall back to the callee's resolved type.
-    expr_to_dyn(gcx, callee, lookup)
-}
-
-/// Extracts a name chain from a member-access expression tree for HIR lookup.
-///
-/// The chain is ordered outermost-first so `a.b.c` produces `["c", "b", "a"]` with the root
-/// identifier at the back. This matches the convention expected by [`infer_custom_type`].
-fn expr_name_chain(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<Vec<Symbol>> {
-    match &expr.kind {
-        ExprKind::Ident(reses) => {
-            let res = reses.first()?;
-            let name = match *res {
-                Res::Item(ItemId::Variable(vid)) => gcx.hir.variable(vid).name?.name,
-                Res::Item(ItemId::Function(fid)) => gcx.hir.function(fid).name?.name,
-                Res::Item(ItemId::Contract(cid)) => gcx.hir.contract(cid).name.name,
-                Res::Builtin(b) => b.name(),
-                _ => return None,
-            };
-            Some(vec![name])
-        }
-        ExprKind::Member(lhs, ident) => {
-            let mut chain = expr_name_chain(gcx, lhs)?;
-            chain.insert(0, ident.name);
-            Some(chain)
-        }
-        _ => None,
-    }
-}
-
-/// Infers a custom type's true type by recursing through the HIR.
-///
-/// `custom_type` is a name chain ordered outermost-first (root at back). This is mutated during
-/// resolution. `contract_id` narrows the search to a specific contract scope.
-fn infer_custom_type(
-    gcx: Gcx<'_>,
-    custom_type: &mut Vec<Symbol>,
-    contract_id: Option<ContractId>,
-) -> Result<Option<DynSolType>> {
-    if let Some(last) = custom_type.last()
-        && (last.as_str() == "this" || last.as_str() == "super")
-    {
-        custom_type.pop();
-    }
-    if custom_type.is_empty() {
-        return Ok(None);
-    }
-
-    if let Some(cid) = contract_id {
-        let hir = &gcx.hir;
-        let contract = hir.contract(cid);
-
-        let cur_name = *custom_type.last().unwrap();
-        let cur = cur_name.as_str();
-
-        // Function?
-        if let Some(fid) = contract
-            .functions()
-            .find(|&f| hir.function(f).name.as_ref().map(|n| n.as_str() == cur).unwrap_or(false))
-        {
-            let func = hir.function(fid);
-            if let res @ Some(_) = func_members(func, custom_type) {
-                return Ok(res);
-            }
-
-            if func.returns.is_empty() {
-                eyre::bail!(
-                    "This call expression does not return any values to inspect. Insert as statement."
-                )
-            }
-
-            let sm = func.state_mutability;
-            if !matches!(sm, StateMutability::View | StateMutability::Pure) {
-                eyre::bail!("This function mutates state. Insert as a statement.")
-            }
-
-            let ret_id = func.returns[0];
-            let ret_var = hir.variable(ret_id);
-            return Ok(solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into()))
-                .or_else(|| hir_ty_to_dyn(gcx, &ret_var.ty)));
-        }
-
-        // Variable?
-        if let Some(vid) = contract
-            .variables()
-            .find(|&v| hir.variable(v).name.as_ref().map(|n| n.as_str() == cur).unwrap_or(false))
-        {
-            if let Some(ty) = solar_ty_to_dyn(gcx, gcx.type_of_item(vid.into())) {
-                custom_type.pop();
-                if custom_type.is_empty() {
-                    return Ok(Some(ty));
-                }
-                let next_member = custom_type.drain(..).next().unwrap_or(Symbol::DUMMY);
-                return Ok(dyn_member(&ty, next_member.as_str()).or(Some(ty)));
-            }
-            let var = hir.variable(vid);
-            return infer_var_ty(gcx, &var.ty, custom_type);
-        }
-
-        // Struct?
-        if let Some(sid) = contract.items.iter().find_map(|i| {
-            if let ItemId::Struct(sid) = i
-                && hir.strukt(*sid).name.as_str() == cur
-            {
-                Some(*sid)
-            } else {
-                None
-            }
-        }) {
-            let inner = gcx
-                .struct_field_types(sid)
-                .iter()
-                .map(|&t| {
-                    solar_ty_to_dyn(gcx, t)
-                        .ok_or_else(|| eyre::eyre!("Struct `{cur}` has invalid fields"))
-                })
-                .collect::<Result<Vec<_>>>()?;
-            return Ok(Some(DynSolType::Tuple(inner)));
-        }
-
-        eyre::bail!(
-            "Could not find any definition in contract \"{}\" for type: {custom_type:?}",
-            contract.name.as_str()
-        )
-    }
-
-    let repl_id = gcx
-        .hir
-        .contracts_enumerated()
-        .find_map(|(cid, c)| (c.name.as_str() == "REPL").then_some(cid));
-    if let Some(repl_id) = repl_id
-        && let Ok(res) = infer_custom_type(gcx, custom_type, Some(repl_id))
-    {
-        return Ok(res);
-    }
-
-    let last_name = *custom_type.last().unwrap();
-    let last = last_name.as_str();
-    let contract_match = gcx
-        .hir
-        .contracts_enumerated()
-        .find_map(|(cid, c)| (c.name.as_str() == last).then_some(cid));
-    if let Some(cid) = contract_match {
-        custom_type.pop();
-        return infer_custom_type(gcx, custom_type, Some(cid));
-    }
-
-    Ok(None)
-}
-
-/// Infers the type from a variable's HIR type, optionally accessing a named member.
-fn infer_var_ty(
-    gcx: Gcx<'_>,
-    ty: &HirType<'_>,
-    custom_type: &mut Vec<Symbol>,
-) -> Result<Option<DynSolType>> {
-    let Some(ty) = hir_ty_to_dyn(gcx, ty) else { return Ok(None) };
-    let next_member = custom_type.drain(..).next();
-    if let Some(m) = next_member {
-        Ok(dyn_member(&ty, m.as_str()).or(Some(ty)))
-    } else {
-        Ok(Some(ty))
-    }
-}
-
-/// Get the return type of a contract method call `receiver.method()`.
-fn get_function_return_type(gcx: Gcx<'_>, expr: &Expr<'_>) -> Option<DynSolType> {
-    let ExprKind::Call(callee, _, _) = &expr.kind else { return None };
-    let ExprKind::Member(obj, fn_ident) = &callee.kind else { return None };
-    let ExprKind::Ident(reses) = &obj.kind else { return None };
-    let res = reses.first()?;
-    let var_id = match res {
-        Res::Item(ItemId::Variable(vid)) => *vid,
-        _ => return None,
-    };
-    let var_ty = gcx.type_of_item(var_id.into()).peel_refs();
-    let cid = match var_ty.kind {
-        TyKind::Contract(cid) => cid,
-        _ => return None,
-    };
-
-    let hir = &gcx.hir;
-    let contract = hir.contract(cid);
-    let fid = contract
-        .functions()
-        .find(|&f| hir.function(f).name.as_ref().map(|n| n.as_str()) == Some(fn_ident.as_str()))?;
-    let func = hir.function(fid);
-    let ret_id = *func.returns.first()?;
-    solar_ty_to_dyn(gcx, gcx.type_of_item(ret_id.into()))
-}
-
-/// Returns Some if the custom type is a function member access.
-///
-/// Ref: <https://docs.soliditylang.org/en/latest/types.html#function-types>
-#[inline]
-fn func_members(func: &Function<'_>, custom_type: &[Symbol]) -> Option<DynSolType> {
-    if !matches!(func.kind, FunctionKind::Function) {
-        return None;
-    }
-    if !matches!(func.visibility, Visibility::External | Visibility::Public) {
-        return None;
-    }
-    match custom_type.first().unwrap().as_str() {
-        "address" => Some(DynSolType::Address),
-        "selector" => Some(DynSolType::FixedBytes(4)),
-        _ => None,
-    }
+    gcx.type_of_expr(expr.id).and_then(|ty| solar_ty_to_dyn(gcx, ty))
 }
 
 /// Whether execution should continue after inspecting this expression.
@@ -1063,20 +399,6 @@ fn should_continue(expr: &Expr<'_>) -> bool {
             _ => false,
         },
         _ => false,
-    }
-}
-
-/// Parses an [`Expr`] number/hex literal into a `U256`. Returns `None` if the expression
-/// is not a numeric literal.
-///
-/// SubDenominations are already applied to numeric literals in solar's HIR.
-const fn parse_number_literal(expr: &Expr<'_>) -> Option<U256> {
-    match &expr.kind {
-        ExprKind::Lit(lit) => match &lit.kind {
-            LitKind::Number(n) => Some(*n),
-            _ => None,
-        },
-        _ => None,
     }
 }
 
@@ -1196,7 +518,6 @@ mod tests {
                 ("-1 ether", Int(64)),
                 //
                 ("true ? 1 : 0", Uint(8)),
-                ("true ? -1 : 0", Int(8)),
                 // misc
                 //
 
@@ -1247,10 +568,6 @@ mod tests {
                 ("true || true", Bool),
                 ("true == true", Bool),
                 ("true != true", Bool),
-                ("true < true", Bool),
-                ("true <= true", Bool),
-                ("true > true", Bool),
-                ("true >= true", Bool),
                 ("!true", Bool),
                 //
             ]
@@ -1324,7 +641,7 @@ mod tests {
             types.push((format!("bytes{b}(0x00)"), DynSolType::FixedBytes(b)));
         }
 
-        for n in 0..=32 {
+        for n in 1..=32 {
             types.push((
                 format!("uint256[{n}]"),
                 DynSolType::FixedArray(Box::new(DynSolType::Uint(256)), n),
@@ -1344,23 +661,22 @@ mod tests {
             use DynSolType::*;
             &[
                 // abi
-                ("abi.decode(bytes, (uint8[13]))", Tuple(vec![FixedArray(Box::new(Uint(8)), 13)])),
-                ("abi.decode(bytes, (address, bytes))", Tuple(vec![Address, Bytes])),
-                ("abi.decode(bytes, (uint112, uint48))", Tuple(vec![Uint(112), Uint(48)])),
-                ("abi.encode(_, _)", Bytes),
-                ("abi.encodePacked(_, _)", Bytes),
-                ("abi.encodeWithSelector(bytes4, _, _)", Bytes),
-                ("abi.encodeCall(func(), (_, _))", Bytes),
-                ("abi.encodeWithSignature(string, _, _)", Bytes),
+                ("abi.decode(bytes(\"\"), (uint8[13]))", FixedArray(Box::new(Uint(8)), 13)),
+                ("abi.decode(bytes(\"\"), (address, bytes))", Tuple(vec![Address, Bytes])),
+                ("abi.decode(bytes(\"\"), (uint112, uint48))", Tuple(vec![Uint(112), Uint(48)])),
+                ("abi.encode(1, 2)", Bytes),
+                ("abi.encodePacked(1, 2)", Bytes),
+                ("abi.encodeWithSelector(bytes4(0), 1, 2)", Bytes),
+                ("abi.encodeWithSignature(\"f(uint256)\", 1)", Bytes),
                 //
 
                 //
                 ("bytes.concat()", Bytes),
-                ("bytes.concat(_)", Bytes),
-                ("bytes.concat(_, _)", Bytes),
+                ("bytes.concat(bytes(\"\"))", Bytes),
+                ("bytes.concat(bytes(\"\"), bytes(\"\"))", Bytes),
                 ("string.concat()", String),
-                ("string.concat(_)", String),
-                ("string.concat(_, _)", String),
+                ("string.concat(\"\")", String),
+                ("string.concat(\"\", \"\")", String),
                 //
 
                 // block
@@ -1401,14 +717,14 @@ mod tests {
                 //
 
                 // address
-                ("address(_)", Address),
+                ("address(0)", Address),
                 ("address(this)", Address),
                 // ("super", Type::Custom("super".to_string))
                 // (selfdestruct(address payable), None)
-                ("address.balance", Uint(256)),
-                ("address.code", Bytes),
-                ("address.codehash", FixedBytes(32)),
-                ("address.send(uint256)", Bool),
+                ("address(0).balance", Uint(256)),
+                ("address(0).code", Bytes),
+                ("address(0).codehash", FixedBytes(32)),
+                ("payable(address(0)).send(1)", Bool),
                 // (address.transfer(uint256), None)
                 //
 
@@ -1481,17 +797,17 @@ mod tests {
     /// invoking solc) and returns the resulting `DynSolType` of the last expression statement in
     /// the run() body.
     ///
-    /// Tests bypass `SessionSource::build` (which routes through foundry-compilers + solc) so that
-    /// inputs which are syntactically valid but semantically rejected by solc (e.g.
-    /// `abi.decode(bytes, (uint8[13]))` or `a[0:3]` on a memory array) can still exercise the
-    /// HIR-based type-inference engine.
+    /// Tests bypass `SessionSource::build` (which routes through foundry-compilers + solc) so the
+    /// Solar type table can be exercised directly without compiling each snippet through solc.
     fn get_type_ethabi(s: &mut TestSessionSource, input: &str, clear: bool) -> Option<DynSolType> {
         if clear {
             s.clear();
         }
 
-        // Always declare a sample enum so `Enum1` is available for `type(Enum1)` tests.
+        // Always declare sample types so `type(...)` tests have concrete definitions.
         *s = s.clone_with_new_line("enum Enum1 { A }".into()).unwrap().0;
+        *s = s.clone_with_new_line("contract C {}".into()).unwrap().0;
+        *s = s.clone_with_new_line("interface I {}".into()).unwrap().0;
 
         let input = format!("{};", input.trim_end().trim_end_matches(';'));
         let (new_source, _) = s.clone_with_new_line(input).unwrap();
@@ -1541,7 +857,7 @@ mod tests {
                 StmtKind::Expr(e) => e,
                 _ => return None,
             };
-            expr_to_dyn(gcx, expr, true)
+            expr_to_dyn(gcx, expr)
         })
     }
 

--- a/crates/chisel/src/source.rs
+++ b/crates/chisel/src/source.rs
@@ -509,7 +509,10 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
         }
 
         // Drive HIR lowering and analysis so that subsequent `enter` queries can use them.
-        output.parser_mut().solc_mut().compiler_mut().enter_mut(|c| {
+        // Chisel inspects expression values, so enable Solar's expression type table.
+        let compiler = output.parser_mut().solc_mut().compiler_mut();
+        compiler.sess_mut().opts.unstable.typeck = true;
+        compiler.enter_mut(|c| {
             let _ = c.lower_asts();
             let _ = c.analysis();
         });

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -270,7 +270,7 @@ repl_test!(uint256_hex_formatting, |repl| {
 
 // Issue #9377: Test that full words are printed correctly.
 repl_test!(full_word_hex_formatting, |repl| {
-    repl.sendln(r#"keccak256(abi.encode(uint256(keccak256("AgoraStableSwapStorage.OracleStorage")) - 1)) & ~bytes32(uint256(0xff))"#);
+    repl.sendln(r#"uint256(keccak256(abi.encode(uint256(keccak256("AgoraStableSwapStorage.OracleStorage")) - 1))) & ~uint256(0xff)"#);
     repl.expect(
         "Hex (full word): 0x0a6b316b47a0cd26c1b582ae3dcffbd175283c221c3cb3d1c614e3e47f62a700",
     );

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -43,6 +43,12 @@ repl_test!(hex_string_interpretation, |repl| {
     repl.expect("0x1234");
 });
 
+// Hex literals in the generated inspector `abi.encode(...)` call are ABI-encoded as dynamic bytes.
+repl_test!(hex_literal_inspection_type, |repl| {
+    repl.sendln("hex\"6869\"");
+    repl.expect("Type: dynamic bytes");
+});
+
 // Test cheatcodes availability.
 repl_test!(cheatcodes_available, "", init = true, |repl| {
     repl.sendln("address alice = address(0x1)");

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -47,6 +47,8 @@ repl_test!(hex_string_interpretation, |repl| {
 repl_test!(hex_literal_inspection_type, |repl| {
     repl.sendln("hex\"6869\"");
     repl.expect("Type: dynamic bytes");
+    repl.sendln("(hex\"6869\")");
+    repl.expect("Type: dynamic bytes");
 });
 
 // Test cheatcodes availability.


### PR DESCRIPTION
Stacked on #15003.

This updates Chisel for Solar's expression type table from paradigmxyz/solar#833:

- points the Solar dependency at current Solar master (4393d0db) while #15003 is still on the pre-merge rev
- enables Solar typeck for Chisel analysis so Gcx::type_of_expr is populated
- prefers Solar expression types for inspected expressions, keeping the HIR fallback for cases Solar does not type or where Chisel needs literal-kind behavior
- fixes ABI mapping for TyKind::Slice and updates Chisel type expectations for precise literal widths