### PR TITLE
perf(fuzz): reduce invariant campaign memory retention

### DIFF
--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -274,6 +274,8 @@ fn fold_outputs(
     let workers = outputs.len();
     let mut errors = HashMap::default();
     let mut handler_errors = HashMap::default();
+    let mut runs = 0;
+    let mut calls = 0;
     let mut cases = Vec::new();
     let mut reverts = 0;
     let mut last_run_inputs = Vec::new();
@@ -293,6 +295,8 @@ fn fold_outputs(
         }
         merge_handler_errors(&mut handler_errors, result.handler_errors);
         corpus_entries.extend(worker_entries);
+        runs += result.runs;
+        calls += result.calls;
         cases.extend(result.cases);
         reverts += result.reverts;
         if !result.last_run_inputs.is_empty() {
@@ -313,6 +317,8 @@ fn fold_outputs(
         InvariantFuzzTestResult::new(
             errors,
             handler_errors,
+            runs,
+            calls,
             cases,
             reverts,
             last_run_inputs,
@@ -443,6 +449,8 @@ mod tests {
         InvariantFuzzTestResult::new(
             HashMap::default(),
             HashMap::default(),
+            0,
+            0,
             Vec::new(),
             reverts,
             Vec::new(),
@@ -490,6 +498,8 @@ mod tests {
     ) -> InvariantFuzzTestResult {
         let mut result = empty_result(reverts, failed_corpus_replays);
         result.cases.push(FuzzedCases::new(vec![FuzzCase { gas: case_gas, stipend: 0 }]));
+        result.runs = result.cases.len();
+        result.calls = result.cases.iter().map(|cases| cases.cases().len()).sum();
         result.last_run_inputs = vec![basic_tx(last_input_sender)];
         result.gas_report_traces.push(vec![CallTraceArena::default()]);
         result.line_coverage = Some(hit_maps(7, coverage_hits));
@@ -726,6 +736,30 @@ mod tests {
     }
 
     #[test]
+    fn aggregator_preserves_run_and_call_counts_without_case_payloads() {
+        let spec = InvariantCampaignSpec::new(3);
+        let plans = [
+            InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+            InvariantWorkerPlan { worker_id: 1, first_global_run: 1, runs: 2 },
+        ];
+        let mut first = empty_result(0, 0);
+        first.runs = 1;
+        first.calls = 1000;
+        let mut second = empty_result(0, 0);
+        second.runs = 2;
+        second.calls = 2000;
+
+        let mut aggregator = InvariantCampaignAggregator::new(spec);
+        aggregator.push(InvariantWorkerOutput::new(plans[1], second));
+        aggregator.push(InvariantWorkerOutput::new(plans[0], first));
+        let result = aggregator.finish().unwrap();
+
+        assert_eq!(result.runs, 3);
+        assert_eq!(result.calls, 3000);
+        assert!(result.cases.is_empty());
+    }
+
+    #[test]
     fn timeout_aggregator_accepts_partial_outputs_with_range_gaps() {
         fn result_with_cases(
             gases: &[u64],
@@ -736,6 +770,8 @@ mod tests {
                 .iter()
                 .map(|&gas| FuzzedCases::new(vec![FuzzCase { gas, stipend: 0 }]))
                 .collect();
+            result.runs = result.cases.len();
+            result.calls = result.cases.iter().map(|cases| cases.cases().len()).sum();
             result.last_run_inputs = gases.last().map_or_else(Vec::new, |_| vec![basic_tx(0x44)]);
             result
         }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -26,7 +26,7 @@ use foundry_evm_core::{
     precompiles::PRECOMPILES,
 };
 use foundry_evm_fuzz::{
-    BasicTxDetails, FuzzCase, FuzzFixtures, FuzzedCases,
+    BasicTxDetails, FuzzCase, FuzzFixtures,
     invariant::{
         ArtifactFilters, FuzzRunIdentifiedContracts, InvariantContract, InvariantSettings,
         RandomCallGenerator, SenderFilters, TargetedContract, TargetedContracts,
@@ -356,8 +356,10 @@ fn build_invariant_progress_json<M: Serialize>(
 
 /// Contains data collected during invariant test runs.
 struct InvariantTestData {
-    // Consumed gas and calldata of every successful fuzz call.
-    fuzz_cases: Vec<FuzzedCases>,
+    // Number of completed invariant runs.
+    runs: usize,
+    // Number of completed fuzzed calls across all invariant runs.
+    calls: usize,
     // Data related to reverts or failed assertions of the test.
     failures: InvariantFailures,
     // Calldata in the last invariant run.
@@ -400,7 +402,8 @@ impl InvariantTest {
         branch_runner: TestRunner,
     ) -> Self {
         let test_data = InvariantTestData {
-            fuzz_cases: vec![],
+            runs: 0,
+            calls: 0,
             failures,
             last_run_inputs: vec![],
             gas_report_traces: vec![],
@@ -460,7 +463,8 @@ impl InvariantTest {
                 .gas_report_traces
                 .push(run.run_traces.into_iter().map(|arena| arena.arena).collect());
         }
-        self.test_data.fuzz_cases.push(FuzzedCases::new(run.fuzz_runs));
+        self.test_data.runs += 1;
+        self.test_data.calls += run.fuzz_runs.len();
 
         // Revert state to not persist values between runs.
         self.fuzz_state.revert();
@@ -1228,7 +1232,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let worker_result = InvariantFuzzTestResult::new(
             errors,
             handler_errors,
-            result.fuzz_cases,
+            result.runs,
+            result.calls,
+            Vec::new(),
             reverts,
             result.last_run_inputs,
             result.gas_report_traces,

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -35,6 +35,10 @@ pub struct InvariantFuzzTestResult {
     /// Handler-side assertion bugs, keyed by `(reverter, selector)` site (deduped per
     /// handler function). Each entry is [`InvariantFuzzError::HandlerAssertion`].
     pub handler_errors: HashMap<(Address, Selector), InvariantFuzzError>,
+    /// Number of completed invariant runs.
+    pub runs: usize,
+    /// Number of completed fuzzed calls across all invariant runs.
+    pub calls: usize,
     /// Every successful fuzz test case
     pub cases: Vec<FuzzedCases>,
     /// Number of reverted fuzz calls
@@ -64,6 +68,8 @@ impl InvariantFuzzTestResult {
     pub(crate) const fn new(
         errors: HashMap<String, InvariantFuzzError>,
         handler_errors: HashMap<(Address, Selector), InvariantFuzzError>,
+        runs: usize,
+        calls: usize,
         cases: Vec<FuzzedCases>,
         reverts: usize,
         last_run_inputs: Vec<BasicTxDetails>,
@@ -78,6 +84,8 @@ impl InvariantFuzzTestResult {
         Self {
             errors,
             handler_errors,
+            runs,
+            calls,
             cases,
             reverts,
             last_run_inputs,

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1171,6 +1171,8 @@ impl TestResult {
         invariant_count: Option<usize>,
         invariant_handler_failures: Vec<InvariantFailure>,
         counterexample: Option<CounterExample>,
+        runs: usize,
+        calls: usize,
         cases: Vec<FuzzedCases>,
         reverts: usize,
         metrics: Map<String, InvariantMetrics>,
@@ -1179,8 +1181,8 @@ impl TestResult {
         optimization_best_value: Option<I256>,
     ) {
         self.kind = TestKind::Invariant {
-            runs: cases.len(),
-            calls: cases.iter().map(|sequence| sequence.cases().len()).sum(),
+            runs,
+            calls,
             reverts,
             workers: workers.max(1),
             metrics,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1749,6 +1749,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             invariant_count,
             invariant_handler_failures,
             counterexample,
+            invariant_result.runs,
+            invariant_result.calls,
             invariant_result.cases,
             invariant_result.reverts,
             invariant_result.metrics,


### PR DESCRIPTION
Follow-up to #15070 for the invariant OOM in Tempo's 5h corpus-reuse workflow.\n\nThis branch includes #15070 and adds a stronger retention fix. #15070 frees per-run corpus payloads, but successful invariant runs still retained one FuzzCase per handler call in InvariantTestData::fuzz_cases until the worker returned. With depth=1000, 32 workers, and a timed 5h campaign, that vector can grow with runs * depth even when there are no failures.\n\nThis changes invariant results to carry explicit run/call counters and leaves the production successful-case payload empty. Reporting still shows correct runs/calls, while the worker no longer retains all successful call gas records.\n\nValidation:\n- cargo fmt --check\n- CARGO_NET_RETRY=5 cargo check -p foundry-evm\n- cargo test -p foundry-evm executors::invariant::campaign::tests:: --lib