### PR TITLE
fix(script): honour --code-size-limit CLI flag

### DIFF
--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -432,8 +432,10 @@ impl ScriptArgs {
 
             let size_limits = pre_simulation
                 .script_config
-                .config
+                .evm_opts
+                .env
                 .code_size_limit
+                .or(pre_simulation.script_config.config.code_size_limit)
                 .map(ContractSizeLimits::with_runtime_limit)
                 .unwrap_or_default();
             pre_simulation.args.check_contract_sizes(
@@ -1259,6 +1261,22 @@ mod tests {
             "50000",
         ]);
         assert_eq!(args.evm.env.code_size_limit, Some(50000));
+    }
+
+    /// `--code-size-limit` on the CLI should be used by `check_contract_sizes`, not silently
+    /// ignored in favour of the foundry.toml value (which defaults to None → EIP-170's 24576).
+    #[test]
+    fn cli_code_size_limit_is_honoured_by_check() {
+        let args = ScriptArgs::parse_from([
+            "foundry-cli",
+            "script",
+            "script/Test.s.sol:TestScript",
+            "--code-size-limit",
+            "2147483647",
+        ]);
+        // The CLI flag must land in evm_opts so that the size_limits computation in run() picks
+        // it up via `.evm_opts.env.code_size_limit.or(config.code_size_limit)`.
+        assert_eq!(args.evm.env.code_size_limit, Some(2147483647));
     }
 
     #[test]


### PR DESCRIPTION
`check_contract_sizes()` ignored the `--code-size-limit CLI` flag, falling back to EIP-170's 24576-byte default. This PR fixes the issue it by reading `evm_opts.env.code_size_limit` before `config.code_size_limit`.

## Motivation

`check_contract_sizes()` built its `size_limits` solely from `config.code_size_limit` (foundry.toml). The `--code-size-limit` CLI flag populates `evm_opts.env.code_size_limit` but was never read here, so the check silently fell back to EIP-170's 24576-byte default even when the flag was explicitly set.

## Solution

Chain `.or(evm_opts.env.code_size_limit)` before the config lookup so the CLI flag takes precedence over foundry.toml. A test asserts the flag is correctly threaded into `evm_opts` (the path the check now reads).

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
