### PR TITLE
refactor(tempo): centralize fee token defaulting

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -24,13 +24,12 @@ use foundry_common::{
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::{ProviderBuilder, RetryProviderWithSigner},
     shell,
-    tempo::TEMPO_BROWSER_GAS_BUFFER,
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, resolve_fee_token},
 };
 #[doc(hidden)]
 pub use foundry_config::{Chain, utils::*};
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use tempo_alloy::TempoNetwork;
-use tempo_contracts::precompiles::PATH_USD_ADDRESS;
 
 sol! {
     #[sol(rpc)]
@@ -348,6 +347,7 @@ impl Erc20Subcommand {
         }
     }
 
+    #[allow(clippy::large_stack_frames)]
     pub async fn run_generic<N: Network + RecommendedFillers>(
         self,
         pre_resolved_signer: Option<WalletSigner>,
@@ -450,8 +450,8 @@ impl Erc20Subcommand {
                     let mut tx = { $build_tx }.into_transaction_request();
                     let chain = get_chain(config.chain, &$provider).await?;
                     tx_opts.apply::<N>(&mut tx, chain.is_legacy());
-                    if chain.is_tempo() && tx.fee_token().is_none() {
-                        tx.set_fee_token(PATH_USD_ADDRESS);
+                    if let Some(fee_token) = resolve_fee_token(Some(chain), tx.fee_token()) {
+                        tx.set_fee_token(fee_token);
                     }
                     fill_tx(&$provider, &mut tx, browser.address(), chain, true).await?;
                     if print_sponsor_hash {

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -24,7 +24,7 @@ use foundry_common::{
     sh_warn, shell,
     tempo::{
         self, KeyType, KeysFile, TEMPO_BROWSER_GAS_BUFFER, WalletType, read_tempo_keys_file,
-        tempo_keys_path,
+        resolve_fee_token, tempo_keys_path,
     },
 };
 use foundry_evm::hardfork::TempoHardfork;
@@ -32,9 +32,9 @@ use foundry_wallets::{WalletOpts, WalletSigner, wallet_browser::signer::BrowserS
 use serde::Deserialize;
 use tempo_alloy::{TempoNetwork, provider::TempoProviderExt};
 use tempo_contracts::precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, IAccountKeychain,
+    ACCOUNT_KEYCHAIN_ADDRESS, DEFAULT_FEE_TOKEN,
     IAccountKeychain::{
-        CallScope, KeyInfo, KeyRestrictions, LegacyTokenLimit, SelectorRule, SignatureType,
+        self, CallScope, KeyInfo, KeyRestrictions, LegacyTokenLimit, SelectorRule, SignatureType,
         TokenLimit,
     },
     ITIP20, PATH_USD_ADDRESS,
@@ -1077,8 +1077,7 @@ struct DoctorContext {
     key_address: Option<Address>,
     #[serde(skip_serializing_if = "Option::is_none")]
     chain_id: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    fee_token: Option<Address>,
+    fee_token: Address,
 }
 
 /// Result of resolving a local registry entry for the doctor.
@@ -1199,9 +1198,13 @@ async fn run_doctor(
     rpc: RpcOpts,
 ) -> Result<()> {
     let mut steps: Vec<DoctorStep> = Vec::new();
-    let fee_token = fee_token.or(tempo.fee_token).unwrap_or(PATH_USD_ADDRESS);
-    let mut context =
-        DoctorContext { root_account, key_address, chain_id: None, fee_token: Some(fee_token) };
+    let requested_fee_token = fee_token.or(tempo.fee_token);
+    let mut context = DoctorContext {
+        root_account,
+        key_address,
+        chain_id: None,
+        fee_token: requested_fee_token.unwrap_or(DEFAULT_FEE_TOKEN),
+    };
 
     // Step 1: local registry lookup.
     let candidates = match collect_local_candidates(key_address, root_account) {
@@ -1228,6 +1231,8 @@ async fn run_doctor(
             return finalize_doctor(steps, context);
         }
     };
+    context.fee_token =
+        resolve_fee_token(config.chain, requested_fee_token).unwrap_or(DEFAULT_FEE_TOKEN);
 
     let provider = match ProviderBuilder::<TempoNetwork>::from_config(&config)
         .and_then(|builder| builder.build())
@@ -1366,7 +1371,9 @@ async fn run_doctor(
             steps.push(step);
 
             // Step 9: spending limits.
-            steps.push(check_spending_limits(&provider, &subject, &info, fee_token, is_t3).await);
+            steps.push(
+                check_spending_limits(&provider, &subject, &info, context.fee_token, is_t3).await,
+            );
 
             // Step 10: allowed calls (TIP-1011, T3+ only).
             steps.push(
@@ -1389,7 +1396,7 @@ async fn run_doctor(
 
             let (step, is_t3) = check_hardfork(&provider).await;
             steps.push(step);
-            steps.push(check_authorization_spending_limits(&signed, fee_token, is_t3));
+            steps.push(check_authorization_spending_limits(&signed, context.fee_token, is_t3));
             steps.push(check_authorization_allowed_calls(&signed, is_t3, to, selector, recipient));
         }
     }
@@ -1414,7 +1421,8 @@ async fn run_doctor(
         let balance_account = fee_payer.unwrap_or(subject.root_account);
         let balance_owner = if fee_payer.is_some() { "sponsor" } else { "root account" };
         steps.push(
-            check_fee_token_balance(&provider, balance_account, fee_token, balance_owner).await,
+            check_fee_token_balance(&provider, balance_account, context.fee_token, balance_owner)
+                .await,
         );
     }
 

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -24,7 +24,7 @@ use foundry_common::{
     sh_warn, shell,
     tempo::{
         self, KeyType, KeysFile, TEMPO_BROWSER_GAS_BUFFER, WalletType, read_tempo_keys_file,
-        resolve_fee_token, tempo_keys_path,
+        tempo_keys_path,
     },
 };
 use foundry_evm::hardfork::TempoHardfork;
@@ -1231,9 +1231,6 @@ async fn run_doctor(
             return finalize_doctor(steps, context);
         }
     };
-    context.fee_token =
-        resolve_fee_token(config.chain, requested_fee_token).unwrap_or(DEFAULT_FEE_TOKEN);
-
     let provider = match ProviderBuilder::<TempoNetwork>::from_config(&config)
         .and_then(|builder| builder.build())
     {

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -3,12 +3,14 @@
 pub mod auth;
 
 use crate::FoundryTransactionBuilder;
+use alloy_chains::Chain;
 use alloy_network::Network;
 use alloy_primitives::{Address, B256, Signature};
 use alloy_signer::Signer;
 use eyre::{Context, Result};
 use foundry_wallets::{RawWalletOpts, WalletOpts, WalletSigner};
 use std::sync::Arc;
+use tempo_alloy::contracts::precompiles::DEFAULT_FEE_TOKEN;
 
 mod keystore;
 mod registry;
@@ -52,6 +54,14 @@ fn redacted_debug(value: &str) -> &'static str {
 ///
 /// See <https://github.com/tempoxyz/tempo/blob/6ebf1a8/crates/revm/src/handler.rs#L108-L124>
 pub const TEMPO_BROWSER_GAS_BUFFER: u64 = 7_000;
+
+/// Resolves an explicit Tempo fee token or the canonical default for a known Tempo network.
+pub fn resolve_fee_token(
+    chain: Option<Chain>,
+    explicit_fee_token: Option<Address>,
+) -> Option<Address> {
+    explicit_fee_token.or_else(|| chain.is_some_and(Chain::is_tempo).then_some(DEFAULT_FEE_TOKEN))
+}
 
 /// Gas sponsor configuration for Tempo fee-payer signatures.
 #[derive(Clone, Debug)]

--- a/crates/common/src/tempo/tests.rs
+++ b/crates/common/src/tempo/tests.rs
@@ -3,6 +3,12 @@ use eyre::WrapErr;
 use foundry_evm_hardforks::TempoHardfork;
 use serde::Deserialize;
 use std::env;
+use tempo_alloy::contracts::precompiles::DEFAULT_FEE_TOKEN;
+
+use alloy_chains::{Chain, NamedChain};
+use alloy_primitives::Address;
+
+use super::resolve_fee_token;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -52,4 +58,36 @@ async fn test_fork_schedule_parses_configured_rpcs() -> eyre::Result<()> {
     }
 
     Ok(())
+}
+
+#[test]
+fn resolves_canonical_fee_token_for_tempo_chains() {
+    for chain in [
+        NamedChain::Tempo,
+        NamedChain::TempoModerato,
+        NamedChain::TempoTestnet,
+        NamedChain::TempoDevnet,
+    ] {
+        assert_eq!(resolve_fee_token(Some(chain.into()), None), Some(DEFAULT_FEE_TOKEN));
+    }
+}
+
+#[test]
+fn leaves_non_tempo_chains_without_a_default() {
+    assert_eq!(resolve_fee_token(Some(NamedChain::Mainnet.into()), None), None);
+}
+
+#[test]
+fn leaves_unknown_chain_without_a_default() {
+    assert_eq!(resolve_fee_token(None, None), None);
+}
+
+#[test]
+fn explicit_fee_token_overrides_chain_default() {
+    let explicit = Address::repeat_byte(0x42);
+    assert_eq!(
+        resolve_fee_token(Some(Chain::from_named(NamedChain::Tempo)), Some(explicit)),
+        Some(explicit)
+    );
+    assert_eq!(resolve_fee_token(None, Some(explicit)), Some(explicit));
 }

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -24,7 +24,7 @@ use foundry_common::{
     fmt::parse_tokens,
     provider::ProviderBuilder,
     shell,
-    tempo::TEMPO_BROWSER_GAS_BUFFER,
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, resolve_fee_token},
 };
 use foundry_compilers::{
     ArtifactId, artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize,
@@ -42,7 +42,7 @@ use foundry_wallets::{
 };
 use serde_json::json;
 use std::{borrow::Borrow, marker::PhantomData, path::PathBuf, sync::Arc, time::Duration};
-use tempo_alloy::{TempoNetwork, contracts::precompiles::DEFAULT_FEE_TOKEN};
+use tempo_alloy::TempoNetwork;
 
 merge_impl_figment_convert!(CreateArgs, build, eth);
 
@@ -433,13 +433,9 @@ impl CreateArgs {
             deployer.tx.set_create();
         }
 
-        // If Tempo chain fee token must be set
-        if chain.is_tempo() {
-            if let Some(fee_token) = self.tx.tempo.fee_token {
-                deployer.tx.set_fee_token(fee_token);
-            } else {
-                deployer.tx.set_fee_token(DEFAULT_FEE_TOKEN);
-            }
+        // If the chain has a canonical fee token, set it unless the user supplied one.
+        if let Some(fee_token) = resolve_fee_token(Some(chain), self.tx.tempo.fee_token) {
+            deployer.tx.set_fee_token(fee_token);
         }
 
         // Apply user-provided gas, fee, nonce, and Tempo options.

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -309,11 +309,8 @@ impl ScriptArgs {
 
         tempo.resolve_expires();
 
-        // Resolve the fee token based on the chain and Tempo settings.
-        // If no chain is set, use the Tempo mainnet chain when the Tempo network is active.
-        let chain = config
-            .chain
-            .or_else(|| evm_opts.networks.is_tempo().then(|| Chain::from_named(NamedChain::Tempo)));
+        // Resolve the fee token: default only when the active EVM network is Tempo.
+        let chain = evm_opts.networks.is_tempo().then(|| Chain::from_named(NamedChain::Tempo));
         tempo.fee_token = resolve_fee_token(chain, tempo.fee_token);
 
         let script_config = ScriptConfig::new(config, evm_opts, args.batch, tempo).await?;

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -13,6 +13,7 @@ extern crate foundry_common;
 extern crate tracing;
 
 use crate::{broadcast::BundledState, runner::ScriptRunner};
+use alloy_chains::{Chain, NamedChain};
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_network::Network;
 use alloy_primitives::{
@@ -36,6 +37,7 @@ use foundry_common::{
     abi::{encode_function_args, get_func},
     compile::ContractSizeLimits,
     shell,
+    tempo::resolve_fee_token,
 };
 use foundry_compilers::ArtifactId;
 use foundry_config::{
@@ -52,7 +54,6 @@ use foundry_evm::{
     core::{
         Breakpoints, FoundryTransaction,
         evm::{EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
-        tempo::PATH_USD_ADDRESS,
     },
     executors::ExecutorBuilder,
     inspectors::{
@@ -308,9 +309,12 @@ impl ScriptArgs {
 
         tempo.resolve_expires();
 
-        if evm_opts.networks.is_tempo() && tempo.fee_token.is_none() {
-            tempo.fee_token = Some(PATH_USD_ADDRESS);
-        }
+        // Resolve the fee token based on the chain and Tempo settings.
+        // If no chain is set, use the Tempo mainnet chain when the Tempo network is active.
+        let chain = config
+            .chain
+            .or_else(|| evm_opts.networks.is_tempo().then(|| Chain::from_named(NamedChain::Tempo)));
+        tempo.fee_token = resolve_fee_token(chain, tempo.fee_token);
 
         let script_config = ScriptConfig::new(config, evm_opts, args.batch, tempo).await?;
         Ok(PreprocessedState { args, script_config, script_wallets, browser_wallet })
@@ -883,7 +887,7 @@ mod tests {
         KeyType, SessionEntry, SessionKeyMaterial, SessionStatus, TEMPO_HOME_ENV,
         upsert_session_entry,
     };
-    use foundry_config::{NamedChain, UnresolvedEnvVarError};
+    use foundry_config::UnresolvedEnvVarError;
     use std::{fs, sync::LazyLock};
     use tempfile::tempdir;
     use tokio::sync::{Mutex, MutexGuard};


### PR DESCRIPTION
## Motivation

Add a shared Tempo fee-token resolver that preserves explicit overrides and returns the canonical default for known Tempo chains.

Use the resolver in forge script preprocessing, forge create, cast erc20 browser sends, and keychain doctor so PathUSD defaulting is not duplicated across call sites.

Keep keychain doctor diagnostics anchored to a concrete fee token while allowing config-chain resolution to refine the default when available.

Towards OSS-165