### PR TITLE
fix(traces): preserve event name when log data is not ABI-decodable

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -901,7 +901,9 @@ impl CallTraceDecoder {
             }
         }
 
-        DecodedCallLog { name: None, params: None }
+        // The data failed to decode, but if topic0 matched a known event we still surface
+        // its name (without params) instead of dropping the log to raw topics/data.
+        DecodedCallLog { name: events.first().map(|e| e.name.clone()), params: None }
     }
 
     /// Prefetches function and event signatures into the identifier cache
@@ -1596,6 +1598,36 @@ mod tests {
             params[0].1.to_ascii_lowercase().contains("0000000000000000000000000000000000000abc")
         );
         assert_eq!(params[1], ("newLogoURI".into(), "\"ipfs://logo\"".into()));
+    }
+
+    #[tokio::test]
+    async fn test_decode_event_preserves_name_when_data_is_not_abi() {
+        // Regression for #10451: an event emitted with hand-packed (non-ABI) data fails to
+        // decode, but its name must still be surfaced from the matched topic0 instead of being
+        // dropped to raw topics/data.
+        let event = Event::parse("Exchange(bytes)").unwrap();
+        let topic0 = event.selector();
+
+        let mut decoder = CallTraceDecoder::new().clone();
+        decoder.events.insert((topic0, 0), vec![event]);
+
+        // Hand-packed payload (not the ABI encoding of `bytes`), so `decode_log` fails.
+        let log = LogData::new_unchecked(
+            vec![topic0],
+            hex!(
+                "1111111111111111111111111111111111111111\
+                 2222222222222222222222222222222222222222\
+                 3333333333333333333333333333333333333333\
+                 00000000000000000000000000000064\
+                 00000000000000000000000000000190"
+            )
+            .to_vec()
+            .into(),
+        );
+
+        let decoded = decoder.decode_event(&log).await;
+        assert_eq!(decoded.name.as_deref(), Some("Exchange"));
+        assert_eq!(decoded.params, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

When an event is emitted with data that is not ABI-encoded (for example
hand-packed bytes written via inline assembly, as reported in #10451), its
`topic0` still matches a known event but `event.decode_log` fails.
`decode_event` (`crates/evm/traces/src/decoder/mod.rs`) then returned
`DecodedCallLog { name: None, params: None }`, so the matched name was
dropped and the trace fell back to raw `topic 0 / data`.

## Solution

When decoding fails but `topic0` matched a known event, surface the matched
event name with `params: None` instead of dropping it. Unknown events (no
match) and anonymous logs (no topics) are unchanged.

## Scope

This is the decoder half of #10451, not the full fix. With the current
revm-inspectors writer, `name: Some / params: None` renders as `emit Exchange()`,
so the raw topics/data are not yet shown next to the name. The writer change that
renders a named header plus raw topics/data is the follow-up:
paradigmxyz/revm-inspectors#466. Once that lands and the `revm-inspectors`
dependency here is bumped, #10451 is fully addressed.

## Test

`test_decode_event_preserves_name_when_data_is_not_abi` registers an event,
feeds a log whose `topic0` matches but whose data is hand-packed (not ABI),
and asserts the decoded name is `Some("Exchange")` with `params: None`. It
fails before the change (name is `None`) and passes after.

Part of #10451 (decoder half).
