### PR TITLE
feat(lint): add incorrect-exp detector

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -8,6 +8,7 @@ It helps enforce best practices and improve code quality within Foundry projects
 `forge-lint` includes rules across several categories:
 
 - **High Severity:**
+  - `incorrect-exp`: Flags `^` (bitwise xor) used where `**` (exponentiation) was likely intended.
   - `incorrect-shift`: Warns against shift operations where operands might be in the wrong order.
   - `unchecked-call`: Low-level calls should check the success return value.
   - `erc20-unchecked-transfer`: ERC20 `transfer` and `transferFrom` calls should check the return value.

--- a/crates/lint/docs/incorrect-exp.md
+++ b/crates/lint/docs/incorrect-exp.md
@@ -1,0 +1,28 @@
+# Incorrect exponentiation
+
+**Severity**: `High`
+**ID**: `incorrect-exp`
+
+Flags `^` used between integer literals where `**` was almost certainly intended.
+
+## What it does
+
+Reports `a ^ b` when both `a` and `b` are non-hex integer literals. In Solidity `^` is bitwise xor, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`. Hex literals are excluded, since xor of a bit pattern is a legitimate operation.
+
+## Why is this bad?
+
+Developers coming from languages where `^` means exponentiation (Python, many calculators) write `10 ^ 18` expecting `10 ** 18`. The contract compiles and silently uses the wrong constant, which can corrupt amounts, decimals, or limits.
+
+## Example
+
+### Bad
+
+```solidity
+uint256 constant WAD = 10 ^ 18; // evaluates to 24, not 1e18
+```
+
+### Good
+
+```solidity
+uint256 constant WAD = 10 ** 18;
+```

--- a/crates/lint/docs/incorrect-exp.md
+++ b/crates/lint/docs/incorrect-exp.md
@@ -7,7 +7,9 @@ Flags `^` used between integer literals where `**` was almost certainly intended
 
 ## What it does
 
-Reports `a ^ b` when both `a` and `b` are non-hex integer literals. In Solidity `^` is bitwise xor, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`. Hex literals are excluded, since xor of a bit pattern is a legitimate operation.
+Reports `a ^ b` when the base `a` is `2` or `10` and both operands are decimal integer literals (looking through casts such as `uint256(10)`). In Solidity `^` is bitwise xor, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`.
+
+The base is restricted to the values people actually write as powers (`2` for bit widths, `10` for decimals), and operands written in hex are left alone. This mirrors GCC's and Clang's `-Wxor-used-as-pow`, so legitimate decimal bitmask xors such as `255 ^ 128` are not flagged.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/incorrect-exp.md
+++ b/crates/lint/docs/incorrect-exp.md
@@ -7,9 +7,9 @@ Flags `^` used between integer literals where `**` was almost certainly intended
 
 ## What it does
 
-Reports `a ^ b` when the base `a` is `2` or `10` and both operands are decimal integer literals (looking through casts such as `uint256(10)`). In Solidity `^` is bitwise xor, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`.
+Reports `a ^ b` when the base `a` is `2` or `10` and both operands are plain decimal integer literals, looking through integer casts such as `uint256(10)`. In Solidity `^` is bitwise xor, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`.
 
-The base is restricted to the values people actually write as powers (`2` for bit widths, `10` for decimals), and operands written in hex are left alone. This mirrors GCC's and Clang's `-Wxor-used-as-pow`, so legitimate decimal bitmask xors such as `255 ^ 128` are not flagged.
+The base is restricted to the values people write as powers (`2` for bit widths, `10` for decimals). Operands written in hex (`0xff`), in scientific notation (`1e1`), or behind a non-integer cast (`bytes32(...)`) are left alone: the lint prefers a false negative to a false positive that would annoy developers. This mirrors GCC's and Clang's `-Wxor-used-as-pow`.
 
 ## Why is this bad?
 

--- a/crates/lint/src/sol/high/incorrect_exp.rs
+++ b/crates/lint/src/sol/high/incorrect_exp.rs
@@ -3,11 +3,12 @@ use crate::{
     linter::{LateLintPass, LintContext},
     sol::{Severity, SolLint},
 };
+use alloy_primitives::U256;
 use solar::{
     ast::{BinOpKind, LitKind},
     sema::{
         Gcx,
-        hir::{self, Expr, ExprKind},
+        hir::{self, Expr, ExprKind, TypeKind},
     },
 };
 
@@ -26,28 +27,54 @@ impl<'hir> LateLintPass<'hir> for IncorrectExp {
         _hir: &'hir hir::Hir<'hir>,
         expr: &'hir hir::Expr<'hir>,
     ) {
-        // `a ^ b` between two decimal integer literals is almost always a mistake for `a ** b`:
-        // `^` is bitwise xor in Solidity, so `10 ^ 18` is `24`, not `10 ** 18`. Hex literals are
-        // excluded since xor of bit patterns is a legitimate operation.
+        // `a ^ b` between integer literals is almost always a mistake for `a ** b`: `^` is bitwise
+        // xor in Solidity, so `10 ^ 18` is `24`, not `10 ** 18`.
+        //
+        // To stay precise, the base is restricted to `2` and `10` (bit widths and decimals, the
+        // only bases people write as powers) and hex operands are left alone. This mirrors GCC's
+        // and Clang's `-Wxor-used-as-pow`; Clippy's `suspicious_xor_used_as_pow`, which drops the
+        // base restriction, is allow-by-default precisely because of the resulting false positives.
         if let ExprKind::Binary(lhs, op, rhs) = &expr.kind
             && matches!(op.kind, BinOpKind::BitXor)
-            && is_decimal_int_lit(lhs)
-            && is_decimal_int_lit(rhs)
+            && let Some(base) = decimal_int_lit(lhs)
+            && (base == U256::from(2u64) || base == U256::from(10u64))
+            && decimal_int_lit(rhs).is_some()
         {
             ctx.emit(&INCORRECT_EXP, expr.span);
         }
     }
 }
 
-/// True for a non-hex integer literal (the form a misplaced `^` usually involves). Solidity has no
-/// binary or octal literals, so only hex (`0x`) needs to be excluded; xor of a hex bit pattern is a
-/// legitimate operation.
-fn is_decimal_int_lit(expr: &Expr<'_>) -> bool {
-    if let ExprKind::Lit(lit) = &expr.peel_parens().kind
-        && matches!(lit.kind, LitKind::Number(_))
+/// Returns the value of a decimal integer literal, looking through parentheses and elementary-type
+/// casts (`uint256(10)`), or `None` for anything else.
+///
+/// Solidity has no binary or octal literals, so only hex (`0x`) is excluded: xor of a hex bit
+/// pattern is a legitimate operation, and writing a number in hex is a strong signal the author
+/// really means bitwise work.
+fn decimal_int_lit(expr: &Expr<'_>) -> Option<U256> {
+    if let ExprKind::Lit(lit) = &peel_casts(expr).kind
+        && let LitKind::Number(value) = &lit.kind
     {
         let s = lit.symbol.as_str();
-        return !s.starts_with("0x") && !s.starts_with("0X");
+        if !s.starts_with("0x") && !s.starts_with("0X") {
+            return Some(*value);
+        }
     }
-    false
+    None
+}
+
+/// Looks through parentheses and elementary-type casts (`uint256(x)`, `int8(x)`), returning the
+/// innermost operand. A misplaced `^` can hide behind a cast (`uint256(10) ^ 18`), which a bare
+/// literal check would miss.
+fn peel_casts<'a, 'hir>(expr: &'a Expr<'hir>) -> &'a Expr<'hir> {
+    let expr = expr.peel_parens();
+    if let ExprKind::Call(callee, args, _) = &expr.kind
+        && let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(_), .. }) =
+            &callee.peel_parens().kind
+        && args.len() == 1
+        && let Some(inner) = args.exprs().next()
+    {
+        return peel_casts(inner);
+    }
+    expr
 }

--- a/crates/lint/src/sol/high/incorrect_exp.rs
+++ b/crates/lint/src/sol/high/incorrect_exp.rs
@@ -1,0 +1,53 @@
+use super::IncorrectExp;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    ast::{BinOpKind, LitKind},
+    sema::{
+        Gcx,
+        hir::{self, Expr, ExprKind},
+    },
+};
+
+declare_forge_lint!(
+    INCORRECT_EXP,
+    Severity::High,
+    "incorrect-exp",
+    "`^` is bitwise xor, not exponentiation; use `**`"
+);
+
+impl<'hir> LateLintPass<'hir> for IncorrectExp {
+    fn check_expr(
+        &mut self,
+        ctx: &LintContext,
+        _gcx: Gcx<'hir>,
+        _hir: &'hir hir::Hir<'hir>,
+        expr: &'hir hir::Expr<'hir>,
+    ) {
+        // `a ^ b` between two decimal integer literals is almost always a mistake for `a ** b`:
+        // `^` is bitwise xor in Solidity, so `10 ^ 18` is `24`, not `10 ** 18`. Hex literals are
+        // excluded since xor of bit patterns is a legitimate operation.
+        if let ExprKind::Binary(lhs, op, rhs) = &expr.kind
+            && matches!(op.kind, BinOpKind::BitXor)
+            && is_decimal_int_lit(lhs)
+            && is_decimal_int_lit(rhs)
+        {
+            ctx.emit(&INCORRECT_EXP, expr.span);
+        }
+    }
+}
+
+/// True for a non-hex integer literal (the form a misplaced `^` usually involves). Solidity has no
+/// binary or octal literals, so only hex (`0x`) needs to be excluded; xor of a hex bit pattern is a
+/// legitimate operation.
+fn is_decimal_int_lit(expr: &Expr<'_>) -> bool {
+    if let ExprKind::Lit(lit) = &expr.peel_parens().kind
+        && matches!(lit.kind, LitKind::Number(_))
+    {
+        let s = lit.symbol.as_str();
+        return !s.starts_with("0x") && !s.starts_with("0X");
+    }
+    false
+}

--- a/crates/lint/src/sol/high/incorrect_exp.rs
+++ b/crates/lint/src/sol/high/incorrect_exp.rs
@@ -8,7 +8,7 @@ use solar::{
     ast::{BinOpKind, LitKind},
     sema::{
         Gcx,
-        hir::{self, Expr, ExprKind, TypeKind},
+        hir::{self, ElementaryType, Expr, ExprKind, TypeKind},
     },
 };
 
@@ -36,45 +36,57 @@ impl<'hir> LateLintPass<'hir> for IncorrectExp {
         // base restriction, is allow-by-default precisely because of the resulting false positives.
         if let ExprKind::Binary(lhs, op, rhs) = &expr.kind
             && matches!(op.kind, BinOpKind::BitXor)
-            && let Some(base) = decimal_int_lit(lhs)
+            && let Some(base) = plain_decimal_int_lit(ctx, lhs)
             && (base == U256::from(2u64) || base == U256::from(10u64))
-            && decimal_int_lit(rhs).is_some()
+            && plain_decimal_int_lit(ctx, rhs).is_some()
         {
             ctx.emit(&INCORRECT_EXP, expr.span);
         }
     }
 }
 
-/// Returns the value of a decimal integer literal, looking through parentheses and elementary-type
+/// Returns the value of a plain decimal integer literal, looking through parentheses and integer
 /// casts (`uint256(10)`), or `None` for anything else.
 ///
-/// Solidity has no binary or octal literals, so only hex (`0x`) is excluded: xor of a hex bit
-/// pattern is a legitimate operation, and writing a number in hex is a strong signal the author
-/// really means bitwise work.
-fn decimal_int_lit(expr: &Expr<'_>) -> Option<U256> {
-    if let ExprKind::Lit(lit) = &peel_casts(expr).kind
+/// Only literals written as plain decimal digits (`10`, `1_000`) qualify. Hex literals (`0x..`) are
+/// bitwise intent, and scientific notation (`1e1`, which solar evaluates to `10`) is not the plain
+/// integer literal the `^`/`**` typo involves. A sub-denomination (`2 wei`, `2 seconds`) is dropped
+/// from the HIR but still present in the source span, so it is filtered out too. All of these are
+/// left alone: this lint prefers a false negative to a false positive that would annoy developers.
+fn plain_decimal_int_lit(ctx: &LintContext, expr: &Expr<'_>) -> Option<U256> {
+    let expr = peel_int_casts(expr);
+    if let ExprKind::Lit(lit) = &expr.kind
         && let LitKind::Number(value) = &lit.kind
     {
         let s = lit.symbol.as_str();
-        if !s.starts_with("0x") && !s.starts_with("0X") {
+        if !s.is_empty()
+            && s.bytes().all(|b| b.is_ascii_digit() || b == b'_')
+            // The source span must be exactly those digits. This rejects a sub-denomination such as
+            // `2 wei` (dropped from the HIR but still in the source). If the source is unavailable,
+            // err toward not flagging.
+            && ctx.span_to_snippet(expr.span).is_some_and(|src| src.trim() == s)
+        {
             return Some(*value);
         }
     }
     None
 }
 
-/// Looks through parentheses and elementary-type casts (`uint256(x)`, `int8(x)`), returning the
-/// innermost operand. A misplaced `^` can hide behind a cast (`uint256(10) ^ 18`), which a bare
-/// literal check would miss.
-fn peel_casts<'a, 'hir>(expr: &'a Expr<'hir>) -> &'a Expr<'hir> {
+/// Looks through parentheses and integer casts (`uint256(x)`, `int8(x)`), returning the innermost
+/// operand. A misplaced `^` can hide behind such a cast (`uint256(10) ^ 18`), which a bare literal
+/// check would miss. Non-integer casts (`bytes32(x)`, `address(x)`) are left alone, since xor of a
+/// `bytesN` bit pattern is a legitimate operation.
+fn peel_int_casts<'a, 'hir>(expr: &'a Expr<'hir>) -> &'a Expr<'hir> {
     let expr = expr.peel_parens();
     if let ExprKind::Call(callee, args, _) = &expr.kind
-        && let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(_), .. }) =
-            &callee.peel_parens().kind
+        && let ExprKind::Type(hir::Type {
+            kind: TypeKind::Elementary(ElementaryType::Int(_) | ElementaryType::UInt(_)),
+            ..
+        }) = &callee.peel_parens().kind
         && args.len() == 1
         && let Some(inner) = args.exprs().next()
     {
-        return peel_casts(inner);
+        return peel_int_casts(inner);
     }
     expr
 }

--- a/crates/lint/src/sol/high/mod.rs
+++ b/crates/lint/src/sol/high/mod.rs
@@ -4,6 +4,7 @@ mod arbitrary_send_erc20;
 mod arbitrary_send_eth;
 mod controlled_delegatecall;
 mod encode_packed_collision;
+mod incorrect_exp;
 mod incorrect_shift;
 mod reentrancy;
 mod rtlo;
@@ -14,6 +15,7 @@ use arbitrary_send_erc20::{ARBITRARY_SEND_ERC20, ARBITRARY_SEND_ERC20_PERMIT};
 use arbitrary_send_eth::ARBITRARY_SEND_ETH;
 use controlled_delegatecall::CONTROLLED_DELEGATECALL;
 use encode_packed_collision::ENCODE_PACKED_COLLISION;
+use incorrect_exp::INCORRECT_EXP;
 use incorrect_shift::INCORRECT_SHIFT;
 use reentrancy::{REENTRANCY_ETH, REENTRANCY_NO_ETH};
 use rtlo::RTLO;
@@ -25,6 +27,7 @@ register_lints!(
     (ArbitrarySendEth, late, (ARBITRARY_SEND_ETH)),
     (ControlledDelegatecall, late, (CONTROLLED_DELEGATECALL)),
     (EncodedPackedCollision, late, (ENCODE_PACKED_COLLISION)),
+    (IncorrectExp, late, (INCORRECT_EXP)),
     (IncorrectShift, early, (INCORRECT_SHIFT)),
     (ReentrancyEth, late, (REENTRANCY_ETH, REENTRANCY_NO_ETH)),
     (UncheckedCall, early, (UNCHECKED_CALL)),

--- a/crates/lint/testdata/IncorrectExp.sol
+++ b/crates/lint/testdata/IncorrectExp.sol
@@ -1,19 +1,39 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-// Tests for the `incorrect-exp` lint: `^` (bitwise xor) used between integer literals where `**`
-// (exponentiation) was meant.
+// Tests for the `incorrect-exp` lint: `^` (bitwise xor) used where `**` (exponentiation) was meant.
+// The base is restricted to `2` and `10` (the bases people write as powers), mirroring GCC and
+// Clang's `-Wxor-used-as-pow`, so decimal bitmask xors like `255 ^ 128` are not flagged.
 
 contract IncorrectExp {
-    function bad() external pure returns (uint256 a, uint256 b, uint256 c) {
-        a = 10 ^ 18; //~WARN: `^` is bitwise xor, not exponentiation; use `**`
-        b = 2 ^ 64; //~WARN: `^` is bitwise xor, not exponentiation; use `**`
-        c = (3) ^ (4); //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+    function id(uint256 v) internal pure returns (uint256) {
+        return v;
     }
 
-    function ok(uint256 x) external pure returns (uint256 a, uint256 b, uint256 c) {
-        a = 0xff ^ 0x0f; // hex xor: legitimate bit manipulation
-        b = x ^ 1; // a variable operand, not two literals
-        c = 2 ** 64; // actual exponentiation
+    function bad()
+        external
+        pure
+        returns (uint256 a, uint256 b, uint256 c, uint256 d, uint256 e, uint256 f)
+    {
+        a = 10 ^ 18; //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+        b = 2 ^ 64; //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+        c = 2 ^ 256; //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+        d = uint256(10) ^ 18; //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+        e = 2 ^ uint256(64); //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+        f = uint256(uint8(2)) ^ 64; //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+    }
+
+    function ok(uint256 x)
+        external
+        pure
+        returns (uint256 a, uint256 b, uint256 c, uint256 d, uint256 e, uint256 f, uint256 g)
+    {
+        a = 255 ^ 128; // decimal bitmask (0xFF ^ 0x80), base is not 2 or 10
+        b = 170 ^ 85; // decimal bitmask (0xAA ^ 0x55), base is not 2 or 10
+        c = 3 ^ 4; // base 3: not a base written as a power
+        d = 0xff ^ 0x0f; // hex xor: legitimate bit manipulation
+        e = x ^ 1; // a variable operand, not two literals
+        f = 2 ** 64; // actual exponentiation
+        g = id(10) ^ 18; // a non-cast call, not a literal: must not be unwrapped
     }
 }

--- a/crates/lint/testdata/IncorrectExp.sol
+++ b/crates/lint/testdata/IncorrectExp.sol
@@ -26,7 +26,20 @@ contract IncorrectExp {
     function ok(uint256 x)
         external
         pure
-        returns (uint256 a, uint256 b, uint256 c, uint256 d, uint256 e, uint256 f, uint256 g)
+        returns (
+            uint256 a,
+            uint256 b,
+            uint256 c,
+            uint256 d,
+            uint256 e,
+            uint256 f,
+            uint256 g,
+            uint256 h,
+            uint256 i,
+            bytes32 j,
+            uint256 k,
+            uint256 l
+        )
     {
         a = 255 ^ 128; // decimal bitmask (0xFF ^ 0x80), base is not 2 or 10
         b = 170 ^ 85; // decimal bitmask (0xAA ^ 0x55), base is not 2 or 10
@@ -35,5 +48,10 @@ contract IncorrectExp {
         e = x ^ 1; // a variable operand, not two literals
         f = 2 ** 64; // actual exponentiation
         g = id(10) ^ 18; // a non-cast call, not a literal: must not be unwrapped
+        h = 1e1 ^ 18; // scientific notation base (1e1 evaluates to 10): not a plain integer literal
+        i = 10 ^ 1e1; // scientific notation exponent: not a plain integer literal
+        j = bytes32(uint256(2)) ^ bytes32(uint256(64)); // bytesN xor: not an integer cast
+        k = 2 wei ^ 64; // denominated literal (2 wei == 2): not a plain integer literal
+        l = 10 seconds ^ 18; // denominated literal (10 seconds == 10): not a plain integer literal
     }
 }

--- a/crates/lint/testdata/IncorrectExp.sol
+++ b/crates/lint/testdata/IncorrectExp.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+// Tests for the `incorrect-exp` lint: `^` (bitwise xor) used between integer literals where `**`
+// (exponentiation) was meant.
+
+contract IncorrectExp {
+    function bad() external pure returns (uint256 a, uint256 b, uint256 c) {
+        a = 10 ^ 18; //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+        b = 2 ^ 64; //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+        c = (3) ^ (4); //~WARN: `^` is bitwise xor, not exponentiation; use `**`
+    }
+
+    function ok(uint256 x) external pure returns (uint256 a, uint256 b, uint256 c) {
+        a = 0xff ^ 0x0f; // hex xor: legitimate bit manipulation
+        b = x ^ 1; // a variable operand, not two literals
+        c = 2 ** 64; // actual exponentiation
+    }
+}

--- a/crates/lint/testdata/IncorrectExp.stderr
+++ b/crates/lint/testdata/IncorrectExp.stderr
@@ -1,0 +1,24 @@
+warning[incorrect-exp]: `^` is bitwise xor, not exponentiation; use `**`
+   ╭▸ ROOT/testdata/IncorrectExp.sol:LL:CC
+   │
+LL │         a = 10 ^ 18;
+   │             ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-exp
+
+warning[incorrect-exp]: `^` is bitwise xor, not exponentiation; use `**`
+   ╭▸ ROOT/testdata/IncorrectExp.sol:LL:CC
+   │
+LL │         b = 2 ^ 64;
+   │             ━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-exp
+
+warning[incorrect-exp]: `^` is bitwise xor, not exponentiation; use `**`
+   ╭▸ ROOT/testdata/IncorrectExp.sol:LL:CC
+   │
+LL │         c = (3) ^ (4);
+   │             ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-exp
+

--- a/crates/lint/testdata/IncorrectExp.stderr
+++ b/crates/lint/testdata/IncorrectExp.stderr
@@ -17,8 +17,32 @@ LL │         b = 2 ^ 64;
 warning[incorrect-exp]: `^` is bitwise xor, not exponentiation; use `**`
    ╭▸ ROOT/testdata/IncorrectExp.sol:LL:CC
    │
-LL │         c = (3) ^ (4);
-   │             ━━━━━━━━━
+LL │         c = 2 ^ 256;
+   │             ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-exp
+
+warning[incorrect-exp]: `^` is bitwise xor, not exponentiation; use `**`
+   ╭▸ ROOT/testdata/IncorrectExp.sol:LL:CC
+   │
+LL │         d = uint256(10) ^ 18;
+   │             ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-exp
+
+warning[incorrect-exp]: `^` is bitwise xor, not exponentiation; use `**`
+   ╭▸ ROOT/testdata/IncorrectExp.sol:LL:CC
+   │
+LL │         e = 2 ^ uint256(64);
+   │             ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/incorrect-exp
+
+warning[incorrect-exp]: `^` is bitwise xor, not exponentiation; use `**`
+   ╭▸ ROOT/testdata/IncorrectExp.sol:LL:CC
+   │
+LL │         f = uint256(uint8(2)) ^ 64;
+   │             ━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/incorrect-exp
 


### PR DESCRIPTION
## Motivation

Adds the `incorrect-exp` detector from the `forge lint` parity checklist in #14381.

In Solidity `^` is bitwise xor, not exponentiation, so `10 ^ 18` evaluates to `24`, not `10 ** 18`. Developers coming from languages where `^` means power write it expecting exponentiation; the contract compiles and silently uses the wrong constant.

## Solution

A `LateLintPass` (`high`, `incorrect-exp`) that flags `a ^ b` when the base `a` is `2` or `10` and both operands are decimal integer literals, looking through elementary-type casts (`uint256(10)`) and parentheses. Hex operands are left alone.

This mirrors GCC's and Clang's `-Wxor-used-as-pow` (base restricted to `2` and `10`, decimal literals). Restricting the base to the values people actually write as powers (`2` for bit widths, `10` for decimals) avoids false positives on decimal bitmask xors such as `255 ^ 128` or `170 ^ 85`. For reference, Clippy's `suspicious_xor_used_as_pow`, which omits the base restriction, ships as an allow-by-default `restriction` lint because of that false-positive surface.

## Test

`crates/lint/testdata/IncorrectExp.sol` covers the flagged forms (`10 ^ 18`, `2 ^ 64`, `2 ^ 256`, and the casts `uint256(10) ^ 18`, `2 ^ uint256(64)`, `uint256(uint8(2)) ^ 64`) and the non-triggering ones (decimal bitmasks `255 ^ 128` / `170 ^ 85`, a base outside `2`/`10` with `3 ^ 4`, hex `0xff ^ 0x0f`, a variable operand, an actual `**`, and a non-cast call `id(10) ^ 18`), with the blessed `.stderr`. `cargo test -p forge --test ui` passes.

## Docs

Companion docs PR: foundry-rs/book#1904.
