### PR TITLE
perf(symbolic): improve solver query handling

### DIFF
--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -205,6 +205,9 @@ pub struct SymbolicStats {
     pub paths: usize,
     /// Number of normalized solver queries issued during the run.
     pub solver_queries: usize,
+    /// Number of queries sent to the SMT backend after local fast paths.
+    #[serde(default)]
+    pub smt_queries: usize,
     /// Number of satisfiability checks requested by the executor.
     #[serde(default)]
     pub sat_queries: usize,
@@ -217,6 +220,9 @@ pub struct SymbolicStats {
     /// Number of model requests served from the normalized model cache.
     #[serde(default)]
     pub model_cache_hits: usize,
+    /// Number of satisfiable witnesses produced by local hard-arithmetic search.
+    #[serde(default)]
+    pub heuristic_witnesses: usize,
     /// Wall-clock time spent waiting on backend solver subprocesses, in milliseconds.
     #[serde(default)]
     pub solver_time_ms: u64,

--- a/crates/evm/symbolic/src/runtime/expressions.rs
+++ b/crates/evm/symbolic/src/runtime/expressions.rs
@@ -1169,7 +1169,17 @@ impl BoolExpr {
     }
 
     /// Implements the `cmp` symbolic expression helper.
-    pub(crate) const fn cmp(op: BoolExprOp, left: Expr, right: Expr) -> Self {
+    pub(crate) fn cmp(op: BoolExprOp, left: Expr, right: Expr) -> Self {
+        if let (Expr::Const(left), Expr::Const(right)) = (&left, &right) {
+            return Self::Const(match op {
+                BoolExprOp::Ult => left < right,
+                BoolExprOp::Ugt => left > right,
+                BoolExprOp::Ule => left <= right,
+                BoolExprOp::Uge => left >= right,
+                BoolExprOp::Slt => slt(*left, *right),
+                BoolExprOp::Sgt => slt(*right, *left),
+            });
+        }
         Self::Cmp(op, left, right)
     }
 

--- a/crates/evm/symbolic/src/runtime/expressions.rs
+++ b/crates/evm/symbolic/src/runtime/expressions.rs
@@ -985,6 +985,10 @@ impl Expr {
             {
                 expr
             }
+            (ExprOp::And, left, right) if left == right => left,
+            (ExprOp::And, Self::Const(mask), expr) | (ExprOp::And, expr, Self::Const(mask)) => {
+                Self::and_const(expr, mask)
+            }
             (ExprOp::Or | ExprOp::Xor, Self::Const(value), expr)
             | (ExprOp::Or | ExprOp::Xor, expr, Self::Const(value))
                 if value.is_zero() =>
@@ -1000,6 +1004,32 @@ impl Expr {
                 Self::Const(U256::ZERO)
             }
             (op, left, right) => Self::Op(op, Box::new(left), Box::new(right)),
+        }
+    }
+
+    fn and_const(expr: Self, mask: U256) -> Self {
+        if mask.is_zero() {
+            return Self::Const(U256::ZERO);
+        }
+        if mask == U256::MAX {
+            return expr;
+        }
+
+        match expr {
+            Self::Op(ExprOp::And, left, right) => match (*left, *right) {
+                (Self::Const(existing), inner) | (inner, Self::Const(existing))
+                    if existing == mask =>
+                {
+                    Self::and_const(inner, mask)
+                }
+                (left, right) if left == right => Self::and_const(left, mask),
+                (left, right) => Self::Op(
+                    ExprOp::And,
+                    Box::new(Self::Op(ExprOp::And, Box::new(left), Box::new(right))),
+                    Box::new(Self::Const(mask)),
+                ),
+            },
+            expr => Self::Op(ExprOp::And, Box::new(expr), Box::new(Self::Const(mask))),
         }
     }
 

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -526,7 +526,7 @@ impl SmtLibSubprocessSolver {
 
 /// Returns a structural key for normalized solver cache lookups.
 fn constraint_cache_key(constraints: &[BoolExpr]) -> Vec<BoolExpr> {
-    let mut key = Vec::new();
+    let mut key = Vec::with_capacity(constraints.len());
     for constraint in constraints.iter().cloned().map(cache_key_bool) {
         collect_cache_key_conjunct(constraint, &mut key);
     }

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -484,7 +484,7 @@ impl SmtLibSubprocessSolver {
         let commands =
             ordered_commands.iter().map(|(_, command)| command.clone()).collect::<Vec<_>>();
 
-        let mut smt = String::new();
+        let mut smt = String::with_capacity(256 + smt_constraints.len().saturating_mul(192));
         smt.push_str("(set-logic QF_BV)\n");
         if commands.iter().all(|command| command.smt_timeout)
             && let Some(timeout) = self.timeout.filter(|timeout| *timeout > 0)

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -277,6 +277,12 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             trace!(result, "is_sat: normalized cache hit");
             return Ok(*result);
         }
+        if self.has_cached_unsat_subset(&cache_key) {
+            self.sat_cache_hits += 1;
+            trace!("is_sat: normalized unsat subset cache hit");
+            self.cache_sat_result(cache_key, false);
+            return Ok(false);
+        }
 
         self.reserve_query()?;
         self.record_query();
@@ -299,19 +305,20 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             return Ok(false);
         }
         if constraints_prefer_hard_arith_fallback_first(&smt_constraints)
-            && hard_arith_fallback_model(&smt_constraints).is_some()
+            && validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some()
         {
             self.heuristic_witnesses += 1;
-            trace!("is_sat: hard arithmetic fallback model before solver");
+            trace!("is_sat: validated hard arithmetic fallback model before solver");
             self.cache_sat_result(cache_key, true);
             return Ok(true);
         }
         let output = match self.query_normalized(&smt_constraints, false, constraints) {
             Ok(output) => output,
             Err(SymbolicError::SolverUnknown) => {
-                if hard_arith_fallback_model(&smt_constraints).is_some() {
+                if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
                     self.heuristic_witnesses += 1;
-                    trace!("is_sat: hard arithmetic fallback model after solver unknown");
+                    trace!("is_sat: validated hard arithmetic fallback model after solver unknown");
+                    self.cache_sat_result(cache_key, true);
                     return Ok(true);
                 }
                 return Err(SymbolicError::SolverUnknown);
@@ -328,8 +335,9 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
                 Ok(false)
             }
             "unknown" => {
-                if hard_arith_fallback_model(&smt_constraints).is_some() {
+                if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
                     self.heuristic_witnesses += 1;
+                    self.cache_sat_result(cache_key, true);
                     Ok(true)
                 } else {
                     Err(SymbolicError::SolverUnknown)
@@ -351,6 +359,12 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         if self.sat_cache.get(&cache_key) == Some(&false) {
             self.model_cache.remove(&cache_key);
             trace!("model: normalized sat cache says unsat");
+            return Err(SymbolicError::Solver("counterexample path became unsat".to_string()));
+        }
+        if self.has_cached_unsat_subset(&cache_key) {
+            self.cache_sat_result(cache_key.clone(), false);
+            self.model_cache.remove(&cache_key);
+            trace!("model: normalized unsat subset cache hit");
             return Err(SymbolicError::Solver("counterexample path became unsat".to_string()));
         }
 
@@ -379,18 +393,24 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         .entered();
         trace!(query_id = self.queries, constraint_count = constraints.len(), "solver model");
         if constraints_prefer_hard_arith_fallback_first(&smt_constraints)
-            && let Some(model) = hard_arith_fallback_model(&smt_constraints)
+            && let Some(model) = validated_hard_arith_fallback_model(&smt_constraints, constraints)
         {
             self.heuristic_witnesses += 1;
-            trace!("model: hard arithmetic fallback model before solver");
+            trace!("model: validated hard arithmetic fallback model before solver");
+            self.cache_sat_result(cache_key.clone(), true);
+            self.cache_model_result(cache_key, model.clone());
             return Ok(model);
         }
         let output = match self.query_normalized(&smt_constraints, true, constraints) {
             Ok(output) => output,
             Err(SymbolicError::SolverUnknown) => {
-                if let Some(model) = hard_arith_fallback_model(&smt_constraints) {
+                if let Some(model) =
+                    validated_hard_arith_fallback_model(&smt_constraints, constraints)
+                {
                     self.heuristic_witnesses += 1;
-                    trace!("model: hard arithmetic fallback model after solver unknown");
+                    trace!("model: validated hard arithmetic fallback model after solver unknown");
+                    self.cache_sat_result(cache_key.clone(), true);
+                    self.cache_model_result(cache_key, model.clone());
                     return Ok(model);
                 }
                 return Err(SymbolicError::SolverUnknown);
@@ -411,8 +431,12 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
                 Err(SymbolicError::Solver("counterexample path became unsat".to_string()))
             }
             "unknown" => {
-                if let Some(model) = hard_arith_fallback_model(&smt_constraints) {
+                if let Some(model) =
+                    validated_hard_arith_fallback_model(&smt_constraints, constraints)
+                {
                     self.heuristic_witnesses += 1;
+                    self.cache_sat_result(cache_key.clone(), true);
+                    self.cache_model_result(cache_key, model.clone());
                     Ok(model)
                 } else {
                     Err(SymbolicError::SolverUnknown)
@@ -474,6 +498,13 @@ impl SmtLibSubprocessSolver {
         {
             self.model_cache.insert(key, model);
         }
+    }
+
+    /// Returns whether an already-proved unsat constraint set is a subset of `key`.
+    fn has_cached_unsat_subset(&self, key: &[BoolExpr]) -> bool {
+        self.sat_cache
+            .iter()
+            .any(|(cached_key, result)| !*result && sorted_bool_exprs_are_subset(cached_key, key))
     }
 
     /// Sends already-normalized constraints to the configured solver portfolio.
@@ -552,6 +583,25 @@ fn constraints_are_directly_unsat(constraints: &[BoolExpr]) -> bool {
         BoolExpr::Not(inner) => constraints.binary_search(inner.as_ref()).is_ok(),
         constraint => constraints.binary_search(&constraint.clone().not()).is_ok(),
     })
+}
+
+/// Returns whether every expression in sorted `subset` appears in sorted `superset`.
+fn sorted_bool_exprs_are_subset(subset: &[BoolExpr], superset: &[BoolExpr]) -> bool {
+    if subset.len() > superset.len() {
+        return false;
+    }
+
+    let mut superset = superset.iter();
+    for expected in subset {
+        loop {
+            match superset.next() {
+                Some(candidate) if candidate < expected => {}
+                Some(candidate) if candidate == expected => break,
+                _ => return false,
+            }
+        }
+    }
+    true
 }
 
 /// Returns a conservative canonical boolean expression for cache-key equality.
@@ -635,6 +685,15 @@ fn cache_key_expr(expr: Expr) -> Expr {
 /// Returns whether a word operation is safe to reorder for cache-key equality.
 const fn expr_op_is_commutative(op: ExprOp) -> bool {
     matches!(op, ExprOp::Add | ExprOp::Mul | ExprOp::And | ExprOp::Or | ExprOp::Xor)
+}
+
+/// Returns a hard-arithmetic fallback model only after validating it against original constraints.
+fn validated_hard_arith_fallback_model(
+    normalized_constraints: &[BoolExpr],
+    original_constraints: &[BoolExpr],
+) -> Option<BTreeMap<String, U256>> {
+    let model = hard_arith_fallback_model(normalized_constraints)?;
+    model_satisfies_constraints(&model, original_constraints).then_some(model)
 }
 
 /// Returns whether a parsed model satisfies the current original constraints.

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -288,6 +288,11 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         )
         .entered();
         trace!(query_id = self.queries, constraint_count = constraints.len(), "solver is_sat");
+        if constraints_are_directly_unsat(&smt_constraints) {
+            trace!("is_sat: direct contradiction");
+            self.cache_sat_result(cache_key, false);
+            return Ok(false);
+        }
         if product_monotonic_unsat_normalized(&smt_constraints) {
             trace!("is_sat: monotonic product contradiction");
             self.cache_sat_result(cache_key, false);
@@ -538,6 +543,15 @@ fn constraint_cache_key(constraints: &[BoolExpr]) -> Vec<BoolExpr> {
     key.sort();
     key.dedup();
     key
+}
+
+/// Returns whether normalized conjunctive constraints contain a direct contradiction.
+fn constraints_are_directly_unsat(constraints: &[BoolExpr]) -> bool {
+    constraints.iter().any(|constraint| match constraint {
+        BoolExpr::Const(false) => true,
+        BoolExpr::Not(inner) => constraints.binary_search(inner.as_ref()).is_ok(),
+        constraint => constraints.binary_search(&constraint.clone().not()).is_ok(),
+    })
 }
 
 /// Returns a conservative canonical boolean expression for cache-key equality.

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -158,6 +158,7 @@ pub(crate) struct SmtLibSubprocessSolver {
     model_queries: usize,
     sat_cache_hits: usize,
     model_cache_hits: usize,
+    smt_queries: usize,
     solver_time: Duration,
 }
 
@@ -186,6 +187,7 @@ impl SmtLibSubprocessSolver {
             model_queries: 0,
             sat_cache_hits: 0,
             model_cache_hits: 0,
+            smt_queries: 0,
             solver_time: Duration::ZERO,
         }
     }
@@ -207,10 +209,12 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         SymbolicStats {
             paths: 0,
             solver_queries: self.queries,
+            smt_queries: self.smt_queries,
             sat_queries: self.sat_queries,
             model_queries: self.model_queries,
             sat_cache_hits: self.sat_cache_hits,
             model_cache_hits: self.model_cache_hits,
+            heuristic_witnesses: self.heuristic_witnesses,
             solver_time_ms: self.solver_time.as_millis().try_into().unwrap_or(u64::MAX),
         }
     }
@@ -474,6 +478,7 @@ impl SmtLibSubprocessSolver {
         model: bool,
         model_constraints: &[BoolExpr],
     ) -> Result<String, SymbolicError> {
+        self.smt_queries += 1;
         let mut vars = BTreeSet::new();
         for constraint in smt_constraints {
             constraint.collect_vars(&mut vars);

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -289,6 +289,14 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             self.cache_sat_result(cache_key, false);
             return Ok(false);
         }
+        if constraints_prefer_hard_arith_fallback_first(&smt_constraints)
+            && hard_arith_fallback_model(&smt_constraints).is_some()
+        {
+            self.heuristic_witnesses += 1;
+            trace!("is_sat: hard arithmetic fallback model before solver");
+            self.cache_sat_result(cache_key, true);
+            return Ok(true);
+        }
         let output = match self.query_normalized(&smt_constraints, false, constraints) {
             Ok(output) => output,
             Err(SymbolicError::SolverUnknown) => {

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -574,7 +574,7 @@ fn collect_cache_key_conjunct(expr: BoolExpr, out: &mut Vec<BoolExpr>) {
 }
 
 /// Returns a conservative canonical comparison for cache-key equality.
-const fn cache_key_cmp(op: BoolExprOp, left: Expr, right: Expr) -> BoolExpr {
+fn cache_key_cmp(op: BoolExprOp, left: Expr, right: Expr) -> BoolExpr {
     match op {
         BoolExprOp::Ugt => BoolExpr::cmp(BoolExprOp::Ult, right, left),
         BoolExprOp::Uge => BoolExpr::cmp(BoolExprOp::Ule, right, left),

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -304,14 +304,6 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             self.cache_sat_result(cache_key, false);
             return Ok(false);
         }
-        if constraints_prefer_hard_arith_fallback_first(&smt_constraints)
-            && validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some()
-        {
-            self.heuristic_witnesses += 1;
-            trace!("is_sat: validated hard arithmetic fallback model before solver");
-            self.cache_sat_result(cache_key, true);
-            return Ok(true);
-        }
         let output = match self.query_normalized(&smt_constraints, false, constraints) {
             Ok(output) => output,
             Err(SymbolicError::SolverUnknown) => {

--- a/crates/evm/symbolic/src/runtime/solver/normalize.rs
+++ b/crates/evm/symbolic/src/runtime/solver/normalize.rs
@@ -2,7 +2,28 @@ use super::*;
 
 /// Normalizes path constraints into an equivalent, solver-friendlier form.
 pub(crate) fn normalize_constraints_for_solver(constraints: &[BoolExpr]) -> Vec<BoolExpr> {
-    constraints.iter().cloned().map(normalize_bool_for_solver).collect()
+    let mut normalized = Vec::with_capacity(constraints.len());
+    for constraint in constraints.iter().cloned().map(normalize_bool_for_solver) {
+        if matches!(constraint, BoolExpr::Const(false)) {
+            return vec![BoolExpr::Const(false)];
+        }
+        collect_normalized_conjunct(constraint, &mut normalized);
+    }
+    normalized.sort();
+    normalized.dedup();
+    normalized
+}
+
+fn collect_normalized_conjunct(expr: BoolExpr, out: &mut Vec<BoolExpr>) {
+    match expr {
+        BoolExpr::Const(true) => {}
+        BoolExpr::And(values) => {
+            for value in values {
+                collect_normalized_conjunct(value, out);
+            }
+        }
+        value => out.push(value),
+    }
 }
 
 /// Normalizes one boolean expression into an equivalent, solver-friendlier form.

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2874,6 +2874,21 @@ fn model_query_populates_sat_cache() {
     let _ = std::fs::remove_file(&marker);
 }
 
+#[test]
+/// Regression coverage for direct contradictions avoiding SMT calls.
+fn direct_contradiction_is_sat_short_circuits_locally() {
+    let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
+    let constraint = BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(1)));
+    let constraints = vec![constraint.clone(), constraint.not()];
+
+    assert!(!solver.is_sat(&constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.sat_queries, 1);
+}
+
 #[cfg(unix)]
 #[test]
 /// Regression coverage for satisfiability cache unsat results short-circuiting model queries.

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2607,6 +2607,38 @@ fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
 
 #[cfg(unix)]
 #[test]
+/// Regression coverage for validated hard-arithmetic model results populating caches.
+fn model_uses_validated_hard_arithmetic_fallback_cache() {
+    let marker = portfolio_test_marker("hard-arith-model-cache");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x = Expr::Var("x".to_string());
+    let y = Expr::Var("y".to_string());
+    let constraints = vec![
+        BoolExpr::cmp(BoolExprOp::Ugt, x.clone(), Expr::Const(U256::ZERO)),
+        BoolExpr::cmp(BoolExprOp::Ugt, y.clone(), Expr::Const(U256::ZERO)),
+        BoolExpr::eq(Expr::op(ExprOp::Mul, x, y), Expr::Const(U256::from(4))),
+    ];
+
+    let first = solver.model(&constraints).unwrap();
+    assert!(constraints.iter().all(|constraint| eval_bool_expr(constraint, &first).unwrap()));
+    let second = solver.model(&constraints).unwrap();
+    assert_eq!(first, second);
+    assert!(solver.is_sat(&constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.model_queries, 2);
+    assert_eq!(stats.model_cache_hits, 1);
+    assert_eq!(stats.sat_queries, 1);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(solver.heuristic_witnesses(), 1);
+    assert_eq!(counted_solver_invocations(&marker), 0);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
 /// Regression coverage for hard-arithmetic `is_sat` preserving solver `unsat`.
 fn is_sat_hard_arithmetic_without_witness_still_honors_solver_unsat() {
     let marker = portfolio_test_marker("hard-arith-is-sat-unsat");
@@ -2887,6 +2919,53 @@ fn direct_contradiction_is_sat_short_circuits_locally() {
     assert_eq!(stats.solver_queries, 1);
     assert_eq!(stats.smt_queries, 0);
     assert_eq!(stats.sat_queries, 1);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for reusing cached unsat subsets without another SMT query.
+fn is_sat_reuses_cached_unsat_subset() {
+    let marker = portfolio_test_marker("unsat-subset-cache");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
+    let x_eq_one = BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(1)));
+    let y_eq_two = BoolExpr::eq(Expr::Var("y".to_string()), Expr::Const(U256::from(2)));
+
+    assert!(!solver.is_sat(std::slice::from_ref(&x_eq_one)).unwrap());
+    assert!(!solver.is_sat(&[x_eq_one, y_eq_two]).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 1);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for not generalizing cached sat subsets to stricter constraints.
+fn is_sat_does_not_reuse_cached_sat_subset() {
+    let marker = portfolio_test_marker("sat-subset-cache");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x_eq_one = BoolExpr::eq(Expr::Var("x".to_string()), Expr::Const(U256::from(1)));
+    let y_eq_two = BoolExpr::eq(Expr::Var("y".to_string()), Expr::Const(U256::from(2)));
+
+    assert!(solver.is_sat(std::slice::from_ref(&x_eq_one)).unwrap());
+    assert!(matches!(
+        solver.is_sat(&[x_eq_one, y_eq_two]),
+        Err(SymbolicError::SolverQueryLimit(1))
+    ));
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 1);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 0);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
 }
 
 #[cfg(unix)]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1969,6 +1969,23 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
         Expr::op(ExprOp::And, Expr::Var("x".to_string()), Expr::Const(U256::MAX)),
         Expr::Var("x".to_string())
     );
+    assert_eq!(Expr::op(ExprOp::And, x.clone(), x.clone()), x);
+    assert_eq!(
+        Expr::op(
+            ExprOp::And,
+            Expr::op(
+                ExprOp::And,
+                Expr::Var("x".to_string()),
+                Expr::Const((U256::from(1) << 160) - U256::from(1))
+            ),
+            Expr::Const((U256::from(1) << 160) - U256::from(1))
+        ),
+        Expr::op(
+            ExprOp::And,
+            Expr::Var("x".to_string()),
+            Expr::Const((U256::from(1) << 160) - U256::from(1))
+        )
+    );
     assert_eq!(
         Expr::op(ExprOp::Mul, Expr::Const(U256::from(6)), Expr::Const(U256::from(7))),
         Expr::Const(U256::from(42))

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2577,10 +2577,10 @@ fn counted_solver_invocations(marker: &Path) -> usize {
 
 #[cfg(unix)]
 #[test]
-/// Regression coverage for hard-arithmetic `is_sat` fast-path witnesses.
-fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
+/// Regression coverage for hard-arithmetic `is_sat` fallback after solver unknown.
+fn is_sat_uses_validated_hard_arithmetic_fallback_after_solver_unknown() {
     let marker = portfolio_test_marker("hard-arith-is-sat");
-    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let commands = vec![counted_solver_command(&marker, "unknown")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
     let x = Expr::Var("x".to_string());
     let y = Expr::Var("y".to_string());
@@ -2598,10 +2598,11 @@ fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
 
     let stats = solver.stats();
     assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 1);
     assert_eq!(stats.sat_queries, 2);
     assert_eq!(stats.sat_cache_hits, 1);
     assert_eq!(solver.heuristic_witnesses(), 1);
-    assert_eq!(counted_solver_invocations(&marker), 0);
+    assert_eq!(counted_solver_invocations(&marker), 1);
     let _ = std::fs::remove_file(&marker);
 }
 

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2034,6 +2034,31 @@ fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
 }
 
 #[test]
+/// Regression coverage for normalized constraint batches being compact and order-stable.
+fn solver_normalizes_constraint_batches_by_flattening_and_deduping() {
+    let x = Expr::Var("x".to_string());
+    let y = Expr::Var("y".to_string());
+    let a = BoolExpr::cmp(BoolExprOp::Ult, x.clone(), Expr::Const(U256::from(10)));
+    let b = BoolExpr::eq(y.clone(), Expr::Const(U256::from(3)));
+    let grouped = vec![
+        BoolExpr::And(vec![b.clone(), BoolExpr::Const(true), a.clone()]),
+        a.clone(),
+        BoolExpr::And(vec![b.clone()]),
+    ];
+
+    let normalized = normalize_constraints_for_solver(&grouped);
+
+    assert_eq!(normalized, vec![b, a]);
+
+    let unsat = normalize_constraints_for_solver(&[
+        BoolExpr::eq(x, y),
+        BoolExpr::Const(false),
+        BoolExpr::Const(true),
+    ]);
+    assert_eq!(unsat, vec![BoolExpr::Const(false)]);
+}
+
+#[test]
 /// Regression coverage for ERC4626-style share predicates losing `bvudiv` before SMT.
 fn solver_normalizes_erc4626_style_share_zero_predicate() {
     let assets = Expr::Var("assets".to_string());
@@ -2531,6 +2556,63 @@ fn counted_solver_command(marker: &Path, response: &'static str) -> SolverComman
 /// Returns how many times a counted fake solver command was invoked.
 fn counted_solver_invocations(marker: &Path) -> usize {
     std::fs::read_to_string(marker).ok().and_then(|count| count.parse().ok()).unwrap_or_default()
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for hard-arithmetic `is_sat` fast-path witnesses.
+fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
+    let marker = portfolio_test_marker("hard-arith-is-sat");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
+    let x = Expr::Var("x".to_string());
+    let y = Expr::Var("y".to_string());
+    let constraints = vec![
+        BoolExpr::cmp(BoolExprOp::Ugt, x.clone(), Expr::Const(U256::ZERO)),
+        BoolExpr::cmp(BoolExprOp::Ugt, y.clone(), Expr::Const(U256::ZERO)),
+        BoolExpr::eq(Expr::op(ExprOp::Mul, x, y), Expr::Const(U256::from(4))),
+    ];
+    let normalized = normalize_constraints_for_solver(&constraints);
+    let model = hard_arith_fallback_model(&normalized).unwrap();
+
+    assert!(normalized.iter().all(|constraint| eval_bool_expr(constraint, &model).unwrap()));
+    assert!(solver.is_sat(&constraints).unwrap());
+    assert!(solver.is_sat(&constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(solver.heuristic_witnesses(), 1);
+    assert_eq!(counted_solver_invocations(&marker), 0);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+/// Regression coverage for hard-arithmetic `is_sat` preserving solver `unsat`.
+fn is_sat_hard_arithmetic_without_witness_still_honors_solver_unsat() {
+    let marker = portfolio_test_marker("hard-arith-is-sat-unsat");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
+    let x = Expr::Var("x".to_string());
+    let y = Expr::Var("y".to_string());
+    let constraints = vec![
+        BoolExpr::eq(x.clone(), Expr::Const(U256::ZERO)),
+        BoolExpr::eq(Expr::op(ExprOp::Mul, x, y), Expr::Const(U256::from(1))),
+    ];
+    let normalized = normalize_constraints_for_solver(&constraints);
+
+    assert!(hard_arith_fallback_model(&normalized).is_none());
+    assert!(!solver.is_sat(&constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.sat_queries, 1);
+    assert_eq!(stats.sat_cache_hits, 0);
+    assert_eq!(solver.heuristic_witnesses(), 0);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
 }
 
 #[cfg(unix)]

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -627,7 +627,10 @@ impl MultiContractRunnerBuilder {
 
             // if it's a test, link it and add to deployable contracts
             if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true)
-                && abi.functions().any(|func| func.name.is_any_test())
+                && abi.functions().any(|func| {
+                    func.name.is_any_test()
+                        || self.config.symbolic.enabled && is_symbolic_entrypoint(func)
+                })
             {
                 linker.ensure_linked(contract, id)?;
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1263,10 +1263,12 @@ impl TestResult {
         self.kind = TestKind::Symbolic {
             paths: stats.paths,
             solver_queries: stats.solver_queries,
+            smt_queries: stats.smt_queries,
             sat_queries: stats.sat_queries,
             model_queries: stats.model_queries,
             sat_cache_hits: stats.sat_cache_hits,
             model_cache_hits: stats.model_cache_hits,
+            heuristic_witnesses: stats.heuristic_witnesses,
             solver_time_ms: stats.solver_time_ms,
         };
         self.status = if success { TestStatus::Success } else { TestStatus::Failure };
@@ -1399,10 +1401,12 @@ pub enum TestKindReport {
     Symbolic {
         paths: usize,
         solver_queries: usize,
+        smt_queries: usize,
         sat_queries: usize,
         model_queries: usize,
         sat_cache_hits: usize,
         model_cache_hits: usize,
+        heuristic_witnesses: usize,
         solver_time_ms: u64,
     },
     /// Showmap corpus replay (no campaign performed).
@@ -1455,15 +1459,17 @@ impl fmt::Display for TestKindReport {
             Self::Symbolic {
                 paths,
                 solver_queries,
+                smt_queries,
                 sat_queries,
                 model_queries,
                 sat_cache_hits,
                 model_cache_hits,
+                heuristic_witnesses,
                 solver_time_ms,
             } => {
                 write!(
                     f,
-                    "(paths: {paths}, queries: {solver_queries}, sat: {sat_queries} ({sat_cache_hits} cached), models: {model_queries} ({model_cache_hits} cached), solver: {solver_time_ms}ms)"
+                    "(paths: {paths}, queries: {solver_queries}, smt: {smt_queries}, sat: {sat_queries} ({sat_cache_hits} cached), models: {model_queries} ({model_cache_hits} cached), hard-arith: {heuristic_witnesses}, solver: {solver_time_ms}ms)"
                 )
             }
             Self::Replay { corpus_entries, showmap_files, skipped_entries } => {
@@ -1527,6 +1533,8 @@ pub enum TestKind {
         paths: usize,
         solver_queries: usize,
         #[serde(default)]
+        smt_queries: usize,
+        #[serde(default)]
         sat_queries: usize,
         #[serde(default)]
         model_queries: usize,
@@ -1534,6 +1542,8 @@ pub enum TestKind {
         sat_cache_hits: usize,
         #[serde(default)]
         model_cache_hits: usize,
+        #[serde(default)]
+        heuristic_witnesses: usize,
         #[serde(default)]
         solver_time_ms: u64,
     },
@@ -1600,18 +1610,22 @@ impl TestKind {
             Self::Symbolic {
                 paths,
                 solver_queries,
+                smt_queries,
                 sat_queries,
                 model_queries,
                 sat_cache_hits,
                 model_cache_hits,
+                heuristic_witnesses,
                 solver_time_ms,
             } => TestKindReport::Symbolic {
                 paths: *paths,
                 solver_queries: *solver_queries,
+                smt_queries: *smt_queries,
                 sat_queries: *sat_queries,
                 model_queries: *model_queries,
                 sat_cache_hits: *sat_cache_hits,
                 model_cache_hits: *model_cache_hits,
+                heuristic_witnesses: *heuristic_witnesses,
                 solver_time_ms: *solver_time_ms,
             },
             Self::Replay { corpus_entries, showmap_files, skipped_entries } => {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -40,6 +40,7 @@ use foundry_evm::{
     traces::{TraceKind, TraceMode, load_contracts},
 };
 use foundry_evm_networks::NetworkVariant;
+use foundry_evm_symbolic::{SymbolicExecutor, SymbolicRunInput, SymbolicRunResult};
 use itertools::Itertools;
 use proptest::test_runner::{RngAlgorithm, TestError, TestRng, TestRunner};
 use rayon::prelude::*;
@@ -793,7 +794,11 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 }
 
                 let sig = func.signature();
-                let kind = func.test_function_kind();
+                let kind = if self.config.symbolic.enabled && is_symbolic_entrypoint(func) {
+                    TestFunctionKind::SymbolicTest
+                } else {
+                    func.test_function_kind()
+                };
 
                 let _guard = debug_span!(
                     "test",
@@ -869,6 +874,11 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         &self.cr.mcr.revert_decoder
     }
 
+    /// Returns whether verbose symbolic diagnostics should be rendered after progress clears.
+    fn should_defer_symbolic_diagnostics(&self) -> bool {
+        self.cr.progress.is_some() && self.config.symbolic.dump_smt
+    }
+
     /// Configures this runner with the inline configuration for the contract.
     fn apply_function_inline_config(&mut self, func: &Function) -> Result<()> {
         if self.inline_config.contains_function(self.cr.name, &func.name) {
@@ -904,6 +914,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             TestFunctionKind::UnitTest { .. } => self.run_unit_test(func),
             TestFunctionKind::FuzzTest { .. } => self.run_fuzz_test(func),
             TestFunctionKind::TableTest => self.run_table_test(func),
+            TestFunctionKind::SymbolicTest => self.run_symbolic_test(func),
             TestFunctionKind::InvariantTest => {
                 let fail_on_revert_for = |f: &Function| {
                     if self.inline_config.contains_function(self.cr.name, &f.name)
@@ -964,6 +975,93 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         let success =
             self.executor.is_raw_call_mut_success(self.address, &mut raw_call_result, false);
         self.result.single_result(success, reason, raw_call_result);
+        self.result
+    }
+
+    /// Runs a symbolic test and replays any discovered counterexample concretely.
+    fn run_symbolic_test(mut self, func: &Function) -> TestResult {
+        if self.prepare_test(func).is_err() {
+            return self.result;
+        }
+
+        let mut symbolic = SymbolicExecutor::new(self.config.symbolic.clone());
+        if self.should_defer_symbolic_diagnostics() {
+            symbolic.capture_diagnostics();
+        }
+        let result = symbolic.run(SymbolicRunInput {
+            executor: self.executor.as_ref(),
+            target: self.address,
+            sender: self.sender,
+            function: func,
+            value: U256::ZERO,
+            ffi_enabled: self.config.ffi,
+        });
+        let portfolio_diagnostics = symbolic.portfolio_diagnostics();
+        let symbolic_diagnostics = symbolic.take_diagnostics();
+
+        match result {
+            SymbolicRunResult::Safe(stats) => {
+                self.result.symbolic_result(true, None, None, stats);
+            }
+            SymbolicRunResult::Incomplete { kind, reason, stats } => {
+                self.result.symbolic_result(
+                    false,
+                    Some(format!("incomplete symbolic execution ({kind:?}): {reason}")),
+                    None,
+                    stats,
+                );
+            }
+            SymbolicRunResult::Counterexample { args, calldata, stats } => {
+                let (mut raw_call_result, reason) = match self.executor.call(
+                    self.sender,
+                    self.address,
+                    func,
+                    &args,
+                    U256::ZERO,
+                    Some(self.revert_decoder()),
+                ) {
+                    Ok(res) => (res.raw, None),
+                    Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
+                    Err(EvmError::Skip(reason)) => {
+                        self.result.single_skip(reason);
+                        self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
+                        self.result.symbolic_diagnostics = symbolic_diagnostics;
+                        return self.result;
+                    }
+                    Err(err) => {
+                        self.result.symbolic_result(false, Some(err.to_string()), None, stats);
+                        self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
+                        self.result.symbolic_diagnostics = symbolic_diagnostics;
+                        return self.result;
+                    }
+                };
+
+                let success = self.executor.is_raw_call_mut_success(
+                    self.address,
+                    &mut raw_call_result,
+                    false,
+                );
+                let counterexample = CounterExample::Single(BaseCounterExample::from_fuzz_call(
+                    calldata,
+                    args,
+                    raw_call_result.traces.clone(),
+                ));
+                self.result.extend(raw_call_result);
+                self.result.symbolic_result(
+                    false,
+                    if success {
+                        Some("symbolic counterexample did not replay".to_string())
+                    } else {
+                        reason
+                    },
+                    Some(counterexample),
+                    stats,
+                );
+            }
+        }
+
+        self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
+        self.result.symbolic_diagnostics = symbolic_diagnostics;
         self.result
     }
 

--- a/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_helpers.rs
@@ -27,7 +27,7 @@ macro_rules! skip_unless_z3 {
 ///   unconstrained address pool.
 pub fn assert_symbolic(cmd: &mut TestCommand) -> OutputAssert {
     cmd.assert_with(&[
-        ("[METRICS]", r"paths: \d+, queries: \d+(?:, sat: \d+ \(\d+ cached\), models: \d+ \(\d+ cached\), solver: \d+ms)?"),
+        ("[METRICS]", r"paths: \d+, queries: \d+(?:, smt: \d+, sat: \d+ \(\d+ cached\), models: \d+ \(\d+ cached\), hard-arith: \d+, solver: \d+ms)?"),
         ("[SENDER]", r"sender=0x[0-9a-fA-F]{40}"),
     ])
 }
@@ -38,7 +38,7 @@ pub fn assert_symbolic(cmd: &mut TestCommand) -> OutputAssert {
 /// *some* counterexample exists, not what it is.
 pub fn assert_symbolic_witness(cmd: &mut TestCommand) -> OutputAssert {
     cmd.assert_with(&[
-        ("[METRICS]", r"paths: \d+, queries: \d+(?:, sat: \d+ \(\d+ cached\), models: \d+ \(\d+ cached\), solver: \d+ms)?"),
+        ("[METRICS]", r"paths: \d+, queries: \d+(?:, smt: \d+, sat: \d+ \(\d+ cached\), models: \d+ \(\d+ cached\), hard-arith: \d+, solver: \d+ms)?"),
         ("[SENDER]", r"sender=0x[0-9a-fA-F]{40}"),
         ("[CALLDATA]", r"calldata=0x[0-9a-fA-F]+"),
         // `args=[...]` may contain nested scientific-notation brackets like


### PR DESCRIPTION
## Summary

- adds small native symbolic query handling candidates: exact direct-contradiction `unsat` short-circuiting before SMT, cached `unsat` subset reuse, validated hard-arithmetic model fallback/caching, constant `BoolExpr` comparison folding, SMT/cache preallocation, normalized constraint batch flattening/deduplication, and repeated `AND` mask simplification
- preserves solver correctness constraints: hard-arithmetic `is_sat` fallback only runs after solver `unknown`, hard-arithmetic model fallback returns a model validated against the original constraints, direct-contradiction handling only returns `unsat` for normalized `false` or exact `p` / `not p` pairs, and cached `unsat` reuse only generalizes previously proved false constraint subsets

## Benchmark

Local replay workload from `grandizzy/symbolic-bug-suite`, prebuilt forge binaries (`BUILD_FORGE=0`). Expected nonzero exit was retained; all selected-workload runs kept 8 `counterexample:` lines and 31 symbolic paths.

| workload | baseline | this PR | query shape |
| --- | ---: | ---: | --- |
| selected 4-contract replay, controlled `REPS=15` median | 918-922 ms | 609 ms | symbolic queries `50 -> 40`, this PR SMT queries `37` |
| selected 4-contract replay, post-review validation | n/a | 8 counterexamples, 31 paths | symbolic queries `40`, SMT `37`, hard-arith `0` |
| full 22-contract replay, post-review validation | n/a | 22/22 expected counterexamples retained | symbolic queries `365`, SMT `336`, sat-cache hits `55`, hard-arith `7` |

Earlier selected replay passes showed cold run-1 outliers (`4517 ms` baseline, `3897 ms` this PR), but medians stayed stable after reversing run order. The post-review validation retained the selected-workload query shape after removing pre-solver hard-arithmetic `is_sat` fallback. That removal intentionally trades some full-suite SMT calls back so decidable safe proofs are not marked incomplete.

## Notes

- This is workload-specific local measurement, not a broad symbolic-performance claim.
- The PR does not include local autoresearch harness files or experiment logs.
