### PR TITLE
test: clarify expect emit mismatch output

### DIFF
--- a/crates/cheatcodes/src/test/expect.rs
+++ b/crates/cheatcodes/src/test/expect.rs
@@ -1172,6 +1172,17 @@ pub(crate) fn get_emit_mismatch_message(
 
     // 1. Different number of topics
     if actual.topics().len() != expected.topics().len() {
+        let expected_name = expected_decoded.and_then(|d| d.name.as_deref()).unwrap_or("log");
+        let actual_name = actual_decoded.and_then(|d| d.name.as_deref()).unwrap_or("log");
+        let expected_topics = checked_topic_count(expected, is_anonymous);
+        let actual_topics = checked_topic_count(actual, is_anonymous);
+
+        if expected_name == actual_name {
+            return format!(
+                "{actual_name} indexed topic count mismatch: expected {expected_topics}, got {actual_topics}"
+            );
+        }
+
         return name_mismatched_logs(expected_decoded, actual_decoded);
     }
 
@@ -1312,6 +1323,10 @@ fn name_mismatched_logs(
     let expected_name = expected_decoded.and_then(|d| d.name.as_deref()).unwrap_or("log");
     let actual_name = actual_decoded.and_then(|d| d.name.as_deref()).unwrap_or("log");
     format!("{actual_name} != expected {expected_name}")
+}
+
+fn checked_topic_count(log: &RawLog, is_anonymous: bool) -> usize {
+    if is_anonymous { log.topics().len() } else { log.topics().len().saturating_sub(1) }
 }
 
 fn expect_safe_memory<FEN: FoundryEvmNetwork>(

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -209,7 +209,7 @@ forgetest!(flaky_expect_emit_tests_should_fail, |prj, cmd| {
     cmd.forge_fuse().args(["test", "--mc", "ExpectEmitFailureTest"]).assert_failure().stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
 ...
 [FAIL: E != expected A] testShouldFailCanMatchConsecutiveEvents() ([GAS])
-[FAIL: log != expected SomethingElse] testShouldFailDifferentIndexedParameters() ([GAS])
+[FAIL: SomethingElse indexed topic count mismatch: expected 1, got 0] testShouldFailDifferentIndexedParameters() ([GAS])
 [FAIL: log != expected log] testShouldFailEmitOnlyAppliesToNextCall() ([GAS])
 [FAIL: next call did not revert as expected] testShouldFailEmitWindowWithRevertDisallowed() ([GAS])
 [FAIL: E != expected A] testShouldFailEventsOnTwoCalls() ([GAS])
@@ -235,7 +235,7 @@ Suite result: FAILED. 0 passed; 15 failed; 0 skipped; [ELAPSED]
 ...
 [FAIL: log != expected log] testShouldFailCountEmitsFromAddress() ([GAS])
 [FAIL: log != expected log] testShouldFailCountLessEmits() ([GAS])
-[FAIL: log != expected Something] testShouldFailEmitSomethingElse() ([GAS])
+[FAIL: SomethingElse != expected Something] testShouldFailEmitSomethingElse() ([GAS])
 [FAIL: log emitted but expected 0 times] testShouldFailNoEmit() ([GAS])
 [FAIL: log emitted but expected 0 times] testShouldFailNoEmitFromAddress() ([GAS])
 Suite result: FAILED. 0 passed; 5 failed; 0 skipped; [ELAPSED]

--- a/crates/forge/tests/cli/test_cmd/repros.rs
+++ b/crates/forge/tests/cli/test_cmd/repros.rs
@@ -255,14 +255,14 @@ contract Issue6170Test is Test {
 Compiler run successful!
 
 Ran 1 test for test/Issue6170.t.sol:Issue6170Test
-[FAIL: Values != expected Values] test() ([GAS])
+[FAIL: Values indexed topic count mismatch: expected 1, got 2] test() ([GAS])
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/Issue6170.t.sol:Issue6170Test
-[FAIL: Values != expected Values] test() ([GAS])
+[FAIL: Values indexed topic count mismatch: expected 1, got 2] test() ([GAS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 


### PR DESCRIPTION
Improves expect emit mismatch reporting for same-name events with different indexed topic layouts, then updates the affected failure assertion snapshots.

The same-name indexed-layout case now reports `SomethingElse indexed topic count mismatch: expected 1, got 0` instead of the misleading `SomethingElse != expected SomethingElse`.

The count-based fixture still reports `SomethingElse != expected Something` because it is a real different-event mismatch: the test expects `Something(...)` and the contract emits `SomethingElse(...)`.

This fixes the nightly flaky test failure in `forge::cli::failure_assertions::flaky_expect_emit_tests_should_fail`.

close #15191 
close #15192

Prompted by: @grandizzy