### PR TITLE
feat(lint): `arbitrary-send-erc20-permit`

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -12,6 +12,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `unchecked-call`: Low-level calls should check the success return value.
   - `erc20-unchecked-transfer`: ERC20 `transfer` and `transferFrom` calls should check the return value.
   - `arbitrary-send-erc20`: Flags `transferFrom`/`safeTransferFrom` calls whose `from` argument is not provably `msg.sender` or `address(this)`.
+  - `arbitrary-send-erc20-permit`: Flags arbitrary `transferFrom` calls preceded by a covering `permit`; on non-permit tokens with a fallback (e.g. WETH) the permit silently succeeds and previously-approved tokens can be drained.
   - `controlled-delegatecall`: Flags `delegatecall` calls whose target is not provably trusted.
   - `encode-packed-collision`: Flags `abi.encodePacked()` calls with multiple dynamic-type arguments (`string`, `bytes`, dynamic arrays) that can produce hash collisions.
   - `rtlo`: Flags Unicode bidirectional override characters ("Trojan Source", CVE-2021-42574) that can hide malicious code.

--- a/crates/lint/docs/arbitrary-send-erc20-permit.md
+++ b/crates/lint/docs/arbitrary-send-erc20-permit.md
@@ -1,0 +1,114 @@
+# Arbitrary `from` in `transferFrom` used with `permit`
+
+**Severity**: `High`
+**ID**: `arbitrary-send-erc20-permit`
+
+Flags `transferFrom` / `safeTransferFrom` calls whose `from` argument is not provably
+`msg.sender` (or `address(this)`) when the function also calls
+`token.permit(owner, address(this), …)` for the same token and owner beforehand.
+
+## What it does
+
+Detects, within a single function, the combination of:
+
+1. A preceding `permit(owner, spender, value, deadline, v, r, s)` on `token` with
+   `spender == address(this)`, and
+2. A subsequent ERC20-style transfer of the same token from the same `owner`, where
+   `owner` cannot be proven equal to `msg.sender` or `address(this)`.
+
+Both common sink shapes are recognised:
+
+- Member calls: `token.transferFrom(owner, to, amount)` and
+  `token.safeTransferFrom(owner, to, amount)`.
+- Library calls: `Lib.safeTransferFrom(token, owner, to, amount)`, including the
+  Solady-shaped `using SafeTransferLib for address` form.
+
+The lint does **not** require the transfer `amount` to equal the permit `value`,
+nor does it inspect deadlines or signatures — the dangerous combination is the
+permit-then-arbitrary-transferFrom pattern itself, not the specific amounts.
+
+Matching EIP-3156 flash-loan repayments (`onFlashLoan` followed by a pull-back of
+`amount + fee`) are excluded.
+
+### Scope
+
+The check is intraprocedural and same-variable. It flags one permit-then-`transferFrom`
+flow inside a single function body and correlates the token, owner, and spender by the
+underlying variable, with the following normalisations applied to both sides of the
+correlation:
+
+- elementary type casts (`address(x)`), interface / contract casts (`IERC20(rawToken)`),
+  `payable(...)` wraps, and parentheses are stripped;
+- local aliases of `address(this)` (e.g. `address self = address(this); permit(..., self, ...)`)
+  are recognised as the permit spender;
+- the `using SafeTransferLib for address` member form is treated as a sink.
+
+Dead code after a top-level `return` / `revert` is skipped, and inline
+`// forge-lint: disable-next-line(arbitrary-send-erc20-permit)` suppresses a single sink.
+
+Patterns the check does **not** classify as the permit-variant (the underlying call
+may still be reported by `arbitrary-send-erc20` when the sink itself is unguarded)
+include: copies of the token or owner into another variable
+(`IERC20 t = token; ...`, `address from2 = from; ...`), permits issued from a
+struct / array / mapping receiver (`cfg.token.permit(...)`), permits issued through
+a library wrapper (`SafeERC20.safePermit(...)`), permits issued inside a called
+helper / modifier / parent contract, permits inside `for` or `while` loop bodies
+(whose execution count the analyzer treats as possibly zero), and permits whose
+success is verified by reading `nonces(owner)` before and after.
+
+## Why is this bad?
+
+A `permit` followed by `transferFrom` is the textbook EIP-2612 flow, so it looks
+safe. It is **not** safe when the token does not actually implement `permit` but
+has a fallback function (the canonical example is WETH). On such tokens:
+
+- `permit(...)` is forwarded to the fallback and silently succeeds without
+  authorizing anything.
+- Any pre-existing allowance from another user to this contract can then be drained
+  by anyone, because the contract trusts the (no-op) permit and forwards the
+  attacker-supplied `from` straight into `transferFrom`.
+
+The recommendation is to pin the supported token(s) at deploy time and verify they
+implement `permit` correctly, or to require `from == msg.sender` so that, even if
+the permit silently no-ops, only the caller's own balance is at risk.
+
+If your code separately proves that `permit` succeeded (for example by reading
+`token.nonces(owner)` before and after and reverting on no change) or restricts the
+sink to a vetted token allowlist, review the finding and suppress with
+`// forge-lint: disable-next-line(arbitrary-send-erc20-permit)`.
+
+## Example
+
+### Bad
+
+```solidity
+function pullWithPermit(
+    address from,
+    address to,
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+) external {
+    token.permit(from, address(this), value, deadline, v, r, s);
+    token.transferFrom(from, to, value); // arbitrary-send-erc20-permit
+}
+```
+
+### Good
+
+```solidity
+function pullWithPermit(
+    uint256 value,
+    uint256 deadline,
+    uint8 v,
+    bytes32 r,
+    bytes32 s
+) external {
+    // `from` is implicitly the caller — permit + transferFrom only touch the
+    // caller's own balance, even if `token` is a non-permit token with a fallback.
+    token.permit(msg.sender, address(this), value, deadline, v, r, s);
+    token.transferFrom(msg.sender, address(this), value);
+}
+```

--- a/crates/lint/docs/arbitrary-send-erc20-permit.md
+++ b/crates/lint/docs/arbitrary-send-erc20-permit.md
@@ -32,27 +32,40 @@ Matching EIP-3156 flash-loan repayments (`onFlashLoan` followed by a pull-back o
 
 ### Scope
 
-The check is intraprocedural and same-variable. It flags one permit-then-`transferFrom`
-flow inside a single function body and correlates the token, owner, and spender by the
-underlying variable, with the following normalisations applied to both sides of the
-correlation:
+The check is intraprocedural. It flags one permit-then-`transferFrom` flow inside a
+single function body and correlates the token, owner, and spender by the underlying
+variable, with the following normalisations applied to both sides of the correlation:
 
 - elementary type casts (`address(x)`), interface / contract casts (`IERC20(rawToken)`),
   `payable(...)` wraps, and parentheses are stripped;
+- local var-to-var copies (`IERC20 t = token; ...`, `address from2 = from; ...`) are
+  tracked as aliases, so the permit and the sink still correlate when one side is a copy;
 - local aliases of `address(this)` (e.g. `address self = address(this); permit(..., self, ...)`)
-  are recognised as the permit spender;
+  and no-arg helpers whose body is `return address(this);` are recognised as the permit
+  spender;
 - the `using SafeTransferLib for address` member form is treated as a sink.
 
-Dead code after a top-level `return` / `revert` is skipped, and inline
+Dead code after a top-level `return` / `revert` is skipped — including function bodies
+whose modifier prefix definitely exits before `_;`. Inline
 `// forge-lint: disable-next-line(arbitrary-send-erc20-permit)` suppresses a single sink.
 
-Patterns the check does **not** classify as the permit-variant (the underlying call
-may still be reported by `arbitrary-send-erc20` when the sink itself is unguarded)
-include: copies of the token or owner into another variable
-(`IERC20 t = token; ...`, `address from2 = from; ...`), permits issued from a
-struct / array / mapping receiver (`cfg.token.permit(...)`), permits issued through
-a library wrapper (`SafeERC20.safePermit(...)`), and permits issued inside a called
-helper / modifier / parent contract.
+Additionally supported correlations:
+
+- struct-field token receivers (`cfg.token.permit(...)` then `cfg.token.transferFrom(...)`)
+  match via a `(base var, field name)` key;
+- the library wrapper `SafeERC20.safePermit(token, ...)` is treated as an EIP-2612
+  permit on the `token` argument when the receiver is a library;
+- immutable / constant state vars proven equal to `address(this)` or `msg.sender`
+  by their declaration initializer or constructor body are recognised as such at
+  the start of every function;
+- internal calls to functions of the same contract drop facts about every state
+  variable the callee (or one nested level of internal callees) assigns to, so a
+  prior permit is no longer trusted after the receiver may have been swapped.
+
+Patterns the check still does **not** classify as the permit-variant (the
+underlying call may still be reported by `arbitrary-send-erc20` when the sink
+itself is unguarded) include permits issued inside a called helper / modifier /
+parent contract.
 
 Permits inside `for` / `while` loop bodies do **not** establish facts visible after
 the loop (the analyzer treats their execution count as possibly zero), so a

--- a/crates/lint/docs/arbitrary-send-erc20-permit.md
+++ b/crates/lint/docs/arbitrary-send-erc20-permit.md
@@ -52,9 +52,8 @@ include: copies of the token or owner into another variable
 (`IERC20 t = token; ...`, `address from2 = from; ...`), permits issued from a
 struct / array / mapping receiver (`cfg.token.permit(...)`), permits issued through
 a library wrapper (`SafeERC20.safePermit(...)`), permits issued inside a called
-helper / modifier / parent contract, permits inside `for` or `while` loop bodies
-(whose execution count the analyzer treats as possibly zero), and permits whose
-success is verified by reading `nonces(owner)` before and after.
+helper / modifier / parent contract, and permits inside `for` or `while` loop bodies
+(whose execution count the analyzer treats as possibly zero).
 
 ## Why is this bad?
 

--- a/crates/lint/docs/arbitrary-send-erc20-permit.md
+++ b/crates/lint/docs/arbitrary-send-erc20-permit.md
@@ -51,9 +51,13 @@ may still be reported by `arbitrary-send-erc20` when the sink itself is unguarde
 include: copies of the token or owner into another variable
 (`IERC20 t = token; ...`, `address from2 = from; ...`), permits issued from a
 struct / array / mapping receiver (`cfg.token.permit(...)`), permits issued through
-a library wrapper (`SafeERC20.safePermit(...)`), permits issued inside a called
-helper / modifier / parent contract, and permits inside `for` or `while` loop bodies
-(whose execution count the analyzer treats as possibly zero).
+a library wrapper (`SafeERC20.safePermit(...)`), and permits issued inside a called
+helper / modifier / parent contract.
+
+Permits inside `for` / `while` loop bodies do **not** establish facts visible after
+the loop (the analyzer treats their execution count as possibly zero), so a
+`transferFrom` placed after the loop is not classified as the permit variant. A
+`transferFrom` inside the same iteration as the permit is still flagged.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/arbitrary-send-erc20.md
+++ b/crates/lint/docs/arbitrary-send-erc20.md
@@ -36,30 +36,18 @@ Safety is established by:
 - Inline equality guards in the prefix of a modifier body (statements
   strictly before its single top-level `_;` placeholder), mapped back to
   the caller's argument variables.
-- A prior EIP-2612 `permit(owner, address(this), …)` on the same token
-  variable, on the **same execution path** as the sink, with the sink's
-  `from` variable matching the permit's `owner`. The record is invalidated
-  if either the token variable or the owner variable is reassigned before
-  the sink.
 
 Branch joins recognise `return`, custom-error `revert`, the `revert(...)`
 builtin, and `assert(false)` / `require(false, ...)` as always-exiting:
 facts proven on the surviving branch propagate past the `if`.
 
-## Limitations
+## Related
 
-The permit suppression is a precision relaxation, not a proof. It matches
-the 7-argument `permit(...)` shape on a member call but does **not**:
-
-- verify the receiver type statically declares the EIP-2612 `permit`
-  signature (any same-named 7-arg method silences the lint),
-- correlate the receiver type between the permit and the sink (only the
-  underlying variable is compared),
-- model the permit's allowance / value against the sink's amount.
-
-False negatives are possible when a non-EIP-2612 contract exposes a
-matching `permit(...)` method. The canonical arbitrary-send pattern (no
-preceding permit) is unaffected.
+A prior EIP-2612 `permit(owner, address(this), …)` does **not** suppress
+this lint — the sink is instead reported as
+[`arbitrary-send-erc20-permit`](./arbitrary-send-erc20-permit.md), since
+non-EIP-2612 tokens with a fallback can silently accept the permit and
+let any prior allowance be drained.
 
 ## Why is this bad?
 

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -605,6 +605,18 @@ impl<'hir> Analyzer<'hir> {
         !var.kind.is_state() || var.is_immutable() || var.is_constant()
     }
 
+    /// Drops permits whose token is `Field(base, name)` when the LHS is the
+    /// corresponding `<base>.<name>` (assignment or `delete`).
+    fn kill_field_permits(&mut self, lhs: &hir::Expr<'_>) {
+        let lhs = lhs.peel_parens();
+        if let ExprKind::Member(base, ident) = &lhs.kind
+            && let Some(base_v) = underlying_var(base)
+        {
+            let key = TokenKey::Field(self.canonical(base_v), ident.name);
+            self.permits.retain(|p| p.token != key);
+        }
+    }
+
     /// Handles single-var and tuple LHS; tuple slots align with a tuple-literal RHS.
     fn handle_assign(&mut self, lhs: &hir::Expr<'_>, rhs: &hir::Expr<'_>) {
         let lhs = lhs.peel_parens();
@@ -991,15 +1003,24 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
                     };
                     self.hits.push((expr.span, lint));
                 } else if let Some(writes) = self.call_state_writes(callee) {
-                    // Internal call may mutate `self`'s state vars: drop facts for them.
+                    // Solidity evaluates args before invoking the callee. Walk first so
+                    // nested sinks see the still-live facts, then invalidate.
+                    let result = self.walk_expr(expr);
                     for v in writes {
                         self.invalidate(v);
                     }
+                    return result;
                 }
             }
-            ExprKind::Assign(lhs, _, rhs) => self.handle_assign(lhs, rhs),
+            ExprKind::Assign(lhs, _, rhs) => {
+                self.kill_field_permits(lhs);
+                self.handle_assign(lhs, rhs);
+            }
             // `delete x` resets `x`; treat as unknown reassignment.
-            ExprKind::Delete(target) => self.assign_one(target.peel_parens(), None),
+            ExprKind::Delete(target) => {
+                self.kill_field_permits(target);
+                self.assign_one(target.peel_parens(), None);
+            }
             _ => {}
         }
         self.walk_expr(expr)
@@ -1700,6 +1721,9 @@ fn branch_always_exits(stmt: &hir::Stmt<'_>) -> bool {
             let user = do_while_user_stmts(block.stmts);
             !body_has_break_or_continue(user) && user.iter().any(branch_always_exits)
         }
+        // `try { ... } catch { ... }` exits the enclosing block only when every clause
+        // (success and all catches) definitely exits.
+        StmtKind::Try(t) => t.clauses.iter().all(|c| c.block.stmts.iter().any(branch_always_exits)),
         _ => false,
     }
 }

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -54,7 +54,17 @@ impl<'hir> LateLintPass<'hir> for ArbitrarySendErc20 {
         let Some(body) = func.body else { return };
 
         let has_solady_lib = has_solady_safe_transfer_lib(hir);
+        // Skip when a modifier's prefix definitely exits before `_;`.
+        if func.modifiers.iter().any(|m| modifier_prefix_always_exits(hir, m)) {
+            return;
+        }
         let mut a = Analyzer::new(hir, has_solady_lib);
+        // Seed `self_vars` / `safe_vars` with immutable/constant state vars proven
+        // equal to `address(this)` / `msg.sender` by their declaration initializer
+        // or the contract's constructor.
+        if let Some(cid) = func.contract {
+            seed_immutable_facts(hir, has_solady_lib, cid, &mut a);
+        }
         for m in func.modifiers {
             collect_modifier_safety(hir, has_solady_lib, m, &mut a.safe_vars, &mut a.self_vars);
         }
@@ -75,8 +85,33 @@ impl<'hir> LateLintPass<'hir> for ArbitrarySendErc20 {
 /// `spender == address(this)`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 struct PermitRecord {
-    token: hir::VariableId,
+    token: TokenKey,
     owner: hir::VariableId,
+}
+
+/// Identifier used to correlate permit / sink token receivers. `Field` lets
+/// `cfg.token.permit(...)` and `cfg.token.transferFrom(...)` match (FN-5).
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+enum TokenKey {
+    Var(hir::VariableId),
+    Field(hir::VariableId, solar::interface::Symbol),
+}
+
+impl TokenKey {
+    fn touches(&self, v: hir::VariableId) -> bool {
+        match self {
+            Self::Var(x) | Self::Field(x, _) => *x == v,
+        }
+    }
+}
+
+/// RHS facts captured before any write so tuple-swap assignments stay consistent.
+#[derive(Clone, Copy, Default)]
+struct AssignRhs {
+    is_safe: bool,
+    is_self: bool,
+    alias: Option<hir::VariableId>,
+    sum: Option<(hir::VariableId, hir::VariableId)>,
 }
 
 /// Outstanding EIP-3156 repayment licensed by a prior `onFlashLoan` call.
@@ -102,6 +137,10 @@ struct Analyzer<'hir> {
     /// Pending flash-loan repayments, as a multiset: repeated `onFlashLoan` calls each
     /// license one consumption.
     repayments: HashMap<PendingRepayment, u32>,
+    /// `x = y` records `x -> canonical(y)`; killed on writes to either side.
+    aliases: HashMap<hir::VariableId, hir::VariableId>,
+    /// `x = a + b` records `x -> (a, b)`; matches flash-repayment sums.
+    sum_of: HashMap<hir::VariableId, (hir::VariableId, hir::VariableId)>,
     /// Gates the `using ... for address` sink branch on a `SafeTransferLib` being present.
     has_solady_lib: bool,
     hits: Vec<(Span, &'static SolLint)>,
@@ -116,9 +155,22 @@ struct FlowState {
     self_vars: HashSet<hir::VariableId>,
     permits: HashSet<PermitRecord>,
     repayments: HashMap<PendingRepayment, u32>,
+    aliases: HashMap<hir::VariableId, hir::VariableId>,
+    sum_of: HashMap<hir::VariableId, (hir::VariableId, hir::VariableId)>,
 }
 
 impl FlowState {
+    fn empty() -> Self {
+        Self {
+            safe_vars: HashSet::new(),
+            self_vars: HashSet::new(),
+            permits: HashSet::new(),
+            repayments: HashMap::new(),
+            aliases: HashMap::new(),
+            sum_of: HashMap::new(),
+        }
+    }
+
     fn intersection(a: &Self, b: &Self) -> Self {
         Self {
             safe_vars: a.safe_vars.intersection(&b.safe_vars).copied().collect(),
@@ -130,16 +182,21 @@ impl FlowState {
                 .iter()
                 .filter_map(|(k, va)| b.repayments.get(k).map(|vb| (*k, *va.min(vb))))
                 .collect(),
+            aliases: a
+                .aliases
+                .iter()
+                .filter_map(|(k, v)| (b.aliases.get(k) == Some(v)).then_some((*k, *v)))
+                .collect(),
+            sum_of: a
+                .sum_of
+                .iter()
+                .filter_map(|(k, v)| (b.sum_of.get(k) == Some(v)).then_some((*k, *v)))
+                .collect(),
         }
     }
 
     fn intersection_all(mut states: impl Iterator<Item = Self>) -> Self {
-        let mut out = states.next().unwrap_or_else(|| Self {
-            safe_vars: HashSet::new(),
-            self_vars: HashSet::new(),
-            permits: HashSet::new(),
-            repayments: HashMap::new(),
-        });
+        let mut out = states.next().unwrap_or_else(Self::empty);
         for state in states {
             out = Self::intersection(&out, &state);
         }
@@ -158,6 +215,8 @@ impl<'hir> Analyzer<'hir> {
             self_vars: HashSet::new(),
             permits: HashSet::new(),
             repayments: HashMap::new(),
+            aliases: HashMap::new(),
+            sum_of: HashMap::new(),
             has_solady_lib,
             hits: Vec::new(),
             written: HashSet::new(),
@@ -170,6 +229,8 @@ impl<'hir> Analyzer<'hir> {
             self_vars: self.self_vars.clone(),
             permits: self.permits.clone(),
             repayments: self.repayments.clone(),
+            aliases: self.aliases.clone(),
+            sum_of: self.sum_of.clone(),
         }
     }
 
@@ -178,6 +239,20 @@ impl<'hir> Analyzer<'hir> {
         self.self_vars = state.self_vars;
         self.permits = state.permits;
         self.repayments = state.repayments;
+        self.aliases = state.aliases;
+        self.sum_of = state.sum_of;
+    }
+
+    /// Follows the alias chain to its root. Bounded to guard against cycles.
+    fn canonical(&self, v: hir::VariableId) -> hir::VariableId {
+        let mut cur = v;
+        for _ in 0..8 {
+            match self.aliases.get(&cur).copied() {
+                Some(next) if next != cur => cur = next,
+                _ => break,
+            }
+        }
+        cur
     }
 
     fn is_safe(&self, expr: &hir::Expr<'_>) -> bool {
@@ -229,25 +304,39 @@ impl<'hir> Analyzer<'hir> {
         })
     }
 
-    /// Updates `safe_vars` / `self_vars` only; permit kills are caller-owned
-    /// (state-var writes skip this).
+    /// Variant of `assign_one_flags` for declarations: skips permit/repayment kills
+    /// since a freshly declared variable has no prior facts.
     fn assign(&mut self, target: hir::VariableId, rhs: &hir::Expr<'_>) {
+        let eval = self.eval_rhs(Some(rhs));
         self.written.insert(target);
-        if self.is_safe(rhs) {
+        if eval.is_safe {
             self.safe_vars.insert(target);
         } else {
             self.safe_vars.remove(&target);
         }
-        if self.is_self_expr(rhs) {
+        if eval.is_self {
             self.self_vars.insert(target);
         } else {
             self.self_vars.remove(&target);
         }
+        if let Some(alias) = eval.alias
+            && alias != target
+        {
+            self.aliases.insert(target, alias);
+        }
+        if let Some(sum) = eval.sum {
+            self.sum_of.insert(target, sum);
+        }
     }
 
     /// `true` when `expr` resolves to `address(this)`: bare form, a local alias,
-    /// `payable(...)`/cast wraps, or a ternary whose both branches are self.
+    /// `payable(...)`/cast wraps, a ternary whose both branches are self, or a no-arg
+    /// helper returning a statically-self expression.
     fn is_self_expr(&self, expr: &hir::Expr<'_>) -> bool {
+        self.is_self_expr_inner(expr, HELPER_DEPTH)
+    }
+
+    fn is_self_expr_inner(&self, expr: &hir::Expr<'_>, depth: u8) -> bool {
         let expr = expr.peel_parens();
         if is_address_self(expr) {
             return true;
@@ -256,40 +345,161 @@ impl<'hir> Analyzer<'hir> {
             ExprKind::Ident(reses) => reses.iter().any(
                 |r| matches!(r, Res::Item(ItemId::Variable(vid)) if self.self_vars.contains(vid)),
             ),
-            ExprKind::Payable(inner) => self.is_self_expr(inner),
+            ExprKind::Payable(inner) => self.is_self_expr_inner(inner, depth),
             ExprKind::Call(callee, args, _) if is_address_cast(callee) => {
-                args.exprs().next().is_some_and(|e| self.is_self_expr(e))
+                args.exprs().next().is_some_and(|e| self.is_self_expr_inner(e, depth))
             }
-            ExprKind::Ternary(_, t, f) => self.is_self_expr(t) && self.is_self_expr(f),
+            ExprKind::Ternary(_, t, f) => {
+                self.is_self_expr_inner(t, depth) && self.is_self_expr_inner(f, depth)
+            }
+            ExprKind::Call(callee, args, _)
+                if depth > 0
+                    && args.exprs().next().is_none()
+                    && self.callee_returns_self(callee, depth - 1) =>
+            {
+                true
+            }
             _ => false,
         }
     }
 
-    /// Matches EIP-2612 `token.permit(owner, <self>, value, deadline, v, r, s)`.
+    fn callee_returns_self(&self, callee: &hir::Expr<'_>, depth: u8) -> bool {
+        let ExprKind::Ident(reses) = &callee.peel_parens().kind else { return false };
+        reses.iter().any(|r| match r {
+            Res::Item(ItemId::Function(fid)) => {
+                let f = self.hir.function(*fid);
+                let Some(body) = f.body else { return false };
+                f.parameters.is_empty()
+                    && body.stmts.len() == 1
+                    && matches!(
+                        &body.stmts[0].kind,
+                        StmtKind::Return(Some(e)) if self.is_self_expr_inner(e, depth)
+                    )
+            }
+            _ => false,
+        })
+    }
+
+    /// Matches EIP-2612 `token.permit(owner, <self>, value, deadline, v, r, s)`, plus
+    /// the library form `Lib.safePermit(token, owner, <self>, value, deadline, v, r, s)`
+    /// (OpenZeppelin-style wrapper that delegates to `token.permit`).
     fn match_permit_call(&self, expr: &hir::Expr<'_>) -> Option<PermitRecord> {
         let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
         let ExprKind::Member(recv, ident) = &callee.peel_parens().kind else { return None };
-        if ident.name.as_str() != "permit" {
-            return None;
+        let name = ident.name.as_str();
+
+        if name == "permit"
+            && let Some(canonical) = canonical_args(
+                args.kind,
+                &[&["owner"], &["spender"], &["value"], &["deadline"], &["v"], &["r"], &["s"]],
+            )
+            && self.is_self_expr(canonical[1])
+        {
+            return Some(PermitRecord {
+                token: self.canonical_key(token_key(recv)?),
+                owner: self.canonical(underlying_var(canonical[0])?),
+            });
         }
-        let args = canonical_args(
-            args.kind,
-            &[&["owner"], &["spender"], &["value"], &["deadline"], &["v"], &["r"], &["s"]],
-        )?;
-        if !self.is_self_expr(args[1]) {
-            return None;
+
+        if name == "safePermit"
+            && let Some(canonical) = canonical_args(
+                args.kind,
+                &[
+                    &["token"],
+                    &["owner"],
+                    &["spender"],
+                    &["value"],
+                    &["deadline"],
+                    &["v"],
+                    &["r"],
+                    &["s"],
+                ],
+            )
+            && self.is_self_expr(canonical[2])
+            && let Some(cid) = receiver_contract_id(self.hir, recv)
+            && self.hir.contract(cid).kind == ContractKind::Library
+        {
+            return Some(PermitRecord {
+                token: self.canonical_key(token_key(canonical[0])?),
+                owner: self.canonical(underlying_var(canonical[1])?),
+            });
         }
-        Some(PermitRecord { token: underlying_var(recv)?, owner: underlying_var(args[0])? })
+
+        None
     }
 
-    /// Drops permits referencing `target`. Sound for any variable kind.
+    /// Drops permits referencing `target` by raw id. Permits are stored at the
+    /// canonical chain root, so reassigning an alias var leaves the root's permit
+    /// intact — only reassigning the root itself kills it.
     fn kill_permits_for(&mut self, target: hir::VariableId) {
-        self.permits.retain(|p| p.token != target && p.owner != target);
+        self.permits.retain(|p| !p.token.touches(target) && p.owner != target);
     }
 
-    fn permit_covers(&self, token: Option<hir::VariableId>, from: &hir::Expr<'_>) -> bool {
+    /// Canonicalizes a `TokenKey`: `Var` chases the alias chain; `Field`'s base
+    /// var is canonicalized so `aCfg = cfg; aCfg.token` aliases to `cfg.token`.
+    fn canonical_key(&self, k: TokenKey) -> TokenKey {
+        match k {
+            TokenKey::Var(v) => TokenKey::Var(self.canonical(v)),
+            TokenKey::Field(v, s) => TokenKey::Field(self.canonical(v), s),
+        }
+    }
+
+    /// Drops all facts about `v` (treats it as freshly assigned an unknown value).
+    fn invalidate(&mut self, v: hir::VariableId) {
+        self.safe_vars.remove(&v);
+        self.self_vars.remove(&v);
+        self.aliases.remove(&v);
+        self.sum_of.remove(&v);
+        self.kill_permits_for(v);
+    }
+
+    /// Returns state vars written by `callee` if it resolves to a function in the
+    /// current contract; walks one level of nested internal calls. Resolution is
+    /// conservative: any unresolved or non-local call returns `None`.
+    fn call_state_writes(&self, callee: &hir::Expr<'_>) -> Option<HashSet<hir::VariableId>> {
+        let fid = resolve_internal_fn(callee)?;
+        let f = self.hir.function(fid);
+        let body = f.body?;
+        // Only same-contract calls to non-view/pure user functions can mutate `self`'s state.
+        if matches!(f.state_mutability, ast::StateMutability::Pure | ast::StateMutability::View) {
+            return Some(HashSet::new());
+        }
+        let mut writes = collect_state_writes(self.hir, body.stmts);
+        // One nested level: pull in writes from internal callees within `body`.
+        let mut nested = NestedCallCollector { hir: self.hir, out: HashSet::new() };
+        for s in body.stmts {
+            let _ = nested.visit_stmt(s);
+        }
+        for cid in nested.out {
+            let nf = self.hir.function(cid);
+            if let Some(nb) = nf.body {
+                writes.extend(collect_state_writes(self.hir, nb.stmts));
+            }
+        }
+        Some(writes)
+    }
+
+    fn permit_covers(&self, token: Option<TokenKey>, from: &hir::Expr<'_>) -> bool {
         let (Some(token), Some(owner)) = (token, underlying_var(from)) else { return false };
-        self.permits.contains(&PermitRecord { token, owner })
+        self.permits.contains(&PermitRecord {
+            token: self.canonical_key(token),
+            owner: self.canonical(owner),
+        })
+    }
+
+    /// `amount_arg` is `amount + fee` syntactically, or a local var bound to that sum.
+    fn amount_matches(
+        &self,
+        amount_arg: &hir::Expr<'_>,
+        amount: hir::VariableId,
+        fee: hir::VariableId,
+    ) -> bool {
+        if is_amount_plus_fee(amount_arg, amount, fee) {
+            return true;
+        }
+        let Some(v) = underlying_var(amount_arg) else { return false };
+        matches!(self.sum_of.get(&v), Some((a, b))
+            if (*a == amount && *b == fee) || (*a == fee && *b == amount))
     }
 
     /// Drops pending repayments referencing `target`.
@@ -305,10 +515,12 @@ impl<'hir> Analyzer<'hir> {
         &mut self,
         call_expr: &hir::Expr<'_>,
         from: &hir::Expr<'_>,
-        token: Option<hir::VariableId>,
+        token: Option<TokenKey>,
     ) -> bool {
         let Some(from_v) = underlying_var(from) else { return false };
-        let Some(token_v) = token else { return false };
+        // Repayments are recorded as `(receiver, token)` raw `VariableId`s; `Field`
+        // sinks cannot match a flash-loan token state var directly.
+        let Some(TokenKey::Var(token_v)) = token else { return false };
         let ExprKind::Call(_, args, _) = &call_expr.kind else { return false };
         // Pick `to` and `amount` from whichever sink shape (3-arg member / 4-arg library).
         let (to_arg, amount_arg) = if let Some(a) =
@@ -328,7 +540,7 @@ impl<'hir> Analyzer<'hir> {
         let matched = self.repayments.keys().copied().find(|r| {
             r.receiver == from_v
                 && r.token == token_v
-                && is_amount_plus_fee(amount_arg, r.amount, r.fee)
+                && self.amount_matches(amount_arg, r.amount, r.fee)
         });
         if let Some(rep) = matched {
             match self.repayments.get_mut(&rep) {
@@ -402,20 +614,19 @@ impl<'hir> Analyzer<'hir> {
                 _ => None,
             };
             // Read all RHS facts before any write — handles `(x, y) = (y, x)` swaps.
-            type EvaluatedSlot<'a> = (Option<&'a hir::Expr<'a>>, Option<(bool, bool)>);
+            type EvaluatedSlot<'a> = (Option<&'a hir::Expr<'a>>, AssignRhs);
             let evaluated: Vec<EvaluatedSlot<'_>> = lhs_elems
                 .iter()
                 .enumerate()
                 .map(|(i, lhs_elem)| {
                     let lhs_expr = lhs_elem.as_deref();
                     let rhs_expr = rhs_elems.and_then(|r| r.get(i).copied()).flatten();
-                    let flags = rhs_expr.map(|r| (self.is_safe(r), self.is_self_expr(r)));
-                    (lhs_expr, flags)
+                    (lhs_expr, self.eval_rhs(rhs_expr))
                 })
                 .collect();
-            for (lhs_expr, flags) in evaluated {
+            for (lhs_expr, eval) in evaluated {
                 if let Some(lhs_expr) = lhs_expr {
-                    self.assign_one_flags(lhs_expr, flags);
+                    self.assign_one_flags(lhs_expr, eval);
                 }
             }
         } else {
@@ -425,29 +636,57 @@ impl<'hir> Analyzer<'hir> {
 
     /// `rhs == None` (unknown slot) drops the target's safe-fact.
     fn assign_one(&mut self, lhs: &hir::Expr<'_>, rhs: Option<&hir::Expr<'_>>) {
-        let flags = rhs.map(|r| (self.is_safe(r), self.is_self_expr(r)));
-        self.assign_one_flags(lhs, flags);
+        let eval = self.eval_rhs(rhs);
+        self.assign_one_flags(lhs, eval);
     }
 
-    /// Like `assign_one` but with pre-evaluated `(is_safe, is_self)` flags.
-    fn assign_one_flags(&mut self, lhs: &hir::Expr<'_>, flags: Option<(bool, bool)>) {
+    /// Pre-evaluates RHS facts; the resulting `AssignRhs` is independent of later
+    /// state changes (needed for tuple-swap assignments).
+    fn eval_rhs(&self, rhs: Option<&hir::Expr<'_>>) -> AssignRhs {
+        let Some(r) = rhs else { return AssignRhs::default() };
+        let alias = underlying_var(r).map(|v| self.canonical(v));
+        let sum = if let ExprKind::Binary(lhs, op, rhs_inner) = &r.peel_parens().kind
+            && matches!(op.kind, ast::BinOpKind::Add)
+        {
+            underlying_var(lhs).zip(underlying_var(rhs_inner))
+        } else {
+            None
+        };
+        AssignRhs { is_safe: self.is_safe(r), is_self: self.is_self_expr(r), alias, sum }
+    }
+
+    /// Applies a pre-evaluated RHS to the LHS variable.
+    fn assign_one_flags(&mut self, lhs: &hir::Expr<'_>, eval: AssignRhs) {
         let Some(target) = underlying_var(lhs) else { return };
         self.written.insert(target);
         self.kill_permits_for(target);
         self.kill_repayments_for(target);
-        // Drop any prior safe-fact before the state-var bail-out.
         self.safe_vars.remove(&target);
         self.self_vars.remove(&target);
-        if self.hir.variable(target).kind.is_state() {
+        // Drop alias / sum edges that reference the target on either side.
+        self.aliases.remove(&target);
+        self.aliases.retain(|_, dst| *dst != target);
+        self.sum_of.remove(&target);
+        self.sum_of.retain(|_, (a, b)| *a != target && *b != target);
+        // Mutable storage can be rewritten between check and sink; only locals and
+        // immutables/constants are safe to track.
+        let var = self.hir.variable(target);
+        if var.kind.is_state() && !var.is_immutable() && !var.is_constant() {
             return;
         }
-        if let Some((is_safe, is_self)) = flags {
-            if is_safe {
-                self.safe_vars.insert(target);
-            }
-            if is_self {
-                self.self_vars.insert(target);
-            }
+        if eval.is_safe {
+            self.safe_vars.insert(target);
+        }
+        if eval.is_self {
+            self.self_vars.insert(target);
+        }
+        if let Some(alias) = eval.alias
+            && alias != target
+        {
+            self.aliases.insert(target, alias);
+        }
+        if let Some(sum) = eval.sum {
+            self.sum_of.insert(target, sum);
         }
     }
 
@@ -588,6 +827,20 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
                             }
                             m
                         },
+                        aliases: {
+                            let mut m = after_then.aliases;
+                            for (k, v) in after_else.aliases {
+                                m.entry(k).or_insert(v);
+                            }
+                            m
+                        },
+                        sum_of: {
+                            let mut m = after_then.sum_of;
+                            for (k, v) in after_else.sum_of {
+                                m.entry(k).or_insert(v);
+                            }
+                            m
+                        },
                     },
                     (true, false) => after_else,
                     (false, true) => after_then,
@@ -609,24 +862,51 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
                             break;
                         }
                     }
+                } else if matches!(source, LoopSource::DoWhile) {
+                    // do-while runs at least once: intersect actual break/continue
+                    // exits and the body's fallthrough, without the pre-loop baseline.
+                    let mut exits = vec![];
+                    if let Some(fallthrough) =
+                        self.visit_stmts_until_loop_exit(block.stmts, &mut exits)
+                    {
+                        exits.push(fallthrough);
+                    }
+                    if !exits.is_empty() {
+                        self.restore(FlowState::intersection_all(exits.into_iter()));
+                    }
                 } else {
                     self.visit_isolated(block.stmts);
                 }
                 return ControlFlow::Continue(());
             }
             StmtKind::Try(t) => {
-                // Catch clauses only run if `t.expr` reverted, so its facts didn't
-                // take effect there. Success clause (`clauses[0]`) inherits them.
+                // Success clause inherits `t.expr`'s facts; catch clauses don't,
+                // since they only run if the call reverted.
                 let baseline = self.snapshot();
                 let _ = self.visit_expr(&t.expr);
                 let after_call = self.snapshot();
                 let mut post_clauses = Vec::with_capacity(t.clauses.len());
                 for (i, clause) in t.clauses.iter().enumerate() {
                     self.restore(if i == 0 { after_call.clone() } else { baseline.clone() });
-                    self.visit_isolated(clause.block.stmts);
-                    post_clauses.push(self.snapshot());
+                    for s in clause.block.stmts {
+                        let _ = self.visit_stmt(s);
+                        if branch_always_exits(s) {
+                            break;
+                        }
+                    }
+                    // Clauses that always exit don't reach the post-try point and
+                    // must not constrain the join.
+                    if !clause.block.stmts.iter().any(branch_always_exits) {
+                        post_clauses.push(self.snapshot());
+                    }
                 }
-                self.restore(FlowState::intersection_all(post_clauses.into_iter()));
+                let joined = if post_clauses.is_empty() {
+                    // All clauses exit; downstream is unreachable.
+                    after_call
+                } else {
+                    FlowState::intersection_all(post_clauses.into_iter())
+                };
+                self.restore(joined);
                 return ControlFlow::Continue(());
             }
 
@@ -641,7 +921,9 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
                 return ControlFlow::Continue(());
             }
 
-            StmtKind::DeclSingle(vid) if is_address(self.hir, *vid) => {
+            // `assign` only sets facts for vars whose RHS produces them, so it's
+            // safe (and necessary, for `sum_of`) to call on all declarations.
+            StmtKind::DeclSingle(vid) => {
                 if let Some(init) = self.hir.variable(*vid).initializer {
                     self.assign(*vid, init);
                 }
@@ -651,9 +933,7 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
             StmtKind::DeclMulti(vars, init) => {
                 if let ExprKind::Tuple(rhs) = &init.peel_parens().kind {
                     for (lhs, rhs) in vars.iter().zip(rhs.iter()) {
-                        if let (Some(vid), Some(expr)) = (lhs, rhs)
-                            && is_address(self.hir, *vid)
-                        {
+                        if let (Some(vid), Some(expr)) = (lhs, rhs) {
                             self.assign(*vid, expr);
                         }
                     }
@@ -692,7 +972,7 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
                 }
                 return result;
             }
-            ExprKind::Call(..) => {
+            ExprKind::Call(callee, ..) => {
                 // EIP-3156: a matching repayment sink consumes the recorded obligation.
                 if let Some(rep) = match_flash_loan_call(self.hir, expr) {
                     *self.repayments.entry(rep).or_insert(0) += 1;
@@ -710,6 +990,11 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
                         &ARBITRARY_SEND_ERC20
                     };
                     self.hits.push((expr.span, lint));
+                } else if let Some(writes) = self.call_state_writes(callee) {
+                    // Internal call may mutate `self`'s state vars: drop facts for them.
+                    for v in writes {
+                        self.invalidate(v);
+                    }
                 }
             }
             ExprKind::Assign(lhs, _, rhs) => self.handle_assign(lhs, rhs),
@@ -773,7 +1058,7 @@ fn match_sink<'hir>(
     hir: &'hir hir::Hir<'hir>,
     has_solady_lib: bool,
     expr: &'hir hir::Expr<'hir>,
-) -> Option<(&'hir hir::Expr<'hir>, Option<hir::VariableId>)> {
+) -> Option<(&'hir hir::Expr<'hir>, Option<TokenKey>)> {
     let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
     let ExprKind::Member(recv, ident) = &callee.peel_parens().kind else { return None };
     let name = ident.name.as_str();
@@ -792,13 +1077,13 @@ fn match_sink<'hir>(
                 &["bool"],
             )
         {
-            return Some((canonical[0], underlying_var(recv)));
+            return Some((canonical[0], token_key(recv)));
         }
         // `addr.safeTransferFrom(...)` via `using SafeTransferLib for address`. HIR doesn't
         // expose `using-for` bindings, so we proxy by requiring `SafeTransferLib` to be
         // declared in the compiled sources.
         if name == "safeTransferFrom" && has_solady_lib && expr_is_address(hir, recv) {
-            return Some((canonical[0], underlying_var(recv)));
+            return Some((canonical[0], token_key(recv)));
         }
     }
 
@@ -809,9 +1094,25 @@ fn match_sink<'hir>(
         && hir.contract(cid).kind == ContractKind::Library
         && library_has_safe_transfer_from(hir, cid)
     {
-        return Some((canonical[1], underlying_var(canonical[0])));
+        return Some((canonical[1], token_key(canonical[0])));
     }
 
+    None
+}
+
+/// Constructs a `TokenKey` for the receiver of a permit/sink call. Supports
+/// `<var>` (with cast / `payable` peeling via `underlying_var`) and
+/// `<var>.<field>` (a struct-field path).
+fn token_key(expr: &hir::Expr<'_>) -> Option<TokenKey> {
+    if let Some(v) = underlying_var(expr) {
+        return Some(TokenKey::Var(v));
+    }
+    let expr = expr.peel_parens();
+    if let ExprKind::Member(base, ident) = &expr.kind
+        && let Some(v) = underlying_var(base)
+    {
+        return Some(TokenKey::Field(v, ident.name));
+    }
     None
 }
 
@@ -886,6 +1187,175 @@ fn collect_modifier_safety<'hir>(
             out_self.insert(caller);
         }
     }
+}
+
+/// Harvests `self_vars` / `safe_vars` facts about immutable / constant state vars
+/// of `cid`: both declaration initializers and direct constructor assignments.
+fn seed_immutable_facts<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    has_solady_lib: bool,
+    cid: hir::ContractId,
+    out: &mut Analyzer<'hir>,
+) {
+    for item in hir.contract_item_ids(cid) {
+        if let Some(vid) = item.as_variable() {
+            let v = hir.variable(vid);
+            if v.kind.is_state()
+                && (v.is_immutable() || v.is_constant())
+                && let Some(init) = v.initializer
+            {
+                if out.is_safe(init) {
+                    out.safe_vars.insert(vid);
+                }
+                if out.is_self_expr(init) {
+                    out.self_vars.insert(vid);
+                }
+            }
+        }
+    }
+    for item in hir.contract_item_ids(cid) {
+        let Some(fid) = item.as_function() else { continue };
+        let f = hir.function(fid);
+        if !f.is_constructor() {
+            continue;
+        }
+        let Some(body) = f.body else { continue };
+        let mut ctor = Analyzer::new(hir, has_solady_lib);
+        for stmt in body.stmts {
+            let _ = ctor.visit_stmt(stmt);
+            if branch_always_exits(stmt) {
+                break;
+            }
+        }
+        for v in &ctor.safe_vars {
+            let var = hir.variable(*v);
+            if var.kind.is_state() && (var.is_immutable() || var.is_constant()) {
+                out.safe_vars.insert(*v);
+            }
+        }
+        for v in &ctor.self_vars {
+            let var = hir.variable(*v);
+            if var.kind.is_state() && (var.is_immutable() || var.is_constant()) {
+                out.self_vars.insert(*v);
+            }
+        }
+    }
+}
+
+/// Collects state-variable assignments / `delete`s reached from the given stmts.
+/// Single-level: does not follow nested function calls.
+struct StateWriteCollector<'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    out: HashSet<hir::VariableId>,
+}
+
+impl<'hir> hir::Visit<'hir> for StateWriteCollector<'hir> {
+    type BreakValue = Never;
+
+    fn hir(&self) -> &'hir hir::Hir<'hir> {
+        self.hir
+    }
+
+    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        match &expr.kind {
+            ExprKind::Assign(lhs, _, _) => self.add_target(lhs),
+            ExprKind::Delete(e) => self.add_target(e),
+            _ => {}
+        }
+        self.walk_expr(expr)
+    }
+}
+
+impl<'hir> StateWriteCollector<'hir> {
+    fn add_target(&mut self, lhs: &hir::Expr<'_>) {
+        let lhs = lhs.peel_parens();
+        if let ExprKind::Tuple(elems) = &lhs.kind {
+            for e in elems.iter().flatten() {
+                self.add_target(e);
+            }
+            return;
+        }
+        if let Some(vid) = underlying_var(lhs) {
+            let v = self.hir.variable(vid);
+            if v.kind.is_state() {
+                self.out.insert(vid);
+            }
+        }
+    }
+}
+
+fn collect_state_writes<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    stmts: &'hir [hir::Stmt<'hir>],
+) -> HashSet<hir::VariableId> {
+    let mut c = StateWriteCollector { hir, out: HashSet::new() };
+    for s in stmts {
+        let _ = c.visit_stmt(s);
+    }
+    c.out
+}
+
+/// Resolves a call's callee to a `FunctionId` for plain `name()` / `this.name()`
+/// patterns inside the same contract. Returns `None` for external / library /
+/// member-of-state-var / unresolved calls.
+fn resolve_internal_fn(callee: &hir::Expr<'_>) -> Option<hir::FunctionId> {
+    let callee = callee.peel_parens();
+    let reses: &[Res] = match &callee.kind {
+        ExprKind::Ident(reses) => reses,
+        ExprKind::Member(recv, _) => match &recv.peel_parens().kind {
+            ExprKind::Ident(reses) => reses,
+            _ => return None,
+        },
+        _ => return None,
+    };
+    reses.iter().find_map(|r| match r {
+        Res::Item(ItemId::Function(fid)) => Some(*fid),
+        _ => None,
+    })
+}
+
+/// Walks an expression tree and records every internal callee resolvable to a
+/// `FunctionId`. Used to widen `collect_state_writes` by one call level.
+struct NestedCallCollector<'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    out: HashSet<hir::FunctionId>,
+}
+
+impl<'hir> hir::Visit<'hir> for NestedCallCollector<'hir> {
+    type BreakValue = Never;
+
+    fn hir(&self) -> &'hir hir::Hir<'hir> {
+        self.hir
+    }
+
+    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let ExprKind::Call(callee, ..) = &expr.kind
+            && let Some(fid) = resolve_internal_fn(callee)
+        {
+            self.out.insert(fid);
+        }
+        self.walk_expr(expr)
+    }
+}
+
+/// `true` when the modifier body has a single `_;` and any preceding statement
+/// definitely exits (making the calling function's body unreachable).
+fn modifier_prefix_always_exits(hir: &hir::Hir<'_>, invocation: &hir::Modifier<'_>) -> bool {
+    let ItemId::Function(fid) = invocation.id else { return false };
+    let modifier = hir.function(fid);
+    if !matches!(modifier.kind, hir::FunctionKind::Modifier) {
+        return false;
+    }
+    let Some(body) = modifier.body else { return false };
+    if count_placeholders(body.stmts) != 1 {
+        return false;
+    }
+    let Some(placeholder_idx) =
+        body.stmts.iter().position(|s| matches!(s.kind, StmtKind::Placeholder))
+    else {
+        return false;
+    };
+    body.stmts[..placeholder_idx].iter().any(branch_always_exits)
 }
 
 /// `true` if any statement is `StmtKind::Err` (currently catches inline assembly,

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -11,13 +11,23 @@ use solar::{
         TypeKind, Visit,
     },
 };
-use std::{collections::HashSet, ops::ControlFlow};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::ControlFlow,
+};
 
 declare_forge_lint!(
     ARBITRARY_SEND_ERC20,
     Severity::High,
     "arbitrary-send-erc20",
     "`transferFrom` uses an arbitrary `from`; require it to equal `msg.sender` or `address(this)`"
+);
+
+declare_forge_lint!(
+    ARBITRARY_SEND_ERC20_PERMIT,
+    Severity::High,
+    "arbitrary-send-erc20-permit",
+    "`transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens"
 );
 
 impl<'hir> LateLintPass<'hir> for ArbitrarySendErc20 {
@@ -46,13 +56,17 @@ impl<'hir> LateLintPass<'hir> for ArbitrarySendErc20 {
         let has_solady_lib = has_solady_safe_transfer_lib(hir);
         let mut a = Analyzer::new(hir, has_solady_lib);
         for m in func.modifiers {
-            collect_modifier_safety(hir, has_solady_lib, m, &mut a.safe_vars);
+            collect_modifier_safety(hir, has_solady_lib, m, &mut a.safe_vars, &mut a.self_vars);
         }
         for stmt in body.stmts {
             let _ = a.visit_stmt(stmt);
+            // Skip dead code after a definite exit.
+            if branch_always_exits(stmt) {
+                break;
+            }
         }
-        for span in a.hits {
-            ctx.emit(&ARBITRARY_SEND_ERC20, span);
+        for (span, lint) in a.hits {
+            ctx.emit(lint, span);
         }
     }
 }
@@ -80,37 +94,51 @@ struct Analyzer<'hir> {
     /// Function-locals and `immutable`/`constant` state vars only — mutable storage may be
     /// rewritten between the check and the sink.
     safe_vars: HashSet<hir::VariableId>,
-    /// Permits seen earlier on this path. Path-sensitive and killed on token/owner reassignment.
+    /// Locals proven equal to `address(this)`. Subset of `safe_vars`, used to recognise
+    /// the permit `spender` arg via an alias.
+    self_vars: HashSet<hir::VariableId>,
+    /// Permits seen earlier on this path. Killed on token/owner reassignment.
     permits: HashSet<PermitRecord>,
-    /// Pending flash-loan repayments. Path-sensitive; killed on reassignment of any
-    /// referenced var; consumed once by a matching sink.
-    repayments: HashSet<PendingRepayment>,
+    /// Pending flash-loan repayments, as a multiset: repeated `onFlashLoan` calls each
+    /// license one consumption.
+    repayments: HashMap<PendingRepayment, u32>,
     /// Gates the `using ... for address` sink branch on a `SafeTransferLib` being present.
     has_solady_lib: bool,
-    hits: Vec<Span>,
+    hits: Vec<(Span, &'static SolLint)>,
+    /// Vars written by an assignment / `delete`. Used to drop unsound modifier-param
+    /// hoists when the modifier rewrote the param.
+    written: HashSet<hir::VariableId>,
 }
 
 #[derive(Clone)]
 struct FlowState {
     safe_vars: HashSet<hir::VariableId>,
+    self_vars: HashSet<hir::VariableId>,
     permits: HashSet<PermitRecord>,
-    repayments: HashSet<PendingRepayment>,
+    repayments: HashMap<PendingRepayment, u32>,
 }
 
 impl FlowState {
     fn intersection(a: &Self, b: &Self) -> Self {
         Self {
             safe_vars: a.safe_vars.intersection(&b.safe_vars).copied().collect(),
+            self_vars: a.self_vars.intersection(&b.self_vars).copied().collect(),
             permits: a.permits.intersection(&b.permits).copied().collect(),
-            repayments: a.repayments.intersection(&b.repayments).copied().collect(),
+            // Multiset intersection: min per key.
+            repayments: a
+                .repayments
+                .iter()
+                .filter_map(|(k, va)| b.repayments.get(k).map(|vb| (*k, *va.min(vb))))
+                .collect(),
         }
     }
 
     fn intersection_all(mut states: impl Iterator<Item = Self>) -> Self {
         let mut out = states.next().unwrap_or_else(|| Self {
             safe_vars: HashSet::new(),
+            self_vars: HashSet::new(),
             permits: HashSet::new(),
-            repayments: HashSet::new(),
+            repayments: HashMap::new(),
         });
         for state in states {
             out = Self::intersection(&out, &state);
@@ -127,16 +155,19 @@ impl<'hir> Analyzer<'hir> {
         Self {
             hir,
             safe_vars: HashSet::new(),
+            self_vars: HashSet::new(),
             permits: HashSet::new(),
-            repayments: HashSet::new(),
+            repayments: HashMap::new(),
             has_solady_lib,
             hits: Vec::new(),
+            written: HashSet::new(),
         }
     }
 
     fn snapshot(&self) -> FlowState {
         FlowState {
             safe_vars: self.safe_vars.clone(),
+            self_vars: self.self_vars.clone(),
             permits: self.permits.clone(),
             repayments: self.repayments.clone(),
         }
@@ -144,6 +175,7 @@ impl<'hir> Analyzer<'hir> {
 
     fn restore(&mut self, state: FlowState) {
         self.safe_vars = state.safe_vars;
+        self.self_vars = state.self_vars;
         self.permits = state.permits;
         self.repayments = state.repayments;
     }
@@ -197,13 +229,57 @@ impl<'hir> Analyzer<'hir> {
         })
     }
 
-    /// Updates `safe_vars` only; permit kills are caller-owned (state-var writes skip this).
+    /// Updates `safe_vars` / `self_vars` only; permit kills are caller-owned
+    /// (state-var writes skip this).
     fn assign(&mut self, target: hir::VariableId, rhs: &hir::Expr<'_>) {
+        self.written.insert(target);
         if self.is_safe(rhs) {
             self.safe_vars.insert(target);
         } else {
             self.safe_vars.remove(&target);
         }
+        if self.is_self_expr(rhs) {
+            self.self_vars.insert(target);
+        } else {
+            self.self_vars.remove(&target);
+        }
+    }
+
+    /// `true` when `expr` resolves to `address(this)`: bare form, a local alias,
+    /// `payable(...)`/cast wraps, or a ternary whose both branches are self.
+    fn is_self_expr(&self, expr: &hir::Expr<'_>) -> bool {
+        let expr = expr.peel_parens();
+        if is_address_self(expr) {
+            return true;
+        }
+        match &expr.kind {
+            ExprKind::Ident(reses) => reses.iter().any(
+                |r| matches!(r, Res::Item(ItemId::Variable(vid)) if self.self_vars.contains(vid)),
+            ),
+            ExprKind::Payable(inner) => self.is_self_expr(inner),
+            ExprKind::Call(callee, args, _) if is_address_cast(callee) => {
+                args.exprs().next().is_some_and(|e| self.is_self_expr(e))
+            }
+            ExprKind::Ternary(_, t, f) => self.is_self_expr(t) && self.is_self_expr(f),
+            _ => false,
+        }
+    }
+
+    /// Matches EIP-2612 `token.permit(owner, <self>, value, deadline, v, r, s)`.
+    fn match_permit_call(&self, expr: &hir::Expr<'_>) -> Option<PermitRecord> {
+        let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
+        let ExprKind::Member(recv, ident) = &callee.peel_parens().kind else { return None };
+        if ident.name.as_str() != "permit" {
+            return None;
+        }
+        let args = canonical_args(
+            args.kind,
+            &[&["owner"], &["spender"], &["value"], &["deadline"], &["v"], &["r"], &["s"]],
+        )?;
+        if !self.is_self_expr(args[1]) {
+            return None;
+        }
+        Some(PermitRecord { token: underlying_var(recv)?, owner: underlying_var(args[0])? })
     }
 
     /// Drops permits referencing `target`. Sound for any variable kind.
@@ -218,13 +294,13 @@ impl<'hir> Analyzer<'hir> {
 
     /// Drops pending repayments referencing `target`.
     fn kill_repayments_for(&mut self, target: hir::VariableId) {
-        self.repayments.retain(|r| {
+        self.repayments.retain(|r, _| {
             r.receiver != target && r.token != target && r.amount != target && r.fee != target
         });
     }
 
     /// Matches `from`/`token` plus a sink call with `to == address(this)` and amount
-    /// `amount + fee` against a pending repayment, consuming it on hit.
+    /// `amount + fee` against a pending repayment, consuming one occurrence on hit.
     fn consume_repayment(
         &mut self,
         call_expr: &hir::Expr<'_>,
@@ -246,42 +322,61 @@ impl<'hir> Analyzer<'hir> {
         } else {
             return false;
         };
-        if !is_address_self(to_arg) {
+        if !self.is_self_expr(to_arg) {
             return false;
         }
-        let matched = self.repayments.iter().copied().find(|r| {
+        let matched = self.repayments.keys().copied().find(|r| {
             r.receiver == from_v
                 && r.token == token_v
                 && is_amount_plus_fee(amount_arg, r.amount, r.fee)
         });
         if let Some(rep) = matched {
-            self.repayments.remove(&rep);
+            match self.repayments.get_mut(&rep) {
+                Some(count) if *count > 1 => *count -= 1,
+                _ => {
+                    self.repayments.remove(&rep);
+                }
+            }
             true
         } else {
             false
         }
     }
 
-    /// Records vars proven equal to a safe origin. Handles `==`/`!=`, `&&`/`||` (via De Morgan)
-    /// and `!`. Disjunctions are skipped — they don't establish a must-fact.
+    /// Records vars proven safe by `pred`. Handles `==`/`!=`, `&&`/`||` and `!` via
+    /// De Morgan; disjunctions keep only facts true on both sides.
     fn add_facts(&mut self, pred: &hir::Expr<'_>, negate: bool) {
         match &pred.peel_parens().kind {
             ExprKind::Binary(lhs, op, rhs) => {
-                let (eq, and) = if negate {
-                    (ast::BinOpKind::Ne, ast::BinOpKind::Or)
+                let (eq, and, or) = if negate {
+                    (ast::BinOpKind::Ne, ast::BinOpKind::Or, ast::BinOpKind::And)
                 } else {
-                    (ast::BinOpKind::Eq, ast::BinOpKind::And)
+                    (ast::BinOpKind::Eq, ast::BinOpKind::And, ast::BinOpKind::Or)
                 };
                 if op.kind == and {
                     self.add_facts(lhs, negate);
                     self.add_facts(rhs, negate);
+                } else if op.kind == or {
+                    // Disjunction: keep facts true in both arms.
+                    let baseline = self.snapshot();
+                    self.add_facts(lhs, negate);
+                    let after_lhs = self.snapshot();
+                    self.restore(baseline);
+                    self.add_facts(rhs, negate);
+                    let after_rhs = self.snapshot();
+                    self.restore(FlowState::intersection(&after_lhs, &after_rhs));
                 } else if op.kind == eq {
                     for (a, b) in [(lhs, rhs), (rhs, lhs)] {
-                        if self.is_safe(a)
-                            && let Some(v) = underlying_var(b)
+                        if let Some(v) = underlying_var(b)
                             && self.is_safe_target(v)
                         {
-                            self.safe_vars.insert(v);
+                            if self.is_safe(a) {
+                                self.safe_vars.insert(v);
+                            }
+                            // Equality with `address(this)` also makes `b` a self alias.
+                            if self.is_self_expr(a) {
+                                self.self_vars.insert(v);
+                            }
                         }
                     }
                 }
@@ -306,10 +401,21 @@ impl<'hir> Analyzer<'hir> {
                 ExprKind::Tuple(r) => Some(*r),
                 _ => None,
             };
-            for (i, lhs_elem) in lhs_elems.iter().enumerate() {
-                if let Some(lhs_expr) = lhs_elem {
+            // Read all RHS facts before any write — handles `(x, y) = (y, x)` swaps.
+            type EvaluatedSlot<'a> = (Option<&'a hir::Expr<'a>>, Option<(bool, bool)>);
+            let evaluated: Vec<EvaluatedSlot<'_>> = lhs_elems
+                .iter()
+                .enumerate()
+                .map(|(i, lhs_elem)| {
+                    let lhs_expr = lhs_elem.as_deref();
                     let rhs_expr = rhs_elems.and_then(|r| r.get(i).copied()).flatten();
-                    self.assign_one(lhs_expr, rhs_expr);
+                    let flags = rhs_expr.map(|r| (self.is_safe(r), self.is_self_expr(r)));
+                    (lhs_expr, flags)
+                })
+                .collect();
+            for (lhs_expr, flags) in evaluated {
+                if let Some(lhs_expr) = lhs_expr {
+                    self.assign_one_flags(lhs_expr, flags);
                 }
             }
         } else {
@@ -319,16 +425,29 @@ impl<'hir> Analyzer<'hir> {
 
     /// `rhs == None` (unknown slot) drops the target's safe-fact.
     fn assign_one(&mut self, lhs: &hir::Expr<'_>, rhs: Option<&hir::Expr<'_>>) {
+        let flags = rhs.map(|r| (self.is_safe(r), self.is_self_expr(r)));
+        self.assign_one_flags(lhs, flags);
+    }
+
+    /// Like `assign_one` but with pre-evaluated `(is_safe, is_self)` flags.
+    fn assign_one_flags(&mut self, lhs: &hir::Expr<'_>, flags: Option<(bool, bool)>) {
         let Some(target) = underlying_var(lhs) else { return };
+        self.written.insert(target);
         self.kill_permits_for(target);
         self.kill_repayments_for(target);
         // Drop any prior safe-fact before the state-var bail-out.
         self.safe_vars.remove(&target);
+        self.self_vars.remove(&target);
         if self.hir.variable(target).kind.is_state() {
             return;
         }
-        if rhs.is_some_and(|r| self.is_safe(r)) {
-            self.safe_vars.insert(target);
+        if let Some((is_safe, is_self)) = flags {
+            if is_safe {
+                self.safe_vars.insert(target);
+            }
+            if is_self {
+                self.self_vars.insert(target);
+            }
         }
     }
 
@@ -401,7 +520,7 @@ impl<'hir> Analyzer<'hir> {
             // Nested loops own their own `break` / `continue`; they do not exit this isolated body.
             StmtKind::Loop(..) => {
                 let _ = self.visit_stmt(stmt);
-                Some(())
+                (!branch_always_exits(stmt)).then_some(())
             }
             _ => {
                 let _ = self.visit_stmt(stmt);
@@ -425,61 +544,56 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
             StmtKind::If(cond, then, else_) => {
                 let _ = self.visit_expr(cond);
 
-                let baseline_safe = self.safe_vars.clone();
-                let baseline_permits = self.permits.clone();
-                let baseline_repayments = self.repayments.clone();
+                let baseline = self.snapshot();
                 self.add_facts(cond, false);
                 let _ = self.visit_stmt(then);
                 let then_exits = branch_always_exits(then);
-                let after_then_safe = std::mem::replace(&mut self.safe_vars, baseline_safe);
-                let after_then_permits = std::mem::replace(&mut self.permits, baseline_permits);
-                let after_then_repayments =
-                    std::mem::replace(&mut self.repayments, baseline_repayments);
+                let after_then = self.snapshot();
 
                 // Both the explicit `else` body and the implicit fall-through inherit `!cond`.
-                let (after_else_safe, after_else_permits, after_else_repayments, else_exits) =
-                    match else_ {
-                        Some(e) => {
-                            self.add_facts(cond, true);
-                            let _ = self.visit_stmt(e);
-                            (
-                                std::mem::take(&mut self.safe_vars),
-                                std::mem::take(&mut self.permits),
-                                std::mem::take(&mut self.repayments),
-                                branch_always_exits(e),
-                            )
-                        }
-                        None => {
-                            self.add_facts(cond, true);
-                            (
-                                std::mem::take(&mut self.safe_vars),
-                                std::mem::take(&mut self.permits),
-                                std::mem::take(&mut self.repayments),
-                                false,
-                            )
-                        }
-                    };
+                self.restore(baseline);
+                self.add_facts(cond, true);
+                let else_exits = match else_ {
+                    Some(e) => {
+                        let _ = self.visit_stmt(e);
+                        branch_always_exits(e)
+                    }
+                    None => false,
+                };
+                let after_else = self.snapshot();
 
-                let (sv, pm, rp) = match (then_exits, else_exits) {
-                    (true, true) => (
-                        after_then_safe.union(&after_else_safe).copied().collect(),
-                        after_then_permits.union(&after_else_permits).copied().collect(),
-                        after_then_repayments.union(&after_else_repayments).copied().collect(),
-                    ),
-                    (true, false) => (after_else_safe, after_else_permits, after_else_repayments),
-                    (false, true) => (after_then_safe, after_then_permits, after_then_repayments),
-                    (false, false) => (
-                        after_then_safe.intersection(&after_else_safe).copied().collect(),
-                        after_then_permits.intersection(&after_else_permits).copied().collect(),
-                        after_then_repayments
-                            .intersection(&after_else_repayments)
+                let joined = match (then_exits, else_exits) {
+                    // Both branches exit: downstream is unreachable, take a conservative
+                    // union to match the previous behaviour.
+                    (true, true) => FlowState {
+                        safe_vars: after_then
+                            .safe_vars
+                            .union(&after_else.safe_vars)
                             .copied()
                             .collect(),
-                    ),
+                        self_vars: after_then
+                            .self_vars
+                            .union(&after_else.self_vars)
+                            .copied()
+                            .collect(),
+                        permits: after_then.permits.union(&after_else.permits).copied().collect(),
+                        // Multiset union: max per key.
+                        repayments: {
+                            let mut m = after_then.repayments;
+                            for (k, vb) in &after_else.repayments {
+                                let entry = m.entry(*k).or_insert(0);
+                                if *entry < *vb {
+                                    *entry = *vb;
+                                }
+                            }
+                            m
+                        },
+                    },
+                    (true, false) => after_else,
+                    (false, true) => after_then,
+                    (false, false) => FlowState::intersection(&after_then, &after_else),
                 };
-                self.safe_vars = sv;
-                self.permits = pm;
-                self.repayments = rp;
+                self.restore(joined);
                 return ControlFlow::Continue(());
             }
 
@@ -491,6 +605,9 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
                 {
                     for s in block.stmts {
                         let _ = self.visit_stmt(s);
+                        if branch_always_exits(s) {
+                            break;
+                        }
                     }
                 } else {
                     self.visit_isolated(block.stmts);
@@ -501,6 +618,17 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
                 let _ = self.visit_expr(&t.expr);
                 for clause in t.clauses {
                     self.visit_isolated(clause.block.stmts);
+                }
+                return ControlFlow::Continue(());
+            }
+
+            // Stop at the first definite-exit inside a sequential block.
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+                for s in block.stmts {
+                    let _ = self.visit_stmt(s);
+                    if branch_always_exits(s) {
+                        break;
+                    }
                 }
                 return ControlFlow::Continue(());
             }
@@ -559,15 +687,21 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
             ExprKind::Call(..) => {
                 // EIP-3156: a matching repayment sink consumes the recorded obligation.
                 if let Some(rep) = match_flash_loan_call(self.hir, expr) {
-                    self.repayments.insert(rep);
-                } else if let Some(p) = match_permit_call(expr) {
+                    *self.repayments.entry(rep).or_insert(0) += 1;
+                } else if let Some(p) = self.match_permit_call(expr) {
                     self.permits.insert(p);
                 } else if let Some((from, token)) = match_sink(self.hir, self.has_solady_lib, expr)
                     && !self.is_safe(from)
-                    && !self.permit_covers(token, from)
                     && !self.consume_repayment(expr, from, token)
                 {
-                    self.hits.push(expr.span);
+                    // A matching prior permit doesn't make the sink safe: a non-permit
+                    // token with a fallback (e.g. WETH) silently accepts the permit.
+                    let lint = if self.permit_covers(token, from) {
+                        &ARBITRARY_SEND_ERC20_PERMIT
+                    } else {
+                        &ARBITRARY_SEND_ERC20
+                    };
+                    self.hits.push((expr.span, lint));
                 }
             }
             ExprKind::Assign(lhs, _, rhs) => self.handle_assign(lhs, rhs),
@@ -673,31 +807,15 @@ fn match_sink<'hir>(
     None
 }
 
-/// Matches `token.permit(owner, address(this), value, deadline, v, r, s)` (EIP-2612 shape).
-/// Only `spender == address(this)` permits are recorded; others can't suppress a sink.
-fn match_permit_call(expr: &hir::Expr<'_>) -> Option<PermitRecord> {
-    let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
-    let ExprKind::Member(recv, ident) = &callee.peel_parens().kind else { return None };
-    if ident.name.as_str() != "permit" {
-        return None;
-    }
-    let args = canonical_args(
-        args.kind,
-        &[&["owner"], &["spender"], &["value"], &["deadline"], &["v"], &["r"], &["s"]],
-    )?;
-    if !is_address_self(args[1]) {
-        return None;
-    }
-    Some(PermitRecord { token: underlying_var(recv)?, owner: underlying_var(args[0])? })
-}
-
-/// Hoists `require(modParam == msg.sender)` style guards from the modifier prefix (statements
-/// before its single top-level `_;`), mapping modifier params back to caller args.
+/// Hoists `require(modParam == msg.sender | address(this))` guards from the modifier
+/// prefix (statements before `_;`) to the caller's argument. `out_self` receives params
+/// proven equal to `address(this)`.
 fn collect_modifier_safety<'hir>(
     hir: &'hir hir::Hir<'hir>,
     has_solady_lib: bool,
     invocation: &hir::Modifier<'hir>,
     out_safe: &mut HashSet<hir::VariableId>,
+    out_self: &mut HashSet<hir::VariableId>,
 ) {
     let ItemId::Function(fid) = invocation.id else { return };
     let modifier = hir.function(fid);
@@ -716,13 +834,30 @@ fn collect_modifier_safety<'hir>(
         return;
     };
 
-    let arg_map: Vec<(hir::VariableId, hir::VariableId)> = invocation
-        .args
-        .exprs()
-        .enumerate()
-        .filter_map(|(i, arg)| Some((*modifier.parameters.get(i)?, underlying_var(arg)?)))
-        .collect();
+    // Modifier-param → caller-side var. Supports positional and named call shapes.
+    let arg_map: Vec<(hir::VariableId, hir::VariableId)> = match invocation.args.kind {
+        hir::CallArgsKind::Unnamed(exprs) => exprs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, arg)| Some((*modifier.parameters.get(i)?, underlying_var(arg)?)))
+            .collect(),
+        hir::CallArgsKind::Named(named) => named
+            .iter()
+            .filter_map(|na| {
+                let mp = modifier.parameters.iter().find(|p| {
+                    hir.variable(**p).name.is_some_and(|n| n.as_str() == na.name.as_str())
+                })?;
+                Some((*mp, underlying_var(&na.value)?))
+            })
+            .collect(),
+    };
     if arg_map.is_empty() {
+        return;
+    }
+
+    // Bail when the prefix contains stmts we can't track writes through (e.g. inline
+    // assembly, which currently lowers to `StmtKind::Err`).
+    if contains_unanalysable(&body.stmts[..placeholder_idx]) {
         return;
     }
 
@@ -730,12 +865,35 @@ fn collect_modifier_safety<'hir>(
     for stmt in &body.stmts[..placeholder_idx] {
         let _ = a.visit_stmt(stmt);
     }
-    // Skip caller-args that can't carry a safe-fact (mutable storage).
+    // Skip mutable-storage callers (no safe-fact) and params written inside the modifier
+    // (the local-copy fact doesn't apply to the caller's var).
     for (mp, caller) in arg_map {
-        if a.safe_vars.contains(&mp) && a.is_safe_target(caller) {
+        if !a.is_safe_target(caller) || a.written.contains(&mp) {
+            continue;
+        }
+        if a.safe_vars.contains(&mp) {
             out_safe.insert(caller);
         }
+        if a.self_vars.contains(&mp) {
+            out_self.insert(caller);
+        }
     }
+}
+
+/// `true` if any statement is `StmtKind::Err` (currently catches inline assembly,
+/// which solar doesn't yet lower to HIR).
+fn contains_unanalysable(stmts: &[hir::Stmt<'_>]) -> bool {
+    fn in_stmt(s: &hir::Stmt<'_>) -> bool {
+        match &s.kind {
+            StmtKind::Err(_) => true,
+            StmtKind::Block(b) | StmtKind::UncheckedBlock(b) => contains_unanalysable(b.stmts),
+            StmtKind::If(_, t, e) => in_stmt(t) || e.as_ref().is_some_and(|s| in_stmt(s)),
+            StmtKind::Loop(b, _) => contains_unanalysable(b.stmts),
+            StmtKind::Try(t) => t.clauses.iter().any(|c| contains_unanalysable(c.block.stmts)),
+            _ => false,
+        }
+    }
+    stmts.iter().any(in_stmt)
 }
 
 /// Strips the synthesized trailing `if (!cond) break;` from the HIR `do-while` lowering.
@@ -790,18 +948,40 @@ fn count_placeholders(stmts: &[hir::Stmt<'_>]) -> usize {
     stmts.iter().map(count_in_stmt).sum()
 }
 
-/// Resolves a `VariableId` for bare idents and `address(...)` / `payable(...)` / parens wraps.
+/// Resolves a `VariableId` for bare idents and type-cast / `payable(...)` / parens wraps.
+///
+/// Strips elementary-type casts (e.g. `address(x)`), contract / interface casts
+/// (e.g. `IERC20(rawToken)` — encoded as `Call` with the contract ident as callee), and
+/// `payable(...)` wrappers. Stripping interface casts lets permit and sink correlate when
+/// both sides wrap the same underlying raw-address variable.
 fn underlying_var(expr: &hir::Expr<'_>) -> Option<hir::VariableId> {
     match &expr.peel_parens().kind {
         ExprKind::Ident(reses) => reses.iter().find_map(|r| match r {
             Res::Item(ItemId::Variable(vid)) => Some(*vid),
             _ => None,
         }),
-        ExprKind::Call(callee, args, _) if is_address_cast(callee) => {
-            args.exprs().next().and_then(underlying_var)
+        ExprKind::Call(callee, args, _) if is_cast_callee(callee) => {
+            // Type conversions are unary; bail out on anything else to keep this peel
+            // strictly a cast-stripping helper.
+            let mut exprs = args.exprs();
+            let inner = exprs.next()?;
+            if exprs.next().is_some() {
+                return None;
+            }
+            underlying_var(inner)
         }
         ExprKind::Payable(inner) => underlying_var(inner),
         _ => None,
+    }
+}
+
+/// `true` when `callee` is a type-cast head, i.e. `address(...)`, an elementary-type cast,
+/// or an interface/contract cast like `IERC20(...)`.
+fn is_cast_callee(callee: &hir::Expr<'_>) -> bool {
+    match &callee.peel_parens().kind {
+        ExprKind::Type(_) => true,
+        ExprKind::Ident(reses) => reses.iter().any(|r| matches!(r, Res::Item(ItemId::Contract(_)))),
+        _ => false,
     }
 }
 
@@ -1010,11 +1190,14 @@ fn is_require_or_assert(callee: &hir::Expr<'_>) -> bool {
     )
 }
 
-/// `address(this)` or bare `this`.
+/// `address(this)` or bare `this`, including through `payable(...)` and parens wraps.
 fn is_address_self(expr: &hir::Expr<'_>) -> bool {
     let expr = expr.peel_parens();
     if is_builtin(expr, sym::this) {
         return true;
+    }
+    if let ExprKind::Payable(inner) = &expr.kind {
+        return is_address_self(inner);
     }
     matches!(&expr.kind, ExprKind::Call(callee, args, _) if is_address_cast(callee)
         && args.exprs().next().is_some_and(is_address_self))
@@ -1030,10 +1213,15 @@ fn branch_always_exits(stmt: &hir::Stmt<'_>) -> bool {
     match &stmt.kind {
         StmtKind::Return(_) | StmtKind::Revert(_) => true,
         StmtKind::Expr(expr) => is_exit_call(expr),
-        StmtKind::Block(b) | StmtKind::UncheckedBlock(b) => {
-            b.stmts.last().is_some_and(branch_always_exits)
-        }
+        // Any sequential definite-exit makes the block exit.
+        StmtKind::Block(b) | StmtKind::UncheckedBlock(b) => b.stmts.iter().any(branch_always_exits),
         StmtKind::If(_, t, Some(e)) => branch_always_exits(t) && branch_always_exits(e),
+        // `do-while` runs the body once: if it can't break/continue out and any stmt
+        // definitely exits, the loop does too.
+        StmtKind::Loop(block, LoopSource::DoWhile) => {
+            let user = do_while_user_stmts(block.stmts);
+            !body_has_break_or_continue(user) && user.iter().any(branch_always_exits)
+        }
         _ => false,
     }
 }

--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -615,10 +615,18 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
                 return ControlFlow::Continue(());
             }
             StmtKind::Try(t) => {
+                // Catch clauses only run if `t.expr` reverted, so its facts didn't
+                // take effect there. Success clause (`clauses[0]`) inherits them.
+                let baseline = self.snapshot();
                 let _ = self.visit_expr(&t.expr);
-                for clause in t.clauses {
+                let after_call = self.snapshot();
+                let mut post_clauses = Vec::with_capacity(t.clauses.len());
+                for (i, clause) in t.clauses.iter().enumerate() {
+                    self.restore(if i == 0 { after_call.clone() } else { baseline.clone() });
                     self.visit_isolated(clause.block.stmts);
+                    post_clauses.push(self.snapshot());
                 }
+                self.restore(FlowState::intersection_all(post_clauses.into_iter()));
                 return ControlFlow::Continue(());
             }
 

--- a/crates/lint/src/sol/high/mod.rs
+++ b/crates/lint/src/sol/high/mod.rs
@@ -10,7 +10,7 @@ mod rtlo;
 mod unchecked_calls;
 mod unprotected_initializer;
 
-use arbitrary_send_erc20::ARBITRARY_SEND_ERC20;
+use arbitrary_send_erc20::{ARBITRARY_SEND_ERC20, ARBITRARY_SEND_ERC20_PERMIT};
 use arbitrary_send_eth::ARBITRARY_SEND_ETH;
 use controlled_delegatecall::CONTROLLED_DELEGATECALL;
 use encode_packed_collision::ENCODE_PACKED_COLLISION;
@@ -21,7 +21,7 @@ use unchecked_calls::{ERC20_UNCHECKED_TRANSFER, UNCHECKED_CALL};
 use unprotected_initializer::UNPROTECTED_INITIALIZER;
 
 register_lints!(
-    (ArbitrarySendErc20, late, (ARBITRARY_SEND_ERC20)),
+    (ArbitrarySendErc20, late, (ARBITRARY_SEND_ERC20, ARBITRARY_SEND_ERC20_PERMIT)),
     (ArbitrarySendEth, late, (ARBITRARY_SEND_ETH)),
     (ControlledDelegatecall, late, (CONTROLLED_DELEGATECALL)),
     (EncodedPackedCollision, late, (ENCODE_PACKED_COLLISION)),

--- a/crates/lint/testdata/ArbitrarySendErc20Permit.sol
+++ b/crates/lint/testdata/ArbitrarySendErc20Permit.sol
@@ -798,6 +798,37 @@ contract ArbitrarySendErc20Permit {
         token.transferFrom(from, to, a);
     }
 
+    // Catch only runs if the permit reverted; its facts didn't take effect.
+    function okPermitRevertedCatchSink(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        try token.permit(from, address(this), a, deadline, v, r, s) {
+        } catch {
+            token.transferFrom(from, to, a);
+        }
+    }
+
+    // Success clause inherits the permit fact.
+    function badPermitTryCallSuccessSink(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        try token.permit(from, address(this), a, deadline, v, r, s) {
+            token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+        } catch {}
+    }
+
     // EIP-3156 repayment matches and suppresses both lints, even when a permit covering
     // `(token, address(receiver))` was recorded beforehand.
     function okPermitPlusFlashRepayment(

--- a/crates/lint/testdata/ArbitrarySendErc20Permit.sol
+++ b/crates/lint/testdata/ArbitrarySendErc20Permit.sol
@@ -67,6 +67,10 @@ library SafeTransferLib {
     }
 }
 
+struct Config {
+    IERC20 token;
+}
+
 contract ArbitrarySendErc20Permit {
     using SafeERC20 for IERC20;
     using SafeTransferLib for address;
@@ -76,13 +80,20 @@ contract ArbitrarySendErc20Permit {
     IERC721 public nft;
     address public owner;
     address public immutable trustedOwner;
+    address public immutable vault;
+    Config public cfg;
 
     constructor(address _trustedOwner) {
         trustedOwner = _trustedOwner;
+        vault = address(this);
     }
 
     function _msgSender() internal view returns (address) {
         return msg.sender;
+    }
+
+    function _self() internal view returns (address) {
+        return address(this);
     }
 
     modifier onlySelf(address f) {
@@ -98,6 +109,12 @@ contract ArbitrarySendErc20Permit {
     // Rewrites its param: the local fact must NOT be hoisted to the caller's var.
     modifier rewriteSpender(address spender) {
         spender = address(this);
+        _;
+    }
+
+    // Prefix definitely exits — the wrapped function body is unreachable.
+    modifier neverRunsBody() {
+        return;
         _;
     }
 
@@ -1021,5 +1038,209 @@ contract ArbitrarySendErc20Permit {
         token.permit(from, address(this), a, deadline, v, r, s);
         // forge-lint: disable-next-line(arbitrary-send-erc20-permit)
         token.transferFrom(from, to, a);
+    }
+
+    // Every catch always reverts, so post-try retains the permit set by `t.expr`.
+    function badPermitTryAllCatchesRevert(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        try token.permit(from, address(this), a, deadline, v, r, s) {} catch {
+            revert("permit failed");
+        }
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // do-while runs at least once and the only exit is after the permit.
+    function badPermitDoWhileBreakAfterPermit(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        do {
+            token.permit(from, address(this), a, deadline, v, r, s);
+            break;
+        } while (true);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Permit's owner is a local alias of the sink's `from`.
+    function badPermitOwnerAlias(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        address ownerAlias = from;
+        token.permit(ownerAlias, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Reverse: sink's `from` is the alias of the permit's owner.
+    function badPermitOwnerAliasReverse(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        address from2 = from;
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from2, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Sink receiver `t` is a local alias of the permit's token.
+    function badPermitTokenAlias(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        IERC20 t = token;
+        token.permit(from, address(this), a, deadline, v, r, s);
+        t.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // No-arg helper returning `address(this)` is recognised as the permit spender.
+    function badPermitHelperSelfSpender(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, _self(), a, deadline, v, r, s);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Modifier prefix definitely exits; body is unreachable.
+    function okModifierKillsBody(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public neverRunsBody {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // `repayment = amount + fee` satisfies the flash-repayment consumer as a sum-alias.
+    function okPermitFlashRepaymentSumAlias(
+        IERC3156FlashBorrower receiver,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        uint256 repayment = amount + fee;
+        token.permit(address(receiver), address(this), repayment, deadline, v, r, s);
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        token.transferFrom(address(receiver), address(this), repayment);
+    }
+
+    // Reassigning the alias kills it; sink no longer correlates with the permit.
+    function okPermitOwnerAliasReassigned(
+        address from,
+        address other,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        address ownerAlias = from;
+        token.permit(ownerAlias, address(this), a, deadline, v, r, s);
+        ownerAlias = other;
+        token.transferFrom(ownerAlias, to, a);
+    }
+
+    // Permit and sink both go through `cfg.token` (struct-field token receiver).
+    function badPermitStructFieldToken(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        cfg.token.permit(from, address(this), a, deadline, v, r, s);
+        cfg.token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Library wrapper `SafeERC20.safePermit(token, ...)`; later raw transferFrom on the
+    // same token must correlate via the library-form permit match.
+    function badPermitSafeWrapperFollowedBySink(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        SafeERC20.safePermit(token, from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Internal call reassigns the token state var; the prior permit no longer covers it.
+    function _switchToken() internal {
+        token = other;
+    }
+    function okPermitInternalCallSwitchesToken(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        _switchToken();
+        token.transferFrom(from, to, a);
+    }
+
+    // Immutable seeded from constructor with `address(this)`; flash-loan repayment
+    // to that immutable must be accepted as self.
+    function okPermitFlashRepaymentToVault(
+        IERC3156FlashBorrower receiver,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        token.permit(address(receiver), address(this), amount + fee, deadline, v, r, s);
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        token.transferFrom(address(receiver), vault, amount + fee);
     }
 }

--- a/crates/lint/testdata/ArbitrarySendErc20Permit.sol
+++ b/crates/lint/testdata/ArbitrarySendErc20Permit.sol
@@ -1227,6 +1227,58 @@ contract ArbitrarySendErc20Permit {
         token.transferFrom(from, to, a);
     }
 
+    // Reassigning a struct field drops permits keyed on `Field(base, name)`.
+    function okPermitStructFieldReassigned(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        cfg.token.permit(from, address(this), a, deadline, v, r, s);
+        cfg.token = other;
+        cfg.token.transferFrom(from, to, a);
+    }
+
+    // Every try clause exits; trailing code is unreachable and must not be analyzed.
+    function okPermitTryAllClausesExit(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        try token.permit(from, address(this), a, deadline, v, r, s) {
+            revert("ok");
+        } catch {
+            revert("bad");
+        }
+        token.transferFrom(from, to, a);
+    }
+
+    // Arg-eval order: nested sink in args must see facts live before the outer call's
+    // state-write side effects are applied.
+    function _switchTokenAndReturn(uint256 x) internal returns (uint256) {
+        token = other;
+        return x;
+    }
+    function badPermitNestedSinkBeforeStateWrite(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        _switchTokenAndReturn(token.transferFrom(from, to, a) ? 0 : 0); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
     // Immutable seeded from constructor with `address(this)`; flash-loan repayment
     // to that immutable must be accepted as self.
     function okPermitFlashRepaymentToVault(

--- a/crates/lint/testdata/ArbitrarySendErc20Permit.sol
+++ b/crates/lint/testdata/ArbitrarySendErc20Permit.sol
@@ -1,0 +1,994 @@
+//@compile-flags: --only-lint arbitrary-send-erc20-permit
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface IERC20 {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function permit(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external;
+}
+
+interface IERC721 {
+    // Same name as ERC20 but a different ABI; permit-variant must not flag.
+    function transferFrom(address from, address to, uint256 tokenId) external;
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+}
+
+interface IERC3156FlashBorrower {
+    function onFlashLoan(
+        address initiator,
+        address token,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data
+    ) external returns (bytes32);
+}
+
+library SafeERC20 {
+    function safeTransferFrom(
+        IERC20 token,
+        address from,
+        address to,
+        uint256 value
+    ) internal {
+        require(token.transferFrom(from, to, value), "SafeERC20: transferFrom failed");
+    }
+
+    function safePermit(
+        IERC20 token,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal {
+        token.permit(owner, spender, value, deadline, v, r, s);
+    }
+}
+
+// Solady-shaped library that takes the token as a raw `address`. Enables the
+// `using ... for address` sink branch in the analyzer.
+library SafeTransferLib {
+    function safeTransferFrom(address token, address from, address to, uint256 amount) internal {
+        // Body intentionally trivial; matched structurally by signature.
+        (token, from, to, amount);
+    }
+}
+
+contract ArbitrarySendErc20Permit {
+    using SafeERC20 for IERC20;
+    using SafeTransferLib for address;
+
+    IERC20 public token;
+    IERC20 public other;
+    IERC721 public nft;
+    address public owner;
+    address public immutable trustedOwner;
+
+    constructor(address _trustedOwner) {
+        trustedOwner = _trustedOwner;
+    }
+
+    function _msgSender() internal view returns (address) {
+        return msg.sender;
+    }
+
+    modifier onlySelf(address f) {
+        require(f == msg.sender, "auth");
+        _;
+    }
+
+    modifier onlyContract(address spender) {
+        require(spender == address(this), "spender");
+        _;
+    }
+
+    // Rewrites its param: the local fact must NOT be hoisted to the caller's var.
+    modifier rewriteSpender(address spender) {
+        spender = address(this);
+        _;
+    }
+
+    // -- POSITIVE CASES (should warn with `arbitrary-send-erc20-permit`) --
+
+    // Plain permit + arbitrary-`from` transferFrom on the same `(token, owner)`.
+    function badPermitPlain(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Same as `badPermitPlain` but the sink is `safeTransferFrom` (member form).
+    function badPermitSafeMember(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.safeTransferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Library-form sink: `SafeERC20.safeTransferFrom(token, from, to, a)` still triggers
+    // when a permit on the same `(token, from)` was recorded earlier.
+    function badPermitLibrary(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        SafeERC20.safeTransferFrom(token, from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Named-args form for both permit and transferFrom.
+    function badPermitNamedArgs(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit({
+            owner: from,
+            spender: address(this),
+            value: a,
+            deadline: deadline,
+            v: v,
+            r: r,
+            s: s
+        });
+        token.transferFrom({from: from, to: to, amount: a}); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Both `then` and `else` permit + sink: each branch sink emits independently.
+    function badPermitBothBranches(
+        bool flag,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        if (flag) {
+            token.permit(from, address(this), a, deadline, v, r, s);
+            token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+        } else {
+            token.permit(from, address(this), a, deadline, v, r, s);
+            token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+        }
+    }
+
+    // Permit set on every path before a post-join sink: join intersection keeps the
+    // permit record, so the single sink emits once.
+    function badPermitBothBranchesThenSink(
+        bool flag,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        if (flag) {
+            token.permit(from, address(this), a, deadline, v, r, s);
+        } else {
+            token.permit(from, address(this), a, deadline, v, r, s);
+        }
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Permit + sink inside a single branch.
+    function badPermitInBranch(
+        bool flag,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        if (flag) {
+            token.permit(from, address(this), a, deadline, v, r, s);
+            token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+        }
+    }
+
+    // Permit + sink across an `unchecked` block.
+    function badPermitInUncheckedBlock(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        unchecked {
+            token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+        }
+    }
+
+    // Interface-cast token: `IERC20(rawToken).permit(...)` then
+    // `IERC20(rawToken).transferFrom(...)` correlates via the underlying address var.
+    function badPermitInterfaceCast(
+        address rawToken,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        IERC20(rawToken).permit(from, address(this), a, deadline, v, r, s);
+        IERC20(rawToken).transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Solady-shaped library: token passed as raw `address`; permit recorded under the
+    // same underlying var via the interface cast.
+    function badPermitSoladyAddressToken(
+        address rawToken,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        IERC20(rawToken).permit(from, address(this), a, deadline, v, r, s);
+        SafeTransferLib.safeTransferFrom(rawToken, from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // `using SafeTransferLib for address;` member form: `rawToken.safeTransferFrom(...)`.
+    function badPermitSoladyUsingForAddress(
+        address rawToken,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        IERC20(rawToken).permit(from, address(this), a, deadline, v, r, s);
+        rawToken.safeTransferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // `do { permit } while (false)` establishes the permit on the only path through the
+    // loop body (no `break`/`continue`).
+    function badPermitDoWhileEstablishesPermit(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        do {
+            token.permit(from, address(this), a, deadline, v, r, s);
+        } while (false);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Try-call succeeds; sink inside the success clause inherits the permit from the
+    // pre-try state. Falls within the try body's isolation scope: established facts from
+    // before the try are visible inside the clause.
+    function badPermitBeforeTrySinkInClause(
+        IERC20 t,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        try t.transfer(to, a) returns (bool) {
+            token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+        } catch {}
+    }
+
+    // Spender alias: `address self = address(this)` then `permit(owner, self, …)`.
+    // The local copy is tracked in `self_vars`, so the permit IS recorded.
+    function badPermitSpenderAlias(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        address self = address(this);
+        token.permit(from, self, a, deadline, v, r, s);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // `payable(address(this))` as spender — also recognised.
+    function badPermitPayableSelfSpender(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, payable(address(this)), a, deadline, v, r, s);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Two distinct permits on two distinct tokens, sinks in reverse order. Permits don't
+    // consume on use, so both transferFroms must warn.
+    function badTwoPermitsTwoSinksDifferentOrder(
+        address from1,
+        address from2,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from1, address(this), a, deadline, v, r, s);
+        other.permit(from2, address(this), a, deadline, v, r, s);
+        other.transferFrom(from2, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+        token.transferFrom(from1, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Modifier-hoisted `spender == address(this)` guard. The modifier proves the caller
+    // arg is a self alias; the permit IS recorded and the post-permit sink flags the
+    // permit variant.
+    function badPermitModifierSpenderGuard(
+        address from,
+        address spender,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public onlyContract(spender) {
+        token.permit(from, spender, a, deadline, v, r, s);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Equality guard `spender == address(this)` makes `spender` a self alias for the
+    // permit call, so the record IS stored and the subsequent sink flags the permit
+    // variant.
+    function badPermitEqualityGuardSpender(
+        address from,
+        address spender,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        require(spender == address(this), "spender");
+        token.permit(from, spender, a, deadline, v, r, s);
+        token.transferFrom(from, to, a); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // After consuming an EIP-3156 repayment, the *same-shape* second pullback no longer
+    // qualifies as a repayment, but the permit record survives → permit-variant fires.
+    function badPermitPlusFlashDoublePull(
+        IERC3156FlashBorrower receiver,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(address(receiver), address(this), amount + fee, deadline, v, r, s);
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        token.transferFrom(address(receiver), address(this), amount + fee);
+        token.transferFrom(address(receiver), address(this), amount + fee); //~WARN: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+    }
+
+    // Permit + double flash-loan: two identical `onFlashLoan` calls each license one
+    // repayment, so two same-shape transferFroms both consume; neither warns. (Negative.)
+    function okPermitDoubleFlashRepayment(
+        IERC3156FlashBorrower receiver,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(address(receiver), address(this), amount + fee, deadline, v, r, s);
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        token.transferFrom(address(receiver), address(this), amount + fee);
+        token.transferFrom(address(receiver), address(this), amount + fee);
+    }
+
+    // Repayment recipient is a local self alias (`address self = address(this)`); the
+    // sink's `to` is the alias, which `is_self_expr` recognises. Repayment is consumed,
+    // no warning.
+    function okPermitFlashRepaymentSelfAlias(
+        IERC3156FlashBorrower receiver,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        address self = address(this);
+        token.permit(address(receiver), self, amount + fee, deadline, v, r, s);
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        token.transferFrom(address(receiver), self, amount + fee);
+    }
+
+    // Disjunction guard: `from == msg.sender || from == address(this)` proves `from` is
+    // safe (both disjuncts establish the same fact); no warning expected.
+    function okPermitDisjunctionGuard(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        require(from == msg.sender || from == address(this), "auth");
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // -- NEGATIVE CASES (should NOT warn with `arbitrary-send-erc20-permit`) --
+
+    // Caller is `msg.sender` — even if permit silently no-ops, only the caller's own balance
+    // is touched.
+    function okPermitMsgSender(
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(msg.sender, address(this), a, deadline, v, r, s);
+        token.transferFrom(msg.sender, address(this), a);
+    }
+
+    // Explicit equality guard makes `from` provably safe before the sink.
+    function okPermitGuarded(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        require(from == msg.sender, "auth");
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // `from = address(this)`: the contract is moving its own tokens.
+    function okPermitSelf(
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(address(this), address(this), a, deadline, v, r, s);
+        token.transferFrom(address(this), to, a);
+    }
+
+    // Modifier-hoisted guard: `f == msg.sender` from the modifier proves `from` safe
+    // before the sink runs.
+    function okPermitModifierGuarded(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public onlySelf(from) {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // `_msgSender()` helper resolves to `msg.sender` within the depth budget.
+    function okPermitMsgSenderHelper(
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(_msgSender(), address(this), a, deadline, v, r, s);
+        token.transferFrom(_msgSender(), address(this), a);
+    }
+
+    // Helper used inside an equality guard.
+    function okPermitMsgSenderHelperGuard(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        require(from == _msgSender(), "auth");
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // Ternary with both safe branches.
+    function okPermitTernaryBothSafe(
+        bool flag,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        address from = flag ? msg.sender : address(this);
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // Permit spender is *not* `address(this)` — record is not stored, falls through to the
+    // plain `arbitrary-send-erc20` lint (out of scope here under `--only-lint`).
+    function okPermitWrongSpender(
+        address from,
+        address spender,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, spender, a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // Permit owner differs from sink `from` — no covering record for this `from`.
+    function okPermitOwnerMismatch(
+        address ownerArg,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(ownerArg, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // Permit on a different token than the sink — no match.
+    function okPermitWrongToken(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        other.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // Sink BEFORE the permit: no covering record at the sink.
+    function okPermitAfterSink(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.transferFrom(from, to, a);
+        token.permit(from, address(this), a, deadline, v, r, s);
+    }
+
+    // ERC721's `transferFrom`/`safeTransferFrom` overloads must not match as sinks.
+    function okErc721NotAffected(
+        address from,
+        address to,
+        uint256 id,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), id, deadline, v, r, s);
+        nft.transferFrom(from, to, id);
+        nft.safeTransferFrom(from, to, id);
+    }
+
+    // View / pure functions are out of scope for the pass entirely.
+    function viewExempt(address from, address to, uint256 a) external view returns (uint256) {
+        from; to; a;
+        return 0;
+    }
+
+    // State-var token reassigned after the permit invalidates the record — the sink falls
+    // through to the plain lint, not the permit-variant.
+    function okPermitStateTokenReassigned(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token = other;
+        token.transferFrom(from, to, a);
+    }
+
+    // State-var owner reassigned after the permit invalidates the record.
+    function okPermitStateOwnerReassigned(
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        owner = to;
+        token.permit(owner, address(this), a, deadline, v, r, s);
+        owner = to;
+        token.transferFrom(owner, to, a);
+    }
+
+    // Permit token reassigned after the permit invalidates the record.
+    function okPermitTokenReassigned(
+        IERC20 t,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        t.permit(from, address(this), a, deadline, v, r, s);
+        t = other;
+        t.transferFrom(from, to, a);
+    }
+
+    // Interface-cast raw-token key: reassigning the underlying `rawToken` variable kills
+    // the permit record indexed by that var, so the post-reassign sink falls through to
+    // the plain lint (filtered out here).
+    function okPermitInterfaceCastTokenReassigned(
+        address rawToken,
+        address otherRawToken,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        IERC20(rawToken).permit(from, address(this), a, deadline, v, r, s);
+        rawToken = otherRawToken;
+        IERC20(rawToken).transferFrom(from, to, a);
+    }
+
+    // Permit owner var reassigned after the permit invalidates the record.
+    function okPermitOwnerReassigned(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        address x = from;
+        token.permit(x, address(this), a, deadline, v, r, s);
+        x = to;
+        token.transferFrom(x, to, a);
+    }
+
+    // Permit on a side branch must not suppress the fall-through path — and conversely,
+    // must not be reported as a permit-variant on the fall-through where no record exists.
+    function okPermitInOtherBranch(
+        bool flag,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        if (flag) {
+            token.permit(from, address(this), a, deadline, v, r, s);
+        }
+        // Falls back to the plain `arbitrary-send-erc20` lint (filtered out here).
+        token.transferFrom(from, to, a);
+    }
+
+    // `do { if (flag) break; permit; } while (false);` may break before permit — the
+    // post-loop join drops the permit; sink only triggers the plain lint, not the permit
+    // variant.
+    function okPermitDoWhileBreakSkipsPermit(
+        bool flag,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        do {
+            if (flag) break;
+            token.permit(from, address(this), a, deadline, v, r, s);
+        } while (false);
+        token.transferFrom(from, to, a);
+    }
+
+    // Permit inside a try clause does NOT leak past the try (visit_isolated semantics);
+    // post-try sink falls through to the plain lint, not the permit variant.
+    function okPermitInsideTryDoesNotLeak(
+        IERC20 t,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        try t.transfer(to, a) returns (bool) {
+            token.permit(from, address(this), a, deadline, v, r, s);
+        } catch {}
+        token.transferFrom(from, to, a);
+    }
+
+    // EIP-3156 repayment matches and suppresses both lints, even when a permit covering
+    // `(token, address(receiver))` was recorded beforehand.
+    function okPermitPlusFlashRepayment(
+        IERC3156FlashBorrower receiver,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(address(receiver), address(this), amount + fee, deadline, v, r, s);
+        receiver.onFlashLoan(msg.sender, address(token), amount, fee, data);
+        token.transferFrom(address(receiver), address(this), amount + fee);
+    }
+
+    // Dead code after a `return` must not trigger either lint (the analyzer stops
+    // visiting unreachable statements at the function-body top level).
+    function okUnreachableAfterReturn(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        return;
+        // dead — no warning expected
+        token.transferFrom(from, to, a);
+    }
+
+    // Code AFTER a `do { ...; return; } while (false);` is dead too: the do-while
+    // definitely exits because the body always returns and there's no break/continue.
+    function okUnreachableAfterExitingDoWhile(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        do {
+            token.permit(from, address(this), a, deadline, v, r, s);
+            return;
+        } while (false);
+        // dead — no warning expected
+        token.transferFrom(from, to, a);
+    }
+
+    // Dead code in the do-while fast path (no break/continue) must also be skipped.
+    function okUnreachableAfterReturnInDoWhile(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        do {
+            token.permit(from, address(this), a, deadline, v, r, s);
+            return;
+            // dead — no warning expected
+            token.transferFrom(from, to, a);
+        } while (false);
+    }
+
+    // Dead code inside a nested branch also must not trigger (block-level dead-code
+    // suppression, not only top-level).
+    function okUnreachableAfterReturnInBranch(
+        bool flag,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        if (flag) {
+            token.permit(from, address(this), a, deadline, v, r, s);
+            return;
+            // dead — no warning expected
+            token.transferFrom(from, to, a);
+        }
+    }
+
+    // Branch returns early; the post-`if` fall-through inherits an empty state, so the
+    // sink falls through to the plain lint (filtered out here), not the permit variant.
+    function okPermitReturningBranchDoesNotLeak(
+        bool flag,
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        if (flag) {
+            token.permit(from, address(this), a, deadline, v, r, s);
+            return;
+        }
+        token.transferFrom(from, to, a);
+    }
+
+    // Modifier that internally rewrites its `spender` parameter must NOT have the
+    // resulting local fact hoisted to the caller's `spender`. The caller-side `spender`
+    // is unproven, so the permit record is NOT stored and the sink falls through to the
+    // plain `arbitrary-send-erc20` lint (out of scope here).
+    function okPermitModifierWritesParam(
+        address from,
+        address spender,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public rewriteSpender(spender) {
+        token.permit(from, spender, a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // Tuple swap must be evaluated simultaneously: after `(x, sp) = (sp, x)` the original
+    // `sp` (self) has moved to `x`; `sp` now holds the original `x` (unproven). A naive
+    // left-to-right model would falsely keep `sp` in `self_vars`. The permit must NOT be
+    // recorded → sink falls through to the plain lint (out of scope here).
+    function okPermitTupleSwapPreservesFacts(
+        address from,
+        address spender,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        address x = spender;
+        address sp = address(this);
+        (x, sp) = (sp, x);
+        token.permit(from, sp, a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // `from = _msgSender()` propagates safety through the local copy.
+    function okPermitFromAssignedMsgSenderHelper(
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        address from = _msgSender();
+        token.permit(from, address(this), a, deadline, v, r, s);
+        token.transferFrom(from, to, a);
+    }
+
+    // `delete token` resets `token`, killing the permit record indexed by it.
+    function okPermitDeleteTokenKillsRecord(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        delete token;
+        token.transferFrom(from, to, a);
+    }
+
+    // Inline `// forge-lint: disable-next-line(arbitrary-send-erc20-permit)` suppresses
+    // the warning at the next statement.
+    function okInlineDisablePermitLint(
+        address from,
+        address to,
+        uint256 a,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) public {
+        token.permit(from, address(this), a, deadline, v, r, s);
+        // forge-lint: disable-next-line(arbitrary-send-erc20-permit)
+        token.transferFrom(from, to, a);
+    }
+}

--- a/crates/lint/testdata/ArbitrarySendErc20Permit.stderr
+++ b/crates/lint/testdata/ArbitrarySendErc20Permit.stderr
@@ -238,3 +238,11 @@ LL │ …     token.transferFrom(from, to, a);
    │
    ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
 
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     _switchTokenAndReturn(token.transferFrom(from, to, a) ? 0 : 0);
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+

--- a/crates/lint/testdata/ArbitrarySendErc20Permit.stderr
+++ b/crates/lint/testdata/ArbitrarySendErc20Permit.stderr
@@ -166,3 +166,11 @@ LL │ …     token.transferFrom(address(receiver), address(this), amount + fee
    │
    ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
 
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+

--- a/crates/lint/testdata/ArbitrarySendErc20Permit.stderr
+++ b/crates/lint/testdata/ArbitrarySendErc20Permit.stderr
@@ -1,0 +1,168 @@
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.safeTransferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     SafeERC20.safeTransferFrom(token, from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom({from: from, to: to, amount: a});
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     IERC20(rawToken).transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     SafeTransferLib.safeTransferFrom(rawToken, from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     rawToken.safeTransferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     other.transferFrom(from2, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from1, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(address(receiver), address(this), amount + fee);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+

--- a/crates/lint/testdata/ArbitrarySendErc20Permit.stderr
+++ b/crates/lint/testdata/ArbitrarySendErc20Permit.stderr
@@ -174,3 +174,67 @@ LL │ …     token.transferFrom(from, to, a);
    │
    ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
 
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from2, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     t.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     cfg.token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+
+warning[arbitrary-send-erc20-permit]: `transferFrom` uses an arbitrary `from` after `permit`; a non-permit token (e.g. WETH) with a fallback can silently accept the permit and let anyone drain previously-approved tokens
+   ╭▸ ROOT/testdata/ArbitrarySendErc20Permit.sol:LL:CC
+   │
+LL │ …     token.transferFrom(from, to, a);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/arbitrary-send-erc20-permit
+


### PR DESCRIPTION
Detects `transferFrom` calls with an arbitrary `from` after a `permit(owner, address(this), …)` on the same (`token`, `owner`). 

Closes OSS-40