### PR TITLE
test(cast): fix Windows session keychain tests by normalizing sh paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,6 +2797,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-flz",
  "op-alloy-network",
+ "path-slash",
  "rand 0.8.6",
  "rand 0.9.4",
  "rayon",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -113,6 +113,7 @@ dirs.workspace = true
 anvil.workspace = true
 foundry-test-utils.workspace = true
 tempo-chainspec.workspace = true
+path-slash.workspace = true
 
 [features]
 default = ["jemalloc", "asm-keccak", "optimism"]

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -3,6 +3,7 @@
 use anvil::NodeConfig;
 use foundry_evm::core::tempo::PATH_USD_ADDRESS;
 use foundry_test_utils::{TestCommand, util::OutputExt};
+use path_slash::PathExt;
 use std::{fs, path::Path};
 
 /// Anvil test accounts (standard mnemonic).
@@ -395,7 +396,10 @@ printf '%s\n' "${TEMPO_SESSION_ID}" > "$1"
         )
         .expect("write child script");
 
-        let for_command = format!("sh {} {}", child_script.display(), child_session_out.display());
+        // Git Bash (the `sh` on Windows) treats backslashes as escapes, so embed the script
+        // paths with forward slashes; `to_slash_lossy` is a no-op on Unix.
+        let for_command =
+            format!("sh {} {}", child_script.to_slash_lossy(), child_session_out.to_slash_lossy());
 
         cmd.cast_fuse();
         cmd.env("TEMPO_HOME", tempo_home.path());
@@ -469,7 +473,7 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     )
     .expect("write child script");
 
-    let for_command = format!("sh {}", child_script.display());
+    let for_command = format!("sh {}", child_script.to_slash_lossy());
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
@@ -553,7 +557,8 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     )
     .expect("write grandchild script");
 
-    let for_command = format!("sh {} {}", child_script.display(), grandchild_script.display());
+    let for_command =
+        format!("sh {} {}", child_script.to_slash_lossy(), grandchild_script.to_slash_lossy());
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
@@ -644,7 +649,7 @@ exit 7
     )
     .expect("write child script");
 
-    let for_command = format!("sh {}", child_script.display());
+    let for_command = format!("sh {}", child_script.to_slash_lossy());
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
@@ -690,7 +695,7 @@ test -n "${TEMPO_SESSION_ID:-}"
         )
         .expect("write child script");
 
-        let for_command = format!("sh {}", child_script.display());
+        let for_command = format!("sh {}", child_script.to_slash_lossy());
 
         cmd.cast_fuse();
         cmd.env("TEMPO_HOME", tempo_home.path());


### PR DESCRIPTION
## Summary

Fixes the two deterministic CI failures on `test / test all (x86_64-pc-windows-msvc)` that have kept `master` red since #15071 (`feat(cast): add Tempo wallet session runner`):

- `keychain::wallet_session_run_for_without_key_use_fails_closed_and_cleans_key_material`
- `keychain::wallet_session_run_for_cleans_key_material_when_child_fails`

Both failed on **all 3 retries** (not flaky).

## Root cause

These tests wrap a child shell script via `--for "sh <script>"`. The command string was built with `Path::display()`, which on Windows yields a **backslash** path. The wrapped `sh` is Git Bash, which treats backslashes as escape characters, so the path collapsed:

```
/usr/bin/bash: C:UsersADMINI~1AppDataLocalTemp.tmpJ2Jp63session-child.sh: No such file or directory
- inner command `sh C:\Users\ADMINI~1\...\session-child.sh` exited with code 127
```

The child exited 127 instead of the expected code, so the cleanup-path assertions (`exited with code 7`, `failed to clean up Tempo session after inner command`) never matched.

## Fix

Embed the script paths with forward slashes via `path_slash::PathExt::to_slash_lossy` — the existing workspace idiom already used across forge/common (e.g. `crates/forge/tests/cli/config.rs`, `crates/common/src/preprocessor/data.rs`). Git Bash accepts `C:/Users/...`, and `to_slash_lossy` is a no-op on Unix. Applied at all five `--for` construction sites in `crates/cast/tests/cli/keychain.rs`; `path-slash` (already a workspace dep) is added to cast's dev-dependencies. No production code changes — the runner feature itself was fine; only the tests fed backslash paths to `sh`.

## Verification

```
cargo nextest run -p cast --test cli 'keychain::wallet_session_run_for'
  5 tests run: 5 passed
```

> Note: the separate macOS (`aarch64-apple-darwin`) failures in CI are pre-existing **flaky network timeouts** (bind/clone/e2e), unrelated to this change and to #15071.

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: george