### PR TITLE
feat(symbolic): Cancun `SELFDESTRUCT` semantics

### DIFF
--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -110,6 +110,11 @@ Current modeling notes:
   incomplete results with an explanatory reason.
 - Symbolic `KECCAK256` supports common Solidity storage patterns; arbitrary
   symbolic hashing may require heuristics and can make a run incomplete.
+- `SELFDESTRUCT` follows the active fork. Before Cancun it deletes the account;
+  from Cancun onward it only deletes contracts created in the same top-level
+  symbolic transaction, otherwise it transfers balance and halts while
+  preserving code and storage. Beneficiaries must resolve to concrete or
+  representative symbolic addresses.
 - Counterexamples are shown only after successful concrete replay.
 
 ## Writing Symbolic Tests
@@ -476,7 +481,7 @@ Known incomplete, bounded, or approximate surfaces include:
 | Area | Current behavior |
 |---|---|
 | Gas-dependent behavior | The engine does not use gas to prove properties. A raw `GAS` / `gasleft()` value is tolerated only as the direct gas operand to a CALL-family opcode and is not used to model gas availability. Explicit CALL-family gas caps are not enforced. Branches, arithmetic, call targets/values, calldata/returndata, memory/log offsets or sizes, `expectCall` gas matching, or solver constraints derived from observed gas report incomplete. Non-observable gas metering helpers are accepted as no-ops; observable gas read/snapshot helpers such as `lastCallGas`, `snapshotGasLastCall`, and `stopSnapshotGas` report incomplete and should not be used as symbolic properties. |
-| Cancun+ `SELFDESTRUCT` | Pre-Cancun deletion is modeled. Cancun/EIP-6780 same-transaction creation/deletion and end-of-transaction finalization are not fully modeled, so Cancun+ `SELFDESTRUCT` reports incomplete. |
+| `SELFDESTRUCT` | Pre-Cancun deletion is modeled. Cancun/EIP-6780 is modeled for concrete and resolved symbolic beneficiaries: contracts created in the current top-level symbolic transaction are deleted, while existing contracts transfer balance and halt without deleting code or storage. |
 | Symbolic account/code queries | `BALANCE`, `EXTCODESIZE`, `EXTCODEHASH`, and `EXTCODECOPY` on symbolic addresses are scoped to the engine's known symbolic/overlay/code-cache candidates plus the documented empty-account fallback. They do not prove quantified properties over every possible fork/backend account. |
 | Symbolic CALL targets | Concrete targets and symbolic targets constrained to known deployed-contract/precompile candidates are supported. By default, a feasible symbolic target outside the known candidate set reports incomplete. With `symbolic_call_targets = true`, the outside-candidate branch is modeled as an empty-account/no-code successful call, including value transfer for `CALL`; it does not model arbitrary unknown external code or custom/future precompiles. Symbolic cheatcode addresses/selectors still report incomplete. |
 | Symbolic CREATE / CREATE2 inputs | Concrete initcode and common bounded symbolic CREATE2 address expressions are supported. Symbolic runtime sizes and unsupported symbolic initcode shapes report incomplete. |
@@ -494,8 +499,7 @@ Known incomplete, bounded, or approximate surfaces include:
 | Resource and scope bounds | `max_paths` / width, execution depth, calldata variant budget, solver query budget, and solver timeout can stop a run as incomplete. Dynamic ABI length settings, `invariant_depth`, and `symbolic.loop` define the explored input/sequence/loop scope; a `PASS` is only within those configured bounds, and skipped larger shapes, deeper sequences, or more loop iterations are not necessarily reported as incomplete. |
 
 Exact failure messages are preserved in the test output, for example
-`unsupported symbolic execution feature: GAS/gasleft() not modeled` or
-`unsupported symbolic execution feature: SELFDESTRUCT/EIP-6780 not modeled`.
+`unsupported symbolic execution feature: GAS/gasleft() not modeled`.
 
 For real-world bug-shaped examples that exercise the current modeled surface,
 see the community-maintained

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -113,8 +113,8 @@ Current modeling notes:
 - `SELFDESTRUCT` follows the active fork. Before Cancun it deletes the account;
   from Cancun onward it only deletes contracts created in the same top-level
   symbolic transaction, otherwise it transfers balance and halts while
-  preserving code and storage. Beneficiaries must resolve to concrete or
-  representative symbolic addresses.
+  preserving code and storage. Cancun beneficiaries must resolve to concrete
+  addresses; unresolved symbolic beneficiaries report incomplete.
 - Counterexamples are shown only after successful concrete replay.
 
 ## Writing Symbolic Tests
@@ -481,7 +481,7 @@ Known incomplete, bounded, or approximate surfaces include:
 | Area | Current behavior |
 |---|---|
 | Gas-dependent behavior | The engine does not use gas to prove properties. A raw `GAS` / `gasleft()` value is tolerated only as the direct gas operand to a CALL-family opcode and is not used to model gas availability. Explicit CALL-family gas caps are not enforced. Branches, arithmetic, call targets/values, calldata/returndata, memory/log offsets or sizes, `expectCall` gas matching, or solver constraints derived from observed gas report incomplete. Non-observable gas metering helpers are accepted as no-ops; observable gas read/snapshot helpers such as `lastCallGas`, `snapshotGasLastCall`, and `stopSnapshotGas` report incomplete and should not be used as symbolic properties. |
-| `SELFDESTRUCT` | Pre-Cancun deletion is modeled. Cancun/EIP-6780 is modeled for concrete and resolved symbolic beneficiaries: contracts created in the current top-level symbolic transaction are deleted, while existing contracts transfer balance and halt without deleting code or storage. |
+| `SELFDESTRUCT` | Pre-Cancun deletion is modeled. Cancun/EIP-6780 is modeled for concrete beneficiaries: contracts created in the current top-level symbolic transaction are deleted, while existing contracts transfer balance and halt without deleting code or storage. Unresolved symbolic Cancun beneficiaries report incomplete. |
 | Symbolic account/code queries | `BALANCE`, `EXTCODESIZE`, `EXTCODEHASH`, and `EXTCODECOPY` on symbolic addresses are scoped to the engine's known symbolic/overlay/code-cache candidates plus the documented empty-account fallback. They do not prove quantified properties over every possible fork/backend account. |
 | Symbolic CALL targets | Concrete targets and symbolic targets constrained to known deployed-contract/precompile candidates are supported. By default, a feasible symbolic target outside the known candidate set reports incomplete. With `symbolic_call_targets = true`, the outside-candidate branch is modeled as an empty-account/no-code successful call, including value transfer for `CALL`; it does not model arbitrary unknown external code or custom/future precompiles. Symbolic cheatcode addresses/selectors still report incomplete. |
 | Symbolic CREATE / CREATE2 inputs | Concrete initcode and common bounded symbolic CREATE2 address expressions are supported. Symbolic runtime sizes and unsupported symbolic initcode shapes report incomplete. |

--- a/crates/evm/symbolic/src/executor/create.rs
+++ b/crates/evm/symbolic/src/executor/create.rs
@@ -99,6 +99,7 @@ impl SymbolicExecutor {
         let mut child = state.child(frame);
         let pending_expected_creates = std::mem::take(&mut child.expected_creates);
         child.world = failure_world.clone();
+        child.world.mark_current_transaction_created(created);
         child.world.set_nonce(created, 1);
         child.world.transfer(executor, state.address, created, value);
         child.expected_revert = None;
@@ -179,8 +180,10 @@ impl SymbolicExecutor {
                         kind,
                         &outcome.return_data,
                     )?;
-                    parent.world.install_code(created, outcome.return_data.to_code()?);
-                    parent.world.set_nonce(created, 1);
+                    if !parent.world.destroyed_accounts.contains(&created) {
+                        parent.world.install_code(created, outcome.return_data.to_code()?);
+                        parent.world.set_nonce(created, 1);
+                    }
                     parent.stack.push(created_word.clone())?;
                 }
                 TopLevelCallStatus::Revert => {

--- a/crates/evm/symbolic/src/executor/invariant.rs
+++ b/crates/evm/symbolic/src/executor/invariant.rs
@@ -112,7 +112,7 @@ impl SymbolicExecutor {
         constraints: Vec<BoolExpr>,
         completed_paths: &mut usize,
     ) -> Result<Vec<TopLevelCallOutcome>, SymbolicError> {
-        state.world.clear_transient_storage();
+        state.world.clear_transaction_scoped_state();
         let code = state.world.extcode(executor, target)?;
         let jumpdests = analyze_jumpdests(&code);
         state.call_depth = 0;

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -601,11 +601,14 @@ impl SymbolicExecutor {
                     return Ok(StepOutcome::Revert);
                 }
                 let spec_id: SpecId = executor.spec_id().into();
-                if spec_id >= SpecId::CANCUN {
-                    return Err(SymbolicError::Unsupported("SELFDESTRUCT/EIP-6780 not modeled"));
-                }
                 let beneficiary = state.pop_address_or_symbolic_slot()?;
-                state.world.selfdestruct(executor, state.address, beneficiary)?;
+                if spec_id < SpecId::CANCUN
+                    || state.world.was_created_in_current_transaction(state.address)
+                {
+                    state.world.selfdestruct_legacy(executor, state.address, beneficiary)?;
+                } else {
+                    state.world.selfdestruct_cancun_existing(executor, state.address, beneficiary);
+                }
                 state.return_data = SymReturnData::default();
                 Ok(StepOutcome::Halt)
             }

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -601,12 +601,17 @@ impl SymbolicExecutor {
                     return Ok(StepOutcome::Revert);
                 }
                 let spec_id: SpecId = executor.spec_id().into();
-                let beneficiary = state.pop_address_or_symbolic_slot()?;
+                let (beneficiary_word, beneficiary) = state.pop_address_word_or_symbolic_slot()?;
                 if spec_id < SpecId::CANCUN
                     || state.world.was_created_in_current_transaction(state.address)
                 {
                     state.world.selfdestruct_legacy(executor, state.address, beneficiary)?;
                 } else {
+                    if state.constrained_word(&beneficiary_word).is_none() {
+                        return Err(SymbolicError::Unsupported(
+                            "symbolic SELFDESTRUCT beneficiary",
+                        ));
+                    }
                     state.world.selfdestruct_cancun_existing(executor, state.address, beneficiary);
                 }
                 state.return_data = SymReturnData::default();

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -139,7 +139,7 @@ impl SymbolicExecutor {
             );
             root.apply_executor_env(input.executor);
             root.world.set_storage_layout(self.config.storage_layout);
-            root.world.clear_transient_storage();
+            root.world.clear_transaction_scoped_state();
             worklist.push_back(root);
         }
         let mut completed_paths = 0usize;
@@ -388,7 +388,7 @@ impl SymbolicExecutor {
                                             );
                                         }
                                         let mut reverted_state = sequence.state.clone();
-                                        reverted_state.world.clear_transient_storage();
+                                        reverted_state.world.clear_transaction_scoped_state();
                                         for invariant_outcome in self.execute_invariant_check(
                                             input.executor,
                                             reverted_state,

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -997,6 +997,7 @@ impl StorageWrite {
 pub(crate) struct SymbolicWorldSnapshot {
     pub(crate) storage: Vec<StorageWrite>,
     pub(crate) transient_storage: Vec<StorageWrite>,
+    pub(crate) current_transaction_created_accounts: BTreeSet<Address>,
     pub(crate) balances: BTreeMap<Address, SymWord>,
     pub(crate) code_cache: BTreeMap<Address, SymCode>,
     pub(crate) nonces: BTreeMap<Address, u64>,
@@ -1014,6 +1015,9 @@ impl From<&SymbolicWorld> for SymbolicWorldSnapshot {
         Self {
             storage: world.storage.clone(),
             transient_storage: world.transient_storage.clone(),
+            current_transaction_created_accounts: world
+                .current_transaction_created_accounts
+                .clone(),
             balances: world.balances.clone(),
             code_cache: world.code_cache.clone(),
             nonces: world.nonces.clone(),
@@ -1031,6 +1035,7 @@ impl From<&SymbolicWorld> for SymbolicWorldSnapshot {
 pub(crate) struct SymbolicWorld {
     pub(crate) storage: Vec<StorageWrite>,
     pub(crate) transient_storage: Vec<StorageWrite>,
+    pub(crate) current_transaction_created_accounts: BTreeSet<Address>,
     pub(crate) balances: BTreeMap<Address, SymWord>,
     pub(crate) code_cache: BTreeMap<Address, SymCode>,
     pub(crate) nonces: BTreeMap<Address, u64>,
@@ -1079,9 +1084,20 @@ impl SymbolicWorld {
         self.transient_storage.push(StorageWrite::new(address, key, value));
     }
 
-    /// Clears transaction-scoped transient storage at a top-level call boundary.
-    pub(crate) fn clear_transient_storage(&mut self) {
+    /// Clears transaction-scoped state at a top-level call boundary.
+    pub(crate) fn clear_transaction_scoped_state(&mut self) {
         self.transient_storage.clear();
+        self.current_transaction_created_accounts.clear();
+    }
+
+    /// Applies the `mark_current_transaction_created` symbolic state helper.
+    pub(crate) fn mark_current_transaction_created(&mut self, address: Address) {
+        self.current_transaction_created_accounts.insert(address);
+    }
+
+    /// Returns whether `address` was created in the current top-level symbolic transaction.
+    pub(crate) fn was_created_in_current_transaction(&self, address: Address) -> bool {
+        self.current_transaction_created_accounts.contains(&address)
     }
 
     /// Applies the `enable_arbitrary_storage` symbolic state helper.
@@ -1133,6 +1149,7 @@ impl SymbolicWorld {
         };
         self.storage = snapshot.storage;
         self.transient_storage = snapshot.transient_storage;
+        self.current_transaction_created_accounts = snapshot.current_transaction_created_accounts;
         self.balances = snapshot.balances;
         self.code_cache = snapshot.code_cache;
         self.nonces = snapshot.nonces;
@@ -1331,8 +1348,8 @@ impl SymbolicWorld {
         self.destroyed_accounts.remove(&address);
     }
 
-    /// Implements the `selfdestruct` symbolic state helper.
-    pub(crate) fn selfdestruct<FEN: FoundryEvmNetwork>(
+    /// Implements legacy `SELFDESTRUCT` semantics.
+    pub(crate) fn selfdestruct_legacy<FEN: FoundryEvmNetwork>(
         &mut self,
         executor: &Executor<FEN>,
         address: Address,
@@ -1355,6 +1372,22 @@ impl SymbolicWorld {
         self.existing_accounts.remove(&address);
         self.destroyed_accounts.insert(address);
         Ok(())
+    }
+
+    /// Implements Cancun+ `SELFDESTRUCT` semantics for accounts not created in the current tx.
+    pub(crate) fn selfdestruct_cancun_existing<FEN: FoundryEvmNetwork>(
+        &mut self,
+        executor: &Executor<FEN>,
+        address: Address,
+        beneficiary: Address,
+    ) {
+        let balance = self.balance_word_for_address(executor, address);
+        if beneficiary != address && !matches!(balance, SymWord::Concrete(value) if value.is_zero())
+        {
+            let beneficiary_balance = self.balance_word_for_address(executor, beneficiary);
+            self.set_balance_word(beneficiary, sym_add(beneficiary_balance, balance));
+            self.balances.insert(address, SymWord::zero());
+        }
     }
 
     /// Implements the `account_exists` symbolic state helper.

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -474,10 +474,13 @@ impl PathState {
         self.world.extcode_bytes_word(executor, word, offset, size)
     }
 
-    /// Implements the `pop_address_or_symbolic_slot` symbolic state helper.
-    pub(crate) fn pop_address_or_symbolic_slot(&mut self) -> Result<Address, SymbolicError> {
+    /// Implements the `pop_address_word_or_symbolic_slot` symbolic state helper.
+    pub(crate) fn pop_address_word_or_symbolic_slot(
+        &mut self,
+    ) -> Result<(SymWord, Address), SymbolicError> {
         let word = self.stack.pop()?;
-        Ok(self.address_or_symbolic_slot(word))
+        let address = self.address_or_symbolic_slot(word.clone());
+        Ok((word, address))
     }
 
     /// Returns the `address_or_symbolic_slot` symbolic state helper result.

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -1388,6 +1388,8 @@ impl SymbolicWorld {
         if beneficiary != address && !matches!(balance, SymWord::Concrete(value) if value.is_zero())
         {
             let beneficiary_balance = self.balance_word_for_address(executor, beneficiary);
+            // Symbolic balances are treated as possibly non-zero, matching transfer's
+            // account-existence approximation.
             self.set_balance_word(beneficiary, sym_add(beneficiary_balance, balance));
             self.balances.insert(address, SymWord::zero());
         }

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -1831,6 +1831,28 @@ fn symbolic_world_snapshot_restores_overlay_state() {
 }
 
 #[test]
+/// Regression coverage for `symbolic_world_tracks_current_transaction_created_accounts`.
+fn symbolic_world_tracks_current_transaction_created_accounts() {
+    let first = Address::from([0x11; 20]);
+    let second = Address::from([0x22; 20]);
+    let mut world = SymbolicWorld::default();
+
+    world.mark_current_transaction_created(first);
+    let snapshot = world.snapshot_state();
+    world.mark_current_transaction_created(second);
+
+    assert!(world.was_created_in_current_transaction(first));
+    assert!(world.was_created_in_current_transaction(second));
+
+    assert!(world.restore_snapshot(snapshot));
+    assert!(world.was_created_in_current_transaction(first));
+    assert!(!world.was_created_in_current_transaction(second));
+
+    world.clear_transaction_scoped_state();
+    assert!(!world.was_created_in_current_transaction(first));
+}
+
+#[test]
 /// Regression coverage for `extra_dynamic_lengths_are_rejected`.
 fn extra_dynamic_lengths_are_rejected() {
     let function = Function::parse("check(bytes)").unwrap();

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -769,10 +769,10 @@ invalid length `nope`
     );
 });
 
-forgetest_init!(symbolic_selfdestruct_cancun_reports_incomplete, |prj, cmd| {
+forgetest_init!(symbolic_selfdestruct_cancun_self_beneficiary_halts, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(
-            "skipping symbolic_selfdestruct_cancun_reports_incomplete because z3 is not available"
+            "skipping symbolic_selfdestruct_cancun_self_beneficiary_halts because z3 is not available"
         );
         return;
     }
@@ -785,8 +785,10 @@ import "forge-std/Test.sol";
 /// forge-config: default.evm_version = "cancun"
 
 contract SymbolicSelfdestructCancun is Test {
-    function checkSelfdestructCancun(address payable beneficiary) public {
-        selfdestruct(beneficiary);
+    function checkSelfdestructCancun(uint256) public {
+        selfdestruct(payable(address(this)));
+
+        assert(false);
     }
 }
 "#,
@@ -794,16 +796,17 @@ contract SymbolicSelfdestructCancun is Test {
 
     let stdout = cmd
         .args(["test", "--symbolic", "--match-test", "checkSelfdestructCancun"])
-        .assert_failure()
+        .assert_success()
         .get_output()
         .stdout_lossy();
 
     assert_relevant_lines(
         &stdout,
         foundry_test_utils::str![[r#"
-SELFDESTRUCT/EIP-6780 not modeled
+[PASS] checkSelfdestructCancun(uint256)
 "#]],
     );
+    assert!(!stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
 });
 forgetest_init!(symbolic_invariant_finds_single_step_counterexample, |prj, cmd| {
     if !z3_available() {

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -1165,6 +1165,8 @@ forgetest_init!(symbolic_selfdestruct_updates_account_overlay, |prj, cmd| {
         r#"
 import "forge-std/Test.sol";
 
+/// forge-config: default.evm_version = "shanghai"
+
 contract Killable {
     receive() external payable {}
 
@@ -1197,17 +1199,25 @@ contract SymbolicSelfdestruct is Test {
     );
 
     let stdout = cmd
-        .args(["test", "--symbolic", "--match-test", "checkSelfdestruct"])
-        .assert_failure()
+        .args([
+            "test",
+            "--symbolic",
+            "--evm-version",
+            "shanghai",
+            "--match-test",
+            "checkSelfdestruct",
+        ])
+        .assert_success()
         .get_output()
         .stdout_lossy();
 
     assert_relevant_lines(
         &stdout,
         foundry_test_utils::str![[r#"
-[FAIL: incomplete symbolic execution (Stuck): unsupported symbolic execution feature: SELFDESTRUCT/EIP-6780 not modeled] checkSelfdestruct(uint256)
+[PASS] checkSelfdestruct(uint256)
 "#]],
     );
+    assert!(!stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
 });
 
 forgetest_init!(symbolic_selfdestruct_accepts_symbolic_beneficiary, |prj, cmd| {
@@ -1253,18 +1263,199 @@ contract SymbolicSelfdestructBeneficiary is Test {
 
     let stdout = cmd
         .args(["test", "--symbolic", "--match-test", "checkSelfdestructBeneficiary"])
-        .assert_failure()
+        .assert_success()
         .get_output()
         .stdout_lossy();
 
     assert_relevant_lines(
         &stdout,
         foundry_test_utils::str![[r#"
-[FAIL: incomplete symbolic execution (Stuck): unsupported symbolic execution feature: SELFDESTRUCT/EIP-6780 not modeled] checkSelfdestructBeneficiary(address)
+[PASS] checkSelfdestructBeneficiary(address)
 "#]],
     );
+    assert!(!stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
     assert!(!stdout.contains("symbolic SELFDESTRUCT beneficiary"), "{stdout}");
     assert!(!stdout.contains("symbolic BALANCE target"), "{stdout}");
+});
+
+forgetest_init!(symbolic_selfdestruct_cancun_existing_preserves_account, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_selfdestruct_cancun_existing_preserves_account because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicSelfdestructCancunExisting.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+/// forge-config: default.evm_version = "cancun"
+
+contract KillableCancun {
+    uint256 value = 42;
+
+    receive() external payable {}
+
+    function die(address payable beneficiary) external {
+        selfdestruct(beneficiary);
+    }
+
+    function get() external view returns (uint256) {
+        return value;
+    }
+}
+
+contract SymbolicSelfdestructCancunExisting is Test {
+    KillableCancun killable;
+    address payable beneficiary = payable(address(0xB0B));
+
+    function setUp() public {
+        killable = new KillableCancun();
+    }
+
+    function checkCancunSelfdestructExisting(uint256) public {
+        vm.deal(address(killable), 7);
+
+        killable.die(beneficiary);
+
+        assertEq(address(killable).balance, 0);
+        assertEq(beneficiary.balance, 7);
+        assertGt(address(killable).code.length, 0);
+        assertEq(killable.get(), 42);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkCancunSelfdestructExisting"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCancunSelfdestructExisting(uint256)
+"#]],
+    );
+    assert!(!stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
+});
+
+forgetest_init!(symbolic_selfdestruct_cancun_same_transaction_deletes_account, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_selfdestruct_cancun_same_transaction_deletes_account because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicSelfdestructCancunSameTx.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+/// forge-config: default.evm_version = "cancun"
+
+contract KillableCancunSameTx {
+    receive() external payable {}
+
+    function die(address payable beneficiary) external {
+        selfdestruct(beneficiary);
+    }
+}
+
+contract SymbolicSelfdestructCancunSameTx is Test {
+    address payable beneficiary = payable(address(0xB0B));
+
+    function checkCancunSelfdestructSameTransaction(uint256) public {
+        KillableCancunSameTx killable = new KillableCancunSameTx();
+        vm.deal(address(killable), 7);
+
+        killable.die(beneficiary);
+
+        assertEq(address(killable).balance, 0);
+        assertEq(beneficiary.balance, 7);
+        assertEq(address(killable).code.length, 0);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-test", "checkCancunSelfdestructSameTransaction"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkCancunSelfdestructSameTransaction(uint256)
+"#]],
+    );
+    assert!(!stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
+});
+
+forgetest_init!(symbolic_selfdestruct_cancun_wrong_delete_assertion_fails, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_selfdestruct_cancun_wrong_delete_assertion_fails because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicSelfdestructCancunWrongDelete.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+/// forge-config: default.evm_version = "cancun"
+
+contract KillableCancunWrongDelete {
+    receive() external payable {}
+
+    function die(address payable beneficiary) external {
+        selfdestruct(beneficiary);
+    }
+}
+
+contract SymbolicSelfdestructCancunWrongDelete is Test {
+    KillableCancunWrongDelete killable;
+    address payable beneficiary = payable(address(0xB0B));
+
+    function setUp() public {
+        killable = new KillableCancunWrongDelete();
+    }
+
+    function checkCancunSelfdestructDoesNotDeleteExisting(uint256) public {
+        killable.die(beneficiary);
+
+        assertEq(address(killable).code.length, 0);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--match-test",
+            "checkCancunSelfdestructDoesNotDeleteExisting",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(stdout.contains("[FAIL"), "{stdout}");
+    assert!(stdout.contains("counterexample"), "{stdout}");
+    assert!(stdout.contains("checkCancunSelfdestructDoesNotDeleteExisting"), "{stdout}");
+    assert!(!stdout.contains("[PASS] checkCancunSelfdestructDoesNotDeleteExisting"), "{stdout}");
+    assert!(!stdout.contains("incomplete symbolic execution"), "{stdout}");
+    assert!(!stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
 });
 
 forgetest_init!(symbolic_vm_set_blockhash, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -1220,18 +1220,22 @@ contract SymbolicSelfdestruct is Test {
     assert!(!stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
 });
 
-forgetest_init!(symbolic_selfdestruct_accepts_symbolic_beneficiary, |prj, cmd| {
-    if !z3_available() {
-        let _ = sh_eprintln!(
-            "skipping symbolic_selfdestruct_accepts_symbolic_beneficiary because z3 is not available"
-        );
-        return;
-    }
+forgetest_init!(
+    symbolic_selfdestruct_cancun_symbolic_beneficiary_reports_incomplete,
+    |prj, cmd| {
+        if !z3_available() {
+            let _ = sh_eprintln!(
+                "skipping symbolic_selfdestruct_cancun_symbolic_beneficiary_reports_incomplete because z3 is not available"
+            );
+            return;
+        }
 
-    prj.add_test(
-        "SymbolicSelfdestructBeneficiary.t.sol",
-        r#"
+        prj.add_test(
+            "SymbolicSelfdestructBeneficiary.t.sol",
+            r#"
 import "forge-std/Test.sol";
+
+/// forge-config: default.evm_version = "cancun"
 
 contract Killable {
     receive() external payable {}
@@ -1259,24 +1263,24 @@ contract SymbolicSelfdestructBeneficiary is Test {
     }
 }
 "#,
-    );
+        );
 
-    let stdout = cmd
-        .args(["test", "--symbolic", "--match-test", "checkSelfdestructBeneficiary"])
-        .assert_success()
-        .get_output()
-        .stdout_lossy();
+        let stdout = cmd
+            .args(["test", "--symbolic", "--match-test", "checkSelfdestructBeneficiary"])
+            .assert_failure()
+            .get_output()
+            .stdout_lossy();
 
-    assert_relevant_lines(
-        &stdout,
-        foundry_test_utils::str![[r#"
-[PASS] checkSelfdestructBeneficiary(address)
+        assert_relevant_lines(
+            &stdout,
+            foundry_test_utils::str![[r#"
+[FAIL: incomplete symbolic execution (Stuck): unsupported symbolic execution feature: symbolic SELFDESTRUCT beneficiary] checkSelfdestructBeneficiary(address)
 "#]],
-    );
-    assert!(!stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
-    assert!(!stdout.contains("symbolic SELFDESTRUCT beneficiary"), "{stdout}");
-    assert!(!stdout.contains("symbolic BALANCE target"), "{stdout}");
-});
+        );
+        assert!(!stdout.contains("SELFDESTRUCT/EIP-6780 not modeled"), "{stdout}");
+        assert!(!stdout.contains("symbolic BALANCE target"), "{stdout}");
+    }
+);
 
 forgetest_init!(symbolic_selfdestruct_cancun_existing_preserves_account, |prj, cmd| {
     if !z3_available() {


### PR DESCRIPTION
## Summary

Models fork-aware symbolic `SELFDESTRUCT` semantics for Cancun/EIP-6780.

Closes OSS-365

## Changes

- Pre-Cancun and same-transaction-created contracts still delete.
- Cancun+ existing contracts transfer balance and halt while preserving code/storage.
- Transaction-scoped created accounts are tracked for this decision.

## Tests

- Added Cancun preservation, same-transaction deletion, and false-pass prevention coverage.
- Added unit coverage for created-account tracking across snapshots.