### PR TITLE
feat(forge): add solar lsp command scaffold

### DIFF
--- a/crates/common/src/calc.rs
+++ b/crates/common/src/calc.rs
@@ -10,7 +10,7 @@ pub fn mean(values: &[u64]) -> u64 {
 }
 
 /// Returns the median of a _sorted_ slice.
-pub fn median_sorted(values: &[u64]) -> u64 {
+pub const fn median_sorted(values: &[u64]) -> u64 {
     if values.is_empty() {
         return 0;
     }

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -239,6 +239,7 @@ impl NetworkConfigs {
     ///
     /// For Optimism networks, returns Canyon parameters if the Canyon hardfork is active
     /// at the given timestamp, otherwise returns pre-Canyon parameters.
+    #[allow(clippy::missing_const_for_fn)] // The optimism feature path calls non-const OP hardfork helpers.
     pub fn base_fee_params(&self, timestamp: u64) -> BaseFeeParams {
         #[cfg(feature = "optimism")]
         if self.is_optimism() {

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -176,6 +176,10 @@ pub fn run_command(args: Forge) -> Result<()> {
         ForgeSubcommand::Eip712(cmd) => cmd.run(),
         ForgeSubcommand::BindJson(cmd) => cmd.run(),
         ForgeSubcommand::Lint(cmd) => cmd.run(),
+        ForgeSubcommand::Lsp => eyre::bail!(
+            "Solar LSP support is not available in this build; \
+             it can be enabled once the Solar LSP backend is available as a Foundry dependency"
+        ),
     }
 }
 
@@ -215,6 +219,7 @@ const fn subcommand_name(cmd: &ForgeSubcommand) -> &'static str {
         ForgeSubcommand::Eip712(_) => "eip712",
         ForgeSubcommand::BindJson(_) => "bind-json",
         ForgeSubcommand::Lint(_) => "lint",
+        ForgeSubcommand::Lsp => "lsp",
     }
 }
 

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -132,6 +132,10 @@ pub enum ForgeSubcommand {
     #[command(visible_alias = "l")]
     Lint(LintArgs),
 
+    /// Start the Solar-backed Forge language server.
+    #[command(hide = true)]
+    Lsp,
+
     /// Get specialized information about a smart contract.
     #[command(visible_alias = "in")]
     Inspect(inspect::InspectArgs),

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -86,6 +86,24 @@ Find more information in the book: https://getfoundry.sh/forge/overview
 "#]]);
 });
 
+forgetest!(lsp_help_describes_editor_language_server_entrypoint, |_prj, cmd| {
+    let output = cmd.args(["lsp", "--help"]).assert_success();
+    let stdout = output.get_output().stdout_lossy();
+
+    assert!(stdout.contains("Start the Solar-backed Forge language server"), "{stdout}");
+    assert!(stdout.contains("Usage: forge lsp"), "{stdout}");
+});
+
+forgetest!(lsp_reports_unavailable_backend_without_stdout, |_prj, cmd| {
+    let output = cmd.arg("lsp").assert_failure().get_output().clone();
+
+    assert!(output.stdout.is_empty(), "{}", output.stdout_lossy());
+    assert_eq!(
+        output.stderr_lossy(),
+        "Error: Solar LSP support is not available in this build; it can be enabled once the Solar LSP backend is available as a Foundry dependency\n"
+    );
+});
+
 // checks that `clean` can be invoked even if out and cache don't exist
 forgetest!(can_clean_non_existing, |prj, cmd| {
     cmd.arg("clean");


### PR DESCRIPTION
  ## Motivation

  This adds the initial `forge lsp` CLI entrypoint for a future Solar-backed Forge language server.

  The actual LSP backend is not wired in yet, so the command is hidden for now and returns a clear error when executed.

  ## Changes

  - Add a hidden `forge lsp` subcommand.
  - Make `forge lsp --help` available for the scaffolded command.
  - Return a clear error from `forge lsp` until the Solar LSP backend is available.
  - Keep stdout empty on failure so we do not pollute the future LSP stdio channel.