### PR TITLE
fix(forge): propagate fail-fast on setUp / suite-validation failures

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -587,6 +587,10 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
         // There are multiple setUp function, so we return a single test result for `setUp`
         if setup_fns.len() > 1 {
+            // Trip the global fail-fast flag so sibling parallel suites (notably long-running
+            // invariant campaigns) observe `should_stop()` and exit at their next run boundary
+            // instead of running to their timeout.
+            self.tcfg.early_exit.record_failure();
             return SuiteResult::new(
                 start.elapsed(),
                 [("setUp()".to_string(), TestResult::fail("multiple setUp functions".to_string()))]
@@ -600,6 +604,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             self.contract.abi.functions().filter(|func| func.name.is_after_invariant()).collect();
         if after_invariant_fns.len() > 1 {
             // Return a single test result failure if multiple functions declared.
+            self.tcfg.early_exit.record_failure();
             return SuiteResult::new(
                 start.elapsed(),
                 [(
@@ -642,6 +647,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             })
             .collect();
         if !invalid_invariants.is_empty() {
+            self.tcfg.early_exit.record_failure();
             return SuiteResult::new(
                 start.elapsed(),
                 invalid_invariants.into_iter().collect(),
@@ -679,6 +685,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             } else {
                 "setUp()".to_string()
             };
+            self.tcfg.early_exit.record_failure();
             return SuiteResult::new(
                 start.elapsed(),
                 [(fail_msg, TestResult::setup_result(setup))].into(),
@@ -714,6 +721,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 TestResult::fail("`testFail*` has been removed. Consider changing to test_Revert[If|When]_Condition and expecting a revert".to_string())
             };
             let test_results = test_fail_functions.map(|func| (func.signature(), fail())).collect();
+            self.tcfg.early_exit.record_failure();
             return SuiteResult::new(start.elapsed(), test_results, warnings);
         }
 

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -665,6 +665,77 @@ contract MultiTest is Test {
     );
 });
 
+// Regression: a `setUp()` failure in one suite must trip the global fail-fast flag so that
+// long-running invariant campaigns in sibling suites (dispatched in parallel via rayon) exit
+// at their next run boundary instead of running to their configured timeout.
+forgetest_init!(fail_fast_cancels_invariant_after_setup_failure, |prj, cmd| {
+    // Need at least 2 worker threads so the two suites run concurrently.
+    if std::thread::available_parallelism().map_or(1, |n| n.get()) < 2 {
+        return;
+    }
+
+    // Use a very large invariant timeout so the with-fix vs without-fix behavior is
+    // dramatically different: with the fix the campaign sees `should_stop()` and exits within
+    // one fuzz sequence (~seconds); without the fix it would run for the full timeout. Same
+    // canary pattern as `test_fail_fast_config`.
+    prj.update_config(|config| {
+        config.invariant.timeout = Some(3600);
+    });
+
+    prj.add_test(
+        "BrokenSetup.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract BrokenSetupTest is Test {
+    function setUp() public pure {
+        require(false, "setUp failure");
+    }
+
+    function test_Noop() public pure {}
+}
+"#,
+    );
+
+    prj.add_test(
+        "LongInvariant.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract Target {
+    uint256 public x;
+    function bump() external { x += 1; }
+}
+
+contract LongInvariantTest is Test {
+    Target internal target;
+
+    function setUp() public {
+        target = new Target();
+        targetContract(address(target));
+    }
+
+    function invariant_alwaysTrue() public view {
+        require(true);
+    }
+}
+"#,
+    );
+
+    let started = std::time::Instant::now();
+    cmd.args(["test", "--fail-fast", "--mc", "BrokenSetupTest|LongInvariantTest"]).assert_failure();
+    let elapsed = started.elapsed();
+
+    // The two suites run in parallel; the broken `setUp()` reverts within milliseconds and must
+    // cancel the in-flight invariant campaign almost immediately. The 1h invariant timeout above
+    // gives us a huge margin: with the fix elapsed is ~seconds; without it elapsed approaches
+    // 1h. 60s is generous slack for CI but still catches the regression unambiguously.
+    assert!(
+        elapsed < std::time::Duration::from_secs(60),
+        "fail-fast did not cancel the in-flight invariant campaign: elapsed {elapsed:?}",
+    );
+});
+
 // https://github.com/foundry-rs/foundry/pull/6531
 forgetest_init!(fork_traces, |prj, cmd| {
     let endpoint = rpc::next_http_archive_rpc_url();


### PR DESCRIPTION
## Summary

When a contract's `setUp()` reverts (or any other early suite-level failure path in `ContractRunner::run` is hit), the suite returns a failing `SuiteResult` without ever calling `early_exit.record_failure()`. Sibling suites already dispatched in parallel via `par_iter().for_each` — most importantly long-running invariant campaigns — therefore never observe `should_stop() == true` and keep running until their configured `invariant.timeout` (potentially hours), even with `--fail-fast`.

## Repro

`forge test --fail-fast` on a workspace where one suite has a reverting `setUp()` and another has a time-based invariant campaign (`invariant.timeout = 18000`). The failure is surfaced within ms but the workflow stays alive for the full 5 h timeout because the in-flight invariant workers never receive the cancellation signal.

## Fix

Trip the existing global `EarlyExit` flag on every early-return failure branch in `ContractRunner::run`:

- multiple `setUp` functions
- multiple `afterInvariant` functions
- invariant function with parameters
- `setUp()` / constructor revert (the real-world case)
- `testFail*` rejection

`EarlyExit::record_failure` is already a no-op when fail-fast is disabled, so this is safe to call unconditionally and changes nothing for non-`--fail-fast` runs.

`InvariantCampaignState::should_stop` already checks the early-exit flag at every run boundary, so in-flight workers exit at their next fuzz sequence (≤ `depth` calls) instead of running to `invariant.timeout`.

## Test

Added `fail_fast_cancels_invariant_after_setup_failure` (mirrors the canary pattern of `test_fail_fast_config`):

- Suite A: `setUp()` reverts immediately
- Suite B: long-running invariant test with `invariant.timeout = 3600`
- Run `forge test --fail-fast --mc 'BrokenSetupTest|LongInvariantTest'`
- Assert wall-clock elapsed `< 60s`

Verified locally:

| | with fix | without fix |
|---|---|---|
| elapsed | ~5 s ✓ | ~60 s+ (asserts) |

Existing fail-fast tests (`test_fail_fast_config`, `exit_code_error_on_fail_fast`, `exit_code_error_on_fail_fast_with_json`, `show_progress_with_fail_fast_exits_early`) still pass.