### PR TITLE
chore: pin Tempo main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4276,7 +4276,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4560,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6895,7 +6895,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7689,7 +7689,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9369,7 +9369,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9449,7 +9449,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9463,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9500,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9514,7 +9514,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9530,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9543,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9557,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9580,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9600,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9613,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9632,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9699,7 +9699,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9714,7 +9714,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9727,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9790,7 +9790,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9804,7 +9804,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.3",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9847,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=fa3859e#fa3859e6ef44cb18178b9bc0148ea9a3a1280765"
+source = "git+https://github.com/paradigmxyz/reth?rev=f955d2907c9b51f101ec93848bce36101a1ee7e3#f955d2907c9b51f101ec93848bce36101a1ee7e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10383,7 +10383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10442,7 +10442,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11167,7 +11167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11716,13 +11716,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
+source = "git+https://github.com/tempoxyz/tempo?rev=2cf84002140367ff6de3268e5bf39972b8a0dc6c#2cf84002140367ff6de3268e5bf39972b8a0dc6c"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11755,7 +11755,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
+source = "git+https://github.com/tempoxyz/tempo?rev=2cf84002140367ff6de3268e5bf39972b8a0dc6c#2cf84002140367ff6de3268e5bf39972b8a0dc6c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11778,7 +11778,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
+source = "git+https://github.com/tempoxyz/tempo?rev=2cf84002140367ff6de3268e5bf39972b8a0dc6c#2cf84002140367ff6de3268e5bf39972b8a0dc6c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11789,7 +11789,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
+source = "git+https://github.com/tempoxyz/tempo?rev=2cf84002140367ff6de3268e5bf39972b8a0dc6c#2cf84002140367ff6de3268e5bf39972b8a0dc6c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11801,7 +11801,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
+source = "git+https://github.com/tempoxyz/tempo?rev=2cf84002140367ff6de3268e5bf39972b8a0dc6c#2cf84002140367ff6de3268e5bf39972b8a0dc6c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11820,6 +11820,7 @@ dependencies = [
  "reth-revm",
  "tempo-chainspec",
  "tempo-contracts",
+ "tempo-precompiles",
  "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.18",
@@ -11829,7 +11830,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
+source = "git+https://github.com/tempoxyz/tempo?rev=2cf84002140367ff6de3268e5bf39972b8a0dc6c#2cf84002140367ff6de3268e5bf39972b8a0dc6c"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11850,7 +11851,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
+source = "git+https://github.com/tempoxyz/tempo?rev=2cf84002140367ff6de3268e5bf39972b8a0dc6c#2cf84002140367ff6de3268e5bf39972b8a0dc6c"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11861,7 +11862,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
+source = "git+https://github.com/tempoxyz/tempo?rev=2cf84002140367ff6de3268e5bf39972b8a0dc6c#2cf84002140367ff6de3268e5bf39972b8a0dc6c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11892,7 +11893,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=563fc42578a9920067d129b0f191250e3a616a38#563fc42578a9920067d129b0f191250e3a616a38"
+source = "git+https://github.com/tempoxyz/tempo?rev=2cf84002140367ff6de3268e5bf39972b8a0dc6c#2cf84002140367ff6de3268e5bf39972b8a0dc6c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11919,7 +11920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13181,7 +13182,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13319,7 +13320,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,17 +507,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "9de5344a961c13dd4b201
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -594,9 +594,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "ba6246789fc12cf8fe78aa74aadf31d663f08c1f" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "563fc42578a9920067d129b0f191250e3a616a38" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -184,7 +184,7 @@ use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::evm::TempoEvmFactory;
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS, extend_tempo_precompiles,
-    storage::StorageCtx,
+    storage::{StorageActions, StorageCtx},
     tip_fee_manager::{IFeeManager, TipFeeManager},
     tip20::{ISSUER_ROLE, ITIP20, TIP20Token},
 };
@@ -1191,7 +1191,7 @@ impl<N: Network> Backend<N> {
         cfg_env: &CfgEnv<TempoHardfork>,
     ) {
         self.inject_precompiles(precompiles);
-        extend_tempo_precompiles(precompiles, cfg_env);
+        extend_tempo_precompiles(precompiles, cfg_env, StorageActions::disabled());
     }
 
     /// Creates a concrete EVM, injects precompiles, transacts, and returns the result mapped

--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -46,6 +46,7 @@ pub struct AnvilStorageProvider<'a> {
     gas_used: u64,
     gas_refunded: i64,
     reservoir: u64,
+    tip1060_storage_credits_enabled: bool,
     transient: HashMap<(Address, U256), U256>,
     hardfork: TempoHardfork,
 }
@@ -66,6 +67,7 @@ impl<'a> AnvilStorageProvider<'a> {
             gas_used: 0,
             gas_refunded: 0,
             reservoir: 0,
+            tip1060_storage_credits_enabled: hardfork.is_t7(),
             transient: HashMap::new(),
             hardfork,
         }
@@ -204,6 +206,10 @@ impl PrecompileStorageProvider for AnvilStorageProvider<'_> {
 
     fn amsterdam_eip8037_enabled(&self) -> bool {
         false
+    }
+
+    fn set_tip1060_storage_credits(&mut self, enabled: bool) {
+        self.tip1060_storage_credits_enabled = enabled && self.hardfork.is_t7();
     }
 }
 

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -13,7 +13,10 @@ use revm::{
     state::Bytecode,
 };
 use tempo_evm::{TempoBlockEnv, TempoEvmFactory, TempoHaltReason, evm::TempoEvm};
-use tempo_precompiles::{extend_tempo_precompiles, storage::StorageCtx};
+use tempo_precompiles::{
+    extend_tempo_precompiles,
+    storage::{StorageActions, StorageCtx},
+};
 use tempo_revm::{
     TempoInvalidTransaction, TempoTxEnv, evm::TempoContext, gas_params::tempo_gas_params,
     handler::TempoEvmHandler,
@@ -46,23 +49,32 @@ pub(crate) fn initialize_tempo_evm<
     is_forked: bool,
 ) {
     let ctx = evm.ctx_mut();
-    StorageCtx::enter_evm(&mut ctx.journaled_state, &ctx.block, &ctx.cfg, &ctx.tx, || {
-        if is_forked {
-            // In fork mode, warm up precompile accounts to avoid repeated RPC fetches.
-            let mut sctx = StorageCtx;
-            let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
-            for addr in
-                TEMPO_PRECOMPILE_ADDRESSES.iter().copied().chain(TEMPO_TIP20_TOKENS.iter().copied())
-            {
-                sctx.set_code(addr, sentinel.clone())
-                    .expect("failed to warm tempo precompile address");
+    StorageCtx::enter_evm(
+        &mut ctx.journaled_state,
+        &ctx.block,
+        &ctx.cfg,
+        &ctx.tx,
+        StorageActions::disabled(),
+        || {
+            if is_forked {
+                // In fork mode, warm up precompile accounts to avoid repeated RPC fetches.
+                let mut sctx = StorageCtx;
+                let sentinel = Bytecode::new_legacy(Bytes::from_static(&[0xef]));
+                for addr in TEMPO_PRECOMPILE_ADDRESSES
+                    .iter()
+                    .copied()
+                    .chain(TEMPO_TIP20_TOKENS.iter().copied())
+                {
+                    sctx.set_code(addr, sentinel.clone())
+                        .expect("failed to warm tempo precompile address");
+                }
+            } else {
+                // In non-fork mode, run full genesis initialization.
+                initialize_tempo_test_genesis_inner(TEST_CONTRACT_ADDRESS, CALLER)
+                    .expect("tempo genesis initialization failed");
             }
-        } else {
-            // In non-fork mode, run full genesis initialization.
-            initialize_tempo_test_genesis_inner(TEST_CONTRACT_ADDRESS, CALLER)
-                .expect("tempo genesis initialization failed");
-        }
-    });
+        },
+    );
 }
 
 impl FoundryEvmFactory for TempoEvmFactory {
@@ -89,7 +101,7 @@ impl FoundryEvmFactory for TempoEvmFactory {
         let networks = tempo_evm.inspector().get_networks();
         networks.inject_precompiles(tempo_evm.precompiles_mut());
         let cfg = tempo_evm.cfg.clone();
-        extend_tempo_precompiles(tempo_evm.precompiles_mut(), &cfg);
+        extend_tempo_precompiles(tempo_evm.precompiles_mut(), &cfg, StorageActions::disabled());
 
         initialize_tempo_evm(&mut tempo_evm, is_forked);
         tempo_evm


### PR DESCRIPTION
Pins Tempo dependencies to current tempoxyz/tempo main (`2cf84002140367ff6de3268e5bf39972b8a0dc6c`) on top of latest foundry-rs/foundry master.

Changes:
- Bumps existing Tempo git revs to `2cf84002...`.
- Updates the corresponding Tempo lockfile entries.
- Keeps Foundry's Tempo precompile setup passing `StorageActions::disabled()`.
- Keeps the TIP-1060 storage-credit trait compatibility implementation for Anvil.

Validation:
- `cargo check --workspace`

Prompted by: @shekhirin