### PR TITLE
feat(debugger): add opcode search to TUI

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -68,6 +68,10 @@ pub(crate) struct TUIContext<'a> {
     pub(crate) key_buffer: String,
     /// Current goto program counter prompt contents, if the prompt is active.
     pub(crate) pc_input: Option<String>,
+    /// Current opcode search prompt contents, if the prompt is active.
+    pub(crate) opcode_search_input: Option<String>,
+    /// Last opcode search term, used by repeat-search shortcuts.
+    pub(crate) last_opcode_search: Option<String>,
     /// Last status or error message to show in the footer.
     pub(crate) status: Option<StatusMessage>,
     /// Current step in the debug steps.
@@ -91,6 +95,8 @@ impl<'a> TUIContext<'a> {
 
             key_buffer: String::with_capacity(64),
             pc_input: None,
+            opcode_search_input: None,
+            last_opcode_search: None,
             status: None,
             current_step: 0,
             draw_memory: DrawMemory::default(),
@@ -178,6 +184,11 @@ impl TUIContext<'_> {
     }
 
     fn handle_key_event(&mut self, event: KeyEvent) -> ControlFlow<ExitReason> {
+        if self.opcode_search_input.is_some() {
+            self.handle_opcode_search_input_key_event(event);
+            return ControlFlow::Continue(());
+        }
+
         if self.pc_input.is_some() {
             self.handle_pc_input_key_event(event);
             return ControlFlow::Continue(());
@@ -314,6 +325,23 @@ impl TUIContext<'_> {
                 self.pc_input = Some(String::new());
             }
 
+            // Search opcodes in the current call
+            KeyCode::Char('/') => {
+                self.key_buffer.clear();
+                self.status = None;
+                self.opcode_search_input = Some(String::new());
+            }
+
+            // Repeat opcode search forward
+            KeyCode::Char('n') => self.repeat(|this| {
+                this.repeat_opcode_search(SearchDirection::Forward);
+            }),
+
+            // Repeat opcode search backward
+            KeyCode::Char('N') => self.repeat(|this| {
+                this.repeat_opcode_search(SearchDirection::Backward);
+            }),
+
             // Toggle help notice
             KeyCode::Char('h') => self.show_shortcuts = !self.show_shortcuts,
 
@@ -357,6 +385,65 @@ impl TUIContext<'_> {
             }
             _ => {}
         }
+    }
+
+    fn handle_opcode_search_input_key_event(&mut self, event: KeyEvent) {
+        match event.code {
+            KeyCode::Esc => {
+                self.opcode_search_input = None;
+            }
+            KeyCode::Enter => {
+                let input = self.opcode_search_input.take().unwrap_or_default();
+                self.search_opcode_from_input(&input);
+            }
+            KeyCode::Backspace => {
+                if let Some(input) = &mut self.opcode_search_input {
+                    input.pop();
+                }
+            }
+            KeyCode::Char(c) if !event.modifiers.contains(KeyModifiers::CONTROL) => {
+                if let Some(input) = &mut self.opcode_search_input {
+                    input.push(c);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn search_opcode_from_input(&mut self, input: &str) {
+        let query = input.trim();
+        if query.is_empty() {
+            self.set_error("Enter an opcode search term".to_string());
+            return;
+        }
+
+        self.last_opcode_search = Some(query.to_string());
+        self.search_opcode(query, SearchDirection::Forward);
+    }
+
+    fn repeat_opcode_search(&mut self, direction: SearchDirection) {
+        let Some(query) = self.last_opcode_search.clone() else {
+            self.set_error("No previous opcode search".to_string());
+            return;
+        };
+
+        self.search_opcode(&query, direction);
+    }
+
+    fn search_opcode(&mut self, query: &str, direction: SearchDirection) {
+        let Some(step_index) =
+            find_opcode_match(&self.opcode_list, self.current_step, query, direction)
+        else {
+            self.set_error(format!("No opcode matching `{query}` in current call"));
+            return;
+        };
+
+        self.current_step = step_index;
+        self.scroll_memory_to_current_write();
+
+        let pc = self.current_step().pc;
+        let opcode = self.opcode_list.get(step_index).map(String::as_str).unwrap_or_default();
+        self.set_info(format!("Found `{query}` at PC 0x{pc:x} ({pc}): {opcode}"));
     }
 
     fn goto_pc_from_input(&mut self, input: &str) {
@@ -460,7 +547,7 @@ impl TUIContext<'_> {
     }
 
     fn handle_mouse_event(&mut self, event: MouseEvent) -> ControlFlow<ExitReason> {
-        if self.pc_input.is_some() {
+        if self.pc_input.is_some() || self.opcode_search_input.is_some() {
             return ControlFlow::Continue(());
         }
 
@@ -558,6 +645,12 @@ fn buffer_as_number(s: &str) -> usize {
 
 const fn is_pc_input_char(c: char) -> bool {
     c.is_ascii_hexdigit() || matches!(c, 'x' | 'X' | ':')
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SearchDirection {
+    Forward,
+    Backward,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -720,6 +813,34 @@ fn pc_exists_outside_code_context(arena: &[DebugNode], current: &DebugNode, pc: 
     })
 }
 
+fn find_opcode_match(
+    opcodes: &[String],
+    current_step: usize,
+    query: &str,
+    direction: SearchDirection,
+) -> Option<usize> {
+    if opcodes.is_empty() {
+        return None;
+    }
+
+    let needle = query.trim().to_ascii_lowercase();
+    if needle.is_empty() {
+        return None;
+    }
+
+    let current = current_step.min(opcodes.len() - 1);
+    let matches = |i: usize| opcodes[i].to_ascii_lowercase().contains(&needle);
+
+    match direction {
+        SearchDirection::Forward => {
+            ((current + 1)..opcodes.len()).chain(0..=current).find(|&i| matches(i))
+        }
+        SearchDirection::Backward => {
+            (0..current).rev().chain((current..opcodes.len()).rev()).find(|&i| matches(i))
+        }
+    }
+}
+
 fn pretty_opcode(step: &CallTraceStep) -> String {
     if let Some(immediate) = step.immediate_bytes.as_ref().filter(|b| !b.is_empty()) {
         format!("{}(0x{})", step.op, hex::encode(immediate))
@@ -762,6 +883,13 @@ mod tests {
 
     fn step(pc: usize) -> CallTraceStep {
         step_with_stack(pc, OpCode::STOP, &[])
+    }
+
+    fn step_with_immediate(pc: usize, op: OpCode, immediate: &'static [u8]) -> CallTraceStep {
+        CallTraceStep {
+            immediate_bytes: Some(Bytes::from_static(immediate)),
+            ..step_with_stack(pc, op, &[])
+        }
     }
 
     fn step_with_stack(pc: usize, op: OpCode, stack: &[usize]) -> CallTraceStep {
@@ -1039,6 +1167,154 @@ mod tests {
         assert_eq!(tui.pc_input, None);
         assert_eq!(tui.current_step, 0);
         assert_eq!(tui.status, None);
+    }
+
+    #[test]
+    fn opcode_search_wraps_and_is_case_insensitive() {
+        let opcodes =
+            vec!["STOP".to_string(), "PUSH4(0x95d89b41)".to_string(), "MSTORE".to_string()];
+
+        assert_eq!(find_opcode_match(&opcodes, 0, "push4", SearchDirection::Forward), Some(1));
+        assert_eq!(find_opcode_match(&opcodes, 0, "95D89B41", SearchDirection::Forward), Some(1));
+        assert_eq!(find_opcode_match(&opcodes, 0, "mstore", SearchDirection::Backward), Some(2));
+        assert_eq!(find_opcode_match(&opcodes, 0, "sload", SearchDirection::Forward), None);
+    }
+
+    #[test]
+    fn opcode_search_input_mode_handles_keys_and_blocks_normal_commands() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![
+                step(1),
+                step_with_immediate(2, OpCode::PUSH4, &[0x95, 0xd8, 0x9b, 0x41]),
+                step_with_stack(3, OpCode::MSTORE, &[]),
+            ],
+            Bytes::new(),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        assert!(matches!(tui.handle_key_event(key(KeyCode::Char('/'))), ControlFlow::Continue(())));
+        assert_eq!(tui.opcode_search_input.as_deref(), Some(""));
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('q')));
+        assert_eq!(tui.opcode_search_input.as_deref(), Some("q"));
+        assert_eq!(tui.current_step, 0);
+
+        let _ = tui.handle_key_event(key(KeyCode::Backspace));
+        let _ = tui.handle_key_event(key(KeyCode::Char('9')));
+        let _ = tui.handle_key_event(key(KeyCode::Char('5')));
+        let _ = tui.handle_key_event(key(KeyCode::Enter));
+
+        assert_eq!(tui.opcode_search_input, None);
+        assert_eq!(tui.last_opcode_search.as_deref(), Some("95"));
+        assert_eq!(tui.current_step, 1);
+        assert_eq!(tui.status.as_ref().unwrap().kind, StatusKind::Info);
+    }
+
+    #[test]
+    fn opcode_search_repeats_forward_and_backward() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![
+                step_with_stack(1, OpCode::MSTORE, &[]),
+                step(2),
+                step_with_stack(3, OpCode::MSTORE, &[]),
+            ],
+            Bytes::new(),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('/')));
+        for c in "mstore".chars() {
+            let _ = tui.handle_key_event(key(KeyCode::Char(c)));
+        }
+        let _ = tui.handle_key_event(key(KeyCode::Enter));
+        assert_eq!(tui.current_step, 2);
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('n')));
+        assert_eq!(tui.current_step, 0);
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('N')));
+        assert_eq!(tui.current_step, 2);
+    }
+
+    #[test]
+    fn opcode_search_escape_cancels_without_moving() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1, 42])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('/')));
+        let _ = tui.handle_key_event(key(KeyCode::Char('s')));
+        let _ = tui.handle_key_event(key(KeyCode::Esc));
+
+        assert_eq!(tui.opcode_search_input, None);
+        assert_eq!(tui.last_opcode_search, None);
+        assert_eq!(tui.current_step, 0);
+        assert_eq!(tui.status, None);
+    }
+
+    #[test]
+    fn opcode_search_reports_empty_input_without_remembering_search() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1, 42])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('/')));
+        let _ = tui.handle_key_event(key(KeyCode::Enter));
+
+        assert_eq!(tui.current_step, 0);
+        assert_eq!(tui.last_opcode_search, None);
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "Enter an opcode search term");
+    }
+
+    #[test]
+    fn opcode_search_reports_repeat_without_previous_search() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1, 42])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('n')));
+
+        assert_eq!(tui.current_step, 0);
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "No previous opcode search");
+    }
+
+    #[test]
+    fn opcode_search_reports_no_match_without_moving() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1, 42])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('/')));
+        for c in "sload".chars() {
+            let _ = tui.handle_key_event(key(KeyCode::Char(c)));
+        }
+        let _ = tui.handle_key_event(key(KeyCode::Enter));
+
+        assert_eq!(tui.current_step, 0);
+        assert_eq!(tui.last_opcode_search.as_deref(), Some("sload"));
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "No opcode matching `sload` in current call");
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -195,7 +195,9 @@ impl TUIContext<'_> {
     }
 
     fn footer_height(&self) -> u16 {
-        let status_or_input = u16::from(self.pc_input.is_some() || self.status.is_some());
+        let status_or_input = u16::from(
+            self.pc_input.is_some() || self.opcode_search_input.is_some() || self.status.is_some(),
+        );
         let shortcuts = if self.show_shortcuts { 2 } else { 0 };
         status_or_input + shortcuts
     }
@@ -216,6 +218,19 @@ impl TUIContext<'_> {
                     Style::new().add_modifier(Modifier::DIM),
                 ),
             ]));
+        } else if let Some(input) = &self.opcode_search_input {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "Search opcodes: /",
+                    Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(input.as_str()),
+                Span::styled("█", Style::new().fg(Color::Cyan)),
+                Span::styled(
+                    "  Enter: jump | Esc: cancel | after search: n/N repeat",
+                    Style::new().add_modifier(Modifier::DIM),
+                ),
+            ]));
         } else if let Some(status) = &self.status {
             let style = match status.kind {
                 StatusKind::Info => Style::new().fg(Color::Green),
@@ -224,8 +239,8 @@ impl TUIContext<'_> {
             lines.push(Line::from(Span::styled(status.text.as_str(), style)));
         }
 
-        let l1 = "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end | [p]: goto PC | [b]: cycle memory/calldata/returndata buffers";
-        let l2 = "[l]: layout | [t]: stack labels | [m]: buffer decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll buffer | ['<char>]: goto breakpoint | [h] toggle help";
+        let l1 = "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end | [p]: goto PC | [/]: search opcodes | [n/N]: next/prev search";
+        let l2 = "[l]: layout | [b]: cycle buffer | [t]: stack labels | [m]: buffer decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll buffer | ['<char>]: goto breakpoint | [h] toggle help";
         let dimmed = Style::new().add_modifier(Modifier::DIM);
         if self.show_shortcuts {
             lines.push(Line::from(Span::styled(l1, dimmed)));


### PR DESCRIPTION
## Summary

- Adds `/` search over the current debugger opcode pane.
- Adds `n` / `N` to repeat the last opcode search forward/backward.
- Shows search prompt/status in the debugger footer and preserves existing buffer-cycle help.
- Adds unit coverage for matching, wrapping, input mode, repeat search, cancel, and error paths.

Refs #927.