### PR TITLE
fix(doc): match inheritdoc overloads with canonical types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4943,6 +4943,7 @@ version = "1.7.2"
 dependencies = [
  "alloy-primitives",
  "eyre",
+ "foundry-common",
  "foundry-compilers",
  "foundry-config",
  "path-slash",

--- a/crates/doc/Cargo.toml
+++ b/crates/doc/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 solar.workspace = true
 
 foundry-compilers.workspace = true
+foundry-common.workspace = true
 foundry-config.workspace = true
 
 alloy-primitives.workspace = true
@@ -29,4 +30,4 @@ tracing.workspace = true
 
 [features]
 default = ["optimism"]
-optimism = []
+optimism = ["foundry-common/optimism"]

--- a/crates/doc/src/hir_ext.rs
+++ b/crates/doc/src/hir_ext.rs
@@ -263,8 +263,8 @@ pub struct InheritedDoc {
 /// matching function and returns its natspec if found.
 ///
 /// When `param_types` is `Some`, the resolver prefers a function whose parameter
-/// type signature matches exactly; this disambiguates overloads. If no exact
-/// signature match is found, it falls back to the first name match.
+/// type signature matches exactly; this disambiguates overloads. Ambiguous
+/// overloads are never matched by name alone.
 pub fn resolve_inheritdoc(
     gcx: Gcx<'_>,
     contract_id: ContractId,
@@ -315,10 +315,11 @@ pub fn resolve_inheritdoc(
         if let Some(want) = param_types
             && name_matches.len() > 1
         {
-            // Try to find a signature-exact match with docs; fall through to name matches below.
+            // Try to find a signature-exact match with docs; fall through only for
+            // non-overloaded name matches below.
             for &fid in &name_matches {
-                let got = function_param_types(gcx, fid);
-                if got.len() == want.len()
+                if let Some(got) = function_param_types(gcx, fid)
+                    && got.len() == want.len()
                     && got.iter().zip(want).all(|(a, b)| a == b)
                     && let Some(doc) = extract_inherited_doc(gcx, fid)
                     && (!doc.notices.is_empty()
@@ -331,7 +332,7 @@ pub fn resolve_inheritdoc(
             }
         }
 
-        if name_matches.len() > 1 && param_types.is_some() {
+        if name_matches.len() > 1 {
             continue;
         }
 
@@ -394,7 +395,7 @@ pub fn resolve_inheritdoc_var(
                 ItemId::Function(fid) => {
                     let f = gcx.hir.function(fid);
                     if f.name.map(|n| n.as_str() == var_name).unwrap_or(false)
-                        && function_param_types(gcx, fid).is_empty()
+                        && function_param_types(gcx, fid).map(|p| p.is_empty()).unwrap_or(false)
                         && let Some(doc) = extract_inherited_doc(gcx, fid)
                         && (!doc.notices.is_empty()
                             || !doc.devs.is_empty()
@@ -434,23 +435,55 @@ fn extract_inherited_doc_var(gcx: Gcx<'_>, vid: VariableId) -> Option<InheritedD
 }
 
 /// Extract the canonical ABI parameter type strings (in source order) for a function.
-pub(crate) fn function_param_types(gcx: Gcx<'_>, fid: FunctionId) -> Vec<String> {
+///
+/// Non-ABI-printable internal parameter types, such as mappings, fall back to their
+/// source spelling so inherited docs can still resolve without panicking.
+pub(crate) fn function_param_types(gcx: Gcx<'_>, fid: FunctionId) -> Option<Vec<String>> {
     let f = gcx.hir.function(fid);
+    let source_types = gcx
+        .sources
+        .get(f.source)
+        .and_then(|source| source.ast.as_ref())
+        .and_then(|ast| {
+            ast.items.iter().find_map(|item| match &item.kind {
+                ItemKind::Function(func) if item.span == f.span => Some(&func.header.parameters),
+                ItemKind::Contract(c) => c.body.iter().find_map(|m| match &m.kind {
+                    ItemKind::Function(func) if m.span == f.span => Some(&func.header.parameters),
+                    _ => None,
+                }),
+                _ => None,
+            })
+        })
+        .map(|params| {
+            let sm = gcx.sess.source_map();
+            params
+                .vars
+                .iter()
+                .map(|v| {
+                    normalize_sol_type(sm.span_to_snippet(v.ty.span).unwrap_or_default().trim())
+                })
+                .collect::<Vec<_>>()
+        });
+
     f.parameters
         .iter()
-        .map(|&param| {
+        .enumerate()
+        .map(|(idx, &param)| {
             let ty = gcx.type_of_item(param.into());
-            let mut out = String::new();
-            TyAbiPrinter::new(gcx, &mut out, TyAbiPrinterMode::Signature)
-                .print(ty)
-                .expect("writing ABI signature type to a String cannot fail");
-            out
+            if ty.can_be_exported(gcx) {
+                let mut out = String::new();
+                TyAbiPrinter::new(gcx, &mut out, TyAbiPrinterMode::Signature)
+                    .print(ty)
+                    .expect("writing ABI signature type to a String cannot fail");
+                Some(out)
+            } else {
+                source_types.as_ref().and_then(|types| types.get(idx).cloned())
+            }
         })
         .collect()
 }
 
-/// Canonicalize Solidity type aliases so that e.g. `uint[]` and `uint256[]`
-/// compare equal during overload matching.
+/// Canonicalize Solidity type aliases for generated anchors and source fallbacks.
 ///
 /// Replaces every occurrence of the bare alias tokens `uint` / `int` (not
 /// followed by a digit) with their canonical ABI equivalents `uint256` /

--- a/crates/doc/src/hir_ext.rs
+++ b/crates/doc/src/hir_ext.rs
@@ -8,13 +8,12 @@
 
 use path_slash::PathBufExt;
 use solar::{
-    ast::{
-        CommentKind, ContractKind, DocComments, FunctionKind, ItemKind, NatSpecKind, ParameterList,
-    },
+    ast::{CommentKind, ContractKind, DocComments, FunctionKind, ItemKind, NatSpecKind},
     interface::source_map::FileName,
     sema::{
         Gcx,
         hir::{ContractId, FunctionId, ItemId, SourceId, VariableId},
+        ty::{TyAbiPrinter, TyAbiPrinterMode},
     },
 };
 use std::{
@@ -318,8 +317,8 @@ pub fn resolve_inheritdoc(
         {
             // Try to find a signature-exact match with docs; fall through to name matches below.
             for &fid in &name_matches {
-                if let Some(got) = function_param_types(gcx, fid)
-                    && got.len() == want.len()
+                let got = function_param_types(gcx, fid);
+                if got.len() == want.len()
                     && got.iter().zip(want).all(|(a, b)| a == b)
                     && let Some(doc) = extract_inherited_doc(gcx, fid)
                     && (!doc.notices.is_empty()
@@ -395,7 +394,7 @@ pub fn resolve_inheritdoc_var(
                 ItemId::Function(fid) => {
                     let f = gcx.hir.function(fid);
                     if f.name.map(|n| n.as_str() == var_name).unwrap_or(false)
-                        && function_param_types(gcx, fid).map(|p| p.is_empty()).unwrap_or(false)
+                        && function_param_types(gcx, fid).is_empty()
                         && let Some(doc) = extract_inherited_doc(gcx, fid)
                         && (!doc.notices.is_empty()
                             || !doc.devs.is_empty()
@@ -434,44 +433,18 @@ fn extract_inherited_doc_var(gcx: Gcx<'_>, vid: VariableId) -> Option<InheritedD
     Some(collect_inherited_doc(docs))
 }
 
-/// Extract the parameter type strings (in source order) for a function.
-///
-/// Returns `None` if the function's AST item cannot be located.
-fn function_param_types(gcx: Gcx<'_>, fid: FunctionId) -> Option<Vec<String>> {
+/// Extract the canonical ABI parameter type strings (in source order) for a function.
+pub(crate) fn function_param_types(gcx: Gcx<'_>, fid: FunctionId) -> Vec<String> {
     let f = gcx.hir.function(fid);
-    let ast_source = gcx.sources.get(f.source)?;
-    let ast = ast_source.ast.as_ref()?;
-    let fn_span = f.span;
-
-    let params = ast.items.iter().find_map(|item| match &item.kind {
-        solar::ast::ItemKind::Function(func) if item.span == fn_span => {
-            Some(&func.header.parameters)
-        }
-        solar::ast::ItemKind::Contract(c) => c.body.iter().find_map(|m| match &m.kind {
-            solar::ast::ItemKind::Function(func) if m.span == fn_span => {
-                Some(&func.header.parameters)
-            }
-            _ => None,
-        }),
-        _ => None,
-    })?;
-
-    Some(parameter_type_strings(gcx, params))
-}
-
-/// Compute the parameter type strings of a [`ParameterList`] from the source map.
-///
-/// Types are normalized to their canonical ABI form so that `uint` and `uint256`
-/// (and `int` / `int256`) compare equal during overload matching.
-pub fn parameter_type_strings(gcx: Gcx<'_>, params: &ParameterList<'_>) -> Vec<String> {
-    let sm = gcx.sess.source_map();
-    params
-        .vars
+    f.parameters
         .iter()
-        .map(|v| {
-            let raw = sm.span_to_snippet(v.ty.span).unwrap_or_default();
-            let t = raw.split_whitespace().collect::<Vec<_>>().join(" ");
-            normalize_sol_type(&t)
+        .map(|&param| {
+            let ty = gcx.type_of_item(param.into());
+            let mut out = String::new();
+            TyAbiPrinter::new(gcx, &mut out, TyAbiPrinterMode::Signature)
+                .print(ty)
+                .expect("writing ABI signature type to a String cannot fail");
+            out
         })
         .collect()
 }

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -327,9 +327,18 @@ fn render_contract<'ast, 'gcx>(
             // Attempt inheritdoc resolution.
             let inherited = fn_name.as_deref().and_then(|fname| {
                 let base = inheritdoc_base(docs)?;
-                let param_types = hir_ext::parameter_type_strings(gcx, &f.header.parameters);
+                let param_types = hir_id
+                    .and_then(|cid| {
+                        gcx.hir.contract(cid).items.iter().find_map(|&item| match item {
+                            hir::ItemId::Function(id) if gcx.hir.function(id).span == *span => {
+                                Some(id)
+                            }
+                            _ => None,
+                        })
+                    })
+                    .map(|fid| hir_ext::function_param_types(gcx, fid));
                 hir_id.and_then(|cid| {
-                    hir_ext::resolve_inheritdoc(gcx, cid, fname, &base, Some(&param_types))
+                    hir_ext::resolve_inheritdoc(gcx, cid, fname, &base, param_types.as_deref())
                 })
             });
             render_function_section(

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -4,6 +4,7 @@ use crate::{
     hir_ext::{self, NameToPage, clean_block_doc_content},
     utils::Deployment,
 };
+use foundry_common::sh_warn;
 use solar::{
     ast::{
         CommentKind, ContractKind, DocComments, FunctionKind, ItemContract, ItemEnum, ItemError,
@@ -329,14 +330,21 @@ fn render_contract<'ast, 'gcx>(
                 let base = inheritdoc_base(docs)?;
                 let param_types = hir_id
                     .and_then(|cid| {
-                        gcx.hir.contract(cid).items.iter().find_map(|&item| match item {
+                        let fid = gcx.hir.contract(cid).items.iter().find_map(|&item| match item {
                             hir::ItemId::Function(id) if gcx.hir.function(id).span == *span => {
                                 Some(id)
                             }
                             _ => None,
-                        })
+                        });
+                        if fid.is_none() {
+                            let _ = sh_warn!(
+                                "forge doc: failed to find HIR function for `{}.{fname}` while resolving @inheritdoc",
+                                c.name
+                            );
+                        }
+                        fid
                     })
-                    .map(|fid| hir_ext::function_param_types(gcx, fid));
+                    .and_then(|fid| hir_ext::function_param_types(gcx, fid));
                 hir_id.and_then(|cid| {
                     hir_ext::resolve_inheritdoc(gcx, cid, fname, &base, param_types.as_deref())
                 })

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -1,4 +1,9 @@
-use foundry_test_utils::util::{RemoteProject, setup_forge_remote};
+use foundry_test_utils::{
+    assert_data_eq,
+    snapbox::Data,
+    str,
+    util::{RemoteProject, setup_forge_remote},
+};
 
 #[test]
 fn can_generate_solmate_docs() {
@@ -54,15 +59,33 @@ contract Example is IExample {
     cmd.args(["doc"]).assert_success();
 
     let doc_path = prj.root().join("docs/src/pages/src/contract.Example.mdx");
-    let content = std::fs::read_to_string(&doc_path).unwrap();
+    assert_data_eq!(
+        Data::read_from(&doc_path, None),
+        str![[r#"
+...
+<a id="deposit-uint256"></a>
 
-    assert!(
-        content.contains("Deposit tokens into the vault"),
-        "deposit notice should be inherited"
-    );
-    assert!(
-        content.contains("Withdraw tokens from the vault"),
-        "withdraw notice should be inherited"
+### deposit
+
+Deposit tokens into the vault
+
+```solidity
+function deposit(uint256 amount) external;
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| amount | `uint256` | The amount to deposit |
+
+<a id="withdraw-uint256"></a>
+
+### withdraw
+
+Withdraw tokens from the vault
+...
+"#]],
     );
 });
 
@@ -482,46 +505,145 @@ interface IMultiline {
     );
 });
 
-// Test that overload matching normalizes uint/int aliases inside compound types so that
-// `Base.foo(uint256[] calldata)` is correctly matched by `Child.foo(uint[] calldata)`.
-forgetest_init!(inheritdoc_overload_normalizes_uint_aliases_in_arrays, |prj, cmd| {
+// Test that overload matching uses canonical HIR/ABI parameter types so that
+// `Base.configure(uint)` is correctly matched by `Child.configure(uint256)`.
+forgetest_init!(inheritdoc_overload_matches_uint_alias, |prj, cmd| {
     prj.add_source(
-        "IAlias.sol",
+        "I.sol",
         r#"
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-interface IAlias {
-    /// @notice Process values
-    /// @param values The input array
-    function process(uint256[] calldata values) external;
+interface I {
+    /// @notice Configure by amount.
+    /// @param amount The configured amount
+    function configure(uint amount) external;
+
+    /// @notice Configure by account.
+    /// @param account The configured account
+    function configure(address account) external;
 }
 "#,
     );
 
     prj.add_source(
-        "Alias.sol",
+        "C.sol",
         r#"
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./IAlias.sol";
+import "./I.sol";
 
-contract Alias is IAlias {
-    /// @inheritdoc IAlias
-    function process(uint[] calldata values) external {}
+contract C is I {
+    /// @inheritdoc I
+    function configure(uint256 amount) external override {}
+
+    /// @inheritdoc I
+    function configure(address account) external override {}
 }
 "#,
     );
 
     cmd.args(["doc"]).assert_success();
 
-    let doc_path = prj.root().join("docs/src/pages/src/contract.Alias.mdx");
-    let content = std::fs::read_to_string(&doc_path).unwrap();
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.C.mdx"), None),
+        str![[r#"
+...
+<a id="configure-uint256"></a>
 
-    assert!(
-        content.contains("Process values"),
-        "@inheritdoc with uint[] calldata should match uint256[] calldata in base, found:\n{content}"
+### configure
+
+Configure by amount.
+
+```solidity
+function configure(uint256 amount) external override;
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| amount | `uint256` | The configured amount |
+
+<a id="configure-address"></a>
+
+### configure
+
+Configure by account.
+...
+"#]],
+    );
+});
+
+// Test that overload matching uses canonical HIR/ABI parameter types so that
+// `Base.batch(uint[])` is correctly matched by `Child.batch(uint256[])`.
+forgetest_init!(inheritdoc_overload_matches_uint_array_alias, |prj, cmd| {
+    prj.add_source(
+        "I.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface I {
+    /// @notice Batch values.
+    /// @param values The input array
+    function batch(uint[] calldata values) external;
+
+    /// @notice Batch accounts.
+    /// @param accounts The account array
+    function batch(address[] calldata accounts) external;
+}
+"#,
+    );
+
+    prj.add_source(
+        "C.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./I.sol";
+
+contract C is I {
+    /// @inheritdoc I
+    function batch(uint256[] calldata values) external override {}
+
+    /// @inheritdoc I
+    function batch(address[] calldata accounts) external override {}
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.C.mdx"), None),
+        str![[r#"
+...
+<a id="batch-uint256"></a>
+
+### batch
+
+Batch values.
+
+```solidity
+function batch(uint256[] calldata values) external override;
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| values | `uint256[]` | The input array |
+
+<a id="batch-address"></a>
+
+### batch
+
+Batch accounts.
+...
+"#]],
     );
 });
 
@@ -568,16 +690,104 @@ contract C is I {
 
     cmd.args(["doc"]).assert_success();
 
-    let content =
-        std::fs::read_to_string(prj.root().join("docs/src/pages/src/contract.C.mdx")).unwrap();
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.C.mdx"), None),
+        str![[r#"
+...
+<a id="configure-status"></a>
 
-    assert!(
-        content.contains("Sets the account status"),
-        "@inheritdoc should match I.Status and Status as the same overload, found:\n{content}"
+### configure
+
+Sets the account status.
+
+```solidity
+function configure(Status s) external override;
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| s | `Status` | the new status |
+
+<a id="configure-uint256"></a>
+
+### configure
+
+Configures by raw id.
+...
+"#]],
     );
-    assert!(
-        content.contains("Configures by raw id"),
-        "uint256 overload should still inherit its notice, found:\n{content}"
+});
+
+// Test that internal overloads with non-ABI-printable parameters use source text
+// as a fallback instead of panicking while resolving @inheritdoc.
+forgetest_init!(inheritdoc_overload_matches_mapping_fallback, |prj, cmd| {
+    prj.add_source(
+        "Base.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+abstract contract Base {
+    /// @notice Configure by store.
+    /// @param store The storage mapping
+    function configure(mapping(uint256 => uint256) storage store) internal virtual;
+
+    /// @notice Configure by account.
+    /// @param account The configured account
+    function configure(address account) internal virtual;
+}
+"#,
+    );
+
+    prj.add_source(
+        "C.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./Base.sol";
+
+contract C is Base {
+    /// @inheritdoc Base
+    function configure(mapping(uint256 => uint256) storage store) internal override {}
+
+    /// @inheritdoc Base
+    function configure(address account) internal override {}
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.C.mdx"), None),
+        str![[r#"
+...
+<a id="configure-mapping-uint256-uint256"></a>
+
+### configure
+
+Configure by store.
+
+```solidity
+function configure(mapping(uint256 => uint256) storage store) internal override;
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| store | `mapping(uint256 => uint256)` | The storage mapping |
+
+<a id="configure-address"></a>
+
+### configure
+
+Configure by account.
+...
+"#]],
     );
 });
 

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -525,6 +525,62 @@ contract Alias is IAlias {
     );
 });
 
+// Test that overload matching uses canonical HIR/ABI parameter types so that
+// semantically identical type spellings (`I.Status` vs `Status`) still match.
+forgetest_init!(inheritdoc_overload_matches_qualified_enum_alias, |prj, cmd| {
+    prj.add_source(
+        "I.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface I {
+    enum Status { Inactive, Active }
+
+    /// @notice Sets the account status.
+    /// @param s the new status
+    function configure(I.Status s) external;
+
+    /// @notice Configures by raw id.
+    /// @param id the raw id
+    function configure(uint256 id) external;
+}
+"#,
+    );
+
+    prj.add_source(
+        "C.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./I.sol";
+
+contract C is I {
+    /// @inheritdoc I
+    function configure(Status s) external override {}
+
+    /// @inheritdoc I
+    function configure(uint256 id) external override {}
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+
+    let content =
+        std::fs::read_to_string(prj.root().join("docs/src/pages/src/contract.C.mdx")).unwrap();
+
+    assert!(
+        content.contains("Sets the account status"),
+        "@inheritdoc should match I.Status and Status as the same overload, found:\n{content}"
+    );
+    assert!(
+        content.contains("Configures by raw id"),
+        "uint256 overload should still inherit its notice, found:\n{content}"
+    );
+});
+
 // Test that @inheritdoc resolves docs from a deeply inherited chain
 // (Base inherits from an interface without redeclaring NatSpec).
 forgetest_init!(inheritdoc_resolves_deep_chain, |prj, cmd| {


### PR DESCRIPTION
## Motivation

https://github.com/foundry-rs/foundry/pull/14568#discussion_r3393747789 follow-up.

Match inheritdoc overloads with canonical types
