### PR TITLE
fix(lint): avoid unnecessary reentrancy call classification

### DIFF
--- a/crates/forge/tests/cli/verify_bytecode.rs
+++ b/crates/forge/tests/cli/verify_bytecode.rs
@@ -322,8 +322,9 @@ forgetest_async!(flaky_can_verify_bytecode_fails_on_source_mismatch, |prj, cmd| 
         bytecode_hash: BytecodeHash::None,
         ..Default::default()
     });
-    // Build once with correct source (creates cache)
-    cmd.forge_fuse().arg("build").assert_success();
+    // Build once with correct source (creates cache). Linting is unrelated to bytecode
+    // verification here and can dominate runtime on the flattened Etherscan source.
+    cmd.forge_fuse().args(["build", "--no-lint"]).assert_success();
 
     let source_code = r#"
     contract SystemConfig {

--- a/crates/lint/src/sol/high/reentrancy.rs
+++ b/crates/lint/src/sol/high/reentrancy.rs
@@ -48,6 +48,9 @@ impl<'hir> LateLintPass<'hir> for ReentrancyEth {
         let Some(body) = func.body else { return };
 
         let mut analyzer = Analyzer::new(ctx, gcx, hir);
+        if !analyzer.has_enabled_lints() {
+            return;
+        }
         let mut state = FlowState::default();
         analyzer.analyze_callable(func, body, &mut state);
     }
@@ -115,11 +118,25 @@ struct Analyzer<'ctx, 's, 'c, 'hir> {
     hir: &'hir hir::Hir<'hir>,
     emitted: HashSet<Span>,
     call_stack: Vec<FunctionId>,
+    reentrancy_eth_enabled: bool,
+    reentrancy_no_eth_enabled: bool,
 }
 
 impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
     fn new(ctx: &'ctx LintContext<'s, 'c>, gcx: Gcx<'hir>, hir: &'hir hir::Hir<'hir>) -> Self {
-        Self { ctx, gcx, hir, emitted: HashSet::new(), call_stack: Vec::new() }
+        Self {
+            ctx,
+            gcx,
+            hir,
+            emitted: HashSet::new(),
+            call_stack: Vec::new(),
+            reentrancy_eth_enabled: ctx.is_lint_enabled(REENTRANCY_ETH.id),
+            reentrancy_no_eth_enabled: ctx.is_lint_enabled(REENTRANCY_NO_ETH.id),
+        }
+    }
+
+    const fn has_enabled_lints(&self) -> bool {
+        self.reentrancy_eth_enabled || self.reentrancy_no_eth_enabled
     }
 
     fn analyze_callable(
@@ -325,7 +342,9 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
                 for func_id in resolved_function_ids(callee) {
                     self.analyze_internal_call(func_id, state);
                 }
-                if let Some(kind) = reentrant_call_kind(self.gcx, self.hir, callee, args, *opts) {
+                if !state.state_reads.is_empty()
+                    && let Some(kind) = self.reentrant_call_kind(callee, args, *opts)
+                {
                     state.push_call(expr.span, kind);
                 }
             }
@@ -462,6 +481,23 @@ impl<'ctx, 's, 'c, 'hir> Analyzer<'ctx, 's, 'c, 'hir> {
             }
         }
     }
+
+    fn reentrant_call_kind(
+        &self,
+        callee: &'hir hir::Expr<'hir>,
+        args: &CallArgs<'hir>,
+        opts: Option<&'hir [hir::NamedArg<'hir>]>,
+    ) -> Option<ReentrantCallKind> {
+        if self.reentrancy_eth_enabled && is_uncapped_value_call(self.hir, callee, opts) {
+            return Some(ReentrantCallKind::Eth);
+        }
+        if self.reentrancy_no_eth_enabled
+            && is_no_eth_reentrant_call(self.gcx, self.hir, callee, args, opts)
+        {
+            return Some(ReentrantCallKind::NoEth);
+        }
+        None
+    }
 }
 
 impl FlowState {
@@ -484,19 +520,6 @@ impl FlowState {
             }
         }
     }
-}
-
-fn reentrant_call_kind<'hir>(
-    gcx: Gcx<'hir>,
-    hir: &'hir hir::Hir<'hir>,
-    callee: &'hir hir::Expr<'hir>,
-    args: &CallArgs<'hir>,
-    opts: Option<&'hir [hir::NamedArg<'hir>]>,
-) -> Option<ReentrantCallKind> {
-    if is_uncapped_value_call(hir, callee, opts) {
-        return Some(ReentrantCallKind::Eth);
-    }
-    is_no_eth_reentrant_call(gcx, hir, callee, args, opts).then_some(ReentrantCallKind::NoEth)
 }
 
 fn is_uncapped_value_call(


### PR DESCRIPTION
## Summary
- skip post-build lint in the verify-bytecode mismatch test's cache warm-up build
- avoid classifying reentrant calls before the analyzer has observed any state reads that could be protected
- gate ETH vs no-ETH call classification on the specific enabled lint, so disabling one sibling lint skips its expensive analysis path

## Root cause
The June 3 `test-flaky` failures timed out in `forge::cli::verify_bytecode::flaky_can_verify_bytecode_fails_on_source_mismatch` during the initial `forge build`. The head commit added `reentrancy-no-eth`, and `forge build` runs lint by default, so the verify-bytecode fixture started linting a large flattened Etherscan source during a cache warm-up build. That lint work is unrelated to bytecode verification and repeatedly exceeded nextest's 180s per-test timeout in both normal and isolated jobs.

A rerun of this PR at `38a6be66c` still failed in the same setup `forge build`, which showed that optimizing the lint pass alone was insufficient. This update also changes that setup build to `forge build --no-lint`.

closes #15038 
closes #15039 

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p forge-lint`
- `cargo test -p forge-lint reentrancy -- --nocapture`

Attempted `cargo test -p forge --test cli flaky_can_verify_bytecode_fails_on_source_mismatch -- --nocapture`, but this sandbox hit a 300s timeout while still compiling the `forge` CLI test dependency graph and did not reach test execution. The original CI rerun evidence for `26871949532` confirmed the remaining timeout was still at the setup `forge build` now changed to `--no-lint`.

Prompted by: @grandizzy