### PR TITLE
fix(anvil): support onlyTopLevelCall tracer config

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -75,9 +75,9 @@ use alloy_rpc_types::{
     trace::{
         filter::TraceFilter,
         geth::{
-            FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
-            GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, NoopFrame,
-            TraceResult,
+            CallConfig, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerConfig,
+            GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
+            NoopFrame, TraceResult,
         },
         parity::{LocalizedTransactionTrace, TraceResultsWithTransactionHash, TraceType},
     },
@@ -215,6 +215,20 @@ impl DatabaseRef for dyn crate::eth::backend::db::Db {}
 pub const MIN_TRANSACTION_GAS: u128 = 21000;
 // Gas per transaction creating a contract.
 pub const MIN_CREATE_GAS: u128 = 53000;
+
+fn call_config_from_tracer_config(
+    tracer_config: GethDebugTracerConfig,
+) -> Result<CallConfig, serde_json::Error> {
+    let mut tracer_config = tracer_config.into_json();
+    if let Some(config) = tracer_config.as_object_mut()
+        && !config.contains_key("onlyTopCall")
+        && let Some(only_top_level_call) = config.remove("onlyTopLevelCall")
+    {
+        config.insert("onlyTopCall".to_string(), only_top_level_call);
+    }
+
+    GethDebugTracerConfig(tracer_config).into_call_config()
+}
 
 pub type State = foundry_evm::utils::StateChangeset;
 
@@ -2975,8 +2989,7 @@ where
                 return match tracer {
                     GethDebugTracerType::BuiltInTracer(tracer) => match tracer {
                         GethDebugBuiltInTracerType::CallTracer => {
-                            let call_config = tracer_config
-                                .into_call_config()
+                            let call_config = call_config_from_tracer_config(tracer_config)
                                 .map_err(|e| RpcError::invalid_params(e.to_string()))?;
 
                             let mut inspector = self.build_inspector().with_tracing_config(
@@ -3640,7 +3653,7 @@ where
                         return Ok(res);
                     }
                     GethDebugBuiltInTracerType::CallTracer => {
-                        return match tracer_config.into_call_config() {
+                        return match call_config_from_tracer_config(tracer_config) {
                             Ok(call_config) => {
                                 let inspector = TracingInspector::new(
                                     TracingInspectorConfig::from_geth_call_config(&call_config),

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -239,6 +239,65 @@ async fn test_call_tracer_debug_trace_call() {
         }
     }
 
+    let receipt = internal_call_tx_builder.send().await.unwrap().get_receipt().await.unwrap();
+    let internal_call_tx_hash = receipt.transaction_hash;
+    let trace_provider = handle.http_provider();
+
+    let internal_call_tx_traces: GethTrace = trace_provider
+        .raw_request(
+            "debug_traceTransaction".into(),
+            (
+                internal_call_tx_hash,
+                serde_json::json!({
+                    "tracer": "callTracer",
+                    "tracerConfig": {
+                        "withLog": true
+                    }
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+
+    match internal_call_tx_traces {
+        GethTrace::CallTracer(call_frame) => {
+            assert_eq!(call_frame.calls.len(), 1);
+            assert_eq!(
+                call_frame.calls.first().unwrap().to.unwrap(),
+                *simple_storage_contract.address()
+            );
+        }
+        _ => {
+            unreachable!()
+        }
+    }
+
+    let internal_call_only_top_level_call_tx_traces: GethTrace = trace_provider
+        .raw_request(
+            "debug_traceTransaction".into(),
+            (
+                internal_call_tx_hash,
+                serde_json::json!({
+                    "tracer": "callTracer",
+                    "tracerConfig": {
+                        "onlyTopLevelCall": true,
+                        "withLog": true
+                    }
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+
+    match internal_call_only_top_level_call_tx_traces {
+        GethTrace::CallTracer(call_frame) => {
+            assert!(call_frame.calls.is_empty());
+        }
+        _ => {
+            unreachable!()
+        }
+    }
+
     // directly calling the SimpleStorage contract should not result in any internal calls
     let direct_call_tx = TransactionRequest::default()
         .from(wallets[1].address())


### PR DESCRIPTION
## Summary
- Support Alchemy-style `onlyTopLevelCall` as an alias for callTracer's existing `onlyTopCall` option.
- Add a JSON-RPC `debug_traceTransaction` regression test that verifies the alias suppresses nested calls.

Closes #9569.