### PR TITLE
test(chisel): relax REPL expect timeout

### DIFF
--- a/crates/chisel/tests/it/repl/session.rs
+++ b/crates/chisel/tests/it/repl/session.rs
@@ -2,7 +2,8 @@ use foundry_compilers::PathStyle;
 use foundry_test_utils::TestProject;
 use rexpect::{reader::Options, session::PtySession, spawn_with_options};
 
-const TIMEOUT_SECS: u64 = 3;
+// Some inputs compile and evaluate code before the next prompt is printed; 3s is tight on CI.
+const TIMEOUT_SECS: u64 = 10;
 const PROMPT: &str = "➜ ";
 
 /// Testing session for Chisel.


### PR DESCRIPTION
## Summary

- Increase the chisel REPL integration-test expect timeout from 3s to 10s.
- Keep the live-logs coverage in regular PR CI instead of moving it behind the flaky-test filter.

## Root cause

The failing CI job on PR #15065 timed out waiting for the chisel prompt after sending `console.log(...)` in `chisel_can_run_with_live_logs_flag`. That path compiles/evaluates code before printing the next prompt, and local runs complete close to the old 3s expect timeout. Under CI load, the hard-coded 3s rexpect timeout has too little headroom.

The mutation test failure in the same job reproduced as a retry-only flaky snapshot mismatch in CI, but it passed locally on current master and was not the final failed test in that run.
