### PR TITLE
feat(tempo): show resolved fee token + clean-ups

### DIFF
--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -8,7 +8,10 @@
 //! uses the shared initialization logic from `foundry-evm-core`.
 
 use alloy_primitives::{Address, U256, address};
-use foundry_evm::core::tempo::{PATH_USD_ADDRESS, initialize_tempo_genesis_at_hardfork};
+use foundry_evm::core::tempo::{
+    ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
+    initialize_tempo_genesis_at_hardfork,
+};
 use revm::{
     context::journaled_state::JournalCheckpoint,
     state::{AccountInfo, Bytecode},
@@ -33,11 +36,6 @@ use super::db::Db;
 const SENDER: Address = address!("0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38");
 /// Admin address used for genesis initialization.
 const ADMIN: Address = address!("0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f");
-
-const PATH_USD: Address = PATH_USD_ADDRESS;
-const ALPHA_USD: Address = address!("0x20C0000000000000000000000000000000000001");
-const BETA_USD: Address = address!("0x20C0000000000000000000000000000000000002");
-const THETA_USD: Address = address!("0x20C0000000000000000000000000000000000003");
 
 /// Storage provider adapter for Anvil's Db to work with Tempo precompiles.
 pub struct AnvilStorageProvider<'a> {
@@ -233,7 +231,7 @@ pub fn initialize_tempo_precompiles(
     // Mint fee tokens to test accounts
     // u64::MAX per account - safe since u128::MAX can hold ~18 quintillion u64::MAX values
     let mint_amount = U256::from(u64::MAX);
-    let tokens = [PATH_USD, ALPHA_USD, BETA_USD, THETA_USD];
+    let tokens = [PATH_USD_ADDRESS, ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, THETA_USD_ADDRESS];
 
     StorageCtx::enter(&mut storage, || -> Result<(), TempoPrecompileError> {
         // Mint fee tokens to test accounts
@@ -274,10 +272,10 @@ pub fn initialize_tempo_precompiles(
 
         for (i, &account) in test_accounts.iter().enumerate() {
             let fee_token = match i {
-                0 => ALPHA_USD, // Alice
-                1 => BETA_USD,  // Bob
-                2 => THETA_USD, // Charlie
-                _ => PATH_USD,  // Everyone else
+                0 => ALPHA_USD_ADDRESS, // Alice
+                1 => BETA_USD_ADDRESS,  // Bob
+                2 => THETA_USD_ADDRESS, // Charlie
+                _ => PATH_USD_ADDRESS,  // Everyone else
             };
             fee_manager
                 .set_user_token(account, IFeeManager::setUserTokenCall { token: fee_token })?;

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1310,10 +1310,7 @@ async fn can_get_node_info_tempo_t1() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_deal_erc20_tempo() {
-    use alloy_primitives::address;
-    use foundry_evm::core::tempo::PATH_USD_ADDRESS;
-
-    const ALPHA_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000001");
+    use foundry_evm::core::tempo::{ALPHA_USD_ADDRESS, PATH_USD_ADDRESS};
 
     let (api, _handle) = spawn(NodeConfig::test_tempo()).await;
 

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -29,7 +29,8 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_sol_types::{SolValue, sol};
 use anvil::{NodeConfig, spawn};
 use foundry_evm::core::tempo::{
-    ITIP20ChannelReserve, PATH_USD_ADDRESS, TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS,
+    ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, ITIP20ChannelReserve, PATH_USD_ADDRESS,
+    TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, THETA_USD_ADDRESS,
     active_tempo_precompile_addresses,
 };
 use tempo_alloy::primitives::TempoTxEnvelope;
@@ -45,9 +46,9 @@ use tempo_primitives::{
 };
 
 const PATH_USD: Address = PATH_USD_ADDRESS;
-const ALPHA_USD: Address = address!("0x20C0000000000000000000000000000000000001");
-const BETA_USD: Address = address!("0x20C0000000000000000000000000000000000002");
-const THETA_USD: Address = address!("0x20C0000000000000000000000000000000000003");
+const ALPHA_USD: Address = ALPHA_USD_ADDRESS;
+const BETA_USD: Address = BETA_USD_ADDRESS;
+const THETA_USD: Address = THETA_USD_ADDRESS;
 const TEMPO_ADMIN: Address = address!("0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f");
 const DEX_MIN_ORDER_AMOUNT: u128 = 100_000_000;
 

--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -20,7 +20,9 @@ use foundry_cli::{
     opts::{EthereumOpts, TempoOpts, TransactionOpts},
     utils::{self, LoadConfig, maybe_print_resolved_lane, resolve_lane},
 };
-use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder};
+use foundry_common::{
+    FoundryTransactionBuilder, provider::ProviderBuilder, tempo::print_fee_token_selection,
+};
 use foundry_wallets::{TempoAccessKeyConfig, WalletOpts, WalletSigner};
 use tempo_alloy::TempoNetwork;
 
@@ -133,6 +135,7 @@ impl BatchMakeTxArgs {
             let from = eth.wallet.from.unwrap_or(Address::ZERO);
             let (tx, _) = tx_builder.build(from).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
+            print_fee_token_selection(tx.fee_token())?;
             let raw_tx =
                 alloy_primitives::hex::encode_prefixed(tx.build_unsigned()?.encoded_for_signing());
             sh_println!("{raw_tx}")?;
@@ -142,6 +145,7 @@ impl BatchMakeTxArgs {
         if ethsign {
             let (tx, _) = tx_builder.build(config.sender).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
+            print_fee_token_selection(tx.fee_token())?;
             let signed_tx = provider.sign_transaction(tx).await?;
             sh_println!("{signed_tx}")?;
             return Ok(());
@@ -157,6 +161,7 @@ impl BatchMakeTxArgs {
             let (tx, _) =
                 tx_builder.build_with_access_key(access_key.wallet_address, access_key).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
+            print_fee_token_selection(tx.fee_token())?;
             let raw_tx = tx
                 .sign_with_access_key(
                     &provider,
@@ -171,6 +176,7 @@ impl BatchMakeTxArgs {
             tx::validate_from_address(eth.wallet.from, Signer::address(&signer))?;
             let (tx, _) = tx_builder.build(&signer).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
+            print_fee_token_selection(tx.fee_token())?;
             let envelope = tx.build(&EthereumWallet::new(signer)).await?;
             alloy_primitives::hex::encode(envelope.encoded_2718())
         };

--- a/crates/cast/src/cmd/batch_mktx.rs
+++ b/crates/cast/src/cmd/batch_mktx.rs
@@ -21,7 +21,7 @@ use foundry_cli::{
     utils::{self, LoadConfig, maybe_print_resolved_lane, resolve_lane},
 };
 use foundry_common::{
-    FoundryTransactionBuilder, provider::ProviderBuilder, tempo::print_fee_token_selection,
+    FoundryTransactionBuilder, provider::ProviderBuilder, tempo::print_resolved_fee_token_selection,
 };
 use foundry_wallets::{TempoAccessKeyConfig, WalletOpts, WalletSigner};
 use tempo_alloy::TempoNetwork;
@@ -135,7 +135,7 @@ impl BatchMakeTxArgs {
             let from = eth.wallet.from.unwrap_or(Address::ZERO);
             let (tx, _) = tx_builder.build(from).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            print_fee_token_selection(tx.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
             let raw_tx =
                 alloy_primitives::hex::encode_prefixed(tx.build_unsigned()?.encoded_for_signing());
             sh_println!("{raw_tx}")?;
@@ -145,7 +145,7 @@ impl BatchMakeTxArgs {
         if ethsign {
             let (tx, _) = tx_builder.build(config.sender).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            print_fee_token_selection(tx.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
             let signed_tx = provider.sign_transaction(tx).await?;
             sh_println!("{signed_tx}")?;
             return Ok(());
@@ -161,7 +161,7 @@ impl BatchMakeTxArgs {
             let (tx, _) =
                 tx_builder.build_with_access_key(access_key.wallet_address, access_key).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            print_fee_token_selection(tx.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
             let raw_tx = tx
                 .sign_with_access_key(
                     &provider,
@@ -176,7 +176,7 @@ impl BatchMakeTxArgs {
             tx::validate_from_address(eth.wallet.from, Signer::address(&signer))?;
             let (tx, _) = tx_builder.build(&signer).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
-            print_fee_token_selection(tx.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
             let envelope = tx.build(&EthereumWallet::new(signer)).await?;
             alloy_primitives::hex::encode(envelope.encoded_2718())
         };

--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -146,6 +146,7 @@ impl BatchSendArgs {
             cast_send(
                 provider,
                 tx,
+                Some(chain),
                 send_tx.cast_async,
                 send_tx.sync,
                 send_tx.confirmations,
@@ -171,6 +172,7 @@ impl BatchSendArgs {
                     tx_request,
                     &signer,
                     access_key,
+                    Some(chain),
                     send_tx.cast_async,
                     send_tx.confirmations,
                     timeout,
@@ -191,6 +193,7 @@ impl BatchSendArgs {
                 cast_send(
                     provider,
                     tx_request,
+                    Some(chain),
                     send_tx.cast_async,
                     send_tx.sync,
                     send_tx.confirmations,

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -24,7 +24,7 @@ use foundry_common::{
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::{ProviderBuilder, RetryProviderWithSigner},
     shell,
-    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_fee_token_selection, resolve_fee_token},
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_resolved_fee_token_selection},
 };
 #[doc(hidden)]
 pub use foundry_config::{Chain, utils::*};
@@ -436,6 +436,7 @@ impl Erc20Subcommand {
                         tx,
                         signer,
                         access_key,
+                        Some(chain),
                         $send_tx.cast_async,
                         $send_tx.confirmations,
                         timeout,
@@ -450,9 +451,6 @@ impl Erc20Subcommand {
                     let mut tx = { $build_tx }.into_transaction_request();
                     let chain = get_chain(config.chain, &$provider).await?;
                     tx_opts.apply::<N>(&mut tx, chain.is_legacy());
-                    if let Some(fee_token) = resolve_fee_token(Some(chain), tx.fee_token()) {
-                        tx.set_fee_token(fee_token);
-                    }
                     fill_tx(&$provider, &mut tx, browser.address(), chain, true).await?;
                     if print_sponsor_hash {
                         let hash = tx.compute_sponsor_hash(browser.address()).ok_or_else(|| {
@@ -464,7 +462,7 @@ impl Erc20Subcommand {
                     if let Some(sponsor) = &tempo_sponsor {
                         sponsor.attach_and_print::<N>(&mut tx, browser.address()).await?;
                     }
-                    print_fee_token_selection(tx.fee_token())?;
+                    print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
                     let tx_hash = browser.send_transaction_via_browser(tx).await?;
                     CastTxSender::new(&$provider)
                         .print_tx_result(
@@ -498,6 +496,7 @@ impl Erc20Subcommand {
                     cast_send(
                         $provider,
                         tx,
+                        Some(chain),
                         $send_tx.cast_async,
                         $send_tx.sync,
                         $send_tx.confirmations,

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -24,7 +24,7 @@ use foundry_common::{
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::{ProviderBuilder, RetryProviderWithSigner},
     shell,
-    tempo::{TEMPO_BROWSER_GAS_BUFFER, resolve_fee_token},
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_fee_token_selection, resolve_fee_token},
 };
 #[doc(hidden)]
 pub use foundry_config::{Chain, utils::*};
@@ -464,6 +464,7 @@ impl Erc20Subcommand {
                     if let Some(sponsor) = &tempo_sponsor {
                         sponsor.attach_and_print::<N>(&mut tx, browser.address()).await?;
                     }
+                    print_fee_token_selection(tx.fee_token())?;
                     let tx_hash = browser.send_transaction_via_browser(tx).await?;
                     CastTxSender::new(&$provider)
                         .print_tx_result(

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -23,8 +23,8 @@ use foundry_common::{
     provider::ProviderBuilder,
     sh_warn, shell,
     tempo::{
-        self, KeyType, KeysFile, TEMPO_BROWSER_GAS_BUFFER, WalletType, read_tempo_keys_file,
-        tempo_keys_path,
+        self, KeyType, KeysFile, TEMPO_BROWSER_GAS_BUFFER, WalletType, print_fee_token_selection,
+        read_tempo_keys_file, tempo_keys_path,
     },
 };
 use foundry_evm::hardfork::TempoHardfork;
@@ -3133,6 +3133,7 @@ pub(crate) async fn send_keychain_tx_with_root_signer(
             if let Some(sponsor) = &tempo_sponsor {
                 sponsor.attach_and_print::<TempoNetwork>(&mut tx, browser.address()).await?;
             }
+            print_fee_token_selection(tx.fee_token())?;
 
             before_submit()?;
             let tx_hash = browser.send_transaction_via_browser(tx).await?;

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -23,8 +23,8 @@ use foundry_common::{
     provider::ProviderBuilder,
     sh_warn, shell,
     tempo::{
-        self, KeyType, KeysFile, TEMPO_BROWSER_GAS_BUFFER, WalletType, print_fee_token_selection,
-        read_tempo_keys_file, tempo_keys_path,
+        self, KeyType, KeysFile, TEMPO_BROWSER_GAS_BUFFER, WalletType,
+        print_resolved_fee_token_selection, read_tempo_keys_file, tempo_keys_path,
     },
 };
 use foundry_evm::hardfork::TempoHardfork;
@@ -3133,7 +3133,7 @@ pub(crate) async fn send_keychain_tx_with_root_signer(
             if let Some(sponsor) = &tempo_sponsor {
                 sponsor.attach_and_print::<TempoNetwork>(&mut tx, browser.address()).await?;
             }
-            print_fee_token_selection(tx.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
 
             before_submit()?;
             let tx_hash = browser.send_transaction_via_browser(tx).await?;
@@ -3143,6 +3143,7 @@ pub(crate) async fn send_keychain_tx_with_root_signer(
         }
         KeychainRootSigner::Wallet(signer) => {
             let from = signer.address();
+            let chain = builder.chain();
             let (mut tx, _) = builder.build(from).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
             if let Some(sponsor) = &tempo_sponsor {
@@ -3158,6 +3159,7 @@ pub(crate) async fn send_keychain_tx_with_root_signer(
             cast_send(
                 provider,
                 tx,
+                Some(chain),
                 send_tx.cast_async,
                 send_tx.sync,
                 send_tx.confirmations,

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -15,7 +15,9 @@ use foundry_cli::{
     opts::{EthereumOpts, TransactionOpts},
     utils::{LoadConfig, maybe_print_resolved_lane, resolve_lane},
 };
-use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder};
+use foundry_common::{
+    FoundryTransactionBuilder, provider::ProviderBuilder, tempo::print_fee_token_selection,
+};
 use std::{path::PathBuf, str::FromStr};
 use tempo_alloy::TempoNetwork;
 
@@ -178,6 +180,7 @@ impl MakeTxArgs {
             if let Some(sponsor) = &tempo_sponsor {
                 sponsor.attach_and_print::<N>(&mut tx, from).await?;
             }
+            print_fee_token_selection(tx.fee_token())?;
             let raw_tx = hex::encode_prefixed(tx.build_unsigned()?.encoded_for_signing());
 
             print_scalar(raw_tx)?;
@@ -192,6 +195,7 @@ impl MakeTxArgs {
             if let Some(sponsor) = &tempo_sponsor {
                 sponsor.attach_and_print::<N>(&mut tx, config.sender).await?;
             }
+            print_fee_token_selection(tx.fee_token())?;
             let signed_tx = provider.sign_transaction(tx).await?;
 
             print_scalar(signed_tx)?;
@@ -210,6 +214,7 @@ impl MakeTxArgs {
         if let Some(sponsor) = &tempo_sponsor {
             sponsor.attach_and_print::<N>(&mut tx, from).await?;
         }
+        print_fee_token_selection(tx.fee_token())?;
 
         let tx = tx.build(&EthereumWallet::new(signer)).await?;
 

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -16,7 +16,7 @@ use foundry_cli::{
     utils::{LoadConfig, maybe_print_resolved_lane, resolve_lane},
 };
 use foundry_common::{
-    FoundryTransactionBuilder, provider::ProviderBuilder, tempo::print_fee_token_selection,
+    FoundryTransactionBuilder, provider::ProviderBuilder, tempo::print_resolved_fee_token_selection,
 };
 use std::{path::PathBuf, str::FromStr};
 use tempo_alloy::TempoNetwork;
@@ -138,6 +138,7 @@ impl MakeTxArgs {
             .with_code_sig_and_args(code, sig, args)
             .await?
             .with_blob_data(blob_data)?;
+        let chain = tx_builder.chain();
 
         // If --tempo.print-sponsor-hash was passed, build the tx, print the hash, and exit.
         if print_sponsor_hash {
@@ -180,7 +181,7 @@ impl MakeTxArgs {
             if let Some(sponsor) = &tempo_sponsor {
                 sponsor.attach_and_print::<N>(&mut tx, from).await?;
             }
-            print_fee_token_selection(tx.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
             let raw_tx = hex::encode_prefixed(tx.build_unsigned()?.encoded_for_signing());
 
             print_scalar(raw_tx)?;
@@ -195,7 +196,7 @@ impl MakeTxArgs {
             if let Some(sponsor) = &tempo_sponsor {
                 sponsor.attach_and_print::<N>(&mut tx, config.sender).await?;
             }
-            print_fee_token_selection(tx.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
             let signed_tx = provider.sign_transaction(tx).await?;
 
             print_scalar(signed_tx)?;
@@ -214,7 +215,7 @@ impl MakeTxArgs {
         if let Some(sponsor) = &tempo_sponsor {
             sponsor.attach_and_print::<N>(&mut tx, from).await?;
         }
-        print_fee_token_selection(tx.fee_token())?;
+        print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
 
         let tx = tx.build(&EthereumWallet::new(signer)).await?;
 

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -18,7 +18,7 @@ use foundry_common::{
     FoundryTransactionBuilder,
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::ProviderBuilder,
-    tempo::TEMPO_BROWSER_GAS_BUFFER,
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_fee_token_selection},
 };
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use tempo_alloy::{
@@ -349,6 +349,7 @@ impl SendTxArgs {
             if let Some(sponsor) = &tempo_sponsor {
                 sponsor.attach_and_print::<N>(&mut tx_request, browser.address()).await?;
             }
+            print_fee_token_selection(tx_request.fee_token())?;
 
             let tx_hash = browser.send_transaction_via_browser(tx_request).await?;
 
@@ -477,6 +478,7 @@ where
     N::ReceiptResponse: UIfmt + UIfmtReceiptExt,
 {
     let cast = CastTxSender::new(provider);
+    print_fee_token_selection(tx.fee_token())?;
 
     if sync {
         // JSON envelope not supported: N::ReceiptResponse is generic over Display but not
@@ -513,6 +515,7 @@ where
 {
     tx.set_from(access_key.wallet_address);
     tx.set_key_id(access_key.key_address);
+    print_fee_token_selection(tx.fee_token())?;
     let raw_tx = tx
         .sign_with_access_key(
             provider,

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -510,6 +510,7 @@ where
 /// with [`CastTxBuilder`] (fields already set) and also with sol!-bindings (fields not yet set).
 ///
 /// NOTE: The default implementation returns an error. Only `TempoNetwork` supports this.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn cast_send_with_access_key<N: Network, P: Provider<N>>(
     provider: &P,
     mut tx: N::TransactionRequest,

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -18,8 +18,9 @@ use foundry_common::{
     FoundryTransactionBuilder,
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::ProviderBuilder,
-    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_fee_token_selection},
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_resolved_fee_token_selection},
 };
+use foundry_config::Chain;
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use tempo_alloy::{
     TempoNetwork,
@@ -309,6 +310,7 @@ impl SendTxArgs {
                 }
             }
 
+            let chain = builder.chain();
             let (mut tx_request, _) = builder.build(config.sender).await?;
             maybe_print_resolved_lane(
                 resolved_lane.as_ref(),
@@ -321,6 +323,7 @@ impl SendTxArgs {
             cast_send(
                 provider,
                 tx_request,
+                Some(chain),
                 send_tx.cast_async,
                 send_tx.sync,
                 send_tx.confirmations,
@@ -349,7 +352,7 @@ impl SendTxArgs {
             if let Some(sponsor) = &tempo_sponsor {
                 sponsor.attach_and_print::<N>(&mut tx_request, browser.address()).await?;
             }
-            print_fee_token_selection(tx_request.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx_request.fee_token())?;
 
             let tx_hash = browser.send_transaction_via_browser(tx_request).await?;
 
@@ -364,6 +367,7 @@ impl SendTxArgs {
                 Some(s) => s,
                 None => send_tx.eth.wallet.signer().await?,
             };
+            let chain = builder.chain();
             let (mut tx_request, _) = builder.build_with_access_key(ak.wallet_address, &ak).await?;
             maybe_print_resolved_lane(
                 resolved_lane.as_ref(),
@@ -377,6 +381,7 @@ impl SendTxArgs {
                 tx_request,
                 &signer,
                 &ak,
+                Some(chain),
                 send_tx.cast_async,
                 send_tx.confirmations,
                 timeout,
@@ -394,6 +399,7 @@ impl SendTxArgs {
 
             tx::validate_from_address(send_tx.eth.wallet.from, from)?;
 
+            let chain = builder.chain();
             let (mut tx_request, _) = builder.build(&signer).await?;
             maybe_print_resolved_lane(
                 resolved_lane.as_ref(),
@@ -416,6 +422,7 @@ impl SendTxArgs {
             cast_send(
                 provider,
                 tx_request,
+                Some(chain),
                 send_tx.cast_async,
                 send_tx.sync,
                 send_tx.confirmations,
@@ -435,6 +442,7 @@ impl SendTxArgs {
 
             tx::validate_from_address(send_tx.eth.wallet.from, from)?;
 
+            let chain = builder.chain();
             let (mut tx_request, _) = builder.build(&signer).await?;
             maybe_print_resolved_lane(
                 resolved_lane.as_ref(),
@@ -453,6 +461,7 @@ impl SendTxArgs {
             cast_send(
                 provider,
                 tx_request,
+                Some(chain),
                 send_tx.cast_async,
                 send_tx.sync,
                 send_tx.confirmations,
@@ -468,6 +477,7 @@ impl SendTxArgs {
 pub(crate) async fn cast_send<N: Network, P: Provider<N>>(
     provider: P,
     tx: N::TransactionRequest,
+    chain: Option<Chain>,
     cast_async: bool,
     sync: bool,
     confs: u64,
@@ -478,7 +488,7 @@ where
     N::ReceiptResponse: UIfmt + UIfmtReceiptExt,
 {
     let cast = CastTxSender::new(provider);
-    print_fee_token_selection(tx.fee_token())?;
+    print_resolved_fee_token_selection(chain, tx.fee_token())?;
 
     if sync {
         // JSON envelope not supported: N::ReceiptResponse is generic over Display but not
@@ -505,6 +515,7 @@ pub(crate) async fn cast_send_with_access_key<N: Network, P: Provider<N>>(
     mut tx: N::TransactionRequest,
     signer: &WalletSigner,
     access_key: &TempoAccessKeyConfig,
+    chain: Option<Chain>,
     cast_async: bool,
     confirmations: u64,
     timeout: u64,
@@ -515,7 +526,7 @@ where
 {
     tx.set_from(access_key.wallet_address);
     tx.set_key_id(access_key.key_address);
-    print_fee_token_selection(tx.fee_token())?;
+    print_resolved_fee_token_selection(chain, tx.fee_token())?;
     let raw_tx = tx
         .sign_with_access_key(
             provider,

--- a/crates/cast/src/cmd/tip20/mine.rs
+++ b/crates/cast/src/cmd/tip20/mine.rs
@@ -120,6 +120,7 @@ pub(super) async fn register(
             tx,
             &signer,
             access_key,
+            Some(chain),
             send_tx.cast_async,
             send_tx.confirmations,
             timeout,
@@ -127,8 +128,16 @@ pub(super) async fn register(
         .await?;
     } else {
         let provider = build_provider_with_signer::<TempoNetwork>(&send_tx, signer)?;
-        cast_send(provider, tx, send_tx.cast_async, send_tx.sync, send_tx.confirmations, timeout)
-            .await?;
+        cast_send(
+            provider,
+            tx,
+            Some(chain),
+            send_tx.cast_async,
+            send_tx.sync,
+            send_tx.confirmations,
+            timeout,
+        )
+        .await?;
     }
 
     Ok(())

--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -17,7 +17,7 @@ use foundry_cli::{
 use foundry_common::{
     FoundryTransactionBuilder,
     provider::ProviderBuilder,
-    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_fee_token_selection},
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_resolved_fee_token_selection},
 };
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use std::{str::FromStr, time::Duration};
@@ -242,6 +242,7 @@ pub(super) async fn send_tip20_transaction(
         .await?
         .with_code_sig_and_args(None, Some(sig.to_string()), args)
         .await?;
+    let chain = builder.chain();
 
     if print_sponsor_hash {
         let (tx, from) = if let Some(ref ak) = access_key {
@@ -276,7 +277,7 @@ pub(super) async fn send_tip20_transaction(
         if let Some(sponsor) = &tempo_sponsor {
             sponsor.attach_and_print::<TempoNetwork>(&mut tx, browser.address()).await?;
         }
-        print_fee_token_selection(tx.fee_token())?;
+        print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
         let tx_hash = browser.send_transaction_via_browser(tx).await?;
         CastTxSender::new(&provider)
             .print_tx_result(tx_hash, send_tx.cast_async, send_tx.confirmations, timeout)
@@ -295,6 +296,7 @@ pub(super) async fn send_tip20_transaction(
             tx,
             signer,
             &ak,
+            Some(chain),
             send_tx.cast_async,
             send_tx.confirmations,
             timeout,
@@ -322,8 +324,16 @@ pub(super) async fn send_tip20_transaction(
             .wallet(wallet)
             .connect_with(&connector)
             .await?;
-        cast_send(provider, tx, send_tx.cast_async, send_tx.sync, send_tx.confirmations, timeout)
-            .await?;
+        cast_send(
+            provider,
+            tx,
+            Some(chain),
+            send_tx.cast_async,
+            send_tx.sync,
+            send_tx.confirmations,
+            timeout,
+        )
+        .await?;
     } else {
         let signer = match pre_resolved_signer {
             Some(signer) => signer,
@@ -342,8 +352,16 @@ pub(super) async fn send_tip20_transaction(
         let provider = AlloyProviderBuilder::<_, _, TempoNetwork>::default()
             .wallet(wallet)
             .connect_provider(&provider);
-        cast_send(provider, tx, send_tx.cast_async, send_tx.sync, send_tx.confirmations, timeout)
-            .await?;
+        cast_send(
+            provider,
+            tx,
+            Some(chain),
+            send_tx.cast_async,
+            send_tx.sync,
+            send_tx.confirmations,
+            timeout,
+        )
+        .await?;
     }
 
     Ok(())

--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -15,7 +15,9 @@ use foundry_cli::{
     utils::{LoadConfig, get_chain, maybe_print_resolved_lane, resolve_lane},
 };
 use foundry_common::{
-    FoundryTransactionBuilder, provider::ProviderBuilder, tempo::TEMPO_BROWSER_GAS_BUFFER,
+    FoundryTransactionBuilder,
+    provider::ProviderBuilder,
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_fee_token_selection},
 };
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use std::{str::FromStr, time::Duration};
@@ -274,6 +276,7 @@ pub(super) async fn send_tip20_transaction(
         if let Some(sponsor) = &tempo_sponsor {
             sponsor.attach_and_print::<TempoNetwork>(&mut tx, browser.address()).await?;
         }
+        print_fee_token_selection(tx.fee_token())?;
         let tx_hash = browser.send_transaction_via_browser(tx).await?;
         CastTxSender::new(&provider)
             .print_tx_result(tx_hash, send_tx.cast_async, send_tx.confirmations, timeout)

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -21,6 +21,7 @@ use foundry_common::{
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::ProviderBuilder,
     shell,
+    tempo::{print_fee_token_selection, resolve_fee_token},
 };
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use serde_json::json;
@@ -182,11 +183,19 @@ async fn register(
     tempo::print_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, chain.is_legacy());
 
+    // Default to the chain's canonical fee token unless the user supplied one, so the resolved
+    // selection is materialized (and reported) consistently with the other cast send paths.
+    if let Some(fee_token) = resolve_fee_token(Some(chain), tx.fee_token()) {
+        tx.set_fee_token(fee_token);
+    }
+
     sh_status!("Submitting registerVirtualMaster({salt})...")?;
 
     if let Some(ref access_key) = tempo_access_key {
         tempo::fill_access_key_transaction(&provider, &mut tx, access_key, chain).await?;
         if shell::is_json() {
+            // JSON mode bypasses `cast_send_with_access_key`, so report the selection here.
+            print_fee_token_selection(tx.fee_token())?;
             let raw_tx = tx
                 .sign_with_access_key(
                     &provider,
@@ -221,6 +230,8 @@ async fn register(
     } else {
         let provider = build_provider_with_signer::<TempoNetwork>(&send_tx, signer)?;
         if shell::is_json() {
+            // JSON mode bypasses `cast_send`, so report the selection here.
+            print_fee_token_selection(tx.fee_token())?;
             let cast = CastTxSender::new(&provider);
             if send_tx.sync {
                 cast.send_sync(tx).await.map(|(tx_hash, _)| tx_hash)

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -21,7 +21,7 @@ use foundry_common::{
     fmt::{UIfmt, UIfmtReceiptExt},
     provider::ProviderBuilder,
     shell,
-    tempo::{print_fee_token_selection, resolve_fee_token},
+    tempo::print_resolved_fee_token_selection,
 };
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use serde_json::json;
@@ -183,19 +183,13 @@ async fn register(
     tempo::print_expires(expires_at)?;
     tx_opts.apply::<TempoNetwork>(&mut tx, chain.is_legacy());
 
-    // Default to the chain's canonical fee token unless the user supplied one, so the resolved
-    // selection is materialized (and reported) consistently with the other cast send paths.
-    if let Some(fee_token) = resolve_fee_token(Some(chain), tx.fee_token()) {
-        tx.set_fee_token(fee_token);
-    }
-
     sh_status!("Submitting registerVirtualMaster({salt})...")?;
 
     if let Some(ref access_key) = tempo_access_key {
         tempo::fill_access_key_transaction(&provider, &mut tx, access_key, chain).await?;
         if shell::is_json() {
             // JSON mode bypasses `cast_send_with_access_key`, so report the selection here.
-            print_fee_token_selection(tx.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
             let raw_tx = tx
                 .sign_with_access_key(
                     &provider,
@@ -221,6 +215,7 @@ async fn register(
                 tx,
                 &signer,
                 access_key,
+                Some(chain),
                 send_tx.cast_async,
                 send_tx.confirmations,
                 timeout,
@@ -231,7 +226,7 @@ async fn register(
         let provider = build_provider_with_signer::<TempoNetwork>(&send_tx, signer)?;
         if shell::is_json() {
             // JSON mode bypasses `cast_send`, so report the selection here.
-            print_fee_token_selection(tx.fee_token())?;
+            print_resolved_fee_token_selection(Some(chain), tx.fee_token())?;
             let cast = CastTxSender::new(&provider);
             if send_tx.sync {
                 cast.send_sync(tx).await.map(|(tx_hash, _)| tx_hash)
@@ -252,6 +247,7 @@ async fn register(
             cast_send(
                 provider,
                 tx,
+                Some(chain),
                 send_tx.cast_async,
                 send_tx.sync,
                 send_tx.confirmations,

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -17,7 +17,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     FoundryTransactionBuilder, TransactionReceiptWithRevertReason, fmt::*,
-    get_pretty_receipt_w_reason_attr, shell,
+    get_pretty_receipt_w_reason_attr, shell, tempo::resolve_fee_token,
 };
 use foundry_config::{Chain, Config};
 use foundry_wallets::{BrowserWalletOpts, TempoAccessKeyConfig, WalletOpts, WalletSigner};
@@ -433,6 +433,12 @@ where
 
         // Apply gas, value, fee, and network-specific options.
         tx_opts.apply::<N>(&mut tx, legacy);
+
+        // Default to the chain's canonical fee token unless the user supplied one, so the
+        // resolved selection is materialized (and reported) consistently across cast commands.
+        if let Some(fee_token) = resolve_fee_token(Some(chain), tx.fee_token()) {
+            tx.set_fee_token(fee_token);
+        }
 
         Ok(Self {
             provider,

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -17,7 +17,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     FoundryTransactionBuilder, TransactionReceiptWithRevertReason, fmt::*,
-    get_pretty_receipt_w_reason_attr, shell, tempo::resolve_fee_token,
+    get_pretty_receipt_w_reason_attr, shell,
 };
 use foundry_config::{Chain, Config};
 use foundry_wallets::{BrowserWalletOpts, TempoAccessKeyConfig, WalletOpts, WalletSigner};
@@ -433,12 +433,6 @@ where
 
         // Apply gas, value, fee, and network-specific options.
         tx_opts.apply::<N>(&mut tx, legacy);
-
-        // Default to the chain's canonical fee token unless the user supplied one, so the
-        // resolved selection is materialized (and reported) consistently across cast commands.
-        if let Some(fee_token) = resolve_fee_token(Some(chain), tx.fee_token()) {
-            tx.set_fee_token(fee_token);
-        }
 
         Ok(Self {
             provider,

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -100,6 +100,15 @@ pub fn print_fee_token_selection(fee_token: Option<Address>) -> Result<()> {
     Ok(())
 }
 
+/// Prints the fee token selected for display, resolving the chain default without mutating a
+/// transaction request.
+pub fn print_resolved_fee_token_selection(
+    chain: Option<Chain>,
+    fee_token: Option<Address>,
+) -> Result<()> {
+    print_fee_token_selection(resolve_fee_token(chain, fee_token))
+}
+
 /// Gas sponsor configuration for Tempo fee-payer signatures.
 #[derive(Clone, Debug)]
 pub struct TempoSponsor {

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -5,12 +5,13 @@ pub mod auth;
 use crate::FoundryTransactionBuilder;
 use alloy_chains::Chain;
 use alloy_network::Network;
-use alloy_primitives::{Address, B256, Signature};
+use alloy_primitives::{Address, B256, Signature, address};
 use alloy_signer::Signer;
 use eyre::{Context, Result};
 use foundry_wallets::{RawWalletOpts, WalletOpts, WalletSigner};
 use std::sync::Arc;
 use tempo_alloy::contracts::precompiles::DEFAULT_FEE_TOKEN;
+pub use tempo_alloy::contracts::precompiles::PATH_USD_ADDRESS;
 
 mod keystore;
 mod registry;
@@ -55,12 +56,48 @@ fn redacted_debug(value: &str) -> &'static str {
 /// See <https://github.com/tempoxyz/tempo/blob/6ebf1a8/crates/revm/src/handler.rs#L108-L124>
 pub const TEMPO_BROWSER_GAS_BUFFER: u64 = 7_000;
 
+/// Reserved Tempo TIP20 fee-token addresses created during Foundry genesis.
+///
+/// Unlike [`PATH_USD_ADDRESS`], these tokens are not defined by the canonical
+/// `tempo-contracts` crate; they only exist in Foundry's local genesis setup, so
+/// they are defined here as the single source of truth and re-exported elsewhere.
+pub const ALPHA_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000001");
+pub const BETA_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000002");
+pub const THETA_USD_ADDRESS: Address = address!("0x20C0000000000000000000000000000000000003");
+
 /// Resolves an explicit Tempo fee token or the canonical default for a known Tempo network.
 pub fn resolve_fee_token(
     chain: Option<Chain>,
     explicit_fee_token: Option<Address>,
 ) -> Option<Address> {
     explicit_fee_token.or_else(|| chain.is_some_and(Chain::is_tempo).then_some(DEFAULT_FEE_TOKEN))
+}
+
+/// Returns the known symbol for a Tempo fee token without making an RPC call.
+pub const fn known_fee_token_symbol(fee_token: Address) -> Option<&'static str> {
+    match fee_token {
+        PATH_USD_ADDRESS => Some("PathUSD"),
+        ALPHA_USD_ADDRESS => Some("AlphaUSD"),
+        BETA_USD_ADDRESS => Some("BetaUSD"),
+        THETA_USD_ADDRESS => Some("ThetaUSD"),
+        _ => None,
+    }
+}
+
+/// Formats a Tempo fee-token selection for command output.
+pub fn format_fee_token_selection(fee_token: Address) -> String {
+    match known_fee_token_symbol(fee_token) {
+        Some(symbol) => format!("Paying gas in {symbol} ({fee_token})"),
+        None => format!("Paying gas in {fee_token}"),
+    }
+}
+
+/// Prints the selected Tempo fee token when one is set.
+pub fn print_fee_token_selection(fee_token: Option<Address>) -> Result<()> {
+    if let Some(fee_token) = fee_token {
+        sh_status!("{}", format_fee_token_selection(fee_token))?;
+    }
+    Ok(())
 }
 
 /// Gas sponsor configuration for Tempo fee-payer signatures.

--- a/crates/common/src/tempo/tests.rs
+++ b/crates/common/src/tempo/tests.rs
@@ -8,7 +8,10 @@ use tempo_alloy::contracts::precompiles::DEFAULT_FEE_TOKEN;
 use alloy_chains::{Chain, NamedChain};
 use alloy_primitives::Address;
 
-use super::resolve_fee_token;
+use super::{
+    ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
+    format_fee_token_selection, known_fee_token_symbol, resolve_fee_token,
+};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -90,4 +93,27 @@ fn explicit_fee_token_overrides_chain_default() {
         Some(explicit)
     );
     assert_eq!(resolve_fee_token(None, Some(explicit)), Some(explicit));
+}
+
+#[test]
+fn formats_known_fee_token_selection_with_label() {
+    for (fee_token, symbol) in [
+        (PATH_USD_ADDRESS, "PathUSD"),
+        (ALPHA_USD_ADDRESS, "AlphaUSD"),
+        (BETA_USD_ADDRESS, "BetaUSD"),
+        (THETA_USD_ADDRESS, "ThetaUSD"),
+    ] {
+        assert_eq!(known_fee_token_symbol(fee_token), Some(symbol));
+        assert_eq!(
+            format_fee_token_selection(fee_token),
+            format!("Paying gas in {symbol} ({fee_token})")
+        );
+    }
+}
+
+#[test]
+fn formats_unknown_fee_token_selection_as_address() {
+    let fee_token = Address::repeat_byte(0x42);
+    assert_eq!(known_fee_token_symbol(fee_token), None);
+    assert_eq!(format_fee_token_selection(fee_token), format!("Paying gas in {fee_token}"));
 }

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -43,8 +43,7 @@ pub use tempo_precompiles::{
 };
 
 /// All well-known TIP20 fee token addresses on Tempo networks.
-pub const TEMPO_TIP20_TOKENS: &[Address] =
-    &[PATH_USD_ADDRESS, ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, THETA_USD_ADDRESS];
+pub const TEMPO_TIP20_TOKENS: &[Address] = &[PATH_USD_ADDRESS];
 
 /// Initialize Tempo precompiles and contracts using a storage provider.
 ///

--- a/crates/evm/core/src/tempo.rs
+++ b/crates/evm/core/src/tempo.rs
@@ -5,7 +5,7 @@
 //!
 //! It includes the shared genesis initialization function used by both anvil and forge.
 
-use alloy_primitives::{Address, Bytes, U256, address};
+use alloy_primitives::{Address, Bytes, U256};
 use revm::state::Bytecode;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::{
@@ -21,14 +21,17 @@ use tempo_precompiles::{
     validator_config,
 };
 
+pub use foundry_common::tempo::{
+    ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
+};
 pub use foundry_evm_networks::{
     TEMPO_PRECOMPILE_ADDRESSES, active_tempo_precompile_addresses, is_tempo_precompile_active_at,
 };
 pub use tempo_contracts::precompiles::{
     ADDRESS_REGISTRY_ADDRESS, IAddressRegistry, IFeeManager, ISignatureVerifier, IStablecoinDEX,
-    ITIP20ChannelReserve, PATH_USD_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS,
-    SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS,
+    ITIP20ChannelReserve, RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS,
+    STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS,
+    TIP20_FACTORY_ADDRESS,
 };
 pub use tempo_precompiles::{
     address_registry::{AddressRegistry, IMPLICIT_APPROVAL_LIST, is_implicitly_approved},
@@ -40,7 +43,8 @@ pub use tempo_precompiles::{
 };
 
 /// All well-known TIP20 fee token addresses on Tempo networks.
-pub const TEMPO_TIP20_TOKENS: &[Address] = &[PATH_USD_ADDRESS];
+pub const TEMPO_TIP20_TOKENS: &[Address] =
+    &[PATH_USD_ADDRESS, ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, THETA_USD_ADDRESS];
 
 /// Initialize Tempo precompiles and contracts using a storage provider.
 ///
@@ -137,7 +141,7 @@ fn initialize_tempo_genesis_inner_with_precompiles(
 
     // Create AlphaUSD token: 0x20C0000000000000000000000000000000000001
     let _alpha_usd_token_address = create_and_mint_token(
-        address!("20C0000000000000000000000000000000000001"),
+        ALPHA_USD_ADDRESS,
         "AlphaUSD",
         "AlphaUSD",
         "USD",
@@ -149,7 +153,7 @@ fn initialize_tempo_genesis_inner_with_precompiles(
 
     // Create BetaUSD token: 0x20C0000000000000000000000000000000000002
     let _beta_usd_token_address = create_and_mint_token(
-        address!("20C0000000000000000000000000000000000002"),
+        BETA_USD_ADDRESS,
         "BetaUSD",
         "BetaUSD",
         "USD",
@@ -161,7 +165,7 @@ fn initialize_tempo_genesis_inner_with_precompiles(
 
     // Create ThetaUSD token: 0x20C0000000000000000000000000000000000003
     let _theta_usd_token_address = create_and_mint_token(
-        address!("20C0000000000000000000000000000000000003"),
+        THETA_USD_ADDRESS,
         "ThetaUSD",
         "ThetaUSD",
         "USD",

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -24,7 +24,7 @@ use foundry_common::{
     fmt::parse_tokens,
     provider::ProviderBuilder,
     shell,
-    tempo::{TEMPO_BROWSER_GAS_BUFFER, resolve_fee_token},
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_fee_token_selection, resolve_fee_token},
 };
 use foundry_compilers::{
     ArtifactId, artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize,
@@ -576,6 +576,7 @@ impl CreateArgs {
         if let Some(sponsor) = &tempo_sponsor {
             sponsor.attach_and_print::<N>(&mut deployer.tx, deployer_address).await?;
         }
+        print_fee_token_selection(deployer.tx.fee_token())?;
 
         // Deploy the actual contract
         let (deployed_contract, receipt) = if let Some(browser) = browser_signer {

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -24,7 +24,7 @@ use foundry_common::{
     fmt::parse_tokens,
     provider::ProviderBuilder,
     shell,
-    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_fee_token_selection, resolve_fee_token},
+    tempo::{TEMPO_BROWSER_GAS_BUFFER, print_resolved_fee_token_selection},
 };
 use foundry_compilers::{
     ArtifactId, artifacts::BytecodeObject, info::ContractInfo, utils::canonicalize,
@@ -433,11 +433,6 @@ impl CreateArgs {
             deployer.tx.set_create();
         }
 
-        // If the chain has a canonical fee token, set it unless the user supplied one.
-        if let Some(fee_token) = resolve_fee_token(Some(chain), self.tx.tempo.fee_token) {
-            deployer.tx.set_fee_token(fee_token);
-        }
-
         // Apply user-provided gas, fee, nonce, and Tempo options.
         self.tx.apply::<N>(&mut deployer.tx, is_legacy);
 
@@ -576,7 +571,7 @@ impl CreateArgs {
         if let Some(sponsor) = &tempo_sponsor {
             sponsor.attach_and_print::<N>(&mut deployer.tx, deployer_address).await?;
         }
-        print_fee_token_selection(deployer.tx.fee_token())?;
+        print_resolved_fee_token_selection(Some(chain), deployer.tx.fee_token())?;
 
         // Deploy the actual contract
         let (deployed_contract, receipt) = if let Some(browser) = browser_signer {

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -35,7 +35,8 @@ use foundry_common::{
     provider::{ProviderBuilder, try_get_http_provider},
     shell,
     tempo::{
-        KeyEntry, KeysFile, TempoSponsor, WALLET_KEYS_PATH, decode_key_authorization, tempo_home,
+        KeyEntry, KeysFile, TempoSponsor, WALLET_KEYS_PATH, decode_key_authorization,
+        print_fee_token_selection, tempo_home,
     },
 };
 use foundry_config::Config;
@@ -182,6 +183,7 @@ where
             let from = tx.from().expect("no sender");
             sponsor.attach_and_print::<N>(tx, from).await?;
         }
+        print_fee_token_selection(tx.fee_token())?;
 
         Ok(())
     }
@@ -1257,6 +1259,7 @@ impl BundledState<TempoEvmNetwork> {
         if let Some(sponsor) = &tempo_sponsor {
             sponsor.attach_and_print::<TempoNetwork>(&mut batch_tx, sender).await?;
         }
+        print_fee_token_selection(batch_tx.fee_token())?;
 
         // Sign and send.
         let tx_hash = match batch_signer {


### PR DESCRIPTION
## Motivation

Materialize Tempo default fee tokens in cast transaction building and print the resolved fee token before sending, signing, or emitting transactions across cast, forge create, and script broadcast paths.

Add no-RPC labels for well-known Tempo fee tokens and centralize the local AlphaUSD, BetaUSD, and ThetaUSD addresses for reuse in EVM core and Anvil.

Towards OSS-165