### PR TITLE
fix: `<=` in `validate_int_mutation`

### DIFF
--- a/crates/evm/fuzz/src/strategies/mutators.rs
+++ b/crates/evm/fuzz/src/strategies/mutators.rs
@@ -537,10 +537,16 @@ fn validate_int_mutation(original: I256, mutated: I256, size: usize) -> Option<I
     }
 
     // Check if mutated value fits the given size.
-    let max_abs = (U256::from(1) << (size - 1)) - U256::from(1);
+    // Valid signed range for `size` bits is `[-2^(size-1), 2^(size-1) - 1]`.
+    let max = I256::overflowing_from_sign_and_abs(
+        Sign::Positive,
+        (U256::from(1) << (size - 1)) - U256::from(1),
+    )
+    .0;
+    let min = I256::overflowing_from_sign_and_abs(Sign::Negative, U256::from(1) << (size - 1)).0;
     match mutated.sign() {
-        Sign::Positive => mutated < I256::overflowing_from_sign_and_abs(Sign::Positive, max_abs).0,
-        Sign::Negative => mutated > I256::overflowing_from_sign_and_abs(Sign::Negative, max_abs).0,
+        Sign::Positive => mutated <= max,
+        Sign::Negative => mutated >= min,
     }
     .then_some(mutated)
 }
@@ -564,6 +570,33 @@ mod tests {
         }
         let original = U256::from(1);
         assert_eq!(super::validate_uint_mutation(original, U256::MAX, 256), Some(U256::MAX));
+    }
+
+    #[test]
+    fn validate_int_mutation_accepts_inclusive_bounds() {
+        // For width `size`, valid signed values are [-2^(size-1), 2^(size-1) - 1].
+        // Regression: strict comparisons rejected the inclusive max and min bounds.
+        for size in [8usize, 16, 32, 64, 128] {
+            let max = I256::overflowing_from_sign_and_abs(
+                Sign::Positive,
+                (U256::from(1) << (size - 1)) - U256::from(1),
+            )
+            .0;
+            let min =
+                I256::overflowing_from_sign_and_abs(Sign::Negative, U256::from(1) << (size - 1)).0;
+            assert_eq!(
+                super::validate_int_mutation(I256::ZERO, max, size),
+                Some(max),
+                "size={size} max"
+            );
+            assert_eq!(
+                super::validate_int_mutation(I256::ZERO, min, size),
+                Some(min),
+                "size={size} min"
+            );
+        }
+        assert_eq!(super::validate_int_mutation(I256::ZERO, I256::MAX, 256), Some(I256::MAX));
+        assert_eq!(super::validate_int_mutation(I256::ZERO, I256::MIN, 256), Some(I256::MIN));
     }
 
     #[test]


### PR DESCRIPTION
Same off-by-one as #14459 but for signed ints. `validate_int_mutation` used strict comparisons (`<`/`>`) and the wrong negative magnitude (`-(2^(size-1)-1)` instead of `-2^(size-1)`), so it rejected the boundary values `type(intN).max`, `type(intN).min` (and `min + 1`). Fixed to inclusive bounds `[-2^(size-1), 2^(size-1) - 1]` using `mutated <= max` / `mutated >= min`, and added a regression test.
