### PR TITLE
fix(debugger): match internal variables by signature

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -876,9 +876,17 @@ fn variable_name(variable: &DebugVariable, index: usize, fallback_prefix: &str) 
 
 fn decoded_internal_name_matches(decoded_name: &str, scope: &DebugSourceScope) -> bool {
     if let Some((contract_name, function_name)) = decoded_name.rsplit_once("::") {
-        return contract_name == scope.contract_name && function_name == scope.function_name;
+        return contract_name == scope.contract_name
+            && decoded_function_matches(function_name, scope);
     }
-    decoded_name == scope.function_name
+    decoded_function_matches(decoded_name, scope)
+}
+
+fn decoded_function_matches(decoded_name: &str, scope: &DebugSourceScope) -> bool {
+    if decoded_name == scope.function_name {
+        return true;
+    }
+    scope_function_signature(scope).as_deref().is_some_and(|signature| decoded_name == signature)
 }
 
 fn decode_external_parameter_values(
@@ -1296,6 +1304,15 @@ mod tests {
         assert!(super::decoded_internal_name_matches("DebugMe::foo", &scope));
         assert!(!super::decoded_internal_name_matches("DebugMe::barfoo", &scope));
         assert!(!super::decoded_internal_name_matches("Other::foo", &scope));
+    }
+
+    #[test]
+    fn decoded_internal_name_matches_canonical_signature_for_overloads() {
+        let scope = scope("foo", "(uint256 amount)");
+
+        assert!(super::decoded_internal_name_matches("DebugMe::foo(uint256)", &scope));
+        assert!(!super::decoded_internal_name_matches("DebugMe::foo(address)", &scope));
+        assert!(!super::decoded_internal_name_matches("Other::foo(uint256)", &scope));
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -8,7 +8,7 @@ use foundry_common::fmt::format_token;
 use foundry_compilers::artifacts::sourcemap::SourceElement;
 use foundry_evm_core::buffer::{BufferKind, get_buffer_accesses};
 use foundry_evm_traces::debug::{
-    DebugSourceScope, DebugVariable, SourceData, decode_step_parameters,
+    DebugSourceScope, DebugVariable, SourceData, decode_step_parameters, function_signature,
 };
 use ratatui::{
     Frame,
@@ -922,20 +922,6 @@ fn function_selector(function_name: &str, types: &[DynSolType]) -> [u8; 4] {
     keccak256(signature.as_bytes())[..4].try_into().unwrap()
 }
 
-fn function_signature(function_name: &str, types: &[DynSolType]) -> String {
-    let mut signature = String::new();
-    signature.push_str(function_name);
-    signature.push('(');
-    for (i, ty) in types.iter().enumerate() {
-        if i > 0 {
-            signature.push(',');
-        }
-        signature.push_str(&ty.sol_type_name());
-    }
-    signature.push(')');
-    signature
-}
-
 fn decode_abi_sequence(types: &[DynSolType], data: &[u8]) -> Option<Vec<String>> {
     if types.is_empty() {
         return Some(Vec::new());
@@ -1124,13 +1110,18 @@ mod tests {
     }
 
     fn internal_call_step(end_step: usize, return_data: Vec<String>) -> CallTraceStep {
+        internal_call_step_named("DebugMe::foo", end_step, Some(Vec::new()), Some(return_data))
+    }
+
+    fn internal_call_step_named(
+        func_name: &str,
+        end_step: usize,
+        args: Option<Vec<String>>,
+        return_data: Option<Vec<String>>,
+    ) -> CallTraceStep {
         let mut step = trace_step(Vec::new());
         step.decoded = Some(Box::new(DecodedTraceStep::InternalCall(
-            DecodedInternalCall {
-                func_name: "DebugMe::foo".to_string(),
-                args: Some(Vec::new()),
-                return_data: Some(return_data),
-            },
+            DecodedInternalCall { func_name: func_name.to_string(), args, return_data },
             end_step,
         )));
         step
@@ -1251,6 +1242,43 @@ mod tests {
     }
 
     #[test]
+    fn decode_internal_parameter_values_accepts_matching_overload_args() {
+        let mut context = context_with_arena(vec![debug_node(
+            0,
+            0,
+            vec![internal_call_step_named(
+                "DebugMe::foo(uint256)",
+                2,
+                Some(vec!["42".to_string()]),
+                None,
+            )],
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+
+        assert_eq!(
+            tui.decode_internal_parameter_values(&scope("foo", "(uint256 amount)")),
+            Some(vec!["42".to_string()])
+        );
+    }
+
+    #[test]
+    fn decode_internal_parameter_values_rejects_wrong_overload_args() {
+        let mut context = context_with_arena(vec![debug_node(
+            0,
+            0,
+            vec![internal_call_step_named(
+                "DebugMe::foo(address)",
+                2,
+                Some(vec!["0x000000000000000000000000000000000000002a".to_string()]),
+                None,
+            )],
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+
+        assert_eq!(tui.decode_internal_parameter_values(&scope("foo", "(uint256 amount)")), None);
+    }
+
+    #[test]
     fn decode_return_values_uses_absolute_internal_call_end_step() {
         let mut context = context_with_arena(vec![debug_node(
             0,
@@ -1274,6 +1302,27 @@ mod tests {
         tui.draw_memory.inner_call_index = 2;
 
         assert_eq!(tui.decode_return_values(&scope("foo", "()")), Some(vec!["7".to_string()]));
+    }
+
+    #[test]
+    fn decode_return_values_rejects_wrong_overload() {
+        let mut context = context_with_arena(vec![debug_node(
+            0,
+            0,
+            vec![
+                internal_call_step_named(
+                    "DebugMe::foo(address)",
+                    1,
+                    None,
+                    Some(vec!["99".to_string()]),
+                ),
+                trace_step(Vec::new()),
+            ],
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.current_step = 1;
+
+        assert_eq!(tui.decode_return_values(&scope("foo", "(uint256 amount)")), None);
     }
 
     #[test]

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -217,7 +217,40 @@ fn parse_function_from_loc(source: &SourceData, loc: &SourceElement) -> Option<S
     let function_name = source_part.split_once("function")?.1.split('(').next()?.trim();
     let contract_name = source.find_contract_name(start, end)?;
 
-    Some(format!("{contract_name}::{function_name}"))
+    Some(internal_function_identifier(contract_name, function_name, source_part))
+}
+
+fn internal_function_identifier(
+    contract_name: &str,
+    function_name: &str,
+    source_part: &str,
+) -> String {
+    let signature = canonical_function_signature(function_name, source_part)
+        .unwrap_or_else(|| function_name.to_string());
+    format!("{contract_name}::{signature}")
+}
+
+fn canonical_function_signature(function_name: &str, source_part: &str) -> Option<String> {
+    let source_part = source_part.replace('\n', "");
+    let (inputs, _) = parse_types(&source_part);
+    let inputs = inputs?;
+    let types =
+        inputs.params.iter().map(|param| param.resolve().ok()).collect::<Option<Vec<_>>>()?;
+    Some(function_signature(function_name, &types))
+}
+
+fn function_signature(function_name: &str, types: &[DynSolType]) -> String {
+    let mut signature = String::new();
+    signature.push_str(function_name);
+    signature.push('(');
+    for (i, ty) in types.iter().enumerate() {
+        if i > 0 {
+            signature.push(',');
+        }
+        signature.push_str(&ty.sol_type_name());
+    }
+    signature.push(')');
+    signature
 }
 
 fn source_span(source: &str, start: usize, len: usize) -> Option<(&str, usize)> {
@@ -347,7 +380,9 @@ fn memory_range(memory: &[u8], start: usize, len: usize) -> Option<&[u8]> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode_from_memory, decode_step_parameters, source_span};
+    use super::{
+        decode_from_memory, decode_step_parameters, internal_function_identifier, source_span,
+    };
     use alloy_dyn_abi::{DynSolType, parser::Parameters};
     use alloy_primitives::{Bytes, U256};
     use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
@@ -377,6 +412,18 @@ mod tests {
         assert_eq!(source_span("abcdef", 2, 3), Some(("cde", 5)));
         assert_eq!(source_span("abcdef", 7, 1), None);
         assert_eq!(source_span("abcdef", usize::MAX, 1), None);
+    }
+
+    #[test]
+    fn internal_function_identifier_includes_canonical_signature() {
+        assert_eq!(
+            internal_function_identifier(
+                "DebugMe",
+                "foo",
+                "function foo(uint256 amount, bool ok) internal returns (uint256) {",
+            ),
+            "DebugMe::foo(uint256,bool)"
+        );
     }
 
     #[test]

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -206,7 +206,8 @@ impl<'a> DebugStepsWalker<'a> {
 /// Tries to parse the function name from the source code and detect the contract name which
 /// contains the given function.
 ///
-/// Returns string in the format `Contract::function`.
+/// Returns a string in the format `Contract::function(types)` when parameters can be resolved,
+/// falling back to `Contract::function`.
 fn parse_function_from_loc(source: &SourceData, loc: &SourceElement) -> Option<String> {
     let start = loc.offset() as usize;
     let (source_part, end) = source_span(&source.source, start, loc.length() as usize)?;
@@ -239,7 +240,8 @@ fn canonical_function_signature(function_name: &str, source_part: &str) -> Optio
     Some(function_signature(function_name, &types))
 }
 
-fn function_signature(function_name: &str, types: &[DynSolType]) -> String {
+/// Formats an ABI-style function signature from a name and canonical parameter types.
+pub fn function_signature(function_name: &str, types: &[DynSolType]) -> String {
     let mut signature = String::new();
     signature.push_str(function_name);
     signature.push('(');

--- a/crates/evm/traces/src/folded_stack_trace.rs
+++ b/crates/evm/traces/src/folded_stack_trace.rs
@@ -228,7 +228,34 @@ impl FoldedStackTraceBuilder {
     }
 }
 
+#[cfg(test)]
 mod tests {
+    use alloy_primitives::{Bytes, U256};
+    use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
+    use revm_inspectors::tracing::{
+        CallTraceArena,
+        types::{CallTraceStep, DecodedInternalCall, DecodedTraceStep, TraceMemberOrder},
+    };
+
+    fn trace_step(gas_remaining: u64) -> CallTraceStep {
+        CallTraceStep {
+            pc: 0,
+            op: OpCode::STOP,
+            stack: Some(Vec::<U256>::new().into_boxed_slice()),
+            push_stack: None,
+            memory: None,
+            returndata: Bytes::new(),
+            gas_remaining,
+            gas_refund_counter: 0,
+            gas_used: 0,
+            gas_cost: 0,
+            storage_change: None,
+            status: Some(InstructionResult::Stop),
+            immediate_bytes: None,
+            decoded: None,
+        }
+    }
+
     #[test]
     fn test_fst_1() {
         let mut trace = super::FoldedStackTraceBuilder::default();
@@ -319,6 +346,29 @@ mod tests {
                 "top;child_b;child_c 500",
                 "top2 1700",
             ]
+        );
+    }
+
+    #[test]
+    fn folded_stack_trace_keeps_precise_internal_function_names() {
+        let mut arena = CallTraceArena::default();
+        let root = &mut arena.nodes_mut()[0];
+        root.trace.gas_used = 100;
+        root.trace.gas_limit = 100;
+        root.trace.steps = vec![trace_step(100), trace_step(70)];
+        root.trace.steps[0].decoded = Some(Box::new(DecodedTraceStep::InternalCall(
+            DecodedInternalCall {
+                func_name: "DebugVarsTest::foo(uint256)".to_string(),
+                args: Some(vec!["42".to_string()]),
+                return_data: Some(vec!["43".to_string()]),
+            },
+            1,
+        )));
+        root.ordering = vec![TraceMemberOrder::Step(0), TraceMemberOrder::Step(1)];
+
+        assert_eq!(
+            super::build(&arena, false),
+            vec!["fallback 70", "fallback;DebugVarsTest::foo(uint256) 30",]
         );
     }
 }

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -55,6 +55,32 @@ fn setup_testdata_cmd(cmd: &mut TestCommand) {
     drop(dotenv);
 }
 
+fn collect_debug_dump_internal_calls<'a>(
+    value: &'a serde_json::Value,
+    calls: &mut Vec<&'a serde_json::Value>,
+) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_debug_dump_internal_calls(value, calls);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            if let Some(call) = map
+                .get("InternalCall")
+                .and_then(|value| value.as_array())
+                .and_then(|values| values.first())
+            {
+                calls.push(call);
+            }
+            for value in map.values() {
+                collect_debug_dump_internal_calls(value, calls);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Contracts excluded from the main `testdata` run because they depend on flaky external RPCs.
 /// These are run separately by the `flaky_testdata` test below.
 /// Format: pipe-separated regex alternation, e.g. `"Foo|Bar|Baz"`.
@@ -2665,6 +2691,70 @@ contract Dummy {
     cmd.assert_success();
 
     assert!(dump_path.exists());
+});
+
+forgetest!(debug_dump_disambiguates_overloaded_internal_functions, |prj, cmd| {
+    prj.add_source(
+        "DebugVars",
+        r"
+contract DebugVarsTest {
+    function testOverloadedInternalDebugVars() public {
+        uint256 amount = foo(uint256(42));
+        address who = foo(address(0x000000000000000000000000000000000000bEEF));
+
+        require(amount == 43, 'bad amount');
+        require(who == address(0x000000000000000000000000000000000000bEEF), 'bad address');
+    }
+
+    function foo(uint256 amount) internal pure returns (uint256 out) {
+        uint256 next = amount + 1;
+        return next;
+    }
+
+    function foo(address who) internal pure returns (address out) {
+        address seen = who;
+        return seen;
+    }
+}
+",
+    );
+
+    let dump_path = prj.root().join("overloads_dump.json");
+
+    cmd.args([
+        "test",
+        "--mt",
+        "testOverloadedInternalDebugVars",
+        "--debug",
+        "--dump",
+        dump_path.to_str().unwrap(),
+    ]);
+    cmd.assert_success();
+
+    let dump: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dump_path).unwrap()).unwrap();
+    let mut calls = Vec::new();
+    collect_debug_dump_internal_calls(&dump, &mut calls);
+
+    let uint_call = calls
+        .iter()
+        .find(|call| call["func_name"] == "DebugVarsTest::foo(uint256)")
+        .expect("missing uint256 overload in debugger dump");
+    assert_eq!(uint_call["args"], serde_json::json!(["42"]));
+    assert_eq!(uint_call["return_data"], serde_json::json!(["43"]));
+
+    let address_call = calls
+        .iter()
+        .find(|call| call["func_name"] == "DebugVarsTest::foo(address)")
+        .expect("missing address overload in debugger dump");
+    assert_eq!(
+        address_call["args"],
+        serde_json::json!(["0x000000000000000000000000000000000000bEEF"])
+    );
+    assert_eq!(
+        address_call["return_data"],
+        serde_json::json!(["0x000000000000000000000000000000000000bEEF"])
+    );
 });
 
 // <https://github.com/foundry-rs/foundry/issues/10322>

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -1520,13 +1520,13 @@ Traces:
     ├─ [165406] → new SimpleContract@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
     │   └─ ← [Return] 826 bytes of code
     ├─ [22630] SimpleContract::increment()
-    │   ├─ [20147] SimpleContract::_setNum(1)
+    │   ├─ [20147] SimpleContract::_setNum(uint256)(1)
     │   │   └─ ← 0
     │   └─ ← [Stop]
     ├─ [23204] SimpleContract::setValues(100, 0x0000000000000000000000000000000000000123)
-    │   ├─ [247] SimpleContract::_setNum(100)
+    │   ├─ [247] SimpleContract::_setNum(uint256)(100)
     │   │   └─ ← 1
-    │   ├─ [22336] SimpleContract::_setAddr(0x0000000000000000000000000000000000000123)
+    │   ├─ [22336] SimpleContract::_setAddr(address)(0x0000000000000000000000000000000000000123)
     │   │   └─ ← 0x0000000000000000000000000000000000000000
     │   └─ ← [Stop]
     └─ ← [Stop]
@@ -1576,7 +1576,7 @@ Traces:
     ├─ [..] → new SimpleContract@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
     │   └─ ← [Return] [..] bytes of code
     ├─ [..] SimpleContract::setStr("new value")
-    │   ├─ [..] SimpleContract::_setStr("new value")
+    │   ├─ [..] SimpleContract::_setStr(string)("new value")
     │   │   └─ ← "initial value"
     │   └─ ← [Stop]
     └─ ← [Stop]

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -1427,7 +1427,7 @@ Traces:
     │   └─ ← [Stop]
     ├─ [..] Counter::number() [staticcall]
     │   └─ ← [Return] 1
-    ├─ [..] StdAssertions::assertEq(1, 1)
+    ├─ [..] StdAssertions::assertEq(uint256,uint256)(1, 1)
     │   └─ ← 
     └─ ← [Stop]
 


### PR DESCRIPTION
## Summary
- Include canonical parameter types in decoded internal debugger call names when source parsing succeeds.
- Match the Variables pane against the canonical internal signature so overloaded internal functions do not reuse parameter or return values from the wrong overload.
- Keep legacy name-only matching for existing dumps and unparseable source spans.
- Add focused unit and `forge test --debug --dump` coverage for overloaded internal calls; folded stack traces now document the same precise internal names.

Refs #410.