### PR TITLE
fix(anvil): backfill the block hash cache after loading state

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3985,6 +3985,27 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
             .into());
         }
 
+        // Backfill the EVM-level block hash cache from the freshly loaded blocks so that the
+        // BLOCKHASH opcode stays consistent after loading state. Reuses the hashes already
+        // computed by `load_blocks` above. Only collect the last 256 blocks since that's all
+        // BLOCKHASH can access.
+        let block_hashes: Vec<_> = {
+            let storage = self.blockchain.storage.read();
+            let min_block = storage.best_number.saturating_sub(256);
+            storage
+                .hashes
+                .iter()
+                .filter(|(num, _)| **num >= min_block)
+                .map(|(&num, &hash)| (num, hash))
+                .collect()
+        };
+        {
+            let mut db = self.db.write().await;
+            for (block_num, hash) in block_hashes {
+                db.insert_block_hash(U256::from(block_num), hash);
+            }
+        }
+
         if let Some(historical_states) = state.historical_states {
             self.states.write().load_states(historical_states);
         }

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -2,9 +2,12 @@
 
 use crate::abi::Greeter;
 use alloy_network::{ReceiptResponse, TransactionBuilder};
-use alloy_primitives::{Bytes, U256, Uint, address, b256, utils::Unit};
+use alloy_primitives::{B256, Bytes, U256, Uint, address, b256, utils::Unit};
 use alloy_provider::Provider;
-use alloy_rpc_types::{BlockId, TransactionRequest};
+use alloy_rpc_types::{
+    BlockId, TransactionRequest,
+    state::{AccountOverride, EvmOverrides, StateOverride},
+};
 use alloy_serde::WithOtherFields;
 use anvil::{NodeConfig, eth::backend::db::SerializableState, spawn};
 use foundry_test_utils::rpc::next_http_archive_rpc_url;
@@ -806,4 +809,46 @@ async fn test_backward_compatibility_state_dump_deserialization_v1_2() {
     // Verify contract code is preserved.
     let contract_code = provider.get_code_at(contract_addr).await.unwrap();
     assert!(!contract_code.is_empty());
+}
+
+// Ensures the BLOCKHASH opcode sees the real hashes of loaded blocks after
+// `anvil_loadState`. The EVM-level block hash cache used to stay empty after loading state,
+// so BLOCKHASH silently returned EmptyDB's placeholder hash for imported blocks.
+#[tokio::test(flavor = "multi_thread")]
+async fn blockhash_opcode_consistent_after_load_state() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state_file = tmp.path().join("state.json");
+
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    api.mine_one().await;
+    api.mine_one().await;
+
+    let block1_hash = api
+        .block_by_number(alloy_eips::BlockNumberOrTag::Number(1))
+        .await
+        .unwrap()
+        .unwrap()
+        .header
+        .hash;
+
+    let state = api.serialized_state(false).await.unwrap();
+    foundry_common::fs::write_json_file(&state_file, &state).unwrap();
+
+    let (api, _handle) = spawn(NodeConfig::test().with_init_state_path(state_file)).await;
+
+    // Runtime code returning BLOCKHASH(1):
+    // PUSH1 1, BLOCKHASH, PUSH1 0, MSTORE, PUSH1 32, PUSH1 0, RETURN
+    let code = Bytes::from_str("0x60014060005260206000f3").unwrap();
+    let target = address!("00000000000000000000000000000000000b10c4");
+
+    let mut overrides = StateOverride::default();
+    overrides.insert(target, AccountOverride { code: Some(code), ..Default::default() });
+
+    let tx = TransactionRequest::default().with_to(target);
+    let res = api
+        .call(WithOtherFields::new(tx), None, EvmOverrides::new(Some(overrides), None))
+        .await
+        .unwrap();
+
+    assert_eq!(B256::from_slice(res.as_ref()), block1_hash);
 }


### PR DESCRIPTION
## Motivation

After `anvil_loadState`, the BLOCKHASH opcode returns wrong values for imported blocks. `Db::load_state` only restores accounts and storage, and `load_blocks` only fills the RPC-level `BlockchainStorage`, which the EVM never reads. The EVM-level block hash cache stays empty, so lookups fall through to `EmptyDB`, which fabricates `keccak256(ascii(block_number))`:

```
assertion `left == right` failed
  left: 0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6   <- keccak256("1")
 right: 0x90cd57122139afc3cf5b0ac2676f129f5eec838e9008e427ee116f7cd51c7f25   <- actual hash of block 1
```

Supersedes #14767, thanks @ml0mbardi for the diagnosis. That PR went stale after review; per the review note there, this version avoids rehashing the headers: it copies the hashes `load_blocks` already computed, the same way the reorg path restores them, capped at the last 256 blocks since that's all BLOCKHASH can access.

## Solution

In `Backend::load_state`, after the database state is loaded, copy the `(number, hash)` pairs from `blockchain.storage.hashes` into the database block hash cache via `insert_block_hash`. This mirrors the existing restore in the reorg path.

Note: this also replaces the fresh instance's own genesis hash with the imported one, consistent with what `load_blocks` already does for the RPC side (see `finalized_block_hash_consistent_after_load_state`).

## Test

`blockhash_opcode_consistent_after_load_state`: dump a chain with two mined blocks, load it into a fresh instance, `eth_call` a contract returning `BLOCKHASH(1)` via state override, and assert it equals the block 1 hash reported by `eth_getBlockByNumber` on the same instance. Fails on master with the placeholder hash above.
