### PR TITLE
perf(symbolic): reduce solver work with path-bounded arithmetic guards

### DIFF
--- a/crates/evm/symbolic/src/runtime/solver/normalize.rs
+++ b/crates/evm/symbolic/src/runtime/solver/normalize.rs
@@ -2,8 +2,28 @@ use super::*;
 
 /// Normalizes path constraints into an equivalent, solver-friendlier form.
 pub(crate) fn normalize_constraints_for_solver(constraints: &[BoolExpr]) -> Vec<BoolExpr> {
-    let mut normalized = Vec::with_capacity(constraints.len());
-    for constraint in constraints.iter().cloned().map(normalize_bool_for_solver) {
+    let normalized = normalize_constraint_batch(
+        constraints.iter().cloned().map(normalize_bool_for_solver),
+        constraints.len(),
+    );
+    if matches!(normalized.as_slice(), [BoolExpr::Const(false)]) {
+        return normalized;
+    }
+
+    let context = ConstraintContext::new(&normalized);
+    let normalized_len = normalized.len();
+    normalize_constraint_batch(
+        normalized.into_iter().map(|constraint| context.normalize_bool(constraint)),
+        normalized_len,
+    )
+}
+
+fn normalize_constraint_batch(
+    constraints: impl IntoIterator<Item = BoolExpr>,
+    capacity: usize,
+) -> Vec<BoolExpr> {
+    let mut normalized = Vec::with_capacity(capacity);
+    for constraint in constraints {
         if matches!(constraint, BoolExpr::Const(false)) {
             return vec![BoolExpr::Const(false)];
         }
@@ -53,6 +73,89 @@ pub(crate) fn normalize_bool_for_solver(expr: BoolExpr) -> BoolExpr {
                 normalize_expr_for_solver(right),
             );
             normalize_udiv_bool_for_solver(&normalized).unwrap_or(normalized)
+        }
+    }
+}
+
+/// Simple facts learned from the normalized conjunction currently being queried.
+#[derive(Default)]
+struct ConstraintContext {
+    upper_bounds: BTreeMap<Expr, U256>,
+}
+
+impl ConstraintContext {
+    fn new(constraints: &[BoolExpr]) -> Self {
+        let mut context = Self::default();
+        for constraint in constraints {
+            context.record_upper_bound_constraint(constraint);
+        }
+        context
+    }
+
+    fn upper_bound(&self, expr: &Expr) -> Option<U256> {
+        self.upper_bounds.get(expr).copied()
+    }
+
+    fn normalize_bool(&self, expr: BoolExpr) -> BoolExpr {
+        match &expr {
+            BoolExpr::Eq(left, Expr::Const(value)) | BoolExpr::Eq(Expr::Const(value), left)
+                if value.is_zero() && self.word_bool_always_true(left) =>
+            {
+                BoolExpr::Const(false)
+            }
+            BoolExpr::Not(value) => match value.as_ref() {
+                BoolExpr::Eq(left, Expr::Const(value)) | BoolExpr::Eq(Expr::Const(value), left)
+                    if value.is_zero() && self.word_bool_always_true(left) =>
+                {
+                    BoolExpr::Const(true)
+                }
+                _ => expr,
+            },
+            _ => expr,
+        }
+    }
+
+    fn record_upper_bound_constraint(&mut self, constraint: &BoolExpr) {
+        if let Some((expr, bound)) = self.upper_bound_constraint(constraint) {
+            self.record_upper_bound(expr.clone(), bound);
+        }
+    }
+
+    fn record_upper_bound(&mut self, expr: Expr, bound: U256) {
+        self.upper_bounds
+            .entry(expr)
+            .and_modify(|existing| *existing = (*existing).min(bound))
+            .or_insert(bound);
+    }
+
+    fn upper_bound_constraint<'a>(&self, constraint: &'a BoolExpr) -> Option<(&'a Expr, U256)> {
+        match constraint {
+            BoolExpr::Eq(left, Expr::Const(value)) | BoolExpr::Eq(Expr::Const(value), left) => {
+                Some((left, *value))
+            }
+            BoolExpr::Cmp(op, left, right) => match (*op, left, right) {
+                (BoolExprOp::Ult, expr, Expr::Const(bound)) => {
+                    (!bound.is_zero()).then(|| (expr, *bound - U256::from(1)))
+                }
+                (BoolExprOp::Ule, expr, Expr::Const(bound)) => Some((expr, *bound)),
+                (BoolExprOp::Ugt, Expr::Const(bound), expr) => {
+                    (!bound.is_zero()).then(|| (expr, *bound - U256::from(1)))
+                }
+                (BoolExprOp::Uge, Expr::Const(bound), expr) => Some((expr, *bound)),
+                _ => None,
+            },
+            BoolExpr::Not(value) => match value.as_ref() {
+                BoolExpr::Cmp(BoolExprOp::Ugt, left, Expr::Const(bound)) => Some((left, *bound)),
+                BoolExpr::Cmp(BoolExprOp::Uge, left, Expr::Const(bound)) => {
+                    (!bound.is_zero()).then(|| (left, *bound - U256::from(1)))
+                }
+                BoolExpr::Cmp(BoolExprOp::Ult, Expr::Const(bound), right) => Some((right, *bound)),
+                BoolExpr::Cmp(BoolExprOp::Ule, Expr::Const(bound), right) => {
+                    (!bound.is_zero()).then(|| (right, *bound - U256::from(1)))
+                }
+                _ => None,
+            },
+            BoolExpr::Eq(_, _) | BoolExpr::Const(_) | BoolExpr::And(_) => None,
         }
     }
 }
@@ -354,26 +457,7 @@ pub(crate) fn add_cannot_overflow_256(left: &Expr, right: &Expr) -> bool {
 
 /// Returns whether a word-valued boolean expression is an exact tautology.
 pub(crate) fn word_bool_always_true(expr: &Expr) -> bool {
-    let mut terms = Vec::new();
-    collect_or_terms(expr, &mut terms);
-    if terms.len() <= 1 {
-        return false;
-    }
-
-    let bool_terms = terms.iter().filter_map(|term| word_bool_term(term)).collect::<Vec<_>>();
-    if bool_terms.iter().any(|term| {
-        let negated = (*term).clone().not();
-        bool_terms.iter().any(|other| **other == negated)
-    }) {
-        return true;
-    }
-    for zero_term in &bool_terms {
-        let Some(zero_operand) = zero_check_operand(zero_term) else { continue };
-        if bool_terms.iter().any(|term| checked_mul_guard_for_operand(term, zero_operand)) {
-            return true;
-        }
-    }
-    false
+    ConstraintContext::default().word_bool_always_true(expr)
 }
 
 /// Converts one `0`/`1` word boolean term into its boolean condition.
@@ -398,39 +482,101 @@ pub(crate) fn zero_check_operand(expr: &BoolExpr) -> Option<&Expr> {
     }
 }
 
-/// Returns whether this condition is Solidity's checked-mul guard for `zero_operand`.
-pub(crate) fn checked_mul_guard_for_operand(expr: &BoolExpr, zero_operand: &Expr) -> bool {
-    let BoolExpr::Eq(left, right) = expr else { return false };
-    checked_mul_guard_side(left, right, zero_operand)
-        || checked_mul_guard_side(right, left, zero_operand)
-}
+impl ConstraintContext {
+    fn word_bool_always_true(&self, expr: &Expr) -> bool {
+        let mut terms = Vec::new();
+        collect_or_terms(expr, &mut terms);
+        if terms.len() <= 1 {
+            return false;
+        }
 
-/// Matches `a == 0 ? 0 : (a * b) / a` against the expected quotient.
-pub(crate) fn checked_mul_guard_side(
-    div_expr: &Expr,
-    expected: &Expr,
-    zero_operand: &Expr,
-) -> bool {
-    let Expr::Ite(condition, then_expr, else_expr) = div_expr else { return false };
-    if zero_check_operand(condition).is_none_or(|operand| operand != zero_operand) {
-        return false;
+        let bool_terms = terms.iter().filter_map(|term| word_bool_term(term)).collect::<Vec<_>>();
+        if bool_terms.iter().any(|term| {
+            let negated = (*term).clone().not();
+            bool_terms.iter().any(|other| **other == negated)
+        }) {
+            return true;
+        }
+        for zero_term in &bool_terms {
+            let Some(zero_operand) = zero_check_operand(zero_term) else { continue };
+            if bool_terms.iter().any(|term| self.checked_mul_guard_for_operand(term, zero_operand))
+            {
+                return true;
+            }
+        }
+        false
     }
-    if !matches!(then_expr.as_ref(), Expr::Const(value) if value.is_zero()) {
-        return false;
+
+    fn checked_mul_guard_for_operand(&self, expr: &BoolExpr, zero_operand: &Expr) -> bool {
+        let BoolExpr::Eq(left, right) = expr else { return false };
+        self.checked_mul_guard_side(left, right, zero_operand)
+            || self.checked_mul_guard_side(right, left, zero_operand)
     }
-    let Some((numerator, denominator)) = udiv_operands(else_expr) else { return false };
-    if denominator != zero_operand {
-        return false;
+
+    fn checked_mul_guard_side(
+        &self,
+        div_expr: &Expr,
+        expected: &Expr,
+        zero_operand: &Expr,
+    ) -> bool {
+        let Expr::Ite(condition, then_expr, else_expr) = div_expr else { return false };
+        if zero_check_operand(condition).is_none_or(|operand| operand != zero_operand) {
+            return false;
+        }
+        if !matches!(then_expr.as_ref(), Expr::Const(value) if value.is_zero()) {
+            return false;
+        }
+        let Some((numerator, denominator)) = udiv_operands(else_expr) else { return false };
+        if denominator != zero_operand {
+            return false;
+        }
+        let Expr::Op(ExprOp::Mul, left, right) = numerator else { return false };
+        let other = if left.as_ref() == zero_operand {
+            right.as_ref()
+        } else if right.as_ref() == zero_operand {
+            left.as_ref()
+        } else {
+            return false;
+        };
+        other == expected && self.mul_cannot_overflow_256(zero_operand, other)
     }
-    let Expr::Op(ExprOp::Mul, left, right) = numerator else { return false };
-    let other = if left.as_ref() == zero_operand {
-        right.as_ref()
-    } else if right.as_ref() == zero_operand {
-        left.as_ref()
-    } else {
-        return false;
-    };
-    other == expected && mul_cannot_overflow_256(zero_operand, other)
+
+    fn mul_cannot_overflow_256(&self, left: &Expr, right: &Expr) -> bool {
+        self.expr_unsigned_bits(left).saturating_add(self.expr_unsigned_bits(right)) <= 256
+    }
+
+    fn expr_unsigned_bits(&self, expr: &Expr) -> usize {
+        let bits = match expr {
+            Expr::Const(_)
+            | Expr::Var(_)
+            | Expr::GasLeft(_)
+            | Expr::Keccak { .. }
+            | Expr::Hash { .. }
+            | Expr::Not(_) => expr_unsigned_bits(expr),
+            Expr::Op(ExprOp::And, left, right) => match (left.as_ref(), right.as_ref()) {
+                (expr, Expr::Const(mask)) | (Expr::Const(mask), expr) => {
+                    self.expr_unsigned_bits(expr).min(mask.bit_len())
+                }
+                _ => 256,
+            },
+            Expr::Op(ExprOp::Add, left, right) => self
+                .expr_unsigned_bits(left)
+                .max(self.expr_unsigned_bits(right))
+                .saturating_add(1)
+                .min(256),
+            Expr::Op(ExprOp::Mul, left, right) => self
+                .expr_unsigned_bits(left)
+                .saturating_add(self.expr_unsigned_bits(right))
+                .min(256),
+            Expr::Op(ExprOp::UDiv, left, _) => self.expr_unsigned_bits(left),
+            Expr::Ite(_, left, right) => {
+                self.expr_unsigned_bits(left).max(self.expr_unsigned_bits(right))
+            }
+            _ => 256,
+        };
+
+        self.upper_bound(expr).map(|bound| bits.min(bound.bit_len().max(1))).unwrap_or(bits)
+    }
 }
 
 /// Returns whether unsigned multiplication of two expressions cannot overflow 256 bits.

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2102,27 +2102,56 @@ fn solver_rebuilds_word_from_extracted_byte_terms() {
     assert_eq!(rebuilt, normalize_expr_for_solver(masked));
 }
 
+fn checked_mul_guard_word(zero_operand: &Expr, expected: &Expr) -> Expr {
+    let operand_is_zero = BoolExpr::eq(zero_operand.clone(), Expr::Const(U256::ZERO));
+    let checked_product = Expr::Ite(
+        Box::new(operand_is_zero.clone()),
+        Box::new(Expr::Const(U256::ZERO)),
+        Box::new(Expr::op(
+            ExprOp::UDiv,
+            Expr::op(ExprOp::Mul, zero_operand.clone(), expected.clone()),
+            zero_operand.clone(),
+        )),
+    );
+
+    Expr::op(
+        ExprOp::Or,
+        SymWord::from_bool(operand_is_zero).into_expr(),
+        SymWord::from_bool(BoolExpr::eq(checked_product, expected.clone())).into_expr(),
+    )
+}
+
 #[test]
 /// Regression coverage for Solidity checked-mul guard tautology normalization.
 fn solver_normalizes_checked_mul_guard_for_bounded_operands() {
     let a = Expr::op(ExprOp::And, Expr::Var("a".to_string()), Expr::Const(U256::from(u64::MAX)));
     let b = Expr::op(ExprOp::And, Expr::Var("b".to_string()), Expr::Const(U256::from(u64::MAX)));
-    let a_is_zero = BoolExpr::eq(a.clone(), Expr::Const(U256::ZERO));
-    let checked_product = Expr::Ite(
-        Box::new(a_is_zero.clone()),
-        Box::new(Expr::Const(U256::ZERO)),
-        Box::new(Expr::op(ExprOp::UDiv, Expr::op(ExprOp::Mul, a.clone(), b.clone()), a)),
-    );
-    let guard = Expr::op(
-        ExprOp::Or,
-        SymWord::from_bool(a_is_zero).into_expr(),
-        SymWord::from_bool(BoolExpr::eq(checked_product, b)).into_expr(),
-    );
+    let guard = checked_mul_guard_word(&a, &b);
 
     assert_eq!(
         normalize_bool_for_solver(BoolExpr::eq(guard, Expr::Const(U256::ZERO))),
         BoolExpr::Const(false)
     );
+}
+
+#[test]
+/// Regression coverage for path-bounded Solidity checked-mul guard tautology normalization.
+fn solver_normalizes_checked_mul_guard_from_path_upper_bound() {
+    let a = Expr::Var("a".to_string());
+    let factor = Expr::Const(U256::from(1_000_000_000_000_000_000u128));
+    let guard_is_false = BoolExpr::eq(checked_mul_guard_word(&a, &factor), Expr::Const(U256::ZERO));
+    let constraints = vec![
+        BoolExpr::cmp(BoolExprOp::Ule, a, Expr::Const(U256::from(1000))),
+        guard_is_false.clone(),
+    ];
+    let normalized = normalize_constraints_for_solver(&constraints);
+
+    assert_eq!(normalized, vec![BoolExpr::Const(false)]);
+
+    for value in [U256::ZERO, U256::from(1), U256::from(1000)] {
+        let model = BTreeMap::from([("a".to_string(), value)]);
+        assert!(!eval_bool_expr(&guard_is_false, &model).unwrap());
+    }
 }
 
 #[test]
@@ -2222,22 +2251,49 @@ fn solver_normalizes_guarded_self_division_add_overflow_guard() {
 }
 
 #[test]
+/// Regression coverage for checked-mul guards proven by normalized path bounds.
+fn solver_normalizes_checked_mul_guard_with_context_bound() {
+    let a = Expr::Var("a".to_string());
+    let scale = Expr::Const(U256::from(1_000_000_000_000_000_000u128));
+    let guard = checked_mul_guard_word(&a, &scale);
+    let constraints = vec![
+        BoolExpr::cmp(BoolExprOp::Ugt, a.clone(), Expr::Const(U256::ZERO)),
+        BoolExpr::cmp(BoolExprOp::Ugt, a, Expr::Const(U256::from(1000))).not(),
+        BoolExpr::eq(guard, Expr::Const(U256::ZERO)),
+    ];
+
+    assert_eq!(normalize_constraints_for_solver(&constraints), vec![BoolExpr::Const(false)]);
+}
+
+#[test]
+/// Regression coverage for preserving checked-mul guards without a useful path bound.
+fn solver_does_not_context_normalize_checked_mul_guard_without_tight_bound() {
+    let a = Expr::Var("a".to_string());
+    let scale = Expr::Const(U256::from(1_000_000_000_000_000_000u128));
+    let guard_is_zero = BoolExpr::eq(checked_mul_guard_word(&a, &scale), Expr::Const(U256::ZERO));
+
+    assert_ne!(
+        normalize_constraints_for_solver(std::slice::from_ref(&guard_is_zero)),
+        vec![BoolExpr::Const(false)]
+    );
+    assert_ne!(
+        normalize_constraints_for_solver(&[
+            BoolExpr::cmp(BoolExprOp::Ule, a, Expr::Const(U256::MAX)),
+            guard_is_zero.clone(),
+        ]),
+        vec![BoolExpr::Const(false)]
+    );
+
+    let model = BTreeMap::from([("a".to_string(), U256::MAX)]);
+    assert!(eval_bool_expr(&guard_is_zero, &model).unwrap());
+}
+
+#[test]
 /// Regression coverage for preserving unbounded checked-mul overflow guards.
 fn solver_does_not_normalize_unbounded_checked_mul_guard_to_tautology() {
     let a = Expr::Var("a".to_string());
     let b = Expr::Var("b".to_string());
-    let a_is_zero = BoolExpr::eq(a.clone(), Expr::Const(U256::ZERO));
-    let checked_product = Expr::Ite(
-        Box::new(a_is_zero.clone()),
-        Box::new(Expr::Const(U256::ZERO)),
-        Box::new(Expr::op(ExprOp::UDiv, Expr::op(ExprOp::Mul, a.clone(), b.clone()), a)),
-    );
-    let guard = Expr::op(
-        ExprOp::Or,
-        SymWord::from_bool(a_is_zero).into_expr(),
-        SymWord::from_bool(BoolExpr::eq(checked_product, b)).into_expr(),
-    );
-    let original = BoolExpr::eq(guard, Expr::Const(U256::ZERO));
+    let original = BoolExpr::eq(checked_mul_guard_word(&a, &b), Expr::Const(U256::ZERO));
     let normalized = normalize_bool_for_solver(original.clone());
 
     assert_ne!(normalized, BoolExpr::Const(false));
@@ -2248,6 +2304,24 @@ fn solver_does_not_normalize_unbounded_checked_mul_guard_to_tautology() {
         eval_bool_expr(&original, &model).unwrap(),
         eval_bool_expr(&normalized, &model).unwrap()
     );
+}
+
+#[test]
+/// Regression coverage for preserving path-bounded checked-mul guards with loose bounds.
+fn solver_does_not_normalize_checked_mul_guard_when_path_bound_can_overflow() {
+    let a = Expr::Var("a".to_string());
+    let factor = Expr::Const(U256::from(2));
+    let original = BoolExpr::eq(checked_mul_guard_word(&a, &factor), Expr::Const(U256::ZERO));
+    let normalized = normalize_constraints_for_solver(&[
+        BoolExpr::cmp(BoolExprOp::Ule, a, Expr::Const(U256::MAX)),
+        original.clone(),
+    ]);
+
+    assert!(!matches!(normalized.as_slice(), [BoolExpr::Const(false)]));
+
+    let model = BTreeMap::from([("a".to_string(), U256::MAX)]);
+    assert!(eval_bool_expr(&original, &model).unwrap());
+    assert!(normalized.iter().all(|constraint| eval_bool_expr(constraint, &model).unwrap()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Use normalized path upper bounds when proving Solidity checked-mul guards are tautological.
- Keep the rewrite query-local: it only collapses `guard == 0` when the current conjunction proves the multiplication cannot overflow.
- Add regression coverage for direct bounds, normalized `not(a > bound)` bounds, and loose/unbounded cases that must remain solver-visible.

## Scope

This optimizes a class of checked-mul guard queries where the overflow proof needs path context, for example `a <= 1000` plus `a == 0 || ((scale * a) / a == scale)`. In the current symbolic bug suite, the only material hit is `MonoXSameTokenTest`; the other replayed counterexamples keep the same query and SMT counts.

## Benchmarks

All benchmark runs still found the expected counterexamples. The MonoX samples replayed the same counterexample bytes with `args=[1000]`.

| Scenario | Queries | SMT | Solver time |
| --- | ---: | ---: | ---: |
| `MonoXSameTokenTest` merged-base direct sample | 18 | 16 | 47,198 ms |
| `MonoXSameTokenTest` after, direct sample 1 | 17 | 14 | 17,150 ms |
| `MonoXSameTokenTest` after, direct sample 2 | 17 | 14 | 17,246 ms |
| `MonoXSameTokenTest` after, direct sample 3 | 17 | 14 | 16,812 ms |
| Full symbolic bug suite merged-base same-session sample | 360 | 327 | 54,608 ms |
| Full symbolic bug suite after same-session sample | 359 | 325 | 26,393 ms |