### PR TITLE
Fix mutation source path normalization on Windows

### DIFF
--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -205,13 +205,16 @@ pub fn run_mutations_parallel_with_progress(
     let source_abs =
         if source_path.is_absolute() { source_path } else { config.root.join(&source_path) };
 
+    let root_abs = config.root.canonicalize().unwrap_or_else(|_| config.root.clone());
+    let source_abs = source_abs.canonicalize().unwrap_or(source_abs);
+
     let source_relative = source_abs
-        .strip_prefix(&config.root)
+        .strip_prefix(&root_abs)
         .map_err(|_| {
             eyre::eyre!(
                 "Source path {} is not under project root {}",
                 source_abs.display(),
-                config.root.display()
+                root_abs.display()
             )
         })?
         .to_path_buf();


### PR DESCRIPTION
## Summary
- canonicalize the mutation project root before stripping it from canonicalized source paths
- fixes Windows mutation runs where source paths use the `\\?\` verbatim prefix but the project root does not

## Validation
- `cargo fmt --check`
- `cargo test -p forge mutation::runner --lib`
- `cargo test -p forge --test cli test_cmd::mutation::can_run_mutation_testing -- --exact --nocapture` built successfully, then failed before mutation execution because `forge init` could not clone `forge-std` from GitHub (`HTTP 400`)

Prompted by: @grandizzy