### PR TITLE
 refactor(script): isolate Tempo session signer handling

### DIFF
--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -600,7 +600,7 @@ contract SessionForgeScript is Script {{
     );
 
     let for_command = format!(
-        "{} script {} --tc SessionForgeScript --broadcast --rpc-url {} --root {}",
+        "{} script {} --tc SessionForgeScript --broadcast --timeout 1 --rpc-url {} --root {}",
         prj.ensure_foundry_bin("forge").to_slash_lossy(),
         script.to_slash_lossy(),
         rpc,

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -2,12 +2,9 @@
 
 use anvil::NodeConfig;
 use foundry_evm::core::tempo::PATH_USD_ADDRESS;
-use foundry_test_utils::{TestCommand, TestProject, util::OutputExt};
+use foundry_test_utils::{TestCommand, util::OutputExt};
 use path_slash::PathExt;
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::Path};
 
 /// Anvil test accounts (standard mnemonic).
 mod accounts {
@@ -24,16 +21,19 @@ fn path_usd() -> String {
 const MISSING_SESSION_ID: &str =
     "0x5555555555555555555555555555555555555555555555555555555555555555";
 
-fn cast_bin(prj: &TestProject) -> PathBuf {
-    prj.foundry_bin_path("cast")
-}
-
-fn forge_bin(prj: &TestProject) -> PathBuf {
-    prj.ensure_foundry_bin("forge")
-}
-
 fn batch_send_transfer_call(path_usd: &str) -> String {
     format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3)
+}
+
+fn cast_send_session_script(path_usd: &str) -> String {
+    format!(
+        r#"#!/bin/sh
+set -eu
+test -n "${{TEMPO_SESSION_ID:-}}"
+"${{CAST_BIN}}" send "{path_usd}" 'transfer(address,uint256)' "{recipient}" 0 --rpc-url "${{RPC_URL}}" --tempo.fee-token "{path_usd}" --async
+"#,
+        recipient = accounts::ADDR3,
+    )
 }
 
 fn create_session(cmd: &mut TestCommand, tempo_home: &Path, chain_id: &str) -> (String, String) {
@@ -480,27 +480,13 @@ casttest!(wallet_session_run_for_cast_send_submits_with_session_key, async |prj,
     let child_dir = tempfile::tempdir().unwrap();
     let child_script = child_dir.path().join("session-cast-send.sh");
     let path_usd = path_usd();
-    let cast_bin = cast_bin(&prj);
-    fs::write(
-        &child_script,
-        format!(
-            r#"#!/bin/sh
-set -eu
-test -n "${{TEMPO_SESSION_ID:-}}"
-"${{CAST_BIN}}" send "{}" 'transfer(address,uint256)' "{}" 0 --rpc-url "${{RPC_URL}}" --tempo.fee-token "{}" --async
-"#,
-            path_usd,
-            accounts::ADDR3,
-            path_usd,
-        ),
-    )
-    .expect("write child script");
+    fs::write(&child_script, cast_send_session_script(&path_usd)).expect("write child script");
 
     let for_command = format!("sh {}", child_script.to_slash_lossy());
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
-    cmd.env("CAST_BIN", &cast_bin);
+    cmd.env("CAST_BIN", prj.foundry_bin_path("cast"));
     cmd.env("RPC_URL", &rpc);
     let assertion = cmd
         .args([
@@ -522,9 +508,8 @@ test -n "${{TEMPO_SESSION_ID:-}}"
             &rpc,
         ])
         .assert_failure();
-    let output = assertion.get_output();
-    let stdout = output.stdout_lossy();
-    let stderr = output.stderr_lossy();
+    let stdout = assertion.get_output().stdout_lossy();
+    let stderr = assertion.get_output().stderr_lossy();
 
     assert_async_tx_hash(&stdout, "child cast send");
     assert_session_cleanup_failure(&stderr);
@@ -539,7 +524,6 @@ casttest!(wallet_session_run_for_batch_send_submits_with_session_key, async |prj
     let child_script = child_dir.path().join("session-batch-send.sh");
     let path_usd = path_usd();
     let call = batch_send_transfer_call(&path_usd);
-    let cast_bin = cast_bin(&prj);
     fs::write(
         &child_script,
         format!(
@@ -556,7 +540,7 @@ test -n "${{TEMPO_SESSION_ID:-}}"
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
-    cmd.env("CAST_BIN", &cast_bin);
+    cmd.env("CAST_BIN", prj.foundry_bin_path("cast"));
     cmd.env("RPC_URL", &rpc);
     let assertion = cmd
         .args([
@@ -578,9 +562,8 @@ test -n "${{TEMPO_SESSION_ID:-}}"
             &rpc,
         ])
         .assert_failure();
-    let output = assertion.get_output();
-    let stdout = output.stdout_lossy();
-    let stderr = output.stderr_lossy();
+    let stdout = assertion.get_output().stdout_lossy();
+    let stderr = assertion.get_output().stderr_lossy();
 
     assert_async_tx_hash(&stdout, "child cast batch-send");
     assert_session_cleanup_failure(&stderr);
@@ -605,12 +588,9 @@ interface PathUsdLike {{
 }}
 
 contract SessionForgeScript is Script {{
-    address constant PATH_USD = {path_usd};
-    address constant RECIPIENT = {recipient};
-
     function run() external {{
         vm.startBroadcast();
-        PathUsdLike(PATH_USD).transfer(RECIPIENT, 0);
+        PathUsdLike({path_usd}).transfer({recipient}, 0);
         vm.stopBroadcast();
     }}
 }}
@@ -621,7 +601,7 @@ contract SessionForgeScript is Script {{
 
     let for_command = format!(
         "{} script {} --tc SessionForgeScript --broadcast --rpc-url {} --root {}",
-        forge_bin(&prj).to_slash_lossy(),
+        prj.ensure_foundry_bin("forge").to_slash_lossy(),
         script.to_slash_lossy(),
         rpc,
         prj.root().to_slash_lossy(),
@@ -651,9 +631,8 @@ contract SessionForgeScript is Script {{
             &rpc,
         ])
         .assert_failure();
-    let output = assertion.get_output();
-    let stdout = output.stdout_lossy();
-    let stderr = output.stderr_lossy();
+    let stdout = assertion.get_output().stdout_lossy();
+    let stderr = assertion.get_output().stderr_lossy();
 
     assert!(
         stdout.contains("ONCHAIN EXECUTION COMPLETE & SUCCESSFUL."),
@@ -722,7 +701,6 @@ casttest!(wallet_session_run_for_grandchild_cast_send_inherits_session_key, asyn
     let child_script = child_dir.path().join("session-child.sh");
     let grandchild_script = child_dir.path().join("session-grandchild-cast-send.sh");
     let path_usd = path_usd();
-    let cast_bin = cast_bin(&prj);
 
     fs::write(
         &child_script,
@@ -734,25 +712,15 @@ sh "$1"
     )
     .expect("write child script");
 
-    fs::write(
-        &grandchild_script,
-        format!(
-            r#"#!/bin/sh
-set -eu
-test -n "${{TEMPO_SESSION_ID:-}}"
-"${{CAST_BIN}}" send "{}" 'transfer(address,uint256)' "{}" 0 --rpc-url "${{RPC_URL}}" --tempo.fee-token "{}" --async
-"#,
-            path_usd, accounts::ADDR3, path_usd,
-        ),
-    )
-    .expect("write grandchild script");
+    fs::write(&grandchild_script, cast_send_session_script(&path_usd))
+        .expect("write grandchild script");
 
     let for_command =
         format!("sh {} {}", child_script.to_slash_lossy(), grandchild_script.to_slash_lossy());
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
-    cmd.env("CAST_BIN", &cast_bin);
+    cmd.env("CAST_BIN", prj.foundry_bin_path("cast"));
     cmd.env("RPC_URL", &rpc);
     let assertion = cmd
         .args([
@@ -774,9 +742,8 @@ test -n "${{TEMPO_SESSION_ID:-}}"
             &rpc,
         ])
         .assert_failure();
-    let output = assertion.get_output();
-    let stdout = output.stdout_lossy();
-    let stderr = output.stderr_lossy();
+    let stdout = assertion.get_output().stdout_lossy();
+    let stderr = assertion.get_output().stderr_lossy();
 
     assert_async_tx_hash(&stdout, "grandchild cast send");
     assert_session_cleanup_failure(&stderr);

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -2,7 +2,7 @@
 
 use anvil::NodeConfig;
 use foundry_evm::core::tempo::PATH_USD_ADDRESS;
-use foundry_test_utils::{TestCommand, util::OutputExt};
+use foundry_test_utils::{TestCommand, TestProject, util::OutputExt};
 use path_slash::PathExt;
 use std::{
     fs,
@@ -24,14 +24,12 @@ fn path_usd() -> String {
 const MISSING_SESSION_ID: &str =
     "0x5555555555555555555555555555555555555555555555555555555555555555";
 
-fn cast_bin() -> PathBuf {
-    std::env::current_exe()
-        .expect("current test executable")
-        .parent()
-        .expect("deps dir")
-        .parent()
-        .expect("target debug dir")
-        .join(format!("cast{}", std::env::consts::EXE_SUFFIX))
+fn cast_bin(prj: &TestProject) -> PathBuf {
+    prj.foundry_bin_path("cast")
+}
+
+fn forge_bin(prj: &TestProject) -> PathBuf {
+    prj.ensure_foundry_bin("forge")
 }
 
 fn batch_send_transfer_call(path_usd: &str) -> String {
@@ -475,14 +473,14 @@ printf '%s\n' "${TEMPO_SESSION_ID}" > "$1"
     }
 );
 
-casttest!(wallet_session_run_for_cast_send_submits_with_session_key, async |_prj, cmd| {
+casttest!(wallet_session_run_for_cast_send_submits_with_session_key, async |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
     let child_dir = tempfile::tempdir().unwrap();
     let child_script = child_dir.path().join("session-cast-send.sh");
     let path_usd = path_usd();
-    let cast_bin = cast_bin();
+    let cast_bin = cast_bin(&prj);
     fs::write(
         &child_script,
         format!(
@@ -533,7 +531,7 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     assert_session_file_status_without_key(tempo_home.path(), "failed");
 });
 
-casttest!(wallet_session_run_for_batch_send_submits_with_session_key, async |_prj, cmd| {
+casttest!(wallet_session_run_for_batch_send_submits_with_session_key, async |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
@@ -541,7 +539,7 @@ casttest!(wallet_session_run_for_batch_send_submits_with_session_key, async |_pr
     let child_script = child_dir.path().join("session-batch-send.sh");
     let path_usd = path_usd();
     let call = batch_send_transfer_call(&path_usd);
-    let cast_bin = cast_bin();
+    let cast_bin = cast_bin(&prj);
     fs::write(
         &child_script,
         format!(
@@ -589,6 +587,104 @@ test -n "${{TEMPO_SESSION_ID:-}}"
     assert_session_file_status_without_key(tempo_home.path(), "failed");
 });
 
+casttest!(wallet_session_run_for_forge_script_submits_with_session_key, async |prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = path_usd();
+
+    foundry_test_utils::util::initialize(prj.root());
+    let script = prj.add_script(
+        "SessionForgeScript.s.sol",
+        &format!(
+            r#"
+import "forge-std/Script.sol";
+
+interface PathUsdLike {{
+    function transfer(address to, uint256 amount) external returns (bool);
+}}
+
+contract SessionForgeScript is Script {{
+    address constant PATH_USD = {path_usd};
+    address constant RECIPIENT = {recipient};
+
+    function run() external {{
+        vm.startBroadcast();
+        PathUsdLike(PATH_USD).transfer(RECIPIENT, 0);
+        vm.stopBroadcast();
+    }}
+}}
+"#,
+            recipient = accounts::ADDR3,
+        ),
+    );
+
+    let for_command = format!(
+        "{} script {} --tc SessionForgeScript --broadcast --rpc-url {} --root {}",
+        forge_bin(&prj).to_slash_lossy(),
+        script.to_slash_lossy(),
+        rpc,
+        prj.root().to_slash_lossy(),
+    );
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    let assertion = cmd
+        .args([
+            "wallet",
+            "session",
+            "--root",
+            accounts::ADDR1,
+            "--expires",
+            "10m",
+            "--target",
+            &path_usd,
+            "--selector",
+            "transfer(address,uint256)",
+            "--spend-limit",
+            "PathUSD=0",
+            "--for",
+            &for_command,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure();
+    let output = assertion.get_output();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+
+    assert!(
+        stdout.contains("ONCHAIN EXECUTION COMPLETE & SUCCESSFUL."),
+        "expected forge script broadcast completion\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let run_latest = foundry_common::fs::json_files(&prj.root().join("broadcast"))
+        .find(|path| path.ends_with("run-latest.json"))
+        .unwrap_or_else(|| {
+            panic!("expected forge broadcast artifact\nstdout:\n{stdout}\nstderr:\n{stderr}")
+        });
+    let broadcast = fs::read_to_string(&run_latest).expect("read forge broadcast artifact");
+    let broadcast: serde_json::Value =
+        serde_json::from_str(&broadcast).expect("forge broadcast artifact is valid JSON");
+    let tx = &broadcast["transactions"][0];
+
+    assert_eq!(tx["transactionType"], "CALL", "unexpected forge broadcast tx: {tx}");
+    assert_eq!(tx["function"], "transfer(address,uint256)", "unexpected forge broadcast tx: {tx}");
+    assert_eq!(
+        tx["contractAddress"].as_str().map(str::to_ascii_lowercase),
+        Some(path_usd.to_ascii_lowercase()),
+        "unexpected forge broadcast tx: {tx}"
+    );
+    assert!(
+        tx["hash"].as_str().is_some_and(|hash| hash.starts_with("0x")),
+        "forge broadcast tx should have a submitted hash: {tx}"
+    );
+    assert_session_cleanup_failure(&stderr);
+    assert_session_file_status_without_key(tempo_home.path(), "failed");
+});
+
 casttest!(batch_send_uses_tempo_session_id_env, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
@@ -618,7 +714,7 @@ casttest!(batch_send_uses_tempo_session_id_env, async |_prj, cmd| {
     assert_async_tx_hash(&stdout, "cast batch-send");
 });
 
-casttest!(wallet_session_run_for_grandchild_cast_send_inherits_session_key, async |_prj, cmd| {
+casttest!(wallet_session_run_for_grandchild_cast_send_inherits_session_key, async |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
@@ -626,7 +722,7 @@ casttest!(wallet_session_run_for_grandchild_cast_send_inherits_session_key, asyn
     let child_script = child_dir.path().join("session-child.sh");
     let grandchild_script = child_dir.path().join("session-grandchild-cast-send.sh");
     let path_usd = path_usd();
-    let cast_bin = cast_bin();
+    let cast_bin = cast_bin(&prj);
 
     fs::write(
         &child_script,

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -5,7 +5,11 @@ use crate::{
     build::LinkedBuildData,
     progress::ScriptProgress,
     sequence::ScriptSequenceKind,
-    session::{RemainingScriptTransaction, ScriptSession, SignerScope},
+    session::{
+        RemainingScriptTransaction, SignerScope,
+        insert_session_access_key_for_remaining_transactions,
+        script_session_expected_sender_if_configured,
+    },
     verify::BroadcastedState,
 };
 use alloy_chains::{Chain, NamedChain};
@@ -476,18 +480,24 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
         let send_kind = if self.args.unlocked {
             SendTransactionsKind::Unlocked(required_addresses.clone())
         } else {
-            let script_session = ScriptSession::new(&self.script_config.tempo, &self.args.wallets);
-            let expected_session_sender = script_session.expected_sender(&required_addresses)?;
+            let expected_session_sender = script_session_expected_sender_if_configured(
+                &self.script_config.tempo,
+                &required_addresses,
+            )?;
 
             // For addresses without an explicit signer, try Tempo keys.toml fallback.
             let mut access_keys: HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)> =
                 HashMap::default();
             if let Some(expected_session_sender) = expected_session_sender
                 && let Some(session) =
-                    script_session.signer_any_chain(Some(expected_session_sender))?
+                    self.script_config.tempo.session_signer_for_multi_wallet_any_chain(
+                        &self.args.wallets,
+                        Some(expected_session_sender),
+                    )?
             {
-                session.insert_access_key_for_remaining_transactions(
+                insert_session_access_key_for_remaining_transactions(
                     &mut access_keys,
+                    session,
                     &remaining_transactions,
                 )?;
             }
@@ -1098,12 +1108,12 @@ impl BundledState<TempoEvmNetwork> {
 
         let batch_signer = if self.args.unlocked {
             BatchSigner::Unlocked
-        } else if let Some(session) =
-            ScriptSession::new(&self.script_config.tempo, &self.args.wallets)
-                .signer_for_chain(sender, chain_id)?
-        {
-            let (signer, access_key) = session.into_signer_parts();
-            BatchSigner::TempoKeychain(Box::new(signer), Box::new(access_key))
+        } else if let Some(session) = self.script_config.tempo.session_signer_for_multi_wallet(
+            &self.args.wallets,
+            Some(sender),
+            chain_id,
+        )? {
+            BatchSigner::TempoKeychain(Box::new(session.signer), Box::new(session.access_key))
         } else {
             let mut signers = self.script_wallets.into_multi_wallet().into_signers()?;
             if let Some(signer) = signers.remove(&sender) {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -1,8 +1,12 @@
 use std::{cmp::Ordering, num::NonZeroU64, sync::Arc, time::Duration};
 
 use crate::{
-    ScriptArgs, ScriptConfig, build::LinkedBuildData, progress::ScriptProgress,
-    sequence::ScriptSequenceKind, verify::BroadcastedState,
+    ScriptArgs, ScriptConfig,
+    build::LinkedBuildData,
+    progress::ScriptProgress,
+    sequence::ScriptSequenceKind,
+    session::{RemainingScriptTransaction, ScriptSession, SignerScope},
+    verify::BroadcastedState,
 };
 use alloy_chains::{Chain, NamedChain};
 use alloy_consensus::{SignableTransaction, Signed};
@@ -28,8 +32,7 @@ use foundry_common::{
     provider::{ProviderBuilder, try_get_http_provider},
     shell,
     tempo::{
-        KeyEntry, KeysFile, ResolvedSessionSigner, TempoSponsor, WALLET_KEYS_PATH,
-        decode_key_authorization, tempo_home,
+        KeyEntry, KeysFile, TempoSponsor, WALLET_KEYS_PATH, decode_key_authorization, tempo_home,
     },
 };
 use foundry_config::Config;
@@ -260,42 +263,6 @@ where
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct SignerScope {
-    chain: u64,
-    sender: Address,
-}
-
-impl SignerScope {
-    pub(crate) const fn new(chain: u64, sender: Address) -> Self {
-        Self { chain, sender }
-    }
-}
-
-fn insert_session_access_key_for_remaining_transactions(
-    access_keys: &mut HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)>,
-    session: ResolvedSessionSigner,
-    remaining_transactions: &[RemainingScriptTransaction],
-) -> Result<()> {
-    let chain = session.session.chain_id;
-    let root = session.session.root_account;
-    if let Some(tx) = remaining_transactions.iter().find(|tx| tx.from == root && tx.chain != chain)
-    {
-        eyre::bail!(
-            "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
-            chain,
-            root,
-            tx.chain,
-        );
-    }
-
-    if remaining_transactions.iter().any(|tx| tx.from == root) {
-        access_keys.insert(SignerScope::new(chain, root), (session.signer, session.access_key));
-    }
-
-    Ok(())
-}
-
 fn build_lookup(entry: &KeyEntry) -> Result<TempoLookup> {
     let Some(ref key) = entry.key else {
         return Ok(TempoLookup::NotFound);
@@ -376,42 +343,6 @@ fn lookup_signer_in(from: Address, chain: u64, file: &KeysFile) -> Result<TempoL
         }
     }
     fallback.map(|e| build_lookup_chain0_fallback(e, chain)).unwrap_or(Ok(TempoLookup::NotFound))
-}
-
-/// Returns the single sender a Tempo session is allowed to cover.
-///
-/// Session signing is intentionally fail-closed: a single session access key represents one root
-/// account, so scripts with multiple pending senders must not silently mix the session key with
-/// other wallets.
-pub(crate) fn script_session_expected_sender(
-    required_addresses: &AddressHashSet,
-) -> Result<Option<Address>> {
-    required_addresses
-        .iter()
-        .copied()
-        .at_most_one()
-        .map_err(|_| eyre::eyre!("Tempo sessions require a single script sender"))
-}
-
-pub(crate) fn script_session_expected_sender_if_configured<FEN: FoundryEvmNetwork>(
-    script_config: &ScriptConfig<FEN>,
-    required_addresses: &AddressHashSet,
-) -> Result<Option<Address>> {
-    script_config
-        .tempo
-        .session_id()?
-        .map_or(Ok(None), |_| script_session_expected_sender(required_addresses))
-}
-
-pub(crate) struct RemainingScriptTransaction {
-    pub(crate) chain: u64,
-    pub(crate) from: Address,
-}
-
-impl RemainingScriptTransaction {
-    pub(crate) const fn scope(&self) -> SignerScope {
-        SignerScope::new(self.chain, self.from)
-    }
 }
 
 pub(crate) fn remaining_unsigned_transactions<N: Network>(
@@ -545,24 +476,18 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
         let send_kind = if self.args.unlocked {
             SendTransactionsKind::Unlocked(required_addresses.clone())
         } else {
-            let expected_session_sender = script_session_expected_sender_if_configured(
-                &self.script_config,
-                &required_addresses,
-            )?;
+            let script_session = ScriptSession::new(&self.script_config.tempo, &self.args.wallets);
+            let expected_session_sender = script_session.expected_sender(&required_addresses)?;
 
             // For addresses without an explicit signer, try Tempo keys.toml fallback.
             let mut access_keys: HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)> =
                 HashMap::default();
             if let Some(expected_session_sender) = expected_session_sender
                 && let Some(session) =
-                    self.script_config.tempo.session_signer_for_multi_wallet_any_chain(
-                        &self.args.wallets,
-                        Some(expected_session_sender),
-                    )?
+                    script_session.signer_any_chain(Some(expected_session_sender))?
             {
-                insert_session_access_key_for_remaining_transactions(
+                session.insert_access_key_for_remaining_transactions(
                     &mut access_keys,
-                    session,
                     &remaining_transactions,
                 )?;
             }
@@ -1173,12 +1098,12 @@ impl BundledState<TempoEvmNetwork> {
 
         let batch_signer = if self.args.unlocked {
             BatchSigner::Unlocked
-        } else if let Some(session) = self.script_config.tempo.session_signer_for_multi_wallet(
-            &self.args.wallets,
-            Some(sender),
-            chain_id,
-        )? {
-            BatchSigner::TempoKeychain(Box::new(session.signer), Box::new(session.access_key))
+        } else if let Some(session) =
+            ScriptSession::new(&self.script_config.tempo, &self.args.wallets)
+                .signer_for_chain(sender, chain_id)?
+        {
+            let (signer, access_key) = session.into_signer_parts();
+            BatchSigner::TempoKeychain(Box::new(signer), Box::new(access_key))
         } else {
             let mut signers = self.script_wallets.into_multi_wallet().into_signers()?;
             if let Some(signer) = signers.remove(&sender) {
@@ -1469,11 +1394,10 @@ mod tests {
     use super::*;
     use alloy_consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom};
     use alloy_network::Ethereum;
-    use alloy_primitives::{B256, Bloom, address};
+    use alloy_primitives::{Bloom, address};
     use alloy_rpc_types::TransactionReceipt;
     use alloy_signer::Signer;
     use forge_script_sequence::TransactionWithMetadata;
-    use foundry_common::tempo::{KeyType, SessionEntry, SessionKeyMaterial, SessionStatus};
 
     const ROOT_PRIVATE_KEY: &str =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
@@ -1518,17 +1442,6 @@ mod tests {
     }
 
     #[test]
-    fn session_sender_requires_single_root_account() {
-        let one = address!("0x1111111111111111111111111111111111111111");
-        let two = address!("0x2222222222222222222222222222222222222222");
-        let single_sender = [one].into_iter().collect();
-        let multiple_senders = [one, two].into_iter().collect();
-
-        assert_eq!(script_session_expected_sender(&single_sender).unwrap(), Some(one));
-        assert!(script_session_expected_sender(&multiple_senders).is_err());
-    }
-
-    #[test]
     fn access_key_signer_is_scoped_to_chain() {
         let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
         let root_address = root.address();
@@ -1561,42 +1474,6 @@ mod tests {
             }
             _ => panic!("expected root wallet signer for non-session chain"),
         }
-    }
-
-    #[test]
-    fn session_access_key_rejects_session_root_on_wrong_chain() {
-        let (session, root_address, _) = session_signer(4217);
-        let remaining = [RemainingScriptTransaction { chain: 1, from: root_address }];
-        let mut access_keys = HashMap::default();
-
-        let err = insert_session_access_key_for_remaining_transactions(
-            &mut access_keys,
-            session,
-            &remaining,
-        )
-        .unwrap_err();
-
-        assert!(access_keys.is_empty());
-        let message = err.to_string();
-        assert!(message.contains("Tempo session is for chain 4217"), "{message}");
-        assert!(message.contains("transaction from session root"), "{message}");
-        assert!(message.contains("chain 1"), "{message}");
-    }
-
-    #[test]
-    fn session_access_key_is_inserted_for_session_chain() {
-        let (session, root_address, access_key_address) = session_signer(4217);
-        let remaining = [RemainingScriptTransaction { chain: 4217, from: root_address }];
-        let mut access_keys = HashMap::default();
-
-        insert_session_access_key_for_remaining_transactions(&mut access_keys, session, &remaining)
-            .unwrap();
-
-        let (signer, config) =
-            access_keys.get(&SignerScope::new(4217, root_address)).expect("session access key");
-        assert_eq!(signer.address(), access_key_address);
-        assert_eq!(config.wallet_address, root_address);
-        assert_eq!(config.key_address, access_key_address);
     }
 
     #[test]
@@ -1697,36 +1574,6 @@ mod tests {
             from: Some(from),
             ..Default::default()
         }))
-    }
-
-    fn session_signer(chain_id: u64) -> (ResolvedSessionSigner, Address, Address) {
-        let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
-        let root_address = root.address();
-        let signer =
-            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
-        let key_address = signer.address();
-        let access_key = TempoAccessKeyConfig {
-            wallet_address: root_address,
-            key_address,
-            key_authorization: None,
-        };
-        let session = SessionEntry {
-            session_id: B256::ZERO,
-            root_account: root_address,
-            chain_id,
-            key_address,
-            expiry: u64::MAX,
-            scope: None,
-            limits: None,
-            status: SessionStatus::Active,
-            key: Some(SessionKeyMaterial {
-                key_type: KeyType::Secp256k1,
-                key: ACCESS_KEY_PRIVATE_KEY.to_string(),
-                key_authorization: None,
-            }),
-        };
-
-        (ResolvedSessionSigner { session, signer, access_key }, root_address, key_address)
     }
 
     fn receipt() -> TransactionReceipt {

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -1,12 +1,10 @@
 use crate::{
     ScriptArgs, ScriptConfig,
-    broadcast::{
-        BundledState, RemainingScriptTransaction, SignerScope, remaining_unsigned_transactions,
-        script_session_expected_sender_if_configured,
-    },
+    broadcast::{BundledState, remaining_unsigned_transactions},
     execute::LinkedState,
     multi_sequence::MultiChainSequence,
     sequence::ScriptSequenceKind,
+    session::{RemainingScriptTransaction, ScriptSession},
 };
 use alloy_network::AnyNetwork;
 use alloy_primitives::{Address, B256, Bytes, map::AddressHashSet};
@@ -48,12 +46,9 @@ fn has_available_script_signers<FEN: FoundryEvmNetwork>(
         return Ok(true);
     }
 
-    let session_scope = script_config
-        .tempo
-        .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
-        .map(|session| {
-            SignerScope::new(session.session.chain_id, session.access_key.wallet_address)
-        });
+    let session_scope = ScriptSession::new(&script_config.tempo, wallets)
+        .signer_any_chain(expected_sender)?
+        .map(|session| session.scope());
 
     Ok(remaining.iter().all(|tx| signers.contains(&tx.from) || Some(tx.scope()) == session_scope))
 }
@@ -340,10 +335,9 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     remaining_unsigned_transactions(sequence.sequences()).collect::<Vec<_>>();
                 let remaining_froms =
                     remaining_transactions.iter().map(|tx| tx.from).collect::<AddressHashSet>();
-                let expected_session_sender = script_session_expected_sender_if_configured(
-                    &self.script_config,
-                    &remaining_froms,
-                )?;
+                let expected_session_sender =
+                    ScriptSession::new(&self.script_config.tempo, &self.args.wallets)
+                        .expected_sender(&remaining_froms)?;
                 let has_available_signers = has_available_script_signers(
                     &self.script_config,
                     &self.args.wallets,
@@ -427,41 +421,16 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use foundry_cli::opts::TEMPO_SESSION_ID_ENV;
+    use foundry_cli::opts::TempoOpts;
     use foundry_evm::core::evm::TempoEvmNetwork;
-    use std::sync::LazyLock;
-    use tokio::sync::{Mutex, MutexGuard};
-
-    static SESSION_ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-    struct SessionEnvGuard {
-        _guard: MutexGuard<'static, ()>,
-    }
-
-    impl SessionEnvGuard {
-        async fn set(session_id: B256) -> Self {
-            let guard = SESSION_ENV_LOCK.lock().await;
-            // SAFETY: test-only environment override guarded by a process-wide mutex.
-            unsafe { std::env::set_var(TEMPO_SESSION_ID_ENV, format!("{session_id:?}")) };
-            Self { _guard: guard }
-        }
-    }
-
-    impl Drop for SessionEnvGuard {
-        fn drop(&mut self) {
-            // SAFETY: restore process environment after the guarded test section.
-            unsafe { std::env::remove_var(TEMPO_SESSION_ID_ENV) };
-        }
-    }
 
     #[tokio::test]
     async fn has_available_script_signers_skips_session_resolution_when_remaining_empty() {
-        let _guard = SessionEnvGuard::set(B256::from([0x99; 32])).await;
         let script_config = ScriptConfig::<TempoEvmNetwork>::new(
             Default::default(),
             Default::default(),
             false,
-            Default::default(),
+            TempoOpts { session: Some(B256::from([0x99; 32])), ..Default::default() },
         )
         .await
         .unwrap();

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -14,6 +14,7 @@ use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
 use forge_script_sequence::ScriptSequence;
 use foundry_cheatcodes::Wallets;
+use foundry_cli::opts::TempoOpts;
 use foundry_common::{
     ContractData, ContractsByArtifact, compile::ProjectCompiler, provider::ProviderBuilder,
 };
@@ -34,8 +35,8 @@ use std::{path::PathBuf, str::FromStr, sync::Arc};
 /// `Wallets` only tracks signers collected from CLI options and script cheatcodes. A Tempo
 /// session signer lives in the session registry instead, so resume needs to treat the session
 /// root account as available only on the chain covered by the session.
-fn has_available_script_signers<FEN: FoundryEvmNetwork>(
-    script_config: &ScriptConfig<FEN>,
+fn has_available_script_signers(
+    tempo: &TempoOpts,
     wallets: &MultiWalletOpts,
     script_wallets: &Wallets,
     expected_sender: Option<Address>,
@@ -48,14 +49,11 @@ fn has_available_script_signers<FEN: FoundryEvmNetwork>(
         return Ok(true);
     }
 
-    let session_scope = script_config
-        .tempo
+    let session_scope = tempo
         .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
-        .map(|session| {
-            SignerScope::new(session.session.chain_id, session.access_key.wallet_address)
-        });
+        .map(|s| SignerScope::new(s.session.chain_id, s.access_key.wallet_address));
 
-    Ok(remaining.iter().all(|tx| signers.contains(&tx.from) || Some(tx.scope()) == session_scope))
+    Ok(remaining.iter().all(|tx| signers.contains(&tx.from) || session_scope == Some(tx.scope())))
 }
 
 /// Container for the compiled contracts.
@@ -345,7 +343,7 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     &remaining_froms,
                 )?;
                 let has_available_signers = has_available_script_signers(
-                    &self.script_config,
+                    &self.script_config.tempo,
                     &self.args.wallets,
                     &self.script_wallets,
                     expected_session_sender,
@@ -427,22 +425,11 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use foundry_cli::opts::TempoOpts;
-    use foundry_evm::core::evm::TempoEvmNetwork;
 
-    #[tokio::test]
-    async fn has_available_script_signers_skips_session_resolution_when_remaining_empty() {
-        let script_config = ScriptConfig::<TempoEvmNetwork>::new(
-            Default::default(),
-            Default::default(),
-            false,
-            TempoOpts { session: Some(B256::from([0x99; 32])), ..Default::default() },
-        )
-        .await
-        .unwrap();
-
+    #[test]
+    fn has_available_script_signers_skips_session_resolution_when_remaining_empty() {
         let has_available = has_available_script_signers(
-            &script_config,
+            &TempoOpts { session: Some(B256::repeat_byte(0x99)), ..Default::default() },
             &MultiWalletOpts::default(),
             &Wallets::new(Default::default(), None),
             None,

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -4,7 +4,9 @@ use crate::{
     execute::LinkedState,
     multi_sequence::MultiChainSequence,
     sequence::ScriptSequenceKind,
-    session::{RemainingScriptTransaction, ScriptSession},
+    session::{
+        RemainingScriptTransaction, SignerScope, script_session_expected_sender_if_configured,
+    },
 };
 use alloy_network::AnyNetwork;
 use alloy_primitives::{Address, B256, Bytes, map::AddressHashSet};
@@ -46,9 +48,12 @@ fn has_available_script_signers<FEN: FoundryEvmNetwork>(
         return Ok(true);
     }
 
-    let session_scope = ScriptSession::new(&script_config.tempo, wallets)
-        .signer_any_chain(expected_sender)?
-        .map(|session| session.scope());
+    let session_scope = script_config
+        .tempo
+        .session_signer_for_multi_wallet_any_chain(wallets, expected_sender)?
+        .map(|session| {
+            SignerScope::new(session.session.chain_id, session.access_key.wallet_address)
+        });
 
     Ok(remaining.iter().all(|tx| signers.contains(&tx.from) || Some(tx.scope()) == session_scope))
 }
@@ -335,9 +340,10 @@ impl<FEN: FoundryEvmNetwork> CompiledState<FEN> {
                     remaining_unsigned_transactions(sequence.sequences()).collect::<Vec<_>>();
                 let remaining_froms =
                     remaining_transactions.iter().map(|tx| tx.from).collect::<AddressHashSet>();
-                let expected_session_sender =
-                    ScriptSession::new(&self.script_config.tempo, &self.args.wallets)
-                        .expected_sender(&remaining_froms)?;
+                let expected_session_sender = script_session_expected_sender_if_configured(
+                    &self.script_config.tempo,
+                    &remaining_froms,
+                )?;
                 let has_available_signers = has_available_script_signers(
                     &self.script_config,
                     &self.args.wallets,

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -77,6 +77,7 @@ mod providers;
 mod receipts;
 mod runner;
 mod sequence;
+mod session;
 mod simulate;
 mod transaction;
 mod verify;
@@ -268,7 +269,7 @@ impl ScriptArgs {
         } else {
             // Initial scripts may only reveal multi-chain transactions during execution. Use the
             // session root as the script sender here and validate chain scope during broadcast.
-            self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
+            session::ScriptSession::new(&self.tempo, &self.wallets).sender(self.evm.sender)?
         };
 
         let script_wallets = Wallets::new(self.wallets.get_multi_wallet().await?, self.evm.sender);
@@ -768,7 +769,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         expected_sender: Option<Address>,
     ) -> Result<()> {
         if let Some(sender) =
-            self.tempo.session_sender_for_multi_wallet(wallets, expected_sender)?
+            crate::session::ScriptSession::new(&self.tempo, wallets).sender(expected_sender)?
         {
             self.update_sender(sender).await?;
         }

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -269,7 +269,7 @@ impl ScriptArgs {
         } else {
             // Initial scripts may only reveal multi-chain transactions during execution. Use the
             // session root as the script sender here and validate chain scope during broadcast.
-            session::ScriptSession::new(&self.tempo, &self.wallets).sender(self.evm.sender)?
+            self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
         };
 
         let script_wallets = Wallets::new(self.wallets.get_multi_wallet().await?, self.evm.sender);
@@ -769,7 +769,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         expected_sender: Option<Address>,
     ) -> Result<()> {
         if let Some(sender) =
-            crate::session::ScriptSession::new(&self.tempo, wallets).sender(expected_sender)?
+            self.tempo.session_sender_for_multi_wallet(wallets, expected_sender)?
         {
             self.update_sender(sender).await?;
         }

--- a/crates/script/src/session.rs
+++ b/crates/script/src/session.rs
@@ -2,10 +2,10 @@ use alloy_primitives::{
     Address,
     map::{AddressHashSet, HashMap},
 };
-use eyre::{Result, ensure};
+use eyre::Result;
 use foundry_cli::opts::TempoOpts;
 use foundry_common::tempo::ResolvedSessionSigner;
-use foundry_wallets::{MultiWalletOpts, TempoAccessKeyConfig, WalletSigner};
+use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use itertools::Itertools;
 
 /// A transaction sender scoped to one chain.
@@ -34,63 +34,16 @@ impl RemainingScriptTransaction {
     }
 }
 
-/// Script-specific view over the configured Tempo wallet session.
+/// Returns the single sender a configured Tempo session is allowed to cover.
 ///
-/// `TempoOpts` owns CLI/env parsing and registry resolution. This wrapper keeps script semantics
-/// local: a session may cover exactly one root sender, and only on its recorded chain.
-pub(crate) struct ScriptSession<'a> {
-    tempo: &'a TempoOpts,
-    wallets: &'a MultiWalletOpts,
-}
-
-impl<'a> ScriptSession<'a> {
-    pub(crate) const fn new(tempo: &'a TempoOpts, wallets: &'a MultiWalletOpts) -> Self {
-        Self { tempo, wallets }
-    }
-
-    /// Returns the single sender a configured Tempo session is allowed to cover.
-    ///
-    /// Session signing is intentionally fail-closed: a single session access key represents one
-    /// root account, so scripts with multiple pending senders must not silently mix the session
-    /// key with other wallets.
-    pub(crate) fn expected_sender(
-        &self,
-        required_addresses: &AddressHashSet,
-    ) -> Result<Option<Address>> {
-        self.tempo.session_id()?.map_or(Ok(None), |_| single_session_sender(required_addresses))
-    }
-
-    /// Resolves only the session root sender, without binding it to a chain.
-    pub(crate) fn sender(&self, expected_sender: Option<Address>) -> Result<Option<Address>> {
-        self.tempo.session_sender_for_multi_wallet(self.wallets, expected_sender)
-    }
-
-    /// Resolves the script session signer without forcing a command-level chain.
-    pub(crate) fn signer_any_chain(
-        &self,
-        expected_sender: Option<Address>,
-    ) -> Result<Option<ScriptSessionSigner>> {
-        self.tempo
-            .session_signer_for_multi_wallet_any_chain(self.wallets, expected_sender)?
-            .map(ScriptSessionSigner::new)
-            .transpose()
-    }
-
-    /// Resolves the script session signer for a known single-chain broadcast.
-    pub(crate) fn signer_for_chain(
-        &self,
-        expected_sender: Address,
-        expected_chain_id: u64,
-    ) -> Result<Option<ScriptSessionSigner>> {
-        self.tempo
-            .session_signer_for_multi_wallet(
-                self.wallets,
-                Some(expected_sender),
-                expected_chain_id,
-            )?
-            .map(ScriptSessionSigner::new)
-            .transpose()
-    }
+/// Session signing is intentionally fail-closed: a single session access key represents one root
+/// account, so scripts with multiple pending senders must not silently mix the session key with
+/// other wallets.
+pub(crate) fn script_session_expected_sender_if_configured(
+    tempo: &TempoOpts,
+    required_addresses: &AddressHashSet,
+) -> Result<Option<Address>> {
+    tempo.session_id()?.map_or(Ok(None), |_| single_session_sender(required_addresses))
 }
 
 fn single_session_sender(required_addresses: &AddressHashSet) -> Result<Option<Address>> {
@@ -101,64 +54,38 @@ fn single_session_sender(required_addresses: &AddressHashSet) -> Result<Option<A
         .map_err(|_| eyre::eyre!("Tempo sessions require a single script sender"))
 }
 
-/// Resolved session signer with its script signer scope precomputed and validated.
-pub(crate) struct ScriptSessionSigner {
-    scope: SignerScope,
-    signer: WalletSigner,
-    access_key: TempoAccessKeyConfig,
-}
+/// Inserts this session access key when it covers the remaining transaction set.
+///
+/// Transactions from the session root on any other chain are rejected up front, so callers do not
+/// accidentally fall back to a long-lived root signer for the same session account.
+pub(crate) fn insert_session_access_key_for_remaining_transactions(
+    access_keys: &mut HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)>,
+    session: ResolvedSessionSigner,
+    remaining_transactions: &[RemainingScriptTransaction],
+) -> Result<()> {
+    let chain = session.session.chain_id;
+    let root = session.session.root_account;
+    let mut has_session_sender = false;
 
-impl ScriptSessionSigner {
-    fn new(resolved: ResolvedSessionSigner) -> Result<Self> {
-        let ResolvedSessionSigner { session, signer, access_key } = resolved;
-        ensure!(
-            session.root_account == access_key.wallet_address,
-            "Tempo session root account {} does not match access key wallet address {}",
-            session.root_account,
-            access_key.wallet_address
-        );
-        Ok(Self {
-            scope: SignerScope::new(session.chain_id, session.root_account),
-            signer,
-            access_key,
-        })
-    }
-
-    pub(crate) const fn scope(&self) -> SignerScope {
-        self.scope
-    }
-
-    pub(crate) fn into_signer_parts(self) -> (WalletSigner, TempoAccessKeyConfig) {
-        (self.signer, self.access_key)
-    }
-
-    /// Inserts this session access key when it covers the remaining transaction set.
-    ///
-    /// Transactions from the session root on any other chain are rejected up front, so callers do
-    /// not accidentally fall back to a long-lived root signer for the same session account.
-    pub(crate) fn insert_access_key_for_remaining_transactions(
-        self,
-        access_keys: &mut HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)>,
-        remaining_transactions: &[RemainingScriptTransaction],
-    ) -> Result<()> {
-        if let Some(tx) = remaining_transactions
-            .iter()
-            .find(|tx| tx.from == self.scope.sender && tx.chain != self.scope.chain)
-        {
-            eyre::bail!(
-                "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
-                self.scope.chain,
-                self.scope.sender,
-                tx.chain,
-            );
+    for tx in remaining_transactions {
+        if tx.from == root {
+            if tx.chain != chain {
+                eyre::bail!(
+                    "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
+                    chain,
+                    root,
+                    tx.chain,
+                );
+            }
+            has_session_sender = true;
         }
-
-        if remaining_transactions.iter().any(|tx| tx.from == self.scope.sender) {
-            access_keys.insert(self.scope, self.into_signer_parts());
-        }
-
-        Ok(())
     }
+
+    if has_session_sender {
+        access_keys.insert(SignerScope::new(chain, root), (session.signer, session.access_key));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -190,9 +117,12 @@ mod tests {
         let remaining = [RemainingScriptTransaction { chain: 1, from: root_address }];
         let mut access_keys = HashMap::default();
 
-        let err = session
-            .insert_access_key_for_remaining_transactions(&mut access_keys, &remaining)
-            .unwrap_err();
+        let err = insert_session_access_key_for_remaining_transactions(
+            &mut access_keys,
+            session,
+            &remaining,
+        )
+        .unwrap_err();
 
         assert!(access_keys.is_empty());
         let message = err.to_string();
@@ -207,7 +137,8 @@ mod tests {
         let remaining = [RemainingScriptTransaction { chain: 4217, from: root_address }];
         let mut access_keys = HashMap::default();
 
-        session.insert_access_key_for_remaining_transactions(&mut access_keys, &remaining).unwrap();
+        insert_session_access_key_for_remaining_transactions(&mut access_keys, session, &remaining)
+            .unwrap();
 
         let (signer, config) =
             access_keys.get(&SignerScope::new(4217, root_address)).expect("session access key");
@@ -216,33 +147,18 @@ mod tests {
         assert_eq!(config.key_address, access_key_address);
     }
 
-    #[test]
-    fn session_signer_rejects_mismatched_root_and_access_key_wallet() {
-        let (session, _, _) = resolved_session_signer(4217, Address::from([0x42; 20]));
-        let err = match ScriptSessionSigner::new(session) {
-            Ok(_) => panic!("expected mismatched session root and access key wallet"),
-            Err(err) => err,
-        };
-
-        assert!(err.to_string().contains("does not match access key wallet address"), "{err}");
+    fn session_signer(chain_id: u64) -> (ResolvedSessionSigner, Address, Address) {
+        resolved_session_signer(chain_id)
     }
 
-    fn session_signer(chain_id: u64) -> (ScriptSessionSigner, Address, Address) {
-        let (session, root_address, key_address) = resolved_session_signer(chain_id, None);
-        (ScriptSessionSigner::new(session).unwrap(), root_address, key_address)
-    }
-
-    fn resolved_session_signer(
-        chain_id: u64,
-        wallet_address_override: impl Into<Option<Address>>,
-    ) -> (ResolvedSessionSigner, Address, Address) {
+    fn resolved_session_signer(chain_id: u64) -> (ResolvedSessionSigner, Address, Address) {
         let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
         let root_address = root.address();
         let signer =
             foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
         let key_address = signer.address();
         let access_key = TempoAccessKeyConfig {
-            wallet_address: wallet_address_override.into().unwrap_or(root_address),
+            wallet_address: root_address,
             key_address,
             key_authorization: None,
         };

--- a/crates/script/src/session.rs
+++ b/crates/script/src/session.rs
@@ -1,0 +1,267 @@
+use alloy_primitives::{
+    Address,
+    map::{AddressHashSet, HashMap},
+};
+use eyre::{Result, ensure};
+use foundry_cli::opts::TempoOpts;
+use foundry_common::tempo::ResolvedSessionSigner;
+use foundry_wallets::{MultiWalletOpts, TempoAccessKeyConfig, WalletSigner};
+use itertools::Itertools;
+
+/// A transaction sender scoped to one chain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct SignerScope {
+    chain: u64,
+    sender: Address,
+}
+
+impl SignerScope {
+    pub(crate) const fn new(chain: u64, sender: Address) -> Self {
+        Self { chain, sender }
+    }
+}
+
+/// A remaining unsigned script transaction, represented only by the data needed for signer lookup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RemainingScriptTransaction {
+    pub(crate) chain: u64,
+    pub(crate) from: Address,
+}
+
+impl RemainingScriptTransaction {
+    pub(crate) const fn scope(&self) -> SignerScope {
+        SignerScope::new(self.chain, self.from)
+    }
+}
+
+/// Script-specific view over the configured Tempo wallet session.
+///
+/// `TempoOpts` owns CLI/env parsing and registry resolution. This wrapper keeps script semantics
+/// local: a session may cover exactly one root sender, and only on its recorded chain.
+pub(crate) struct ScriptSession<'a> {
+    tempo: &'a TempoOpts,
+    wallets: &'a MultiWalletOpts,
+}
+
+impl<'a> ScriptSession<'a> {
+    pub(crate) const fn new(tempo: &'a TempoOpts, wallets: &'a MultiWalletOpts) -> Self {
+        Self { tempo, wallets }
+    }
+
+    /// Returns the single sender a configured Tempo session is allowed to cover.
+    ///
+    /// Session signing is intentionally fail-closed: a single session access key represents one
+    /// root account, so scripts with multiple pending senders must not silently mix the session
+    /// key with other wallets.
+    pub(crate) fn expected_sender(
+        &self,
+        required_addresses: &AddressHashSet,
+    ) -> Result<Option<Address>> {
+        self.tempo.session_id()?.map_or(Ok(None), |_| single_session_sender(required_addresses))
+    }
+
+    /// Resolves only the session root sender, without binding it to a chain.
+    pub(crate) fn sender(&self, expected_sender: Option<Address>) -> Result<Option<Address>> {
+        self.tempo.session_sender_for_multi_wallet(self.wallets, expected_sender)
+    }
+
+    /// Resolves the script session signer without forcing a command-level chain.
+    pub(crate) fn signer_any_chain(
+        &self,
+        expected_sender: Option<Address>,
+    ) -> Result<Option<ScriptSessionSigner>> {
+        self.tempo
+            .session_signer_for_multi_wallet_any_chain(self.wallets, expected_sender)?
+            .map(ScriptSessionSigner::new)
+            .transpose()
+    }
+
+    /// Resolves the script session signer for a known single-chain broadcast.
+    pub(crate) fn signer_for_chain(
+        &self,
+        expected_sender: Address,
+        expected_chain_id: u64,
+    ) -> Result<Option<ScriptSessionSigner>> {
+        self.tempo
+            .session_signer_for_multi_wallet(
+                self.wallets,
+                Some(expected_sender),
+                expected_chain_id,
+            )?
+            .map(ScriptSessionSigner::new)
+            .transpose()
+    }
+}
+
+fn single_session_sender(required_addresses: &AddressHashSet) -> Result<Option<Address>> {
+    required_addresses
+        .iter()
+        .copied()
+        .at_most_one()
+        .map_err(|_| eyre::eyre!("Tempo sessions require a single script sender"))
+}
+
+/// Resolved session signer with its script signer scope precomputed and validated.
+pub(crate) struct ScriptSessionSigner {
+    scope: SignerScope,
+    signer: WalletSigner,
+    access_key: TempoAccessKeyConfig,
+}
+
+impl ScriptSessionSigner {
+    fn new(resolved: ResolvedSessionSigner) -> Result<Self> {
+        let ResolvedSessionSigner { session, signer, access_key } = resolved;
+        ensure!(
+            session.root_account == access_key.wallet_address,
+            "Tempo session root account {} does not match access key wallet address {}",
+            session.root_account,
+            access_key.wallet_address
+        );
+        Ok(Self {
+            scope: SignerScope::new(session.chain_id, session.root_account),
+            signer,
+            access_key,
+        })
+    }
+
+    pub(crate) const fn scope(&self) -> SignerScope {
+        self.scope
+    }
+
+    pub(crate) fn into_signer_parts(self) -> (WalletSigner, TempoAccessKeyConfig) {
+        (self.signer, self.access_key)
+    }
+
+    /// Inserts this session access key when it covers the remaining transaction set.
+    ///
+    /// Transactions from the session root on any other chain are rejected up front, so callers do
+    /// not accidentally fall back to a long-lived root signer for the same session account.
+    pub(crate) fn insert_access_key_for_remaining_transactions(
+        self,
+        access_keys: &mut HashMap<SignerScope, (WalletSigner, TempoAccessKeyConfig)>,
+        remaining_transactions: &[RemainingScriptTransaction],
+    ) -> Result<()> {
+        if let Some(tx) = remaining_transactions
+            .iter()
+            .find(|tx| tx.from == self.scope.sender && tx.chain != self.scope.chain)
+        {
+            eyre::bail!(
+                "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
+                self.scope.chain,
+                self.scope.sender,
+                tx.chain,
+            );
+        }
+
+        if remaining_transactions.iter().any(|tx| tx.from == self.scope.sender) {
+            access_keys.insert(self.scope, self.into_signer_parts());
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{B256, address};
+    use alloy_signer::Signer;
+    use foundry_common::tempo::{KeyType, SessionEntry, SessionKeyMaterial, SessionStatus};
+
+    const ROOT_PRIVATE_KEY: &str =
+        "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    const ACCESS_KEY_PRIVATE_KEY: &str =
+        "0x59c6995e998f97a5a004497e5da3b5d2b2b66a87f064d39c44da0b6d6e4f8ff0";
+
+    #[test]
+    fn session_sender_requires_single_root_account() {
+        let one = address!("0x1111111111111111111111111111111111111111");
+        let two = address!("0x2222222222222222222222222222222222222222");
+        let single_sender = [one].into_iter().collect();
+        let multiple_senders = [one, two].into_iter().collect();
+
+        assert_eq!(single_session_sender(&single_sender).unwrap(), Some(one));
+        assert!(single_session_sender(&multiple_senders).is_err());
+    }
+
+    #[test]
+    fn session_access_key_rejects_session_root_on_wrong_chain() {
+        let (session, root_address, _) = session_signer(4217);
+        let remaining = [RemainingScriptTransaction { chain: 1, from: root_address }];
+        let mut access_keys = HashMap::default();
+
+        let err = session
+            .insert_access_key_for_remaining_transactions(&mut access_keys, &remaining)
+            .unwrap_err();
+
+        assert!(access_keys.is_empty());
+        let message = err.to_string();
+        assert!(message.contains("Tempo session is for chain 4217"), "{message}");
+        assert!(message.contains("transaction from session root"), "{message}");
+        assert!(message.contains("chain 1"), "{message}");
+    }
+
+    #[test]
+    fn session_access_key_is_inserted_for_session_chain() {
+        let (session, root_address, access_key_address) = session_signer(4217);
+        let remaining = [RemainingScriptTransaction { chain: 4217, from: root_address }];
+        let mut access_keys = HashMap::default();
+
+        session.insert_access_key_for_remaining_transactions(&mut access_keys, &remaining).unwrap();
+
+        let (signer, config) =
+            access_keys.get(&SignerScope::new(4217, root_address)).expect("session access key");
+        assert_eq!(signer.address(), access_key_address);
+        assert_eq!(config.wallet_address, root_address);
+        assert_eq!(config.key_address, access_key_address);
+    }
+
+    #[test]
+    fn session_signer_rejects_mismatched_root_and_access_key_wallet() {
+        let (session, _, _) = resolved_session_signer(4217, Address::from([0x42; 20]));
+        let err = match ScriptSessionSigner::new(session) {
+            Ok(_) => panic!("expected mismatched session root and access key wallet"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("does not match access key wallet address"), "{err}");
+    }
+
+    fn session_signer(chain_id: u64) -> (ScriptSessionSigner, Address, Address) {
+        let (session, root_address, key_address) = resolved_session_signer(chain_id, None);
+        (ScriptSessionSigner::new(session).unwrap(), root_address, key_address)
+    }
+
+    fn resolved_session_signer(
+        chain_id: u64,
+        wallet_address_override: impl Into<Option<Address>>,
+    ) -> (ResolvedSessionSigner, Address, Address) {
+        let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
+        let root_address = root.address();
+        let signer =
+            foundry_wallets::utils::create_private_key_signer(ACCESS_KEY_PRIVATE_KEY).unwrap();
+        let key_address = signer.address();
+        let access_key = TempoAccessKeyConfig {
+            wallet_address: wallet_address_override.into().unwrap_or(root_address),
+            key_address,
+            key_authorization: None,
+        };
+        let session = SessionEntry {
+            session_id: B256::ZERO,
+            root_account: root_address,
+            chain_id,
+            key_address,
+            expiry: u64::MAX,
+            scope: None,
+            limits: None,
+            status: SessionStatus::Active,
+            key: Some(SessionKeyMaterial {
+                key_type: KeyType::Secp256k1,
+                key: ACCESS_KEY_PRIVATE_KEY.to_string(),
+                key_authorization: None,
+            }),
+        };
+
+        (ResolvedSessionSigner { session, signer, access_key }, root_address, key_address)
+    }
+}

--- a/crates/script/src/session.rs
+++ b/crates/script/src/session.rs
@@ -65,23 +65,17 @@ pub(crate) fn insert_session_access_key_for_remaining_transactions(
 ) -> Result<()> {
     let chain = session.session.chain_id;
     let root = session.session.root_account;
-    let mut has_session_sender = false;
-
-    for tx in remaining_transactions {
-        if tx.from == root {
-            if tx.chain != chain {
-                eyre::bail!(
-                    "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
-                    chain,
-                    root,
-                    tx.chain,
-                );
-            }
-            has_session_sender = true;
-        }
+    if let Some(tx) = remaining_transactions.iter().find(|tx| tx.from == root && tx.chain != chain)
+    {
+        eyre::bail!(
+            "Tempo session is for chain {}, but a remaining transaction from session root {} is on chain {}",
+            chain,
+            root,
+            tx.chain,
+        );
     }
 
-    if has_session_sender {
+    if remaining_transactions.iter().any(|tx| tx.from == root) {
         access_keys.insert(SignerScope::new(chain, root), (session.signer, session.access_key));
     }
 
@@ -148,10 +142,6 @@ mod tests {
     }
 
     fn session_signer(chain_id: u64) -> (ResolvedSessionSigner, Address, Address) {
-        resolved_session_signer(chain_id)
-    }
-
-    fn resolved_session_signer(chain_id: u64) -> (ResolvedSessionSigner, Address, Address) {
         let root = foundry_wallets::utils::create_private_key_signer(ROOT_PRIVATE_KEY).unwrap();
         let root_address = root.address();
         let signer =

--- a/crates/test-utils/src/ext.rs
+++ b/crates/test-utils/src/ext.rs
@@ -99,7 +99,7 @@ impl ExtTester {
         // Export vyper and forge in test command - workaround for snekmate venom tests.
         if let Some(vyper) = &prj.inner.project().compiler.vyper {
             let vyper_dir = vyper.path.parent().expect("vyper path should have a parent");
-            let forge_bin = prj.forge_path();
+            let forge_bin = prj.foundry_bin_path("forge");
             let forge_dir = forge_bin.parent().expect("forge path should have a parent");
 
             let existing_path = std::env::var_os("PATH").unwrap_or_default();

--- a/crates/test-utils/src/prj.rs
+++ b/crates/test-utils/src/prj.rs
@@ -468,15 +468,9 @@ impl TestProject {
         }
 
         let package = format!("{name}@{}", env!("CARGO_PKG_VERSION"));
-        let manifest = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .parent()
-            .and_then(Path::parent)
-            .expect("workspace root")
-            .join("Cargo.toml");
-        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-        let output = Command::new(cargo)
+        let output = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
             .args(["build", "-p", &package, "--bin", name, "--manifest-path"])
-            .arg(manifest)
+            .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../Cargo.toml"))
             .output()
             .expect("build Foundry sibling binary");
         assert!(

--- a/crates/test-utils/src/prj.rs
+++ b/crates/test-utils/src/prj.rs
@@ -468,11 +468,17 @@ impl TestProject {
         }
 
         let package = format!("{name}@{}", env!("CARGO_PKG_VERSION"));
-        let output = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()))
-            .args(["build", "-p", &package, "--bin", name, "--manifest-path"])
+        let (target_dir, profile) = cargo_build_target_dir_and_profile(&self.exe_root);
+        let mut cmd = Command::new(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
+        cmd.args(["build", "-p", &package, "--bin", name, "--manifest-path"])
             .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../Cargo.toml"))
-            .output()
-            .expect("build Foundry sibling binary");
+            .arg("--target-dir")
+            .arg(target_dir);
+        if let Some(profile) = profile {
+            cmd.arg("--profile").arg(profile);
+        }
+
+        let output = cmd.output().expect("build Foundry sibling binary");
         assert!(
             output.status.success(),
             "failed to build {name} for CLI test\nstdout:\n{}\nstderr:\n{}",
@@ -900,4 +906,16 @@ pub fn lossy_string(bytes: &[u8]) -> String {
 fn canonicalize(path: impl AsRef<Path>) -> PathBuf {
     foundry_common::fs::canonicalize_path(path.as_ref())
         .unwrap_or_else(|_| path.as_ref().to_path_buf())
+}
+
+fn cargo_build_target_dir_and_profile(exe_root: &Path) -> (&Path, Option<&str>) {
+    let profile_dir = exe_root.parent().expect("test executable profile directory");
+    let target_dir = profile_dir.parent().expect("Cargo target directory");
+    let profile = match profile_dir.file_name().and_then(OsStr::to_str) {
+        // Cargo's dev profile writes to `debug`, so the default `cargo build` profile is correct.
+        Some("debug") => None,
+        Some(profile) => Some(profile),
+        None => panic!("test executable profile directory must be UTF-8"),
+    };
+    (target_dir, profile)
 }

--- a/crates/test-utils/src/prj.rs
+++ b/crates/test-utils/src/prj.rs
@@ -448,21 +448,50 @@ impl TestProject {
 
     /// Returns the path to the forge executable.
     pub fn forge_bin(&self) -> Command {
-        let mut cmd = Command::new(self.forge_path());
+        let mut cmd = Command::new(self.foundry_bin_path("forge"));
         cmd.current_dir(self.inner.root());
         // Disable color output for comparisons; can be overridden with `--color always`.
         cmd.env("NO_COLOR", "1");
         cmd
     }
 
-    pub(crate) fn forge_path(&self) -> PathBuf {
-        canonicalize(self.exe_root.join(format!("../forge{}", env::consts::EXE_SUFFIX)))
+    /// Returns the path to a sibling Foundry executable in the current test target directory.
+    pub fn foundry_bin_path(&self, name: &str) -> PathBuf {
+        canonicalize(self.exe_root.join(format!("../{name}{}", env::consts::EXE_SUFFIX)))
+    }
+
+    /// Returns the path to a sibling Foundry executable, building it when cargo did not.
+    pub fn ensure_foundry_bin(&self, name: &str) -> PathBuf {
+        let bin = self.foundry_bin_path(name);
+        if bin.exists() {
+            return bin;
+        }
+
+        let package = format!("{name}@{}", env!("CARGO_PKG_VERSION"));
+        let manifest = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .expect("workspace root")
+            .join("Cargo.toml");
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let output = Command::new(cargo)
+            .args(["build", "-p", &package, "--bin", name, "--manifest-path"])
+            .arg(manifest)
+            .output()
+            .expect("build Foundry sibling binary");
+        assert!(
+            output.status.success(),
+            "failed to build {name} for CLI test\nstdout:\n{}\nstderr:\n{}",
+            output.stdout_lossy(),
+            output.stderr_lossy(),
+        );
+
+        bin
     }
 
     /// Returns the path to the cast executable.
     pub fn cast_bin(&self) -> Command {
-        let cast = canonicalize(self.exe_root.join(format!("../cast{}", env::consts::EXE_SUFFIX)));
-        let mut cmd = Command::new(cast);
+        let mut cmd = Command::new(self.foundry_bin_path("cast"));
         // disable color output for comparisons
         cmd.env("NO_COLOR", "1");
         cmd


### PR DESCRIPTION
Towards OSS-162 , 

Extract the Forge script Tempo session signer policy into `script::session`, including:

- scoped signer identity by `(chain, sender)`
- remaining unsigned transaction signer lookup data
- single-session-sender validation
- insertion of a live session access key only when it covers the remaining transaction set

`broadcast.rs` now uses this module when preparing raw signer maps, and `build.rs` uses the same scope model when checking whether a resumed script has all required signers available.

Also adds a CLI regression test for `cast wallet session --for "<forge> script ... --broadcast"` and updates the test utility helper that builds sibling Foundry binaries so it preserves the current Cargo target directory and profile.