### PR TITLE
perf(symbolic): prune selectors and model deployCode

### DIFF
--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -863,15 +863,25 @@ impl SymbolicExecutor {
                 return Ok(outcome);
             }
 
-            let return_data = if to == CHEATCODE_ADDRESS {
-                match self.handle_foundry_cheatcode(
+            if to == CHEATCODE_ADDRESS
+                && let Some(outcome) = self.deploy_code_cheatcode_if_needed(
                     executor,
                     state,
+                    worklist,
                     completed_paths,
                     selector,
                     in_offset,
-                    in_size,
-                )? {
+                    out_offset.clone(),
+                    &out_size,
+                )?
+            {
+                return Ok(outcome);
+            }
+
+            let return_data = if to == CHEATCODE_ADDRESS {
+                match self
+                    .handle_foundry_cheatcode(executor, state, selector, in_offset, in_size)?
+                {
                     CheatcodeOutcome::Continue(ret) => SymReturnData::from_words(ret),
                     CheatcodeOutcome::ContinueData(ret) => ret,
                     CheatcodeOutcome::AssumeRejected => return Ok(StepOutcome::AssumeRejected),

--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -864,9 +864,14 @@ impl SymbolicExecutor {
             }
 
             let return_data = if to == CHEATCODE_ADDRESS {
-                match self
-                    .handle_foundry_cheatcode(executor, state, selector, in_offset, in_size)?
-                {
+                match self.handle_foundry_cheatcode(
+                    executor,
+                    state,
+                    completed_paths,
+                    selector,
+                    in_offset,
+                    in_size,
+                )? {
                     CheatcodeOutcome::Continue(ret) => SymReturnData::from_words(ret),
                     CheatcodeOutcome::ContinueData(ret) => ret,
                     CheatcodeOutcome::AssumeRejected => return Ok(StepOutcome::AssumeRejected),

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -93,6 +93,86 @@ impl SymbolicExecutor {
         CheatcodeOutcome::Continue(Vec::new())
     }
 
+    /// Applies the `deploy_code_cheatcode` symbolic executor helper.
+    pub(super) fn deploy_code_cheatcode<FEN: FoundryEvmNetwork>(
+        &mut self,
+        executor: &Executor<FEN>,
+        state: &mut PathState,
+        completed_paths: &mut usize,
+        artifact: String,
+        constructor_args: Vec<u8>,
+    ) -> Result<CheatcodeOutcome, SymbolicError> {
+        if state.is_static {
+            return Ok(CheatcodeOutcome::Failure);
+        }
+
+        let mut initcode = artifact_code(&artifact, false)?;
+        initcode.extend_from_slice(&constructor_args);
+        let initcode = SymCode::concrete(initcode);
+
+        let nonce = state.world.nonce(executor, state.address)?;
+        let created = state.address.create(nonce);
+        let created_word = SymWord::Concrete(address_word(created));
+
+        let mut failure_world = state.world.clone();
+        failure_world.increment_nonce(executor, state.address)?;
+        if failure_world.has_code_or_nonce(executor, created)? {
+            return Ok(CheatcodeOutcome::Failure);
+        }
+
+        let mut frame = CallFrame::new(
+            created,
+            created,
+            created,
+            state.address,
+            SymWord::zero(),
+            false,
+            SymCalldata::new(Vec::new()),
+        );
+        frame.address_word = created_word.clone();
+        frame.caller_word = state.address_word.clone();
+        let mut child = state.child(frame);
+        let pending_expected_creates = std::mem::take(&mut child.expected_creates);
+        child.world = failure_world.clone();
+        child.world.set_nonce(created, 1);
+        child.expected_revert = None;
+        child.assume_no_revert_next_call = None;
+
+        let mut outcomes =
+            self.execute_external_call(executor, child, &initcode, completed_paths)?;
+        if outcomes.len() != 1 {
+            return Err(SymbolicError::Unsupported("symbolic vm.deployCode branching constructor"));
+        }
+        let outcome = outcomes.remove(0);
+        match outcome.status {
+            TopLevelCallStatus::Success => {
+                state.constraints = outcome.state.constraints;
+                state.next_symbol = outcome.state.next_symbol;
+                state.world = outcome.state.world;
+                state.block = outcome.state.block;
+                state.recorded_logs = outcome.state.recorded_logs;
+                state.access_record = outcome.state.access_record;
+                state.expected_emit = outcome.state.expected_emit;
+                state.expected_calls = outcome.state.expected_calls;
+                state.expected_creates = pending_expected_creates;
+                state.call_mocks = outcome.state.call_mocks;
+                state.function_mocks = outcome.state.function_mocks;
+                self.observe_expected_create(
+                    state,
+                    state.address,
+                    CreateKind::Create,
+                    &outcome.return_data,
+                )?;
+                state.world.install_code(created, outcome.return_data.to_code()?);
+                state.world.set_nonce(created, 1);
+                Ok(CheatcodeOutcome::Continue(vec![created_word]))
+            }
+            TopLevelCallStatus::Revert | TopLevelCallStatus::Failure => {
+                Ok(CheatcodeOutcome::Failure)
+            }
+        }
+    }
+
     /// Applies the `observe_expected_create` symbolic executor helper.
     pub(super) fn observe_expected_create(
         &mut self,
@@ -281,6 +361,7 @@ impl SymbolicExecutor {
         &mut self,
         executor: &Executor<FEN>,
         state: &mut PathState,
+        completed_paths: &mut usize,
         selector: [u8; 4],
         in_offset: usize,
         in_size: usize,
@@ -1234,6 +1315,28 @@ impl SymbolicExecutor {
                 read_abi_string_arg(&state.memory, args_offset, 0, "symbolic vm.getCode")?;
             let code = artifact_code(&artifact, selector == selector!("getDeployedCode(string)"))?;
             return Ok(CheatcodeOutcome::ContinueData(abi_concrete_bytes_return(code)));
+        }
+        if selector == selector!("deployCode(string)") {
+            let artifact =
+                read_abi_string_arg(&state.memory, args_offset, 0, "symbolic vm.deployCode")?;
+            return self.deploy_code_cheatcode(
+                executor,
+                state,
+                completed_paths,
+                artifact,
+                Vec::new(),
+            );
+        }
+        if selector == selector!("deployCode(string,bytes)") {
+            let artifact =
+                read_abi_string_arg(&state.memory, args_offset, 0, "symbolic vm.deployCode")?;
+            let args = read_abi_dynamic_bytes_arg(
+                &state.memory,
+                args_offset,
+                1,
+                "symbolic vm.deployCode args",
+            )?;
+            return self.deploy_code_cheatcode(executor, state, completed_paths, artifact, args);
         }
         if selector == selector!("deal(address,uint256)") {
             let target = read_abi_address_or_symbolic_slot_arg(state, args_offset, 0)?;

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -93,17 +93,67 @@ impl SymbolicExecutor {
         CheatcodeOutcome::Continue(Vec::new())
     }
 
-    /// Applies the `deploy_code_cheatcode` symbolic executor helper.
-    pub(super) fn deploy_code_cheatcode<FEN: FoundryEvmNetwork>(
+    #[expect(clippy::too_many_arguments)]
+    /// Implements the `deploy_code_cheatcode_if_needed` symbolic executor helper.
+    pub(super) fn deploy_code_cheatcode_if_needed<FEN: FoundryEvmNetwork>(
         &mut self,
         executor: &Executor<FEN>,
         state: &mut PathState,
+        worklist: &mut VecDeque<PathState>,
+        completed_paths: &mut usize,
+        selector: [u8; 4],
+        in_offset: usize,
+        out_offset: SymWord,
+        out_size: &BoundedCopySize,
+    ) -> Result<Option<StepOutcome>, SymbolicError> {
+        let args_offset = in_offset + 4;
+        let (artifact, constructor_args) = if selector == selector!("deployCode(string)") {
+            let artifact =
+                read_abi_string_arg(&state.memory, args_offset, 0, "symbolic vm.deployCode")?;
+            (artifact, Vec::new())
+        } else if selector == selector!("deployCode(string,bytes)") {
+            let artifact =
+                read_abi_string_arg(&state.memory, args_offset, 0, "symbolic vm.deployCode")?;
+            let args = read_abi_dynamic_bytes_arg(
+                &state.memory,
+                args_offset,
+                1,
+                "symbolic vm.deployCode args",
+            )?;
+            (artifact, args)
+        } else {
+            return Ok(None);
+        };
+
+        self.deploy_code_cheatcode_call(
+            executor,
+            state,
+            worklist,
+            completed_paths,
+            artifact,
+            constructor_args,
+            out_offset,
+            out_size,
+        )
+        .map(Some)
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    /// Applies the `deploy_code_cheatcode_call` symbolic executor helper.
+    pub(super) fn deploy_code_cheatcode_call<FEN: FoundryEvmNetwork>(
+        &mut self,
+        executor: &Executor<FEN>,
+        state: &mut PathState,
+        worklist: &mut VecDeque<PathState>,
         completed_paths: &mut usize,
         artifact: String,
         constructor_args: Vec<u8>,
-    ) -> Result<CheatcodeOutcome, SymbolicError> {
+        out_offset: SymWord,
+        out_size: &BoundedCopySize,
+    ) -> Result<StepOutcome, SymbolicError> {
         if state.is_static {
-            return Ok(CheatcodeOutcome::Failure);
+            state.return_data = SymReturnData::default();
+            return Ok(StepOutcome::Revert);
         }
 
         let mut initcode = artifact_code(&artifact, false)?;
@@ -117,7 +167,14 @@ impl SymbolicExecutor {
         let mut failure_world = state.world.clone();
         failure_world.increment_nonce(executor, state.address)?;
         if failure_world.has_code_or_nonce(executor, created)? {
-            return Ok(CheatcodeOutcome::Failure);
+            state.world = failure_world;
+            complete_cheatcode_call(
+                state,
+                out_offset,
+                out_size,
+                SymReturnData::from_words(vec![SymWord::zero()]),
+            )?;
+            return Ok(StepOutcome::Continue);
         }
 
         let mut frame = CallFrame::new(
@@ -134,43 +191,127 @@ impl SymbolicExecutor {
         let mut child = state.child(frame);
         let pending_expected_creates = std::mem::take(&mut child.expected_creates);
         child.world = failure_world.clone();
+        child.world.mark_current_transaction_created(created);
         child.world.set_nonce(created, 1);
         child.expected_revert = None;
         child.assume_no_revert_next_call = None;
 
-        let mut outcomes =
-            self.execute_external_call(executor, child, &initcode, completed_paths)?;
-        if outcomes.len() != 1 {
-            return Err(SymbolicError::Unsupported("symbolic vm.deployCode branching constructor"));
-        }
-        let outcome = outcomes.remove(0);
-        match outcome.status {
-            TopLevelCallStatus::Success => {
-                state.constraints = outcome.state.constraints;
-                state.next_symbol = outcome.state.next_symbol;
-                state.world = outcome.state.world;
-                state.block = outcome.state.block;
-                state.recorded_logs = outcome.state.recorded_logs;
-                state.access_record = outcome.state.access_record;
-                state.expected_emit = outcome.state.expected_emit;
-                state.expected_calls = outcome.state.expected_calls;
-                state.expected_creates = pending_expected_creates;
-                state.call_mocks = outcome.state.call_mocks;
-                state.function_mocks = outcome.state.function_mocks;
-                self.observe_expected_create(
-                    state,
-                    state.address,
-                    CreateKind::Create,
+        let outcomes = self.execute_external_call(executor, child, &initcode, completed_paths)?;
+        let Some((first, rest)) = outcomes.split_first() else {
+            return Ok(StepOutcome::AssumeRejected);
+        };
+
+        let mut parents = VecDeque::with_capacity(outcomes.len());
+        for outcome in std::iter::once(first).chain(rest.iter()) {
+            let mut parent = state.clone();
+            parent.constraints = outcome.state.constraints.clone();
+            parent.next_symbol = outcome.state.next_symbol;
+
+            if let Some(assumption) = parent.assume_no_revert_next_call.take()
+                && matches!(outcome.status, TopLevelCallStatus::Revert)
+                && self.assume_no_revert_rejects(
+                    &mut parent,
+                    &assumption,
+                    created,
                     &outcome.return_data,
-                )?;
-                state.world.install_code(created, outcome.return_data.to_code()?);
-                state.world.set_nonce(created, 1);
-                Ok(CheatcodeOutcome::Continue(vec![created_word]))
+                )?
+            {
+                continue;
             }
-            TopLevelCallStatus::Revert | TopLevelCallStatus::Failure => {
-                Ok(CheatcodeOutcome::Failure)
+
+            if let Some(mut expected) = parent.expected_revert.clone() {
+                match outcome.status {
+                    TopLevelCallStatus::Success => {
+                        *state = parent;
+                        return Ok(StepOutcome::Failure);
+                    }
+                    TopLevelCallStatus::Revert | TopLevelCallStatus::Failure => {
+                        if !self.expected_revert_matches(
+                            &mut parent,
+                            &expected,
+                            created,
+                            &outcome.return_data,
+                        )? {
+                            *state = parent;
+                            return Ok(StepOutcome::Failure);
+                        }
+                        if expected.consume_one() {
+                            parent.expected_revert = None;
+                        } else {
+                            parent.expected_revert = Some(expected);
+                        }
+                        parent.access_record = outcome.state.access_record.clone();
+                        parent.expected_calls = outcome.state.expected_calls.clone();
+                        parent.expected_creates = pending_expected_creates.clone();
+                        parent.call_mocks = outcome.state.call_mocks.clone();
+                        parent.function_mocks = outcome.state.function_mocks.clone();
+                        parent.world = failure_world.clone();
+                        complete_cheatcode_call(
+                            &mut parent,
+                            out_offset.clone(),
+                            out_size,
+                            SymReturnData::from_words(vec![SymWord::zero()]),
+                        )?;
+                        parents.push_back(parent);
+                        continue;
+                    }
+                }
             }
+
+            match outcome.status {
+                TopLevelCallStatus::Success => {
+                    parent.world = outcome.state.world.clone();
+                    parent.block = outcome.state.block.clone();
+                    parent.recorded_logs = outcome.state.recorded_logs.clone();
+                    parent.access_record = outcome.state.access_record.clone();
+                    parent.expected_emit = outcome.state.expected_emit.clone();
+                    parent.expected_calls = outcome.state.expected_calls.clone();
+                    parent.expected_creates = pending_expected_creates.clone();
+                    parent.call_mocks = outcome.state.call_mocks.clone();
+                    parent.function_mocks = outcome.state.function_mocks.clone();
+                    self.observe_expected_create(
+                        &mut parent,
+                        state.address,
+                        CreateKind::Create,
+                        &outcome.return_data,
+                    )?;
+                    if !parent.world.destroyed_accounts.contains(&created) {
+                        parent.world.install_code(created, outcome.return_data.to_code()?);
+                        parent.world.set_nonce(created, 1);
+                    }
+                    complete_cheatcode_call(
+                        &mut parent,
+                        out_offset.clone(),
+                        out_size,
+                        SymReturnData::from_words(vec![created_word.clone()]),
+                    )?;
+                }
+                TopLevelCallStatus::Revert => {
+                    parent.world = failure_world.clone();
+                    parent.return_data = outcome.return_data.clone();
+                    let return_data = parent.return_data.clone();
+                    parent.memory.copy_call_output_offset(
+                        out_offset.clone(),
+                        out_size,
+                        &return_data,
+                    )?;
+                    parent.stack.push(SymWord::zero())?;
+                }
+                TopLevelCallStatus::Failure => {
+                    *state = parent;
+                    return Ok(StepOutcome::Failure);
+                }
+            }
+
+            parents.push_back(parent);
         }
+
+        let Some(first) = pop_batch(&mut parents, self.config.exploration_order) else {
+            return Ok(StepOutcome::AssumeRejected);
+        };
+        *state = first;
+        spill_batch(parents, worklist, self.config.exploration_order);
+        Ok(StepOutcome::Continue)
     }
 
     /// Applies the `observe_expected_create` symbolic executor helper.
@@ -361,7 +502,6 @@ impl SymbolicExecutor {
         &mut self,
         executor: &Executor<FEN>,
         state: &mut PathState,
-        completed_paths: &mut usize,
         selector: [u8; 4],
         in_offset: usize,
         in_size: usize,
@@ -1315,28 +1455,6 @@ impl SymbolicExecutor {
                 read_abi_string_arg(&state.memory, args_offset, 0, "symbolic vm.getCode")?;
             let code = artifact_code(&artifact, selector == selector!("getDeployedCode(string)"))?;
             return Ok(CheatcodeOutcome::ContinueData(abi_concrete_bytes_return(code)));
-        }
-        if selector == selector!("deployCode(string)") {
-            let artifact =
-                read_abi_string_arg(&state.memory, args_offset, 0, "symbolic vm.deployCode")?;
-            return self.deploy_code_cheatcode(
-                executor,
-                state,
-                completed_paths,
-                artifact,
-                Vec::new(),
-            );
-        }
-        if selector == selector!("deployCode(string,bytes)") {
-            let artifact =
-                read_abi_string_arg(&state.memory, args_offset, 0, "symbolic vm.deployCode")?;
-            let args = read_abi_dynamic_bytes_arg(
-                &state.memory,
-                args_offset,
-                1,
-                "symbolic vm.deployCode args",
-            )?;
-            return self.deploy_code_cheatcode(executor, state, completed_paths, artifact, args);
         }
         if selector == selector!("deal(address,uint256)") {
             let target = read_abi_address_or_symbolic_slot_arg(state, args_offset, 0)?;

--- a/crates/evm/symbolic/src/runtime/cheatcodes.rs
+++ b/crates/evm/symbolic/src/runtime/cheatcodes.rs
@@ -1234,17 +1234,17 @@ pub(crate) fn artifact_json_fallback_paths(path: &str) -> Vec<PathBuf> {
     let mut parts = path.split(':');
     let first = parts.next().unwrap_or_default();
     let second = parts.next();
-    let file = Path::new(first);
-    let Some(file_name) = file.file_name() else { return Vec::new() };
+    let Some(file_name) = first.rsplit(['/', '\\']).find(|part| !part.is_empty()) else {
+        return Vec::new();
+    };
 
     if !first.contains('/') && !first.contains('\\') {
         return Vec::new();
     }
 
-    let contract = second
-        .map(str::to_string)
-        .or_else(|| file.file_stem().map(|stem| stem.to_string_lossy().to_string()))
-        .unwrap_or_else(|| first.to_string());
+    let contract = second.map(str::to_string).unwrap_or_else(|| {
+        file_name.rsplit_once('.').map(|(stem, _)| stem).unwrap_or(file_name).to_string()
+    });
     vec![PathBuf::from("out").join(file_name).join(format!("{contract}.json"))]
 }
 

--- a/crates/evm/symbolic/src/runtime/cheatcodes.rs
+++ b/crates/evm/symbolic/src/runtime/cheatcodes.rs
@@ -1225,10 +1225,40 @@ pub(crate) fn artifact_json_path(path: &str) -> PathBuf {
     }
 }
 
+/// Returns fallback paths for symbolic artifact lookup.
+pub(crate) fn artifact_json_fallback_paths(path: &str) -> Vec<PathBuf> {
+    if path.ends_with(".json") {
+        return Vec::new();
+    }
+
+    let mut parts = path.split(':');
+    let first = parts.next().unwrap_or_default();
+    let second = parts.next();
+    let file = Path::new(first);
+    let Some(file_name) = file.file_name() else { return Vec::new() };
+
+    if !first.contains('/') && !first.contains('\\') {
+        return Vec::new();
+    }
+
+    let contract = second
+        .map(str::to_string)
+        .or_else(|| file.file_stem().map(|stem| stem.to_string_lossy().to_string()))
+        .unwrap_or_else(|| first.to_string());
+    vec![PathBuf::from("out").join(file_name).join(format!("{contract}.json"))]
+}
+
 /// Implements the `artifact_code` cheatcode runtime helper.
 pub(crate) fn artifact_code(path: &str, deployed: bool) -> Result<Vec<u8>, SymbolicError> {
-    let data = std::fs::read_to_string(artifact_json_path(path))
-        .map_err(|_| SymbolicError::Unsupported("symbolic vm.getCode artifact"))?;
+    let mut data = None;
+    for path in std::iter::once(artifact_json_path(path)).chain(artifact_json_fallback_paths(path))
+    {
+        if let Ok(contents) = std::fs::read_to_string(path) {
+            data = Some(contents);
+            break;
+        }
+    }
+    let data = data.ok_or(SymbolicError::Unsupported("symbolic vm.getCode artifact"))?;
     let artifact: serde_json::Value = serde_json::from_str(&data)
         .map_err(|_| SymbolicError::Unsupported("symbolic vm.getCode artifact"))?;
     let key = if deployed { "deployedBytecode" } else { "bytecode" };

--- a/crates/evm/symbolic/src/runtime/expressions.rs
+++ b/crates/evm/symbolic/src/runtime/expressions.rs
@@ -1237,6 +1237,18 @@ impl BoolExpr {
         }
         match (&left, &right) {
             (Expr::Const(left), Expr::Const(right)) => Self::Const(left == right),
+            (left, Expr::Const(right)) => {
+                if let Some(left) = expr_known_word(left) {
+                    return Self::Const(left == *right);
+                }
+                Self::Eq(left.clone(), Expr::Const(*right))
+            }
+            (Expr::Const(left), right) => {
+                if let Some(right) = expr_known_word(right) {
+                    return Self::Const(*left == right);
+                }
+                Self::Eq(Expr::Const(*left), right.clone())
+            }
             (
                 Expr::Keccak { len: left_len, bytes: left_bytes, .. },
                 Expr::Keccak { len: right_len, bytes: right_bytes, .. },

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -349,6 +349,44 @@ fn selector_shift_simplifies_to_concrete_word() {
 }
 
 #[test]
+/// Regression coverage for `selector_equality_folds_known_word_expressions`.
+fn selector_equality_folds_known_word_expressions() {
+    let selector = U256::from(0x12345678u32);
+    let other = U256::from(0x9a8325a0u32);
+    let call_word = Expr::op(
+        ExprOp::Or,
+        Expr::op(ExprOp::Shl, Expr::Const(selector), Expr::Const(U256::from(224))),
+        Expr::op(ExprOp::Shr, Expr::Var("arg".to_string()), Expr::Const(U256::from(32))),
+    );
+    let selector_expr = Expr::op(ExprOp::Shr, call_word, Expr::Const(U256::from(224)));
+
+    assert_eq!(BoolExpr::eq(selector_expr.clone(), Expr::Const(selector)), BoolExpr::Const(true));
+    assert_eq!(BoolExpr::eq(selector_expr, Expr::Const(other)), BoolExpr::Const(false));
+}
+
+#[test]
+/// Regression coverage for `calldata_selector_load_simplifies_to_concrete_word`.
+fn calldata_selector_load_simplifies_to_concrete_word() {
+    let function = Function::parse("check(bytes32)").unwrap();
+    let calldata = SymbolicCalldata::new(&function, &SymbolicConfig::default()).unwrap();
+    let selector = U256::from_be_slice(function.selector().as_slice());
+    let loaded = calldata.call_data().load_word(SymWord::zero()).unwrap();
+    let selector_expr = Expr::op(ExprOp::Shr, loaded.into_expr(), Expr::Const(U256::from(224)));
+
+    assert_eq!(expr_known_word(&selector_expr), Some(selector));
+    assert_eq!(BoolExpr::eq(selector_expr, Expr::Const(selector)), BoolExpr::Const(true));
+}
+
+#[test]
+/// Regression coverage for `artifact_json_fallback_paths`.
+fn artifact_json_fallback_paths_uses_foundry_artifact_basename() {
+    assert_eq!(
+        artifact_json_fallback_paths("src/01_NomadZeroRoot.sol:NomadLike"),
+        vec![std::path::PathBuf::from("out/01_NomadZeroRoot.sol/NomadLike.json")]
+    );
+}
+
+#[test]
 /// Regression coverage for `dynamic_calldata_encodes_bounded_bytes`.
 fn dynamic_calldata_encodes_bounded_bytes() {
     let function = Function::parse("check(bytes)").unwrap();

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -384,6 +384,14 @@ fn artifact_json_fallback_paths_uses_foundry_artifact_basename() {
         artifact_json_fallback_paths("src/01_NomadZeroRoot.sol:NomadLike"),
         vec![std::path::PathBuf::from("out/01_NomadZeroRoot.sol/NomadLike.json")]
     );
+    assert_eq!(
+        artifact_json_fallback_paths(r"src\01_NomadZeroRoot.sol:NomadLike"),
+        vec![std::path::PathBuf::from("out/01_NomadZeroRoot.sol/NomadLike.json")]
+    );
+    assert_eq!(
+        artifact_json_fallback_paths(r"src\01_NomadZeroRoot.sol"),
+        vec![std::path::PathBuf::from("out/01_NomadZeroRoot.sol/01_NomadZeroRoot.json")]
+    );
 }
 
 #[test]

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -4124,3 +4124,112 @@ unsupported symbolic execution feature: symbolic vm.prank delegatecall
 "#]],
     );
 });
+
+forgetest_init!(symbolic_vm_deploy_code_models_constructor_outcomes, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_vm_deploy_code_models_constructor_outcomes because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicDeployCodeCheatcode.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+/// forge-config: default.evm_version = "cancun"
+
+interface SymbolicDeployCodeVm {
+    function randomBool() external view returns (bool);
+}
+
+contract OkDeployCodeCtor {
+    uint256 public value = 1;
+}
+
+contract RevertingDeployCodeCtor {
+    constructor() {
+        require(false, "ctor");
+    }
+}
+
+contract EnvBranchingDeployCodeCtor {
+    SymbolicDeployCodeVm constant VM =
+        SymbolicDeployCodeVm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    constructor() {
+        if (VM.randomBool()) {
+            revert("branch");
+        }
+    }
+}
+
+contract SelfDestructDeployCodeCtor {
+    constructor() payable {
+        selfdestruct(payable(msg.sender));
+    }
+}
+
+contract SymbolicDeployCodeCheatcode is Test {
+    string constant TARGET = "test/SymbolicDeployCodeCheatcode.t.sol";
+
+    function checkDeployCodeExpectedRevert() public {
+        vm.expectRevert();
+        vm.deployCode(string.concat(TARGET, ":RevertingDeployCodeCtor"));
+    }
+
+    function checkDeployCodeBranchingConstructor() public {
+        vm.deployCode(string.concat(TARGET, ":EnvBranchingDeployCodeCtor"));
+    }
+
+    function checkDeployCodeStaticContext() public {
+        (bool ok,) = address(this).staticcall(abi.encodeCall(this.helperDeployCode, ()));
+        assertFalse(ok);
+    }
+
+    function helperDeployCode() external {
+        vm.deployCode(string.concat(TARGET, ":OkDeployCodeCtor"));
+    }
+
+    function checkDeployCodeSelfDestructConstructor() public {
+        address deployed = vm.deployCode(string.concat(TARGET, ":SelfDestructDeployCodeCtor"));
+        assertEq(deployed.code.length, 0);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--symbolic", "--match-contract", "SymbolicDeployCodeCheatcode"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkDeployCodeExpectedRevert()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkDeployCodeBranchingConstructor()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkDeployCodeStaticContext()
+"#]],
+    );
+    assert_relevant_lines(
+        &stdout,
+        foundry_test_utils::str![[r#"
+[PASS] checkDeployCodeSelfDestructConstructor()
+"#]],
+    );
+    assert!(!stdout.contains("symbolic vm.deployCode"), "{stdout}");
+    assert!(!stdout.contains("symbolic Foundry cheatcode"), "{stdout}");
+});


### PR DESCRIPTION
## Summary
- fold equality against known-word expressions, avoiding solver work for concrete selector/calldata comparisons
- model `vm.deployCode(string)` and `vm.deployCode(string,bytes)` in symbolic execution by running artifact initcode and installing the returned runtime code
- add artifact path fallback for common Foundry `src/File.sol:Contract` references used by deployment cheatcodes

## Context
These changes improve symbolic testing for regular Foundry test suites. Selector and calldata equality checks can now collapse before reaching the solver when the compared expression is already known, and tests that deploy fixture contracts through `vm.deployCode` can continue through symbolic execution instead of stopping at an unsupported cheatcode.

The local Foundry-vs-Halmos run below validates the changes against an external bug-finding corpus by checking that Foundry finds replay-confirmed counterexamples on the same `check*` targets where Halmos reports valid models.

## Local Validation Benchmark
Suite: `grandizzy/symbolic-bug-suite` at `fdadd49`
Solver: `z3`
Timing: warm artifact median of 3 runs

| Run | Result | Wall time |
| --- | ---: | ---: |
| This PR | 22/22 replay-confirmed counterexamples | 5.90s |
| Halmos | 22/22 valid models | 31.09s |

On this corpus, this PR finds the same 22 counterexample targets while running in 81.0% less wall time than Halmos, or 5.27x faster.
