### PR TITLE
fix(docker): refresh Rust builder digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM rust:1-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55 AS chef
+FROM rust:1-bookworm@sha256:13c186980fa33cc12759b429662a1322939dbe697484b7c33b47dd2698d28460 AS chef
 WORKDIR /app
 
 RUN apt update && apt install -y build-essential libssl-dev git pkg-config curl perl


### PR DESCRIPTION
## Summary

- refresh the pinned `rust:1-bookworm` builder image digest
- preserve the existing Dockerfile tag intent while moving the pinned image to a Rust toolchain new enough for the current dependency graph
- fixes the Docker release dependency layer failure introduced when the floating builder image was pinned to an older April 2026 digest

Closes #15058

## Context

The Docker release job is failing during `cargo chef cook` because the currently pinned `rust:1-bookworm` digest contains `rustc 1.94.1`, while the current Solar revision requires Rust 1.95:

```text
error: rustc 1.94.1 is not supported by the following packages:
  solar-ast@0.1.8 requires rustc 1.95
  solar-compiler@0.1.8 requires rustc 1.95
```

`rust:1-bookworm` itself has been the Docker builder base since #12491. The regression comes from #14316 pinning that tag to a fixed April 2026 digest, so the builder stopped tracking newer stable Rust images while dependencies continued to move.

## Verification

Reproduced the failing Docker dependency layer with the old pinned digest:

```text
$ docker buildx build --progress=plain --no-cache --target builder-deps \
  --build-arg RUST_IMAGE=rust:1-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55 \
  --build-arg RUST_PROFILE=dist \
  --build-arg RUST_FEATURES=aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer \
  -f Dockerfile.verify-cook .
...
error: rustc 1.94.1 is not supported by the following packages:
  solar-ast@0.1.8 requires rustc 1.95
  solar-compiler@0.1.8 requires rustc 1.95
```

Verified the same Docker dependency layer passes with the refreshed digest:

```text
$ docker buildx build --progress=plain --no-cache --target builder-deps \
  --build-arg RUST_IMAGE=rust:1-bookworm@sha256:13c186980fa33cc12759b429662a1322939dbe697484b7c33b47dd2698d28460 \
  --build-arg RUST_PROFILE=dist \
  --build-arg RUST_FEATURES=aws-kms,gcp-kms,turnkey,cli,asm-keccak,js-tracer \
  -f Dockerfile.verify-cook .
...
Finished `dist` profile [optimized] target(s) in 3m 27s
```
