### PR TITLE
fix(ci): bench dispatch permissions + rename

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -30,8 +30,7 @@ jobs:
     # Scopes the EVENTS_* mTLS secrets; shared across all `bench` subcommands.
     environment: bench
     permissions:
-      issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - name: Validate request
         id: request

--- a/.github/workflows/benchmarks-dispatch.yml
+++ b/.github/workflows/benchmarks-dispatch.yml
@@ -1,6 +1,6 @@
 ---
 # yamllint disable rule:line-length
-name: bench
+name: bench (dispatch)
 
 permissions: {}
 


### PR DESCRIPTION
Follow-up to #15138.

## Changes
- **Permissions fix:** the dispatch job requested `issues: write` + `pull-requests: read`, but commenting on a PR needs `pull-requests: write` (matches `benchmarks.yml`). Without it the run fails at the acknowledge step with `403 Resource not accessible by integration`.
- **Rename:** `bench.yml` → `benchmarks-dispatch.yml` to group it with the other benchmark workflows (`benchmarks.yml`, `benchmarks-nightly.yml`). This workflow dispatches an event rather than running benchmarks locally. Public command (`derek bench …`) is unchanged — `issue_comment` matching is driven by comment text, not the filename.