### PR TITLE
feat: add T6 admin access key authorization tooling

### DIFF
--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -386,10 +386,18 @@ pub enum KeyAuthorizationSubcommand {
 
     /// Sign and RLP-encode a Tempo key authorization.
     ///
-    /// For `--admin`, the bound account is derived from the signer and need not be passed.
+    /// With an admin access-key signer the bound account is the key's root and is derived
+    /// automatically; with a direct signer, `--bind-account` binds to another root. A root-signed
+    /// `--admin` authorization defaults the account to the signer.
     Sign {
         #[command(flatten)]
         authorization: KeyAuthorizationArgs,
+
+        /// Bind this authorization to a target (root) account (T6).
+        ///
+        /// Named `--bind-account` to avoid clashing with the wallet keystore `--account` selector.
+        #[arg(long = "bind-account", value_name = "ADDRESS")]
+        account: Option<Address>,
 
         #[command(flatten)]
         wallet: Box<WalletOpts>,
@@ -826,8 +834,8 @@ impl KeyAuthorizationSubcommand {
     pub async fn run(self) -> Result<()> {
         match self {
             Self::Encode { authorization, account } => run_key_auth_encode(authorization, account),
-            Self::Sign { authorization, wallet, browser } => {
-                run_key_auth_sign(authorization, *wallet, browser).await
+            Self::Sign { authorization, account, wallet, browser } => {
+                run_key_auth_sign(authorization, account, *wallet, browser).await
             }
             Self::Inspect { authorization, account } => {
                 run_key_auth_inspect(&authorization, account)
@@ -2897,6 +2905,7 @@ fn run_key_auth_encode(args: KeyAuthorizationArgs, account: Option<Address>) -> 
 
 async fn run_key_auth_sign(
     args: KeyAuthorizationArgs,
+    account: Option<Address>,
     wallet: WalletOpts,
     browser: BrowserWalletOpts,
 ) -> Result<()> {
@@ -2904,7 +2913,7 @@ async fn run_key_auth_sign(
 
     // TODO: remove this check once browser supports T5/T6 KeyAuthorization fields. Guard before
     // `browser.run()` so the browser flow never starts for unsupported authorizations.
-    if browser.browser && (args.witness.is_some() || is_admin) {
+    if browser.browser && (args.witness.is_some() || is_admin || account.is_some()) {
         eyre::bail!(
             "browser key authorization signing does not support T5/T6 fields yet: witness, admin, account"
         );
@@ -2913,7 +2922,7 @@ async fn run_key_auth_sign(
     if let Some(browser) = browser.run::<TempoNetwork>().await? {
         let signer_address = browser.address();
         ensure_key_authorization_root_sender(signer_address, wallet.from)?;
-        // The browser path rejects admin/witness above, so there is nothing to bind.
+        // The browser path rejects admin/witness/account above, so there is nothing to bind.
         let authorization = args.into_authorization(None)?;
         let authorized_key_type = auth_signature_type_name(&authorization.key_type);
         let signature_hash = authorization.signature_hash();
@@ -2927,23 +2936,35 @@ async fn run_key_auth_sign(
     }
 
     let (signer, tempo_access_key) = wallet.maybe_signer().await?;
-    if tempo_access_key.is_some() {
-        eyre::bail!(
-            "Tempo access keys cannot sign key authorizations; use a persistent root signer"
-        );
-    }
     let signer = signer.ok_or_else(|| {
         eyre::eyre!(
-            "a persistent root signer is required to sign key authorizations; pass a signer with \
+            "a signer is required to sign key authorizations; pass a signer with \
              --browser, --private-key, --keystore, Ledger, Trezor, AWS, GCP, or Turnkey"
         )
     })?;
     let signer_address = signer.address();
-    ensure_key_authorization_root_sender(signer_address, wallet.from)?;
 
-    // Admin authorizations are bound to the signer's own account for T6 replay protection.
-    let account = is_admin.then_some(signer_address);
-    let authorization = args.into_authorization(account)?;
+    // Resolve the account this authorization is bound to (T6 replay protection).
+    let bound_account = if let Some(access_key) = tempo_access_key.as_ref() {
+        // The access key (an admin key) signs for its root, so bind to the root, not the signer.
+        if let Some(explicit) = account {
+            eyre::ensure!(
+                explicit == access_key.wallet_address,
+                "--bind-account {explicit} does not match the selected Tempo access key's root account {}",
+                access_key.wallet_address,
+            );
+        }
+        Some(access_key.wallet_address)
+    } else {
+        ensure_key_authorization_root_sender(signer_address, wallet.from)?;
+        match account {
+            Some(explicit) => Some(explicit),
+            None if is_admin => Some(signer_address),
+            None => None,
+        }
+    };
+
+    let authorization = args.into_authorization(bound_account)?;
     let authorized_key_type = auth_signature_type_name(&authorization.key_type);
     let signature_hash = authorization.signature_hash();
     let signature = signer.sign_hash(&signature_hash).await?;
@@ -3021,10 +3042,9 @@ fn decode_and_validate_key_authorization(
         );
     }
     if auth.is_admin() {
-        eyre::ensure!(
-            auth.account.is_some(),
-            "admin key authorization is missing its required account field"
-        );
+        // A root-signed admin authorization may omit `account` (it is only required when the signer
+        // is not the target root), so `inspect` does not require it here. Binding is still enforced
+        // below when `--account` is supplied.
         eyre::ensure!(auth.expiry.is_none(), "admin key authorization cannot carry an expiry");
         eyre::ensure!(
             auth.limits.is_none(),
@@ -3495,11 +3515,18 @@ pub(crate) async fn resolve_keychain_root_signer(
         return Ok(KeychainRootSigner::Browser(browser));
     }
 
+    // The T6 spec allows an active admin access key to authorize/revoke other keys, but submitting
+    // these AccountKeychain mutators as access-key-signed precompile calldata reverts on-chain with
+    // `UnauthorizedCaller()` on the pinned Tempo build (gas estimation succeeds because it injects
+    // an override key id, while real execution recovers the signer). Reject before broadcasting
+    // rather than emitting a guaranteed-revert transaction; use a root signer for direct mutations.
     if tempo_access_key.is_some() {
         eyre::bail!(
-            "keychain policy changes must be signed by the root account; the selected `--from` \
-             resolved to a Tempo access key. Use `--browser` for passkey roots, or pass a root \
-             account signer with `--private-key`, `--keystore`, Ledger, Trezor, AWS, GCP, or Turnkey."
+            "submitting AccountKeychain admin mutators (authorize / revoke / policy) signed by a \
+             Tempo access key currently reverts on-chain with UnauthorizedCaller() on the pinned \
+             Tempo build, even for an active admin key. Use a root account signer (--browser for \
+             passkey roots, or --private-key / --keystore / Ledger / Trezor / AWS / GCP / Turnkey) \
+             for direct mutations."
         );
     }
 
@@ -4580,15 +4607,33 @@ mod tests {
     }
 
     #[test]
-    fn test_inspect_rejects_admin_auth_without_account() {
-        // An admin authorization with no bound account must be rejected on decode.
+    fn test_inspect_accepts_root_signed_admin_auth_without_account() {
+        // T6 allows a root-signed admin authorization to omit `account` (account is only required
+        // when the signer is not the target root). `inspect` is a decoder and must not reject it.
         let mut authorization =
             KeyAuthorization::unrestricted(31337, AuthSignatureType::Secp256k1, target_addr(0x42));
         authorization.is_admin = true;
         let hex = hex::encode_prefixed(encode_key_authorization(&authorization));
 
-        let err = decode_and_validate_key_authorization(&hex, None).unwrap_err().to_string();
-        assert!(err.contains("missing its required account field"), "got: {err}");
+        let (auth, _signed, _signer) =
+            decode_and_validate_key_authorization(&hex, None).expect("admin auth may omit account");
+        assert!(auth.is_admin());
+        assert_eq!(auth.account, None);
+    }
+
+    #[test]
+    fn test_inspect_admin_auth_without_account_rejected_when_account_expected() {
+        // When the caller supplies `--account`, an admin authorization that omits `account` must
+        // still be rejected: the binding cannot be verified.
+        let mut authorization =
+            KeyAuthorization::unrestricted(31337, AuthSignatureType::Secp256k1, target_addr(0x42));
+        authorization.is_admin = true;
+        let hex = hex::encode_prefixed(encode_key_authorization(&authorization));
+
+        let err = decode_and_validate_key_authorization(&hex, Some(target_addr(0xAB)))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("no account field"), "got: {err}");
     }
 
     #[test]

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -4,7 +4,7 @@ use foundry_wallets::BrowserWalletOpts;
 use std::time::Duration;
 
 use alloy_network::{EthereumWallet, TransactionBuilder};
-use alloy_primitives::{Address, B256, U256, hex};
+use alloy_primitives::{Address, B256, Bytes, U256, hex};
 use alloy_provider::{Provider, ProviderBuilder as AlloyProviderBuilder};
 use alloy_rlp::Encodable;
 use alloy_rpc_types::BlockId;
@@ -38,8 +38,11 @@ use tempo_contracts::precompiles::{
         self, CallScope, KeyInfo, KeyRestrictions, LegacyTokenLimit, SelectorRule, SignatureType,
         TokenLimit,
     },
-    ITIP20, PATH_USD_ADDRESS,
-    account_keychain::{authorizeKeyCall, authorizeKeyWithWitnessCall, legacyAuthorizeKeyCall},
+    ISignatureVerifier, ITIP20, PATH_USD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS,
+    account_keychain::{
+        authorizeAdminKeyCall, authorizeKeyCall, authorizeKeyWithWitnessCall,
+        legacyAuthorizeKeyCall,
+    },
 };
 use tempo_primitives::transaction::{
     CallScope as AuthCallScope, KeyAuthorization, PrimitiveSignature,
@@ -179,8 +182,18 @@ pub enum KeychainSubcommand {
         /// Optional TIP-1053 witness to bind to this on-chain authorization.
         ///
         /// `0x000...000` is a valid present witness and is distinct from omitting the flag.
+        ///
+        /// For `--admin`, the `authorizeAdminKey` precompile always takes a witness; omitting
+        /// this flag submits `bytes32(0)` (which fails if that witness is already burned).
         #[arg(long)]
         witness: Option<B256>,
+
+        /// Authorize a T6 admin access key via `authorizeAdminKey` (key-management only).
+        ///
+        /// Admin keys may authorize/revoke other keys but cannot carry an expiry, spending limits,
+        /// or call scopes. The account is the signing (precompile caller) account.
+        #[arg(long)]
+        admin: bool,
 
         #[command(flatten)]
         tx: TransactionOpts,
@@ -223,6 +236,58 @@ pub enum KeychainSubcommand {
 
         /// Witness to check. `bytes32(0)` is valid.
         witness: B256,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Check whether a key is the root key or an active admin key for an account (T6).
+    #[command(name = "is-admin")]
+    IsAdmin {
+        /// The account (root) address.
+        account: Address,
+
+        /// The key address to check.
+        key_address: Address,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Verify a Tempo keychain signature against an account's active access key (T6).
+    ///
+    /// `signature` must be an encoded Tempo keychain signature (not a raw 65-byte secp256k1
+    /// signature). Returns true only for an active access key, never the root key. The supplied
+    /// `hash` should already be domain-separated by the caller.
+    Verify {
+        /// The expected (root) account that embeds the key.
+        account: Address,
+
+        /// The 32-byte message hash that was signed.
+        hash: B256,
+
+        /// The encoded Tempo keychain signature.
+        signature: Bytes,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Verify a Tempo keychain signature against an account's root or admin key (T6).
+    ///
+    /// `signature` must be an encoded Tempo keychain signature (not a raw 65-byte secp256k1
+    /// signature). Returns true for the root key or an active admin key. `hash` should already be
+    /// domain-separated by the caller.
+    #[command(name = "verify-admin")]
+    VerifyAdmin {
+        /// The expected (root) account that embeds the key.
+        account: Address,
+
+        /// The 32-byte message hash that was signed.
+        hash: B256,
+
+        /// The encoded Tempo keychain signature.
+        signature: Bytes,
 
         #[command(flatten)]
         rpc: RpcOpts,
@@ -310,9 +375,18 @@ pub enum KeyAuthorizationSubcommand {
     Encode {
         #[command(flatten)]
         authorization: KeyAuthorizationArgs,
+
+        /// Bind this authorization to a target account (T6).
+        ///
+        /// Required for `--admin` so the authorization cannot be replayed across accounts sharing
+        /// the same admin key. May also bind a plain authorization without `--admin`.
+        #[arg(long, value_name = "ADDRESS")]
+        account: Option<Address>,
     },
 
     /// Sign and RLP-encode a Tempo key authorization.
+    ///
+    /// For `--admin`, the bound account is derived from the signer and need not be passed.
     Sign {
         #[command(flatten)]
         authorization: KeyAuthorizationArgs,
@@ -322,6 +396,19 @@ pub enum KeyAuthorizationSubcommand {
 
         #[command(flatten)]
         browser: BrowserWalletOpts,
+    },
+
+    /// Decode and inspect a Tempo key authorization (signed or unsigned).
+    ///
+    /// Accepts the hex RLP from `encode` (unsigned) or `sign` (signed) and prints its fields,
+    /// including the T6 `is_admin`/`account` fields and the recovered signer for signed input.
+    Inspect {
+        /// Hex-encoded RLP key authorization (signed or unsigned).
+        authorization: String,
+
+        /// Expected bound account; rejects a mismatched or replayed account-bound authorization.
+        #[arg(long, value_name = "ADDRESS")]
+        account: Option<Address>,
     },
 }
 
@@ -366,6 +453,14 @@ pub struct KeyAuthorizationArgs {
     /// `0x000...000` is a valid present witness and is distinct from omitting the flag.
     #[arg(long)]
     witness: Option<B256>,
+
+    /// Authorize a T6 admin access key (key-management only).
+    ///
+    /// Admin keys may authorize/revoke other keys but cannot carry an expiry, spending limits, or
+    /// call scopes, and require a bound account (`--account` for `encode`, signer-derived for
+    /// `sign`).
+    #[arg(long)]
+    admin: bool,
 }
 
 /// Higher-level access-key policy editing commands.
@@ -669,9 +764,11 @@ impl KeychainSubcommand {
                 scope,
                 scopes_json,
                 witness,
+                admin,
                 tx,
                 send_tx,
             } => {
+                let scopes_present = scopes_json.is_some() || !scope.is_empty();
                 let all_scopes = if let Some(ScopesJson(json_scopes)) = scopes_json {
                     json_scopes
                 } else {
@@ -684,7 +781,9 @@ impl KeychainSubcommand {
                     enforce_limits,
                     limits,
                     all_scopes,
+                    scopes_present,
                     witness,
+                    admin,
                     tx,
                     send_tx,
                 )
@@ -696,6 +795,15 @@ impl KeychainSubcommand {
             }
             Self::IsWitnessBurned { account, witness, rpc } => {
                 run_is_witness_burned(account, witness, rpc).await
+            }
+            Self::IsAdmin { account, key_address, rpc } => {
+                run_is_admin(account, key_address, rpc).await
+            }
+            Self::Verify { account, hash, signature, rpc } => {
+                run_verify_keychain(account, hash, signature, rpc, false).await
+            }
+            Self::VerifyAdmin { account, hash, signature, rpc } => {
+                run_verify_keychain(account, hash, signature, rpc, true).await
             }
             Self::RemainingLimit { wallet_address, key_address, token, rpc } => {
                 run_remaining_limit(wallet_address, key_address, token, rpc).await
@@ -717,9 +825,12 @@ impl KeychainSubcommand {
 impl KeyAuthorizationSubcommand {
     pub async fn run(self) -> Result<()> {
         match self {
-            Self::Encode { authorization } => run_key_auth_encode(authorization),
+            Self::Encode { authorization, account } => run_key_auth_encode(authorization, account),
             Self::Sign { authorization, wallet, browser } => {
                 run_key_auth_sign(authorization, *wallet, browser).await
+            }
+            Self::Inspect { authorization, account } => {
+                run_key_auth_inspect(&authorization, account)
             }
         }
     }
@@ -852,6 +963,21 @@ async fn run_inspect(
     let info: KeyInfo = provider.get_keychain_key(metadata.root_account, key_address).await?;
     let provisioned = info.keyId != Address::ZERO;
     let is_t3 = is_tempo_hardfork_active(&provider, TempoHardfork::T3).await?;
+    let is_t6 = is_tempo_hardfork_active(&provider, TempoHardfork::T6).await?;
+
+    // On T6, `isAdminKey` is authoritative for the root/admin distinction.
+    let is_admin = if is_t6 {
+        provider.account_keychain().isAdminKey(metadata.root_account, key_address).call().await?
+    } else {
+        false
+    };
+    let role = if key_address == metadata.root_account {
+        "root"
+    } else if is_admin {
+        "admin"
+    } else {
+        "limited"
+    };
 
     let mut limits = Vec::new();
     if info.enforceLimits {
@@ -912,6 +1038,8 @@ async fn run_inspect(
             "key_id": key_address.to_string(),
             "provisioned": provisioned,
             "type": key_type,
+            "role": role,
+            "is_admin": is_admin,
             "expiry": provisioned.then_some(info.expiry),
             "expiry_human": provisioned.then(|| format_expiry_for_inspect(info.expiry)),
             "enforce_limits": info.enforceLimits,
@@ -932,6 +1060,7 @@ async fn run_inspect(
     sh_println!("Root account: {}", metadata.root_account)?;
     sh_println!("Key id:       {key_address}")?;
     sh_println!("Type:         {key_type}")?;
+    sh_println!("Role:         {role}")?;
 
     if info.isRevoked {
         sh_println!("Status:       revoked")?;
@@ -2651,7 +2780,9 @@ async fn run_authorize(
     enforce_limits: bool,
     limits: Vec<TokenLimit>,
     allowed_calls: Vec<CallScope>,
+    scopes_present: bool,
     witness: Option<B256>,
+    admin: bool,
     tx_opts: TransactionOpts,
     send_tx: SendTxOpts,
 ) -> Result<()> {
@@ -2659,6 +2790,33 @@ async fn run_authorize(
 
     let config = send_tx.eth.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+
+    // T6 admin keys are key-management only and use a dedicated precompile entrypoint.
+    if admin {
+        if !is_tempo_hardfork_active(&provider, TempoHardfork::T6).await? {
+            eyre::bail!("--admin requires a Tempo T6-capable AccountKeychain RPC");
+        }
+        // u64::MAX is the no-expiry default; anything else is an explicit expiry admin keys reject.
+        eyre::ensure!(expiry == u64::MAX, "--admin cannot be combined with an explicit --expiry");
+        eyre::ensure!(
+            !enforce,
+            "--admin cannot be combined with spending limits (--enforce-limits / --limit)"
+        );
+        eyre::ensure!(
+            !scopes_present,
+            "--admin cannot be combined with call scopes (--scope / --scopes)"
+        );
+
+        // `authorizeAdminKey` requires a witness argument; omitting `--witness` submits bytes32(0).
+        let calldata = authorizeAdminKeyCall {
+            keyId: key_address,
+            signatureType: key_type,
+            witness: witness.unwrap_or(B256::ZERO),
+        }
+        .abi_encode();
+        send_keychain_tx(calldata, tx_opts, &send_tx, None).await?;
+        return Ok(());
+    }
 
     let is_t3 = is_tempo_hardfork_active(&provider, TempoHardfork::T3).await?;
     if witness.is_some() && !is_tempo_hardfork_active(&provider, TempoHardfork::T5).await? {
@@ -2716,8 +2874,8 @@ async fn run_authorize(
     Ok(())
 }
 
-fn run_key_auth_encode(args: KeyAuthorizationArgs) -> Result<()> {
-    let authorization = args.into_authorization()?;
+fn run_key_auth_encode(args: KeyAuthorizationArgs, account: Option<Address>) -> Result<()> {
+    let authorization = args.into_authorization(account)?;
     let encoded = encode_key_authorization(&authorization);
 
     if shell::is_json() {
@@ -2725,6 +2883,9 @@ fn run_key_auth_encode(args: KeyAuthorizationArgs) -> Result<()> {
             "key_authorization": hex::encode_prefixed(&encoded),
             "signature_hash": authorization.signature_hash().to_string(),
             "rlp_length": encoded.len(),
+            "is_admin": authorization.is_admin(),
+            "account": authorization.account.map(|account| account.to_string()),
+            "witness": authorization.witness().map(|witness| witness.to_string()),
         });
         sh_println!("{}", serde_json::to_string_pretty(&json)?)?;
     } else {
@@ -2739,19 +2900,23 @@ async fn run_key_auth_sign(
     wallet: WalletOpts,
     browser: BrowserWalletOpts,
 ) -> Result<()> {
-    let authorization = args.into_authorization()?;
+    let is_admin = args.admin;
 
-    // TODO: remove this check once browser supports T5 KeyAuthorization fields
-    if browser.browser && authorization.witness().is_some() {
-        eyre::bail!("browser key authorization signing does not support T5 fields yet: witness");
+    // TODO: remove this check once browser supports T5/T6 KeyAuthorization fields. Guard before
+    // `browser.run()` so the browser flow never starts for unsupported authorizations.
+    if browser.browser && (args.witness.is_some() || is_admin) {
+        eyre::bail!(
+            "browser key authorization signing does not support T5/T6 fields yet: witness, admin, account"
+        );
     }
-
-    let authorized_key_type = auth_signature_type_name(&authorization.key_type);
-    let signature_hash = authorization.signature_hash();
 
     if let Some(browser) = browser.run::<TempoNetwork>().await? {
         let signer_address = browser.address();
         ensure_key_authorization_root_sender(signer_address, wallet.from)?;
+        // The browser path rejects admin/witness above, so there is nothing to bind.
+        let authorization = args.into_authorization(None)?;
+        let authorized_key_type = auth_signature_type_name(&authorization.key_type);
+        let signature_hash = authorization.signature_hash();
         let signed = browser.sign_key_authorization(authorization).await?;
         return print_signed_key_authorization(
             &signed,
@@ -2775,6 +2940,12 @@ async fn run_key_auth_sign(
     })?;
     let signer_address = signer.address();
     ensure_key_authorization_root_sender(signer_address, wallet.from)?;
+
+    // Admin authorizations are bound to the signer's own account for T6 replay protection.
+    let account = is_admin.then_some(signer_address);
+    let authorization = args.into_authorization(account)?;
+    let authorized_key_type = auth_signature_type_name(&authorization.key_type);
+    let signature_hash = authorization.signature_hash();
     let signature = signer.sign_hash(&signature_hash).await?;
     let signed = authorization.into_signed(PrimitiveSignature::Secp256k1(signature));
     print_signed_key_authorization(&signed, signature_hash, signer_address, authorized_key_type)
@@ -2798,6 +2969,8 @@ fn print_signed_key_authorization(
             "authorized_key_type": authorized_key_type,
             "signature_type": signature_type,
             "witness": signed.authorization.witness().map(|witness| witness.to_string()),
+            "is_admin": signed.authorization.is_admin(),
+            "account": signed.authorization.account.map(|account| account.to_string()),
         });
         sh_println!("{}", serde_json::to_string_pretty(&json)?)?;
     } else {
@@ -2813,14 +2986,141 @@ fn encode_key_authorization<T: Encodable>(authorization: &T) -> Vec<u8> {
     out
 }
 
+/// Decode a hex RLP key authorization (signed or unsigned) and validate its account binding.
+///
+/// Tries the signed shape first, then the unsigned one. Returns the authorization, whether the
+/// input was signed, and the best-effort recovered signer. When `expected_account` is set the
+/// decoded authorization must be bound to exactly that account.
+fn decode_and_validate_key_authorization(
+    authorization: &str,
+    expected_account: Option<Address>,
+) -> Result<(KeyAuthorization, bool, Option<Address>)> {
+    let raw = authorization.trim();
+
+    let (auth, signed, signer) =
+        match tempo::decode_key_authorization::<SignedKeyAuthorization>(raw) {
+            // Signer recovery is best-effort so `inspect` still surfaces fields for a corrupt sig.
+            Ok(signed) => {
+                let signer = signed.recover_signer().ok();
+                (signed.authorization, true, signer)
+            }
+            Err(signed_err) => match tempo::decode_key_authorization::<KeyAuthorization>(raw) {
+                Ok(unsigned) => (unsigned, false, None),
+                Err(unsigned_err) => eyre::bail!(
+                    "could not decode key authorization as signed ({signed_err}) or unsigned \
+                 ({unsigned_err})"
+                ),
+            },
+        };
+
+    // Mirror the chain's T6 admin invariants so `inspect` rejects a malformed admin authorization.
+    if let Some(account) = auth.account {
+        eyre::ensure!(
+            account != Address::ZERO,
+            "key authorization account cannot be the zero address"
+        );
+    }
+    if auth.is_admin() {
+        eyre::ensure!(
+            auth.account.is_some(),
+            "admin key authorization is missing its required account field"
+        );
+        eyre::ensure!(auth.expiry.is_none(), "admin key authorization cannot carry an expiry");
+        eyre::ensure!(
+            auth.limits.is_none(),
+            "admin key authorization cannot carry spending limits"
+        );
+        eyre::ensure!(
+            auth.allowed_calls.is_none(),
+            "admin key authorization cannot carry call scopes"
+        );
+    }
+
+    // `--account` rejects a replayed or mismatched account-bound authorization.
+    if let Some(expected) = expected_account {
+        match auth.account {
+            Some(account) if account == expected => {}
+            Some(account) => eyre::bail!(
+                "key authorization is bound to account {account} but {expected} was expected"
+            ),
+            None => eyre::bail!(
+                "expected key authorization bound to account {expected} but it has no account field"
+            ),
+        }
+    }
+
+    Ok((auth, signed, signer))
+}
+
+/// `cast key-authorization inspect` — decode a signed or unsigned key authorization and print its
+/// fields, including the T6 `is_admin` / `account` fields.
+fn run_key_auth_inspect(authorization: &str, expected_account: Option<Address>) -> Result<()> {
+    let (auth, signed, signer) =
+        decode_and_validate_key_authorization(authorization, expected_account)?;
+
+    if shell::is_json() {
+        let json = serde_json::json!({
+            "signed": signed,
+            "signer": signer.map(|signer| signer.to_string()),
+            "chain_id": auth.chain_id,
+            "key_address": auth.key_id.to_string(),
+            "key_type": auth_signature_type_name(&auth.key_type),
+            "is_admin": auth.is_admin(),
+            "account": auth.account.map(|account| account.to_string()),
+            "expiry": auth.expiry.map(|expiry| expiry.get()),
+            "witness": auth.witness().map(|witness| witness.to_string()),
+            "enforce_limits": auth.limits.is_some(),
+            "scoped_calls": auth.allowed_calls.is_some(),
+        });
+        sh_println!("{}", serde_json::to_string_pretty(&json)?)?;
+    } else {
+        sh_println!("Signed:       {signed}")?;
+        if let Some(signer) = signer {
+            sh_println!("Signer:       {signer}")?;
+        }
+        sh_println!("Chain ID:     {}", auth.chain_id)?;
+        sh_println!("Key Address:  {}", auth.key_id)?;
+        sh_println!("Key Type:     {}", auth_signature_type_name(&auth.key_type))?;
+        sh_println!("Admin:        {}", auth.is_admin())?;
+        if let Some(account) = auth.account {
+            sh_println!("Account:      {account}")?;
+        }
+        match auth.expiry {
+            Some(expiry) => sh_println!("Expiry:       {}", expiry.get())?,
+            None => sh_println!("Expiry:       none")?,
+        }
+        match auth.witness() {
+            Some(witness) => sh_println!("Witness:      {witness}")?,
+            None => sh_println!("Witness:      none")?,
+        }
+        sh_println!("Enforce Lim:  {}", auth.limits.is_some())?;
+        sh_println!("Scoped Calls: {}", auth.allowed_calls.is_some())?;
+    }
+
+    Ok(())
+}
+
 impl KeyAuthorizationArgs {
-    fn into_authorization(self) -> Result<KeyAuthorization> {
+    /// Build a [`KeyAuthorization`] from these args, binding it to `account` when present.
+    ///
+    /// For `--admin`, `account` must be `Some` (passed via `--account` for `encode`, or derived
+    /// from the root signer for `sign`).
+    fn into_authorization(self, account: Option<Address>) -> Result<KeyAuthorization> {
         let (scopes, explicit_scopes_json) =
             if let Some(AuthScopesJson(json_scopes)) = self.scopes_json {
                 (json_scopes, true)
             } else {
                 (self.scope, false)
             };
+
+        let scopes_present = explicit_scopes_json || !scopes.is_empty();
+        validate_admin_key_authorization(
+            self.admin,
+            account,
+            self.expiry.is_some(),
+            self.enforce_limits || !self.limits.is_empty(),
+            scopes_present,
+        )?;
 
         let mut authorization =
             KeyAuthorization::unrestricted(self.chain_id, self.key_type, self.key_address);
@@ -2836,7 +3136,7 @@ impl KeyAuthorizationArgs {
             authorization = authorization.with_limits(self.limits);
         }
 
-        if explicit_scopes_json || !scopes.is_empty() {
+        if scopes_present {
             authorization = authorization.with_allowed_calls(scopes);
         }
 
@@ -2844,8 +3144,48 @@ impl KeyAuthorizationArgs {
             authorization = authorization.with_witness(witness);
         }
 
+        // Apply T6 admin / account binding last, after the restriction fields are validated above.
+        if self.admin {
+            // `validate_admin_key_authorization` guarantees `account` is `Some` here.
+            authorization = authorization.into_admin(account.expect("admin requires account"));
+        } else if let Some(account) = account {
+            authorization = authorization.with_account(account);
+        }
+
         Ok(authorization)
     }
+}
+
+/// Enforce the T6 admin access-key invariants when constructing a key authorization.
+///
+/// Admin keys are key-management only: no expiry, spending limits, or call scopes, and they must be
+/// bound to a target account (to prevent cross-account replay). A TIP-1053 witness is still
+/// allowed.
+fn validate_admin_key_authorization(
+    admin: bool,
+    account: Option<Address>,
+    has_expiry: bool,
+    has_limits: bool,
+    has_scopes: bool,
+) -> Result<()> {
+    if let Some(account) = account {
+        eyre::ensure!(account != Address::ZERO, "--account cannot be the zero address");
+    }
+
+    if admin {
+        eyre::ensure!(account.is_some(), "--admin requires --account");
+        eyre::ensure!(!has_expiry, "--admin cannot be combined with --expiry");
+        eyre::ensure!(
+            !has_limits,
+            "--admin cannot be combined with spending limits (--enforce-limits / --limit)"
+        );
+        eyre::ensure!(
+            !has_scopes,
+            "--admin cannot be combined with call scopes (--scope / --scopes)"
+        );
+    }
+
+    Ok(())
 }
 
 /// `cast keychain revoke` / `cast keychain rev` — revoke a key on-chain.
@@ -2899,6 +3239,68 @@ async fn run_is_witness_burned(account: Address, witness: B256, rpc: RpcOpts) ->
         sh_println!("{}", serde_json::to_string_pretty(&json)?)?;
     } else {
         sh_println!("{burned}")?;
+    }
+
+    Ok(())
+}
+
+/// `cast keychain is-admin` — check whether a key is the root or an active admin key (T6).
+async fn run_is_admin(account: Address, key_address: Address, rpc: RpcOpts) -> Result<()> {
+    let config = rpc.load_config()?;
+    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+    if !is_tempo_hardfork_active(&provider, TempoHardfork::T6).await? {
+        eyre::bail!("is-admin requires a Tempo T6-capable AccountKeychain RPC");
+    }
+
+    let is_admin = provider.account_keychain().isAdminKey(account, key_address).call().await?;
+
+    if shell::is_json() {
+        let json = serde_json::json!({
+            "account": account.to_string(),
+            "key_address": key_address.to_string(),
+            "is_admin": is_admin,
+        });
+        sh_println!("{}", serde_json::to_string_pretty(&json)?)?;
+    } else {
+        sh_println!("{is_admin}")?;
+    }
+
+    Ok(())
+}
+
+/// `cast keychain verify` / `verify-admin` — verify a Tempo keychain signature (T6).
+async fn run_verify_keychain(
+    account: Address,
+    hash: B256,
+    signature: Bytes,
+    rpc: RpcOpts,
+    admin: bool,
+) -> Result<()> {
+    let config = rpc.load_config()?;
+    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+    let command = if admin { "verify-admin" } else { "verify" };
+    if !is_tempo_hardfork_active(&provider, TempoHardfork::T6).await? {
+        eyre::bail!("{command} requires a Tempo T6-capable SignatureVerifier RPC");
+    }
+
+    let verifier = ISignatureVerifier::new(SIGNATURE_VERIFIER_ADDRESS, &provider);
+    let valid = if admin {
+        verifier.verifyKeychainAdmin(account, hash, signature.clone()).call().await?
+    } else {
+        verifier.verifyKeychain(account, hash, signature.clone()).call().await?
+    };
+
+    if shell::is_json() {
+        let json = serde_json::json!({
+            "account": account.to_string(),
+            "hash": hash.to_string(),
+            "signature": signature.to_string(),
+            "admin": admin,
+            "valid": valid,
+        });
+        sh_println!("{}", serde_json::to_string_pretty(&json)?)?;
+    } else {
+        sh_println!("{valid}")?;
     }
 
     Ok(())
@@ -3665,15 +4067,23 @@ fn print_key_entry(entry: &tempo::KeyEntry) -> Result<()> {
         sh_println!("Expiry:       {}", format_expiry(expiry))?;
     }
 
+    let decoded = decoded_entry_key_authorization(entry);
+    let is_admin = decoded.as_ref().is_some_and(|signed| signed.authorization.is_admin());
+    sh_println!("Role:         {}", local_key_role(entry, is_admin))?;
+
     sh_println!("Has Key:      {}", entry.has_inline_key())?;
     sh_println!("Has Auth:     {}", entry.key_authorization.is_some())?;
-    if let Some(signed) = decoded_entry_key_authorization(entry) {
+    if let Some(signed) = &decoded {
         let witness = signed
             .authorization
             .witness()
             .map(|witness| witness.to_string())
             .unwrap_or_else(|| "(none)".to_string());
         sh_println!("Auth Witness: {witness}")?;
+        sh_println!("Auth Admin:   {}", signed.authorization.is_admin())?;
+        if let Some(account) = signed.authorization.account {
+            sh_println!("Auth Account: {account}")?;
+        }
     }
 
     if !entry.limits.is_empty() {
@@ -3688,9 +4098,16 @@ fn print_key_entry(entry: &tempo::KeyEntry) -> Result<()> {
 
 fn key_entry_to_json(entry: &tempo::KeyEntry) -> serde_json::Value {
     let is_direct = entry.key_address.is_none_or(|key_address| key_address == entry.wallet_address);
-    let authorization_witness = decoded_entry_key_authorization(entry)
-        .and_then(|signed| signed.authorization.witness())
-        .map(|witness| witness.to_string());
+    let decoded = decoded_entry_key_authorization(entry);
+    let authorization_witness =
+        decoded.as_ref().and_then(|signed| signed.authorization.witness()).map(|w| w.to_string());
+    let authorization_is_admin =
+        decoded.as_ref().is_some_and(|signed| signed.authorization.is_admin());
+    let authorization_account = decoded
+        .as_ref()
+        .and_then(|signed| signed.authorization.account)
+        .map(|account| account.to_string());
+    let role = local_key_role(entry, authorization_is_admin);
 
     let limits: Vec<_> = entry
         .limits
@@ -3714,9 +4131,28 @@ fn key_entry_to_json(entry: &tempo::KeyEntry) -> serde_json::Value {
         "expiry_human": entry.expiry.map(format_expiry),
         "has_key": entry.has_inline_key(),
         "has_authorization": entry.key_authorization.is_some(),
+        "role": role,
         "authorization_witness": authorization_witness,
+        "authorization_is_admin": authorization_is_admin,
+        "authorization_account": authorization_account,
         "limits": limits,
     })
+}
+
+/// Classify a local key entry's role for display.
+///
+/// `root` when the key is the account EOA itself, `admin` when a decoded local authorization marks
+/// the key as a T6 admin key, otherwise `access`. This reflects only locally available data; use
+/// `keychain is-admin` for the authoritative on-chain role.
+fn local_key_role(entry: &tempo::KeyEntry, is_admin: bool) -> &'static str {
+    let is_direct = entry.key_address.is_none_or(|key_address| key_address == entry.wallet_address);
+    if is_direct {
+        "root"
+    } else if is_admin {
+        "admin"
+    } else {
+        "limited"
+    }
 }
 
 fn decoded_entry_key_authorization(entry: &tempo::KeyEntry) -> Option<SignedKeyAuthorization> {
@@ -3885,6 +4321,7 @@ mod tests {
                         witness,
                         ..
                     },
+                ..
             } => {
                 assert_eq!(chain_id, 4217);
                 assert_eq!(key_address, Address::from_str(key).unwrap());
@@ -3943,6 +4380,7 @@ mod tests {
             scope: vec![],
             scopes_json: None,
             witness: None,
+            admin: false,
         }
     }
 
@@ -3968,10 +4406,10 @@ mod tests {
 
     #[test]
     fn test_key_auth_encode_preserves_zero_witness_presence() {
-        let absent = key_auth_args().into_authorization().unwrap();
+        let absent = key_auth_args().into_authorization(None).unwrap();
         let mut args = key_auth_args();
         args.witness = Some(B256::ZERO);
-        let zero_witness = args.into_authorization().unwrap();
+        let zero_witness = args.into_authorization(None).unwrap();
 
         assert_eq!(absent.witness(), None);
         assert_eq!(zero_witness.witness(), Some(B256::ZERO));
@@ -3980,11 +4418,206 @@ mod tests {
     }
 
     #[test]
+    fn test_admin_key_auth_roundtrip_preserves_admin_and_account() {
+        use alloy_rlp::Decodable;
+
+        let account = target_addr(0xAB);
+        let mut args = key_auth_args();
+        args.admin = true;
+        let authorization = args.into_authorization(Some(account)).unwrap();
+        assert!(authorization.is_admin());
+        assert_eq!(authorization.account, Some(account));
+
+        let signed = authorization.into_signed(PrimitiveSignature::from_bytes(&[0u8; 65]).unwrap());
+        let encoded = encode_key_authorization(&signed);
+        let decoded = SignedKeyAuthorization::decode(&mut encoded.as_slice()).unwrap();
+        assert!(decoded.authorization.is_admin());
+        assert_eq!(decoded.authorization.account, Some(account));
+    }
+
+    #[test]
+    fn test_account_bound_non_admin_roundtrip() {
+        use alloy_rlp::Decodable;
+
+        let account = target_addr(0xCD);
+        let authorization = key_auth_args().into_authorization(Some(account)).unwrap();
+        assert!(!authorization.is_admin());
+        assert_eq!(authorization.account, Some(account));
+
+        let signed = authorization.into_signed(PrimitiveSignature::from_bytes(&[0u8; 65]).unwrap());
+        let encoded = encode_key_authorization(&signed);
+        let decoded = SignedKeyAuthorization::decode(&mut encoded.as_slice()).unwrap();
+        assert!(!decoded.authorization.is_admin());
+        assert_eq!(decoded.authorization.account, Some(account));
+    }
+
+    #[test]
+    fn test_non_admin_authorization_omits_t6_fields() {
+        // Backward compatibility: a plain authorization must not carry admin/account.
+        let authorization = key_auth_args().into_authorization(None).unwrap();
+        assert!(!authorization.is_admin());
+        assert_eq!(authorization.account, None);
+        assert!(authorization.is_legacy_compatible());
+    }
+
+    #[test]
+    fn test_admin_account_binding_changes_signature_hash() {
+        let mut admin_a = key_auth_args();
+        admin_a.admin = true;
+        let auth_a = admin_a.into_authorization(Some(target_addr(0x01))).unwrap();
+
+        let mut admin_b = key_auth_args();
+        admin_b.admin = true;
+        let auth_b = admin_b.into_authorization(Some(target_addr(0x02))).unwrap();
+
+        // Account binding feeds the signing hash so a signature cannot be replayed across accounts.
+        assert_ne!(auth_a.signature_hash(), auth_b.signature_hash());
+    }
+
+    #[test]
+    fn test_admin_requires_account() {
+        let mut args = key_auth_args();
+        args.admin = true;
+        let err = args.into_authorization(None).unwrap_err().to_string();
+        assert!(err.contains("--admin requires --account"), "got: {err}");
+    }
+
+    #[test]
+    fn test_admin_rejects_expiry_limits_and_scopes() {
+        let account = target_addr(0xAB);
+
+        let mut expiry = key_auth_args();
+        expiry.admin = true;
+        expiry.expiry = Some(1_782_647_677);
+        assert!(
+            expiry.into_authorization(Some(account)).unwrap_err().to_string().contains("--expiry"),
+            "expiry must be rejected for admin keys"
+        );
+
+        let mut limits = key_auth_args();
+        limits.admin = true;
+        limits.enforce_limits = true;
+        assert!(
+            limits
+                .into_authorization(Some(account))
+                .unwrap_err()
+                .to_string()
+                .contains("spending limits"),
+            "spending limits must be rejected for admin keys"
+        );
+
+        let mut scopes = key_auth_args();
+        scopes.admin = true;
+        scopes.scopes_json = Some(AuthScopesJson(vec![]));
+        assert!(
+            scopes
+                .into_authorization(Some(account))
+                .unwrap_err()
+                .to_string()
+                .contains("call scopes"),
+            "call scopes must be rejected for admin keys"
+        );
+    }
+
+    #[test]
+    fn test_account_zero_is_rejected() {
+        let err = key_auth_args().into_authorization(Some(Address::ZERO)).unwrap_err().to_string();
+        assert!(err.contains("--account cannot be the zero address"), "got: {err}");
+    }
+
+    /// Hex-encode a signed admin authorization bound to `account` for inspect tests.
+    fn signed_admin_auth_hex(account: Address) -> String {
+        let mut args = key_auth_args();
+        args.admin = true;
+        let authorization = args.into_authorization(Some(account)).unwrap();
+        let signed = authorization.into_signed(PrimitiveSignature::from_bytes(&[0u8; 65]).unwrap());
+        hex::encode_prefixed(encode_key_authorization(&signed))
+    }
+
+    #[test]
+    fn test_inspect_decodes_signed_and_unsigned_shapes() {
+        // Signed admin authorization: reported as signed with its T6 fields exposed.
+        let account = target_addr(0xAB);
+        let (auth, signed, _signer) =
+            decode_and_validate_key_authorization(&signed_admin_auth_hex(account), None).unwrap();
+        assert!(signed, "signed input must be reported as signed");
+        assert!(auth.is_admin());
+        assert_eq!(auth.account, Some(account));
+
+        // Unsigned authorization: the other RLP shape decodes with no signer.
+        let unsigned = key_auth_args().into_authorization(None).unwrap();
+        let hex = hex::encode_prefixed(encode_key_authorization(&unsigned));
+        let (auth, signed, signer) = decode_and_validate_key_authorization(&hex, None).unwrap();
+        assert!(!signed, "unsigned input must be reported as unsigned");
+        assert!(!auth.is_admin());
+        assert_eq!(auth.account, None);
+        assert!(signer.is_none(), "unsigned input must not recover a signer");
+    }
+
+    #[test]
+    fn test_inspect_account_mismatch_is_rejected() {
+        let account = target_addr(0xAB);
+        let hex = signed_admin_auth_hex(account);
+        let err = decode_and_validate_key_authorization(&hex, Some(target_addr(0xCD)))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("is bound to account") && err.contains("was expected"), "got: {err}");
+    }
+
+    #[test]
+    fn test_inspect_rejects_admin_auth_carrying_restrictions() {
+        // Build an admin authorization that carries an expiry directly (bypassing the CLI
+        // constructor's guard) to prove `inspect` mirrors the chain's admin invariants.
+        let account = target_addr(0xAB);
+        let authorization =
+            KeyAuthorization::unrestricted(31337, AuthSignatureType::Secp256k1, target_addr(0x42))
+                .with_expiry(1_782_647_677)
+                .into_admin(account);
+        let hex = hex::encode_prefixed(encode_key_authorization(&authorization));
+
+        let err = decode_and_validate_key_authorization(&hex, None).unwrap_err().to_string();
+        assert!(err.contains("cannot carry an expiry"), "got: {err}");
+    }
+
+    #[test]
+    fn test_inspect_rejects_admin_auth_without_account() {
+        // An admin authorization with no bound account must be rejected on decode.
+        let mut authorization =
+            KeyAuthorization::unrestricted(31337, AuthSignatureType::Secp256k1, target_addr(0x42));
+        authorization.is_admin = true;
+        let hex = hex::encode_prefixed(encode_key_authorization(&authorization));
+
+        let err = decode_and_validate_key_authorization(&hex, None).unwrap_err().to_string();
+        assert!(err.contains("missing its required account field"), "got: {err}");
+    }
+
+    #[test]
+    fn test_local_key_role_classification() {
+        let wallet = target_addr(0x01);
+        let key = target_addr(0x02);
+
+        let root = tempo::KeyEntry {
+            wallet_address: wallet,
+            key_address: Some(wallet),
+            ..Default::default()
+        };
+        assert_eq!(local_key_role(&root, false), "root");
+
+        let access = tempo::KeyEntry {
+            wallet_address: wallet,
+            key_address: Some(key),
+            ..Default::default()
+        };
+        assert_eq!(local_key_role(&access, false), "limited");
+        assert_eq!(local_key_role(&access, true), "admin");
+    }
+
+    #[test]
     fn test_key_auth_encode_preserves_explicit_empty_scopes_json() {
-        let absent = key_auth_args().into_authorization().unwrap();
+        let absent = key_auth_args().into_authorization(None).unwrap();
         let mut args = key_auth_args();
         args.scopes_json = Some(AuthScopesJson(vec![]));
-        let deny_all = args.into_authorization().unwrap();
+        let deny_all = args.into_authorization(None).unwrap();
 
         assert_eq!(absent.allowed_calls, None);
         assert_eq!(deny_all.allowed_calls, Some(vec![]));
@@ -3996,7 +4629,7 @@ mod tests {
     fn test_key_auth_encode_rejects_zero_expiry() {
         let mut args = key_auth_args();
         args.expiry = Some(0);
-        let err = args.into_authorization().unwrap_err();
+        let err = args.into_authorization(None).unwrap_err();
         assert!(
             err.to_string().contains("--expiry must be greater than zero"),
             "unexpected error: {err}"

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -213,7 +213,7 @@ casttest!(keychain_authorize_sponsor_hash_json_is_object, async |_prj, cmd| {
     assert_eq!(hash.len(), 66, "sponsor_hash should be 32-byte hex (66 chars), got: {hash}");
 });
 
-// TODO: remove this check once browser supports T5 KeyAuthorization fields
+// TODO: remove this check once browser supports T5/T6 KeyAuthorization fields
 casttest!(key_authorization_sign_rejects_browser_witness_before_browser_run, |_prj, cmd| {
     let stderr = cmd
         .args([
@@ -232,14 +232,279 @@ casttest!(key_authorization_sign_rejects_browser_witness_before_browser_run, |_p
         .stderr_lossy();
 
     assert!(
-        stderr
-            .contains("browser key authorization signing does not support T5 fields yet: witness"),
+        stderr.contains(
+            "browser key authorization signing does not support T5/T6 fields yet: witness, admin, account"
+        ),
         "unexpected stderr:\n{stderr}"
     );
     assert!(
         !stderr.contains("Waiting for browser wallet connection"),
         "browser flow should not start before rejecting --browser --witness:\n{stderr}"
     );
+});
+
+// Offline: signing an admin key authorization round-trips `is_admin`/`account` into the JSON.
+casttest!(key_authorization_sign_admin_emits_admin_json, |_prj, cmd| {
+    // `sign --admin` derives the bound account from the signer (it has no auth-level --account),
+    // so signing with PK1 binds the authorization to ADDR1.
+    let output = cmd
+        .args([
+            "key-authorization",
+            "sign",
+            accounts::ADDR2,
+            "--chain-id",
+            "31337",
+            "--admin",
+            "--private-key",
+            accounts::PK1,
+            "--json",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    let parsed: serde_json::Value = serde_json::from_str(output.trim())
+        .expect("cast key-authorization sign --admin --json should emit valid JSON");
+    assert_eq!(parsed["is_admin"], serde_json::Value::Bool(true), "got: {output}");
+    // The bound account equals the signer (ADDR1), not the authorized key (ADDR2).
+    assert_eq!(
+        parsed["account"].as_str().map(str::to_lowercase),
+        Some(accounts::ADDR1.to_lowercase()),
+        "got: {output}"
+    );
+    assert!(
+        parsed["signed_key_authorization"].as_str().is_some_and(|s| s.starts_with("0x")),
+        "got: {output}"
+    );
+});
+
+// Offline: `--admin` without `--account` is rejected before any signing happens.
+casttest!(key_authorization_encode_admin_requires_account, |_prj, cmd| {
+    let stderr = cmd
+        .args(["key-authorization", "encode", accounts::ADDR2, "--chain-id", "31337", "--admin"])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("--admin requires --account"), "unexpected stderr:\n{stderr}");
+});
+
+// Offline: an admin key authorization cannot carry an expiry.
+casttest!(key_authorization_encode_admin_rejects_expiry, |_prj, cmd| {
+    let stderr = cmd
+        .args([
+            "key-authorization",
+            "encode",
+            accounts::ADDR2,
+            "--chain-id",
+            "31337",
+            "--admin",
+            "--account",
+            accounts::ADDR1,
+            "--expiry",
+            "1782647677",
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("--expiry"), "unexpected stderr:\n{stderr}");
+});
+
+// Offline: `key-authorization inspect` decodes a signed admin authorization and exposes T6 fields.
+casttest!(key_authorization_inspect_signed_admin_json, |_prj, cmd| {
+    let signed = cmd
+        .args([
+            "key-authorization",
+            "sign",
+            accounts::ADDR2,
+            "--chain-id",
+            "31337",
+            "--admin",
+            "--private-key",
+            accounts::PK1, // root account ADDR1; the bound account is derived from the signer
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let signed = signed.trim().to_string();
+
+    let output = cmd
+        .cast_fuse()
+        .args(["key-authorization", "inspect", &signed, "--json"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    let parsed: serde_json::Value = serde_json::from_str(output.trim())
+        .expect("cast key-authorization inspect --json should emit valid JSON");
+    assert_eq!(parsed["signed"], serde_json::Value::Bool(true), "got: {output}");
+    assert_eq!(parsed["is_admin"], serde_json::Value::Bool(true), "got: {output}");
+    assert_eq!(
+        parsed["account"].as_str().map(str::to_lowercase),
+        Some(accounts::ADDR1.to_lowercase()),
+        "got: {output}"
+    );
+    assert_eq!(
+        parsed["signer"].as_str().map(str::to_lowercase),
+        Some(accounts::ADDR1.to_lowercase()),
+        "got: {output}"
+    );
+});
+
+// Offline: inspecting with a mismatched `--account` rejects a replayed admin authorization.
+casttest!(key_authorization_inspect_account_mismatch_rejected, |_prj, cmd| {
+    let signed = cmd
+        .args([
+            "key-authorization",
+            "sign",
+            accounts::ADDR2,
+            "--chain-id",
+            "31337",
+            "--admin",
+            "--private-key",
+            accounts::PK1, // bound to ADDR1
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let signed = signed.trim().to_string();
+
+    let stderr = cmd
+        .cast_fuse()
+        .args(["key-authorization", "inspect", &signed, "--account", accounts::ADDR2])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("is bound to account"), "unexpected stderr:\n{stderr}");
+});
+
+// On-chain (T6): authorize an admin key, then confirm it via `keychain is-admin --json`.
+casttest!(keychain_authorize_admin_then_is_admin, async |_prj, cmd| {
+    use tempo_chainspec::hardfork::TempoHardfork;
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let rpc = handle.http_endpoint();
+
+    cmd.cast_fuse()
+        .args([
+            "keychain",
+            "authorize",
+            accounts::ADDR2, // admin key to authorize
+            "--admin",
+            "--private-key",
+            accounts::PK1, // root account ADDR1
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+
+    let output = cmd
+        .cast_fuse()
+        .args([
+            "keychain",
+            "is-admin",
+            accounts::ADDR1, // root account
+            accounts::ADDR2, // admin key
+            "--rpc-url",
+            &rpc,
+            "--json",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    let parsed: serde_json::Value = serde_json::from_str(output.trim())
+        .expect("cast keychain is-admin --json should emit valid JSON");
+    assert!(parsed.is_object(), "expected JSON object, got: {output}");
+    assert_eq!(parsed["is_admin"], serde_json::Value::Bool(true), "got: {output}");
+});
+
+// On-chain (T6): a keychain signature from an authorized admin key passes `verify-admin`.
+casttest!(keychain_verify_admin_accepts_admin_signature, async |_prj, cmd| {
+    use alloy_primitives::{Address, B256, hex};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_primitives::transaction::{KeychainSignature, PrimitiveSignature, TempoSignature};
+
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let rpc = handle.http_endpoint();
+
+    // Authorize ADDR2 as an admin key for ADDR1 (PK1).
+    cmd.cast_fuse()
+        .args([
+            "keychain",
+            "authorize",
+            accounts::ADDR2,
+            "--admin",
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+
+    // Build a keychain signature over an arbitrary hash, signed by the admin key (PK2) for ADDR1.
+    let account: Address = accounts::ADDR1.parse().unwrap();
+    let hash = B256::repeat_byte(0x42);
+    let key: PrivateKeySigner = accounts::PK2.parse().unwrap();
+    let signing_hash = KeychainSignature::signing_hash(hash, account);
+    let inner = key.sign_hash_sync(&signing_hash).unwrap();
+    let signature = TempoSignature::Keychain(KeychainSignature::new(
+        account,
+        PrimitiveSignature::Secp256k1(inner),
+    ))
+    .to_bytes();
+    let signature_hex = hex::encode_prefixed(signature);
+
+    let output = cmd
+        .cast_fuse()
+        .args([
+            "keychain",
+            "verify-admin",
+            accounts::ADDR1,
+            &hash.to_string(),
+            &signature_hex,
+            "--rpc-url",
+            &rpc,
+            "--json",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    let parsed: serde_json::Value = serde_json::from_str(output.trim())
+        .expect("cast keychain verify-admin --json should emit valid JSON");
+    assert_eq!(parsed["valid"], serde_json::Value::Bool(true), "got: {output}");
+});
+
+// On-chain (T6): `keychain authorize --admin` rejects spending limits before submitting.
+casttest!(keychain_authorize_admin_rejects_limits, async |_prj, cmd| {
+    use tempo_chainspec::hardfork::TempoHardfork;
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let rpc = handle.http_endpoint();
+
+    let stderr = cmd
+        .args([
+            "keychain",
+            "authorize",
+            accounts::ADDR2,
+            "--admin",
+            "--enforce-limits",
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("spending limits"), "unexpected stderr:\n{stderr}");
 });
 
 casttest!(keychain_doctor_json_keeps_report_schema_version, async |_prj, cmd| {

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -507,6 +507,92 @@ casttest!(keychain_authorize_admin_rejects_limits, async |_prj, cmd| {
     assert!(stderr.contains("spending limits"), "unexpected stderr:\n{stderr}");
 });
 
+// An access-key signer is rejected for admin-gated keychain mutators even when it is an active
+// admin key, because submitting the mutator as access-key-signed calldata reverts on-chain with
+// `UnauthorizedCaller()` on the pinned Tempo build.
+casttest!(keychain_access_key_cannot_submit_admin_mutator, async |_prj, cmd| {
+    use tempo_chainspec::hardfork::TempoHardfork;
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let rpc = handle.http_endpoint();
+
+    // Root ADDR1 (PK1) authorizes ADDR2 (PK2) as an admin key.
+    cmd.cast_fuse()
+        .args([
+            "keychain",
+            "authorize",
+            accounts::ADDR2,
+            "--admin",
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+
+    // ADDR2 is an active admin key, but the access-key mutator is still rejected locally.
+    let stderr = cmd
+        .cast_fuse()
+        .args([
+            "keychain",
+            "authorize",
+            accounts::ADDR3,
+            "--tempo.access-key",
+            accounts::PK2,
+            "--tempo.root-account",
+            accounts::ADDR1,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(
+        stderr.contains("currently reverts on-chain with UnauthorizedCaller()"),
+        "unexpected stderr:\n{stderr}"
+    );
+});
+
+// Offline (T6): an admin access key signing a child authorization binds the authorization to the
+// root account it manages, not to the signing admin key. This covers the delegated admin-signing
+// path in `run_key_auth_sign`.
+casttest!(key_authorization_sign_admin_access_key_binds_root_account, |_prj, cmd| {
+    let output = cmd
+        .args([
+            "key-authorization",
+            "sign",
+            accounts::ADDR3, // the child key being authorized
+            "--chain-id",
+            "31337",
+            "--admin",
+            "--tempo.access-key",
+            accounts::PK2, // admin key ADDR2 signs
+            "--tempo.root-account",
+            accounts::ADDR1, // on behalf of root ADDR1
+            "--json",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+
+    let parsed: serde_json::Value = serde_json::from_str(output.trim())
+        .expect("cast key-authorization sign --json should emit valid JSON");
+    assert_eq!(parsed["is_admin"], serde_json::Value::Bool(true), "got: {output}");
+    // The signer is the admin key (ADDR2)...
+    assert_eq!(
+        parsed["signer"].as_str().map(str::to_lowercase),
+        Some(accounts::ADDR2.to_lowercase()),
+        "got: {output}"
+    );
+    // ...but the bound account is the root account being modified (ADDR1), not the signer.
+    assert_eq!(
+        parsed["account"].as_str().map(str::to_lowercase),
+        Some(accounts::ADDR1.to_lowercase()),
+        "got: {output}"
+    );
+});
+
 casttest!(keychain_doctor_json_keeps_report_schema_version, async |_prj, cmd| {
     let output = cmd
         .args([

--- a/crates/common/src/tempo/auth.rs
+++ b/crates/common/src/tempo/auth.rs
@@ -366,6 +366,15 @@ mod tests {
         Address::from_public_key(&vk)
     }
 
+    /// Shape of the `keyAuthorization` the mock `/poll` returns.
+    #[derive(Clone, Copy, Default)]
+    struct MockAuthShape {
+        /// Return a T6 admin key authorization.
+        admin: bool,
+        /// Bind the authorization to this account.
+        account: Option<Address>,
+    }
+
     #[derive(Clone)]
     struct MockState {
         wallet: Arc<Mutex<Option<Address>>>,
@@ -374,6 +383,8 @@ mod tests {
         key_id: Arc<Mutex<Option<Address>>>,
         /// Chain ID the mock `/poll` returns in `keyAuthorization`.
         poll_chain_id: u64,
+        /// Shape of the returned authorization, for exercising rejection paths.
+        shape: MockAuthShape,
     }
 
     async fn create_code_handler(
@@ -400,11 +411,25 @@ mod tests {
 
     /// Build the RLP-hex `SignedKeyAuthorization` blob the live server returns
     /// in the `key_authorization` field.
-    fn signed_key_auth_hex(chain_id: u64, key_id: Address, expiry: u64) -> String {
+    fn signed_key_auth_hex(
+        chain_id: u64,
+        key_id: Address,
+        expiry: u64,
+        shape: MockAuthShape,
+    ) -> String {
         use alloy_rlp::Encodable;
         use tempo_primitives::transaction::{KeyAuthorization, PrimitiveSignature};
-        let auth = KeyAuthorization::unrestricted(chain_id, SignatureType::Secp256k1, key_id)
-            .with_expiry(expiry);
+        let mut auth = KeyAuthorization::unrestricted(chain_id, SignatureType::Secp256k1, key_id);
+        if shape.admin {
+            // An admin authorization carries no expiry; bind it to its account (or zero, which the
+            // `is_admin` check rejects before the account is even inspected).
+            auth = auth.into_admin(shape.account.unwrap_or(Address::ZERO));
+        } else {
+            auth = auth.with_expiry(expiry);
+            if let Some(account) = shape.account {
+                auth = auth.with_account(account);
+            }
+        }
         let sig: PrimitiveSignature = serde_json::from_value(serde_json::json!({
             "type": "secp256k1", "r": "0x0", "s": "0x0", "yParity": 0
         }))
@@ -421,12 +446,21 @@ mod tests {
         Json(serde_json::json!({
             "status": "authorized",
             "account_address": wallet,
-            "key_authorization": signed_key_auth_hex(state.poll_chain_id, key_id, 9_999_999_999),
+            "key_authorization":
+                signed_key_auth_hex(state.poll_chain_id, key_id, 9_999_999_999, state.shape),
         }))
     }
 
     /// Spawn a mock wallet.tempo server whose `/poll` echoes `poll_chain_id`.
     async fn spawn_mock_wallet(poll_chain_id: u64) -> (String, tokio::task::JoinHandle<()>) {
+        spawn_mock_wallet_with(poll_chain_id, MockAuthShape::default()).await
+    }
+
+    /// Spawn a mock wallet.tempo server with a custom authorization shape.
+    async fn spawn_mock_wallet_with(
+        poll_chain_id: u64,
+        shape: MockAuthShape,
+    ) -> (String, tokio::task::JoinHandle<()>) {
         let app = Router::new()
             .route("/code", post(create_code_handler))
             .route("/poll/{code}", post(poll_handler))
@@ -434,6 +468,7 @@ mod tests {
                 wallet: Arc::default(),
                 key_id: Arc::default(),
                 poll_chain_id,
+                shape,
             });
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -501,6 +536,60 @@ mod tests {
             "expected chain mismatch error, got: {err}"
         );
         assert!(read_tempo_keys_file().is_none_or(|f| f.keys.is_empty()));
+
+        server.abort();
+        unsafe { std::env::remove_var(TEMPO_HOME_ENV) };
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ensure_access_key_rejects_admin_authorization() {
+        // An admin key authorization from the wallet must be rejected before keys.toml is written.
+        let _g = test_env_mutex().lock().await;
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(TEMPO_HOME_ENV, tmp.path()) };
+
+        // Bind the admin auth to the mock wallet account (0x..42) so it is rejected purely for
+        // being an admin key, not for an account mismatch.
+        let account: Address = "0x0000000000000000000000000000000000000042".parse().unwrap();
+        let shape = MockAuthShape { admin: true, account: Some(account) };
+        let (service_url, server) = spawn_mock_wallet_with(4217, shape).await;
+
+        let err = ensure_access_key(test_cfg(service_url)).await.unwrap_err();
+        assert!(
+            err.to_string().contains("admin key authorization"),
+            "expected admin-key rejection, got: {err}"
+        );
+        assert!(
+            read_tempo_keys_file().is_none_or(|f| f.keys.is_empty()),
+            "an admin authorization must not be persisted to keys.toml"
+        );
+
+        server.abort();
+        unsafe { std::env::remove_var(TEMPO_HOME_ENV) };
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ensure_access_key_rejects_cross_account_binding() {
+        // An authorization bound to an account other than the authorizing one must be rejected
+        // before keys.toml is written.
+        let _g = test_env_mutex().lock().await;
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var(TEMPO_HOME_ENV, tmp.path()) };
+
+        // The mock authorizes account 0x..42 but binds the authorization to 0x..dead.
+        let other: Address = "0x000000000000000000000000000000000000dead".parse().unwrap();
+        let shape = MockAuthShape { admin: false, account: Some(other) };
+        let (service_url, server) = spawn_mock_wallet_with(4217, shape).await;
+
+        let err = ensure_access_key(test_cfg(service_url)).await.unwrap_err();
+        assert!(
+            err.to_string().contains("wallet authorized account"),
+            "expected cross-account rejection, got: {err}"
+        );
+        assert!(
+            read_tempo_keys_file().is_none_or(|f| f.keys.is_empty()),
+            "a cross-account authorization must not be persisted to keys.toml"
+        );
 
         server.abort();
         unsafe { std::env::remove_var(TEMPO_HOME_ENV) };

--- a/crates/common/src/tempo/auth.rs
+++ b/crates/common/src/tempo/auth.rs
@@ -198,6 +198,20 @@ pub async fn ensure_access_key(cfg: EnsureAccessKeyConfig) -> Result<AccessKeyOu
                         signed.authorization.key_type,
                     );
                 }
+                // A 402 access key is a limited key; an admin key is never valid here.
+                if signed.authorization.is_admin() {
+                    eyre::bail!(
+                        "wallet returned an admin key authorization, expected a limited access key"
+                    );
+                }
+                // A T6 account-bound authorization must target the authorizing account.
+                if let Some(account) = signed.authorization.account
+                    && account != account_address
+                {
+                    eyre::bail!(
+                        "wallet authorized account {account} but the authorizing account is {account_address}",
+                    );
+                }
                 let chain_id = signed.authorization.chain_id;
                 let key_authorization =
                     if hex_str.starts_with("0x") { hex_str } else { format!("0x{hex_str}") };

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -364,6 +364,23 @@ pub(crate) fn validate_signed_session_authorization(
         auth.key_type,
         expected_key_type
     );
+    // A session uses a limited access key; T6 admin keys must never be used as a session key.
+    ensure!(
+        !auth.is_admin(),
+        "session {} key_authorization is an admin key, expected a limited access key",
+        session.session_id
+    );
+    // A T6 account-bound authorization must target this session's root account (no cross-account
+    // replay).
+    if let Some(account) = auth.account {
+        ensure!(
+            account == session.root_account,
+            "session {} key_authorization is bound to account {}, expected {}",
+            session.session_id,
+            account,
+            session.root_account
+        );
+    }
     // `session_id` is local metadata; the signed binding lives in the authorization witness.
     ensure!(
         auth.witness == Some(session.session_id),
@@ -1117,6 +1134,62 @@ mod tests {
             let error = resolve_live_session_signer(session_id, 100).unwrap_err();
 
             assert!(error.to_string().contains("witness"));
+        });
+    }
+
+    #[test]
+    fn resolve_rejects_admin_key_authorization() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x17; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            // A session must use a limited access key, never a T6 admin key.
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex_with(&entry, |mut auth| {
+                    auth.is_admin = true;
+                    auth
+                }));
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("admin key"), "got: {error}");
+        });
+    }
+
+    #[test]
+    fn resolve_rejects_account_bound_to_other_account() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x18; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            // An account-bound authorization minted for another account must not be replayable.
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex_with(&entry, |auth| {
+                    auth.with_account(
+                        Address::from_str("0x000000000000000000000000000000000000dead").unwrap(),
+                    )
+                }));
+            upsert_session_entry(entry).unwrap();
+
+            let error = resolve_live_session_signer(session_id, 100).unwrap_err();
+
+            assert!(error.to_string().contains("bound to account"), "got: {error}");
+        });
+    }
+
+    #[test]
+    fn resolve_accepts_account_bound_to_root() {
+        with_tempo_home(|| {
+            let session_id = B256::from([0x19; 32]);
+            let mut entry = sample_entry_with_valid_key(session_id, 200, SessionStatus::Active);
+            let root_account = entry.root_account;
+            // An account binding that targets the session root is valid (backward compatible).
+            entry.key.as_mut().unwrap().key_authorization =
+                Some(signed_key_authorization_hex_with(&entry, |auth| {
+                    auth.with_account(root_account)
+                }));
+            upsert_session_entry(entry).unwrap();
+
+            assert!(resolve_live_session_signer(session_id, 100).is_ok());
         });
     }
 


### PR DESCRIPTION
Adds support for T6 admin access keys: preserves/exposes the new `is_admin` and `account` `KeyAuthorization` fields, adds `cast key-authorization encode/sign/inspect` (`--admin`, `--account`, `--witness`) plus `keychain authorize --admin`, `is-admin`, and `verify-admin` with `--json` output, and rejects admin authorizations carrying expiry/limits/scopes or a mismatched account. Non-admin authorizations remain backward compatible.

Closes OSS-341