### PR TITLE
feat(cheatcodes): `vm.rpcJson` 

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -9452,6 +9452,46 @@
     },
     {
       "func": {
+        "id": "rpcJson_0",
+        "description": "Performs an Ethereum JSON-RPC request to the current fork URL and returns the JSON result.",
+        "declaration": "function rpcJson(string calldata method, string calldata params) external returns (string memory data);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rpcJson(string,string)",
+        "selector": "0x9519f228",
+        "selectorBytes": [
+          149,
+          25,
+          242,
+          40
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
+        "id": "rpcJson_1",
+        "description": "Performs an Ethereum JSON-RPC request to the given endpoint and returns the JSON result.",
+        "declaration": "function rpcJson(string calldata urlOrAlias, string calldata method, string calldata params) external returns (string memory data);",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "rpcJson(string,string,string)",
+        "selector": "0x273b74f8",
+        "selectorBytes": [
+          39,
+          59,
+          116,
+          248
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "rpcUrl",
         "description": "Returns the RPC url for the given alias.",
         "declaration": "function rpcUrl(string calldata rpcAlias) external view returns (string memory json);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -931,6 +931,16 @@ interface Vm {
         external
         returns (bytes memory data);
 
+    /// Performs an Ethereum JSON-RPC request to the current fork URL and returns the JSON result.
+    #[cheatcode(group = Evm, safety = Safe)]
+    function rpcJson(string calldata method, string calldata params) external returns (string memory data);
+
+    /// Performs an Ethereum JSON-RPC request to the given endpoint and returns the JSON result.
+    #[cheatcode(group = Evm, safety = Safe)]
+    function rpcJson(string calldata urlOrAlias, string calldata method, string calldata params)
+        external
+        returns (string memory data);
+
     /// Gets all the logs according to specified filter.
     #[cheatcode(group = Evm, safety = Safe)]
     function eth_getLogs(uint256 fromBlock, uint256 toBlock, address target, bytes32[] calldata topics)

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -457,7 +457,7 @@ fn rpc_result(url: &str, method: &str, params: &str) -> Result<serde_json::Value
     let provider = ProviderBuilder::<AnyNetwork>::new(url).build()?;
     let params_json: serde_json::Value = serde_json::from_str(params)?;
     foundry_common::block_on(provider.raw_request(method.to_string().into(), params_json))
-        .map_err(|err| fmt_err!("{method:?}: {err}").into())
+        .map_err(|err| fmt_err!("{method:?}: {err}"))
 }
 
 /// Convert fixed bytes and address values to bytes in order to prevent encoding issues.

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -228,6 +228,23 @@ impl Cheatcode for rpc_1Call {
     }
 }
 
+impl Cheatcode for rpcJson_0Call {
+    fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
+        let Self { method, params } = self;
+        let url =
+            ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
+        rpc_json_call(&url, method, params)
+    }
+}
+
+impl Cheatcode for rpcJson_1Call {
+    fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { urlOrAlias, method, params } = self;
+        let url = state.config.rpc_endpoint(urlOrAlias)?.url()?;
+        rpc_json_call(&url, method, params)
+    }
+}
+
 impl Cheatcode for eth_getLogsCall {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { fromBlock, toBlock, target, topics } = self;
@@ -417,11 +434,7 @@ fn persist_caller<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCtxt<'_, '_, FEN>) {
 
 /// Performs an Ethereum JSON-RPC request to the given endpoint.
 fn rpc_call(url: &str, method: &str, params: &str) -> Result {
-    let provider = ProviderBuilder::<AnyNetwork>::new(url).build()?;
-    let params_json: serde_json::Value = serde_json::from_str(params)?;
-    let result =
-        foundry_common::block_on(provider.raw_request(method.to_string().into(), params_json))
-            .map_err(|err| fmt_err!("{method:?}: {err}"))?;
+    let result = rpc_result(url, method, params)?;
     let result_as_tokens = convert_to_bytes(
         &json_value_to_token(&result, None)
             .map_err(|err| fmt_err!("failed to parse result: {err}"))?,
@@ -432,6 +445,19 @@ fn rpc_call(url: &str, method: &str, params: &str) -> Result {
         _ => result_as_tokens.abi_encode(),
     };
     Ok(DynSolValue::Bytes(payload).abi_encode())
+}
+
+/// Performs an Ethereum JSON-RPC request to the given endpoint and returns the JSON result.
+fn rpc_json_call(url: &str, method: &str, params: &str) -> Result {
+    let result = rpc_result(url, method, params)?;
+    Ok(serde_json::to_string(&result)?.abi_encode())
+}
+
+fn rpc_result(url: &str, method: &str, params: &str) -> Result<serde_json::Value> {
+    let provider = ProviderBuilder::<AnyNetwork>::new(url).build()?;
+    let params_json: serde_json::Value = serde_json::from_str(params)?;
+    foundry_common::block_on(provider.raw_request(method.to_string().into(), params_json))
+        .map_err(|err| fmt_err!("{method:?}: {err}").into())
 }
 
 /// Convert fixed bytes and address values to bytes in order to prevent encoding issues.

--- a/testdata/default/cheats/Fork2.t.sol
+++ b/testdata/default/cheats/Fork2.t.sol
@@ -232,6 +232,20 @@ contract ForkTest is Test {
         assertGt(decodedResult, 20_000_000);
     }
 
+    function testRpcJson() public {
+        vm.selectFork(mainnetFork);
+        string memory path = "fixtures/Rpc/balance_params.json";
+        string memory file = vm.readFile(path);
+        string memory result = vm.rpcJson("eth_getBalance", file);
+        assertEq(result, '"0x10b7c11bcb51e6"');
+    }
+
+    function testRpcJsonWithUrl() public {
+        string memory result = vm.rpcJson("mainnet", "eth_blockNumber", "[]");
+        uint256 decodedResult = vm.parseUint(vm.parseJsonString(result, "$"));
+        assertGt(decodedResult, 20_000_000);
+    }
+
     struct Withdrawal {
         address addr;
         bytes amount;
@@ -359,6 +373,23 @@ contract ForkTest is Test {
         assertEq(txn.from, 0x8Be6209bC9BD1a8e6e015ADe090F6BE7BE6f032A, "tx from mismatch");
         assertEq(txn.to, 0xF04fd9a66DE511BC389D3b830C1F850a4A4A8c61, "tx to mismatch");
         assertEq(txn.blockNumber, hex"588b24", "tx blockNumber mismatch");
+    }
+
+    function testRpcJsonTransactionByHashPreservesKeys() public {
+        string memory data = vm.rpcJson(
+            "https://sepolia.drpc.org",
+            "eth_getTransactionByHash",
+            '["0xe1a0fba63292976050b2fbf4379a1901691355ed138784b4e0d1854b4cf9193e"]'
+        );
+
+        assertEq(
+            vm.parseJsonBytes32(data, ".hash"),
+            bytes32(hex"e1a0fba63292976050b2fbf4379a1901691355ed138784b4e0d1854b4cf9193e"),
+            "tx hash mismatch"
+        );
+        assertEq(vm.parseJsonAddress(data, ".from"), 0x8Be6209bC9BD1a8e6e015ADe090F6BE7BE6f032A, "tx from mismatch");
+        assertEq(vm.parseJsonAddress(data, ".to"), 0xF04fd9a66DE511BC389D3b830C1F850a4A4A8c61, "tx to mismatch");
+        assertEq(vm.parseJsonBytes(data, ".blockNumber"), hex"588b24", "tx blockNumber mismatch");
     }
 }
 

--- a/testdata/default/cheats/Fork2.t.sol
+++ b/testdata/default/cheats/Fork2.t.sol
@@ -377,19 +377,19 @@ contract ForkTest is Test {
 
     function testRpcJsonTransactionByHashPreservesKeys() public {
         string memory data = vm.rpcJson(
-            "https://sepolia.drpc.org",
+            "mainnet",
             "eth_getTransactionByHash",
-            '["0xe1a0fba63292976050b2fbf4379a1901691355ed138784b4e0d1854b4cf9193e"]'
+            '["0x67cbad73764049e228495a3f90144aab4a37cb4b5fd697dffc234aa5ed811ace"]'
         );
 
         assertEq(
             vm.parseJsonBytes32(data, ".hash"),
-            bytes32(hex"e1a0fba63292976050b2fbf4379a1901691355ed138784b4e0d1854b4cf9193e"),
+            bytes32(hex"67cbad73764049e228495a3f90144aab4a37cb4b5fd697dffc234aa5ed811ace"),
             "tx hash mismatch"
         );
-        assertEq(vm.parseJsonAddress(data, ".from"), 0x8Be6209bC9BD1a8e6e015ADe090F6BE7BE6f032A, "tx from mismatch");
-        assertEq(vm.parseJsonAddress(data, ".to"), 0xF04fd9a66DE511BC389D3b830C1F850a4A4A8c61, "tx to mismatch");
-        assertEq(vm.parseJsonBytes(data, ".blockNumber"), hex"588b24", "tx blockNumber mismatch");
+        assertEq(vm.parseJsonAddress(data, ".from"), 0x106aEe384Db47379b38f4212eB512b9c327e5F56, "tx from mismatch");
+        assertEq(vm.parseJsonAddress(data, ".to"), 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D, "tx to mismatch");
+        assertEq(vm.parseJsonBytes(data, ".blockNumber"), hex"f82248", "tx blockNumber mismatch");
     }
 }
 

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -465,6 +465,8 @@ interface Vm {
     function rollFork(bytes32 txHash) external;
     function rollFork(uint256 forkId, uint256 blockNumber) external;
     function rollFork(uint256 forkId, bytes32 txHash) external;
+    function rpcJson(string calldata method, string calldata params) external returns (string memory data);
+    function rpcJson(string calldata urlOrAlias, string calldata method, string calldata params) external returns (string memory data);
     function rpcUrl(string calldata rpcAlias) external view returns (string memory json);
     function rpcUrlStructs() external view returns (Rpc[] memory urls);
     function rpcUrls() external view returns (string[2][] memory urls);


### PR DESCRIPTION
## Summary

Adds `vm.rpcJson` overloads that perform JSON-RPC requests like `vm.rpc`, but return the serialized JSON result as a Solidity string.

This keeps the existing `vm.rpc` bytes/tuple conversion behavior intact for compatibility while making complex provider-specific RPC object responses usable with the existing JSON parsing cheatcodes.

## Details

- Adds `rpcJson(string method, string params)` for the active fork URL.
- Adds `rpcJson(string urlOrAlias, string method, string params)` for explicit endpoints or aliases.
- Shares the underlying RPC request helper with `vm.rpc`.
- Adds fork cheatcode coverage for JSON scalar results and key-preserving transaction object parsing.

Closes #15072.
