### PR TITLE
feat(symbolic): add json result schema

### DIFF
--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -78,6 +78,14 @@ Forge reports symbolic test outcomes as:
   search or validate a counterexample for this run. Treat this outcome as "not
   established".
 
+When `--json` is enabled, each symbolic test result includes a stable
+`symbolic` object in addition to the legacy test fields. The schema lives at
+`crates/evm/symbolic/assets/symbolic-result.schema.json` and records the
+normalized status (`pass`, `fail_counterexample`, or `incomplete`), incomplete
+reason kind, effective bounds, solver identity and counters, explicit
+assumptions, call-trace location metadata, replay status, and counterexample
+payload when one exists.
+
 > **Hash-model caveat:** `PASS` also assumes collision and preimage resistance
 > for symbolic `KECCAK256` and hash-like precompile terms. The executor may use
 > equal symbolic hashes to infer equal symbolic preimages or lengths in modeled
@@ -91,6 +99,10 @@ dynamic calldata length settings, and `symbolic.invariant_depth`.
 `Incomplete` can occur when exploration reaches a configured bound, the solver
 times out or returns `unknown`, a test uses unsupported EVM or cheatcode
 semantics, a backend error occurs, or a solver model does not replay concretely.
+When a solver candidate does not replay, it can still be shown as a diagnostic
+legacy top-level `counterexample`; treat it as confirmed only when
+`symbolic.status` is `fail_counterexample` and `symbolic.replay.status` is
+`confirmed`.
 
 Current modeling notes:
 

--- a/crates/evm/symbolic/assets/symbolic-result.schema.json
+++ b/crates/evm/symbolic/assets/symbolic-result.schema.json
@@ -1,0 +1,455 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://foundry-rs.github.io/schemas/symbolic-result.v1.schema.json",
+  "title": "Foundry symbolic test result",
+  "description": "Stable machine-readable result object emitted at test_results[*].symbolic for forge test --symbolic --json.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "status",
+    "incomplete",
+    "bounds",
+    "solver",
+    "assumptions",
+    "call_trace",
+    "replay",
+    "counterexample"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "status": {
+      "type": "string",
+      "enum": ["pass", "fail_counterexample", "incomplete"]
+    },
+    "incomplete": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/incomplete" }
+      ]
+    },
+    "bounds": {
+      "$ref": "#/$defs/bounds"
+    },
+    "solver": {
+      "$ref": "#/$defs/solver"
+    },
+    "assumptions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/assumption" }
+    },
+    "call_trace": {
+      "$ref": "#/$defs/call_trace"
+    },
+    "replay": {
+      "$ref": "#/$defs/replay"
+    },
+    "counterexample": {
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/counterexample" }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["status"],
+        "properties": {
+          "status": { "const": "pass" }
+        }
+      },
+      "then": {
+        "properties": {
+          "incomplete": { "type": "null" },
+          "counterexample": { "type": "null" },
+          "replay": {
+            "properties": {
+              "required": { "const": false },
+              "status": { "const": "not_required" },
+              "reason": { "type": "null" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["status"],
+        "properties": {
+          "status": { "const": "fail_counterexample" }
+        }
+      },
+      "then": {
+        "properties": {
+          "incomplete": { "type": "null" },
+          "counterexample": { "$ref": "#/$defs/counterexample" },
+          "replay": {
+            "properties": {
+              "required": { "const": true },
+              "status": { "const": "confirmed" },
+              "reason": { "type": "null" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["status"],
+        "properties": {
+          "status": { "const": "incomplete" }
+        }
+      },
+      "then": {
+        "properties": {
+          "incomplete": { "$ref": "#/$defs/incomplete" },
+          "replay": {
+            "properties": {
+              "status": {
+                "enum": ["not_required", "mismatch", "error", "skipped"]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["replay"],
+        "properties": {
+          "replay": {
+            "required": ["required"],
+            "properties": {
+              "required": { "const": false }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "replay": {
+            "properties": {
+              "status": { "const": "not_required" },
+              "reason": { "type": "null" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["replay"],
+        "properties": {
+          "replay": {
+            "required": ["required"],
+            "properties": {
+              "required": { "const": true }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "replay": {
+            "properties": {
+              "status": {
+                "enum": ["confirmed", "mismatch", "error", "skipped"]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["replay"],
+        "properties": {
+          "replay": {
+            "required": ["status"],
+            "properties": {
+              "status": { "const": "confirmed" }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "replay": {
+            "properties": {
+              "required": { "const": true },
+              "reason": { "type": "null" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["call_trace"],
+        "properties": {
+          "call_trace": {
+            "required": ["available"],
+            "properties": {
+              "available": { "const": false }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "call_trace": {
+            "properties": {
+              "source": { "type": "null" },
+              "format": { "type": "null" }
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "required": ["call_trace"],
+        "properties": {
+          "call_trace": {
+            "required": ["available"],
+            "properties": {
+              "available": { "const": true }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "call_trace": {
+            "properties": {
+              "source": { "type": "string" },
+              "format": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "incomplete": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "reason"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["stuck", "revert_all", "timeout", "error"]
+        },
+        "reason": {
+          "type": "string"
+        }
+      }
+    },
+    "bounds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "timeout_seconds",
+        "loop_bound",
+        "max_depth",
+        "max_paths",
+        "invariant_depth",
+        "exploration_order",
+        "max_solver_queries",
+        "default_dynamic_length",
+        "max_dynamic_length",
+        "array_lengths",
+        "dynamic_lengths",
+        "default_array_lengths",
+        "default_bytes_lengths",
+        "max_calldata_bytes",
+        "symbolic_call_targets",
+        "storage_layout"
+      ],
+      "properties": {
+        "timeout_seconds": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "loop_bound": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "max_depth": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_paths": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "invariant_depth": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "exploration_order": {
+          "type": "string",
+          "enum": ["bfs", "dfs"]
+        },
+        "max_solver_queries": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "default_dynamic_length": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_dynamic_length": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "array_lengths": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 0 }
+        },
+        "dynamic_lengths": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "default_array_lengths": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 0 }
+        },
+        "default_bytes_lengths": {
+          "type": "array",
+          "items": { "type": "integer", "minimum": 0 }
+        },
+        "max_calldata_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "symbolic_call_targets": {
+          "type": "boolean"
+        },
+        "storage_layout": {
+          "type": "string",
+          "enum": ["solidity", "generic", "zero_init"]
+        }
+      }
+    },
+    "solver": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "command", "portfolio", "stats"],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "command": {
+          "type": ["string", "null"]
+        },
+        "portfolio": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "stats": {
+          "$ref": "#/$defs/solver_stats"
+        }
+      }
+    },
+    "solver_stats": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "paths",
+        "solver_queries",
+        "smt_queries",
+        "sat_queries",
+        "model_queries",
+        "sat_cache_hits",
+        "model_cache_hits",
+        "heuristic_witnesses",
+        "solver_time_ms"
+      ],
+      "properties": {
+        "paths": { "type": "integer", "minimum": 0 },
+        "solver_queries": { "type": "integer", "minimum": 0 },
+        "smt_queries": { "type": "integer", "minimum": 0 },
+        "sat_queries": { "type": "integer", "minimum": 0 },
+        "model_queries": { "type": "integer", "minimum": 0 },
+        "sat_cache_hits": { "type": "integer", "minimum": 0 },
+        "model_cache_hits": { "type": "integer", "minimum": 0 },
+        "heuristic_witnesses": { "type": "integer", "minimum": 0 },
+        "solver_time_ms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "assumption": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "description"],
+      "properties": {
+        "kind": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "call_trace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available", "source", "format"],
+      "properties": {
+        "available": {
+          "type": "boolean"
+        },
+        "source": {
+          "type": ["string", "null"]
+        },
+        "format": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "status", "reason"],
+      "properties": {
+        "required": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["not_required", "confirmed", "mismatch", "error", "skipped"]
+        },
+        "reason": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "counterexample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["calldata", "args", "raw_args", "value"],
+      "properties": {
+        "calldata": {
+          "type": "string",
+          "pattern": "^0x([0-9a-fA-F]{2})*$"
+        },
+        "args": {
+          "type": ["string", "null"]
+        },
+        "raw_args": {
+          "type": ["string", "null"]
+        },
+        "value": {
+          "type": ["string", "null"]
+        }
+      }
+    }
+  }
+}

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -7,6 +7,7 @@ use alloy_primitives::{
 };
 use eyre::Report;
 use foundry_common::{ContractsByArtifact, get_contract_name, get_file_name, shell};
+use foundry_config::{SymbolicConfig, SymbolicExplorationOrder, SymbolicStorageLayout};
 use foundry_evm::{
     core::{Breakpoints, evm::FoundryEvmNetwork},
     coverage::HitMaps,
@@ -15,7 +16,7 @@ use foundry_evm::{
     fuzz::{CounterExample, FuzzCase, FuzzFixtures, FuzzTestResult},
     traces::{CallTraceArena, CallTraceDecoder, TraceKind, Traces},
 };
-use foundry_evm_symbolic::{PortfolioDiagnostics, SymbolicStats};
+use foundry_evm_symbolic::{PortfolioDiagnostics, SymbolicStats, SymbolicStopReason};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -30,6 +31,11 @@ pub(crate) fn invariant_campaign_display_name(contract_name: &str) -> String {
 }
 
 const INVARIANT_CAMPAIGN_FALLBACK_NAME: &str = "Invariant campaign";
+const SYMBOLIC_RESULT_SCHEMA_VERSION: u32 = 1;
+
+const fn symbolic_result_schema_version() -> u32 {
+    SYMBOLIC_RESULT_SCHEMA_VERSION
+}
 
 /// The aggregated result of a test run.
 #[derive(Clone, Debug)]
@@ -601,6 +607,398 @@ pub struct InvariantPredicateResult {
     pub reason: Option<String>,
 }
 
+/// Stable machine-readable outcome for `forge test --symbolic` JSON output.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicResult {
+    /// Schema version for the symbolic result object.
+    #[serde(default = "symbolic_result_schema_version")]
+    pub schema_version: u32,
+    /// Normalized symbolic outcome.
+    pub status: SymbolicResultStatus,
+    /// Incomplete reason when [`Self::status`] is [`SymbolicResultStatus::Incomplete`].
+    pub incomplete: Option<SymbolicIncomplete>,
+    /// Effective bounds used by this symbolic run.
+    pub bounds: SymbolicBounds,
+    /// Solver identity and counters collected during this run.
+    pub solver: SymbolicSolverMetadata,
+    /// Soundness assumptions that bound what a `pass` proves.
+    pub assumptions: Vec<SymbolicAssumption>,
+    /// Where an agent can find the concrete replay trace, when one was produced.
+    pub call_trace: SymbolicCallTrace,
+    /// Concrete replay metadata for counterexample candidates.
+    pub replay: SymbolicReplayMetadata,
+    /// Concrete counterexample data, when the solver produced a candidate.
+    pub counterexample: Option<SymbolicCounterexample>,
+}
+
+impl SymbolicResult {
+    /// Creates a symbolic pass result.
+    pub fn pass(config: &SymbolicConfig, stats: SymbolicStats) -> Self {
+        Self::new(
+            SymbolicResultStatus::Pass,
+            config,
+            stats,
+            None,
+            SymbolicReplayMetadata::not_required(),
+            SymbolicCallTrace::none(),
+            None,
+        )
+    }
+
+    /// Creates a symbolic counterexample result that concrete replay confirmed.
+    pub fn fail_counterexample(
+        config: &SymbolicConfig,
+        stats: SymbolicStats,
+        call_trace: SymbolicCallTrace,
+        counterexample: SymbolicCounterexample,
+    ) -> Self {
+        Self::new(
+            SymbolicResultStatus::FailCounterexample,
+            config,
+            stats,
+            None,
+            SymbolicReplayMetadata::confirmed(),
+            call_trace,
+            Some(counterexample),
+        )
+    }
+
+    /// Creates an incomplete symbolic result.
+    pub fn incomplete(
+        config: &SymbolicConfig,
+        kind: SymbolicStopReason,
+        reason: impl Into<String>,
+        stats: SymbolicStats,
+        replay: SymbolicReplayMetadata,
+        call_trace: SymbolicCallTrace,
+        counterexample: Option<SymbolicCounterexample>,
+    ) -> Self {
+        Self::new(
+            SymbolicResultStatus::Incomplete,
+            config,
+            stats,
+            Some(SymbolicIncomplete::new(kind, reason)),
+            replay,
+            call_trace,
+            counterexample,
+        )
+    }
+
+    fn new(
+        status: SymbolicResultStatus,
+        config: &SymbolicConfig,
+        stats: SymbolicStats,
+        incomplete: Option<SymbolicIncomplete>,
+        replay: SymbolicReplayMetadata,
+        call_trace: SymbolicCallTrace,
+        counterexample: Option<SymbolicCounterexample>,
+    ) -> Self {
+        Self {
+            schema_version: SYMBOLIC_RESULT_SCHEMA_VERSION,
+            status,
+            incomplete,
+            bounds: SymbolicBounds::from_config(config),
+            solver: SymbolicSolverMetadata::from_config_and_stats(config, stats),
+            assumptions: SymbolicAssumption::default_assumptions(),
+            call_trace,
+            replay,
+            counterexample,
+        }
+    }
+}
+
+/// Normalized symbolic outcome names for agents and other JSON consumers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolicResultStatus {
+    /// All explored paths completed without a feasible failure.
+    Pass,
+    /// A solver counterexample was replayed concretely and still failed.
+    FailCounterexample,
+    /// The engine stopped before a proof or replayed counterexample.
+    Incomplete,
+}
+
+/// Incomplete symbolic run reason.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicIncomplete {
+    /// Stable reason kind.
+    pub kind: String,
+    /// Human-readable detail.
+    pub reason: String,
+}
+
+impl SymbolicIncomplete {
+    fn new(kind: SymbolicStopReason, reason: impl Into<String>) -> Self {
+        Self { kind: symbolic_stop_reason_kind(kind).to_string(), reason: reason.into() }
+    }
+}
+
+const fn symbolic_stop_reason_kind(kind: SymbolicStopReason) -> &'static str {
+    match kind {
+        SymbolicStopReason::Stuck => "stuck",
+        SymbolicStopReason::RevertAll => "revert_all",
+        SymbolicStopReason::Timeout => "timeout",
+        SymbolicStopReason::Error => "error",
+    }
+}
+
+/// Effective symbolic exploration bounds used by the run.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicBounds {
+    /// Optional solver timeout in seconds.
+    pub timeout_seconds: Option<u32>,
+    /// Optional loop-unrolling bound.
+    pub loop_bound: Option<u32>,
+    /// Effective per-path opcode depth limit.
+    pub max_depth: u32,
+    /// Effective symbolic path width limit.
+    pub max_paths: u32,
+    /// Maximum calls in a bounded symbolic invariant sequence.
+    pub invariant_depth: u32,
+    /// Pending path exploration order.
+    pub exploration_order: SymbolicExplorationOrder,
+    /// Maximum normalized solver queries.
+    pub max_solver_queries: u32,
+    /// Default bounded length for dynamic ABI inputs.
+    pub default_dynamic_length: u32,
+    /// Maximum permitted bounded dynamic ABI input length.
+    pub max_dynamic_length: u32,
+    /// Positional dynamic-leaf bounded lengths.
+    pub array_lengths: Vec<u32>,
+    /// Named dynamic-leaf bounded lengths.
+    pub dynamic_lengths: BTreeMap<String, Vec<u32>>,
+    /// Default array lengths when no explicit dynamic length exists.
+    pub default_array_lengths: Vec<u32>,
+    /// Default bytes/string lengths when no explicit dynamic length exists.
+    pub default_bytes_lengths: Vec<u32>,
+    /// Maximum generated symbolic calldata size in bytes.
+    pub max_calldata_bytes: u32,
+    /// Whether symbolic call targets can range over known deployed contracts.
+    pub symbolic_call_targets: bool,
+    /// Storage modelling mode.
+    pub storage_layout: SymbolicStorageLayout,
+}
+
+impl SymbolicBounds {
+    fn from_config(config: &SymbolicConfig) -> Self {
+        Self {
+            timeout_seconds: config.timeout,
+            loop_bound: config.loop_bound,
+            max_depth: config.execution_depth(),
+            max_paths: config.path_width(),
+            invariant_depth: config.invariant_depth,
+            exploration_order: config.exploration_order,
+            max_solver_queries: config.max_solver_queries,
+            default_dynamic_length: config.default_dynamic_length,
+            max_dynamic_length: config.max_dynamic_length,
+            array_lengths: config.array_lengths.clone(),
+            dynamic_lengths: config.dynamic_lengths.clone(),
+            default_array_lengths: config.default_array_lengths.clone(),
+            default_bytes_lengths: config.default_bytes_lengths.clone(),
+            max_calldata_bytes: config.max_calldata_bytes,
+            symbolic_call_targets: config.symbolic_call_targets,
+            storage_layout: config.storage_layout,
+        }
+    }
+}
+
+/// Solver identity and counters.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicSolverMetadata {
+    /// Configured solver name.
+    pub name: String,
+    /// Exact configured solver command, when set.
+    pub command: Option<String>,
+    /// Configured solver portfolio entries, when any.
+    pub portfolio: Vec<String>,
+    /// Run counters.
+    pub stats: SymbolicSolverStats,
+}
+
+impl SymbolicSolverMetadata {
+    fn from_config_and_stats(config: &SymbolicConfig, stats: SymbolicStats) -> Self {
+        Self {
+            name: config.solver.clone(),
+            command: config.solver_command.clone(),
+            portfolio: config.solver_portfolio.clone(),
+            stats: SymbolicSolverStats::from(stats),
+        }
+    }
+}
+
+/// Symbolic engine and solver counters.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SymbolicSolverStats {
+    /// Number of explored symbolic paths.
+    pub paths: usize,
+    /// Number of normalized solver queries issued during the run.
+    pub solver_queries: usize,
+    /// Number of queries sent to the SMT backend after local fast paths.
+    pub smt_queries: usize,
+    /// Number of satisfiability checks requested by the executor.
+    pub sat_queries: usize,
+    /// Number of concrete model requests requested by the executor.
+    pub model_queries: usize,
+    /// Number of satisfiability checks served from the normalized cache.
+    pub sat_cache_hits: usize,
+    /// Number of model requests served from the normalized model cache.
+    pub model_cache_hits: usize,
+    /// Number of satisfiable witnesses produced by local hard-arithmetic search.
+    pub heuristic_witnesses: usize,
+    /// Wall-clock time spent waiting on backend solver subprocesses, in milliseconds.
+    pub solver_time_ms: u64,
+}
+
+impl From<SymbolicStats> for SymbolicSolverStats {
+    fn from(stats: SymbolicStats) -> Self {
+        Self {
+            paths: stats.paths,
+            solver_queries: stats.solver_queries,
+            smt_queries: stats.smt_queries,
+            sat_queries: stats.sat_queries,
+            model_queries: stats.model_queries,
+            sat_cache_hits: stats.sat_cache_hits,
+            model_cache_hits: stats.model_cache_hits,
+            heuristic_witnesses: stats.heuristic_witnesses,
+            solver_time_ms: stats.solver_time_ms,
+        }
+    }
+}
+
+/// Explicit symbolic assumption attached to a result.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicAssumption {
+    /// Stable assumption kind.
+    pub kind: String,
+    /// Human-readable detail.
+    pub description: String,
+}
+
+impl SymbolicAssumption {
+    fn default_assumptions() -> Vec<Self> {
+        vec![
+            Self {
+                kind: "bounded_exploration".to_string(),
+                description: "Result is scoped to the configured path, depth, solver-query, loop, calldata, and dynamic-length bounds.".to_string(),
+            },
+            Self {
+                kind: "hash_model".to_string(),
+                description: "Symbolic Keccak and hash-like precompile reasoning assumes collision and preimage resistance for modeled cases.".to_string(),
+            },
+        ]
+    }
+}
+
+/// Concrete replay trace locator.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicCallTrace {
+    /// Whether replay produced a trace that may be present in this test result.
+    pub available: bool,
+    /// JSON location for the trace when available.
+    pub source: Option<String>,
+    /// Trace format at the source location.
+    pub format: Option<String>,
+}
+
+impl SymbolicCallTrace {
+    /// No concrete trace was produced.
+    pub const fn none() -> Self {
+        Self { available: false, source: None, format: None }
+    }
+
+    /// A concrete replay trace may be available in the normal test result traces field.
+    pub fn test_result_traces(available: bool) -> Self {
+        if !available {
+            return Self::none();
+        }
+
+        Self {
+            available: true,
+            source: Some("test_result.traces".to_string()),
+            format: Some("foundry_call_trace_arena".to_string()),
+        }
+    }
+}
+
+/// Counterexample replay status.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolicReplayStatus {
+    /// No replay was required for this result.
+    NotRequired,
+    /// Concrete replay confirmed the symbolic counterexample.
+    Confirmed,
+    /// Concrete replay did not reproduce the symbolic counterexample.
+    Mismatch,
+    /// Concrete replay could not execute because of an error.
+    Error,
+    /// Concrete replay was skipped by `vm.skip`.
+    Skipped,
+}
+
+/// Replay metadata for symbolic counterexample candidates.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicReplayMetadata {
+    /// Whether the symbolic outcome required concrete replay.
+    pub required: bool,
+    /// Stable replay status.
+    pub status: SymbolicReplayStatus,
+    /// Optional replay detail or mismatch reason.
+    pub reason: Option<String>,
+}
+
+impl SymbolicReplayMetadata {
+    /// No replay was required.
+    pub const fn not_required() -> Self {
+        Self { required: false, status: SymbolicReplayStatus::NotRequired, reason: None }
+    }
+
+    /// Concrete replay confirmed the counterexample.
+    pub const fn confirmed() -> Self {
+        Self { required: true, status: SymbolicReplayStatus::Confirmed, reason: None }
+    }
+
+    /// Concrete replay did not reproduce the symbolic counterexample.
+    pub fn mismatch(reason: impl Into<String>) -> Self {
+        Self { required: true, status: SymbolicReplayStatus::Mismatch, reason: Some(reason.into()) }
+    }
+
+    /// Concrete replay errored before the candidate could be confirmed.
+    pub fn error(reason: impl Into<String>) -> Self {
+        Self { required: true, status: SymbolicReplayStatus::Error, reason: Some(reason.into()) }
+    }
+
+    /// Concrete replay was skipped by the test.
+    pub fn skipped(reason: impl Into<String>) -> Self {
+        Self { required: true, status: SymbolicReplayStatus::Skipped, reason: Some(reason.into()) }
+    }
+}
+
+/// Stable symbolic counterexample payload.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicCounterexample {
+    /// ABI-encoded calldata for replay.
+    pub calldata: Bytes,
+    /// Pretty-formatted ABI arguments, when decoded.
+    pub args: Option<String>,
+    /// Raw ABI arguments, when decoded.
+    pub raw_args: Option<String>,
+    /// Ether value sent with the call, when any.
+    pub value: Option<U256>,
+}
+
+impl From<&BaseCounterExample> for SymbolicCounterexample {
+    fn from(counterexample: &BaseCounterExample) -> Self {
+        Self {
+            calldata: counterexample.calldata.clone(),
+            args: counterexample.args.clone(),
+            raw_args: counterexample.raw_args.clone(),
+            value: counterexample.value,
+        }
+    }
+}
+
 /// The result of an executed test.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct TestResult {
@@ -658,6 +1056,10 @@ pub struct TestResult {
 
     /// What kind of test this was
     pub kind: TestKind,
+
+    /// Stable symbolic result object for `forge test --symbolic --json`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbolic: Option<SymbolicResult>,
 
     /// Traces
     pub traces: Traces,
@@ -1253,11 +1655,12 @@ impl TestResult {
     /// Returns the result for a symbolic test.
     pub fn symbolic_result(
         &mut self,
-        success: bool,
+        status: TestStatus,
         reason: Option<String>,
         counterexample: Option<CounterExample>,
-        stats: SymbolicStats,
+        symbolic: SymbolicResult,
     ) {
+        let stats = symbolic.solver.stats;
         self.kind = TestKind::Symbolic {
             paths: stats.paths,
             solver_queries: stats.solver_queries,
@@ -1269,9 +1672,10 @@ impl TestResult {
             heuristic_witnesses: stats.heuristic_witnesses,
             solver_time_ms: stats.solver_time_ms,
         };
-        self.status = if success { TestStatus::Success } else { TestStatus::Failure };
+        self.status = status;
         self.reason = reason;
         self.counterexample = counterexample;
+        self.symbolic = Some(symbolic);
         self.duration = Duration::default();
     }
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -7,8 +7,9 @@ use crate::{
     multi_runner::{TestContract, TestRunnerConfig},
     progress::{TestsProgress, start_fuzz_progress},
     result::{
-        InvariantFailure, InvariantPredicateResult, SuiteResult, TestResult, TestSetup, TestStatus,
-        invariant_campaign_display_name,
+        InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicCallTrace,
+        SymbolicCounterexample, SymbolicReplayMetadata, SymbolicResult, TestResult, TestSetup,
+        TestStatus, invariant_campaign_display_name,
     },
 };
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
@@ -40,7 +41,9 @@ use foundry_evm::{
     traces::{TraceKind, TraceMode, load_contracts},
 };
 use foundry_evm_networks::NetworkVariant;
-use foundry_evm_symbolic::{SymbolicExecutor, SymbolicRunInput, SymbolicRunResult};
+use foundry_evm_symbolic::{
+    SymbolicExecutor, SymbolicRunInput, SymbolicRunResult, SymbolicStopReason,
+};
 use itertools::Itertools;
 use proptest::test_runner::{RngAlgorithm, TestError, TestRng, TestRunner};
 use rayon::prelude::*;
@@ -1009,17 +1012,34 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
 
         match result {
             SymbolicRunResult::Safe(stats) => {
-                self.result.symbolic_result(true, None, None, stats);
+                self.result.symbolic_result(
+                    TestStatus::Success,
+                    None,
+                    None,
+                    SymbolicResult::pass(&self.config.symbolic, stats),
+                );
             }
             SymbolicRunResult::Incomplete { kind, reason, stats } => {
+                let display_reason = format!("incomplete symbolic execution ({kind:?}): {reason}");
                 self.result.symbolic_result(
-                    false,
-                    Some(format!("incomplete symbolic execution ({kind:?}): {reason}")),
+                    TestStatus::Failure,
+                    Some(display_reason),
                     None,
-                    stats,
+                    SymbolicResult::incomplete(
+                        &self.config.symbolic,
+                        kind,
+                        reason,
+                        stats,
+                        SymbolicReplayMetadata::not_required(),
+                        SymbolicCallTrace::none(),
+                        None,
+                    ),
                 );
             }
             SymbolicRunResult::Counterexample { args, calldata, stats } => {
+                let symbolic_counterexample = SymbolicCounterexample::from(
+                    &BaseCounterExample::from_fuzz_call(calldata.clone(), args.clone(), None),
+                );
                 let (mut raw_call_result, reason) = match self.executor.call(
                     self.sender,
                     self.address,
@@ -1031,13 +1051,41 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     Ok(res) => (res.raw, None),
                     Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
                     Err(EvmError::Skip(reason)) => {
-                        self.result.single_skip(reason);
+                        let replay_reason = format!("vm.skip during concrete replay: {reason}");
+                        self.result.symbolic_result(
+                            TestStatus::Skipped,
+                            reason.0,
+                            None,
+                            SymbolicResult::incomplete(
+                                &self.config.symbolic,
+                                SymbolicStopReason::Error,
+                                "concrete replay skipped the symbolic counterexample",
+                                stats,
+                                SymbolicReplayMetadata::skipped(replay_reason),
+                                SymbolicCallTrace::none(),
+                                Some(symbolic_counterexample),
+                            ),
+                        );
                         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
                         self.result.symbolic_diagnostics = symbolic_diagnostics;
                         return self.result;
                     }
                     Err(err) => {
-                        self.result.symbolic_result(false, Some(err.to_string()), None, stats);
+                        let reason = err.to_string();
+                        self.result.symbolic_result(
+                            TestStatus::Failure,
+                            Some(reason.clone()),
+                            None,
+                            SymbolicResult::incomplete(
+                                &self.config.symbolic,
+                                SymbolicStopReason::Error,
+                                reason.clone(),
+                                stats,
+                                SymbolicReplayMetadata::error(reason),
+                                SymbolicCallTrace::none(),
+                                Some(symbolic_counterexample),
+                            ),
+                        );
                         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
                         self.result.symbolic_diagnostics = symbolic_diagnostics;
                         return self.result;
@@ -1049,22 +1097,45 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     &mut raw_call_result,
                     false,
                 );
-                let counterexample = CounterExample::Single(BaseCounterExample::from_fuzz_call(
+                let call_trace =
+                    SymbolicCallTrace::test_result_traces(raw_call_result.traces.is_some());
+                let base_counterexample = BaseCounterExample::from_fuzz_call(
                     calldata,
                     args,
                     raw_call_result.traces.clone(),
-                ));
-                self.result.extend(raw_call_result);
-                self.result.symbolic_result(
-                    false,
-                    if success {
-                        Some("symbolic counterexample did not replay".to_string())
-                    } else {
-                        reason
-                    },
-                    Some(counterexample),
-                    stats,
                 );
+                self.result.extend(raw_call_result);
+                if success {
+                    let reason = "symbolic counterexample did not replay".to_string();
+                    let counterexample = CounterExample::Single(base_counterexample);
+                    self.result.symbolic_result(
+                        TestStatus::Failure,
+                        Some(reason.clone()),
+                        Some(counterexample),
+                        SymbolicResult::incomplete(
+                            &self.config.symbolic,
+                            SymbolicStopReason::Error,
+                            reason.clone(),
+                            stats,
+                            SymbolicReplayMetadata::mismatch(reason),
+                            call_trace,
+                            Some(symbolic_counterexample),
+                        ),
+                    );
+                } else {
+                    let counterexample = CounterExample::Single(base_counterexample);
+                    self.result.symbolic_result(
+                        TestStatus::Failure,
+                        reason,
+                        Some(counterexample),
+                        SymbolicResult::fail_counterexample(
+                            &self.config.symbolic,
+                            stats,
+                            call_trace,
+                            symbolic_counterexample,
+                        ),
+                    );
+                }
             }
         }
 

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1,11 +1,23 @@
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, str, util::OutputExt};
+use serde_json::Value;
 use std::process::Command;
 
 use super::symbolic_helpers::{assert_relevant_lines, assert_symbolic};
 
 fn z3_available() -> bool {
     Command::new("z3").arg("--version").output().is_ok_and(|output| output.status.success())
+}
+
+fn json_test_result(stdout: &[u8], signature: &str) -> Value {
+    let json: Value = serde_json::from_slice(stdout).expect("forge test --json output");
+    let suites = json.as_object().expect("top-level suites object");
+    for suite in suites.values() {
+        if let Some(result) = suite["test_results"].get(signature) {
+            return result.clone();
+        }
+    }
+    panic!("missing JSON test result for {signature}: {json}");
 }
 
 forgetest_init!(symbolic_tests_are_ignored_without_flag, |prj, cmd| {
@@ -67,6 +79,43 @@ contract SymbolicPass {
 (paths:
 "#]],
     );
+});
+
+forgetest_init!(symbolic_json_schema_reports_pass, |prj, cmd| {
+    if !z3_available() {
+        let _ =
+            sh_eprintln!("skipping symbolic_json_schema_reports_pass because z3 is not available");
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicJsonPass.t.sol",
+        r#"
+contract SymbolicJsonPass {
+    function checkNoop(uint256) public pure {}
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--json", "--match-test", "checkNoop"])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let result = json_test_result(&output, "checkNoop(uint256)");
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["schema_version"], 1);
+    assert_eq!(symbolic["status"], "pass");
+    assert!(symbolic["incomplete"].is_null());
+    assert_eq!(symbolic["replay"]["required"], false);
+    assert_eq!(symbolic["replay"]["status"], "not_required");
+    assert!(symbolic["counterexample"].is_null());
+    assert_eq!(symbolic["bounds"]["max_paths"], 1024);
+    assert_eq!(symbolic["solver"]["name"], "z3");
+    assert!(symbolic["solver"]["stats"]["paths"].as_u64().unwrap() >= 1);
+    assert_eq!(symbolic["assumptions"][0]["kind"], "bounded_exploration");
 });
 
 forgetest_init!(symbolic_loop_bound_limits_symbolic_unrolling, |prj, cmd| {
@@ -157,6 +206,138 @@ checkRejectsFortyTwo(uint256)
 args=[42]
 "#]],
     );
+});
+
+forgetest_init!(symbolic_json_schema_reports_replayed_counterexample, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_json_schema_reports_replayed_counterexample because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicJsonCounterexample.t.sol",
+        r#"
+contract SymbolicJsonCounterexample {
+    function checkRejectsFortyTwo(uint256 x) public pure {
+        assert(x != 42);
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--json", "--match-test", "checkRejectsFortyTwo"])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let result = json_test_result(&output, "checkRejectsFortyTwo(uint256)");
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["status"], "fail_counterexample");
+    assert!(symbolic["incomplete"].is_null());
+    assert_eq!(symbolic["replay"]["required"], true);
+    assert_eq!(symbolic["replay"]["status"], "confirmed");
+    assert!(symbolic["counterexample"]["calldata"].as_str().unwrap().starts_with("0x"));
+    assert_eq!(symbolic["counterexample"]["args"], "42");
+    assert_eq!(symbolic["counterexample"]["raw_args"], "42");
+    assert!(symbolic["solver"]["stats"]["model_queries"].as_u64().unwrap() >= 1);
+});
+
+forgetest_init!(symbolic_json_schema_reports_replay_skip, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_json_schema_reports_replay_skip because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicJsonReplaySkip.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicJsonReplaySkip is Test {
+    function checkReplaySkip(uint256 x) public {
+        uint256 startedAt = vm.unixTime();
+        vm.sleep(500);
+        vm.skip(vm.unixTime() >= startedAt + 250, "replay slept");
+        assert(x != 42);
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--json", "--match-test", "checkReplaySkip"])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let result = json_test_result(&output, "checkReplaySkip(uint256)");
+    assert_eq!(result["status"], "Skipped");
+    assert_eq!(result["reason"], "replay slept");
+    assert!(result["counterexample"].is_null());
+
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["status"], "incomplete");
+    assert_eq!(symbolic["incomplete"]["kind"], "error");
+    assert_eq!(symbolic["replay"]["required"], true);
+    assert_eq!(symbolic["replay"]["status"], "skipped");
+    assert!(
+        symbolic["replay"]["reason"].as_str().unwrap().contains("vm.skip during concrete replay")
+    );
+    assert_eq!(symbolic["counterexample"]["args"], "42");
+});
+
+forgetest_init!(symbolic_json_schema_reports_incomplete, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_json_schema_reports_incomplete because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicJsonIncomplete.t.sol",
+        r#"
+contract SymbolicJsonIncomplete {
+    function checkWidth(uint8 x) public pure {
+        uint256 acc;
+        if ((x & 0x01) != 0) acc += 1; else acc += 2;
+        if ((x & 0x02) != 0) acc += 4; else acc += 8;
+        assert(acc != 0);
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--json",
+            "--symbolic-width",
+            "1",
+            "--match-test",
+            "checkWidth",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let result = json_test_result(&output, "checkWidth(uint8)");
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["status"], "incomplete");
+    assert_eq!(symbolic["incomplete"]["kind"], "stuck");
+    assert!(symbolic["incomplete"]["reason"].as_str().unwrap().contains("path limit"));
+    assert_eq!(symbolic["bounds"]["max_paths"], 1);
+    assert_eq!(symbolic["replay"]["status"], "not_required");
+    assert!(symbolic["counterexample"].is_null());
 });
 
 forgetest_init!(symbolic_finds_wrapping_arithmetic_riddle_counterexample, |prj, cmd| {


### PR DESCRIPTION
## Summary

- Adds a v1 JSON Schema artifact for symbolic test result objects.
- Emits a stable `symbolic` object in `forge test --symbolic --json` results with normalized status, incomplete reason, bounds, solver stats, assumptions, trace metadata, replay metadata, and counterexample payloads.
- Classifies replay mismatches/errors/skips as machine-readable `incomplete` results instead of confirmed counterexamples.
- Documents the schema location in the symbolic executor README.

## Why

This is the T0.1 trust-plumbing item from the symbolic testing roadmap: agents and tooling need structured symbolic outcomes rather than parsing display strings or overloaded fuzz counterexample fields.

## Validation

- `cargo fmt`
- `cargo +1.95.0 check -p forge`
- `cargo +1.95.0 test -p forge --test cli symbolic_json_schema -- --nocapture`
- `jq empty crates/evm/symbolic/assets/symbolic-result.schema.json`
- Python `jsonschema.Draft202012Validator` semantic check for valid pass/fail/incomplete samples and contradictory status/replay/call_trace states
