### PR TITLE
perf(symbolic): reduce solver work for guarded division checks

### DIFF
--- a/crates/evm/symbolic/src/runtime/solver/normalize.rs
+++ b/crates/evm/symbolic/src/runtime/solver/normalize.rs
@@ -95,6 +95,9 @@ pub(crate) fn normalize_ite_expr_for_solver(cond: BoolExpr, left: Expr, right: E
     if left == right {
         return left;
     }
+    if let Some(condition) = guarded_self_div_word_condition(&cond, &left, &right) {
+        return word_from_bool_expr(condition);
+    }
     if matches!(left, Expr::Const(value) if value == U256::from(1))
         && bool_from_word_expr(&right).as_ref() == Some(&cond)
     {
@@ -106,6 +109,32 @@ pub(crate) fn normalize_ite_expr_for_solver(cond: BoolExpr, left: Expr, right: E
         return left;
     }
     Expr::Ite(Box::new(cond), Box::new(left), Box::new(right))
+}
+
+/// Converts a boolean condition into its 0/1 word representation.
+fn word_from_bool_expr(condition: BoolExpr) -> Expr {
+    Expr::Ite(
+        Box::new(condition),
+        Box::new(Expr::Const(U256::from(1))),
+        Box::new(Expr::Const(U256::ZERO)),
+    )
+}
+
+/// Returns the boolean represented by `a == 0 ? 0 : a / a`.
+fn guarded_self_div_word_condition(cond: &BoolExpr, left: &Expr, right: &Expr) -> Option<BoolExpr> {
+    if matches!(left, Expr::Const(value) if value.is_zero())
+        && self_div_expr_matches_zero_check(cond, right)
+    {
+        return Some(cond.clone().not());
+    }
+    None
+}
+
+/// Returns whether `expr` is `a / a` for the operand guarded by `cond`.
+fn self_div_expr_matches_zero_check(cond: &BoolExpr, expr: &Expr) -> bool {
+    let Some(zero_operand) = zero_check_operand(cond) else { return false };
+    let Some((numerator, denominator)) = udiv_operands(expr) else { return false };
+    numerator == zero_operand && denominator == zero_operand
 }
 
 /// Rebuilds a word from OR-ed byte-extraction terms when the source is recoverable.
@@ -332,6 +361,12 @@ pub(crate) fn word_bool_always_true(expr: &Expr) -> bool {
     }
 
     let bool_terms = terms.iter().filter_map(|term| word_bool_term(term)).collect::<Vec<_>>();
+    if bool_terms.iter().any(|term| {
+        let negated = (*term).clone().not();
+        bool_terms.iter().any(|other| **other == negated)
+    }) {
+        return true;
+    }
     for zero_term in &bool_terms {
         let Some(zero_operand) = zero_check_operand(zero_term) else { continue };
         if bool_terms.iter().any(|term| checked_mul_guard_for_operand(term, zero_operand)) {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2126,6 +2126,102 @@ fn solver_normalizes_checked_mul_guard_for_bounded_operands() {
 }
 
 #[test]
+/// Regression coverage for guarded self-division boolean tautology normalization.
+fn solver_normalizes_guarded_self_division_guard() {
+    let a = Expr::Var("a".to_string());
+    let a_is_zero = BoolExpr::eq(a.clone(), Expr::Const(U256::ZERO));
+    let checked_quotient = Expr::Ite(
+        Box::new(a_is_zero.clone()),
+        Box::new(Expr::Const(U256::ZERO)),
+        Box::new(Expr::op(ExprOp::UDiv, a.clone(), a)),
+    );
+    let guard = Expr::op(
+        ExprOp::Or,
+        SymWord::from_bool(a_is_zero).into_expr(),
+        SymWord::from_bool(BoolExpr::eq(checked_quotient, Expr::Const(U256::from(1)))).into_expr(),
+    );
+    let original = BoolExpr::eq(guard, Expr::Const(U256::ZERO));
+    let normalized = normalize_bool_for_solver(original.clone());
+
+    assert_eq!(normalized, BoolExpr::Const(false));
+
+    for value in [U256::ZERO, U256::from(1), U256::from(2), U256::MAX] {
+        let model = BTreeMap::from([("a".to_string(), value)]);
+        assert!(!eval_bool_expr(&original, &model).unwrap());
+    }
+}
+
+#[test]
+/// Regression coverage for guarded self-division word normalization.
+fn solver_normalizes_guarded_self_division_word() {
+    let a = Expr::Var("a".to_string());
+    let a_is_zero = BoolExpr::eq(a.clone(), Expr::Const(U256::ZERO));
+    let checked_quotient = Expr::Ite(
+        Box::new(a_is_zero.clone()),
+        Box::new(Expr::Const(U256::ZERO)),
+        Box::new(Expr::op(ExprOp::UDiv, a.clone(), a)),
+    );
+    let normalized = normalize_expr_for_solver(checked_quotient.clone());
+
+    assert!(!normalized.smt().contains("bvudiv"));
+    assert_eq!(
+        normalized,
+        Expr::Ite(
+            Box::new(a_is_zero.not()),
+            Box::new(Expr::Const(U256::from(1))),
+            Box::new(Expr::Const(U256::ZERO)),
+        )
+    );
+
+    for value in [U256::ZERO, U256::from(1), U256::from(2), U256::MAX] {
+        let model = BTreeMap::from([("a".to_string(), value)]);
+        assert_eq!(
+            eval_expr(&checked_quotient, &model).unwrap(),
+            eval_expr(&normalized, &model).unwrap()
+        );
+    }
+}
+
+#[test]
+/// Regression coverage for preserving mirrored zero-guarded self-division semantics.
+fn solver_does_not_invert_guarded_zero_self_division() {
+    let a = Expr::Var("a".to_string());
+    let a_is_zero = BoolExpr::eq(a.clone(), Expr::Const(U256::ZERO));
+    let mirrored = Expr::Ite(
+        Box::new(a_is_zero),
+        Box::new(Expr::op(ExprOp::UDiv, a.clone(), a)),
+        Box::new(Expr::Const(U256::ZERO)),
+    );
+    let normalized = normalize_expr_for_solver(mirrored.clone());
+
+    for value in [U256::ZERO, U256::from(1), U256::from(2), U256::MAX] {
+        let model = BTreeMap::from([("a".to_string(), value)]);
+        assert_eq!(eval_expr(&mirrored, &model).unwrap(), eval_expr(&normalized, &model).unwrap());
+    }
+}
+
+#[test]
+/// Regression coverage for guarded self-division overflow-guard normalization.
+fn solver_normalizes_guarded_self_division_add_overflow_guard() {
+    let a = Expr::Var("a".to_string());
+    let a_is_zero = BoolExpr::eq(a.clone(), Expr::Const(U256::ZERO));
+    let checked_quotient = Expr::Ite(
+        Box::new(a_is_zero),
+        Box::new(Expr::Const(U256::ZERO)),
+        Box::new(Expr::op(ExprOp::UDiv, a.clone(), a)),
+    );
+
+    assert_eq!(
+        normalize_bool_for_solver(BoolExpr::cmp(
+            BoolExprOp::Ugt,
+            checked_quotient.clone(),
+            Expr::op(ExprOp::Add, Expr::Const(U256::from(1)), checked_quotient),
+        )),
+        BoolExpr::Const(false)
+    );
+}
+
+#[test]
 /// Regression coverage for preserving unbounded checked-mul overflow guards.
 fn solver_does_not_normalize_unbounded_checked_mul_guard_to_tautology() {
     let a = Expr::Var("a".to_string());


### PR DESCRIPTION
## Summary

- Normalize the guarded EVM self-division word `a == 0 ? 0 : a / a` into the equivalent 0/1 word for `a != 0`.
- Treat ORs of complementary 0/1 boolean words as tautological during solver normalization.
- Preserve the mirrored zero-guarded form `a == 0 ? a / a : 0`, since EVM `0 / 0 == 0`, and add regression coverage for that case.
- Add regression coverage for the guarded self-division word, the boolean guard, and the downstream add-overflow guard simplification.

## Benchmarks

Benchmark suite: `/Users/gustavo/dev/forks/symbolic-bug-suite-ar`, built local `forge`, expected nonzero exit because counterexamples are replayed.

| Benchmark | Base | This PR |
| --- | ---: | ---: |
| Full suite solver time | 447,353ms | 57,634ms |
| Full suite SMT queries | 336 | 327 |
| Full suite logical queries | 365 | 360 |
| Full suite sat-cache hits | 55 | 60 |
| Full suite hard-arith witnesses | 7 | 6 |
| Full suite correctness | 44 counterexample lines, 0 incomplete | 44 counterexample lines, 0 incomplete |
| Selected 4-contract replay median | 604ms | 568ms |
| Selected 4-contract replay SMT queries | 37 | 37 |
| Selected 4-contract correctness | 8 counterexample lines, 0 incomplete | 8 counterexample lines, 0 incomplete |

Per-case solver-time examples after the fix:

| Contract | Base | This PR |
| --- | ---: | ---: |
| HundredEmptyMarketTest | 68,640ms | 1,076ms |
| ZkLendFirstDepositorTest | 69,068ms | 145ms |
