### PR TITLE
chore: bump mpp-rs rev to T5 precompile escrow merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7676,7 +7676,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.10.4"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=929cb8e77d055600dbe7ebdd65a1e7c3441ef9e6#929cb8e77d055600dbe7ebdd65a1e7c3441ef9e6"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=ea69acd3a6c9c6f7c328b3e99c03b678cabf07b3#ea69acd3a6c9c6f7c328b3e99c03b678cabf07b3"
 dependencies = [
  "alloy",
  "alloy-sol-type-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -509,7 +509,7 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "929cb8e77d055600dbe7ebdd65a1e7c3441ef9e6", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "ea69acd3a6c9c6f7c328b3e99c03b678cabf07b3", default-features = false, features = [
     "tempo",
     "client",
     "reqwest-rustls-tls",


### PR DESCRIPTION
Bumps the mpp dep to ea69acd3 (squash-merge of tempoxyz/mpp-rs#276: T5 precompile escrow support for TempoSessionProvider).