### PR TITLE
chore: ignore proc-macro-error2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,8 @@ ignore = [
     "RUSTSEC-2025-0141",
     # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand is unsound with a custom logger
     "RUSTSEC-2026-0097",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
+    "RUSTSEC-2026-0173",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Summary
- ignore RUSTSEC-2026-0173 for transitive proc-macro-error2 usage
- keep cargo-deny unblocked while upstream dependencies migrate away from the unmaintained crate

## Test plan
- cargo deny check

Prompted by: @grandizzy