### PR TITLE
feat(symbolic): model ADDMOD and MULMOD

### DIFF
--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -67,12 +67,15 @@ impl SymbolicExecutor {
                 let n = state.stack.pop()?;
                 match (a, b, n) {
                     (SymWord::Concrete(a), SymWord::Concrete(b), SymWord::Concrete(n)) => {
-                        state.stack.push(SymWord::Concrete(addmod_exact(a, b, n)))?;
+                        state.stack.push(SymWord::Concrete(addmod_word(a, b, n)))?;
                     }
-                    _ => {
-                        return Err(SymbolicError::Unsupported(
-                            "symbolic ADDMOD unbounded intermediate not modeled",
-                        ));
+                    (a, b, n) => {
+                        state.stack.push(
+                            match Expr::addmod(a.into_expr(), b.into_expr(), n.into_expr()) {
+                                Expr::Const(value) => SymWord::Concrete(value),
+                                expr => SymWord::Expr(expr),
+                            },
+                        )?;
                     }
                 }
                 Ok(StepOutcome::Continue)
@@ -83,12 +86,15 @@ impl SymbolicExecutor {
                 let n = state.stack.pop()?;
                 match (a, b, n) {
                     (SymWord::Concrete(a), SymWord::Concrete(b), SymWord::Concrete(n)) => {
-                        state.stack.push(SymWord::Concrete(mulmod_exact(a, b, n)))?;
+                        state.stack.push(SymWord::Concrete(mulmod_word(a, b, n)))?;
                     }
-                    _ => {
-                        return Err(SymbolicError::Unsupported(
-                            "symbolic MULMOD unbounded intermediate not modeled",
-                        ));
+                    (a, b, n) => {
+                        state.stack.push(
+                            match Expr::mulmod(a.into_expr(), b.into_expr(), n.into_expr()) {
+                                Expr::Const(value) => SymWord::Concrete(value),
+                                expr => SymWord::Expr(expr),
+                            },
+                        )?;
                     }
                 }
                 Ok(StepOutcome::Continue)
@@ -800,16 +806,4 @@ impl SymbolicExecutor {
             StepOutcome::Revert
         }
     }
-}
-
-fn addmod_exact(a: U256, b: U256, n: U256) -> U256 {
-    if n.is_zero() { U256::ZERO } else { u512_mod_to_u256(U512::from(a) + U512::from(b), n) }
-}
-
-fn mulmod_exact(a: U256, b: U256, n: U256) -> U256 {
-    if n.is_zero() { U256::ZERO } else { u512_mod_to_u256(U512::from(a) * U512::from(b), n) }
-}
-
-fn u512_mod_to_u256(value: U512, modulus: U256) -> U256 {
-    U256::from_limbs_slice((value % U512::from(modulus)).as_limbs())
 }

--- a/crates/evm/symbolic/src/runtime/address.rs
+++ b/crates/evm/symbolic/src/runtime/address.rs
@@ -174,6 +174,7 @@ pub(crate) fn expr_byte_term(expr: &Expr, index: usize) -> Option<Expr> {
             | ExprOp::SRem
             | ExprOp::Sar => None,
         },
+        Expr::AddMod { .. } | Expr::MulMod { .. } => None,
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/evm.rs
+++ b/crates/evm/symbolic/src/runtime/evm.rs
@@ -215,6 +215,7 @@ pub(crate) fn expr_known_byte(expr: &Expr, index: usize) -> Option<u8> {
             | ExprOp::SRem
             | ExprOp::Sar => None,
         },
+        Expr::AddMod { .. } | Expr::MulMod { .. } => None,
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/expressions.rs
+++ b/crates/evm/symbolic/src/runtime/expressions.rs
@@ -309,6 +309,29 @@ pub(crate) fn sym_sub(left: SymWord, right: SymWord) -> SymWord {
     }
 }
 
+/// Computes the exact EVM `ADDMOD` semantics without truncating the intermediate sum.
+pub(crate) fn addmod_word(left: U256, right: U256, modulus: U256) -> U256 {
+    if modulus.is_zero() {
+        return U256::ZERO;
+    }
+    u256_from_u512((U512::from(left) + U512::from(right)) % U512::from(modulus))
+}
+
+/// Computes the exact EVM `MULMOD` semantics without truncating the intermediate product.
+pub(crate) fn mulmod_word(left: U256, right: U256, modulus: U256) -> U256 {
+    if modulus.is_zero() {
+        return U256::ZERO;
+    }
+    u256_from_u512((U512::from(left) * U512::from(right)) % U512::from(modulus))
+}
+
+/// Converts a known 256-bit-range `U512` result back into `U256`.
+fn u256_from_u512(value: U512) -> U256 {
+    let limbs = value.as_limbs();
+    debug_assert!(limbs[4..].iter().all(|limb| *limb == 0));
+    U256::from_limbs([limbs[0], limbs[1], limbs[2], limbs[3]])
+}
+
 /// Returns the `expr_contains_keccak` symbolic expression helper result.
 pub(crate) fn expr_contains_keccak(expr: &Expr) -> bool {
     match expr {
@@ -316,6 +339,11 @@ pub(crate) fn expr_contains_keccak(expr: &Expr) -> bool {
         Expr::Const(_) | Expr::Var(_) | Expr::GasLeft(_) | Expr::Hash { .. } => false,
         Expr::Not(value) => expr_contains_keccak(value),
         Expr::Op(_, left, right) => expr_contains_keccak(left) || expr_contains_keccak(right),
+        Expr::AddMod { left, right, modulus } | Expr::MulMod { left, right, modulus } => {
+            expr_contains_keccak(left)
+                || expr_contains_keccak(right)
+                || expr_contains_keccak(modulus)
+        }
         Expr::Ite(cond, left, right) => {
             bool_contains_keccak(cond) || expr_contains_keccak(left) || expr_contains_keccak(right)
         }
@@ -334,6 +362,11 @@ pub(crate) fn expr_contains_gasleft(expr: &Expr) -> bool {
         Expr::Hash { bytes, .. } => bytes.iter().any(expr_contains_gasleft),
         Expr::Not(value) => expr_contains_gasleft(value),
         Expr::Op(_, left, right) => expr_contains_gasleft(left) || expr_contains_gasleft(right),
+        Expr::AddMod { left, right, modulus } | Expr::MulMod { left, right, modulus } => {
+            expr_contains_gasleft(left)
+                || expr_contains_gasleft(right)
+                || expr_contains_gasleft(modulus)
+        }
         Expr::Ite(cond, left, right) => {
             bool_contains_gasleft(cond)
                 || expr_contains_gasleft(left)
@@ -434,6 +467,7 @@ pub(crate) fn expr_nonzero_forces_const(
         {
             expr_nonzero_forces_const(value, target, context)
         }
+        Expr::AddMod { .. } | Expr::MulMod { .. } => None,
         Expr::Op(_, _, _) => None,
     }
 }
@@ -468,6 +502,16 @@ pub(crate) fn expr_const_value(expr: &Expr) -> Option<U256> {
         Expr::Op(op, left, right) => {
             Some(eval_expr_op(*op, expr_const_value(left)?, expr_const_value(right)?))
         }
+        Expr::AddMod { left, right, modulus } => Some(addmod_word(
+            expr_const_value(left)?,
+            expr_const_value(right)?,
+            expr_const_value(modulus)?,
+        )),
+        Expr::MulMod { left, right, modulus } => Some(mulmod_word(
+            expr_const_value(left)?,
+            expr_const_value(right)?,
+            expr_const_value(modulus)?,
+        )),
         Expr::Ite(cond, then_expr, else_expr) => {
             if bool_const_value(cond)? {
                 expr_const_value(then_expr)
@@ -720,6 +764,16 @@ pub(crate) fn eval_expr(
             let right = eval_expr(right, model)?;
             eval_expr_op(*op, left, right)
         }
+        Expr::AddMod { left, right, modulus } => addmod_word(
+            eval_expr(left, model)?,
+            eval_expr(right, model)?,
+            eval_expr(modulus, model)?,
+        ),
+        Expr::MulMod { left, right, modulus } => mulmod_word(
+            eval_expr(left, model)?,
+            eval_expr(right, model)?,
+            eval_expr(modulus, model)?,
+        ),
         Expr::Ite(cond, then_expr, else_expr) => {
             if eval_bool_expr(cond, model)? {
                 eval_expr(then_expr, model)?
@@ -937,6 +991,8 @@ pub(crate) enum Expr {
     Hash { name: String, algorithm: &'static str, bytes: Vec<Self> },
     Not(Box<Self>),
     Op(ExprOp, Box<Self>, Box<Self>),
+    AddMod { left: Box<Self>, right: Box<Self>, modulus: Box<Self> },
+    MulMod { left: Box<Self>, right: Box<Self>, modulus: Box<Self> },
     Ite(Box<BoolExpr>, Box<Self>, Box<Self>),
 }
 
@@ -1008,6 +1064,32 @@ impl Expr {
         }
     }
 
+    /// Builds an exact EVM `ADDMOD` expression.
+    pub(crate) fn addmod(left: Self, right: Self, modulus: Self) -> Self {
+        if matches!(modulus, Self::Const(value) if value.is_zero() || value == U256::from(1)) {
+            return Self::Const(U256::ZERO);
+        }
+        if let (Self::Const(left), Self::Const(right), Self::Const(modulus)) =
+            (&left, &right, &modulus)
+        {
+            return Self::Const(addmod_word(*left, *right, *modulus));
+        }
+        Self::AddMod { left: Box::new(left), right: Box::new(right), modulus: Box::new(modulus) }
+    }
+
+    /// Builds an exact EVM `MULMOD` expression.
+    pub(crate) fn mulmod(left: Self, right: Self, modulus: Self) -> Self {
+        if matches!(modulus, Self::Const(value) if value.is_zero() || value == U256::from(1)) {
+            return Self::Const(U256::ZERO);
+        }
+        if let (Self::Const(left), Self::Const(right), Self::Const(modulus)) =
+            (&left, &right, &modulus)
+        {
+            return Self::Const(mulmod_word(*left, *right, *modulus));
+        }
+        Self::MulMod { left: Box::new(left), right: Box::new(right), modulus: Box::new(modulus) }
+    }
+
     fn and_const(expr: Self, mask: U256) -> Self {
         if mask.is_zero() {
             return Self::Const(U256::ZERO);
@@ -1050,6 +1132,11 @@ impl Expr {
                 left.collect_vars(vars);
                 right.collect_vars(vars);
             }
+            Self::AddMod { left, right, modulus } | Self::MulMod { left, right, modulus } => {
+                left.collect_vars(vars);
+                right.collect_vars(vars);
+                modulus.collect_vars(vars);
+            }
             Self::Ite(cond, left, right) => {
                 cond.collect_vars(vars);
                 left.collect_vars(vars);
@@ -1067,11 +1154,32 @@ impl Expr {
             Self::Keccak { name, .. } | Self::Hash { name, .. } => name.clone(),
             Self::Not(value) => format!("(bvnot {})", value.smt()),
             Self::Op(op, left, right) => format!("({} {} {})", op.smt(), left.smt(), right.smt()),
+            Self::AddMod { left, right, modulus } => {
+                smt_wide_modular_arithmetic("bvadd", left, right, modulus)
+            }
+            Self::MulMod { left, right, modulus } => {
+                smt_wide_modular_arithmetic("bvmul", left, right, modulus)
+            }
             Self::Ite(cond, left, right) => {
                 format!("(ite {} {} {})", cond.smt(), left.smt(), right.smt())
             }
         }
     }
+}
+
+/// Encodes EVM `ADDMOD`/`MULMOD` by widening operands before modular reduction.
+fn smt_wide_modular_arithmetic(
+    op: &'static str,
+    left: &Expr,
+    right: &Expr,
+    modulus: &Expr,
+) -> String {
+    let left = left.smt();
+    let right = right.smt();
+    let modulus = modulus.smt();
+    format!(
+        "(ite (= {modulus} (_ bv0 256)) (_ bv0 256) ((_ extract 255 0) (bvurem ({op} ((_ zero_extend 256) {left}) ((_ zero_extend 256) {right})) ((_ zero_extend 256) {modulus}))))"
+    )
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -674,6 +674,26 @@ fn cache_key_expr(expr: Expr) -> Expr {
                 Expr::op(op, left, right)
             }
         }
+        Expr::AddMod { left, right, modulus } => {
+            let left = cache_key_expr(*left);
+            let right = cache_key_expr(*right);
+            let modulus = cache_key_expr(*modulus);
+            if right < left {
+                Expr::addmod(right, left, modulus)
+            } else {
+                Expr::addmod(left, right, modulus)
+            }
+        }
+        Expr::MulMod { left, right, modulus } => {
+            let left = cache_key_expr(*left);
+            let right = cache_key_expr(*right);
+            let modulus = cache_key_expr(*modulus);
+            if right < left {
+                Expr::mulmod(right, left, modulus)
+            } else {
+                Expr::mulmod(left, right, modulus)
+            }
+        }
         Expr::Ite(cond, left, right) => Expr::Ite(
             Box::new(cache_key_bool(*cond)),
             Box::new(cache_key_expr(*left)),

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -25,6 +25,9 @@ pub(crate) fn expr_contains_hard_arith(expr: &Expr) -> bool {
         Expr::Op(ExprOp::UDiv | ExprOp::URem | ExprOp::SDiv | ExprOp::SRem, left, right) => {
             expr_contains_var(left) || expr_contains_var(right)
         }
+        Expr::AddMod { left, right, modulus } | Expr::MulMod { left, right, modulus } => {
+            expr_contains_var(left) || expr_contains_var(right) || expr_contains_var(modulus)
+        }
         Expr::Op(_, left, right) => {
             expr_contains_hard_arith(left) || expr_contains_hard_arith(right)
         }
@@ -47,6 +50,11 @@ pub(crate) fn expr_contains_symbolic_hash(expr: &Expr) -> bool {
         Expr::Not(value) => expr_contains_symbolic_hash(value),
         Expr::Op(_, left, right) => {
             expr_contains_symbolic_hash(left) || expr_contains_symbolic_hash(right)
+        }
+        Expr::AddMod { left, right, modulus } | Expr::MulMod { left, right, modulus } => {
+            expr_contains_symbolic_hash(left)
+                || expr_contains_symbolic_hash(right)
+                || expr_contains_symbolic_hash(modulus)
         }
         Expr::Ite(cond, left, right) => {
             bool_contains_symbolic_hash(cond)
@@ -76,6 +84,9 @@ pub(crate) fn expr_contains_var(expr: &Expr) -> bool {
         Expr::GasLeft(_) => false,
         Expr::Not(value) => expr_contains_var(value),
         Expr::Op(_, left, right) => expr_contains_var(left) || expr_contains_var(right),
+        Expr::AddMod { left, right, modulus } | Expr::MulMod { left, right, modulus } => {
+            expr_contains_var(left) || expr_contains_var(right) || expr_contains_var(modulus)
+        }
         Expr::Ite(cond, left, right) => {
             bool_contains_var(cond) || expr_contains_var(left) || expr_contains_var(right)
         }
@@ -320,6 +331,11 @@ pub(crate) fn collect_expr_fallback_vars(expr: &Expr, vars: &mut BTreeSet<String
             collect_expr_fallback_vars(left, vars);
             collect_expr_fallback_vars(right, vars);
         }
+        Expr::AddMod { left, right, modulus } | Expr::MulMod { left, right, modulus } => {
+            collect_expr_fallback_vars(left, vars);
+            collect_expr_fallback_vars(right, vars);
+            collect_expr_fallback_vars(modulus, vars);
+        }
         Expr::Ite(cond, left, right) => {
             collect_bool_fallback_vars(cond, vars);
             collect_expr_fallback_vars(left, vars);
@@ -421,6 +437,11 @@ pub(crate) fn collect_expr_constants(expr: &Expr, constants: &mut BTreeSet<U256>
         Expr::Op(_, left, right) => {
             collect_expr_constants(left, constants);
             collect_expr_constants(right, constants);
+        }
+        Expr::AddMod { left, right, modulus } | Expr::MulMod { left, right, modulus } => {
+            collect_expr_constants(left, constants);
+            collect_expr_constants(right, constants);
+            collect_expr_constants(modulus, constants);
         }
         Expr::Ite(cond, left, right) => {
             collect_bool_constants(cond, constants);

--- a/crates/evm/symbolic/src/runtime/solver/normalize.rs
+++ b/crates/evm/symbolic/src/runtime/solver/normalize.rs
@@ -186,6 +186,16 @@ pub(crate) fn normalize_expr_for_solver(expr: Expr) -> Expr {
                 Expr::op(op, left, right)
             }
         }
+        Expr::AddMod { left, right, modulus } => Expr::addmod(
+            normalize_expr_for_solver(*left),
+            normalize_expr_for_solver(*right),
+            normalize_expr_for_solver(*modulus),
+        ),
+        Expr::MulMod { left, right, modulus } => Expr::mulmod(
+            normalize_expr_for_solver(*left),
+            normalize_expr_for_solver(*right),
+            normalize_expr_for_solver(*modulus),
+        ),
         Expr::Ite(cond, left, right) => normalize_ite_expr_for_solver(*cond, *left, *right),
     }
 }
@@ -399,6 +409,9 @@ pub(crate) fn expr_contains_udiv(expr: &Expr) -> bool {
         Expr::Op(op, left, right) => {
             matches!(op, ExprOp::UDiv) || expr_contains_udiv(left) || expr_contains_udiv(right)
         }
+        Expr::AddMod { left, right, modulus } | Expr::MulMod { left, right, modulus } => {
+            expr_contains_udiv(left) || expr_contains_udiv(right) || expr_contains_udiv(modulus)
+        }
         Expr::Ite(condition, then_expr, else_expr) => {
             bool_contains_udiv(condition)
                 || expr_contains_udiv(then_expr)
@@ -601,6 +614,7 @@ pub(crate) fn expr_unsigned_bits(expr: &Expr) -> usize {
             expr_unsigned_bits(left).saturating_add(expr_unsigned_bits(right)).min(256)
         }
         Expr::Op(ExprOp::UDiv, left, _) => expr_unsigned_bits(left),
+        Expr::AddMod { modulus, .. } | Expr::MulMod { modulus, .. } => expr_unsigned_bits(modulus),
         Expr::Ite(_, left, right) => expr_unsigned_bits(left).max(expr_unsigned_bits(right)),
         _ => 256,
     }

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -206,6 +206,15 @@ impl PathState {
             Expr::Const(value) => u256_to_usize(*value),
             Expr::Var(_) | Expr::GasLeft(_) | Expr::Keccak { .. } | Expr::Hash { .. } => None,
             Expr::Not(_) => None,
+            Expr::AddMod { modulus, .. } | Expr::MulMod { modulus, .. } => {
+                match expr_const_value(modulus) {
+                    Some(modulus) if modulus.is_zero() => Some(0),
+                    Some(modulus) => u256_to_usize(modulus - U256::from(1)),
+                    None => {
+                        self.expr_upper_bound_usize(modulus).and_then(|bound| bound.checked_sub(1))
+                    }
+                }
+            }
             Expr::Ite(_, left, right) => {
                 Some(self.expr_upper_bound_usize(left)?.max(self.expr_upper_bound_usize(right)?))
             }
@@ -1617,6 +1626,11 @@ fn collect_eval_vars(expr: &Expr, vars: &mut BTreeSet<String>) {
         Expr::Op(_, left, right) => {
             collect_eval_vars(left, vars);
             collect_eval_vars(right, vars);
+        }
+        Expr::AddMod { left, right, modulus } | Expr::MulMod { left, right, modulus } => {
+            collect_eval_vars(left, vars);
+            collect_eval_vars(right, vars);
+            collect_eval_vars(modulus, vars);
         }
         Expr::Ite(condition, left, right) => {
             collect_eval_bool_vars(condition, vars);

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2031,6 +2031,84 @@ fn bool_comparison_folds_unsigned_boundaries() {
 }
 
 #[test]
+/// Regression coverage for exact `ADDMOD`/`MULMOD` edge-case semantics.
+fn exact_modular_arithmetic_handles_zero_modulus_and_wide_intermediates() {
+    assert_eq!(addmod_word(U256::MAX, U256::from(2), U256::ZERO), U256::ZERO);
+    assert_eq!(mulmod_word(U256::MAX, U256::MAX, U256::ZERO), U256::ZERO);
+
+    assert_eq!(addmod_word(U256::MAX, U256::from(2), U256::MAX), U256::from(2));
+    assert_eq!(mulmod_word(U256::MAX, U256::MAX, U256::MAX), U256::ZERO);
+
+    let model = BTreeMap::from([("a".to_string(), U256::MAX)]);
+    assert_eq!(
+        eval_expr(
+            &Expr::addmod(
+                Expr::Var("a".to_string()),
+                Expr::Const(U256::from(2)),
+                Expr::Const(U256::MAX)
+            ),
+            &model,
+        )
+        .unwrap(),
+        U256::from(2)
+    );
+    assert_eq!(
+        eval_expr(
+            &Expr::mulmod(
+                Expr::Var("a".to_string()),
+                Expr::Var("a".to_string()),
+                Expr::Const(U256::MAX)
+            ),
+            &model,
+        )
+        .unwrap(),
+        U256::ZERO
+    );
+}
+
+#[test]
+/// Regression coverage for exact modular arithmetic SMT emission widening intermediates.
+fn exact_modular_arithmetic_smt_widens_before_modulo() {
+    let addmod = Expr::addmod(
+        Expr::Var("a".to_string()),
+        Expr::Const(U256::from(2)),
+        Expr::Var("m".to_string()),
+    )
+    .smt();
+    let mulmod = Expr::mulmod(
+        Expr::Var("a".to_string()),
+        Expr::Var("b".to_string()),
+        Expr::Var("m".to_string()),
+    )
+    .smt();
+
+    assert!(addmod.contains("((_ zero_extend 256) a)"));
+    assert!(addmod.contains("bvadd"));
+    assert!(addmod.contains("bvurem"));
+    assert!(mulmod.contains("((_ zero_extend 256) b)"));
+    assert!(mulmod.contains("bvmul"));
+    assert!(mulmod.contains("((_ extract 255 0)"));
+}
+
+#[test]
+/// Regression coverage for rejecting old wrapping-intermediate false witnesses.
+fn exact_addmod_model_validation_rejects_wrapping_false_pass() {
+    let constraints = vec![BoolExpr::eq(
+        Expr::addmod(
+            Expr::Var("a".to_string()),
+            Expr::Const(U256::from(2)),
+            Expr::Const(U256::MAX),
+        ),
+        Expr::Const(U256::from(1)),
+    )];
+    let output = format!("sat\n((define-fun a () (_ BitVec 256) #x{}))\n", "f".repeat(64));
+
+    let err = validate_solver_model_output(&output, &constraints).unwrap_err();
+
+    assert!(err.to_string().contains("does not satisfy path constraints"));
+}
+
+#[test]
 /// Regression coverage for exact unsigned-division zero predicate normalization.
 fn solver_normalizes_udiv_zero_predicates_without_bvudiv() {
     let numerator = Expr::Var("numerator".to_string());
@@ -2518,6 +2596,21 @@ fn hard_arithmetic_fallback_finds_wrapping_product_inequality_candidate() {
     let model = hard_arith_fallback_model(&constraints).unwrap();
 
     assert!(constraints.iter().all(|constraint| eval_bool_expr(constraint, &model).unwrap()));
+}
+
+#[test]
+/// Regression coverage for solver-hard exact `MULMOD` witness search.
+fn hard_arithmetic_fallback_finds_exact_mulmod_wide_intermediate_candidate() {
+    let a = Expr::Var("a".to_string());
+    let constraints = vec![
+        BoolExpr::cmp(BoolExprOp::Ugt, a.clone(), Expr::Const(U256::ZERO)),
+        BoolExpr::eq(Expr::mulmod(a.clone(), a, Expr::Const(U256::MAX)), Expr::Const(U256::ZERO)),
+    ];
+
+    let model = hard_arith_fallback_model(&constraints).unwrap();
+
+    assert!(constraints.iter().all(|constraint| eval_bool_expr(constraint, &model).unwrap()));
+    assert_eq!(model.get("a"), Some(&U256::MAX));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- model EVM ADDMOD and MULMOD with exact zero-modulus semantics and full-width intermediates
- emit SMT that zero-extends operands before modular reduction instead of using wrapped 256-bit intermediates
- validate hard-arithmetic fallback witnesses against the exact expression semantics

## Tests

- cargo +1.95.0 test -p foundry-evm-symbolic exact_
- cargo +1.95.0 test -p foundry-evm-symbolic
