### PR TITLE
feat(mpp): wire T5 precompile escrow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7674,8 +7674,8 @@ dependencies = [
 
 [[package]]
 name = "mpp"
-version = "0.10.3"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=8d008eefacacf608b6ceb70636c777672fdccd88#8d008eefacacf608b6ceb70636c777672fdccd88"
+version = "0.10.4"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=c6707e3c36bc15ff449b7ce7f7773689e430f24c#c6707e3c36bc15ff449b7ce7f7773689e430f24c"
 dependencies = [
  "alloy",
  "alloy-sol-type-parser",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3050,7 +3050,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3209,7 +3209,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4271,7 +4271,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4573,7 +4573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6935,7 +6935,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7675,7 +7675,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.10.4"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=c6707e3c36bc15ff449b7ce7f7773689e430f24c#c6707e3c36bc15ff449b7ce7f7773689e430f24c"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=929cb8e77d055600dbe7ebdd65a1e7c3441ef9e6#929cb8e77d055600dbe7ebdd65a1e7c3441ef9e6"
 dependencies = [
  "alloy",
  "alloy-sol-type-parser",
@@ -7858,7 +7858,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8976,7 +8976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9145,7 +9145,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10569,7 +10569,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10628,7 +10628,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11421,7 +11421,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11433,7 +11433,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11456,7 +11456,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11926,7 +11926,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12137,7 +12137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13410,7 +13410,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13560,7 +13560,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -509,7 +509,7 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "8d008eefacacf608b6ceb70636c777672fdccd88", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "c6707e3c36bc15ff449b7ce7f7773689e430f24c", default-features = false, features = [
     "tempo",
     "client",
     "reqwest-rustls-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -509,7 +509,7 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "c6707e3c36bc15ff449b7ce7f7773689e430f24c", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "929cb8e77d055600dbe7ebdd65a1e7c3441ef9e6", default-features = false, features = [
     "tempo",
     "client",
     "reqwest-rustls-tls",

--- a/crates/common/src/provider/mpp/persist.rs
+++ b/crates/common/src/provider/mpp/persist.rs
@@ -7,7 +7,7 @@
 
 use alloy_primitives::{Address, B256};
 use foundry_wallets::{Channel, ChannelDb};
-use mpp::client::channel_ops::ChannelEntry;
+use mpp::client::channel_ops::{ChannelEntry, is_precompile_escrow};
 use std::{
     collections::HashMap,
     sync::OnceLock,
@@ -67,6 +67,12 @@ fn channel_key_from_persisted(ch: &Channel) -> String {
         Address::ZERO,
     )
     .to_lowercase()
+}
+
+/// Precompile channels aren't persisted: the `Channel` schema has no column for
+/// their `operator`, so they'd reload under a wrong `operator=ZERO` key.
+fn is_precompile_channel(ch: &Channel) -> bool {
+    matches!(ch.escrow_contract.parse::<Address>(), Ok(addr) if is_precompile_escrow(addr))
 }
 
 /// Whether a channel can still be used (active and not fully spent).
@@ -147,7 +153,7 @@ pub fn load_channels() -> HashMap<String, Channel> {
 
     let usable: HashMap<String, Channel> = channels
         .into_iter()
-        .filter(is_usable)
+        .filter(|ch| is_usable(ch) && !is_precompile_channel(ch))
         .map(|ch| {
             let key = channel_key_from_persisted(&ch);
             (key, ch)
@@ -164,12 +170,15 @@ pub fn save_channels(channels: &HashMap<String, Channel>) {
         return;
     };
 
-    for ch in channels.values() {
+    let mut saved = 0;
+    for ch in channels.values().filter(|ch| !is_precompile_channel(ch)) {
         if let Err(e) = db.upsert(ch) {
             warn!(%e, channel_id = %ch.channel_id, "failed to save channel");
+        } else {
+            saved += 1;
         }
     }
-    debug!(count = channels.len(), "saved MPP channels");
+    debug!(count = saved, "saved MPP channels");
 }
 
 /// Delete a channel from the database by its channel ID.
@@ -278,8 +287,7 @@ mod tests {
         assert!(find_channel(&channels, "missing").is_none());
     }
 
-    /// Persisted key must match the 8-field runtime shape with operator=ZERO
-    /// so legacy channels rehydrate under the same key `pay_session()` looks up.
+    /// Persisted key must match the 8-field runtime shape (operator=ZERO).
     #[test]
     fn persisted_key_matches_runtime_legacy_shape() {
         let ch = test_channel("active", "1000", "100000");
@@ -287,5 +295,14 @@ mod tests {
 
         assert_eq!(key.split(':').count(), 8);
         assert!(key.ends_with(":0x0000000000000000000000000000000000000000"));
+    }
+
+    #[test]
+    fn precompile_channels_are_not_persisted() {
+        let mut ch = test_channel("active", "1000", "100000");
+        assert!(!is_precompile_channel(&ch));
+
+        ch.escrow_contract = "0x4D50500000000000000000000000000000000000".to_string();
+        assert!(is_precompile_channel(&ch));
     }
 }

--- a/crates/common/src/provider/mpp/persist.rs
+++ b/crates/common/src/provider/mpp/persist.rs
@@ -50,18 +50,21 @@ fn global_db() -> Option<&'static ChannelDb> {
 
 /// Reconstruct the composite HashMap key from a persisted `Channel`.
 ///
-/// Mirrors `SessionProvider::channel_key()` in session.rs.
+/// Mirrors `SessionProvider::channel_key()` in session.rs. The persisted
+/// schema has no `operator` column, so we always emit `Address::ZERO` as the
+/// operator component — correct for legacy escrow rows.
 fn channel_key_from_persisted(ch: &Channel) -> String {
     let origin_hash = &alloy_primitives::keccak256(ch.origin.as_bytes()).to_string()[..18];
     format!(
-        "{}:{}:{}:{}:{}:{}:{}",
+        "{}:{}:{}:{}:{}:{}:{}:{}",
         origin_hash,
         ch.chain_id,
         ch.payer,
         ch.authorized_signer,
         ch.payee,
         ch.token,
-        ch.escrow_contract
+        ch.escrow_contract,
+        Address::ZERO,
     )
     .to_lowercase()
 }
@@ -273,5 +276,16 @@ mod tests {
         assert!(find_channel(&channels, "usable").is_some());
         assert!(find_channel(&channels, "spent").is_none());
         assert!(find_channel(&channels, "missing").is_none());
+    }
+
+    /// Persisted key must match the 8-field runtime shape with operator=ZERO
+    /// so legacy channels rehydrate under the same key `pay_session()` looks up.
+    #[test]
+    fn persisted_key_matches_runtime_legacy_shape() {
+        let ch = test_channel("active", "1000", "100000");
+        let key = channel_key_from_persisted(&ch);
+
+        assert_eq!(key.split(':').count(), 8);
+        assert!(key.ends_with(":0x0000000000000000000000000000000000000000"));
     }
 }

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -589,8 +589,9 @@ impl SessionProvider {
         // fail loudly rather than send legacy calldata to the precompile.
         if is_precompile_escrow(entry.escrow_contract) {
             return Err(MppError::InvalidConfig(
-                "precompile escrow top-up is not yet supported; raise initial deposit via \
-                 MPP_DEPOSIT"
+                "T5 precompile escrow top-up is not supported. Close the channel (or wait \
+                 for expiry) and re-run with a larger MPP_DEPOSIT. T5 cumulative_amount is \
+                 capped at uint96."
                     .to_string(),
             ));
         }
@@ -1209,16 +1210,135 @@ mod tests {
         assert!((u128::MAX - 1).checked_add(5).is_none());
     }
 
-    /// Live T5 acceptance probe. Skipped unless `FOUNDRY_MPP_T5_RPC_URL`
-    /// is set; full e2e wiring deferred until a concrete endpoint exists.
+    /// Precompile open carries the key-auth witness iff the key is not yet
+    /// provisioned (otherwise the tx reverts with "access key already exists").
     #[tokio::test]
-    #[ignore = "integration-only: requires FOUNDRY_MPP_T5_RPC_URL"]
+    async fn precompile_open_key_auth_tracks_provisioned_flag() {
+        use alloy_eips::eip2718::Decodable2718;
+        use tempo_primitives::transaction::TempoTxEnvelope;
+
+        async fn key_auth_present(provisioned: bool) -> bool {
+            let signer = mpp::PrivateKeySigner::random();
+            let signing_mode = TempoSigningMode::Keychain {
+                wallet: Address::repeat_byte(0xAA),
+                key_authorization: Some(Box::new(test_key_authorization())),
+                version: KeychainVersion::V2,
+            };
+            let provider =
+                SessionProvider::new(signer, unique_origin()).with_signing_mode(signing_mode);
+            provider.set_key_provisioned(provisioned);
+
+            let payer = provider.funding_wallet_address();
+            let opts = OpenPayloadOptions {
+                authorized_signer: None,
+                escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+                payee: Address::repeat_byte(0x11),
+                currency: Address::repeat_byte(0x22),
+                deposit: 100_000,
+                initial_amount: 1_000,
+                chain_id: 4217,
+                fee_payer: false,
+            };
+            let (_entry, payload) =
+                provider.create_open_tx(payer, opts, Address::ZERO).await.expect("precompile open");
+            let SessionCredentialPayload::Open { transaction, .. } = payload else {
+                panic!("expected Open payload");
+            };
+            let tx_bytes = alloy_primitives::hex::decode(&transaction).expect("hex tx");
+            let envelope =
+                TempoTxEnvelope::decode_2718(&mut tx_bytes.as_slice()).expect("decode envelope");
+            let TempoTxEnvelope::AA(aa_signed) = envelope else {
+                panic!("expected AA envelope (0x76)");
+            };
+            aa_signed.strip_signature().key_authorization.is_some()
+        }
+
+        assert!(key_auth_present(false).await, "must include witness when not provisioned");
+        assert!(!key_auth_present(true).await, "must omit witness once provisioned");
+    }
+
+    /// Live T5 probe: pays one challenge fetched from
+    /// `FOUNDRY_MPP_T5_RPC_URL` with `FOUNDRY_MPP_T5_PRIVATE_KEY`.
+    #[tokio::test]
+    #[ignore = "integration-only: requires FOUNDRY_MPP_T5_RPC_URL + FOUNDRY_MPP_T5_PRIVATE_KEY"]
     async fn integration_pay_t5_precompile_endpoint() {
+        use mpp::protocol::core::parse_www_authenticate_all;
+
         let Ok(url) = std::env::var("FOUNDRY_MPP_T5_RPC_URL") else {
             let _ = crate::sh_eprintln!("skip: set FOUNDRY_MPP_T5_RPC_URL");
             return;
         };
-        let _ = crate::sh_eprintln!("would exercise SessionProvider::pay against {url}");
+        let Ok(key_hex) = std::env::var("FOUNDRY_MPP_T5_PRIVATE_KEY") else {
+            let _ = crate::sh_eprintln!("skip: set FOUNDRY_MPP_T5_PRIVATE_KEY");
+            return;
+        };
+
+        let signer: mpp::PrivateKeySigner = key_hex.parse().expect("invalid private key");
+        let deposit: u128 =
+            std::env::var("MPP_DEPOSIT").ok().and_then(|s| s.parse().ok()).unwrap_or(100_000);
+        let provider = SessionProvider::new(signer, url.clone()).with_default_deposit(deposit);
+
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_blockNumber",
+            "params": []
+        });
+        let resp = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .body(serde_json::to_vec(&body).unwrap())
+            .send()
+            .await
+            .expect("request");
+
+        assert_eq!(
+            resp.status(),
+            reqwest::StatusCode::PAYMENT_REQUIRED,
+            "endpoint did not return 402; not MPP-gated?"
+        );
+        let www: Vec<_> = resp
+            .headers()
+            .get_all("www-authenticate")
+            .into_iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+        // Only accept a T5 precompile-escrow session challenge: filtering on
+        // `supports()` alone would pass against a legacy session endpoint.
+        let challenge = parse_www_authenticate_all(www)
+            .into_iter()
+            .filter_map(|r| r.ok())
+            .find(|c| {
+                if c.intent.as_str() != "session"
+                    || !provider.supports(c.method.as_str(), c.intent.as_str())
+                {
+                    return false;
+                }
+                let Ok(req) = c.request.decode::<mpp::protocol::intents::SessionRequest>() else {
+                    return false;
+                };
+                req.escrow_contract().ok().and_then(|s| s.parse::<Address>().ok())
+                    == Some(TIP20_CHANNEL_RESERVE_ADDRESS)
+            })
+            .expect("no T5 precompile session challenge offered by endpoint");
+
+        let credential = provider.pay(&challenge).await.expect("pay must succeed");
+        let payload: mpp::protocol::methods::tempo::session::SessionCredentialPayload =
+            credential.payload_as().expect("session payload");
+        match payload {
+            mpp::protocol::methods::tempo::session::SessionCredentialPayload::Open {
+                channel_id,
+                ..
+            }
+            | mpp::protocol::methods::tempo::session::SessionCredentialPayload::Voucher {
+                channel_id,
+                ..
+            } => {
+                assert!(channel_id.starts_with("0x") && channel_id.len() == 66, "{channel_id}");
+            }
+            other => panic!("unexpected payload variant: {other:?}"),
+        }
     }
 
     /// `channel_key` scopes by escrow + operator so cached channels can't be

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -730,19 +730,24 @@ impl SessionProvider {
             .map_err(|_e| MppError::InvalidConfig("invalid currency address".to_string()))?;
         let amount: u128 = session_req.parse_amount()?;
 
-        // Precompile-only operator from methodDetails; missing → ZERO,
-        // malformed → error. Parsed before the cache lookup since operator
-        // participates in `channel_key`.
-        let operator = match session_req.method_details.as_ref().and_then(|v| v.get("operator")) {
-            None => Address::ZERO,
-            Some(v) => {
-                let s = v.as_str().ok_or_else(|| {
-                    MppError::InvalidConfig("methodDetails.operator must be a string".to_string())
-                })?;
-                s.parse::<Address>().map_err(|_| {
-                    MppError::InvalidConfig(format!("invalid operator address: {s}"))
-                })?
+        // Operator only applies to precompile escrow; legacy escrow forces ZERO
+        // so a stray `methodDetails.operator` can't fragment the cache key.
+        let operator = if is_precompile_escrow(escrow_contract) {
+            match session_req.method_details.as_ref().and_then(|v| v.get("operator")) {
+                None => Address::ZERO,
+                Some(v) => {
+                    let s = v.as_str().ok_or_else(|| {
+                        MppError::InvalidConfig(
+                            "methodDetails.operator must be a string".to_string(),
+                        )
+                    })?;
+                    s.parse::<Address>().map_err(|_| {
+                        MppError::InvalidConfig(format!("invalid operator address: {s}"))
+                    })?
+                }
             }
+        } else {
+            Address::ZERO
         };
 
         let payer = self.signing_mode.from_address(self.signer.address());

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -8,13 +8,14 @@
 
 use super::persist;
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use alloy_sol_types::SolCall as _;
 use foundry_wallets::Channel;
 use mpp::{
     client::{
         PaymentProvider,
         channel_ops::{
-            ChannelEntry, OpenPayloadOptions, build_credential, create_voucher_payload,
-            resolve_chain_id, resolve_escrow,
+            ChannelEntry, OpenPayloadOptions, build_credential, compute_expiring_nonce_hash,
+            create_voucher_payload, is_precompile_escrow, resolve_chain_id, resolve_escrow,
         },
         tempo::signing::{TempoSigningMode, sign_and_encode_async},
     },
@@ -22,7 +23,13 @@ use mpp::{
     protocol::{
         core::{PaymentChallenge, PaymentCredential},
         intents::SessionRequest,
-        methods::tempo::session::TempoSessionExt,
+        methods::tempo::{
+            precompile_voucher::{
+                PRECOMPILE_MAX_CUMULATIVE_AMOUNT, compute_precompile_channel_id,
+                sign_precompile_voucher,
+            },
+            session::TempoSessionExt,
+        },
     },
     tempo::{Call, SessionCredentialPayload, compute_channel_id, sign_voucher},
 };
@@ -30,6 +37,7 @@ use std::{
     collections::HashMap,
     sync::{Arc, Mutex, OnceLock},
 };
+use tempo_alloy::contracts::precompiles::{ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS};
 
 /// Shared per-origin in-memory channel state: (channels, key_provisioned).
 type SharedChannelState = (Arc<Mutex<HashMap<String, ChannelEntry>>>, Arc<Mutex<bool>>);
@@ -296,6 +304,7 @@ impl SessionProvider {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn channel_key(
         origin: &str,
         payer: &Address,
@@ -304,12 +313,14 @@ impl SessionProvider {
         currency: &Address,
         escrow: &Address,
         chain_id: u64,
+        operator: Address,
     ) -> String {
         // Use first 8 bytes of origin hash to scope the key without persisting
         // the full URL (which may contain secrets in query params).
+        // `operator` scopes precompile channels (legacy passes ZERO).
         let origin_hash = &alloy_primitives::keccak256(origin.as_bytes()).to_string()[..18];
         let signer = authorized_signer.unwrap_or(*payer);
-        format!("{origin_hash}:{chain_id}:{payer}:{signer}:{payee}:{currency}:{escrow}")
+        format!("{origin_hash}:{chain_id}:{payer}:{signer}:{payee}:{currency}:{escrow}:{operator}")
             .to_lowercase()
     }
 
@@ -338,8 +349,11 @@ impl SessionProvider {
         &self,
         payer: Address,
         options: OpenPayloadOptions,
+        operator: Address,
     ) -> Result<(ChannelEntry, SessionCredentialPayload), MppError> {
-        use alloy_sol_types::SolCall as _;
+        if is_precompile_escrow(options.escrow_contract) {
+            return self.create_precompile_open_tx(payer, options, operator).await;
+        }
 
         let authorized_signer = options.authorized_signer.unwrap_or(payer);
         let salt = B256::random();
@@ -457,6 +471,113 @@ impl SessionProvider {
         ))
     }
 
+    /// Open path for the T5 TIP-1034 reserve channel precompile.
+    /// Single-call tx (no `approve` — TIP-1035). `expiringNonceHash` is
+    /// computed before signing so the derived `channel_id` matches on-chain.
+    async fn create_precompile_open_tx(
+        &self,
+        payer: Address,
+        options: OpenPayloadOptions,
+        operator: Address,
+    ) -> Result<(ChannelEntry, SessionCredentialPayload), MppError> {
+        if options.deposit > PRECOMPILE_MAX_CUMULATIVE_AMOUNT
+            || options.initial_amount > PRECOMPILE_MAX_CUMULATIVE_AMOUNT
+        {
+            return Err(MppError::InvalidConfig(
+                "precompile escrow deposit/initial_amount must fit uint96".to_string(),
+            ));
+        }
+
+        let authorized_signer = options.authorized_signer.unwrap_or(payer);
+        let salt = B256::random();
+
+        let open_data = ITIP20ChannelReserve::openCall::new((
+            options.payee,
+            operator,
+            options.currency,
+            alloy_primitives::Uint::<96, 2>::from(options.deposit),
+            salt,
+            authorized_signer,
+        ))
+        .abi_encode();
+
+        let calls = vec![Call {
+            to: TxKind::Call(TIP20_CHANNEL_RESERVE_ADDRESS),
+            value: U256::ZERO,
+            input: Bytes::from(open_data),
+        }];
+
+        let valid_before = {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            Some(now + VALID_BEFORE_SECS)
+        };
+
+        let tx = mpp::client::tempo::charge::tx_builder::build_tempo_tx(
+            mpp::client::tempo::charge::tx_builder::TempoTxOptions {
+                calls,
+                chain_id: options.chain_id,
+                fee_token: options.currency,
+                nonce: 0,
+                nonce_key: EXPIRING_NONCE_KEY,
+                gas_limit: SESSION_OPEN_GAS_LIMIT,
+                max_fee_per_gas: MAX_FEE_PER_GAS,
+                max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+                fee_payer: options.fee_payer,
+                valid_before,
+                key_authorization: (!*self.key_provisioned.lock().unwrap())
+                    .then(|| self.signing_mode.key_authorization().cloned())
+                    .flatten(),
+            },
+        );
+
+        // Must derive before signing: expiringNonceHash binds signing-payload bytes.
+        let expiring_nonce_hash = compute_expiring_nonce_hash(&tx, payer);
+        let channel_id = compute_precompile_channel_id(
+            payer,
+            options.payee,
+            operator,
+            options.currency,
+            salt,
+            authorized_signer,
+            expiring_nonce_hash,
+            options.chain_id,
+        );
+
+        let signed_tx = sign_and_encode_async(tx, &self.signer, &self.signing_mode).await?;
+
+        let voucher = sign_precompile_voucher(
+            &self.signer,
+            channel_id,
+            options.initial_amount,
+            options.chain_id,
+        )
+        .await?;
+
+        let entry = ChannelEntry {
+            channel_id,
+            salt,
+            cumulative_amount: options.initial_amount,
+            escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+            chain_id: options.chain_id,
+            opened: true,
+        };
+
+        Ok((
+            entry,
+            SessionCredentialPayload::Open {
+                payload_type: "transaction".to_string(),
+                channel_id: channel_id.to_string(),
+                transaction: alloy_primitives::hex::encode_prefixed(&signed_tx),
+                authorized_signer: Some(format!("{authorized_signer}")),
+                cumulative_amount: options.initial_amount.to_string(),
+                signature: alloy_primitives::hex::encode_prefixed(&voucher),
+            },
+        ))
+    }
+
     async fn create_topup_tx(
         &self,
         entry: &ChannelEntry,
@@ -464,7 +585,15 @@ impl SessionProvider {
         currency: Address,
         fee_payer: bool,
     ) -> Result<SessionCredentialPayload, MppError> {
-        use alloy_sol_types::SolCall as _;
+        // Precompile top-up uses different (descriptor-based, uint96) calldata;
+        // fail loudly rather than send legacy calldata to the precompile.
+        if is_precompile_escrow(entry.escrow_contract) {
+            return Err(MppError::InvalidConfig(
+                "precompile escrow top-up is not yet supported; raise initial deposit via \
+                 MPP_DEPOSIT"
+                    .to_string(),
+            ));
+        }
 
         alloy_sol_types::sol! {
             interface ITIP20 {
@@ -600,6 +729,21 @@ impl SessionProvider {
             .map_err(|_e| MppError::InvalidConfig("invalid currency address".to_string()))?;
         let amount: u128 = session_req.parse_amount()?;
 
+        // Precompile-only operator from methodDetails; missing → ZERO,
+        // malformed → error. Parsed before the cache lookup since operator
+        // participates in `channel_key`.
+        let operator = match session_req.method_details.as_ref().and_then(|v| v.get("operator")) {
+            None => Address::ZERO,
+            Some(v) => {
+                let s = v.as_str().ok_or_else(|| {
+                    MppError::InvalidConfig("methodDetails.operator must be a string".to_string())
+                })?;
+                s.parse::<Address>().map_err(|_| {
+                    MppError::InvalidConfig(format!("invalid operator address: {s}"))
+                })?
+            }
+        };
+
         let payer = self.signing_mode.from_address(self.signer.address());
 
         let key = Self::channel_key(
@@ -610,6 +754,7 @@ impl SessionProvider {
             &currency,
             &escrow_contract,
             chain_id,
+            operator,
         );
 
         let voucher_info = {
@@ -625,13 +770,15 @@ impl SessionProvider {
                     .and_then(|p| p.deposit.parse::<u128>().ok())
                     .unwrap_or(u128::MAX);
 
-                if entry.cumulative_amount + amount > deposit {
-                    Some(Err((entry.clone(), deposit)))
-                } else {
-                    // Clone without incrementing — only commit after
-                    // create_voucher_payload succeeds.
-                    Some(Ok(entry.clone()))
-                }
+                // checked_add: hostile amount must not wrap or panic.
+                let projected = entry.cumulative_amount.checked_add(amount).ok_or_else(|| {
+                    MppError::InvalidConfig("voucher cumulative_amount overflow".to_string())
+                });
+                Some(match projected {
+                    Err(e) => return Err(e),
+                    Ok(p) if p > deposit => Err((entry.clone(), deposit)),
+                    Ok(_) => Ok(entry.clone()),
+                })
             } else {
                 None
             }
@@ -660,7 +807,10 @@ impl SessionProvider {
                         if let Some(p) = persisted.get_mut(&key) {
                             let old = p.deposit.clone();
                             let old_val: u128 = old.parse().unwrap_or(0);
-                            p.deposit = (old_val + additional).to_string();
+                            let new_val = old_val.checked_add(additional).ok_or_else(|| {
+                                MppError::InvalidConfig("top-up deposit overflow".to_string())
+                            })?;
+                            p.deposit = new_val.to_string();
                             old
                         } else {
                             "0".to_string()
@@ -673,15 +823,37 @@ impl SessionProvider {
                 }
                 Ok(entry) => {
                     let old_cumulative = entry.cumulative_amount;
-                    let new_cumulative = old_cumulative + amount;
-                    let payload = create_voucher_payload(
-                        &self.signer,
-                        entry.channel_id,
-                        new_cumulative,
-                        escrow_contract,
-                        chain_id,
-                    )
-                    .await?;
+                    let new_cumulative = old_cumulative.checked_add(amount).ok_or_else(|| {
+                        MppError::InvalidConfig("voucher cumulative_amount overflow".to_string())
+                    })?;
+                    let payload = if is_precompile_escrow(escrow_contract) {
+                        if new_cumulative > PRECOMPILE_MAX_CUMULATIVE_AMOUNT {
+                            return Err(MppError::InvalidConfig(
+                                "precompile voucher cumulative_amount must fit uint96".to_string(),
+                            ));
+                        }
+                        let sig = sign_precompile_voucher(
+                            &self.signer,
+                            entry.channel_id,
+                            new_cumulative,
+                            chain_id,
+                        )
+                        .await?;
+                        SessionCredentialPayload::Voucher {
+                            channel_id: entry.channel_id.to_string(),
+                            cumulative_amount: new_cumulative.to_string(),
+                            signature: alloy_primitives::hex::encode_prefixed(&sig),
+                        }
+                    } else {
+                        create_voucher_payload(
+                            &self.signer,
+                            entry.channel_id,
+                            new_cumulative,
+                            escrow_contract,
+                            chain_id,
+                        )
+                        .await?
+                    };
 
                     // Payload succeeded — now commit the cumulative increment.
                     {
@@ -727,6 +899,7 @@ impl SessionProvider {
                     chain_id,
                     fee_payer: session_req.fee_payer(),
                 },
+                operator,
             )
             .await?;
 
@@ -861,6 +1034,251 @@ mod tests {
             matches!(result_mode, TempoSigningMode::Direct),
             "Direct mode should pass through unchanged"
         );
+    }
+
+    /// Legacy escrow address must flow into the entry's channel id.
+    #[tokio::test]
+    async fn legacy_solidity_escrow_address_flows_through_open_payload() {
+        let escrow: Address = "0x33b901018174DDabE4841042ab76ba85D4e24f25".parse().unwrap();
+
+        let signer = mpp::PrivateKeySigner::random();
+        let provider = SessionProvider::new(signer, unique_origin());
+        let payer = provider.funding_wallet_address();
+        let opts = OpenPayloadOptions {
+            authorized_signer: None,
+            escrow_contract: escrow,
+            payee: Address::repeat_byte(0x11),
+            currency: Address::repeat_byte(0x22),
+            deposit: 100_000,
+            initial_amount: 1_000,
+            chain_id: 4217,
+            fee_payer: false,
+        };
+        let (payee, currency, chain_id) = (opts.payee, opts.currency, opts.chain_id);
+
+        let (entry, _payload) = provider
+            .create_open_tx(payer, opts, Address::ZERO)
+            .await
+            .expect("create_open_tx with legacy Solidity escrow");
+
+        assert_eq!(entry.escrow_contract, escrow);
+
+        let recomputed =
+            compute_channel_id(payer, payee, currency, entry.salt, payer, escrow, chain_id);
+        assert_eq!(entry.channel_id, recomputed);
+    }
+
+    /// Precompile escrow routes to the precompile branch; id ≠ legacy formula.
+    #[tokio::test]
+    async fn precompile_escrow_open_uses_precompile_channel_id() {
+        let signer = mpp::PrivateKeySigner::random();
+        let provider = SessionProvider::new(signer, unique_origin());
+        let payer = provider.funding_wallet_address();
+        let opts = OpenPayloadOptions {
+            authorized_signer: None,
+            escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+            payee: Address::repeat_byte(0x11),
+            currency: Address::repeat_byte(0x22),
+            deposit: 100_000,
+            initial_amount: 1_000,
+            chain_id: 4217,
+            fee_payer: false,
+        };
+
+        let (entry, _payload) =
+            provider.create_open_tx(payer, opts, Address::ZERO).await.expect("precompile open");
+
+        assert_eq!(entry.escrow_contract, TIP20_CHANNEL_RESERVE_ADDRESS);
+        let legacy = compute_channel_id(
+            payer,
+            Address::repeat_byte(0x11),
+            Address::repeat_byte(0x22),
+            entry.salt,
+            payer,
+            TIP20_CHANNEL_RESERVE_ADDRESS,
+            4217,
+        );
+        assert_ne!(entry.channel_id, legacy);
+    }
+
+    /// Precompile open rejects `deposit`/`initial_amount` > uint96.
+    #[tokio::test]
+    async fn precompile_escrow_open_rejects_uint96_overflow() {
+        let signer = mpp::PrivateKeySigner::random();
+        let provider = SessionProvider::new(signer, unique_origin());
+        let payer = provider.funding_wallet_address();
+        let opts = OpenPayloadOptions {
+            authorized_signer: None,
+            escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+            payee: Address::repeat_byte(0x11),
+            currency: Address::repeat_byte(0x22),
+            deposit: PRECOMPILE_MAX_CUMULATIVE_AMOUNT + 1,
+            initial_amount: 1,
+            chain_id: 4217,
+            fee_payer: false,
+        };
+        let err = provider
+            .create_open_tx(payer, opts, Address::ZERO)
+            .await
+            .expect_err("deposit > uint96 must reject");
+        assert!(matches!(err, MppError::InvalidConfig(_)));
+    }
+
+    /// Precompile channels must not fall through to legacy top-up calldata.
+    #[tokio::test]
+    async fn precompile_escrow_topup_is_rejected() {
+        let signer = mpp::PrivateKeySigner::random();
+        let provider = SessionProvider::new(signer, unique_origin());
+        let entry = ChannelEntry {
+            channel_id: B256::ZERO,
+            salt: B256::ZERO,
+            cumulative_amount: 0,
+            escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+            chain_id: 4217,
+            opened: true,
+        };
+        let err = provider
+            .create_topup_tx(&entry, 1_000, Address::repeat_byte(0x22), false)
+            .await
+            .expect_err("precompile top-up must be rejected");
+        assert!(matches!(err, MppError::InvalidConfig(_)));
+    }
+
+    /// Operator must reach the precompile `open` calldata and bind into the
+    /// returned `channel_id`. Decodes the produced tx to verify both.
+    #[tokio::test]
+    async fn precompile_escrow_open_binds_operator_into_calldata() {
+        use alloy_eips::eip2718::Decodable2718;
+        use tempo_primitives::transaction::TempoTxEnvelope;
+
+        let signer = mpp::PrivateKeySigner::random();
+        let provider = SessionProvider::new(signer, unique_origin());
+        let payer = provider.funding_wallet_address();
+        let base_opts = || OpenPayloadOptions {
+            authorized_signer: None,
+            escrow_contract: TIP20_CHANNEL_RESERVE_ADDRESS,
+            payee: Address::repeat_byte(0x11),
+            currency: Address::repeat_byte(0x22),
+            deposit: 100_000,
+            initial_amount: 1_000,
+            chain_id: 4217,
+            fee_payer: false,
+        };
+        let expected_operator = Address::repeat_byte(0x99);
+
+        let (entry, payload) = provider
+            .create_open_tx(payer, base_opts(), expected_operator)
+            .await
+            .expect("precompile open with explicit operator");
+
+        let SessionCredentialPayload::Open { transaction, .. } = payload else {
+            panic!("expected Open payload");
+        };
+        let tx_bytes = alloy_primitives::hex::decode(&transaction).expect("hex tx");
+        let envelope =
+            TempoTxEnvelope::decode_2718(&mut tx_bytes.as_slice()).expect("decode envelope");
+        let TempoTxEnvelope::AA(aa_signed) = envelope else {
+            panic!("expected AA envelope (0x76)");
+        };
+        let unsigned = aa_signed.strip_signature();
+        assert_eq!(unsigned.calls.len(), 1);
+        let call = &unsigned.calls[0];
+        assert_eq!(call.to, TxKind::Call(TIP20_CHANNEL_RESERVE_ADDRESS));
+
+        let decoded =
+            ITIP20ChannelReserve::openCall::abi_decode(&call.input).expect("decode openCall");
+        assert_eq!(decoded.operator, expected_operator);
+
+        let authorized_signer = payer;
+        let expected_id = compute_precompile_channel_id(
+            payer,
+            base_opts().payee,
+            expected_operator,
+            base_opts().currency,
+            entry.salt,
+            authorized_signer,
+            mpp::client::channel_ops::compute_expiring_nonce_hash(&unsigned, payer),
+            base_opts().chain_id,
+        );
+        assert_eq!(entry.channel_id, expected_id);
+    }
+
+    /// Cumulative addition near `u128::MAX` must not wrap.
+    #[test]
+    fn voucher_cumulative_overflow_is_rejected() {
+        assert!((u128::MAX - 1).checked_add(5).is_none());
+    }
+
+    /// Live T5 acceptance probe. Skipped unless `FOUNDRY_MPP_T5_RPC_URL`
+    /// is set; full e2e wiring deferred until a concrete endpoint exists.
+    #[tokio::test]
+    #[ignore = "integration-only: requires FOUNDRY_MPP_T5_RPC_URL"]
+    async fn integration_pay_t5_precompile_endpoint() {
+        let Ok(url) = std::env::var("FOUNDRY_MPP_T5_RPC_URL") else {
+            let _ = crate::sh_eprintln!("skip: set FOUNDRY_MPP_T5_RPC_URL");
+            return;
+        };
+        let _ = crate::sh_eprintln!("would exercise SessionProvider::pay against {url}");
+    }
+
+    /// `channel_key` scopes by escrow + operator so cached channels can't be
+    /// reused across legacy/precompile or across operators.
+    #[test]
+    fn channel_key_distinguishes_legacy_and_precompile_escrow() {
+        let origin = "https://rpc.example.com";
+        let payer = Address::repeat_byte(0xAA);
+        let payee = Address::repeat_byte(0x11);
+        let currency = Address::repeat_byte(0x22);
+        let chain_id = 4217u64;
+
+        let legacy_escrow: Address = "0x33b901018174DDabE4841042ab76ba85D4e24f25".parse().unwrap();
+        let t5_precompile: Address = "0x4D50500000000000000000000000000000000000".parse().unwrap();
+
+        let legacy_key = SessionProvider::channel_key(
+            origin,
+            &payer,
+            None,
+            &payee,
+            &currency,
+            &legacy_escrow,
+            chain_id,
+            Address::ZERO,
+        );
+        let precompile_key = SessionProvider::channel_key(
+            origin,
+            &payer,
+            None,
+            &payee,
+            &currency,
+            &t5_precompile,
+            chain_id,
+            Address::ZERO,
+        );
+
+        assert_ne!(legacy_key, precompile_key);
+
+        let precompile_op_a = SessionProvider::channel_key(
+            origin,
+            &payer,
+            None,
+            &payee,
+            &currency,
+            &t5_precompile,
+            chain_id,
+            Address::repeat_byte(0xAA),
+        );
+        let precompile_op_b = SessionProvider::channel_key(
+            origin,
+            &payer,
+            None,
+            &payee,
+            &currency,
+            &t5_precompile,
+            chain_id,
+            Address::repeat_byte(0xBB),
+        );
+        assert_ne!(precompile_op_a, precompile_op_b);
+        assert_ne!(precompile_key, precompile_op_a);
     }
 
     /// Verify that a payment serialization lock (mirroring `lock_pay()` in

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -44,6 +44,8 @@ const DEFAULT_DEPOSIT: u128 = 100_000;
 const MPP_RETRY_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Resolve the deposit amount from `MPP_DEPOSIT` env var or the default.
+/// Only applied at channel open. On T5 precompile channels the cumulative
+/// amount is capped at `uint96`.
 fn default_deposit() -> u128 {
     env::var("MPP_DEPOSIT").ok().and_then(|s| s.parse().ok()).unwrap_or(DEFAULT_DEPOSIT)
 }
@@ -1671,6 +1673,145 @@ mod tests {
             b64(serde_json::json!({"amount":"1000","currency":"0x20c0","recipient":"0xabc"}))
         );
         assert_eq!(extract(vec![&no_details]), vec![(None, Some("0x20c0".into()))]);
+    }
+
+    /// Real `SessionProvider` + mock server: 402 with precompile escrow →
+    /// `Open` credential, then second 402 → `Voucher` reusing the channel.
+    #[tokio::test]
+    async fn mpp_transport_t5_precompile_open_then_voucher() {
+        use alloy_eips::eip2718::Decodable2718;
+        use alloy_primitives::{Address, TxKind};
+        use alloy_sol_types::SolCall;
+        use mpp::protocol::methods::tempo::session::SessionCredentialPayload;
+        use tempo_alloy::contracts::precompiles::{
+            ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS,
+        };
+        use tempo_primitives::transaction::TempoTxEnvelope;
+
+        let payee = Address::repeat_byte(0x11);
+        let currency = Address::repeat_byte(0x22);
+        let operator = Address::repeat_byte(0x99);
+        let chain_id = 4217u64;
+
+        let request_json = serde_json::json!({
+            "amount": "1000",
+            "currency": format!("{currency:#x}"),
+            "recipient": format!("{payee:#x}"),
+            "methodDetails": {
+                "chainId": chain_id,
+                "escrowContract": format!("{TIP20_CHANNEL_RESERVE_ADDRESS:#x}"),
+                "operator": format!("{operator:#x}"),
+            },
+        });
+        let request = Base64UrlJson::from_value(&request_json).unwrap();
+        let challenge = PaymentChallenge {
+            id: "t5-precompile-challenge".to_string(),
+            realm: "test-t5".to_string(),
+            method: MethodName::new("tempo"),
+            intent: IntentName::new("session"),
+            request,
+            expires: None,
+            description: None,
+            digest: None,
+            opaque: None,
+        };
+        let www_auth = format_www_authenticate(&challenge).unwrap();
+
+        #[derive(Clone)]
+        struct AppState {
+            www_auth: String,
+            captured: Arc<Mutex<Vec<PaymentCredential>>>,
+        }
+        let state = AppState { www_auth, captured: Arc::new(Mutex::new(Vec::new())) };
+
+        let captured = state.captured.clone();
+        let app =
+            axum::Router::new()
+                .route(
+                    "/",
+                    post(
+                        |State(state): State<AppState>,
+                         req: axum::http::Request<axum::body::Body>| async move {
+                            if let Some(auth) = req.headers().get("authorization") {
+                                let auth_str = auth.to_str().unwrap();
+                                let credential = parse_authorization(auth_str).unwrap();
+                                state.captured.lock().unwrap().push(credential);
+                                (
+                                    AxumStatusCode::OK,
+                                    axum::Json(serde_json::json!({
+                                        "jsonrpc": "2.0",
+                                        "id": 1,
+                                        "result": "0xabc",
+                                    })),
+                                )
+                                    .into_response()
+                            } else {
+                                (
+                                    AxumStatusCode::PAYMENT_REQUIRED,
+                                    [("www-authenticate", state.www_auth.clone())],
+                                    "Payment Required",
+                                )
+                                    .into_response()
+                            }
+                        },
+                    ),
+                )
+                .with_state(state);
+
+        let (base_url, handle) = spawn_server(app).await;
+
+        let signer = mpp::PrivateKeySigner::random();
+        let session_provider =
+            super::super::session::SessionProvider::new(signer, base_url.clone())
+                .with_default_deposit(100_000);
+        let mut transport =
+            MppHttpTransport::new(test_client(), Url::parse(&base_url).unwrap(), session_provider);
+
+        let resp1 = tower::Service::call(&mut transport, test_request()).await.unwrap();
+        assert!(matches!(resp1, ResponsePacket::Single(r) if r.is_success()));
+        let resp2 = tower::Service::call(&mut transport, test_request()).await.unwrap();
+        assert!(matches!(resp2, ResponsePacket::Single(r) if r.is_success()));
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 2);
+
+        let open: SessionCredentialPayload = captured[0].payload_as().expect("Open payload");
+        let (open_channel_id, open_transaction, open_cumulative) = match open {
+            SessionCredentialPayload::Open {
+                channel_id, transaction, cumulative_amount, ..
+            } => (channel_id, transaction, cumulative_amount),
+            other => panic!("first credential must be Open, got {other:?}"),
+        };
+        assert_eq!(open_cumulative, "1000");
+
+        let tx_bytes = alloy_primitives::hex::decode(&open_transaction).expect("hex tx");
+        let envelope =
+            TempoTxEnvelope::decode_2718(&mut tx_bytes.as_slice()).expect("decode envelope");
+        let TempoTxEnvelope::AA(aa_signed) = envelope else {
+            panic!("expected AA envelope (0x76)");
+        };
+        let unsigned = aa_signed.strip_signature();
+        // Single-call (no TIP20.approve per TIP-1035), targets the precompile.
+        assert_eq!(unsigned.calls.len(), 1);
+        let call = &unsigned.calls[0];
+        assert_eq!(call.to, TxKind::Call(TIP20_CHANNEL_RESERVE_ADDRESS));
+        let decoded =
+            ITIP20ChannelReserve::openCall::abi_decode(&call.input).expect("decode openCall");
+        assert_eq!(decoded.operator, operator);
+        assert_eq!(decoded.payee, payee);
+        assert_eq!(decoded.token, currency);
+
+        let voucher: SessionCredentialPayload = captured[1].payload_as().expect("Voucher payload");
+        let (voucher_channel_id, voucher_cumulative) = match voucher {
+            SessionCredentialPayload::Voucher { channel_id, cumulative_amount, .. } => {
+                (channel_id, cumulative_amount)
+            }
+            other => panic!("second credential must be Voucher, got {other:?}"),
+        };
+        assert_eq!(voucher_channel_id, open_channel_id);
+        assert_eq!(voucher_cumulative, "2000");
+
+        handle.abort();
     }
 
     /// Auth must trigger when a key matches the chain but not the currency.


### PR DESCRIPTION
Wires Foundry's MPP session transport to the T5 TIP-1034 channel reserve precompile while preserving legacy Solidity escrow compatibility.

`pay_session` discriminates on `is_precompile_escrow(escrow)` per challenge.
Precompile open: single-call `ITIP20ChannelReserve.open` (no `approve`, TIP-1035), `uint96` caps, `expiringNonceHash` derived pre-sign, voucher signed via `sign_precompile_voucher`.
Cached vouchers and channel cache (`channel_key` now includes operator) branch the same way.
Precompile top-up hard-fails (descriptor-based path not implemented); legacy top-up gets `checked_add` overflow guard.
Optional `methodDetails.operator`: missing → ZERO; malformed → error.

https://github.com/tempoxyz/mpp-rs/pull/276

Part of OSS-266