### PR TITLE
fix(tempo): mark all precompiles during genesis setup

### DIFF
--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -24,9 +24,7 @@ use crate::{
     backend::{DatabaseExt, JournaledState},
     constants::{CALLER, TEST_CONTRACT_ADDRESS},
     evm::{FoundryEvmFactory, NestedEvm},
-    tempo::{
-        TEMPO_TIP20_TOKENS, active_tempo_precompile_addresses, initialize_tempo_genesis_inner,
-    },
+    tempo::{TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, initialize_tempo_test_genesis_inner},
 };
 
 // Will be removed when the next revm release includes bluealloy/revm#3518.
@@ -53,15 +51,15 @@ pub(crate) fn initialize_tempo_evm<
             // In fork mode, warm up precompile accounts to avoid repeated RPC fetches.
             let mut sctx = StorageCtx;
             let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
-            for addr in active_tempo_precompile_addresses(ctx.cfg.spec)
-                .chain(TEMPO_TIP20_TOKENS.iter().copied())
+            for addr in
+                TEMPO_PRECOMPILE_ADDRESSES.iter().copied().chain(TEMPO_TIP20_TOKENS.iter().copied())
             {
                 sctx.set_code(addr, sentinel.clone())
                     .expect("failed to warm tempo precompile address");
             }
         } else {
             // In non-fork mode, run full genesis initialization.
-            initialize_tempo_genesis_inner(TEST_CONTRACT_ADDRESS, CALLER, ctx.cfg.spec)
+            initialize_tempo_test_genesis_inner(TEST_CONTRACT_ADDRESS, CALLER)
                 .expect("tempo genesis initialization failed");
         }
     });

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -82,6 +82,34 @@ pub fn initialize_tempo_genesis_inner(
     recipient: Address,
     hardfork: TempoHardfork,
 ) -> Result<(), TempoPrecompileError> {
+    initialize_tempo_genesis_inner_with_precompiles(
+        admin,
+        recipient,
+        active_tempo_precompile_addresses(hardfork),
+    )
+}
+
+/// Inner genesis initialization for Forge's local test EVM.
+///
+/// Forge tests use sentinel bytecode to identify well-known Tempo precompile accounts, even when
+/// the current setup spec is earlier than the precompile's activation hardfork. This does not
+/// affect hardfork-aware execution, which remains handled by the precompile lookup.
+pub fn initialize_tempo_test_genesis_inner(
+    admin: Address,
+    recipient: Address,
+) -> Result<(), TempoPrecompileError> {
+    initialize_tempo_genesis_inner_with_precompiles(
+        admin,
+        recipient,
+        TEMPO_PRECOMPILE_ADDRESSES.iter().copied(),
+    )
+}
+
+fn initialize_tempo_genesis_inner_with_precompiles(
+    admin: Address,
+    recipient: Address,
+    precompiles: impl IntoIterator<Item = Address>,
+) -> Result<(), TempoPrecompileError> {
     // Idempotent: PATH_USD is the first token created during genesis; if it already exists, skip.
     if TIP20Factory::new().is_tip20(PATH_USD_ADDRESS)? {
         return Ok(());
@@ -91,7 +119,7 @@ pub fn initialize_tempo_genesis_inner(
 
     // Set sentinel bytecode for precompile addresses
     let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
-    for precompile in active_tempo_precompile_addresses(hardfork) {
+    for precompile in precompiles {
         ctx.set_code(precompile, sentinel.clone())?;
     }
 


### PR DESCRIPTION
## Summary

Fix Forge's Tempo setup so well-known Tempo precompile addresses always have sentinel bytecode during local Forge genesis and fork warmup.

## Why

`d981ef491` started seeding sentinel code from `active_tempo_precompile_addresses(ctx.cfg.spec)`. That made `AddressRegistry.code.length == 0` when Forge setup ran with a pre-T3 spec, causing `TempoTest.setUp()` to fail with `MissingPrecompile("AddressRegistry", 0xfDC0000000000000000000000000000000000000)`.

This keeps Anvil and hardfork-aware precompile activation unchanged. Anvil genesis still seeds only precompiles active at the selected hardfork; Forge's local test genesis gets marker bytecode for all known Tempo precompile accounts.

## Tests

- `cargo fmt --check`
- `cargo test -p foundry-evm-networks canonical_tempo_network_reports_precompiles`
- `cargo check -p foundry-evm-core`
- `cargo test -p anvil --test it tempo::test_pre_t5_channel_reserve_has_no_sentinel_code`

Prompted by: @grandizzy
