### PR TITLE
feat(cast): add Tempo wallet session runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ dependencies = [
  "foundry-wallets",
  "futures",
  "itertools 0.14.0",
+ "libc",
  "op-alloy-consensus",
  "op-alloy-flz",
  "op-alloy-network",
@@ -2813,6 +2814,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "windows-sys 0.61.2",
  "yansi",
 ]
 

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -89,7 +89,7 @@ regex = { workspace = true, default-features = false }
 rpassword = "7"
 semver.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "signal"] }
+tokio = { workspace = true, features = ["macros", "process", "signal"] }
 tracing.workspace = true
 yansi.workspace = true
 evmole.workspace = true

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -89,11 +89,22 @@ regex = { workspace = true, default-features = false }
 rpassword = "7"
 semver.workspace = true
 tempfile.workspace = true
-tokio = { workspace = true, features = ["macros", "process", "signal"] }
+tokio = { workspace = true, features = ["macros", "process", "signal", "time"] }
 tracing.workspace = true
 yansi.workspace = true
 evmole.workspace = true
 url.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 alloy-hardforks.workspace = true

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -25,6 +25,8 @@ use vanity::VanityArgs;
 pub mod list;
 use list::ListArgs;
 
+mod process_tree;
+
 pub mod session;
 use session::SessionArgs;
 

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -26,7 +26,7 @@ pub mod list;
 use list::ListArgs;
 
 pub mod session;
-use session::SessionSubcommands;
+use session::SessionArgs;
 
 /// CLI arguments for `cast wallet`.
 #[derive(Debug, Parser)]
@@ -230,10 +230,7 @@ pub enum WalletSubcommands {
     List(ListArgs),
 
     /// Manage temporary Tempo wallet sessions.
-    Session {
-        #[command(subcommand)]
-        command: SessionSubcommands,
-    },
+    Session(SessionArgs),
 
     /// Remove a wallet from the keystore.
     ///
@@ -779,8 +776,8 @@ flag to set your key via:
             Self::List(cmd) => {
                 cmd.run().await?;
             }
-            Self::Session { command } => {
-                command.run().await?;
+            Self::Session(args) => {
+                args.run().await?;
             }
             Self::Remove { name, dir, unsafe_password } => {
                 let dir = if let Some(path) = dir {
@@ -987,7 +984,7 @@ flag to set your key via:
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{session::SessionSubcommands, *};
     use alloy_primitives::{address, keccak256};
     use std::str::FromStr;
 
@@ -1130,15 +1127,15 @@ mod tests {
         ]);
 
         match args {
-            WalletSubcommands::Session { command } => match command {
-                SessionSubcommands::Create {
+            WalletSubcommands::Session(args) => match args.command {
+                Some(SessionSubcommands::Create {
                     root_account,
                     chain_id,
                     expires,
                     scope,
                     spend_limits,
                     wallet,
-                } => {
+                }) => {
                     assert_eq!(
                         root_account,
                         address!("0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf")
@@ -1174,8 +1171,8 @@ mod tests {
             );
 
             match args {
-                WalletSubcommands::Session { command } => match command {
-                    SessionSubcommands::Revoke { session_id, local, .. } => {
+                WalletSubcommands::Session(args) => match args.command {
+                    Some(SessionSubcommands::Revoke { session_id, local, .. }) => {
                         assert_eq!(session_id, B256::from([0x11; 32]));
                         assert_eq!(local, expected_local);
                     }
@@ -1183,6 +1180,54 @@ mod tests {
                 },
                 _ => panic!("expected WalletSubcommands::Session"),
             }
+        }
+    }
+
+    #[test]
+    fn can_parse_wallet_session_run_for_command() {
+        let args = WalletSubcommands::parse_from([
+            "foundry-cli",
+            "session",
+            "--root",
+            "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+            "--chain-id",
+            "4217",
+            "--expires",
+            "10m",
+            "--target",
+            "0x20c0000000000000000000000000000000000001",
+            "--selector",
+            "transfer(address,uint256)",
+            "--spend-limit",
+            "PathUSD=0",
+            "--for",
+            "forge script Deploy --broadcast",
+            "--private-key",
+            "0x59c6995e998f97a5a004497e5da3b5d2b2b66a87f064d39c44da0b6d6e4f8ff0",
+        ]);
+
+        match args {
+            WalletSubcommands::Session(args) => {
+                assert!(args.command.is_none());
+                assert_eq!(
+                    args.root_account,
+                    Some(address!("0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf"))
+                );
+                assert_eq!(args.send_tx.eth.etherscan.chain.map(|chain| chain.id()), Some(4217));
+                assert_eq!(args.expires, Some(600));
+                assert_eq!(
+                    args.target,
+                    Some(address!("0x20c0000000000000000000000000000000000001"))
+                );
+                assert_eq!(args.selectors.len(), 1);
+                assert_eq!(args.spend_limits.len(), 1);
+                assert_eq!(args.for_command.as_deref(), Some("forge script Deploy --broadcast"));
+                assert_eq!(
+                    args.send_tx.eth.wallet.raw.private_key.as_deref(),
+                    Some("0x59c6995e998f97a5a004497e5da3b5d2b2b66a87f064d39c44da0b6d6e4f8ff0")
+                );
+            }
+            _ => panic!("expected WalletSubcommands::Session"),
         }
     }
 

--- a/crates/cast/src/cmd/wallet/process_tree.rs
+++ b/crates/cast/src/cmd/wallet/process_tree.rs
@@ -1,0 +1,255 @@
+use std::{
+    io,
+    process::{Command, ExitStatus},
+    time::Duration,
+};
+
+use tokio::process::{Child, Command as TokioCommand};
+
+const TERMINATION_GRACE: Duration = Duration::from_millis(250);
+
+pub(super) struct ManagedChild {
+    child: Child,
+    group: PlatformProcessGroup,
+    waited: bool,
+}
+
+impl ManagedChild {
+    pub(super) fn spawn(command: Command) -> io::Result<Self> {
+        let mut command = TokioCommand::from(command);
+        let group = PlatformProcessGroup::configure(&mut command)?;
+        let child = command.kill_on_drop(true).spawn()?;
+        let group = group.attach(&child)?;
+        Ok(Self { child, group, waited: false })
+    }
+
+    pub(super) async fn wait(&mut self) -> io::Result<ExitStatus> {
+        let status = self.child.wait().await?;
+        self.waited = true;
+        Ok(status)
+    }
+
+    pub(super) async fn terminate_tree(&mut self) -> io::Result<()> {
+        if self.group.terminate()? {
+            tokio::time::sleep(TERMINATION_GRACE).await;
+            self.group.kill()?;
+        }
+
+        if self.waited {
+            return Ok(());
+        }
+
+        match tokio::time::timeout(TERMINATION_GRACE, self.child.wait()).await {
+            Ok(result) => {
+                self.waited = true;
+                result.map(|_| ())
+            }
+            Err(_) => {
+                self.child.start_kill()?;
+                self.child.wait().await?;
+                self.waited = true;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+struct PlatformProcessGroup {
+    pgid: Option<libc::pid_t>,
+}
+
+#[cfg(unix)]
+impl PlatformProcessGroup {
+    fn configure(command: &mut TokioCommand) -> io::Result<Self> {
+        command.process_group(0);
+        Ok(Self { pgid: None })
+    }
+
+    fn attach(mut self, child: &Child) -> io::Result<Self> {
+        self.pgid = child.id().map(|id| id as libc::pid_t);
+        Ok(self)
+    }
+
+    fn terminate(&mut self) -> io::Result<bool> {
+        let Some(pgid) = self.pgid else {
+            return Ok(false);
+        };
+        signal_process_group(pgid, libc::SIGTERM)
+    }
+
+    fn kill(&mut self) -> io::Result<()> {
+        let Some(pgid) = self.pgid.take() else {
+            return Ok(());
+        };
+        signal_process_group(pgid, libc::SIGKILL).map(|_| ())
+    }
+}
+
+#[cfg(unix)]
+fn signal_process_group(pgid: libc::pid_t, signal: libc::c_int) -> io::Result<bool> {
+    // SAFETY: negative pid targets the process group created for the child process.
+    let rc = unsafe { libc::kill(-pgid, signal) };
+    if rc == 0 {
+        Ok(true)
+    } else {
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::ESRCH) { Ok(false) } else { Err(err) }
+    }
+}
+
+#[cfg(windows)]
+struct PlatformProcessGroup {
+    job: Option<WindowsJob>,
+}
+
+#[cfg(windows)]
+impl PlatformProcessGroup {
+    fn configure(_command: &mut TokioCommand) -> io::Result<Self> {
+        Ok(Self { job: Some(WindowsJob::new()?) })
+    }
+
+    fn attach(self, child: &Child) -> io::Result<Self> {
+        if let Some(job) = &self.job {
+            let handle = child.raw_handle().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::Other, "session child exited before job assignment")
+            })?;
+            job.assign_process(handle)?;
+        }
+        Ok(self)
+    }
+
+    fn terminate(&mut self) -> io::Result<bool> {
+        if let Some(job) = self.job.take() {
+            job.terminate()?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn kill(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+struct WindowsJob {
+    handle: windows_sys::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+impl WindowsJob {
+    fn new() -> io::Result<Self> {
+        use windows_sys::Win32::{
+            Foundation::INVALID_HANDLE_VALUE,
+            System::JobObjects::{
+                CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+                SetInformationJobObject,
+            },
+        };
+
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let ok = unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                std::ptr::addr_of!(limits).cast(),
+                std::mem::size_of_val(&limits) as u32,
+            )
+        };
+        if ok == 0 {
+            let err = io::Error::last_os_error();
+            unsafe {
+                windows_sys::Win32::Foundation::CloseHandle(handle);
+            }
+            return Err(err);
+        }
+
+        Ok(Self { handle })
+    }
+
+    fn assign_process(&self, process: std::os::windows::io::RawHandle) -> io::Result<()> {
+        use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
+
+        let ok = unsafe { AssignProcessToJobObject(self.handle, process.cast()) };
+        if ok == 0 { Err(io::Error::last_os_error()) } else { Ok(()) }
+    }
+
+    fn terminate(self) -> io::Result<()> {
+        use windows_sys::Win32::System::JobObjects::TerminateJobObject;
+
+        let ok = unsafe { TerminateJobObject(self.handle, 1) };
+        let err = if ok == 0 { Some(io::Error::last_os_error()) } else { None };
+        drop(self);
+        match err {
+            Some(err) => Err(err),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsJob {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+struct PlatformProcessGroup;
+
+#[cfg(not(any(unix, windows)))]
+impl PlatformProcessGroup {
+    fn configure(_command: &mut TokioCommand) -> io::Result<Self> {
+        Ok(Self)
+    }
+
+    fn attach(self, _child: &Child) -> io::Result<Self> {
+        Ok(self)
+    }
+
+    fn terminate(&mut self) -> io::Result<bool> {
+        Ok(false)
+    }
+
+    fn kill(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cleanup_terminates_background_grandchild() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let tmp = tempfile::tempdir().unwrap();
+            let marker = tmp.path().join("session-child-leaked");
+            let mut command = Command::new("sh");
+            command.args([
+                "-c",
+                "(sleep 1; touch \"$1\") &",
+                "session-child",
+                &marker.to_string_lossy(),
+            ]);
+
+            let mut child = ManagedChild::spawn(command).unwrap();
+            child.wait().await.unwrap();
+            child.terminate_tree().await.unwrap();
+            tokio::time::sleep(Duration::from_millis(1200)).await;
+
+            assert!(!marker.exists(), "background grandchild escaped session cleanup");
+        });
+    }
+}

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -111,21 +111,23 @@ impl SessionArgs {
             root_account.ok_or_else(|| eyre::eyre!("cast wallet session requires --root"))?;
         let expires =
             expires.ok_or_else(|| eyre::eyre!("cast wallet session requires --expires"))?;
-        let for_command =
+        let command =
             for_command.ok_or_else(|| eyre::eyre!("cast wallet session requires --for"))?;
+        let command = InnerCommand::parse(command)?;
+        let scope = session_scope(scope, target, selectors)?;
         let send_tx = *send_tx;
         let chain_id = resolve_session_chain_id(&send_tx).await?;
 
-        run_for_command(
+        run_for_command(SessionRunRequest {
             root_account,
             chain_id,
             expires,
-            session_scope(scope, target, selectors)?,
+            scope,
             spend_limits,
-            for_command,
-            *tx,
+            command,
+            tx: *tx,
             send_tx,
-        )
+        })
         .await
     }
 }
@@ -190,17 +192,29 @@ impl SessionSubcommands {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-async fn run_for_command(
+struct SessionRunRequest {
     root_account: Address,
     chain_id: u64,
     expires: u64,
     scope: Vec<CallScope>,
     spend_limits: Vec<SessionSpendLimit>,
-    for_command: String,
+    command: InnerCommand,
     tx: TransactionOpts,
     send_tx: SendTxOpts,
-) -> Result<()> {
+}
+
+async fn run_for_command(request: SessionRunRequest) -> Result<()> {
+    let SessionRunRequest {
+        root_account,
+        chain_id,
+        expires,
+        scope,
+        spend_limits,
+        command,
+        tx,
+        send_tx,
+    } = request;
+
     if tx.tempo.print_sponsor_hash {
         eyre::bail!(PRINT_SPONSOR_HASH_REVOKE_ERROR);
     }
@@ -217,45 +231,68 @@ async fn run_for_command(
     let session_id = entry.session_id;
     upsert_session_entry(entry)?;
 
-    let child_result = run_inner_command(&for_command, session_id);
+    let child_result = command.run(session_id);
     let revoke_result = run_revoke(session_id, false, tx, send_tx).await;
 
-    let revoke_err = revoke_result.err();
+    finish_session_run(session_id, child_result, revoke_result)
+}
 
-    match (child_result, revoke_err) {
-        (Ok(status), None) if status.success() => Ok(()),
-        (Ok(status), None) => Err(inner_command_status_error(&for_command, status)),
-        (Err(child_err), None) => Err(child_err),
-        (Ok(status), Some(revoke_err)) if status.success() => {
+fn finish_session_run(
+    session_id: B256,
+    child_result: Result<()>,
+    revoke_result: Result<()>,
+) -> Result<()> {
+    match (child_result, revoke_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(child_err), Ok(())) => Err(child_err),
+        (Ok(()), Err(revoke_err)) => {
             Err(revoke_err.wrap_err("failed to revoke Tempo session after inner command"))
         }
-        (Ok(status), Some(revoke_err)) => Err(inner_command_status_error(&for_command, status)
-            .wrap_err(format!("also failed to revoke Tempo session {session_id:?}: {revoke_err}"))),
-        (Err(child_err), Some(revoke_err)) => Err(child_err
-            .wrap_err(format!("also failed to revoke Tempo session {session_id:?}: {revoke_err}"))),
+        (Err(child_err), Err(revoke_err)) => {
+            Err(child_err.wrap_err(revoke_failure_context(session_id, &revoke_err)))
+        }
     }
 }
 
-fn run_inner_command(command: &str, session_id: B256) -> Result<ExitStatus> {
-    inner_command(command, session_id)?
-        .status()
-        .wrap_err_with(|| format!("failed to run inner command `{command}`"))
+fn revoke_failure_context(session_id: B256, err: &eyre::Report) -> String {
+    format!("also failed to revoke Tempo session {session_id:?}: {err}")
 }
 
-fn inner_command(command: &str, session_id: B256) -> Result<Command> {
-    let argv = split_for_command(command)?;
-    let (program, args) =
-        argv.split_first().ok_or_else(|| eyre::eyre!("--for command cannot be empty"))?;
-
-    let mut command = Command::new(program);
-    command.args(args).env(TEMPO_SESSION_ID_ENV, format!("{session_id:?}"));
-    Ok(command)
+#[derive(Debug)]
+struct InnerCommand {
+    raw: String,
+    program: String,
+    args: Vec<String>,
 }
 
-fn inner_command_status_error(command: &str, status: ExitStatus) -> eyre::Report {
-    match status.code() {
-        Some(code) => eyre::eyre!("inner command `{command}` exited with code {code}"),
-        None => eyre::eyre!("inner command `{command}` terminated by a signal"),
+impl InnerCommand {
+    fn parse(raw: String) -> Result<Self> {
+        let mut argv = split_for_command(&raw)?.into_iter();
+        let program = argv.next().ok_or_else(|| eyre::eyre!("--for command cannot be empty"))?;
+        let args = argv.collect();
+        Ok(Self { raw, program, args })
+    }
+
+    fn run(&self, session_id: B256) -> Result<()> {
+        let status = self
+            .command(session_id)
+            .status()
+            .wrap_err_with(|| format!("failed to run inner command `{}`", self.raw))?;
+
+        if status.success() { Ok(()) } else { Err(self.status_error(status)) }
+    }
+
+    fn command(&self, session_id: B256) -> Command {
+        let mut command = Command::new(&self.program);
+        command.args(&self.args).env(TEMPO_SESSION_ID_ENV, format!("{session_id:?}"));
+        command
+    }
+
+    fn status_error(&self, status: ExitStatus) -> eyre::Report {
+        match status.code() {
+            Some(code) => eyre::eyre!("inner command `{}` exited with code {code}", self.raw),
+            None => eyre::eyre!("inner command `{}` terminated by a signal", self.raw),
+        }
     }
 }
 
@@ -362,10 +399,6 @@ fn split_for_command(command: &str) -> Result<Vec<String>> {
     if in_token {
         args.push(current);
     }
-    if args.is_empty() {
-        eyre::bail!("--for command cannot be empty");
-    }
-
     Ok(args)
 }
 
@@ -693,6 +726,29 @@ mod tests {
         let limit = parse_spend_limit("PathUSD=0").unwrap();
         assert_eq!(limit.token, PATH_USD_ADDRESS);
         assert_eq!(limit.amount, U256::ZERO);
+    }
+
+    #[test]
+    fn inner_command_parse_preserves_literal_argv() {
+        let raw =
+            r#"forge script "Deploy Script" --sig 'run(uint256)' value\ with\ spaces #literal"#;
+        let command = InnerCommand::parse(raw.to_string()).unwrap();
+
+        assert_eq!(command.raw, raw);
+        assert_eq!(command.program, "forge");
+        assert_eq!(
+            command.args,
+            ["script", "Deploy Script", "--sig", "run(uint256)", "value with spaces", "#literal",]
+        );
+    }
+
+    #[test]
+    fn inner_command_parse_rejects_invalid_input() {
+        let err = InnerCommand::parse("   ".to_string()).unwrap_err();
+        assert!(err.to_string().contains("--for command cannot be empty"), "{err}");
+
+        let err = InnerCommand::parse("forge 'script".to_string()).unwrap_err();
+        assert!(err.to_string().contains("unterminated"), "{err}");
     }
 
     #[test]

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -27,7 +27,7 @@ use std::{
 use tempo_alloy::{TempoNetwork, provider::TempoProviderExt};
 use tempo_contracts::precompiles::IAccountKeychain;
 use tempo_primitives::transaction::{CallScope, PrimitiveSignature, SelectorRule};
-use tokio::{process::Command as TokioCommand, signal};
+use tokio::signal;
 
 use crate::{
     cmd::{
@@ -41,6 +41,8 @@ use crate::{
     },
     tx::SendTxOpts,
 };
+
+use super::process_tree::ManagedChild;
 
 const PRINT_SPONSOR_HASH_REVOKE_ERROR: &str = "--tempo.print-sponsor-hash only prints a sponsor hash and does not revoke the session on-chain";
 const SESSION_CHILD_SIGNER_ENV: &[&str] = &[
@@ -226,7 +228,8 @@ async fn cleanup_session_run(
     send_tx: SendTxOpts,
 ) -> Result<()> {
     let retire_result = retire_session_run_locally(session_id);
-    let revoke_result = run_revoke(session_id, false, tx, send_tx).await;
+    let revoke_result =
+        run_revoke_with_policy(session_id, false, tx, send_tx, UnprovisionedKeyPolicy::Fail).await;
 
     match (retire_result, revoke_result) {
         (Ok(()), Ok(())) => Ok(()),
@@ -290,9 +293,7 @@ impl InnerCommand {
     where
         I: std::future::Future<Output = Result<&'static str>>,
     {
-        let mut child = TokioCommand::from(self.command(session_id))
-            .kill_on_drop(true)
-            .spawn()
+        let mut child = ManagedChild::spawn(self.command(session_id))
             .wrap_err_with(|| format!("failed to run inner command `{}`", self.raw))?;
 
         let status = tokio::select! {
@@ -300,8 +301,7 @@ impl InnerCommand {
                 format!("failed to wait for inner command `{}`", self.raw)
             })?,
             interrupt = interrupt => {
-                let _ = child.start_kill();
-                let _ = child.wait().await;
+                let _ = child.terminate_tree().await;
 
                 return match interrupt {
                     Ok(interrupt) => Err(self.interrupted_error(interrupt)),
@@ -309,6 +309,8 @@ impl InnerCommand {
                 };
             }
         };
+
+        let _ = child.terminate_tree().await;
 
         if status.success() { Ok(()) } else { Err(self.status_error(status)) }
     }
@@ -541,6 +543,23 @@ async fn run_revoke(
     tx: TransactionOpts,
     send_tx: SendTxOpts,
 ) -> Result<()> {
+    run_revoke_with_policy(session_id, local, tx, send_tx, UnprovisionedKeyPolicy::RevokeLocally)
+        .await
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum UnprovisionedKeyPolicy {
+    RevokeLocally,
+    Fail,
+}
+
+async fn run_revoke_with_policy(
+    session_id: B256,
+    local: bool,
+    tx: TransactionOpts,
+    send_tx: SendTxOpts,
+    unprovisioned_policy: UnprovisionedKeyPolicy,
+) -> Result<()> {
     let Some(entry) = read_session_entry(session_id)? else {
         print_revoke_status(session_id, None, SessionRevokeStatus::NotFound)?;
         return Ok(());
@@ -575,9 +594,7 @@ async fn run_revoke(
         return Ok(());
     }
     if info.keyId == Address::ZERO {
-        update_session_status(session_id, SessionStatus::Revoked)?;
-        print_revoke_status(session_id, Some(&entry), SessionRevokeStatus::NotProvisioned)?;
-        return Ok(());
+        return handle_unprovisioned_revoke(session_id, &entry, unprovisioned_policy);
     }
 
     let root_signer =
@@ -607,6 +624,27 @@ async fn run_revoke(
     update_session_status(session_id, SessionStatus::Revoked)?;
 
     Ok(())
+}
+
+fn handle_unprovisioned_revoke(
+    session_id: B256,
+    entry: &SessionEntry,
+    policy: UnprovisionedKeyPolicy,
+) -> Result<()> {
+    match policy {
+        UnprovisionedKeyPolicy::RevokeLocally => {
+            update_session_status(session_id, SessionStatus::Revoked)?;
+            print_revoke_status(session_id, Some(entry), SessionRevokeStatus::NotProvisioned)?;
+            Ok(())
+        }
+        UnprovisionedKeyPolicy::Fail => {
+            eyre::bail!(
+                "session key is not provisioned on-chain yet; pending transactions from the \
+                 wrapped command may still provision it. Wait for pending transactions to settle, \
+                 then run `cast wallet session revoke {session_id}`."
+            )
+        }
+    }
 }
 
 async fn handle_revoke_error(
@@ -945,6 +983,24 @@ mod tests {
                 assert_eq!(session.status, SessionStatus::Failed, "{err:#}");
                 assert!(session.key.is_none());
             });
+        });
+    }
+
+    #[test]
+    fn run_for_unprovisioned_cleanup_remains_retryable() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0xd6; 32]);
+            upsert_session_entry(sample_session_entry(session_id, SessionStatus::Active)).unwrap();
+
+            retire_session_run_locally(session_id).unwrap();
+            let entry = read_session_entry(session_id).unwrap().unwrap();
+            let err = handle_unprovisioned_revoke(session_id, &entry, UnprovisionedKeyPolicy::Fail)
+                .unwrap_err();
+
+            assert!(err.to_string().contains("pending transactions"), "{err}");
+            let session = read_session_entry(session_id).unwrap().unwrap();
+            assert_eq!(session.status, SessionStatus::Failed);
+            assert!(session.key.is_none());
         });
     }
 

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -232,9 +232,38 @@ async fn run_for_command(request: SessionRunRequest) -> Result<()> {
     upsert_session_entry(entry)?;
 
     let child_result = command.run(session_id);
+    let cleanup_result = cleanup_session_run(session_id, tx, send_tx).await;
+
+    finish_session_run(session_id, child_result, cleanup_result)
+}
+
+async fn cleanup_session_run(
+    session_id: B256,
+    tx: TransactionOpts,
+    send_tx: SendTxOpts,
+) -> Result<()> {
+    let retire_result = retire_session_run_locally(session_id);
     let revoke_result = run_revoke(session_id, false, tx, send_tx).await;
 
-    finish_session_run(session_id, child_result, revoke_result)
+    match (retire_result, revoke_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(retire_err), Ok(())) => Err(retire_err),
+        (Ok(()), Err(revoke_err)) => Err(revoke_err),
+        (Err(retire_err), Err(revoke_err)) => {
+            Err(revoke_err
+                .wrap_err(format!("also failed to retire local Tempo session: {retire_err}")))
+        }
+    }
+}
+
+fn retire_session_run_locally(session_id: B256) -> Result<()> {
+    let Some(entry) = read_session_entry(session_id)? else {
+        return Ok(());
+    };
+    let status = if entry.status.is_terminal() { entry.status } else { SessionStatus::Failed };
+    update_session_status(session_id, status)
+        .map(|_| ())
+        .wrap_err_with(|| format!("failed to retire local Tempo session {session_id:?}"))
 }
 
 fn finish_session_run(
@@ -246,7 +275,7 @@ fn finish_session_run(
         (Ok(()), Ok(())) => Ok(()),
         (Err(child_err), Ok(())) => Err(child_err),
         (Ok(()), Err(revoke_err)) => {
-            Err(revoke_err.wrap_err("failed to revoke Tempo session after inner command"))
+            Err(revoke_err.wrap_err("failed to clean up Tempo session after inner command"))
         }
         (Err(child_err), Err(revoke_err)) => {
             Err(child_err.wrap_err(revoke_failure_context(session_id, &revoke_err)))
@@ -255,7 +284,7 @@ fn finish_session_run(
 }
 
 fn revoke_failure_context(session_id: B256, err: &eyre::Report) -> String {
-    format!("also failed to revoke Tempo session {session_id:?}: {err}")
+    format!("also failed to clean up Tempo session {session_id:?}: {err}")
 }
 
 #[derive(Debug)]
@@ -752,7 +781,7 @@ mod tests {
     }
 
     #[test]
-    fn revoke_preflight_error_preserves_local_key_material() {
+    fn explicit_revoke_preflight_error_preserves_local_key_material_for_retry() {
         with_tempo_home(|| {
             let runtime = tokio::runtime::Runtime::new().unwrap();
             runtime.block_on(async {
@@ -771,6 +800,45 @@ mod tests {
                 assert_eq!(session.status, SessionStatus::Active, "{err:#}");
                 assert!(session.key.is_some());
             });
+        });
+    }
+
+    #[test]
+    fn run_for_retire_local_session_before_revoke_preflight() {
+        with_tempo_home(|| {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            runtime.block_on(async {
+                let session_id = B256::from([0xd4; 32]);
+                upsert_session_entry(sample_session_entry(session_id, SessionStatus::Active))
+                    .unwrap();
+
+                retire_session_run_locally(session_id).unwrap();
+
+                let mut send_tx = empty_send_tx_opts();
+                send_tx.eth.rpc.common.rpc_url = Some("http://127.0.0.1:9".to_string());
+                let err =
+                    run_revoke(session_id, false, TransactionOpts::parse_from(["cast"]), send_tx)
+                        .await
+                        .unwrap_err();
+
+                let session = read_session_entry(session_id).unwrap().unwrap();
+                assert_eq!(session.status, SessionStatus::Failed, "{err:#}");
+                assert!(session.key.is_none());
+            });
+        });
+    }
+
+    #[test]
+    fn run_for_retire_local_session_does_not_downgrade_revoked_status() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0xd5; 32]);
+            upsert_session_entry(sample_session_entry(session_id, SessionStatus::Revoked)).unwrap();
+
+            retire_session_run_locally(session_id).unwrap();
+
+            let session = read_session_entry(session_id).unwrap().unwrap();
+            assert_eq!(session.status, SessionStatus::Revoked);
+            assert!(session.key.is_none());
         });
     }
 

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -228,12 +228,6 @@ async fn handle_revoke_error(
         .unwrap_or(false)
     {
         let _ = update_session_status(session_id, SessionStatus::Revoked);
-    } else if !matches!(
-        read_session_entry(session_id).ok().flatten().map(|entry| entry.status),
-        Some(SessionStatus::Revoked)
-    ) {
-        let _ =
-            update_session_status_if(session_id, SessionStatus::Revoking, SessionStatus::Failed);
     }
 }
 
@@ -486,7 +480,7 @@ mod tests {
     }
 
     #[test]
-    fn revoke_submit_error_marks_revoking_session_failed() {
+    fn revoke_submit_error_keeps_revoking_session_retryable() {
         with_tempo_home(|| {
             let runtime = tokio::runtime::Runtime::new().unwrap();
             runtime.block_on(async {
@@ -510,8 +504,8 @@ mod tests {
                 handle_revoke_error(&provider, session_id, &entry).await;
 
                 let session = read_session_entry(session_id).unwrap().unwrap();
-                assert_eq!(session.status, SessionStatus::Failed);
-                assert!(session.key.is_none());
+                assert_eq!(session.status, SessionStatus::Revoking);
+                assert!(session.key.is_some());
             });
         });
     }
@@ -602,10 +596,7 @@ mod tests {
 
     fn sample_session_entry(session_id: B256, status: SessionStatus) -> SessionEntry {
         let key = match status {
-            SessionStatus::Revoking
-            | SessionStatus::Revoked
-            | SessionStatus::Expired
-            | SessionStatus::Failed => None,
+            SessionStatus::Revoked | SessionStatus::Expired | SessionStatus::Failed => None,
             _ => Some(foundry_common::tempo::SessionKeyMaterial {
                 key_type: foundry_common::tempo::KeyType::Secp256k1,
                 key: ROOT_PRIVATE_KEY.to_string(),

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -2,9 +2,12 @@ use alloy_primitives::{Address, B256, U256};
 use alloy_provider::Provider;
 use alloy_signer::Signer;
 use alloy_sol_types::SolCall;
-use clap::Parser;
+use clap::{Args, Parser};
 use eyre::{Context, Result};
-use foundry_cli::{opts::TransactionOpts, utils::LoadConfig};
+use foundry_cli::{
+    opts::{TEMPO_SESSION_ID_ENV, TransactionOpts},
+    utils::LoadConfig,
+};
 use foundry_common::{
     provider::ProviderBuilder,
     sh_println, shell,
@@ -18,6 +21,7 @@ use foundry_wallets::{WalletOpts, WalletSigner};
 use serde_json::json;
 use std::{
     num::NonZeroU64,
+    process::{Command, ExitStatus},
     time::{SystemTime, UNIX_EPOCH},
 };
 use tempo_alloy::{TempoNetwork, provider::TempoProviderExt};
@@ -29,12 +33,102 @@ use crate::{
         keychain::{
             KeychainTxOutcome, resolve_keychain_root_signer, send_keychain_tx_with_root_signer,
         },
-        tempo_policy_args::{parse_period, parse_policy_token, parse_scope as parse_policy_scope},
+        tempo_policy_args::{
+            parse_period, parse_policy_token, parse_scope as parse_policy_scope,
+            parse_selector_bytes,
+        },
     },
     tx::SendTxOpts,
 };
 
 const PRINT_SPONSOR_HASH_REVOKE_ERROR: &str = "--tempo.print-sponsor-hash only prints a sponsor hash and does not revoke the session on-chain";
+
+/// Arguments for `cast wallet session`.
+///
+/// Without a subcommand, this runs an issue-style temporary session around `--for <COMMAND>`.
+/// The existing `create` and `revoke` subcommands remain explicit lifecycle operations.
+#[derive(Debug, Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct SessionArgs {
+    #[command(subcommand)]
+    pub command: Option<SessionSubcommands>,
+
+    /// Root account that will authorize the temporary session.
+    #[arg(long = "root", value_name = "ADDRESS")]
+    pub root_account: Option<Address>,
+
+    /// Session lifetime, expressed as a duration like `10m`, `2h`, or `7d`.
+    #[arg(long = "expires", id = "session_expires", value_name = "DURATION", value_parser = parse_period)]
+    pub expires: Option<u64>,
+
+    /// Allowed call scope, in `TARGET[:SELECTORS[@RECIPIENTS]]` format.
+    #[arg(long = "scope", value_parser = parse_scope)]
+    pub scope: Vec<CallScope>,
+
+    /// Allowed call target for issue-style `--target ... --selector ...` input.
+    #[arg(long = "target", value_name = "ADDRESS")]
+    pub target: Option<Address>,
+
+    /// Function selector allowed for `--target`, such as `register(address)`.
+    #[arg(long = "selector", value_name = "SELECTOR")]
+    pub selectors: Vec<String>,
+
+    /// Token spend limit, in `TOKEN:AMOUNT` or `TOKEN=AMOUNT` format.
+    #[arg(long = "spend-limit", value_parser = parse_spend_limit)]
+    pub spend_limits: Vec<SessionSpendLimit>,
+
+    /// Command to run with the temporary Tempo session.
+    #[arg(long = "for", value_name = "COMMAND")]
+    pub for_command: Option<String>,
+
+    #[command(flatten)]
+    pub tx: Box<TransactionOpts>,
+
+    #[command(flatten)]
+    pub send_tx: Box<SendTxOpts>,
+}
+
+impl SessionArgs {
+    pub async fn run(self) -> Result<()> {
+        let Self {
+            command,
+            root_account,
+            expires,
+            scope,
+            target,
+            selectors,
+            spend_limits,
+            for_command,
+            tx,
+            send_tx,
+        } = self;
+
+        if let Some(command) = command {
+            return command.run().await;
+        }
+
+        let root_account =
+            root_account.ok_or_else(|| eyre::eyre!("cast wallet session requires --root"))?;
+        let expires =
+            expires.ok_or_else(|| eyre::eyre!("cast wallet session requires --expires"))?;
+        let for_command =
+            for_command.ok_or_else(|| eyre::eyre!("cast wallet session requires --for"))?;
+        let send_tx = *send_tx;
+        let chain_id = resolve_session_chain_id(&send_tx).await?;
+
+        run_for_command(
+            root_account,
+            chain_id,
+            expires,
+            session_scope(scope, target, selectors)?,
+            spend_limits,
+            for_command,
+            *tx,
+            send_tx,
+        )
+        .await
+    }
+}
 
 /// Tempo wallet session lifecycle commands.
 #[derive(Debug, Parser)]
@@ -94,6 +188,201 @@ impl SessionSubcommands {
             }
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_for_command(
+    root_account: Address,
+    chain_id: u64,
+    expires: u64,
+    scope: Vec<CallScope>,
+    spend_limits: Vec<SessionSpendLimit>,
+    for_command: String,
+    tx: TransactionOpts,
+    send_tx: SendTxOpts,
+) -> Result<()> {
+    if tx.tempo.print_sponsor_hash {
+        eyre::bail!(PRINT_SPONSOR_HASH_REVOKE_ERROR);
+    }
+
+    let entry = build_session_entry(
+        root_account,
+        chain_id,
+        expires,
+        scope,
+        spend_limits,
+        send_tx.eth.wallet.clone(),
+    )
+    .await?;
+    let session_id = entry.session_id;
+    upsert_session_entry(entry)?;
+
+    let child_result = run_inner_command(&for_command, session_id);
+    let revoke_result = run_revoke(session_id, false, tx, send_tx).await;
+
+    match (child_result, revoke_result) {
+        (Ok(status), Ok(())) if status.success() => Ok(()),
+        (Ok(status), Ok(())) => Err(inner_command_status_error(&for_command, status)),
+        (Err(child_err), Ok(())) => Err(child_err),
+        (Ok(status), Err(revoke_err)) if status.success() => {
+            mark_session_failed(session_id);
+            Err(revoke_err.wrap_err("failed to revoke Tempo session after inner command"))
+        }
+        (Ok(status), Err(revoke_err)) => {
+            mark_session_failed(session_id);
+            Err(inner_command_status_error(&for_command, status).wrap_err(format!(
+                "also failed to revoke Tempo session {session_id:?}: {revoke_err}"
+            )))
+        }
+        (Err(child_err), Err(revoke_err)) => {
+            mark_session_failed(session_id);
+            Err(child_err.wrap_err(format!(
+                "also failed to revoke Tempo session {session_id:?}: {revoke_err}"
+            )))
+        }
+    }
+}
+
+fn run_inner_command(command: &str, session_id: B256) -> Result<ExitStatus> {
+    inner_command(command, session_id)?
+        .status()
+        .wrap_err_with(|| format!("failed to run inner command `{command}`"))
+}
+
+fn inner_command(command: &str, session_id: B256) -> Result<Command> {
+    let argv = split_for_command(command)?;
+    let (program, args) =
+        argv.split_first().ok_or_else(|| eyre::eyre!("--for command cannot be empty"))?;
+
+    let mut command = Command::new(program);
+    command.args(args).env(TEMPO_SESSION_ID_ENV, format!("{session_id:?}"));
+    Ok(command)
+}
+
+fn inner_command_status_error(command: &str, status: ExitStatus) -> eyre::Report {
+    match status.code() {
+        Some(code) => eyre::eyre!("inner command `{command}` exited with code {code}"),
+        None => eyre::eyre!("inner command `{command}` terminated by a signal"),
+    }
+}
+
+fn mark_session_failed(session_id: B256) {
+    if !matches!(
+        read_session_entry(session_id).ok().flatten().map(|entry| entry.status),
+        Some(SessionStatus::Revoked)
+    ) {
+        let _ = update_session_status(session_id, SessionStatus::Failed);
+    }
+}
+
+async fn resolve_session_chain_id(send_tx: &SendTxOpts) -> Result<u64> {
+    let config = send_tx.eth.load_config()?;
+    if let Some(chain) = config.chain {
+        return Ok(chain.id());
+    }
+
+    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+    provider.get_chain_id().await.wrap_err(
+        "failed to resolve session chain id from RPC; pass --chain/--chain-id or --rpc-url",
+    )
+}
+
+fn session_scope(
+    mut scope: Vec<CallScope>,
+    target: Option<Address>,
+    selectors: Vec<String>,
+) -> Result<Vec<CallScope>> {
+    if !selectors.is_empty() && target.is_none() {
+        eyre::bail!("--selector requires --target");
+    }
+
+    if let Some(target) = target {
+        let selector_rules = selectors
+            .into_iter()
+            .map(|selector| {
+                parse_selector_bytes(&selector)
+                    .map(|selector| SelectorRule { selector, recipients: vec![] })
+                    .map_err(|err| eyre::eyre!("{err}"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        scope.push(CallScope { target, selector_rules });
+    }
+
+    if scope.is_empty() {
+        eyre::bail!("cast wallet session requires --scope or --target");
+    }
+
+    Ok(scope)
+}
+
+fn split_for_command(command: &str) -> Result<Vec<String>> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+    let mut in_token = false;
+
+    for ch in command.chars() {
+        if escaped {
+            current.push(ch);
+            escaped = false;
+            in_token = true;
+            continue;
+        }
+
+        match quote {
+            Some('\'') => {
+                if ch == '\'' {
+                    quote = None;
+                } else {
+                    current.push(ch);
+                }
+            }
+            Some('"') => {
+                if ch == '"' {
+                    quote = None;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else {
+                    current.push(ch);
+                }
+            }
+            Some(_) => unreachable!(),
+            None if ch.is_whitespace() => {
+                if in_token {
+                    args.push(std::mem::take(&mut current));
+                    in_token = false;
+                }
+            }
+            None if ch == '\'' || ch == '"' => {
+                quote = Some(ch);
+                in_token = true;
+            }
+            None if ch == '\\' => {
+                escaped = true;
+                in_token = true;
+            }
+            None => {
+                current.push(ch);
+                in_token = true;
+            }
+        }
+    }
+
+    if escaped {
+        eyre::bail!("unterminated escape in --for command");
+    }
+    if let Some(quote) = quote {
+        eyre::bail!("unterminated {quote} quote in --for command");
+    }
+    if in_token {
+        args.push(current);
+    }
+    if args.is_empty() {
+        eyre::bail!("--for command cannot be empty");
+    }
+
+    Ok(args)
 }
 
 /// Creates a signed session entry and stores it in the local registry.

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -313,6 +313,9 @@ impl InnerCommand {
 
     fn command(&self, session_id: B256) -> Command {
         let mut command = Command::new(&self.program);
+        // TODO: Wire cast single-wallet signer paths through
+        // TempoOpts::session_signer_for_wallet so cast commands launched via --for can consume
+        // TEMPO_SESSION_ID without requiring explicit signer options.
         command.args(&self.args).env(TEMPO_SESSION_ID_ENV, format!("{session_id:?}"));
         command
     }

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -27,6 +27,7 @@ use std::{
 use tempo_alloy::{TempoNetwork, provider::TempoProviderExt};
 use tempo_contracts::precompiles::IAccountKeychain;
 use tempo_primitives::transaction::{CallScope, PrimitiveSignature, SelectorRule};
+use tokio::{process::Command as TokioCommand, signal};
 
 use crate::{
     cmd::{
@@ -213,7 +214,7 @@ async fn run_for_command(
     let session_id = entry.session_id;
     upsert_session_entry(entry)?;
 
-    let child_result = command.run(session_id);
+    let child_result = command.run(session_id).await;
     let cleanup_result = cleanup_session_run(session_id, tx, send_tx).await;
 
     finish_session_run(session_id, child_result, cleanup_result)
@@ -280,11 +281,34 @@ impl InnerCommand {
         Ok(Self { raw, program, args })
     }
 
-    fn run(&self, session_id: B256) -> Result<()> {
-        let status = self
-            .command(session_id)
-            .status()
+    async fn run(&self, session_id: B256) -> Result<()> {
+        let mut interrupt = SessionInterrupt::new()?;
+        self.run_with_interrupt(session_id, interrupt.recv()).await
+    }
+
+    async fn run_with_interrupt<I>(&self, session_id: B256, interrupt: I) -> Result<()>
+    where
+        I: std::future::Future<Output = Result<&'static str>>,
+    {
+        let mut child = TokioCommand::from(self.command(session_id))
+            .kill_on_drop(true)
+            .spawn()
             .wrap_err_with(|| format!("failed to run inner command `{}`", self.raw))?;
+
+        let status = tokio::select! {
+            status = child.wait() => status.wrap_err_with(|| {
+                format!("failed to wait for inner command `{}`", self.raw)
+            })?,
+            interrupt = interrupt => {
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+
+                return match interrupt {
+                    Ok(interrupt) => Err(self.interrupted_error(interrupt)),
+                    Err(err) => Err(err),
+                };
+            }
+        };
 
         if status.success() { Ok(()) } else { Err(self.status_error(status)) }
     }
@@ -307,6 +331,50 @@ impl InnerCommand {
             Some(code) => eyre::eyre!("inner command `{}` exited with code {code}", self.raw),
             None => eyre::eyre!("inner command `{}` terminated by a signal", self.raw),
         }
+    }
+
+    fn interrupted_error(&self, interrupt: &'static str) -> eyre::Report {
+        eyre::eyre!("inner command `{}` interrupted by {interrupt}", self.raw)
+    }
+}
+
+#[cfg(unix)]
+struct SessionInterrupt {
+    sigint: signal::unix::Signal,
+    sigterm: signal::unix::Signal,
+}
+
+#[cfg(unix)]
+impl SessionInterrupt {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            sigint: signal::unix::signal(signal::unix::SignalKind::interrupt())
+                .wrap_err("failed to listen for SIGINT")?,
+            sigterm: signal::unix::signal(signal::unix::SignalKind::terminate())
+                .wrap_err("failed to listen for SIGTERM")?,
+        })
+    }
+
+    async fn recv(&mut self) -> Result<&'static str> {
+        tokio::select! {
+            _ = self.sigint.recv() => Ok("SIGINT"),
+            _ = self.sigterm.recv() => Ok("SIGTERM"),
+        }
+    }
+}
+
+#[cfg(not(unix))]
+struct SessionInterrupt;
+
+#[cfg(not(unix))]
+impl SessionInterrupt {
+    fn new() -> Result<Self> {
+        Ok(Self)
+    }
+
+    async fn recv(&mut self) -> Result<&'static str> {
+        signal::ctrl_c().await.wrap_err("failed to listen for Ctrl-C")?;
+        Ok("Ctrl-C")
     }
 }
 
@@ -810,6 +878,22 @@ mod tests {
             None,
             "ETH_FROM is a sender hint and should not be stripped by session --for"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn inner_command_interrupt_terminates_child() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let session_id = B256::from([0x7b; 32]);
+            let command = InnerCommand::parse("sh -c 'sleep 30'".to_string()).unwrap();
+            let err = command
+                .run_with_interrupt(session_id, std::future::ready(Ok("test interrupt")))
+                .await
+                .unwrap_err();
+
+            assert!(err.to_string().contains("interrupted by test interrupt"), "{err}");
+        });
     }
 
     fn command_env<'a>(command: &'a Command, key: &str) -> Option<Option<&'a OsStr>> {

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -363,6 +363,11 @@ fn session_scope(
     if !selectors.is_empty() && target.is_none() {
         eyre::bail!("--selector requires --target");
     }
+    if target.is_some() && selectors.is_empty() {
+        eyre::bail!(
+            "--target requires at least one --selector; use --scope TARGET for target-wide access"
+        );
+    }
 
     if let Some(target) = target {
         let selector_rules = selectors
@@ -796,6 +801,22 @@ mod tests {
 
         let err = InnerCommand::parse("forge 'script".to_string()).unwrap_err();
         assert!(err.to_string().contains("unterminated"), "{err}");
+    }
+
+    #[test]
+    fn session_scope_requires_selector_for_target_shortcut() {
+        let target = address!("0x00000000000000000000000000000000000000aa");
+        let err = session_scope(vec![], Some(target), vec![]).unwrap_err();
+
+        assert!(err.to_string().contains("--target requires at least one --selector"), "{err}");
+    }
+
+    #[test]
+    fn session_scope_preserves_explicit_scope_target_wildcard() {
+        let target = address!("0x00000000000000000000000000000000000000aa");
+        let scope = vec![CallScope { target, selector_rules: vec![] }];
+
+        assert_eq!(session_scope(scope.clone(), None, vec![]).unwrap(), scope);
     }
 
     #[test]

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -220,26 +220,19 @@ async fn run_for_command(
     let child_result = run_inner_command(&for_command, session_id);
     let revoke_result = run_revoke(session_id, false, tx, send_tx).await;
 
-    match (child_result, revoke_result) {
-        (Ok(status), Ok(())) if status.success() => Ok(()),
-        (Ok(status), Ok(())) => Err(inner_command_status_error(&for_command, status)),
-        (Err(child_err), Ok(())) => Err(child_err),
-        (Ok(status), Err(revoke_err)) if status.success() => {
-            mark_session_failed(session_id);
+    let revoke_err = revoke_result.err();
+
+    match (child_result, revoke_err) {
+        (Ok(status), None) if status.success() => Ok(()),
+        (Ok(status), None) => Err(inner_command_status_error(&for_command, status)),
+        (Err(child_err), None) => Err(child_err),
+        (Ok(status), Some(revoke_err)) if status.success() => {
             Err(revoke_err.wrap_err("failed to revoke Tempo session after inner command"))
         }
-        (Ok(status), Err(revoke_err)) => {
-            mark_session_failed(session_id);
-            Err(inner_command_status_error(&for_command, status).wrap_err(format!(
-                "also failed to revoke Tempo session {session_id:?}: {revoke_err}"
-            )))
-        }
-        (Err(child_err), Err(revoke_err)) => {
-            mark_session_failed(session_id);
-            Err(child_err.wrap_err(format!(
-                "also failed to revoke Tempo session {session_id:?}: {revoke_err}"
-            )))
-        }
+        (Ok(status), Some(revoke_err)) => Err(inner_command_status_error(&for_command, status)
+            .wrap_err(format!("also failed to revoke Tempo session {session_id:?}: {revoke_err}"))),
+        (Err(child_err), Some(revoke_err)) => Err(child_err
+            .wrap_err(format!("also failed to revoke Tempo session {session_id:?}: {revoke_err}"))),
     }
 }
 
@@ -263,15 +256,6 @@ fn inner_command_status_error(command: &str, status: ExitStatus) -> eyre::Report
     match status.code() {
         Some(code) => eyre::eyre!("inner command `{command}` exited with code {code}"),
         None => eyre::eyre!("inner command `{command}` terminated by a signal"),
-    }
-}
-
-fn mark_session_failed(session_id: B256) {
-    if !matches!(
-        read_session_entry(session_id).ok().flatten().map(|entry| entry.status),
-        Some(SessionStatus::Revoked)
-    ) {
-        let _ = update_session_status(session_id, SessionStatus::Failed);
     }
 }
 
@@ -656,11 +640,7 @@ fn parse_scope(s: &str) -> Result<CallScope, String> {
 
 /// Parses a session spend limit into the session policy model.
 fn parse_spend_limit(s: &str) -> Result<SessionSpendLimit, String> {
-    let (token_str, amount_str) = if let Some(pair) = s.split_once(':') {
-        pair
-    } else if let Some(pair) = s.split_once('=') {
-        pair
-    } else {
+    let Some((token_str, amount_str)) = s.split_once(':').or_else(|| s.split_once('=')) else {
         return Err(format!("invalid limit format: {s} (expected TOKEN:AMOUNT or TOKEN=AMOUNT)"));
     };
 

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -125,17 +125,22 @@ impl SessionArgs {
         let send_tx = *send_tx;
         let chain_id = resolve_session_chain_id(&send_tx).await?;
 
-        run_for_command(SessionRunRequest {
+        let tx = *tx;
+        if tx.tempo.print_sponsor_hash {
+            eyre::bail!(PRINT_SPONSOR_HASH_REVOKE_ERROR);
+        }
+
+        let entry = build_session_entry(
             root_account,
             chain_id,
             expires,
             scope,
             spend_limits,
-            command,
-            tx: *tx,
-            send_tx,
-        })
-        .await
+            send_tx.eth.wallet.clone(),
+        )
+        .await?;
+
+        run_for_command(entry, command, tx, send_tx).await
     }
 }
 
@@ -199,42 +204,12 @@ impl SessionSubcommands {
     }
 }
 
-struct SessionRunRequest {
-    root_account: Address,
-    chain_id: u64,
-    expires: u64,
-    scope: Vec<CallScope>,
-    spend_limits: Vec<SessionSpendLimit>,
+async fn run_for_command(
+    entry: SessionEntry,
     command: InnerCommand,
     tx: TransactionOpts,
     send_tx: SendTxOpts,
-}
-
-async fn run_for_command(request: SessionRunRequest) -> Result<()> {
-    let SessionRunRequest {
-        root_account,
-        chain_id,
-        expires,
-        scope,
-        spend_limits,
-        command,
-        tx,
-        send_tx,
-    } = request;
-
-    if tx.tempo.print_sponsor_hash {
-        eyre::bail!(PRINT_SPONSOR_HASH_REVOKE_ERROR);
-    }
-
-    let entry = build_session_entry(
-        root_account,
-        chain_id,
-        expires,
-        scope,
-        spend_limits,
-        send_tx.eth.wallet.clone(),
-    )
-    .await?;
+) -> Result<()> {
     let session_id = entry.session_id;
     upsert_session_entry(entry)?;
 
@@ -284,14 +259,10 @@ fn finish_session_run(
         (Ok(()), Err(revoke_err)) => {
             Err(revoke_err.wrap_err("failed to clean up Tempo session after inner command"))
         }
-        (Err(child_err), Err(revoke_err)) => {
-            Err(child_err.wrap_err(revoke_failure_context(session_id, &revoke_err)))
-        }
+        (Err(child_err), Err(revoke_err)) => Err(child_err.wrap_err(format!(
+            "also failed to clean up Tempo session {session_id:?}: {revoke_err}"
+        ))),
     }
-}
-
-fn revoke_failure_context(session_id: B256, err: &eyre::Report) -> String {
-    format!("also failed to clean up Tempo session {session_id:?}: {err}")
 }
 
 #[derive(Debug)]
@@ -321,7 +292,13 @@ impl InnerCommand {
     fn command(&self, session_id: B256) -> Command {
         let mut command = Command::new(&self.program);
         command.args(&self.args);
-        configure_session_child_environment(&mut command, session_id);
+        for key in SESSION_CHILD_SIGNER_ENV {
+            command.env_remove(key);
+        }
+        // TODO: Wire cast single-wallet signer paths through TempoOpts::session_signer_for_wallet
+        // so cast commands launched via --for can consume TEMPO_SESSION_ID without
+        // requiring explicit signer options.
+        command.env(TEMPO_SESSION_ID_ENV, format!("{session_id:?}"));
         command
     }
 
@@ -331,16 +308,6 @@ impl InnerCommand {
             None => eyre::eyre!("inner command `{}` terminated by a signal", self.raw),
         }
     }
-}
-
-fn configure_session_child_environment(command: &mut Command, session_id: B256) {
-    for key in SESSION_CHILD_SIGNER_ENV {
-        command.env_remove(key);
-    }
-    // TODO: Wire cast single-wallet signer paths through TempoOpts::session_signer_for_wallet so
-    // cast commands launched via --for can consume TEMPO_SESSION_ID without requiring explicit
-    // signer options.
-    command.env(TEMPO_SESSION_ID_ENV, format!("{session_id:?}"));
 }
 
 async fn resolve_session_chain_id(send_tx: &SendTxOpts) -> Result<u64> {

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -42,6 +42,13 @@ use crate::{
 };
 
 const PRINT_SPONSOR_HASH_REVOKE_ERROR: &str = "--tempo.print-sponsor-hash only prints a sponsor hash and does not revoke the session on-chain";
+const SESSION_CHILD_SIGNER_ENV: &[&str] = &[
+    "ETH_KEYSTORE",
+    "ETH_KEYSTORE_ACCOUNT",
+    "ETH_PASSWORD",
+    "TEMPO_ACCESS_KEY",
+    "TEMPO_ROOT_ACCOUNT",
+];
 
 /// Arguments for `cast wallet session`.
 ///
@@ -313,10 +320,8 @@ impl InnerCommand {
 
     fn command(&self, session_id: B256) -> Command {
         let mut command = Command::new(&self.program);
-        // TODO: Wire cast single-wallet signer paths through
-        // TempoOpts::session_signer_for_wallet so cast commands launched via --for can consume
-        // TEMPO_SESSION_ID without requiring explicit signer options.
-        command.args(&self.args).env(TEMPO_SESSION_ID_ENV, format!("{session_id:?}"));
+        command.args(&self.args);
+        configure_session_child_environment(&mut command, session_id);
         command
     }
 
@@ -326,6 +331,16 @@ impl InnerCommand {
             None => eyre::eyre!("inner command `{}` terminated by a signal", self.raw),
         }
     }
+}
+
+fn configure_session_child_environment(command: &mut Command, session_id: B256) {
+    for key in SESSION_CHILD_SIGNER_ENV {
+        command.env_remove(key);
+    }
+    // TODO: Wire cast single-wallet signer paths through TempoOpts::session_signer_for_wallet so
+    // cast commands launched via --for can consume TEMPO_SESSION_ID without requiring explicit
+    // signer options.
+    command.env(TEMPO_SESSION_ID_ENV, format!("{session_id:?}"));
 }
 
 async fn resolve_session_chain_id(send_tx: &SendTxOpts) -> Result<u64> {
@@ -727,7 +742,7 @@ mod tests {
     use super::*;
     use alloy_primitives::address;
     use foundry_cli::opts::EthereumOpts;
-    use std::sync::Mutex;
+    use std::{ffi::OsStr, sync::Mutex};
     use tempo_contracts::precompiles::PATH_USD_ADDRESS;
 
     const ROOT_PRIVATE_KEY: &str =
@@ -781,6 +796,36 @@ mod tests {
 
         let err = InnerCommand::parse("forge 'script".to_string()).unwrap_err();
         assert!(err.to_string().contains("unterminated"), "{err}");
+    }
+
+    #[test]
+    fn inner_command_clears_inherited_signer_env_for_session_child() {
+        let session_id = B256::from([0x7a; 32]);
+        let command = InnerCommand::parse("forge script Deploy".to_string()).unwrap();
+        let child = command.command(session_id);
+
+        for key in SESSION_CHILD_SIGNER_ENV {
+            assert_eq!(
+                command_env(&child, key),
+                Some(None),
+                "expected {key} to be removed from session child environment"
+            );
+        }
+
+        let expected_session_id = format!("{session_id:?}");
+        assert_eq!(
+            command_env(&child, TEMPO_SESSION_ID_ENV),
+            Some(Some(OsStr::new(&expected_session_id)))
+        );
+        assert_eq!(
+            command_env(&child, "ETH_FROM"),
+            None,
+            "ETH_FROM is a sender hint and should not be stripped by session --for"
+        );
+    }
+
+    fn command_env<'a>(command: &'a Command, key: &str) -> Option<Option<&'a OsStr>> {
+        command.get_envs().find_map(|(name, value)| (name == key).then_some(value))
     }
 
     #[test]

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -463,3 +463,52 @@ exit 7
     assert!(stderr.contains("exited with code 7"), "unexpected stderr:\n{stderr}");
     assert_session_file_status_without_key(tempo_home.path(), "revoked");
 });
+
+casttest!(
+    wallet_session_run_for_retires_local_key_when_revoke_preflight_fails,
+    async |_prj, cmd| {
+        let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+        let rpc = handle.http_endpoint();
+        let tempo_home = tempfile::tempdir().unwrap();
+        let child_dir = tempfile::tempdir().unwrap();
+        let child_script = child_dir.path().join("session-child.sh");
+        fs::write(
+            &child_script,
+            r#"#!/bin/sh
+set -eu
+test -n "${TEMPO_SESSION_ID:-}"
+"#,
+        )
+        .expect("write child script");
+
+        let for_command = format!("sh {}", child_script.display());
+
+        cmd.cast_fuse();
+        cmd.env("TEMPO_HOME", tempo_home.path());
+        let stderr = cmd
+            .args([
+                "wallet",
+                "session",
+                "--root",
+                accounts::ADDR1,
+                "--chain-id",
+                "31338",
+                "--expires",
+                "10m",
+                "--scope",
+                accounts::TOKEN,
+                "--for",
+                &for_command,
+                "--private-key",
+                accounts::PK1,
+                "--rpc-url",
+                &rpc,
+            ])
+            .assert_failure()
+            .get_output()
+            .stderr_lossy();
+
+        assert!(stderr.contains("created for chain 31338"), "unexpected stderr:\n{stderr}");
+        assert_session_file_status_without_key(tempo_home.path(), "failed");
+    }
+);

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -362,3 +362,104 @@ casttest!(wallet_session_revoke_wrong_chain_preserves_local_key, async |_prj, cm
 
     assert_session_file_status_with_key(tempo_home.path(), "active");
 });
+
+casttest!(wallet_session_run_for_wraps_child_and_cleans_key_material, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let child_dir = tempfile::tempdir().unwrap();
+    let child_script = child_dir.path().join("session-child.sh");
+    let child_session_out = child_dir.path().join("child-session-id.txt");
+    fs::write(
+        &child_script,
+        r#"#!/bin/sh
+set -eu
+test -n "${TEMPO_SESSION_ID:-}"
+session_file="${TEMPO_HOME}/wallet/sessions.toml"
+grep -q 'status = "active"' "${session_file}"
+grep -q 'key = "0x' "${session_file}"
+grep -q 'key_authorization = "0x' "${session_file}"
+printf '%s\n' "${TEMPO_SESSION_ID}" > "$1"
+"#,
+    )
+    .expect("write child script");
+
+    let for_command = format!("sh {} {}", child_script.display(), child_session_out.display());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.args([
+        "wallet",
+        "session",
+        "--root",
+        accounts::ADDR1,
+        "--expires",
+        "10m",
+        "--scope",
+        accounts::TOKEN,
+        "--spend-limit",
+        "PathUSD=0",
+        "--for",
+        &for_command,
+        "--private-key",
+        accounts::PK1,
+        "--rpc-url",
+        &rpc,
+    ])
+    .assert_success();
+
+    let child_session_id =
+        fs::read_to_string(&child_session_out).expect("child wrote TEMPO_SESSION_ID");
+    assert!(
+        child_session_id.trim().starts_with("0x"),
+        "unexpected child session id: {child_session_id}"
+    );
+    assert_session_file_status_without_key(tempo_home.path(), "revoked");
+});
+
+casttest!(wallet_session_run_for_cleans_key_material_when_child_fails, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let child_dir = tempfile::tempdir().unwrap();
+    let child_script = child_dir.path().join("failing-session-child.sh");
+    fs::write(
+        &child_script,
+        r#"#!/bin/sh
+set -eu
+test -n "${TEMPO_SESSION_ID:-}"
+session_file="${TEMPO_HOME}/wallet/sessions.toml"
+grep -q 'status = "active"' "${session_file}"
+grep -q 'key = "0x' "${session_file}"
+exit 7
+"#,
+    )
+    .expect("write child script");
+
+    let for_command = format!("sh {}", child_script.display());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    let stderr = cmd
+        .args([
+            "wallet",
+            "session",
+            "--root",
+            accounts::ADDR1,
+            "--expires",
+            "10m",
+            "--scope",
+            accounts::TOKEN,
+            "--for",
+            &for_command,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+    assert!(stderr.contains("exited with code 7"), "unexpected stderr:\n{stderr}");
+    assert_session_file_status_without_key(tempo_home.path(), "revoked");
+});

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -363,16 +363,18 @@ casttest!(wallet_session_revoke_wrong_chain_preserves_local_key, async |_prj, cm
     assert_session_file_status_with_key(tempo_home.path(), "active");
 });
 
-casttest!(wallet_session_run_for_wraps_child_and_cleans_key_material, async |_prj, cmd| {
-    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
-    let rpc = handle.http_endpoint();
-    let tempo_home = tempfile::tempdir().unwrap();
-    let child_dir = tempfile::tempdir().unwrap();
-    let child_script = child_dir.path().join("session-child.sh");
-    let child_session_out = child_dir.path().join("child-session-id.txt");
-    fs::write(
-        &child_script,
-        r#"#!/bin/sh
+casttest!(
+    wallet_session_run_for_without_key_use_fails_closed_and_cleans_key_material,
+    async |_prj, cmd| {
+        let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+        let rpc = handle.http_endpoint();
+        let tempo_home = tempfile::tempdir().unwrap();
+        let child_dir = tempfile::tempdir().unwrap();
+        let child_script = child_dir.path().join("session-child.sh");
+        let child_session_out = child_dir.path().join("child-session-id.txt");
+        fs::write(
+            &child_script,
+            r#"#!/bin/sh
 set -eu
 test -n "${TEMPO_SESSION_ID:-}"
 session_file="${TEMPO_HOME}/wallet/sessions.toml"
@@ -381,41 +383,53 @@ grep -q 'key = "0x' "${session_file}"
 grep -q 'key_authorization = "0x' "${session_file}"
 printf '%s\n' "${TEMPO_SESSION_ID}" > "$1"
 "#,
-    )
-    .expect("write child script");
+        )
+        .expect("write child script");
 
-    let for_command = format!("sh {} {}", child_script.display(), child_session_out.display());
+        let for_command = format!("sh {} {}", child_script.display(), child_session_out.display());
 
-    cmd.cast_fuse();
-    cmd.env("TEMPO_HOME", tempo_home.path());
-    cmd.args([
-        "wallet",
-        "session",
-        "--root",
-        accounts::ADDR1,
-        "--expires",
-        "10m",
-        "--scope",
-        accounts::TOKEN,
-        "--spend-limit",
-        "PathUSD=0",
-        "--for",
-        &for_command,
-        "--private-key",
-        accounts::PK1,
-        "--rpc-url",
-        &rpc,
-    ])
-    .assert_success();
+        cmd.cast_fuse();
+        cmd.env("TEMPO_HOME", tempo_home.path());
+        let stderr = cmd
+            .args([
+                "wallet",
+                "session",
+                "--root",
+                accounts::ADDR1,
+                "--expires",
+                "10m",
+                "--scope",
+                accounts::TOKEN,
+                "--spend-limit",
+                "PathUSD=0",
+                "--for",
+                &for_command,
+                "--private-key",
+                accounts::PK1,
+                "--rpc-url",
+                &rpc,
+            ])
+            .assert_failure()
+            .get_output()
+            .stderr_lossy();
+        assert!(
+            stderr.contains("failed to clean up Tempo session after inner command"),
+            "unexpected stderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("session key is not provisioned on-chain yet"),
+            "unexpected stderr:\n{stderr}"
+        );
 
-    let child_session_id =
-        fs::read_to_string(&child_session_out).expect("child wrote TEMPO_SESSION_ID");
-    assert!(
-        child_session_id.trim().starts_with("0x"),
-        "unexpected child session id: {child_session_id}"
-    );
-    assert_session_file_status_without_key(tempo_home.path(), "revoked");
-});
+        let child_session_id =
+            fs::read_to_string(&child_session_out).expect("child wrote TEMPO_SESSION_ID");
+        assert!(
+            child_session_id.trim().starts_with("0x"),
+            "unexpected child session id: {child_session_id}"
+        );
+        assert_session_file_status_without_key(tempo_home.path(), "failed");
+    }
+);
 
 casttest!(wallet_session_run_for_cleans_key_material_when_child_fails, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
@@ -461,7 +475,7 @@ exit 7
         .get_output()
         .stderr_lossy();
     assert!(stderr.contains("exited with code 7"), "unexpected stderr:\n{stderr}");
-    assert_session_file_status_without_key(tempo_home.path(), "revoked");
+    assert_session_file_status_without_key(tempo_home.path(), "failed");
 });
 
 casttest!(

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -38,7 +38,7 @@ impl SessionStatus {
 
     /// Returns `true` if entering this status must erase local key material.
     const fn clears_key_material(self) -> bool {
-        matches!(self, Self::Revoked | Self::Expired | Self::Failed)
+        self.is_terminal()
     }
 
     /// Returns `true` if the session is still in-flight or usable.

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -38,7 +38,7 @@ impl SessionStatus {
 
     /// Returns `true` if entering this status must erase local key material.
     const fn clears_key_material(self) -> bool {
-        matches!(self, Self::Revoking | Self::Revoked | Self::Expired | Self::Failed)
+        matches!(self, Self::Revoked | Self::Expired | Self::Failed)
     }
 
     /// Returns `true` if the session is still in-flight or usable.
@@ -176,7 +176,7 @@ impl SessionRecord {
         self.get(session_id).filter(|session| session.has_live_key_at(now))
     }
 
-    /// Update a session status by id. Revoking and terminal statuses clear local key material.
+    /// Update a session status by id. Terminal statuses clear local key material.
     ///
     /// Returns `true` when the record changed. Missing sessions and idempotent
     /// updates return `false`.
@@ -793,7 +793,7 @@ mod tests {
     }
 
     #[test]
-    fn session_record_status_updates_preserve_live_keys_and_clear_terminal_keys() {
+    fn session_record_status_updates_preserve_retryable_keys_and_clear_terminal_keys() {
         let active_id = B256::from([0x67; 32]);
         let revoking_id = B256::from([0x68; 32]);
         let revoked_id = B256::from([0x69; 32]);
@@ -818,7 +818,7 @@ mod tests {
         assert_eq!(record.get(active_id).unwrap().status, SessionStatus::Active);
         assert!(record.get(active_id).unwrap().key.is_some());
         assert_eq!(record.get(revoking_id).unwrap().status, SessionStatus::Revoking);
-        assert!(record.get(revoking_id).unwrap().key.is_none());
+        assert!(record.get(revoking_id).unwrap().key.is_some());
         assert_eq!(record.get(revoked_id).unwrap().status, SessionStatus::Revoked);
         assert!(record.get(revoked_id).unwrap().key.is_none());
         assert_eq!(record.get(failed_id).unwrap().status, SessionStatus::Failed);
@@ -847,6 +847,7 @@ mod tests {
         let revoked_id = B256::from([0x03; 32]);
         let no_key_id = B256::from([0x04; 32]);
         let pending_id = B256::from([0x05; 32]);
+        let revoking_id = B256::from([0x06; 32]);
 
         let record = SessionRecord {
             sessions: vec![
@@ -855,6 +856,7 @@ mod tests {
                 sample_entry_with_key(revoked_id, 200, SessionStatus::Revoked),
                 sample_entry(no_key_id, 200, SessionStatus::Active),
                 sample_entry_with_key(pending_id, 200, SessionStatus::Pending),
+                sample_entry_with_key(revoking_id, 200, SessionStatus::Revoking),
             ],
         };
 
@@ -863,6 +865,7 @@ mod tests {
         assert!(record.live_key(revoked_id, 100).is_none());
         assert!(record.live_key(no_key_id, 100).is_none());
         assert!(record.live_key(pending_id, 100).is_none());
+        assert!(record.live_key(revoking_id, 100).is_none());
     }
 
     #[test]
@@ -1244,7 +1247,7 @@ key = "0x1111"
             let record = read_session_record().unwrap();
             let session = record.get(session_id).unwrap();
             assert_eq!(session.status, SessionStatus::Revoking);
-            assert!(session.key.is_none());
+            assert!(session.key.is_some());
 
             assert!(update_session_status(session_id, SessionStatus::Revoked).unwrap());
             let record = read_session_record().unwrap();
@@ -1292,7 +1295,7 @@ key = "0x1111"
             let record = read_session_record().unwrap();
             let session = record.get(session_id).unwrap();
             assert_eq!(session.status, SessionStatus::Revoking);
-            assert!(session.key.is_none());
+            assert!(session.key.is_some());
 
             assert!(!update_session_status_if(
                 session_id,


### PR DESCRIPTION
Step towards OSS-162 , 

Adds a top-level `cast wallet session` runner mode alongside the existing explicit `create` and `revoke` subcommands.

The new flow:

  - parses session policy flags such as `--root`, `--expires`, `--scope`, `--target`, `--selector`, and `--spend-limit`
  - resolves the session chain id from CLI config or RPC
  - creates and stores a temporary session entry signed by the root account
  - runs the inner command with `TEMPO_SESSION_ID` in its environment
  - strips inherited signer-related environment variables from the child process
  - retires local session key material before revoke preflight
  - revokes the session on-chain after the child command exits
  - handles child failures and wrapper interrupts while still attempting cleanup

This also keeps `Revoking` session entries retryable by preserving key material until a terminal status is reached. That makes explicit revoke attempts remain retryable, while the session runner can still retire its local key material before attempting cleanup.