### PR TITLE
feat(cast): support Tempo sessions in transaction commands

### DIFF
--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -56,10 +56,22 @@ impl BatchMakeTxArgs {
     pub async fn run(self) -> Result<()> {
         let Self { calls, mut tx, eth, raw_unsigned, ethsign } = self;
         let has_nonce = tx.nonce.is_some();
+        let has_session = tx.tempo.session_id()?.is_some();
         let expires_at = tx.tempo.resolve_expires();
 
         if calls.is_empty() {
             return Err(eyre!("No calls specified. Use --call to specify at least one call."));
+        }
+
+        if has_session {
+            if raw_unsigned {
+                eyre::bail!(
+                    "--tempo.session/TEMPO_SESSION_ID cannot be combined with --raw-unsigned"
+                );
+            }
+            if ethsign {
+                eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --ethsign");
+            }
         }
 
         let config = eth.load_config()?;
@@ -69,15 +81,17 @@ impl BatchMakeTxArgs {
         // `<root>/tempo.lanes.toml`) and populate `tx.tempo.nonce_key` from the lane.
         let resolved_lane = resolve_lane(&mut tx.tempo, &config.root)?;
 
-        // Resolve signer to detect keychain mode
-        let (signer, tempo_access_key) = eth.wallet.maybe_signer().await?;
-
         // Parse all call specs
         let call_specs: Vec<CallSpec> =
             calls.iter().map(|s| CallSpec::parse(s)).collect::<Result<Vec<_>>>()?;
 
         // Get chain for parsing function args
         let chain = utils::get_chain(config.chain, &provider).await?;
+        let (signer, tempo_access_key) = if raw_unsigned {
+            (None, None)
+        } else {
+            tempo::resolve_session_or_wallet_signer(&tx.tempo, &eth.wallet, chain.id()).await?
+        };
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain)).ok().flatten();
         let etherscan_api_key = etherscan_config.as_ref().map(|c| c.key.clone());
         let etherscan_api_url = etherscan_config.map(|c| c.api_url);

--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -17,10 +17,11 @@ use alloy_signer::Signer;
 use clap::Parser;
 use eyre::{Result, eyre};
 use foundry_cli::{
-    opts::{EthereumOpts, TransactionOpts},
+    opts::{EthereumOpts, TempoOpts, TransactionOpts},
     utils::{self, LoadConfig, maybe_print_resolved_lane, resolve_lane},
 };
 use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder};
+use foundry_wallets::{TempoAccessKeyConfig, WalletOpts, WalletSigner};
 use tempo_alloy::TempoNetwork;
 
 /// CLI arguments for `cast batch-mktx`.
@@ -83,11 +84,8 @@ impl BatchMakeTxArgs {
 
         // Get chain for parsing function args
         let chain = utils::get_chain(config.chain, &provider).await?;
-        let (signer, tempo_access_key) = if raw_unsigned {
-            (None, None)
-        } else {
-            tempo::resolve_session_or_wallet_signer(&tx.tempo, &eth.wallet, chain.id()).await?
-        };
+        let (signer, tempo_access_key) =
+            resolve_signer(&tx.tempo, &eth.wallet, chain.id(), raw_unsigned).await?;
         let etherscan_config = config.get_etherscan_config_with_chain(Some(chain)).ok().flatten();
         let etherscan_api_key = etherscan_config.as_ref().map(|c| c.key.clone());
         let etherscan_api_url = etherscan_config.map(|c| c.api_url);
@@ -180,5 +178,54 @@ impl BatchMakeTxArgs {
         sh_println!("0x{signed_tx}")?;
 
         Ok(())
+    }
+}
+
+async fn resolve_signer(
+    tempo: &TempoOpts,
+    wallet: &WalletOpts,
+    chain_id: u64,
+    raw_unsigned: bool,
+) -> Result<(Option<WalletSigner>, Option<TempoAccessKeyConfig>)> {
+    if raw_unsigned {
+        let (_, access_key) = wallet.maybe_signer().await?;
+        return Ok((None, access_key));
+    }
+
+    tempo::resolve_session_or_wallet_signer(tempo, wallet, chain_id).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::address;
+
+    #[test]
+    fn raw_unsigned_resolver_discards_signer_but_keeps_access_key_metadata() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let wallet = WalletOpts {
+                tempo_access_key: Some(
+                    "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+                        .to_string(),
+                ),
+                tempo_root_account: Some(address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")),
+                ..Default::default()
+            };
+
+            let (signer, access_key) =
+                resolve_signer(&TempoOpts::default(), &wallet, 31337, true).await.unwrap();
+
+            assert!(signer.is_none());
+            let access_key = access_key.expect("access-key metadata");
+            assert_eq!(
+                access_key.wallet_address,
+                address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+            );
+            assert_eq!(
+                access_key.key_address,
+                address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+            );
+        });
     }
 }

--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -63,15 +63,11 @@ impl BatchMakeTxArgs {
             return Err(eyre!("No calls specified. Use --call to specify at least one call."));
         }
 
-        if has_session {
-            if raw_unsigned {
-                eyre::bail!(
-                    "--tempo.session/TEMPO_SESSION_ID cannot be combined with --raw-unsigned"
-                );
-            }
-            if ethsign {
-                eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --ethsign");
-            }
+        if has_session && raw_unsigned {
+            eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --raw-unsigned");
+        }
+        if has_session && ethsign {
+            eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --ethsign");
         }
 
         let config = eth.load_config()?;

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -2,7 +2,7 @@ use std::{str::FromStr, time::Duration};
 
 use crate::{
     cmd::send::{cast_send, cast_send_with_access_key},
-    format_uint_exp,
+    format_uint_exp, tempo,
     tx::{CastTxSender, SendTxOpts, TxParams, fill_transaction_gas_fees},
 };
 use alloy_consensus::{SignableTransaction, Signed};
@@ -299,6 +299,7 @@ impl Erc20Subcommand {
         tempo_access_key: &Option<TempoAccessKeyConfig>,
     ) -> eyre::Result<bool> {
         if self.erc20_opts().is_some_and(|erc20| erc20.tempo.is_tempo())
+            || self.has_tempo_session()?
             || tempo_access_key.is_some()
         {
             return Ok(true);
@@ -312,15 +313,24 @@ impl Erc20Subcommand {
         Ok(false)
     }
 
+    fn has_tempo_session(&self) -> eyre::Result<bool> {
+        Ok(self.erc20_opts().map(|opts| opts.tempo.session_id()).transpose()?.flatten().is_some())
+    }
+
     pub async fn run(self) -> eyre::Result<()> {
+        let has_session = self.has_tempo_session()?;
         // Resolve the signer once for state-changing variants.
         let (signer, tempo_access_key) = match &self {
             Self::Transfer { send_tx, .. }
             | Self::Approve { send_tx, .. }
             | Self::Mint { send_tx, .. }
             | Self::Burn { send_tx, .. } => {
-                // Only attempt Tempo lookup if --from is set (avoids unnecessary I/O).
-                if send_tx.eth.wallet.from.is_some() {
+                // Only attempt persistent Tempo lookup if --from is set (avoids unnecessary I/O).
+                // Explicit Tempo sessions are resolved after network selection, once the chain is
+                // known.
+                if has_session {
+                    (None, None)
+                } else if send_tx.eth.wallet.from.is_some() {
                     let (s, ak) = send_tx.eth.wallet.maybe_signer().await?;
                     (s, ak)
                 } else {
@@ -364,6 +374,28 @@ impl Erc20Subcommand {
                 $build_tx:expr
             ) => {{
                 let mut tx_opts = $tx_opts;
+                tempo::ensure_session_not_browser(&tx_opts.tempo, $send_tx.browser.browser)?;
+                let session_signer = if tx_opts.tempo.session_id()?.is_some() {
+                    let $provider =
+                        ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+                    let chain = get_chain(config.chain, &$provider).await?;
+                    Some(
+                        tempo::resolve_session_or_wallet_signer(
+                            &tx_opts.tempo,
+                            &$send_tx.eth.wallet,
+                            chain.id(),
+                        )
+                        .await?,
+                    )
+                } else {
+                    None
+                };
+                let (pre_resolved_signer, tempo_keychain) =
+                    if let Some((signer, access_key)) = session_signer {
+                        (signer, access_key)
+                    } else {
+                        (pre_resolved_signer, tempo_keychain)
+                    };
                 let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
                 let expires_at = tx_opts.tempo.resolve_expires();
                 let tempo_sponsor =
@@ -384,17 +416,9 @@ impl Erc20Subcommand {
                     let mut tx = { $build_tx }.into_transaction_request();
                     let chain = get_chain(config.chain, &$provider).await?;
                     tx_opts.apply::<TempoNetwork>(&mut tx, chain.is_legacy());
-                    if needs_sponsor_payload {
-                        tx.set_key_id(access_key.key_address);
-                        tx.prepare_access_key_authorization(
-                            &$provider,
-                            access_key.wallet_address,
-                            access_key.key_address,
-                            access_key.key_authorization.as_ref(),
-                        )
+                    tempo::fill_access_key_transaction(&$provider, &mut tx, access_key, chain)
                         .await?;
-                        fill_tx(&$provider, &mut tx, access_key.wallet_address, chain, false)
-                            .await?;
+                    if needs_sponsor_payload {
                         if print_sponsor_hash {
                             let hash = tx
                                 .compute_sponsor_hash(access_key.wallet_address)

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -297,9 +297,10 @@ impl Erc20Subcommand {
     async fn should_use_tempo_network(
         &self,
         tempo_access_key: &Option<TempoAccessKeyConfig>,
+        has_session: bool,
     ) -> eyre::Result<bool> {
         if self.erc20_opts().is_some_and(|erc20| erc20.tempo.is_tempo())
-            || self.has_tempo_session()?
+            || has_session
             || tempo_access_key.is_some()
         {
             return Ok(true);
@@ -338,12 +339,12 @@ impl Erc20Subcommand {
             _ => (None, None),
         };
 
-        let is_tempo = self.should_use_tempo_network(&tempo_access_key).await?;
+        let is_tempo = self.should_use_tempo_network(&tempo_access_key, has_session).await?;
 
         if is_tempo {
-            self.run_generic::<TempoNetwork>(signer, tempo_access_key).await
+            self.run_generic::<TempoNetwork>(signer, tempo_access_key, has_session).await
         } else {
-            self.run_generic::<Ethereum>(signer, None).await
+            self.run_generic::<Ethereum>(signer, None, has_session).await
         }
     }
 
@@ -351,6 +352,7 @@ impl Erc20Subcommand {
         self,
         pre_resolved_signer: Option<WalletSigner>,
         tempo_keychain: Option<TempoAccessKeyConfig>,
+        has_session: bool,
     ) -> eyre::Result<()>
     where
         N::TxEnvelope: From<Signed<N::UnsignedTx>>,
@@ -373,8 +375,7 @@ impl Erc20Subcommand {
             ) => {{
                 let mut tx_opts = $tx_opts;
                 tempo::ensure_session_not_browser(&tx_opts.tempo, $send_tx.browser.browser)?;
-                let (pre_resolved_signer, tempo_keychain) = if tx_opts.tempo.session_id()?.is_some()
-                {
+                let (pre_resolved_signer, tempo_keychain) = if has_session {
                     let $provider =
                         ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
                     let chain = get_chain(config.chain, &$provider).await?;

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -314,7 +314,7 @@ impl Erc20Subcommand {
     }
 
     fn has_tempo_session(&self) -> eyre::Result<bool> {
-        Ok(self.erc20_opts().map(|opts| opts.tempo.session_id()).transpose()?.flatten().is_some())
+        self.erc20_opts().map_or(Ok(false), |opts| opts.tempo.session_id().map(|id| id.is_some()))
     }
 
     pub async fn run(self) -> eyre::Result<()> {
@@ -328,9 +328,7 @@ impl Erc20Subcommand {
                 // Only attempt persistent Tempo lookup if --from is set (avoids unnecessary I/O).
                 // Explicit Tempo sessions are resolved after network selection, once the chain is
                 // known.
-                if has_session {
-                    (None, None)
-                } else if send_tx.eth.wallet.from.is_some() {
+                if !has_session && send_tx.eth.wallet.from.is_some() {
                     let (s, ak) = send_tx.eth.wallet.maybe_signer().await?;
                     (s, ak)
                 } else {
@@ -375,27 +373,20 @@ impl Erc20Subcommand {
             ) => {{
                 let mut tx_opts = $tx_opts;
                 tempo::ensure_session_not_browser(&tx_opts.tempo, $send_tx.browser.browser)?;
-                let session_signer = if tx_opts.tempo.session_id()?.is_some() {
+                let (pre_resolved_signer, tempo_keychain) = if tx_opts.tempo.session_id()?.is_some()
+                {
                     let $provider =
                         ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
                     let chain = get_chain(config.chain, &$provider).await?;
-                    Some(
-                        tempo::resolve_session_or_wallet_signer(
-                            &tx_opts.tempo,
-                            &$send_tx.eth.wallet,
-                            chain.id(),
-                        )
-                        .await?,
+                    tempo::resolve_session_or_wallet_signer(
+                        &tx_opts.tempo,
+                        &$send_tx.eth.wallet,
+                        chain.id(),
                     )
+                    .await?
                 } else {
-                    None
+                    (pre_resolved_signer, tempo_keychain)
                 };
-                let (pre_resolved_signer, tempo_keychain) =
-                    if let Some((signer, access_key)) = session_signer {
-                        (signer, access_key)
-                    } else {
-                        (pre_resolved_signer, tempo_keychain)
-                    };
                 let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
                 let expires_at = tx_opts.tempo.resolve_expires();
                 let tempo_sponsor =

--- a/crates/cast/src/cmd/tip20/create.rs
+++ b/crates/cast/src/cmd/tip20/create.rs
@@ -54,7 +54,11 @@ pub(super) async fn run(
         super::logo::validate_logo_uri(logo_uri)?;
     }
 
-    let (signer, tempo_access_key) = super::resolve_tip20_signer(&send_tx).await?;
+    let (signer, tempo_access_key) = if tx_opts.tempo.session_id()?.is_some() {
+        (None, None)
+    } else {
+        send_tx.eth.wallet.maybe_signer().await?
+    };
 
     let config = send_tx.eth.rpc.load_config()?;
 

--- a/crates/cast/src/cmd/tip20/create.rs
+++ b/crates/cast/src/cmd/tip20/create.rs
@@ -54,12 +54,6 @@ pub(super) async fn run(
         super::logo::validate_logo_uri(logo_uri)?;
     }
 
-    let (signer, tempo_access_key) = if tx_opts.tempo.session_id()?.is_some() {
-        (None, None)
-    } else {
-        send_tx.eth.wallet.maybe_signer().await?
-    };
-
     let config = send_tx.eth.rpc.load_config()?;
 
     if !is_iso4217_currency(&currency) && !force {
@@ -118,8 +112,6 @@ pub(super) async fn run(
         std::mem::take(&mut args),
         send_tx,
         tx_opts,
-        signer,
-        tempo_access_key,
     )
     .await?;
 

--- a/crates/cast/src/cmd/tip20/create.rs
+++ b/crates/cast/src/cmd/tip20/create.rs
@@ -54,6 +54,8 @@ pub(super) async fn run(
         super::logo::validate_logo_uri(logo_uri)?;
     }
 
+    let (signer, tempo_access_key) = super::resolve_tip20_signer(&send_tx, &tx_opts).await?;
+
     let config = send_tx.eth.rpc.load_config()?;
 
     if !is_iso4217_currency(&currency) && !force {
@@ -112,6 +114,8 @@ pub(super) async fn run(
         std::mem::take(&mut args),
         send_tx,
         tx_opts,
+        signer,
+        tempo_access_key,
     )
     .await?;
 

--- a/crates/cast/src/cmd/tip20/logo.rs
+++ b/crates/cast/src/cmd/tip20/logo.rs
@@ -21,7 +21,11 @@ pub(super) async fn set(
 ) -> eyre::Result<()> {
     validate_logo_uri(&logo_uri)?;
 
-    let (signer, tempo_access_key) = super::resolve_tip20_signer(&send_tx).await?;
+    let (signer, tempo_access_key) = if tx_opts.tempo.session_id()?.is_some() {
+        (None, None)
+    } else {
+        send_tx.eth.wallet.maybe_signer().await?
+    };
 
     let config = send_tx.eth.rpc.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;

--- a/crates/cast/src/cmd/tip20/logo.rs
+++ b/crates/cast/src/cmd/tip20/logo.rs
@@ -21,12 +21,6 @@ pub(super) async fn set(
 ) -> eyre::Result<()> {
     validate_logo_uri(&logo_uri)?;
 
-    let (signer, tempo_access_key) = if tx_opts.tempo.session_id()?.is_some() {
-        (None, None)
-    } else {
-        send_tx.eth.wallet.maybe_signer().await?
-    };
-
     let config = send_tx.eth.rpc.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
     let token_addr = token.resolve(&provider).await?;
@@ -37,8 +31,6 @@ pub(super) async fn set(
         vec![logo_uri],
         send_tx,
         tx_opts,
-        signer,
-        tempo_access_key,
     )
     .await?;
 

--- a/crates/cast/src/cmd/tip20/logo.rs
+++ b/crates/cast/src/cmd/tip20/logo.rs
@@ -21,6 +21,8 @@ pub(super) async fn set(
 ) -> eyre::Result<()> {
     validate_logo_uri(&logo_uri)?;
 
+    let (signer, tempo_access_key) = super::resolve_tip20_signer(&send_tx, &tx_opts).await?;
+
     let config = send_tx.eth.rpc.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
     let token_addr = token.resolve(&provider).await?;
@@ -31,6 +33,8 @@ pub(super) async fn set(
         vec![logo_uri],
         send_tx,
         tx_opts,
+        signer,
+        tempo_access_key,
     )
     .await?;
 

--- a/crates/cast/src/cmd/tip20/mine.rs
+++ b/crates/cast/src/cmd/tip20/mine.rs
@@ -81,7 +81,14 @@ pub(super) async fn register(
     send_tx: SendTxOpts,
     mut tx_opts: TxParams,
 ) -> Result<()> {
-    let (signer, tempo_access_key) = send_tx.eth.wallet.maybe_signer().await?;
+    let config = send_tx.eth.load_config()?;
+    let timeout = send_tx.timeout.unwrap_or(config.transaction_timeout);
+    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+    let chain = get_chain(config.chain, &provider).await?;
+    tempo::ensure_session_not_browser(&tx_opts.tempo, send_tx.browser.browser)?;
+    let (signer, tempo_access_key) =
+        tempo::resolve_session_or_wallet_signer(&tx_opts.tempo, &send_tx.eth.wallet, chain.id())
+            .await?;
     let signer = signer.ok_or_else(|| {
         eyre::eyre!(
             "--register requires a signer or Tempo keychain identity (for example --private-key or --from)"
@@ -97,20 +104,17 @@ pub(super) async fn register(
         );
     }
 
-    let config = send_tx.eth.load_config()?;
-    let timeout = send_tx.timeout.unwrap_or(config.transaction_timeout);
-    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
-
     let mut tx = IAddressRegistry::new(ADDRESS_REGISTRY_ADDRESS, &provider)
         .registerVirtualMaster(salt)
         .into_transaction_request();
     let expires_at = tx_opts.tempo.resolve_expires();
     tempo::print_expires(expires_at)?;
-    tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
+    tx_opts.apply::<TempoNetwork>(&mut tx, chain.is_legacy());
 
     sh_status!("Submitting registerVirtualMaster({salt}) on Tempo...")?;
 
     if let Some(ref access_key) = tempo_access_key {
+        tempo::fill_access_key_transaction(&provider, &mut tx, access_key, chain).await?;
         cast_send_with_access_key(
             &provider,
             tx,

--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -11,7 +11,7 @@ use alloy_signer::Signer;
 use clap::Parser;
 use foundry_cli::{
     opts::TransactionOpts,
-    utils::{LoadConfig, maybe_print_resolved_lane, resolve_lane},
+    utils::{LoadConfig, get_chain, maybe_print_resolved_lane, resolve_lane},
 };
 use foundry_common::{
     FoundryTransactionBuilder, provider::ProviderBuilder, tempo::TEMPO_BROWSER_GAS_BUFFER,
@@ -179,8 +179,22 @@ impl Tip20Subcommand {
 
 pub(super) async fn resolve_tip20_signer(
     send_tx: &SendTxOpts,
-) -> eyre::Result<(Option<WalletSigner>, Option<TempoAccessKeyConfig>)> {
-    send_tx.eth.wallet.maybe_signer().await
+    tx_params: &TxParams,
+) -> eyre::Result<Option<(WalletSigner, TempoAccessKeyConfig)>> {
+    let Some(session_id) = tx_params.tempo.session_id()? else {
+        return Ok(None);
+    };
+
+    crate::tempo::ensure_session_not_browser(&tx_params.tempo, send_tx.browser.browser)?;
+
+    let config = send_tx.eth.load_config()?;
+    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+    let chain = get_chain(config.chain, &provider).await?;
+    let session =
+        tx_params.tempo.session_signer_for_wallet(&send_tx.eth.wallet, chain.id())?.ok_or_else(
+            || eyre::eyre!("Tempo session {session_id:?} is not active or has no live key"),
+        )?;
+    Ok(Some((session.signer, session.access_key)))
 }
 
 pub(super) async fn send_tip20_transaction(
@@ -192,7 +206,13 @@ pub(super) async fn send_tip20_transaction(
     pre_resolved_signer: Option<WalletSigner>,
     access_key: Option<TempoAccessKeyConfig>,
 ) -> eyre::Result<()> {
+    let session_signer = resolve_tip20_signer(&send_tx, &tx_params).await?;
     let mut tx_opts = tx_params.into_transaction_opts();
+    let (pre_resolved_signer, access_key) = if let Some((signer, access_key)) = session_signer {
+        (Some(signer), Some(access_key))
+    } else {
+        (pre_resolved_signer, access_key)
+    };
     let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
     let sponsor_url = tx_opts.tempo.sponsor_url.clone();
     let expires_at = tx_opts.tempo.resolve_expires();

--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -206,13 +206,13 @@ pub(super) async fn send_tip20_transaction(
     pre_resolved_signer: Option<WalletSigner>,
     access_key: Option<TempoAccessKeyConfig>,
 ) -> eyre::Result<()> {
-    let session_signer = resolve_tip20_signer(&send_tx, &tx_params).await?;
+    let (pre_resolved_signer, access_key) =
+        if let Some((signer, access_key)) = resolve_tip20_signer(&send_tx, &tx_params).await? {
+            (Some(signer), Some(access_key))
+        } else {
+            (pre_resolved_signer, access_key)
+        };
     let mut tx_opts = tx_params.into_transaction_opts();
-    let (pre_resolved_signer, access_key) = if let Some((signer, access_key)) = session_signer {
-        (Some(signer), Some(access_key))
-    } else {
-        (pre_resolved_signer, access_key)
-    };
     let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
     let sponsor_url = tx_opts.tempo.sponsor_url.clone();
     let expires_at = tx_opts.tempo.resolve_expires();

--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -200,8 +200,9 @@ pub(super) async fn send_tip20_transaction(
     args: Vec<String>,
     send_tx: SendTxOpts,
     tx_params: TxParams,
+    pre_resolved_signer: Option<WalletSigner>,
+    access_key: Option<TempoAccessKeyConfig>,
 ) -> eyre::Result<()> {
-    let (pre_resolved_signer, access_key) = resolve_tip20_signer(&send_tx, &tx_params).await?;
     let mut tx_opts = tx_params.into_transaction_opts();
     let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
     let sponsor_url = tx_opts.tempo.sponsor_url.clone();

--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     cmd::send::{cast_send, cast_send_with_access_key, validate_sponsor_url},
+    tempo,
     tx::{CastTxBuilder, CastTxSender, SendTxOpts, TxParams},
 };
 use alloy_ens::NameOrAddress;
@@ -180,21 +181,17 @@ impl Tip20Subcommand {
 pub(super) async fn resolve_tip20_signer(
     send_tx: &SendTxOpts,
     tx_params: &TxParams,
-) -> eyre::Result<Option<(WalletSigner, TempoAccessKeyConfig)>> {
-    let Some(session_id) = tx_params.tempo.session_id()? else {
-        return Ok(None);
-    };
+) -> eyre::Result<(Option<WalletSigner>, Option<TempoAccessKeyConfig>)> {
+    if tx_params.tempo.session_id()?.is_none() {
+        return send_tx.eth.wallet.maybe_signer().await;
+    }
 
-    crate::tempo::ensure_session_not_browser(&tx_params.tempo, send_tx.browser.browser)?;
+    tempo::ensure_session_not_browser(&tx_params.tempo, send_tx.browser.browser)?;
 
     let config = send_tx.eth.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
     let chain = get_chain(config.chain, &provider).await?;
-    let session =
-        tx_params.tempo.session_signer_for_wallet(&send_tx.eth.wallet, chain.id())?.ok_or_else(
-            || eyre::eyre!("Tempo session {session_id:?} is not active or has no live key"),
-        )?;
-    Ok(Some((session.signer, session.access_key)))
+    tempo::resolve_session_or_wallet_signer(&tx_params.tempo, &send_tx.eth.wallet, chain.id()).await
 }
 
 pub(super) async fn send_tip20_transaction(
@@ -203,15 +200,8 @@ pub(super) async fn send_tip20_transaction(
     args: Vec<String>,
     send_tx: SendTxOpts,
     tx_params: TxParams,
-    pre_resolved_signer: Option<WalletSigner>,
-    access_key: Option<TempoAccessKeyConfig>,
 ) -> eyre::Result<()> {
-    let (pre_resolved_signer, access_key) =
-        if let Some((signer, access_key)) = resolve_tip20_signer(&send_tx, &tx_params).await? {
-            (Some(signer), Some(access_key))
-        } else {
-            (pre_resolved_signer, access_key)
-        };
+    let (pre_resolved_signer, access_key) = resolve_tip20_signer(&send_tx, &tx_params).await?;
     let mut tx_opts = tx_params.into_transaction_opts();
     let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
     let sponsor_url = tx_opts.tempo.sponsor_url.clone();

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -7,7 +7,7 @@ use crate::{
     tempo,
     tx::{CastTxSender, SendTxOpts, TxParams},
 };
-use alloy_network::{Network, TransactionBuilder};
+use alloy_network::Network;
 use alloy_primitives::{Address, B256};
 use alloy_provider::Provider;
 use alloy_signer::Signer;
@@ -154,7 +154,14 @@ async fn register(
     send_tx: SendTxOpts,
     mut tx_opts: TxParams,
 ) -> Result<B256> {
-    let (signer, tempo_access_key) = send_tx.eth.wallet.maybe_signer().await?;
+    let config = send_tx.eth.load_config()?;
+    let timeout = send_tx.timeout.unwrap_or(config.transaction_timeout);
+    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+    let chain = get_chain(config.chain, &provider).await?;
+    tempo::ensure_session_not_browser(&tx_opts.tempo, send_tx.browser.browser)?;
+    let (signer, tempo_access_key) =
+        tempo::resolve_session_or_wallet_signer(&tx_opts.tempo, &send_tx.eth.wallet, chain.id())
+            .await?;
     let signer = signer.ok_or_else(|| {
         eyre::eyre!("cast vaddr create requires a signer (for example --private-key or --from)")
     })?;
@@ -168,23 +175,18 @@ async fn register(
         );
     }
 
-    let config = send_tx.eth.load_config()?;
-    let timeout = send_tx.timeout.unwrap_or(config.transaction_timeout);
-    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
-
     let mut tx = IAddressRegistry::new(ADDRESS_REGISTRY_ADDRESS, &provider)
         .registerVirtualMaster(salt)
         .into_transaction_request();
     let expires_at = tx_opts.tempo.resolve_expires();
     tempo::print_expires(expires_at)?;
-    tx_opts.apply::<TempoNetwork>(&mut tx, get_chain(config.chain, &provider).await?.is_legacy());
+    tx_opts.apply::<TempoNetwork>(&mut tx, chain.is_legacy());
 
     sh_status!("Submitting registerVirtualMaster({salt})...")?;
 
     if let Some(ref access_key) = tempo_access_key {
+        tempo::fill_access_key_transaction(&provider, &mut tx, access_key, chain).await?;
         if shell::is_json() {
-            tx.set_from(access_key.wallet_address);
-            tx.set_key_id(access_key.key_address);
             let raw_tx = tx
                 .sign_with_access_key(
                     &provider,

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -1,6 +1,14 @@
 //! Tempo transaction helpers used by Cast-facing commands.
 
+use crate::tx::fill_transaction_gas_fees;
+use alloy_network::{Network, TransactionBuilder};
+use alloy_provider::Provider;
 use eyre::Result;
+use foundry_cli::opts::TempoOpts;
+use foundry_common::FoundryTransactionBuilder;
+use foundry_config::Chain;
+use foundry_wallets::{TempoAccessKeyConfig, WalletOpts, WalletSigner};
+use tempo_alloy::TempoNetwork;
 
 pub use foundry_common::tempo::{TempoSponsor, TempoSponsorPreview, resolve_tempo_sponsor_signer};
 
@@ -8,5 +16,62 @@ pub(crate) fn print_expires(expires_at: Option<u64>) -> Result<()> {
     if let Some(ts) = expires_at {
         sh_status!("Transaction expires at unix timestamp {ts}")?;
     }
+    Ok(())
+}
+
+/// Resolves a command signer, preferring an explicitly selected Tempo session.
+///
+/// Session resolution is fail-closed: when `--tempo.session` or `TEMPO_SESSION_ID` is set, wallet
+/// signer options are rejected by [`TempoOpts::session_signer_for_wallet`] instead of falling back
+/// to a long-lived signer.
+pub(crate) async fn resolve_session_or_wallet_signer(
+    tempo: &TempoOpts,
+    wallet: &WalletOpts,
+    chain_id: u64,
+) -> Result<(Option<WalletSigner>, Option<TempoAccessKeyConfig>)> {
+    if let Some(session) = tempo.session_signer_for_wallet(wallet, chain_id)? {
+        return Ok((Some(session.signer), Some(session.access_key)));
+    }
+
+    wallet.maybe_signer().await
+}
+
+pub(crate) fn ensure_session_not_browser(tempo: &TempoOpts, browser: bool) -> Result<()> {
+    if browser && tempo.session_id()?.is_some() {
+        eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --browser");
+    }
+    Ok(())
+}
+
+/// Fills a Tempo transaction request that was built outside [`crate::tx::CastTxBuilder`] before
+/// access-key signing.
+pub(crate) async fn fill_access_key_transaction<P>(
+    provider: &P,
+    tx: &mut <TempoNetwork as Network>::TransactionRequest,
+    access_key: &TempoAccessKeyConfig,
+    chain: Chain,
+) -> Result<()>
+where
+    P: Provider<TempoNetwork>,
+{
+    tx.set_from(access_key.wallet_address);
+    tx.set_chain_id(chain.id());
+    tx.set_key_id(access_key.key_address);
+    tx.prepare_access_key_authorization(
+        provider,
+        access_key.wallet_address,
+        access_key.key_address,
+        access_key.key_authorization.as_ref(),
+    )
+    .await?;
+
+    if tx.nonce().is_none() {
+        tx.set_nonce(provider.get_transaction_count(access_key.wallet_address).await?);
+    }
+    fill_transaction_gas_fees(provider, tx, chain.is_legacy(), false).await?;
+    if tx.gas_limit().is_none() {
+        tx.set_gas_limit(provider.estimate_gas(tx.clone()).await?);
+    }
+
     Ok(())
 }

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -29,11 +29,10 @@ pub(crate) async fn resolve_session_or_wallet_signer(
     wallet: &WalletOpts,
     chain_id: u64,
 ) -> Result<(Option<WalletSigner>, Option<TempoAccessKeyConfig>)> {
-    if let Some(session) = tempo.session_signer_for_wallet(wallet, chain_id)? {
-        return Ok((Some(session.signer), Some(session.access_key)));
+    match tempo.session_signer_for_wallet(wallet, chain_id)? {
+        Some(session) => Ok((Some(session.signer), Some(session.access_key))),
+        None => wallet.maybe_signer().await,
     }
-
-    wallet.maybe_signer().await
 }
 
 pub(crate) fn ensure_session_not_browser(tempo: &TempoOpts, browser: bool) -> Result<()> {

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -10,6 +10,7 @@ use tempo_contracts::precompiles::TIP20_FACTORY_ADDRESS;
 /// Anvil test accounts (standard mnemonic).
 mod accounts {
     pub const PK1: &str = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    pub const PK2: &str = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d";
     pub const ADDR1: &str = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
     pub const ADDR2: &str = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
     pub const ADDR3: &str = "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC";
@@ -747,6 +748,42 @@ casttest!(batch_mktx_uses_tempo_session_id_env, async |_prj, cmd| {
     assert!(
         stdout.trim().starts_with("0x"),
         "expected cast batch-mktx to print raw tx hex, got:\n{stdout}"
+    );
+});
+
+casttest!(batch_mktx_raw_unsigned_resolves_tempo_access_key_metadata, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let path_usd = path_usd();
+    let call = batch_send_transfer_call(&path_usd);
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "batch-mktx",
+            "--call",
+            &call,
+            "--raw-unsigned",
+            "--from",
+            accounts::ADDR1,
+            "--nonce",
+            "0",
+            "--gas-price",
+            "1",
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+            "--tempo.access-key",
+            accounts::PK2,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(
+        stderr.contains("--tempo.root-account is required when --tempo.access-key is set"),
+        "raw unsigned must still resolve Tempo access-key metadata, got:\n{stderr}"
     );
 });
 

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -19,9 +19,7 @@ fn path_usd() -> String {
     PATH_USD_ADDRESS.to_string()
 }
 
-const fn address_registry() -> &'static str {
-    "0xFDC0000000000000000000000000000000000000"
-}
+const ADDRESS_REGISTRY: &str = "0xFDC0000000000000000000000000000000000000";
 
 fn tip20_factory() -> String {
     TIP20_FACTORY_ADDRESS.to_string()
@@ -34,9 +32,8 @@ fn batch_send_transfer_call(path_usd: &str) -> String {
     format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3)
 }
 
-const fn precomputed_vaddr_salt_for_addr1() -> &'static str {
-    "0x00000000000000000000000000000000000000000000000000000000abf52baf"
-}
+const PRECOMPUTED_VADDR_SALT_FOR_ADDR1: &str =
+    "0x00000000000000000000000000000000000000000000000000000000abf52baf";
 
 fn assert_wrong_chain_error(stderr: &str) {
     assert!(stderr.contains("is for chain 31338"), "unexpected stderr:\n{stderr}");
@@ -55,8 +52,7 @@ test -n "${{TEMPO_SESSION_ID:-}}"
 }
 
 fn create_session(cmd: &mut TestCommand, tempo_home: &Path, chain_id: &str) -> (String, String) {
-    let path_usd = path_usd();
-    create_session_with_scope(cmd, tempo_home, chain_id, &path_usd)
+    create_session_with_scope(cmd, tempo_home, chain_id, &path_usd())
 }
 
 fn create_session_with_scope(
@@ -759,7 +755,7 @@ casttest!(vaddr_create_uses_tempo_session_id_env, async |_prj, cmd| {
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
     let (session_id, _) =
-        create_session_with_scope(&mut cmd, tempo_home.path(), "31337", address_registry());
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31337", ADDRESS_REGISTRY);
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
@@ -772,7 +768,7 @@ casttest!(vaddr_create_uses_tempo_session_id_env, async |_prj, cmd| {
             "--owner",
             accounts::ADDR1,
             "--salt",
-            precomputed_vaddr_salt_for_addr1(),
+            PRECOMPUTED_VADDR_SALT_FOR_ADDR1,
             "--rpc-url",
             &rpc,
             "--async",
@@ -830,7 +826,7 @@ casttest!(tip20_mine_register_uses_tempo_session_id_env, async |_prj, cmd| {
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
     let (session_id, _) =
-        create_session_with_scope(&mut cmd, tempo_home.path(), "31337", address_registry());
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31337", ADDRESS_REGISTRY);
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
@@ -841,7 +837,7 @@ casttest!(tip20_mine_register_uses_tempo_session_id_env, async |_prj, cmd| {
             "mine",
             accounts::ADDR1,
             "--salt",
-            precomputed_vaddr_salt_for_addr1(),
+            PRECOMPUTED_VADDR_SALT_FOR_ADDR1,
             "--register",
             "--rpc-url",
             &rpc,
@@ -1029,7 +1025,7 @@ casttest!(vaddr_create_rejects_session_with_explicit_signer, async |_prj, cmd| {
             "--owner",
             accounts::ADDR1,
             "--salt",
-            precomputed_vaddr_salt_for_addr1(),
+            PRECOMPUTED_VADDR_SALT_FOR_ADDR1,
             "--tempo.session",
             MISSING_SESSION_ID,
             "--private-key",
@@ -1056,7 +1052,7 @@ casttest!(vaddr_create_rejects_session_with_browser, async |_prj, cmd| {
             "--owner",
             accounts::ADDR1,
             "--salt",
-            precomputed_vaddr_salt_for_addr1(),
+            PRECOMPUTED_VADDR_SALT_FOR_ADDR1,
             "--tempo.session",
             MISSING_SESSION_ID,
             "--browser",
@@ -1075,7 +1071,7 @@ casttest!(vaddr_create_rejects_session_on_wrong_chain, async |_prj, cmd| {
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
     let (session_id, _) =
-        create_session_with_scope(&mut cmd, tempo_home.path(), "31338", address_registry());
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31338", ADDRESS_REGISTRY);
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
@@ -1086,7 +1082,7 @@ casttest!(vaddr_create_rejects_session_on_wrong_chain, async |_prj, cmd| {
             "--owner",
             accounts::ADDR1,
             "--salt",
-            precomputed_vaddr_salt_for_addr1(),
+            PRECOMPUTED_VADDR_SALT_FOR_ADDR1,
             "--tempo.session",
             &session_id,
             "--rpc-url",
@@ -1207,7 +1203,7 @@ casttest!(tip20_mine_register_rejects_session_with_explicit_signer, async |_prj,
             "mine",
             accounts::ADDR1,
             "--salt",
-            precomputed_vaddr_salt_for_addr1(),
+            PRECOMPUTED_VADDR_SALT_FOR_ADDR1,
             "--register",
             "--tempo.session",
             MISSING_SESSION_ID,
@@ -1234,7 +1230,7 @@ casttest!(tip20_mine_register_rejects_session_with_browser, async |_prj, cmd| {
             "mine",
             accounts::ADDR1,
             "--salt",
-            precomputed_vaddr_salt_for_addr1(),
+            PRECOMPUTED_VADDR_SALT_FOR_ADDR1,
             "--register",
             "--tempo.session",
             MISSING_SESSION_ID,
@@ -1254,7 +1250,7 @@ casttest!(tip20_mine_register_rejects_session_on_wrong_chain, async |_prj, cmd| 
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
     let (session_id, _) =
-        create_session_with_scope(&mut cmd, tempo_home.path(), "31338", address_registry());
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31338", ADDRESS_REGISTRY);
 
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home.path());
@@ -1264,7 +1260,7 @@ casttest!(tip20_mine_register_rejects_session_on_wrong_chain, async |_prj, cmd| 
             "mine",
             accounts::ADDR1,
             "--salt",
-            precomputed_vaddr_salt_for_addr1(),
+            PRECOMPUTED_VADDR_SALT_FOR_ADDR1,
             "--register",
             "--tempo.session",
             &session_id,

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -5,6 +5,7 @@ use foundry_evm::core::tempo::PATH_USD_ADDRESS;
 use foundry_test_utils::{TestCommand, util::OutputExt};
 use path_slash::PathExt;
 use std::{fs, path::Path};
+use tempo_contracts::precompiles::TIP20_FACTORY_ADDRESS;
 
 /// Anvil test accounts (standard mnemonic).
 mod accounts {
@@ -18,11 +19,28 @@ fn path_usd() -> String {
     PATH_USD_ADDRESS.to_string()
 }
 
+const fn address_registry() -> &'static str {
+    "0xFDC0000000000000000000000000000000000000"
+}
+
+fn tip20_factory() -> String {
+    TIP20_FACTORY_ADDRESS.to_string()
+}
+
 const MISSING_SESSION_ID: &str =
     "0x5555555555555555555555555555555555555555555555555555555555555555";
 
 fn batch_send_transfer_call(path_usd: &str) -> String {
     format!("{path_usd}::transfer(address,uint256):{},0", accounts::ADDR3)
+}
+
+const fn precomputed_vaddr_salt_for_addr1() -> &'static str {
+    "0x00000000000000000000000000000000000000000000000000000000abf52baf"
+}
+
+fn assert_wrong_chain_error(stderr: &str) {
+    assert!(stderr.contains("is for chain 31338"), "unexpected stderr:\n{stderr}");
+    assert!(stderr.contains("command is using chain 31337"), "unexpected stderr:\n{stderr}");
 }
 
 fn cast_send_session_script(path_usd: &str) -> String {
@@ -38,7 +56,15 @@ test -n "${{TEMPO_SESSION_ID:-}}"
 
 fn create_session(cmd: &mut TestCommand, tempo_home: &Path, chain_id: &str) -> (String, String) {
     let path_usd = path_usd();
+    create_session_with_scope(cmd, tempo_home, chain_id, &path_usd)
+}
 
+fn create_session_with_scope(
+    cmd: &mut TestCommand,
+    tempo_home: &Path,
+    chain_id: &str,
+    scope: &str,
+) -> (String, String) {
     cmd.cast_fuse();
     cmd.env("TEMPO_HOME", tempo_home);
     let create_output = cmd
@@ -54,7 +80,7 @@ fn create_session(cmd: &mut TestCommand, tempo_home: &Path, chain_id: &str) -> (
             "--expires",
             "10m",
             "--scope",
-            &path_usd,
+            scope,
             "--private-key",
             accounts::PK1,
         ])
@@ -99,6 +125,18 @@ fn assert_async_tx_hash(stdout: &str, command: &str) {
     assert!(
         stdout.trim().starts_with("0x"),
         "expected {command} --async to print a tx hash, got:\n{stdout}"
+    );
+}
+
+fn assert_contains_tx_hash(stdout: &str, command: &str) {
+    assert!(
+        stdout.lines().any(|line| {
+            let line = line.trim();
+            line.len() == 66
+                && line.starts_with("0x")
+                && line[2..].chars().all(|c| c.is_ascii_hexdigit())
+        }),
+        "expected {command} to print a tx hash, got:\n{stdout}"
     );
 }
 
@@ -691,6 +729,611 @@ casttest!(batch_send_uses_tempo_session_id_env, async |_prj, cmd| {
         .stdout_lossy();
 
     assert_async_tx_hash(&stdout, "cast batch-send");
+});
+
+casttest!(batch_mktx_uses_tempo_session_id_env, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = path_usd();
+    let call = batch_send_transfer_call(&path_usd);
+    let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31337");
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.env("TEMPO_SESSION_ID", &session_id);
+    let stdout = cmd
+        .args(["batch-mktx", "--call", &call, "--rpc-url", &rpc, "--tempo.fee-token", &path_usd])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(
+        stdout.trim().starts_with("0x"),
+        "expected cast batch-mktx to print raw tx hex, got:\n{stdout}"
+    );
+});
+
+casttest!(vaddr_create_uses_tempo_session_id_env, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let (session_id, _) =
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31337", address_registry());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.env("TEMPO_SESSION_ID", &session_id);
+    let stdout = cmd
+        .args([
+            "--json",
+            "vaddr",
+            "create",
+            "--owner",
+            accounts::ADDR1,
+            "--salt",
+            precomputed_vaddr_salt_for_addr1(),
+            "--rpc-url",
+            &rpc,
+            "--async",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    let envelope: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("vaddr create emits JSON");
+    assert!(
+        envelope["data"]["registration_tx_hash"]
+            .as_str()
+            .is_some_and(|hash| hash.starts_with("0x")),
+        "expected vaddr create --json to include registration tx hash, got:\n{stdout}"
+    );
+});
+
+casttest!(tip20_create_uses_tempo_session_id_env, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = path_usd();
+    let (session_id, _) =
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31337", &tip20_factory());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.env("TEMPO_SESSION_ID", &session_id);
+    let stdout = cmd
+        .args([
+            "tip20",
+            "create",
+            "Session Dollar",
+            "SESS",
+            "USD",
+            &path_usd,
+            accounts::ADDR1,
+            "0x0000000000000000000000000000000000000000000000000000000000005151",
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+            "--async",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_async_tx_hash(&stdout, "cast tip20 create");
+});
+
+casttest!(tip20_mine_register_uses_tempo_session_id_env, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let (session_id, _) =
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31337", address_registry());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.env("TEMPO_SESSION_ID", &session_id);
+    let stdout = cmd
+        .args([
+            "tip20",
+            "mine",
+            accounts::ADDR1,
+            "--salt",
+            precomputed_vaddr_salt_for_addr1(),
+            "--register",
+            "--rpc-url",
+            &rpc,
+            "--async",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_contains_tx_hash(&stdout, "cast tip20 mine --register");
+});
+
+casttest!(erc20_transfer_uses_tempo_session_id_env, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = path_usd();
+    let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31337");
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    cmd.env("TEMPO_SESSION_ID", &session_id);
+    let stdout = cmd
+        .args([
+            "erc20",
+            "transfer",
+            &path_usd,
+            accounts::ADDR3,
+            "0",
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+            "--async",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_async_tx_hash(&stdout, "cast erc20 transfer");
+});
+
+casttest!(batch_mktx_rejects_session_with_explicit_signer, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let path_usd = path_usd();
+    let call = batch_send_transfer_call(&path_usd);
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "batch-mktx",
+            "--call",
+            &call,
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("explicit wallet signer"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(erc20_rejects_session_with_explicit_signer, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let path_usd = path_usd();
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "erc20",
+            "transfer",
+            &path_usd,
+            accounts::ADDR3,
+            "0",
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("explicit wallet signer"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(batch_mktx_rejects_session_with_ethsign, |_prj, cmd| {
+    let path_usd = path_usd();
+    let call = batch_send_transfer_call(&path_usd);
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "batch-mktx",
+            "--call",
+            &call,
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--ethsign",
+            "--from",
+            accounts::ADDR1,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("cannot be combined with --ethsign"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(batch_mktx_rejects_session_with_raw_unsigned, |_prj, cmd| {
+    let path_usd = path_usd();
+    let call = batch_send_transfer_call(&path_usd);
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "batch-mktx",
+            "--call",
+            &call,
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--raw-unsigned",
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(
+        stderr.contains("cannot be combined with --raw-unsigned"),
+        "unexpected stderr:\n{stderr}"
+    );
+});
+
+casttest!(batch_mktx_rejects_session_on_wrong_chain, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = path_usd();
+    let call = batch_send_transfer_call(&path_usd);
+    let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31338");
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    let stderr = cmd
+        .args([
+            "batch-mktx",
+            "--call",
+            &call,
+            "--tempo.session",
+            &session_id,
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert_wrong_chain_error(&stderr);
+});
+
+casttest!(vaddr_create_rejects_session_with_explicit_signer, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "vaddr",
+            "create",
+            "--owner",
+            accounts::ADDR1,
+            "--salt",
+            precomputed_vaddr_salt_for_addr1(),
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("explicit wallet signer"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(vaddr_create_rejects_session_with_browser, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "vaddr",
+            "create",
+            "--owner",
+            accounts::ADDR1,
+            "--salt",
+            precomputed_vaddr_salt_for_addr1(),
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--browser",
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("cannot be combined with --browser"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(vaddr_create_rejects_session_on_wrong_chain, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let (session_id, _) =
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31338", address_registry());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    let stderr = cmd
+        .args([
+            "vaddr",
+            "create",
+            "--owner",
+            accounts::ADDR1,
+            "--salt",
+            precomputed_vaddr_salt_for_addr1(),
+            "--tempo.session",
+            &session_id,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert_wrong_chain_error(&stderr);
+});
+
+casttest!(tip20_create_rejects_session_with_explicit_signer, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let path_usd = path_usd();
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "tip20",
+            "create",
+            "Session Dollar",
+            "SESS",
+            "USD",
+            &path_usd,
+            accounts::ADDR1,
+            "0x0000000000000000000000000000000000000000000000000000000000005152",
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("explicit wallet signer"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(tip20_create_rejects_session_with_browser, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let path_usd = path_usd();
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "tip20",
+            "create",
+            "Session Dollar",
+            "SESS",
+            "USD",
+            &path_usd,
+            accounts::ADDR1,
+            "0x0000000000000000000000000000000000000000000000000000000000005153",
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--browser",
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("cannot be combined with --browser"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(tip20_create_rejects_session_on_wrong_chain, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = path_usd();
+    let (session_id, _) =
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31338", &tip20_factory());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    let stderr = cmd
+        .args([
+            "tip20",
+            "create",
+            "Session Dollar",
+            "SESS",
+            "USD",
+            &path_usd,
+            accounts::ADDR1,
+            "0x0000000000000000000000000000000000000000000000000000000000005154",
+            "--tempo.session",
+            &session_id,
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert_wrong_chain_error(&stderr);
+});
+
+casttest!(tip20_mine_register_rejects_session_with_explicit_signer, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "tip20",
+            "mine",
+            accounts::ADDR1,
+            "--salt",
+            precomputed_vaddr_salt_for_addr1(),
+            "--register",
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("explicit wallet signer"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(tip20_mine_register_rejects_session_with_browser, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "tip20",
+            "mine",
+            accounts::ADDR1,
+            "--salt",
+            precomputed_vaddr_salt_for_addr1(),
+            "--register",
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--browser",
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("cannot be combined with --browser"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(tip20_mine_register_rejects_session_on_wrong_chain, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let (session_id, _) =
+        create_session_with_scope(&mut cmd, tempo_home.path(), "31338", address_registry());
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    let stderr = cmd
+        .args([
+            "tip20",
+            "mine",
+            accounts::ADDR1,
+            "--salt",
+            precomputed_vaddr_salt_for_addr1(),
+            "--register",
+            "--tempo.session",
+            &session_id,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert_wrong_chain_error(&stderr);
+});
+
+casttest!(erc20_rejects_session_with_browser, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let path_usd = path_usd();
+
+    cmd.cast_fuse();
+    let stderr = cmd
+        .args([
+            "erc20",
+            "transfer",
+            &path_usd,
+            accounts::ADDR3,
+            "0",
+            "--tempo.session",
+            MISSING_SESSION_ID,
+            "--browser",
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("cannot be combined with --browser"), "unexpected stderr:\n{stderr}");
+});
+
+casttest!(erc20_rejects_session_on_wrong_chain, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+    let tempo_home = tempfile::tempdir().unwrap();
+    let path_usd = path_usd();
+    let (session_id, _) = create_session(&mut cmd, tempo_home.path(), "31338");
+
+    cmd.cast_fuse();
+    cmd.env("TEMPO_HOME", tempo_home.path());
+    let stderr = cmd
+        .args([
+            "erc20",
+            "transfer",
+            &path_usd,
+            accounts::ADDR3,
+            "0",
+            "--tempo.session",
+            &session_id,
+            "--rpc-url",
+            &rpc,
+            "--tempo.fee-token",
+            &path_usd,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert_wrong_chain_error(&stderr);
 });
 
 casttest!(wallet_session_run_for_grandchild_cast_send_inherits_session_key, async |prj, cmd| {


### PR DESCRIPTION
Towards oss-162
Adds shared Tempo helpers for resolving an explicit session before falling back to wallet signer resolution, and applies them to:

- `cast batch-mktx`
- `cast erc20`
- `cast tip20 create`
- `cast tip20 mine --register`
- `cast vaddr create`

Also rejects unsupported session combinations such as `--browser`, `--ethsign`, and `--raw-unsigned` where applicable,
validates sessions against the active chain, and fills access-key transaction metadata before signing transactions built outside `CastTxBuilder`.

Additionally, `batch-mktx --raw-unsigned` now preserves Tempo access-key metadata while set signer to None.