### PR TITLE
perf(symbolic): reduce solver queries with witnesses and exact folds

### DIFF
--- a/crates/evm/symbolic/src/runtime/expressions.rs
+++ b/crates/evm/symbolic/src/runtime/expressions.rs
@@ -954,6 +954,7 @@ impl Expr {
                 expr
             }
             (ExprOp::Sub, expr, Self::Const(value)) if value.is_zero() => expr,
+            (ExprOp::Sub, left, right) if left == right => Self::Const(U256::ZERO),
             (ExprOp::Mul, Self::Const(value), _) | (ExprOp::Mul, _, Self::Const(value))
                 if value.is_zero() =>
             {
@@ -1200,6 +1201,9 @@ impl BoolExpr {
 
     /// Implements the `cmp` symbolic expression helper.
     pub(crate) fn cmp(op: BoolExprOp, left: Expr, right: Expr) -> Self {
+        if left == right {
+            return Self::Const(matches!(op, BoolExprOp::Ule | BoolExprOp::Uge));
+        }
         if let (Expr::Const(left), Expr::Const(right)) = (&left, &right) {
             return Self::Const(match op {
                 BoolExprOp::Ult => left < right,
@@ -1209,6 +1213,33 @@ impl BoolExpr {
                 BoolExprOp::Slt => slt(*left, *right),
                 BoolExprOp::Sgt => slt(*right, *left),
             });
+        }
+        match (op, &left, &right) {
+            (BoolExprOp::Ugt, Expr::Const(value), _) if value.is_zero() => {
+                return Self::Const(false);
+            }
+            (BoolExprOp::Ule, Expr::Const(value), _) if value.is_zero() => {
+                return Self::Const(true);
+            }
+            (BoolExprOp::Ult, _, Expr::Const(value)) if value.is_zero() => {
+                return Self::Const(false);
+            }
+            (BoolExprOp::Uge, _, Expr::Const(value)) if value.is_zero() => {
+                return Self::Const(true);
+            }
+            (BoolExprOp::Ult, Expr::Const(value), _) if *value == U256::MAX => {
+                return Self::Const(false);
+            }
+            (BoolExprOp::Uge, Expr::Const(value), _) if *value == U256::MAX => {
+                return Self::Const(true);
+            }
+            (BoolExprOp::Ugt, _, Expr::Const(value)) if *value == U256::MAX => {
+                return Self::Const(false);
+            }
+            (BoolExprOp::Ule, _, Expr::Const(value)) if *value == U256::MAX => {
+                return Self::Const(true);
+            }
+            _ => {}
         }
         Self::Cmp(op, left, right)
     }

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -304,6 +304,14 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             self.cache_sat_result(cache_key, false);
             return Ok(false);
         }
+        if constraints_prefer_hard_arith_fallback_first(&smt_constraints)
+            && validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some()
+        {
+            self.heuristic_witnesses += 1;
+            trace!("is_sat: validated hard arithmetic fallback model before solver");
+            self.cache_sat_result(cache_key, true);
+            return Ok(true);
+        }
         let output = match self.query_normalized(&smt_constraints, false, constraints) {
             Ok(output) => output,
             Err(SymbolicError::SolverUnknown) => {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1966,6 +1966,10 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
         Expr::Const(U256::ZERO)
     );
     assert_eq!(
+        Expr::op(ExprOp::Sub, Expr::Var("x".to_string()), Expr::Var("x".to_string())),
+        Expr::Const(U256::ZERO)
+    );
+    assert_eq!(
         Expr::op(ExprOp::And, Expr::Var("x".to_string()), Expr::Const(U256::MAX)),
         Expr::Var("x".to_string())
     );
@@ -1990,6 +1994,40 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
         Expr::op(ExprOp::Mul, Expr::Const(U256::from(6)), Expr::Const(U256::from(7))),
         Expr::Const(U256::from(42))
     );
+}
+
+#[test]
+/// Regression coverage for reflexive comparison simplification.
+fn bool_comparison_folds_reflexive_operands() {
+    let x = || Expr::Var("x".to_string());
+
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Ult, x(), x()), BoolExpr::Const(false));
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Ugt, x(), x()), BoolExpr::Const(false));
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Ule, x(), x()), BoolExpr::Const(true));
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Uge, x(), x()), BoolExpr::Const(true));
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Slt, x(), x()), BoolExpr::Const(false));
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Sgt, x(), x()), BoolExpr::Const(false));
+}
+
+#[test]
+/// Regression coverage for unsigned min/max comparison simplification.
+fn bool_comparison_folds_unsigned_boundaries() {
+    let x = || Expr::Var("x".to_string());
+
+    assert_eq!(
+        BoolExpr::cmp(BoolExprOp::Ugt, Expr::Const(U256::ZERO), x()),
+        BoolExpr::Const(false)
+    );
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Ule, Expr::Const(U256::ZERO), x()), BoolExpr::Const(true));
+    assert_eq!(
+        BoolExpr::cmp(BoolExprOp::Ult, x(), Expr::Const(U256::ZERO)),
+        BoolExpr::Const(false)
+    );
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Uge, x(), Expr::Const(U256::ZERO)), BoolExpr::Const(true));
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Ult, Expr::Const(U256::MAX), x()), BoolExpr::Const(false));
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Uge, Expr::Const(U256::MAX), x()), BoolExpr::Const(true));
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Ugt, x(), Expr::Const(U256::MAX)), BoolExpr::Const(false));
+    assert_eq!(BoolExpr::cmp(BoolExprOp::Ule, x(), Expr::Const(U256::MAX)), BoolExpr::Const(true));
 }
 
 #[test]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2747,10 +2747,10 @@ fn counted_solver_invocations(marker: &Path) -> usize {
 
 #[cfg(unix)]
 #[test]
-/// Regression coverage for hard-arithmetic `is_sat` fallback after solver unknown.
-fn is_sat_uses_validated_hard_arithmetic_fallback_after_solver_unknown() {
+/// Regression coverage for hard-arithmetic `is_sat` fallback before SMT.
+fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
     let marker = portfolio_test_marker("hard-arith-is-sat");
-    let commands = vec![counted_solver_command(&marker, "unknown")];
+    let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
     let x = Expr::Var("x".to_string());
     let y = Expr::Var("y".to_string());
@@ -2768,11 +2768,11 @@ fn is_sat_uses_validated_hard_arithmetic_fallback_after_solver_unknown() {
 
     let stats = solver.stats();
     assert_eq!(stats.solver_queries, 1);
-    assert_eq!(stats.smt_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
     assert_eq!(stats.sat_queries, 2);
     assert_eq!(stats.sat_cache_hits, 1);
     assert_eq!(solver.heuristic_witnesses(), 1);
-    assert_eq!(counted_solver_invocations(&marker), 1);
+    assert_eq!(counted_solver_invocations(&marker), 0);
     let _ = std::fs::remove_file(&marker);
 }
 


### PR DESCRIPTION
## Summary

This PR reduces symbolic solver work in two small ways:

1. `is_sat` can use the existing validated hard-arithmetic witness path before launching an SMT subprocess, matching the earlier `model()` fast path.
2. Exact expression/comparison identities are folded during construction, including `x - x = 0`, reflexive comparisons, and unsigned min/max boundary comparisons such as `x >= 0`, `0 > x`, `x <= U256::MAX`, and `x > U256::MAX`.

The hard-arithmetic fast path only returns `sat` when `validated_hard_arith_fallback_model(&smt_constraints, constraints)` produces a concrete model that validates against the original constraints. If no witness validates, execution continues to the solver path, so solver `unsat` cases are not hidden.

## Counter interpretation

`hard-arith` is a count of local validated witnesses, not an additional SMT subprocess count.

The first commit moved existing satisfiable hard-arithmetic checks from external SMT to local validated witnesses:

- Baseline: `smt + hard-arith = 325 + 6 = 331`
- After witness fast path: `smt + hard-arith = 289 + 42 = 331`

The exact identity folds then remove tautological/contradictory checks entirely:

- After exact folds: `smt + hard-arith = 241 + 32 = 273`

So the final state has fewer logical solver queries, fewer SMT subprocesses, and fewer hard-arithmetic witnesses than the intermediate PR state.

I also profiled the candidate with `samply record --save-only --unstable-presymbolicate`. The sampled hot path remains the SMT subprocess path:

`is_sat -> query_normalized -> run_solver_commands -> run_solver_process -> read_pipe_to_string`

The hard-arithmetic fallback did not show up as a sampled hotpath in either the MonoX profile or the full 22-test suite profile.

A read-only Pi/autoresearch pass suggested SAT-superset cache reuse. I left that out because it adds cache-scan cost on misses; the exact identity folds are lower risk and remove solver work directly.

## Benchmarks

Target: `/Users/gustavo/dev/forks/symbolic-bug-suite-ar`, command `target/debug/forge test --symbolic -vv`. Nonzero exit is expected because the suite should find counterexamples.

| Run | Counterexamples | Incomplete | Replay failures | Queries | SMT | Hard-arith witnesses | Solver ms |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| merged target baseline | 44 | 0 | 0 | 359 | 325 | 6 | 28452 |
| after witness fast path #1 | 44 | 0 | 0 | 359 | 289 | 42 | 10616 |
| after witness fast path #2 | 44 | 0 | 0 | 359 | 289 | 42 | 23333 |
| after witness fast path #3 | 44 | 0 | 0 | 359 | 289 | 42 | 11600 |
| final #1 | 44 | 0 | 0 | 301 | 241 | 32 | 10599 |
| final #2 | 44 | 0 | 0 | 301 | 241 | 32 | 10521 |
| final #3 | 44 | 0 | 0 | 301 | 241 | 32 | 10521 |

Final vs merged target baseline:

- `58` fewer logical solver queries: `359 -> 301`
- `84` fewer SMT subprocess queries: `325 -> 241`
- same `44` counterexample lines
- `0` incomplete symbolic executions
- `0` replay failures

DFX targeted samples, same counterexample `args=[1662517248]` in every final run:

| Run | Queries | SMT | Hard-arith witnesses | Solver ms |
| --- | ---: | ---: | ---: | ---: |
| merged target / before exact folds | 31 | 30 | 0 | 338 |
| final #1 | 21 | 20 | 0 | 131 |
| final #2 | 21 | 20 | 0 | 140 |
| final #3 | 21 | 20 | 0 | 132 |

MonoX targeted samples, same counterexample `args=[1000]` in every run:

| Run | Queries | SMT | Hard-arith witnesses | Solver ms |
| --- | ---: | ---: | ---: | ---: |
| merged target baseline | 17 | 14 | 1 | 18143 |
| after witness fast path #1 | 17 | 11 | 4 | 4464 |
| after witness fast path #2 | 17 | 11 | 4 | 4540 |
| after witness fast path #3 | 17 | 11 | 4 | 4560 |
| after witness fast path #4 | 17 | 11 | 4 | 4417 |
| after witness fast path #5 | 17 | 11 | 4 | 4445 |
| final #1 | 17 | 11 | 4 | 4669 |
| final #2 | 17 | 11 | 4 | 4680 |
| final #3 | 17 | 11 | 4 | 4889 |
