### PR TITLE
ci: limit isolate tests to linux

### DIFF
--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -75,7 +75,12 @@ t_linux_arm = Target(
 )
 t_macos = Target("depot-macos-latest", "aarch64-apple-darwin", "macosx-aarch64")
 t_windows = Target("depot-windows-latest-16", "x86_64-pc-windows-msvc", "windows-amd64")
-targets = [t_linux_x86] if is_pr else [t_linux_x86, t_linux_arm, t_macos, t_windows]
+if is_pr:
+    targets = [t_linux_x86]
+elif profile == "isolate":
+    targets = [t_linux_x86, t_linux_arm]
+else:
+    targets = [t_linux_x86, t_linux_arm, t_macos, t_windows]
 
 config = [
     Case(


### PR DESCRIPTION
## Summary
- limit the `test-isolate` matrix to Linux x86_64 and Linux aarch64 on master pushes
- keep the regular CI matrix unchanged for Windows and macOS coverage
- keep existing PR behavior unchanged: Linux x86_64 only

## Why
- Windows/macOS isolate currently provides little unique coverage beyond Linux isolate plus regular cross-platform CI
- recent isolate failures on Windows/macOS were duplicated slow CLI timeout pressure rather than platform-specific isolate failures
- this reduces master CI flake and runner load while preserving isolate coverage on Linux

## Validation
- `EVENT_NAME=push PROFILE=isolate uv run python .github/scripts/matrices.py | jq -r '.include[].name'`
- `EVENT_NAME=push PROFILE=default uv run python .github/scripts/matrices.py | jq -r '.include[].name'`
- `EVENT_NAME=pull_request PROFILE=isolate uv run python .github/scripts/matrices.py | jq -r '.include[].name'`
- `git diff --check`

Prompted by: @grandizzy