### PR TITLE
chore: test solar import resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4276,7 +4276,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4560,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6104,7 +6104,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -6895,7 +6895,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7689,7 +7689,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7914,7 +7914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -8159,9 +8159,9 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "oxc_index"
-version = "4.1.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3e6120999627ec9703025eab7c9f410ebb7e95557632a8902ca48210416c2b"
+checksum = "191884bee6c3744909a51acc7d78d4ae370d817b25875b10642f632327b6296e"
 dependencies = [
  "nonmax",
 ]
@@ -8776,7 +8776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8927,7 +8927,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10383,7 +10383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10442,7 +10442,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11167,13 +11167,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "solar-ast"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=da6b0c3a8c0edd23f8b1414c61418ba78d6c4670#da6b0c3a8c0edd23f8b1414c61418ba78d6c4670"
+source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11187,12 +11187,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "solar-codegen"
+version = "0.1.8"
+source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+dependencies = [
+ "alloy-primitives",
+ "derive_more",
+ "smallvec",
+ "solar-ast",
+ "solar-data-structures",
+ "solar-interface",
+ "solar-sema",
+ "tracing",
+]
+
+[[package]]
 name = "solar-compiler"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=da6b0c3a8c0edd23f8b1414c61418ba78d6c4670#da6b0c3a8c0edd23f8b1414c61418ba78d6c4670"
+source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
 dependencies = [
  "alloy-primitives",
  "solar-ast",
+ "solar-codegen",
  "solar-config",
  "solar-data-structures",
  "solar-interface",
@@ -11204,7 +11220,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=da6b0c3a8c0edd23f8b1414c61418ba78d6c4670#da6b0c3a8c0edd23f8b1414c61418ba78d6c4670"
+source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
 dependencies = [
  "colorchoice",
  "strum 0.28.0",
@@ -11213,7 +11229,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=da6b0c3a8c0edd23f8b1414c61418ba78d6c4670#da6b0c3a8c0edd23f8b1414c61418ba78d6c4670"
+source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
 dependencies = [
  "bumpalo",
  "indexmap 2.14.0",
@@ -11227,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=da6b0c3a8c0edd23f8b1414c61418ba78d6c4670#da6b0c3a8c0edd23f8b1414c61418ba78d6c4670"
+source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream 1.0.0",
@@ -11235,7 +11251,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11247,7 +11263,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11255,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=da6b0c3a8c0edd23f8b1414c61418ba78d6c4670#da6b0c3a8c0edd23f8b1414c61418ba78d6c4670"
+source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11265,12 +11281,12 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=da6b0c3a8c0edd23f8b1414c61418ba78d6c4670#da6b0c3a8c0edd23f8b1414c61418ba78d6c4670"
+source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11286,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=da6b0c3a8c0edd23f8b1414c61418ba78d6c4670#da6b0c3a8c0edd23f8b1414c61418ba78d6c4670"
+source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -11299,8 +11315,6 @@ dependencies = [
  "once_map",
  "paste",
  "rayon",
- "serde",
- "serde_json",
  "solar-ast",
  "solar-data-structures",
  "solar-interface",
@@ -11588,7 +11602,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -11716,7 +11730,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11920,7 +11934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13182,7 +13196,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13320,7 +13334,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4276,7 +4276,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4560,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4727,7 +4727,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6895,7 +6895,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7689,7 +7689,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7914,7 +7914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.17.1",
+ "hashbrown 0.16.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -8776,7 +8776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8927,7 +8927,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10383,7 +10383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10442,7 +10442,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11167,13 +11167,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "solar-ast"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
+source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11189,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
+source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
+source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
 dependencies = [
  "alloy-primitives",
  "solar-ast",
@@ -11220,7 +11220,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
+source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
 dependencies = [
  "colorchoice",
  "strum 0.28.0",
@@ -11229,7 +11229,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
+source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
 dependencies = [
  "bumpalo",
  "indexmap 2.14.0",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
+source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream 1.0.0",
@@ -11251,7 +11251,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11263,7 +11263,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11271,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
+source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11281,12 +11281,12 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
+source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11302,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
+source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -11602,7 +11602,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -11730,7 +11730,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11934,7 +11934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13196,7 +13196,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13334,7 +13334,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4560,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6895,7 +6895,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7914,7 +7914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -8776,7 +8776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8927,7 +8927,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10383,7 +10383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10442,7 +10442,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11167,13 +11167,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "solar-ast"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11189,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
 dependencies = [
  "alloy-primitives",
  "solar-ast",
@@ -11220,7 +11220,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
 dependencies = [
  "colorchoice",
  "strum 0.28.0",
@@ -11229,7 +11229,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
 dependencies = [
  "bumpalo",
  "indexmap 2.14.0",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream 1.0.0",
@@ -11251,7 +11251,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11263,7 +11263,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11271,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11281,12 +11281,12 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11302,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=bdfb7979a308c9863e283829052b60679af3ed66#bdfb7979a308c9863e283829052b60679af3ed66"
+source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -11602,7 +11602,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "zip",
 ]
@@ -11730,7 +11730,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13334,7 +13334,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11173,7 +11173,7 @@ dependencies = [
 [[package]]
 name = "solar-ast"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
+source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11189,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
+source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
+source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
 dependencies = [
  "alloy-primitives",
  "solar-ast",
@@ -11220,7 +11220,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
+source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
 dependencies = [
  "colorchoice",
  "strum 0.28.0",
@@ -11229,7 +11229,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
+source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
 dependencies = [
  "bumpalo",
  "indexmap 2.14.0",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
+source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream 1.0.0",
@@ -11271,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
+source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11281,7 +11281,7 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
+source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
@@ -11302,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=6fc7b6feb4746f61fc6c206f38297dd68518419e#6fc7b6feb4746f61fc6c206f38297dd68518419e"
+source = "git+https://github.com/paradigmxyz/solar?rev=fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7#fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1207,7 +1207,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3055,7 +3055,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3214,7 +3214,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4276,7 +4276,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4560,7 +4560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4727,7 +4727,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6895,7 +6895,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7689,7 +7689,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7914,7 +7914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -8776,7 +8776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8927,7 +8927,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10383,7 +10383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10442,7 +10442,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11167,13 +11167,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "solar-ast"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
+source = "git+https://github.com/paradigmxyz/solar?rev=fd466a277fdcd75ff36301387aef560b43bf25b8#fd466a277fdcd75ff36301387aef560b43bf25b8"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -11189,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "solar-codegen"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
+source = "git+https://github.com/paradigmxyz/solar?rev=fd466a277fdcd75ff36301387aef560b43bf25b8#fd466a277fdcd75ff36301387aef560b43bf25b8"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "solar-compiler"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
+source = "git+https://github.com/paradigmxyz/solar?rev=fd466a277fdcd75ff36301387aef560b43bf25b8#fd466a277fdcd75ff36301387aef560b43bf25b8"
 dependencies = [
  "alloy-primitives",
  "solar-ast",
@@ -11220,7 +11220,7 @@ dependencies = [
 [[package]]
 name = "solar-config"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
+source = "git+https://github.com/paradigmxyz/solar?rev=fd466a277fdcd75ff36301387aef560b43bf25b8#fd466a277fdcd75ff36301387aef560b43bf25b8"
 dependencies = [
  "colorchoice",
  "strum 0.28.0",
@@ -11229,7 +11229,7 @@ dependencies = [
 [[package]]
 name = "solar-data-structures"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
+source = "git+https://github.com/paradigmxyz/solar?rev=fd466a277fdcd75ff36301387aef560b43bf25b8#fd466a277fdcd75ff36301387aef560b43bf25b8"
 dependencies = [
  "bumpalo",
  "indexmap 2.14.0",
@@ -11243,7 +11243,7 @@ dependencies = [
 [[package]]
 name = "solar-interface"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
+source = "git+https://github.com/paradigmxyz/solar?rev=fd466a277fdcd75ff36301387aef560b43bf25b8#fd466a277fdcd75ff36301387aef560b43bf25b8"
 dependencies = [
  "annotate-snippets 0.12.16",
  "anstream 1.0.0",
@@ -11251,7 +11251,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11263,7 +11263,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11271,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "solar-macros"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
+source = "git+https://github.com/paradigmxyz/solar?rev=fd466a277fdcd75ff36301387aef560b43bf25b8#fd466a277fdcd75ff36301387aef560b43bf25b8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11281,12 +11281,12 @@ dependencies = [
 [[package]]
 name = "solar-parse"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
+source = "git+https://github.com/paradigmxyz/solar?rev=fd466a277fdcd75ff36301387aef560b43bf25b8#fd466a277fdcd75ff36301387aef560b43bf25b8"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.11.1",
  "bumpalo",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11302,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "solar-sema"
 version = "0.1.8"
-source = "git+https://github.com/paradigmxyz/solar?rev=8a582beab829c7d53dc6084b3a7c295b274f8c74#8a582beab829c7d53dc6084b3a7c295b274f8c74"
+source = "git+https://github.com/paradigmxyz/solar?rev=fd466a277fdcd75ff36301387aef560b43bf25b8#fd466a277fdcd75ff36301387aef560b43bf25b8"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -11602,7 +11602,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "zip",
 ]
@@ -11730,7 +11730,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11934,7 +11934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13196,7 +13196,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13334,7 +13334,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -599,10 +599,10 @@ tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367
 tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
 
 # solar
-solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "bdfb7979a308c9863e283829052b60679af3ed66" }
-solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "bdfb7979a308c9863e283829052b60679af3ed66" }
-solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "bdfb7979a308c9863e283829052b60679af3ed66" }
-solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "bdfb7979a308c9863e283829052b60679af3ed66" }
+solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "6fc7b6feb4746f61fc6c206f38297dd68518419e" }
+solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "6fc7b6feb4746f61fc6c206f38297dd68518419e" }
+solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "6fc7b6feb4746f61fc6c206f38297dd68518419e" }
+solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "6fc7b6feb4746f61fc6c206f38297dd68518419e" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -599,10 +599,10 @@ tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367
 tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
 
 # solar
-solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "8a582beab829c7d53dc6084b3a7c295b274f8c74" }
-solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "8a582beab829c7d53dc6084b3a7c295b274f8c74" }
-solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "8a582beab829c7d53dc6084b3a7c295b274f8c74" }
-solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "8a582beab829c7d53dc6084b3a7c295b274f8c74" }
+solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "fd466a277fdcd75ff36301387aef560b43bf25b8" }
+solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "fd466a277fdcd75ff36301387aef560b43bf25b8" }
+solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "fd466a277fdcd75ff36301387aef560b43bf25b8" }
+solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "fd466a277fdcd75ff36301387aef560b43bf25b8" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -599,10 +599,10 @@ tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367
 tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
 
 # solar
-solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }
-solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }
-solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }
-solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }
+solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "bdfb7979a308c9863e283829052b60679af3ed66" }
+solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "bdfb7979a308c9863e283829052b60679af3ed66" }
+solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "bdfb7979a308c9863e283829052b60679af3ed66" }
+solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "bdfb7979a308c9863e283829052b60679af3ed66" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -599,10 +599,10 @@ tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367
 tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
 
 # solar
-solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "6fc7b6feb4746f61fc6c206f38297dd68518419e" }
-solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "6fc7b6feb4746f61fc6c206f38297dd68518419e" }
-solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "6fc7b6feb4746f61fc6c206f38297dd68518419e" }
-solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "6fc7b6feb4746f61fc6c206f38297dd68518419e" }
+solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7" }
+solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7" }
+solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7" }
+solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -599,10 +599,10 @@ tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367
 tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "2cf84002140367ff6de3268e5bf39972b8a0dc6c" }
 
 # solar
-solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7" }
-solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7" }
-solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7" }
-solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "fe3931dc6c6ddfce2ce0ab77e24c852bd042b2a7" }
+solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "8a582beab829c7d53dc6084b3a7c295b274f8c74" }
+solar-interface = { package = "solar-interface", git = "https://github.com/paradigmxyz/solar", rev = "8a582beab829c7d53dc6084b3a7c295b274f8c74" }
+solar-ast = { package = "solar-ast", git = "https://github.com/paradigmxyz/solar", rev = "8a582beab829c7d53dc6084b3a7c295b274f8c74" }
+solar-sema = { package = "solar-sema", git = "https://github.com/paradigmxyz/solar", rev = "8a582beab829c7d53dc6084b3a7c295b274f8c74" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -461,7 +461,7 @@ contract ContractB {
 
     cmd.args(["build", "src/ContractWithInvalidNatspec.sol"]).assert_success().stderr_eq(str![[
         r#"
-warning: invalid natspec tag '@deprecated', custom tags must use format '@custom:name'
+warning[6546]: invalid natspec tag '@deprecated', custom tags must use format '@custom:name'
   [FILE]:5:5
   │
 5 │     /// @deprecated quoteExactOutputSingle and exactOutput. Use QuoterV2 instead.
@@ -469,7 +469,7 @@ warning: invalid natspec tag '@deprecated', custom tags must use format '@custom
   │
 ...
 
-warning: invalid natspec tag '@note', custom tags must use format '@custom:name'
+warning[6546]: invalid natspec tag '@note', custom tags must use format '@custom:name'
   [FILE]:9:1
   │
 9 │ /// @note foo bar


### PR DESCRIPTION
Draft CI PR for paradigmxyz/solar#860.

This pins the Solar git dependencies to fd466a277fdcd75ff36301387aef560b43bf25b8 so Foundry CI runs against the import-resolution changes.
