### PR TITLE
feat(debugger): show scoped variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5516,6 +5516,7 @@ dependencies = [
 name = "foundry-debugger"
 version = "1.7.2"
 dependencies = [
+ "alloy-dyn-abi",
  "alloy-primitives",
  "crossterm",
  "eyre",

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -21,6 +21,7 @@ foundry-tui.workspace = true
 revm-inspectors.workspace = true
 
 alloy-primitives.workspace = true
+alloy-dyn-abi.workspace = true
 
 crossterm.workspace = true
 eyre.workspace = true

--- a/crates/debugger/src/builder.rs
+++ b/crates/debugger/src/builder.rs
@@ -1,17 +1,20 @@
 //! Debugger builder.
 
-use crate::{DebugNode, Debugger, debugger::DebuggerStats, node::flatten_call_trace};
+use crate::{Debugger, debugger::DebuggerStats, node::flatten_call_trace};
 use alloy_primitives::{Address, map::AddressHashMap};
 use foundry_common::get_contract_name;
 use foundry_evm_core::Breakpoints;
-use foundry_evm_traces::{CallTraceArena, CallTraceDecoder, Traces, debug::ContractSources};
+use foundry_evm_traces::{
+    CallTraceArena, CallTraceDecoder, Traces,
+    debug::{ContractSources, DebugTraceIdentifier},
+};
 
 /// Debugger builder.
 #[derive(Debug, Default)]
 #[must_use = "builders do nothing unless you call `build` on them"]
 pub struct DebuggerBuilder {
     /// Debug traces returned from the EVM execution.
-    debug_arena: Vec<DebugNode>,
+    trace_arenas: Vec<CallTraceArena>,
     /// Aggregate stats for the traces passed to the debugger.
     stats: DebuggerStats,
     /// Identified contracts.
@@ -47,7 +50,7 @@ impl DebuggerBuilder {
         }
         self.stats.session_subcalls =
             self.stats.session_subcalls.saturating_add(arena.nodes().len().saturating_sub(1));
-        flatten_call_trace(arena, &mut self.debug_arena);
+        self.trace_arenas.push(arena);
         self
     }
 
@@ -94,8 +97,33 @@ impl DebuggerBuilder {
     /// Builds the debugger.
     #[inline]
     pub fn build(self) -> Debugger {
-        let Self { debug_arena, stats, identified_contracts, sources, breakpoints } = self;
+        let Self { mut trace_arenas, stats, identified_contracts, sources, breakpoints } = self;
+        identify_internal_calls(&mut trace_arenas, &identified_contracts, &sources);
+        let mut debug_arena = Vec::new();
+        for arena in trace_arenas {
+            flatten_call_trace(arena, &mut debug_arena);
+        }
         Debugger::new_with_stats(debug_arena, stats, identified_contracts, sources, breakpoints)
+    }
+}
+
+fn identify_internal_calls(
+    trace_arenas: &mut [CallTraceArena],
+    identified_contracts: &AddressHashMap<String>,
+    sources: &ContractSources,
+) {
+    if sources.artifacts_by_name.is_empty() {
+        return;
+    }
+
+    let identifier = DebugTraceIdentifier::new(sources.clone());
+    for arena in trace_arenas {
+        for node in arena.nodes_mut() {
+            let Some(contract_name) = identified_contracts.get(&node.trace.address) else {
+                continue;
+            };
+            identifier.identify_node_steps(node, contract_name);
+        }
     }
 }
 
@@ -160,7 +188,7 @@ mod tests {
 
         assert_eq!(builder.stats.session_subcalls, 1);
         assert_eq!(builder.stats.session_trace_gas_used, 100);
-        assert_eq!(builder.debug_arena.len(), 1);
+        assert_eq!(builder.trace_arenas.len(), 1);
     }
 
     #[test]
@@ -171,6 +199,6 @@ mod tests {
 
         assert_eq!(builder.stats.session_subcalls, 3);
         assert_eq!(builder.stats.session_trace_gas_used, 300);
-        assert_eq!(builder.debug_arena.len(), 2);
+        assert_eq!(builder.trace_arenas.len(), 2);
     }
 }

--- a/crates/debugger/src/builder.rs
+++ b/crates/debugger/src/builder.rs
@@ -116,13 +116,12 @@ fn identify_internal_calls(
         return;
     }
 
-    let identifier = DebugTraceIdentifier::new(sources.clone());
     for arena in trace_arenas {
         for node in arena.nodes_mut() {
             let Some(contract_name) = identified_contracts.get(&node.trace.address) else {
                 continue;
             };
-            identifier.identify_node_steps(node, contract_name);
+            DebugTraceIdentifier::identify_node_steps_with_sources(node, sources, contract_name);
         }
     }
 }

--- a/crates/debugger/src/node.rs
+++ b/crates/debugger/src/node.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::{Address, Bytes};
 use foundry_evm_traces::{CallKind, CallTraceArena};
-use revm_inspectors::tracing::types::{CallTraceStep, TraceMemberOrder};
+use revm_inspectors::tracing::types::{CallTraceStep, DecodedCallTrace, TraceMemberOrder};
 use serde::{Deserialize, Serialize};
 
 /// Represents a part of the execution frame before the next call or end of the execution.
@@ -16,6 +16,15 @@ pub struct DebugNode {
     pub calldata: Bytes,
     /// The gas limit of the call.
     pub gas_limit: u64,
+    /// Stable id for the original call trace node within the flattened debugger arena.
+    #[serde(default)]
+    pub trace_node_idx: usize,
+    /// Index of the first step in the original call trace node.
+    #[serde(default)]
+    pub step_offset: usize,
+    /// Decoded call data for the current execution context, if available.
+    #[serde(default)]
+    pub decoded: Option<Box<DecodedCallTrace>>,
     /// The debug steps.
     pub steps: Vec<CallTraceStep>,
 }
@@ -28,8 +37,18 @@ impl DebugNode {
         steps: Vec<CallTraceStep>,
         calldata: Bytes,
         gas_limit: u64,
+        decoded: Option<Box<DecodedCallTrace>>,
     ) -> Self {
-        Self { address, kind, steps, calldata, gas_limit }
+        Self {
+            address,
+            kind,
+            steps,
+            calldata,
+            gas_limit,
+            trace_node_idx: 0,
+            step_offset: 0,
+            decoded,
+        }
     }
 }
 
@@ -42,20 +61,27 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
     struct PendingNode {
         node_idx: usize,
         steps_count: usize,
+        step_offset: usize,
     }
 
     fn inner(arena: &CallTraceArena, node_idx: usize, out: &mut Vec<PendingNode>) {
-        let mut pending = PendingNode { node_idx, steps_count: 0 };
+        let mut pending = PendingNode { node_idx, steps_count: 0, step_offset: 0 };
+        let mut next_step_offset = 0;
         let node = &arena.nodes()[node_idx];
         for order in &node.ordering {
             match order {
                 TraceMemberOrder::Call(idx) => {
                     out.push(pending);
-                    pending.steps_count = 0;
+                    pending =
+                        PendingNode { node_idx, steps_count: 0, step_offset: next_step_offset };
                     inner(arena, node.children[*idx], out);
                 }
-                TraceMemberOrder::Step(_) => {
+                TraceMemberOrder::Step(step_idx) => {
+                    if pending.steps_count == 0 {
+                        pending.step_offset = *step_idx;
+                    }
                     pending.steps_count += 1;
+                    next_step_offset = step_idx.saturating_add(1);
                 }
                 _ => {}
             }
@@ -66,6 +92,8 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
     inner(&arena, 0, &mut nodes);
 
     let mut arena_nodes = arena.into_nodes();
+    let trace_node_idx_offset =
+        out.iter().map(|node| node.trace_node_idx).max().map_or(0, |idx| idx.saturating_add(1));
 
     for pending in nodes {
         let steps = {
@@ -81,8 +109,97 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
 
         let call = &arena_nodes[pending.node_idx].trace;
         let calldata = if call.kind.is_any_create() { Bytes::new() } else { call.data.clone() };
-        let node = DebugNode::new(call.address, call.kind, steps, calldata, call.gas_limit);
+        let mut node = DebugNode::new(
+            call.address,
+            call.kind,
+            steps,
+            calldata,
+            call.gas_limit,
+            call.decoded.clone(),
+        );
+        node.trace_node_idx = trace_node_idx_offset.saturating_add(pending.node_idx);
+        node.step_offset = pending.step_offset;
 
         out.push(node);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_evm_traces::{CallTrace, CallTraceNode};
+    use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
+
+    fn step(pc: usize) -> CallTraceStep {
+        CallTraceStep {
+            pc,
+            op: OpCode::STOP,
+            stack: None,
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: Some(InstructionResult::Stop),
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
+
+    #[test]
+    fn flatten_records_original_step_offsets_for_split_segments() {
+        let mut arena = CallTraceArena::default();
+
+        {
+            let root = &mut arena.nodes_mut()[0];
+            root.trace.steps = vec![step(0), step(1), step(2)];
+            root.ordering = vec![
+                TraceMemberOrder::Step(0),
+                TraceMemberOrder::Call(0),
+                TraceMemberOrder::Step(1),
+                TraceMemberOrder::Step(2),
+            ];
+            root.children.push(1);
+        }
+
+        arena.nodes_mut().push(CallTraceNode {
+            parent: Some(0),
+            idx: 1,
+            trace: CallTrace { kind: CallKind::Call, steps: vec![step(10)], ..Default::default() },
+            ordering: vec![TraceMemberOrder::Step(0)],
+            ..Default::default()
+        });
+
+        let mut flattened = Vec::new();
+        flatten_call_trace(arena, &mut flattened);
+
+        assert_eq!(flattened.len(), 3);
+        assert_eq!((flattened[0].trace_node_idx, flattened[0].step_offset), (0, 0));
+        assert_eq!(flattened[0].steps.iter().map(|step| step.pc).collect::<Vec<_>>(), [0]);
+        assert_eq!((flattened[1].trace_node_idx, flattened[1].step_offset), (1, 0));
+        assert_eq!(flattened[1].steps.iter().map(|step| step.pc).collect::<Vec<_>>(), [10]);
+        assert_eq!((flattened[2].trace_node_idx, flattened[2].step_offset), (0, 1));
+        assert_eq!(flattened[2].steps.iter().map(|step| step.pc).collect::<Vec<_>>(), [1, 2]);
+    }
+
+    #[test]
+    fn flatten_keeps_trace_node_ids_unique_when_appending_multiple_arenas() {
+        let mut existing = DebugNode::default();
+        existing.trace_node_idx = 1;
+        let mut flattened = vec![existing];
+
+        let mut arena = CallTraceArena::default();
+        {
+            let root = &mut arena.nodes_mut()[0];
+            root.trace.steps = vec![step(0)];
+            root.ordering = vec![TraceMemberOrder::Step(0)];
+        }
+
+        flatten_call_trace(arena, &mut flattened);
+
+        assert_eq!(flattened[1].trace_node_idx, 2);
     }
 }

--- a/crates/debugger/src/node.rs
+++ b/crates/debugger/src/node.rs
@@ -187,9 +187,7 @@ mod tests {
 
     #[test]
     fn flatten_keeps_trace_node_ids_unique_when_appending_multiple_arenas() {
-        let mut existing = DebugNode::default();
-        existing.trace_node_idx = 1;
-        let mut flattened = vec![existing];
+        let mut flattened = vec![DebugNode { trace_node_idx: 1, ..Default::default() }];
 
         let mut arena = CallTraceArena::default();
         {

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -22,12 +22,41 @@ pub(crate) struct StatusMessage {
     pub(crate) text: String,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ActiveInternalCallLocation {
+    pub(crate) start_node_idx: usize,
+    pub(crate) start_step: usize,
+    pub(crate) end_step: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ActiveInternalCallCache {
+    pub(crate) current_node_idx: usize,
+    pub(crate) trace_node_idx: usize,
+    pub(crate) absolute_step: usize,
+    pub(crate) location: Option<ActiveInternalCallLocation>,
+}
+
+impl ActiveInternalCallCache {
+    pub(crate) const fn matches(
+        self,
+        current_node_idx: usize,
+        trace_node_idx: usize,
+        absolute_step: usize,
+    ) -> bool {
+        self.current_node_idx == current_node_idx
+            && self.trace_node_idx == trace_node_idx
+            && self.absolute_step == absolute_step
+    }
+}
+
 /// This is currently used to remember last scroll position so screen doesn't wiggle as much.
 #[derive(Default)]
 pub(crate) struct DrawMemory {
     pub(crate) inner_call_index: usize,
     pub(crate) current_buf_startline: usize,
     pub(crate) current_stack_startline: usize,
+    pub(crate) active_internal_call: Option<ActiveInternalCallCache>,
 }
 
 pub(crate) struct TUIContext<'a> {

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -24,8 +24,10 @@ pub(crate) struct StatusMessage {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ActiveInternalCallLocation {
-    pub(crate) start_node_idx: usize,
-    pub(crate) start_step: usize,
+    pub(crate) trace_node_idx: usize,
+    pub(crate) marker_node_idx: usize,
+    pub(crate) marker_step_idx: usize,
+    pub(crate) entry_step: usize,
     pub(crate) end_step: usize,
 }
 

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -686,7 +686,14 @@ mod tests {
     }
 
     fn node(address: Address, kind: CallKind, pcs: &[usize]) -> DebugNode {
-        DebugNode::new(address, kind, pcs.iter().copied().map(step).collect(), Bytes::new(), 0)
+        DebugNode::new(
+            address,
+            kind,
+            pcs.iter().copied().map(step).collect(),
+            Bytes::new(),
+            0,
+            None,
+        )
     }
 
     fn context_with_arena(arena: Vec<DebugNode>) -> DebuggerContext {

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -2,10 +2,15 @@
 
 use super::context::{StatusKind, TUIContext};
 use crate::{debugger::DebuggerStats, op::OpcodeParam};
-use alloy_primitives::{Address, U256};
+use alloy_dyn_abi::{
+    DynSolType, DynSolValue, Specifier,
+    parser::{Parameters, Storage},
+};
+use alloy_primitives::{Address, U256, keccak256};
+use foundry_common::fmt::format_token;
 use foundry_compilers::artifacts::sourcemap::SourceElement;
 use foundry_evm_core::buffer::{BufferKind, get_buffer_accesses};
-use foundry_evm_traces::debug::SourceData;
+use foundry_evm_traces::debug::{DebugSourceScope, DebugVariable, SourceData};
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -13,7 +18,7 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
-use revm_inspectors::tracing::types::CallKind;
+use revm_inspectors::tracing::types::{CallKind, CallTraceStep, DecodedTraceStep};
 use std::{collections::VecDeque, fmt::Write};
 
 impl TUIContext<'_> {
@@ -69,6 +74,8 @@ impl TUIContext<'_> {
     /// |-----------------------------|
     /// |             op              |
     /// |-----------------------------|
+    /// |          variables          |
+    /// |-----------------------------|
     /// |            stack            |
     /// |-----------------------------|
     /// |             buf             |
@@ -94,14 +101,15 @@ impl TUIContext<'_> {
             unreachable!()
         };
 
-        // Split the app in 4 vertically to construct all the panes.
-        let [op_pane, stack_pane, memory_pane, src_pane] = Layout::new(
+        // Split the app vertically to construct all the panes.
+        let [op_pane, variables_pane, stack_pane, memory_pane, src_pane] = Layout::new(
             Direction::Vertical,
             [
-                Constraint::Ratio(1, 6),
-                Constraint::Ratio(1, 6),
-                Constraint::Ratio(1, 6),
-                Constraint::Ratio(3, 6),
+                Constraint::Ratio(1, 7),
+                Constraint::Ratio(1, 7),
+                Constraint::Ratio(1, 7),
+                Constraint::Ratio(1, 7),
+                Constraint::Ratio(3, 7),
             ],
         )
         .split(app)[..] else {
@@ -113,6 +121,7 @@ impl TUIContext<'_> {
         }
         self.draw_src(f, src_pane);
         self.draw_op_list(f, op_pane);
+        self.draw_variables(f, variables_pane);
         self.draw_stack(f, stack_pane);
         self.draw_buffer(f, memory_pane);
     }
@@ -121,10 +130,12 @@ impl TUIContext<'_> {
     ///
     /// ```text
     /// |-----------------|-----------|
-    /// |        op       |   stack   |
+    /// |        op       | variables |
     /// |-----------------|-----------|
+    /// |                 |   stack   |
+    /// |       src       |-----------|
     /// |                 |           |
-    /// |       src       |    buf    |
+    /// |                 |    buf    |
     /// |                 |           |
     /// |-----------------|-----------|
     /// ```
@@ -157,11 +168,12 @@ impl TUIContext<'_> {
             unreachable!()
         };
 
-        // Split right pane horizontally to construct stack and memory.
-        let [stack_pane, memory_pane] =
-            Layout::new(Direction::Vertical, [Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)])
-                .split(app_right)[..]
-        else {
+        // Split right pane vertically to construct variables, stack and memory.
+        let [variables_pane, stack_pane, memory_pane] = Layout::new(
+            Direction::Vertical,
+            [Constraint::Ratio(1, 4), Constraint::Ratio(1, 4), Constraint::Ratio(2, 4)],
+        )
+        .split(app_right)[..] else {
             unreachable!()
         };
 
@@ -170,6 +182,7 @@ impl TUIContext<'_> {
         }
         self.draw_src(f, src_pane);
         self.draw_op_list(f, op_pane);
+        self.draw_variables(f, variables_pane);
         self.draw_stack(f, stack_pane);
         self.draw_buffer(f, memory_pane);
     }
@@ -449,6 +462,29 @@ impl TUIContext<'_> {
         f.render_widget(paragraph, area);
     }
 
+    fn draw_variables(&self, f: &mut Frame<'_>, area: Rect) {
+        let variables = self.scope_variables();
+        let known = variables.iter().filter(|variable| variable.value.is_some()).count();
+        let title = if variables.is_empty() {
+            "Variables".to_string()
+        } else {
+            format!("Variables: {known}/{}", variables.len())
+        };
+
+        let text = if variables.is_empty() {
+            vec![Line::from(Span::styled(
+                "No variables in current scope",
+                Style::new().add_modifier(Modifier::DIM),
+            ))]
+        } else {
+            variables.into_iter().map(scope_variable_line).collect()
+        };
+
+        let block = Block::default().title(title).borders(Borders::ALL);
+        let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
+        f.render_widget(paragraph, area);
+    }
+
     fn draw_buffer(&self, f: &mut Frame<'_>, area: Rect) {
         let call = self.debug_call();
         let step = self.current_step();
@@ -583,6 +619,330 @@ impl TUIContext<'_> {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ScopeVariable {
+    kind: ScopeVariableKind,
+    name: String,
+    value: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScopeVariableKind {
+    Parameter,
+    Return,
+    Local,
+}
+
+struct ActiveInternalCall<'a> {
+    start_node_idx: usize,
+    start_step: usize,
+    end_step: usize,
+    decoded: &'a revm_inspectors::tracing::types::DecodedInternalCall,
+}
+
+impl ScopeVariableKind {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Parameter => "param",
+            Self::Return => "return",
+            Self::Local => "local",
+        }
+    }
+
+    const fn color(self) -> Color {
+        match self {
+            Self::Parameter => Color::Cyan,
+            Self::Return => Color::Green,
+            Self::Local => Color::White,
+        }
+    }
+}
+
+impl TUIContext<'_> {
+    fn scope_variables(&self) -> Vec<ScopeVariable> {
+        let Ok((source_element, source)) = self.src_map() else {
+            return Vec::new();
+        };
+        let start = source_element.offset() as usize;
+        let end = start.saturating_add(source_element.length() as usize);
+        let Some(scope) = source.find_debug_scope(start, end) else {
+            return Vec::new();
+        };
+
+        let parameter_values = self.decode_parameter_values(scope);
+        let return_values = self.decode_return_values(scope);
+        let mut variables = Vec::new();
+
+        variables.extend(scope.parameters.iter().enumerate().map(|(i, variable)| ScopeVariable {
+            kind: ScopeVariableKind::Parameter,
+            name: variable_name(variable, i, "arg"),
+            value: parameter_values.as_ref().and_then(|values| values.get(i).cloned()),
+        }));
+
+        variables.extend(scope.returns.iter().enumerate().map(|(i, variable)| ScopeVariable {
+            kind: ScopeVariableKind::Return,
+            name: variable_name(variable, i, "ret"),
+            value: return_values.as_ref().and_then(|values| values.get(i).cloned()),
+        }));
+
+        variables.extend(scope.visible_locals(start).enumerate().map(|(i, variable)| {
+            ScopeVariable {
+                kind: ScopeVariableKind::Local,
+                name: variable_name(variable, i, "local"),
+                value: None,
+            }
+        }));
+
+        variables
+    }
+
+    fn decode_parameter_values(&self, scope: &DebugSourceScope) -> Option<Vec<String>> {
+        self.decode_internal_parameter_values(scope)
+            .or_else(|| decode_external_parameter_values(scope, &self.debug_call().calldata))
+            .or_else(|| {
+                self.debug_call().decoded.as_ref().and_then(|decoded| {
+                    let call_data = decoded.call_data.as_ref()?;
+                    call_data_signature_name(&call_data.signature)
+                        .is_some_and(|name| name == scope.function_name)
+                        .then(|| call_data.args.clone())
+                })
+            })
+    }
+
+    fn decode_return_values(&self, scope: &DebugSourceScope) -> Option<Vec<String>> {
+        let current_step = self.absolute_current_step();
+        self.active_internal_call().and_then(|active| {
+            (current_step >= active.end_step
+                && decoded_internal_name_matches(&active.decoded.func_name, scope))
+            .then(|| active.decoded.return_data.clone())
+            .flatten()
+        })
+    }
+
+    fn decode_internal_parameter_values(&self, scope: &DebugSourceScope) -> Option<Vec<String>> {
+        let active = self.active_internal_call()?;
+        if !decoded_internal_name_matches(&active.decoded.func_name, scope) {
+            return None;
+        }
+
+        active.decoded.args.clone().or_else(|| {
+            let step =
+                self.debug_arena().get(active.start_node_idx)?.steps.get(active.start_step)?;
+            decode_step_parameters(&scope.parameters_src, step)
+        })
+    }
+
+    fn active_internal_call(&self) -> Option<ActiveInternalCall<'_>> {
+        let current_node_idx = self.draw_memory.inner_call_index;
+        let trace_node_idx = self.debug_call().trace_node_idx;
+        let current_step = self.absolute_current_step();
+        let mut active = None;
+
+        for (node_idx, node) in
+            self.debug_arena().iter().enumerate().take(current_node_idx.saturating_add(1))
+        {
+            if node.trace_node_idx != trace_node_idx {
+                continue;
+            }
+
+            for (step_idx, step) in node.steps.iter().enumerate() {
+                let start_step = node.step_offset.saturating_add(step_idx);
+                if start_step > current_step {
+                    break;
+                }
+
+                let Some(decoded) = step.decoded.as_deref() else { continue };
+                let DecodedTraceStep::InternalCall(call, end_step) = decoded else { continue };
+                if current_step <= *end_step {
+                    active = Some(ActiveInternalCall {
+                        start_node_idx: node_idx,
+                        start_step: step_idx,
+                        end_step: *end_step,
+                        decoded: call,
+                    });
+                }
+            }
+        }
+
+        active
+    }
+
+    fn absolute_current_step(&self) -> usize {
+        self.debug_call().step_offset.saturating_add(self.current_step)
+    }
+}
+
+fn scope_variable_line(variable: ScopeVariable) -> Line<'static> {
+    let color = variable.kind.color();
+    let mut spans = Vec::with_capacity(6);
+    spans.push(Span::styled(variable.kind.label(), Style::new().fg(Color::Gray)));
+    spans.push(Span::raw(" "));
+    spans.push(Span::styled(variable.name, Style::new().fg(color).add_modifier(Modifier::BOLD)));
+    spans.push(Span::raw(" = "));
+    if let Some(value) = variable.value {
+        spans.push(Span::styled(value, Style::new().fg(color)));
+    } else {
+        spans.push(Span::styled("<unavailable>", Style::new().fg(Color::Gray)));
+    }
+    Line::from(spans)
+}
+
+fn variable_name(variable: &DebugVariable, index: usize, fallback_prefix: &str) -> String {
+    variable
+        .name
+        .as_deref()
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("{fallback_prefix}{index}"))
+}
+
+fn call_data_signature_name(signature: &str) -> Option<&str> {
+    signature.split_once('(').map(|(name, _)| name).or(Some(signature))
+}
+
+fn decoded_internal_name_matches(decoded_name: &str, scope: &DebugSourceScope) -> bool {
+    if let Some((contract_name, function_name)) = decoded_name.rsplit_once("::") {
+        return contract_name == scope.contract_name && function_name == scope.function_name;
+    }
+    decoded_name == scope.function_name
+}
+
+fn decode_external_parameter_values(
+    scope: &DebugSourceScope,
+    calldata: &[u8],
+) -> Option<Vec<String>> {
+    if calldata.len() < 4 {
+        return None;
+    }
+
+    let parameters = Parameters::parse(&scope.parameters_src).ok()?;
+    let types = resolved_types(&parameters)?;
+    let selector = function_selector(&scope.function_name, &types);
+    if calldata.get(..4)? != selector.as_slice() {
+        return None;
+    }
+
+    decode_abi_sequence(&types, &calldata[4..])
+}
+
+fn decode_step_parameters(parameters_src: &str, step: &CallTraceStep) -> Option<Vec<String>> {
+    let parameters = Parameters::parse(parameters_src).ok()?;
+    if parameters.params.is_empty() {
+        return Some(Vec::new());
+    }
+
+    let types = parameters
+        .params
+        .iter()
+        .map(|param| param.resolve().ok().map(|ty| (ty, param.storage)))
+        .collect::<Option<Vec<_>>>()?;
+    let stack = step.stack.as_ref()?;
+    if stack.len() < types.len() {
+        return None;
+    }
+
+    let inputs = &stack[stack.len() - types.len()..];
+    Some(
+        inputs
+            .iter()
+            .zip(types.iter())
+            .map(|(input, (ty, storage))| {
+                match (ty, storage) {
+                    (DynSolType::Uint(8), Some(Storage::Memory | Storage::Storage)) => None,
+                    (_, Some(Storage::Memory)) => {
+                        let memory = step.memory.as_ref().map(|memory| memory.as_bytes());
+                        let location = input.try_into().ok();
+                        memory
+                            .zip(location)
+                            .and_then(|(memory, location)| decode_from_memory(ty, memory, location))
+                    }
+                    _ => ty.abi_decode(&input.to_be_bytes::<32>()).ok(),
+                }
+                .as_ref()
+                .map(format_token)
+                .unwrap_or_else(|| "<unknown>".to_string())
+            })
+            .collect(),
+    )
+}
+
+fn resolved_types(parameters: &Parameters<'_>) -> Option<Vec<DynSolType>> {
+    parameters.params.iter().map(|param| param.resolve().ok()).collect()
+}
+
+fn function_selector(function_name: &str, types: &[DynSolType]) -> [u8; 4] {
+    let mut signature = String::new();
+    signature.push_str(function_name);
+    signature.push('(');
+    for (i, ty) in types.iter().enumerate() {
+        if i > 0 {
+            signature.push(',');
+        }
+        signature.push_str(&ty.sol_type_name());
+    }
+    signature.push(')');
+    keccak256(signature.as_bytes())[..4].try_into().unwrap()
+}
+
+fn decode_abi_sequence(types: &[DynSolType], data: &[u8]) -> Option<Vec<String>> {
+    if types.is_empty() {
+        return Some(Vec::new());
+    }
+
+    let value = DynSolType::Tuple(types.to_vec()).abi_decode_sequence(data).ok()?;
+    let values = value.as_fixed_seq()?;
+    Some(values.iter().map(format_token).collect())
+}
+
+fn decode_from_memory(ty: &DynSolType, memory: &[u8], location: usize) -> Option<DynSolValue> {
+    let first_word = memory_range(memory, location, 32)?;
+
+    match ty {
+        DynSolType::String | DynSolType::Bytes => {
+            let length: usize = U256::from_be_slice(first_word).try_into().ok()?;
+            let data = memory_range(memory, location.checked_add(32)?, length)?;
+
+            match ty {
+                DynSolType::Bytes => Some(DynSolValue::Bytes(data.to_vec())),
+                DynSolType::String => {
+                    Some(DynSolValue::String(String::from_utf8_lossy(data).to_string()))
+                }
+                _ => unreachable!(),
+            }
+        }
+        DynSolType::Array(inner) | DynSolType::FixedArray(inner, _) => {
+            let (length, start) = match ty {
+                DynSolType::FixedArray(_, length) => (*length, location),
+                DynSolType::Array(_) => {
+                    (U256::from_be_slice(first_word).try_into().ok()?, location.checked_add(32)?)
+                }
+                _ => unreachable!(),
+            };
+            memory_range(memory, start, length.checked_mul(32)?)?;
+            let mut decoded = Vec::with_capacity(length);
+
+            for i in 0..length {
+                let offset = start.checked_add(i.checked_mul(32)?)?;
+                let location = match inner.as_ref() {
+                    DynSolType::String | DynSolType::Bytes | DynSolType::Array(_) => {
+                        U256::from_be_slice(memory_range(memory, offset, 32)?).try_into().ok()?
+                    }
+                    _ => offset,
+                };
+
+                decoded.push(decode_from_memory(inner, memory, location)?);
+            }
+
+            Some(DynSolValue::Array(decoded))
+        }
+        _ => ty.abi_decode(first_word).ok(),
+    }
+}
+
+fn memory_range(memory: &[u8], start: usize, len: usize) -> Option<&[u8]> {
+    memory.get(start..start.checked_add(len)?)
+}
+
 fn op_list_title(
     address: &Address,
     pc: usize,
@@ -703,15 +1063,199 @@ fn hex_digits(n: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use crate::{debugger::DebuggerStats, op::OpcodeParam};
-    use alloy_primitives::{Address, U256, address};
+    use super::TUIContext;
+    use crate::{
+        DebugNode,
+        debugger::{DebuggerContext, DebuggerStats},
+        op::OpcodeParam,
+    };
+    use alloy_dyn_abi::{DynSolType, parser::Parameters};
+    use alloy_primitives::{Address, Bytes, U256, address};
+    use foundry_evm_core::Breakpoints;
+    use foundry_evm_traces::debug::{ContractSources, DebugSourceScope, DebugVariable};
     use ratatui::{
         style::{Color, Style},
         text::Line,
     };
+    use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
+    use revm_inspectors::tracing::types::{
+        CallKind, CallTraceStep, DecodedInternalCall, DecodedTraceStep,
+    };
 
     fn line_text(line: &Line<'_>) -> String {
         line.spans.iter().map(|span| span.content.as_ref()).collect()
+    }
+
+    fn scope(function_name: &str, parameters_src: &str) -> DebugSourceScope {
+        DebugSourceScope {
+            contract_name: "DebugMe".to_string(),
+            function_name: function_name.to_string(),
+            range: 0..100,
+            body_range: 10..90,
+            parameters_src: parameters_src.to_string(),
+            returns_src: None,
+            parameters: Vec::new(),
+            returns: Vec::new(),
+            locals: Vec::new(),
+        }
+    }
+
+    fn trace_step(stack: Vec<U256>) -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: Some(stack.into_boxed_slice()),
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: Some(InstructionResult::Stop),
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
+
+    fn internal_call_step(end_step: usize, return_data: Vec<String>) -> CallTraceStep {
+        let mut step = trace_step(Vec::new());
+        step.decoded = Some(Box::new(DecodedTraceStep::InternalCall(
+            DecodedInternalCall {
+                func_name: "DebugMe::foo".to_string(),
+                args: Some(Vec::new()),
+                return_data: Some(return_data),
+            },
+            end_step,
+        )));
+        step
+    }
+
+    fn debug_node(
+        trace_node_idx: usize,
+        step_offset: usize,
+        steps: Vec<CallTraceStep>,
+    ) -> DebugNode {
+        let mut node = DebugNode::new(Address::ZERO, CallKind::Call, steps, Bytes::new(), 0, None);
+        node.trace_node_idx = trace_node_idx;
+        node.step_offset = step_offset;
+        node
+    }
+
+    fn context_with_arena(arena: Vec<DebugNode>) -> DebuggerContext {
+        DebuggerContext {
+            debug_arena: arena,
+            stats: None,
+            identified_contracts: Default::default(),
+            contracts_sources: ContractSources::default(),
+            breakpoints: Breakpoints::default(),
+        }
+    }
+
+    fn abi_word(value: U256) -> [u8; 32] {
+        value.to_be_bytes::<32>()
+    }
+
+    #[test]
+    fn decode_external_parameter_values_decodes_named_params() {
+        let scope = scope("foo", "(uint256 amount, bool ok)");
+        let parameters = Parameters::parse(&scope.parameters_src).unwrap();
+        let types = super::resolved_types(&parameters).unwrap();
+        let mut calldata = Vec::new();
+        calldata.extend_from_slice(&super::function_selector(&scope.function_name, &types));
+        calldata.extend_from_slice(&abi_word(U256::from(42)));
+        calldata.extend_from_slice(&abi_word(U256::from(1)));
+
+        let values = super::decode_external_parameter_values(&scope, &calldata).unwrap();
+
+        assert_eq!(values, ["42", "true"]);
+    }
+
+    #[test]
+    fn decode_external_parameter_values_rejects_selector_mismatch() {
+        let scope = scope("foo", "(uint256 amount)");
+        let parameters = Parameters::parse("(uint256 amount)").unwrap();
+        let types = super::resolved_types(&parameters).unwrap();
+        let mut calldata = Vec::new();
+        calldata.extend_from_slice(&super::function_selector("bar", &types));
+        calldata.extend_from_slice(&abi_word(U256::from(42)));
+
+        assert_eq!(super::decode_external_parameter_values(&scope, &calldata), None);
+    }
+
+    #[test]
+    fn decode_step_parameters_reads_static_values_from_stack() {
+        let step = trace_step(vec![U256::from(42), U256::from(1)]);
+        let values = super::decode_step_parameters("(uint256 amount, bool ok)", &step).unwrap();
+
+        assert_eq!(values, ["42", "true"]);
+    }
+
+    #[test]
+    fn decode_return_values_uses_absolute_internal_call_end_step() {
+        let mut context = context_with_arena(vec![debug_node(
+            0,
+            3,
+            vec![internal_call_step(4, vec!["99".to_string()]), trace_step(Vec::new())],
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.current_step = 1;
+
+        assert_eq!(tui.decode_return_values(&scope("foo", "()")), Some(vec!["99".to_string()]));
+    }
+
+    #[test]
+    fn decode_return_values_finds_internal_call_split_by_child_node() {
+        let mut context = context_with_arena(vec![
+            debug_node(0, 0, vec![internal_call_step(2, vec!["7".to_string()])]),
+            debug_node(1, 0, vec![trace_step(Vec::new())]),
+            debug_node(0, 2, vec![trace_step(Vec::new())]),
+        ]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.draw_memory.inner_call_index = 2;
+
+        assert_eq!(tui.decode_return_values(&scope("foo", "()")), Some(vec!["7".to_string()]));
+    }
+
+    #[test]
+    fn decode_from_memory_rejects_overflow_location() {
+        assert_eq!(super::decode_from_memory(&DynSolType::Bytes, &[0; 64], usize::MAX), None);
+    }
+
+    #[test]
+    fn decode_from_memory_rejects_oversized_dynamic_array_length() {
+        let memory = abi_word(U256::from(1_000_000)).to_vec();
+        let ty = DynSolType::Array(Box::new(DynSolType::Uint(256)));
+
+        assert_eq!(super::decode_from_memory(&ty, &memory, 0), None);
+    }
+
+    #[test]
+    fn decoded_internal_name_matches_exact_contract_and_function() {
+        let scope = scope("foo", "()");
+
+        assert!(super::decoded_internal_name_matches("DebugMe::foo", &scope));
+        assert!(!super::decoded_internal_name_matches("DebugMe::barfoo", &scope));
+        assert!(!super::decoded_internal_name_matches("Other::foo", &scope));
+    }
+
+    #[test]
+    fn scope_variable_line_marks_unavailable_locals() {
+        let variable = super::ScopeVariable {
+            kind: super::ScopeVariableKind::Local,
+            name: "sum".to_string(),
+            value: None,
+        };
+
+        assert_eq!(line_text(&super::scope_variable_line(variable)), "local sum = <unavailable>");
+    }
+
+    #[test]
+    fn variable_name_falls_back_for_unnamed_values() {
+        let variable = DebugVariable { name: None, declaration: 0..1, scope: 0..2 };
+
+        assert_eq!(super::variable_name(&variable, 2, "arg"), "arg2");
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -1,16 +1,15 @@
 //! TUI draw implementation.
 
-use super::context::{StatusKind, TUIContext};
+use super::context::{ActiveInternalCallCache, ActiveInternalCallLocation, StatusKind, TUIContext};
 use crate::{debugger::DebuggerStats, op::OpcodeParam};
-use alloy_dyn_abi::{
-    DynSolType, DynSolValue, Specifier,
-    parser::{Parameters, Storage},
-};
+use alloy_dyn_abi::{DynSolType, Specifier, parser::Parameters};
 use alloy_primitives::{Address, U256, keccak256};
 use foundry_common::fmt::format_token;
 use foundry_compilers::artifacts::sourcemap::SourceElement;
 use foundry_evm_core::buffer::{BufferKind, get_buffer_accesses};
-use foundry_evm_traces::debug::{DebugSourceScope, DebugVariable, SourceData};
+use foundry_evm_traces::debug::{
+    DebugSourceScope, DebugVariable, SourceData, decode_step_parameters,
+};
 use ratatui::{
     Frame,
     layout::{Alignment, Constraint, Direction, Layout, Rect},
@@ -18,11 +17,11 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
-use revm_inspectors::tracing::types::{CallKind, CallTraceStep, DecodedTraceStep};
+use revm_inspectors::tracing::types::{CallKind, DecodedInternalCall, DecodedTraceStep};
 use std::{collections::VecDeque, fmt::Write};
 
 impl TUIContext<'_> {
-    pub(crate) fn draw_layout(&self, f: &mut Frame<'_>) {
+    pub(crate) fn draw_layout(&mut self, f: &mut Frame<'_>) {
         // We need 100 columns to display a 32 byte word in the memory and stack panes.
         let area = f.area();
         let min_width = 100;
@@ -85,7 +84,7 @@ impl TUIContext<'_> {
     /// |                             |
     /// |-----------------------------|
     /// ```
-    fn vertical_layout(&self, f: &mut Frame<'_>) {
+    fn vertical_layout(&mut self, f: &mut Frame<'_>) {
         let area = f.area();
         let footer_height = self.footer_height();
 
@@ -139,7 +138,7 @@ impl TUIContext<'_> {
     /// |                 |           |
     /// |-----------------|-----------|
     /// ```
-    fn horizontal_layout(&self, f: &mut Frame<'_>) {
+    fn horizontal_layout(&mut self, f: &mut Frame<'_>) {
         let area = f.area();
         let footer_height = self.footer_height();
 
@@ -462,7 +461,7 @@ impl TUIContext<'_> {
         f.render_widget(paragraph, area);
     }
 
-    fn draw_variables(&self, f: &mut Frame<'_>, area: Rect) {
+    fn draw_variables(&mut self, f: &mut Frame<'_>, area: Rect) {
         let variables = self.scope_variables();
         let known = variables.iter().filter(|variable| variable.value.is_some()).count();
         let title = if variables.is_empty() {
@@ -637,7 +636,7 @@ struct ActiveInternalCall<'a> {
     start_node_idx: usize,
     start_step: usize,
     end_step: usize,
-    decoded: &'a revm_inspectors::tracing::types::DecodedInternalCall,
+    decoded: &'a DecodedInternalCall,
 }
 
 impl ScopeVariableKind {
@@ -659,18 +658,21 @@ impl ScopeVariableKind {
 }
 
 impl TUIContext<'_> {
-    fn scope_variables(&self) -> Vec<ScopeVariable> {
-        let Ok((source_element, source)) = self.src_map() else {
-            return Vec::new();
-        };
-        let start = source_element.offset() as usize;
-        let end = start.saturating_add(source_element.length() as usize);
-        let Some(scope) = source.find_debug_scope(start, end) else {
-            return Vec::new();
+    fn scope_variables(&mut self) -> Vec<ScopeVariable> {
+        let (scope, start) = {
+            let Ok((source_element, source)) = self.src_map() else {
+                return Vec::new();
+            };
+            let start = source_element.offset() as usize;
+            let end = start.saturating_add(source_element.length() as usize);
+            let Some(scope) = source.find_debug_scope(start, end) else {
+                return Vec::new();
+            };
+            (scope.clone(), start)
         };
 
-        let parameter_values = self.decode_parameter_values(scope);
-        let return_values = self.decode_return_values(scope);
+        let parameter_values = self.decode_parameter_values(&scope);
+        let return_values = self.decode_return_values(&scope);
         let mut variables = Vec::new();
 
         variables.extend(scope.parameters.iter().enumerate().map(|(i, variable)| ScopeVariable {
@@ -696,20 +698,22 @@ impl TUIContext<'_> {
         variables
     }
 
-    fn decode_parameter_values(&self, scope: &DebugSourceScope) -> Option<Vec<String>> {
+    fn decode_parameter_values(&mut self, scope: &DebugSourceScope) -> Option<Vec<String>> {
+        let scope_signature = scope_function_signature(scope);
         self.decode_internal_parameter_values(scope)
             .or_else(|| decode_external_parameter_values(scope, &self.debug_call().calldata))
             .or_else(|| {
                 self.debug_call().decoded.as_ref().and_then(|decoded| {
                     let call_data = decoded.call_data.as_ref()?;
-                    call_data_signature_name(&call_data.signature)
-                        .is_some_and(|name| name == scope.function_name)
+                    scope_signature
+                        .as_deref()
+                        .is_some_and(|signature| signature == call_data.signature)
                         .then(|| call_data.args.clone())
                 })
             })
     }
 
-    fn decode_return_values(&self, scope: &DebugSourceScope) -> Option<Vec<String>> {
+    fn decode_return_values(&mut self, scope: &DebugSourceScope) -> Option<Vec<String>> {
         let current_step = self.absolute_current_step();
         self.active_internal_call().and_then(|active| {
             (current_step >= active.end_step
@@ -719,23 +723,55 @@ impl TUIContext<'_> {
         })
     }
 
-    fn decode_internal_parameter_values(&self, scope: &DebugSourceScope) -> Option<Vec<String>> {
+    fn decode_internal_parameter_values(
+        &mut self,
+        scope: &DebugSourceScope,
+    ) -> Option<Vec<String>> {
         let active = self.active_internal_call()?;
         if !decoded_internal_name_matches(&active.decoded.func_name, scope) {
             return None;
         }
 
-        active.decoded.args.clone().or_else(|| {
-            let step =
-                self.debug_arena().get(active.start_node_idx)?.steps.get(active.start_step)?;
-            decode_step_parameters(&scope.parameters_src, step)
-        })
+        if let Some(args) = active.decoded.args.clone() {
+            return Some(args);
+        }
+
+        let start_node_idx = active.start_node_idx;
+        let start_step = active.start_step;
+        let parameters = Parameters::parse(&scope.parameters_src).ok()?;
+        let step = self.debug_arena().get(start_node_idx)?.steps.get(start_step)?;
+        decode_step_parameters(&parameters, step)
     }
 
-    fn active_internal_call(&self) -> Option<ActiveInternalCall<'_>> {
+    fn active_internal_call(&mut self) -> Option<ActiveInternalCall<'_>> {
         let current_node_idx = self.draw_memory.inner_call_index;
         let trace_node_idx = self.debug_call().trace_node_idx;
         let current_step = self.absolute_current_step();
+        let location = if let Some(cache) = self.draw_memory.active_internal_call
+            && cache.matches(current_node_idx, trace_node_idx, current_step)
+        {
+            cache.location
+        } else {
+            let location =
+                self.find_active_internal_call(current_node_idx, trace_node_idx, current_step);
+            self.draw_memory.active_internal_call = Some(ActiveInternalCallCache {
+                current_node_idx,
+                trace_node_idx,
+                absolute_step: current_step,
+                location,
+            });
+            location
+        }?;
+
+        self.active_internal_call_at(location)
+    }
+
+    fn find_active_internal_call(
+        &self,
+        current_node_idx: usize,
+        trace_node_idx: usize,
+        current_step: usize,
+    ) -> Option<ActiveInternalCallLocation> {
         let mut active = None;
 
         for (node_idx, node) in
@@ -752,19 +788,35 @@ impl TUIContext<'_> {
                 }
 
                 let Some(decoded) = step.decoded.as_deref() else { continue };
-                let DecodedTraceStep::InternalCall(call, end_step) = decoded else { continue };
+                let DecodedTraceStep::InternalCall(_, end_step) = decoded else { continue };
                 if current_step <= *end_step {
-                    active = Some(ActiveInternalCall {
+                    active = Some(ActiveInternalCallLocation {
                         start_node_idx: node_idx,
                         start_step: step_idx,
                         end_step: *end_step,
-                        decoded: call,
                     });
                 }
             }
         }
 
         active
+    }
+
+    fn active_internal_call_at(
+        &self,
+        location: ActiveInternalCallLocation,
+    ) -> Option<ActiveInternalCall<'_>> {
+        let step =
+            self.debug_arena().get(location.start_node_idx)?.steps.get(location.start_step)?;
+        let DecodedTraceStep::InternalCall(decoded, end_step) = step.decoded.as_deref()? else {
+            return None;
+        };
+        (*end_step == location.end_step).then_some(ActiveInternalCall {
+            start_node_idx: location.start_node_idx,
+            start_step: location.start_step,
+            end_step: location.end_step,
+            decoded,
+        })
     }
 
     fn absolute_current_step(&self) -> usize {
@@ -796,10 +848,6 @@ fn variable_name(variable: &DebugVariable, index: usize, fallback_prefix: &str) 
         .unwrap_or_else(|| format!("{fallback_prefix}{index}"))
 }
 
-fn call_data_signature_name(signature: &str) -> Option<&str> {
-    signature.split_once('(').map(|(name, _)| name).or(Some(signature))
-}
-
 fn decoded_internal_name_matches(decoded_name: &str, scope: &DebugSourceScope) -> bool {
     if let Some((contract_name, function_name)) = decoded_name.rsplit_once("::") {
         return contract_name == scope.contract_name && function_name == scope.function_name;
@@ -825,52 +873,22 @@ fn decode_external_parameter_values(
     decode_abi_sequence(&types, &calldata[4..])
 }
 
-fn decode_step_parameters(parameters_src: &str, step: &CallTraceStep) -> Option<Vec<String>> {
-    let parameters = Parameters::parse(parameters_src).ok()?;
-    if parameters.params.is_empty() {
-        return Some(Vec::new());
-    }
-
-    let types = parameters
-        .params
-        .iter()
-        .map(|param| param.resolve().ok().map(|ty| (ty, param.storage)))
-        .collect::<Option<Vec<_>>>()?;
-    let stack = step.stack.as_ref()?;
-    if stack.len() < types.len() {
-        return None;
-    }
-
-    let inputs = &stack[stack.len() - types.len()..];
-    Some(
-        inputs
-            .iter()
-            .zip(types.iter())
-            .map(|(input, (ty, storage))| {
-                match (ty, storage) {
-                    (DynSolType::Uint(8), Some(Storage::Memory | Storage::Storage)) => None,
-                    (_, Some(Storage::Memory)) => {
-                        let memory = step.memory.as_ref().map(|memory| memory.as_bytes());
-                        let location = input.try_into().ok();
-                        memory
-                            .zip(location)
-                            .and_then(|(memory, location)| decode_from_memory(ty, memory, location))
-                    }
-                    _ => ty.abi_decode(&input.to_be_bytes::<32>()).ok(),
-                }
-                .as_ref()
-                .map(format_token)
-                .unwrap_or_else(|| "<unknown>".to_string())
-            })
-            .collect(),
-    )
-}
-
 fn resolved_types(parameters: &Parameters<'_>) -> Option<Vec<DynSolType>> {
     parameters.params.iter().map(|param| param.resolve().ok()).collect()
 }
 
+fn scope_function_signature(scope: &DebugSourceScope) -> Option<String> {
+    let parameters = Parameters::parse(&scope.parameters_src).ok()?;
+    let types = resolved_types(&parameters)?;
+    Some(function_signature(&scope.function_name, &types))
+}
+
 fn function_selector(function_name: &str, types: &[DynSolType]) -> [u8; 4] {
+    let signature = function_signature(function_name, types);
+    keccak256(signature.as_bytes())[..4].try_into().unwrap()
+}
+
+fn function_signature(function_name: &str, types: &[DynSolType]) -> String {
     let mut signature = String::new();
     signature.push_str(function_name);
     signature.push('(');
@@ -881,7 +899,7 @@ fn function_selector(function_name: &str, types: &[DynSolType]) -> [u8; 4] {
         signature.push_str(&ty.sol_type_name());
     }
     signature.push(')');
-    keccak256(signature.as_bytes())[..4].try_into().unwrap()
+    signature
 }
 
 fn decode_abi_sequence(types: &[DynSolType], data: &[u8]) -> Option<Vec<String>> {
@@ -892,55 +910,6 @@ fn decode_abi_sequence(types: &[DynSolType], data: &[u8]) -> Option<Vec<String>>
     let value = DynSolType::Tuple(types.to_vec()).abi_decode_sequence(data).ok()?;
     let values = value.as_fixed_seq()?;
     Some(values.iter().map(format_token).collect())
-}
-
-fn decode_from_memory(ty: &DynSolType, memory: &[u8], location: usize) -> Option<DynSolValue> {
-    let first_word = memory_range(memory, location, 32)?;
-
-    match ty {
-        DynSolType::String | DynSolType::Bytes => {
-            let length: usize = U256::from_be_slice(first_word).try_into().ok()?;
-            let data = memory_range(memory, location.checked_add(32)?, length)?;
-
-            match ty {
-                DynSolType::Bytes => Some(DynSolValue::Bytes(data.to_vec())),
-                DynSolType::String => {
-                    Some(DynSolValue::String(String::from_utf8_lossy(data).to_string()))
-                }
-                _ => unreachable!(),
-            }
-        }
-        DynSolType::Array(inner) | DynSolType::FixedArray(inner, _) => {
-            let (length, start) = match ty {
-                DynSolType::FixedArray(_, length) => (*length, location),
-                DynSolType::Array(_) => {
-                    (U256::from_be_slice(first_word).try_into().ok()?, location.checked_add(32)?)
-                }
-                _ => unreachable!(),
-            };
-            memory_range(memory, start, length.checked_mul(32)?)?;
-            let mut decoded = Vec::with_capacity(length);
-
-            for i in 0..length {
-                let offset = start.checked_add(i.checked_mul(32)?)?;
-                let location = match inner.as_ref() {
-                    DynSolType::String | DynSolType::Bytes | DynSolType::Array(_) => {
-                        U256::from_be_slice(memory_range(memory, offset, 32)?).try_into().ok()?
-                    }
-                    _ => offset,
-                };
-
-                decoded.push(decode_from_memory(inner, memory, location)?);
-            }
-
-            Some(DynSolValue::Array(decoded))
-        }
-        _ => ty.abi_decode(first_word).ok(),
-    }
-}
-
-fn memory_range(memory: &[u8], start: usize, len: usize) -> Option<&[u8]> {
-    memory.get(start..start.checked_add(len)?)
 }
 
 fn op_list_title(
@@ -1069,7 +1038,7 @@ mod tests {
         debugger::{DebuggerContext, DebuggerStats},
         op::OpcodeParam,
     };
-    use alloy_dyn_abi::{DynSolType, parser::Parameters};
+    use alloy_dyn_abi::parser::Parameters;
     use alloy_primitives::{Address, Bytes, U256, address};
     use foundry_evm_core::Breakpoints;
     use foundry_evm_traces::debug::{ContractSources, DebugSourceScope, DebugVariable};
@@ -1079,7 +1048,8 @@ mod tests {
     };
     use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
     use revm_inspectors::tracing::types::{
-        CallKind, CallTraceStep, DecodedInternalCall, DecodedTraceStep,
+        CallKind, CallTraceStep, DecodedCallData, DecodedCallTrace, DecodedInternalCall,
+        DecodedTraceStep,
     };
 
     fn line_text(line: &Line<'_>) -> String {
@@ -1185,9 +1155,33 @@ mod tests {
     }
 
     #[test]
+    fn scope_function_signature_includes_resolved_parameter_types() {
+        let scope = scope("foo", "(uint256 amount, bool ok)");
+
+        assert_eq!(super::scope_function_signature(&scope).as_deref(), Some("foo(uint256,bool)"));
+    }
+
+    #[test]
+    fn decode_parameter_values_rejects_decoded_call_data_for_wrong_overload() {
+        let mut node = debug_node(0, 0, vec![trace_step(Vec::new())]);
+        node.decoded = Some(Box::new(DecodedCallTrace {
+            call_data: Some(DecodedCallData {
+                signature: "foo(address)".to_string(),
+                args: vec!["0x000000000000000000000000000000000000002a".to_string()],
+            }),
+            ..Default::default()
+        }));
+        let mut context = context_with_arena(vec![node]);
+        let mut tui = TUIContext::new(&mut context);
+
+        assert_eq!(tui.decode_parameter_values(&scope("foo", "(uint256 amount)")), None);
+    }
+
+    #[test]
     fn decode_step_parameters_reads_static_values_from_stack() {
         let step = trace_step(vec![U256::from(42), U256::from(1)]);
-        let values = super::decode_step_parameters("(uint256 amount, bool ok)", &step).unwrap();
+        let parameters = Parameters::parse("(uint256 amount, bool ok)").unwrap();
+        let values = super::decode_step_parameters(&parameters, &step).unwrap();
 
         assert_eq!(values, ["42", "true"]);
     }
@@ -1219,16 +1213,24 @@ mod tests {
     }
 
     #[test]
-    fn decode_from_memory_rejects_overflow_location() {
-        assert_eq!(super::decode_from_memory(&DynSolType::Bytes, &[0; 64], usize::MAX), None);
-    }
+    fn active_internal_call_caches_by_current_node_and_step() {
+        let mut context = context_with_arena(vec![debug_node(
+            0,
+            0,
+            vec![internal_call_step(2, vec!["1".to_string()]), trace_step(Vec::new())],
+        )]);
+        let mut tui = TUIContext::new(&mut context);
 
-    #[test]
-    fn decode_from_memory_rejects_oversized_dynamic_array_length() {
-        let memory = abi_word(U256::from(1_000_000)).to_vec();
-        let ty = DynSolType::Array(Box::new(DynSolType::Uint(256)));
+        assert!(tui.active_internal_call().is_some());
+        let cache = tui.draw_memory.active_internal_call;
+        assert!(cache.and_then(|cache| cache.location).is_some());
 
-        assert_eq!(super::decode_from_memory(&ty, &memory, 0), None);
+        assert!(tui.active_internal_call().is_some());
+        assert_eq!(tui.draw_memory.active_internal_call, cache);
+
+        tui.current_step = 1;
+        assert!(tui.active_internal_call().is_some());
+        assert_ne!(tui.draw_memory.active_internal_call, cache);
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -17,7 +17,9 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
-use revm_inspectors::tracing::types::{CallKind, DecodedInternalCall, DecodedTraceStep};
+use revm_inspectors::tracing::types::{
+    CallKind, CallTraceStep, DecodedInternalCall, DecodedTraceStep,
+};
 use std::{collections::VecDeque, fmt::Write};
 
 impl TUIContext<'_> {
@@ -633,8 +635,8 @@ enum ScopeVariableKind {
 }
 
 struct ActiveInternalCall<'a> {
-    start_node_idx: usize,
-    start_step: usize,
+    trace_node_idx: usize,
+    entry_step: usize,
     end_step: usize,
     decoded: &'a DecodedInternalCall,
 }
@@ -727,19 +729,21 @@ impl TUIContext<'_> {
         &mut self,
         scope: &DebugSourceScope,
     ) -> Option<Vec<String>> {
-        let active = self.active_internal_call()?;
-        if !decoded_internal_name_matches(&active.decoded.func_name, scope) {
-            return None;
-        }
+        let (args, trace_node_idx, entry_step) = {
+            let active = self.active_internal_call()?;
+            if !decoded_internal_name_matches(&active.decoded.func_name, scope) {
+                return None;
+            }
 
-        if let Some(args) = active.decoded.args.clone() {
+            (active.decoded.args.clone(), active.trace_node_idx, active.entry_step)
+        };
+
+        if let Some(args) = args {
             return Some(args);
         }
 
-        let start_node_idx = active.start_node_idx;
-        let start_step = active.start_step;
         let parameters = Parameters::parse(&scope.parameters_src).ok()?;
-        let step = self.debug_arena().get(start_node_idx)?.steps.get(start_step)?;
+        let step = self.step_by_absolute_index(trace_node_idx, entry_step)?;
         decode_step_parameters(&parameters, step)
     }
 
@@ -782,8 +786,8 @@ impl TUIContext<'_> {
             }
 
             for (step_idx, step) in node.steps.iter().enumerate() {
-                let start_step = node.step_offset.saturating_add(step_idx);
-                if start_step > current_step {
+                let marker_step = node.step_offset.saturating_add(step_idx);
+                if marker_step > current_step {
                     break;
                 }
 
@@ -791,8 +795,10 @@ impl TUIContext<'_> {
                 let DecodedTraceStep::InternalCall(_, end_step) = decoded else { continue };
                 if current_step <= *end_step {
                     active = Some(ActiveInternalCallLocation {
-                        start_node_idx: node_idx,
-                        start_step: step_idx,
+                        trace_node_idx,
+                        marker_node_idx: node_idx,
+                        marker_step_idx: step_idx,
+                        entry_step: marker_step.saturating_add(1),
                         end_step: *end_step,
                     });
                 }
@@ -806,17 +812,31 @@ impl TUIContext<'_> {
         &self,
         location: ActiveInternalCallLocation,
     ) -> Option<ActiveInternalCall<'_>> {
-        let step =
-            self.debug_arena().get(location.start_node_idx)?.steps.get(location.start_step)?;
+        let step = self
+            .debug_arena()
+            .get(location.marker_node_idx)?
+            .steps
+            .get(location.marker_step_idx)?;
         let DecodedTraceStep::InternalCall(decoded, end_step) = step.decoded.as_deref()? else {
             return None;
         };
         (*end_step == location.end_step).then_some(ActiveInternalCall {
-            start_node_idx: location.start_node_idx,
-            start_step: location.start_step,
+            trace_node_idx: location.trace_node_idx,
+            entry_step: location.entry_step,
             end_step: location.end_step,
             decoded,
         })
+    }
+
+    fn step_by_absolute_index(
+        &self,
+        trace_node_idx: usize,
+        absolute_step: usize,
+    ) -> Option<&CallTraceStep> {
+        self.debug_arena()
+            .iter()
+            .filter(|node| node.trace_node_idx == trace_node_idx)
+            .find_map(|node| node.steps.get(absolute_step.checked_sub(node.step_offset)?))
     }
 
     fn absolute_current_step(&self) -> usize {
@@ -1102,6 +1122,19 @@ mod tests {
         step
     }
 
+    fn internal_call_step_without_args(end_step: usize) -> CallTraceStep {
+        let mut step = trace_step(Vec::new());
+        step.decoded = Some(Box::new(DecodedTraceStep::InternalCall(
+            DecodedInternalCall {
+                func_name: "DebugMe::foo".to_string(),
+                args: None,
+                return_data: None,
+            },
+            end_step,
+        )));
+        step
+    }
+
     fn debug_node(
         trace_node_idx: usize,
         step_offset: usize,
@@ -1184,6 +1217,22 @@ mod tests {
         let values = super::decode_step_parameters(&parameters, &step).unwrap();
 
         assert_eq!(values, ["42", "true"]);
+    }
+
+    #[test]
+    fn decode_internal_parameter_values_uses_absolute_entry_step() {
+        let mut context = context_with_arena(vec![
+            debug_node(0, 0, vec![internal_call_step_without_args(2)]),
+            debug_node(1, 0, vec![trace_step(Vec::new())]),
+            debug_node(0, 1, vec![trace_step(vec![U256::from(42)])]),
+        ]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.draw_memory.inner_call_index = 2;
+
+        assert_eq!(
+            tui.decode_internal_parameter_values(&scope("foo", "(uint256 amount)")),
+            Some(vec!["42".to_string()])
+        );
     }
 
     #[test]

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -26,7 +26,16 @@ impl DebugTraceIdentifier {
     ///
     /// Accepts the node itself and identified name of the contract which node corresponds to.
     pub fn identify_node_steps(&self, node: &mut CallTraceNode, contract_name: &str) {
-        DebugStepsWalker::new(node, &self.contracts_sources, contract_name).walk();
+        Self::identify_node_steps_with_sources(node, &self.contracts_sources, contract_name);
+    }
+
+    /// Identifies internal function invocations without taking ownership of source metadata.
+    pub fn identify_node_steps_with_sources(
+        node: &mut CallTraceNode,
+        sources: &ContractSources,
+        contract_name: &str,
+    ) {
+        DebugStepsWalker::new(node, sources, contract_name).walk();
     }
 }
 
@@ -152,9 +161,9 @@ impl<'a> DebugStepsWalker<'a> {
 
                 Some((
                     inputs.and_then(|t| {
-                        try_decode_args_from_step(&t, &self.node.trace.steps[start_idx + 1])
+                        decode_step_parameters(&t, &self.node.trace.steps[start_idx + 1])
                     }),
-                    outputs.and_then(|t| try_decode_args_from_step(&t, self.current_step())),
+                    outputs.and_then(|t| decode_step_parameters(&t, self.current_step())),
                 ))
             })
             .unwrap_or_default();
@@ -233,7 +242,7 @@ fn parse_types(source: &str) -> (Option<Parameters<'_>>, Option<Parameters<'_>>)
 }
 
 /// Given [Parameters] and [CallTraceStep], tries to decode parameters by using stack and memory.
-fn try_decode_args_from_step(args: &Parameters<'_>, step: &CallTraceStep) -> Option<Vec<String>> {
+pub fn decode_step_parameters(args: &Parameters<'_>, step: &CallTraceStep) -> Option<Vec<String>> {
     let params = &args.params;
 
     if params.is_empty() {
@@ -263,6 +272,7 @@ fn try_decode_args_from_step(args: &Parameters<'_>, step: &CallTraceStep) -> Opt
                         // filter out `uint8` params which are marked as storage or memory as this
                         // is not possible in Solidity and means that type is user-defined
                         (DynSolType::Uint(8), Some(Storage::Memory | Storage::Storage)) => None,
+                        (_, Some(Storage::Storage)) => None,
                         (_, Some(Storage::Memory)) => decode_from_memory(
                             type_,
                             step.memory.as_ref()?.as_bytes(),
@@ -337,9 +347,30 @@ fn memory_range(memory: &[u8], start: usize, len: usize) -> Option<&[u8]> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_from_memory, source_span};
-    use alloy_dyn_abi::DynSolType;
-    use alloy_primitives::U256;
+    use super::{decode_from_memory, decode_step_parameters, source_span};
+    use alloy_dyn_abi::{DynSolType, parser::Parameters};
+    use alloy_primitives::{Bytes, U256};
+    use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
+    use revm_inspectors::tracing::types::CallTraceStep;
+
+    fn trace_step(stack: Vec<U256>) -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: Some(stack.into_boxed_slice()),
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining: 0,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: Some(InstructionResult::Stop),
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
 
     #[test]
     fn source_span_returns_none_for_invalid_ranges() {
@@ -359,5 +390,13 @@ mod tests {
         let ty = DynSolType::Array(Box::new(DynSolType::Uint(256)));
 
         assert_eq!(decode_from_memory(&ty, &memory, 0), None);
+    }
+
+    #[test]
+    fn decode_step_parameters_marks_storage_params_unknown() {
+        let params = Parameters::parse("(uint256[] storage values)").unwrap();
+        let step = trace_step(vec![U256::from(5)]);
+
+        assert_eq!(decode_step_parameters(&params, &step), Some(vec!["<unknown>".to_string()]));
     }
 }

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -9,7 +9,7 @@ use foundry_common::fmt::format_token;
 use foundry_compilers::artifacts::sourcemap::{Jump, SourceElement};
 use revm::bytecode::opcode::OpCode;
 use revm_inspectors::tracing::types::{CallTraceStep, DecodedInternalCall, DecodedTraceStep};
-pub use sources::{ArtifactData, ContractSources, SourceData};
+pub use sources::{ArtifactData, ContractSources, DebugSourceScope, DebugVariable, SourceData};
 
 #[derive(Clone, Debug)]
 pub struct DebugTraceIdentifier {
@@ -283,13 +283,13 @@ fn try_decode_args_from_step(args: &Parameters<'_>, step: &CallTraceStep) -> Opt
 
 /// Decodes given [DynSolType] from memory.
 fn decode_from_memory(ty: &DynSolType, memory: &[u8], location: usize) -> Option<DynSolValue> {
-    let first_word = memory.get(location..location + 32)?;
+    let first_word = memory_range(memory, location, 32)?;
 
     match ty {
         // For `string` and `bytes` layout is a word with length followed by the data
         DynSolType::String | DynSolType::Bytes => {
             let length: usize = U256::from_be_slice(first_word).try_into().ok()?;
-            let data = memory.get(location + 32..location + 32 + length)?;
+            let data = memory_range(memory, location.checked_add(32)?, length)?;
 
             match ty {
                 DynSolType::Bytes => Some(DynSolValue::Bytes(data.to_vec())),
@@ -305,18 +305,19 @@ fn decode_from_memory(ty: &DynSolType, memory: &[u8], location: usize) -> Option
             let (length, start) = match ty {
                 DynSolType::FixedArray(_, length) => (*length, location),
                 DynSolType::Array(_) => {
-                    (U256::from_be_slice(first_word).try_into().ok()?, location + 32)
+                    (U256::from_be_slice(first_word).try_into().ok()?, location.checked_add(32)?)
                 }
                 _ => unreachable!(),
             };
+            memory_range(memory, start, length.checked_mul(32)?)?;
             let mut decoded = Vec::with_capacity(length);
 
             for i in 0..length {
-                let offset = start + i * 32;
+                let offset = start.checked_add(i.checked_mul(32)?)?;
                 let location = match inner.as_ref() {
                     // Arrays of variable length types are arrays of pointers to the values
                     DynSolType::String | DynSolType::Bytes | DynSolType::Array(_) => {
-                        U256::from_be_slice(memory.get(offset..offset + 32)?).try_into().ok()?
+                        U256::from_be_slice(memory_range(memory, offset, 32)?).try_into().ok()?
                     }
                     _ => offset,
                 };
@@ -330,14 +331,33 @@ fn decode_from_memory(ty: &DynSolType, memory: &[u8], location: usize) -> Option
     }
 }
 
+fn memory_range(memory: &[u8], start: usize, len: usize) -> Option<&[u8]> {
+    memory.get(start..start.checked_add(len)?)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::source_span;
+    use super::{decode_from_memory, source_span};
+    use alloy_dyn_abi::DynSolType;
+    use alloy_primitives::U256;
 
     #[test]
     fn source_span_returns_none_for_invalid_ranges() {
         assert_eq!(source_span("abcdef", 2, 3), Some(("cde", 5)));
         assert_eq!(source_span("abcdef", 7, 1), None);
         assert_eq!(source_span("abcdef", usize::MAX, 1), None);
+    }
+
+    #[test]
+    fn decode_from_memory_rejects_overflow_location() {
+        assert_eq!(decode_from_memory(&DynSolType::Bytes, &[0; 64], usize::MAX), None);
+    }
+
+    #[test]
+    fn decode_from_memory_rejects_oversized_dynamic_array_length() {
+        let memory = U256::from(1_000_000).to_be_bytes::<32>();
+        let ty = DynSolType::Array(Box::new(DynSolType::Uint(256)));
+
+        assert_eq!(decode_from_memory(&ty, &memory, 0), None);
     }
 }

--- a/crates/evm/traces/src/debug/sources.rs
+++ b/crates/evm/traces/src/debug/sources.rs
@@ -86,7 +86,10 @@ impl SourceData {
                     let source_map = compiler.sess().source_map();
                     for item in source.ast.as_ref()?.items.iter() {
                         if let solar::ast::ItemKind::Contract(contract) = &item.kind {
-                            let contract_range = source_map.span_to_range(item.span).ok()?;
+                            let Some(contract_range) = source_map.span_to_range(item.span).ok()
+                            else {
+                                continue;
+                            };
                             contract_definitions
                                 .push((contract.name.to_string(), contract_range.clone()));
                             collect_contract_debug_scopes(

--- a/crates/evm/traces/src/debug/sources.rs
+++ b/crates/evm/traces/src/debug/sources.rs
@@ -11,6 +11,7 @@ use foundry_compilers::{
 use foundry_evm_core::ic::PcIcMap;
 use foundry_linking::Linker;
 use rayon::prelude::*;
+use solar::{ast, interface::SpannedOption};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::Write,
@@ -27,6 +28,38 @@ pub struct SourceData {
     /// Maps contract name to (start, end) of the contract definition in the source code.
     /// This is useful for determining which contract contains given function definition.
     pub contract_definitions: Vec<(String, Range<usize>)>,
+    /// Solidity function scopes and variable declarations available to the debugger.
+    pub debug_scopes: Vec<DebugSourceScope>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DebugSourceScope {
+    pub contract_name: String,
+    pub function_name: String,
+    pub range: Range<usize>,
+    pub body_range: Range<usize>,
+    pub parameters_src: String,
+    pub returns_src: Option<String>,
+    pub parameters: Vec<DebugVariable>,
+    pub returns: Vec<DebugVariable>,
+    pub locals: Vec<DebugVariable>,
+}
+
+impl DebugSourceScope {
+    pub fn visible_locals(&self, offset: usize) -> impl Iterator<Item = &DebugVariable> {
+        self.locals.iter().filter(move |local| {
+            local.declaration.end <= offset
+                && offset >= local.scope.start
+                && offset <= local.scope.end
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DebugVariable {
+    pub name: Option<String>,
+    pub declaration: Range<usize>,
+    pub scope: Range<usize>,
 }
 
 impl SourceData {
@@ -38,6 +71,7 @@ impl SourceData {
         root: &Path,
     ) -> Self {
         let mut contract_definitions = Vec::new();
+        let mut debug_scopes = Vec::new();
 
         match language {
             MultiCompilerLanguage::Vyper(_) => {
@@ -49,12 +83,18 @@ impl SourceData {
             MultiCompilerLanguage::Solc(_) => {
                 let r = output.parser().solc().compiler().enter(|compiler| -> Option<()> {
                     let (_, source) = compiler.gcx().get_ast_source(root.join(&path))?;
+                    let source_map = compiler.sess().source_map();
                     for item in source.ast.as_ref()?.items.iter() {
                         if let solar::ast::ItemKind::Contract(contract) = &item.kind {
-                            contract_definitions.push((
-                                contract.name.to_string(),
-                                compiler.sess().source_map().span_to_range(item.span).unwrap(),
-                            ));
+                            let contract_range = source_map.span_to_range(item.span).ok()?;
+                            contract_definitions
+                                .push((contract.name.to_string(), contract_range.clone()));
+                            collect_contract_debug_scopes(
+                                source_map,
+                                contract,
+                                contract_range,
+                                &mut debug_scopes,
+                            );
                         }
                     }
                     Some(())
@@ -65,7 +105,7 @@ impl SourceData {
             }
         }
 
-        Self { source, language, path, contract_definitions }
+        Self { source, language, path, contract_definitions, debug_scopes }
     }
 
     /// Finds name of contract that contains given loc.
@@ -75,6 +115,205 @@ impl SourceData {
             .find(|(_, r)| start >= r.start && end <= r.end)
             .map(|(name, _)| name.as_str())
     }
+
+    /// Finds the innermost Solidity function scope containing the given byte range.
+    pub fn find_debug_scope(&self, start: usize, end: usize) -> Option<&DebugSourceScope> {
+        self.debug_scopes
+            .iter()
+            .filter(|scope| start >= scope.range.start && end <= scope.range.end)
+            .min_by_key(|scope| scope.range.end.saturating_sub(scope.range.start))
+    }
+}
+
+fn collect_contract_debug_scopes(
+    source_map: &solar::interface::source_map::SourceMap,
+    contract: &ast::ItemContract<'_>,
+    contract_range: Range<usize>,
+    out: &mut Vec<DebugSourceScope>,
+) {
+    let mut scopes = Vec::new();
+    for item in contract.body.iter() {
+        let ast::ItemKind::Function(func) = &item.kind else { continue };
+        if !func.is_implemented() {
+            continue;
+        }
+
+        let Some(function_range) = span_to_range(source_map, item.span) else { continue };
+        let body_range =
+            span_to_range(source_map, func.body_span).unwrap_or_else(|| function_range.clone());
+        let function_name = function_name(func);
+        let parameters_src =
+            source_map.span_to_snippet(func.header.parameters.span).unwrap_or_default();
+        let returns_src = func
+            .header
+            .returns
+            .as_ref()
+            .and_then(|returns| source_map.span_to_snippet(returns.span).ok());
+
+        let mut locals = Vec::new();
+        if let Some(body) = &func.body {
+            collect_block_locals(source_map, body, body_range.clone(), &mut locals);
+        }
+
+        scopes.push(DebugSourceScope {
+            contract_name: contract.name.to_string(),
+            function_name,
+            range: function_range.clone(),
+            body_range: body_range.clone(),
+            parameters_src,
+            returns_src,
+            parameters: variables_from_list(
+                source_map,
+                &func.header.parameters,
+                function_range.clone(),
+            ),
+            returns: func
+                .header
+                .returns
+                .as_ref()
+                .map(|returns| variables_from_list(source_map, returns, function_range.clone()))
+                .unwrap_or_default(),
+            locals,
+        });
+    }
+
+    // Keep inherited/inline source-map lookups deterministic when multiple ranges contain a PC.
+    scopes.sort_by_key(|scope| {
+        (
+            scope.range.start,
+            scope.range.end.saturating_sub(scope.range.start),
+            scope.contract_name.clone(),
+            scope.function_name.clone(),
+        )
+    });
+
+    // Do not let a malformed nested item extend past the contract it was collected from.
+    scopes.retain(|scope| {
+        scope.range.start >= contract_range.start && scope.range.end <= contract_range.end
+    });
+    out.extend(scopes);
+}
+
+fn function_name(func: &ast::ItemFunction<'_>) -> String {
+    match func.kind {
+        ast::FunctionKind::Constructor => "constructor".to_string(),
+        ast::FunctionKind::Fallback => "fallback".to_string(),
+        ast::FunctionKind::Receive => "receive".to_string(),
+        ast::FunctionKind::Modifier => {
+            func.header.name.as_ref().map(|n| n.as_str()).unwrap_or("modifier").to_string()
+        }
+        ast::FunctionKind::Function => {
+            func.header.name.as_ref().map(|n| n.as_str()).unwrap_or("function").to_string()
+        }
+    }
+}
+
+fn variables_from_list(
+    source_map: &solar::interface::source_map::SourceMap,
+    vars: &[ast::VariableDefinition<'_>],
+    scope: Range<usize>,
+) -> Vec<DebugVariable> {
+    vars.iter().filter_map(|var| variable_from_definition(source_map, var, scope.clone())).collect()
+}
+
+fn collect_block_locals(
+    source_map: &solar::interface::source_map::SourceMap,
+    block: &ast::Block<'_>,
+    fallback_scope: Range<usize>,
+    out: &mut Vec<DebugVariable>,
+) {
+    let scope = span_to_range(source_map, block.span).unwrap_or(fallback_scope);
+    for stmt in block.stmts.iter() {
+        collect_stmt_locals(source_map, stmt, scope.clone(), out);
+    }
+}
+
+fn collect_stmt_locals(
+    source_map: &solar::interface::source_map::SourceMap,
+    stmt: &ast::Stmt<'_>,
+    scope: Range<usize>,
+    out: &mut Vec<DebugVariable>,
+) {
+    match &stmt.kind {
+        ast::StmtKind::DeclSingle(var) => {
+            if let Some(var) = variable_from_definition(source_map, var, scope) {
+                out.push(var);
+            }
+        }
+        ast::StmtKind::DeclMulti(vars, _) => {
+            for var in vars.iter() {
+                let SpannedOption::Some(var) = var else { continue };
+                if let Some(var) = variable_from_definition(source_map, var, scope.clone()) {
+                    out.push(var);
+                }
+            }
+        }
+        ast::StmtKind::Block(block) | ast::StmtKind::UncheckedBlock(block) => {
+            collect_block_locals(source_map, block, scope, out);
+        }
+        ast::StmtKind::If(_, then_stmt, else_stmt) => {
+            let then_scope =
+                span_to_range(source_map, then_stmt.span).unwrap_or_else(|| scope.clone());
+            collect_stmt_locals(source_map, then_stmt, then_scope, out);
+            if let Some(else_stmt) = else_stmt {
+                let else_scope =
+                    span_to_range(source_map, else_stmt.span).unwrap_or_else(|| scope.clone());
+                collect_stmt_locals(source_map, else_stmt, else_scope, out);
+            }
+        }
+        ast::StmtKind::For { init, body, .. } => {
+            let for_scope = span_to_range(source_map, stmt.span).unwrap_or_else(|| scope.clone());
+            if let Some(init) = init {
+                collect_stmt_locals(source_map, init, for_scope.clone(), out);
+            }
+            collect_stmt_locals(source_map, body, for_scope, out);
+        }
+        ast::StmtKind::While(_, body) | ast::StmtKind::DoWhile(body, _) => {
+            let stmt_scope = span_to_range(source_map, stmt.span).unwrap_or(scope);
+            collect_stmt_locals(source_map, body, stmt_scope, out);
+        }
+        ast::StmtKind::Try(try_stmt) => {
+            for clause in try_stmt.clauses.iter() {
+                let clause_scope =
+                    span_to_range(source_map, clause.span).unwrap_or_else(|| scope.clone());
+                for arg in clause.args.iter() {
+                    if let Some(arg) =
+                        variable_from_definition(source_map, arg, clause_scope.clone())
+                    {
+                        out.push(arg);
+                    }
+                }
+                collect_block_locals(source_map, &clause.block, clause_scope, out);
+            }
+        }
+        ast::StmtKind::Assembly(_)
+        | ast::StmtKind::Break
+        | ast::StmtKind::Continue
+        | ast::StmtKind::Emit(..)
+        | ast::StmtKind::Expr(_)
+        | ast::StmtKind::Return(_)
+        | ast::StmtKind::Revert(..)
+        | ast::StmtKind::Placeholder => {}
+    }
+}
+
+fn variable_from_definition(
+    source_map: &solar::interface::source_map::SourceMap,
+    var: &ast::VariableDefinition<'_>,
+    scope: Range<usize>,
+) -> Option<DebugVariable> {
+    Some(DebugVariable {
+        name: var.name.map(|name| name.to_string()),
+        declaration: span_to_range(source_map, var.span)?,
+        scope,
+    })
+}
+
+fn span_to_range(
+    source_map: &solar::interface::source_map::SourceMap,
+    span: solar::interface::Span,
+) -> Option<Range<usize>> {
+    source_map.span_to_range(span).ok()
 }
 
 #[derive(Clone, Debug)]
@@ -305,5 +544,49 @@ impl ContractSources {
                         .map(|source| (source_element.clone(), source.as_ref()))
                 })
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn variable(name: &str, declaration: Range<usize>, scope: Range<usize>) -> DebugVariable {
+        DebugVariable { name: Some(name.to_string()), declaration, scope }
+    }
+
+    fn scope(locals: Vec<DebugVariable>) -> DebugSourceScope {
+        DebugSourceScope {
+            contract_name: "DebugMe".to_string(),
+            function_name: "foo".to_string(),
+            range: 0..100,
+            body_range: 10..90,
+            parameters_src: String::new(),
+            returns_src: None,
+            parameters: Vec::new(),
+            returns: Vec::new(),
+            locals,
+        }
+    }
+
+    #[test]
+    fn visible_locals_require_declaration_and_scope() {
+        let scope = scope(vec![
+            variable("before", 10..15, 10..90),
+            variable("after", 70..75, 10..90),
+            variable("nested", 20..25, 20..40),
+        ]);
+
+        let names = |offset| {
+            scope
+                .visible_locals(offset)
+                .map(|variable| variable.name.as_deref().unwrap())
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(names(14), Vec::<&str>::new());
+        assert_eq!(names(30), ["before", "nested"]);
+        assert_eq!(names(50), ["before"]);
+        assert_eq!(names(80), ["before", "after"]);
     }
 }


### PR DESCRIPTION

## Summary
- add Solidity function-scope metadata for debugger source lookup, including parameters, returns, and visible local declarations
- preserve decoded call data on debugger nodes and run the existing internal-call identifier before flattening traces
- add a Variables pane that decodes external/internal function parameters and completed internal return values when reliable data is available
- list visible locals by name without guessing runtime values when source maps do not expose stable stack/memory slots

Refs #410

## Tests
- cargo +1.95.0 test -p foundry-debugger -p foundry-evm-traces --lib
- cargo +1.95.0 test -p forge --test cli test_cmd::test_debug_with_dump -- --exact
