### PR TITLE
Bump Tempo dependencies for T7 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3051,7 +3051,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3210,7 +3210,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4272,7 +4272,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4574,7 +4574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6936,7 +6936,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7859,7 +7859,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8977,7 +8977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9146,7 +9146,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10570,7 +10570,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10629,7 +10629,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11422,7 +11422,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11434,7 +11434,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11457,7 +11457,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11927,13 +11927,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
+source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11966,7 +11966,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.5.4"
-source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
+source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11989,7 +11989,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
+source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12000,7 +12000,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
+source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12012,7 +12012,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
+source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12038,10 +12038,11 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
+source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
 dependencies = [
  "alloy",
  "alloy-evm",
+ "alloy-primitives",
  "commonware-codec",
  "commonware-cryptography",
  "derive_more",
@@ -12058,7 +12059,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
+source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12069,7 +12070,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
+source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12100,7 +12101,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=32bb1d454f0fb70f8085c93bc04f35ed9715dc0c#32bb1d454f0fb70f8085c93bc04f35ed9715dc0c"
+source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12138,7 +12139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13411,7 +13412,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13561,7 +13562,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,17 +515,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "8d008eefacacf608b6ceb
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -599,9 +599,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8027e5ccdfe55e562a1111495d2c9acb6e27a930" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "32bb1d454f0fb70f8085c93bc04f35ed9715dc0c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "4393d0dbb8d37df4df5c2840350a73a189441988" }

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -489,6 +489,7 @@ mod tests {
     fn test_evm_spec_id_from_str_parses_network_hardforks() {
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("T3"), Some(TempoHardfork::T3));
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("tempo:T2"), Some(TempoHardfork::T2));
+        assert_eq!(evm_spec_id_from_str::<TempoHardfork>("tempo:T7"), Some(TempoHardfork::T7));
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("ethereum:prague"), None);
     }
 


### PR DESCRIPTION
## Summary
- bump Tempo git dependencies from `32bb1d454f0fb70f8085c93bc04f35ed9715dc0c` to `4d3f1db11a496d5fc98bb33d8055de102e5f5e11`
- update `Cargo.lock` for the new Tempo source revision
- add a regression assertion that `tempo:T7` parses as a Tempo hardfork

## Context
Tempo devnets can now report T7 active. Foundry needs the bumped `tempo-chainspec` so `cast keychain auth` detects T3+ correctly instead of falling back to the legacy `authorizeKey` ABI.

## Testing
- `cargo test -p foundry-evm-hardforks test_evm_spec_id_from_str_parses_network_hardforks -- --nocapture`
- `cargo check -p cast@1.7.2`
- `cargo fmt --check`
- `git diff --check`