### PR TITLE
fix(debugger): identify forked script contracts

### DIFF
--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -64,7 +64,8 @@ contract ScriptForkDebugTarget {
     let rpc = handle.http_endpoint();
     let pk = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
 
-    cmd.forge_fuse()
+    let create_output = cmd
+        .forge_fuse()
         .args([
             "create",
             "./src/ScriptForkDebugTarget.sol:ScriptForkDebugTarget",
@@ -73,10 +74,14 @@ contract ScriptForkDebugTarget {
             "--private-key",
             pk,
             "--broadcast",
+            "--json",
         ])
-        .assert_success();
-
-    let deployed = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266").create(0).to_string();
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+    let create_output: Value = serde_json::from_slice(&create_output).unwrap();
+    let deployed = create_output["deployedTo"].as_str().unwrap().to_owned();
 
     prj.add_script(
         "DebugRemote.s.sol",
@@ -88,8 +93,14 @@ interface IScriptForkDebugTarget {{
 }}
 
 contract DebugRemote {{
+    IScriptForkDebugTarget private target = IScriptForkDebugTarget({deployed});
+
+    function setUp() public {{
+        target.set(7);
+        require(target.value() == 7, "setup value");
+    }}
+
     function run() public {{
-        IScriptForkDebugTarget target = IScriptForkDebugTarget({deployed});
         target.set(19);
         require(target.value() == 19, "value");
     }}

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1,6 +1,9 @@
 //! Contains various tests related to `forge script`.
 
-use crate::{constants::TEMPLATE_CONTRACT, utils::generate_large_runtime_contract};
+use crate::{
+    constants::TEMPLATE_CONTRACT,
+    utils::{assert_debug_dump_identifies_contract, generate_large_runtime_contract},
+};
 use alloy_hardforks::EthereumHardfork;
 use alloy_network::Ethereum;
 use alloy_primitives::{Address, Bytes, address, hex};
@@ -42,6 +45,72 @@ contract ContractScript is Script {
         cmd.arg("script").arg(script).args(["--fork-url", rpc.as_str(), "-vvvvv"]).assert_success();
     }
 );
+
+forgetest_async!(script_debug_dump_identifies_contracts_loaded_from_fork, |prj, cmd| {
+    prj.add_source(
+        "ScriptForkDebugTarget.sol",
+        r#"
+contract ScriptForkDebugTarget {
+    uint256 public value;
+
+    function set(uint256 newValue) public {
+        value = newValue;
+    }
+}
+"#,
+    );
+
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    let pk = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+    cmd.forge_fuse()
+        .args([
+            "create",
+            "./src/ScriptForkDebugTarget.sol:ScriptForkDebugTarget",
+            "--rpc-url",
+            rpc.as_str(),
+            "--private-key",
+            pk,
+            "--broadcast",
+        ])
+        .assert_success();
+
+    let deployed = address!("f39fd6e51aad88f6f4ce6ab8827279cfffb92266").create(0).to_string();
+
+    prj.add_script(
+        "DebugRemote.s.sol",
+        &format!(
+            r#"
+interface IScriptForkDebugTarget {{
+    function set(uint256 newValue) external;
+    function value() external view returns (uint256);
+}}
+
+contract DebugRemote {{
+    function run() public {{
+        IScriptForkDebugTarget target = IScriptForkDebugTarget({deployed});
+        target.set(19);
+        require(target.value() == 19, "value");
+    }}
+}}
+"#
+        ),
+    );
+
+    let dump_path = prj.root().join("script_dump.json");
+    cmd.forge_fuse().args([
+        "script",
+        "script/DebugRemote.s.sol:DebugRemote",
+        "--fork-url",
+        rpc.as_str(),
+        "--debug",
+        "--dump",
+        dump_path.to_str().unwrap(),
+    ]);
+    cmd.assert_success();
+    assert_debug_dump_identifies_contract(&dump_path, &deployed, "ScriptForkDebugTarget");
+});
 
 // Tests that the `run` command works correctly
 forgetest!(can_execute_script_command2, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -1,5 +1,6 @@
 //! Contains various tests for `forge test`.
 
+use crate::utils::assert_debug_dump_identifies_contract;
 use alloy_primitives::{Address, U256};
 use anvil::{NodeConfig, spawn};
 use foundry_test_utils::{
@@ -9,11 +10,7 @@ use foundry_test_utils::{
     util::{OTHER_SOLC_VERSION, OutputExt, SOLC_VERSION},
 };
 use similar_asserts::assert_eq;
-use std::{
-    io::Write,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::{io::Write, path::PathBuf, str::FromStr};
 
 mod core;
 mod fuzz;
@@ -2852,17 +2849,6 @@ contract ForkDebugTest {{
     cmd.assert_success();
     assert_debug_dump_identifies_contract(&table_dump_path, &deployed, "ForkDebugTarget");
 });
-
-fn assert_debug_dump_identifies_contract(dump_path: &Path, address: &str, contract_name: &str) {
-    let dump: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(dump_path).unwrap()).unwrap();
-    let identified = dump["contracts"]["identified_contracts"].as_object().unwrap();
-    let target_identified = identified.iter().any(|(identified_address, name)| {
-        identified_address.eq_ignore_ascii_case(address)
-            && name.as_str().is_some_and(|name| name == contract_name)
-    });
-    assert!(target_identified, "forked target was not identified in debugger dump: {identified:?}");
-}
 
 forgetest_init!(test_assume_no_revert_with_data, |prj, cmd| {
     prj.update_config(|config| {

--- a/crates/forge/tests/cli/utils.rs
+++ b/crates/forge/tests/cli/utils.rs
@@ -3,6 +3,7 @@
 use alloy_chains::NamedChain;
 use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
+use std::path::Path;
 
 /// Returns the current millis since unix epoch.
 ///
@@ -180,6 +181,17 @@ pub fn parse_deployed_address(out: &str) -> Option<String> {
         }
     }
     None
+}
+
+pub fn assert_debug_dump_identifies_contract(dump_path: &Path, address: &str, contract_name: &str) {
+    let dump: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dump_path).unwrap()).unwrap();
+    let identified = dump["contracts"]["identified_contracts"].as_object().unwrap();
+    let target_identified = identified.iter().any(|(identified_address, name)| {
+        identified_address.eq_ignore_ascii_case(address)
+            && name.as_str().is_some_and(|name| name == contract_name)
+    });
+    assert!(target_identified, "forked target was not identified in debugger dump: {identified:?}");
 }
 
 pub fn parse_verification_guid(out: &str) -> Option<String> {

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -168,7 +168,9 @@ impl<FEN: FoundryEvmNetwork> PreExecutionState<FEN> {
             setup_result.logs.extend(script_result.logs);
             setup_result.traces.extend(script_result.traces);
             setup_result.labeled_addresses.extend(script_result.labeled_addresses);
-            setup_result.debug_bytecodes.extend(script_result.debug_bytecodes);
+            if self.args.debug {
+                setup_result.debug_bytecodes.extend(script_result.debug_bytecodes);
+            }
             setup_result.returned = script_result.returned;
             setup_result.exit_reason = script_result.exit_reason;
             setup_result.breakpoints = script_result.breakpoints;
@@ -360,11 +362,13 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
             )
             .build();
 
-        let mut identifier = if self.execution_result.debug_bytecodes.is_empty() {
-            TraceIdentifiers::new().with_local(known_contracts)
-        } else {
+        let use_debug_bytecodes =
+            self.args.debug && !self.execution_result.debug_bytecodes.is_empty();
+        let mut identifier = if use_debug_bytecodes {
             TraceIdentifiers::new()
                 .with_local_and_bytecodes(known_contracts, &self.execution_result.debug_bytecodes)
+        } else {
+            TraceIdentifiers::new().with_local(known_contracts)
         }
         .with_external(&self.script_config.config, chain_id)?;
 

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -168,6 +168,7 @@ impl<FEN: FoundryEvmNetwork> PreExecutionState<FEN> {
             setup_result.logs.extend(script_result.logs);
             setup_result.traces.extend(script_result.traces);
             setup_result.labeled_addresses.extend(script_result.labeled_addresses);
+            setup_result.debug_bytecodes.extend(script_result.debug_bytecodes);
             setup_result.returned = script_result.returned;
             setup_result.exit_reason = script_result.exit_reason;
             setup_result.breakpoints = script_result.breakpoints;
@@ -359,9 +360,13 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
             )
             .build();
 
-        let mut identifier = TraceIdentifiers::new()
-            .with_local(known_contracts)
-            .with_external(&self.script_config.config, chain_id)?;
+        let mut identifier = if self.execution_result.debug_bytecodes.is_empty() {
+            TraceIdentifiers::new().with_local(known_contracts)
+        } else {
+            TraceIdentifiers::new()
+                .with_local_and_bytecodes(known_contracts, &self.execution_result.debug_bytecodes)
+        }
+        .with_external(&self.script_config.config, chain_id)?;
 
         for (_, trace) in &self.execution_result.traces {
             decoder.identify(trace, &mut identifier);

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -880,7 +880,8 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         // (e.g. script deployment, setUp) use the correct fee token for Tempo networks.
         tx_env.set_fee_token(self.tempo.fee_token);
 
-        Ok(ScriptRunner::new(builder.build(evm_env, tx_env, db), self.evm_opts.clone()))
+        Ok(ScriptRunner::new(builder.build(evm_env, tx_env, db), self.evm_opts.clone())
+            .with_debug_bytecodes(debug))
     }
 }
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -684,6 +684,8 @@ pub struct ScriptResult<N: Network> {
     pub gas_used: u64,
     pub labeled_addresses: AddressHashMap<String>,
     #[serde(skip)]
+    pub debug_bytecodes: AddressHashMap<Bytes>,
+    #[serde(skip)]
     pub transactions: Option<BroadcastableTransactions<N>>,
     pub returned: Bytes,
     #[serde(skip)]
@@ -701,6 +703,7 @@ impl<N: Network> Default for ScriptResult<N> {
             traces: Default::default(),
             gas_used: Default::default(),
             labeled_addresses: Default::default(),
+            debug_bytecodes: Default::default(),
             transactions: Default::default(),
             returned: Default::default(),
             exit_reason: Default::default(),

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -26,11 +26,34 @@ use std::collections::VecDeque;
 pub struct ScriptRunner<FEN: FoundryEvmNetwork> {
     pub executor: Executor<FEN>,
     pub evm_opts: EvmOpts,
+    collect_debug_bytecodes: bool,
 }
 
 impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
     pub const fn new(executor: Executor<FEN>, evm_opts: EvmOpts) -> Self {
-        Self { executor, evm_opts }
+        Self { executor, evm_opts, collect_debug_bytecodes: false }
+    }
+
+    pub const fn with_debug_bytecodes(mut self, collect_debug_bytecodes: bool) -> Self {
+        self.collect_debug_bytecodes = collect_debug_bytecodes;
+        self
+    }
+
+    fn maybe_debug_bytecodes(
+        &self,
+        debug_bytecodes: AddressHashMap<Bytes>,
+    ) -> AddressHashMap<Bytes> {
+        if self.collect_debug_bytecodes { debug_bytecodes } else { Default::default() }
+    }
+
+    fn extend_debug_bytecodes(
+        &self,
+        target: &mut AddressHashMap<Bytes>,
+        debug_bytecodes: AddressHashMap<Bytes>,
+    ) {
+        if self.collect_debug_bytecodes {
+            target.extend(debug_bytecodes);
+        }
     }
 
     /// Deploys the libraries and broadcast contract. Calls setUp method if requested.
@@ -81,7 +104,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                         .expect("couldn't deploy library")
                         .raw;
 
-                    debug_bytecodes.extend(deploy_debug_bytecodes);
+                    self.extend_debug_bytecodes(&mut debug_bytecodes, deploy_debug_bytecodes);
 
                     if let Some(deploy_traces) = deploy_traces {
                         traces.push((TraceKind::Deployment, deploy_traces));
@@ -123,7 +146,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                         )
                         .expect("couldn't deploy library");
 
-                    debug_bytecodes.extend(deploy_debug_bytecodes);
+                    self.extend_debug_bytecodes(&mut debug_bytecodes, deploy_debug_bytecodes);
 
                     if let Some(deploy_traces) = deploy_traces {
                         traces.push((TraceKind::Deployment, deploy_traces));
@@ -194,7 +217,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
         }
 
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)));
-        debug_bytecodes.extend(constructor_debug_bytecodes);
+        self.extend_debug_bytecodes(&mut debug_bytecodes, constructor_debug_bytecodes);
 
         // Optionally call the `setUp` function
         let (success, gas_used, labeled_addresses, transactions) = if setup {
@@ -211,7 +234,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                 }) => {
                     traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
-                    debug_bytecodes.extend(setup_debug_bytecodes);
+                    self.extend_debug_bytecodes(&mut debug_bytecodes, setup_debug_bytecodes);
 
                     if let Some(txs) = setup_transactions {
                         library_transactions.extend(txs);
@@ -232,7 +255,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                     } = err.raw;
                     traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
-                    debug_bytecodes.extend(setup_debug_bytecodes);
+                    self.extend_debug_bytecodes(&mut debug_bytecodes, setup_debug_bytecodes);
 
                     if let Some(txs) = transactions {
                         library_transactions.extend(txs);
@@ -254,7 +277,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                 success,
                 gas_used,
                 labeled_addresses,
-                debug_bytecodes,
+                debug_bytecodes: self.maybe_debug_bytecodes(debug_bytecodes),
                 transactions,
                 logs,
                 traces,
@@ -316,7 +339,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                 success: address != Address::ZERO,
                 gas_used,
                 logs,
-                debug_bytecodes,
+                debug_bytecodes: self.maybe_debug_bytecodes(debug_bytecodes),
                 // Manually adjust gas for the trace to add back the stipend/real used gas
                 traces: traces
                     .map(|traces| vec![(TraceKind::Execution, traces)])
@@ -395,7 +418,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
             success: !reverted,
             gas_used,
             logs,
-            debug_bytecodes,
+            debug_bytecodes: self.maybe_debug_bytecodes(debug_bytecodes),
             traces: traces
                 .map(|traces| {
                     // Manually adjust gas for the trace to add back the stipend/real used gas

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -3,7 +3,7 @@ use crate::build::ScriptPredeployLibraries;
 use alloy_eips::eip7702::SignedAuthorization;
 use alloy_evm::revm::context::Transaction;
 use alloy_network::TransactionBuilder;
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{Address, Bytes, U256, map::AddressHashMap};
 use eyre::Result;
 use foundry_cheatcodes::BroadcastableTransaction;
 use foundry_common::TransactionMaybeSigned;
@@ -65,18 +65,25 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
 
         let mut library_transactions = VecDeque::new();
         let mut traces = Traces::default();
+        let mut debug_bytecodes: AddressHashMap<Bytes> = Default::default();
 
         // Deploy libraries
         match libraries {
             ScriptPredeployLibraries::Default(libraries) => {
                 for code in libraries {
-                    let result = self
+                    let RawCallResult {
+                        traces: deploy_traces,
+                        debug_bytecodes: deploy_debug_bytecodes,
+                        ..
+                    } = self
                         .executor
                         .deploy(self.evm_opts.sender, code.clone(), U256::ZERO, None)
                         .expect("couldn't deploy library")
                         .raw;
 
-                    if let Some(deploy_traces) = result.traces {
+                    debug_bytecodes.extend(deploy_debug_bytecodes);
+
+                    if let Some(deploy_traces) = deploy_traces {
                         traces.push((TraceKind::Deployment, deploy_traces));
                     }
 
@@ -102,7 +109,11 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                         continue;
                     }
                     let calldata = [salt.as_ref(), library.as_ref()].concat();
-                    let result = self
+                    let RawCallResult {
+                        traces: deploy_traces,
+                        debug_bytecodes: deploy_debug_bytecodes,
+                        ..
+                    } = self
                         .executor
                         .transact_raw(
                             self.evm_opts.sender,
@@ -112,7 +123,9 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                         )
                         .expect("couldn't deploy library");
 
-                    if let Some(deploy_traces) = result.traces {
+                    debug_bytecodes.extend(deploy_debug_bytecodes);
+
+                    if let Some(deploy_traces) = deploy_traces {
                         traces.push((TraceKind::Deployment, deploy_traces));
                     }
 
@@ -159,7 +172,13 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
         // Deploy an instance of the contract
         let DeployResult {
             address,
-            raw: RawCallResult { mut logs, traces: constructor_traces, .. },
+            raw:
+                RawCallResult {
+                    mut logs,
+                    traces: constructor_traces,
+                    debug_bytecodes: constructor_debug_bytecodes,
+                    ..
+                },
         } = self
             .executor
             .deploy(CALLER, code, U256::ZERO, None)
@@ -175,6 +194,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
         }
 
         traces.extend(constructor_traces.map(|traces| (TraceKind::Deployment, traces)));
+        debug_bytecodes.extend(constructor_debug_bytecodes);
 
         // Optionally call the `setUp` function
         let (success, gas_used, labeled_addresses, transactions) = if setup {
@@ -185,11 +205,13 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                     labels,
                     logs: setup_logs,
                     gas_used,
+                    debug_bytecodes: setup_debug_bytecodes,
                     transactions: setup_transactions,
                     ..
                 }) => {
                     traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
+                    debug_bytecodes.extend(setup_debug_bytecodes);
 
                     if let Some(txs) = setup_transactions {
                         library_transactions.extend(txs);
@@ -204,11 +226,13 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                         labels,
                         logs: setup_logs,
                         gas_used,
+                        debug_bytecodes: setup_debug_bytecodes,
                         transactions,
                         ..
                     } = err.raw;
                     traces.extend(setup_traces.map(|traces| (TraceKind::Setup, traces)));
                     logs.extend_from_slice(&setup_logs);
+                    debug_bytecodes.extend(setup_debug_bytecodes);
 
                     if let Some(txs) = transactions {
                         library_transactions.extend(txs);
@@ -230,6 +254,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                 success,
                 gas_used,
                 labeled_addresses,
+                debug_bytecodes,
                 transactions,
                 logs,
                 traces,
@@ -273,7 +298,10 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                 value.unwrap_or(U256::ZERO),
                 None,
             );
-            let (address, RawCallResult { gas_used, logs, traces, exit_reason, .. }) = match res {
+            let (
+                address,
+                RawCallResult { gas_used, logs, traces, debug_bytecodes, exit_reason, .. },
+            ) = match res {
                 Ok(DeployResult { address, raw }) => (address, raw),
                 Err(EvmError::Execution(err)) => {
                     let ExecutionErr { raw, reason } = *err;
@@ -288,6 +316,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                 success: address != Address::ZERO,
                 gas_used,
                 logs,
+                debug_bytecodes,
                 // Manually adjust gas for the trace to add back the stipend/real used gas
                 traces: traces
                     .map(|traces| vec![(TraceKind::Execution, traces)])
@@ -348,15 +377,25 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
         }
 
         let RawCallResult {
-            result, reverted, logs, traces, labels, transactions, exit_reason, ..
+            result,
+            reverted,
+            logs,
+            traces,
+            labels,
+            transactions,
+            debug_bytecodes,
+            exit_reason,
+            cheatcodes,
+            ..
         } = res;
-        let breakpoints = res.cheatcodes.map(|cheats| cheats.breakpoints).unwrap_or_default();
+        let breakpoints = cheatcodes.map(|cheats| cheats.breakpoints).unwrap_or_default();
 
         Ok(ScriptResult {
             returned: result,
             success: !reverted,
             gas_used,
             logs,
+            debug_bytecodes,
             traces: traces
                 .map(|traces| {
                     // Manually adjust gas for the trace to add back the stipend/real used gas


### PR DESCRIPTION
## Summary

Refs #5435.

Extends the debugger bytecode mapping added for `forge test --debug` to the `forge script --debug` path. Script execution now preserves `RawCallResult::debug_bytecodes` in `ScriptResult` and uses those bytecodes when building the local trace identifier, so debugger dumps can identify forked/deployed contracts that match local project artifacts.

Also moves the debugger dump contract-identification assertion into a shared CLI test helper and adds a `forge script --debug --dump` regression that deploys a local artifact to Anvil, forks that node, calls the deployed address from a script, and asserts the dump identifies the target contract.

## Context

`#7058` fixed source lookup by file id once a contract was already identified. `#15048` fixed forked/predeployed contract identification for `forge test --debug` by collecting runtime bytecode from the execution database. The remaining `#5435` script repro still lost that bytecode map because `ScriptResult` discarded it before trace decoding.
