### PR TITLE
chore: bump Tempo dependencies for T8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4276,7 +4276,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4578,7 +4578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6960,7 +6960,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7883,7 +7883,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9001,7 +9001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9170,7 +9170,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9612,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9625,7 +9625,7 @@ dependencies = [
  "derive_more",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "serde_json",
 ]
 
@@ -9650,9 +9650,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f54468f34d9ed03356dee71bb182a2815a490934f1a291f58158053eee946ba"
+checksum = "f9c37bb4d1bac98661bf9128e1141b969034640d68697b22f70377e492fd332c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9662,8 +9662,8 @@ dependencies = [
  "bytes",
  "modular-bitfield",
  "parity-scale-codec",
- "reth-codecs-derive 0.4.0",
- "reth-zstd-compressors 0.4.0",
+ "reth-codecs-derive 0.4.2",
+ "reth-zstd-compressors 0.4.2",
  "serde",
 ]
 
@@ -9680,9 +9680,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80c0516faf1698c57f91f07c98ecd9f3a9d3f163f1ad4bb263d9c495b3928e0"
+checksum = "ceeb8dab90194305d3f7e3f043a22d2db1fb54b6dcf5d8e75c5a4fa8540e1f57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9692,21 +9692,34 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "reth-consensus-common"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-primitives-traits 0.4.2",
 ]
 
 [[package]]
 name = "reth-db-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9715,10 +9728,10 @@ dependencies = [
  "derive_more",
  "metrics",
  "modular-bitfield",
- "reth-codecs 0.4.0",
+ "reth-codecs 0.4.2",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -9730,21 +9743,37 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs 0.4.0",
- "reth-primitives-traits 0.4.0",
+ "reth-codecs 0.4.2",
+ "reth-primitives-traits 0.4.2",
  "serde",
+]
+
+[[package]]
+name = "reth-ethereum-consensus"
+version = "2.2.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "reth-chainspec",
+ "reth-consensus",
+ "reth-consensus-common",
+ "reth-execution-types",
+ "reth-primitives-traits 0.4.2",
+ "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9757,21 +9786,21 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "reth-codecs 0.4.0",
- "reth-primitives-traits 0.4.0",
+ "reth-codecs 0.4.2",
+ "reth-primitives-traits 0.4.2",
  "serde",
 ]
 
 [[package]]
 name = "reth-evm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -9784,7 +9813,7 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
@@ -9794,7 +9823,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9806,7 +9835,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "reth-storage-errors",
  "revm",
 ]
@@ -9814,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9827,7 +9856,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9836,7 +9865,7 @@ dependencies = [
  "alloy-rlp",
  "derive_more",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "reth-trie-common",
  "revm",
  "serde",
@@ -9846,7 +9875,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9883,9 +9912,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1216ba179909d41d8d55c5eae6c1c33698bc7a3053c35fd425c7789a5de3c1"
+checksum = "9102518f0bbf99bc8f0e656a56fb2a7513248630275b608d3706076a82fde42b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9901,7 +9930,7 @@ dependencies = [
  "modular-bitfield",
  "once_cell",
  "quanta",
- "reth-codecs 0.4.0",
+ "reth-codecs 0.4.2",
  "revm-bytecode 11.0.1",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
@@ -9913,12 +9942,12 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-primitives",
  "derive_more",
  "modular-bitfield",
- "reth-codecs 0.4.0",
+ "reth-codecs 0.4.2",
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.18",
@@ -9928,11 +9957,11 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "reth-storage-api",
  "reth-storage-errors",
  "revm",
@@ -9941,7 +9970,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9953,8 +9982,8 @@ dependencies = [
  "dyn-clone",
  "jsonrpsee-types",
  "reth-evm",
- "reth-primitives-traits 0.4.0",
- "reth-rpc-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
+ "reth-rpc-traits 0.4.2",
  "thiserror 2.0.18",
 ]
 
@@ -9975,28 +10004,28 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75186b77fef29e0160f476c9a6bde3363e503f0f32ac4ef47726ef1e3da81118"
+checksum = "9fa03a2c9681c385ae1c72b169ac9c3525163b71db0b3362f16e8929e19e45fd"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-stages-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs 0.4.0",
+ "reth-codecs 0.4.2",
  "reth-trie-common",
  "serde",
 ]
@@ -10004,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10018,7 +10047,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
@@ -10030,7 +10059,7 @@ dependencies = [
  "reth-db-models",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -10043,14 +10072,14 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-codecs 0.4.0",
- "reth-primitives-traits 0.4.0",
+ "reth-codecs 0.4.2",
+ "reth-primitives-traits 0.4.2",
  "reth-prune-types",
  "reth-static-file-types",
  "revm-database-interface",
@@ -10061,7 +10090,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10071,7 +10100,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=259b8dc#259b8dc3be74fd70e1a157a33a0a45785b8521c4"
+source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10084,8 +10113,8 @@ dependencies = [
  "derive_more",
  "itertools 0.14.0",
  "nybbles",
- "reth-codecs 0.4.0",
- "reth-primitives-traits 0.4.0",
+ "reth-codecs 0.4.2",
+ "reth-primitives-traits 0.4.2",
  "revm-database",
  "serde",
  "serde_with",
@@ -10102,9 +10131,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80dcfa0327b7642cc41c71d8cd3626a48ac76fb8304c28bcbdf416a45615d020"
+checksum = "dc0e86cf594718932d42cebce1fa48292fb7b92721f7c914631add1ca970e814"
 dependencies = [
  "zstd",
 ]
@@ -10594,7 +10623,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10653,7 +10682,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11378,7 +11407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11446,7 +11475,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11481,7 +11510,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11951,13 +11980,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
+source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11989,8 +12018,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.5.4"
-source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12013,7 +12042,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
+source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12024,7 +12053,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
+source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12036,7 +12065,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
+source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12047,9 +12076,11 @@ dependencies = [
  "derive_more",
  "reth-chainspec",
  "reth-consensus",
+ "reth-consensus-common",
+ "reth-ethereum-consensus",
  "reth-evm",
  "reth-evm-ethereum",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "reth-revm",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12062,7 +12093,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
+source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12083,7 +12114,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
+source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12094,7 +12125,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
+source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12110,10 +12141,10 @@ dependencies = [
  "modular-bitfield",
  "once_cell",
  "p256",
- "reth-codecs 0.4.0",
+ "reth-codecs 0.4.2",
  "reth-db-api",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.4.0",
+ "reth-primitives-traits 0.4.2",
  "reth-rpc-convert",
  "revm",
  "serde",
@@ -12125,12 +12156,11 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=4d3f1db11a496d5fc98bb33d8055de102e5f5e11#4d3f1db11a496d5fc98bb33d8055de102e5f5e11"
+source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
@@ -12163,7 +12193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13436,7 +13466,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13586,7 +13616,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -517,17 +517,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "0d57f96ff670b290801b2
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -601,9 +601,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8027e5ccdfe55e562a1111495d2c9acb6e27a930" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "4d3f1db11a496d5fc98bb33d8055de102e5f5e11" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -191,7 +191,7 @@ impl From<FoundryHardfork> for SpecId {
             FoundryHardfork::Ethereum(hardfork) => spec_id_from_ethereum_hardfork(hardfork),
             #[cfg(feature = "optimism")]
             FoundryHardfork::Optimism(hardfork) => eth_spec_id_from_optimism_hardfork(hardfork),
-            FoundryHardfork::Tempo(hardfork) => hardfork.into(),
+            FoundryHardfork::Tempo(hardfork) => spec_id_from_tempo_hardfork(hardfork),
         }
     }
 }
@@ -269,6 +269,11 @@ pub fn eth_spec_id_from_optimism_hardfork(hardfork: OpHardfork) -> SpecId {
         OpHardfork::Karst => SpecId::OSAKA,
         f => unreachable!("unimplemented {}", f),
     }
+}
+
+/// Map a `TempoHardfork` enum into its corresponding Ethereum `SpecId`.
+pub fn spec_id_from_tempo_hardfork(_: TempoHardfork) -> SpecId {
+    SpecId::OSAKA
 }
 
 /// Trait for converting an [`EvmVersion`] into a network-specific spec type.
@@ -464,7 +469,8 @@ mod tests {
 
     #[test]
     fn test_tempo_spec_id_mapping() {
-        assert_eq!(SpecId::from(TempoHardfork::Genesis), SpecId::OSAKA);
+        assert_eq!(spec_id_from_tempo_hardfork(TempoHardfork::Genesis), SpecId::OSAKA);
+        assert_eq!(spec_id_from_tempo_hardfork(TempoHardfork::T8), SpecId::OSAKA);
     }
 
     #[test]
@@ -477,11 +483,11 @@ mod tests {
     fn test_tempo_hardfork_from_chain_and_timestamp() {
         assert_eq!(
             FoundryHardfork::from_chain_and_timestamp(4217, u64::MAX),
-            Some(FoundryHardfork::Tempo(TempoHardfork::T5))
+            Some(FoundryHardfork::Tempo(TempoHardfork::T6))
         );
         assert_eq!(
             FoundryHardfork::from_chain_and_timestamp(42431, u64::MAX),
-            Some(FoundryHardfork::Tempo(TempoHardfork::T5))
+            Some(FoundryHardfork::Tempo(TempoHardfork::T6))
         );
     }
 
@@ -490,6 +496,7 @@ mod tests {
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("T3"), Some(TempoHardfork::T3));
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("tempo:T2"), Some(TempoHardfork::T2));
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("tempo:T7"), Some(TempoHardfork::T7));
+        assert_eq!(evm_spec_id_from_str::<TempoHardfork>("tempo:T8"), Some(TempoHardfork::T8));
         assert_eq!(evm_spec_id_from_str::<TempoHardfork>("ethereum:prague"), None);
     }
 

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -272,7 +272,7 @@ pub fn eth_spec_id_from_optimism_hardfork(hardfork: OpHardfork) -> SpecId {
 }
 
 /// Map a `TempoHardfork` enum into its corresponding Ethereum `SpecId`.
-pub fn spec_id_from_tempo_hardfork(_: TempoHardfork) -> SpecId {
+pub const fn spec_id_from_tempo_hardfork(_: TempoHardfork) -> SpecId {
     SpecId::OSAKA
 }
 


### PR DESCRIPTION
## Summary
- bump Foundry's pinned Tempo crates to `tempoxyz/tempo@d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5`, which includes T8 wiring
- keep Foundry's Tempo-to-REVM `SpecId` mapping local now that the upstream `From<TempoHardfork> for SpecId` impl is gone
- add/adjust hardfork tests for `tempo:T8` parsing and the updated Tempo chain schedule

## Validation
- `cargo test -p foundry-evm-hardforks`
- `cargo fmt --check` (passes; rustfmt emits existing nightly-only config warnings)

Prompted by: @grandizzy
