### PR TITLE
ci: bump Tempo CI Depot runner

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -43,7 +43,7 @@ jobs:
     if: |
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: depot-ubuntu-latest
+    runs-on: depot-ubuntu-latest-16
     timeout-minutes: 60
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- move the Tempo CI job to the 16-core Depot runner already used by Foundry flaky tests
- gives the Rust cache restore/build more runner capacity after the linked job failed before build during cache setup

## Validation
- `uv run --with pyyaml python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/ci-tempo.yml').read_text()); print('ci-tempo.yml parses')"`
- `git diff --check`

Prompted by: @grandizzy