### PR TITLE
fix(`anvil`): commit transactionsRoot over canonical EIP-4844 tx encoding

### DIFF
--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -57,13 +57,20 @@ impl MaybeImpersonatedTransaction<FoundryTxEnvelope> {
     /// Removes the blob sidecar from the wrapped transaction so it can be included in a block
     /// body in its canonical (non-pooled) form, returning the sidecar, if any.
     ///
-    /// For impersonated transactions, the synthetic hash is derived from the transaction hash
-    /// rather than the pooled sidecarful encoding (see [`Self::hash`]), so stripping the sidecar
-    /// does not change the hash users received at submission.
+    /// Impersonated transactions are left untouched: their synthetic hash is derived from the
+    /// encoded transaction (see [`Self::hash`]), so stripping the sidecar would change the hash
+    /// users received at submission, and changing the hash derivation would break loading state
+    /// files written by earlier versions (which key mined transactions by the stored synthetic
+    /// hash). Their sidecar is still returned so callers can index it.
     pub fn strip_blob_sidecar(self) -> (Self, Option<BlobTransactionSidecarVariant>) {
         let Self { transaction, impersonated_sender } = self;
-        let (transaction, sidecar) = transaction.strip_blob_sidecar();
-        (Self { transaction, impersonated_sender }, sidecar)
+        if impersonated_sender.is_some() {
+            let sidecar = transaction.sidecar().map(|tx| tx.sidecar.clone());
+            (Self { transaction, impersonated_sender }, sidecar)
+        } else {
+            let (transaction, sidecar) = transaction.strip_blob_sidecar();
+            (Self { transaction, impersonated_sender }, sidecar)
+        }
     }
 
     /// Reattaches a blob sidecar to the wrapped transaction, returning the pooled (sidecarful)
@@ -75,7 +82,7 @@ impl MaybeImpersonatedTransaction<FoundryTxEnvelope> {
     }
 }
 
-impl<T: SignerRecoverable + TxHashRef> MaybeImpersonatedTransaction<T> {
+impl<T: SignerRecoverable + TxHashRef + Encodable> MaybeImpersonatedTransaction<T> {
     /// Recovers the Ethereum address which was used to sign the transaction.
     pub fn recover(&self) -> Result<Address, RecoveryError> {
         if let Some(sender) = self.impersonated_sender {
@@ -87,11 +94,11 @@ impl<T: SignerRecoverable + TxHashRef> MaybeImpersonatedTransaction<T> {
     /// Returns the hash of the transaction.
     ///
     /// If the transaction is impersonated, returns a unique hash derived by appending the
-    /// impersonated sender address to the transaction hash before hashing.
+    /// impersonated sender address to the encoded transaction before hashing.
     pub fn hash(&self) -> B256 {
         if let Some(sender) = self.impersonated_sender {
-            let mut buffer = Vec::with_capacity(52);
-            buffer.extend_from_slice(self.transaction.tx_hash().as_ref());
+            let mut buffer = Vec::new();
+            self.transaction.encode(&mut buffer);
             buffer.extend_from_slice(sender.as_ref());
             return B256::from_slice(alloy_primitives::utils::keccak256(&buffer).as_slice());
         }
@@ -168,7 +175,7 @@ impl<T> PendingTransaction<T> {
     }
 }
 
-impl<T: SignerRecoverable + TxHashRef> PendingTransaction<T> {
+impl<T: SignerRecoverable + TxHashRef + Encodable> PendingTransaction<T> {
     pub fn new(transaction: T) -> Result<Self, RecoveryError> {
         let transaction = MaybeImpersonatedTransaction::new(transaction);
         let sender = transaction.recover()?;
@@ -248,14 +255,30 @@ mod tests {
         (FoundryTxEnvelope::Eip4844(variant.into_signed(signature)), sidecar)
     }
 
+    // Impersonated transactions are not stripped (their synthetic hash is derived from the
+    // encoded transaction), but the sidecar is still returned so callers can index it.
     #[test]
-    fn impersonated_blob_strip_preserves_hash() {
+    fn impersonated_blob_strip_keeps_sidecar_and_hash() {
         let (transaction, sidecar) = sidecarful_4844_envelope();
         let transaction =
             MaybeImpersonatedTransaction::impersonated(transaction, Address::with_last_byte(1));
         let hash = transaction.hash();
 
         assert!(transaction.as_ref().sidecar().is_some());
+
+        let (kept, returned_sidecar) = transaction.strip_blob_sidecar();
+
+        assert_eq!(returned_sidecar, Some(sidecar));
+        assert!(kept.as_ref().sidecar().is_some());
+        assert_eq!(kept.hash(), hash);
+    }
+
+    // Properly-signed transactions are stripped to their canonical form, hash unchanged.
+    #[test]
+    fn signed_blob_strip_removes_sidecar_and_preserves_hash() {
+        let (transaction, sidecar) = sidecarful_4844_envelope();
+        let transaction = MaybeImpersonatedTransaction::new(transaction);
+        let hash = transaction.hash();
 
         let (stripped, stripped_sidecar) = transaction.strip_blob_sidecar();
 

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -1,6 +1,6 @@
 //! Transaction related types
 use alloy_consensus::{
-    Transaction, Typed2718,
+    BlobTransactionSidecarVariant, Transaction, Typed2718,
     crypto::RecoveryError,
     transaction::{SignerRecoverable, TxHashRef},
 };
@@ -50,6 +50,33 @@ impl<T> MaybeImpersonatedTransaction<T> {
     /// Returns the inner transaction.
     pub fn into_inner(self) -> T {
         self.transaction
+    }
+}
+
+impl MaybeImpersonatedTransaction<FoundryTxEnvelope> {
+    /// Removes the blob sidecar from the wrapped transaction so it can be included in a block
+    /// body in its canonical (non-pooled) form, returning the sidecar, if any.
+    ///
+    /// Impersonated transactions are left untouched: their synthetic hash is derived from the
+    /// encoded transaction (see [`Self::hash`]), so stripping the sidecar would change the hash
+    /// users received at submission. Their sidecar is still returned so callers can index it.
+    pub fn strip_blob_sidecar(self) -> (Self, Option<BlobTransactionSidecarVariant>) {
+        let Self { transaction, impersonated_sender } = self;
+        if impersonated_sender.is_some() {
+            let sidecar = transaction.sidecar().map(|tx| tx.sidecar.clone());
+            (Self { transaction, impersonated_sender }, sidecar)
+        } else {
+            let (transaction, sidecar) = transaction.strip_blob_sidecar();
+            (Self { transaction, impersonated_sender }, sidecar)
+        }
+    }
+
+    /// Reattaches a blob sidecar to the wrapped transaction, returning the pooled (sidecarful)
+    /// form. No-op for non-EIP-4844 transactions and transactions that already carry a sidecar,
+    /// so the hash is unchanged in all cases (see [`FoundryTxEnvelope::with_blob_sidecar`]).
+    pub fn with_blob_sidecar(self, sidecar: BlobTransactionSidecarVariant) -> Self {
+        let Self { transaction, impersonated_sender } = self;
+        Self { transaction: transaction.with_blob_sidecar(sidecar), impersonated_sender }
     }
 }
 

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -57,18 +57,13 @@ impl MaybeImpersonatedTransaction<FoundryTxEnvelope> {
     /// Removes the blob sidecar from the wrapped transaction so it can be included in a block
     /// body in its canonical (non-pooled) form, returning the sidecar, if any.
     ///
-    /// Impersonated transactions are left untouched: their synthetic hash is derived from the
-    /// encoded transaction (see [`Self::hash`]), so stripping the sidecar would change the hash
-    /// users received at submission. Their sidecar is still returned so callers can index it.
+    /// For impersonated transactions, the synthetic hash is derived from the transaction hash
+    /// rather than the pooled sidecarful encoding (see [`Self::hash`]), so stripping the sidecar
+    /// does not change the hash users received at submission.
     pub fn strip_blob_sidecar(self) -> (Self, Option<BlobTransactionSidecarVariant>) {
         let Self { transaction, impersonated_sender } = self;
-        if impersonated_sender.is_some() {
-            let sidecar = transaction.sidecar().map(|tx| tx.sidecar.clone());
-            (Self { transaction, impersonated_sender }, sidecar)
-        } else {
-            let (transaction, sidecar) = transaction.strip_blob_sidecar();
-            (Self { transaction, impersonated_sender }, sidecar)
-        }
+        let (transaction, sidecar) = transaction.strip_blob_sidecar();
+        (Self { transaction, impersonated_sender }, sidecar)
     }
 
     /// Reattaches a blob sidecar to the wrapped transaction, returning the pooled (sidecarful)
@@ -80,7 +75,7 @@ impl MaybeImpersonatedTransaction<FoundryTxEnvelope> {
     }
 }
 
-impl<T: SignerRecoverable + TxHashRef + Encodable> MaybeImpersonatedTransaction<T> {
+impl<T: SignerRecoverable + TxHashRef> MaybeImpersonatedTransaction<T> {
     /// Recovers the Ethereum address which was used to sign the transaction.
     pub fn recover(&self) -> Result<Address, RecoveryError> {
         if let Some(sender) = self.impersonated_sender {
@@ -92,11 +87,11 @@ impl<T: SignerRecoverable + TxHashRef + Encodable> MaybeImpersonatedTransaction<
     /// Returns the hash of the transaction.
     ///
     /// If the transaction is impersonated, returns a unique hash derived by appending the
-    /// impersonated sender address to the encoded transaction before hashing.
+    /// impersonated sender address to the transaction hash before hashing.
     pub fn hash(&self) -> B256 {
         if let Some(sender) = self.impersonated_sender {
-            let mut buffer = Vec::new();
-            self.transaction.encode(&mut buffer);
+            let mut buffer = Vec::with_capacity(52);
+            buffer.extend_from_slice(self.transaction.tx_hash().as_ref());
             buffer.extend_from_slice(sender.as_ref());
             return B256::from_slice(alloy_primitives::utils::keccak256(&buffer).as_slice());
         }
@@ -173,7 +168,7 @@ impl<T> PendingTransaction<T> {
     }
 }
 
-impl<T: SignerRecoverable + TxHashRef + Encodable> PendingTransaction<T> {
+impl<T: SignerRecoverable + TxHashRef> PendingTransaction<T> {
     pub fn new(transaction: T) -> Result<Self, RecoveryError> {
         let transaction = MaybeImpersonatedTransaction::new(transaction);
         let sender = transaction.recover()?;
@@ -218,4 +213,68 @@ pub struct TransactionInfo {
     pub out: Option<Bytes>,
     pub nonce: u64,
     pub gas_used: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_consensus::{
+        BlobTransactionSidecar, SignableTransaction, TxEip4844,
+        transaction::eip4844::TxEip4844Variant,
+    };
+    use alloy_primitives::{Signature, U256};
+
+    fn sidecarful_4844_envelope() -> (FoundryTxEnvelope, BlobTransactionSidecarVariant) {
+        let tx = TxEip4844 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 21_000,
+            max_fee_per_gas: 1,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO,
+            value: U256::ZERO,
+            access_list: Default::default(),
+            blob_versioned_hashes: vec![B256::ZERO],
+            max_fee_per_blob_gas: 1,
+            input: Bytes::default(),
+        };
+        let sidecar = BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar::new(
+            vec![Default::default()],
+            vec![Default::default()],
+            vec![Default::default()],
+        ));
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let variant = TxEip4844Variant::TxEip4844WithSidecar(tx.with_sidecar(sidecar.clone()));
+        (FoundryTxEnvelope::Eip4844(variant.into_signed(signature)), sidecar)
+    }
+
+    #[test]
+    fn impersonated_blob_strip_preserves_hash() {
+        let (transaction, sidecar) = sidecarful_4844_envelope();
+        let transaction =
+            MaybeImpersonatedTransaction::impersonated(transaction, Address::with_last_byte(1));
+        let hash = transaction.hash();
+
+        assert!(transaction.as_ref().sidecar().is_some());
+
+        let (stripped, stripped_sidecar) = transaction.strip_blob_sidecar();
+
+        assert_eq!(stripped_sidecar, Some(sidecar));
+        assert!(stripped.as_ref().sidecar().is_none());
+        assert_eq!(stripped.hash(), hash);
+    }
+
+    #[test]
+    fn impersonated_hash_includes_sender() {
+        let (transaction, _) = sidecarful_4844_envelope();
+
+        let first = MaybeImpersonatedTransaction::impersonated(
+            transaction.clone(),
+            Address::with_last_byte(1),
+        );
+        let second =
+            MaybeImpersonatedTransaction::impersonated(transaction, Address::with_last_byte(2));
+
+        assert_ne!(first.hash(), second.hash());
+    }
 }

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -6,7 +6,7 @@ use crate::{
     mem::inspector::{AnvilInspector, InspectorTxConfig},
 };
 use alloy_consensus::{
-    Eip658Value, Transaction, TransactionEnvelope, TxReceipt,
+    BlobTransactionSidecarVariant, Eip658Value, Transaction, TransactionEnvelope, TxReceipt,
     transaction::{Either, Recovered},
 };
 use alloy_eips::{
@@ -24,7 +24,7 @@ use alloy_evm::{
         receipt_builder::{ReceiptBuilder, ReceiptBuilderCtx},
     },
 };
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, TxHash, U256};
 use anvil_core::eth::transaction::{
     MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo,
 };
@@ -313,8 +313,11 @@ pub struct ExecutedPoolTransactions<T> {
     pub not_yet_valid: Vec<Arc<PoolTransaction<T>>>,
     /// Per-transaction execution info.
     pub tx_info: Vec<TransactionInfo>,
-    /// The raw pending transactions that were included (in order).
+    /// The included transactions (in order), in their canonical block-body form, i.e. EIP-4844
+    /// transactions without their blob sidecar.
     pub txs: Vec<MaybeImpersonatedTransaction<T>>,
+    /// Blob sidecars stripped from included EIP-4844 transactions, keyed by transaction hash.
+    pub blob_sidecars: Vec<(TxHash, BlobTransactionSidecarVariant)>,
 }
 
 /// Gas-related configuration for pool transaction execution.
@@ -362,6 +365,7 @@ where
     let mut not_yet_valid = Vec::new();
     let mut tx_info: Vec<TransactionInfo> = Vec::new();
     let mut transactions = Vec::new();
+    let mut blob_sidecars = Vec::new();
     let mut blob_gas_used = 0u64;
 
     for pool_tx in pool_transactions {
@@ -481,7 +485,15 @@ where
 
                 included.push(pool_tx.clone());
                 tx_info.push(info);
-                transactions.push(pending.transaction.clone());
+
+                // Strip the blob sidecar before the transaction enters the block body: the
+                // transaction trie commits to the canonical EIP-2718 encoding, not the pooled
+                // sidecarful one. The sidecar is kept so it can be served via `anvil_getBlobs*`.
+                let (transaction, sidecar) = pending.transaction.clone().strip_blob_sidecar();
+                if let Some(sidecar) = sidecar {
+                    blob_sidecars.push((transaction.hash(), sidecar));
+                }
+                transactions.push(transaction);
             }
             Err(err) => {
                 if err.as_validation().is_some() {
@@ -494,7 +506,14 @@ where
         }
     }
 
-    ExecutedPoolTransactions { included, invalid, not_yet_valid, tx_info, txs: transactions }
+    ExecutedPoolTransactions {
+        included,
+        invalid,
+        not_yet_valid,
+        tx_info,
+        txs: transactions,
+        blob_sidecars,
+    }
 }
 
 /// Builds the EVM transaction env from a pending pool transaction.

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -314,7 +314,8 @@ pub struct ExecutedPoolTransactions<T> {
     /// Per-transaction execution info.
     pub tx_info: Vec<TransactionInfo>,
     /// The included transactions (in order), in their canonical block-body form, i.e. EIP-4844
-    /// transactions without their blob sidecar.
+    /// transactions without their blob sidecar (except impersonated ones, whose synthetic hash
+    /// depends on the encoded transaction).
     pub txs: Vec<MaybeImpersonatedTransaction<T>>,
     /// Blob sidecars stripped from included EIP-4844 transactions, keyed by transaction hash.
     pub blob_sidecars: Vec<(TxHash, BlobTransactionSidecarVariant)>,
@@ -489,6 +490,9 @@ where
                 // Strip the blob sidecar before the transaction enters the block body: the
                 // transaction trie commits to the canonical EIP-2718 encoding, not the pooled
                 // sidecarful one. The sidecar is kept so it can be served via `anvil_getBlobs*`.
+                // Impersonated transactions are deliberately not stripped (see
+                // `MaybeImpersonatedTransaction::strip_blob_sidecar`), but their sidecar is
+                // still mirrored into the store.
                 let (transaction, sidecar) = pending.transaction.clone().strip_blob_sidecar();
                 if let Some(sidecar) = sidecar {
                     blob_sidecars.push((transaction.hash(), sidecar));

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3264,7 +3264,7 @@ where
         for<'a> F:
             FnOnce(ResultAndState<HaltReason>, CacheDB<Box<&'a StateDb>>, I, TxEnv, EvmEnv) -> T,
     {
-        let block = {
+        let (block, blob_sidecars) = {
             let storage = self.blockchain.storage.read();
             let MinedTransaction { block_hash, .. } = storage
                 .transactions
@@ -3272,7 +3272,20 @@ where
                 .cloned()
                 .ok_or(BlockchainError::TransactionNotFound)?;
 
-            storage.blocks.get(&block_hash).cloned().ok_or(BlockchainError::BlockNotFound)?
+            let block =
+                storage.blocks.get(&block_hash).cloned().ok_or(BlockchainError::BlockNotFound)?;
+            let blob_sidecars: HashMap<_, _> = block
+                .body
+                .transactions
+                .iter()
+                .filter_map(|tx| {
+                    storage
+                        .blob_sidecars
+                        .get(&tx.hash())
+                        .map(|sidecar| (tx.hash(), Arc::clone(sidecar)))
+                })
+                .collect();
+            (block, blob_sidecars)
         };
 
         let index = block
@@ -3287,7 +3300,7 @@ where
         // blob transactions.
         let rehydrate = |tx: &MaybeImpersonatedTransaction<FoundryTxEnvelope>| {
             let tx = tx.clone();
-            match self.blockchain.storage.read().blob_sidecars.get(&tx.hash()) {
+            match blob_sidecars.get(&tx.hash()) {
                 Some(sidecar) => tx.with_blob_sidecar((**sidecar).clone()),
                 None => tx,
             }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1912,14 +1912,13 @@ impl<N: Network> Backend<N> {
         versioned_hashes: Vec<B256>,
     ) -> Result<Option<Vec<alloy_consensus::Blob>>> {
         Ok(self.get_block(id).map(|block| {
+            let storage = self.blockchain.storage.read();
             block
                 .body
                 .transactions
                 .iter()
-                .filter_map(|tx| tx.as_ref().sidecar())
-                .flat_map(|sidecar| {
-                    sidecar.sidecar.blobs().iter().zip(sidecar.sidecar.commitments().iter())
-                })
+                .filter_map(|tx| storage.blob_sidecars.get(&tx.hash()))
+                .flat_map(|sidecar| sidecar.blobs().iter().zip(sidecar.commitments().iter()))
                 .filter(|(_, commitment)| {
                     // Filter blobs by versioned_hashes if provided
                     versioned_hashes.is_empty()
@@ -1933,22 +1932,14 @@ impl<N: Network> Backend<N> {
     #[allow(clippy::large_stack_frames)]
     pub fn get_blob_by_versioned_hash(&self, hash: B256) -> Result<Option<Blob>> {
         let storage = self.blockchain.storage.read();
-        for block in storage.blocks.values() {
-            for tx in &block.body.transactions {
-                let typed_tx = tx.as_ref();
-                if let Some(sidecar) = typed_tx.sidecar() {
-                    for versioned_hash in sidecar.sidecar.versioned_hashes() {
-                        if versioned_hash == hash
-                            && let Some(index) =
-                                sidecar.sidecar.commitments().iter().position(|commitment| {
-                                    kzg_to_versioned_hash(commitment.as_slice()) == *hash
-                                })
-                            && let Some(blob) = sidecar.sidecar.blobs().get(index)
-                        {
-                            return Ok(Some(*blob));
-                        }
-                    }
-                }
+        for sidecar in storage.blob_sidecars.values() {
+            if let Some(index) = sidecar
+                .commitments()
+                .iter()
+                .position(|commitment| kzg_to_versioned_hash(commitment.as_slice()) == hash)
+                && let Some(blob) = sidecar.blobs().get(index)
+            {
+                return Ok(Some(*blob));
             }
         }
         Ok(None)
@@ -2341,6 +2332,7 @@ impl<N: Network> Backend<N> {
                     {
                         for tx in block.body.transactions {
                             let _ = storage.transactions.remove(&tx.hash());
+                            let _ = storage.blob_sidecars.remove(&tx.hash());
                         }
                     }
                 }
@@ -2640,7 +2632,7 @@ where
                 self.states.write().insert(best_hash, db);
             }
 
-            let (block_info, included, invalid, not_yet_valid, block_hash) = {
+            let (block_info, included, invalid, not_yet_valid, blob_sidecars, block_hash) = {
                 let mut db = self.db.write().await;
 
                 // finally set the next block timestamp, this is done just before execution, because
@@ -2669,6 +2661,7 @@ where
                 let included = pool_result.included;
                 let invalid = pool_result.invalid;
                 let not_yet_valid = pool_result.not_yet_valid;
+                let blob_sidecars = pool_result.blob_sidecars;
 
                 let state_root = db.maybe_state_root().unwrap_or_default();
                 let block_info = Self::build_block_info(
@@ -2685,7 +2678,7 @@ where
                 let block_hash = block_info.block.header.hash_slow();
                 db.insert_block_hash(U256::from(block_info.block.header.number()), block_hash);
 
-                (block_info, included, invalid, not_yet_valid, block_hash)
+                (block_info, included, invalid, not_yet_valid, blob_sidecars, block_hash)
             };
 
             // create the new block with the current timestamp
@@ -2713,6 +2706,9 @@ where
 
             storage.blocks.insert(block_hash, block);
             storage.hashes.insert(block_number, block_hash);
+            storage
+                .blob_sidecars
+                .extend(blob_sidecars.into_iter().map(|(hash, sidecar)| (hash, Arc::new(sidecar))));
 
             node_info!("");
             // insert all transactions
@@ -3286,12 +3282,23 @@ where
             .position(|tx| tx.hash() == hash)
             .expect("transaction not found in block");
 
+        // Block bodies store blob transactions in their canonical form; reattach the stored
+        // sidecars for replay, since pool transaction validation expects pooled (sidecarful)
+        // blob transactions.
+        let rehydrate = |tx: &MaybeImpersonatedTransaction<FoundryTxEnvelope>| {
+            let tx = tx.clone();
+            match self.blockchain.storage.read().blob_sidecars.get(&tx.hash()) {
+                Some(sidecar) => tx.with_blob_sidecar((**sidecar).clone()),
+                None => tx,
+            }
+        };
+
         let pool_txs: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>> = block.body.transactions
             [..index]
             .iter()
             .map(|tx| {
                 let pending_tx =
-                    PendingTransaction::from_maybe_impersonated(tx.clone()).expect("is valid");
+                    PendingTransaction::from_maybe_impersonated(rehydrate(tx)).expect("is valid");
                 Arc::new(PoolTransaction {
                     pending_transaction: pending_tx,
                     requires: vec![],
@@ -3328,7 +3335,7 @@ where
             // Extract inner CacheDB to match the expected types for the target tx execution
             let cache_db = cache_db.0;
 
-            let target_tx = block.body.transactions[index].clone();
+            let target_tx = rehydrate(&block.body.transactions[index]);
             let target_tx = PendingTransaction::from_maybe_impersonated(target_tx)?;
             let (result, base_tx_env) = self.transact_envelope_with_inspector_ref(
                 &cache_db,
@@ -4214,15 +4221,8 @@ impl Backend<FoundryNetwork> {
     }
 
     pub fn get_blob_by_tx_hash(&self, hash: B256) -> Result<Option<Vec<alloy_consensus::Blob>>> {
-        // Try to get the mined transaction by hash
-        if let Some(tx) = self.mined_transaction_by_hash(hash)
-            && let Ok(typed_tx) = FoundryTxEnvelope::try_from(tx)
-            && let Some(sidecar) = typed_tx.sidecar()
-        {
-            return Ok(Some(sidecar.sidecar.blobs().to_vec()));
-        }
-
-        Ok(None)
+        let storage = self.blockchain.storage.read();
+        Ok(storage.blob_sidecars.get(&hash).map(|sidecar| sidecar.blobs().to_vec()))
     }
 
     /// Sets the fee token for a user address (Tempo-only).

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3295,9 +3295,10 @@ where
             .position(|tx| tx.hash() == hash)
             .expect("transaction not found in block");
 
-        // Block bodies store blob transactions in their canonical form; reattach the stored
-        // sidecars for replay, since pool transaction validation expects pooled (sidecarful)
-        // blob transactions.
+        // Block bodies store blob transactions in their canonical form (impersonated ones
+        // excepted, which never lose their sidecar); reattach the stored sidecars for replay,
+        // since pool transaction validation expects pooled (sidecarful) blob transactions.
+        // Reattachment is a no-op for transactions that already carry a sidecar.
         let rehydrate = |tx: &MaybeImpersonatedTransaction<FoundryTxEnvelope>| {
             let tx = tx.clone();
             match blob_sidecars.get(&tx.hash()) {

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -9,7 +9,9 @@ use crate::eth::{
     },
     pool::transactions::PoolTransaction,
 };
-use alloy_consensus::{BlockHeader, Header, constants::EMPTY_WITHDRAWALS};
+use alloy_consensus::{
+    BlobTransactionSidecarVariant, BlockHeader, Header, constants::EMPTY_WITHDRAWALS,
+};
 use alloy_eips::eip7685::EMPTY_REQUESTS_HASH;
 use alloy_evm::EvmEnv;
 use alloy_network::Network;
@@ -293,6 +295,13 @@ pub struct BlockchainStorage<N: Network> {
     /// Mapping from the transaction hash to a tuple containing the transaction as well as the
     /// transaction receipt
     pub transactions: B256HashMap<MinedTransaction<N>>,
+    /// Blob sidecars of mined EIP-4844 transactions (transaction hash -> sidecar).
+    ///
+    /// Block bodies store blob transactions in their canonical form, without the sidecar, so
+    /// that the transaction trie commits to the canonical EIP-2718 encoding. The sidecars are
+    /// kept here so they can be served via the `anvil_getBlobs*` endpoints and reattached when
+    /// replaying block transactions.
+    pub blob_sidecars: B256HashMap<Arc<BlobTransactionSidecarVariant>>,
     /// The total difficulty of the chain until this block
     pub total_difficulty: U256,
 }
@@ -342,6 +351,7 @@ impl<N: Network> BlockchainStorage<N> {
             best_number,
             genesis_hash,
             transactions: Default::default(),
+            blob_sidecars: Default::default(),
             total_difficulty: Default::default(),
         }
     }
@@ -357,6 +367,7 @@ impl<N: Network> BlockchainStorage<N> {
             best_number: block_number,
             genesis_hash: Default::default(),
             transactions: Default::default(),
+            blob_sidecars: Default::default(),
             total_difficulty,
         }
     }
@@ -393,6 +404,7 @@ impl<N: Network> BlockchainStorage<N> {
             best_number: Default::default(),
             genesis_hash: Default::default(),
             transactions: Default::default(),
+            blob_sidecars: Default::default(),
             total_difficulty: Default::default(),
         }
     }
@@ -409,20 +421,57 @@ impl<N: Network> BlockchainStorage<N> {
         if let Some(block) = self.blocks.get_mut(&block_hash) {
             for tx in &block.body.transactions {
                 self.transactions.remove(&tx.hash());
+                self.blob_sidecars.remove(&tx.hash());
             }
             block.body.transactions.clear();
         }
     }
 
     /// Serialize all blocks in storage
+    ///
+    /// Blob sidecars are reattached to their transactions so the on-disk format stays
+    /// compatible with state files produced before sidecars were stored separately from block
+    /// bodies.
     pub fn serialized_blocks(&self) -> Vec<SerializableBlock> {
-        self.blocks.values().map(|block| block.clone().into()).collect()
+        self.blocks
+            .values()
+            .map(|block| {
+                let mut block = block.clone();
+                block.body.transactions = block
+                    .body
+                    .transactions
+                    .into_iter()
+                    .map(|tx| match self.blob_sidecars.get(&tx.hash()) {
+                        Some(sidecar) => tx.with_blob_sidecar((**sidecar).clone()),
+                        None => tx,
+                    })
+                    .collect();
+                block.into()
+            })
+            .collect()
     }
 
     /// Deserialize and add all blocks data to the backend storage
+    ///
+    /// Blob sidecars carried inside the serialized block bodies are moved into the sidecar
+    /// store, leaving the block-body transactions in their canonical form. The headers are kept
+    /// as-is: blocks mined before the canonical encoding fix keep their historical
+    /// `transactions_root` and block hash.
     pub fn load_blocks(&mut self, serializable_blocks: Vec<SerializableBlock>) {
         for serializable_block in &serializable_blocks {
-            let block: Block = serializable_block.clone().into();
+            let mut block: Block = serializable_block.clone().into();
+            block.body.transactions = block
+                .body
+                .transactions
+                .into_iter()
+                .map(|tx| {
+                    let (tx, sidecar) = tx.strip_blob_sidecar();
+                    if let Some(sidecar) = sidecar {
+                        self.blob_sidecars.insert(tx.hash(), Arc::new(sidecar));
+                    }
+                    tx
+                })
+                .collect();
             let block_hash = block.header.hash_slow();
             let block_number = block.header.number();
             self.blocks.insert(block_hash, block);
@@ -827,5 +876,72 @@ mod tests {
         assert_eq!(loaded_block.header.gas_limit(), header.gas_limit());
         let loaded_tx = loaded_block.body.transactions.first().unwrap();
         assert_eq!(loaded_tx, &tx);
+    }
+
+    // Verifies that blob sidecars are reattached to their transactions on dump (keeping the
+    // on-disk format compatible with state files that carry sidecars inside block bodies) and
+    // stripped back into the sidecar store on load, without changing the block hash.
+    #[test]
+    fn test_storage_dump_reload_blob_sidecar_cycle() {
+        use alloy_consensus::{
+            BlobTransactionSidecar, SignableTransaction, TxEip4844,
+            transaction::eip4844::TxEip4844Variant,
+        };
+        use alloy_primitives::{Signature, U256};
+
+        let mut dump_storage = BlockchainStorage::<FoundryNetwork>::empty();
+
+        let tx = TxEip4844 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 21_000,
+            max_fee_per_gas: 1,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO,
+            value: U256::ZERO,
+            access_list: Default::default(),
+            blob_versioned_hashes: vec![B256::ZERO],
+            max_fee_per_blob_gas: 1,
+            input: Bytes::default(),
+        };
+        let sidecar = BlobTransactionSidecarVariant::Eip4844(BlobTransactionSidecar::new(
+            vec![Default::default()],
+            vec![Default::default()],
+            vec![Default::default()],
+        ));
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let variant = TxEip4844Variant::TxEip4844WithSidecar(tx.with_sidecar(sidecar));
+        let pooled_tx: MaybeImpersonatedTransaction<FoundryTxEnvelope> =
+            FoundryTxEnvelope::Eip4844(variant.into_signed(signature)).into();
+
+        // Mining stores the canonical transaction in the block body and the sidecar separately.
+        let (canonical_tx, sidecar) = pooled_tx.strip_blob_sidecar();
+        let sidecar = sidecar.unwrap();
+        let block = create_block(Header::default(), vec![canonical_tx.clone()]);
+        let block_hash = block.header.hash_slow();
+        let block_number = block.header.number();
+        dump_storage.blocks.insert(block_hash, block);
+        dump_storage.hashes.insert(block_number, block_hash);
+        dump_storage.blob_sidecars.insert(canonical_tx.hash(), Arc::new(sidecar.clone()));
+
+        // The serialized block carries the sidecar inside the transaction (legacy format).
+        let serialized_blocks = dump_storage.serialized_blocks();
+        let serialized_tx_block: Block = serialized_blocks[0].clone().into();
+        assert!(serialized_tx_block.body.transactions[0].as_ref().sidecar().is_some());
+
+        // Loading strips the sidecar back into the store and keeps the block hash unchanged.
+        let mut load_storage = BlockchainStorage::<FoundryNetwork>::empty();
+        load_storage.load_blocks(serialized_blocks);
+
+        let loaded_block = load_storage.blocks.get(&block_hash).unwrap();
+        assert_eq!(loaded_block.body.transactions.first().unwrap(), &canonical_tx);
+        assert_eq!(
+            load_storage.blob_sidecars.get(&canonical_tx.hash()).map(|s| (**s).clone()),
+            Some(sidecar)
+        );
+
+        // Removing the block's transactions clears the sidecar store as well.
+        load_storage.remove_block_transactions(block_hash);
+        assert!(load_storage.blob_sidecars.is_empty());
     }
 }

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -300,7 +300,10 @@ pub struct BlockchainStorage<N: Network> {
     /// Block bodies store blob transactions in their canonical form, without the sidecar, so
     /// that the transaction trie commits to the canonical EIP-2718 encoding. The sidecars are
     /// kept here so they can be served via the `anvil_getBlobs*` endpoints and reattached when
-    /// replaying block transactions.
+    /// replaying block transactions. Exception: impersonated blob transactions keep their
+    /// sidecar in the block body (their synthetic hash depends on the encoded transaction, see
+    /// `MaybeImpersonatedTransaction::strip_blob_sidecar`); their sidecar is mirrored here so
+    /// lookups have a single source.
     pub blob_sidecars: B256HashMap<Arc<BlobTransactionSidecarVariant>>,
     /// The total difficulty of the chain until this block
     pub total_difficulty: U256,
@@ -454,8 +457,9 @@ impl<N: Network> BlockchainStorage<N> {
     /// Deserialize and add all blocks data to the backend storage
     ///
     /// Blob sidecars carried inside the serialized block bodies are moved into the sidecar
-    /// store, leaving the block-body transactions in their canonical form. The headers are kept
-    /// as-is: blocks mined before the canonical encoding fix keep their historical
+    /// store, leaving the block-body transactions in their canonical form (impersonated blob
+    /// transactions stay sidecarful, with the sidecar mirrored into the store). The headers are
+    /// kept as-is: blocks mined before the canonical encoding fix keep their historical
     /// `transactions_root` and block hash.
     pub fn load_blocks(&mut self, serializable_blocks: Vec<SerializableBlock>) {
         for serializable_block in &serializable_blocks {

--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -1,11 +1,17 @@
 use crate::utils::{http_provider, http_provider_with_signer};
-use alloy_consensus::{BlobTransactionSidecar, SidecarBuilder, SimpleCoder, Transaction};
+use alloy_consensus::{
+    BlobTransactionSidecar, EthereumTxEnvelope, SidecarBuilder, SimpleCoder, Transaction,
+    TxEip4844, proofs::calculate_transaction_root,
+};
 use alloy_eips::{
     Typed2718,
-    eip4844::{BLOB_TX_MIN_BLOB_GASPRICE, DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK_DENCUN},
+    eip2718::Decodable2718,
+    eip4844::{
+        BLOB_TX_MIN_BLOB_GASPRICE, BYTES_PER_BLOB, DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK_DENCUN,
+    },
 };
 use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder, TransactionBuilder4844};
-use alloy_primitives::{Address, U256, b256};
+use alloy_primitives::{Address, Bytes, U64, U256, b256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::{BlockId, TransactionRequest};
 use alloy_serde::WithOtherFields;
@@ -484,4 +490,316 @@ async fn can_get_blobs_by_tx_hash() {
     api.anvil_set_auto_mine(true).await.unwrap();
     let blobs = api.anvil_get_blob_by_tx_hash(hash).unwrap().unwrap();
     assert_eq!(blobs, sidecar.blobs);
+}
+
+/// Mines one block containing a blob tx and a plain tx, then asserts the mined block commits to
+/// the canonical (sidecar-less) EIP-2718 transaction encodings, like blocks on a real network.
+async fn assert_mined_blob_block_is_canonical(node_config: NodeConfig, use_7594: bool) {
+    let (api, handle) = spawn(node_config).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let from = wallets[0].address();
+    let to = wallets[1].address();
+    let provider = http_provider(&handle.http_endpoint());
+
+    let eip1559_est = provider.estimate_eip1559_fees().await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+
+    let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"canonical root test");
+
+    let blob_tx = TransactionRequest::default()
+        .with_from(from)
+        .with_to(to)
+        .with_nonce(0)
+        .with_max_fee_per_blob_gas(gas_price + 1)
+        .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
+        .value(U256::from(1));
+    let blob_tx = if use_7594 {
+        blob_tx.with_blob_sidecar_7594(sidecar.build_7594().unwrap())
+    } else {
+        blob_tx.with_blob_sidecar_4844(sidecar.build().unwrap())
+    };
+    let blob_pending = provider.send_transaction(WithOtherFields::new(blob_tx)).await.unwrap();
+
+    let plain_tx = TransactionRequest::default()
+        .with_from(from)
+        .with_to(to)
+        .with_nonce(1)
+        .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
+        .value(U256::from(2));
+    let plain_pending = provider.send_transaction(WithOtherFields::new(plain_tx)).await.unwrap();
+
+    api.mine_one().await;
+
+    let blob_receipt = blob_pending.get_receipt().await.unwrap();
+    let plain_receipt = plain_pending.get_receipt().await.unwrap();
+    assert_eq!(blob_receipt.block_number, plain_receipt.block_number);
+    let block_number = blob_receipt.block_number.unwrap();
+
+    let block = provider.get_block_by_number(block_number.into()).await.unwrap().unwrap();
+    assert_eq!(block.transactions.len(), 2);
+
+    // Fetch the raw EIP-2718 encoding of every transaction in the block. Decoding into the
+    // sidecar-less envelope type enforces that mined blob transactions are served in their
+    // canonical form rather than the pooled `rlp([tx, blobs, commitments, proofs])` wrapper.
+    let mut leaves = Vec::new();
+    for index in 0..block.transactions.len() {
+        let raw: Bytes = provider
+            .client()
+            .request(
+                "eth_getRawTransactionByBlockNumberAndIndex",
+                (U64::from(block_number), U64::from(index as u64)),
+            )
+            .await
+            .unwrap();
+        assert!(
+            raw.len() < BYTES_PER_BLOB,
+            "raw mined tx {index} should not contain blob data ({} bytes)",
+            raw.len()
+        );
+        let envelope = EthereumTxEnvelope::<TxEip4844>::decode_2718(&mut raw.as_ref())
+            .unwrap_or_else(|err| panic!("mined tx {index} is not canonically encoded: {err}"));
+        leaves.push(envelope);
+    }
+    assert_eq!(*leaves[0].tx_hash(), blob_receipt.transaction_hash);
+
+    // The header must commit to the canonical transaction trie root and hash to the reported
+    // block hash.
+    assert_eq!(
+        block.header.transactions_root,
+        calculate_transaction_root(&leaves),
+        "header.transactionsRoot is not the canonical transaction trie root"
+    );
+    let consensus_header: alloy_consensus::Header = block.header.inner.clone().try_into().unwrap();
+    assert_eq!(consensus_header.hash_slow(), block.header.hash);
+
+    // The block's blobs must remain retrievable after mining.
+    let blobs = api.anvil_get_blob_by_tx_hash(blob_receipt.transaction_hash).unwrap().unwrap();
+    assert!(!blobs.is_empty());
+
+    // Full-block RPC responses must serve the standard transaction shape, without the pooled
+    // sidecar fields.
+    let full_block: serde_json::Value = provider
+        .client()
+        .request("eth_getBlockByNumber", (U64::from(block_number), true))
+        .await
+        .unwrap();
+    let tx_json = &full_block["transactions"][0];
+    for field in ["blobs", "commitments", "proofs", "cellProofs"] {
+        assert!(
+            tx_json.get(field).is_none(),
+            "mined blob tx RPC response must not expose `{field}`"
+        );
+    }
+}
+
+// <https://github.com/foundry-rs/foundry/issues/15132>
+#[tokio::test(flavor = "multi_thread")]
+async fn mined_blob_block_has_canonical_transactions_root() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
+    assert_mined_blob_block_is_canonical(node_config, false).await;
+}
+
+// <https://github.com/foundry-rs/foundry/issues/15132>
+#[tokio::test(flavor = "multi_thread")]
+async fn mined_blob_block_has_canonical_transactions_root_eip7594() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Osaka.into()));
+    assert_mined_blob_block_is_canonical(node_config, true).await;
+}
+
+// <https://github.com/foundry-rs/foundry/issues/15132>
+#[tokio::test(flavor = "multi_thread")]
+async fn can_trace_transaction_after_blob_tx() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
+    let (api, handle) = spawn(node_config).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let from = wallets[0].address();
+    let to = wallets[1].address();
+    let provider = http_provider(&handle.http_endpoint());
+
+    let eip1559_est = provider.estimate_eip1559_fees().await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+
+    let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"trace replay");
+    let blob_tx = TransactionRequest::default()
+        .with_from(from)
+        .with_to(to)
+        .with_nonce(0)
+        .with_max_fee_per_blob_gas(gas_price + 1)
+        .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
+        .with_blob_sidecar_4844(sidecar.build().unwrap())
+        .value(U256::from(1));
+    let blob_pending = provider.send_transaction(WithOtherFields::new(blob_tx)).await.unwrap();
+
+    let plain_tx = TransactionRequest::default()
+        .with_from(from)
+        .with_to(to)
+        .with_nonce(1)
+        .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
+        .value(U256::from(2));
+    let plain_pending = provider.send_transaction(WithOtherFields::new(plain_tx)).await.unwrap();
+
+    api.mine_one().await;
+
+    let blob_receipt = blob_pending.get_receipt().await.unwrap();
+    let plain_receipt = plain_pending.get_receipt().await.unwrap();
+    assert_eq!(blob_receipt.block_number, plain_receipt.block_number);
+
+    // Tracing the plain tx replays the preceding blob tx from the stored block body, which
+    // requires reattaching its sidecar for pool transaction validation.
+    api.debug_trace_transaction(
+        plain_receipt.transaction_hash,
+        alloy_rpc_types::trace::geth::GethDebugTracingOptions::default(),
+    )
+    .await
+    .unwrap();
+
+    // Tracing the blob tx itself must work as well.
+    api.debug_trace_transaction(
+        blob_receipt.transaction_hash,
+        alloy_rpc_types::trace::geth::GethDebugTracingOptions::default(),
+    )
+    .await
+    .unwrap();
+}
+
+// <https://github.com/foundry-rs/foundry/issues/15132>
+#[tokio::test(flavor = "multi_thread")]
+async fn can_load_state_with_blob_txs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state_file = tmp.path().join("state.json");
+
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
+    let (api, handle) = spawn(node_config).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let from = wallets[0].address();
+    let to = wallets[1].address();
+    let provider = http_provider(&handle.http_endpoint());
+
+    let eip1559_est = provider.estimate_eip1559_fees().await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+
+    let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"dump and reload");
+    let sidecar: BlobTransactionSidecar = sidecar.build().unwrap();
+    let blob_tx = TransactionRequest::default()
+        .with_from(from)
+        .with_to(to)
+        .with_nonce(0)
+        .with_max_fee_per_blob_gas(gas_price + 1)
+        .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
+        .with_blob_sidecar_4844(sidecar.clone())
+        .value(U256::from(1));
+    let blob_pending = provider.send_transaction(WithOtherFields::new(blob_tx)).await.unwrap();
+
+    let plain_tx = TransactionRequest::default()
+        .with_from(from)
+        .with_to(to)
+        .with_nonce(1)
+        .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
+        .value(U256::from(2));
+    let plain_pending = provider.send_transaction(WithOtherFields::new(plain_tx)).await.unwrap();
+
+    api.mine_one().await;
+
+    let receipt = blob_pending.get_receipt().await.unwrap();
+    let plain_receipt = plain_pending.get_receipt().await.unwrap();
+    assert_eq!(receipt.block_number, plain_receipt.block_number);
+    let tx_hash = receipt.transaction_hash;
+    let block_number = receipt.block_number.unwrap();
+    let block_hash = receipt.block_hash.unwrap();
+
+    let state = api.serialized_state(true).await.unwrap();
+    foundry_common::fs::write_json_file(&state_file, &state).unwrap();
+
+    let node_config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Cancun.into()))
+        .with_init_state_path(state_file);
+    let (api, handle) = spawn(node_config).await;
+    let provider = http_provider(&handle.http_endpoint());
+
+    // The block hash must be unchanged after the dump/load round trip.
+    let block = provider.get_block_by_number(block_number.into()).await.unwrap().unwrap();
+    assert_eq!(block.header.hash, block_hash);
+
+    // Blobs must be retrievable from the migrated sidecar store.
+    let blobs = api.anvil_get_blob_by_tx_hash(tx_hash).unwrap().unwrap();
+    assert_eq!(blobs, sidecar.blobs);
+
+    // The mined blob tx is still served in its canonical raw form.
+    let raw: Bytes = provider
+        .client()
+        .request(
+            "eth_getRawTransactionByBlockNumberAndIndex",
+            (U64::from(block_number), U64::from(0u64)),
+        )
+        .await
+        .unwrap();
+    assert!(raw.len() < BYTES_PER_BLOB);
+    EthereumTxEnvelope::<TxEip4844>::decode_2718(&mut raw.as_ref()).unwrap();
+
+    // Tracing a tx mined after the blob tx works on the loaded chain: the replay reattaches
+    // the migrated sidecar.
+    api.debug_trace_transaction(
+        plain_receipt.transaction_hash,
+        alloy_rpc_types::trace::geth::GethDebugTracingOptions::default(),
+    )
+    .await
+    .unwrap();
+}
+
+// <https://github.com/foundry-rs/foundry/issues/15132>
+#[tokio::test(flavor = "multi_thread")]
+async fn reverting_snapshot_removes_blob_sidecars() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
+    let (api, handle) = spawn(node_config).await;
+
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let from = wallets[0].address();
+    let to = wallets[1].address();
+    let provider = http_provider(&handle.http_endpoint());
+
+    let eip1559_est = provider.estimate_eip1559_fees().await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+
+    let snapshot_id = api.evm_snapshot().await.unwrap();
+
+    let sidecar: SidecarBuilder<SimpleCoder> = SidecarBuilder::from_slice(b"reverted away");
+    let sidecar: BlobTransactionSidecar = sidecar.build().unwrap();
+    let tx = TransactionRequest::default()
+        .with_from(from)
+        .with_to(to)
+        .with_nonce(0)
+        .with_max_fee_per_blob_gas(gas_price + 1)
+        .with_max_fee_per_gas(eip1559_est.max_fee_per_gas)
+        .with_max_priority_fee_per_gas(eip1559_est.max_priority_fee_per_gas)
+        .with_blob_sidecar_4844(sidecar.clone())
+        .value(U256::from(1));
+    let receipt = provider
+        .send_transaction(WithOtherFields::new(tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let tx_hash = receipt.transaction_hash;
+    let versioned_hash = sidecar.versioned_hash_for_blob(0).unwrap();
+
+    assert!(api.anvil_get_blob_by_tx_hash(tx_hash).unwrap().is_some());
+    assert!(api.anvil_get_blob_by_versioned_hash(versioned_hash).unwrap().is_some());
+
+    // Reverting to the snapshot must also drop the reverted transactions' sidecars.
+    assert!(api.evm_revert(snapshot_id).await.unwrap());
+    assert!(api.anvil_get_blob_by_tx_hash(tx_hash).unwrap().is_none());
+    assert!(api.anvil_get_blob_by_versioned_hash(versioned_hash).unwrap().is_none());
 }

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -1,13 +1,14 @@
-#[cfg(feature = "optimism")]
-use alloy_consensus::{Sealed, Transaction as _};
 use alloy_consensus::{
-    Signed, TransactionEnvelope, TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType, Typed2718,
+    BlobTransactionSidecarVariant, Signed, TransactionEnvelope, TxEip1559, TxEip2930, TxEnvelope,
+    TxLegacy, TxType, Typed2718,
     crypto::RecoveryError,
     transaction::{
         SignerRecoverable, TxEip7702, TxHashRef,
         eip4844::{TxEip4844Variant, TxEip4844WithSidecar},
     },
 };
+#[cfg(feature = "optimism")]
+use alloy_consensus::{Sealed, Transaction as _};
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded};
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
 use alloy_primitives::{Address, B256, Bytes, TxHash};
@@ -95,6 +96,45 @@ impl FoundryTxEnvelope {
                 _ => None,
             },
             _ => None,
+        }
+    }
+
+    /// Reattaches a blob sidecar to an EIP-4844 transaction, returning the pooled (sidecarful)
+    /// form. The transaction hash and signature are unchanged.
+    ///
+    /// No-op for non-EIP-4844 transactions and transactions that already carry a sidecar.
+    pub fn with_blob_sidecar(self, sidecar: BlobTransactionSidecarVariant) -> Self {
+        match self {
+            Self::Eip4844(signed) => Self::Eip4844(signed.map(|variant| match variant {
+                TxEip4844Variant::TxEip4844(tx) => {
+                    TxEip4844Variant::TxEip4844WithSidecar(tx.with_sidecar(sidecar))
+                }
+                variant @ TxEip4844Variant::TxEip4844WithSidecar(_) => variant,
+            })),
+            tx => tx,
+        }
+    }
+
+    /// Removes the blob sidecar from an EIP-4844 transaction, returning the transaction in its
+    /// canonical (non-pooled) form along with the sidecar, if any.
+    ///
+    /// The canonical form is what belongs in a block body: its EIP-2718 encoding is the bare
+    /// `0x03 || rlp([...])` payload used for the transaction trie, without the pooled
+    /// `rlp([tx, blobs, commitments, proofs])` wrapper. The transaction hash and signature are
+    /// unchanged, since the EIP-4844 transaction hash is always computed over the non-sidecar
+    /// encoding.
+    pub fn strip_blob_sidecar(self) -> (Self, Option<BlobTransactionSidecarVariant>) {
+        match self {
+            Self::Eip4844(signed) => {
+                let mut sidecar = None;
+                let signed = signed.map(|variant| {
+                    let (tx, stripped) = variant.strip_sidecar();
+                    sidecar = stripped;
+                    tx
+                });
+                (Self::Eip4844(signed), sidecar)
+            }
+            tx => (tx, None),
         }
     }
 
@@ -475,6 +515,74 @@ mod tests {
     use alloy_signer::Signature;
 
     use super::*;
+
+    fn sidecarful_4844_envelope(sidecar: BlobTransactionSidecarVariant) -> FoundryTxEnvelope {
+        use alloy_consensus::{SignableTransaction, TxEip4844};
+
+        let tx = TxEip4844 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 21_000,
+            max_fee_per_gas: 1,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO,
+            value: U256::ZERO,
+            access_list: Default::default(),
+            blob_versioned_hashes: vec![B256::ZERO],
+            max_fee_per_blob_gas: 1,
+            input: Bytes::default(),
+        };
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let variant = TxEip4844Variant::TxEip4844WithSidecar(tx.with_sidecar(sidecar));
+        FoundryTxEnvelope::Eip4844(variant.into_signed(signature))
+    }
+
+    fn assert_strip_blob_sidecar_roundtrip(sidecar: BlobTransactionSidecarVariant) {
+        use alloy_network::eip2718::Encodable2718;
+
+        let envelope = sidecarful_4844_envelope(sidecar.clone());
+        let pooled_len = envelope.encode_2718_len();
+
+        // Stripping yields the canonical (shorter) encoding and preserves the hash, which is
+        // always computed over the non-sidecar encoding.
+        let (canonical, stripped) = envelope.clone().strip_blob_sidecar();
+        assert_eq!(stripped, Some(sidecar));
+        assert_eq!(canonical.hash(), envelope.hash());
+        assert!(canonical.sidecar().is_none());
+        assert!(canonical.encode_2718_len() < pooled_len);
+
+        // Reattaching restores the exact pooled encoding.
+        let reattached = canonical.with_blob_sidecar(stripped.unwrap());
+        assert_eq!(reattached.hash(), envelope.hash());
+        assert_eq!(reattached.encoded_2718(), envelope.encoded_2718());
+    }
+
+    #[test]
+    fn test_strip_blob_sidecar_roundtrip_eip4844() {
+        assert_strip_blob_sidecar_roundtrip(BlobTransactionSidecarVariant::Eip4844(
+            alloy_consensus::BlobTransactionSidecar::new(
+                vec![Default::default()],
+                vec![Default::default()],
+                vec![Default::default()],
+            ),
+        ));
+    }
+
+    #[test]
+    fn test_strip_blob_sidecar_roundtrip_eip7594() {
+        assert_strip_blob_sidecar_roundtrip(BlobTransactionSidecarVariant::Eip7594(
+            Default::default(),
+        ));
+    }
+
+    #[test]
+    fn test_strip_blob_sidecar_non_blob_tx() {
+        let bytes = hex::decode("02f872018307910d808507204d2cb1827d0094388c818ca8b9251b393131c08a736a67ccb19297880320d04823e2701c80c001a0cf024f4815304df2867a1a74e9d2707b6abda0337d2d54a4438d453f4160f190a07ac0e6b3bc9395b5b9c8b9e6d77204a236577a5b18467b9175c01de4faa208d9").unwrap();
+        let envelope = FoundryTxEnvelope::decode(&mut &bytes[..]).unwrap();
+        let (unchanged, sidecar) = envelope.clone().strip_blob_sidecar();
+        assert!(sidecar.is_none());
+        assert_eq!(unchanged.hash(), envelope.hash());
+    }
 
     #[test]
     fn test_decode_call() {


### PR DESCRIPTION
## Motivation

Closes #15132.

When Anvil mines a block containing an EIP-4844 blob transaction, the pooled (sidecarful) envelope is stored in the block body and the transaction trie root is computed over its `encode_2718` leaves. Since alloy's `TxEip4844WithSidecar` encodes the pooled networking wrapper `rlp([tx, blobs, commitments, proofs])`, the block's `transactionsRoot` — and therefore the block hash — diverges from what a canonical client (geth/reth, mainnet/Sepolia) would produce for the same transactions. Per [EIP-4844 § Networking](https://eips.ethereum.org/EIPS/eip-4844#networking), that wrapper is mempool-gossip-only; block bodies use the standard [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) payload.

Concretely, on master (repro in the issue): a mined blob tx's raw bytes are ~131 KB and `header.transactionsRoot == root(sidecarful leaves) != root(canonical leaves)`, so trie inclusion proofs and any tooling that recomputes roots/hashes against Anvil headers fail.

## Solution

Strip the sidecar at the single point where a pool transaction is included in a block, and keep sidecars in a dedicated store so the `anvil_getBlobs*` endpoints and trace replay keep working — mirroring how real nodes separate execution data from blob data:

- **`FoundryTxEnvelope::strip_blob_sidecar` / `with_blob_sidecar`** (foundry-primitives): convert between the canonical and pooled forms. Hash and signature are unchanged (the 4844 tx hash is always computed over the non-sidecar encoding), so all hash-keyed lookups stay consistent.
- **Executor** (`execute_pool_transactions`): strips the cloned pool tx before it enters the block-body tx list and returns the sidecars in `ExecutedPoolTransactions.blob_sidecars`. This chokepoint covers all mining paths (automine, interval, `evm_mine`, reorg, pending block).
- **`BlockchainStorage.blob_sidecars`** (`tx hash → Arc<BlobTransactionSidecarVariant>`): populated in `do_mine_block`; entries are removed in `remove_block_transactions` (unwind/reorg/pruning) and on `evm_revert` snapshot rollback.
- **Blob endpoints** (`anvil_getBlobByHash`, `anvil_getBlobsByBlockId`, `anvil_getBlobsByTransactionHash`) read from the store instead of scanning block bodies.
- **`debug_trace*` replay** (`replay_tx_with_inspector`) reattaches stored sidecars when rebuilding pool transactions, since pool validation (`blob_tx.validate`) requires the sidecar.
- **State files**: the on-disk format is unchanged — sidecars are reattached to their transactions on dump and stripped back into the store on load. Old state files load fine (their historical headers and block hashes are preserved as-is), and new dumps remain readable by older versions.

Behavior changes for blocks containing blob transactions:

- `transactionsRoot` and the block hash are now canonical and reproducible from the block's transactions.
- `eth_getRawTransaction*` for **mined** blob txs returns the bare `0x03 || rlp([...])` payload (matching geth/reth); pending pool txs still return the pooled form.
- `eth_getBlockBy*(full)` / `eth_getTransactionByHash` no longer expose non-standard `blobs`/`commitments`/`proofs` fields on mined transactions.

Known limitation (documented in code): **impersonated** blob transactions are not stripped, because their synthetic hash is derived from the encoded transaction, and changing either the hash derivation or the encoding would break loading state files from earlier versions (mined transactions are keyed by the stored synthetic hash). Their sidecar is mirrored into the sidecar store so blob endpoints and replay read from one source. Canonical roots are guaranteed for properly-signed transactions; impersonated blocks are non-canonical regardless due to the bypass signature.

### Tests

- `mined_blob_block_has_canonical_transactions_root` (+ EIP-7594/Osaka variant): raw txs decode as bare envelopes, recomputed `calculate_transaction_root` matches the header, recomputed header hash matches the block hash, blobs stay retrievable, full-block RPC JSON has no sidecar fields. Both fail on master and pass with this change.
- `can_trace_transaction_after_blob_tx`: `debug_traceTransaction` of a tx mined after a blob tx (exercises replay rehydration) and of the blob tx itself.
- `can_load_state_with_blob_txs`: dump → load round trip; block hash unchanged, blobs retrievable from the migrated store, raw tx canonical, tracing works on the loaded chain.
- `reverting_snapshot_removes_blob_sidecars`: `evm_revert` drops sidecars of reverted txs.
- Unit tests: strip/reattach roundtrip for both sidecar variants (foundry-primitives), dump/load/remove cycle for the sidecar store (anvil storage).
- All pre-existing blob tests pass unchanged (`can_get_blobs_by_versioned_hash`, `can_get_blobs_by_tx_hash`, fork/7594/multi-blob/bypass-sidecar, beacon API, state, traces).

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes

## AI Disclosure

This PR was developed with AI assistance (Claude Code) for the root-cause analysis, implementation, and tests; I directed and reviewed the work.
