### PR TITLE
fix: update tempo dependency pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7516,7 +7516,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.10.4"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=0d57f96ff670b290801b2ead9e0f1d637e0f2b3e#0d57f96ff670b290801b2ead9e0f1d637e0f2b3e"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=9de5344a961c13dd4b20186e665bdcf61ed0e2df#9de5344a961c13dd4b20186e665bdcf61ed0e2df"
 dependencies = [
  "alloy",
  "alloy-sol-type-parser",
@@ -11722,8 +11722,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-alloy"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11755,8 +11755,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-chainspec"
-version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11778,8 +11778,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-contracts"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11789,8 +11789,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11801,8 +11801,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11829,8 +11829,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11850,8 +11850,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11861,8 +11861,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-primitives"
-version = "1.8.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
+version = "1.8.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11892,8 +11892,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5#d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5"
+version = "1.8.2"
+source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -502,23 +502,23 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "0d57f96ff670b290801b2ead9e0f1d637e0f2b3e", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "9de5344a961c13dd4b20186e665bdcf61ed0e2df", default-features = false, features = [
     "tempo",
     "client",
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -592,9 +592,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8027e5ccdfe55e562a1111495d2c9acb6e27a930" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "d53f860fb29c64027bf16a3ddd7b60a65cb9bfe5" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -60,7 +60,10 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_chainspec::{
+    hardfork::TempoHardfork,
+    spec::{TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE},
+};
 use tokio::sync::RwLock as TokioRwLock;
 use yansi::Paint;
 
@@ -553,7 +556,7 @@ impl NodeConfig {
     /// In Tempo mode, uses the hardfork-specific base fee (10 gwei pre-T1, 20 gwei T1+).
     pub fn get_base_fee(&self) -> u64 {
         let default = if self.networks.is_tempo() {
-            TempoHardfork::from(self.get_hardfork()).base_fee()
+            tempo_default_base_fee(TempoHardfork::from(self.get_hardfork()))
         } else {
             INITIAL_BASE_FEE
         };
@@ -567,7 +570,7 @@ impl NodeConfig {
     /// In Tempo mode, defaults to the hardfork-specific base fee.
     pub fn get_gas_price(&self) -> u128 {
         let default = if self.networks.is_tempo() {
-            TempoHardfork::from(self.get_hardfork()).base_fee() as u128
+            tempo_default_base_fee(TempoHardfork::from(self.get_hardfork())) as u128
         } else {
             INITIAL_GAS_PRICE
         };
@@ -1569,6 +1572,10 @@ latest block number: {latest_block}"
 
         self.gas_limit.unwrap_or(DEFAULT_GAS_LIMIT)
     }
+}
+
+const fn tempo_default_base_fee(hardfork: TempoHardfork) -> u64 {
+    if hardfork.is_t1() { TEMPO_T1_BASE_FEE } else { TEMPO_T0_BASE_FEE }
 }
 
 /// If the fork choice is a block number, simply return it with an empty list of transactions.


### PR DESCRIPTION
Updates Foundry's Tempo dependency pins to the current Tempo release state from tempoxyz/tempo#5497 and points `mpp` at the merged dependency fix from tempoxyz/mpp-rs#295.

This keeps Foundry, `mpp`, and the `[patch.crates-io]` Tempo crates resolving from one compatible Tempo source. The CI failure came from `mpp` retaining exact `=1.8.0` Tempo crate requirements while the Tempo workspace moved to `1.8.1`, which allowed incompatible `tempo_primitives` types into the same build graph.

Impact is limited to the Tempo dependency graph used by the Forge build without default features.