### PR TITLE
feat(cast): support Tempo sessions in batch-send

### DIFF
--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -92,8 +92,7 @@ impl BatchSendArgs {
             && let Some(session) =
                 tx.tempo.session_signer_for_wallet(&send_tx.eth.wallet, chain.id())?
         {
-            signer = Some(session.signer);
-            tempo_access_key = Some(session.access_key);
+            (signer, tempo_access_key) = (Some(session.signer), Some(session.access_key));
         }
 
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain)).ok().flatten();

--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -53,6 +53,8 @@ impl BatchSendArgs {
     pub async fn run(self) -> Result<()> {
         let Self { calls, send_tx, mut tx, unlocked } = self;
         let has_session = tx.tempo.session_id()?.is_some();
+        // Tempo sessions must sign with the session key; these modes route signing through a
+        // node-managed account or browser wallet instead.
         if has_session && unlocked {
             eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --unlocked");
         }

--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -52,6 +52,14 @@ pub struct BatchSendArgs {
 impl BatchSendArgs {
     pub async fn run(self) -> Result<()> {
         let Self { calls, send_tx, mut tx, unlocked } = self;
+        let has_session = tx.tempo.session_id()?.is_some();
+        if has_session && unlocked {
+            eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --unlocked");
+        }
+        if has_session && send_tx.browser.browser {
+            eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --browser");
+        }
+
         let expires_at = tx.tempo.resolve_expires();
 
         if calls.is_empty() {
@@ -69,8 +77,10 @@ impl BatchSendArgs {
             provider.client().set_poll_interval(Duration::from_secs(interval))
         }
 
-        // Resolve signer to detect keychain mode
-        let (signer, tempo_access_key) = send_tx.eth.wallet.maybe_signer().await?;
+        // Resolve signer to detect keychain mode. Tempo sessions are resolved after chain lookup
+        // so they can fail closed on wrong-chain session use.
+        let (mut signer, mut tempo_access_key) =
+            if has_session { (None, None) } else { send_tx.eth.wallet.maybe_signer().await? };
 
         // Parse all call specs
         let call_specs: Vec<CallSpec> =
@@ -78,6 +88,14 @@ impl BatchSendArgs {
 
         // Get chain for parsing function args
         let chain = utils::get_chain(config.chain, &provider).await?;
+        if has_session
+            && let Some(session) =
+                tx.tempo.session_signer_for_wallet(&send_tx.eth.wallet, chain.id())?
+        {
+            signer = Some(session.signer);
+            tempo_access_key = Some(session.access_key);
+        }
+
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain)).ok().flatten();
         let etherscan_api_key = etherscan_config.as_ref().map(|c| c.key.clone());
         let etherscan_api_url = etherscan_config.map(|c| c.api_url);

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -4,7 +4,10 @@ use anvil::NodeConfig;
 use foundry_evm::core::tempo::PATH_USD_ADDRESS;
 use foundry_test_utils::{TestCommand, util::OutputExt};
 use path_slash::PathExt;
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 /// Anvil test accounts (standard mnemonic).
 mod accounts {
@@ -16,6 +19,23 @@ mod accounts {
 
 fn path_usd() -> String {
     PATH_USD_ADDRESS.to_string()
+}
+
+const MISSING_SESSION_ID: &str =
+    "0x5555555555555555555555555555555555555555555555555555555555555555";
+
+fn cast_bin() -> PathBuf {
+    std::env::current_exe()
+        .expect("current test executable")
+        .parent()
+        .expect("deps dir")
+        .parent()
+        .expect("target debug dir")
+        .join(format!("cast{}", std::env::consts::EXE_SUFFIX))
+}
+
+fn batch_send_transfer_call(path_usd: &str) -> String {
+    format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3)
 }
 
 fn create_session(cmd: &mut TestCommand, tempo_home: &Path, chain_id: &str) -> (String, String) {
@@ -74,6 +94,24 @@ fn assert_session_file_status_with_key(tempo_home: &Path, status: &str) {
     assert!(
         contents.contains("key = \"0x"),
         "{status} session should retain private key material:\n{contents}"
+    );
+}
+
+fn assert_async_tx_hash(stdout: &str, command: &str) {
+    assert!(
+        stdout.trim().starts_with("0x"),
+        "expected {command} --async to print a tx hash, got:\n{stdout}"
+    );
+}
+
+fn assert_session_cleanup_failure(stderr: &str) {
+    assert!(
+        stderr.contains("failed to clean up Tempo session after inner command"),
+        "unexpected stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("session key is not provisioned on-chain yet"),
+        "unexpected stderr:\n{stderr}"
     );
 }
 
@@ -425,14 +463,7 @@ printf '%s\n' "${TEMPO_SESSION_ID}" > "$1"
             .assert_failure()
             .get_output()
             .stderr_lossy();
-        assert!(
-            stderr.contains("failed to clean up Tempo session after inner command"),
-            "unexpected stderr:\n{stderr}"
-        );
-        assert!(
-            stderr.contains("session key is not provisioned on-chain yet"),
-            "unexpected stderr:\n{stderr}"
-        );
+        assert_session_cleanup_failure(&stderr);
 
         let child_session_id =
             fs::read_to_string(&child_session_out).expect("child wrote TEMPO_SESSION_ID");
@@ -451,13 +482,7 @@ casttest!(wallet_session_run_for_cast_send_submits_with_session_key, async |_prj
     let child_dir = tempfile::tempdir().unwrap();
     let child_script = child_dir.path().join("session-cast-send.sh");
     let path_usd = path_usd();
-    let cast_bin = std::env::current_exe()
-        .expect("current test executable")
-        .parent()
-        .expect("deps dir")
-        .parent()
-        .expect("target debug dir")
-        .join(format!("cast{}", std::env::consts::EXE_SUFFIX));
+    let cast_bin = cast_bin();
     fs::write(
         &child_script,
         format!(
@@ -503,18 +528,8 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     let stdout = output.stdout_lossy();
     let stderr = output.stderr_lossy();
 
-    assert!(
-        stdout.trim().starts_with("0x"),
-        "expected child cast send --async to print a tx hash, got:\n{stdout}"
-    );
-    assert!(
-        stderr.contains("failed to clean up Tempo session after inner command"),
-        "unexpected stderr:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("session key is not provisioned on-chain yet"),
-        "unexpected stderr:\n{stderr}"
-    );
+    assert_async_tx_hash(&stdout, "child cast send");
+    assert_session_cleanup_failure(&stderr);
     assert_session_file_status_without_key(tempo_home.path(), "failed");
 });
 
@@ -525,24 +540,16 @@ casttest!(wallet_session_run_for_batch_send_submits_with_session_key, async |_pr
     let child_dir = tempfile::tempdir().unwrap();
     let child_script = child_dir.path().join("session-batch-send.sh");
     let path_usd = path_usd();
-    let cast_bin = std::env::current_exe()
-        .expect("current test executable")
-        .parent()
-        .expect("deps dir")
-        .parent()
-        .expect("target debug dir")
-        .join(format!("cast{}", std::env::consts::EXE_SUFFIX));
+    let call = batch_send_transfer_call(&path_usd);
+    let cast_bin = cast_bin();
     fs::write(
         &child_script,
         format!(
             r#"#!/bin/sh
 set -eu
 test -n "${{TEMPO_SESSION_ID:-}}"
-"${{CAST_BIN}}" batch-send --call "{}::transfer(address,uint256):{},0" --rpc-url "${{RPC_URL}}" --tempo.fee-token "{}" --async
+"${{CAST_BIN}}" batch-send --call "{call}" --rpc-url "${{RPC_URL}}" --tempo.fee-token "{path_usd}" --async
 "#,
-            path_usd,
-            accounts::ADDR3,
-            path_usd,
         ),
     )
     .expect("write child script");
@@ -577,18 +584,8 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     let stdout = output.stdout_lossy();
     let stderr = output.stderr_lossy();
 
-    assert!(
-        stdout.trim().starts_with("0x"),
-        "expected child cast batch-send --async to print a tx hash, got:\n{stdout}"
-    );
-    assert!(
-        stderr.contains("failed to clean up Tempo session after inner command"),
-        "unexpected stderr:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("session key is not provisioned on-chain yet"),
-        "unexpected stderr:\n{stderr}"
-    );
+    assert_async_tx_hash(&stdout, "child cast batch-send");
+    assert_session_cleanup_failure(&stderr);
     assert_session_file_status_without_key(tempo_home.path(), "failed");
 });
 
@@ -597,6 +594,7 @@ casttest!(batch_send_uses_tempo_session_id_env, async |_prj, cmd| {
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
     let path_usd = path_usd();
+    let call = batch_send_transfer_call(&path_usd);
     let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31337");
 
     cmd.cast_fuse();
@@ -606,7 +604,7 @@ casttest!(batch_send_uses_tempo_session_id_env, async |_prj, cmd| {
         .args([
             "batch-send",
             "--call",
-            &format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3),
+            &call,
             "--rpc-url",
             &rpc,
             "--tempo.fee-token",
@@ -617,10 +615,7 @@ casttest!(batch_send_uses_tempo_session_id_env, async |_prj, cmd| {
         .get_output()
         .stdout_lossy();
 
-    assert!(
-        stdout.trim().starts_with("0x"),
-        "expected cast batch-send --async to print a tx hash, got:\n{stdout}"
-    );
+    assert_async_tx_hash(&stdout, "cast batch-send");
 });
 
 casttest!(wallet_session_run_for_grandchild_cast_send_inherits_session_key, async |_prj, cmd| {
@@ -631,13 +626,7 @@ casttest!(wallet_session_run_for_grandchild_cast_send_inherits_session_key, asyn
     let child_script = child_dir.path().join("session-child.sh");
     let grandchild_script = child_dir.path().join("session-grandchild-cast-send.sh");
     let path_usd = path_usd();
-    let cast_bin = std::env::current_exe()
-        .expect("current test executable")
-        .parent()
-        .expect("deps dir")
-        .parent()
-        .expect("target debug dir")
-        .join(format!("cast{}", std::env::consts::EXE_SUFFIX));
+    let cast_bin = cast_bin();
 
     fs::write(
         &child_script,
@@ -693,25 +682,14 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     let stdout = output.stdout_lossy();
     let stderr = output.stderr_lossy();
 
-    assert!(
-        stdout.trim().starts_with("0x"),
-        "expected grandchild cast send --async to print a tx hash, got:\n{stdout}"
-    );
-    assert!(
-        stderr.contains("failed to clean up Tempo session after inner command"),
-        "unexpected stderr:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("session key is not provisioned on-chain yet"),
-        "unexpected stderr:\n{stderr}"
-    );
+    assert_async_tx_hash(&stdout, "grandchild cast send");
+    assert_session_cleanup_failure(&stderr);
     assert_session_file_status_without_key(tempo_home.path(), "failed");
 });
 
 casttest!(cast_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
-    let session_id = "0x5555555555555555555555555555555555555555555555555555555555555555";
 
     cmd.cast_fuse();
     let stderr = cmd
@@ -721,7 +699,7 @@ casttest!(cast_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
             "--value",
             "1",
             "--tempo.session",
-            session_id,
+            MISSING_SESSION_ID,
             "--private-key",
             accounts::PK1,
             "--rpc-url",
@@ -738,16 +716,16 @@ casttest!(batch_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let path_usd = path_usd();
-    let session_id = "0x5555555555555555555555555555555555555555555555555555555555555555";
+    let call = batch_send_transfer_call(&path_usd);
 
     cmd.cast_fuse();
     let stderr = cmd
         .args([
             "batch-send",
             "--call",
-            &format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3),
+            &call,
             "--tempo.session",
-            session_id,
+            MISSING_SESSION_ID,
             "--private-key",
             accounts::PK1,
             "--rpc-url",
@@ -766,16 +744,16 @@ casttest!(batch_send_rejects_session_with_unlocked, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let path_usd = path_usd();
-    let session_id = "0x5555555555555555555555555555555555555555555555555555555555555555";
+    let call = batch_send_transfer_call(&path_usd);
 
     cmd.cast_fuse();
     let stderr = cmd
         .args([
             "batch-send",
             "--call",
-            &format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3),
+            &call,
             "--tempo.session",
-            session_id,
+            MISSING_SESSION_ID,
             "--unlocked",
             "--from",
             accounts::ADDR1,
@@ -796,6 +774,7 @@ casttest!(batch_send_rejects_session_on_wrong_chain, async |_prj, cmd| {
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
     let path_usd = path_usd();
+    let call = batch_send_transfer_call(&path_usd);
     let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31338");
 
     cmd.cast_fuse();
@@ -804,7 +783,7 @@ casttest!(batch_send_rejects_session_on_wrong_chain, async |_prj, cmd| {
         .args([
             "batch-send",
             "--call",
-            &format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3),
+            &call,
             "--tempo.session",
             &session_id,
             "--rpc-url",

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -518,6 +518,111 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     assert_session_file_status_without_key(tempo_home.path(), "failed");
 });
 
+casttest!(wallet_session_run_for_batch_send_submits_with_session_key, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let child_dir = tempfile::tempdir().unwrap();
+    let child_script = child_dir.path().join("session-batch-send.sh");
+    let path_usd = path_usd();
+    let cast_bin = std::env::current_exe()
+        .expect("current test executable")
+        .parent()
+        .expect("deps dir")
+        .parent()
+        .expect("target debug dir")
+        .join(format!("cast{}", std::env::consts::EXE_SUFFIX));
+    fs::write(
+        &child_script,
+        format!(
+            r#"#!/bin/sh
+set -eu
+test -n "${{TEMPO_SESSION_ID:-}}"
+"${{CAST_BIN}}" batch-send --call "{}::transfer(address,uint256):{},0" --rpc-url "${{RPC_URL}}" --tempo.fee-token "{}" --async
+"#,
+            path_usd,
+            accounts::ADDR3,
+            path_usd,
+        ),
+    )
+    .expect("write child script");
+
+    let for_command = format!("sh {}", child_script.to_slash_lossy());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.env("CAST_BIN", &cast_bin);
+    cmd.env("RPC_URL", &rpc);
+    let assertion = cmd
+        .args([
+            "wallet",
+            "session",
+            "--root",
+            accounts::ADDR1,
+            "--expires",
+            "10m",
+            "--scope",
+            &path_usd,
+            "--spend-limit",
+            "PathUSD=1000000",
+            "--for",
+            &for_command,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure();
+    let output = assertion.get_output();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+
+    assert!(
+        stdout.trim().starts_with("0x"),
+        "expected child cast batch-send --async to print a tx hash, got:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("failed to clean up Tempo session after inner command"),
+        "unexpected stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("session key is not provisioned on-chain yet"),
+        "unexpected stderr:\n{stderr}"
+    );
+    assert_session_file_status_without_key(tempo_home.path(), "failed");
+});
+
+casttest!(batch_send_uses_tempo_session_id_env, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = path_usd();
+    let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31337");
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.env("TEMPO_SESSION_ID", &session_id);
+    let stdout = cmd
+        .args([
+            "batch-send",
+            "--call",
+            &format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3),
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+            "--async",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(
+        stdout.trim().starts_with("0x"),
+        "expected cast batch-send --async to print a tx hash, got:\n{stdout}"
+    );
+});
+
 casttest!(wallet_session_run_for_grandchild_cast_send_inherits_session_key, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
@@ -627,6 +732,92 @@ casttest!(cast_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
         .stderr_lossy();
 
     assert!(stderr.contains("explicit wallet signer"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(batch_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let path_usd = path_usd();
+    let session_id = "0x5555555555555555555555555555555555555555555555555555555555555555";
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "batch-send",
+            "--call",
+            &format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3),
+            "--tempo.session",
+            session_id,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("explicit wallet signer"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(batch_send_rejects_session_with_unlocked, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let path_usd = path_usd();
+    let session_id = "0x5555555555555555555555555555555555555555555555555555555555555555";
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "batch-send",
+            "--call",
+            &format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3),
+            "--tempo.session",
+            session_id,
+            "--unlocked",
+            "--from",
+            accounts::ADDR1,
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("cannot be combined with --unlocked"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(batch_send_rejects_session_on_wrong_chain, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = path_usd();
+    let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31338");
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    let stderr = cmd
+        .args([
+            "batch-send",
+            "--call",
+            &format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3),
+            "--tempo.session",
+            &session_id,
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("is for chain 31338"), "unexpected stderr:\n{stderr}");
+    assert!(stderr.contains("command is using chain 31337"), "unexpected stderr:\n{stderr}");
 });
 
 casttest!(wallet_session_run_for_cleans_key_material_when_child_fails, async |_prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -3273,7 +3273,7 @@ contract ForkTest is Test {
     cmd.args(["test", "--mt", "test_fork_err_message"]).assert_failure().stdout_eq(str![[r#"
 ...
 Ran 1 test for test/ForkTest.t.sol:ForkTest
-[FAIL: vm.createSelectFork: could not instantiate forked environment with provider eth-mainnet.g.alchemy.com; HTTP error 401 with body: Must be authenticated!
+[FAIL: vm.createSelectFork: could not instantiate forked environment with provider eth-mainnet.g.alchemy.com; HTTP error 401 with body: [..]
 
 ...
 


### PR DESCRIPTION
Towards OSS-162 , 

Add Tempo session support to `cast batch-send` by deferring signer resolution until after the chain is known, so session keys can be validated against the active chain before use. The command now rejects incompatible signing modes such as explicit wallet signers, `--unlocked`, and `--browser` when a Tempo session is active.

This also adds CLI coverage for successful batch-send session usage, inherited session usage through `wallet session --for`, explicit signer rejection, unlocked signer rejection, and wrong-chain session rejection.
