### PR TITLE
test: update expect emit failure snapshot

### DIFF
--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -206,7 +206,7 @@ forgetest!(flaky_expect_emit_tests_should_fail, |prj, cmd| {
     cmd.forge_fuse().arg("build").assert_success();
     cmd.forge_fuse().args(["selectors", "cache"]).assert_success();
 
-    cmd.forge_fuse().args(["test", "--mc", "ExpectEmitFailureTest"]).assert_failure().stdout_eq(str![[r#"No files changed, compilation skipped
+    cmd.forge_fuse().args(["test", "--mc", "ExpectEmitFailureTest"]).assert_failure().stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
 ...
 [FAIL: E != expected A] testShouldFailCanMatchConsecutiveEvents() ([GAS])
 [FAIL: log != expected SomethingElse] testShouldFailDifferentIndexedParameters() ([GAS])


### PR DESCRIPTION
Updates the expected stdout line for `flaky_expect_emit_tests_should_fail` to match the current compile output placeholder.
closes https://github.com/foundry-rs/foundry/issues/15109
closes https://github.com/foundry-rs/foundry/issues/15108

Prompted by: @grandizzy