### PR TITLE
perf(fuzz): reduce invariant campaign memory retention

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -188,7 +188,6 @@ impl CorpusEntry {
 #[derive(Debug, Clone)]
 pub(crate) struct CampaignCorpusEntry {
     tx_seq: Vec<BasicTxDetails>,
-    cmp_seq: Vec<Vec<CmpOperands>>,
     dedupe_by_coverage: bool,
 }
 
@@ -248,6 +247,21 @@ impl WorkerCorpusSeed {
         if let Some((value, sequence)) = load_optimization_state(config) {
             self.optimization_best_value = Some(value);
             self.optimization_best_sequence = sequence;
+        }
+        self
+    }
+
+    pub(crate) fn for_worker(mut self, worker_id: usize, worker_count: usize) -> Self {
+        if worker_count > 1 {
+            self.in_memory_corpus = self
+                .in_memory_corpus
+                .into_iter()
+                .enumerate()
+                .filter_map(|(idx, entry)| (idx % worker_count == worker_id).then_some(entry))
+                .collect();
+            self.metrics.corpus_count = self.in_memory_corpus.len();
+            self.metrics.favored_items =
+                self.in_memory_corpus.iter().filter(|entry| entry.is_favored).count();
         }
         self
     }
@@ -800,7 +814,6 @@ impl WorkerCorpus {
             cmp_seq.iter().take(corpus_inputs.len()).cloned().collect();
         let campaign_entry = (!persist_now).then(|| CampaignCorpusEntry {
             tx_seq: corpus_inputs.clone(),
-            cmp_seq: corpus_cmp_seq.clone(),
             dedupe_by_coverage: new_coverage,
         });
         let corpus = CorpusEntry::new_with_cmp(corpus_inputs, corpus_cmp_seq, Uuid::new_v4());
@@ -1599,7 +1612,7 @@ fn persist_campaign_entry(config: &FuzzCorpusConfig, entry: CampaignCorpusEntry)
         return;
     };
     let corpus_dir = root.join(format!("{WORKER}0")).join(CORPUS_DIR);
-    let corpus = CorpusEntry::new_with_cmp(entry.tx_seq, entry.cmp_seq, Uuid::new_v4());
+    let corpus = CorpusEntry::new(entry.tx_seq);
     let write_result = corpus.write_to_disk_in(&corpus_dir, config.corpus_gzip);
     if let Err(err) = write_result {
         debug!(target: "corpus", %err, "failed to record call sequence {:?}", corpus.tx_seq);

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -216,7 +216,7 @@ impl InvariantWorkerOutput {
 ///   earlier logical worker;
 /// - optimization mode keeps the maximum value, with ties preserving the earlier logical worker;
 /// - `failed_corpus_replays` is a master-worker-only value from worker `0`;
-/// - cases, reverts, gas traces, selector metrics, and line coverage accumulate into the logical
+/// - run/call counts, reverts, gas traces, selector metrics, and line coverage accumulate into the logical
 ///   campaign result.
 #[derive(Debug)]
 pub struct InvariantCampaignAggregator {
@@ -256,7 +256,7 @@ impl InvariantCampaignAggregator {
     /// Timeout campaigns share a wall-clock deadline across workers. When the deadline hits, any
     /// worker may have completed fewer than its assigned runs, so the original static ranges can
     /// contain gaps. The merge still validates worker identity and preserves deterministic worker
-    /// order, but final run count is derived from the completed cases.
+    /// order, but final run count is derived from the completed worker counters.
     pub fn finish_partial_with_corpus_entries(
         mut self,
     ) -> Result<(InvariantFuzzTestResult, Vec<CampaignCorpusEntry>)> {
@@ -276,7 +276,6 @@ fn fold_outputs(
     let mut handler_errors = HashMap::default();
     let mut runs = 0;
     let mut calls = 0;
-    let mut cases = Vec::new();
     let mut reverts = 0;
     let mut last_run_inputs = Vec::new();
     let mut gas_report_traces = Vec::new();
@@ -297,7 +296,6 @@ fn fold_outputs(
         corpus_entries.extend(worker_entries);
         runs += result.runs;
         calls += result.calls;
-        cases.extend(result.cases);
         reverts += result.reverts;
         if !result.last_run_inputs.is_empty() {
             last_run_inputs = result.last_run_inputs;
@@ -319,7 +317,6 @@ fn fold_outputs(
             handler_errors,
             runs,
             calls,
-            cases,
             reverts,
             last_run_inputs,
             gas_report_traces,
@@ -441,7 +438,7 @@ mod tests {
     };
     use alloy_primitives::{B256, Bytes};
     use foundry_evm_coverage::HitMap;
-    use foundry_evm_fuzz::{CallDetails, FuzzCase, FuzzedCases};
+    use foundry_evm_fuzz::CallDetails;
     use proptest::test_runner::TestError;
     use revm_inspectors::tracing::CallTraceArena;
 
@@ -451,7 +448,6 @@ mod tests {
             HashMap::default(),
             0,
             0,
-            Vec::new(),
             reverts,
             Vec::new(),
             Vec::new(),
@@ -488,7 +484,6 @@ mod tests {
 
     /// Builds a worker-local result fixture with the fields merged by the aggregator.
     fn worker_result(
-        case_gas: u64,
         reverts: usize,
         last_input_sender: u8,
         metric_name: &str,
@@ -497,9 +492,8 @@ mod tests {
         failed_corpus_replays: usize,
     ) -> InvariantFuzzTestResult {
         let mut result = empty_result(reverts, failed_corpus_replays);
-        result.cases.push(FuzzedCases::new(vec![FuzzCase { gas: case_gas, stipend: 0 }]));
-        result.runs = result.cases.len();
-        result.calls = result.cases.iter().map(|cases| cases.cases().len()).sum();
+        result.runs = 1;
+        result.calls = metrics.calls;
         result.last_run_inputs = vec![basic_tx(last_input_sender)];
         result.gas_report_traces.push(vec![CallTraceArena::default()]);
         result.line_coverage = Some(hit_maps(7, coverage_hits));
@@ -682,7 +676,6 @@ mod tests {
         aggregator.push(InvariantWorkerOutput::new(
             plans[2],
             worker_result(
-                30,
                 3,
                 0x30,
                 "transfer(address)",
@@ -694,7 +687,6 @@ mod tests {
         aggregator.push(InvariantWorkerOutput::new(
             plans[0],
             worker_result(
-                10,
                 1,
                 0x10,
                 "transfer(address)",
@@ -706,7 +698,6 @@ mod tests {
         aggregator.push(InvariantWorkerOutput::new(
             plans[1],
             worker_result(
-                20,
                 2,
                 0x20,
                 "approve(address)",
@@ -718,9 +709,8 @@ mod tests {
 
         let result = aggregator.finish().unwrap();
 
-        let merged_case_gas =
-            result.cases.iter().map(|cases| cases.last().unwrap().gas).collect::<Vec<_>>();
-        assert_eq!(merged_case_gas, vec![10, 20, 30]);
+        assert_eq!(result.runs, 3);
+        assert_eq!(result.calls, 6);
         assert_eq!(result.reverts, 6);
         assert_eq!(result.gas_report_traces.len(), 3);
         assert_eq!(result.last_run_inputs[0].sender, Address::repeat_byte(0x30));
@@ -736,7 +726,7 @@ mod tests {
     }
 
     #[test]
-    fn aggregator_preserves_run_and_call_counts_without_case_payloads() {
+    fn aggregator_preserves_run_and_call_counts() {
         let spec = InvariantCampaignSpec::new(3);
         let plans = [
             InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
@@ -756,23 +746,20 @@ mod tests {
 
         assert_eq!(result.runs, 3);
         assert_eq!(result.calls, 3000);
-        assert!(result.cases.is_empty());
     }
 
     #[test]
     fn timeout_aggregator_accepts_partial_outputs_with_range_gaps() {
-        fn result_with_cases(
-            gases: &[u64],
+        fn result_with_counts(
+            runs: usize,
+            calls: usize,
+            has_last_run: bool,
             failed_corpus_replays: usize,
         ) -> InvariantFuzzTestResult {
             let mut result = empty_result(0, failed_corpus_replays);
-            result.cases = gases
-                .iter()
-                .map(|&gas| FuzzedCases::new(vec![FuzzCase { gas, stipend: 0 }]))
-                .collect();
-            result.runs = result.cases.len();
-            result.calls = result.cases.iter().map(|cases| cases.cases().len()).sum();
-            result.last_run_inputs = gases.last().map_or_else(Vec::new, |_| vec![basic_tx(0x44)]);
+            result.runs = runs;
+            result.calls = calls;
+            result.last_run_inputs = if has_last_run { vec![basic_tx(0x44)] } else { Vec::new() };
             result
         }
 
@@ -780,15 +767,15 @@ mod tests {
         let outputs = [
             InvariantWorkerOutput::new(
                 InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 2 },
-                result_with_cases(&[10, 11], 5),
+                result_with_counts(2, 20, true, 5),
             ),
             InvariantWorkerOutput::new(
                 InvariantWorkerPlan { worker_id: 1, first_global_run: 4, runs: 0 },
-                result_with_cases(&[], 0),
+                result_with_counts(0, 0, false, 0),
             ),
             InvariantWorkerOutput::new(
                 InvariantWorkerPlan { worker_id: 2, first_global_run: 7, runs: 1 },
-                result_with_cases(&[20], 0),
+                result_with_counts(1, 10, true, 0),
             ),
         ];
 
@@ -802,22 +789,21 @@ mod tests {
         let mut partial = InvariantCampaignAggregator::new(spec);
         partial.push(InvariantWorkerOutput::new(
             InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 2 },
-            result_with_cases(&[10, 11], 5),
+            result_with_counts(2, 20, true, 5),
         ));
         partial.push(InvariantWorkerOutput::new(
             InvariantWorkerPlan { worker_id: 1, first_global_run: 4, runs: 0 },
-            result_with_cases(&[], 0),
+            result_with_counts(0, 0, false, 0),
         ));
         partial.push(InvariantWorkerOutput::new(
             InvariantWorkerPlan { worker_id: 2, first_global_run: 7, runs: 1 },
-            result_with_cases(&[20], 0),
+            result_with_counts(1, 10, true, 0),
         ));
 
         let (result, corpus_entries) = partial.finish_partial_with_corpus_entries().unwrap();
 
-        let merged_case_gas =
-            result.cases.iter().map(|cases| cases.last().unwrap().gas).collect::<Vec<_>>();
-        assert_eq!(merged_case_gas, vec![10, 11, 20]);
+        assert_eq!(result.runs, 3);
+        assert_eq!(result.calls, 30);
         assert_eq!(result.failed_corpus_replays, 5);
         assert!(corpus_entries.is_empty());
     }

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -274,6 +274,8 @@ fn fold_outputs(
     let workers = outputs.len();
     let mut errors = HashMap::default();
     let mut handler_errors = HashMap::default();
+    let mut runs = 0;
+    let mut calls = 0;
     let mut cases = Vec::new();
     let mut reverts = 0;
     let mut last_run_inputs = Vec::new();
@@ -293,6 +295,8 @@ fn fold_outputs(
         }
         merge_handler_errors(&mut handler_errors, result.handler_errors);
         corpus_entries.extend(worker_entries);
+        runs += result.runs;
+        calls += result.calls;
         cases.extend(result.cases);
         reverts += result.reverts;
         if !result.last_run_inputs.is_empty() {
@@ -313,6 +317,8 @@ fn fold_outputs(
         InvariantFuzzTestResult::new(
             errors,
             handler_errors,
+            runs,
+            calls,
             cases,
             reverts,
             last_run_inputs,
@@ -443,6 +449,8 @@ mod tests {
         InvariantFuzzTestResult::new(
             HashMap::default(),
             HashMap::default(),
+            0,
+            0,
             Vec::new(),
             reverts,
             Vec::new(),
@@ -490,6 +498,8 @@ mod tests {
     ) -> InvariantFuzzTestResult {
         let mut result = empty_result(reverts, failed_corpus_replays);
         result.cases.push(FuzzedCases::new(vec![FuzzCase { gas: case_gas, stipend: 0 }]));
+        result.runs = result.cases.len();
+        result.calls = result.cases.iter().map(|cases| cases.cases().len()).sum();
         result.last_run_inputs = vec![basic_tx(last_input_sender)];
         result.gas_report_traces.push(vec![CallTraceArena::default()]);
         result.line_coverage = Some(hit_maps(7, coverage_hits));
@@ -726,6 +736,30 @@ mod tests {
     }
 
     #[test]
+    fn aggregator_preserves_run_and_call_counts_without_case_payloads() {
+        let spec = InvariantCampaignSpec::new(3);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 2 },
+        ];
+        let mut first = empty_result(0, 0);
+        first.runs = 1;
+        first.calls = 1000;
+        let mut second = empty_result(0, 0);
+        second.runs = 2;
+        second.calls = 2000;
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], second));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], first));
+        let result = aggregator.finish().unwrap();
+
+        assert_eq!(result.runs, 3);
+        assert_eq!(result.calls, 3000);
+        assert!(result.cases.is_empty());
+    }
+
+    #[test]
     fn timeout_aggregator_accepts_partial_outputs_with_range_gaps() {
         fn result_with_cases(
             gases: &[u64],
@@ -736,6 +770,8 @@ mod tests {
                 .iter()
                 .map(|&gas| FuzzedCases::new(vec![FuzzCase { gas, stipend: 0 }]))
                 .collect();
+            result.runs = result.cases.len();
+            result.calls = result.cases.iter().map(|cases| cases.cases().len()).sum();
             result.last_run_inputs = gases.last().map_or_else(Vec::new, |_| vec![basic_tx(0x44)]);
             result
         }

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -216,8 +216,8 @@ impl InvariantWorkerOutput {
 ///   earlier logical worker;
 /// - optimization mode keeps the maximum value, with ties preserving the earlier logical worker;
 /// - `failed_corpus_replays` is a master-worker-only value from worker `0`;
-/// - run/call counts, reverts, gas traces, selector metrics, and line coverage accumulate into the logical
-///   campaign result.
+/// - run/call counts, reverts, gas traces, selector metrics, and line coverage accumulate into the
+///   logical campaign result.
 #[derive(Debug)]
 pub struct InvariantCampaignAggregator {
     spec: InvariantCampaignSpec,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1234,7 +1234,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             handler_errors,
             result.runs,
             result.calls,
-            Vec::new(),
             reverts,
             result.last_run_inputs,
             result.gas_report_traces,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -26,7 +26,7 @@ use foundry_evm_core::{
     precompiles::PRECOMPILES,
 };
 use foundry_evm_fuzz::{
-    BasicTxDetails, FuzzCase, FuzzFixtures, FuzzedCases,
+    BasicTxDetails, FuzzCase, FuzzFixtures,
     invariant::{
         ArtifactFilters, FuzzRunIdentifiedContracts, InvariantContract, InvariantSettings,
         RandomCallGenerator, SenderFilters, TargetedContract, TargetedContracts,
@@ -356,8 +356,10 @@ fn build_invariant_progress_json<M: Serialize>(
 
 /// Contains data collected during invariant test runs.
 struct InvariantTestData {
-    // Consumed gas and calldata of every successful fuzz call.
-    fuzz_cases: Vec<FuzzedCases>,
+    // Number of completed invariant runs.
+    runs: usize,
+    // Number of completed fuzzed calls across all invariant runs.
+    calls: usize,
     // Data related to reverts or failed assertions of the test.
     failures: InvariantFailures,
     // Calldata in the last invariant run.
@@ -400,7 +402,8 @@ impl InvariantTest {
         branch_runner: TestRunner,
     ) -> Self {
         let test_data = InvariantTestData {
-            fuzz_cases: vec![],
+            runs: 0,
+            calls: 0,
             failures,
             last_run_inputs: vec![],
             gas_report_traces: vec![],
@@ -460,7 +463,8 @@ impl InvariantTest {
                 .gas_report_traces
                 .push(run.run_traces.into_iter().map(|arena| arena.arena).collect());
         }
-        self.test_data.fuzz_cases.push(FuzzedCases::new(run.fuzz_runs));
+        self.test_data.runs += 1;
+        self.test_data.calls += run.fuzz_runs.len();
 
         // Revert state to not persist values between runs.
         self.fuzz_state.revert();
@@ -1228,7 +1232,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let worker_result = InvariantFuzzTestResult::new(
             errors,
             handler_errors,
-            result.fuzz_cases,
+            result.runs,
+            result.calls,
+            Vec::new(),
             reverts,
             result.last_run_inputs,
             result.gas_report_traces,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -528,6 +528,19 @@ impl<FEN: FoundryEvmNetwork> InvariantTestRun<FEN> {
             optimization_prefix_len: 0,
         }
     }
+
+    /// Releases per-run corpus payloads once the worker corpus manager has consumed them.
+    ///
+    /// Successful runs only need `fuzz_runs`, traces, and created-contract bookkeeping for final
+    /// reporting. Counterexample inputs are copied into `InvariantTestData::last_run_inputs`
+    /// before this point, so retaining the full per-run input/cmp buffers until `end_run` only
+    /// extends peak memory in long invariant campaigns.
+    fn drop_corpus_payloads(&mut self) {
+        self.inputs.clear();
+        self.inputs.shrink_to_fit();
+        self.cmp_seq.clear();
+        self.cmp_seq.shrink_to_fit();
+    }
 }
 
 /// Wrapper around any [`Executor`] implementer which provides fuzzing support using [`proptest`].
@@ -1122,6 +1135,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             }
 
             // End current invariant test run.
+            current_run.drop_corpus_payloads();
             invariant_test.end_run(current_run, gas_report_samples);
             runs += 1;
             let total_runs = campaign_state.increment_runs();
@@ -1204,7 +1218,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             campaign_state.early_exit(),
         );
 
-        let result = invariant_test.test_data;
+        // Move out the final test data and drop worker-local fuzz state before returning this
+        // worker's aggregate output. Long invariant campaigns can leave large dictionaries and
+        // target state behind; once shrinking is complete, only `test_data` is needed.
+        let InvariantTest { fuzz_state: _, targeted_contracts: _, test_data: result } =
+            invariant_test;
         let reverts = result.failures.reverts;
         let (errors, handler_errors) = result.failures.partition();
         let worker_result = InvariantFuzzTestResult::new(
@@ -1221,6 +1239,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             result.optimization_best_value,
             result.optimization_best_sequence,
         );
+        drop(corpus_manager);
         let reported_plan = if campaign_state.is_timed_campaign() {
             InvariantWorkerPlan { runs, ..plan }
         } else {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -712,7 +712,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         progress,
                         &campaign_state,
                         campaign_seed.clone(),
-                        corpus_seed.clone(),
+                        corpus_seed
+                            .clone()
+                            .for_worker(worker_plan.worker_id as usize, actual_worker_count),
                         corpus_persistence,
                         gas_report_samples,
                     );

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -35,6 +35,10 @@ pub struct InvariantFuzzTestResult {
     /// Handler-side assertion bugs, keyed by `(reverter, selector)` site (deduped per
     /// handler function). Each entry is [`InvariantFuzzError::HandlerAssertion`].
     pub handler_errors: HashMap<(Address, Selector), InvariantFuzzError>,
+    /// Number of completed invariant runs.
+    pub runs: usize,
+    /// Number of completed fuzzed calls across all invariant runs.
+    pub calls: usize,
     /// Every successful fuzz test case
     pub cases: Vec<FuzzedCases>,
     /// Number of reverted fuzz calls
@@ -64,6 +68,8 @@ impl InvariantFuzzTestResult {
     pub(crate) const fn new(
         errors: HashMap<String, InvariantFuzzError>,
         handler_errors: HashMap<(Address, Selector), InvariantFuzzError>,
+        runs: usize,
+        calls: usize,
         cases: Vec<FuzzedCases>,
         reverts: usize,
         last_run_inputs: Vec<BasicTxDetails>,
@@ -78,6 +84,8 @@ impl InvariantFuzzTestResult {
         Self {
             errors,
             handler_errors,
+            runs,
+            calls,
             cases,
             reverts,
             last_run_inputs,

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -19,7 +19,7 @@ use foundry_evm_core::{
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::{
-    BasicTxDetails, FuzzedCases,
+    BasicTxDetails,
     invariant::{FuzzRunIdentifiedContracts, InvariantContract},
 };
 use proptest::test_runner::TestError;
@@ -39,8 +39,6 @@ pub struct InvariantFuzzTestResult {
     pub runs: usize,
     /// Number of completed fuzzed calls across all invariant runs.
     pub calls: usize,
-    /// Every successful fuzz test case
-    pub cases: Vec<FuzzedCases>,
     /// Number of reverted fuzz calls
     pub reverts: usize,
     /// The entire inputs of the last run of the invariant campaign, used for
@@ -70,7 +68,6 @@ impl InvariantFuzzTestResult {
         handler_errors: HashMap<(Address, Selector), InvariantFuzzError>,
         runs: usize,
         calls: usize,
-        cases: Vec<FuzzedCases>,
         reverts: usize,
         last_run_inputs: Vec<BasicTxDetails>,
         gas_report_traces: Vec<Vec<CallTraceArena>>,
@@ -86,7 +83,6 @@ impl InvariantFuzzTestResult {
             handler_errors,
             runs,
             calls,
-            cases,
             reverts,
             last_run_inputs,
             gas_report_traces,

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1,9 +1,6 @@
 //! Test outcomes.
 
-use crate::{
-    fuzz::{BaseCounterExample, FuzzedCases},
-    gas_report::GasReport,
-};
+use crate::{fuzz::BaseCounterExample, gas_report::GasReport};
 use alloy_primitives::{
     Address, Bytes, I256, Log, Selector, U256,
     map::{AddressHashMap, HashMap},
@@ -1173,7 +1170,6 @@ impl TestResult {
         counterexample: Option<CounterExample>,
         runs: usize,
         calls: usize,
-        cases: Vec<FuzzedCases>,
         reverts: usize,
         metrics: Map<String, InvariantMetrics>,
         failed_corpus_replays: usize,

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1171,6 +1171,8 @@ impl TestResult {
         invariant_count: Option<usize>,
         invariant_handler_failures: Vec<InvariantFailure>,
         counterexample: Option<CounterExample>,
+        runs: usize,
+        calls: usize,
         cases: Vec<FuzzedCases>,
         reverts: usize,
         metrics: Map<String, InvariantMetrics>,
@@ -1179,8 +1181,8 @@ impl TestResult {
         optimization_best_value: Option<I256>,
     ) {
         self.kind = TestKind::Invariant {
-            runs: cases.len(),
-            calls: cases.iter().map(|sequence| sequence.cases().len()).sum(),
+            runs,
+            calls,
             reverts,
             workers: workers.max(1),
             metrics,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1749,6 +1749,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             invariant_count,
             invariant_handler_failures,
             counterexample,
+            invariant_result.runs,
+            invariant_result.calls,
             invariant_result.cases,
             invariant_result.reverts,
             invariant_result.metrics,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1751,7 +1751,6 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             counterexample,
             invariant_result.runs,
             invariant_result.calls,
-            invariant_result.cases,
             invariant_result.reverts,
             invariant_result.metrics,
             invariant_result.failed_corpus_replays,


### PR DESCRIPTION
## Summary
- clear per-run invariant input/cmp buffers after the corpus manager has consumed them
- track invariant run/call counts directly instead of retaining every successful fuzz case payload
- shard restored in-memory corpus entries across invariant workers
- persist successful campaign corpus entries without cmp operand payloads
- move out final invariant test data so worker-local fuzz state and targeted-contract state are dropped before returning worker output
- explicitly drop the worker corpus manager once the aggregate worker result has been built

## Context
Tempo saw long invariant campaigns pin memory near the pod limit across completed invariant contracts. This is a follow-up to #15057 that targets worker-local retained campaign state, retained success-case payloads, and duplicated corpus state rather than final corpus filtering clones.

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p foundry-evm --lib executors::invariant --no-default-features
