### PR TITLE
test: match minute-form durations in [ELAPSED] redaction

### DIFF
--- a/crates/test-utils/src/prj.rs
+++ b/crates/test-utils/src/prj.rs
@@ -808,7 +808,7 @@ fn test_redactions() -> snapbox::Redactions {
     static REDACTIONS: LazyLock<snapbox::Redactions> = LazyLock::new(|| {
         make_redactions(&[
             ("[SOLC_VERSION]", r"Solc( version)? \d+.\d+.\d+"),
-            ("[ELAPSED]", r"(finished )?in \d+(\.\d+)?\w?s( \(.*?s CPU time\))?"),
+            ("[ELAPSED]", r"(finished )?in (\d+m )?\d+(\.\d+)?\w?s( \(.*?s CPU time\))?"),
             ("[GAS]", r"[Gg]as( used)?: \d+"),
             ("[GAS_COST]", r"[Gg]as cost\s*\(\d+\)"),
             ("[GAS_LIMIT]", r"[Gg]as limit\s*\(\d+\)"),


### PR DESCRIPTION
## Summary

The `[ELAPSED]` snapshot redaction only matched the seconds form (`in 52.30s`), but foundry formats durations >= 60s with a minutes prefix (`in 1m 22.50s`, see `crates/forge/src/mutation/reporter.rs`). So whenever a command crosses one minute on a slow runner, the redaction misses and the snapshot fails — this is why `mutation_testing_require_mutator` flakes on CI.

Fix: allow an optional `<m>m ` prefix.

```diff
-(finished )?in \d+(\.\d+)?\w?s( \(.*?s CPU time\))?
+(finished )?in (\d+m )?\d+(\.\d+)?\w?s( \(.*?s CPU time\))?
```

Used by ~600 assertions, so this hardens the whole suite, not just the mutation test.

> Note: this fixes the assertion flake; the test can still hit the 90s nextest timeout since it's genuinely slow — separate follow-up.

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: george