### PR TITLE
fix(ci): restrict nightly Tempo testnet check to check-only mode

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
           VERIFIER_URL: ${{ secrets.VERIFIER_URL }}
-          SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
+          SCRIPTS: ${{ github.event_name == 'schedule' && 'check' || github.event.inputs.scripts || 'both' }}
         run: |
           if [ "$SCRIPTS" = "check" ] || [ "$SCRIPTS" = "both" ]; then
             ./.github/scripts/tempo-check.sh


### PR DESCRIPTION
Scheduled runs default to SCRIPTS=both, which runs stateful deploy flows against shared testnet infrastructure. Restrict scheduled runs to check mode only while preserving deploy coverage for manual workflow_dispatch.

Fixes #15073