### PR TITLE
fix: clean up Tempo sessions after use

### DIFF
--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -217,17 +217,23 @@ async fn run_for_command(
     upsert_session_entry(entry)?;
 
     let child_result = command.run(session_id).await;
-    let cleanup_result = cleanup_session_run(session_id, tx, send_tx).await;
+    let child_succeeded = child_result.is_ok();
+    let cleanup_result = cleanup_session_run(session_id, child_succeeded, tx, send_tx).await;
 
     finish_session_run(session_id, child_result, cleanup_result)
 }
 
 async fn cleanup_session_run(
     session_id: B256,
+    child_succeeded: bool,
     tx: TransactionOpts,
     send_tx: SendTxOpts,
 ) -> Result<()> {
-    let retire_result = retire_session_run_locally(session_id);
+    let retire_result = if child_succeeded {
+        mark_session_run_revoking(session_id)
+    } else {
+        retire_session_run_locally(session_id)
+    };
     let revoke_result =
         run_revoke_with_policy(session_id, false, tx, send_tx, UnprovisionedKeyPolicy::Fail).await;
 
@@ -240,6 +246,16 @@ async fn cleanup_session_run(
                 .wrap_err(format!("also failed to retire local Tempo session: {retire_err}")))
         }
     }
+}
+
+fn mark_session_run_revoking(session_id: B256) -> Result<()> {
+    let Some(entry) = read_session_entry(session_id)? else {
+        return Ok(());
+    };
+    let status = if entry.status.is_terminal() { entry.status } else { SessionStatus::Revoking };
+    update_session_status(session_id, status)
+        .map(|_| ())
+        .wrap_err_with(|| format!("failed to mark Tempo session {session_id:?} as revoking"))
 }
 
 fn retire_session_run_locally(session_id: B256) -> Result<()> {
@@ -959,6 +975,33 @@ mod tests {
     }
 
     #[test]
+    fn run_for_success_marks_session_revoking_before_revoke_preflight() {
+        with_tempo_home(|| {
+            let runtime = tokio::runtime::Runtime::new().unwrap();
+            runtime.block_on(async {
+                let session_id = B256::from([0xd7; 32]);
+                upsert_session_entry(sample_session_entry(session_id, SessionStatus::Active))
+                    .unwrap();
+
+                let mut send_tx = empty_send_tx_opts();
+                send_tx.eth.rpc.common.rpc_url = Some("http://127.0.0.1:9".to_string());
+                let err = cleanup_session_run(
+                    session_id,
+                    true,
+                    TransactionOpts::parse_from(["cast"]),
+                    send_tx,
+                )
+                .await
+                .unwrap_err();
+
+                let session = read_session_entry(session_id).unwrap().unwrap();
+                assert_eq!(session.status, SessionStatus::Revoking, "{err:#}");
+                assert!(session.key.is_none());
+            });
+        });
+    }
+
+    #[test]
     fn run_for_retire_local_session_before_revoke_preflight() {
         with_tempo_home(|| {
             let runtime = tokio::runtime::Runtime::new().unwrap();
@@ -1071,7 +1114,7 @@ mod tests {
 
                 let session = read_session_entry(session_id).unwrap().unwrap();
                 assert_eq!(session.status, SessionStatus::Revoking);
-                assert!(session.key.is_some());
+                assert!(session.key.is_none());
             });
         });
     }
@@ -1162,7 +1205,10 @@ mod tests {
 
     fn sample_session_entry(session_id: B256, status: SessionStatus) -> SessionEntry {
         let key = match status {
-            SessionStatus::Revoked | SessionStatus::Expired | SessionStatus::Failed => None,
+            SessionStatus::Revoking
+            | SessionStatus::Revoked
+            | SessionStatus::Expired
+            | SessionStatus::Failed => None,
             _ => Some(foundry_common::tempo::SessionKeyMaterial {
                 key_type: foundry_common::tempo::KeyType::Secp256k1,
                 key: ROOT_PRIVATE_KEY.to_string(),

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -217,8 +217,7 @@ async fn run_for_command(
     upsert_session_entry(entry)?;
 
     let child_result = command.run(session_id).await;
-    let child_succeeded = child_result.is_ok();
-    let cleanup_result = cleanup_session_run(session_id, child_succeeded, tx, send_tx).await;
+    let cleanup_result = cleanup_session_run(session_id, child_result.is_ok(), tx, send_tx).await;
 
     finish_session_run(session_id, child_result, cleanup_result)
 }
@@ -249,23 +248,21 @@ async fn cleanup_session_run(
 }
 
 fn mark_session_run_revoking(session_id: B256) -> Result<()> {
-    let Some(entry) = read_session_entry(session_id)? else {
-        return Ok(());
-    };
-    let status = if entry.status.is_terminal() { entry.status } else { SessionStatus::Revoking };
-    update_session_status(session_id, status)
-        .map(|_| ())
+    update_session_run_status(session_id, SessionStatus::Revoking)
         .wrap_err_with(|| format!("failed to mark Tempo session {session_id:?} as revoking"))
 }
 
 fn retire_session_run_locally(session_id: B256) -> Result<()> {
+    update_session_run_status(session_id, SessionStatus::Failed)
+        .wrap_err_with(|| format!("failed to retire local Tempo session {session_id:?}"))
+}
+
+fn update_session_run_status(session_id: B256, status: SessionStatus) -> Result<()> {
     let Some(entry) = read_session_entry(session_id)? else {
         return Ok(());
     };
-    let status = if entry.status.is_terminal() { entry.status } else { SessionStatus::Failed };
-    update_session_status(session_id, status)
-        .map(|_| ())
-        .wrap_err_with(|| format!("failed to retire local Tempo session {session_id:?}"))
+    let status = if entry.status.is_terminal() { entry.status } else { status };
+    update_session_status(session_id, status).map(|_| ())
 }
 
 fn finish_session_run(

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -469,7 +469,7 @@ printf '%s\n' "${TEMPO_SESSION_ID}" > "$1"
             child_session_id.trim().starts_with("0x"),
             "unexpected child session id: {child_session_id}"
         );
-        assert_session_file_status_without_key(tempo_home.path(), "failed");
+        assert_session_file_status_without_key(tempo_home.path(), "revoking");
     }
 );
 
@@ -513,7 +513,7 @@ casttest!(wallet_session_run_for_cast_send_submits_with_session_key, async |prj,
 
     assert_async_tx_hash(&stdout, "child cast send");
     assert_session_cleanup_failure(&stderr);
-    assert_session_file_status_without_key(tempo_home.path(), "failed");
+    assert_session_file_status_without_key(tempo_home.path(), "revoking");
 });
 
 casttest!(wallet_session_run_for_batch_send_submits_with_session_key, async |prj, cmd| {
@@ -567,7 +567,7 @@ test -n "${{TEMPO_SESSION_ID:-}}"
 
     assert_async_tx_hash(&stdout, "child cast batch-send");
     assert_session_cleanup_failure(&stderr);
-    assert_session_file_status_without_key(tempo_home.path(), "failed");
+    assert_session_file_status_without_key(tempo_home.path(), "revoking");
 });
 
 casttest!(wallet_session_run_for_forge_script_submits_with_session_key, async |prj, cmd| {
@@ -661,7 +661,7 @@ contract SessionForgeScript is Script {{
         "forge broadcast tx should have a submitted hash: {tx}"
     );
     assert_session_cleanup_failure(&stderr);
-    assert_session_file_status_without_key(tempo_home.path(), "failed");
+    assert_session_file_status_without_key(tempo_home.path(), "revoking");
 });
 
 casttest!(batch_send_uses_tempo_session_id_env, async |_prj, cmd| {
@@ -747,7 +747,7 @@ sh "$1"
 
     assert_async_tx_hash(&stdout, "grandchild cast send");
     assert_session_cleanup_failure(&stderr);
-    assert_session_file_status_without_key(tempo_home.path(), "failed");
+    assert_session_file_status_without_key(tempo_home.path(), "revoking");
 });
 
 casttest!(cast_send_rejects_session_with_explicit_signer, async |_prj, cmd| {
@@ -956,6 +956,6 @@ test -n "${TEMPO_SESSION_ID:-}"
             .stderr_lossy();
 
         assert!(stderr.contains("created for chain 31338"), "unexpected stderr:\n{stderr}");
-        assert_session_file_status_without_key(tempo_home.path(), "failed");
+        assert_session_file_status_without_key(tempo_home.path(), "revoking");
     }
 );

--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -28,7 +28,7 @@ pub struct TempoOpts {
     ///
     /// When set, Foundry resolves the session from `$TEMPO_HOME/wallet/sessions.toml` and signs
     /// Tempo transactions with the session's temporary access key on behalf of its root account.
-    #[arg(long = "tempo.session", value_name = "SESSION_ID")]
+    #[arg(long = "tempo.session", id = "tempo_session", value_name = "SESSION_ID")]
     pub session: Option<B256>,
 
     /// Fee token address for Tempo transactions.

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -24,6 +24,8 @@ pub enum SessionStatus {
     #[default]
     Pending,
     Active,
+    /// Local use has stopped and key material has been erased, but on-chain revoke is still
+    /// pending or retryable.
     Revoking,
     Revoked,
     Expired,
@@ -38,10 +40,11 @@ impl SessionStatus {
 
     /// Returns `true` if entering this status must erase local key material.
     const fn clears_key_material(self) -> bool {
-        self.is_terminal()
+        matches!(self, Self::Revoking) || self.is_terminal()
     }
 
-    /// Returns `true` if the session is still in-flight or usable.
+    /// Returns `true` if the session is not terminal. This does not imply usable key material:
+    /// [`Self::Revoking`] is in-flight cleanup state and has no local signing key.
     pub const fn is_live(self) -> bool {
         !self.is_terminal()
     }
@@ -190,7 +193,7 @@ impl SessionRecord {
         self.get(session_id).filter(|session| session.has_live_key_at(now))
     }
 
-    /// Update a session status by id. Terminal statuses clear local key material.
+    /// Update a session status by id. Cleanup and terminal statuses clear local key material.
     ///
     /// Returns `true` when the record changed. Missing sessions and idempotent
     /// updates return `false`.
@@ -568,9 +571,8 @@ pub fn upsert_session_entry(entry: SessionEntry) -> eyre::Result<()> {
 
 /// Atomically update a session status in the registry.
 ///
-/// Terminal statuses (`revoked`, `expired`, `failed`) also clear the
-/// session-scoped private key material. Returns `true` when an entry was found
-/// and changed.
+/// Cleanup and terminal statuses (`revoking`, `revoked`, `expired`, `failed`) also clear the
+/// session-scoped private key material. Returns `true` when an entry was found and changed.
 pub fn update_session_status(session_id: B256, status: SessionStatus) -> eyre::Result<bool> {
     mutate_session_record(|record| {
         let changed = record.set_status(session_id, status);
@@ -828,7 +830,7 @@ mod tests {
     }
 
     #[test]
-    fn session_record_status_updates_preserve_retryable_keys_and_clear_terminal_keys() {
+    fn session_record_status_updates_clear_cleanup_and_terminal_keys() {
         let active_id = B256::from([0x67; 32]);
         let revoking_id = B256::from([0x68; 32]);
         let revoked_id = B256::from([0x69; 32]);
@@ -853,7 +855,7 @@ mod tests {
         assert_eq!(record.get(active_id).unwrap().status, SessionStatus::Active);
         assert!(record.get(active_id).unwrap().key.is_some());
         assert_eq!(record.get(revoking_id).unwrap().status, SessionStatus::Revoking);
-        assert!(record.get(revoking_id).unwrap().key.is_some());
+        assert!(record.get(revoking_id).unwrap().key.is_none());
         assert_eq!(record.get(revoked_id).unwrap().status, SessionStatus::Revoked);
         assert!(record.get(revoked_id).unwrap().key.is_none());
         assert_eq!(record.get(failed_id).unwrap().status, SessionStatus::Failed);
@@ -862,7 +864,7 @@ mod tests {
 
     #[test]
     fn session_entry_roundtrips_scope_limits_and_status() {
-        let entry = sample_entry_with_key(B256::from([0x66; 32]), 1234, SessionStatus::Revoking);
+        let entry = sample_entry(B256::from([0x66; 32]), 1234, SessionStatus::Revoking);
         let toml = toml::to_string(&entry).unwrap();
         let decoded: SessionEntry = toml::from_str(&toml).unwrap();
 
@@ -870,8 +872,8 @@ mod tests {
         assert_eq!(decoded.scope.as_ref().unwrap().len(), 1);
         assert_eq!(decoded.limits.as_ref().unwrap().len(), 1);
         assert_eq!(decoded.status, SessionStatus::Revoking);
-        assert_eq!(decoded.key.as_ref().unwrap().key, "0xdeadbeef");
-        assert!(decoded.has_inline_key());
+        assert!(decoded.key.is_none());
+        assert!(!decoded.has_inline_key());
         assert!(decoded.is_expired_at(1234));
     }
 
@@ -1241,11 +1243,12 @@ key = "0x1111"
     }
 
     #[test]
-    fn mark_expired_session_entries_clears_terminal_session_keys() {
+    fn mark_expired_session_entries_clears_unusable_session_keys() {
         with_tempo_home(|| {
             let expired_id = B256::from([0xbc; 32]);
             let revoked_id = B256::from([0xbd; 32]);
             let failed_id = B256::from([0xbe; 32]);
+            let revoking_id = B256::from([0xbf; 32]);
 
             upsert_session_entry(sample_entry_with_key(expired_id, 100, SessionStatus::Expired))
                 .unwrap();
@@ -1253,15 +1256,18 @@ key = "0x1111"
                 .unwrap();
             upsert_session_entry(sample_entry_with_key(failed_id, 200, SessionStatus::Failed))
                 .unwrap();
+            upsert_session_entry(sample_entry_with_key(revoking_id, 200, SessionStatus::Revoking))
+                .unwrap();
 
-            assert_eq!(mark_expired_session_entries(100).unwrap(), 3);
+            assert_eq!(mark_expired_session_entries(100).unwrap(), 4);
             let record = read_session_record().unwrap();
-            for session_id in [expired_id, revoked_id, failed_id] {
+            for session_id in [expired_id, revoked_id, failed_id, revoking_id] {
                 assert!(record.get(session_id).unwrap().key.is_none());
             }
             assert_eq!(record.get(expired_id).unwrap().status, SessionStatus::Expired);
             assert_eq!(record.get(revoked_id).unwrap().status, SessionStatus::Revoked);
             assert_eq!(record.get(failed_id).unwrap().status, SessionStatus::Failed);
+            assert_eq!(record.get(revoking_id).unwrap().status, SessionStatus::Revoking);
         });
     }
 
@@ -1282,7 +1288,7 @@ key = "0x1111"
             let record = read_session_record().unwrap();
             let session = record.get(session_id).unwrap();
             assert_eq!(session.status, SessionStatus::Revoking);
-            assert!(session.key.is_some());
+            assert!(session.key.is_none());
 
             assert!(update_session_status(session_id, SessionStatus::Revoked).unwrap());
             let record = read_session_record().unwrap();
@@ -1330,7 +1336,7 @@ key = "0x1111"
             let record = read_session_record().unwrap();
             let session = record.get(session_id).unwrap();
             assert_eq!(session.status, SessionStatus::Revoking);
-            assert!(session.key.is_some());
+            assert!(session.key.is_none());
 
             assert!(!update_session_status_if(
                 session_id,

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -252,18 +252,19 @@ pub struct ScriptArgs {
 impl ScriptArgs {
     fn normalized_tempo(&self) -> TempoOpts {
         let mut tempo = self.tempo.clone();
-        if let Some(session) = self.session {
-            tempo.session = Some(session);
-        }
+        tempo.session = self.session.or(tempo.session);
         tempo
+    }
+
+    fn has_tempo_session(&self) -> Result<bool> {
+        Ok(self.session.is_some() || self.tempo.session_id()?.is_some())
     }
 
     /// Loads config, resolves evm_opts (including network inference from fork), and returns them.
     async fn resolved_evm_opts(&self) -> Result<(Config, EvmOpts)> {
         let (config, mut evm_opts) = self.load_config_and_evm_opts()?;
-        let tempo = self.normalized_tempo();
 
-        if tempo.is_tempo() || tempo.session_id()?.is_some() {
+        if self.tempo.is_tempo() || self.has_tempo_session()? {
             // If Tempo tx options or a session are set, select the Tempo network.
             evm_opts.networks = NetworkConfigs::with_tempo();
         } else {
@@ -279,9 +280,8 @@ impl ScriptArgs {
         config: Config,
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
-        let mut args = self;
+        let args = self;
         let mut tempo = args.normalized_tempo();
-        args.tempo = tempo.clone();
 
         let session_sender = if args.resume {
             None
@@ -334,7 +334,7 @@ impl ScriptArgs {
             eyre::bail!("--batch mode is only supported on Tempo networks");
         }
 
-        if self.unlocked && self.normalized_tempo().session_id()?.is_some() {
+        if self.unlocked && self.has_tempo_session()? {
             eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --unlocked");
         }
 
@@ -891,6 +891,10 @@ mod tests {
 
     const SESSION_PRIVATE_KEY: &str =
         "0x59c6995e998f97a5a004497e5da3b5d2b2b66a87f064d39c44da0b6d6e4f8ff0";
+    const SESSION_ID_HEX: &str =
+        "0x1111111111111111111111111111111111111111111111111111111111111111";
+    const OTHER_SESSION_ID_HEX: &str =
+        "0x2222222222222222222222222222222222222222222222222222222222222222";
     static TEMPO_HOME_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     fn active_session_entry(
@@ -999,7 +1003,7 @@ mod tests {
             "foundry-cli",
             "Contract.sol",
             "--tempo.session",
-            "0x1111111111111111111111111111111111111111111111111111111111111111",
+            SESSION_ID_HEX,
         ]);
 
         assert_eq!(args.tempo.session, Some(B256::from([0x11; 32])),);
@@ -1007,12 +1011,8 @@ mod tests {
 
     #[test]
     fn can_parse_session_alias_for_tempo_session() {
-        let args = ScriptArgs::parse_from([
-            "foundry-cli",
-            "Contract.sol",
-            "--session",
-            "0x1111111111111111111111111111111111111111111111111111111111111111",
-        ]);
+        let args =
+            ScriptArgs::parse_from(["foundry-cli", "Contract.sol", "--session", SESSION_ID_HEX]);
 
         assert_eq!(args.session, Some(B256::from([0x11; 32])));
         assert_eq!(args.normalized_tempo().session, Some(B256::from([0x11; 32])));
@@ -1024,9 +1024,9 @@ mod tests {
             "foundry-cli",
             "Contract.sol",
             "--session",
-            "0x1111111111111111111111111111111111111111111111111111111111111111",
+            SESSION_ID_HEX,
             "--tempo.session",
-            "0x2222222222222222222222222222222222222222222222222222222222222222",
+            OTHER_SESSION_ID_HEX,
         ])
         .unwrap_err();
 
@@ -1035,15 +1035,8 @@ mod tests {
 
     #[tokio::test]
     async fn session_alias_selects_tempo_network() {
-        let temp = tempdir().unwrap();
-        let _guard = TempoHomeGuard::set(temp.path()).await;
-
-        let args = ScriptArgs::parse_from([
-            "foundry-cli",
-            "Contract.sol",
-            "--session",
-            "0x1111111111111111111111111111111111111111111111111111111111111111",
-        ]);
+        let args =
+            ScriptArgs::parse_from(["foundry-cli", "Contract.sol", "--session", SESSION_ID_HEX]);
         let (_, evm_opts) = args.resolved_evm_opts().await.unwrap();
 
         assert!(evm_opts.networks.is_tempo());

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -16,7 +16,7 @@ use crate::{broadcast::BundledState, runner::ScriptRunner};
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_network::Network;
 use alloy_primitives::{
-    Address, Bytes, Log, U256, hex,
+    Address, B256, Bytes, Log, U256, hex,
     map::{AddressHashMap, HashMap},
 };
 use alloy_signer::Signer;
@@ -141,6 +141,12 @@ pub struct ScriptArgs {
     #[command(flatten)]
     pub tempo: TempoOpts,
 
+    /// Use a live Tempo wallet session for signing.
+    ///
+    /// This is a forge-script convenience alias for `--tempo.session`.
+    #[arg(long = "session", value_name = "SESSION_ID", conflicts_with = "tempo_session")]
+    pub session: Option<B256>,
+
     /// Skips on-chain simulation.
     #[arg(long)]
     pub skip_simulation: bool,
@@ -244,11 +250,20 @@ pub struct ScriptArgs {
 }
 
 impl ScriptArgs {
+    fn normalized_tempo(&self) -> TempoOpts {
+        let mut tempo = self.tempo.clone();
+        if let Some(session) = self.session {
+            tempo.session = Some(session);
+        }
+        tempo
+    }
+
     /// Loads config, resolves evm_opts (including network inference from fork), and returns them.
     async fn resolved_evm_opts(&self) -> Result<(Config, EvmOpts)> {
         let (config, mut evm_opts) = self.load_config_and_evm_opts()?;
+        let tempo = self.normalized_tempo();
 
-        if self.tempo.is_tempo() || self.tempo.session_id()?.is_some() {
+        if tempo.is_tempo() || tempo.session_id()?.is_some() {
             // If Tempo tx options or a session are set, select the Tempo network.
             evm_opts.networks = NetworkConfigs::with_tempo();
         } else {
@@ -264,22 +279,26 @@ impl ScriptArgs {
         config: Config,
         mut evm_opts: EvmOpts,
     ) -> Result<PreprocessedState<FEN>> {
-        let session_sender = if self.resume {
+        let mut args = self;
+        let mut tempo = args.normalized_tempo();
+        args.tempo = tempo.clone();
+
+        let session_sender = if args.resume {
             None
         } else {
             // Initial scripts may only reveal multi-chain transactions during execution. Use the
             // session root as the script sender here and validate chain scope during broadcast.
-            self.tempo.session_sender_for_multi_wallet(&self.wallets, self.evm.sender)?
+            tempo.session_sender_for_multi_wallet(&args.wallets, args.evm.sender)?
         };
 
-        let script_wallets = Wallets::new(self.wallets.get_multi_wallet().await?, self.evm.sender);
-        let browser_wallet = self.wallets.browser_signer::<FEN::Network>().await?;
+        let script_wallets = Wallets::new(args.wallets.get_multi_wallet().await?, args.evm.sender);
+        let browser_wallet = args.wallets.browser_signer::<FEN::Network>().await?;
 
         if let Some(sender) = session_sender {
             evm_opts.sender = sender;
-        } else if let Some(sender) = self.maybe_load_private_key()? {
+        } else if let Some(sender) = args.maybe_load_private_key()? {
             evm_opts.sender = sender;
-        } else if self.evm.sender.is_none() {
+        } else if args.evm.sender.is_none() {
             // If no sender was explicitly set via --sender, auto-detect it from available signers:
             // use the sole signer's address if there's exactly one, or fall back to the browser
             // wallet address if present.
@@ -292,15 +311,14 @@ impl ScriptArgs {
             }
         }
 
-        let mut tempo = self.tempo.clone();
         tempo.resolve_expires();
 
         if evm_opts.networks.is_tempo() && tempo.fee_token.is_none() {
             tempo.fee_token = Some(PATH_USD_ADDRESS);
         }
 
-        let script_config = ScriptConfig::new(config, evm_opts, self.batch, tempo).await?;
-        Ok(PreprocessedState { args: self, script_config, script_wallets, browser_wallet })
+        let script_config = ScriptConfig::new(config, evm_opts, args.batch, tempo).await?;
+        Ok(PreprocessedState { args, script_config, script_wallets, browser_wallet })
     }
 
     /// Executes the script
@@ -316,7 +334,7 @@ impl ScriptArgs {
             eyre::bail!("--batch mode is only supported on Tempo networks");
         }
 
-        if self.unlocked && self.tempo.session_id()?.is_some() {
+        if self.unlocked && self.normalized_tempo().session_id()?.is_some() {
             eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --unlocked");
         }
 
@@ -860,7 +878,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
 mod tests {
     use super::*;
     use alloy_network::Ethereum;
-    use alloy_primitives::{B256, address};
+    use alloy_primitives::address;
     use foundry_cli::opts::TEMPO_SESSION_ID_ENV;
     use foundry_common::tempo::{
         KeyType, SessionEntry, SessionKeyMaterial, SessionStatus, TEMPO_HOME_ENV,
@@ -985,6 +1003,50 @@ mod tests {
         ]);
 
         assert_eq!(args.tempo.session, Some(B256::from([0x11; 32])),);
+    }
+
+    #[test]
+    fn can_parse_session_alias_for_tempo_session() {
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--session",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+        ]);
+
+        assert_eq!(args.session, Some(B256::from([0x11; 32])));
+        assert_eq!(args.normalized_tempo().session, Some(B256::from([0x11; 32])));
+    }
+
+    #[test]
+    fn session_alias_conflicts_with_tempo_session_opt() {
+        let err = ScriptArgs::try_parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--session",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "--tempo.session",
+            "0x2222222222222222222222222222222222222222222222222222222222222222",
+        ])
+        .unwrap_err();
+
+        assert!(err.to_string().contains("cannot be used with"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn session_alias_selects_tempo_network() {
+        let temp = tempdir().unwrap();
+        let _guard = TempoHomeGuard::set(temp.path()).await;
+
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--session",
+            "0x1111111111111111111111111111111111111111111111111111111111111111",
+        ]);
+        let (_, evm_opts) = args.resolved_evm_opts().await.unwrap();
+
+        assert!(evm_opts.networks.is_tempo());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Step closer to OSS-162 , 

Previously, cleanup could fail during revoke preflight and leave the session entry `active` with local key material still present. This kept the session usable locally after the intended command lifecycle had ended.

Now  treat `revoking` as a cleanup state that clears local session key material while keeping the session metadata available for revoke retries. 
 
 Also:
 - Marks successful `cast wallet session --for` runs as `revoking` before revoke preflight, so local key material is erased even if on-chain revoke must be retried.
  - Keeps failed wrapped commands retiring the local session as `failed`.
  - Preserves existing terminal statuses instead of downgrading them during cleanup.
  - Adds `forge script --session` as a convenience alias for `--tempo.session`.
  - Makes the new alias participate in Tempo session detection, including Tempo network selection and the `--unlocked` conflict check.
  - Updates tests for revoking key cleanup and `forge script --session` parsing/behavior.