### PR TITLE
chore: make clippy happy

### DIFF
--- a/crates/common/src/calc.rs
+++ b/crates/common/src/calc.rs
@@ -10,7 +10,7 @@ pub fn mean(values: &[u64]) -> u64 {
 }
 
 /// Returns the median of a _sorted_ slice.
-pub fn median_sorted(values: &[u64]) -> u64 {
+pub const fn median_sorted(values: &[u64]) -> u64 {
     if values.is_empty() {
         return 0;
     }

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -88,7 +88,7 @@ impl CallStack {
 
     /// Returns true if the direct parent chain has its own indentation.
     /// Used to determine if commasep should skip its own indentation (to avoid double indent).
-    pub(crate) fn has_indented_parent_chain(&self) -> bool {
+    pub(crate) const fn has_indented_parent_chain(&self) -> bool {
         matches!(
             self.stack.as_slice(),
             [.., parent, last] if last.is_nested() && parent.is_chained() && parent.has_indent


### PR DESCRIPTION
The clippy CI job (`cargo clippy --workspace --all-targets --all-features --locked` with `-Dwarnings`, nightly) fails on the current nightly: clippy now flags two functions as `missing_const_for_fn`.

- `foundry_common::calc::median_sorted` (`crates/common/src/calc.rs`)
- `State::has_indented_parent_chain` (`crates/fmt/src/state/mod.rs`)

Make both `const`, as clippy suggests. No behavior change.
