### PR TITLE
fix(mpp): update TIP-1034 session payments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6136,7 +6136,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -7699,7 +7699,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.10.4"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=ea69acd3a6c9c6f7c328b3e99c03b678cabf07b3#ea69acd3a6c9c6f7c328b3e99c03b678cabf07b3"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=0d57f96ff670b290801b2ead9e0f1d637e0f2b3e#0d57f96ff670b290801b2ead9e0f1d637e0f2b3e"
 dependencies = [
  "alloy",
  "alloy-sol-type-parser",
@@ -8122,7 +8122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -11377,7 +11377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11822,7 +11822,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -511,7 +511,7 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "ea69acd3a6c9c6f7c328b3e99c03b678cabf07b3", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "0d57f96ff670b290801b2ead9e0f1d637e0f2b3e", default-features = false, features = [
     "tempo",
     "client",
     "reqwest-rustls-tls",

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -19,6 +19,7 @@ use mpp::{
         },
         tempo::signing::{
             TempoSigningMode, sign_and_encode_async, sign_and_encode_fee_payer_envelope_async,
+            sign_and_encode_fee_payer_request_async,
         },
     },
     error::MppError,
@@ -30,7 +31,7 @@ use mpp::{
                 PRECOMPILE_MAX_CUMULATIVE_AMOUNT, compute_precompile_channel_id,
                 sign_precompile_voucher,
             },
-            session::TempoSessionExt,
+            session::{ChannelDescriptor, TempoSessionExt},
         },
     },
     tempo::{Call, SessionCredentialPayload, compute_channel_id, sign_voucher},
@@ -41,8 +42,12 @@ use std::{
 };
 use tempo_alloy::contracts::precompiles::{ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS};
 
-/// Shared per-origin in-memory channel state: (channels, key_provisioned).
-type SharedChannelState = (Arc<Mutex<HashMap<String, ChannelEntry>>>, Arc<Mutex<bool>>);
+/// Shared per-origin in-memory channel state: (channels, precompile descriptors, key_provisioned).
+type SharedChannelState = (
+    Arc<Mutex<HashMap<String, ChannelEntry>>>,
+    Arc<Mutex<HashMap<String, ChannelDescriptor>>>,
+    Arc<Mutex<bool>>,
+);
 
 /// Process-wide channel state registry, keyed by origin URL.
 ///
@@ -110,6 +115,7 @@ pub struct SessionProvider {
     authorized_signer: Option<Address>,
     default_deposit: Option<u128>,
     channels: Arc<Mutex<HashMap<String, ChannelEntry>>>,
+    precompile_descriptors: Arc<Mutex<HashMap<String, ChannelDescriptor>>>,
     key_provisioned: Arc<Mutex<bool>>,
     persisted: Arc<Mutex<HashMap<String, Channel>>>,
     /// Tracks uncommitted open/top-up state for deferred persistence.
@@ -147,7 +153,7 @@ impl SessionProvider {
             GLOBAL_PERSISTED.get_or_init(|| Arc::new(Mutex::new(persist::load_channels()))).clone();
 
         // Per-origin in-memory channel map + key provisioning state.
-        let (channels, key_provisioned) = {
+        let (channels, precompile_descriptors, key_provisioned) = {
             let global = GLOBAL_CHANNELS.get_or_init(|| Mutex::new(HashMap::new()));
             let mut map = global.lock().unwrap();
             map.entry(origin.clone())
@@ -161,7 +167,11 @@ impl SessionProvider {
                             channels.insert(key.clone(), entry);
                         }
                     }
-                    (Arc::new(Mutex::new(channels)), Arc::new(Mutex::new(true)))
+                    (
+                        Arc::new(Mutex::new(channels)),
+                        Arc::new(Mutex::new(HashMap::new())),
+                        Arc::new(Mutex::new(true)),
+                    )
                 })
                 .clone()
         };
@@ -172,6 +182,7 @@ impl SessionProvider {
             authorized_signer: None,
             default_deposit: None,
             channels,
+            precompile_descriptors,
             key_provisioned,
             persisted,
             pending: Arc::new(Mutex::new(None)),
@@ -251,6 +262,7 @@ impl SessionProvider {
             .collect();
         for (key, channel_id) in &keys_to_remove {
             channels.remove(key);
+            self.precompile_descriptors.lock().unwrap().remove(key);
             persisted.remove(key);
             persist::delete_channel_from_db(channel_id);
         }
@@ -301,6 +313,7 @@ impl SessionProvider {
             match action {
                 PendingAction::Open { key } => {
                     self.channels.lock().unwrap().remove(&key);
+                    self.precompile_descriptors.lock().unwrap().remove(&key);
                     self.persisted.lock().unwrap().remove(&key);
                 }
                 PendingAction::TopUp { key, old_deposit } => {
@@ -338,6 +351,21 @@ impl SessionProvider {
         let signer = authorized_signer.unwrap_or(*payer);
         format!("{origin_hash}:{chain_id}:{payer}:{signer}:{payee}:{currency}:{escrow}:{operator}")
             .to_lowercase()
+    }
+
+    /// Compute the TIP-1034 expiring nonce hash for fee-sponsored opens.
+    ///
+    /// The submitted transaction uses a fee-payer marker signature that the
+    /// sponsor replaces, and TIP-1034 derives channel identity from that same
+    /// marked transaction preimage.
+    fn compute_fee_payer_expiring_nonce_hash(
+        unsigned_tx: &tempo_primitives::transaction::TempoTransaction,
+        sender: Address,
+    ) -> B256 {
+        let mut tx = unsigned_tx.clone();
+        tx.fee_payer_signature =
+            Some(alloy_primitives::Signature::new(U256::ZERO, U256::ZERO, false));
+        compute_expiring_nonce_hash(&tx, sender)
     }
 
     fn resolve_deposit(&self, suggested: Option<&str>) -> Result<u128, MppError> {
@@ -492,6 +520,7 @@ impl SessionProvider {
                 payload_type: "transaction".to_string(),
                 channel_id: channel_id.to_string(),
                 transaction: signed_tx_hex,
+                descriptor: None,
                 authorized_signer: Some(format!("{authorized_signer}")),
                 cumulative_amount: options.initial_amount.to_string(),
                 signature: voucher_sig_hex,
@@ -562,7 +591,20 @@ impl SessionProvider {
         );
 
         // Must derive before signing: expiringNonceHash binds signing-payload bytes.
-        let expiring_nonce_hash = compute_expiring_nonce_hash(&tx, payer);
+        let expiring_nonce_hash = if options.fee_payer {
+            Self::compute_fee_payer_expiring_nonce_hash(&tx, payer)
+        } else {
+            compute_expiring_nonce_hash(&tx, payer)
+        };
+        let descriptor = ChannelDescriptor {
+            payer: payer.to_string(),
+            payee: options.payee.to_string(),
+            operator: operator.to_string(),
+            token: options.currency.to_string(),
+            salt: salt.to_string(),
+            authorized_signer: authorized_signer.to_string(),
+            expiring_nonce_hash: expiring_nonce_hash.to_string(),
+        };
         let channel_id = compute_precompile_channel_id(
             payer,
             options.payee,
@@ -574,7 +616,11 @@ impl SessionProvider {
             options.chain_id,
         );
 
-        let signed_tx = sign_and_encode_async(tx, &self.signer, &self.signing_mode).await?;
+        let signed_tx = if options.fee_payer {
+            sign_and_encode_fee_payer_request_async(tx, &self.signer, &self.signing_mode).await?
+        } else {
+            sign_and_encode_async(tx, &self.signer, &self.signing_mode).await?
+        };
 
         let voucher = sign_precompile_voucher(
             &self.signer,
@@ -599,6 +645,7 @@ impl SessionProvider {
                 payload_type: "transaction".to_string(),
                 channel_id: channel_id.to_string(),
                 transaction: alloy_primitives::hex::encode_prefixed(&signed_tx),
+                descriptor: Some(descriptor),
                 authorized_signer: Some(format!("{authorized_signer}")),
                 cumulative_amount: options.initial_amount.to_string(),
                 signature: alloy_primitives::hex::encode_prefixed(&voucher),
@@ -695,6 +742,7 @@ impl SessionProvider {
             payload_type: "transaction".to_string(),
             channel_id: entry.channel_id.to_string(),
             transaction: alloy_primitives::hex::encode_prefixed(&signed_tx),
+            descriptor: None,
             additional_deposit: additional_deposit.to_string(),
         })
     }
@@ -878,6 +926,18 @@ impl SessionProvider {
                                 "precompile voucher cumulative_amount must fit uint96".to_string(),
                             ));
                         }
+                        let descriptor = self
+                            .precompile_descriptors
+                            .lock()
+                            .unwrap()
+                            .get(&key)
+                            .cloned()
+                            .ok_or_else(|| {
+                                MppError::InvalidConfig(
+                                    "missing TIP-1034 descriptor for cached precompile channel"
+                                        .to_string(),
+                                )
+                            })?;
                         let sig = sign_precompile_voucher(
                             &self.signer,
                             entry.channel_id,
@@ -887,6 +947,7 @@ impl SessionProvider {
                         .await?;
                         SessionCredentialPayload::Voucher {
                             channel_id: entry.channel_id.to_string(),
+                            descriptor: Some(descriptor),
                             cumulative_amount: new_cumulative.to_string(),
                             signature: alloy_primitives::hex::encode_prefixed(&sig),
                         }
@@ -951,6 +1012,9 @@ impl SessionProvider {
 
         // Update in-memory state but defer disk persistence until server confirms.
         self.channels.lock().unwrap().insert(key.clone(), entry.clone());
+        if let SessionCredentialPayload::Open { descriptor: Some(descriptor), .. } = &payload {
+            self.precompile_descriptors.lock().unwrap().insert(key.clone(), descriptor.clone());
+        }
         let authorized_signer = self.authorized_signer.unwrap_or(payer);
         self.persisted.lock().unwrap().insert(
             key.clone(),

--- a/crates/common/src/provider/mpp/session.rs
+++ b/crates/common/src/provider/mpp/session.rs
@@ -579,9 +579,17 @@ impl SessionProvider {
                 fee_token: options.currency,
                 nonce: 0,
                 nonce_key: EXPIRING_NONCE_KEY,
-                gas_limit: SESSION_OPEN_GAS_LIMIT,
+                gas_limit: if options.fee_payer {
+                    SESSION_OPEN_FEE_PAYER_GAS_LIMIT
+                } else {
+                    SESSION_OPEN_GAS_LIMIT
+                },
                 max_fee_per_gas: MAX_FEE_PER_GAS,
-                max_priority_fee_per_gas: MAX_PRIORITY_FEE_PER_GAS,
+                max_priority_fee_per_gas: if options.fee_payer {
+                    MAX_PRIORITY_FEE_PER_GAS_FEE_PAYER
+                } else {
+                    MAX_PRIORITY_FEE_PER_GAS
+                },
                 fee_payer: options.fee_payer,
                 valid_before,
                 key_authorization: (!*self.key_provisioned.lock().unwrap())

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -1768,13 +1768,18 @@ mod tests {
         assert_eq!(captured.len(), 2);
 
         let open: SessionCredentialPayload = captured[0].payload_as().expect("Open payload");
-        let (open_channel_id, open_transaction, open_cumulative) = match open {
+        let (open_channel_id, open_transaction, open_cumulative, open_descriptor) = match open {
             SessionCredentialPayload::Open {
-                channel_id, transaction, cumulative_amount, ..
-            } => (channel_id, transaction, cumulative_amount),
+                channel_id,
+                transaction,
+                cumulative_amount,
+                descriptor,
+                ..
+            } => (channel_id, transaction, cumulative_amount, descriptor),
             other => panic!("first credential must be Open, got {other:?}"),
         };
         assert_eq!(open_cumulative, "1000");
+        let open_descriptor = open_descriptor.expect("precompile Open must include descriptor");
 
         let tx_bytes = alloy_primitives::hex::decode(&open_transaction).expect("hex tx");
         let envelope =
@@ -1794,14 +1799,18 @@ mod tests {
         assert_eq!(decoded.token, currency);
 
         let voucher: SessionCredentialPayload = captured[1].payload_as().expect("Voucher payload");
-        let (voucher_channel_id, voucher_cumulative) = match voucher {
-            SessionCredentialPayload::Voucher { channel_id, cumulative_amount, .. } => {
-                (channel_id, cumulative_amount)
-            }
+        let (voucher_channel_id, voucher_cumulative, voucher_descriptor) = match voucher {
+            SessionCredentialPayload::Voucher {
+                channel_id, cumulative_amount, descriptor, ..
+            } => (channel_id, cumulative_amount, descriptor),
             other => panic!("second credential must be Voucher, got {other:?}"),
         };
         assert_eq!(voucher_channel_id, open_channel_id);
         assert_eq!(voucher_cumulative, "2000");
+        assert_eq!(
+            voucher_descriptor.expect("precompile Voucher must include descriptor"),
+            open_descriptor
+        );
 
         handle.abort();
     }


### PR DESCRIPTION
## Summary
- bump `mpp-rs` to `0d57f96` for TIP-1034 session descriptor support
- include descriptors on precompile-backed MPP open credentials and reused vouchers
- submit precompile fee-payer opens in the sponsor request shape and derive their channel id from the same fee-payer marker preimage
- apply the existing fee-payer gas and priority-fee caps to precompile opens

## Tests
- `cargo fmt --check`
- `cargo check -p foundry-common`
- `cargo test -p foundry-common provider::mpp --lib`

Prompted by: @grandizzy