### PR TITLE
ci: increase timeouts for slow CLI integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,6 +17,12 @@ slow-timeout = { period = "5m", terminate-after = 4 }
 filter = "test(/vaddr_e2e::/)"
 slow-timeout = { period = "5m", terminate-after = 4 }
 
+# Integration-style CLI tests can exceed the default 90s timeout on slower
+# Windows, macOS, and ARM runners while shelling out to forge/solc/git.
+[[profile.default.overrides]]
+filter = "test(/^bind_event_module_name_shadowing$/) | test(/^bind_event_module_prefix_does_not_shadow_aliases$/) | test(/^can_bind_e2e$/) | test(/^test_clone_/) | test(/^can_deploy_and_simulate_25_txes_concurrently$/)"
+slow-timeout = { period = "5m", terminate-after = 4 }
+
 # Do not re-run so that `cargo cheats` is ran locally.
 [[profile.default.overrides]]
 filter = "package(foundry-cheatcodes-spec)"


### PR DESCRIPTION
## Summary
- increase nextest slow-timeout for CLI integration tests that timed out on slower Windows, macOS, and ARM runners
- keep existing runners, filters, retries, and flaky workflow unchanged

## Testing
- uv run python -c "import tomllib; tomllib.load(open('.config/nextest.toml','rb')); print('nextest TOML parsed')"
- git diff --check
- cargo nextest list --locked --workspace --no-run --message-format short (not run: cargo-nextest is not installed in this sandbox)

Prompted by: @grandizzy