### PR TITLE
fix(cheatcodes): decode expectEmit mismatches from project ABIs

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -774,7 +774,17 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
 
     /// Returns the signatures identifier.
     pub fn signatures_identifier(&self) -> Option<&SignaturesIdentifier> {
-        self.signatures_identifier.get_or_init(|| SignaturesIdentifier::new(true).ok()).as_ref()
+        self.signatures_identifier
+            .get_or_init(|| {
+                if let Some(artifacts) = &self.config.available_artifacts {
+                    return SignaturesIdentifier::new_offline_with_abis(
+                        artifacts.values().map(|contract| &contract.abi),
+                    )
+                    .ok();
+                }
+                SignaturesIdentifier::new(true).ok()
+            })
+            .as_ref()
     }
 
     /// Decodes the input data and applies the cheatcode.

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -778,7 +778,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             .get_or_init(|| {
                 if let Some(artifacts) = &self.config.available_artifacts {
                     return SignaturesIdentifier::new_offline_with_abis(
-                        artifacts.values().map(|contract| &contract.abi),
+                        artifacts.iter().map(|(_, contract)| &contract.abi),
                     )
                     .ok();
                 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -778,7 +778,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             .get_or_init(|| {
                 if let Some(artifacts) = &self.config.available_artifacts {
                     return SignaturesIdentifier::new_offline_with_abis(
-                        artifacts.iter().map(|(_, contract)| &contract.abi),
+                        artifacts.values().map(|contract| &contract.abi),
                     )
                     .ok();
                 }

--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -1114,7 +1114,9 @@ fn decode_event(
     }
     let t0 = topics[0]; // event sig
     // Try to identify the event
-    let event = foundry_common::block_on(identifier.identify_event(t0))?;
+    let event = foundry_common::block_on(
+        identifier.identify_event_with_indexed_count(t0, topics.len().saturating_sub(1)),
+    )?;
 
     // Check if event already has indexed information from signatures
     let has_indexed_info = event.inputs.iter().any(|p| p.indexed);

--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -444,7 +444,7 @@ mod tests {
         let mut first_abi = JsonAbi::default();
         first_abi.events.insert(first.name.clone(), vec![first.clone()]);
         let mut second_abi = JsonAbi::default();
-        second_abi.events.insert(second.name.clone(), vec![second.clone()]);
+        second_abi.events.insert(second.name.clone(), vec![second]);
 
         let mut cache = SignaturesCache::default();
         cache.extend_from_abis_without_collisions([&first_abi, &second_abi]);

--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -1,5 +1,8 @@
 use alloy_json_abi::{Error, Event, Function, JsonAbi};
-use alloy_primitives::{B256, Selector, map::HashMap};
+use alloy_primitives::{
+    B256, Selector,
+    map::{HashMap, HashSet},
+};
 use eyre::Result;
 use foundry_common::{
     abi::{get_error, get_event, get_func},
@@ -114,7 +117,28 @@ impl SignaturesCache {
 
     /// Updates the cache from an ABI.
     pub fn extend_from_abi(&mut self, abi: &JsonAbi) {
-        self.extend(abi.items().filter_map(|item| match item {
+        self.extend(Self::signatures_from_abi(abi));
+    }
+
+    /// Updates the cache from ABIs without overwriting previous entries from the same batch.
+    fn extend_from_abis_without_collisions<'a>(
+        &mut self,
+        abis: impl IntoIterator<Item = &'a JsonAbi>,
+    ) {
+        let mut seeded: HashSet<SelectorKind> = HashSet::default();
+        for abi in abis {
+            for (selector, signature) in Self::signatures_from_abi(abi) {
+                if seeded.insert(selector) {
+                    self.insert(selector, signature);
+                } else {
+                    trace!(target: "evm::traces", ?selector, %signature, "skipping duplicate ABI signature");
+                }
+            }
+        }
+    }
+
+    fn signatures_from_abi(abi: &JsonAbi) -> impl Iterator<Item = (SelectorKind, String)> + '_ {
+        abi.items().filter_map(|item| match item {
             alloy_json_abi::AbiItem::Function(f) => {
                 Some((SelectorKind::Function(f.selector()), f.signature()))
             }
@@ -125,7 +149,7 @@ impl SignaturesCache {
                 Some((SelectorKind::Event(e.selector()), e.full_signature()))
             }
             _ => None,
-        }));
+        })
     }
 
     /// Inserts a single signature into the cache.
@@ -159,6 +183,8 @@ pub struct SignaturesIdentifier(Arc<SignaturesIdentifierInner>);
 struct SignaturesIdentifierInner {
     /// Cached selectors for functions, events and custom errors.
     cache: RwLock<SignaturesCache>,
+    /// ABI events keyed by topic0 and indexed topic count.
+    local_events: HashMap<(B256, usize), Vec<Event>>,
     /// Location where to save the signature cache.
     cache_path: Option<PathBuf>,
     /// The OpenChain client to fetch signatures from. `None` if disabled on construction.
@@ -178,7 +204,7 @@ impl SignaturesIdentifier {
 
     /// Creates an offline `SignaturesIdentifier` with the default cache directory and local ABIs.
     pub fn new_offline_with_abis<'a>(abis: impl IntoIterator<Item = &'a JsonAbi>) -> Result<Self> {
-        Self::new_with_abis(Config::foundry_cache_dir().as_deref(), true, abis)
+        Ok(Self::new_offline_with_abis_from_cache(Config::foundry_cache_dir().as_deref(), abis))
     }
 
     /// Creates a new `SignaturesIdentifier`.
@@ -186,35 +212,67 @@ impl SignaturesIdentifier {
     /// - `cache_dir` is the cache directory to store the signatures.
     /// - `offline` disables the OpenChain client.
     pub fn new_with(cache_dir: Option<&Path>, offline: bool) -> Result<Self> {
-        Self::new_with_abis(cache_dir, offline, [])
+        let client = if offline { None } else { Some(OpenChainClient::new()?) };
+        Ok(Self::from_cache(Self::load_cache(cache_dir), client))
     }
 
-    /// Creates a new `SignaturesIdentifier`, seeding the cache with local ABIs.
-    ///
-    /// - `cache_dir` is the cache directory to store the signatures.
-    /// - `offline` disables the OpenChain client.
-    /// - `abis` contains local ABI signatures that should be preferred without persisting them.
-    pub fn new_with_abis<'a>(
+    fn new_offline_with_abis_from_cache<'a>(
         cache_dir: Option<&Path>,
-        offline: bool,
         abis: impl IntoIterator<Item = &'a JsonAbi>,
-    ) -> Result<Self> {
-        let client = if offline { None } else { Some(OpenChainClient::new()?) };
-        let (mut cache, cache_path) = if let Some(cache_dir) = cache_dir {
+    ) -> Self {
+        let abis = abis.into_iter().collect::<Vec<_>>();
+        let (mut cache, cache_path) = Self::load_cache(cache_dir);
+        cache.extend_from_abis_without_collisions(abis.iter().copied());
+        let local_events = Self::local_events_from_abis(abis);
+        Self::from_cache_and_events((cache, cache_path), None, local_events)
+    }
+
+    fn load_cache(cache_dir: Option<&Path>) -> (SignaturesCache, Option<PathBuf>) {
+        if let Some(cache_dir) = cache_dir {
             let path = cache_dir.join("signatures");
             let cache = SignaturesCache::load(&path);
             (cache, Some(path))
         } else {
             Default::default()
-        };
-        for abi in abis {
-            cache.extend_from_abi(abi);
         }
-        Ok(Self(Arc::new(SignaturesIdentifierInner {
+    }
+
+    fn from_cache(
+        (cache, cache_path): (SignaturesCache, Option<PathBuf>),
+        client: Option<OpenChainClient>,
+    ) -> Self {
+        Self::from_cache_and_events((cache, cache_path), client, Default::default())
+    }
+
+    fn from_cache_and_events(
+        (cache, cache_path): (SignaturesCache, Option<PathBuf>),
+        client: Option<OpenChainClient>,
+        local_events: HashMap<(B256, usize), Vec<Event>>,
+    ) -> Self {
+        Self(Arc::new(SignaturesIdentifierInner {
             cache: RwLock::new(cache),
+            local_events,
             cache_path,
             client,
-        })))
+        }))
+    }
+
+    fn local_events_from_abis<'a>(
+        abis: impl IntoIterator<Item = &'a JsonAbi>,
+    ) -> HashMap<(B256, usize), Vec<Event>> {
+        let mut local_events: HashMap<(B256, usize), Vec<Event>> = HashMap::default();
+        for abi in abis {
+            for event in abi.events() {
+                local_events
+                    .entry((
+                        event.selector(),
+                        event.inputs.iter().filter(|input| input.indexed).count(),
+                    ))
+                    .or_default()
+                    .push(event.clone());
+            }
+        }
+        local_events
     }
 
     /// Saves the cache to the file system.
@@ -246,6 +304,20 @@ impl SignaturesIdentifier {
     /// Identifies an `Event`.
     pub async fn identify_event(&self, identifier: B256) -> Option<Event> {
         self.identify_events([identifier]).await.pop().unwrap()
+    }
+
+    /// Identifies an `Event`, preferring local ABI events with the matching indexed topic count.
+    pub async fn identify_event_with_indexed_count(
+        &self,
+        identifier: B256,
+        indexed_count: usize,
+    ) -> Option<Event> {
+        if let Some(events) = self.0.local_events.get(&(identifier, indexed_count))
+            && let Some(event) = events.first()
+        {
+            return Some(event.clone());
+        }
+        self.identify_event(identifier).await
     }
 
     /// Identifies `Error`s.
@@ -343,5 +415,70 @@ mod tests {
         // Unknown signature is gone — it will be re-queried next session.
         assert_eq!(reloaded.get(&unknown_selector), None);
         assert!(!reloaded.contains_key(&unknown_selector));
+    }
+
+    #[tokio::test]
+    async fn abi_seeded_signatures_are_not_persisted_to_disk() {
+        let temp = tempfile::tempdir().unwrap();
+        let event = Event::parse("event CodexEphemeral(uint256 indexed value)").unwrap();
+        let mut abi = JsonAbi::default();
+        abi.events.insert(event.name.clone(), vec![event.clone()]);
+
+        {
+            let identifier =
+                SignaturesIdentifier::new_offline_with_abis_from_cache(Some(temp.path()), [&abi]);
+            let decoded = identifier.identify_event(event.selector()).await;
+            assert_eq!(decoded.as_ref().map(Event::full_signature), Some(event.full_signature()));
+            identifier.save();
+        }
+
+        let reloaded = SignaturesCache::load(&temp.path().join("signatures"));
+        assert!(!reloaded.contains_key(&SelectorKind::Event(event.selector())));
+    }
+
+    #[test]
+    fn abi_seeded_collisions_keep_first_signature() {
+        let first = Event::parse("event CodexCollision(uint256 indexed value)").unwrap();
+        let second = Event::parse("event CodexCollision(uint256 value)").unwrap();
+
+        let mut first_abi = JsonAbi::default();
+        first_abi.events.insert(first.name.clone(), vec![first.clone()]);
+        let mut second_abi = JsonAbi::default();
+        second_abi.events.insert(second.name.clone(), vec![second.clone()]);
+
+        let mut cache = SignaturesCache::default();
+        cache.extend_from_abis_without_collisions([&first_abi, &second_abi]);
+
+        assert_eq!(
+            cache.get(&SelectorKind::Event(first.selector())),
+            Some(Some(first.full_signature()))
+        );
+    }
+
+    #[tokio::test]
+    async fn abi_seeded_events_prefer_matching_indexed_count() {
+        let one_topic =
+            Event::parse("event CodexIndexedCount(uint256 indexed marker, uint256 value)").unwrap();
+        let two_topics =
+            Event::parse("event CodexIndexedCount(uint256 indexed marker, uint256 indexed value)")
+                .unwrap();
+
+        let mut one_topic_abi = JsonAbi::default();
+        one_topic_abi.events.insert(one_topic.name.clone(), vec![one_topic.clone()]);
+        let mut two_topics_abi = JsonAbi::default();
+        two_topics_abi.events.insert(two_topics.name.clone(), vec![two_topics.clone()]);
+
+        let identifier = SignaturesIdentifier::new_offline_with_abis_from_cache(
+            None,
+            [&two_topics_abi, &one_topic_abi],
+        );
+
+        let decoded_one_topic =
+            identifier.identify_event_with_indexed_count(one_topic.selector(), 1).await.unwrap();
+        let decoded_two_topics =
+            identifier.identify_event_with_indexed_count(two_topics.selector(), 2).await.unwrap();
+
+        assert_eq!(decoded_one_topic.full_signature(), one_topic.full_signature());
+        assert_eq!(decoded_two_topics.full_signature(), two_topics.full_signature());
     }
 }

--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -176,19 +176,40 @@ impl SignaturesIdentifier {
         Self::new(config.offline)
     }
 
+    /// Creates an offline `SignaturesIdentifier` with the default cache directory and local ABIs.
+    pub fn new_offline_with_abis<'a>(abis: impl IntoIterator<Item = &'a JsonAbi>) -> Result<Self> {
+        Self::new_with_abis(Config::foundry_cache_dir().as_deref(), true, abis)
+    }
+
     /// Creates a new `SignaturesIdentifier`.
     ///
     /// - `cache_dir` is the cache directory to store the signatures.
     /// - `offline` disables the OpenChain client.
     pub fn new_with(cache_dir: Option<&Path>, offline: bool) -> Result<Self> {
+        Self::new_with_abis(cache_dir, offline, [])
+    }
+
+    /// Creates a new `SignaturesIdentifier`, seeding the cache with local ABIs.
+    ///
+    /// - `cache_dir` is the cache directory to store the signatures.
+    /// - `offline` disables the OpenChain client.
+    /// - `abis` contains local ABI signatures that should be preferred without persisting them.
+    pub fn new_with_abis<'a>(
+        cache_dir: Option<&Path>,
+        offline: bool,
+        abis: impl IntoIterator<Item = &'a JsonAbi>,
+    ) -> Result<Self> {
         let client = if offline { None } else { Some(OpenChainClient::new()?) };
-        let (cache, cache_path) = if let Some(cache_dir) = cache_dir {
+        let (mut cache, cache_path) = if let Some(cache_dir) = cache_dir {
             let path = cache_dir.join("signatures");
             let cache = SignaturesCache::load(&path);
             (cache, Some(path))
         } else {
             Default::default()
         };
+        for abi in abis {
+            cache.extend_from_abi(abi);
+        }
         Ok(Self(Arc::new(SignaturesIdentifierInner {
             cache: RwLock::new(cache),
             cache_path,

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -322,6 +322,53 @@ Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 "#]]);
 });
 
+forgetest!(expect_emit_decodes_stable_project_abi_collision, |prj, cmd| {
+    prj.insert_vm();
+
+    prj.add_source(
+        "AExpectEmitIndexedCollision.t.sol",
+        r#"
+import "./Vm.sol";
+import "./ZIndexedCollisionEmitter.sol";
+
+contract AExpectEmitIndexedCollisionTest {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    ZIndexedCollisionEmitter emitter = new ZIndexedCollisionEmitter();
+
+    event CodexExpectEmitIndexedCollision(uint256 indexed marker, uint256 value);
+
+    function testMismatch() public {
+        vm.expectEmit(true, true, false, true);
+        emit CodexExpectEmitIndexedCollision(69, 420);
+        emitter.emitEvent(421, 69);
+    }
+}
+"#,
+    );
+    prj.add_source(
+        "ZIndexedCollisionEmitter.sol",
+        r#"
+contract ZIndexedCollisionEmitter {
+    event CodexExpectEmitIndexedCollision(uint256 value, uint256 indexed marker);
+
+    function emitEvent(uint256 value, uint256 marker) external {
+        emit CodexExpectEmitIndexedCollision(value, marker);
+    }
+}
+"#,
+    );
+
+    cmd.forge_fuse()
+        .args(["test", "--mc", "AExpectEmitIndexedCollisionTest"])
+        .assert_failure()
+        .stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
+...
+[FAIL: CodexExpectEmitIndexedCollision param mismatch at value: expected=420, got=421] testMismatch() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+...
+"#]]);
+});
+
 forgetest!(mem_safety_test_should_fail, |prj, cmd| {
     prj.insert_ds_test();
     prj.insert_vm();

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -280,6 +280,48 @@ Encountered a total of 8 failing tests, 1 tests succeeded
     );
 });
 
+forgetest!(expect_emit_params_decode_project_abi_without_selector_cache, |prj, cmd| {
+    prj.insert_vm();
+
+    prj.add_source(
+        "ExpectEmitProjectAbiFailure.sol",
+        r#"
+import "./Vm.sol";
+
+contract CodexProjectAbiEmitter10342 {
+    event CodexExpectEmitProjectAbi10342(uint256 indexed topicValue, uint256 dataValue);
+
+    function emitEvent(uint256 topicValue, uint256 dataValue) external {
+        emit CodexExpectEmitProjectAbi10342(topicValue, dataValue);
+    }
+}
+
+contract ExpectEmitProjectAbiFailureTest {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    CodexProjectAbiEmitter10342 emitter = new CodexProjectAbiEmitter10342();
+
+    event CodexExpectEmitProjectAbi10342(uint256 indexed topicValue, uint256 dataValue);
+
+    function testMismatch() public {
+        vm.expectEmit(true, true, true, true);
+        emit CodexExpectEmitProjectAbi10342(1, 2);
+        emitter.emitEvent(1, 3);
+    }
+}
+"#,
+    );
+
+    cmd.forge_fuse()
+        .args(["test", "--mc", "ExpectEmitProjectAbiFailureTest"])
+        .assert_failure()
+        .stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
+...
+[FAIL: CodexExpectEmitProjectAbi10342 param mismatch at dataValue: expected=2, got=3] testMismatch() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+...
+"#]]);
+});
+
 forgetest!(mem_safety_test_should_fail, |prj, cmd| {
     prj.insert_ds_test();
     prj.insert_vm();

--- a/crates/forge/tests/cli/test_cmd/repros.rs
+++ b/crates/forge/tests/cli/test_cmd/repros.rs
@@ -255,14 +255,14 @@ contract Issue6170Test is Test {
 Compiler run successful!
 
 Ran 1 test for test/Issue6170.t.sol:Issue6170Test
-[FAIL: log != expected Values] test() ([GAS])
+[FAIL: Values != expected Values] test() ([GAS])
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/Issue6170.t.sol:Issue6170Test
-[FAIL: log != expected Values] test() ([GAS])
+[FAIL: Values != expected Values] test() ([GAS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 

--- a/crates/forge/tests/cli/test_cmd/repros.rs
+++ b/crates/forge/tests/cli/test_cmd/repros.rs
@@ -255,14 +255,14 @@ contract Issue6170Test is Test {
 Compiler run successful!
 
 Ran 1 test for test/Issue6170.t.sol:Issue6170Test
-[FAIL: log != expected log] test() ([GAS])
+[FAIL: log != expected Values] test() ([GAS])
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/Issue6170.t.sol:Issue6170Test
-[FAIL: log != expected log] test() ([GAS])
+[FAIL: log != expected Values] test() ([GAS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 


### PR DESCRIPTION
## Summary

Refs #10342.

This seeds the cheatcode event signature identifier with the current project's compiled ABIs. `expectEmit` mismatch diagnostics can now decode local event names and parameter values without requiring users to run `forge selectors cache` first.

The new regression uses a unique event signature and asserts that a default `forge test` failure reports the mismatched parameter by name.

## Root Cause

`Cheatcodes::signatures_identifier` built an offline `SignaturesIdentifier` from the global selector cache only. If the project event signature was not already cached, event mismatches fell back to generic `log mismatch at param N` output with raw ABI words.
