### PR TITLE
feat(debugger): add layout selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5518,6 +5518,7 @@ version = "1.7.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
+ "clap",
  "crossterm",
  "eyre",
  "foundry-common",

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -23,6 +23,7 @@ revm-inspectors.workspace = true
 alloy-primitives.workspace = true
 alloy-dyn-abi.workspace = true
 
+clap = { version = "4", features = ["derive"] }
 crossterm.workspace = true
 eyre.workspace = true
 ratatui = { workspace = true, features = ["crossterm"] }

--- a/crates/debugger/src/builder.rs
+++ b/crates/debugger/src/builder.rs
@@ -1,7 +1,6 @@
 //! Debugger builder.
 
-use crate::DebuggerLayout;
-use crate::{Debugger, debugger::DebuggerStats, node::flatten_call_trace};
+use crate::{Debugger, DebuggerLayout, debugger::DebuggerStats, node::flatten_call_trace};
 use alloy_primitives::{Address, map::AddressHashMap};
 use foundry_common::get_contract_name;
 use foundry_evm_core::Breakpoints;
@@ -99,7 +98,7 @@ impl DebuggerBuilder {
 
     /// Sets the TUI layout for the debugger.
     #[inline]
-    pub fn layout(mut self, layout: DebuggerLayout) -> Self {
+    pub const fn layout(mut self, layout: DebuggerLayout) -> Self {
         self.layout = layout;
         self
     }

--- a/crates/debugger/src/builder.rs
+++ b/crates/debugger/src/builder.rs
@@ -1,5 +1,6 @@
 //! Debugger builder.
 
+use crate::DebuggerLayout;
 use crate::{Debugger, debugger::DebuggerStats, node::flatten_call_trace};
 use alloy_primitives::{Address, map::AddressHashMap};
 use foundry_common::get_contract_name;
@@ -23,6 +24,8 @@ pub struct DebuggerBuilder {
     sources: ContractSources,
     /// Map of the debugger breakpoints.
     breakpoints: Breakpoints,
+    /// TUI layout selection.
+    layout: DebuggerLayout,
 }
 
 impl DebuggerBuilder {
@@ -94,16 +97,31 @@ impl DebuggerBuilder {
         self
     }
 
+    /// Sets the TUI layout for the debugger.
+    #[inline]
+    pub fn layout(mut self, layout: DebuggerLayout) -> Self {
+        self.layout = layout;
+        self
+    }
+
     /// Builds the debugger.
     #[inline]
     pub fn build(self) -> Debugger {
-        let Self { mut trace_arenas, stats, identified_contracts, sources, breakpoints } = self;
+        let Self { mut trace_arenas, stats, identified_contracts, sources, breakpoints, layout } =
+            self;
         identify_internal_calls(&mut trace_arenas, &identified_contracts, &sources);
         let mut debug_arena = Vec::new();
         for arena in trace_arenas {
             flatten_call_trace(arena, &mut debug_arena);
         }
-        Debugger::new_with_stats(debug_arena, stats, identified_contracts, sources, breakpoints)
+        Debugger::new_with_stats(
+            debug_arena,
+            stats,
+            identified_contracts,
+            sources,
+            breakpoints,
+            layout,
+        )
     }
 }
 

--- a/crates/debugger/src/debugger.rs
+++ b/crates/debugger/src/debugger.rs
@@ -7,6 +7,36 @@ use foundry_evm_core::Breakpoints;
 use foundry_evm_traces::debug::ContractSources;
 use std::path::Path;
 
+/// Debugger TUI layout selection.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DebuggerLayout {
+    /// Select horizontal or vertical layout from the terminal size.
+    #[default]
+    Auto,
+    /// Force the two-column debugger layout.
+    Horizontal,
+    /// Force the single-column debugger layout.
+    Vertical,
+}
+
+impl DebuggerLayout {
+    pub(crate) const fn next(self) -> Self {
+        match self {
+            Self::Auto => Self::Horizontal,
+            Self::Horizontal => Self::Vertical,
+            Self::Vertical => Self::Auto,
+        }
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Horizontal => "horizontal",
+            Self::Vertical => "vertical",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct DebuggerStats {
     /// Sum of root-call gas used across every trace arena passed to the debugger.
@@ -22,6 +52,7 @@ pub struct DebuggerContext {
     /// Source map of contract sources
     pub contracts_sources: ContractSources,
     pub breakpoints: Breakpoints,
+    pub layout: DebuggerLayout,
 }
 
 pub struct Debugger {
@@ -49,6 +80,7 @@ impl Debugger {
                 identified_contracts,
                 contracts_sources,
                 breakpoints,
+                layout: DebuggerLayout::Auto,
             },
         }
     }
@@ -59,6 +91,7 @@ impl Debugger {
         identified_contracts: AddressHashMap<String>,
         contracts_sources: ContractSources,
         breakpoints: Breakpoints,
+        layout: DebuggerLayout,
     ) -> Self {
         Self {
             context: DebuggerContext {
@@ -67,6 +100,7 @@ impl Debugger {
                 identified_contracts,
                 contracts_sources,
                 breakpoints,
+                layout,
             },
         }
     }

--- a/crates/debugger/src/debugger.rs
+++ b/crates/debugger/src/debugger.rs
@@ -2,13 +2,14 @@
 
 use crate::{DebugNode, DebuggerBuilder, ExitReason, tui::TUI};
 use alloy_primitives::map::AddressHashMap;
+use clap::ValueEnum;
 use eyre::Result;
 use foundry_evm_core::Breakpoints;
 use foundry_evm_traces::debug::ContractSources;
 use std::path::Path;
 
 /// Debugger TUI layout selection.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub enum DebuggerLayout {
     /// Select horizontal or vertical layout from the terminal size.
     #[default]
@@ -22,9 +23,8 @@ pub enum DebuggerLayout {
 impl DebuggerLayout {
     pub(crate) const fn next(self) -> Self {
         match self {
-            Self::Auto => Self::Horizontal,
+            Self::Auto | Self::Vertical => Self::Horizontal,
             Self::Horizontal => Self::Vertical,
-            Self::Vertical => Self::Auto,
         }
     }
 

--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -23,5 +23,5 @@ mod node;
 pub use node::DebugNode;
 
 pub use builder::DebuggerBuilder;
-pub use debugger::Debugger;
+pub use debugger::{Debugger, DebuggerLayout};
 pub use tui::{ExitReason, TUI};

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -1,6 +1,6 @@
 //! Debugger context and event handler implementation.
 
-use crate::{DebugNode, ExitReason, debugger::DebuggerContext};
+use crate::{DebugNode, DebuggerLayout, ExitReason, debugger::DebuggerContext};
 use alloy_primitives::{Address, hex};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use foundry_evm_core::buffer::{BufferKind, get_buffer_accesses};
@@ -110,6 +110,10 @@ impl<'a> TUIContext<'a> {
 
     pub(crate) fn debug_arena(&self) -> &[DebugNode] {
         &self.debugger_context.debug_arena
+    }
+
+    pub(crate) const fn layout(&self) -> DebuggerLayout {
+        self.debugger_context.layout
     }
 
     pub(crate) fn debug_call(&self) -> &DebugNode {
@@ -231,6 +235,9 @@ impl TUIContext<'_> {
                 self.active_buffer = self.active_buffer.next();
                 self.draw_memory.current_buf_startline = 0;
             }
+
+            // Cycle layout
+            KeyCode::Char('l') => self.cycle_layout(),
 
             // Go to top of file
             KeyCode::Char('g') => {
@@ -519,6 +526,15 @@ impl TUIContext<'_> {
     fn n_steps(&self) -> usize {
         self.debug_steps().len()
     }
+
+    fn cycle_layout(&mut self) {
+        let layout = self.debugger_context.layout.next();
+        self.debugger_context.layout = layout;
+        self.status = Some(StatusMessage {
+            kind: StatusKind::Info,
+            text: format!("Debugger layout: {}", layout.as_str()),
+        });
+    }
 }
 
 impl TuiApp for TUIContext<'_> {
@@ -787,6 +803,7 @@ mod tests {
             identified_contracts: Default::default(),
             contracts_sources: ContractSources::default(),
             breakpoints: Breakpoints::default(),
+            layout: Default::default(),
         }
     }
 

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -812,6 +812,28 @@ mod tests {
     }
 
     #[test]
+    fn layout_shortcut_cycles_only_concrete_layouts() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        assert_eq!(tui.debugger_context.layout, DebuggerLayout::Auto);
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('l')));
+        assert_eq!(tui.debugger_context.layout, DebuggerLayout::Horizontal);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Debugger layout: horizontal");
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('l')));
+        assert_eq!(tui.debugger_context.layout, DebuggerLayout::Vertical);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Debugger layout: vertical");
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('l')));
+        assert_eq!(tui.debugger_context.layout, DebuggerLayout::Horizontal);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Debugger layout: horizontal");
+    }
+
+    #[test]
     fn parses_prefixed_hex_pc() {
         assert_eq!(
             parse_pc_candidates("0x2a").unwrap(),

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -1,7 +1,7 @@
 //! TUI draw implementation.
 
 use super::context::{ActiveInternalCallCache, ActiveInternalCallLocation, StatusKind, TUIContext};
-use crate::{debugger::DebuggerStats, op::OpcodeParam};
+use crate::{DebuggerLayout, debugger::DebuggerStats, op::OpcodeParam};
 use alloy_dyn_abi::{DynSolType, Specifier, parser::Parameters};
 use alloy_primitives::{Address, U256, keccak256};
 use foundry_common::fmt::format_token;
@@ -33,12 +33,18 @@ impl TUIContext<'_> {
             return;
         }
 
-        // The horizontal layout draws these panes at 50% width.
-        let min_column_width_for_horizontal = 200;
-        if area.width >= min_column_width_for_horizontal {
-            self.horizontal_layout(f);
-        } else {
-            self.vertical_layout(f);
+        match self.layout() {
+            DebuggerLayout::Horizontal => self.horizontal_layout(f),
+            DebuggerLayout::Vertical => self.vertical_layout(f),
+            DebuggerLayout::Auto => {
+                // The horizontal layout draws these panes at 50% width.
+                let min_column_width_for_horizontal = 200;
+                if area.width >= min_column_width_for_horizontal {
+                    self.horizontal_layout(f);
+                } else {
+                    self.vertical_layout(f);
+                }
+            }
         }
     }
 
@@ -219,7 +225,7 @@ impl TUIContext<'_> {
         }
 
         let l1 = "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end | [p]: goto PC | [b]: cycle memory/calldata/returndata buffers";
-        let l2 = "[t]: stack labels | [m]: buffer decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll buffer | ['<char>]: goto breakpoint | [h] toggle help";
+        let l2 = "[l]: layout | [t]: stack labels | [m]: buffer decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll buffer | ['<char>]: goto breakpoint | [h] toggle help";
         let dimmed = Style::new().add_modifier(Modifier::DIM);
         if self.show_shortcuts {
             lines.push(Line::from(Span::styled(l1, dimmed)));
@@ -1153,6 +1159,7 @@ mod tests {
             identified_contracts: Default::default(),
             contracts_sources: ContractSources::default(),
             breakpoints: Breakpoints::default(),
+            layout: Default::default(),
         }
     }
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -123,7 +123,7 @@ pub struct TestArgs {
 
     /// Debugger layout to use.
     #[arg(long = "debug-layout", requires = "debug", value_enum)]
-    debug_layout: Option<DebuggerLayoutArg>,
+    debug_layout: Option<DebuggerLayout>,
 
     /// Generate a flamegraph for a single test. Implies `--decode-internal`.
     ///
@@ -429,24 +429,6 @@ pub struct TestArgs {
     /// Analogous to `--invariant-timeout` for invariant campaigns.
     #[arg(long, value_name = "TIMEOUT", requires = "mutate")]
     pub mutation_timeout: Option<u32>,
-}
-
-#[derive(Clone, Copy, Debug, Default, ValueEnum)]
-enum DebuggerLayoutArg {
-    #[default]
-    Auto,
-    Horizontal,
-    Vertical,
-}
-
-impl From<DebuggerLayoutArg> for DebuggerLayout {
-    fn from(value: DebuggerLayoutArg) -> Self {
-        match value {
-            DebuggerLayoutArg::Auto => Self::Auto,
-            DebuggerLayoutArg::Horizontal => Self::Horizontal,
-            DebuggerLayoutArg::Vertical => Self::Vertical,
-        }
-    }
 }
 
 impl TestArgs {
@@ -909,7 +891,7 @@ impl TestArgs {
                 .traces(traces)
                 .sources(sources)
                 .breakpoints(test_result.breakpoints)
-                .layout(self.debug_layout.unwrap_or_default().into());
+                .layout(self.debug_layout.unwrap_or_default());
 
             if let Some(decoder) = &outcome.last_run_decoder {
                 builder = builder.decoder(decoder);

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -44,7 +44,7 @@ use foundry_config::{
     },
     filter::GlobMatcher,
 };
-use foundry_debugger::Debugger;
+use foundry_debugger::{Debugger, DebuggerLayout};
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -120,6 +120,10 @@ pub struct TestArgs {
     /// case. If the fuzz test does not fail, it will open the debugger on the last fuzz case.
     #[arg(long, conflicts_with_all = ["flamegraph", "flamechart", "decode_internal", "rerun"])]
     debug: bool,
+
+    /// Debugger layout to use.
+    #[arg(long = "debug-layout", requires = "debug", value_enum)]
+    debug_layout: Option<DebuggerLayoutArg>,
 
     /// Generate a flamegraph for a single test. Implies `--decode-internal`.
     ///
@@ -425,6 +429,24 @@ pub struct TestArgs {
     /// Analogous to `--invariant-timeout` for invariant campaigns.
     #[arg(long, value_name = "TIMEOUT", requires = "mutate")]
     pub mutation_timeout: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+enum DebuggerLayoutArg {
+    #[default]
+    Auto,
+    Horizontal,
+    Vertical,
+}
+
+impl From<DebuggerLayoutArg> for DebuggerLayout {
+    fn from(value: DebuggerLayoutArg) -> Self {
+        match value {
+            DebuggerLayoutArg::Auto => Self::Auto,
+            DebuggerLayoutArg::Horizontal => Self::Horizontal,
+            DebuggerLayoutArg::Vertical => Self::Vertical,
+        }
+    }
 }
 
 impl TestArgs {
@@ -886,7 +908,8 @@ impl TestArgs {
             let mut builder = Debugger::builder()
                 .traces(traces)
                 .sources(sources)
-                .breakpoints(test_result.breakpoints);
+                .breakpoints(test_result.breakpoints)
+                .layout(self.debug_layout.unwrap_or_default().into());
 
             if let Some(decoder) = &outcome.last_run_decoder {
                 builder = builder.decoder(decoder);

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -549,6 +549,7 @@ impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
             .decoder(&self.execution_artifacts.decoder)
             .sources(self.build_data.sources)
             .breakpoints(self.execution_result.breakpoints)
+            .layout(self.args.debug_layout.unwrap_or_default().into())
             .build()
     }
 }

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -549,7 +549,7 @@ impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
             .decoder(&self.execution_artifacts.decoder)
             .sources(self.build_data.sources)
             .breakpoints(self.execution_result.breakpoints)
-            .layout(self.args.debug_layout.unwrap_or_default().into())
+            .layout(self.args.debug_layout.unwrap_or_default())
             .build()
     }
 }

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -23,7 +23,7 @@ use alloy_primitives::{
 use alloy_signer::Signer;
 use broadcast::next_nonce;
 use build::PreprocessedState;
-use clap::{Parser, ValueEnum, ValueHint};
+use clap::{Parser, ValueHint};
 use dialoguer::Confirm;
 use eyre::{ContextCompat, Result};
 use forge_script_sequence::{AdditionalContract, NestedValue};
@@ -186,7 +186,7 @@ pub struct ScriptArgs {
 
     /// Debugger layout to use.
     #[arg(long = "debug-layout", requires = "debug", value_enum)]
-    pub debug_layout: Option<DebuggerLayoutArg>,
+    pub debug_layout: Option<DebuggerLayout>,
 
     /// Dumps all debugger steps to file.
     #[arg(
@@ -254,24 +254,6 @@ pub struct ScriptArgs {
 
     #[command(flatten)]
     pub retry: RetryArgs,
-}
-
-#[derive(Clone, Copy, Debug, Default, ValueEnum)]
-pub enum DebuggerLayoutArg {
-    #[default]
-    Auto,
-    Horizontal,
-    Vertical,
-}
-
-impl From<DebuggerLayoutArg> for DebuggerLayout {
-    fn from(value: DebuggerLayoutArg) -> Self {
-        match value {
-            DebuggerLayoutArg::Auto => Self::Auto,
-            DebuggerLayoutArg::Horizontal => Self::Horizontal,
-            DebuggerLayoutArg::Vertical => Self::Vertical,
-        }
-    }
 }
 
 impl ScriptArgs {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -23,7 +23,7 @@ use alloy_primitives::{
 use alloy_signer::Signer;
 use broadcast::next_nonce;
 use build::PreprocessedState;
-use clap::{Parser, ValueHint};
+use clap::{Parser, ValueEnum, ValueHint};
 use dialoguer::Confirm;
 use eyre::{ContextCompat, Result};
 use forge_script_sequence::{AdditionalContract, NestedValue};
@@ -47,6 +47,7 @@ use foundry_config::{
         value::{Dict, Map},
     },
 };
+use foundry_debugger::DebuggerLayout;
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -183,6 +184,10 @@ pub struct ScriptArgs {
     #[arg(long)]
     pub debug: bool,
 
+    /// Debugger layout to use.
+    #[arg(long = "debug-layout", requires = "debug", value_enum)]
+    pub debug_layout: Option<DebuggerLayoutArg>,
+
     /// Dumps all debugger steps to file.
     #[arg(
         long,
@@ -249,6 +254,24 @@ pub struct ScriptArgs {
 
     #[command(flatten)]
     pub retry: RetryArgs,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub enum DebuggerLayoutArg {
+    #[default]
+    Auto,
+    Horizontal,
+    Vertical,
+}
+
+impl From<DebuggerLayoutArg> for DebuggerLayout {
+    fn from(value: DebuggerLayoutArg) -> Self {
+        match value {
+            DebuggerLayoutArg::Auto => Self::Auto,
+            DebuggerLayoutArg::Horizontal => Self::Horizontal,
+            DebuggerLayoutArg::Vertical => Self::Vertical,
+        }
+    }
 }
 
 impl ScriptArgs {


### PR DESCRIPTION
## Summary
- add debugger layout selection with auto, horizontal, and vertical modes
- wire `--debug-layout` into `forge test --debug` and `forge script --debug`
- add an in-TUI `l` shortcut to cycle layouts while debugging

Closes #8256

## Validation
- `cargo +nightly fmt --all --check`
- `cargo +1.95.0 clippy -p foundry-debugger --all-targets --all-features --locked -- -D warnings`
- `cargo +1.95.0 check -p foundry-debugger -p forge -p forge-script`
- `cargo +1.95.0 test -p foundry-debugger`
- `cargo +1.95.0 build -p forge --bin forge`
- live PTY smoke at 120 columns: `forge test --debug --debug-layout horizontal --match-test test_Increment` opened the two-column debugger layout and exited cleanly with `q`
- `git diff --check`