### PR TITLE
feat(forge): derive invariant workers from --jobs

### DIFF
--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -8,13 +8,18 @@ use serde::{
 use std::{fmt, num::NonZeroUsize, path::PathBuf, str::FromStr};
 
 /// Worker selection mode for invariant campaign sharding.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum InvariantWorkers {
     /// Automatically derive invariant workers from the active `--jobs` / rayon thread pool.
-    #[default]
     Auto,
     /// Explicit user override for invariant campaign sharding.
     Fixed(NonZeroUsize),
+}
+
+impl Default for InvariantWorkers {
+    fn default() -> Self {
+        Self::Fixed(NonZeroUsize::MIN)
+    }
 }
 
 impl Serialize for InvariantWorkers {
@@ -101,8 +106,8 @@ pub struct InvariantConfig {
     pub depth: u32,
     /// Worker selection mode used to shard invariant runs.
     ///
-    /// Defaults to `auto`, which derives the worker count from `--jobs`. Use a positive integer
-    /// to request a fixed worker count independent of `--jobs` for reproducibility.
+    /// Defaults to `1` for reproducible seeded campaigns. Use `auto` to derive the worker count
+    /// from `--jobs`, or a positive integer for an explicit worker count.
     pub workers: InvariantWorkers,
     /// Fails the invariant fuzzing if a revert occurs
     pub fail_on_revert: bool,
@@ -149,7 +154,7 @@ impl Default for InvariantConfig {
         Self {
             runs: 256,
             depth: 500,
-            workers: InvariantWorkers::Auto,
+            workers: InvariantWorkers::default(),
             fail_on_revert: false,
             call_override: false,
             dictionary: FuzzDictionaryConfig { dictionary_weight: 80, ..Default::default() },
@@ -199,6 +204,12 @@ mod tests {
             serde_json::from_str::<InvariantWorkers>(r#""4""#).unwrap(),
             InvariantWorkers::Fixed(NonZeroUsize::new(4).unwrap())
         );
+    }
+
+    #[test]
+    fn invariant_workers_default_to_one() {
+        assert_eq!(InvariantWorkers::default(), InvariantWorkers::Fixed(NonZeroUsize::MIN));
+        assert_eq!(InvariantConfig::default().workers, InvariantWorkers::Fixed(NonZeroUsize::MIN));
     }
 
     #[test]

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -1,8 +1,88 @@
 //! Configuration for invariant testing
 
 use crate::fuzz::{FuzzCorpusConfig, FuzzDictionaryConfig};
-use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{Error, Visitor},
+};
+use std::{fmt, num::NonZeroUsize, path::PathBuf};
+
+/// Worker selection mode for invariant campaign sharding.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum InvariantWorkers {
+    /// Automatically derive invariant workers from the active `--jobs` / rayon thread pool.
+    #[default]
+    Auto,
+    /// Explicit user override for the maximum number of invariant workers.
+    Fixed(NonZeroUsize),
+}
+
+impl Serialize for InvariantWorkers {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Auto => serializer.serialize_str("auto"),
+            Self::Fixed(workers) => workers.get().serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for InvariantWorkers {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(InvariantWorkersVisitor)
+    }
+}
+
+struct InvariantWorkersVisitor;
+
+impl Visitor<'_> for InvariantWorkersVisitor {
+    type Value = InvariantWorkers;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("`auto` or a positive integer worker count")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        let value = value.trim();
+        if value.eq_ignore_ascii_case("auto") {
+            return Ok(InvariantWorkers::Auto);
+        }
+
+        let workers = value.parse::<usize>().map_err(E::custom)?;
+        fixed_workers(workers)
+    }
+
+    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        let workers = usize::try_from(value).map_err(E::custom)?;
+        fixed_workers(workers)
+    }
+
+    fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        let workers =
+            usize::try_from(value).map_err(|_| E::custom("invariant workers must be positive"))?;
+        fixed_workers(workers)
+    }
+}
+
+fn fixed_workers<E: Error>(workers: usize) -> Result<InvariantWorkers, E> {
+    NonZeroUsize::new(workers)
+        .map(InvariantWorkers::Fixed)
+        .ok_or_else(|| E::custom("invariant workers must be greater than 0"))
+}
 
 /// Contains for invariant testing
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -11,11 +91,11 @@ pub struct InvariantConfig {
     pub runs: u32,
     /// The number of calls executed to attempt to break invariants in one run.
     pub depth: u32,
-    /// Number of workers used to shard invariant runs.
+    /// Worker selection mode used to shard invariant runs.
     ///
-    /// Defaults to `1` to preserve seeded reproducibility unless the user explicitly opts into
-    /// parallel invariant campaigns.
-    pub workers: usize,
+    /// Defaults to `auto`, which derives the worker count from `--jobs`. Use a positive integer
+    /// to force a fixed maximum worker count for reproducibility.
+    pub workers: InvariantWorkers,
     /// Fails the invariant fuzzing if a revert occurs
     pub fail_on_revert: bool,
     /// Allows overriding an unsafe external call when running invariant tests. eg. reentrancy
@@ -61,7 +141,7 @@ impl Default for InvariantConfig {
         Self {
             runs: 256,
             depth: 500,
-            workers: 1,
+            workers: InvariantWorkers::Auto,
             fail_on_revert: false,
             call_override: false,
             dictionary: FuzzDictionaryConfig { dictionary_weight: 80, ..Default::default() },
@@ -89,5 +169,32 @@ impl InvariantConfig {
     /// Returns true if generated invariant calls may advance block time or height.
     pub const fn has_delay(&self) -> bool {
         self.max_block_delay.is_some() || self.max_time_delay.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invariant_workers_accept_auto_and_fixed_counts() {
+        assert_eq!(
+            serde_json::from_str::<InvariantWorkers>(r#""auto""#).unwrap(),
+            InvariantWorkers::Auto
+        );
+        assert_eq!(
+            serde_json::from_str::<InvariantWorkers>(r#"4"#).unwrap(),
+            InvariantWorkers::Fixed(NonZeroUsize::new(4).unwrap())
+        );
+        assert_eq!(
+            serde_json::from_str::<InvariantWorkers>(r#""4""#).unwrap(),
+            InvariantWorkers::Fixed(NonZeroUsize::new(4).unwrap())
+        );
+    }
+
+    #[test]
+    fn invariant_workers_reject_zero() {
+        let err = serde_json::from_str::<InvariantWorkers>(r#"0"#).unwrap_err();
+        assert!(err.to_string().contains("greater than 0"));
     }
 }

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -5,7 +5,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{Error, Visitor},
 };
-use std::{fmt, num::NonZeroUsize, path::PathBuf};
+use std::{fmt, num::NonZeroUsize, path::PathBuf, str::FromStr};
 
 /// Worker selection mode for invariant campaign sharding.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -13,7 +13,7 @@ pub enum InvariantWorkers {
     /// Automatically derive invariant workers from the active `--jobs` / rayon thread pool.
     #[default]
     Auto,
-    /// Explicit user override for the maximum number of invariant workers.
+    /// Explicit user override for invariant campaign sharding.
     Fixed(NonZeroUsize),
 }
 
@@ -38,6 +38,20 @@ impl<'de> Deserialize<'de> for InvariantWorkers {
     }
 }
 
+impl FromStr for InvariantWorkers {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let value = value.trim();
+        if value.eq_ignore_ascii_case("auto") {
+            return Ok(Self::Auto);
+        }
+
+        let workers = value.parse::<usize>().map_err(|err| err.to_string())?;
+        fixed_workers(workers)
+    }
+}
+
 struct InvariantWorkersVisitor;
 
 impl Visitor<'_> for InvariantWorkersVisitor {
@@ -51,13 +65,7 @@ impl Visitor<'_> for InvariantWorkersVisitor {
     where
         E: Error,
     {
-        let value = value.trim();
-        if value.eq_ignore_ascii_case("auto") {
-            return Ok(InvariantWorkers::Auto);
-        }
-
-        let workers = value.parse::<usize>().map_err(E::custom)?;
-        fixed_workers(workers)
+        value.parse().map_err(E::custom)
     }
 
     fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
@@ -65,7 +73,7 @@ impl Visitor<'_> for InvariantWorkersVisitor {
         E: Error,
     {
         let workers = usize::try_from(value).map_err(E::custom)?;
-        fixed_workers(workers)
+        fixed_workers(workers).map_err(E::custom)
     }
 
     fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
@@ -74,14 +82,14 @@ impl Visitor<'_> for InvariantWorkersVisitor {
     {
         let workers =
             usize::try_from(value).map_err(|_| E::custom("invariant workers must be positive"))?;
-        fixed_workers(workers)
+        fixed_workers(workers).map_err(E::custom)
     }
 }
 
-fn fixed_workers<E: Error>(workers: usize) -> Result<InvariantWorkers, E> {
+fn fixed_workers(workers: usize) -> Result<InvariantWorkers, String> {
     NonZeroUsize::new(workers)
         .map(InvariantWorkers::Fixed)
-        .ok_or_else(|| E::custom("invariant workers must be greater than 0"))
+        .ok_or_else(|| "invariant workers must be greater than 0".to_string())
 }
 
 /// Contains for invariant testing
@@ -94,7 +102,7 @@ pub struct InvariantConfig {
     /// Worker selection mode used to shard invariant runs.
     ///
     /// Defaults to `auto`, which derives the worker count from `--jobs`. Use a positive integer
-    /// to force a fixed maximum worker count for reproducibility.
+    /// to request a fixed worker count independent of `--jobs` for reproducibility.
     pub workers: InvariantWorkers,
     /// Fails the invariant fuzzing if a revert occurs
     pub fail_on_revert: bool,
@@ -178,6 +186,7 @@ mod tests {
 
     #[test]
     fn invariant_workers_accept_auto_and_fixed_counts() {
+        assert_eq!("AUTO".parse::<InvariantWorkers>().unwrap(), InvariantWorkers::Auto);
         assert_eq!(
             serde_json::from_str::<InvariantWorkers>(r#""auto""#).unwrap(),
             InvariantWorkers::Auto

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5039,6 +5039,26 @@ mod tests {
     }
 
     #[test]
+    fn test_invariant_workers_env_accepts_auto() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r"
+                [invariant]
+                workers = 3
+            ",
+            )?;
+
+            jail.set_env("FOUNDRY_INVARIANT_WORKERS", "auto");
+
+            let config = Config::load().unwrap();
+            assert_eq!(config.invariant.workers, InvariantWorkers::Auto);
+
+            Ok(())
+        });
+    }
+
+    #[test]
     fn test_parse_with_profile() {
         let foundry_str = r"
             [profile.default]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -111,7 +111,7 @@ mod fuzz;
 pub use fuzz::{FuzzConfig, FuzzCorpusConfig, FuzzDictionaryConfig};
 
 mod invariant;
-pub use invariant::InvariantConfig;
+pub use invariant::{InvariantConfig, InvariantWorkers};
 
 mod inline;
 pub use inline::{InlineConfig, InlineConfigError, NatSpec};
@@ -2958,7 +2958,7 @@ mod tests {
     use foundry_evm_hardforks::{TempoHardfork, latest_active_tempo_hardfork};
     use similar_asserts::assert_eq;
     use soldeer_core::remappings::RemappingsLocation;
-    use std::{fs::File, io::Write};
+    use std::{fs::File, io::Write, num::NonZeroUsize};
     use tempfile::tempdir;
 
     // Helper function to clear `__warnings` in config, since it will be populated during loading
@@ -4996,7 +4996,7 @@ mod tests {
                 InvariantConfig {
                     runs: 512,
                     depth: 10,
-                    workers: 4,
+                    workers: InvariantWorkers::Fixed(NonZeroUsize::new(4).unwrap()),
                     failure_persist_dir: Some(PathBuf::from("cache/invariant")),
                     ..Default::default()
                 }
@@ -5029,7 +5029,10 @@ mod tests {
             assert_eq!(config.fmt.line_length, 95);
             assert_eq!(config.fuzz.dictionary.dictionary_weight, 99);
             assert_eq!(config.invariant.depth, 5);
-            assert_eq!(config.invariant.workers, 3);
+            assert_eq!(
+                config.invariant.workers,
+                InvariantWorkers::Fixed(NonZeroUsize::new(3).unwrap())
+            );
 
             Ok(())
         });

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -271,6 +271,7 @@ impl InvariantCampaignAggregator {
 fn fold_outputs(
     outputs: Vec<InvariantWorkerOutput>,
 ) -> Result<(InvariantFuzzTestResult, Vec<CampaignCorpusEntry>)> {
+    let workers = outputs.len();
     let mut errors = HashMap::default();
     let mut handler_errors = HashMap::default();
     let mut cases = Vec::new();
@@ -319,6 +320,7 @@ fn fold_outputs(
             line_coverage,
             metrics,
             failed_corpus_replays,
+            workers,
             optimization_best_value,
             optimization_best_sequence,
         ),
@@ -448,6 +450,7 @@ mod tests {
             None,
             HashMap::default(),
             failed_corpus_replays,
+            1,
             None,
             Vec::new(),
         )

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -2013,8 +2013,12 @@ mod tests {
 
     #[test]
     fn invariant_worker_count_splits_available_threads_for_auto_workers() {
-        let mut config =
-            InvariantConfig { runs: MIN_RUNS_PER_INVARIANT_WORKER * 4, ..Default::default() };
+        let mut config = InvariantConfig {
+            runs: MIN_RUNS_PER_INVARIANT_WORKER * 4,
+            depth: DEFAULT_DEPTH_FOR_INVARIANT_WORKER_CAP,
+            workers: foundry_config::InvariantWorkers::Auto,
+            ..Default::default()
+        };
 
         assert_eq!(invariant_worker_count_with_threads(&config, 4, 1), 4);
         assert_eq!(invariant_worker_count_with_threads(&config, 8, 2), 4);

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -175,10 +175,11 @@ fn invariant_worker_count_with_threads(
     let invariant_contracts = invariant_contracts.max(1);
     let available_threads = available_threads.max(1);
     let requested = match config.workers {
-        InvariantWorkers::Auto => (available_threads / invariant_contracts).max(1),
+        InvariantWorkers::Auto => {
+            (available_threads / invariant_contracts).max(1).min(available_threads)
+        }
         InvariantWorkers::Fixed(workers) => workers.get(),
-    }
-    .min(available_threads);
+    };
 
     if config.timeout.is_some() {
         return requested;
@@ -1963,10 +1964,24 @@ mod tests {
     }
 
     #[test]
+    fn invariant_worker_count_does_not_cap_configured_workers_by_available_threads() {
+        let config = InvariantConfig {
+            runs: MIN_RUNS_PER_INVARIANT_WORKER * 8,
+            workers: foundry_config::InvariantWorkers::Fixed(
+                std::num::NonZeroUsize::new(8).unwrap(),
+            ),
+            ..Default::default()
+        };
+
+        assert_eq!(invariant_worker_count_with_threads(&config, 4, 1), 8);
+    }
+
+    #[test]
     fn invariant_worker_count_splits_available_threads_for_auto_workers() {
         let mut config =
             InvariantConfig { runs: MIN_RUNS_PER_INVARIANT_WORKER * 4, ..Default::default() };
 
+        assert_eq!(invariant_worker_count_with_threads(&config, 4, 1), 4);
         assert_eq!(invariant_worker_count_with_threads(&config, 8, 2), 4);
         assert_eq!(invariant_worker_count_with_threads(&config, 8, 3), 2);
         assert_eq!(invariant_worker_count_with_threads(&config, 3, 8), 1);

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -170,15 +170,13 @@ impl InvariantThroughputMetrics {
 }
 
 fn max_invariant_workers_for_campaign(runs: u32, depth: u32) -> usize {
-    let estimated_calls = u64::from(runs).saturating_mul(u64::from(depth.max(1)));
-    let workers = (estimated_calls / MIN_ESTIMATED_CALLS_PER_INVARIANT_WORKER).max(1);
-    usize::try_from(workers).unwrap_or(usize::MAX)
+    let estimated_calls = u64::from(runs) * u64::from(depth.max(1));
+    usize::try_from((estimated_calls / MIN_ESTIMATED_CALLS_PER_INVARIANT_WORKER).max(1))
+        .unwrap_or(usize::MAX)
 }
 
 fn auto_invariant_worker_count(available_threads: usize, invariant_contracts: usize) -> usize {
-    let invariant_contracts = invariant_contracts.max(1);
-    let available_threads = available_threads.max(1);
-    (available_threads / invariant_contracts).max(1).min(available_threads)
+    (available_threads.max(1) / invariant_contracts.max(1)).max(1)
 }
 
 fn invariant_worker_count_with_threads(

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -16,7 +16,7 @@ use foundry_common::{
     contracts::{ContractsByAddress, ContractsByArtifact},
     sh_eprintln, sh_println,
 };
-use foundry_config::InvariantConfig;
+use foundry_config::{InvariantConfig, InvariantWorkers};
 use foundry_evm_core::{
     FoundryBlock,
     constants::{
@@ -167,12 +167,24 @@ fn max_invariant_workers_for_runs(runs: u32) -> usize {
     (runs / MIN_RUNS_PER_INVARIANT_WORKER).max(1) as usize
 }
 
-fn invariant_worker_count(config: &InvariantConfig) -> usize {
+fn invariant_worker_count_with_threads(
+    config: &InvariantConfig,
+    available_threads: usize,
+    invariant_contracts: usize,
+) -> usize {
+    let invariant_contracts = invariant_contracts.max(1);
+    let available_threads = available_threads.max(1);
+    let requested = match config.workers {
+        InvariantWorkers::Auto => (available_threads / invariant_contracts).max(1),
+        InvariantWorkers::Fixed(workers) => workers.get(),
+    }
+    .min(available_threads);
+
     if config.timeout.is_some() {
-        return config.workers;
+        return requested;
     }
 
-    config.workers.min(max_invariant_workers_for_runs(config.runs))
+    requested.min(max_invariant_workers_for_runs(config.runs))
 }
 
 fn gas_report_samples_for_worker(total_samples: u32, worker_id: u32, worker_count: usize) -> usize {
@@ -513,6 +525,8 @@ pub struct InvariantExecutor<'a, FEN: FoundryEvmNetwork> {
     project_contracts: &'a ContractsByArtifact,
     /// Filters contracts to be fuzzed through their artifact identifiers.
     artifact_filters: ArtifactFilters,
+    /// Number of matching test contracts that contain invariant tests.
+    invariant_contracts: usize,
 }
 
 impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
@@ -524,7 +538,15 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         setup_contracts: &'a ContractsByAddress,
         project_contracts: &'a ContractsByArtifact,
     ) -> Self {
-        Self::new_with_fuzz_seed(executor, runner, None, config, setup_contracts, project_contracts)
+        Self::new_with_fuzz_seed(
+            executor,
+            runner,
+            None,
+            config,
+            setup_contracts,
+            project_contracts,
+            1,
+        )
     }
 
     /// Instantiates an invariant executor with the configured fuzz seed for deterministic worker
@@ -536,6 +558,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         config: InvariantConfig,
         setup_contracts: &'a ContractsByAddress,
         project_contracts: &'a ContractsByArtifact,
+        invariant_contracts: usize,
     ) -> Self {
         Self {
             executor,
@@ -545,6 +568,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             setup_contracts,
             project_contracts,
             artifact_filters: ArtifactFilters::default(),
+            invariant_contracts,
         }
     }
 
@@ -580,7 +604,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         >,
     ) -> Result<InvariantFuzzTestResult> {
         let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
-        let worker_plans = campaign_spec.worker_plans(invariant_worker_count(&self.config))?;
+        let worker_plans = campaign_spec.worker_plans(invariant_worker_count_with_threads(
+            &self.config,
+            rayon::current_num_threads(),
+            self.invariant_contracts,
+        ))?;
         let actual_worker_count = worker_plans.len();
         let campaign_seed =
             self.prepare_campaign_seed(&invariant_contract, initial_handler_failures)?;
@@ -1160,6 +1188,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.line_coverage,
             result.metrics,
             if plan.worker_id == 0 { corpus_manager.failed_replays } else { 0 },
+            1,
             result.optimization_best_value,
             result.optimization_best_sequence,
         );
@@ -1911,24 +1940,43 @@ mod tests {
     fn invariant_worker_count_uses_configured_workers_and_caps_short_campaigns() {
         let mut config = InvariantConfig {
             runs: MIN_RUNS_PER_INVARIANT_WORKER * 4,
-            workers: 4,
+            workers: foundry_config::InvariantWorkers::Fixed(
+                std::num::NonZeroUsize::new(4).unwrap(),
+            ),
             ..Default::default()
         };
-        assert_eq!(invariant_worker_count(&config), 4);
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 1), 4);
 
         config.corpus.show_edge_coverage = true;
-        assert_eq!(invariant_worker_count(&config), 4);
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 1), 4);
 
         config.corpus.show_edge_coverage = false;
         config.corpus.corpus_dir = Some(std::path::PathBuf::from("corpus"));
-        assert_eq!(invariant_worker_count(&config), 4);
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 1), 4);
 
         config.runs = MIN_RUNS_PER_INVARIANT_WORKER - 1;
         config.timeout = None;
-        assert_eq!(invariant_worker_count(&config), 1);
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 1), 1);
 
         config.timeout = Some(1);
-        assert_eq!(invariant_worker_count(&config), 4);
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 4), 4);
+    }
+
+    #[test]
+    fn invariant_worker_count_splits_available_threads_for_auto_workers() {
+        let mut config =
+            InvariantConfig { runs: MIN_RUNS_PER_INVARIANT_WORKER * 4, ..Default::default() };
+
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 2), 4);
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 3), 2);
+        assert_eq!(invariant_worker_count_with_threads(&config, 3, 8), 1);
+        assert_eq!(invariant_worker_count_with_threads(&config, 0, 0), 1);
+
+        config.runs = MIN_RUNS_PER_INVARIANT_WORKER - 1;
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 2), 1);
+
+        config.timeout = Some(1);
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 2), 4);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -76,10 +76,16 @@ pub use shrink::{
     replay_handler_failure_sequence,
 };
 
-/// Minimum number of logical runs assigned to each invariant worker.
+/// Minimum number of logical runs assigned to each auto invariant worker at the default invariant
+/// depth.
 ///
 /// Keeps short campaigns single-threaded and avoids producing many small rayon jobs.
 const MIN_RUNS_PER_INVARIANT_WORKER: u32 = 10_000;
+/// Baseline depth used to preserve the previous default-depth worker heuristic.
+const DEFAULT_DEPTH_FOR_INVARIANT_WORKER_CAP: u32 = 500;
+/// Minimum estimated handler calls assigned to each auto invariant worker.
+const MIN_ESTIMATED_CALLS_PER_INVARIANT_WORKER: u64 =
+    MIN_RUNS_PER_INVARIANT_WORKER as u64 * DEFAULT_DEPTH_FOR_INVARIANT_WORKER_CAP as u64;
 
 sol! {
     interface IInvariantTest {
@@ -163,8 +169,16 @@ impl InvariantThroughputMetrics {
     }
 }
 
-fn max_invariant_workers_for_runs(runs: u32) -> usize {
-    (runs / MIN_RUNS_PER_INVARIANT_WORKER).max(1) as usize
+fn max_invariant_workers_for_campaign(runs: u32, depth: u32) -> usize {
+    let estimated_calls = u64::from(runs).saturating_mul(u64::from(depth.max(1)));
+    let workers = (estimated_calls / MIN_ESTIMATED_CALLS_PER_INVARIANT_WORKER).max(1);
+    usize::try_from(workers).unwrap_or(usize::MAX)
+}
+
+fn auto_invariant_worker_count(available_threads: usize, invariant_contracts: usize) -> usize {
+    let invariant_contracts = invariant_contracts.max(1);
+    let available_threads = available_threads.max(1);
+    (available_threads / invariant_contracts).max(1).min(available_threads)
 }
 
 fn invariant_worker_count_with_threads(
@@ -172,20 +186,17 @@ fn invariant_worker_count_with_threads(
     available_threads: usize,
     invariant_contracts: usize,
 ) -> usize {
-    let invariant_contracts = invariant_contracts.max(1);
-    let available_threads = available_threads.max(1);
-    let requested = match config.workers {
-        InvariantWorkers::Auto => {
-            (available_threads / invariant_contracts).max(1).min(available_threads)
-        }
+    match config.workers {
         InvariantWorkers::Fixed(workers) => workers.get(),
-    };
-
-    if config.timeout.is_some() {
-        return requested;
+        InvariantWorkers::Auto => {
+            let requested = auto_invariant_worker_count(available_threads, invariant_contracts);
+            if config.timeout.is_some() {
+                requested
+            } else {
+                requested.min(max_invariant_workers_for_campaign(config.runs, config.depth))
+            }
+        }
     }
-
-    requested.min(max_invariant_workers_for_runs(config.runs))
 }
 
 fn gas_report_samples_for_worker(total_samples: u32, worker_id: u32, worker_count: usize) -> usize {
@@ -1931,14 +1942,36 @@ mod tests {
 
     #[test]
     fn invariant_worker_count_keeps_short_campaigns_single_worker() {
-        assert_eq!(max_invariant_workers_for_runs(0), 1);
-        assert_eq!(max_invariant_workers_for_runs(MIN_RUNS_PER_INVARIANT_WORKER - 1), 1);
-        assert_eq!(max_invariant_workers_for_runs(MIN_RUNS_PER_INVARIANT_WORKER), 1);
-        assert_eq!(max_invariant_workers_for_runs(MIN_RUNS_PER_INVARIANT_WORKER * 2), 2);
+        assert_eq!(
+            max_invariant_workers_for_campaign(0, DEFAULT_DEPTH_FOR_INVARIANT_WORKER_CAP),
+            1
+        );
+        assert_eq!(
+            max_invariant_workers_for_campaign(
+                MIN_RUNS_PER_INVARIANT_WORKER - 1,
+                DEFAULT_DEPTH_FOR_INVARIANT_WORKER_CAP
+            ),
+            1
+        );
+        assert_eq!(
+            max_invariant_workers_for_campaign(
+                MIN_RUNS_PER_INVARIANT_WORKER,
+                DEFAULT_DEPTH_FOR_INVARIANT_WORKER_CAP
+            ),
+            1
+        );
+        assert_eq!(
+            max_invariant_workers_for_campaign(
+                MIN_RUNS_PER_INVARIANT_WORKER * 2,
+                DEFAULT_DEPTH_FOR_INVARIANT_WORKER_CAP
+            ),
+            2
+        );
+        assert_eq!(max_invariant_workers_for_campaign(256, 100_000), 5);
     }
 
     #[test]
-    fn invariant_worker_count_uses_configured_workers_and_caps_short_campaigns() {
+    fn invariant_worker_count_preserves_fixed_workers() {
         let mut config = InvariantConfig {
             runs: MIN_RUNS_PER_INVARIANT_WORKER * 4,
             workers: foundry_config::InvariantWorkers::Fixed(
@@ -1957,7 +1990,7 @@ mod tests {
 
         config.runs = MIN_RUNS_PER_INVARIANT_WORKER - 1;
         config.timeout = None;
-        assert_eq!(invariant_worker_count_with_threads(&config, 8, 1), 1);
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 1), 4);
 
         config.timeout = Some(1);
         assert_eq!(invariant_worker_count_with_threads(&config, 8, 4), 4);
@@ -1989,6 +2022,9 @@ mod tests {
 
         config.runs = MIN_RUNS_PER_INVARIANT_WORKER - 1;
         assert_eq!(invariant_worker_count_with_threads(&config, 8, 2), 1);
+
+        config.depth = 100_000;
+        assert_eq!(invariant_worker_count_with_threads(&config, 8, 2), 4);
 
         config.timeout = Some(1);
         assert_eq!(invariant_worker_count_with_threads(&config, 8, 2), 4);

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -175,19 +175,23 @@ fn max_invariant_workers_for_campaign(runs: u32, depth: u32) -> usize {
         .unwrap_or(usize::MAX)
 }
 
-fn auto_invariant_worker_count(available_threads: usize, invariant_contracts: usize) -> usize {
-    (available_threads.max(1) / invariant_contracts.max(1)).max(1)
+fn auto_invariant_worker_count(
+    available_threads: usize,
+    invariant_campaign_anchors: usize,
+) -> usize {
+    (available_threads.max(1) / invariant_campaign_anchors.max(1)).max(1)
 }
 
 fn invariant_worker_count_with_threads(
     config: &InvariantConfig,
     available_threads: usize,
-    invariant_contracts: usize,
+    invariant_campaign_anchors: usize,
 ) -> usize {
     match config.workers {
         InvariantWorkers::Fixed(workers) => workers.get(),
         InvariantWorkers::Auto => {
-            let requested = auto_invariant_worker_count(available_threads, invariant_contracts);
+            let requested =
+                auto_invariant_worker_count(available_threads, invariant_campaign_anchors);
             if config.timeout.is_some() {
                 requested
             } else {
@@ -535,8 +539,8 @@ pub struct InvariantExecutor<'a, FEN: FoundryEvmNetwork> {
     project_contracts: &'a ContractsByArtifact,
     /// Filters contracts to be fuzzed through their artifact identifiers.
     artifact_filters: ArtifactFilters,
-    /// Number of matching test contracts that contain invariant tests.
-    invariant_contracts: usize,
+    /// Number of matching invariant campaign anchors in the current test pass.
+    invariant_campaign_anchors: usize,
 }
 
 impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
@@ -568,7 +572,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         config: InvariantConfig,
         setup_contracts: &'a ContractsByAddress,
         project_contracts: &'a ContractsByArtifact,
-        invariant_contracts: usize,
+        invariant_campaign_anchors: usize,
     ) -> Self {
         Self {
             executor,
@@ -578,7 +582,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             setup_contracts,
             project_contracts,
             artifact_filters: ArtifactFilters::default(),
-            invariant_contracts,
+            invariant_campaign_anchors,
         }
     }
 
@@ -617,7 +621,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let worker_plans = campaign_spec.worker_plans(invariant_worker_count_with_threads(
             &self.config,
             rayon::current_num_threads(),
-            self.invariant_contracts,
+            self.invariant_campaign_anchors,
         ))?;
         let actual_worker_count = worker_plans.len();
         let campaign_seed =

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -50,6 +50,8 @@ pub struct InvariantFuzzTestResult {
     pub metrics: HashMap<String, InvariantMetrics>,
     /// Number of failed replays from persisted corpus.
     pub failed_corpus_replays: usize,
+    /// Actual number of workers used for this logical campaign.
+    pub workers: usize,
     /// For optimization mode (int256 return): the best (maximum) value achieved.
     /// None means standard invariant check mode.
     pub optimization_best_value: Option<I256>,
@@ -69,6 +71,7 @@ impl InvariantFuzzTestResult {
         line_coverage: Option<HitMaps>,
         metrics: HashMap<String, InvariantMetrics>,
         failed_corpus_replays: usize,
+        workers: usize,
         optimization_best_value: Option<I256>,
         optimization_best_sequence: Vec<BasicTxDetails>,
     ) -> Self {
@@ -82,6 +85,7 @@ impl InvariantFuzzTestResult {
             line_coverage,
             metrics,
             failed_corpus_replays,
+            workers,
             optimization_best_value,
             optimization_best_sequence,
         }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -486,10 +486,6 @@ impl TestArgs {
         if config.fuzz.run == Some(0) {
             bail!("`fuzz.run` must be greater than 0");
         }
-        if config.invariant.workers == 0 {
-            bail!("`invariant.workers` must be greater than 0");
-        }
-        let invariant_workers = config.invariant.workers;
 
         // Explicitly enable isolation for gas reports for more correct gas accounting.
         if self.gas_report {
@@ -623,7 +619,6 @@ impl TestArgs {
 
             (libraries, outcome)
         };
-        outcome.invariant_workers = invariant_workers;
 
         if should_draw {
             let (suite_name, test_name, mut test_result) =

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1448,12 +1448,11 @@ impl Provider for TestArgs {
         }
         dict.insert("fuzz".to_string(), fuzz_dict.into());
 
-        let mut invariant_dict = Dict::default();
         if let Some(invariant_workers) = self.invariant_workers {
-            invariant_dict.insert("workers".to_string(), Value::serialize(invariant_workers)?);
-        }
-        if !invariant_dict.is_empty() {
-            dict.insert("invariant".to_string(), invariant_dict.into());
+            dict.insert(
+                "invariant".to_string(),
+                Dict::from([("workers".to_string(), Value::serialize(invariant_workers)?)]).into(),
+            );
         }
 
         if let Some(etherscan_api_key) =

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -195,7 +195,7 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_RUNS", value_name = "RUNS")]
     pub fuzz_runs: Option<u64>,
 
-    /// Number of workers to use for invariant test campaigns.
+    /// Number of workers to use for invariant test campaigns, or `auto` to derive from `--jobs`.
     #[arg(long, env = "FOUNDRY_INVARIANT_WORKERS", value_name = "WORKERS")]
     pub invariant_workers: Option<InvariantWorkers>,
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -34,10 +34,10 @@ use foundry_compilers::{
     utils::source_files_iter,
 };
 use foundry_config::{
-    Config, InlineConfig, figment,
+    Config, InlineConfig, InvariantWorkers, figment,
     figment::{
         Metadata, Profile, Provider,
-        value::{Dict, Map},
+        value::{Dict, Map, Value},
     },
     filter::GlobMatcher,
 };
@@ -197,7 +197,7 @@ pub struct TestArgs {
 
     /// Number of workers to use for invariant test campaigns.
     #[arg(long, env = "FOUNDRY_INVARIANT_WORKERS", value_name = "WORKERS")]
-    pub invariant_workers: Option<usize>,
+    pub invariant_workers: Option<InvariantWorkers>,
 
     /// Run only the fuzz case at the given 1-based run index.
     #[arg(long, env = "FOUNDRY_FUZZ_RUN", value_name = "RUN")]
@@ -1450,7 +1450,7 @@ impl Provider for TestArgs {
 
         let mut invariant_dict = Dict::default();
         if let Some(invariant_workers) = self.invariant_workers {
-            invariant_dict.insert("workers".to_string(), invariant_workers.into());
+            invariant_dict.insert("workers".to_string(), Value::serialize(invariant_workers)?);
         }
         if !invariant_dict.is_empty() {
             dict.insert("invariant".to_string(), invariant_dict.into());
@@ -1784,10 +1784,51 @@ mod tests {
     #[test]
     fn invariant_workers() {
         let args = TestArgs::parse_from(["foundry-cli", "--invariant-workers", "4"]);
-        assert_eq!(args.invariant_workers, Some(4));
+        assert_eq!(
+            args.invariant_workers,
+            Some(InvariantWorkers::Fixed(std::num::NonZeroUsize::new(4).unwrap()))
+        );
 
         let figment = figment::Figment::from(&args);
-        assert_eq!(figment.extract_inner::<usize>("invariant.workers").unwrap(), 4);
+        assert_eq!(
+            figment.extract_inner::<InvariantWorkers>("invariant.workers").unwrap(),
+            InvariantWorkers::Fixed(std::num::NonZeroUsize::new(4).unwrap())
+        );
+    }
+
+    #[test]
+    fn invariant_workers_accepts_auto() {
+        let args = TestArgs::parse_from(["foundry-cli", "--invariant-workers", "auto"]);
+        assert_eq!(args.invariant_workers, Some(InvariantWorkers::Auto));
+
+        let figment = figment::Figment::from(&args);
+        assert_eq!(
+            figment.extract_inner::<InvariantWorkers>("invariant.workers").unwrap(),
+            InvariantWorkers::Auto
+        );
+    }
+
+    #[test]
+    fn invariant_workers_env_accepts_auto() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+        let _guard = ENV_LOCK.lock().unwrap();
+        let previous = std::env::var_os("FOUNDRY_INVARIANT_WORKERS");
+        unsafe {
+            std::env::set_var("FOUNDRY_INVARIANT_WORKERS", "auto");
+        }
+
+        let args = TestArgs::try_parse_from(["foundry-cli"]);
+
+        unsafe {
+            if let Some(previous) = previous {
+                std::env::set_var("FOUNDRY_INVARIANT_WORKERS", previous);
+            } else {
+                std::env::remove_var("FOUNDRY_INVARIANT_WORKERS");
+            }
+        }
+
+        assert_eq!(args.unwrap().invariant_workers, Some(InvariantWorkers::Auto));
     }
 
     #[test]

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -193,6 +193,10 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
             self.contracts.len(),
             find_time,
         );
+        let num_invariant_contracts = contracts
+            .iter()
+            .filter(|(_, contract)| contract.abi.functions().any(|func| func.is_invariant_test()))
+            .count();
 
         if show_progress {
             let tests_progress = TestsProgress::new(contracts.len(), rayon::current_num_threads());
@@ -210,6 +214,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
                         filter,
                         &tokio_handle,
                         Some(&tests_progress),
+                        num_invariant_contracts,
                     );
 
                     tests_progress
@@ -229,7 +234,15 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         } else {
             contracts.par_iter().for_each(|&(id, contract)| {
                 let _guard = tokio_handle.enter();
-                let result = self.run_test_suite(id, contract, &db, filter, &tokio_handle, None);
+                let result = self.run_test_suite(
+                    id,
+                    contract,
+                    &db,
+                    filter,
+                    &tokio_handle,
+                    None,
+                    num_invariant_contracts,
+                );
                 let _ = tx.send((id.identifier(), result));
             })
         }
@@ -245,6 +258,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         filter: &dyn TestFilter,
         tokio_handle: &tokio::runtime::Handle,
         progress: Option<&TestsProgress>,
+        num_invariant_contracts: usize,
     ) -> SuiteResult {
         let identifier = artifact_id.identifier();
         let span_name = if enabled!(tracing::Level::TRACE) {
@@ -272,6 +286,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
             tokio_handle,
             span,
             self,
+            num_invariant_contracts,
         );
         let r = runner.run_tests(filter);
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -195,7 +195,12 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         );
         let num_invariant_contracts = contracts
             .iter()
-            .filter(|(_, contract)| contract.abi.functions().any(|func| func.is_invariant_test()))
+            .filter(|(_, contract)| {
+                contract
+                    .abi
+                    .functions()
+                    .any(|func| func.is_invariant_test() && filter.matches_test_function(func))
+            })
             .count();
 
         if show_progress {
@@ -212,7 +217,6 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
                         contract,
                         &db,
                         filter,
-                        &tokio_handle,
                         Some(&tests_progress),
                         num_invariant_contracts,
                     );
@@ -234,15 +238,8 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         } else {
             contracts.par_iter().for_each(|&(id, contract)| {
                 let _guard = tokio_handle.enter();
-                let result = self.run_test_suite(
-                    id,
-                    contract,
-                    &db,
-                    filter,
-                    &tokio_handle,
-                    None,
-                    num_invariant_contracts,
-                );
+                let result =
+                    self.run_test_suite(id, contract, &db, filter, None, num_invariant_contracts);
                 let _ = tx.send((id.identifier(), result));
             })
         }
@@ -256,7 +253,6 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         contract: &TestContract,
         db: &Backend<FEN>,
         filter: &dyn TestFilter,
-        tokio_handle: &tokio::runtime::Handle,
         progress: Option<&TestsProgress>,
         num_invariant_contracts: usize,
     ) -> SuiteResult {
@@ -283,7 +279,6 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
             contract,
             executor,
             progress,
-            tokio_handle,
             span,
             self,
             num_invariant_contracts,

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -4,7 +4,10 @@ use crate::{
     ContractRunner, TestFilter,
     progress::TestsProgress,
     result::SuiteResult,
-    runner::{InvariantCampaignScope, LIBRARY_DEPLOYER, count_runnable_invariant_campaign_anchors},
+    runner::{
+        ContractRunnerContext, InvariantCampaignScope, LIBRARY_DEPLOYER,
+        count_runnable_invariant_campaign_anchors,
+    },
 };
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, U256};
@@ -226,8 +229,11 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
                         contract,
                         &db,
                         filter,
-                        Some(&tests_progress),
-                        num_invariant_campaign_anchors,
+                        ContractRunnerContext {
+                            progress: Some(&tests_progress),
+                            tokio_handle: tokio_handle.clone(),
+                            num_invariant_campaign_anchors,
+                        },
                     );
 
                     tests_progress
@@ -252,8 +258,11 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
                     contract,
                     &db,
                     filter,
-                    None,
-                    num_invariant_campaign_anchors,
+                    ContractRunnerContext {
+                        progress: None,
+                        tokio_handle: tokio_handle.clone(),
+                        num_invariant_campaign_anchors,
+                    },
                 );
                 let _ = tx.send((id.identifier(), result));
             })
@@ -268,8 +277,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         contract: &TestContract,
         db: &Backend<FEN>,
         filter: &dyn TestFilter,
-        progress: Option<&TestsProgress>,
-        num_invariant_campaign_anchors: usize,
+        context: ContractRunnerContext<'_>,
     ) -> SuiteResult {
         let identifier = artifact_id.identifier();
         let span_name = if enabled!(tracing::Level::TRACE) {
@@ -289,15 +297,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
             artifact_id,
             db.clone(),
         );
-        let runner = ContractRunner::new(
-            &identifier,
-            contract,
-            executor,
-            progress,
-            span,
-            self,
-            num_invariant_campaign_anchors,
-        );
+        let runner = ContractRunner::new(&identifier, contract, executor, span, self, context);
         let r = runner.run_tests(filter);
 
         debug!(duration=?r.duration, "executed all tests in contract");

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -1,8 +1,10 @@
 //! Forge test runner for multiple contracts.
 
 use crate::{
-    ContractRunner, TestFilter, progress::TestsProgress, result::SuiteResult,
-    runner::LIBRARY_DEPLOYER,
+    ContractRunner, TestFilter,
+    progress::TestsProgress,
+    result::SuiteResult,
+    runner::{InvariantCampaignScope, LIBRARY_DEPLOYER, count_runnable_invariant_campaign_anchors},
 };
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, U256};
@@ -193,15 +195,22 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
             self.contracts.len(),
             find_time,
         );
-        let num_invariant_contracts = contracts
+        let num_invariant_campaign_anchors = contracts
             .iter()
-            .filter(|(_, contract)| {
-                contract
-                    .abi
-                    .functions()
-                    .any(|func| func.is_invariant_test() && filter.matches_test_function(func))
+            .map(|(id, contract)| {
+                count_runnable_invariant_campaign_anchors(
+                    &contract.abi,
+                    filter,
+                    InvariantCampaignScope {
+                        config: &self.tcfg.config,
+                        inline_config: &self.tcfg.inline_config,
+                        contract_name: &id.identifier(),
+                        all_override_networks: &self.tcfg.multi_network.all_override_networks,
+                        pass_network: self.tcfg.multi_network.pass_network.as_ref(),
+                    },
+                )
             })
-            .count();
+            .sum();
 
         if show_progress {
             let tests_progress = TestsProgress::new(contracts.len(), rayon::current_num_threads());
@@ -218,7 +227,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
                         &db,
                         filter,
                         Some(&tests_progress),
-                        num_invariant_contracts,
+                        num_invariant_campaign_anchors,
                     );
 
                     tests_progress
@@ -238,8 +247,14 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         } else {
             contracts.par_iter().for_each(|&(id, contract)| {
                 let _guard = tokio_handle.enter();
-                let result =
-                    self.run_test_suite(id, contract, &db, filter, None, num_invariant_contracts);
+                let result = self.run_test_suite(
+                    id,
+                    contract,
+                    &db,
+                    filter,
+                    None,
+                    num_invariant_campaign_anchors,
+                );
                 let _ = tx.send((id.identifier(), result));
             })
         }
@@ -254,7 +269,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         db: &Backend<FEN>,
         filter: &dyn TestFilter,
         progress: Option<&TestsProgress>,
-        num_invariant_contracts: usize,
+        num_invariant_campaign_anchors: usize,
     ) -> SuiteResult {
         let identifier = artifact_id.identifier();
         let span_name = if enabled!(tracing::Level::TRACE) {
@@ -281,7 +296,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
             progress,
             span,
             self,
-            num_invariant_contracts,
+            num_invariant_campaign_anchors,
         );
         let r = runner.run_tests(filter);
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -156,12 +156,13 @@ impl TestOutcome {
         self.failures().any(|(_, t)| t.kind.is_invariant())
     }
 
-    fn invariant_workers(&self) -> usize {
-        self.failures()
+    fn invariant_workers_hint(&self) -> Option<usize> {
+        let mut workers = self
+            .failures()
             .filter(|(_, result)| result.kind.is_invariant())
-            .map(|(_, result)| result.invariant_workers.max(1))
-            .max()
-            .unwrap_or(1)
+            .map(|(_, result)| result.invariant_workers.max(1));
+        let first = workers.next()?;
+        (first > 1 && workers.all(|workers| workers == first)).then_some(first)
     }
 
     /// Sums up all the durations of all individual test suites.
@@ -247,8 +248,7 @@ impl TestOutcome {
                 format!("{seed:#x}").cyan(),
                 "`--fuzz-seed`".cyan()
             )?;
-            let invariant_workers = outcome.invariant_workers();
-            if invariant_workers > 1 {
+            if let Some(invariant_workers) = outcome.invariant_workers_hint() {
                 sh_println!(
                     "Invariant workers: {} (use {} to reproduce)",
                     invariant_workers,
@@ -276,6 +276,55 @@ impl TestOutcome {
 /// Process exit code emitted when at least one test failed.
 fn test_failure_exit_code() -> i32 {
     if foundry_cli::is_machine() { foundry_cli::ExitCode::TestFailure.to_i32() } else { 1 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outcome_with_failed_invariant_workers(workers: &[usize]) -> TestOutcome {
+        let test_results = workers
+            .iter()
+            .enumerate()
+            .map(|(idx, workers)| {
+                (
+                    format!("invariant{idx}()"),
+                    TestResult {
+                        status: TestStatus::Failure,
+                        kind: TestKind::Invariant {
+                            runs: 0,
+                            calls: 0,
+                            reverts: 0,
+                            metrics: Map::new(),
+                            failed_corpus_replays: 0,
+                            optimization_best_value: None,
+                        },
+                        invariant_workers: *workers,
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
+        TestOutcome::new(
+            None,
+            BTreeMap::from([(
+                "suite".to_string(),
+                SuiteResult::new(Duration::ZERO, test_results, Vec::new()),
+            )]),
+            false,
+            None,
+        )
+    }
+
+    #[test]
+    fn invariant_workers_hint_requires_matching_parallel_worker_counts() {
+        assert_eq!(
+            outcome_with_failed_invariant_workers(&[3, 3]).invariant_workers_hint(),
+            Some(3)
+        );
+        assert_eq!(outcome_with_failed_invariant_workers(&[2, 3]).invariant_workers_hint(), None);
+        assert_eq!(outcome_with_failed_invariant_workers(&[1]).invariant_workers_hint(), None);
+    }
 }
 
 /// A set of test results for a single test suite, which is all the tests in a single contract.

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -54,8 +54,6 @@ pub struct TestOutcome {
     pub known_contracts: Option<ContractsByArtifact>,
     /// The fuzz seed used for the test run.
     pub fuzz_seed: Option<U256>,
-    /// Explicit invariant worker count used for the test run.
-    pub invariant_workers: usize,
 }
 
 impl TestOutcome {
@@ -73,7 +71,6 @@ impl TestOutcome {
             gas_report: None,
             known_contracts,
             fuzz_seed,
-            invariant_workers: 1,
         }
     }
 
@@ -159,6 +156,14 @@ impl TestOutcome {
         self.failures().any(|(_, t)| t.kind.is_invariant())
     }
 
+    fn invariant_workers(&self) -> usize {
+        self.failures()
+            .filter(|(_, result)| result.kind.is_invariant())
+            .map(|(_, result)| result.invariant_workers.max(1))
+            .max()
+            .unwrap_or(1)
+    }
+
     /// Sums up all the durations of all individual test suites.
     ///
     /// Note that this is not necessarily the wall clock time of the entire test run.
@@ -242,11 +247,12 @@ impl TestOutcome {
                 format!("{seed:#x}").cyan(),
                 "`--fuzz-seed`".cyan()
             )?;
-            if outcome.has_invariant_failures() && outcome.invariant_workers > 1 {
+            let invariant_workers = outcome.invariant_workers();
+            if invariant_workers > 1 {
                 sh_println!(
                     "Invariant workers: {} (use {} to reproduce)",
-                    outcome.invariant_workers,
-                    format!("`--invariant-workers {}`", outcome.invariant_workers).cyan()
+                    invariant_workers,
+                    format!("`--invariant-workers {invariant_workers}`").cyan()
                 )?;
             }
         }
@@ -566,6 +572,10 @@ pub struct TestResult {
     /// `Assertion Tests` section.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub invariant_handler_failures: Vec<InvariantFailure>,
+
+    /// Actual worker count used by this invariant campaign.
+    #[serde(skip)]
+    pub invariant_workers: usize,
 
     /// Minimal reproduction test case for failing test
     pub counterexample: Option<CounterExample>,
@@ -1095,6 +1105,7 @@ impl TestResult {
         reverts: usize,
         metrics: Map<String, InvariantMetrics>,
         failed_corpus_replays: usize,
+        workers: usize,
         optimization_best_value: Option<I256>,
     ) {
         self.kind = TestKind::Invariant {
@@ -1116,6 +1127,7 @@ impl TestResult {
         self.invariant_failure_dir = invariant_failure_dir;
         self.invariant_count = invariant_count;
         self.invariant_handler_failures = invariant_handler_failures;
+        self.invariant_workers = workers.max(1);
         // `counterexample` is only used by the renderer for optimization mode (the "best
         // sequence" rendered on success). Invariant check-mode failures live entirely in
         // `invariant_failures`; `reason`/`counterexample` stay `None` for invariant tests.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -340,6 +340,12 @@ pub struct ContractRunner<'a, FEN: FoundryEvmNetwork> {
     num_invariant_campaign_anchors: usize,
 }
 
+pub(crate) struct ContractRunnerContext<'a> {
+    pub(crate) progress: Option<&'a TestsProgress>,
+    pub(crate) tokio_handle: tokio::runtime::Handle,
+    pub(crate) num_invariant_campaign_anchors: usize,
+}
+
 impl<'a, FEN: FoundryEvmNetwork> Deref for ContractRunner<'a, FEN> {
     type Target = Cow<'a, TestRunnerConfig<FEN>>;
 
@@ -350,25 +356,24 @@ impl<'a, FEN: FoundryEvmNetwork> Deref for ContractRunner<'a, FEN> {
 }
 
 impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
-    pub fn new(
+    pub(crate) fn new(
         name: &'a str,
         contract: &'a TestContract,
         executor: Executor<FEN>,
-        progress: Option<&'a TestsProgress>,
         span: Span,
         mcr: &'a MultiContractRunner<FEN>,
-        num_invariant_campaign_anchors: usize,
+        context: ContractRunnerContext<'a>,
     ) -> Self {
         Self {
             name,
             contract,
             executor,
-            progress,
-            tokio_handle: tokio::runtime::Handle::current(),
+            progress: context.progress,
+            tokio_handle: context.tokio_handle,
             span,
             tcfg: Cow::Borrowed(&mcr.tcfg),
             mcr,
-            num_invariant_campaign_anchors,
+            num_invariant_campaign_anchors: context.num_invariant_campaign_anchors,
         }
     }
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -80,6 +80,8 @@ pub struct ContractRunner<'a, FEN: FoundryEvmNetwork> {
     tcfg: Cow<'a, TestRunnerConfig<FEN>>,
     /// The parent runner.
     mcr: &'a MultiContractRunner<FEN>,
+    /// Number of matching test contracts that contain invariant tests.
+    num_invariant_contracts: usize,
 }
 
 impl<'a, FEN: FoundryEvmNetwork> Deref for ContractRunner<'a, FEN> {
@@ -100,6 +102,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         tokio_handle: &'a tokio::runtime::Handle,
         span: Span,
         mcr: &'a MultiContractRunner<FEN>,
+        num_invariant_contracts: usize,
     ) -> Self {
         Self {
             name,
@@ -110,6 +113,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             span,
             tcfg: Cow::Borrowed(&mcr.tcfg),
             mcr,
+            num_invariant_contracts,
         }
     }
 
@@ -921,6 +925,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             config,
             identified_contracts,
             &self.cr.mcr.known_contracts,
+            self.cr.num_invariant_contracts,
         );
 
         // Showmap replay mode: replay the persisted corpus and emit coverage
@@ -1502,6 +1507,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             invariant_result.reverts,
             invariant_result.metrics,
             invariant_result.failed_corpus_replays,
+            invariant_result.workers,
             invariant_result.optimization_best_value,
         );
         self.result

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -12,12 +12,12 @@ use crate::{
     },
 };
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
-use alloy_json_abi::Function;
+use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, Selector, U256, address, map::HashMap};
 use eyre::Result;
 use foundry_common::{TestFunctionExt, TestFunctionKind, contracts::ContractsByAddress};
 use foundry_compilers::utils::canonicalized;
-use foundry_config::{Config, FuzzCorpusConfig, InvariantConfig};
+use foundry_config::{Config, FuzzCorpusConfig, InlineConfig, InvariantConfig};
 use foundry_evm::{
     constants::CALLER,
     core::evm::FoundryEvmNetwork,
@@ -39,6 +39,7 @@ use foundry_evm::{
     revm::primitives::hardfork::SpecId,
     traces::{TraceKind, TraceMode, load_contracts},
 };
+use foundry_evm_networks::NetworkVariant;
 use itertools::Itertools;
 use proptest::test_runner::{RngAlgorithm, TestError, TestRng, TestRunner};
 use rayon::prelude::*;
@@ -62,6 +63,261 @@ use tracing::Span;
 /// `address(uint160(uint256(keccak256("foundry library deployer"))))`
 pub const LIBRARY_DEPLOYER: Address = address!("0x1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
 
+pub(crate) struct InvariantCampaignScope<'a> {
+    pub config: &'a Config,
+    pub inline_config: &'a InlineConfig,
+    pub contract_name: &'a str,
+    pub all_override_networks: &'a [NetworkVariant],
+    pub pass_network: Option<&'a NetworkVariant>,
+}
+
+struct InvariantCampaignSelection<'a> {
+    matched_boolean_invariant_fns: Vec<&'a Function>,
+    merge_boolean_suite: bool,
+    boolean_suite_anchor: Option<&'a Function>,
+    optimization_anchors: usize,
+}
+
+impl InvariantCampaignSelection<'_> {
+    const fn anchor_count(&self) -> usize {
+        self.optimization_anchors
+            + if self.matched_boolean_invariant_fns.is_empty() {
+                0
+            } else if self.merge_boolean_suite {
+                1
+            } else {
+                self.matched_boolean_invariant_fns.len()
+            }
+    }
+}
+
+pub(crate) fn count_runnable_invariant_campaign_anchors(
+    abi: &JsonAbi,
+    filter: &dyn TestFilter,
+    scope: InvariantCampaignScope<'_>,
+) -> usize {
+    let invariant_fns = abi.functions().filter(|func| func.is_invariant_test()).collect::<Vec<_>>();
+    if invariant_fns.iter().any(|func| !func.inputs.is_empty()) {
+        return 0;
+    }
+
+    let functions = abi
+        .functions()
+        .filter(|func| filter.matches_test_function(func))
+        .filter(|func| {
+            function_matches_network_pass(
+                scope.all_override_networks,
+                scope.pass_network,
+                scope.inline_config.network_for(
+                    &scope.config.profile,
+                    scope.contract_name,
+                    &func.name,
+                ),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    select_invariant_campaigns(
+        &invariant_fns,
+        &functions,
+        scope.config,
+        scope.inline_config,
+        scope.contract_name,
+    )
+    .anchor_count()
+}
+
+fn function_matches_network_pass(
+    all_override_networks: &[NetworkVariant],
+    pass_network: Option<&NetworkVariant>,
+    func_network: Option<NetworkVariant>,
+) -> bool {
+    if all_override_networks.is_empty() {
+        return true;
+    }
+    match pass_network {
+        None => func_network.is_none_or(|network| !all_override_networks.contains(&network)),
+        Some(target) => func_network.as_ref() == Some(target),
+    }
+}
+
+fn inline_config_for(
+    config: &Config,
+    inline_config: &InlineConfig,
+    contract_name: &str,
+    func: Option<&Function>,
+) -> Result<Config> {
+    let function = func.map(|f| f.name.as_str()).unwrap_or("");
+    Ok(config.merge_inline_provider(inline_config.provide(contract_name, function))?)
+}
+
+fn invariant_suite_configs_match(
+    config: &Config,
+    inline_config: &InlineConfig,
+    contract_name: &str,
+    funcs: &[&Function],
+) -> bool {
+    let Some((anchor, rest)) = funcs.split_first() else {
+        return true;
+    };
+    let anchor_config = match inline_config_for(config, inline_config, contract_name, Some(anchor))
+    {
+        Ok(config) => config.invariant,
+        Err(_) => return false,
+    };
+    rest.iter().all(|func| {
+        inline_config_for(config, inline_config, contract_name, Some(func))
+            .map(|config| config.invariant == anchor_config)
+            .unwrap_or(false)
+    })
+}
+
+fn select_invariant_campaigns<'a>(
+    invariant_fns: &[&'a Function],
+    functions: &[&'a Function],
+    config: &Config,
+    inline_config: &InlineConfig,
+    contract_name: &str,
+) -> InvariantCampaignSelection<'a> {
+    let boolean_invariant_fns =
+        invariant_fns.iter().copied().filter(|func| !is_optimization_invariant(func));
+    let matched_boolean_invariant_fns = functions
+        .iter()
+        .copied()
+        .filter(|func| func.is_invariant_test() && !is_optimization_invariant(func))
+        .collect::<Vec<_>>();
+    let optimization_anchors = functions
+        .iter()
+        .filter(|func| func.is_invariant_test() && is_optimization_invariant(func))
+        .count();
+
+    // The boolean invariant campaign is contract-level. Test filters only select which predicates
+    // are evaluated/reported inside that campaign; they must not decide the corpus/failure
+    // namespace. Use the canonical anchor when it is part of the filtered set, but preserve
+    // `--mt`/`--nmt` isolation when the filter deliberately excludes it.
+    let canonical_boolean_anchor = boolean_invariant_fns.into_iter().next();
+    let merge_boolean_suite = !matched_boolean_invariant_fns.is_empty()
+        && invariant_suite_configs_match(
+            config,
+            inline_config,
+            contract_name,
+            &matched_boolean_invariant_fns,
+        );
+    let boolean_suite_anchor = merge_boolean_suite
+        .then(|| {
+            canonical_boolean_anchor
+                .filter(|anchor| matched_boolean_invariant_fns.contains(anchor))
+                .or_else(|| matched_boolean_invariant_fns.first().copied())
+        })
+        .flatten();
+
+    InvariantCampaignSelection {
+        matched_boolean_invariant_fns,
+        merge_boolean_suite,
+        boolean_suite_anchor,
+        optimization_anchors,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_common::EmptyTestFilter;
+    use foundry_config::NatSpec;
+
+    const CONTRACT_NAME: &str = "src/Test.t.sol:InvariantTest";
+
+    fn count_anchors(abi: &JsonAbi, inline_config: &InlineConfig) -> usize {
+        let config = Config::default();
+        count_runnable_invariant_campaign_anchors(
+            abi,
+            &EmptyTestFilter::default(),
+            InvariantCampaignScope {
+                config: &config,
+                inline_config,
+                contract_name: CONTRACT_NAME,
+                all_override_networks: &[],
+                pass_network: None,
+            },
+        )
+    }
+
+    #[test]
+    fn runnable_campaign_anchor_count_merges_boolean_suite_and_counts_optimizations() {
+        let abi = JsonAbi::parse([
+            "function invariantOne() external",
+            "function invariantTwo() external",
+            "function invariantOptimizeA() external returns (int256)",
+            "function invariantOptimizeB() external returns (int256)",
+        ])
+        .unwrap();
+
+        assert_eq!(count_anchors(&abi, &InlineConfig::new()), 3);
+    }
+
+    #[test]
+    fn runnable_campaign_anchor_count_splits_boolean_suite_when_configs_differ() {
+        let abi = JsonAbi::parse([
+            "function invariantOne() external",
+            "function invariantTwo() external",
+        ])
+        .unwrap();
+        let mut inline_config = InlineConfig::new();
+        inline_config
+            .insert(&NatSpec {
+                contract: CONTRACT_NAME.to_string(),
+                function: Some("invariantTwo".to_string()),
+                line: "1:1".to_string(),
+                docs: "forge-config: default.invariant.depth = 1".to_string(),
+            })
+            .unwrap();
+
+        assert_eq!(count_anchors(&abi, &inline_config), 2);
+    }
+
+    #[test]
+    fn runnable_campaign_anchor_count_respects_network_pass() {
+        let abi = JsonAbi::parse(["function invariantTempoOnly() external"]).unwrap();
+        let mut inline_config = InlineConfig::new();
+        inline_config
+            .insert(&NatSpec {
+                contract: CONTRACT_NAME.to_string(),
+                function: Some("invariantTempoOnly".to_string()),
+                line: "1:1".to_string(),
+                docs: r#"forge-config: default.networks.network = "tempo""#.to_string(),
+            })
+            .unwrap();
+        let config = Config::default();
+        let override_networks = [NetworkVariant::Tempo];
+
+        let default_pass = count_runnable_invariant_campaign_anchors(
+            &abi,
+            &EmptyTestFilter::default(),
+            InvariantCampaignScope {
+                config: &config,
+                inline_config: &inline_config,
+                contract_name: CONTRACT_NAME,
+                all_override_networks: &override_networks,
+                pass_network: None,
+            },
+        );
+        let tempo_pass = count_runnable_invariant_campaign_anchors(
+            &abi,
+            &EmptyTestFilter::default(),
+            InvariantCampaignScope {
+                config: &config,
+                inline_config: &inline_config,
+                contract_name: CONTRACT_NAME,
+                all_override_networks: &override_networks,
+                pass_network: Some(&NetworkVariant::Tempo),
+            },
+        );
+
+        assert_eq!(default_pass, 0);
+        assert_eq!(tempo_pass, 1);
+    }
+}
+
 /// A type that executes all tests of a contract
 pub struct ContractRunner<'a, FEN: FoundryEvmNetwork> {
     /// The name of the contract.
@@ -80,8 +336,8 @@ pub struct ContractRunner<'a, FEN: FoundryEvmNetwork> {
     tcfg: Cow<'a, TestRunnerConfig<FEN>>,
     /// The parent runner.
     mcr: &'a MultiContractRunner<FEN>,
-    /// Number of matching test contracts that contain invariant tests.
-    num_invariant_contracts: usize,
+    /// Number of matching invariant campaign anchors in the current test pass.
+    num_invariant_campaign_anchors: usize,
 }
 
 impl<'a, FEN: FoundryEvmNetwork> Deref for ContractRunner<'a, FEN> {
@@ -101,7 +357,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         progress: Option<&'a TestsProgress>,
         span: Span,
         mcr: &'a MultiContractRunner<FEN>,
-        num_invariant_contracts: usize,
+        num_invariant_campaign_anchors: usize,
     ) -> Self {
         Self {
             name,
@@ -112,7 +368,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             span,
             tcfg: Cow::Borrowed(&mcr.tcfg),
             mcr,
-            num_invariant_contracts,
+            num_invariant_campaign_anchors,
         }
     }
 
@@ -123,16 +379,11 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
     /// - Default pass (`pass_network = None`): includes functions *without* an override annotation.
     /// - Override pass (`pass_network = Some(v)`): includes only functions annotated with `v`.
     fn function_matches_network_pass(&self, func: &Function) -> bool {
-        let multi = &self.mcr.tcfg.multi_network;
-        if multi.all_override_networks.is_empty() {
-            return true;
-        }
-        let profile = &self.tcfg.config.profile;
-        let func_network = self.mcr.inline_config.network_for(profile, self.name, &func.name);
-        match &multi.pass_network {
-            None => func_network.is_none_or(|n| !multi.all_override_networks.contains(&n)),
-            Some(target) => func_network.as_ref() == Some(target),
-        }
+        function_matches_network_pass(
+            &self.mcr.tcfg.multi_network.all_override_networks,
+            self.mcr.tcfg.multi_network.pass_network.as_ref(),
+            self.mcr.inline_config.network_for(&self.tcfg.config.profile, self.name, &func.name),
+        )
     }
 
     /// Deploys the test contract inside the runner from the sending account, and optionally runs
@@ -253,27 +504,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
     /// Returns the configuration for a contract or function.
     fn inline_config(&self, func: Option<&Function>) -> Result<Config> {
-        let function = func.map(|f| f.name.as_str()).unwrap_or("");
-        let config = self
-            .config
-            .merge_inline_provider(self.mcr.inline_config.provide(self.name, function))?;
-        Ok(config)
-    }
-
-    /// Returns true if all invariant functions share the same effective inline invariant config.
-    fn invariant_suite_configs_match(&self, funcs: &[&Function]) -> bool {
-        let Some((anchor, rest)) = funcs.split_first() else {
-            return true;
-        };
-        let anchor_config = match self.inline_config(Some(anchor)) {
-            Ok(config) => config.invariant,
-            Err(_) => return false,
-        };
-        rest.iter().all(|func| {
-            self.inline_config(Some(func))
-                .map(|config| config.invariant == anchor_config)
-                .unwrap_or(false)
-        })
+        inline_config_for(&self.config, &self.mcr.inline_config, self.name, func)
     }
 
     /// Collect fixtures from test contract.
@@ -483,31 +714,19 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             });
         }
 
-        // Keep only boolean invariants; optimization invariants stay isolated per function.
-        let boolean_invariant_fns = invariant_fns
-            .iter()
-            .copied()
-            .filter(|func| !is_optimization_invariant(func))
-            .collect::<Vec<_>>();
-        let matched_boolean_invariant_fns = functions
-            .iter()
-            .copied()
-            .filter(|func| func.is_invariant_test() && !is_optimization_invariant(func))
-            .collect::<Vec<_>>();
-        // The boolean invariant campaign is contract-level. Test filters only select which
-        // predicates are evaluated/reported inside that campaign; they must not decide the
-        // corpus/failure namespace. Use the canonical anchor when it is part of the filtered
-        // set, but preserve `--mt`/`--nmt` isolation when the filter deliberately excludes it.
-        let canonical_boolean_anchor = boolean_invariant_fns.first().copied();
-        let merge_invariant_suite = !matched_boolean_invariant_fns.is_empty()
-            && self.invariant_suite_configs_match(&matched_boolean_invariant_fns);
-        let invariant_suite_anchor = merge_invariant_suite
-            .then(|| {
-                canonical_boolean_anchor
-                    .filter(|anchor| matched_boolean_invariant_fns.contains(anchor))
-                    .or_else(|| matched_boolean_invariant_fns.first().copied())
-            })
-            .flatten();
+        let invariant_campaigns = select_invariant_campaigns(
+            &invariant_fns,
+            &functions,
+            &self.config,
+            &self.mcr.inline_config,
+            self.name,
+        );
+        let InvariantCampaignSelection {
+            matched_boolean_invariant_fns,
+            merge_boolean_suite: merge_invariant_suite,
+            boolean_suite_anchor: invariant_suite_anchor,
+            optimization_anchors: _,
+        } = invariant_campaigns;
 
         let test_results = functions
             .par_iter()
@@ -924,7 +1143,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             config,
             identified_contracts,
             &self.cr.mcr.known_contracts,
-            self.cr.num_invariant_contracts,
+            self.cr.num_invariant_campaign_anchors,
         );
 
         // Showmap replay mode: replay the persisted corpus and emit coverage

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -73,7 +73,7 @@ pub struct ContractRunner<'a, FEN: FoundryEvmNetwork> {
     /// Overall test run progress.
     progress: Option<&'a TestsProgress>,
     /// The handle to the tokio runtime.
-    tokio_handle: &'a tokio::runtime::Handle,
+    tokio_handle: tokio::runtime::Handle,
     /// The span of the contract.
     span: tracing::Span,
     /// The contract-level configuration.
@@ -94,12 +94,11 @@ impl<'a, FEN: FoundryEvmNetwork> Deref for ContractRunner<'a, FEN> {
 }
 
 impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
-    pub const fn new(
+    pub fn new(
         name: &'a str,
         contract: &'a TestContract,
         executor: Executor<FEN>,
         progress: Option<&'a TestsProgress>,
-        tokio_handle: &'a tokio::runtime::Handle,
         span: Span,
         mcr: &'a MultiContractRunner<FEN>,
         num_invariant_contracts: usize,
@@ -109,7 +108,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             contract,
             executor,
             progress,
-            tokio_handle,
+            tokio_handle: tokio::runtime::Handle::current(),
             span,
             tcfg: Cow::Borrowed(&mcr.tcfg),
             mcr,
@@ -1591,7 +1590,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             &self.cr.mcr.revert_decoder,
             progress.as_ref(),
             &self.tcfg.early_exit,
-            self.cr.tokio_handle,
+            &self.cr.tokio_handle,
         ) {
             Ok(x) => x,
             Err(e) => {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -205,7 +205,7 @@ show_logs = false
 [invariant]
 runs = 256
 depth = 500
-workers = 1
+workers = "auto"
 fail_on_revert = false
 call_override = false
 dictionary_weight = 80
@@ -1387,7 +1387,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "invariant": {
     "runs": 256,
     "depth": 500,
-    "workers": 1,
+    "workers": "auto",
     "fail_on_revert": false,
     "call_override": false,
     "dictionary_weight": 80,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -205,7 +205,7 @@ show_logs = false
 [invariant]
 runs = 256
 depth = 500
-workers = "auto"
+workers = 1
 fail_on_revert = false
 call_override = false
 dictionary_weight = 80
@@ -1387,7 +1387,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "invariant": {
     "runs": 256,
     "depth": 500,
-    "workers": "auto",
+    "workers": 1,
     "fail_on_revert": false,
     "call_override": false,
     "dictionary_weight": 80,

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -281,7 +281,7 @@ Ran 1 test for test/TimeoutTest.t.sol:TimeoutTest
 ╭----------------+-----------+-------+---------+----------╮
 | Contract       | Selector  | Calls | Reverts | Discards |
 +=========================================================+
-| TimeoutHandler | increment | [..]  | [..]    | [..]     |
+| TimeoutHandler | increment | [..]| [..]| [..]|
 ╰----------------+-----------+-------+---------+----------╯
 
 Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]

--- a/crates/lint/src/sol/gas/external_function.rs
+++ b/crates/lint/src/sol/gas/external_function.rs
@@ -287,10 +287,8 @@ impl<'hir> hir::Visit<'hir> for ParamEscapeFinder<'_, 'hir> {
                     return ControlFlow::Break(());
                 }
             }
-            ExprKind::Delete(inner) => {
-                if expr_root_is_param(inner, self.params) {
-                    return ControlFlow::Break(());
-                }
+            ExprKind::Delete(inner) if expr_root_is_param(inner, self.params) => {
+                return ControlFlow::Break(());
             }
             ExprKind::Unary(op, inner)
                 if matches!(
@@ -298,9 +296,7 @@ impl<'hir> hir::Visit<'hir> for ParamEscapeFinder<'_, 'hir> {
                     UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec
                 ) =>
             {
-                if expr_root_is_param(inner, self.params) {
-                    return ControlFlow::Break(());
-                }
+                return ControlFlow::Break(());
             }
             ExprKind::Call(callee, args, opts) if !is_type_conversion_callee(callee) => {
                 for arg in args.exprs() {

--- a/crates/lint/src/sol/gas/external_function.rs
+++ b/crates/lint/src/sol/gas/external_function.rs
@@ -296,7 +296,9 @@ impl<'hir> hir::Visit<'hir> for ParamEscapeFinder<'_, 'hir> {
                     UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec
                 ) =>
             {
-                return ControlFlow::Break(());
+                if expr_root_is_param(inner, self.params) {
+                    return ControlFlow::Break(());
+                }
             }
             ExprKind::Call(callee, args, opts) if !is_type_conversion_callee(callee) => {
                 for arg in args.exprs() {

--- a/crates/lint/testdata/ExternalFunction.sol
+++ b/crates/lint/testdata/ExternalFunction.sol
@@ -42,6 +42,12 @@ contract ExternalFunction {
         stored = payload;
     }
 
+    function localUnaryStillExternal(bytes memory data) public { //~NOTE: public function can be declared external
+        uint256 i = 0;
+        i++;
+        stored = data;
+    }
+
     // SHOULD PASS:
 
     // Already external.

--- a/crates/lint/testdata/ExternalFunction.stderr
+++ b/crates/lint/testdata/ExternalFunction.stderr
@@ -41,6 +41,14 @@ LL │     function calledOnlyExternally(bytes memory payload) public {
 note[external-function]: public function can be declared external
    ╭▸ ROOT/testdata/ExternalFunction.sol:LL:CC
    │
+LL │     function localUnaryStillExternal(bytes memory data) public {
+   │              ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/external-function
+
+note[external-function]: public function can be declared external
+   ╭▸ ROOT/testdata/ExternalFunction.sol:LL:CC
+   │
 LL │     function isolatedSuperTarget(bytes memory data) public {
    │              ━━━━━━━━━━━━━━━━━━━
    │


### PR DESCRIPTION
Towards OSS-273 

This changes invariant worker selection from a plain numeric count to an explicit mode:

- `auto` derives invariant workers from the active rayon / `--jobs` thread pool.
- positive integers keep the existing fixed-worker override behavior.
- `0` is rejected during config parsing.

Auto worker selection also accounts for the number of matching invariant contracts, so parallel test suites share the available job pool instead of allowing every invariant contract to claim all threads. Short non-timeout campaigns are capped by estimated work (`runs * depth`) to avoid creating many tiny jobs, while timeout campaigns can use the requested auto parallelism because they share a wall-clock deadline.

The actual worker count used by failing invariant campaigns is recorded and printed in the reproduction hint, so users can rerun failures with a fixed `--invariant-workers N`.