### PR TITLE
fix(verify): print Sourcify job UI URL instead of status API URL on submission

### DIFF
--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -100,7 +100,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
             .await?;
 
         if let Some(resp) = resp {
-            let job_url = Self::get_job_status_url(
+            let job_url = Self::get_job_ui_url(
                 args.verifier.verifier_url.as_deref(),
                 resp.verification_id.clone(),
             );
@@ -206,6 +206,11 @@ impl SourcifyVerificationProvider {
     fn get_job_status_url(verifier_url: Option<&str>, job_id: String) -> String {
         let base_url = Self::get_base_url(verifier_url);
         format!("{base_url}v2/verify/{job_id}")
+    }
+
+    fn get_job_ui_url(verifier_url: Option<&str>, job_id: String) -> String {
+        let base_url = Self::get_base_url(verifier_url);
+        format!("{base_url}verify-ui/jobs/{job_id}")
     }
 
     fn get_lookup_url(


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This change is for consistency with the Etherscan submission. When you submit on Etherscan, a URL to the explorer UI is printed to the user. Currently, when you verify on Sourcify, it prints an API URL. I added this behavior originally in #11438, because the server and the UI have different base URLs. However, the Sourcify server provides an endpoint now which redirects to the job UI. This endpoint solves the original problem.

## Solution

Replace the printed URL with the `sourcify.dev/server/verify-ui/jobs/{job_id}` URL for better UX.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
