### PR TITLE
feat: preparing for new corpus sharing policy

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1208,6 +1208,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
                     }
+                    let msg = if corpus_policy.finalizes_campaign_outputs() {
+                        format!("[w{}] {msg}", plan.worker_id)
+                    } else {
+                        msg
+                    };
                     progress.set_message(msg);
                 }
             } else if edge_coverage_enabled

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -275,6 +275,9 @@ struct InvariantCorpusPolicy {
 }
 
 impl InvariantCorpusPolicy {
+    // Today, campaign output finalization is only a persistence decision. The sharing dimension is
+    // modeled separately so a future campaign-local corpus broker can extend this policy without
+    // changing worker call sites.
     const fn finalizes_campaign_outputs(self) -> bool {
         self.persistence.writes_after_campaign()
     }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -249,13 +249,39 @@ fn invariant_worker_runner(
 enum InvariantCorpusPersistence {
     /// Preserve the legacy single-worker behavior: each interesting input is written immediately.
     Live,
-    /// Parallel workers return interesting inputs to the campaign coordinator for merged writes.
-    Deferred,
+    /// Return interesting inputs to the campaign coordinator for one final deduped write.
+    FinalOnly,
 }
 
 impl InvariantCorpusPersistence {
-    const fn is_deferred(self) -> bool {
-        matches!(self, Self::Deferred)
+    const fn writes_after_campaign(self) -> bool {
+        matches!(self, Self::FinalOnly)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InvariantCorpusSharing {
+    /// Workers only use their local corpus during campaign execution.
+    None,
+    /// TODO: exchange new corpus entries through an in-memory campaign-local broker.
+    #[allow(dead_code)]
+    CampaignLocal,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct InvariantCorpusPolicy {
+    persistence: InvariantCorpusPersistence,
+    sharing: InvariantCorpusSharing,
+}
+
+impl InvariantCorpusPolicy {
+    const fn finalizes_campaign_outputs(self) -> bool {
+        self.persistence.writes_after_campaign()
+    }
+
+    const fn uses_worker_local_progress(self) -> bool {
+        matches!(self.persistence, InvariantCorpusPersistence::FinalOnly)
+            || matches!(self.sharing, InvariantCorpusSharing::CampaignLocal)
     }
 }
 
@@ -666,10 +692,17 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             Some(&replay_targets),
             Some(self.dynamic_target_ctx()),
         )?;
+        // Persistence describes write timing; the worker count only selects today's compatible
+        // behavior. Single-worker campaigns retain live writes, while parallel campaigns collect
+        // outputs for one coordinator-finalized write after workers finish.
         let corpus_persistence = if actual_worker_count > 1 {
-            InvariantCorpusPersistence::Deferred
+            InvariantCorpusPersistence::FinalOnly
         } else {
             InvariantCorpusPersistence::Live
+        };
+        let corpus_policy = InvariantCorpusPolicy {
+            persistence: corpus_persistence,
+            sharing: InvariantCorpusSharing::None,
         };
         let mut runner = self.runner.clone();
         let config = self.config.clone();
@@ -679,7 +712,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let campaign_state =
             Arc::new(InvariantCampaignState::new(early_exit.clone(), self.config.timeout));
 
-        let worker_outputs = if corpus_persistence.is_deferred() {
+        let worker_outputs = if actual_worker_count > 1 {
             let worker_jobs = worker_plans
                 .into_iter()
                 .map(|worker_plan| {
@@ -714,7 +747,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         campaign_seed.clone(),
                         corpus_seed
                             .clone_for_worker(worker_plan.worker_id as usize, actual_worker_count),
-                        corpus_persistence,
+                        corpus_policy,
                         gas_report_samples,
                     );
                     debug!("finished in {:?}", timer.elapsed());
@@ -740,7 +773,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 &campaign_state,
                 campaign_seed,
                 corpus_seed.clone(),
-                corpus_persistence,
+                corpus_policy,
                 gas_report_samples,
             )?]
         };
@@ -754,7 +787,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         } else {
             aggregator.finish_with_corpus_entries()?
         };
-        if corpus_persistence.is_deferred() {
+        if corpus_policy.finalizes_campaign_outputs() {
             let dynamic_target_ctx = self.dynamic_target_ctx();
             corpus_seed.persist_filtered_campaign_outputs(
                 &self.config.corpus,
@@ -789,7 +822,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         campaign_state: &InvariantCampaignState,
         campaign_seed: InvariantCampaignSeed,
         corpus_seed: WorkerCorpusSeed,
-        corpus_persistence: InvariantCorpusPersistence,
+        corpus_policy: InvariantCorpusPolicy,
         gas_report_samples: usize,
     ) -> Result<InvariantWorkerOutput> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
@@ -1098,7 +1131,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 let prefix = current_run.inputs[..current_run.optimization_prefix_len].to_vec();
                 (v, prefix)
             });
-            if corpus_persistence.is_deferred() {
+            if corpus_policy.finalizes_campaign_outputs() {
                 if let Some(input) = corpus_manager.process_inputs_for_campaign(
                     &current_run.inputs,
                     &current_run.cmp_seq,
@@ -1180,7 +1213,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
                     }
-                    let msg = if corpus_persistence.is_deferred() {
+                    let msg = if corpus_policy.uses_worker_local_progress() {
                         format!("[w{}] {msg}", plan.worker_id)
                     } else {
                         msg
@@ -2010,6 +2043,42 @@ mod tests {
             2
         );
         assert_eq!(max_invariant_workers_for_campaign(256, 100_000), 5);
+    }
+
+    #[test]
+    fn invariant_corpus_policy_keeps_single_worker_live_and_isolated() {
+        let policy = InvariantCorpusPolicy {
+            persistence: InvariantCorpusPersistence::Live,
+            sharing: InvariantCorpusSharing::None,
+        };
+
+        assert_eq!(policy.persistence, InvariantCorpusPersistence::Live);
+        assert_eq!(policy.sharing, InvariantCorpusSharing::None);
+        assert!(!policy.finalizes_campaign_outputs());
+        assert!(!policy.uses_worker_local_progress());
+    }
+
+    #[test]
+    fn invariant_corpus_policy_keeps_parallel_workers_final_only_and_isolated() {
+        let policy = InvariantCorpusPolicy {
+            persistence: InvariantCorpusPersistence::FinalOnly,
+            sharing: InvariantCorpusSharing::None,
+        };
+
+        assert_eq!(policy.persistence, InvariantCorpusPersistence::FinalOnly);
+        assert_eq!(policy.sharing, InvariantCorpusSharing::None);
+        assert!(policy.finalizes_campaign_outputs());
+        assert!(policy.uses_worker_local_progress());
+    }
+
+    #[test]
+    fn invariant_corpus_policy_treats_campaign_local_sharing_as_worker_local_progress() {
+        let policy = InvariantCorpusPolicy {
+            persistence: InvariantCorpusPersistence::Live,
+            sharing: InvariantCorpusSharing::CampaignLocal,
+        };
+
+        assert!(policy.uses_worker_local_progress());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -707,7 +707,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let campaign_state =
             Arc::new(InvariantCampaignState::new(early_exit.clone(), self.config.timeout));
 
-        let worker_outputs = if actual_worker_count > 1 {
+        let worker_outputs = if corpus_policy.finalizes_campaign_outputs() {
             let worker_jobs = worker_plans
                 .into_iter()
                 .map(|worker_plan| {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -249,13 +249,13 @@ fn invariant_worker_runner(
 enum InvariantCorpusPersistence {
     /// Preserve the legacy single-worker behavior: each interesting input is written immediately.
     Live,
-    /// Return interesting inputs to the campaign coordinator for one final deduped write.
-    FinalOnly,
+    /// Return interesting inputs to the campaign coordinator for delayed merged writes.
+    Deferred,
 }
 
 impl InvariantCorpusPersistence {
     const fn writes_after_campaign(self) -> bool {
-        matches!(self, Self::FinalOnly)
+        matches!(self, Self::Deferred)
     }
 }
 
@@ -280,7 +280,7 @@ impl InvariantCorpusPolicy {
     }
 
     const fn uses_worker_local_progress(self) -> bool {
-        matches!(self.persistence, InvariantCorpusPersistence::FinalOnly)
+        matches!(self.persistence, InvariantCorpusPersistence::Deferred)
             || matches!(self.sharing, InvariantCorpusSharing::CampaignLocal)
     }
 }
@@ -696,7 +696,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // behavior. Single-worker campaigns retain live writes, while parallel campaigns collect
         // outputs for one coordinator-finalized write after workers finish.
         let corpus_persistence = if actual_worker_count > 1 {
-            InvariantCorpusPersistence::FinalOnly
+            InvariantCorpusPersistence::Deferred
         } else {
             InvariantCorpusPersistence::Live
         };
@@ -2059,13 +2059,13 @@ mod tests {
     }
 
     #[test]
-    fn invariant_corpus_policy_keeps_parallel_workers_final_only_and_isolated() {
+    fn invariant_corpus_policy_keeps_parallel_workers_deferred_and_isolated() {
         let policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::FinalOnly,
+            persistence: InvariantCorpusPersistence::Deferred,
             sharing: InvariantCorpusSharing::None,
         };
 
-        assert_eq!(policy.persistence, InvariantCorpusPersistence::FinalOnly);
+        assert_eq!(policy.persistence, InvariantCorpusPersistence::Deferred);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);
         assert!(policy.finalizes_campaign_outputs());
         assert!(policy.uses_worker_local_progress());

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -278,11 +278,6 @@ impl InvariantCorpusPolicy {
     const fn finalizes_campaign_outputs(self) -> bool {
         self.persistence.writes_after_campaign()
     }
-
-    const fn uses_worker_local_progress(self) -> bool {
-        matches!(self.persistence, InvariantCorpusPersistence::Deferred)
-            || matches!(self.sharing, InvariantCorpusSharing::CampaignLocal)
-    }
 }
 
 /// Converts a cumulative campaign total into an average per-second rate.
@@ -1213,11 +1208,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
                     }
-                    let msg = if corpus_policy.uses_worker_local_progress() {
-                        format!("[w{}] {msg}", plan.worker_id)
-                    } else {
-                        msg
-                    };
                     progress.set_message(msg);
                 }
             } else if edge_coverage_enabled
@@ -2055,7 +2045,6 @@ mod tests {
         assert_eq!(policy.persistence, InvariantCorpusPersistence::Live);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);
         assert!(!policy.finalizes_campaign_outputs());
-        assert!(!policy.uses_worker_local_progress());
     }
 
     #[test]
@@ -2068,17 +2057,6 @@ mod tests {
         assert_eq!(policy.persistence, InvariantCorpusPersistence::Deferred);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);
         assert!(policy.finalizes_campaign_outputs());
-        assert!(policy.uses_worker_local_progress());
-    }
-
-    #[test]
-    fn invariant_corpus_policy_treats_campaign_local_sharing_as_worker_local_progress() {
-        let policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::Live,
-            sharing: InvariantCorpusSharing::CampaignLocal,
-        };
-
-        assert!(policy.uses_worker_local_progress());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -254,7 +254,13 @@ enum InvariantCorpusPersistence {
 }
 
 impl InvariantCorpusPersistence {
-    const fn writes_after_campaign(self) -> bool {
+    // Worker count only selects today's compatible write timing. The in-campaign sharing strategy
+    // is modeled separately by `InvariantCorpusSharing`.
+    const fn for_worker_count(worker_count: usize) -> Self {
+        if worker_count > 1 { Self::Deferred } else { Self::Live }
+    }
+
+    const fn is_deferred(self) -> bool {
         matches!(self, Self::Deferred)
     }
 }
@@ -263,7 +269,8 @@ impl InvariantCorpusPersistence {
 enum InvariantCorpusSharing {
     /// Workers only use their local corpus during campaign execution.
     None,
-    /// TODO: exchange new corpus entries through an in-memory campaign-local broker.
+    /// TODO: publish worker discoveries after campaign processing and import sibling entries
+    /// before generating new inputs.
     #[allow(dead_code)]
     CampaignLocal,
 }
@@ -279,7 +286,7 @@ impl InvariantCorpusPolicy {
     // modeled separately so a future campaign-local corpus broker can extend this policy without
     // changing worker call sites.
     const fn finalizes_campaign_outputs(self) -> bool {
-        self.persistence.writes_after_campaign()
+        self.persistence.is_deferred()
     }
 }
 
@@ -690,16 +697,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             Some(&replay_targets),
             Some(self.dynamic_target_ctx()),
         )?;
-        // Persistence describes write timing; the worker count only selects today's compatible
-        // behavior. Single-worker campaigns retain live writes, while parallel campaigns collect
-        // outputs for one coordinator-finalized write after workers finish.
-        let corpus_persistence = if actual_worker_count > 1 {
-            InvariantCorpusPersistence::Deferred
-        } else {
-            InvariantCorpusPersistence::Live
-        };
         let corpus_policy = InvariantCorpusPolicy {
-            persistence: corpus_persistence,
+            persistence: InvariantCorpusPersistence::for_worker_count(actual_worker_count),
             sharing: InvariantCorpusSharing::None,
         };
         let mut runner = self.runner.clone();
@@ -2044,11 +2043,9 @@ mod tests {
     }
 
     #[test]
-    fn invariant_corpus_policy_keeps_single_worker_live_and_isolated() {
-        let policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::Live,
-            sharing: InvariantCorpusSharing::None,
-        };
+    fn invariant_corpus_persistence_selects_live_writes_for_single_worker() {
+        let persistence = InvariantCorpusPersistence::for_worker_count(1);
+        let policy = InvariantCorpusPolicy { persistence, sharing: InvariantCorpusSharing::None };
 
         assert_eq!(policy.persistence, InvariantCorpusPersistence::Live);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);
@@ -2056,11 +2053,9 @@ mod tests {
     }
 
     #[test]
-    fn invariant_corpus_policy_keeps_parallel_workers_deferred_and_isolated() {
-        let policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::Deferred,
-            sharing: InvariantCorpusSharing::None,
-        };
+    fn invariant_corpus_persistence_selects_deferred_writes_for_parallel_workers() {
+        let persistence = InvariantCorpusPersistence::for_worker_count(2);
+        let policy = InvariantCorpusPolicy { persistence, sharing: InvariantCorpusSharing::None };
 
         assert_eq!(policy.persistence, InvariantCorpusPersistence::Deferred);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -254,12 +254,6 @@ enum InvariantCorpusPersistence {
 }
 
 impl InvariantCorpusPersistence {
-    // Worker count only selects today's compatible write timing. The in-campaign sharing strategy
-    // is modeled separately by `InvariantCorpusSharing`.
-    const fn for_worker_count(worker_count: usize) -> Self {
-        if worker_count > 1 { Self::Deferred } else { Self::Live }
-    }
-
     const fn is_deferred(self) -> bool {
         matches!(self, Self::Deferred)
     }
@@ -697,8 +691,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             Some(&replay_targets),
             Some(self.dynamic_target_ctx()),
         )?;
+        let corpus_persistence = if actual_worker_count > 1 {
+            InvariantCorpusPersistence::Deferred
+        } else {
+            InvariantCorpusPersistence::Live
+        };
         let corpus_policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::for_worker_count(actual_worker_count),
+            persistence: corpus_persistence,
             sharing: InvariantCorpusSharing::None,
         };
         let mut runner = self.runner.clone();
@@ -2040,26 +2039,6 @@ mod tests {
             2
         );
         assert_eq!(max_invariant_workers_for_campaign(256, 100_000), 5);
-    }
-
-    #[test]
-    fn invariant_corpus_persistence_selects_live_writes_for_single_worker() {
-        let persistence = InvariantCorpusPersistence::for_worker_count(1);
-        let policy = InvariantCorpusPolicy { persistence, sharing: InvariantCorpusSharing::None };
-
-        assert_eq!(policy.persistence, InvariantCorpusPersistence::Live);
-        assert_eq!(policy.sharing, InvariantCorpusSharing::None);
-        assert!(!policy.finalizes_campaign_outputs());
-    }
-
-    #[test]
-    fn invariant_corpus_persistence_selects_deferred_writes_for_parallel_workers() {
-        let persistence = InvariantCorpusPersistence::for_worker_count(2);
-        let policy = InvariantCorpusPolicy { persistence, sharing: InvariantCorpusSharing::None };
-
-        assert_eq!(policy.persistence, InvariantCorpusPersistence::Deferred);
-        assert_eq!(policy.sharing, InvariantCorpusSharing::None);
-        assert!(policy.finalizes_campaign_outputs());
     }
 
     #[test]


### PR DESCRIPTION
Starting  OSS-377

- Introduce InvariantCorpusPolicy to pass corpus campaign behavior through worker execution.
- Keep the existing worker-count based persistence behavior unchanged:
      - single-worker campaigns use live persistence
      - parallel campaigns use deferred coordinator persistence

- Add an explicit InvariantCorpusSharing axis:
     - current behavior is None
     - CampaignLocal is left as the future insertion point for publishing worker discoveries and importing sibling entries before input generation

- Route corpus finalization decisions through InvariantCorpusPolicy::finalizes_campaign_outputs() instead of checking persistence directly at every call site.
