### PR TITLE
deps: bump revm for Tempo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,7 +1203,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1227,7 +1227,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3075,7 +3075,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3234,7 +3234,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4296,7 +4296,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4580,7 +4580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5790,7 +5790,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.26.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=8027e5ccdfe55e562a1111495d2c9acb6e27a930#8027e5ccdfe55e562a1111495d2c9acb6e27a930"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=ba6246789fc12cf8fe78aa74aadf31d663f08c1f#ba6246789fc12cf8fe78aa74aadf31d663f08c1f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5799,7 +5799,7 @@ dependencies = [
  "eyre",
  "futures",
  "parking_lot",
- "revm 40.0.3",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6129,8 +6129,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -6579,7 +6579,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6920,7 +6920,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7714,7 +7714,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8952,7 +8952,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10254,7 +10254,6 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
- "blst",
  "c-kzg",
  "cfg-if",
  "k256",
@@ -10601,7 +10600,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10660,7 +10659,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11385,7 +11384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11465,7 +11464,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11806,7 +11805,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -11934,7 +11933,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12137,7 +12136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13399,7 +13398,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13537,7 +13536,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,27 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "revm",
+ "revm 40.0.3",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-evm"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70634e39510c13a4f69f51a474d98030ecb1dcff54b909d2a9a020ee05e44867"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "auto_impl",
+ "derive_more",
+ "revm 41.0.0",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -452,13 +472,13 @@ source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
  "op-alloy",
  "op-revm",
- "revm",
+ "revm 40.0.3",
  "thiserror 2.0.18",
 ]
 
@@ -1183,7 +1203,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1207,7 +1227,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1219,7 +1239,7 @@ dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-network",
  "alloy-op-evm",
@@ -1266,7 +1286,7 @@ dependencies = [
  "rand 0.8.6",
  "rand 0.9.4",
  "reqwest 0.13.4",
- "revm",
+ "revm 41.0.0",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -1302,7 +1322,7 @@ dependencies = [
  "foundry-evm",
  "foundry-primitives",
  "rand 0.9.4",
- "revm",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2574,7 +2594,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2754,7 +2774,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
  "alloy-ens",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-hardforks",
  "alloy-json-abi",
  "alloy-json-rpc",
@@ -2802,7 +2822,7 @@ dependencies = [
  "rand 0.9.4",
  "rayon",
  "regex",
- "revm",
+ "revm 41.0.0",
  "rpassword",
  "semver 1.0.28",
  "serde",
@@ -3055,7 +3075,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3214,7 +3234,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4276,7 +4296,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4560,7 +4580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4913,7 +4933,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest 0.13.4",
- "revm",
+ "revm 41.0.0",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -4991,7 +5011,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
@@ -5070,7 +5090,7 @@ version = "1.7.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-provider",
@@ -5090,7 +5110,7 @@ dependencies = [
  "itertools 0.14.0",
  "regex",
  "reqwest 0.13.4",
- "revm",
+ "revm 41.0.0",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -5153,7 +5173,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-ens",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-json-abi",
  "alloy-network",
@@ -5186,7 +5206,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.4",
- "revm",
+ "revm 41.0.0",
  "revm-inspectors",
  "semver 1.0.28",
  "serde",
@@ -5326,7 +5346,7 @@ dependencies = [
  "path-slash",
  "regex",
  "reqwest 0.13.4",
- "revm",
+ "revm 41.0.0",
  "rustls",
  "semver 1.0.28",
  "serde",
@@ -5364,7 +5384,7 @@ dependencies = [
  "foundry-macros",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
- "revm",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -5527,7 +5547,7 @@ dependencies = [
  "foundry-evm-traces",
  "foundry-tui",
  "ratatui",
- "revm",
+ "revm 41.0.0",
  "revm-inspectors",
  "serde",
  "tracing",
@@ -5559,7 +5579,7 @@ dependencies = [
  "proptest",
  "rand 0.9.4",
  "rayon",
- "revm",
+ "revm 41.0.0",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -5590,7 +5610,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-json-abi",
@@ -5620,7 +5640,7 @@ dependencies = [
  "op-alloy-rpc-types",
  "op-revm",
  "parking_lot",
- "revm",
+ "revm 41.0.0",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -5646,7 +5666,7 @@ dependencies = [
  "foundry-compilers",
  "foundry-evm-core",
  "rayon",
- "revm",
+ "revm 41.0.0",
  "semver 1.0.28",
  "solar-compiler",
  "tracing",
@@ -5670,7 +5690,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.4",
- "revm",
+ "revm 41.0.0",
  "serde",
  "solar-compiler",
  "thiserror 2.0.18",
@@ -5687,7 +5707,7 @@ dependencies = [
  "alloy-rpc-types",
  "foundry-compilers",
  "op-revm",
- "revm",
+ "revm 41.0.0",
  "serde",
  "tempo-chainspec",
 ]
@@ -5698,12 +5718,12 @@ version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-op-hardforks",
  "alloy-primitives",
  "clap",
  "foundry-evm-hardforks",
- "revm",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "tempo-contracts",
@@ -5754,7 +5774,7 @@ dependencies = [
  "memchr",
  "rayon",
  "reqwest 0.13.4",
- "revm",
+ "revm 41.0.0",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -5779,7 +5799,7 @@ dependencies = [
  "eyre",
  "futures",
  "parking_lot",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5815,7 +5835,7 @@ name = "foundry-primitives"
 version = "1.7.2"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.37.0",
  "alloy-network",
  "alloy-op-evm",
  "alloy-primitives",
@@ -5829,7 +5849,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "op-revm",
- "revm",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "tempo-alloy",
@@ -6900,7 +6920,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7694,7 +7714,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8043,7 +8063,7 @@ version = "20.0.0"
 source = "git+https://github.com/foundry-rs/op-revm?rev=4201f16a746f2da2df38f1eac477500d492eaed5#4201f16a746f2da2df38f1eac477500d492eaed5"
 dependencies = [
  "auto_impl",
- "revm",
+ "revm 40.0.3",
  "serde",
 ]
 
@@ -9379,7 +9399,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -9567,7 +9587,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.1",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9579,7 +9599,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm",
+ "revm 40.0.3",
 ]
 
 [[package]]
@@ -9589,7 +9609,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c240
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-chainspec",
@@ -9599,7 +9619,7 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits 0.4.2",
  "reth-storage-errors",
- "revm",
+ "revm 40.0.3",
 ]
 
 [[package]]
@@ -9607,7 +9627,7 @@ name = "reth-execution-errors"
 version = "2.2.0"
 source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -9622,14 +9642,14 @@ source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c240
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
  "reth-ethereum-primitives",
  "reth-primitives-traits 0.4.2",
  "reth-trie-common",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_with",
 ]
@@ -9726,7 +9746,7 @@ dependencies = [
  "reth-primitives-traits 0.4.2",
  "reth-storage-api",
  "reth-storage-errors",
- "revm",
+ "revm 40.0.3",
 ]
 
 [[package]]
@@ -9735,7 +9755,7 @@ version = "2.2.0"
 source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -9827,7 +9847,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm-database",
+ "revm-database 15.0.2",
  "serde_json",
 ]
 
@@ -9844,7 +9864,7 @@ dependencies = [
  "reth-primitives-traits 0.4.2",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface",
+ "revm-database-interface 12.1.1",
  "revm-state 12.0.1",
  "thiserror 2.0.18",
 ]
@@ -9877,7 +9897,7 @@ dependencies = [
  "nybbles",
  "reth-codecs 0.4.2",
  "reth-primitives-traits 0.4.2",
- "revm-database",
+ "revm-database 15.0.2",
  "serde",
  "serde_with",
 ]
@@ -9907,16 +9927,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
 dependencies = [
  "revm-bytecode 11.0.1",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
+ "revm-context 18.0.3",
+ "revm-context-interface 19.0.3",
+ "revm-database 15.0.2",
+ "revm-database-interface 12.1.1",
+ "revm-handler 20.0.3",
+ "revm-inspector 21.0.3",
+ "revm-interpreter 37.0.3",
+ "revm-precompile 36.0.3",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
+]
+
+[[package]]
+name = "revm"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
+dependencies = [
+ "revm-bytecode 41.0.0",
+ "revm-context 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-database 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-handler 41.0.0",
+ "revm-inspector 41.0.0",
+ "revm-interpreter 41.0.0",
+ "revm-precompile 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
 ]
 
 [[package]]
@@ -9944,6 +9983,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-bytecode"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
+dependencies = [
+ "bitvec",
+ "phf 0.13.1",
+ "revm-primitives 41.0.0",
+ "serde",
+]
+
+[[package]]
 name = "revm-context"
 version = "18.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9953,10 +10004,27 @@ dependencies = [
  "cfg-if",
  "derive-where",
  "revm-bytecode 11.0.1",
- "revm-context-interface",
- "revm-database-interface",
+ "revm-context-interface 19.0.3",
+ "revm-database-interface 12.1.1",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -9970,9 +10038,25 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
+ "revm-database-interface 12.1.1",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -9985,9 +10069,25 @@ dependencies = [
  "alloy-eips",
  "derive_more",
  "revm-bytecode 11.0.1",
- "revm-database-interface",
+ "revm-database-interface 12.1.1",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
+dependencies = [
+ "alloy-eips",
+ "derive_more",
+ "either",
+ "revm-bytecode 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10006,6 +10106,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-database-interface"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "revm-handler"
 version = "20.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10014,13 +10128,32 @@ dependencies = [
  "auto_impl",
  "derive-where",
  "revm-bytecode 11.0.1",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
+ "revm-context 18.0.3",
+ "revm-context-interface 19.0.3",
+ "revm-database-interface 12.1.1",
+ "revm-interpreter 37.0.3",
+ "revm-precompile 36.0.3",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 41.0.0",
+ "revm-context 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-interpreter 41.0.0",
+ "revm-precompile 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10032,10 +10165,10 @@ checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
+ "revm-context 18.0.3",
+ "revm-database-interface 12.1.1",
+ "revm-handler 20.0.3",
+ "revm-interpreter 37.0.3",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
  "serde",
@@ -10043,10 +10176,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-inspectors"
-version = "0.40.0"
+name = "revm-inspector"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2854f2c48cecac90e8ad48fe8d8842707f79df2b748913b67bd2439a9ea3b4ab"
+checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-handler 41.0.0",
+ "revm-interpreter 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-inspectors"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e0cdc845c8dbf41255c9add80923b45df7bf1dd0473e41483ac398005dba12"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10056,7 +10207,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -10069,9 +10220,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
 dependencies = [
  "revm-bytecode 11.0.1",
- "revm-context-interface",
+ "revm-context-interface 19.0.3",
  "revm-primitives 24.0.1",
  "revm-state 12.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
+dependencies = [
+ "revm-bytecode 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10093,8 +10257,33 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface",
+ "revm-context-interface 19.0.3",
  "revm-primitives 24.0.1",
+ "ripemd",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-context-interface 41.0.0",
+ "revm-primitives 41.0.0",
  "ripemd",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
@@ -10117,6 +10306,17 @@ name = "revm-primitives"
 version = "24.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
+dependencies = [
+ "alloy-primitives",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -10147,6 +10347,20 @@ dependencies = [
  "nonmax",
  "revm-bytecode 11.0.1",
  "revm-primitives 24.0.1",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
+dependencies = [
+ "alloy-eip7928 0.4.1",
+ "bitflags 2.11.1",
+ "nonmax",
+ "revm-bytecode 41.0.0",
+ "revm-primitives 41.0.0",
  "serde",
 ]
 
@@ -10385,7 +10599,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10444,7 +10658,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11169,7 +11383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11718,7 +11932,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11760,7 +11974,7 @@ version = "1.8.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy-eips",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-primitives",
@@ -11806,7 +12020,7 @@ version = "1.8.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-rlp",
  "commonware-codec",
@@ -11834,12 +12048,12 @@ version = "1.8.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "commonware-codec",
  "commonware-cryptography",
  "derive_more",
- "revm",
+ "revm 40.0.3",
  "scoped-tls",
  "tempo-chainspec",
  "tempo-contracts",
@@ -11884,7 +12098,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits 0.4.2",
  "reth-rpc-convert",
- "revm",
+ "revm 40.0.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -11897,14 +12111,14 @@ version = "1.8.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
 dependencies = [
  "alloy-consensus",
- "alloy-evm",
+ "alloy-evm 0.36.0",
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
  "reth-evm",
  "reth-storage-api",
- "revm",
+ "revm 40.0.3",
  "serde",
  "tempo-chainspec",
  "tempo-contracts",
@@ -11921,7 +12135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13183,7 +13397,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13321,7 +13535,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.4.7"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -1183,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4560,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4727,7 +4727,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6900,7 +6900,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7919,7 +7919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -7933,7 +7933,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "op-alloy"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -7945,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7972,7 +7972,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-provider"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -7999,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8019,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8040,7 +8040,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "20.0.0"
-source = "git+https://github.com/foundry-rs/op-revm?rev=8f4569092ca8c41780eccacb9e5ffa1f03202450#8f4569092ca8c41780eccacb9e5ffa1f03202450"
+source = "git+https://github.com/foundry-rs/op-revm?rev=c10fd76e66fd46cebc08ba370aa58bde72b94140#c10fd76e66fd46cebc08ba370aa58bde72b94140"
 dependencies = [
  "auto_impl",
  "revm",
@@ -8932,7 +8932,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10388,7 +10388,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10447,7 +10447,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11172,7 +11172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11721,7 +11721,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13324,7 +13324,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d93ce7e41bcd2b9ee2c1d92c223c1be4a274d387538d6d3f956b768986ce451"
+checksum = "55c4584eaf235a861172e30d0d8adfa95957186f59b93f997851df90b32da7ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2594,7 +2594,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3075,7 +3075,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3234,7 +3234,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4296,7 +4296,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4580,7 +4580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6920,7 +6920,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7714,7 +7714,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8801,7 +8801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8952,7 +8952,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9393,13 +9393,13 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -9407,7 +9407,7 @@ dependencies = [
  "derive_more",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "serde_json",
 ]
 
@@ -9432,9 +9432,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c37bb4d1bac98661bf9128e1141b969034640d68697b22f70377e492fd332c"
+checksum = "83efa17684a1114821f6a32bd1672b7cd7f22c0517042d48e778e50e6a6b81af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9444,8 +9444,8 @@ dependencies = [
  "bytes",
  "modular-bitfield",
  "parity-scale-codec",
- "reth-codecs-derive 0.4.2",
- "reth-zstd-compressors 0.4.2",
+ "reth-codecs-derive 0.5.1",
+ "reth-zstd-compressors 0.5.1",
  "serde",
 ]
 
@@ -9462,9 +9462,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceeb8dab90194305d3f7e3f043a22d2db1fb54b6dcf5d8e75c5a4fa8540e1f57"
+checksum = "d821c52c4700e2cd72d9267a10e7e8c321199757fc2729ff072c1eb058ae875b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9473,35 +9473,35 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
 ]
 
 [[package]]
 name = "reth-db-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9510,10 +9510,10 @@ dependencies = [
  "derive_more",
  "metrics",
  "modular-bitfield",
- "reth-codecs 0.4.2",
+ "reth-codecs 0.5.1",
  "reth-db-models",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
@@ -9524,22 +9524,22 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs 0.4.2",
- "reth-primitives-traits 0.4.2",
+ "reth-codecs 0.5.1",
+ "reth-primitives-traits 0.5.1",
  "serde",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9548,14 +9548,14 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9567,27 +9567,27 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "reth-codecs 0.4.2",
- "reth-primitives-traits 0.4.2",
+ "reth-codecs 0.5.1",
+ "reth-primitives-traits 0.5.1",
  "serde",
 ]
 
 [[package]]
 name = "reth-evm"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9595,21 +9595,21 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm 40.0.3",
+ "revm 41.0.0",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-chainspec",
@@ -9617,17 +9617,17 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "reth-storage-errors",
- "revm 40.0.3",
+ "revm 41.0.0",
 ]
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -9637,27 +9637,27 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "reth-trie-common",
- "revm 40.0.3",
+ "revm 41.0.0",
  "serde",
  "serde_with",
 ]
 
 [[package]]
 name = "reth-network-peers"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9694,9 +9694,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9102518f0bbf99bc8f0e656a56fb2a7513248630275b608d3706076a82fde42b"
+checksum = "3a0984a773deb58bb5671adf10f264461bb3b8b0e32af0b7c6742c15c1e327e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9712,10 +9712,10 @@ dependencies = [
  "modular-bitfield",
  "once_cell",
  "quanta",
- "reth-codecs 0.4.2",
- "revm-bytecode 11.0.1",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
+ "reth-codecs 0.5.1",
+ "revm-bytecode 41.0.0",
+ "revm-primitives 41.0.0",
+ "revm-state 41.0.0",
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
@@ -9723,13 +9723,13 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "derive_more",
  "modular-bitfield",
- "reth-codecs 0.4.2",
+ "reth-codecs 0.5.1",
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.18",
@@ -9738,24 +9738,24 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "reth-storage-api",
  "reth-storage-errors",
- "revm 40.0.3",
+ "revm 41.0.0",
 ]
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -9764,8 +9764,8 @@ dependencies = [
  "dyn-clone",
  "jsonrpsee-types",
  "reth-evm",
- "reth-primitives-traits 0.4.2",
- "reth-rpc-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
+ "reth-rpc-traits 0.5.1",
  "thiserror 2.0.18",
 ]
 
@@ -9786,36 +9786,36 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa03a2c9681c385ae1c72b169ac9c3525163b71db0b3362f16e8929e19e45fd"
+checksum = "42b71fe3bf79402a60631000a4babc62aba9acfeb9692b3bb8c43530f7e05343"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-stages-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "bytes",
  "modular-bitfield",
- "reth-codecs 0.4.2",
+ "reth-codecs 0.5.1",
  "reth-trie-common",
  "serde",
 ]
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9828,11 +9828,11 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -9841,38 +9841,38 @@ dependencies = [
  "reth-db-models",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm-database 15.0.2",
+ "revm-database 41.0.0",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-codecs 0.4.2",
- "reth-primitives-traits 0.4.2",
+ "reth-codecs 0.5.1",
+ "reth-primitives-traits 0.5.1",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface 12.1.1",
- "revm-state 12.0.1",
+ "revm-database-interface 41.0.0",
+ "revm-state 41.0.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9881,8 +9881,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.2.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=72fafb5#72fafb577ce102c2408b75516907aa4438cf3d06"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9895,9 +9895,10 @@ dependencies = [
  "derive_more",
  "itertools 0.14.0",
  "nybbles",
- "reth-codecs 0.4.2",
- "reth-primitives-traits 0.4.2",
- "revm-database 15.0.2",
+ "reth-codecs 0.5.1",
+ "reth-primitives-traits 0.5.1",
+ "revm-database 41.0.0",
+ "revm-state 41.0.0",
  "serde",
  "serde_with",
 ]
@@ -9913,9 +9914,9 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e86cf594718932d42cebce1fa48292fb7b92721f7c914631add1ca970e814"
+checksum = "1c171c591b909a808c319e4848a0f247ef9ce947b18f6f7be98258fb41999cb9"
 dependencies = [
  "zstd",
 ]
@@ -10343,7 +10344,7 @@ version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
 dependencies = [
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "bitflags 2.11.1",
  "nonmax",
  "revm-bytecode 11.0.1",
@@ -10357,7 +10358,7 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
 dependencies = [
- "alloy-eip7928 0.4.1",
+ "alloy-eip7928 0.4.3",
  "bitflags 2.11.1",
  "nonmax",
  "revm-bytecode 41.0.0",
@@ -10600,7 +10601,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10659,7 +10660,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11452,7 +11453,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11487,7 +11488,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11933,13 +11934,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
+source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11972,10 +11973,10 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
+source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy-eips",
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-primitives",
@@ -11995,7 +11996,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
+source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12006,7 +12007,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
+source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12018,10 +12019,10 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
+source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-rlp",
  "commonware-codec",
@@ -12033,7 +12034,7 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-evm",
  "reth-evm-ethereum",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "reth-revm",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12046,15 +12047,15 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
+source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy",
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "commonware-codec",
  "commonware-cryptography",
  "derive_more",
- "revm 40.0.3",
+ "revm 41.0.0",
  "scoped-tls",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12067,7 +12068,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
+source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12078,7 +12079,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
+source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12094,12 +12095,12 @@ dependencies = [
  "modular-bitfield",
  "once_cell",
  "p256",
- "reth-codecs 0.4.2",
+ "reth-codecs 0.5.1",
  "reth-db-api",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.4.2",
+ "reth-primitives-traits 0.5.1",
  "reth-rpc-convert",
- "revm 40.0.3",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -12109,17 +12110,17 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=ad7eb1662417042a7304115ea18c54f505eb78fd#ad7eb1662417042a7304115ea18c54f505eb78fd"
+source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.36.0",
+ "alloy-evm 0.37.0",
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
  "reth-evm",
  "reth-storage-api",
- "revm 40.0.3",
+ "revm 41.0.0",
  "serde",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12136,7 +12137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13398,7 +13399,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13536,7 +13537,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10195,9 +10195,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.40.1"
+version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e0cdc845c8dbf41255c9add80923b45df7bf1dd0473e41483ac398005dba12"
+checksum = "ac492384995d832d6910920a932c000436623ec18668ff9291cb78f96c8b710f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10207,10 +10207,11 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm 40.0.3",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4276,7 +4276,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4560,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6109,8 +6109,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -6559,7 +6559,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6900,7 +6900,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7694,7 +7694,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8781,7 +8781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8932,7 +8932,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10388,7 +10388,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10447,7 +10447,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11172,7 +11172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11240,7 +11240,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11252,7 +11252,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11275,7 +11275,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11593,7 +11593,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "zip",
 ]
@@ -11721,13 +11721,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
+source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11760,7 +11760,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
+source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11783,7 +11783,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
+source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11794,7 +11794,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
+source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11806,7 +11806,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
+source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11834,7 +11834,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
+source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11855,7 +11855,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
+source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11866,7 +11866,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
+source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11897,7 +11897,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
+source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11924,7 +11924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13186,7 +13186,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13324,7 +13324,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,26 +332,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e494529570a4d25eb4d1a7456d8f969c3202aceaf703e4006cec5f730aee96"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "auto_impl",
- "derive_more",
- "revm 40.0.3",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "alloy-evm"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70634e39510c13a4f69f51a474d98030ecb1dcff54b909d2a9a020ee05e44867"
@@ -365,7 +345,7 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "revm 41.0.0",
+ "revm",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -468,24 +448,24 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.36.0",
+ "alloy-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
  "op-alloy",
  "op-revm",
- "revm 40.0.3",
+ "revm",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.4.7"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -1203,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1227,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1239,7 +1219,7 @@ dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-network",
  "alloy-op-evm",
@@ -1286,7 +1266,7 @@ dependencies = [
  "rand 0.8.6",
  "rand 0.9.4",
  "reqwest 0.13.4",
- "revm 41.0.0",
+ "revm",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -1322,7 +1302,7 @@ dependencies = [
  "foundry-evm",
  "foundry-primitives",
  "rand 0.9.4",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2774,7 +2754,7 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
  "alloy-ens",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-hardforks",
  "alloy-json-abi",
  "alloy-json-rpc",
@@ -2822,7 +2802,7 @@ dependencies = [
  "rand 0.9.4",
  "rayon",
  "regex",
- "revm 41.0.0",
+ "revm",
  "rpassword",
  "semver 1.0.28",
  "serde",
@@ -3234,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4580,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4747,7 +4727,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4933,7 +4913,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest 0.13.4",
- "revm 41.0.0",
+ "revm",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -5011,7 +4991,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
@@ -5090,7 +5070,7 @@ version = "1.7.2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-provider",
@@ -5110,7 +5090,7 @@ dependencies = [
  "itertools 0.14.0",
  "regex",
  "reqwest 0.13.4",
- "revm 41.0.0",
+ "revm",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -5173,7 +5153,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-ens",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-json-abi",
  "alloy-network",
@@ -5206,7 +5186,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.4",
- "revm 41.0.0",
+ "revm",
  "revm-inspectors",
  "semver 1.0.28",
  "serde",
@@ -5346,7 +5326,7 @@ dependencies = [
  "path-slash",
  "regex",
  "reqwest 0.13.4",
- "revm 41.0.0",
+ "revm",
  "rustls",
  "semver 1.0.28",
  "serde",
@@ -5384,7 +5364,7 @@ dependencies = [
  "foundry-macros",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "similar-asserts",
@@ -5547,7 +5527,7 @@ dependencies = [
  "foundry-evm-traces",
  "foundry-tui",
  "ratatui",
- "revm 41.0.0",
+ "revm",
  "revm-inspectors",
  "serde",
  "tracing",
@@ -5579,7 +5559,7 @@ dependencies = [
  "proptest",
  "rand 0.9.4",
  "rayon",
- "revm 41.0.0",
+ "revm",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -5610,7 +5590,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-dyn-abi",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-json-abi",
@@ -5640,7 +5620,7 @@ dependencies = [
  "op-alloy-rpc-types",
  "op-revm",
  "parking_lot",
- "revm 41.0.0",
+ "revm",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -5666,7 +5646,7 @@ dependencies = [
  "foundry-compilers",
  "foundry-evm-core",
  "rayon",
- "revm 41.0.0",
+ "revm",
  "semver 1.0.28",
  "solar-compiler",
  "tracing",
@@ -5690,7 +5670,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.4",
- "revm 41.0.0",
+ "revm",
  "serde",
  "solar-compiler",
  "thiserror 2.0.18",
@@ -5707,7 +5687,7 @@ dependencies = [
  "alloy-rpc-types",
  "foundry-compilers",
  "op-revm",
- "revm 41.0.0",
+ "revm",
  "serde",
  "tempo-chainspec",
 ]
@@ -5718,12 +5698,12 @@ version = "1.7.2"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
  "clap",
  "foundry-evm-hardforks",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "tempo-contracts",
@@ -5774,7 +5754,7 @@ dependencies = [
  "memchr",
  "rayon",
  "reqwest 0.13.4",
- "revm 41.0.0",
+ "revm",
  "revm-inspectors",
  "serde",
  "serde_json",
@@ -5799,7 +5779,7 @@ dependencies = [
  "eyre",
  "futures",
  "parking_lot",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5835,7 +5815,7 @@ name = "foundry-primitives"
 version = "1.7.2"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-network",
  "alloy-op-evm",
  "alloy-primitives",
@@ -5849,7 +5829,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "op-revm",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "tempo-alloy",
@@ -6920,7 +6900,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7939,7 +7919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -7953,7 +7933,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "op-alloy"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -7965,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7992,7 +7972,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8005,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-provider"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8019,7 +7999,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8039,7 +8019,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#2d608a6b9a4cac60bddadc951c07d01c0e98fe5a"
+source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#285b963a0883e07867dfc6e6840016b577b12030"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8060,10 +8040,10 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "20.0.0"
-source = "git+https://github.com/foundry-rs/op-revm?rev=4201f16a746f2da2df38f1eac477500d492eaed5#4201f16a746f2da2df38f1eac477500d492eaed5"
+source = "git+https://github.com/foundry-rs/op-revm?rev=8f4569092ca8c41780eccacb9e5ffa1f03202450#8f4569092ca8c41780eccacb9e5ffa1f03202450"
 dependencies = [
  "auto_impl",
- "revm 40.0.3",
+ "revm",
  "serde",
 ]
 
@@ -8952,7 +8932,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9399,7 +9379,7 @@ dependencies = [
  "alloy-chains",
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -9587,7 +9567,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "auto_impl",
  "derive_more",
@@ -9599,7 +9579,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm 41.0.0",
+ "revm",
 ]
 
 [[package]]
@@ -9609,7 +9589,7 @@ source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb1817
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "reth-chainspec",
@@ -9619,7 +9599,7 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits 0.5.1",
  "reth-storage-errors",
- "revm 41.0.0",
+ "revm",
 ]
 
 [[package]]
@@ -9627,7 +9607,7 @@ name = "reth-execution-errors"
 version = "2.3.0"
 source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "nybbles",
@@ -9642,14 +9622,14 @@ source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb1817
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
  "reth-ethereum-primitives",
  "reth-primitives-traits 0.5.1",
  "reth-trie-common",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_with",
 ]
@@ -9746,7 +9726,7 @@ dependencies = [
  "reth-primitives-traits 0.5.1",
  "reth-storage-api",
  "reth-storage-errors",
- "revm 41.0.0",
+ "revm",
 ]
 
 [[package]]
@@ -9755,7 +9735,7 @@ version = "2.3.0"
 source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-primitives",
@@ -9847,7 +9827,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm-database 41.0.0",
+ "revm-database",
  "serde_json",
 ]
 
@@ -9864,7 +9844,7 @@ dependencies = [
  "reth-primitives-traits 0.5.1",
  "reth-prune-types",
  "reth-static-file-types",
- "revm-database-interface 41.0.0",
+ "revm-database-interface",
  "revm-state 41.0.0",
  "thiserror 2.0.18",
 ]
@@ -9897,7 +9877,7 @@ dependencies = [
  "nybbles",
  "reth-codecs 0.5.1",
  "reth-primitives-traits 0.5.1",
- "revm-database 41.0.0",
+ "revm-database",
  "revm-state 41.0.0",
  "serde",
  "serde_with",
@@ -9923,38 +9903,19 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "40.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
-dependencies = [
- "revm-bytecode 11.0.1",
- "revm-context 18.0.3",
- "revm-context-interface 19.0.3",
- "revm-database 15.0.2",
- "revm-database-interface 12.1.1",
- "revm-handler 20.0.3",
- "revm-inspector 21.0.3",
- "revm-interpreter 37.0.3",
- "revm-precompile 36.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
-]
-
-[[package]]
-name = "revm"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
 dependencies = [
  "revm-bytecode 41.0.0",
- "revm-context 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-database 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-handler 41.0.0",
- "revm-inspector 41.0.0",
- "revm-interpreter 41.0.0",
- "revm-precompile 41.0.0",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
 ]
@@ -9973,18 +9934,6 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
-dependencies = [
- "bitvec",
- "phf 0.13.1",
- "revm-primitives 24.0.1",
- "serde",
-]
-
-[[package]]
-name = "revm-bytecode"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
@@ -9992,23 +9941,6 @@ dependencies = [
  "bitvec",
  "phf 0.13.1",
  "revm-primitives 41.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-context"
-version = "18.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
-dependencies = [
- "bitvec",
- "cfg-if",
- "derive-where",
- "revm-bytecode 11.0.1",
- "revm-context-interface 19.0.3",
- "revm-database-interface 12.1.1",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
  "serde",
 ]
 
@@ -10022,26 +9954,10 @@ dependencies = [
  "cfg-if",
  "derive-where",
  "revm-bytecode 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-database-interface 41.0.0",
+ "revm-context-interface",
+ "revm-database-interface",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-context-interface"
-version = "19.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "auto_impl",
- "either",
- "revm-database-interface 12.1.1",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
  "serde",
 ]
 
@@ -10055,24 +9971,9 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface 41.0.0",
+ "revm-database-interface",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-database"
-version = "15.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
-dependencies = [
- "alloy-eips",
- "derive_more",
- "revm-bytecode 11.0.1",
- "revm-database-interface 12.1.1",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
  "serde",
 ]
 
@@ -10086,24 +9987,10 @@ dependencies = [
  "derive_more",
  "either",
  "revm-bytecode 41.0.0",
- "revm-database-interface 41.0.0",
+ "revm-database-interface",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
  "serde",
-]
-
-[[package]]
-name = "revm-database-interface"
-version = "12.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
-dependencies = [
- "auto_impl",
- "either",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
- "serde",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10122,25 +10009,6 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "20.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
-dependencies = [
- "auto_impl",
- "derive-where",
- "revm-bytecode 11.0.1",
- "revm-context 18.0.3",
- "revm-context-interface 19.0.3",
- "revm-database-interface 12.1.1",
- "revm-interpreter 37.0.3",
- "revm-precompile 36.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
- "serde",
-]
-
-[[package]]
-name = "revm-handler"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
@@ -10148,32 +10016,14 @@ dependencies = [
  "auto_impl",
  "derive-where",
  "revm-bytecode 41.0.0",
- "revm-context 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-interpreter 41.0.0",
- "revm-precompile 41.0.0",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
  "serde",
-]
-
-[[package]]
-name = "revm-inspector"
-version = "21.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
-dependencies = [
- "auto_impl",
- "either",
- "revm-context 18.0.3",
- "revm-database-interface 12.1.1",
- "revm-handler 20.0.3",
- "revm-interpreter 37.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -10184,10 +10034,10 @@ checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-handler 41.0.0",
- "revm-interpreter 41.0.0",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
  "serde",
@@ -10208,24 +10058,11 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "time",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "37.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
-dependencies = [
- "revm-bytecode 11.0.1",
- "revm-context-interface 19.0.3",
- "revm-primitives 24.0.1",
- "revm-state 12.0.1",
- "serde",
 ]
 
 [[package]]
@@ -10235,34 +10072,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
 dependencies = [
  "revm-bytecode 41.0.0",
- "revm-context-interface 41.0.0",
+ "revm-context-interface",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
  "serde",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "36.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "arrayref",
- "aurora-engine-modexp",
- "c-kzg",
- "cfg-if",
- "k256",
- "p256",
- "revm-context-interface 19.0.3",
- "revm-primitives 24.0.1",
- "ripemd",
- "secp256k1 0.31.1",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10283,7 +10096,7 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface 41.0.0",
+ "revm-context-interface",
  "revm-primitives 41.0.0",
  "ripemd",
  "secp256k1 0.31.1",
@@ -10298,17 +10111,6 @@ checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "once_cell",
- "serde",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "24.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
-dependencies = [
- "alloy-primitives",
  "once_cell",
  "serde",
 ]
@@ -10334,20 +10136,6 @@ dependencies = [
  "bitflags 2.11.1",
  "revm-bytecode 9.0.0",
  "revm-primitives 22.1.0",
- "serde",
-]
-
-[[package]]
-name = "revm-state"
-version = "12.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
-dependencies = [
- "alloy-eip7928 0.4.3",
- "bitflags 2.11.1",
- "nonmax",
- "revm-bytecode 11.0.1",
- "revm-primitives 24.0.1",
  "serde",
 ]
 
@@ -10600,7 +10388,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10659,7 +10447,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11384,7 +11172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11933,7 +11721,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11975,7 +11763,7 @@ version = "1.8.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy-eips",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-genesis",
  "alloy-hardforks",
  "alloy-primitives",
@@ -12021,7 +11809,7 @@ version = "1.8.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "commonware-codec",
@@ -12049,12 +11837,12 @@ version = "1.8.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "commonware-codec",
  "commonware-cryptography",
  "derive_more",
- "revm 41.0.0",
+ "revm",
  "scoped-tls",
  "tempo-chainspec",
  "tempo-contracts",
@@ -12099,7 +11887,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits 0.5.1",
  "reth-rpc-convert",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -12112,14 +11900,14 @@ version = "1.8.2"
 source = "git+https://github.com/tempoxyz/tempo?rev=8e09dcfc3665dce3403fd367cfce96b31317fbf0#8e09dcfc3665dce3403fd367cfce96b31317fbf0"
 dependencies = [
  "alloy-consensus",
- "alloy-evm 0.37.0",
+ "alloy-evm",
  "alloy-primitives",
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
  "reth-evm",
  "reth-storage-api",
- "revm 41.0.0",
+ "revm",
  "serde",
  "tempo-chainspec",
  "tempo-contracts",
@@ -13536,7 +13324,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -588,7 +588,7 @@ op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = 
 alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
 
 ## foundry-fork-db
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8027e5ccdfe55e562a1111495d2c9acb6e27a930" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "ba6246789fc12cf8fe78aa74aadf31d663f08c1f" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,7 +405,7 @@ alloy-op-evm = "0.32.0"
 
 # revm
 revm = { version = "41.0.0", default-features = false }
-revm-inspectors = { version = "0.40.1", features = ["serde"] }
+revm-inspectors = { version = "0.41.1", features = ["serde"] }
 op-revm = { version = "20.0.0", default-features = false }
 
 ## cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -579,8 +579,8 @@ idna_adapter = "=1.1.0"
 # alloy-evm = { git = "https://github.com/paradigmxyz/evm.git", rev = "04d8e4a" }
 
 ## op-revm / op-alloy / alloy-op-evm
-## Pinned to foundry-rs forks until upstream optimism bumps to revm 40.
-op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "4201f16a746f2da2df38f1eac477500d492eaed5" }
+## Pinned to foundry-rs forks until upstream optimism bumps to revm 41.
+op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "8f4569092ca8c41780eccacb9e5ffa1f03202450" }
 alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
 op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
 op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,17 +507,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "9de5344a961c13dd4b201
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -591,9 +591,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "ba6246789fc12cf8fe78aa74aadf31d663f08c1f" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,17 +507,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "9de5344a961c13dd4b201
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -591,9 +591,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "8027e5ccdfe55e562a1111495d2c9acb6e27a930" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ad7eb1662417042a7304115ea18c54f505eb78fd" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8e09dcfc3665dce3403fd367cfce96b31317fbf0" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -400,12 +400,12 @@ op-alloy-rpc-types = "0.24.0"
 op-alloy-flz = "0.13.1"
 
 ## alloy-evm
-alloy-evm = "0.36.0"
+alloy-evm = "0.37.0"
 alloy-op-evm = "0.32.0"
 
 # revm
-revm = { version = "40.0.3", default-features = false }
-revm-inspectors = { version = "0.40.0", features = ["serde"] }
+revm = { version = "41.0.0", default-features = false }
+revm-inspectors = { version = "0.40.1", features = ["serde"] }
 op-revm = { version = "20.0.0", default-features = false }
 
 ## cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -579,8 +579,8 @@ idna_adapter = "=1.1.0"
 # alloy-evm = { git = "https://github.com/paradigmxyz/evm.git", rev = "04d8e4a" }
 
 ## op-revm / op-alloy / alloy-op-evm
-## Pinned to foundry-rs forks until upstream optimism bumps to revm 41.
-op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "8f4569092ca8c41780eccacb9e5ffa1f03202450" }
+## Pinned to foundry-rs forks until upstream optimism bumps to revm 40.
+op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "c10fd76e66fd46cebc08ba370aa58bde72b94140" }
 alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
 op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
 op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -176,7 +176,7 @@ where
                 .map_err(BlockExecutionError::other)?;
 
             if let Some(hook) = &mut self.state_hook {
-                hook.on_state(&result.state);
+                hook.on_state(result.state.clone());
             }
             self.evm.db_mut().commit(result.state);
         }
@@ -223,7 +223,7 @@ where
         } = output;
 
         if let Some(hook) = &mut self.state_hook {
-            hook.on_state(&state);
+            hook.on_state(state.clone());
         }
 
         let gas_used = result.tx_gas_used();

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     constants::{CALLER, CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, TEST_CONTRACT_ADDRESS},
     evm::{
         BlockEnvFor, EthEvmNetwork, EvmEnvFor, FoundryContextFor, FoundryEvmFactory,
-        FoundryEvmNetwork, HaltReasonFor, PrecompilesFor, SpecFor, TxEnvFor,
+        FoundryEvmNetwork, HaltReasonFor, SpecFor, TxEnvFor,
     },
     fork::{CreateFork, ForkId, MultiFork},
     state_snapshot::StateSnapshots,
@@ -22,7 +22,6 @@ use alloy_rpc_types::BlockNumberOrTag;
 use eyre::Context;
 use foundry_common::{SYSTEM_TRANSACTION_TYPE, is_known_system_sender};
 pub use foundry_fork_db::{BlockchainDb, ForkBlockEnv, SharedBackend, cache::BlockchainDbMeta};
-use itertools::Itertools;
 use revm::{
     Database, DatabaseCommit, JournalEntry,
     bytecode::Bytecode,
@@ -832,7 +831,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
 
     /// Returns true if the address is a precompile
     pub fn is_existing_precompile(&self, addr: &Address) -> bool {
-        self.inner.precompiles().addresses().contains(addr)
+        self.inner.precompile_addresses().contains(addr)
     }
 
     /// Sets the initial journaled state to use when initializing forks
@@ -1958,12 +1957,12 @@ impl<FEN: FoundryEvmNetwork> BackendInner<FEN> {
         self.issued_local_fork_ids.is_empty()
     }
 
-    pub fn precompiles(&self) -> PrecompilesFor<FEN> {
+    pub fn precompile_addresses(&self) -> AddressSet {
         let evm = FEN::EvmFactory::default().create_evm(
             EmptyDB::default(),
             EvmEnv::new(CfgEnv::new_with_spec(self.spec_id), Default::default()),
         );
-        evm.precompiles().clone()
+        evm.precompiles().addresses().copied().collect()
     }
 
     /// Returns a new, empty, `JournaledState` with set precompiles
@@ -1973,7 +1972,7 @@ impl<FEN: FoundryEvmNetwork> BackendInner<FEN> {
             journal_inner.set_spec_id(self.spec_id.into());
             journal_inner
         };
-        let precompile_addresses: AddressSet = self.precompiles().addresses().copied().collect();
+        let precompile_addresses = self.precompile_addresses();
         journal.warm_addresses.set_precompile_addresses(&precompile_addresses);
         journal
     }


### PR DESCRIPTION
Bumps Foundry workspace deps toward the versions required by tempoxyz/tempo#5564:

- revm 41.0.0
- alloy-evm 0.37.0
- revm-inspectors 0.41.1
- op-revm pinned to foundry-rs/op-revm@8f4569092ca8c41780eccacb9e5ffa1f03202450
- optimism fork branch updated to align alloy-op-evm with the revm 41 stack

Local verification:

- `cargo check -p foundry-primitives --features optimism`

Prompted by: @0xrusowsky