### PR TITLE
feat(config): support solc --experimental

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5375,8 +5375,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce324cefbd0ad6b8c78acd082a4929e854286dd80835715c46d54aa2116401a3"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5407,8 +5406,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f06259ea4e0d34b2c05324601bdd5808653738ad88928be8b1d0c244f46acb"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5417,8 +5415,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385384abbe9a9e47362e95a0df90a345a78191e8040277580bc391f4eb3390b1"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5438,8 +5435,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8331540e110836cdfc2ecdf8ac67263e821911ea27108b51a5ad0b6d4a755b84"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5452,8 +5448,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad57930a31d0577202846e76aa2d14f57d25044057c3a688feed52747cf2b49"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
 dependencies = [
  "alloy-primitives",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -530,6 +530,9 @@ snapbox = { version = "0.6", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
+## Temporary dependency on foundry-rs/foundry-core#94 until foundry-compilers is released.
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "39f19b016c2ba793b24255bda83bd3822c8cb525" }
+
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
 # alloy-json-abi = { path = "../../alloy-rs/core/crates/json-abi" }

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -280,6 +280,10 @@ impl Provider for BuildOpts {
             dict.insert("ast".to_string(), true.into());
         }
 
+        if self.compiler.experimental {
+            dict.insert("experimental".to_string(), true.into());
+        }
+
         if let Some(optimize) = self.compiler.optimize {
             dict.insert("optimizer".to_string(), optimize.into());
         }

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -33,6 +33,14 @@ pub struct CompilerOpts {
     #[serde(skip)]
     pub optimize: Option<bool>,
 
+    /// Enable Solidity's experimental mode.
+    ///
+    /// This passes `--experimental` to solc, which is required by Solidity 0.8.35+ for
+    /// experimental features.
+    #[arg(long, help_heading = "Compiler options")]
+    #[serde(skip)]
+    pub experimental: bool,
+
     /// The number of runs specifies roughly how often each opcode of the deployed code will be
     /// executed across the life-time of the contract. This means it is a trade-off parameter
     /// between code size (deploy cost) and code execution cost (cost after deployment).
@@ -78,6 +86,12 @@ mod tests {
             args.extra_output,
             vec![ContractOutputSelection::Metadata, ContractOutputSelection::IrOptimized]
         );
+    }
+
+    #[test]
+    fn can_parse_experimental() {
+        let args: CompilerOpts = CompilerOpts::parse_from(["foundry-cli", "--experimental"]);
+        assert!(args.experimental);
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -470,6 +470,11 @@ pub struct Config {
     /// If set to true, changes compilation pipeline to go through the Yul intermediate
     /// representation.
     pub via_ir: bool,
+    /// Whether to enable Solidity's experimental mode.
+    ///
+    /// This passes `--experimental` to solc, which is required by Solidity 0.8.35+ for
+    /// experimental features.
+    pub experimental: bool,
     /// Whether to include the AST as JSON in the compiler output.
     pub ast: bool,
     /// RPC storage caching settings determines what chains and endpoints to cache
@@ -1846,6 +1851,7 @@ impl Config {
             }),
             model_checker,
             via_ir: Some(self.via_ir),
+            experimental: Some(self.experimental),
             // Not used.
             stop_after: None,
             // Set in project paths.
@@ -2762,6 +2768,7 @@ impl Default for Config {
             deny: DenyLevel::Never,
             deny_warnings: false,
             via_ir: false,
+            experimental: false,
             ast: false,
             rpc_storage_caching: Default::default(),
             rpc_endpoints: Default::default(),
@@ -5144,6 +5151,23 @@ mod tests {
         };
 
         assert_eq!(config.evm_spec_id::<TempoHardfork>(), TempoHardfork::T3);
+    }
+
+    #[test]
+    fn solc_settings_include_experimental_setting() {
+        let config = Config { experimental: true, ..Config::default() };
+        let settings = config.solc_settings().unwrap();
+        assert_eq!(settings.settings.experimental, Some(true));
+        assert!(settings.cli_settings.extra_args.is_empty());
+
+        let config = Config {
+            experimental: false,
+            extra_args: vec!["--experimental".to_string()],
+            ..Config::default()
+        };
+        let settings = config.solc_settings().unwrap();
+        assert_eq!(settings.settings.experimental, Some(false));
+        assert_eq!(settings.cli_settings.extra_args, vec!["--experimental".to_string()]);
     }
 
     #[test]

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -4159,6 +4159,7 @@ forgetest_init!(can_inspect_standard_json, |prj, cmd| {
     },
     "evmVersion": "osaka",
     "viaIR": false,
+    "experimental": false,
     "libraries": {}
   }
 }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -96,6 +96,7 @@ extra_output_files = []
 names = false
 sizes = false
 via_ir = false
+experimental = false
 ast = false
 no_storage_caching = false
 no_rpc_rate_limit = false
@@ -447,6 +448,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         assertions_revert: true,
         legacy_assertions: false,
         extra_args: vec![],
+        experimental: false,
         networks: Default::default(),
         transaction_timeout: 120,
         additional_compiler_profiles: Default::default(),
@@ -672,8 +674,9 @@ forgetest_init!(eth_rpc_url_env_does_not_set_fork_url, |prj, _cmd| {
 // checks that we can set various config values
 forgetest_init!(can_set_config_values, |prj, _cmd| {
     prj.initialize_default_contracts();
-    let config = prj.config_from_output(["--via-ir", "--no-metadata"]);
+    let config = prj.config_from_output(["--via-ir", "--experimental", "--no-metadata"]);
     assert!(config.via_ir);
+    assert!(config.experimental);
     assert_eq!(config.cbor_metadata, false);
     assert_eq!(config.bytecode_hash, BytecodeHash::None);
 });
@@ -1534,6 +1537,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "names": false,
   "sizes": false,
   "via_ir": false,
+  "experimental": false,
   "ast": false,
   "rpc_storage_caching": {
     "chains": "all",


### PR DESCRIPTION
## Summary

- Adds an `experimental` config option and `--experimental` compiler CLI flag.
- Maps Foundry config to solc Standard JSON `settings.experimental` through `foundry-compilers`.
- Updates config defaults, CLI parsing, and config output tests for the new field.

## Dependency

Depends on the merged foundry-core compiler support from foundry-rs/foundry-core#94. This PR temporarily patches `foundry-compilers` to `foundry-rs/foundry-core@39f19b016c2ba793b24255bda83bd3822c8cb525` until the next `foundry-compilers` crate release.

## Context

Solidity 0.8.35 introduced experimental mode via `--experimental` and `settings.experimental`. Foundry should expose the flag while using typed compiler settings instead of injecting the flag into raw solc extra args.

Reference: https://www.soliditylang.org/blog/2026/04/29/solidity-0.8.35-release-announcement/

## Validation

- `cargo +1.95.0 test --locked -p foundry-config solc_settings_include_experimental_setting`
- `cargo +1.95.0 test -p foundry-cli can_parse_experimental`
- `cargo +1.95.0 test -p forge can_set_config_values`
- `cargo +1.95.0 test --locked -p forge can_inspect_standard_json`
- `cargo +1.95.0 fmt --check` (passes; stable rustfmt emits warnings for nightly-only rustfmt options)
