### PR TITLE
refactor(lint): finish solar expression type cleanup

### DIFF
--- a/crates/lint/src/sol/high/arbitrary_send_erc20.rs
+++ b/crates/lint/src/sol/high/arbitrary_send_erc20.rs
@@ -6,9 +6,13 @@ use crate::{
 use solar::{
     ast,
     interface::{Span, data_structures::Never, kw, sym},
-    sema::hir::{
-        self, ContractKind, ElementaryType, ExprKind, ItemId, LoopSource, Res, StmtKind, StructId,
-        TypeKind, Visit,
+    sema::{
+        Gcx,
+        hir::{
+            self, ContractKind, ElementaryType, ExprKind, ItemId, LoopSource, Res, StmtKind,
+            TypeKind, Visit,
+        },
+        ty::{Ty, TyKind},
     },
 };
 use std::{
@@ -34,7 +38,7 @@ impl<'hir> LateLintPass<'hir> for ArbitrarySendErc20 {
     fn check_function(
         &mut self,
         ctx: &LintContext,
-        _gcx: solar::sema::Gcx<'hir>,
+        gcx: Gcx<'hir>,
         hir: &'hir hir::Hir<'hir>,
         func: &'hir hir::Function<'hir>,
     ) {
@@ -58,15 +62,22 @@ impl<'hir> LateLintPass<'hir> for ArbitrarySendErc20 {
         if func.modifiers.iter().any(|m| modifier_prefix_always_exits(hir, m)) {
             return;
         }
-        let mut a = Analyzer::new(hir, has_solady_lib);
+        let mut a = Analyzer::new(gcx, hir, has_solady_lib);
         // Seed `self_vars` / `safe_vars` with immutable/constant state vars proven
         // equal to `address(this)` / `msg.sender` by their declaration initializer
         // or the contract's constructor.
         if let Some(cid) = func.contract {
-            seed_immutable_facts(hir, has_solady_lib, cid, &mut a);
+            seed_immutable_facts(gcx, hir, has_solady_lib, cid, &mut a);
         }
         for m in func.modifiers {
-            collect_modifier_safety(hir, has_solady_lib, m, &mut a.safe_vars, &mut a.self_vars);
+            collect_modifier_safety(
+                gcx,
+                hir,
+                has_solady_lib,
+                m,
+                &mut a.safe_vars,
+                &mut a.self_vars,
+            );
         }
         for stmt in body.stmts {
             let _ = a.visit_stmt(stmt);
@@ -124,6 +135,7 @@ struct PendingRepayment {
 }
 
 struct Analyzer<'hir> {
+    gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
     /// Variables proven safe (equal to `msg.sender` or `address(this)`) on this path.
     /// Function-locals and `immutable`/`constant` state vars only — mutable storage may be
@@ -208,8 +220,9 @@ impl FlowState {
 const HELPER_DEPTH: u8 = 3;
 
 impl<'hir> Analyzer<'hir> {
-    fn new(hir: &'hir hir::Hir<'hir>, has_solady_lib: bool) -> Self {
+    fn new(gcx: Gcx<'hir>, hir: &'hir hir::Hir<'hir>, has_solady_lib: bool) -> Self {
         Self {
+            gcx,
             hir,
             safe_vars: HashSet::new(),
             self_vars: HashSet::new(),
@@ -383,7 +396,7 @@ impl<'hir> Analyzer<'hir> {
     /// Matches EIP-2612 `token.permit(owner, <self>, value, deadline, v, r, s)`, plus
     /// the library form `Lib.safePermit(token, owner, <self>, value, deadline, v, r, s)`
     /// (OpenZeppelin-style wrapper that delegates to `token.permit`).
-    fn match_permit_call(&self, expr: &hir::Expr<'_>) -> Option<PermitRecord> {
+    fn match_permit_call(&self, expr: &'hir hir::Expr<'hir>) -> Option<PermitRecord> {
         let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
         let ExprKind::Member(recv, ident) = &callee.peel_parens().kind else { return None };
         let name = ident.name.as_str();
@@ -416,7 +429,7 @@ impl<'hir> Analyzer<'hir> {
                 ],
             )
             && self.is_self_expr(canonical[2])
-            && let Some(cid) = receiver_contract_id(self.hir, recv)
+            && let Some(cid) = receiver_contract_id(self.gcx, recv)
             && self.hir.contract(cid).kind == ContractKind::Library
         {
             return Some(PermitRecord {
@@ -986,11 +999,12 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
             }
             ExprKind::Call(callee, ..) => {
                 // EIP-3156: a matching repayment sink consumes the recorded obligation.
-                if let Some(rep) = match_flash_loan_call(self.hir, expr) {
+                if let Some(rep) = match_flash_loan_call(self.gcx, self.hir, expr) {
                     *self.repayments.entry(rep).or_insert(0) += 1;
                 } else if let Some(p) = self.match_permit_call(expr) {
                     self.permits.insert(p);
-                } else if let Some((from, token)) = match_sink(self.hir, self.has_solady_lib, expr)
+                } else if let Some((from, token)) =
+                    match_sink(self.gcx, self.hir, self.has_solady_lib, expr)
                     && !self.is_safe(from)
                     && !self.consume_repayment(expr, from, token)
                 {
@@ -1030,7 +1044,11 @@ impl<'hir> hir::Visit<'hir> for Analyzer<'hir> {
 /// EIP-3156 `onFlashLoan(address,address,uint256,uint256,bytes) returns (bytes32)`. Only
 /// returns a record when the receiver type declares the exact sig and every tracked arg
 /// resolves to a `VariableId`; literal args yield `None`.
-fn match_flash_loan_call(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<PendingRepayment> {
+fn match_flash_loan_call<'hir>(
+    gcx: Gcx<'hir>,
+    hir: &hir::Hir<'hir>,
+    expr: &hir::Expr<'hir>,
+) -> Option<PendingRepayment> {
     let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
     let ExprKind::Member(recv, ident) = &callee.peel_parens().kind else { return None };
     if ident.name.as_str() != "onFlashLoan" {
@@ -1038,7 +1056,7 @@ fn match_flash_loan_call(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<Pen
     }
     let args =
         canonical_args(args.kind, &[&["initiator"], &["token"], &["amount"], &["fee"], &["data"]])?;
-    let cid = receiver_contract_id(hir, recv)?;
+    let cid = receiver_contract_id(gcx, recv)?;
     if !contract_has_function(
         hir,
         cid,
@@ -1076,6 +1094,7 @@ fn is_amount_plus_fee(expr: &hir::Expr<'_>, amount: hir::VariableId, fee: hir::V
 ///   same-named, no-return overload is excluded).
 /// - `Lib.safeTransferFrom(token, from, to, amt)` library form.
 fn match_sink<'hir>(
+    gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
     has_solady_lib: bool,
     expr: &'hir hir::Expr<'hir>,
@@ -1089,7 +1108,7 @@ fn match_sink<'hir>(
             canonical_args(args.kind, &[&["from"], &["to"], &["value", "amount"]])
     {
         // Contract-typed receiver: must actually declare ERC20's `transferFrom`.
-        if let Some(cid) = receiver_contract_id(hir, recv)
+        if let Some(cid) = receiver_contract_id(gcx, recv)
             && contract_has_function(
                 hir,
                 cid,
@@ -1103,7 +1122,7 @@ fn match_sink<'hir>(
         // `addr.safeTransferFrom(...)` via `using SafeTransferLib for address`. HIR doesn't
         // expose `using-for` bindings, so we proxy by requiring `SafeTransferLib` to be
         // declared in the compiled sources.
-        if name == "safeTransferFrom" && has_solady_lib && expr_is_address(hir, recv) {
+        if name == "safeTransferFrom" && has_solady_lib && expr_is_address(gcx, recv) {
             return Some((canonical[0], token_key(recv)));
         }
     }
@@ -1111,7 +1130,7 @@ fn match_sink<'hir>(
     if name == "safeTransferFrom"
         && let Some(canonical) =
             canonical_args(args.kind, &[&["token"], &["from"], &["to"], &["value", "amount"]])
-        && let Some(cid) = receiver_contract_id(hir, recv)
+        && let Some(cid) = receiver_contract_id(gcx, recv)
         && hir.contract(cid).kind == ContractKind::Library
         && library_has_safe_transfer_from(hir, cid)
     {
@@ -1141,6 +1160,7 @@ fn token_key(expr: &hir::Expr<'_>) -> Option<TokenKey> {
 /// prefix (statements before `_;`) to the caller's argument. `out_self` receives params
 /// proven equal to `address(this)`.
 fn collect_modifier_safety<'hir>(
+    gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
     has_solady_lib: bool,
     invocation: &hir::Modifier<'hir>,
@@ -1191,7 +1211,7 @@ fn collect_modifier_safety<'hir>(
         return;
     }
 
-    let mut a = Analyzer::new(hir, has_solady_lib);
+    let mut a = Analyzer::new(gcx, hir, has_solady_lib);
     for stmt in &body.stmts[..placeholder_idx] {
         let _ = a.visit_stmt(stmt);
     }
@@ -1213,6 +1233,7 @@ fn collect_modifier_safety<'hir>(
 /// Harvests `self_vars` / `safe_vars` facts about immutable / constant state vars
 /// of `cid`: both declaration initializers and direct constructor assignments.
 fn seed_immutable_facts<'hir>(
+    gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
     has_solady_lib: bool,
     cid: hir::ContractId,
@@ -1241,7 +1262,7 @@ fn seed_immutable_facts<'hir>(
             continue;
         }
         let Some(body) = f.body else { continue };
-        let mut ctor = Analyzer::new(hir, has_solady_lib);
+        let mut ctor = Analyzer::new(gcx, hir, has_solady_lib);
         for stmt in body.stmts {
             let _ = ctor.visit_stmt(stmt);
             if branch_always_exits(stmt) {
@@ -1484,88 +1505,31 @@ fn is_cast_callee(callee: &hir::Expr<'_>) -> bool {
     }
 }
 
-/// Resolves the static contract type of `recv`: a contract-typed variable, a direct contract
-/// reference (e.g. a library), an `IERC20(addr)` interface wrap, a struct field, or an
-/// array/mapping element of contract type.
-fn receiver_contract_id(hir: &hir::Hir<'_>, recv: &hir::Expr<'_>) -> Option<hir::ContractId> {
-    let recv = recv.peel_parens();
-    match &recv.kind {
-        ExprKind::Ident(reses) => reses.iter().find_map(|r| match r {
-            Res::Item(ItemId::Variable(vid)) => match hir.variable(*vid).ty.kind {
-                TypeKind::Custom(ItemId::Contract(cid)) => Some(cid),
-                _ => None,
-            },
-            Res::Item(ItemId::Contract(cid)) => Some(*cid),
-            _ => None,
-        }),
-        ExprKind::Call(callee, ..) => match &callee.peel_parens().kind {
-            ExprKind::Ident(reses) => reses.iter().find_map(|r| match r {
-                Res::Item(ItemId::Contract(cid)) => Some(*cid),
-                _ => None,
-            }),
-            _ => None,
-        },
-        // `cfg.token.transferFrom(...)`.
-        ExprKind::Member(base, ident) => {
-            let sid = struct_of(hir, base)?;
-            let strukt = hir.strukt(sid);
-            strukt.fields.iter().find_map(|fid| {
-                let v = hir.variable(*fid);
-                if v.name.is_some_and(|n| n.as_str() == ident.as_str())
-                    && let TypeKind::Custom(ItemId::Contract(cid)) = v.ty.kind
-                {
-                    Some(cid)
-                } else {
-                    None
-                }
-            })
-        }
-        // `tokens[i].transferFrom(...)`, `tokenMap[k].transferFrom(...)`. Direct-ident bases only.
-        ExprKind::Index(base, _) => {
-            let ExprKind::Ident(reses) = &base.peel_parens().kind else { return None };
-            let var = reses.iter().find_map(|r| match r {
-                Res::Item(ItemId::Variable(vid)) => Some(hir.variable(*vid)),
-                _ => None,
-            })?;
-            let element = match &var.ty.kind {
-                TypeKind::Array(arr) => &arr.element.kind,
-                TypeKind::Mapping(m) => &m.value.kind,
-                _ => return None,
-            };
-            match element {
-                TypeKind::Custom(ItemId::Contract(cid)) => Some(*cid),
-                _ => None,
-            }
-        }
+/// Resolves the static contract type of `recv`: a contract-typed expression, a direct contract
+/// reference (e.g. a library), or an interface/contract cast.
+fn receiver_contract_id<'hir>(gcx: Gcx<'hir>, recv: &hir::Expr<'hir>) -> Option<hir::ContractId> {
+    expr_contract_id(gcx, recv).or_else(|| direct_contract_id(recv))
+}
+
+fn expr_contract_id<'hir>(gcx: Gcx<'hir>, expr: &hir::Expr<'hir>) -> Option<hir::ContractId> {
+    expr_ty(gcx, expr).and_then(ty_contract_id)
+}
+
+fn ty_contract_id(ty: Ty<'_>) -> Option<hir::ContractId> {
+    match ty.peel_refs().kind {
+        TyKind::Contract(id) => Some(id),
+        TyKind::Type(ty) => ty_contract_id(ty),
         _ => None,
     }
 }
 
-/// Returns the [`StructId`] of `expr` when it is a (possibly chained) struct value.
-fn struct_of(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> Option<StructId> {
-    let expr = expr.peel_parens();
-    match &expr.kind {
+fn direct_contract_id(expr: &hir::Expr<'_>) -> Option<hir::ContractId> {
+    match &expr.peel_parens().kind {
         ExprKind::Ident(reses) => reses.iter().find_map(|r| match r {
-            Res::Item(ItemId::Variable(vid)) => match hir.variable(*vid).ty.kind {
-                TypeKind::Custom(ItemId::Struct(sid)) => Some(sid),
-                _ => None,
-            },
+            Res::Item(ItemId::Contract(cid)) => Some(*cid),
             _ => None,
         }),
-        ExprKind::Member(inner, member) => {
-            let sid = struct_of(hir, inner)?;
-            let strukt = hir.strukt(sid);
-            strukt.fields.iter().find_map(|fid| {
-                let v = hir.variable(*fid);
-                if v.name.is_some_and(|n| n.as_str() == member.as_str())
-                    && let TypeKind::Custom(ItemId::Struct(inner_sid)) = v.ty.kind
-                {
-                    Some(inner_sid)
-                } else {
-                    None
-                }
-            })
-        }
+        ExprKind::Call(callee, ..) => direct_contract_id(callee),
         _ => None,
     }
 }
@@ -1629,19 +1593,17 @@ fn is_address(hir: &hir::Hir<'_>, id: hir::VariableId) -> bool {
     matches!(hir.variable(id).ty.kind, TypeKind::Elementary(ElementaryType::Address(_)))
 }
 
-/// True when `expr`'s static type is `address` / `address payable`. Covers bare idents,
-/// `address(...)` / `payable(...)` casts, and parenthesised wraps.
-fn expr_is_address(hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
-    match &expr.peel_parens().kind {
-        ExprKind::Ident(reses) => reses.iter().any(|r| {
-            matches!(
-                r, Res::Item(ItemId::Variable(vid)) if is_address(hir, *vid)
-            )
-        }),
-        ExprKind::Call(callee, _, _) if is_address_cast(callee) => true,
-        ExprKind::Payable(_) => true,
-        _ => false,
-    }
+/// True when `expr`'s static type is `address` / `address payable`.
+fn expr_is_address<'hir>(gcx: Gcx<'hir>, expr: &hir::Expr<'hir>) -> bool {
+    expr_ty(gcx, expr).is_some_and(ty_is_address)
+}
+
+fn expr_ty<'hir>(gcx: Gcx<'hir>, expr: &hir::Expr<'hir>) -> Option<Ty<'hir>> {
+    gcx.type_of_expr(expr.peel_parens().id)
+}
+
+fn ty_is_address(ty: Ty<'_>) -> bool {
+    matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::Address(_)))
 }
 
 fn is_elementary(hir: &hir::Hir<'_>, id: hir::VariableId, abi: &str) -> bool {

--- a/crates/lint/src/sol/high/controlled_delegatecall.rs
+++ b/crates/lint/src/sol/high/controlled_delegatecall.rs
@@ -13,6 +13,7 @@ use solar::{
             self, CallArgs, ElementaryType, ExprKind, FunctionId, FunctionKind, ItemId, LoopSource,
             Res, StmtKind, TypeKind, Visit,
         },
+        ty::{Ty, TyKind},
     },
 };
 use std::{collections::HashSet, ops::ControlFlow};
@@ -28,14 +29,14 @@ impl<'hir> LateLintPass<'hir> for ControlledDelegatecall {
     fn check_function(
         &mut self,
         ctx: &LintContext,
-        _gcx: Gcx<'hir>,
+        gcx: Gcx<'hir>,
         hir: &'hir hir::Hir<'hir>,
         func: &'hir hir::Function<'hir>,
     ) {
         let Some(body) = func.body else { return };
-        let mut analyzer = Analyzer::new(hir, func.contract);
+        let mut analyzer = Analyzer::new(gcx, hir);
         for modifier in func.modifiers {
-            collect_modifier_safety(hir, modifier, &mut analyzer.safe_vars);
+            collect_modifier_safety(gcx, hir, modifier, &mut analyzer.safe_vars);
         }
         for stmt in body.stmts {
             let _ = analyzer.visit_stmt(stmt);
@@ -50,8 +51,8 @@ impl<'hir> LateLintPass<'hir> for ControlledDelegatecall {
 }
 
 struct Analyzer<'hir> {
+    gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
-    contract: Option<hir::ContractId>,
     safe_vars: HashSet<hir::VariableId>,
     hits: Vec<Span>,
 }
@@ -78,8 +79,8 @@ impl FlowState {
 const HELPER_DEPTH: u8 = 3;
 
 impl<'hir> Analyzer<'hir> {
-    fn new(hir: &'hir hir::Hir<'hir>, contract: Option<hir::ContractId>) -> Self {
-        Self { hir, contract, safe_vars: HashSet::new(), hits: Vec::new() }
+    fn new(gcx: Gcx<'hir>, hir: &'hir hir::Hir<'hir>) -> Self {
+        Self { gcx, hir, safe_vars: HashSet::new(), hits: Vec::new() }
     }
 
     fn snapshot(&self) -> FlowState {
@@ -198,7 +199,7 @@ impl<'hir> Analyzer<'hir> {
             return false;
         };
         member.name == kw::Delegatecall
-            && receiver_is_address(self.hir, self.contract, receiver)
+            && receiver_is_address(self.gcx, receiver)
             && !self.is_trusted_target(receiver)
     }
 
@@ -574,12 +575,8 @@ const fn var_is_address_like(var: &hir::Variable<'_>) -> bool {
     )
 }
 
-fn receiver_is_address<'hir>(
-    hir: &'hir hir::Hir<'hir>,
-    contract: Option<hir::ContractId>,
-    expr: &'hir hir::Expr<'hir>,
-) -> bool {
-    matches!(expr_type(hir, contract, expr), Some(TypeKind::Elementary(ElementaryType::Address(_))))
+fn receiver_is_address<'hir>(gcx: Gcx<'hir>, expr: &'hir hir::Expr<'hir>) -> bool {
+    gcx.type_of_expr(expr.peel_parens().id).is_some_and(ty_is_address)
 }
 
 fn is_address_like_cast_callee(callee: &hir::Expr<'_>) -> bool {
@@ -605,284 +602,8 @@ fn is_numeric_cast_callee(callee: &hir::Expr<'_>) -> bool {
     }
 }
 
-fn expr_type<'hir>(
-    hir: &'hir hir::Hir<'hir>,
-    contract: Option<hir::ContractId>,
-    expr: &hir::Expr<'hir>,
-) -> Option<hir::TypeKind<'hir>> {
-    match &expr.peel_parens().kind {
-        ExprKind::Payable(_) => Some(TypeKind::Elementary(ElementaryType::Address(true))),
-        ExprKind::Lit(lit) => match &lit.kind {
-            LitKind::Address(_) => Some(TypeKind::Elementary(ElementaryType::Address(false))),
-            LitKind::Bool(_) => Some(TypeKind::Elementary(ElementaryType::Bool)),
-            _ => None,
-        },
-        ExprKind::Call(callee, args, _) => match &callee.peel_parens().kind {
-            ExprKind::Type(ty) => Some(ty.kind.clone()),
-            ExprKind::New(ty) => Some(ty.kind.clone()),
-            ExprKind::Member(base, member)
-                if member.name == sym::decode && is_builtin(base, sym::abi) && args.len() == 2 =>
-            {
-                let mut args = args.exprs();
-                let _data = args.next()?;
-                let ty_arg = args.next()?;
-                let ty_expr = match &ty_arg.peel_parens().kind {
-                    ExprKind::Tuple(elems) if elems.len() == 1 => elems[0]?,
-                    _ => ty_arg,
-                };
-                match &ty_expr.peel_parens().kind {
-                    ExprKind::Type(ty) => Some(ty.kind.clone()),
-                    ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
-                        Res::Item(ItemId::Contract(cid)) => {
-                            Some(TypeKind::Custom(ItemId::Contract(*cid)))
-                        }
-                        _ => None,
-                    }),
-                    _ => None,
-                }
-            }
-            ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
-                Res::Item(ItemId::Contract(cid)) => Some(TypeKind::Custom(ItemId::Contract(*cid))),
-                Res::Item(ItemId::Function(fid)) => {
-                    let func = hir.function(*fid);
-                    (func.returns.len() == 1).then(|| hir.variable(func.returns[0]).ty.kind.clone())
-                }
-                Res::Item(ItemId::Variable(vid)) => match &hir.variable(*vid).ty.kind {
-                    TypeKind::Function(function) if function.returns.len() == 1 => {
-                        Some(hir.variable(function.returns[0]).ty.kind.clone())
-                    }
-                    _ => None,
-                },
-                _ => None,
-            }),
-            ExprKind::Member(base, member) => {
-                if let Some(ty) = member_call_return_type(hir, contract, base, *member, args) {
-                    return Some(ty);
-                }
-                match expr_type(hir, contract, base)? {
-                    TypeKind::Custom(ItemId::Contract(cid)) => {
-                        let receiver_contract = hir.contract(cid);
-                        let bases: &[hir::ContractId] = if receiver_contract.linearization_failed()
-                        {
-                            std::slice::from_ref(&cid)
-                        } else {
-                            receiver_contract.linearized_bases
-                        };
-                        let mut fallback: Option<TypeKind<'_>> = None;
-                        for &bid in bases {
-                            for fid in hir.contract(bid).all_functions() {
-                                let func = hir.function(fid);
-                                if func.name.is_none_or(|n| n.name != member.name)
-                                    || func.returns.len() != 1
-                                    || !args_match(hir, contract, args, func.parameters)
-                                {
-                                    continue;
-                                }
-                                let ret = hir.variable(func.returns[0]).ty.kind.clone();
-                                if matches!(
-                                    ret,
-                                    TypeKind::Elementary(ElementaryType::Address(_))
-                                        | TypeKind::Custom(ItemId::Contract(_))
-                                ) {
-                                    return Some(ret);
-                                }
-                                fallback = fallback.or(Some(ret));
-                            }
-                        }
-                        fallback
-                    }
-                    _ => None,
-                }
-            }
-            _ => match expr_type(hir, contract, callee)? {
-                TypeKind::Function(function) if function.returns.len() == 1 => {
-                    Some(hir.variable(function.returns[0]).ty.kind.clone())
-                }
-                _ => None,
-            },
-        },
-        ExprKind::New(ty) => Some(ty.kind.clone()),
-        ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
-            Res::Item(ItemId::Variable(id)) => Some(hir.variable(*id).ty.kind.clone()),
-            Res::Item(ItemId::Contract(id)) => Some(TypeKind::Custom(ItemId::Contract(*id))),
-            Res::Builtin(Builtin::This | Builtin::Super) => {
-                contract.map(|id| TypeKind::Custom(ItemId::Contract(id)))
-            }
-            _ => None,
-        }),
-        ExprKind::Member(base, member) => {
-            if let ExprKind::Ident(reses) = &base.peel_parens().kind
-                && reses.iter().any(|res| {
-                    let Res::Builtin(builtin) = res else { return false };
-                    matches!(
-                        (builtin.name(), member.name),
-                        (sym::msg, sym::sender)
-                            | (sym::tx, kw::Origin)
-                            | (sym::block, kw::Coinbase)
-                    )
-                })
-            {
-                return Some(TypeKind::Elementary(ElementaryType::Address(false)));
-            }
-            match expr_type(hir, contract, base)? {
-                TypeKind::Custom(ItemId::Struct(sid)) => {
-                    hir.strukt(sid).fields.iter().find_map(|&field| {
-                        let var = hir.variable(field);
-                        (var.name?.name == member.name).then(|| var.ty.kind.clone())
-                    })
-                }
-                _ => None,
-            }
-        }
-        ExprKind::Index(base, _) => match &base.peel_parens().kind {
-            ExprKind::Array(elems) => elems.first().and_then(|expr| expr_type(hir, contract, expr)),
-            _ => match expr_type(hir, contract, base)? {
-                TypeKind::Mapping(mapping) => Some(mapping.value.kind.clone()),
-                TypeKind::Array(array) => Some(array.element.kind.clone()),
-                _ => None,
-            },
-        },
-        ExprKind::Ternary(_, then_expr, else_expr) => {
-            expr_type(hir, contract, then_expr).or_else(|| expr_type(hir, contract, else_expr))
-        }
-        ExprKind::Assign(lhs, _, rhs) => {
-            expr_type(hir, contract, rhs).or_else(|| expr_type(hir, contract, lhs))
-        }
-        _ => None,
-    }
-}
-
-fn member_call_return_type<'hir>(
-    hir: &'hir hir::Hir<'hir>,
-    contract: Option<hir::ContractId>,
-    base: &hir::Expr<'hir>,
-    member: solar::interface::Ident,
-    args: &CallArgs<'hir>,
-) -> Option<hir::TypeKind<'hir>> {
-    let ExprKind::Ident(reses) = &base.peel_parens().kind else { return None };
-    for res in *reses {
-        let ty = match res {
-            Res::Builtin(Builtin::This) => {
-                let cid = contract?;
-                named_single_return_type(
-                    hir,
-                    contract,
-                    std::slice::from_ref(&cid),
-                    member.name,
-                    args,
-                )
-            }
-            Res::Builtin(Builtin::Super) => {
-                let cid = contract?;
-                let call_site = hir.contract(cid);
-                if call_site.linearization_failed() || call_site.linearized_bases.len() <= 1 {
-                    return None;
-                }
-                named_single_return_type(
-                    hir,
-                    contract,
-                    &call_site.linearized_bases[1..],
-                    member.name,
-                    args,
-                )
-            }
-            Res::Item(ItemId::Contract(cid)) => named_single_return_type(
-                hir,
-                contract,
-                std::slice::from_ref(cid),
-                member.name,
-                args,
-            ),
-            _ => continue,
-        };
-        if let Some(ty) = ty {
-            return Some(ty);
-        }
-    }
-    None
-}
-
-fn named_single_return_type<'hir>(
-    hir: &'hir hir::Hir<'hir>,
-    call_site_contract: Option<hir::ContractId>,
-    contracts: &[hir::ContractId],
-    name: Symbol,
-    args: &CallArgs<'hir>,
-) -> Option<hir::TypeKind<'hir>> {
-    for &cid in contracts {
-        for fid in hir.contract(cid).all_functions() {
-            let func = hir.function(fid);
-            if func.name.is_some_and(|n| n.name == name)
-                && func.returns.len() == 1
-                && args_match(hir, call_site_contract, args, func.parameters)
-            {
-                return Some(hir.variable(func.returns[0]).ty.kind.clone());
-            }
-        }
-    }
-    None
-}
-
-fn args_match<'hir>(
-    hir: &'hir hir::Hir<'hir>,
-    contract: Option<hir::ContractId>,
-    args: &CallArgs<'hir>,
-    params: &[hir::VariableId],
-) -> bool {
-    if args.len() != params.len() {
-        return false;
-    }
-    let compatible = |arg: &hir::Expr<'hir>, param: hir::VariableId| -> bool {
-        match expr_type(hir, contract, arg) {
-            Some(arg_ty) => types_compatible(&arg_ty, &hir.variable(param).ty.kind),
-            None => true,
-        }
-    };
-    match &args.kind {
-        hir::CallArgsKind::Unnamed(exprs) => {
-            exprs.iter().zip(params.iter()).all(|(arg, &param)| compatible(arg, param))
-        }
-        hir::CallArgsKind::Named(named) => named.iter().all(|arg| {
-            let Some(&param) = params
-                .iter()
-                .find(|&&param| hir.variable(param).name.is_some_and(|n| n.name == arg.name.name))
-            else {
-                return false;
-            };
-            compatible(&arg.value, param)
-        }),
-    }
-}
-
-fn types_compatible(arg: &hir::TypeKind<'_>, param: &hir::TypeKind<'_>) -> bool {
-    match (arg, param) {
-        (
-            TypeKind::Elementary(ElementaryType::Address(arg_payable)),
-            TypeKind::Elementary(ElementaryType::Address(param_payable)),
-        ) => !param_payable || *arg_payable,
-        (
-            TypeKind::Custom(ItemId::Contract(_)),
-            TypeKind::Elementary(ElementaryType::Address(_)),
-        ) => true,
-        (TypeKind::Array(arg), TypeKind::Array(param)) => {
-            arg.size.is_some() == param.size.is_some()
-                && types_compatible(&arg.element.kind, &param.element.kind)
-        }
-        (TypeKind::Mapping(arg), TypeKind::Mapping(param)) => {
-            types_compatible(&arg.key.kind, &param.key.kind)
-                && types_compatible(&arg.value.kind, &param.value.kind)
-        }
-        (TypeKind::Function(arg), TypeKind::Function(param)) => {
-            arg.visibility == param.visibility
-                && arg.state_mutability == param.state_mutability
-                && arg.parameters.len() == param.parameters.len()
-                && arg.returns.len() == param.returns.len()
-        }
-        (TypeKind::Elementary(arg), TypeKind::Elementary(param)) => arg == param,
-        (TypeKind::Custom(arg), TypeKind::Custom(param)) => arg == param,
-        (TypeKind::Err(_), _) | (_, TypeKind::Err(_)) => true,
-        _ => false,
-    }
+fn ty_is_address(ty: Ty<'_>) -> bool {
+    matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::Address(_)))
 }
 
 fn callee_no_arg_returns<'hir>(
@@ -908,6 +629,7 @@ const fn function_is_statically_trusted(func: &hir::Function<'_>) -> bool {
 }
 
 fn collect_modifier_safety<'hir>(
+    gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
     invocation: &'hir hir::Modifier<'hir>,
     out_safe: &mut HashSet<hir::VariableId>,
@@ -932,7 +654,7 @@ fn collect_modifier_safety<'hir>(
         let _ = collector.visit_stmt(stmt);
     }
 
-    let mut analyzer = Analyzer::new(hir, modifier.contract);
+    let mut analyzer = Analyzer::new(gcx, hir);
     for stmt in &prefix {
         let _ = analyzer.visit_stmt(stmt);
         if branch_always_exits(stmt) {


### PR DESCRIPTION
Follow-up to #15003/#15035 after auditing current `master`, including the later `arbitrary-send-erc20-permit` lint from #15037.

This finishes the Solar expression type cleanup in the remaining lints that were still reconstructing expression types from HIR:

- `controlled-delegatecall`: remove the local expression type resolver and use `Gcx::type_of_expr` for delegatecall receiver address typing; thread `Gcx` through modifier-prefix analysis.
- `arbitrary-send-erc20[-permit]`: thread `Gcx` through the analyzer, modifier/constructor seeding, permit/flash-loan/sink matching, and use Solar expression types for contract/address receiver checks. The existing identity/alias tracking and declaration ABI checks remain HIR-based.