### PR TITLE
fix(cast): make cast logs --query-size a working opt-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,6 +2813,7 @@ dependencies = [
  "tempo-contracts",
  "tempo-primitives",
  "tokio",
+ "tower",
  "tracing",
  "url",
  "windows-sys 0.61.2",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -114,6 +114,7 @@ anvil.workspace = true
 foundry-test-utils.workspace = true
 tempo-chainspec.workspace = true
 path-slash.workspace = true
+tower.workspace = true
 
 [features]
 default = ["jemalloc", "asm-keccak", "optimism"]

--- a/crates/cast/src/cmd/logs.rs
+++ b/crates/cast/src/cmd/logs.rs
@@ -48,10 +48,13 @@ pub struct LogsArgs {
     #[arg(long)]
     subscribe: bool,
 
-    /// Number of blocks to query in each chunk when the provider has range limits.
-    /// Defaults to 10000 blocks per chunk.
-    #[arg(long, default_value_t = 10000)]
-    query_size: u64,
+    /// Split the query into chunks of this many blocks to work around provider range/result
+    /// limits.
+    ///
+    /// When omitted, the range is queried in a single request. Pass a value (e.g. `10000`) to
+    /// fetch the logs in `query-size`-block chunks instead.
+    #[arg(long, value_name = "BLOCKS")]
+    query_size: Option<u64>,
 
     #[command(flatten)]
     rpc: RpcOpts,
@@ -93,7 +96,10 @@ impl LogsArgs {
         let filter = build_filter(from_block, to_block, addresses, sig_or_topic, topics_or_args)?;
 
         if !subscribe {
-            let logs = cast.filter_logs_chunked(filter, query_size).await?;
+            let logs = match query_size {
+                Some(chunk_size) => cast.filter_logs_chunked(filter, chunk_size).await?,
+                None => cast.filter_logs(filter).await?,
+            };
             sh_println!("{logs}")?;
             return Ok(());
         }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -40,7 +40,7 @@ use foundry_common::{
 use foundry_config::Chain;
 use foundry_evm::core::bytecode::InstIter;
 use foundry_primitives::FoundryTxEnvelope;
-use futures::{FutureExt, StreamExt, future::Either};
+use futures::{FutureExt, StreamExt, TryStreamExt, future::Either};
 #[cfg(feature = "optimism")]
 use op_alloy_consensus as _;
 
@@ -654,98 +654,127 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
         Ok(res)
     }
 
-    fn extract_block_range(filter: &Filter) -> (Option<u64>, Option<u64>) {
+    /// Resolves the filter's block range to concrete block numbers.
+    ///
+    /// Returns `None` when the filter does not target a block-number range (e.g. it filters by
+    /// block hash), in which case chunking is not possible. Tags such as `latest` and `earliest`
+    /// are resolved against the provider so that the common case (`--to-block` defaulting to
+    /// `latest`) can still be chunked.
+    async fn resolve_block_range(&self, filter: &Filter) -> Result<Option<(u64, u64)>> {
         let FilterBlockOption::Range { from_block, to_block } = &filter.block_option else {
-            return (None, None);
+            return Ok(None);
         };
 
-        (from_block.and_then(|b| b.as_number()), to_block.and_then(|b| b.as_number()))
+        let from = self.resolve_block_tag(from_block.unwrap_or(BlockNumberOrTag::Earliest)).await?;
+        let to = self.resolve_block_tag(to_block.unwrap_or(BlockNumberOrTag::Latest)).await?;
+        Ok(Some((from, to)))
     }
 
-    /// Retrieves logs with automatic chunking fallback.
-    ///
-    /// First tries to fetch logs for the entire range. If that fails,
-    /// falls back to concurrent chunked requests with rate limiting.
+    /// Resolves a [`BlockNumberOrTag`] to a concrete block number, querying the provider for tags.
+    async fn resolve_block_tag(&self, tag: BlockNumberOrTag) -> Result<u64> {
+        if let BlockNumberOrTag::Number(number) = tag {
+            return Ok(number);
+        }
+        let block = self
+            .provider
+            .get_block(BlockId::Number(tag))
+            .await?
+            .ok_or_else(|| eyre::eyre!("could not resolve block tag `{tag}`"))?;
+        Ok(block.header().number())
+    }
+
+    /// Retrieves logs, splitting the request into fixed-size block chunks when needed.
     async fn get_logs_chunked(&self, filter: &Filter, chunk_size: u64) -> Result<Vec<Log>>
     where
         P: Clone + Unpin,
     {
-        // Try the full range first
-        if let Ok(logs) = self.provider.get_logs(filter).await {
-            return Ok(logs);
+        // Only chunk a finite block-number range larger than one chunk; `chunk_size == 0`
+        // disables chunking and falls back to a single request.
+        let Some((from, to)) = self.resolve_block_range(filter).await? else {
+            return self.provider.get_logs(filter).await.map_err(Into::into);
+        };
+        // Empty range.
+        if from > to {
+            return Ok(vec![]);
+        }
+        if chunk_size == 0 || to - from < chunk_size {
+            return self.provider.get_logs(filter).await.map_err(Into::into);
         }
 
-        // Fallback: use concurrent chunked approach
-        self.get_logs_chunked_concurrent(filter, chunk_size).await
+        self.get_logs_chunked_concurrent(filter, from, to, chunk_size).await
     }
 
-    /// Retrieves logs using concurrent chunked requests with rate limiting.
-    ///
-    /// Divides the block range into chunks and processes them with a maximum of
-    /// 5 concurrent requests. Falls back to single-block queries if chunks fail.
+    /// Retrieves logs for the inclusive `[from, to]` range using concurrent chunked requests.
     async fn get_logs_chunked_concurrent(
         &self,
         filter: &Filter,
+        from: u64,
+        to: u64,
         chunk_size: u64,
     ) -> Result<Vec<Log>>
     where
         P: Clone + Unpin,
     {
-        let (from_block, to_block) = Self::extract_block_range(filter);
-        let (Some(from), Some(to)) = (from_block, to_block) else {
-            return self.provider.get_logs(filter).await.map_err(Into::into);
-        };
-
-        if from >= to {
-            return Ok(vec![]);
+        let mut chunk_ranges: Vec<(u64, u64)> = Vec::new();
+        let mut start = from;
+        loop {
+            let end = start.saturating_add(chunk_size - 1).min(to);
+            chunk_ranges.push((start, end));
+            if end >= to {
+                break;
+            }
+            start = end + 1;
         }
 
-        // Create chunk ranges using iterator
-        let chunk_ranges: Vec<(u64, u64)> = (from..to)
-            .step_by(chunk_size as usize)
-            .map(|chunk_start| (chunk_start, (chunk_start + chunk_size).min(to)))
-            .collect();
-
-        // Process chunks with controlled concurrency using buffered stream
-        let mut all_results: Vec<(u64, Vec<Log>)> = futures::stream::iter(chunk_ranges)
-            .map(|(start_block, chunk_end)| {
-                let chunk_filter = filter.clone().from_block(start_block).to_block(chunk_end - 1);
-                let provider = self.provider.clone();
-
-                async move {
-                    // Try direct chunk request with simplified fallback
-                    match provider.get_logs(&chunk_filter).await {
-                        Ok(logs) => (start_block, logs),
-                        Err(_) => {
-                            // Simple fallback: try individual blocks in this chunk
-                            let mut fallback_logs = Vec::new();
-                            for single_block in start_block..chunk_end {
-                                let single_filter = chunk_filter
-                                    .clone()
-                                    .from_block(single_block)
-                                    .to_block(single_block);
-                                if let Ok(logs) = provider.get_logs(&single_filter).await {
-                                    fallback_logs.extend(logs);
-                                }
-                            }
-                            (start_block, fallback_logs)
-                        }
+        // `buffered` preserves input order, so results stay ordered by block. `try_collect` stops
+        // early and surfaces the error if any chunk ultimately fails.
+        let chunks: Vec<Vec<Log>> =
+            futures::stream::iter(chunk_ranges)
+                .map(|(start_block, end_block)| {
+                    let filter = filter.clone();
+                    let provider = self.provider.clone();
+                    async move {
+                        Self::get_logs_bisecting(&provider, &filter, start_block, end_block).await
                     }
+                })
+                .buffered(5)
+                .try_collect()
+                .await?;
+
+        Ok(chunks.into_iter().flatten().collect())
+    }
+
+    /// Fetches logs for the inclusive `[from, to]` range, recursively bisecting on failure.
+    fn get_logs_bisecting<'a>(
+        provider: &'a P,
+        filter: &'a Filter,
+        from: u64,
+        to: u64,
+    ) -> futures::future::BoxFuture<'a, Result<Vec<Log>>>
+    where
+        P: Clone + Unpin,
+    {
+        Box::pin(async move {
+            let range_filter = filter.clone().from_block(from).to_block(to);
+            match provider.get_logs(&range_filter).await {
+                Ok(logs) => Ok(logs),
+                Err(e) => {
+                    // A single block already failed; nothing left to split.
+                    if from >= to {
+                        return Err(e.into());
+                    }
+
+                    // Bisect sequentially: this path is only reached after a provider failure, so
+                    // fanning out concurrently here would risk amplifying rate-limit errors and
+                    // would defeat the top-level concurrency cap.
+                    let mid = from + (to - from) / 2;
+                    let mut left = Self::get_logs_bisecting(provider, filter, from, mid).await?;
+                    let right = Self::get_logs_bisecting(provider, filter, mid + 1, to).await?;
+                    left.extend(right);
+                    Ok(left)
                 }
-            })
-            .buffered(5) // Limit to 5 concurrent requests to avoid rate limits
-            .collect()
-            .await;
-
-        // Sort once at the end by block number and flatten
-        all_results.sort_by_key(|(block_num, _)| *block_num);
-
-        let mut all_logs = Vec::new();
-        for (_, logs) in all_results {
-            all_logs.extend(logs);
-        }
-
-        Ok(all_logs)
+            }
+        })
     }
 
     /// Converts a block identifier into a block number.

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -2513,13 +2513,67 @@ fn explorer_client(
 #[cfg(test)]
 mod logs_bisecting {
     use super::Cast;
+    use alloy_json_rpc::{RequestPacket, ResponsePacket, SerializedRequest};
     use alloy_network::AnyNetwork;
     use alloy_provider::ProviderBuilder;
+    use alloy_rpc_client::RpcClient;
     use alloy_rpc_types::{Filter, Log};
-    use alloy_transport::mock::Asserter;
+    use alloy_transport::{
+        TransportError, TransportFut,
+        mock::{Asserter, MockTransport},
+    };
+    use std::{
+        sync::{Arc, Mutex},
+        task::{Context, Poll},
+    };
+    use tower::Service;
 
     fn log_at(block: u64) -> Log {
         Log { block_number: Some(block), ..Default::default() }
+    }
+
+    /// Mock transport that records the `eth_getLogs` `[fromBlock, toBlock]` ranges it is asked for
+    /// while delegating the actual responses to a FIFO [`Asserter`].
+    #[derive(Clone)]
+    struct RecordingTransport {
+        inner: MockTransport,
+        ranges: Arc<Mutex<Vec<(String, String)>>>,
+    }
+
+    impl RecordingTransport {
+        fn new(asserter: Asserter) -> Self {
+            Self { inner: MockTransport::new(asserter), ranges: Arc::new(Mutex::new(Vec::new())) }
+        }
+
+        fn record(&self, req: &SerializedRequest) {
+            if req.method() != "eth_getLogs" {
+                return;
+            }
+            let Some(params) = req.params() else { return };
+            let Ok(value) = serde_json::from_str::<serde_json::Value>(params.get()) else { return };
+            let Some(filter) = value.get(0) else { return };
+            let field =
+                |name| filter.get(name).and_then(|v| v.as_str()).unwrap_or_default().to_string();
+            self.ranges.lock().unwrap().push((field("fromBlock"), field("toBlock")));
+        }
+    }
+
+    impl Service<RequestPacket> for RecordingTransport {
+        type Response = ResponsePacket;
+        type Error = TransportError;
+        type Future = TransportFut<'static>;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        fn call(&mut self, req: RequestPacket) -> Self::Future {
+            match &req {
+                RequestPacket::Single(req) => self.record(req),
+                RequestPacket::Batch(reqs) => reqs.iter().for_each(|req| self.record(req)),
+            }
+            self.inner.call(req)
+        }
     }
 
     // A range-limit failure splits depth-first into [0,1]/[2,3] and aggregates in range order.
@@ -2530,12 +2584,25 @@ mod logs_bisecting {
         asserter.push_success(&vec![log_at(0)]);
         asserter.push_success(&vec![log_at(2)]);
 
-        let provider =
-            ProviderBuilder::<_, _, AnyNetwork>::default().connect_mocked_client(asserter);
+        let transport = RecordingTransport::new(asserter);
+        let ranges = transport.ranges.clone();
+        let provider = ProviderBuilder::<_, _, AnyNetwork>::default()
+            .connect_client(RpcClient::new(transport, true));
 
         let logs = Cast::get_logs_bisecting(&provider, &Filter::new(), 0, 3).await.unwrap();
         let blocks: Vec<_> = logs.iter().map(|l| l.block_number).collect();
         assert_eq!(blocks, vec![Some(0), Some(2)]);
+
+        // The original range fails, then bisection requests exactly the two halves in order.
+        let ranges = ranges.lock().unwrap();
+        assert_eq!(
+            *ranges,
+            vec![
+                ("0x0".to_string(), "0x3".to_string()),
+                ("0x0".to_string(), "0x1".to_string()),
+                ("0x2".to_string(), "0x3".to_string()),
+            ]
+        );
     }
 
     // A single-block failure can't be split, so the error is surfaced.

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -16,6 +16,7 @@ use alloy_dyn_abi::{DynSolType, DynSolValue, FunctionExt};
 use alloy_eips::Encodable2718;
 use alloy_ens::NameOrAddress;
 use alloy_json_abi::Function;
+use alloy_json_rpc::RpcError;
 use alloy_network::{AnyNetwork, BlockResponse, Network, TransactionBuilder};
 use alloy_primitives::{
     Address, B256, I256, Keccak256, LogData, Selector, TxHash, U64, U256, hex,
@@ -26,6 +27,7 @@ use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, BlockOverrides, Filter, FilterBlockOption, Log, state::StateOverride,
 };
+use alloy_transport::TransportErrorKind;
 use base::{Base, NumberWithBase, ToBase};
 use chrono::DateTime;
 use eyre::{Context, ContextCompat, OptionExt, Result};
@@ -707,8 +709,11 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
         let Some((from, to)) = self.resolve_block_range(filter).await? else {
             return self.provider.get_logs(filter).await.map_err(Into::into);
         };
-        // Empty range.
+        // Inverted range yields no logs; warn instead of returning empty silently.
         if from > to {
+            sh_warn!(
+                "requested block range is inverted (from-block {from} > to-block {to}); no logs to return"
+            )?;
             return Ok(vec![]);
         }
         if chunk_size == 0 || to - from < chunk_size {
@@ -773,8 +778,9 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
             match provider.get_logs(&range_filter).await {
                 Ok(logs) => Ok(logs),
                 Err(e) => {
-                    // A single block already failed; nothing left to split.
-                    if from >= to {
+                    // Only bisect range-limit errors with room left to split; surface anything
+                    // else immediately.
+                    if from >= to || !is_range_limit_error(&e) {
                         return Err(e.into());
                     }
 
@@ -931,6 +937,38 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
 
         Ok(())
     }
+}
+
+/// Returns `true` if `err` is a provider range/result-size limit that retrying over a smaller
+/// range can fix. Network, auth, rate-limit, and malformed-response errors return `false`.
+fn is_range_limit_error(err: &RpcError<TransportErrorKind>) -> bool {
+    // Only HTTP 413 (payload too large) is fixable by a smaller range; other transport errors
+    // (network, auth 401/403, rate-limit 429) are not.
+    if let RpcError::Transport(kind) = err {
+        return kind.as_http_error().is_some_and(|http| http.status == 413);
+    }
+
+    // Range/result-size limits are reported as JSON-RPC server error responses; every other
+    // variant falls through to `false`.
+    let RpcError::ErrorResp(payload) = err else { return false };
+    let message = payload.message.to_ascii_lowercase();
+
+    // Phrases providers use for range/result-size limits, kept specific so rate-limit/quota
+    // wording (e.g. "no more than 10 requests per second") doesn't match.
+    const RANGE_LIMIT_HINTS: &[&str] = &[
+        "block range",
+        "blocks range",
+        "range is too",
+        "range too",
+        "returned more than",
+        "response size",
+        "result set",
+        "too many results",
+        "too many blocks",
+        "maximum block range",
+        "max block range",
+    ];
+    RANGE_LIMIT_HINTS.iter().any(|hint| message.contains(hint))
 }
 
 impl<P: Provider<N>, N: Network> Cast<P, N>
@@ -2468,6 +2506,63 @@ fn explorer_client(
     }
 
     builder.build().map_err(Into::into)
+}
+
+/// Tests for the `eth_getLogs` chunking/bisection helpers, kept in a separate module so they can
+/// use the provider-based [`Cast`] (the `tests` module aliases `Cast` to `SimpleCast`).
+#[cfg(test)]
+mod logs_bisecting {
+    use super::Cast;
+    use alloy_network::AnyNetwork;
+    use alloy_provider::ProviderBuilder;
+    use alloy_rpc_types::{Filter, Log};
+    use alloy_transport::mock::Asserter;
+
+    fn log_at(block: u64) -> Log {
+        Log { block_number: Some(block), ..Default::default() }
+    }
+
+    // A range-limit failure splits depth-first into [0,1]/[2,3] and aggregates in range order.
+    #[tokio::test]
+    async fn bisects_failed_range_and_aggregates_in_order() {
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("query returned more than 10000 results");
+        asserter.push_success(&vec![log_at(0)]);
+        asserter.push_success(&vec![log_at(2)]);
+
+        let provider =
+            ProviderBuilder::<_, _, AnyNetwork>::default().connect_mocked_client(asserter);
+
+        let logs = Cast::get_logs_bisecting(&provider, &Filter::new(), 0, 3).await.unwrap();
+        let blocks: Vec<_> = logs.iter().map(|l| l.block_number).collect();
+        assert_eq!(blocks, vec![Some(0), Some(2)]);
+    }
+
+    // A single-block failure can't be split, so the error is surfaced.
+    #[tokio::test]
+    async fn surfaces_single_block_failure() {
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("query returned more than 10000 results");
+
+        let provider =
+            ProviderBuilder::<_, _, AnyNetwork>::default().connect_mocked_client(asserter);
+
+        let err = Cast::get_logs_bisecting(&provider, &Filter::new(), 5, 5).await.unwrap_err();
+        assert!(err.to_string().contains("more than 10000 results"), "got: {err}");
+    }
+
+    // A non-range error fails after one request instead of bisecting.
+    #[tokio::test]
+    async fn does_not_bisect_non_range_errors() {
+        let asserter = Asserter::new();
+        asserter.push_failure_msg("unauthorized: invalid api key");
+
+        let provider =
+            ProviderBuilder::<_, _, AnyNetwork>::default().connect_mocked_client(asserter);
+
+        let err = Cast::get_logs_bisecting(&provider, &Filter::new(), 0, 3).await.unwrap_err();
+        assert!(err.to_string().contains("unauthorized"), "got: {err}");
+    }
 }
 
 #[cfg(test)]

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -665,22 +665,36 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
             return Ok(None);
         };
 
-        let from = self.resolve_block_tag(from_block.unwrap_or(BlockNumberOrTag::Earliest)).await?;
-        let to = self.resolve_block_tag(to_block.unwrap_or(BlockNumberOrTag::Latest)).await?;
+        let from_tag = from_block.unwrap_or(BlockNumberOrTag::Earliest);
+        let to_tag = to_block.unwrap_or(BlockNumberOrTag::Latest);
+
+        // `pending` is not a concrete canonical range boundary; don't chunk it, so the single
+        // request preserves the provider's native `pending` semantics.
+        if from_tag.is_pending() || to_tag.is_pending() {
+            return Ok(None);
+        }
+
+        let from = self.resolve_block_tag(from_tag).await?;
+        // Resolve identical tags only once so a moving head (e.g. `latest`..`latest`) can't yield
+        // an inconsistent range.
+        let to = if from_tag == to_tag { from } else { self.resolve_block_tag(to_tag).await? };
         Ok(Some((from, to)))
     }
 
     /// Resolves a [`BlockNumberOrTag`] to a concrete block number, querying the provider for tags.
     async fn resolve_block_tag(&self, tag: BlockNumberOrTag) -> Result<u64> {
-        if let BlockNumberOrTag::Number(number) = tag {
-            return Ok(number);
+        match tag {
+            BlockNumberOrTag::Number(number) => Ok(number),
+            BlockNumberOrTag::Earliest => Ok(0),
+            tag => {
+                let block = self
+                    .provider
+                    .get_block(BlockId::Number(tag))
+                    .await?
+                    .ok_or_else(|| eyre::eyre!("could not resolve block tag `{tag}`"))?;
+                Ok(block.header().number())
+            }
         }
-        let block = self
-            .provider
-            .get_block(BlockId::Number(tag))
-            .await?
-            .ok_or_else(|| eyre::eyre!("could not resolve block tag `{tag}`"))?;
-        Ok(block.header().number())
     }
 
     /// Retrieves logs, splitting the request into fixed-size block chunks when needed.

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2216,22 +2216,36 @@ casttest!(logs_sig_2, |_prj, cmd| {
     .stdout_eq(file!["../fixtures/cast_logs.stdout"]);
 });
 
-casttest!(logs_chunked_large_range, |_prj, cmd| {
+// Queries a 60k-block range (which `--query-size` splits into multiple chunks) and asserts the
+// chunked result is byte-for-byte identical to a single unchunked request. This proves chunking
+// collects logs from every chunk without gaps, duplicates, or reordering, and that the inclusive
+// `to` block is covered.
+casttest!(logs_chunked, |_prj, cmd| {
     let rpc = next_http_archive_rpc_url();
-    cmd.args([
+    let args = [
         "logs",
         "--rpc-url",
         rpc.as_str(),
         "--from-block",
-        "18000000",
+        "12400000",
         "--to-block",
-        "18050000",
-        "--query-size",
-        "1000",
+        "12460000",
         "Transfer(address indexed from, address indexed to, uint256 value)",
-        "0xA0b86a33E6441d02dd8C6B2b7E5D1E3eD7F73b4b",
-    ])
-    .assert_success();
+        "0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B",
+    ];
+
+    // Baseline: single request over the whole range.
+    let unchunked = cmd.args(args).assert_success().get_output().stdout_lossy();
+
+    // Same query split into 10k-block chunks (6 chunks).
+    cmd.cast_fuse();
+    let chunked =
+        cmd.args(args).args(["--query-size", "10000"]).assert_success().get_output().stdout_lossy();
+
+    assert_eq!(chunked, unchunked, "chunked logs must match the unchunked result");
+    // Sanity check: results actually span the first and last chunk of the range.
+    assert!(chunked.contains("12400314"), "missing log from the first chunk");
+    assert!(chunked.contains("12454418"), "missing log from the last chunk");
 });
 
 // tests that `cast create2` writes `address\tsalt` to stdout and prose to stderr


### PR DESCRIPTION
- Make `--query-size` opt-in (`Option<u64>`): omitted = single request, set = chunk.
- Chunk proactively over the inclusive range and resolve `latest`/`earliest` tags.
- Bisect failed chunks instead of dropping the last block or swallowing errors.