### PR TITLE
feat(evm): share invariant corpus live across workers

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -202,7 +202,7 @@ impl CampaignCorpusEntry {
 ///
 /// The cursor lives with a worker-local corpus manager. The exchange remains append-only, while
 /// each worker independently advances through entries published since its last pull.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Default)]
 pub(crate) struct CampaignCorpusCursor {
     next_entry: usize,
 }
@@ -222,7 +222,6 @@ impl CampaignCorpusCandidate {
     }
 }
 
-#[derive(Clone)]
 struct CampaignCorpusBroadcast {
     producer_worker: usize,
     candidate: CampaignCorpusCandidate,
@@ -245,10 +244,6 @@ pub(crate) struct CampaignCorpusExchange {
 }
 
 impl CampaignCorpusExchange {
-    pub(crate) fn new() -> Self {
-        Self::default()
-    }
-
     /// Publishes a new candidate sequence.
     ///
     /// Returns `true` when the sequence was accepted into the exchange, and `false` when it was
@@ -263,16 +258,14 @@ impl CampaignCorpusExchange {
         }
 
         let fingerprint = corpus_sequence_fingerprint(tx_seq)?;
-        {
-            let mut inner = self.inner.write();
-            if !inner.seen_sequences.insert(fingerprint) {
-                return Ok(false);
-            }
-        }
-
-        let candidate = CampaignCorpusCandidate::new(tx_seq);
         let mut inner = self.inner.write();
-        inner.entries.push(CampaignCorpusBroadcast { producer_worker, candidate });
+        if !inner.seen_sequences.insert(fingerprint) {
+            return Ok(false);
+        }
+        inner.entries.push(CampaignCorpusBroadcast {
+            producer_worker,
+            candidate: CampaignCorpusCandidate::new(tx_seq),
+        });
         Ok(true)
     }
 
@@ -285,13 +278,11 @@ impl CampaignCorpusExchange {
     ) -> Vec<CampaignCorpusCandidate> {
         let inner = self.inner.read();
         let start = cursor.next_entry.min(inner.entries.len());
-        let mut entries = Vec::with_capacity(inner.entries.len() - start);
-        entries.extend(
-            inner.entries[start..]
-                .iter()
-                .filter(|entry| entry.producer_worker != worker_id)
-                .map(|entry| entry.candidate.clone()),
-        );
+        let entries = inner.entries[start..]
+            .iter()
+            .filter(|entry| entry.producer_worker != worker_id)
+            .map(|entry| entry.candidate.clone())
+            .collect();
         cursor.next_entry = inner.entries.len();
         entries
     }
@@ -1481,13 +1472,10 @@ impl WorkerCorpus {
         &mut self,
         entries: impl IntoIterator<Item = CampaignCorpusCandidate>,
         executor: &Executor<FEN>,
-        fuzzed_function: Option<&Function>,
-        fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
-        dynamic: Option<&DynamicTargetCtx<'_>>,
+        target: ReplayTarget<'_>,
     ) -> Result<usize> {
         let mut imported = 0;
         for entry in entries {
-            let target = ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic };
             let coverage = ReplayCoverage {
                 history_map: &mut self.history_map,
                 edge_indices: &mut self.edge_indices,
@@ -1884,13 +1872,9 @@ mod tests {
     }
 
     fn basic_tx_with_calldata(byte: u8) -> BasicTxDetails {
-        BasicTxDetails {
-            call_details: foundry_evm_fuzz::CallDetails {
-                calldata: Bytes::from(vec![byte]),
-                ..basic_tx().call_details
-            },
-            ..basic_tx()
-        }
+        let mut tx = basic_tx();
+        tx.call_details.calldata = Bytes::from(vec![byte]);
+        tx
     }
 
     fn seeded_worker_corpus(
@@ -1907,7 +1891,7 @@ mod tests {
 
     #[test]
     fn campaign_corpus_exchange_publishes_entries_to_other_workers_only() {
-        let exchange = CampaignCorpusExchange::new();
+        let exchange = CampaignCorpusExchange::default();
         let mut worker0_cursor = CampaignCorpusCursor::default();
         let mut worker1_cursor = CampaignCorpusCursor::default();
         let mut worker2_cursor = CampaignCorpusCursor::default();
@@ -1928,7 +1912,7 @@ mod tests {
 
     #[test]
     fn campaign_corpus_exchange_dedupes_identical_sequences() {
-        let exchange = CampaignCorpusExchange::new();
+        let exchange = CampaignCorpusExchange::default();
         let sequence = vec![basic_tx_with_calldata(1)];
 
         assert!(exchange.publish(0, &sequence).unwrap());

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -41,7 +41,7 @@ use crate::{
 };
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, Bytes, I256};
+use alloy_primitives::{Address, B256, Bytes, I256, keccak256};
 use eyre::{Result, eyre};
 use foundry_common::{ContractsByAddress, ContractsByArtifact, sh_warn};
 use foundry_config::FuzzCorpusConfig;
@@ -53,6 +53,7 @@ use foundry_evm_fuzz::{
         EvmFuzzState, FuzzStateReader, InvariantFuzzState, generate_msg_value, mutate_param_value,
     },
 };
+use parking_lot::RwLock;
 use proptest::{
     prelude::{Just, Rng, Strategy},
     prop_oneof,
@@ -189,6 +190,118 @@ impl CorpusEntry {
 pub(crate) struct CampaignCorpusEntry {
     tx_seq: Vec<BasicTxDetails>,
     dedupe_by_coverage: bool,
+}
+
+impl CampaignCorpusEntry {
+    pub(crate) fn tx_seq(&self) -> &[BasicTxDetails] {
+        &self.tx_seq
+    }
+}
+
+/// Per-worker position in a [`CampaignCorpusExchange`].
+///
+/// The cursor lives with a worker-local corpus manager. The exchange remains append-only, while
+/// each worker independently advances through entries published since its last pull.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct CampaignCorpusCursor {
+    next_entry: usize,
+}
+
+#[derive(Clone)]
+pub(crate) struct CampaignCorpusCandidate {
+    tx_seq: Arc<[BasicTxDetails]>,
+}
+
+impl CampaignCorpusCandidate {
+    fn new(tx_seq: &[BasicTxDetails]) -> Self {
+        Self { tx_seq: Arc::from(tx_seq) }
+    }
+
+    pub(crate) fn tx_seq(&self) -> &[BasicTxDetails] {
+        &self.tx_seq
+    }
+}
+
+#[derive(Clone)]
+struct CampaignCorpusBroadcast {
+    producer_worker: usize,
+    candidate: CampaignCorpusCandidate,
+}
+
+#[derive(Default)]
+struct CampaignCorpusExchangeInner {
+    entries: Vec<CampaignCorpusBroadcast>,
+    seen_sequences: HashSet<B256>,
+}
+
+/// In-memory exchange for campaign-local corpus candidates.
+///
+/// This deliberately shares only immutable transaction sequences. Workers keep their own
+/// [`WorkerCorpus`] and coverage maps, replay pulled candidates locally, and decide whether a
+/// sequence is useful for their own corpus.
+#[derive(Clone, Default)]
+pub(crate) struct CampaignCorpusExchange {
+    inner: Arc<RwLock<CampaignCorpusExchangeInner>>,
+}
+
+impl CampaignCorpusExchange {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Publishes a new candidate sequence.
+    ///
+    /// Returns `true` when the sequence was accepted into the exchange, and `false` when it was
+    /// empty or already published by any worker in this campaign.
+    pub(crate) fn publish(
+        &self,
+        producer_worker: usize,
+        tx_seq: &[BasicTxDetails],
+    ) -> Result<bool> {
+        if tx_seq.is_empty() {
+            return Ok(false);
+        }
+
+        let fingerprint = corpus_sequence_fingerprint(tx_seq)?;
+        {
+            let mut inner = self.inner.write();
+            if !inner.seen_sequences.insert(fingerprint) {
+                return Ok(false);
+            }
+        }
+
+        let candidate = CampaignCorpusCandidate::new(tx_seq);
+        let mut inner = self.inner.write();
+        inner.entries.push(CampaignCorpusBroadcast { producer_worker, candidate });
+        Ok(true)
+    }
+
+    /// Returns candidates published since `cursor` last pulled, excluding this worker's own
+    /// entries.
+    pub(crate) fn pull_new_for_worker(
+        &self,
+        worker_id: usize,
+        cursor: &mut CampaignCorpusCursor,
+    ) -> Vec<CampaignCorpusCandidate> {
+        let inner = self.inner.read();
+        let start = cursor.next_entry.min(inner.entries.len());
+        let mut entries = Vec::with_capacity(inner.entries.len() - start);
+        entries.extend(
+            inner.entries[start..]
+                .iter()
+                .filter(|entry| entry.producer_worker != worker_id)
+                .map(|entry| entry.candidate.clone()),
+        );
+        cursor.next_entry = inner.entries.len();
+        entries
+    }
+}
+
+fn corpus_sequence_fingerprint(tx_seq: &[BasicTxDetails]) -> Result<B256> {
+    let estimated_size = tx_seq.iter().map(BasicTxDetails::estimate_serialized_size).sum();
+    let mut bytes = Vec::with_capacity(estimated_size);
+    serde_json::to_writer(&mut bytes, tx_seq)?;
+    Ok(keccak256(bytes))
 }
 
 struct ReplayOutcome {
@@ -1357,6 +1470,47 @@ impl WorkerCorpus {
         Ok(imports)
     }
 
+    /// Imports campaign-local corpus candidates after replaying them against this worker's coverage
+    /// maps.
+    ///
+    /// Candidates are only retained when they produce new coverage for this worker. This keeps
+    /// coverage ownership local while allowing workers to consume sibling discoveries in the same
+    /// invariant campaign.
+    #[instrument(skip_all)]
+    pub(crate) fn import_campaign_entries<FEN: FoundryEvmNetwork>(
+        &mut self,
+        entries: impl IntoIterator<Item = CampaignCorpusCandidate>,
+        executor: &Executor<FEN>,
+        fuzzed_function: Option<&Function>,
+        fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
+        dynamic: Option<&DynamicTargetCtx<'_>>,
+    ) -> Result<usize> {
+        let mut imported = 0;
+        for entry in entries {
+            let target = ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic };
+            let coverage = ReplayCoverage {
+                history_map: &mut self.history_map,
+                edge_indices: &mut self.edge_indices,
+                sancov_history_map: &mut self.sancov_history_map,
+                metrics: Some(&mut self.metrics),
+            };
+            let ReplayOutcome { keep_entry, new_coverage, cmp_seq, .. } =
+                replay_corpus_sequence(entry.tx_seq(), executor, target, coverage)?;
+
+            if keep_entry && new_coverage {
+                self.in_memory_corpus.push(CorpusEntry::new_with_cmp(
+                    entry.tx_seq().to_vec(),
+                    cmp_seq,
+                    Uuid::new_v4(),
+                ));
+                self.metrics.corpus_count += 1;
+                imported += 1;
+            }
+        }
+
+        Ok(imported)
+    }
+
     /// Syncs and calibrates the in memory corpus and updates the history_map if new coverage is
     /// found from the corpus findings of other workers.
     #[instrument(skip_all)]
@@ -1408,6 +1562,7 @@ impl WorkerCorpus {
 
                 let corpus_entry = CorpusEntry::new_with_cmp(tx_seq.clone(), cmp_seq, entry.uuid);
                 self.in_memory_corpus.push(corpus_entry);
+                self.metrics.corpus_count += 1;
             } else {
                 // Remove the file as it did not generate new coverage.
                 if let Err(err) = std::fs::remove_file(&entry.path) {
@@ -1728,6 +1883,16 @@ mod tests {
         worker_corpus(id, corpus_root, WorkerCorpusSeed::default())
     }
 
+    fn basic_tx_with_calldata(byte: u8) -> BasicTxDetails {
+        BasicTxDetails {
+            call_details: foundry_evm_fuzz::CallDetails {
+                calldata: Bytes::from(vec![byte]),
+                ..basic_tx().call_details
+            },
+            ..basic_tx()
+        }
+    }
+
     fn seeded_worker_corpus(
         id: usize,
         corpus_root: PathBuf,
@@ -1738,6 +1903,41 @@ mod tests {
             corpus_root,
             WorkerCorpusSeed { in_memory_corpus: entries, ..Default::default() },
         )
+    }
+
+    #[test]
+    fn campaign_corpus_exchange_publishes_entries_to_other_workers_only() {
+        let exchange = CampaignCorpusExchange::new();
+        let mut worker0_cursor = CampaignCorpusCursor::default();
+        let mut worker1_cursor = CampaignCorpusCursor::default();
+        let mut worker2_cursor = CampaignCorpusCursor::default();
+
+        exchange.publish(0, &[basic_tx_with_calldata(1)]).unwrap();
+
+        assert!(exchange.pull_new_for_worker(0, &mut worker0_cursor).is_empty());
+
+        let worker1_entries = exchange.pull_new_for_worker(1, &mut worker1_cursor);
+        assert_eq!(worker1_entries.len(), 1);
+        assert_eq!(worker1_entries[0].tx_seq()[0].call_details.calldata, Bytes::from(vec![1]));
+        assert!(exchange.pull_new_for_worker(1, &mut worker1_cursor).is_empty());
+
+        let worker2_entries = exchange.pull_new_for_worker(2, &mut worker2_cursor);
+        assert_eq!(worker2_entries.len(), 1);
+        assert_eq!(worker2_entries[0].tx_seq()[0].call_details.calldata, Bytes::from(vec![1]));
+    }
+
+    #[test]
+    fn campaign_corpus_exchange_dedupes_identical_sequences() {
+        let exchange = CampaignCorpusExchange::new();
+        let sequence = vec![basic_tx_with_calldata(1)];
+
+        assert!(exchange.publish(0, &sequence).unwrap());
+        assert!(!exchange.publish(1, &sequence).unwrap());
+
+        let mut cursor = CampaignCorpusCursor::default();
+        let entries = exchange.pull_new_for_worker(2, &mut cursor);
+        assert_eq!(entries.len(), 1);
+        assert!(exchange.pull_new_for_worker(2, &mut cursor).is_empty());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -248,7 +248,7 @@ fn invariant_worker_runner(
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 enum InvariantCorpusPersistence {
     /// Preserve the legacy single-worker behavior: each interesting input is written immediately.
     Live,
@@ -256,35 +256,18 @@ enum InvariantCorpusPersistence {
     Deferred,
 }
 
-impl InvariantCorpusPersistence {
-    const fn is_deferred(self) -> bool {
-        matches!(self, Self::Deferred)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum InvariantCorpusSharing {
-    /// Workers only use their local corpus during campaign execution.
-    None,
-    /// Workers exchange new corpus candidates in memory during one invariant campaign.
-    CampaignLocal,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 struct InvariantCorpusPolicy {
     persistence: InvariantCorpusPersistence,
-    sharing: InvariantCorpusSharing,
+    /// Workers exchange new corpus candidates in memory during one invariant campaign.
+    shares_campaign_local: bool,
 }
 
 impl InvariantCorpusPolicy {
     // Deferred persistence is still what makes a worker return campaign outputs to the coordinator;
     // campaign-local sharing is handled independently by the exchange policy.
     const fn finalizes_campaign_outputs(self) -> bool {
-        self.persistence.is_deferred()
-    }
-
-    const fn shares_campaign_local(self) -> bool {
-        matches!(self.sharing, InvariantCorpusSharing::CampaignLocal)
+        matches!(self.persistence, InvariantCorpusPersistence::Deferred)
     }
 }
 
@@ -297,12 +280,8 @@ const fn invariant_corpus_policy(
     } else {
         InvariantCorpusPersistence::Live
     };
-    let sharing = if worker_count > 1 && config.corpus.is_coverage_guided() {
-        InvariantCorpusSharing::CampaignLocal
-    } else {
-        InvariantCorpusSharing::None
-    };
-    InvariantCorpusPolicy { persistence, sharing }
+    let shares_campaign_local = worker_count > 1 && config.corpus.is_coverage_guided();
+    InvariantCorpusPolicy { persistence, shares_campaign_local }
 }
 
 /// Converts a cumulative campaign total into an average per-second rate.
@@ -714,7 +693,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         )?;
         let corpus_policy = invariant_corpus_policy(&self.config, actual_worker_count);
         let corpus_exchange =
-            corpus_policy.shares_campaign_local().then(CampaignCorpusExchange::new);
+            corpus_policy.shares_campaign_local.then(CampaignCorpusExchange::default);
         let mut runner = self.runner.clone();
         let config = self.config.clone();
         let setup_contracts = self.setup_contracts;
@@ -880,9 +859,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     let imported = corpus_manager.import_campaign_entries(
                         entries,
                         &executor,
-                        None,
-                        Some(&invariant_test.targeted_contracts),
-                        Some(&dynamic_target_ctx),
+                        ReplayTarget {
+                            fuzzed_function: None,
+                            fuzzed_contracts: Some(&invariant_test.targeted_contracts),
+                            dynamic: Some(&dynamic_target_ctx),
+                        },
                     )?;
                     trace!(
                         target: "corpus",
@@ -2046,18 +2027,18 @@ mod tests {
         };
 
         let parallel = invariant_corpus_policy(&config, 2);
-        assert_eq!(parallel.persistence, InvariantCorpusPersistence::Deferred);
-        assert_eq!(parallel.sharing, InvariantCorpusSharing::CampaignLocal);
+        assert!(parallel.finalizes_campaign_outputs());
+        assert!(parallel.shares_campaign_local);
 
         let single = invariant_corpus_policy(&config, 1);
-        assert_eq!(single.persistence, InvariantCorpusPersistence::Live);
-        assert_eq!(single.sharing, InvariantCorpusSharing::None);
+        assert!(!single.finalizes_campaign_outputs());
+        assert!(!single.shares_campaign_local);
 
         config.corpus.corpus_dir = None;
         config.corpus.show_edge_coverage = true;
         let metrics_only = invariant_corpus_policy(&config, 2);
-        assert_eq!(metrics_only.persistence, InvariantCorpusPersistence::Deferred);
-        assert_eq!(metrics_only.sharing, InvariantCorpusSharing::None);
+        assert!(metrics_only.finalizes_campaign_outputs());
+        assert!(!metrics_only.shares_campaign_local);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1208,6 +1208,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
                     }
+                    let msg = if corpus_policy.finalizes_campaign_outputs() {
+                        format!("[w{}] {msg}", plan.worker_id)
+                    } else {
+                        msg
+                    };
                     progress.set_message(msg);
                 }
             } else if edge_coverage_enabled

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -275,6 +275,9 @@ struct InvariantCorpusPolicy {
 }
 
 impl InvariantCorpusPolicy {
+    // Today, campaign output finalization is only a persistence decision. The sharing dimension is
+    // modeled separately so a future campaign-local corpus broker can extend this policy without
+    // changing worker call sites.
     const fn finalizes_campaign_outputs(self) -> bool {
         self.persistence.writes_after_campaign()
     }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1,7 +1,10 @@
 use crate::{
     executors::{
         DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, RawCallResult,
-        corpus::{DynamicTargetCtx, ReplayTarget, WorkerCorpus, WorkerCorpusSeed},
+        corpus::{
+            CampaignCorpusCursor, CampaignCorpusExchange, DynamicTargetCtx, ReplayTarget,
+            WorkerCorpus, WorkerCorpusSeed,
+        },
     },
     inspectors::Fuzzer,
 };
@@ -263,9 +266,7 @@ impl InvariantCorpusPersistence {
 enum InvariantCorpusSharing {
     /// Workers only use their local corpus during campaign execution.
     None,
-    /// TODO: publish worker discoveries after campaign processing and import sibling entries
-    /// before generating new inputs.
-    #[allow(dead_code)]
+    /// Workers exchange new corpus candidates in memory during one invariant campaign.
     CampaignLocal,
 }
 
@@ -276,12 +277,32 @@ struct InvariantCorpusPolicy {
 }
 
 impl InvariantCorpusPolicy {
-    // Today, campaign output finalization is only a persistence decision. The sharing dimension is
-    // modeled separately so a future campaign-local corpus broker can extend this policy without
-    // changing worker call sites.
+    // Deferred persistence is still what makes a worker return campaign outputs to the coordinator;
+    // campaign-local sharing is handled independently by the exchange policy.
     const fn finalizes_campaign_outputs(self) -> bool {
         self.persistence.is_deferred()
     }
+
+    const fn shares_campaign_local(self) -> bool {
+        matches!(self.sharing, InvariantCorpusSharing::CampaignLocal)
+    }
+}
+
+const fn invariant_corpus_policy(
+    config: &InvariantConfig,
+    worker_count: usize,
+) -> InvariantCorpusPolicy {
+    let persistence = if worker_count > 1 {
+        InvariantCorpusPersistence::Deferred
+    } else {
+        InvariantCorpusPersistence::Live
+    };
+    let sharing = if worker_count > 1 && config.corpus.is_coverage_guided() {
+        InvariantCorpusSharing::CampaignLocal
+    } else {
+        InvariantCorpusSharing::None
+    };
+    InvariantCorpusPolicy { persistence, sharing }
 }
 
 /// Converts a cumulative campaign total into an average per-second rate.
@@ -691,15 +712,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             Some(&replay_targets),
             Some(self.dynamic_target_ctx()),
         )?;
-        let corpus_persistence = if actual_worker_count > 1 {
-            InvariantCorpusPersistence::Deferred
-        } else {
-            InvariantCorpusPersistence::Live
-        };
-        let corpus_policy = InvariantCorpusPolicy {
-            persistence: corpus_persistence,
-            sharing: InvariantCorpusSharing::None,
-        };
+        let corpus_policy = invariant_corpus_policy(&self.config, actual_worker_count);
+        let corpus_exchange =
+            corpus_policy.shares_campaign_local().then(CampaignCorpusExchange::new);
         let mut runner = self.runner.clone();
         let config = self.config.clone();
         let setup_contracts = self.setup_contracts;
@@ -744,6 +759,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         corpus_seed
                             .clone_for_worker(worker_plan.worker_id as usize, actual_worker_count),
                         corpus_policy,
+                        corpus_exchange.clone(),
                         gas_report_samples,
                     );
                     debug!("finished in {:?}", timer.elapsed());
@@ -770,6 +786,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 campaign_seed,
                 corpus_seed.clone(),
                 corpus_policy,
+                None,
                 gas_report_samples,
             )?]
         };
@@ -819,6 +836,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         campaign_seed: InvariantCampaignSeed,
         corpus_seed: WorkerCorpusSeed,
         corpus_policy: InvariantCorpusPolicy,
+        corpus_exchange: Option<CampaignCorpusExchange>,
         gas_report_samples: usize,
     ) -> Result<InvariantWorkerOutput> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
@@ -837,6 +855,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             corpus_seed,
         )?;
         let mut corpus_entries = Vec::new();
+        let mut corpus_cursor = CampaignCorpusCursor::default();
+        let dynamic_target_ctx = DynamicTargetCtx {
+            project_contracts,
+            setup_contracts,
+            artifact_filters: &campaign_seed.artifact_filters,
+        };
 
         let mut runs = 0;
         campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
@@ -848,6 +872,26 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             // Per-run failure count snapshot used to gate `afterInvariant` below.
             let failures_before_run = invariant_test.test_data.failures.invariant_count();
             let mut stop_after_run = false;
+
+            if let Some(exchange) = &corpus_exchange {
+                let entries =
+                    exchange.pull_new_for_worker(plan.worker_id as usize, &mut corpus_cursor);
+                if !entries.is_empty() {
+                    let imported = corpus_manager.import_campaign_entries(
+                        entries,
+                        &executor,
+                        None,
+                        Some(&invariant_test.targeted_contracts),
+                        Some(&dynamic_target_ctx),
+                    )?;
+                    trace!(
+                        target: "corpus",
+                        worker = plan.worker_id,
+                        imported,
+                        "imported campaign-local corpus entries"
+                    );
+                }
+            }
 
             let initial_seq = corpus_manager.new_inputs(
                 &mut invariant_test.test_data.branch_runner,
@@ -1134,6 +1178,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run.new_coverage,
                     optimization,
                 ) {
+                    if current_run.new_coverage
+                        && let Some(exchange) = &corpus_exchange
+                    {
+                        let _ = exchange.publish(plan.worker_id as usize, input.tx_seq())?;
+                    }
                     corpus_entries.push(input);
                 }
             } else {
@@ -1984,6 +2033,31 @@ mod tests {
             first_generated_u64(&mut worker),
             first_generated_u64(&mut worker_from_advanced_parent)
         );
+    }
+
+    #[test]
+    fn invariant_corpus_policy_enables_campaign_local_sharing_for_parallel_corpus_mode() {
+        let mut config = InvariantConfig {
+            corpus: foundry_config::FuzzCorpusConfig {
+                corpus_dir: Some(std::path::PathBuf::from("corpus")),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let parallel = invariant_corpus_policy(&config, 2);
+        assert_eq!(parallel.persistence, InvariantCorpusPersistence::Deferred);
+        assert_eq!(parallel.sharing, InvariantCorpusSharing::CampaignLocal);
+
+        let single = invariant_corpus_policy(&config, 1);
+        assert_eq!(single.persistence, InvariantCorpusPersistence::Live);
+        assert_eq!(single.sharing, InvariantCorpusSharing::None);
+
+        config.corpus.corpus_dir = None;
+        config.corpus.show_edge_coverage = true;
+        let metrics_only = invariant_corpus_policy(&config, 2);
+        assert_eq!(metrics_only.persistence, InvariantCorpusPersistence::Deferred);
+        assert_eq!(metrics_only.sharing, InvariantCorpusSharing::None);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -249,13 +249,39 @@ fn invariant_worker_runner(
 enum InvariantCorpusPersistence {
     /// Preserve the legacy single-worker behavior: each interesting input is written immediately.
     Live,
-    /// Parallel workers return interesting inputs to the campaign coordinator for merged writes.
-    Deferred,
+    /// Return interesting inputs to the campaign coordinator for one final deduped write.
+    FinalOnly,
 }
 
 impl InvariantCorpusPersistence {
-    const fn is_deferred(self) -> bool {
-        matches!(self, Self::Deferred)
+    const fn writes_after_campaign(self) -> bool {
+        matches!(self, Self::FinalOnly)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InvariantCorpusSharing {
+    /// Workers only use their local corpus during campaign execution.
+    None,
+    /// TODO: exchange new corpus entries through an in-memory campaign-local broker.
+    #[allow(dead_code)]
+    CampaignLocal,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct InvariantCorpusPolicy {
+    persistence: InvariantCorpusPersistence,
+    sharing: InvariantCorpusSharing,
+}
+
+impl InvariantCorpusPolicy {
+    const fn finalizes_campaign_outputs(self) -> bool {
+        self.persistence.writes_after_campaign()
+    }
+
+    const fn uses_worker_local_progress(self) -> bool {
+        matches!(self.persistence, InvariantCorpusPersistence::FinalOnly)
+            || matches!(self.sharing, InvariantCorpusSharing::CampaignLocal)
     }
 }
 
@@ -666,10 +692,17 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             Some(&replay_targets),
             Some(self.dynamic_target_ctx()),
         )?;
+        // Persistence describes write timing; the worker count only selects today's compatible
+        // behavior. Single-worker campaigns retain live writes, while parallel campaigns collect
+        // outputs for one coordinator-finalized write after workers finish.
         let corpus_persistence = if actual_worker_count > 1 {
-            InvariantCorpusPersistence::Deferred
+            InvariantCorpusPersistence::FinalOnly
         } else {
             InvariantCorpusPersistence::Live
+        };
+        let corpus_policy = InvariantCorpusPolicy {
+            persistence: corpus_persistence,
+            sharing: InvariantCorpusSharing::None,
         };
         let mut runner = self.runner.clone();
         let config = self.config.clone();
@@ -679,7 +712,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let campaign_state =
             Arc::new(InvariantCampaignState::new(early_exit.clone(), self.config.timeout));
 
-        let worker_outputs = if corpus_persistence.is_deferred() {
+        let worker_outputs = if actual_worker_count > 1 {
             let worker_jobs = worker_plans
                 .into_iter()
                 .map(|worker_plan| {
@@ -714,7 +747,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         campaign_seed.clone(),
                         corpus_seed
                             .clone_for_worker(worker_plan.worker_id as usize, actual_worker_count),
-                        corpus_persistence,
+                        corpus_policy,
                         gas_report_samples,
                     );
                     debug!("finished in {:?}", timer.elapsed());
@@ -740,7 +773,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 &campaign_state,
                 campaign_seed,
                 corpus_seed.clone(),
-                corpus_persistence,
+                corpus_policy,
                 gas_report_samples,
             )?]
         };
@@ -754,7 +787,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         } else {
             aggregator.finish_with_corpus_entries()?
         };
-        if corpus_persistence.is_deferred() {
+        if corpus_policy.finalizes_campaign_outputs() {
             let dynamic_target_ctx = self.dynamic_target_ctx();
             corpus_seed.persist_filtered_campaign_outputs(
                 &self.config.corpus,
@@ -789,7 +822,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         campaign_state: &InvariantCampaignState,
         campaign_seed: InvariantCampaignSeed,
         corpus_seed: WorkerCorpusSeed,
-        corpus_persistence: InvariantCorpusPersistence,
+        corpus_policy: InvariantCorpusPolicy,
         gas_report_samples: usize,
     ) -> Result<InvariantWorkerOutput> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
@@ -1098,7 +1131,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 let prefix = current_run.inputs[..current_run.optimization_prefix_len].to_vec();
                 (v, prefix)
             });
-            if corpus_persistence.is_deferred() {
+            if corpus_policy.finalizes_campaign_outputs() {
                 if let Some(input) = corpus_manager.process_inputs_for_campaign(
                     &current_run.inputs,
                     &current_run.cmp_seq,
@@ -1180,7 +1213,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
                     }
-                    let msg = if corpus_persistence.is_deferred() {
+                    let msg = if corpus_policy.uses_worker_local_progress() {
                         format!("[w{}] {msg}", plan.worker_id)
                     } else {
                         msg
@@ -2010,6 +2043,42 @@ mod tests {
             2
         );
         assert_eq!(max_invariant_workers_for_campaign(256, 100_000), 5);
+    }
+
+    #[test]
+    fn invariant_corpus_policy_keeps_single_worker_live_and_isolated() {
+        let policy = InvariantCorpusPolicy {
+            persistence: InvariantCorpusPersistence::Live,
+            sharing: InvariantCorpusSharing::None,
+        };
+
+        assert_eq!(policy.persistence, InvariantCorpusPersistence::Live);
+        assert_eq!(policy.sharing, InvariantCorpusSharing::None);
+        assert!(!policy.finalizes_campaign_outputs());
+        assert!(!policy.uses_worker_local_progress());
+    }
+
+    #[test]
+    fn invariant_corpus_policy_keeps_parallel_workers_final_only_and_isolated() {
+        let policy = InvariantCorpusPolicy {
+            persistence: InvariantCorpusPersistence::FinalOnly,
+            sharing: InvariantCorpusSharing::None,
+        };
+
+        assert_eq!(policy.persistence, InvariantCorpusPersistence::FinalOnly);
+        assert_eq!(policy.sharing, InvariantCorpusSharing::None);
+        assert!(policy.finalizes_campaign_outputs());
+        assert!(policy.uses_worker_local_progress());
+    }
+
+    #[test]
+    fn invariant_corpus_policy_treats_campaign_local_sharing_as_worker_local_progress() {
+        let policy = InvariantCorpusPolicy {
+            persistence: InvariantCorpusPersistence::Live,
+            sharing: InvariantCorpusSharing::CampaignLocal,
+        };
+
+        assert!(policy.uses_worker_local_progress());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -707,7 +707,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let campaign_state =
             Arc::new(InvariantCampaignState::new(early_exit.clone(), self.config.timeout));
 
-        let worker_outputs = if actual_worker_count > 1 {
+        let worker_outputs = if corpus_policy.finalizes_campaign_outputs() {
             let worker_jobs = worker_plans
                 .into_iter()
                 .map(|worker_plan| {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -249,13 +249,13 @@ fn invariant_worker_runner(
 enum InvariantCorpusPersistence {
     /// Preserve the legacy single-worker behavior: each interesting input is written immediately.
     Live,
-    /// Return interesting inputs to the campaign coordinator for one final deduped write.
-    FinalOnly,
+    /// Return interesting inputs to the campaign coordinator for delayed merged writes.
+    Deferred,
 }
 
 impl InvariantCorpusPersistence {
     const fn writes_after_campaign(self) -> bool {
-        matches!(self, Self::FinalOnly)
+        matches!(self, Self::Deferred)
     }
 }
 
@@ -280,7 +280,7 @@ impl InvariantCorpusPolicy {
     }
 
     const fn uses_worker_local_progress(self) -> bool {
-        matches!(self.persistence, InvariantCorpusPersistence::FinalOnly)
+        matches!(self.persistence, InvariantCorpusPersistence::Deferred)
             || matches!(self.sharing, InvariantCorpusSharing::CampaignLocal)
     }
 }
@@ -696,7 +696,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // behavior. Single-worker campaigns retain live writes, while parallel campaigns collect
         // outputs for one coordinator-finalized write after workers finish.
         let corpus_persistence = if actual_worker_count > 1 {
-            InvariantCorpusPersistence::FinalOnly
+            InvariantCorpusPersistence::Deferred
         } else {
             InvariantCorpusPersistence::Live
         };
@@ -2059,13 +2059,13 @@ mod tests {
     }
 
     #[test]
-    fn invariant_corpus_policy_keeps_parallel_workers_final_only_and_isolated() {
+    fn invariant_corpus_policy_keeps_parallel_workers_deferred_and_isolated() {
         let policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::FinalOnly,
+            persistence: InvariantCorpusPersistence::Deferred,
             sharing: InvariantCorpusSharing::None,
         };
 
-        assert_eq!(policy.persistence, InvariantCorpusPersistence::FinalOnly);
+        assert_eq!(policy.persistence, InvariantCorpusPersistence::Deferred);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);
         assert!(policy.finalizes_campaign_outputs());
         assert!(policy.uses_worker_local_progress());

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -278,11 +278,6 @@ impl InvariantCorpusPolicy {
     const fn finalizes_campaign_outputs(self) -> bool {
         self.persistence.writes_after_campaign()
     }
-
-    const fn uses_worker_local_progress(self) -> bool {
-        matches!(self.persistence, InvariantCorpusPersistence::Deferred)
-            || matches!(self.sharing, InvariantCorpusSharing::CampaignLocal)
-    }
 }
 
 /// Converts a cumulative campaign total into an average per-second rate.
@@ -1213,11 +1208,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
                     }
-                    let msg = if corpus_policy.uses_worker_local_progress() {
-                        format!("[w{}] {msg}", plan.worker_id)
-                    } else {
-                        msg
-                    };
                     progress.set_message(msg);
                 }
             } else if edge_coverage_enabled
@@ -2055,7 +2045,6 @@ mod tests {
         assert_eq!(policy.persistence, InvariantCorpusPersistence::Live);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);
         assert!(!policy.finalizes_campaign_outputs());
-        assert!(!policy.uses_worker_local_progress());
     }
 
     #[test]
@@ -2068,17 +2057,6 @@ mod tests {
         assert_eq!(policy.persistence, InvariantCorpusPersistence::Deferred);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);
         assert!(policy.finalizes_campaign_outputs());
-        assert!(policy.uses_worker_local_progress());
-    }
-
-    #[test]
-    fn invariant_corpus_policy_treats_campaign_local_sharing_as_worker_local_progress() {
-        let policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::Live,
-            sharing: InvariantCorpusSharing::CampaignLocal,
-        };
-
-        assert!(policy.uses_worker_local_progress());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -254,7 +254,13 @@ enum InvariantCorpusPersistence {
 }
 
 impl InvariantCorpusPersistence {
-    const fn writes_after_campaign(self) -> bool {
+    // Worker count only selects today's compatible write timing. The in-campaign sharing strategy
+    // is modeled separately by `InvariantCorpusSharing`.
+    const fn for_worker_count(worker_count: usize) -> Self {
+        if worker_count > 1 { Self::Deferred } else { Self::Live }
+    }
+
+    const fn is_deferred(self) -> bool {
         matches!(self, Self::Deferred)
     }
 }
@@ -263,7 +269,8 @@ impl InvariantCorpusPersistence {
 enum InvariantCorpusSharing {
     /// Workers only use their local corpus during campaign execution.
     None,
-    /// TODO: exchange new corpus entries through an in-memory campaign-local broker.
+    /// TODO: publish worker discoveries after campaign processing and import sibling entries
+    /// before generating new inputs.
     #[allow(dead_code)]
     CampaignLocal,
 }
@@ -279,7 +286,7 @@ impl InvariantCorpusPolicy {
     // modeled separately so a future campaign-local corpus broker can extend this policy without
     // changing worker call sites.
     const fn finalizes_campaign_outputs(self) -> bool {
-        self.persistence.writes_after_campaign()
+        self.persistence.is_deferred()
     }
 }
 
@@ -690,16 +697,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             Some(&replay_targets),
             Some(self.dynamic_target_ctx()),
         )?;
-        // Persistence describes write timing; the worker count only selects today's compatible
-        // behavior. Single-worker campaigns retain live writes, while parallel campaigns collect
-        // outputs for one coordinator-finalized write after workers finish.
-        let corpus_persistence = if actual_worker_count > 1 {
-            InvariantCorpusPersistence::Deferred
-        } else {
-            InvariantCorpusPersistence::Live
-        };
         let corpus_policy = InvariantCorpusPolicy {
-            persistence: corpus_persistence,
+            persistence: InvariantCorpusPersistence::for_worker_count(actual_worker_count),
             sharing: InvariantCorpusSharing::None,
         };
         let mut runner = self.runner.clone();
@@ -2044,11 +2043,9 @@ mod tests {
     }
 
     #[test]
-    fn invariant_corpus_policy_keeps_single_worker_live_and_isolated() {
-        let policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::Live,
-            sharing: InvariantCorpusSharing::None,
-        };
+    fn invariant_corpus_persistence_selects_live_writes_for_single_worker() {
+        let persistence = InvariantCorpusPersistence::for_worker_count(1);
+        let policy = InvariantCorpusPolicy { persistence, sharing: InvariantCorpusSharing::None };
 
         assert_eq!(policy.persistence, InvariantCorpusPersistence::Live);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);
@@ -2056,11 +2053,9 @@ mod tests {
     }
 
     #[test]
-    fn invariant_corpus_policy_keeps_parallel_workers_deferred_and_isolated() {
-        let policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::Deferred,
-            sharing: InvariantCorpusSharing::None,
-        };
+    fn invariant_corpus_persistence_selects_deferred_writes_for_parallel_workers() {
+        let persistence = InvariantCorpusPersistence::for_worker_count(2);
+        let policy = InvariantCorpusPolicy { persistence, sharing: InvariantCorpusSharing::None };
 
         assert_eq!(policy.persistence, InvariantCorpusPersistence::Deferred);
         assert_eq!(policy.sharing, InvariantCorpusSharing::None);

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -254,12 +254,6 @@ enum InvariantCorpusPersistence {
 }
 
 impl InvariantCorpusPersistence {
-    // Worker count only selects today's compatible write timing. The in-campaign sharing strategy
-    // is modeled separately by `InvariantCorpusSharing`.
-    const fn for_worker_count(worker_count: usize) -> Self {
-        if worker_count > 1 { Self::Deferred } else { Self::Live }
-    }
-
     const fn is_deferred(self) -> bool {
         matches!(self, Self::Deferred)
     }
@@ -697,8 +691,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             Some(&replay_targets),
             Some(self.dynamic_target_ctx()),
         )?;
+        let corpus_persistence = if actual_worker_count > 1 {
+            InvariantCorpusPersistence::Deferred
+        } else {
+            InvariantCorpusPersistence::Live
+        };
         let corpus_policy = InvariantCorpusPolicy {
-            persistence: InvariantCorpusPersistence::for_worker_count(actual_worker_count),
+            persistence: corpus_persistence,
             sharing: InvariantCorpusSharing::None,
         };
         let mut runner = self.runner.clone();
@@ -2040,26 +2039,6 @@ mod tests {
             2
         );
         assert_eq!(max_invariant_workers_for_campaign(256, 100_000), 5);
-    }
-
-    #[test]
-    fn invariant_corpus_persistence_selects_live_writes_for_single_worker() {
-        let persistence = InvariantCorpusPersistence::for_worker_count(1);
-        let policy = InvariantCorpusPolicy { persistence, sharing: InvariantCorpusSharing::None };
-
-        assert_eq!(policy.persistence, InvariantCorpusPersistence::Live);
-        assert_eq!(policy.sharing, InvariantCorpusSharing::None);
-        assert!(!policy.finalizes_campaign_outputs());
-    }
-
-    #[test]
-    fn invariant_corpus_persistence_selects_deferred_writes_for_parallel_workers() {
-        let persistence = InvariantCorpusPersistence::for_worker_count(2);
-        let policy = InvariantCorpusPolicy { persistence, sharing: InvariantCorpusSharing::None };
-
-        assert_eq!(policy.persistence, InvariantCorpusPersistence::Deferred);
-        assert_eq!(policy.sharing, InvariantCorpusSharing::None);
-        assert!(policy.finalizes_campaign_outputs());
     }
 
     #[test]


### PR DESCRIPTION
This is still under experimenting 

Trying to fix the invariant campaign corpus flow in parallel mode . Instead of only sharing corpus at the start and end of a run, workers now exchange newly interesting tx sequences through a campaign-local in-memory broker while the campaign is running.

The following design would possibly change for shared coverage map : 
Each worker still replays pulled candidates locally and keeps its own coverage maps. The broker only moves immutable tx sequences with light deduping, and final corpus persistence stays merged and deferred on the master worker. Single-worker behavior stays unchanged.