### PR TITLE
feat(anvil): add `eth_resend`

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -1,6 +1,6 @@
 use crate::{eth::subscription::SubscriptionId, types::ReorgOptions};
 use alloy_primitives::{
-    Address, B64, B256, Bytes, TxHash, U256,
+    Address, B64, B256, Bytes, TxHash, U64, U256,
     map::{HashMap, HashSet},
 };
 use alloy_rpc_types::{
@@ -164,6 +164,9 @@ pub enum EthRequest {
 
     #[serde(rename = "eth_sendTransaction", with = "sequence")]
     EthSendTransaction(Box<WithOtherFields<TransactionRequest>>),
+
+    #[serde(rename = "eth_resend")]
+    EthResend(Box<WithOtherFields<TransactionRequest>>, Option<U256>, Option<U64>),
 
     #[serde(rename = "eth_sendTransactionSync", with = "sequence")]
     EthSendTransactionSync(Box<WithOtherFields<TransactionRequest>>),

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1515,6 +1515,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::EthSendTransaction(request) => {
                 self.send_transaction(*request).await.to_rpc_result()
             }
+            EthRequest::EthResend(request, gas_price, gas_limit) => {
+                self.resend_transaction(*request, gas_price, gas_limit).await.to_rpc_result()
+            }
             EthRequest::EthSendTransactionSync(request) => {
                 self.send_transaction_sync(*request).await.to_rpc_result()
             }
@@ -2214,6 +2217,65 @@ impl EthApi<FoundryNetwork> {
         // pre-validate
         self.backend.validate_pool_transaction(&pending_transaction).await?;
 
+        let (requires, provides) = if let Some((requires, provides)) =
+            tempo_parallel_nonce_markers(&pending_transaction)
+        {
+            (requires, provides)
+        } else {
+            (required_marker(nonce, on_chain_nonce, from), vec![to_marker(nonce, from)])
+        };
+
+        self.add_pending_transaction(pending_transaction, requires, provides)
+    }
+
+    /// Resends a pending transaction with an updated gas price or gas limit.
+    ///
+    /// Handler for ETH RPC call: `eth_resend`
+    pub async fn resend_transaction(
+        &self,
+        mut request: WithOtherFields<TransactionRequest>,
+        gas_price: Option<U256>,
+        gas_limit: Option<U64>,
+    ) -> Result<TxHash> {
+        node_info!("eth_resend");
+
+        let from = request.from.map(Ok).unwrap_or_else(|| {
+            self.accounts()?.first().copied().ok_or(BlockchainError::NoSignerAvailable)
+        })?;
+        let nonce = request.nonce.ok_or_else(|| {
+            BlockchainError::InvalidTransactionRequest(
+                "missing transaction nonce in transaction spec".to_string(),
+            )
+        })?;
+
+        if !self.pool.contains_sender_nonce(from, nonce) {
+            return Err(BlockchainError::TransactionNotFound);
+        }
+
+        if let Some(gas_price) = gas_price.filter(|gas_price| !gas_price.is_zero()) {
+            request.set_gas_price(gas_price.saturating_to());
+        }
+
+        if let Some(gas_limit) = gas_limit.filter(|gas_limit| *gas_limit != U64::ZERO) {
+            request.set_gas_limit(gas_limit.to());
+        }
+
+        let typed_tx = self.build_tx_request(request, nonce).await?;
+
+        let pending_transaction = if self.is_impersonated(from) {
+            let transaction = sign::build_impersonated(typed_tx);
+            self.ensure_typed_transaction_supported(&transaction)?;
+            trace!(target : "node", ?from, "eth_resend: impersonating");
+            PendingTransaction::with_impersonated(transaction, from)
+        } else {
+            let transaction = self.sign_request(&from, typed_tx)?;
+            self.ensure_typed_transaction_supported(&transaction)?;
+            PendingTransaction::new(transaction)?
+        };
+
+        self.backend.validate_pool_transaction(&pending_transaction).await?;
+
+        let on_chain_nonce = self.backend.current_nonce(from).await?;
         let (requires, provides) = if let Some((requires, provides)) =
             tempo_parallel_nonce_markers(&pending_transaction)
         {

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -95,6 +95,17 @@ impl<T> Pool<T> {
         self.inner.read().contains(tx_hash)
     }
 
+    /// Returns true if this pool contains a transaction from `sender` with `nonce`.
+    pub fn contains_sender_nonce(&self, sender: Address, nonce: u64) -> bool
+    where
+        T: Transaction,
+    {
+        self.inner
+            .read()
+            .transactions_by_sender(sender)
+            .any(|tx| tx.pending_transaction.nonce() == nonce)
+    }
+
     /// Removes all transactions from the pool
     pub fn clear(&self) {
         let mut pool = self.inner.write();

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -3,8 +3,12 @@ use crate::{
     utils::{connect_pubsub, http_provider_with_signer},
 };
 use alloy_consensus::Transaction;
-use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder, TransactionResponse};
-use alloy_primitives::{Address, Bytes, FixedBytes, U256, address, hex, map::B256HashSet};
+use alloy_network::{
+    AnyRpcTransaction, EthereumWallet, ReceiptResponse, TransactionBuilder, TransactionResponse,
+};
+use alloy_primitives::{
+    Address, Bytes, FixedBytes, TxHash, U64, U256, address, hex, map::B256HashSet,
+};
 use alloy_provider::{Provider, WsConnect};
 use alloy_rpc_types::{
     AccessList, AccessListItem, BlockId, BlockNumberOrTag, BlockOverrides, BlockTransactions,
@@ -193,6 +197,57 @@ async fn can_replace_transaction() {
         BlockTransactions::Hashes(vec![higher_priced_receipt.transaction_hash]),
         block.transactions
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_resend_transaction() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let provider = handle.http_provider();
+
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let from = accounts[0].address();
+    let to = accounts[1].address();
+
+    let nonce = provider.get_transaction_count(from).await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+    let amount = handle.genesis_balance().checked_div(U256::from(3u64)).unwrap();
+
+    let tx = TransactionRequest::default()
+        .to(to)
+        .value(amount)
+        .from(from)
+        .nonce(nonce)
+        .gas_price(gas_price);
+
+    let tx = WithOtherFields::new(tx);
+    let original_pending_tx = provider.send_transaction(tx.clone()).await.unwrap();
+
+    let replacement_gas_price = gas_price + 1;
+    let replacement_gas_limit = 22_000;
+    let replacement_hash: TxHash = provider
+        .client()
+        .request(
+            "eth_resend",
+            (tx, Some(U256::from(replacement_gas_price)), Some(U64::from(replacement_gas_limit))),
+        )
+        .await
+        .unwrap();
+
+    assert_ne!(*original_pending_tx.tx_hash(), replacement_hash);
+
+    api.mine_one().await;
+
+    let block = provider.get_block(1.into()).await.unwrap().unwrap();
+    assert_eq!(BlockTransactions::Hashes(vec![replacement_hash]), block.transactions);
+
+    let replacement_tx: AnyRpcTransaction =
+        provider.get_transaction_by_hash(replacement_hash).await.unwrap().unwrap();
+    assert_eq!(replacement_tx.inner.tx_hash(), replacement_hash);
+    assert_eq!(replacement_tx.inner.gas_limit(), replacement_gas_limit);
+    assert_eq!(Transaction::max_fee_per_gas(&replacement_tx.inner), replacement_gas_price);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -251,6 +251,59 @@ async fn can_resend_transaction() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_reject_invalid_resend_transaction() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let provider = handle.http_provider();
+
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let from = accounts[0].address();
+    let to = accounts[1].address();
+
+    let nonce = provider.get_transaction_count(from).await.unwrap();
+    let gas_price = provider.get_gas_price().await.unwrap();
+    let amount = handle.genesis_balance().checked_div(U256::from(3u64)).unwrap();
+
+    let missing_nonce_tx =
+        TransactionRequest::default().to(to).value(amount).from(from).gas_price(gas_price);
+    let missing_nonce_resend: Result<TxHash, _> = provider
+        .client()
+        .request("eth_resend", (WithOtherFields::new(missing_nonce_tx), None::<U256>, None::<U64>))
+        .await;
+    assert!(missing_nonce_resend.unwrap_err().to_string().contains("missing transaction nonce"));
+
+    let tx = TransactionRequest::default()
+        .to(to)
+        .value(amount)
+        .from(from)
+        .nonce(nonce)
+        .gas_price(gas_price);
+
+    let not_in_pool_resend: Result<TxHash, _> = provider
+        .client()
+        .request("eth_resend", (WithOtherFields::new(tx.clone()), None::<U256>, None::<U64>))
+        .await;
+    assert!(not_in_pool_resend.unwrap_err().to_string().contains("transaction not found"));
+
+    let mut tx = WithOtherFields::new(tx);
+    tx.set_gas_price(gas_price + 1);
+    let pending_tx = provider.send_transaction(tx.clone()).await.unwrap();
+
+    let underpriced_resend: Result<TxHash, _> = provider
+        .client()
+        .request("eth_resend", (tx, Some(U256::from(gas_price)), None::<U64>))
+        .await;
+    assert!(
+        underpriced_resend.unwrap_err().to_string().contains("replacement transaction underpriced")
+    );
+
+    api.mine_one().await;
+    pending_tx.get_receipt().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_reject_too_high_gas_limits() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
Adds `eth_resend` support to Anvil so pending unlocked-account transactions can be replaced with an updated gas price or gas limit. The method checks that the requested sender and nonce are already pending before signing and submitting the replacement.

ref: https://github.com/paradigmxyz/reth/pull/24339