### PR TITLE
test(cast): trim to_base test values to avoid CI timeout

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1946,15 +1946,14 @@ Transaction successfully executed.
 
 // tests that `cast --to-base` commands are working correctly.
 casttest!(to_base, |_prj, cmd| {
+    // One value per distinct code path (small positive, u256 max in decimal and
+    // hex form, small negative, i256 min) to keep the number of spawned `cast`
+    // processes low and avoid timing out on slow Windows/macOS/ARM CI runners.
     let values = [
         "1",
-        "100",
-        "100000",
         "115792089237316195423570985008687907853269984665640564039457584007913129639935",
         "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
         "-1",
-        "-100",
-        "-100000",
         "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
     ];
     for value in values {


### PR DESCRIPTION
## Motivation

The `to_base` cast CLI test is flaky on Windows (and slow macOS/ARM) CI runners. It does not fail an assertion — it **times out**. Example: [run 27293361070](https://github.com/foundry-rs/foundry/actions/runs/27293361070/job/80619569785), where all 3 retries hit the 90s nextest `slow-timeout` and were terminated (`TRY 1/2/3 TMT ~90s`).

The test spawns one `cast` process per combination:

```
9 values x ( 4 (--to-base: bin/oct/dec/hex) + 1 (--to-hex) + 1 (--to-dec) ) = 54 sequential process launches
```

The loops are already sequential (`assert_success()` waits for each process), so the cost is pure process-startup overhead. On a loaded Windows runner, 54 sequential `cast` spawns cross the 90s cutoff.

## Solution

Trim the value matrix to one value per distinct code path, keeping every meaningful edge case:

- `1` — small positive
- u256 max (decimal) — upper boundary
- u256 max (hex) — exercises hex input parsing
- `-1` — small negative
- i256 min — negative boundary

The dropped values (`100`, `100000`, `-100`, `-100000`) were redundant in-range numbers hitting the same parse/convert paths as `1`/`-1`.

This reduces spawns from 54 to 30 (~45% fewer), comfortably under the timeout, with no loss of coverage.