### PR TITLE
feat(tempo): expose T5 payment lane classifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,7 @@ dependencies = [
  "foundry-debugger",
  "foundry-evm",
  "foundry-evm-networks",
+ "foundry-primitives",
  "foundry-test-utils",
  "foundry-wallets",
  "futures",

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -174,6 +174,9 @@ pub enum EthRequest {
     #[serde(rename = "eth_sendRawTransactionSync", with = "sequence")]
     EthSendRawTransactionSync(Bytes),
 
+    #[serde(rename = "anvil_classifyTransaction", with = "sequence")]
+    AnvilClassifyTransaction(Bytes),
+
     #[serde(rename = "eth_call")]
     EthCall(
         WithOtherFields<TransactionRequest>,

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -83,7 +83,7 @@ use foundry_common::{
 use foundry_evm::decode::RevertDecoder;
 use foundry_primitives::{
     FoundryNetwork, FoundryReceiptEnvelope, FoundryTransactionRequest, FoundryTxEnvelope,
-    FoundryTxReceipt, FoundryTxType, FoundryTypedTx,
+    FoundryTxReceipt, FoundryTxType, FoundryTypedTx, PaymentLaneClassification, PaymentLaneReason,
 };
 use futures::{
     StreamExt, TryFutureExt,
@@ -101,6 +101,7 @@ use revm::{
     primitives::eip7702::PER_EMPTY_ACCOUNT_COST,
 };
 use std::{sync::Arc, time::Duration};
+use tempo_chainspec::hardfork::TempoHardfork;
 use tokio::{
     sync::mpsc::{UnboundedReceiver, unbounded_channel},
     try_join,
@@ -1587,6 +1588,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::EthSendRawTransactionSync(tx) => {
                 self.send_raw_transaction_sync(tx).await.to_rpc_result()
             }
+            EthRequest::AnvilClassifyTransaction(tx) => {
+                self.anvil_classify_transaction(tx).to_rpc_result()
+            }
             EthRequest::EthCall(call, block, state_override, block_overrides) => self
                 .call(call, block, EvmOverrides::new(state_override, block_overrides))
                 .await
@@ -2278,6 +2282,11 @@ impl EthApi<FoundryNetwork> {
 
         self.ensure_typed_transaction_supported(&transaction)?;
 
+        if self.backend.is_tempo() && TempoHardfork::from(self.backend.hardfork()).is_t5() {
+            let classification = transaction.classify_t5_payment_lane();
+            trace!(target: "node", tx = ?transaction.hash(), ?classification, "classified transaction lane");
+        }
+
         let pending_transaction = PendingTransaction::new(transaction)?;
 
         // pre-validate
@@ -2303,6 +2312,35 @@ impl EthApi<FoundryNetwork> {
         let tx = self.pool.add_transaction(pool_transaction)?;
         trace!(target: "node", "Added transaction: [{:?}] sender={:?}", tx.hash(), from);
         Ok(*tx.hash())
+    }
+
+    /// Classifies a raw transaction with the active Anvil Tempo/T5 payment-lane classifier.
+    pub fn anvil_classify_transaction(&self, tx: Bytes) -> Result<PaymentLaneClassification> {
+        node_info!("anvil_classifyTransaction");
+        let mut data = tx.as_ref();
+        if data.is_empty() {
+            return Err(BlockchainError::EmptyRawTransactionData);
+        }
+
+        let transaction = FoundryTxEnvelope::decode_2718(&mut data)
+            .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?;
+
+        Ok(self.classify_transaction_envelope(&transaction))
+    }
+
+    fn classify_transaction_envelope(
+        &self,
+        transaction: &FoundryTxEnvelope,
+    ) -> PaymentLaneClassification {
+        if !self.backend.is_tempo() {
+            return PaymentLaneClassification::general(PaymentLaneReason::NotTempo);
+        }
+
+        if !TempoHardfork::from(self.backend.hardfork()).is_t5() {
+            return PaymentLaneClassification::general(PaymentLaneReason::T5NotActive);
+        }
+
+        transaction.classify_t5_payment_lane()
     }
 
     /// Sends signed transaction, returning its receipt.

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -29,6 +29,7 @@ foundry-config.workspace = true
 foundry-debugger.workspace = true
 foundry-evm.workspace = true
 foundry-evm-networks.workspace = true
+foundry-primitives.workspace = true
 foundry-wallets = { workspace = true, features = ["browser", "tempo"] }
 forge-fmt.workspace = true
 

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -63,24 +63,6 @@ pub fn setup() -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn classify_raw_transaction_output(raw_tx: &str) -> Result<String> {
-    let raw_tx = hex::decode(raw_tx)?;
-    let mut data = raw_tx.as_slice();
-    let tx =
-        FoundryTxEnvelope::decode_2718(&mut data).wrap_err("failed to decode raw transaction")?;
-    format_lane_classification(&tx.classify_t5_payment_lane())
-}
-
-pub(crate) fn format_lane_classification(
-    classification: &PaymentLaneClassification,
-) -> Result<String> {
-    if shell::is_json() {
-        Ok(serde_json::to_string_pretty(classification)?)
-    } else {
-        Ok(serde_json::to_string(classification)?)
-    }
-}
-
 /// Run the subcommand.
 #[allow(clippy::large_stack_frames)]
 pub async fn run_command(args: CastArgs) -> Result<()> {
@@ -993,6 +975,24 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
     };
 
     Ok(())
+}
+
+pub(crate) fn classify_raw_transaction_output(raw_tx: &str) -> Result<String> {
+    let raw_tx = hex::decode(raw_tx)?;
+    let mut data = raw_tx.as_slice();
+    let tx =
+        FoundryTxEnvelope::decode_2718(&mut data).wrap_err("failed to decode raw transaction")?;
+    format_lane_classification(&tx.classify_t5_payment_lane())
+}
+
+pub(crate) fn format_lane_classification(
+    classification: &PaymentLaneClassification,
+) -> Result<String> {
+    if shell::is_json() {
+        Ok(serde_json::to_string_pretty(classification)?)
+    } else {
+        Ok(serde_json::to_string(classification)?)
+    }
 }
 
 #[cfg(test)]

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloy_dyn_abi::{ErrorExt, EventExt};
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_ens::{ProviderEnsExt, namehash};
-use alloy_network::Ethereum;
+use alloy_network::{Ethereum, eip2718::Decodable2718};
 use alloy_primitives::{Address, B256, eip191_hash_message, hex, keccak256};
 use alloy_provider::Provider;
 use alloy_rpc_types::{BlockId, BlockNumberOrTag::Latest};
@@ -33,6 +33,7 @@ use foundry_common::{
     shell, stdin,
 };
 use foundry_evm_networks::NetworkVariant;
+use foundry_primitives::{FoundryTxEnvelope, PaymentLaneClassification};
 #[cfg(feature = "optimism")]
 use op_alloy_network::Optimism;
 use std::time::Instant;
@@ -60,6 +61,24 @@ pub fn setup() -> Result<()> {
     utils::subscriber();
 
     Ok(())
+}
+
+pub(crate) fn classify_raw_transaction_output(raw_tx: &str) -> Result<String> {
+    let raw_tx = hex::decode(raw_tx)?;
+    let mut data = raw_tx.as_slice();
+    let tx =
+        FoundryTxEnvelope::decode_2718(&mut data).wrap_err("failed to decode raw transaction")?;
+    format_lane_classification(&tx.classify_t5_payment_lane())
+}
+
+pub(crate) fn format_lane_classification(
+    classification: &PaymentLaneClassification,
+) -> Result<String> {
+    if shell::is_json() {
+        Ok(serde_json::to_string_pretty(classification)?)
+    } else {
+        Ok(serde_json::to_string(classification)?)
+    }
 }
 
 /// Run the subcommand.
@@ -714,7 +733,11 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         CastSubcommand::SendTx(cmd) => cmd.run().await?,
         CastSubcommand::BatchMakeTx(cmd) => cmd.run().await?,
         CastSubcommand::BatchSend(cmd) => cmd.run().await?,
-        CastSubcommand::Tx { tx_hash, from, nonce, field, raw, rpc, to_request, network } => {
+        CastSubcommand::Classify { raw_tx } => {
+            let raw_tx = stdin::unwrap_line(raw_tx)?;
+            print_json_value_or_scalar(classify_raw_transaction_output(&raw_tx)?)?
+        }
+        CastSubcommand::Tx { tx_hash, from, nonce, field, raw, lane, rpc, to_request, network } => {
             let config = rpc.load_config()?;
             // Can use either --raw or specify raw as a field
             let is_raw = raw || field.as_ref().is_some_and(|f| f == "raw");
@@ -724,21 +747,21 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                     let provider = ProviderBuilder::<Optimism>::from_config(&config)?.build()?;
 
                     Cast::new(&provider)
-                        .transaction(tx_hash, from, nonce, field, is_raw, to_request)
+                        .transaction(tx_hash, from, nonce, field, is_raw, to_request, lane)
                         .await?
                 }
                 Some(NetworkVariant::Tempo) => {
                     let provider =
                         ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
                     Cast::new(&provider)
-                        .transaction(tx_hash, from, nonce, field, is_raw, to_request)
+                        .transaction(tx_hash, from, nonce, field, is_raw, to_request, lane)
                         .await?
                 }
                 // Ethereum (default) or no --raw flag
                 _ => {
                     let provider = utils::get_provider(&config)?;
                     Cast::new(&provider)
-                        .transaction(tx_hash, from, nonce, field, is_raw, to_request)
+                        .transaction(tx_hash, from, nonce, field, is_raw, to_request, lane)
                         .await?
                 }
             };

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -39,6 +39,7 @@ use foundry_common::{
 };
 use foundry_config::Chain;
 use foundry_evm::core::bytecode::InstIter;
+use foundry_primitives::FoundryTxEnvelope;
 use futures::{FutureExt, StreamExt, future::Either};
 #[cfg(feature = "optimism")]
 use op_alloy_consensus as _;
@@ -1092,11 +1093,13 @@ where
     ///     ProviderBuilder::<_, _, AnyNetwork>::default().connect("http://localhost:8545").await?;
     /// let cast = Cast::new(provider);
     /// let tx_hash = "0xf8d1713ea15a81482958fb7ddf884baee8d3bcc478c5f2f604e008dc788ee4fc";
-    /// let tx = cast.transaction(Some(tx_hash.to_string()), None, None, None, false, false).await?;
+    /// let tx =
+    ///     cast.transaction(Some(tx_hash.to_string()), None, None, None, false, false, false).await?;
     /// println!("{}", tx);
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(clippy::too_many_arguments)]
     pub async fn transaction(
         &self,
         tx_hash: Option<String>,
@@ -1105,6 +1108,7 @@ where
         field: Option<String>,
         raw: bool,
         to_request: bool,
+        lane: bool,
     ) -> Result<String> {
         let tx = if let Some(tx_hash) = tx_hash {
             let tx_hash = TxHash::from_str(&tx_hash).wrap_err("invalid tx hash")?;
@@ -1133,6 +1137,12 @@ where
         Ok(if raw {
             let encoded = tx.as_ref().encoded_2718();
             format!("0x{}", hex::encode(encoded))
+        } else if lane {
+            let encoded = tx.as_ref().encoded_2718();
+            let mut data = encoded.as_slice();
+            let tx = FoundryTxEnvelope::decode_2718(&mut data)
+                .wrap_err("failed to decode transaction for lane classification")?;
+            crate::args::format_lane_classification(&tx.classify_t5_payment_lane())?
         } else if let Some(ref field) = field {
             if let Some(value) = get_pretty_tx_attr::<N>(&tx, field.as_str()) {
                 value

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -515,6 +515,12 @@ pub enum CastSubcommand {
     #[command(name = "mktx", visible_alias = "m")]
     MakeTx(MakeTxArgs),
 
+    /// Classify a raw transaction as Tempo T5 payment/general lane.
+    Classify {
+        /// The raw signed transaction.
+        raw_tx: Option<String>,
+    },
+
     /// Calculate the ENS namehash of a name.
     #[command(visible_aliases = &["na", "nh"])]
     Namehash { name: Option<String> },
@@ -540,6 +546,10 @@ pub enum CastSubcommand {
         /// Print the raw RLP encoded transaction.
         #[arg(long, conflicts_with = "field")]
         raw: bool,
+
+        /// Classify the transaction as Tempo T5 payment/general lane.
+        #[arg(long, conflicts_with_all = ["field", "raw", "to_request"])]
+        lane: bool,
 
         #[command(flatten)]
         rpc: RpcOpts,

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -19,53 +19,6 @@ use serde::{Deserialize, Serialize};
 use tempo_primitives::{AASigned, TempoTransaction};
 use tempo_revm::TempoTxEnv;
 
-/// Structured T5 payment-lane classification for Foundry-facing APIs.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PaymentLaneClassification {
-    /// The classified lane.
-    pub lane: PaymentLane,
-    /// Convenience boolean for consumers that only need the lane predicate.
-    pub payment: bool,
-    /// Structured reason for general-lane classification, when known.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<PaymentLaneReason>,
-}
-
-impl PaymentLaneClassification {
-    /// Constructs a payment-lane classification.
-    pub const fn payment() -> Self {
-        Self { lane: PaymentLane::Payment, payment: true, reason: None }
-    }
-
-    /// Constructs a general-lane classification with a structured reason.
-    pub const fn general(reason: PaymentLaneReason) -> Self {
-        Self { lane: PaymentLane::General, payment: false, reason: Some(reason) }
-    }
-}
-
-/// Payment-lane classifier output lane.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PaymentLane {
-    Payment,
-    General,
-}
-
-/// Stable Foundry-facing reasons for general-lane classification.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PaymentLaneReason {
-    /// The active network is not Tempo.
-    NotTempo,
-    /// Tempo is active but the T5 classifier is not active.
-    T5NotActive,
-    /// The transaction type cannot be classified by Tempo's payment-lane classifier.
-    UnsupportedTransactionType,
-    /// Tempo's T5 classifier classified the transaction as general.
-    NotPaymentLane,
-}
-
 //
 /// Container type for signed, typed transactions.
 // NOTE(onbjerg): Boxing `Tempo(AASigned)` breaks `TransactionEnvelope` derive macro trait bounds.
@@ -220,6 +173,53 @@ impl FoundryTxEnvelope {
             PaymentLaneClassification::general(PaymentLaneReason::NotPaymentLane)
         }
     }
+}
+
+/// Structured T5 payment-lane classification for Foundry-facing APIs.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaymentLaneClassification {
+    /// The classified lane.
+    pub lane: PaymentLane,
+    /// Convenience boolean for consumers that only need the lane predicate.
+    pub payment: bool,
+    /// Structured reason for general-lane classification, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<PaymentLaneReason>,
+}
+
+impl PaymentLaneClassification {
+    /// Constructs a payment-lane classification.
+    pub const fn payment() -> Self {
+        Self { lane: PaymentLane::Payment, payment: true, reason: None }
+    }
+
+    /// Constructs a general-lane classification with a structured reason.
+    pub const fn general(reason: PaymentLaneReason) -> Self {
+        Self { lane: PaymentLane::General, payment: false, reason: Some(reason) }
+    }
+}
+
+/// Payment-lane classifier output lane.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PaymentLane {
+    Payment,
+    General,
+}
+
+/// Stable Foundry-facing reasons for general-lane classification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PaymentLaneReason {
+    /// The active network is not Tempo.
+    NotTempo,
+    /// Tempo is active but the T5 classifier is not active.
+    T5NotActive,
+    /// The transaction type cannot be classified by Tempo's payment-lane classifier.
+    UnsupportedTransactionType,
+    /// Tempo's T5 classifier classified the transaction as general.
+    NotPaymentLane,
 }
 
 impl TxHashRef for FoundryTxEnvelope {

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -15,8 +15,56 @@ use alloy_rpc_types::ConversionError;
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, POST_EXEC_TX_TYPE_ID, TxDeposit, TxPostExec};
 use revm::context::TxEnv;
+use serde::{Deserialize, Serialize};
 use tempo_primitives::{AASigned, TempoTransaction};
 use tempo_revm::TempoTxEnv;
+
+/// Structured T5 payment-lane classification for Foundry-facing APIs.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaymentLaneClassification {
+    /// The classified lane.
+    pub lane: PaymentLane,
+    /// Convenience boolean for consumers that only need the lane predicate.
+    pub payment: bool,
+    /// Structured reason for general-lane classification, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<PaymentLaneReason>,
+}
+
+impl PaymentLaneClassification {
+    /// Constructs a payment-lane classification.
+    pub const fn payment() -> Self {
+        Self { lane: PaymentLane::Payment, payment: true, reason: None }
+    }
+
+    /// Constructs a general-lane classification with a structured reason.
+    pub const fn general(reason: PaymentLaneReason) -> Self {
+        Self { lane: PaymentLane::General, payment: false, reason: Some(reason) }
+    }
+}
+
+/// Payment-lane classifier output lane.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PaymentLane {
+    Payment,
+    General,
+}
+
+/// Stable Foundry-facing reasons for general-lane classification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PaymentLaneReason {
+    /// The active network is not Tempo.
+    NotTempo,
+    /// Tempo is active but the T5 classifier is not active.
+    T5NotActive,
+    /// The transaction type cannot be classified by Tempo's payment-lane classifier.
+    UnsupportedTransactionType,
+    /// Tempo's T5 classifier classified the transaction as general.
+    NotPaymentLane,
+}
 
 //
 /// Container type for signed, typed transactions.
@@ -142,6 +190,35 @@ impl FoundryTxEnvelope {
             Self::PostExec(tx) => tx.inner().signer_address(),
             Self::Tempo(tx) => tx.signature().recover_signer(&tx.signature_hash())?,
         })
+    }
+
+    /// Converts this envelope into Tempo's classifier envelope, when supported.
+    pub fn clone_into_tempo_envelope(&self) -> Option<tempo_primitives::TempoTxEnvelope> {
+        Some(match self {
+            Self::Legacy(tx) => tempo_primitives::TempoTxEnvelope::Legacy(tx.clone()),
+            Self::Eip2930(tx) => tempo_primitives::TempoTxEnvelope::Eip2930(tx.clone()),
+            Self::Eip1559(tx) => tempo_primitives::TempoTxEnvelope::Eip1559(tx.clone()),
+            Self::Eip7702(tx) => tempo_primitives::TempoTxEnvelope::Eip7702(tx.clone()),
+            Self::Tempo(tx) => tempo_primitives::TempoTxEnvelope::AA(tx.clone()),
+            Self::Eip4844(_) => return None,
+            #[cfg(feature = "optimism")]
+            Self::Deposit(_) | Self::PostExec(_) => return None,
+        })
+    }
+
+    /// Classifies this transaction with Tempo's T5 payment-lane classifier.
+    pub fn classify_t5_payment_lane(&self) -> PaymentLaneClassification {
+        let Some(tx) = self.clone_into_tempo_envelope() else {
+            return PaymentLaneClassification::general(
+                PaymentLaneReason::UnsupportedTransactionType,
+            );
+        };
+
+        if tx.is_payment_v2() {
+            PaymentLaneClassification::payment()
+        } else {
+            PaymentLaneClassification::general(PaymentLaneReason::NotPaymentLane)
+        }
     }
 }
 

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -4,7 +4,10 @@ mod optimism;
 mod receipt;
 mod request;
 
-pub use envelope::{FoundryTxEnvelope, FoundryTxType, FoundryTypedTx};
+pub use envelope::{
+    FoundryTxEnvelope, FoundryTxType, FoundryTypedTx, PaymentLane, PaymentLaneClassification,
+    PaymentLaneReason,
+};
 #[cfg(feature = "optimism")]
 pub use optimism::get_deposit_tx_parts;
 pub use receipt::FoundryReceiptEnvelope;


### PR DESCRIPTION
## Summary

- add a reusable Foundry payment-lane classification adapter around Tempo's T5 `is_payment_v2()` classifier
- expose `anvil_classifyTransaction(rawTx)` and log classification during `eth_sendRawTransaction` without affecting admission, ordering, pricing, or execution
- add local Cast surfaces via `cast classify <rawTx>` and `cast tx --lane`

## Notes
- Cheatcodes such as `vm.assumePayment()` / `vm.assumeGeneral(...)` are intentionally deferred for now because the cheatcode API doesn't fit for this since it doesn't carry the signed raw transaction envelope needed for full top-level classification (access lists, authorization lists, AA calls, tempo authorization list, key authorization RLP size). Maybe we should extend it?