### PR TITLE
feat(cast): support Tempo sessions in cast send

### DIFF
--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -12,7 +12,7 @@ use clap::Parser;
 use eyre::{Result, eyre};
 use foundry_cli::{
     opts::TransactionOpts,
-    utils::{LoadConfig, maybe_print_resolved_lane, resolve_lane},
+    utils::{LoadConfig, get_chain, maybe_print_resolved_lane, resolve_lane},
 };
 use foundry_common::{
     FoundryTransactionBuilder,
@@ -217,9 +217,10 @@ impl SendTxArgs {
         }
 
         if has_session
-            && let Some(session) = tx
-                .tempo
-                .session_signer_for_wallet(&send_tx.eth.wallet, provider.get_chain_id().await?)?
+            && let Some(session) = tx.tempo.session_signer_for_wallet(
+                &send_tx.eth.wallet,
+                get_chain(config.chain, &provider).await?.id(),
+            )?
         {
             pre_resolved_signer = Some(session.signer);
             access_key = Some(session.access_key);

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -119,8 +119,8 @@ impl SendTxArgs {
 
     pub async fn run_generic<N: Network>(
         self,
-        pre_resolved_signer: Option<WalletSigner>,
-        access_key: Option<TempoAccessKeyConfig>,
+        mut pre_resolved_signer: Option<WalletSigner>,
+        mut access_key: Option<TempoAccessKeyConfig>,
     ) -> Result<()>
     where
         N::TxEnvelope: From<Signed<N::UnsignedTx>>,
@@ -216,17 +216,14 @@ impl SendTxArgs {
             provider.client().set_poll_interval(Duration::from_secs(interval))
         }
 
-        let session = if has_session {
-            tx.tempo
+        if has_session
+            && let Some(session) = tx
+                .tempo
                 .session_signer_for_wallet(&send_tx.eth.wallet, provider.get_chain_id().await?)?
-        } else {
-            None
-        };
-        let (pre_resolved_signer, access_key) = if let Some(session) = session {
-            (Some(session.signer), Some(session.access_key))
-        } else {
-            (pre_resolved_signer, access_key)
-        };
+        {
+            pre_resolved_signer = Some(session.signer);
+            access_key = Some(session.access_key);
+        }
 
         // Inject access key ID into TempoOpts so it's set before gas estimation.
         if let Some(ref ak) = access_key {

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -103,6 +103,10 @@ pub enum SendTxSubcommands {
 
 impl SendTxArgs {
     pub async fn run(self) -> Result<()> {
+        if self.tx.tempo.session_id()?.is_some() {
+            return self.run_generic::<TempoNetwork>(None, None).await;
+        }
+
         // Resolve the signer early so we know if it's a Tempo access key.
         let (signer, tempo_access_key) = self.send_tx.eth.wallet.maybe_signer().await?;
 
@@ -126,6 +130,14 @@ impl SendTxArgs {
     {
         let Self { to, mut sig, mut args, data, send_tx, mut tx, command, unlocked, force, path } =
             self;
+
+        let has_session = tx.tempo.session_id()?.is_some();
+        if has_session && unlocked {
+            eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --unlocked");
+        }
+        if has_session && send_tx.browser.browser {
+            eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --browser");
+        }
 
         let print_sponsor_hash = tx.tempo.print_sponsor_hash;
         let sponsor_url = tx.tempo.sponsor_url.clone();
@@ -203,6 +215,18 @@ impl SendTxArgs {
         if let Some(interval) = send_tx.poll_interval {
             provider.client().set_poll_interval(Duration::from_secs(interval))
         }
+
+        let session = if has_session {
+            tx.tempo
+                .session_signer_for_wallet(&send_tx.eth.wallet, provider.get_chain_id().await?)?
+        } else {
+            None
+        };
+        let (pre_resolved_signer, access_key) = if let Some(session) = session {
+            (Some(session.signer), Some(session.access_key))
+        } else {
+            (pre_resolved_signer, access_key)
+        };
 
         // Inject access key ID into TempoOpts so it's set before gas estimation.
         if let Some(ref ak) = access_key {

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -321,9 +321,6 @@ impl InnerCommand {
         for key in SESSION_CHILD_SIGNER_ENV {
             command.env_remove(key);
         }
-        // TODO: Wire cast single-wallet signer paths through TempoOpts::session_signer_for_wallet
-        // so cast commands launched via --for can consume TEMPO_SESSION_ID without
-        // requiring explicit signer options.
         command.env(TEMPO_SESSION_ID_ENV, format!("{session_id:?}"));
         command
     }

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -13,8 +13,12 @@ mod accounts {
     pub const ADDR3: &str = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC";
 }
 
+fn path_usd() -> String {
+    PATH_USD_ADDRESS.to_string()
+}
+
 fn create_session(cmd: &mut TestCommand, tempo_home: &Path, chain_id: &str) -> (String, String) {
-    let path_usd = PATH_USD_ADDRESS.to_string();
+    let path_usd = path_usd();
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home);
@@ -76,7 +80,7 @@ fn assert_session_file_status_with_key(tempo_home: &Path, status: &str) {
 casttest!(keychain_rl_json_is_object, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
-    let path_usd = PATH_USD_ADDRESS.to_string();
+    let path_usd = path_usd();
 
     let output = cmd
         .args([
@@ -373,7 +377,7 @@ casttest!(
         let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
         let rpc = handle.http_endpoint();
         let tempo_home = tempfile::tempdir().unwrap();
-        let path_usd = PATH_USD_ADDRESS.to_string();
+        let path_usd = path_usd();
         let child_dir = tempfile::tempdir().unwrap();
         let child_script = child_dir.path().join("session-child.sh");
         let child_session_out = child_dir.path().join("child-session-id.txt");
@@ -442,7 +446,7 @@ casttest!(wallet_session_run_for_cast_send_submits_with_session_key, async |_prj
     let tempo_home = tempfile::tempdir().unwrap();
     let child_dir = tempfile::tempdir().unwrap();
     let child_script = child_dir.path().join("session-cast-send.sh");
-    let path_usd = PATH_USD_ADDRESS.to_string();
+    let path_usd = path_usd();
     let cast_bin = std::env::current_exe()
         .expect("current test executable")
         .parent()
@@ -471,7 +475,7 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     cmd.env("TEMPO_HOME", tempo_home.path());
     cmd.env("CAST_BIN", &cast_bin);
     cmd.env("RPC_URL", &rpc);
-    let output = cmd
+    let assertion = cmd
         .args([
             "wallet",
             "session",
@@ -490,9 +494,8 @@ test -n "${{TEMPO_SESSION_ID:-}}"
             "--rpc-url",
             &rpc,
         ])
-        .assert_failure()
-        .get_output()
-        .clone();
+        .assert_failure();
+    let output = assertion.get_output();
     let stdout = output.stdout_lossy();
     let stderr = output.stderr_lossy();
 
@@ -511,14 +514,96 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     assert_session_file_status_without_key(tempo_home.path(), "failed");
 });
 
-casttest!(cast_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
+casttest!(wallet_session_run_for_grandchild_cast_send_inherits_session_key, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
-    let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31337");
+    let child_dir = tempfile::tempdir().unwrap();
+    let child_script = child_dir.path().join("session-child.sh");
+    let grandchild_script = child_dir.path().join("session-grandchild-cast-send.sh");
+    let path_usd = path_usd();
+    let cast_bin = std::env::current_exe()
+        .expect("current test executable")
+        .parent()
+        .expect("deps dir")
+        .parent()
+        .expect("target debug dir")
+        .join(format!("cast{}", std::env::consts::EXE_SUFFIX));
+
+    fs::write(
+        &child_script,
+        r#"#!/bin/sh
+set -eu
+test -n "${TEMPO_SESSION_ID:-}"
+sh "$1"
+"#,
+    )
+    .expect("write child script");
+
+    fs::write(
+        &grandchild_script,
+        format!(
+            r#"#!/bin/sh
+set -eu
+test -n "${{TEMPO_SESSION_ID:-}}"
+"${{CAST_BIN}}" send "{}" 'transfer(address,uint256)' "{}" 0 --rpc-url "${{RPC_URL}}" --tempo.fee-token "{}" --async
+"#,
+            path_usd, accounts::ADDR3, path_usd,
+        ),
+    )
+    .expect("write grandchild script");
+
+    let for_command = format!("sh {} {}", child_script.display(), grandchild_script.display());
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.env("CAST_BIN", &cast_bin);
+    cmd.env("RPC_URL", &rpc);
+    let assertion = cmd
+        .args([
+            "wallet",
+            "session",
+            "--root",
+            accounts::ADDR1,
+            "--expires",
+            "10m",
+            "--scope",
+            &path_usd,
+            "--spend-limit",
+            "PathUSD=1000000",
+            "--for",
+            &for_command,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure();
+    let output = assertion.get_output();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+
+    assert!(
+        stdout.trim().starts_with("0x"),
+        "expected grandchild cast send --async to print a tx hash, got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("failed to clean up Tempo session after inner command"),
+        "unexpected stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("session key is not provisioned on-chain yet"),
+        "unexpected stderr:\n{stderr}"
+    );
+    assert_session_file_status_without_key(tempo_home.path(), "failed");
+});
+
+casttest!(cast_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let session_id = "0x5555555555555555555555555555555555555555555555555555555555555555";
+
+    cmd.cast_fuse();
     let stderr = cmd
         .args([
             "send",
@@ -543,7 +628,7 @@ casttest!(wallet_session_run_for_cleans_key_material_when_child_fails, async |_p
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
-    let path_usd = PATH_USD_ADDRESS.to_string();
+    let path_usd = path_usd();
     let child_dir = tempfile::tempdir().unwrap();
     let child_script = child_dir.path().join("failing-session-child.sh");
     fs::write(
@@ -593,7 +678,7 @@ casttest!(
         let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
         let rpc = handle.http_endpoint();
         let tempo_home = tempfile::tempdir().unwrap();
-        let path_usd = PATH_USD_ADDRESS.to_string();
+        let path_usd = path_usd();
         let child_dir = tempfile::tempdir().unwrap();
         let child_script = child_dir.path().join("session-child.sh");
         fs::write(

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -1,6 +1,7 @@
 //! CLI tests for `cast keychain` subcommands.
 
 use anvil::NodeConfig;
+use foundry_evm::core::tempo::PATH_USD_ADDRESS;
 use foundry_test_utils::{TestCommand, util::OutputExt};
 use std::{fs, path::Path};
 
@@ -9,10 +10,12 @@ mod accounts {
     pub const PK1: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
     pub const ADDR1: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
     pub const ADDR2: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
-    pub const TOKEN: &str = "0x20C000000000000000000000b9537d11c60E8b50"; // PathUSD
+    pub const ADDR3: &str = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC";
 }
 
 fn create_session(cmd: &mut TestCommand, tempo_home: &Path, chain_id: &str) -> (String, String) {
+    let path_usd = PATH_USD_ADDRESS.to_string();
+
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home);
     let create_output = cmd
@@ -28,7 +31,7 @@ fn create_session(cmd: &mut TestCommand, tempo_home: &Path, chain_id: &str) -> (
             "--expires",
             "10m",
             "--scope",
-            accounts::TOKEN,
+            &path_usd,
             "--private-key",
             accounts::PK1,
         ])
@@ -73,6 +76,7 @@ fn assert_session_file_status_with_key(tempo_home: &Path, status: &str) {
 casttest!(keychain_rl_json_is_object, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
+    let path_usd = PATH_USD_ADDRESS.to_string();
 
     let output = cmd
         .args([
@@ -80,7 +84,7 @@ casttest!(keychain_rl_json_is_object, async |_prj, cmd| {
             "rl",
             accounts::ADDR1,
             accounts::ADDR2,
-            accounts::TOKEN,
+            &path_usd,
             "--rpc-url",
             &rpc,
             "--json",
@@ -369,6 +373,7 @@ casttest!(
         let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
         let rpc = handle.http_endpoint();
         let tempo_home = tempfile::tempdir().unwrap();
+        let path_usd = PATH_USD_ADDRESS.to_string();
         let child_dir = tempfile::tempdir().unwrap();
         let child_script = child_dir.path().join("session-child.sh");
         let child_session_out = child_dir.path().join("child-session-id.txt");
@@ -399,7 +404,7 @@ printf '%s\n' "${TEMPO_SESSION_ID}" > "$1"
                 "--expires",
                 "10m",
                 "--scope",
-                accounts::TOKEN,
+                &path_usd,
                 "--spend-limit",
                 "PathUSD=0",
                 "--for",
@@ -431,10 +436,114 @@ printf '%s\n' "${TEMPO_SESSION_ID}" > "$1"
     }
 );
 
+casttest!(wallet_session_run_for_cast_send_submits_with_session_key, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let child_dir = tempfile::tempdir().unwrap();
+    let child_script = child_dir.path().join("session-cast-send.sh");
+    let path_usd = PATH_USD_ADDRESS.to_string();
+    let cast_bin = std::env::current_exe()
+        .expect("current test executable")
+        .parent()
+        .expect("deps dir")
+        .parent()
+        .expect("target debug dir")
+        .join(format!("cast{}", std::env::consts::EXE_SUFFIX));
+    fs::write(
+        &child_script,
+        format!(
+            r#"#!/bin/sh
+set -eu
+test -n "${{TEMPO_SESSION_ID:-}}"
+"${{CAST_BIN}}" send "{}" 'transfer(address,uint256)' "{}" 0 --rpc-url "${{RPC_URL}}" --tempo.fee-token "{}" --async
+"#,
+            path_usd,
+            accounts::ADDR3,
+            path_usd,
+        ),
+    )
+    .expect("write child script");
+
+    let for_command = format!("sh {}", child_script.display());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.env("CAST_BIN", &cast_bin);
+    cmd.env("RPC_URL", &rpc);
+    let output = cmd
+        .args([
+            "wallet",
+            "session",
+            "--root",
+            accounts::ADDR1,
+            "--expires",
+            "10m",
+            "--scope",
+            &path_usd,
+            "--spend-limit",
+            "PathUSD=1000000",
+            "--for",
+            &for_command,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .clone();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+
+    assert!(
+        stdout.trim().starts_with("0x"),
+        "expected child cast send --async to print a tx hash, got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("failed to clean up Tempo session after inner command"),
+        "unexpected stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("session key is not provisioned on-chain yet"),
+        "unexpected stderr:\n{stderr}"
+    );
+    assert_session_file_status_without_key(tempo_home.path(), "failed");
+});
+
+casttest!(cast_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31337");
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    let stderr = cmd
+        .args([
+            "send",
+            accounts::ADDR3,
+            "--value",
+            "1",
+            "--tempo.session",
+            &session_id,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("explicit wallet signer"), "unexpected stderr:\n{stderr}");
+});
+
 casttest!(wallet_session_run_for_cleans_key_material_when_child_fails, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = PATH_USD_ADDRESS.to_string();
     let child_dir = tempfile::tempdir().unwrap();
     let child_script = child_dir.path().join("failing-session-child.sh");
     fs::write(
@@ -463,7 +572,7 @@ exit 7
             "--expires",
             "10m",
             "--scope",
-            accounts::TOKEN,
+            &path_usd,
             "--for",
             &for_command,
             "--private-key",
@@ -484,6 +593,7 @@ casttest!(
         let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
         let rpc = handle.http_endpoint();
         let tempo_home = tempfile::tempdir().unwrap();
+        let path_usd = PATH_USD_ADDRESS.to_string();
         let child_dir = tempfile::tempdir().unwrap();
         let child_script = child_dir.path().join("session-child.sh");
         fs::write(
@@ -510,7 +620,7 @@ test -n "${TEMPO_SESSION_ID:-}"
                 "--expires",
                 "10m",
                 "--scope",
-                accounts::TOKEN,
+                &path_usd,
                 "--for",
                 &for_command,
                 "--private-key",

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -611,7 +611,7 @@ casttest!(cast_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
             "--value",
             "1",
             "--tempo.session",
-            &session_id,
+            session_id,
             "--private-key",
             accounts::PK1,
             "--rpc-url",


### PR DESCRIPTION
This PR wires Tempo wallet session resolution into `cast send`.

  - Detects `--tempo.session` / `TEMPO_SESSION_ID` before resolving normal wallet signers and routes the command through
  `TempoNetwork`.
  - Resolves the live session signer once the provider chain id is available.
  - Reuses the existing Tempo access-key signing path with the resolved session key and access-key metadata.
  - Rejects incompatible signing modes such as `--unlocked`, `--browser`, and explicit wallet signer options when a session is selected.
  - Adds CLI coverage for `cast wallet session --for` running `cast send`, including a nested child process that inherits `TEMPO_SESSION_ID`.