### PR TITLE
fix(foundryup): resolve latest/stable via release redirect to avoid API limit

### DIFF
--- a/.github/scripts/shellcheck.sh
+++ b/.github/scripts/shellcheck.sh
@@ -13,7 +13,10 @@ for dir in "${IGNORE_DIRS[@]}"; do
   ignore_args+=(-not -path "$dir")
 done
 
-find . -name "*.sh" "${ignore_args[@]}" -exec shellcheck -f gcc {} + | \
+# Also lint the extensionless foundryup scripts, which `*.sh` would miss.
+find . \
+  \( -name "*.sh" -o -path "./foundryup/foundryup" -o -path "./foundryup/install" \) \
+  "${ignore_args[@]}" -exec shellcheck -f gcc {} + | \
   while IFS=: read -r file line col severity msg; do
     level="warning"
     [[ "$severity" == *error* ]] && level="error"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
       - name: Shellcheck
         shell: bash
         run: ./.github/scripts/shellcheck.sh
+      - name: foundryup tests
+        shell: bash
+        run: ./foundryup/test.sh
 
   clippy:
     runs-on: depot-ubuntu-latest

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# `use` and `err` always exit, so code following them is reachable but flagged.
+# shellcheck disable=SC2317
+
 set -eo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
@@ -449,7 +453,7 @@ update() {
 
 list() {
   if [ -d "$FOUNDRY_VERSIONS_DIR" ]; then
-    for VERSION in $FOUNDRY_VERSIONS_DIR/*; do
+    for VERSION in "$FOUNDRY_VERSIONS_DIR"/*; do
       say "${VERSION##*/}"
       for bin in "${BINS[@]}"; do
         bin_path="$VERSION/$bin"
@@ -810,4 +814,7 @@ Contribute : https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md
 }
 
 
-main "$@"
+# Skip execution when sourced by tests.
+if [ "${FOUNDRYUP_TEST:-0}" != "1" ]; then
+  main "$@"
+fi

--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -3,7 +3,7 @@ set -eo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-FOUNDRYUP_INSTALLER_VERSION="1.8.5"
+FOUNDRYUP_INSTALLER_VERSION="1.8.6"
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
@@ -672,11 +672,15 @@ ensure() {
 resolve_version_and_tag() {
   FOUNDRYUP_REPO=${FOUNDRYUP_REPO:-foundry-rs/foundry}
   if [[ "$FOUNDRYUP_VERSION" == "latest" || "$FOUNDRYUP_VERSION" == "stable" ]]; then
-    # Resolve to the latest release (non-prerelease) via the GitHub API.
+    # Resolve to the latest release (non-prerelease) via the `releases/latest`
+    # web redirect, falling back to the GitHub API if it cannot be resolved.
     say "fetching latest release tag from ${FOUNDRYUP_REPO}..."
-    FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases/latest" | awk '
-      /"tag_name"[[:space:]]*:/ && !found { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); print; found=1 }
-    ') || err "failed to fetch release tags from GitHub API"
+    FOUNDRYUP_TAG=$(resolve_latest_tag_via_redirect "$FOUNDRYUP_REPO")
+    if [ -z "$FOUNDRYUP_TAG" ]; then
+      FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases/latest" | awk '
+        /"tag_name"[[:space:]]*:/ && !found { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); print; found=1 }
+      ') || err "failed to fetch release tags from GitHub API"
+    fi
     if [ -z "$FOUNDRYUP_TAG" ]; then
       err "could not find a latest release tag for ${FOUNDRYUP_REPO}"
     fi
@@ -714,6 +718,36 @@ resolve_version_and_tag() {
   else
     FOUNDRYUP_TAG="${FOUNDRYUP_VERSION}"
   fi
+}
+
+# Resolves the latest release tag for repo $1 by following the `releases/latest`
+# redirect and reading the tag from the final URL. Prints the tag (e.g.
+# `v1.7.1`) to stdout, or nothing if it could not be resolved.
+resolve_latest_tag_via_redirect() {
+  local _repo="$1"
+  local _url="https://github.com/${_repo}/releases/latest"
+  local _final=""
+  if check_cmd curl; then
+    _final=$(curl -fsSIL \
+      --retry "$FOUNDRYUP_MAX_RETRIES" \
+      --retry-delay "$FOUNDRYUP_RETRY_DELAY" \
+      --retry-max-time "$FOUNDRYUP_RETRY_MAX_TIME" \
+      --retry-all-errors \
+      -o /dev/null -w '%{url_effective}' "$_url" 2>/dev/null) || return 0
+  else
+    _final=$(wget -q -O /dev/null --max-redirect=10 --server-response "$_url" 2>&1 \
+      | awk 'tolower($1) == "location:" { loc = $2 } END { print loc }' \
+      | tr -d '\r') || return 0
+  fi
+  # Extract the tag from the `.../releases/tag/<tag>` URL and validate it;
+  # anything unexpected returns nothing so the caller falls back to the API.
+  local _tag="${_final##*/releases/tag/}"
+  [ "$_tag" != "$_final" ] || return 0
+  case "$_tag" in
+    *[!A-Za-z0-9._-]*) return 0 ;;
+    v[0-9]*) printf '%s\n' "$_tag" ;;
+    *) return 0 ;;
+  esac
 }
 
 # Silently fetches $1 to stdout.

--- a/foundryup/test.sh
+++ b/foundryup/test.sh
@@ -5,7 +5,7 @@
 # so no network calls are made.
 
 # Mocks/globals are used indirectly by the sourced foundryup functions.
-# shellcheck disable=SC2329,SC2034
+# shellcheck disable=SC2329,SC2034,SC2317
 
 set -uo pipefail
 

--- a/foundryup/test.sh
+++ b/foundryup/test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Tests for foundryup's `latest`/`stable` tag resolution: the `releases/latest`
+# redirect resolver and its fallback to the GitHub API. `curl`/`fetch` are mocked
+# so no network calls are made.
+
+# Mocks/globals are used indirectly by the sourced foundryup functions.
+# shellcheck disable=SC2329,SC2034
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source foundryup for its function definitions without running an install.
+export FOUNDRYUP_TEST=1
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/foundryup"
+
+failures=0
+
+check_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf 'ok   - %s\n' "$desc"
+  else
+    printf 'FAIL - %s\n      expected: %q\n      actual:   %q\n' "$desc" "$expected" "$actual"
+    failures=$((failures + 1))
+  fi
+}
+
+# Silence progress/log output.
+say() { :; }
+warn() { :; }
+
+# --- resolve_latest_tag_via_redirect --------------------------------------
+
+curl() { printf 'https://github.com/foundry-rs/foundry/releases/tag/v1.7.1'; }
+check_eq "redirect success returns tag" \
+  "v1.7.1" "$(resolve_latest_tag_via_redirect foundry-rs/foundry)"
+
+curl() { printf 'https://github.com/foundry-rs/foundry/releases/latest'; }
+check_eq "redirect without tag returns empty" \
+  "" "$(resolve_latest_tag_via_redirect foundry-rs/foundry)"
+
+curl() { return 1; }
+check_eq "redirect curl failure returns empty" \
+  "" "$(resolve_latest_tag_via_redirect foundry-rs/foundry)"
+
+curl() { printf 'https://github.com/foundry-rs/foundry/releases/tag/not-a-version'; }
+check_eq "redirect with non-version tag returns empty" \
+  "" "$(resolve_latest_tag_via_redirect foundry-rs/foundry)"
+
+# --- resolve_version_and_tag (redirect + API fallback) --------------------
+
+API_JSON='{"tag_name": "v9.9.9", "name": "v9.9.9"}'
+
+# `fetch` runs in a command-substitution subshell, so track calls via a file.
+api_marker="$(mktemp)"
+trap 'rm -f "$api_marker"' EXIT
+fetch() { echo called >> "$api_marker"; printf '%s' "$API_JSON"; }
+
+: > "$api_marker"
+curl() { printf 'https://github.com/foundry-rs/foundry/releases/tag/v1.7.1'; }
+FOUNDRYUP_VERSION="stable"
+resolve_version_and_tag
+check_eq "stable resolves via redirect" "v1.7.1" "$FOUNDRYUP_TAG"
+check_eq "stable does not call API when redirect works" "0" "$(wc -l < "$api_marker" | tr -d ' ')"
+
+: > "$api_marker"
+curl() { return 1; }
+FOUNDRYUP_VERSION="latest"
+resolve_version_and_tag
+check_eq "latest falls back to API tag" "v9.9.9" "$FOUNDRYUP_TAG"
+check_eq "latest calls API when redirect fails" "1" "$(wc -l < "$api_marker" | tr -d ' ')"
+
+# --- summary --------------------------------------------------------------
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d test(s) failed\n' "$failures"
+  exit 1
+fi
+printf '\nall tests passed\n'


### PR DESCRIPTION
Resolving `stable`/`latest` hit `api.github.com`, which is rate limited to 60 req/hr per IP. Shared CI IPs exhaust this and fail with `curl: (56) ... 403`.

Resolve via the `github.com/<repo>/releases/latest` redirect instead, which isn't subject to that limit (no `GITHUB_TOKEN` needed). Falls back to the API if the redirect can't be resolved. `nightly` and explicit tags unchanged.

Closes #14836 
Closes OSS-279