### PR TITLE
fix(forge): keep script `creationCode` native

### DIFF
--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -6,7 +6,10 @@ use foundry_compilers::Updates;
 use itertools::Itertools;
 use solar::sema::{
     Gcx, Hir,
-    hir::{CallArgs, CallOptions, ContractId, Expr, ExprKind, Stmt, StmtKind, TypeKind, Visit},
+    hir::{
+        CallArgs, CallOptions, ContractId, Expr, ExprKind, Function, StateMutability, Stmt,
+        StmtKind, TypeKind, Visit,
+    },
     interface::{SourceMap, data_structures::Never, source_map::FileName},
 };
 use std::{
@@ -153,10 +156,12 @@ struct BytecodeDependencyCollector<'gcx, 'src> {
     /// Project source dir, used to determine if referenced contract is a source contract.
     src_dir: &'src Path,
     /// Whether the contract being analyzed lives in a script file.
-    /// `new Contract(...)` in scripts must not be rewritten: native script CREATE/CREATE2 frames
-    /// are handled by the script execution inspector, but `vm.deployCode` runs at a deeper call
-    /// depth and bypasses that machinery.
+    /// Script bytecode references must not be rewritten: native script CREATE/CREATE2 frames
+    /// are handled by the script execution inspector, and `type(Contract).creationCode` must keep
+    /// its native mutability semantics.
     is_script: bool,
+    /// Whether the visitor is currently inside a pure function.
+    in_pure_function: bool,
     /// Dependencies collected for current contract.
     dependencies: Vec<BytecodeDependency>,
     /// Unique HIR ids of contracts referenced from current contract.
@@ -170,6 +175,7 @@ impl<'gcx, 'src> BytecodeDependencyCollector<'gcx, 'src> {
             src,
             src_dir,
             is_script,
+            in_pure_function: false,
             dependencies: vec![],
             referenced_contracts: HashSet::default(),
         }
@@ -179,9 +185,25 @@ impl<'gcx, 'src> BytecodeDependencyCollector<'gcx, 'src> {
     /// Discards any reference that is not in project src directory (e.g. external
     /// libraries or mock contracts that extend source contracts).
     fn collect_dependency(&mut self, dependency: BytecodeDependency) {
-        // New-expressions in scripts must not be rewritten. See field doc on `is_script`.
-        if self.is_script && matches!(&dependency.kind, BytecodeDependencyKind::New { .. }) {
-            trace!("skip new-expression in script");
+        // Script bytecode references must not be rewritten. See field doc on `is_script`.
+        if self.is_script {
+            match &dependency.kind {
+                BytecodeDependencyKind::CreationCode => {
+                    trace!("skip creationCode in script");
+                    return;
+                }
+                BytecodeDependencyKind::New { .. } => {
+                    trace!("skip new-expression in script");
+                    return;
+                }
+            }
+        }
+
+        // `type(Contract).creationCode` has native `pure` semantics. Rewriting it to a `view`
+        // cheatcode call would make valid pure functions fail to compile.
+        if self.in_pure_function && matches!(&dependency.kind, BytecodeDependencyKind::CreationCode)
+        {
+            trace!("skip creationCode in pure function");
             return;
         }
 
@@ -207,6 +229,14 @@ impl<'gcx> Visit<'gcx> for BytecodeDependencyCollector<'gcx, '_> {
 
     fn hir(&self) -> &'gcx Hir<'gcx> {
         &self.gcx.hir
+    }
+
+    fn visit_function(&mut self, func: &'gcx Function<'gcx>) -> ControlFlow<Self::BreakValue> {
+        let previous = self.in_pure_function;
+        self.in_pure_function = func.state_mutability == StateMutability::Pure;
+        self.walk_function(func)?;
+        self.in_pure_function = previous;
+        ControlFlow::Continue(())
     }
 
     fn visit_expr(&mut self, expr: &'gcx Expr<'gcx>) -> ControlFlow<Self::BreakValue> {

--- a/crates/common/src/preprocessor/deps.rs
+++ b/crates/common/src/preprocessor/deps.rs
@@ -7,8 +7,8 @@ use itertools::Itertools;
 use solar::sema::{
     Gcx, Hir,
     hir::{
-        CallArgs, CallOptions, ContractId, Expr, ExprKind, Function, StateMutability, Stmt,
-        StmtKind, TypeKind, Visit,
+        CallArgs, CallOptions, ContractId, Expr, ExprKind, Function, FunctionKind, StateMutability,
+        Stmt, StmtKind, TypeKind, Visit,
     },
     interface::{SourceMap, data_structures::Never, source_map::FileName},
 };
@@ -160,8 +160,8 @@ struct BytecodeDependencyCollector<'gcx, 'src> {
     /// are handled by the script execution inspector, and `type(Contract).creationCode` must keep
     /// its native mutability semantics.
     is_script: bool,
-    /// Whether the visitor is currently inside a pure function.
-    in_pure_function: bool,
+    /// Whether `type(Contract).creationCode` should keep native Solidity semantics.
+    preserve_native_creation_code: bool,
     /// Dependencies collected for current contract.
     dependencies: Vec<BytecodeDependency>,
     /// Unique HIR ids of contracts referenced from current contract.
@@ -175,7 +175,7 @@ impl<'gcx, 'src> BytecodeDependencyCollector<'gcx, 'src> {
             src,
             src_dir,
             is_script,
-            in_pure_function: false,
+            preserve_native_creation_code: false,
             dependencies: vec![],
             referenced_contracts: HashSet::default(),
         }
@@ -201,9 +201,10 @@ impl<'gcx, 'src> BytecodeDependencyCollector<'gcx, 'src> {
 
         // `type(Contract).creationCode` has native `pure` semantics. Rewriting it to a `view`
         // cheatcode call would make valid pure functions fail to compile.
-        if self.in_pure_function && matches!(&dependency.kind, BytecodeDependencyKind::CreationCode)
+        if self.preserve_native_creation_code
+            && matches!(&dependency.kind, BytecodeDependencyKind::CreationCode)
         {
-            trace!("skip creationCode in pure function");
+            trace!("skip creationCode in native creationCode context");
             return;
         }
 
@@ -232,10 +233,12 @@ impl<'gcx> Visit<'gcx> for BytecodeDependencyCollector<'gcx, '_> {
     }
 
     fn visit_function(&mut self, func: &'gcx Function<'gcx>) -> ControlFlow<Self::BreakValue> {
-        let previous = self.in_pure_function;
-        self.in_pure_function = func.state_mutability == StateMutability::Pure;
+        let previous = self.preserve_native_creation_code;
+        self.preserve_native_creation_code = previous
+            || func.state_mutability == StateMutability::Pure
+            || matches!(func.kind, FunctionKind::Modifier);
         self.walk_function(func)?;
-        self.in_pure_function = previous;
+        self.preserve_native_creation_code = previous;
         ControlFlow::Continue(())
     }
 

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3457,6 +3457,42 @@ contract SaltedSrcScript is Script {
     assert_eq!(tx["arguments"][0], "SaltedSrc");
 });
 
+// Regression: `type(Foo).creationCode` in scripts must not be rewritten to `vm.getCode(...)`.
+// The injected cheatcode is `view`, so using it in a `pure` script helper breaks compilation.
+forgetest_init!(can_build_script_creation_code_in_pure_function, |prj, cmd| {
+    prj.update_config(|c| c.dynamic_test_linking = true);
+    prj.add_source(
+        "Token.sol",
+        r#"
+contract Token {
+    string public name;
+    constructor(string memory _name) { name = _name; }
+}
+        "#,
+    );
+    prj.add_script(
+        "CreationCode.s.sol",
+        r#"
+import "forge-std/Script.sol";
+import {Token} from "../src/Token.sol";
+
+contract CreationCodeScript is Script {
+    function run() public {
+        vm.broadcast();
+        (bool ok,) = address(0).call(_getCreationCode());
+        ok;
+    }
+
+    function _getCreationCode() internal pure returns (bytes memory) {
+        return type(Token).creationCode;
+    }
+}
+        "#,
+    );
+
+    cmd.args(["build"]).assert_success();
+});
+
 forgetest_async!(flaky_can_deploy_with_broadcast_in_setup, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
     prj.add_script(

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -1818,3 +1818,37 @@ contract TargetTest is Test {
 
     cmd.args(["build"]).assert_success();
 });
+
+// Test that `type(Contract).creationCode` keeps native pure semantics when it is used in a
+// modifier body that is applied to a pure function.
+forgetest_init!(preprocess_creation_code_in_modifier_used_by_pure_function, |prj, cmd| {
+    prj.update_config(|config| {
+        config.dynamic_test_linking = true;
+    });
+
+    prj.add_source(
+        "Target.sol",
+        r#"
+contract Target {}
+        "#,
+    );
+
+    prj.add_test(
+        "ModifierCreationCode.t.sol",
+        r#"
+import {Target} from "../src/Target.sol";
+
+contract ModifierCreationCodeTest {
+    modifier usesCreationCode() {
+        bytes memory code = type(Target).creationCode;
+        code;
+        _;
+    }
+
+    function testModifierCreationCode() public pure usesCreationCode {}
+}
+        "#,
+    );
+
+    cmd.args(["build"]).assert_success();
+});

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -1772,3 +1772,49 @@ contract TargetTest is Test {
 
     cmd.args(["build"]).assert_success();
 });
+
+// Test that `type(Contract).creationCode` keeps native pure semantics when dynamic linking is
+// enabled.
+forgetest_init!(preprocess_creation_code_in_pure_function, |prj, cmd| {
+    prj.update_config(|config| {
+        config.dynamic_test_linking = true;
+    });
+
+    prj.add_source(
+        "Target.sol",
+        r#"
+contract Target {
+    uint256 public immutable value;
+    constructor(uint256 _value) { value = _value; }
+}
+        "#,
+    );
+
+    prj.add_test(
+        "Target.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {Target} from "../src/Target.sol";
+
+contract TargetTest is Test {
+    function computeAddress(address factory, uint256 salt, uint256 value) internal pure returns (address) {
+        bytes32 hash = keccak256(
+            abi.encodePacked(
+                bytes1(0xff),
+                factory,
+                salt,
+                keccak256(abi.encodePacked(type(Target).creationCode, abi.encode(value)))
+            )
+        );
+        return address(uint160(uint256(hash)));
+    }
+
+    function testComputeAddress() public pure {
+        computeAddress(address(0xBEEF), 1, 100);
+    }
+}
+        "#,
+    );
+
+    cmd.args(["build"]).assert_success();
+});


### PR DESCRIPTION
## Summary

- skip dynamic test linking rewrites for `type(Contract).creationCode` when rewriting would change native Solidity semantics
- keep script `creationCode` references native, matching the existing script exception for native CREATE/CREATE2 handling
- keep `creationCode` native inside pure functions, because the generated `getCode` helper is necessarily `view`
- preserve existing `creationCode` preprocessing behavior for non-pure test contracts
- add regressions for script `creationCode` in a pure helper and test-contract `creationCode` in a pure helper

## Root cause

The dynamic test linking preprocessor collected `type(Contract).creationCode` dependencies and rewrote them to `VmContractHelper(...).getCode(...)`. `getCode` is a `view` cheatcode, so Solc rejects the rewritten expression when the original native `creationCode` expression appears inside a `pure` function.

Scripts also need native bytecode expressions preserved consistently with the existing script deploy handling: native script CREATE/CREATE2 frames are handled by the script execution inspector, while cheatcode-backed rewrites run through a different path.

Fixes #15145.
