### PR TITLE
feat(debugger): display debugger gas stats

### DIFF
--- a/crates/debugger/src/builder.rs
+++ b/crates/debugger/src/builder.rs
@@ -42,11 +42,11 @@ impl DebuggerBuilder {
     #[inline]
     pub fn trace_arena(mut self, arena: CallTraceArena) -> Self {
         if let Some(root) = arena.nodes().first() {
-            self.stats.total_trace_gas_used =
-                self.stats.total_trace_gas_used.saturating_add(root.trace.gas_used);
+            self.stats.session_trace_gas_used =
+                self.stats.session_trace_gas_used.saturating_add(root.trace.gas_used);
         }
-        self.stats.subcalls =
-            self.stats.subcalls.saturating_add(arena.nodes().len().saturating_sub(1));
+        self.stats.session_subcalls =
+            self.stats.session_subcalls.saturating_add(arena.nodes().len().saturating_sub(1));
         flatten_call_trace(arena, &mut self.debug_arena);
         self
     }
@@ -126,28 +126,51 @@ mod tests {
         }
     }
 
+    fn trace_arena(gas_used: u64, subcalls: usize) -> CallTraceArena {
+        let mut arena = CallTraceArena::default();
+
+        {
+            let root = &mut arena.nodes_mut()[0];
+            root.trace.steps.push(step());
+            root.trace.gas_limit = 1;
+            root.trace.gas_used = gas_used;
+            root.ordering.push(TraceMemberOrder::Step(0));
+
+            for idx in 1..=subcalls {
+                root.ordering.push(TraceMemberOrder::Call(idx - 1));
+                root.children.push(idx);
+            }
+        }
+
+        for idx in 1..=subcalls {
+            arena.nodes_mut().push(CallTraceNode {
+                parent: Some(0),
+                idx,
+                trace: CallTrace { depth: 1, kind: CallKind::Call, ..Default::default() },
+                ..Default::default()
+            });
+        }
+
+        arena
+    }
+
     #[test]
     fn trace_arena_accumulates_stats() {
-        let mut arena = CallTraceArena::default();
-        let root = &mut arena.nodes_mut()[0];
-        root.trace.steps.push(step());
-        root.trace.gas_limit = 1;
-        root.trace.gas_used = 100;
-        root.ordering.push(TraceMemberOrder::Step(0));
-        root.ordering.push(TraceMemberOrder::Call(0));
-        root.children.push(1);
+        let builder = DebuggerBuilder::new().trace_arena(trace_arena(100, 1));
 
-        arena.nodes_mut().push(CallTraceNode {
-            parent: Some(0),
-            idx: 1,
-            trace: CallTrace { depth: 1, kind: CallKind::Call, ..Default::default() },
-            ..Default::default()
-        });
-
-        let builder = DebuggerBuilder::new().trace_arena(arena);
-
-        assert_eq!(builder.stats.subcalls, 1);
-        assert_eq!(builder.stats.total_trace_gas_used, 100);
+        assert_eq!(builder.stats.session_subcalls, 1);
+        assert_eq!(builder.stats.session_trace_gas_used, 100);
         assert_eq!(builder.debug_arena.len(), 1);
+    }
+
+    #[test]
+    fn trace_arena_accumulates_session_stats_across_multiple_arenas() {
+        let builder = DebuggerBuilder::new()
+            .trace_arena(trace_arena(100, 1))
+            .trace_arena(trace_arena(200, 2));
+
+        assert_eq!(builder.stats.session_subcalls, 3);
+        assert_eq!(builder.stats.session_trace_gas_used, 300);
+        assert_eq!(builder.debug_arena.len(), 2);
     }
 }

--- a/crates/debugger/src/builder.rs
+++ b/crates/debugger/src/builder.rs
@@ -42,8 +42,8 @@ impl DebuggerBuilder {
     #[inline]
     pub fn trace_arena(mut self, arena: CallTraceArena) -> Self {
         if let Some(root) = arena.nodes().first() {
-            self.stats.total_gas_used =
-                self.stats.total_gas_used.saturating_add(root.trace.gas_used);
+            self.stats.total_trace_gas_used =
+                self.stats.total_trace_gas_used.saturating_add(root.trace.gas_used);
         }
         self.stats.subcalls =
             self.stats.subcalls.saturating_add(arena.nodes().len().saturating_sub(1));
@@ -127,7 +127,7 @@ mod tests {
     }
 
     #[test]
-    fn trace_arena_counts_empty_step_subcalls() {
+    fn trace_arena_accumulates_stats() {
         let mut arena = CallTraceArena::default();
         let root = &mut arena.nodes_mut()[0];
         root.trace.steps.push(step());
@@ -147,7 +147,7 @@ mod tests {
         let builder = DebuggerBuilder::new().trace_arena(arena);
 
         assert_eq!(builder.stats.subcalls, 1);
-        assert_eq!(builder.stats.total_gas_used, 100);
+        assert_eq!(builder.stats.total_trace_gas_used, 100);
         assert_eq!(builder.debug_arena.len(), 1);
     }
 }

--- a/crates/debugger/src/builder.rs
+++ b/crates/debugger/src/builder.rs
@@ -1,6 +1,6 @@
 //! Debugger builder.
 
-use crate::{DebugNode, Debugger, node::flatten_call_trace};
+use crate::{DebugNode, Debugger, debugger::DebuggerStats, node::flatten_call_trace};
 use alloy_primitives::{Address, map::AddressHashMap};
 use foundry_common::get_contract_name;
 use foundry_evm_core::Breakpoints;
@@ -12,6 +12,8 @@ use foundry_evm_traces::{CallTraceArena, CallTraceDecoder, Traces, debug::Contra
 pub struct DebuggerBuilder {
     /// Debug traces returned from the EVM execution.
     debug_arena: Vec<DebugNode>,
+    /// Aggregate stats for the traces passed to the debugger.
+    stats: DebuggerStats,
     /// Identified contracts.
     identified_contracts: AddressHashMap<String>,
     /// Map of source files.
@@ -39,6 +41,12 @@ impl DebuggerBuilder {
     /// Extends the debug arena.
     #[inline]
     pub fn trace_arena(mut self, arena: CallTraceArena) -> Self {
+        if let Some(root) = arena.nodes().first() {
+            self.stats.total_gas_used =
+                self.stats.total_gas_used.saturating_add(root.trace.gas_used);
+        }
+        self.stats.subcalls =
+            self.stats.subcalls.saturating_add(arena.nodes().len().saturating_sub(1));
         flatten_call_trace(arena, &mut self.debug_arena);
         self
     }
@@ -86,7 +94,60 @@ impl DebuggerBuilder {
     /// Builds the debugger.
     #[inline]
     pub fn build(self) -> Debugger {
-        let Self { debug_arena, identified_contracts, sources, breakpoints } = self;
-        Debugger::new(debug_arena, identified_contracts, sources, breakpoints)
+        let Self { debug_arena, stats, identified_contracts, sources, breakpoints } = self;
+        Debugger::new_with_stats(debug_arena, stats, identified_contracts, sources, breakpoints)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::Bytes;
+    use foundry_evm_traces::{CallKind, CallTrace, CallTraceNode};
+    use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
+    use revm_inspectors::tracing::types::{CallTraceStep, TraceMemberOrder};
+
+    fn step() -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: Some(InstructionResult::Stop),
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
+
+    #[test]
+    fn trace_arena_counts_empty_step_subcalls() {
+        let mut arena = CallTraceArena::default();
+        let root = &mut arena.nodes_mut()[0];
+        root.trace.steps.push(step());
+        root.trace.gas_limit = 1;
+        root.trace.gas_used = 100;
+        root.ordering.push(TraceMemberOrder::Step(0));
+        root.ordering.push(TraceMemberOrder::Call(0));
+        root.children.push(1);
+
+        arena.nodes_mut().push(CallTraceNode {
+            parent: Some(0),
+            idx: 1,
+            trace: CallTrace { depth: 1, kind: CallKind::Call, ..Default::default() },
+            ..Default::default()
+        });
+
+        let builder = DebuggerBuilder::new().trace_arena(arena);
+
+        assert_eq!(builder.stats.subcalls, 1);
+        assert_eq!(builder.stats.total_gas_used, 100);
+        assert_eq!(builder.debug_arena.len(), 1);
     }
 }

--- a/crates/debugger/src/debugger.rs
+++ b/crates/debugger/src/debugger.rs
@@ -9,22 +9,15 @@ use std::path::Path;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DebuggerStats {
-    /// Total gas used by the traces passed to the debugger.
-    pub total_gas_used: u64,
+    /// Sum of root-call gas used across every trace arena passed to the debugger.
+    pub total_trace_gas_used: u64,
     /// Number of subcalls in the traces passed to the debugger.
     pub subcalls: usize,
 }
 
-impl DebuggerStats {
-    #[cfg(test)]
-    pub(crate) const fn from_debug_arena(debug_arena: &[DebugNode]) -> Self {
-        Self { subcalls: debug_arena.len().saturating_sub(1), total_gas_used: 0 }
-    }
-}
-
 pub struct DebuggerContext {
     pub debug_arena: Vec<DebugNode>,
-    pub stats: DebuggerStats,
+    pub stats: Option<DebuggerStats>,
     pub identified_contracts: AddressHashMap<String>,
     /// Source map of contract sources
     pub contracts_sources: ContractSources,
@@ -49,15 +42,15 @@ impl Debugger {
         contracts_sources: ContractSources,
         breakpoints: Breakpoints,
     ) -> Self {
-        let stats =
-            DebuggerStats { subcalls: debug_arena.len().saturating_sub(1), total_gas_used: 0 };
-        Self::new_with_stats(
-            debug_arena,
-            stats,
-            identified_contracts,
-            contracts_sources,
-            breakpoints,
-        )
+        Self {
+            context: DebuggerContext {
+                debug_arena,
+                stats: None,
+                identified_contracts,
+                contracts_sources,
+                breakpoints,
+            },
+        }
     }
 
     pub(crate) const fn new_with_stats(
@@ -70,7 +63,7 @@ impl Debugger {
         Self {
             context: DebuggerContext {
                 debug_arena,
-                stats,
+                stats: Some(stats),
                 identified_contracts,
                 contracts_sources,
                 breakpoints,

--- a/crates/debugger/src/debugger.rs
+++ b/crates/debugger/src/debugger.rs
@@ -7,8 +7,24 @@ use foundry_evm_core::Breakpoints;
 use foundry_evm_traces::debug::ContractSources;
 use std::path::Path;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DebuggerStats {
+    /// Total gas used by the traces passed to the debugger.
+    pub total_gas_used: u64,
+    /// Number of subcalls in the traces passed to the debugger.
+    pub subcalls: usize,
+}
+
+impl DebuggerStats {
+    #[cfg(test)]
+    pub(crate) const fn from_debug_arena(debug_arena: &[DebugNode]) -> Self {
+        Self { subcalls: debug_arena.len().saturating_sub(1), total_gas_used: 0 }
+    }
+}
+
 pub struct DebuggerContext {
     pub debug_arena: Vec<DebugNode>,
+    pub stats: DebuggerStats,
     pub identified_contracts: AddressHashMap<String>,
     /// Source map of contract sources
     pub contracts_sources: ContractSources,
@@ -33,9 +49,28 @@ impl Debugger {
         contracts_sources: ContractSources,
         breakpoints: Breakpoints,
     ) -> Self {
+        let stats =
+            DebuggerStats { subcalls: debug_arena.len().saturating_sub(1), total_gas_used: 0 };
+        Self::new_with_stats(
+            debug_arena,
+            stats,
+            identified_contracts,
+            contracts_sources,
+            breakpoints,
+        )
+    }
+
+    pub(crate) const fn new_with_stats(
+        debug_arena: Vec<DebugNode>,
+        stats: DebuggerStats,
+        identified_contracts: AddressHashMap<String>,
+        contracts_sources: ContractSources,
+        breakpoints: Breakpoints,
+    ) -> Self {
         Self {
             context: DebuggerContext {
                 debug_arena,
+                stats,
                 identified_contracts,
                 contracts_sources,
                 breakpoints,

--- a/crates/debugger/src/debugger.rs
+++ b/crates/debugger/src/debugger.rs
@@ -10,9 +10,9 @@ use std::path::Path;
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DebuggerStats {
     /// Sum of root-call gas used across every trace arena passed to the debugger.
-    pub total_trace_gas_used: u64,
+    pub session_trace_gas_used: u64,
     /// Number of subcalls in the traces passed to the debugger.
-    pub subcalls: usize,
+    pub session_subcalls: usize,
 }
 
 pub struct DebuggerContext {

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -661,7 +661,6 @@ fn is_jump(step: &CallTraceStep, prev: &CallTraceStep) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::debugger::DebuggerStats;
     use alloy_primitives::Bytes;
     use foundry_evm_core::Breakpoints;
     use foundry_evm_traces::debug::ContractSources;
@@ -691,10 +690,9 @@ mod tests {
     }
 
     fn context_with_arena(arena: Vec<DebugNode>) -> DebuggerContext {
-        let stats = DebuggerStats::from_debug_arena(&arena);
         DebuggerContext {
             debug_arena: arena,
-            stats,
+            stats: None,
             identified_contracts: Default::default(),
             contracts_sources: ContractSources::default(),
             breakpoints: Breakpoints::default(),

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -661,6 +661,7 @@ fn is_jump(step: &CallTraceStep, prev: &CallTraceStep) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::debugger::DebuggerStats;
     use alloy_primitives::Bytes;
     use foundry_evm_core::Breakpoints;
     use foundry_evm_traces::debug::ContractSources;
@@ -690,8 +691,10 @@ mod tests {
     }
 
     fn context_with_arena(arena: Vec<DebugNode>) -> DebuggerContext {
+        let stats = DebuggerStats::from_debug_arena(&arena);
         DebuggerContext {
             debug_arena: arena,
+            stats,
             identified_contracts: Default::default(),
             contracts_sources: ContractSources::default(),
             breakpoints: Breakpoints::default(),

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -1,7 +1,7 @@
 //! TUI draw implementation.
 
 use super::context::{StatusKind, TUIContext};
-use crate::op::OpcodeParam;
+use crate::{debugger::DebuggerStats, op::OpcodeParam};
 use alloy_primitives::Address;
 use foundry_compilers::artifacts::sourcemap::SourceElement;
 use foundry_evm_core::buffer::{BufferKind, get_buffer_accesses};
@@ -405,10 +405,9 @@ impl TUIContext<'_> {
             self.address(),
             step.pc,
             step.gas_remaining,
-            self.debugger_context.stats.total_gas_used,
             call_gas_used,
             step.gas_refund_counter,
-            self.debugger_context.stats.subcalls,
+            self.debugger_context.stats,
         );
         let block = Block::default().title(title).borders(Borders::ALL);
         let list = List::new(items)
@@ -614,22 +613,30 @@ fn op_list_title(
     address: &Address,
     pc: usize,
     gas_remaining: u64,
-    total_gas_used: u64,
     call_gas_used: u64,
     gas_refund_counter: u64,
-    subcalls: usize,
+    stats: Option<DebuggerStats>,
 ) -> String {
-    let address = short_address(address);
-    format!(
-        "Addr: {address} | PC: 0x{pc:x} ({pc}) | gasleft: {gas_remaining} | totalGasUsed: \
-         {total_gas_used} | subcalls: {subcalls} | callGas: {call_gas_used} | refund: \
-         {gas_refund_counter}"
-    )
+    let address = short_checksum_address(address);
+    let mut title = format!(
+        "address: {address} | pc: 0x{pc:x} ({pc}) | gasLeft: {gas_remaining} | \
+         callGasUsed: {call_gas_used} | gasRefund: {gas_refund_counter}"
+    );
+
+    if let Some(stats) = stats {
+        write!(
+            title,
+            " | totalTraceGasUsed: {} | subcalls: {}",
+            stats.total_trace_gas_used, stats.subcalls
+        )
+        .unwrap();
+    }
+
+    title
 }
 
-fn short_address(address: &Address) -> String {
-    let address = address.to_string();
-    format!("{}...{}", &address[..6], &address[address.len() - 4..])
+fn short_checksum_address(address: &Address) -> String {
+    format!("{address:#}")
 }
 
 /// Wrapper around a list of [`Line`]s that prepends the line number on each new line.
@@ -692,20 +699,37 @@ fn hex_digits(n: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::Address;
+    use crate::debugger::DebuggerStats;
+    use alloy_primitives::{Address, address};
 
     #[test]
     fn op_list_title_includes_gas_and_subcall_stats() {
-        let title =
-            super::op_list_title(&Address::from([0x42; 20]), 0x2a, 123_456, 789_012, 42, 7, 3);
+        let stats = DebuggerStats { total_trace_gas_used: 789_012, subcalls: 3 };
+        let address = Address::from([0x42; 20]);
+        let title = super::op_list_title(&address, 0x2a, 123_456, 42, 7, Some(stats));
 
-        assert!(title.contains("PC: 0x2a (42)"));
-        assert!(title.contains("Addr: 0x4242...4242"));
-        assert!(title.contains("gasleft: 123456"));
-        assert!(title.contains("totalGasUsed: 789012"));
+        assert!(title.contains("pc: 0x2a (42)"));
+        assert!(title.contains(&format!("address: {}", super::short_checksum_address(&address))));
+        assert!(title.contains("gasLeft: 123456"));
+        assert!(title.contains("totalTraceGasUsed: 789012"));
         assert!(title.contains("subcalls: 3"));
-        assert!(title.contains("callGas: 42"));
-        assert!(title.contains("refund: 7"));
+        assert!(title.contains("callGasUsed: 42"));
+        assert!(title.contains("gasRefund: 7"));
+    }
+
+    #[test]
+    fn op_list_title_omits_aggregate_stats_when_unavailable() {
+        let title = super::op_list_title(&Address::from([0x42; 20]), 0x2a, 123_456, 42, 7, None);
+
+        assert!(!title.contains("totalTraceGasUsed"));
+        assert!(!title.contains("subcalls"));
+    }
+
+    #[test]
+    fn short_checksum_address_uses_standard_address_compression() {
+        let address = address!("0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
+
+        assert_eq!(super::short_checksum_address(&address), format!("{address:#}"));
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -617,7 +617,7 @@ fn op_list_title(
     gas_refund_counter: u64,
     stats: Option<DebuggerStats>,
 ) -> String {
-    let address = short_checksum_address(address);
+    let address = full_checksum_address(address);
     let mut title = format!(
         "address: {address} | pc: 0x{pc:x} ({pc}) | gasLeft: {gas_remaining} | \
          callGasUsed: {call_gas_used} | gasRefund: {gas_refund_counter}"
@@ -626,8 +626,8 @@ fn op_list_title(
     if let Some(stats) = stats {
         write!(
             title,
-            " | totalTraceGasUsed: {} | subcalls: {}",
-            stats.total_trace_gas_used, stats.subcalls
+            " | sessionTraceGasUsed: {} | sessionSubcalls: {}",
+            stats.session_trace_gas_used, stats.session_subcalls
         )
         .unwrap();
     }
@@ -635,8 +635,8 @@ fn op_list_title(
     title
 }
 
-fn short_checksum_address(address: &Address) -> String {
-    format!("{address:#}")
+fn full_checksum_address(address: &Address) -> String {
+    address.to_string()
 }
 
 /// Wrapper around a list of [`Line`]s that prepends the line number on each new line.
@@ -704,15 +704,15 @@ mod tests {
 
     #[test]
     fn op_list_title_includes_gas_and_subcall_stats() {
-        let stats = DebuggerStats { total_trace_gas_used: 789_012, subcalls: 3 };
+        let stats = DebuggerStats { session_trace_gas_used: 789_012, session_subcalls: 3 };
         let address = Address::from([0x42; 20]);
         let title = super::op_list_title(&address, 0x2a, 123_456, 42, 7, Some(stats));
 
         assert!(title.contains("pc: 0x2a (42)"));
-        assert!(title.contains(&format!("address: {}", super::short_checksum_address(&address))));
+        assert!(title.contains(&format!("address: {}", super::full_checksum_address(&address))));
         assert!(title.contains("gasLeft: 123456"));
-        assert!(title.contains("totalTraceGasUsed: 789012"));
-        assert!(title.contains("subcalls: 3"));
+        assert!(title.contains("sessionTraceGasUsed: 789012"));
+        assert!(title.contains("sessionSubcalls: 3"));
         assert!(title.contains("callGasUsed: 42"));
         assert!(title.contains("gasRefund: 7"));
     }
@@ -721,15 +721,17 @@ mod tests {
     fn op_list_title_omits_aggregate_stats_when_unavailable() {
         let title = super::op_list_title(&Address::from([0x42; 20]), 0x2a, 123_456, 42, 7, None);
 
-        assert!(!title.contains("totalTraceGasUsed"));
-        assert!(!title.contains("subcalls"));
+        assert!(!title.contains("sessionTraceGasUsed"));
+        assert!(!title.contains("sessionSubcalls"));
     }
 
     #[test]
-    fn short_checksum_address_uses_standard_address_compression() {
+    fn op_list_title_uses_full_checksum_address() {
         let address = address!("0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
+        let title = super::op_list_title(&address, 0x2a, 123_456, 42, 7, None);
 
-        assert_eq!(super::short_checksum_address(&address), format!("{address:#}"));
+        assert!(title.contains("address: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"));
+        assert!(!title.contains('…'));
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -2,6 +2,7 @@
 
 use super::context::{StatusKind, TUIContext};
 use crate::op::OpcodeParam;
+use alloy_primitives::Address;
 use foundry_compilers::artifacts::sourcemap::SourceElement;
 use foundry_evm_core::buffer::{BufferKind, get_buffer_accesses};
 use foundry_evm_traces::debug::SourceData;
@@ -398,13 +399,16 @@ impl TUIContext<'_> {
             })
             .collect::<Vec<_>>();
 
-        let title = format!(
-            "Address: {} | PC: 0x{:x} ({}) | Gas used: {} | Gas refund: {}",
+        let step = self.current_step();
+        let call_gas_used = self.debug_call().gas_limit.saturating_sub(step.gas_remaining);
+        let title = op_list_title(
             self.address(),
-            self.current_step().pc,
-            self.current_step().pc,
-            self.debug_call().gas_limit - self.current_step().gas_remaining,
-            self.current_step().gas_refund_counter
+            step.pc,
+            step.gas_remaining,
+            self.debugger_context.stats.total_gas_used,
+            call_gas_used,
+            step.gas_refund_counter,
+            self.debugger_context.stats.subcalls,
         );
         let block = Block::default().title(title).borders(Borders::ALL);
         let list = List::new(items)
@@ -606,6 +610,28 @@ impl TUIContext<'_> {
     }
 }
 
+fn op_list_title(
+    address: &Address,
+    pc: usize,
+    gas_remaining: u64,
+    total_gas_used: u64,
+    call_gas_used: u64,
+    gas_refund_counter: u64,
+    subcalls: usize,
+) -> String {
+    let address = short_address(address);
+    format!(
+        "Addr: {address} | PC: 0x{pc:x} ({pc}) | gasleft: {gas_remaining} | totalGasUsed: \
+         {total_gas_used} | subcalls: {subcalls} | callGas: {call_gas_used} | refund: \
+         {gas_refund_counter}"
+    )
+}
+
+fn short_address(address: &Address) -> String {
+    let address = address.to_string();
+    format!("{}...{}", &address[..6], &address[address.len() - 4..])
+}
+
 /// Wrapper around a list of [`Line`]s that prepends the line number on each new line.
 struct SourceLines<'a> {
     lines: Vec<Line<'a>>,
@@ -666,6 +692,22 @@ fn hex_digits(n: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::Address;
+
+    #[test]
+    fn op_list_title_includes_gas_and_subcall_stats() {
+        let title =
+            super::op_list_title(&Address::from([0x42; 20]), 0x2a, 123_456, 789_012, 42, 7, 3);
+
+        assert!(title.contains("PC: 0x2a (42)"));
+        assert!(title.contains("Addr: 0x4242...4242"));
+        assert!(title.contains("gasleft: 123456"));
+        assert!(title.contains("totalGasUsed: 789012"));
+        assert!(title.contains("subcalls: 3"));
+        assert!(title.contains("callGas: 42"));
+        assert!(title.contains("refund: 7"));
+    }
+
     #[test]
     fn decimal_digits() {
         assert_eq!(super::decimal_digits(0), 1);


### PR DESCRIPTION
## Summary

Closes #8784.

- Display live `gasLeft`, aggregate `totalTraceGasUsed`, and total subcall count in the debugger opcode pane.
- Keep call-frame gas usage and refund visible with shorter lower-camel labels so the requested stats fit in normal TUI layouts.
- Count subcalls from the raw `CallTraceArena` before debugger flattening drops empty-step calls.