### PR TITLE
feat(cast): support rendering debug_traceCall traces

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -1,4 +1,4 @@
-use super::run::fetch_contracts_bytecode_from_trace;
+use super::run::{fetch_contracts_bytecode_from_trace, fetch_contracts_bytecode_via_rpc};
 use crate::{
     Cast,
     debug::handle_traces,
@@ -343,7 +343,21 @@ impl CallArgs {
                 call_options = call_options.with_block_overrides(block_overrides);
             }
 
-            let geth_trace = provider.debug_trace_call(tx, block, call_options).await?;
+            let geth_trace = provider
+                .debug_trace_call(tx, block, call_options)
+                .await
+                .map_err(|err| -> eyre::Report {
+                    // The `debug` namespace is often disabled on public RPCs, which reject the
+                    // call with JSON-RPC error -32601 (method not found). Surface an
+                    // actionable hint instead of the raw transport error.
+                    if err.as_error_resp().is_some_and(|resp| resp.code == -32601) {
+                        eyre::eyre!(
+                            "the RPC endpoint does not support `debug_traceCall` (method not found); use a node with the `debug` namespace enabled (e.g. a local anvil/reth or an archive endpoint), or drop `--debug-trace-call` to run the call locally with `--trace`"
+                        )
+                    } else {
+                        err.into()
+                    }
+                })?;
             let GethTrace::CallTracer(frame) = geth_trace else {
                 eyre::bail!(
                     "`debug_traceCall` did not return a callTracer frame; the RPC endpoint may not \
@@ -363,12 +377,22 @@ impl CallArgs {
                 gas_used,
             };
 
+            // Local-artifact labeling matches deployed runtime bytecode against the
+            // project artifacts. There is no local executor on this path, so fetch the code
+            // over RPC for the addresses in the trace. Skip the extra round-trips unless
+            // local artifacts were requested.
+            let contracts_bytecode = if with_local_artifacts {
+                fetch_contracts_bytecode_via_rpc(&provider, &result, block).await?
+            } else {
+                Default::default()
+            };
+
             let chain = alloy_chains::Chain::from_id(provider.get_chain_id().await?);
             handle_traces(
                 result,
                 &config,
                 chain,
-                &Default::default(),
+                &contracts_bytecode,
                 labels,
                 with_local_artifacts,
                 false,

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -122,7 +122,7 @@ pub struct CallArgs {
     debug_trace_call: bool,
 
     /// Disables the labels in the traces.
-    /// Can only be set with `--trace`.
+    /// Can only be set with `--trace` or `--debug-trace-call`.
     #[arg(long, default_value_t = false, requires = "trace")]
     disable_labels: bool,
 
@@ -141,7 +141,7 @@ pub struct CallArgs {
     decode_internal: bool,
 
     /// Labels to apply to the traces; format: `address:label`.
-    /// Can only be used with `--trace`.
+    /// Can only be used with `--trace` or `--debug-trace-call`.
     #[arg(long, requires = "trace")]
     labels: Vec<String>,
 
@@ -619,11 +619,27 @@ impl CallArgs {
             }
         }).transpose()?;
 
-        // Build eth_call params
-        let call_object = serde_json::json!({
+        // Build eth_call params. `--curl` builds the request offline, so the fields the
+        // RPC-backed builder would resolve against the node (fee style, blob sidecars,
+        // authorization lists) are left to the node's defaults; the scalar fields given on the
+        // command line are forwarded as-is so the printed request runs the same call as the
+        // non-curl command.
+        let mut call_object = serde_json::json!({
             "to": to,
             "data": format!("0x{}", hex::encode(&data)),
         });
+        if let Some(from) = self.wallet.from {
+            call_object["from"] = serde_json::json!(from);
+        }
+        if let Some(value) = self.tx.value {
+            call_object["value"] = serde_json::json!(value);
+        }
+        if let Some(gas_limit) = self.tx.gas_limit {
+            call_object["gas"] = serde_json::json!(gas_limit);
+        }
+        if let Some(nonce) = self.tx.nonce {
+            call_object["nonce"] = serde_json::json!(nonce);
+        }
 
         let block_param = self
             .block

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -106,6 +106,9 @@ pub struct CallArgs {
     /// Fetch the call trace from the node via `debug_traceCall` (callTracer) and render it,
     /// instead of re-executing the call locally like `--trace`.
     ///
+    /// This is a call-tree view: nested calls, value, gas, emitted logs and revert data. It does
+    /// not provide the opcode / struct-log level detail of a local `--trace` / `--debug` run.
+    ///
     /// The local-execution-only trace flags (`--debug`, `--decode-internal`, `--evm-version`) do
     /// not apply, since the trace comes from the node rather than a local run.
     #[arg(
@@ -347,12 +350,35 @@ impl CallArgs {
                 .debug_trace_call(tx, block, call_options)
                 .await
                 .map_err(|err| -> eyre::Report {
-                    // The `debug` namespace is often disabled on public RPCs, which reject the
-                    // call with JSON-RPC error -32601 (method not found). Surface an
-                    // actionable hint instead of the raw transport error.
-                    if err.as_error_resp().is_some_and(|resp| resp.code == -32601) {
+                    // Two RPC rejections deserve an actionable hint instead of the raw transport
+                    // error, and they need different fixes:
+                    // - `debug` namespace disabled: rejected with JSON-RPC -32601 (method not found).
+                    // - missing historical state: an archive-depth error, usually with a generic
+                    //   code (-32000) distinguishable only by message, hit whenever `--block`
+                    //   targets a block a full node has pruned.
+                    let is_method_not_found =
+                        err.as_error_resp().is_some_and(|resp| resp.code == -32601);
+                    let message = err
+                        .as_error_resp()
+                        .map(|resp| resp.message.to_ascii_lowercase())
+                        .unwrap_or_else(|| err.to_string().to_ascii_lowercase());
+                    let is_missing_state = [
+                        "missing trie node",
+                        "required historical state",
+                        "historical state",
+                        "header not found",
+                        "missing state",
+                    ]
+                    .iter()
+                    .any(|needle| message.contains(*needle));
+
+                    if is_method_not_found {
                         eyre::eyre!(
                             "the RPC endpoint does not support `debug_traceCall` (method not found); use a node with the `debug` namespace enabled (e.g. a local anvil/reth or an archive endpoint), or drop `--debug-trace-call` to run the call locally with `--trace`"
+                        )
+                    } else if is_missing_state {
+                        eyre::eyre!(
+                            "the RPC endpoint does not have the historical state for the requested block; use an archive endpoint, or target a more recent block with `--block`"
                         )
                     } else {
                         err.into()

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -2,16 +2,21 @@ use super::run::fetch_contracts_bytecode_from_trace;
 use crate::{
     Cast,
     debug::handle_traces,
+    rpc_trace::call_frame_to_arena,
     traces::TraceKind,
     tx::{CastTxBuilder, SenderKind},
 };
 use alloy_ens::NameOrAddress;
 use alloy_network::{Network, NetworkTransactionBuilder, TransactionBuilder};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex, map::HashMap};
-use alloy_provider::Provider;
+use alloy_provider::{Provider, ext::DebugApi};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, BlockOverrides,
     state::{StateOverride, StateOverridesBuilder},
+    trace::geth::{
+        CallConfig, GethDebugBuiltInTracerType, GethDebugTracerType, GethDebugTracingCallOptions,
+        GethDebugTracingOptions, GethTrace,
+    },
 };
 use clap::Parser;
 use eyre::Result;
@@ -42,7 +47,7 @@ use foundry_evm::{
     },
     executors::TracingExecutor,
     opts::EvmOpts,
-    traces::{InternalTraceMode, TraceRequirements},
+    traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements},
 };
 use foundry_wallets::WalletOpts;
 use regex::Regex;
@@ -97,6 +102,18 @@ pub struct CallArgs {
     /// Forks the remote rpc, executes the transaction locally and prints a trace
     #[arg(long, default_value_t = false)]
     trace: bool,
+
+    /// Fetch the call trace from the node via `debug_traceCall` (callTracer) and render it,
+    /// instead of re-executing the call locally like `--trace`.
+    ///
+    /// The local-execution-only trace flags (`--debug`, `--decode-internal`, `--evm-version`) do
+    /// not apply, since the trace comes from the node rather than a local run.
+    #[arg(
+        long = "debug-trace-call",
+        default_value_t = false,
+        conflicts_with_all = ["trace", "debug", "decode_internal", "evm_version"]
+    )]
+    debug_trace_call: bool,
 
     /// Disables the labels in the traces.
     /// Can only be set with `--trace`.
@@ -310,6 +327,60 @@ impl CallArgs {
             .raw()
             .build(sender)
             .await?;
+
+        if self.debug_trace_call {
+            let block = self.block.unwrap_or(BlockId::latest());
+            let mut call_options = GethDebugTracingCallOptions::default().with_tracing_options(
+                GethDebugTracingOptions::default()
+                    .with_tracer(GethDebugTracerType::from(GethDebugBuiltInTracerType::CallTracer))
+                    .with_call_config(CallConfig::default().with_log()),
+            );
+            // Honour the same state / block overrides as the local `--trace` path.
+            if let Some(state_overrides) = state_overrides {
+                call_options = call_options.with_state_overrides(state_overrides);
+            }
+            if let Some(block_overrides) = block_overrides {
+                call_options = call_options.with_block_overrides(block_overrides);
+            }
+
+            let geth_trace = provider.debug_trace_call(tx, block, call_options).await?;
+            let GethTrace::CallTracer(frame) = geth_trace else {
+                eyre::bail!(
+                    "`debug_traceCall` did not return a callTracer frame; the RPC endpoint may not \
+                     support the `callTracer`"
+                );
+            };
+
+            let success = frame.error.is_none() && frame.revert_reason.is_none();
+            let gas_used = frame.gas_used.saturating_to();
+            let arena = SparsedTraceArena {
+                arena: call_frame_to_arena(&frame),
+                ignored: Default::default(),
+            };
+            let result = TraceResult {
+                success,
+                traces: Some(vec![(TraceKind::Execution, arena)]),
+                gas_used,
+            };
+
+            let chain = alloy_chains::Chain::from_id(provider.get_chain_id().await?);
+            handle_traces(
+                result,
+                &config,
+                chain,
+                &Default::default(),
+                labels,
+                with_local_artifacts,
+                false,
+                false,
+                disable_labels,
+                None,
+                None,
+            )
+            .await?;
+
+            return Ok(());
+        }
 
         if trace {
             if let Some(BlockId::Number(BlockNumberOrTag::Number(block_number))) = self.block {
@@ -846,5 +917,33 @@ mod tests {
         assert_eq!(args.tx.nonce, Some(U64::from(42)));
         assert_eq!(args.tx.value, Some(U256::from(1000000000000000000u64)));
         assert_eq!(args.tx.blob_gas_price, Some(U256::from(10000000000u64)));
+    }
+
+    #[test]
+    fn debug_trace_call_conflicts_with_trace() {
+        let result = CallArgs::try_parse_from(["foundry-cli", "--trace", "--debug-trace-call"]);
+        assert!(result.is_err(), "--trace and --debug-trace-call must be mutually exclusive");
+    }
+
+    #[test]
+    fn debug_trace_call_rejects_local_trace_flags() {
+        for flag in ["--debug", "--decode-internal"] {
+            let result = CallArgs::try_parse_from([
+                "foundry-cli",
+                "--debug-trace-call",
+                "0xDeaDBeeFcAfEbAbEfAcEfEeDcBaDbEeFcAfEbAbE",
+                flag,
+            ]);
+            assert!(result.is_err(), "--debug-trace-call must reject {flag}");
+        }
+        // --evm-version takes a value, so it is checked separately from the boolean flags above.
+        let result = CallArgs::try_parse_from([
+            "foundry-cli",
+            "--debug-trace-call",
+            "0xDeaDBeeFcAfEbAbEfAcEfEeDcBaDbEeFcAfEbAbE",
+            "--evm-version",
+            "shanghai",
+        ]);
+        assert!(result.is_err(), "--debug-trace-call must reject --evm-version");
     }
 }

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -631,17 +631,22 @@ impl CallArgs {
             .unwrap_or(serde_json::json!("latest"));
 
         // `--debug-trace-call` fetches a callTracer trace of the call instead of executing it,
-        // so the curl payload must target `debug_traceCall` with the same tracer options as the
-        // non-curl path.
+        // so the curl payload must target `debug_traceCall` with the same third param as the
+        // non-curl path: the tracer options plus any state / block overrides, so the printed
+        // request traces the same state as the command it represents.
         let (method, params) = if self.debug_trace_call {
-            (
-                "debug_traceCall",
-                serde_json::json!([
-                    call_object,
-                    block_param,
-                    { "tracer": "callTracer", "tracerConfig": { "withLog": true } }
-                ]),
-            )
+            let mut call_options = GethDebugTracingCallOptions::default().with_tracing_options(
+                GethDebugTracingOptions::default()
+                    .with_tracer(GethDebugTracerType::from(GethDebugBuiltInTracerType::CallTracer))
+                    .with_call_config(CallConfig::default().with_log()),
+            );
+            if let Some(state_overrides) = self.get_state_overrides()? {
+                call_options = call_options.with_state_overrides(state_overrides);
+            }
+            if let Some(block_overrides) = self.get_block_overrides()? {
+                call_options = call_options.with_block_overrides(block_overrides);
+            }
+            ("debug_traceCall", serde_json::json!([call_object, block_param, call_options]))
         } else {
             ("eth_call", serde_json::json!([call_object, block_param]))
         };

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -8,7 +8,10 @@ use crate::{
 };
 use alloy_ens::NameOrAddress;
 use alloy_network::{Network, NetworkTransactionBuilder, TransactionBuilder};
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256, hex, map::HashMap};
+use alloy_primitives::{
+    Address, B256, Bytes, TxKind, U256, hex,
+    map::{AddressHashMap, HashMap},
+};
 use alloy_provider::{Provider, ext::DebugApi};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, BlockOverrides,
@@ -338,6 +341,18 @@ impl CallArgs {
                     .with_tracer(GethDebugTracerType::from(GethDebugBuiltInTracerType::CallTracer))
                     .with_call_config(CallConfig::default().with_log()),
             );
+            // A contract that only exists through a `--override-code` entry has no on-chain
+            // code to fetch for local-artifact matching, so remember the override code before
+            // handing the overrides to `debug_traceCall`.
+            let mut override_bytecode = AddressHashMap::<Bytes>::default();
+            if with_local_artifacts && let Some(overrides) = &state_overrides {
+                for (address, account) in overrides {
+                    if let Some(code) = &account.code {
+                        override_bytecode.insert(*address, code.clone());
+                    }
+                }
+            }
+
             // Honour the same state / block overrides as the local `--trace` path.
             if let Some(state_overrides) = state_overrides {
                 call_options = call_options.with_state_overrides(state_overrides);
@@ -408,7 +423,12 @@ impl CallArgs {
             // over RPC for the addresses in the trace. Skip the extra round-trips unless
             // local artifacts were requested.
             let contracts_bytecode = if with_local_artifacts {
-                fetch_contracts_bytecode_via_rpc(&provider, &result, block).await?
+                let mut contracts_bytecode =
+                    fetch_contracts_bytecode_via_rpc(&provider, &result, block).await?;
+                // The trace ran the override code, not the on-chain code, so the override
+                // wins for artifact matching.
+                contracts_bytecode.extend(override_bytecode);
+                contracts_bytecode
             } else {
                 Default::default()
             };
@@ -610,11 +630,25 @@ impl CallArgs {
             .map(|b| serde_json::to_value(b).unwrap_or(serde_json::json!("latest")))
             .unwrap_or(serde_json::json!("latest"));
 
-        let params = serde_json::json!([call_object, block_param]);
+        // `--debug-trace-call` fetches a callTracer trace of the call instead of executing it,
+        // so the curl payload must target `debug_traceCall` with the same tracer options as the
+        // non-curl path.
+        let (method, params) = if self.debug_trace_call {
+            (
+                "debug_traceCall",
+                serde_json::json!([
+                    call_object,
+                    block_param,
+                    { "tracer": "callTracer", "tracerConfig": { "withLog": true } }
+                ]),
+            )
+        } else {
+            ("eth_call", serde_json::json!([call_object, block_param]))
+        };
 
         let curl_cmd = generate_curl_command(
             url.as_ref(),
-            "eth_call",
+            method,
             params,
             config.eth_rpc_headers.as_deref(),
             jwt.as_deref(),

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -5,14 +5,14 @@ use crate::{
 use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
 
 use alloy_evm::FromRecoveredTx;
-use alloy_network::{BlockResponse, TransactionResponse};
+use alloy_network::{BlockResponse, Network, TransactionResponse};
 use alloy_primitives::{
     Address, B256, Bytes, U256,
     map::{AddressHashMap, AddressSet},
 };
 use alloy_provider::{Provider, ext::DebugApi};
 use alloy_rpc_types::{
-    BlockTransactions,
+    BlockId, BlockTransactions,
     trace::geth::{GethDebugTracingOptions, PreStateConfig},
 };
 use clap::Parser;
@@ -445,6 +445,33 @@ pub fn fetch_contracts_bytecode_from_trace<FEN: FoundryEvmNetwork>(
             }
             Some((addr, code))
         }));
+    }
+    Ok(contracts_bytecode)
+}
+
+/// Fetches the runtime bytecode of the addresses seen in `result` over RPC.
+///
+/// The RPC trace path (`cast call --debug-trace-call`) has no local executor to read code
+/// from, so the bytecode needed to match local artifacts is fetched from the node with
+/// `eth_getCode`. Addresses whose code cannot be fetched are skipped with a warning.
+pub async fn fetch_contracts_bytecode_via_rpc<N: Network, P: Provider<N>>(
+    provider: &P,
+    result: &TraceResult,
+    block: BlockId,
+) -> Result<AddressHashMap<Bytes>> {
+    let mut contracts_bytecode = AddressHashMap::default();
+    if let Some(ref traces) = result.traces {
+        for addr in gather_trace_addresses(traces) {
+            match provider.get_code_at(addr).block_id(block).await {
+                Ok(code) if !code.is_empty() => {
+                    contracts_bytecode.insert(addr, code);
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    let _ = sh_warn!("Failed to fetch code for {addr}: {err}");
+                }
+            }
+        }
     }
     Ok(contracts_bytecode)
 }

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -31,7 +31,8 @@ pub(crate) async fn handle_traces(
     tempo_hardfork: Option<TempoHardfork>,
 ) -> eyre::Result<()> {
     let (known_contracts, mut sources) = if with_local_artifacts {
-        let _ = sh_println!("Compiling project to generate artifacts");
+        // Status prose goes to stderr so `--json` output on stdout stays machine-readable.
+        let _ = sh_status!("Compiling project to generate artifacts");
         let project = config.project()?;
         let compiler = ProjectCompiler::new();
         let output = compiler.compile(&project)?;

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -71,6 +71,7 @@ pub mod call_spec;
 pub(crate) mod debug;
 pub mod errors;
 mod rlp_converter;
+pub mod rpc_trace;
 pub mod tx;
 
 use rlp_converter::Item;

--- a/crates/cast/src/rpc_trace.rs
+++ b/crates/cast/src/rpc_trace.rs
@@ -174,7 +174,7 @@ fn call_log(log: &CallLogFrame) -> CallLog {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{U256, address, b256, bytes};
+    use alloy_primitives::{address, b256, bytes};
 
     /// A geth `callTracer` `SELFDESTRUCT` frame encodes `from` as the destructed contract, `to` as
     /// the refund target and `value` as the transferred balance (the inverse of

--- a/crates/cast/src/rpc_trace.rs
+++ b/crates/cast/src/rpc_trace.rs
@@ -1,0 +1,313 @@
+//! Conversion from geth `callTracer` output into a [`CallTraceArena`].
+//!
+//! This lets traces fetched over RPC (via `debug_traceCall` / `debug_traceTransaction` with the
+//! `callTracer`) be decoded and rendered with the same machinery used for locally executed traces.
+//! `callTracer` does not record opcode-level steps, so [`CallTrace::steps`] is left empty;
+//! everything the call-tree view needs (calls, value, gas, logs, revert reasons) is preserved.
+
+use alloy_primitives::LogData;
+use alloy_rpc_types::trace::geth::{CallFrame, CallLogFrame};
+use foundry_evm::traces::{
+    CallKind, CallLog, CallTrace, CallTraceArena, CallTraceNode, TraceMemberOrder,
+};
+use revm::interpreter::InstructionResult;
+
+/// Builds a [`CallTraceArena`] from a geth `callTracer` [`CallFrame`] tree.
+pub fn call_frame_to_arena(root: &CallFrame) -> CallTraceArena {
+    let mut arena = CallTraceArena::default();
+    let nodes = arena.nodes_mut();
+    nodes.clear();
+    push_frame(nodes, root, None, 0);
+    arena
+}
+
+/// Pushes `frame` and all of its children into `nodes`, returning the index of the pushed node.
+fn push_frame(
+    nodes: &mut Vec<CallTraceNode>,
+    frame: &CallFrame,
+    parent: Option<usize>,
+    depth: usize,
+) -> usize {
+    let idx = nodes.len();
+
+    let success = frame.error.is_none() && frame.revert_reason.is_none();
+    let status = Some(status_from_frame(frame));
+
+    let trace = CallTrace {
+        depth,
+        success,
+        caller: frame.from,
+        address: frame.to.unwrap_or_default(),
+        maybe_precompile: None,
+        selfdestruct_address: None,
+        selfdestruct_refund_target: None,
+        selfdestruct_transferred_value: None,
+        kind: call_kind(&frame.typ),
+        value: frame.value.unwrap_or_default(),
+        data: frame.input.clone(),
+        output: frame.output.clone().unwrap_or_default(),
+        gas_used: frame.gas_used.saturating_to(),
+        gas_limit: frame.gas.saturating_to(),
+        gas_refund_counter: 0,
+        status,
+        steps: Vec::new(),
+        decoded: None,
+    };
+
+    let logs = frame.logs.iter().map(call_log).collect::<Vec<_>>();
+
+    nodes.push(CallTraceNode {
+        parent,
+        children: Vec::new(),
+        idx,
+        trace,
+        logs,
+        ordering: Vec::new(),
+    });
+
+    let mut children = Vec::with_capacity(frame.calls.len());
+    for child in &frame.calls {
+        children.push(push_frame(nodes, child, Some(idx), depth + 1));
+    }
+
+    // Reconstruct the interleaving of logs and child calls in linear time. A log's `position` is
+    // the number of child calls emitted before it, so bucketing the logs by position places each
+    // one after that many calls. `TraceMemberOrder::Call`/`Log` index into the node's local
+    // `children`/`logs` vectors. A position past the last call is clamped to the end so the log is
+    // never dropped.
+    let num_calls = children.len();
+    let mut logs_by_position: Vec<Vec<usize>> = vec![Vec::new(); num_calls + 1];
+    for (li, log) in frame.logs.iter().enumerate() {
+        let position = (log.position.unwrap_or(0) as usize).min(num_calls);
+        logs_by_position[position].push(li);
+    }
+    let mut ordering = Vec::with_capacity(num_calls + frame.logs.len());
+    for (i, logs_at_position) in logs_by_position.iter().enumerate() {
+        for &li in logs_at_position {
+            ordering.push(TraceMemberOrder::Log(li));
+        }
+        if i < num_calls {
+            ordering.push(TraceMemberOrder::Call(i));
+        }
+    }
+
+    nodes[idx].children = children;
+    nodes[idx].ordering = ordering;
+    idx
+}
+
+/// Maps a `callTracer` frame to the [`InstructionResult`] used for the rendered `[status]` label.
+///
+/// `callTracer` only exposes a coarse, human-readable `error` string (plus an optional
+/// `revert_reason`), not a machine status code, so we recognise the two halts geth and reth report
+/// reliably (an explicit revert and running out of gas) and fall back to
+/// [`InstructionResult::Revert`] for anything else. The frame's `output` / `revert_reason` still
+/// carries the decoded message, and the call is coloured by [`CallTrace::success`], so an imperfect
+/// status never hides a failure.
+fn status_from_frame(frame: &CallFrame) -> InstructionResult {
+    if frame.error.is_none() && frame.revert_reason.is_none() {
+        return InstructionResult::Return;
+    }
+    if frame.revert_reason.is_some() {
+        return InstructionResult::Revert;
+    }
+    match frame.error.as_deref() {
+        Some(err) if err.contains("out of gas") => InstructionResult::OutOfGas,
+        // "execution reverted" and any other unclassified halt render as a revert.
+        _ => InstructionResult::Revert,
+    }
+}
+
+/// Maps a geth `callTracer` call type string to a [`CallKind`].
+fn call_kind(typ: &str) -> CallKind {
+    match typ {
+        "STATICCALL" => CallKind::StaticCall,
+        "DELEGATECALL" => CallKind::DelegateCall,
+        "CALLCODE" => CallKind::CallCode,
+        "AUTHCALL" => CallKind::AuthCall,
+        "CREATE" => CallKind::Create,
+        "CREATE2" => CallKind::Create2,
+        // "CALL", "SELFDESTRUCT" and anything unknown render as a plain call.
+        _ => CallKind::Call,
+    }
+}
+
+/// Maps a geth `callTracer` log frame to a [`CallLog`].
+fn call_log(log: &CallLogFrame) -> CallLog {
+    CallLog {
+        address: log.address.unwrap_or_default(),
+        raw_log: LogData::new_unchecked(
+            log.topics.clone().unwrap_or_default(),
+            log.data.clone().unwrap_or_default(),
+        ),
+        decoded: None,
+        position: log.position.unwrap_or_default(),
+        index: log.index.unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{U256, address, b256, bytes};
+
+    /// A nested `callTracer` frame (root CALL -> child STATICCALL) with a log on the root,
+    /// mirroring a real `debug_traceCall` response, must convert into a well-formed two-node
+    /// arena.
+    #[test]
+    fn converts_nested_call_frame() {
+        let frame = CallFrame {
+            from: address!("1111111111111111111111111111111111111111"),
+            to: Some(address!("2222222222222222222222222222222222222222")),
+            gas: U256::from(100_000u64),
+            gas_used: U256::from(21_000u64),
+            input: bytes!("dead"),
+            output: Some(bytes!("beef")),
+            value: Some(U256::from(7u64)),
+            typ: "CALL".to_string(),
+            logs: vec![CallLogFrame {
+                address: Some(address!("2222222222222222222222222222222222222222")),
+                topics: Some(vec![]),
+                data: Some(bytes!("00")),
+                position: Some(1),
+                index: Some(0),
+            }],
+            calls: vec![CallFrame {
+                from: address!("2222222222222222222222222222222222222222"),
+                to: Some(address!("3333333333333333333333333333333333333333")),
+                gas: U256::from(50_000u64),
+                gas_used: U256::from(5_000u64),
+                input: bytes!("cafe"),
+                typ: "STATICCALL".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let arena = call_frame_to_arena(&frame);
+        let nodes = arena.nodes();
+        assert_eq!(nodes.len(), 2, "root + one child");
+
+        let root = &nodes[0];
+        assert_eq!(root.parent, None);
+        assert_eq!(root.children, vec![1]);
+        assert_eq!(root.trace.kind, CallKind::Call);
+        assert_eq!(root.trace.caller, frame.from);
+        assert_eq!(root.trace.value, U256::from(7u64));
+        assert_eq!(root.trace.gas_used, 21_000);
+        assert!(root.trace.success);
+        assert_eq!(root.logs.len(), 1);
+
+        // The log has position 1, so it must be ordered after the single child call.
+        assert_eq!(root.ordering, vec![TraceMemberOrder::Call(0), TraceMemberOrder::Log(0)]);
+
+        let child = &nodes[1];
+        assert_eq!(child.parent, Some(0));
+        assert_eq!(child.trace.depth, 1);
+        assert_eq!(child.trace.kind, CallKind::StaticCall);
+    }
+
+    /// `callTracer` error strings must map onto the status used for the rendered `[status]` label:
+    /// a clean call returns, an explicit revert and a `revert_reason` map to `Revert`, an
+    /// out-of-gas halt maps to `OutOfGas`, and any other halt falls back to `Revert`.
+    #[test]
+    fn maps_frame_status() {
+        let ok = CallFrame { typ: "CALL".to_string(), ..Default::default() };
+        assert_eq!(status_from_frame(&ok), InstructionResult::Return);
+
+        let reverted = CallFrame {
+            typ: "CALL".to_string(),
+            error: Some("execution reverted".to_string()),
+            revert_reason: Some("boom".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(status_from_frame(&reverted), InstructionResult::Revert);
+
+        let oog = CallFrame {
+            typ: "CALL".to_string(),
+            error: Some("out of gas".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(status_from_frame(&oog), InstructionResult::OutOfGas);
+
+        let other = CallFrame {
+            typ: "CALL".to_string(),
+            error: Some("invalid opcode: opcode 0xfe not defined".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(status_from_frame(&other), InstructionResult::Revert);
+    }
+
+    /// A log whose `position` points past the last child call must be clamped to the end rather
+    /// than dropped, and a `position` of zero must order the log before the first call.
+    #[test]
+    fn clamps_out_of_range_log_position() {
+        let frame = CallFrame {
+            from: address!("1111111111111111111111111111111111111111"),
+            to: Some(address!("2222222222222222222222222222222222222222")),
+            typ: "CALL".to_string(),
+            logs: vec![
+                CallLogFrame { position: Some(0), index: Some(0), ..Default::default() },
+                CallLogFrame { position: Some(5), index: Some(1), ..Default::default() },
+            ],
+            calls: vec![CallFrame { typ: "CALL".to_string(), ..Default::default() }],
+            ..Default::default()
+        };
+
+        let arena = call_frame_to_arena(&frame);
+        let root = &arena.nodes()[0];
+
+        assert_eq!(root.logs.len(), 2, "no log dropped");
+        // position 0 -> before the only call; position 5 -> clamped to after it.
+        assert_eq!(
+            root.ordering,
+            vec![TraceMemberOrder::Log(0), TraceMemberOrder::Call(0), TraceMemberOrder::Log(1),]
+        );
+    }
+
+    /// `call_kind` must map every geth `callTracer` call-type string to the right `CallKind`, and
+    /// treat anything unknown as a plain call. The conversion tests only exercise
+    /// `CALL`/`STATICCALL`, so a swapped or dropped arm would otherwise go unnoticed.
+    #[test]
+    fn maps_call_kind() {
+        assert_eq!(call_kind("CALL"), CallKind::Call);
+        assert_eq!(call_kind("STATICCALL"), CallKind::StaticCall);
+        assert_eq!(call_kind("DELEGATECALL"), CallKind::DelegateCall);
+        assert_eq!(call_kind("CALLCODE"), CallKind::CallCode);
+        assert_eq!(call_kind("AUTHCALL"), CallKind::AuthCall);
+        assert_eq!(call_kind("CREATE"), CallKind::Create);
+        assert_eq!(call_kind("CREATE2"), CallKind::Create2);
+        // "SELFDESTRUCT" and any unknown type render as a plain call.
+        assert_eq!(call_kind("SELFDESTRUCT"), CallKind::Call);
+        assert_eq!(call_kind("NOT_A_REAL_TYPE"), CallKind::Call);
+    }
+
+    /// `call_log` must map each `callTracer` log field to the right place. Distinct topics, data,
+    /// position and index catch a swapped or dropped field (e.g. topics/data or position/index).
+    #[test]
+    fn maps_call_log_fields() {
+        let frame_log = CallLogFrame {
+            address: Some(address!("3333333333333333333333333333333333333333")),
+            topics: Some(vec![
+                b256!("0x00000000000000000000000000000000000000000000000000000000000000aa"),
+                b256!("0x00000000000000000000000000000000000000000000000000000000000000bb"),
+            ]),
+            data: Some(bytes!("dead")),
+            position: Some(2),
+            index: Some(5),
+        };
+
+        let log = call_log(&frame_log);
+        assert_eq!(log.address, address!("3333333333333333333333333333333333333333"));
+        assert_eq!(
+            log.raw_log.topics(),
+            &[
+                b256!("0x00000000000000000000000000000000000000000000000000000000000000aa"),
+                b256!("0x00000000000000000000000000000000000000000000000000000000000000bb"),
+            ]
+        );
+        assert_eq!(log.raw_log.data, bytes!("dead"));
+        assert_eq!(log.position, 2);
+        assert_eq!(log.index, 5);
+    }
+}

--- a/crates/cast/src/rpc_trace.rs
+++ b/crates/cast/src/rpc_trace.rs
@@ -5,7 +5,7 @@
 //! `callTracer` does not record opcode-level steps, so [`CallTrace::steps`] is left empty;
 //! everything the call-tree view needs (calls, value, gas, logs, revert reasons) is preserved.
 
-use alloy_primitives::{Bytes, LogData};
+use alloy_primitives::{Bytes, LogData, U256};
 use alloy_rpc_types::trace::geth::{CallFrame, CallLogFrame};
 use foundry_evm::traces::{
     CallKind, CallLog, CallTrace, CallTraceArena, CallTraceNode, TraceMemberOrder,
@@ -31,7 +31,20 @@ fn push_frame(
     let idx = nodes.len();
 
     let success = frame.error.is_none() && frame.revert_reason.is_none();
-    let status = Some(status_from_frame(frame));
+
+    // A `SELFDESTRUCT` frame is not an ordinary call: geth encodes `from` as the destructed
+    // contract, `to` as the refund target and `value` as the transferred balance (the inverse of
+    // `CallTraceNode::geth_selfdestruct_call_trace`). Mirror the local trace representation, which
+    // records the selfdestruct through the dedicated fields and an
+    // `InstructionResult::SelfDestruct` status, so the destructed contract (not the
+    // beneficiary) is identified and `is_selfdestruct` holds. The transferred balance lives in
+    // `selfdestruct_transferred_value`, so the call `value` stays zero.
+    let is_selfdestruct = frame.typ == "SELFDESTRUCT";
+    let status = if is_selfdestruct {
+        Some(InstructionResult::SelfDestruct)
+    } else {
+        Some(status_from_frame(frame))
+    };
 
     // `callTracer` reports an unclassified halt (invalid opcode, a provider-specific quirk) only in
     // the `error` string. When the frame failed but returned no data, surface that string (or the
@@ -49,13 +62,13 @@ fn push_frame(
         depth,
         success,
         caller: frame.from,
-        address: frame.to.unwrap_or_default(),
+        address: if is_selfdestruct { frame.from } else { frame.to.unwrap_or_default() },
         maybe_precompile: None,
-        selfdestruct_address: None,
-        selfdestruct_refund_target: None,
-        selfdestruct_transferred_value: None,
+        selfdestruct_address: is_selfdestruct.then_some(frame.from),
+        selfdestruct_refund_target: if is_selfdestruct { frame.to } else { None },
+        selfdestruct_transferred_value: if is_selfdestruct { frame.value } else { None },
         kind: call_kind(&frame.typ),
-        value: frame.value.unwrap_or_default(),
+        value: if is_selfdestruct { U256::ZERO } else { frame.value.unwrap_or_default() },
         data: frame.input.clone(),
         output,
         gas_used: frame.gas_used.saturating_to(),
@@ -162,6 +175,35 @@ fn call_log(log: &CallLogFrame) -> CallLog {
 mod tests {
     use super::*;
     use alloy_primitives::{U256, address, b256, bytes};
+
+    /// A geth `callTracer` `SELFDESTRUCT` frame encodes `from` as the destructed contract, `to` as
+    /// the refund target and `value` as the transferred balance (the inverse of
+    /// `CallTraceNode::geth_selfdestruct_call_trace`). It must convert into a node that identifies
+    /// the destructed contract (not the beneficiary) and carries the selfdestruct fields, so
+    /// `is_selfdestruct()` holds and the status renders as `[SelfDestruct]`.
+    #[test]
+    fn converts_selfdestruct_frame() {
+        let destructed = address!("1111111111111111111111111111111111111111");
+        let beneficiary = address!("2222222222222222222222222222222222222222");
+        let frame = CallFrame {
+            from: destructed,
+            to: Some(beneficiary),
+            value: Some(U256::from(9u64)),
+            typ: "SELFDESTRUCT".to_string(),
+            ..Default::default()
+        };
+
+        let arena = call_frame_to_arena(&frame);
+        let trace = &arena.nodes()[0].trace;
+
+        // The destructed contract is the identified address, not the refund target.
+        assert_eq!(trace.address, destructed);
+        assert_eq!(trace.selfdestruct_address, Some(destructed));
+        assert_eq!(trace.selfdestruct_refund_target, Some(beneficiary));
+        assert_eq!(trace.selfdestruct_transferred_value, Some(U256::from(9u64)));
+        assert_eq!(trace.status, Some(InstructionResult::SelfDestruct));
+        assert!(trace.is_selfdestruct());
+    }
 
     /// A nested `callTracer` frame (root CALL -> child STATICCALL) with a log on the root,
     /// mirroring a real `debug_traceCall` response, must convert into a well-formed two-node

--- a/crates/cast/src/rpc_trace.rs
+++ b/crates/cast/src/rpc_trace.rs
@@ -5,7 +5,7 @@
 //! `callTracer` does not record opcode-level steps, so [`CallTrace::steps`] is left empty;
 //! everything the call-tree view needs (calls, value, gas, logs, revert reasons) is preserved.
 
-use alloy_primitives::LogData;
+use alloy_primitives::{Bytes, LogData};
 use alloy_rpc_types::trace::geth::{CallFrame, CallLogFrame};
 use foundry_evm::traces::{
     CallKind, CallLog, CallTrace, CallTraceArena, CallTraceNode, TraceMemberOrder,
@@ -33,6 +33,18 @@ fn push_frame(
     let success = frame.error.is_none() && frame.revert_reason.is_none();
     let status = Some(status_from_frame(frame));
 
+    // `callTracer` reports an unclassified halt (invalid opcode, a provider-specific quirk) only in
+    // the `error` string. When the frame failed but returned no data, surface that string (or the
+    // decoded `revert_reason`, preferred) as the output so the renderer shows it instead of a
+    // coarse `EvmError: Revert`.
+    let mut output = frame.output.clone().unwrap_or_default();
+    if output.is_empty()
+        && !success
+        && let Some(text) = frame.revert_reason.as_deref().or(frame.error.as_deref())
+    {
+        output = Bytes::copy_from_slice(text.as_bytes());
+    }
+
     let trace = CallTrace {
         depth,
         success,
@@ -45,7 +57,7 @@ fn push_frame(
         kind: call_kind(&frame.typ),
         value: frame.value.unwrap_or_default(),
         data: frame.input.clone(),
-        output: frame.output.clone().unwrap_or_default(),
+        output,
         gas_used: frame.gas_used.saturating_to(),
         gas_limit: frame.gas.saturating_to(),
         gas_refund_counter: 0,
@@ -101,9 +113,9 @@ fn push_frame(
 /// `callTracer` only exposes a coarse, human-readable `error` string (plus an optional
 /// `revert_reason`), not a machine status code, so we recognise the two halts geth and reth report
 /// reliably (an explicit revert and running out of gas) and fall back to
-/// [`InstructionResult::Revert`] for anything else. The frame's `output` / `revert_reason` still
-/// carries the decoded message, and the call is coloured by [`CallTrace::success`], so an imperfect
-/// status never hides a failure.
+/// [`InstructionResult::Revert`] for anything else. `push_frame` preserves the frame's `error` /
+/// `revert_reason` text in the trace output, and the call is coloured by [`CallTrace::success`], so
+/// an imperfect status never hides a failure or the original error message.
 fn status_from_frame(frame: &CallFrame) -> InstructionResult {
     if frame.error.is_none() && frame.revert_reason.is_none() {
         return InstructionResult::Return;
@@ -238,6 +250,29 @@ mod tests {
         assert_eq!(status_from_frame(&other), InstructionResult::Revert);
     }
 
+    /// An unclassified halt with no return data (e.g. an invalid opcode) must keep its original
+    /// `error` string as the trace output, so the renderer surfaces it instead of a coarse
+    /// `EvmError: Revert`.
+    #[test]
+    fn surfaces_error_string_in_output() {
+        let frame = CallFrame {
+            from: address!("1111111111111111111111111111111111111111"),
+            to: Some(address!("2222222222222222222222222222222222222222")),
+            typ: "CALL".to_string(),
+            error: Some("invalid opcode: opcode 0xfe not defined".to_string()),
+            ..Default::default()
+        };
+
+        let arena = call_frame_to_arena(&frame);
+        let root = &arena.nodes()[0];
+
+        assert!(!root.trace.success);
+        assert_eq!(
+            core::str::from_utf8(&root.trace.output[..]).unwrap(),
+            "invalid opcode: opcode 0xfe not defined"
+        );
+    }
+
     /// A log whose `position` points past the last child call must be clamped to the end rather
     /// than dropped, and a `position` of zero must order the log before the first call.
     #[test]
@@ -262,6 +297,35 @@ mod tests {
         assert_eq!(
             root.ordering,
             vec![TraceMemberOrder::Log(0), TraceMemberOrder::Call(0), TraceMemberOrder::Log(1),]
+        );
+    }
+
+    /// A log whose `position` falls strictly between two child calls must be ordered between them.
+    /// The single-child cases above only exercise before-first and after-last, so an off-by-one in
+    /// the `Call(i)` / `Log(li)` indexing would otherwise go unnoticed.
+    #[test]
+    fn orders_log_between_two_children() {
+        let frame = CallFrame {
+            from: address!("1111111111111111111111111111111111111111"),
+            to: Some(address!("2222222222222222222222222222222222222222")),
+            typ: "CALL".to_string(),
+            // position 1 -> one child emitted before the log, so it lands between the two children.
+            logs: vec![CallLogFrame { position: Some(1), index: Some(0), ..Default::default() }],
+            calls: vec![
+                CallFrame { typ: "CALL".to_string(), ..Default::default() },
+                CallFrame { typ: "CALL".to_string(), ..Default::default() },
+            ],
+            ..Default::default()
+        };
+
+        let arena = call_frame_to_arena(&frame);
+        let root = &arena.nodes()[0];
+
+        assert_eq!(arena.nodes().len(), 3, "root + two children");
+        assert_eq!(root.children, vec![1, 2]);
+        assert_eq!(
+            root.ordering,
+            vec![TraceMemberOrder::Call(0), TraceMemberOrder::Log(0), TraceMemberOrder::Call(1),]
         );
     }
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -6016,6 +6016,39 @@ casttest!(curl_call_debug_trace_call, |_prj, cmd| {
     assert!(!output.contains("eth_call"), "unexpected eth_call request:\n{output}");
 });
 
+// tests that `--debug-trace-call --curl` forwards state and block overrides in the request,
+// like the non-curl path does, so the printed request traces the same state
+casttest!(curl_call_debug_trace_call_forwards_overrides, |_prj, cmd| {
+    let rpc = "https://eth.example.com";
+    let to = "0xdead000000000000000000000000000000000000";
+
+    let output = cmd
+        .args([
+            "call",
+            to,
+            "number()(uint256)",
+            "--rpc-url",
+            rpc,
+            "--debug-trace-call",
+            "--override-code",
+            "0x00000000000000000000000000000000000000aa:0x60005460005260206000f3",
+            "--block.number",
+            "1234",
+            "--curl",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(output.contains("debug_traceCall"), "expected debug_traceCall method:\n{output}");
+    assert!(output.contains("stateOverrides"), "expected state overrides in params:\n{output}");
+    assert!(
+        output.contains("0x60005460005260206000f3"),
+        "expected the override code in params:\n{output}"
+    );
+    assert!(output.contains("blockOverrides"), "expected block overrides in params:\n{output}");
+});
+
 // tests that the --jwt-secret flag outputs a valid curl command with Authorization header
 casttest!(curl_rpc_with_jwt, |_prj, cmd| {
     let rpc = "https://eth.example.com";

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3714,7 +3714,6 @@ contract LocalProjectScript is Script {
         .args(["run", "--la", format!("{tx_hash}").as_str(), "--rpc-url", &handle.http_endpoint()])
         .assert_success()
         .stdout_eq(str![[r#"
-Compiling project to generate artifacts
 Nothing to compile
 
 "#]])
@@ -3756,7 +3755,6 @@ Executing previous transactions from the block.
         .args(["run", "--la", format!("{tx_hash}").as_str(), "--rpc-url", &handle.http_endpoint()])
         .assert_success()
         .stdout_eq(str![[r#"
-Compiling project to generate artifacts
 No files changed, compilation skipped
 Traces:
   [..] → new LocalProjectContract@0x5FbDB2315678afecb367f032d93F642f64180aa3
@@ -4379,7 +4377,6 @@ forgetest_async!(cast_call_debug_trace_call_with_local_artifacts, |prj, cmd| {
     ])
     .assert_success()
     .stdout_eq(str![[r#"
-Compiling project to generate artifacts
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
@@ -4392,6 +4389,108 @@ Transaction successfully executed.
 [GAS]
 
 "#]]);
+});
+
+// `--debug-trace-call --with-local-artifacts` must label a contract that only exists through a
+// `--override-code` state override: the trace runs the override code, so artifact matching must
+// see that code instead of the (empty) on-chain code.
+forgetest_async!(cast_call_debug_trace_call_override_code_local_artifacts, |prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    foundry_test_utils::util::initialize(prj.root());
+    prj.initialize_default_contracts();
+
+    // Deploy counter contract, only to read its runtime bytecode back.
+    cmd.args([
+        "script",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "--rpc-url",
+        &handle.http_endpoint(),
+        "--broadcast",
+        "CounterScript",
+    ])
+    .assert_success();
+
+    let runtime_code = cmd
+        .cast_fuse()
+        .args([
+            "code",
+            "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy()
+        .trim()
+        .to_string();
+
+    // Call an address that has no code on chain, overriding it with Counter's runtime code.
+    cmd.cast_fuse();
+    cmd.set_current_dir(prj.root());
+    let output = cmd
+        .args([
+            "call",
+            "0x00000000000000000000000000000000000000aa",
+            "number()(uint256)",
+            "--debug-trace-call",
+            "--with-local-artifacts",
+            "--override-code",
+            &format!("0x00000000000000000000000000000000000000aa:{runtime_code}"),
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(
+        output.contains("Counter::number()"),
+        "expected the override-code contract to be labeled from local artifacts:\n{output}"
+    );
+});
+
+// `--json --debug-trace-call --with-local-artifacts` must keep stdout machine-readable: the
+// compile banner/progress goes to stderr, so stdout is exactly one JSON document.
+forgetest_async!(cast_call_debug_trace_call_local_artifacts_json_stdout, |prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    foundry_test_utils::util::initialize(prj.root());
+    prj.initialize_default_contracts();
+
+    // Deploy counter contract.
+    cmd.args([
+        "script",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "--rpc-url",
+        &handle.http_endpoint(),
+        "--broadcast",
+        "CounterScript",
+    ])
+    .assert_success();
+
+    cmd.cast_fuse();
+    cmd.set_current_dir(prj.root());
+    let output = cmd
+        .args([
+            "call",
+            "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+            "number()(uint256)",
+            "--debug-trace-call",
+            "--with-local-artifacts",
+            "--json",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    serde_json::from_str::<serde_json::Value>(output.trim()).unwrap_or_else(|err| {
+        panic!("expected stdout to be a single JSON document ({err}):\n{output}")
+    });
 });
 
 forgetest_async!(cast_call_custom_override, |prj, cmd| {
@@ -5895,6 +5994,26 @@ casttest!(curl_call_with_jwt, |_prj, cmd| {
         .expect("malformed Authorization header");
     let secret = JwtSecret::from_hex(jwt_secret).unwrap();
     secret.validate(jwt).unwrap();
+});
+
+// tests that `--debug-trace-call --curl` emits a `debug_traceCall` request with the
+// callTracer, not a plain `eth_call`
+casttest!(curl_call_debug_trace_call, |_prj, cmd| {
+    let rpc = "https://eth.example.com";
+    let to = "0xdead000000000000000000000000000000000000";
+
+    let output = cmd
+        .args(["call", to, "number()(uint256)", "--rpc-url", rpc, "--debug-trace-call", "--curl"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    // Verify curl command structure
+    assert!(output.contains("curl -X POST"));
+    assert!(output.contains(rpc));
+    assert!(output.contains("debug_traceCall"), "expected debug_traceCall method:\n{output}");
+    assert!(output.contains("callTracer"), "expected callTracer tracer param:\n{output}");
+    assert!(!output.contains("eth_call"), "unexpected eth_call request:\n{output}");
 });
 
 // tests that the --jwt-secret flag outputs a valid curl command with Authorization header

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -6049,6 +6049,86 @@ casttest!(curl_call_debug_trace_call_forwards_overrides, |_prj, cmd| {
     assert!(output.contains("blockOverrides"), "expected block overrides in params:\n{output}");
 });
 
+// tests that `--curl` forwards the scalar transaction fields into the call object, so the
+// printed request runs the same call as the non-curl command
+casttest!(curl_call_debug_trace_call_forwards_tx_fields, |_prj, cmd| {
+    let rpc = "https://eth.example.com";
+    let to = "0xdead000000000000000000000000000000000000";
+
+    let output = cmd
+        .args([
+            "call",
+            to,
+            "number()(uint256)",
+            "--rpc-url",
+            rpc,
+            "--debug-trace-call",
+            "--from",
+            "0x000000000000000000000000000000000000beef",
+            "--value",
+            "1ether",
+            "--gas-limit",
+            "12345",
+            "--nonce",
+            "7",
+            "--curl",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(output.contains("debug_traceCall"), "expected debug_traceCall method:\n{output}");
+    assert!(
+        output.contains("0x000000000000000000000000000000000000beef"),
+        "expected the from address in params:\n{output}"
+    );
+    assert!(
+        output.contains("0xde0b6b3a7640000"),
+        "expected the value (1 ether) in params:\n{output}"
+    );
+    assert!(output.contains("0x3039"), "expected the gas limit (12345) in params:\n{output}");
+    assert!(output.contains("nonce"), "expected the nonce in params:\n{output}");
+});
+
+// tests that `--labels` / `--disable-labels` are accepted with `--debug-trace-call`, which
+// forwards them to the trace renderer like `--trace` does
+casttest!(call_labels_accepted_with_debug_trace_call, |_prj, cmd| {
+    let rpc = "https://eth.example.com";
+    let to = "0xdead000000000000000000000000000000000000";
+
+    cmd.args([
+        "call",
+        to,
+        "number()(uint256)",
+        "--rpc-url",
+        rpc,
+        "--debug-trace-call",
+        "--labels",
+        "0xdead000000000000000000000000000000000000:Counter",
+        "--disable-labels",
+        "--curl",
+    ])
+    .assert_success();
+});
+
+// tests that `--labels` still requires one of the trace modes
+casttest!(call_labels_rejected_without_trace_mode, |_prj, cmd| {
+    let rpc = "https://eth.example.com";
+    let to = "0xdead000000000000000000000000000000000000";
+
+    cmd.args([
+        "call",
+        to,
+        "number()(uint256)",
+        "--rpc-url",
+        rpc,
+        "--labels",
+        "0xdead000000000000000000000000000000000000:Counter",
+        "--curl",
+    ])
+    .assert_failure();
+});
+
 // tests that the --jwt-secret flag outputs a valid curl command with Authorization header
 casttest!(curl_rpc_with_jwt, |_prj, cmd| {
     let rpc = "https://eth.example.com";

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4185,6 +4185,168 @@ Transaction successfully executed.
 });
 
 // https://github.com/foundry-rs/foundry/issues/10189
+// `cast call --debug-trace-call` fetches the call trace from the node via `debug_traceCall`
+// (callTracer) and renders it with the same decoding/rendering machinery as `--trace`. The call
+// targets the identity precompile so the test needs no deployed contract.
+casttest!(cast_call_debug_trace_call, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            "0x0000000000000000000000000000000000000004",
+            "--data",
+            "0xdeadbeef",
+            "--debug-trace-call",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [21160] PRECOMPILES::identity(0xdeadbeef)
+    └─ ← [Return] 0xdeadbeef
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+});
+
+// `--debug-trace-call` must honour state overrides: here we override the code of an address with a
+// tiny runtime that returns storage slot 0, and override slot 0 itself, then check the traced call
+// returns the overridden value. If the overrides were not forwarded to `debug_traceCall`, the
+// address would have no code and the return would not be the overridden value, so this test can
+// fail.
+casttest!(cast_call_debug_trace_call_applies_overrides, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            "0x00000000000000000000000000000000000000aa",
+            "number()(uint256)",
+            "--debug-trace-call",
+            // runtime: PUSH1 0 SLOAD PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+            "--override-code",
+            "0x00000000000000000000000000000000000000aa:0x60005460005260206000f3",
+            "--override-state",
+            "0x00000000000000000000000000000000000000aa:0x0:0x1234",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [23182] 0x00000000000000000000000000000000000000AA::number()
+    └─ ← [Return] 0x0000000000000000000000000000000000000000000000000000000000001234
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+});
+
+// `--debug-trace-call` must also forward block overrides: override an address with a runtime that
+// returns `block.number` and pass `--block.number`, then check the traced call returns that number.
+// If `with_block_overrides` were not forwarded to `debug_traceCall`, the call would run at anvil's
+// real block number and the return would differ, so this test can fail.
+casttest!(cast_call_debug_trace_call_applies_block_overrides, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            "0x00000000000000000000000000000000000000bb",
+            "number()(uint256)",
+            "--debug-trace-call",
+            // runtime: NUMBER PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+            "--override-code",
+            "0x00000000000000000000000000000000000000bb:0x4360005260206000f3",
+            "--block.number",
+            "1234",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [21160] 0x00000000000000000000000000000000000000bb::number()
+    └─ ← [Return] 0x00000000000000000000000000000000000000000000000000000000000004d2
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+});
+
+// `--debug-trace-call` must render a multi-node trace (a call that emits a log AND makes a
+// sub-call), exercising the log/sub-call interleaving and nesting through the real pipeline, not
+// just in the unit tests. The overridden runtime emits a LOG0 then STATICCALLs the identity
+// precompile, so the trace has a child call ordered after the log.
+casttest!(cast_call_debug_trace_call_renders_nested_call_and_log, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            "0x00000000000000000000000000000000000000cc",
+            "run()",
+            "--debug-trace-call",
+            // runtime: LOG0(0,0); STATICCALL(gas, 0x4, 0,0,0,0); POP; STOP
+            "--override-code",
+            "0x00000000000000000000000000000000000000cc:0x60006000a060006000600060007300000000000000000000000000000000000000045afa5000",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [21579] 0x00000000000000000000000000000000000000cc::run()
+    ├─           data: 0x
+    ├─ [15] PRECOMPILES::identity(0x) [staticcall]
+    │   └─ ← [Return] 0x
+    └─ ← [Return]
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+});
+
+// `--debug-trace-call` must render a reverting call as `[Revert]` (success = false), exercising
+// `status_from_frame` and the failure rendering end-to-end. The overridden runtime just reverts.
+casttest!(cast_call_debug_trace_call_renders_revert, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    cmd.cast_fuse()
+        .args([
+            "call",
+            "0x00000000000000000000000000000000000000dd",
+            "run()",
+            "--debug-trace-call",
+            // runtime: PUSH1 0 PUSH1 0 REVERT
+            "--override-code",
+            "0x00000000000000000000000000000000000000dd:0x60006000fd",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [21160] 0x00000000000000000000000000000000000000dd::run()
+    └─ ← [Revert] EvmError: Revert
+
+
+[GAS]
+
+"#]]);
+});
+
 forgetest_async!(cast_call_custom_override, |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4347,6 +4347,53 @@ Traces:
 "#]]);
 });
 
+// --debug-trace-call with --with-local-artifacts labels the called contract by its local
+// artifact name (Counter::) instead of the raw address. Without the RPC bytecode-map fetch the
+// trace falls back to the bare address, so this test can fail.
+forgetest_async!(cast_call_debug_trace_call_with_local_artifacts, |prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    foundry_test_utils::util::initialize(prj.root());
+    prj.initialize_default_contracts();
+    cmd.args([
+        "script",
+        "--private-key",
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        "--rpc-url",
+        &handle.http_endpoint(),
+        "--broadcast",
+        "CounterScript",
+    ])
+    .assert_success();
+
+    cmd.cast_fuse();
+    cmd.set_current_dir(prj.root());
+    cmd.args([
+        "call",
+        "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        "number()(uint256)",
+        "--debug-trace-call",
+        "--with-local-artifacts",
+        "--rpc-url",
+        &handle.http_endpoint(),
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+Compiling project to generate artifacts
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+Traces:
+  [23488] Counter::number()
+    └─ ← [Return] 0
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+});
+
 forgetest_async!(cast_call_custom_override, |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4339,7 +4339,7 @@ casttest!(cast_call_debug_trace_call_renders_revert, async |_prj, cmd| {
         .stdout_eq(str![[r#"
 Traces:
   [21160] 0x00000000000000000000000000000000000000dd::run()
-    └─ ← [Revert] EvmError: Revert
+    └─ ← [Revert] execution reverted
 
 
 [GAS]

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -16,10 +16,7 @@ use foundry_common::{
     shell,
 };
 use revm::bytecode::opcode::OpCode;
-use revm_inspectors::tracing::{
-    OpcodeFilter,
-    types::{DecodedTraceStep, TraceMemberOrder},
-};
+use revm_inspectors::tracing::{OpcodeFilter, types::DecodedTraceStep};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -35,7 +32,7 @@ pub use revm_inspectors::tracing::{
     TraceWriter, TracingInspector, TracingInspectorConfig,
     types::{
         CallKind, CallLog, CallTrace, CallTraceNode, DecodedCallData, DecodedCallLog,
-        DecodedCallTrace,
+        DecodedCallTrace, TraceMemberOrder,
     },
 };
 


### PR DESCRIPTION
Converts a `callTracer` response into a `CallTraceArena` so traces fetched over RPC can reuse the existing decoding and rendering, wired to `cast call --debug-trace-call`.

## Scope

A remote call-tree renderer, not a local struct-log replacement. Backed by `callTracer` with `withLog`, it preserves nested calls, value, gas, logs and revert data, but not opcode-level steps. The local-execution-only flags (`--trace`, `--debug`, `--decode-internal`, `--evm-version`) conflict with `--debug-trace-call`.

## Design decisions (after review)

- The `CallFrame -> CallTraceArena` converter stays in `cast` (`rpc_trace.rs`). `cast run` uses the prestateTracer with a local replay, so it is not a consumer of this converter; there is a single call site today. If a real second consumer lands, the converter can move to the shared traces crate then (a file relocation, no API debt), rather than pulling geth RPC types into that crate now.
- Unclassified `callTracer` errors (invalid opcode, provider quirks) keep their original message: when a frame fails with no return data, the raw `error` / `revert_reason` text is surfaced as the trace output instead of collapsing to a coarse `EvmError: Revert`.
- Precompiles are not flagged by the converter; the trace decoder already skips them by address.
- `debug_traceCall` failures map to actionable hints: `-32601` (debug namespace disabled) and missing historical/archive state are distinguished, since they need different fixes.

## Manual acceptance coverage

These callTracer response shapes vary by client and are checked manually against geth / reth / anvil rather than in unit tests:

- normal call tree with logs interleaved between child calls
- CREATE / CREATE2 frame with no `to`
- provider error with a generic code but archive/history text (missing-state hint)
- `-32601` / debug namespace disabled (method-not-found hint)

Addresses the `cast call` part of #12336.
