### PR TITLE
fix(forge): hide unreliable mutation score

### DIFF
--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -181,6 +181,16 @@ impl MutationsSummary {
         if valid_mutants == 0 { 0.0 } else { self.dead.len() as f64 / valid_mutants as f64 * 100.0 }
     }
 
+    /// Mutants that reached a test verdict and can contribute to the score.
+    pub const fn total_evaluated(&self) -> usize {
+        self.dead.len() + self.survived.len()
+    }
+
+    /// Whether the score is useful enough to present as a coverage signal.
+    pub const fn has_reliable_score(&self) -> bool {
+        self.total_evaluated() > 0 && self.timed_out.len() < self.total_evaluated()
+    }
+
     /// Convert to JSON output format.
     ///
     /// Output is sorted deterministically: files in lexicographic order
@@ -663,5 +673,36 @@ mod tests {
         assert!(
             handler.retrieve_cached_mutant_results("build", "exec", &changed_mutants).is_none()
         );
+    }
+
+    #[test]
+    fn mutation_score_is_unreliable_when_evaluated_mutants_equal_timeouts() {
+        let mut summary = MutationsSummary::new();
+        summary.add_dead_mutant(mutant(10, 20, "number++"));
+        summary.add_timed_out_mutant(mutant(30, 40, "number--"));
+
+        assert_eq!(summary.total_evaluated(), 1);
+        assert!(!summary.has_reliable_score());
+    }
+
+    #[test]
+    fn mutation_score_is_unreliable_when_timeouts_dominate() {
+        let mut summary = MutationsSummary::new();
+        summary.add_dead_mutant(mutant(10, 20, "number++"));
+        summary.add_timed_out_mutant(mutant(30, 40, "number--"));
+        summary.add_timed_out_mutant(mutant(50, 60, "number += 1"));
+
+        assert_eq!(summary.total_evaluated(), 1);
+        assert!(!summary.has_reliable_score());
+    }
+
+    #[test]
+    fn mutation_score_is_unreliable_with_no_evaluated_mutants() {
+        let mut summary = MutationsSummary::new();
+        summary.add_timed_out_mutant(mutant(10, 20, "number++"));
+
+        assert_eq!(summary.total_evaluated(), 0);
+        assert!(!summary.has_reliable_score());
+        assert_eq!(summary.mutation_score(), 0.0);
     }
 }

--- a/crates/forge/src/mutation/reporter.rs
+++ b/crates/forge/src/mutation/reporter.rs
@@ -65,17 +65,6 @@ impl MutationReporter {
             Paint::magenta("Timed out")
         );
 
-        // Mutation score with color
-        let score = summary.mutation_score();
-        let score_display = format!("{score:.1}%");
-        let score_colored = if score >= 80.0 {
-            Paint::green(&score_display).bold()
-        } else if score >= 60.0 {
-            Paint::yellow(&score_display).bold()
-        } else {
-            Paint::red(&score_display).bold()
-        };
-
         // Format duration similar to test output
         let duration_str = if duration.as_secs() >= 60 {
             format!("{}m {:.2}s", duration.as_secs() / 60, duration.as_secs_f64() % 60.0)
@@ -83,13 +72,41 @@ impl MutationReporter {
             format!("{:.2}s", duration.as_secs_f64())
         };
 
-        let _ = sh_println!(
-            "Mutation Score: {} ({}/{} mutants killed); finished in {}",
-            score_colored,
-            summary.total_dead(),
-            summary.total_dead() + summary.total_survived(),
-            duration_str
-        );
+        if summary.has_reliable_score() {
+            // Mutation score with color
+            let score = summary.mutation_score();
+            let score_display = format!("{score:.1}%");
+            let score_colored = if score >= 80.0 {
+                Paint::green(&score_display).bold()
+            } else if score >= 60.0 {
+                Paint::yellow(&score_display).bold()
+            } else {
+                Paint::red(&score_display).bold()
+            };
+
+            let _ = sh_println!(
+                "Mutation Score: {} ({}/{} mutants killed); finished in {}",
+                score_colored,
+                summary.total_dead(),
+                summary.total_evaluated(),
+                duration_str
+            );
+        } else {
+            let _ = sh_println!(
+                "Mutation Score: unavailable ({} timed out, {} evaluated); finished in {}",
+                summary.total_timed_out(),
+                summary.total_evaluated(),
+                duration_str
+            );
+            let _ = sh_println!(
+                "{}",
+                Paint::yellow(
+                    "Timed-out mutants dominate this run. Increase --mutation-timeout or use a \
+                     faster mutation profile, for example lower optimizer_runs or disable via_ir."
+                )
+                .bold()
+            );
+        }
 
         // Survived mutants section - the most important for developers.
         if !summary.get_survived().is_empty() {


### PR DESCRIPTION
## Summary

Fixes misleading mutation testing reports when most mutants time out before reaching a test verdict.

When timed-out mutants dominate, `forge test --mutate` now reports the mutation score as unavailable instead of showing values like `0.0% (0/0 mutants killed)`, and prints guidance to increase `--mutation-timeout` or use a faster mutation profile.

Closes #15102