### PR TITLE
perf(fuzz): clone only assigned corpus shard

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -251,19 +251,29 @@ impl WorkerCorpusSeed {
         self
     }
 
-    pub(crate) fn for_worker(mut self, worker_id: usize, worker_count: usize) -> Self {
-        if worker_count > 1 {
-            self.in_memory_corpus = self
-                .in_memory_corpus
-                .into_iter()
-                .enumerate()
-                .filter_map(|(idx, entry)| (idx % worker_count == worker_id).then_some(entry))
-                .collect();
-            self.metrics.corpus_count = self.in_memory_corpus.len();
-            self.metrics.favored_items =
-                self.in_memory_corpus.iter().filter(|entry| entry.is_favored).count();
+    pub(crate) fn clone_for_worker(&self, worker_id: usize, worker_count: usize) -> Self {
+        let in_memory_corpus = self
+            .in_memory_corpus
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| idx % worker_count == worker_id)
+            .map(|(_, entry)| entry.clone())
+            .collect::<Vec<_>>();
+
+        let mut metrics = self.metrics.clone();
+        metrics.corpus_count = in_memory_corpus.len();
+        metrics.favored_items = in_memory_corpus.iter().filter(|entry| entry.is_favored).count();
+
+        Self {
+            in_memory_corpus,
+            history_map: self.history_map.clone(),
+            edge_indices: self.edge_indices.clone(),
+            sancov_history_map: self.sancov_history_map.clone(),
+            metrics,
+            failed_replays: self.failed_replays,
+            optimization_best_value: self.optimization_best_value,
+            optimization_best_sequence: self.optimization_best_sequence.clone(),
         }
-        self
     }
 
     pub(crate) fn load_from_disk<FEN: FoundryEvmNetwork>(
@@ -1924,6 +1934,75 @@ mod tests {
         let (value, sequence) = manager.optimization_initial_state();
         assert_eq!(value, Some(I256::try_from(17).unwrap()));
         assert_eq!(sequence.len(), 1);
+    }
+
+    #[test]
+    fn clone_for_worker_shards_warmed_corpus_and_recomputes_metrics() {
+        let entries = (0..10)
+            .map(|idx| {
+                let mut entry = CorpusEntry::new(vec![basic_tx()]);
+                entry.is_favored = idx % 2 == 0;
+                entry
+            })
+            .collect::<Vec<_>>();
+        let entry_ids = entries.iter().map(|entry| entry.uuid).collect::<Vec<_>>();
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: entries,
+            history_map: vec![1, 2, 3],
+            edge_indices: EdgeIndexMap::default(),
+            sancov_history_map: vec![4, 5],
+            metrics: CorpusMetrics {
+                cumulative_edges_seen: 7,
+                cumulative_features_seen: 11,
+                corpus_count: 10,
+                favored_items: 5,
+            },
+            failed_replays: 13,
+            optimization_best_value: Some(I256::try_from(17).unwrap()),
+            optimization_best_sequence: vec![basic_tx()],
+        };
+
+        let worker_count = 3;
+        let shards = (0..worker_count)
+            .map(|worker_id| seed.clone_for_worker(worker_id, worker_count))
+            .collect::<Vec<_>>();
+        let mut sharded_ids = shards
+            .iter()
+            .flat_map(|shard| shard.in_memory_corpus.iter().map(|entry| entry.uuid))
+            .collect::<Vec<_>>();
+        let mut expected_ids = entry_ids.clone();
+        sharded_ids.sort_unstable();
+        expected_ids.sort_unstable();
+
+        assert_eq!(sharded_ids, expected_ids);
+        assert_eq!(
+            shards[0].in_memory_corpus.iter().map(|entry| entry.uuid).collect::<Vec<_>>(),
+            [entry_ids[0], entry_ids[3], entry_ids[6], entry_ids[9]]
+        );
+        assert_eq!(
+            shards[1].in_memory_corpus.iter().map(|entry| entry.uuid).collect::<Vec<_>>(),
+            [entry_ids[1], entry_ids[4], entry_ids[7]]
+        );
+        assert_eq!(
+            shards[2].in_memory_corpus.iter().map(|entry| entry.uuid).collect::<Vec<_>>(),
+            [entry_ids[2], entry_ids[5], entry_ids[8]]
+        );
+        assert_eq!(
+            shards.iter().map(|shard| shard.in_memory_corpus.len()).collect::<Vec<_>>(),
+            [4, 3, 3]
+        );
+        assert_eq!(
+            shards.iter().map(|shard| shard.metrics.corpus_count).collect::<Vec<_>>(),
+            [4, 3, 3]
+        );
+        assert_eq!(
+            shards.iter().map(|shard| shard.metrics.favored_items).collect::<Vec<_>>(),
+            [2, 1, 2]
+        );
+        assert!(shards.iter().all(|shard| shard.history_map == seed.history_map));
+        assert!(shards.iter().all(|shard| shard.sancov_history_map == seed.sancov_history_map));
+        assert!(shards.iter().all(|shard| shard.metrics.cumulative_edges_seen == 7));
+        assert!(shards.iter().all(|shard| shard.metrics.cumulative_features_seen == 11));
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -713,8 +713,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         &campaign_state,
                         campaign_seed.clone(),
                         corpus_seed
-                            .clone()
-                            .for_worker(worker_plan.worker_id as usize, actual_worker_count),
+                            .clone_for_worker(worker_plan.worker_id as usize, actual_worker_count),
                         corpus_persistence,
                         gas_report_samples,
                     );


### PR DESCRIPTION
## Problem

PR #15070 shards the warmed corpus with `corpus_seed.clone().for_worker(..)`. That means each parallel worker first materializes a full cloned seed, then filters it down to the entries assigned to that worker.

## Fix

`corpus_seed.clone_for_worker(..)` borrows the campaign seed and clones only the entries assigned to the target worker. Shared warmed coverage and optimization state are still copied per worker, and corpus-content metrics are recomputed for the shard.

## Methodology

End-to-end real invariant campaign: 370-entry persisted corpus, depth-2000 sequences, `--invariant-workers 8`, 3 interleaved iterations per binary, peak RSS via `/usr/bin/time -l`.

Three `forge` binaries built from the parent commit, #15070, and this fix, run on the same persisted corpus. Source: https://gist.github.com/mablr/cb84076c6c0712ce4b2cb11efc39df0b

## Results (8 workers, 370 entries)

| Variant | Wall-clock | Peak RSS |
|---|---|---|
| Parent (`clone()`)              | 66.6–70.4 s | 4.0–5.5 GB |
| #15070 (`clone().for_worker`)   | 67.0–68.7 s | 5.7–6.7 GB |
| Fix (`clone_for_worker`)        | 64.3–68.7 s | 2.79–2.80 GB |

## Conclusion

Wall-clock was comparable across variants.

Peak RSS is the important metric for the memory issue #15070 targeted.

In this benchmark, #15070 increased peak RSS vs the parent, while this follow-up reduced peak RSS to ~2.8 GB, about 2.4x lower than #15070.
