### PR TITLE
feat(lint): flag bare `require` in `custom-errors`

### DIFF
--- a/crates/lint/docs/custom-errors.md
+++ b/crates/lint/docs/custom-errors.md
@@ -3,13 +3,13 @@
 **Severity**: `Gas`
 **ID**: `custom-errors`
 
-Flags `require(cond, "message")`, `revert("message")`, and `revert()` calls; suggests replacing
-them with a `revert CustomError(...)`.
+Flags `require(cond)`, `require(cond, "message")`, `revert("message")`, and `revert()` calls;
+suggests replacing them with a `revert CustomError(...)`.
 
 ## What it does
 
-Reports `require` calls whose second argument is a string literal, and `revert(...)` calls that
-are either bare or have a string-literal argument.
+Reports `require` calls with no reason or whose second argument is a string literal, and
+`revert(...)` calls that are either bare or have a string-literal argument.
 
 ## Why is this bad?
 
@@ -26,6 +26,7 @@ Solidity 0.8.4+ supports custom errors natively.
 
 ```solidity
 require(amount > 0, "amount must be > 0");
+require(amount > 0);
 revert("not authorized");
 revert();
 ```

--- a/crates/lint/src/sol/gas/custom_errors.rs
+++ b/crates/lint/src/sol/gas/custom_errors.rs
@@ -40,10 +40,10 @@ fn should_lint_revert(args: &solar::ast::CallArgs<'_>) -> bool {
     })
 }
 
-/// Checks if a require call should be linted: has string literal as second argument.
+/// Checks if a require call should be linted: bare `require(condition)` or string literal reason.
 fn should_lint_require(args: &solar::ast::CallArgs<'_>) -> bool {
     matches!(&args.kind, CallArgsKind::Unnamed(arg_exprs) if {
-        arg_exprs.get(1).is_some_and(|e| is_string_literal(e))
+        arg_exprs.len() == 1 || arg_exprs.get(1).is_some_and(|e| is_string_literal(e))
     })
 }
 

--- a/crates/lint/testdata/CustomErrors.sol
+++ b/crates/lint/testdata/CustomErrors.sol
@@ -25,7 +25,7 @@ contract CustomErrors {
     function customErrors(uint256 value) public pure {
         require(value > 0, CustomError());
         require(value < 100, CustomErrorWithArg(value));
-        require(value > 0);
+        require(value > 0); //~NOTE: prefer using custom errors on revert and require calls
         revert CustomError();
         revert CustomErrorWithArg(value);
         revert CustomErrorWithNamedArgs({x: value, message: "test"});
@@ -39,4 +39,3 @@ contract CustomErrors {
         revert("This should not lint");
     }
 }
-

--- a/crates/lint/testdata/CustomErrors.stderr
+++ b/crates/lint/testdata/CustomErrors.stderr
@@ -38,3 +38,11 @@ LL │         revert();
    │
    ╰ help: https://getfoundry.sh/forge/linting/custom-errors
 
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/CustomErrors.sol:LL:CC
+   │
+LL │         require(value > 0);
+   │         ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+

--- a/crates/lint/testdata/UnusedStateVariables.sol
+++ b/crates/lint/testdata/UnusedStateVariables.sol
@@ -1,4 +1,4 @@
-//@compile-flags: --severity gas
+//@compile-flags: --only-lint unused-state-variables
 
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;

--- a/crates/lint/testdata/UnusedStateVariables.stderr
+++ b/crates/lint/testdata/UnusedStateVariables.stderr
@@ -1,11 +1,3 @@
-note[could-be-immutable]: state variable could be declared immutable
-   ╭▸ ROOT/testdata/UnusedStateVariables.sol:LL:CC
-   │
-LL │     address usedInBoth;
-   │             ━━━━━━━━━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/could-be-immutable
-
 note[unused-state-variables]: state variable is never used
    ╭▸ ROOT/testdata/UnusedStateVariables.sol:LL:CC
    │


### PR DESCRIPTION
## Motivation

Close OSS-379

Covers Aderyn's `empty-require-revert` lint, our message is bit broad but represent no extra impl effort and still useful imo.