### PR TITLE
feat(symbolic): persist replayable counterexample artifacts

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1918,6 +1918,31 @@ pub fn execute_tx<FEN: FoundryEvmNetwork>(
         .map_err(|e| eyre!(format!("Could not make raw evm call: {e}")))
 }
 
+/// Executes a replay call on a validation executor and registers any created targets.
+///
+/// This mirrors sequence replay's non-reverted commit behavior while allowing callers to update
+/// updatable target sets before validating later calls in the same artifact.
+pub fn execute_tx_and_register_created<FEN: FoundryEvmNetwork>(
+    executor: &mut Executor<FEN>,
+    tx: &BasicTxDetails,
+    targeted_contracts: &FuzzRunIdentifiedContracts,
+    dynamic_target_ctx: &DynamicTargetCtx<'_>,
+    created_contracts: &mut Vec<Address>,
+) -> Result<()> {
+    let mut call_result = execute_tx(executor, tx)?;
+    if !call_result.reverted {
+        targeted_contracts.collect_created_contracts(
+            &call_result.state_changeset,
+            dynamic_target_ctx.project_contracts,
+            dynamic_target_ctx.setup_contracts,
+            dynamic_target_ctx.artifact_filters,
+            created_contracts,
+        )?;
+        executor.commit(&mut call_result);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1878,7 +1878,7 @@ pub(crate) fn call_invariant_function<FEN: FoundryEvmNetwork>(
 
 /// Executes a fuzz call and returns the result.
 /// Applies any block timestamp (warp) and block number (roll) adjustments before the call.
-pub(crate) fn execute_tx<FEN: FoundryEvmNetwork>(
+pub fn execute_tx<FEN: FoundryEvmNetwork>(
     executor: &mut Executor<FEN>,
     tx: &BasicTxDetails,
 ) -> Result<RawCallResult<FEN>> {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1934,7 +1934,12 @@ pub(crate) fn call_invariant_function<FEN: FoundryEvmNetwork>(
     Ok((call_result, success))
 }
 
-/// Executes a fuzz call and returns the result.
+/// Executes an invariant replay fuzz call and returns the result.
+///
+/// This applies invariant replay semantics: warp/roll deltas are applied before the call and the
+/// requested value is clamped to the sender balance. It is intended for invariant sequence replay,
+/// shrinking, and artifact validation rather than as a general raw-call helper.
+///
 /// Applies any block timestamp (warp) and block number (roll) adjustments before the call.
 pub fn execute_tx<FEN: FoundryEvmNetwork>(
     executor: &mut Executor<FEN>,
@@ -1976,7 +1981,7 @@ pub fn execute_tx<FEN: FoundryEvmNetwork>(
         .map_err(|e| eyre!(format!("Could not make raw evm call: {e}")))
 }
 
-/// Executes a replay call on a validation executor and registers any created targets.
+/// Executes an invariant replay call on a validation executor and registers created targets.
 ///
 /// This mirrors sequence replay's non-reverted commit behavior while allowing callers to update
 /// updatable target sets before validating later calls in the same artifact.

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -255,7 +255,7 @@ pub(crate) fn shrink_sequence<FEN: FoundryEvmNetwork>(
         // do not roll back the removal.
         ShrinkErrorPolicy::KeepRemoved,
         |shrinker| {
-            let (success, _, _) = check_sequence(
+            let (success, _, _, _) = check_sequence(
                 executor.clone(),
                 calls,
                 shrinker.current().collect(),
@@ -357,13 +357,17 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
     test_address: Address,
     calldata: Bytes,
     options: CheckSequenceOptions<'_>,
-) -> eyre::Result<(bool, bool, Option<String>)> {
+) -> eyre::Result<(bool, bool, Option<String>, usize)> {
+    let mut reverts = 0;
     let early = replay_sequence(
         &mut executor,
         calls,
         &sequence,
         options.accumulate_warp_roll,
         |_idx, call_result| {
+            if call_result.reverted {
+                reverts += 1;
+            }
             // Ignore calls reverted with `MAGIC_ASSUME`. This is needed to handle failed
             // scenarios that are replayed with a modified version of test driver (that use
             // new `vm.assume` cheatcodes).
@@ -375,16 +379,18 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
                     false,
                     false,
                     assertion_failure_reason(call_result, options.rd),
+                    reverts,
                 )));
             }
             if call_result.reverted && options.fail_on_revert {
                 if options.expect_assertion_failure {
-                    return Ok(ReplayDecision::Stop((true, false, None)));
+                    return Ok(ReplayDecision::Stop((true, false, None, reverts)));
                 }
                 return Ok(ReplayDecision::Stop((
                     false,
                     false,
                     call_failure_reason(call_result, options.rd),
+                    reverts,
                 )));
             }
             Ok(ReplayDecision::Continue(call_result))
@@ -396,7 +402,9 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
 
     // Unlike optimization mode we intentionally do not apply trailing warp/roll before the
     // invariant call: those delays would not be representable in the final shrunk sequence.
-    finish_sequence_check(&executor, test_address, calldata, &options)
+    let (success, replayed_entirely, reason) =
+        finish_sequence_check(&executor, test_address, calldata, &options)?;
+    Ok((success, replayed_entirely, reason, reverts))
 }
 
 fn finish_sequence_check<FEN: FoundryEvmNetwork>(

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -255,7 +255,7 @@ pub(crate) fn shrink_sequence<FEN: FoundryEvmNetwork>(
         // do not roll back the removal.
         ShrinkErrorPolicy::KeepRemoved,
         |shrinker| {
-            let (success, _, _, _) = check_sequence(
+            let (success, _, _, _, _) = check_sequence(
                 executor.clone(),
                 calls,
                 shrinker.current().collect(),
@@ -357,14 +357,14 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
     test_address: Address,
     calldata: Bytes,
     options: CheckSequenceOptions<'_>,
-) -> eyre::Result<(bool, bool, Option<String>, usize)> {
+) -> eyre::Result<(bool, bool, Option<String>, usize, usize)> {
     let mut reverts = 0;
     let early = replay_sequence(
         &mut executor,
         calls,
         &sequence,
         options.accumulate_warp_roll,
-        |_idx, call_result| {
+        |idx, call_result| {
             // Ignore calls reverted with `MAGIC_ASSUME`. This is needed to handle failed
             // scenarios that are replayed with a modified version of test driver (that use
             // new `vm.assume` cheatcodes).
@@ -379,17 +379,19 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
                     false,
                     false,
                     assertion_failure_reason(call_result, options.rd),
+                    idx + 1,
                     reverts,
                 )));
             }
             if call_result.reverted && options.fail_on_revert {
                 if options.expect_assertion_failure {
-                    return Ok(ReplayDecision::Stop((true, false, None, reverts)));
+                    return Ok(ReplayDecision::Stop((true, false, None, idx + 1, reverts)));
                 }
                 return Ok(ReplayDecision::Stop((
                     false,
                     false,
                     call_failure_reason(call_result, options.rd),
+                    idx + 1,
                     reverts,
                 )));
             }
@@ -404,7 +406,7 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
     // invariant call: those delays would not be representable in the final shrunk sequence.
     let (success, replayed_entirely, reason) =
         finish_sequence_check(&executor, test_address, calldata, &options)?;
-    Ok((success, replayed_entirely, reason, reverts))
+    Ok((success, replayed_entirely, reason, sequence.len(), reverts))
 }
 
 fn finish_sequence_check<FEN: FoundryEvmNetwork>(

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -365,14 +365,14 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
         &sequence,
         options.accumulate_warp_roll,
         |_idx, call_result| {
-            if call_result.reverted {
-                reverts += 1;
-            }
             // Ignore calls reverted with `MAGIC_ASSUME`. This is needed to handle failed
             // scenarios that are replayed with a modified version of test driver (that use
             // new `vm.assume` cheatcodes).
             if call_result.result.as_ref() == MAGIC_ASSUME {
                 return Ok(ReplayDecision::Continue(call_result));
+            }
+            if call_result.reverted {
+                reverts += 1;
             }
             if did_fail_on_assert(&call_result, &call_result.state_changeset) {
                 return Ok(ReplayDecision::Stop((

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -358,13 +358,15 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
     calldata: Bytes,
     options: CheckSequenceOptions<'_>,
 ) -> eyre::Result<(bool, bool, Option<String>, usize, usize)> {
+    let mut calls_executed = 0;
     let mut reverts = 0;
     let early = replay_sequence(
         &mut executor,
         calls,
         &sequence,
         options.accumulate_warp_roll,
-        |idx, call_result| {
+        |_idx, call_result| {
+            calls_executed += 1;
             // Ignore calls reverted with `MAGIC_ASSUME`. This is needed to handle failed
             // scenarios that are replayed with a modified version of test driver (that use
             // new `vm.assume` cheatcodes).
@@ -379,19 +381,19 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
                     false,
                     false,
                     assertion_failure_reason(call_result, options.rd),
-                    idx + 1,
+                    calls_executed,
                     reverts,
                 )));
             }
             if call_result.reverted && options.fail_on_revert {
                 if options.expect_assertion_failure {
-                    return Ok(ReplayDecision::Stop((true, false, None, idx + 1, reverts)));
+                    return Ok(ReplayDecision::Stop((true, false, None, calls_executed, reverts)));
                 }
                 return Ok(ReplayDecision::Stop((
                     false,
                     false,
                     call_failure_reason(call_result, options.rd),
-                    idx + 1,
+                    calls_executed,
                     reverts,
                 )));
             }
@@ -406,7 +408,7 @@ pub fn check_sequence<FEN: FoundryEvmNetwork>(
     // invariant call: those delays would not be representable in the final shrunk sequence.
     let (success, replayed_entirely, reason) =
         finish_sequence_check(&executor, test_address, calldata, &options)?;
-    Ok((success, replayed_entirely, reason, sequence.len(), reverts))
+    Ok((success, replayed_entirely, reason, calls_executed, reverts))
 }
 
 fn finish_sequence_check<FEN: FoundryEvmNetwork>(

--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -161,6 +161,18 @@ impl TargetedContracts {
         }
     }
 
+    /// Returns whether the given transaction targets a known ABI function.
+    pub fn has_abi_function(&self, tx: &BasicTxDetails) -> bool {
+        match self.inner.get(&tx.call_details.target) {
+            Some(c) => tx
+                .call_details
+                .calldata
+                .get(..4)
+                .is_some_and(|selector| c.abi.functions().any(|f| f.selector() == selector)),
+            None => false,
+        }
+    }
+
     /// Identifies fuzzed contract and function based on given tx details and returns unique metric
     /// key composed from contract identifier and function name.
     pub fn fuzzed_metric_key(&self, tx: &BasicTxDetails) -> Option<String> {

--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -161,18 +161,6 @@ impl TargetedContracts {
         }
     }
 
-    /// Returns whether the given transaction targets a known ABI function.
-    pub fn has_abi_function(&self, tx: &BasicTxDetails) -> bool {
-        match self.inner.get(&tx.call_details.target) {
-            Some(c) => tx
-                .call_details
-                .calldata
-                .get(..4)
-                .is_some_and(|selector| c.abi.functions().any(|f| f.selector() == selector)),
-            None => false,
-        }
-    }
-
     /// Identifies fuzzed contract and function based on given tx details and returns unique metric
     /// key composed from contract identifier and function name.
     pub fn fuzzed_metric_key(&self, tx: &BasicTxDetails) -> Option<String> {

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -86,6 +86,13 @@ reason kind, effective bounds, solver identity and counters, explicit
 assumptions, call-trace location metadata, replay status, and counterexample
 payload when one exists.
 
+When Forge materializes a replay candidate, `symbolic.artifact` points to a
+durable replay artifact written under the configured cache path. The artifact
+schema lives at
+`crates/evm/symbolic/assets/symbolic-counterexample.schema.json` and records
+the replay status, bounds, assumptions, solver metadata, optional trace
+reference, and concrete call data needed by downstream minimizers and exporters.
+
 > **Hash-model caveat:** `PASS` also assumes collision and preimage resistance
 > for symbolic `KECCAK256` and hash-like precompile terms. The executor may use
 > equal symbolic hashes to infer equal symbolic preimages or lengths in modeled

--- a/crates/evm/symbolic/assets/symbolic-counterexample.schema.json
+++ b/crates/evm/symbolic/assets/symbolic-counterexample.schema.json
@@ -11,6 +11,7 @@
     "kind",
     "test",
     "replay",
+    "replay_semantics",
     "bounds",
     "solver",
     "assumptions",
@@ -41,6 +42,17 @@
     },
     "replay": {
       "$ref": "https://foundry-rs.github.io/schemas/symbolic-result.v1.schema.json#/$defs/replay"
+    },
+    "replay_semantics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["fail_on_revert"],
+      "properties": {
+        "fail_on_revert": {
+          "type": "boolean",
+          "description": "Whether invariant sequence replay treats target-call reverts as failures."
+        }
+      }
     },
     "bounds": {
       "$ref": "https://foundry-rs.github.io/schemas/symbolic-result.v1.schema.json#/$defs/bounds"

--- a/crates/evm/symbolic/assets/symbolic-counterexample.schema.json
+++ b/crates/evm/symbolic/assets/symbolic-counterexample.schema.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://foundry-rs.github.io/schemas/symbolic-counterexample.v1.schema.json",
+  "title": "Foundry symbolic counterexample artifact",
+  "description": "Stable replayable counterexample artifact emitted for forge symbolic test results.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "schema",
+    "kind",
+    "test",
+    "replay",
+    "bounds",
+    "solver",
+    "assumptions",
+    "call_trace",
+    "calls"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "schema": {
+      "type": "string",
+      "const": "foundry:symbolic.counterexample@v1"
+    },
+    "kind": {
+      "type": "string",
+      "enum": ["single_call", "sequence"]
+    },
+    "test": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["contract", "test"],
+      "properties": {
+        "contract": { "type": "string" },
+        "test": { "type": "string" }
+      }
+    },
+    "replay": {
+      "$ref": "https://foundry-rs.github.io/schemas/symbolic-result.v1.schema.json#/$defs/replay"
+    },
+    "bounds": {
+      "$ref": "https://foundry-rs.github.io/schemas/symbolic-result.v1.schema.json#/$defs/bounds"
+    },
+    "solver": {
+      "$ref": "https://foundry-rs.github.io/schemas/symbolic-result.v1.schema.json#/$defs/solver"
+    },
+    "assumptions": {
+      "type": "array",
+      "items": {
+        "$ref": "https://foundry-rs.github.io/schemas/symbolic-result.v1.schema.json#/$defs/assumption"
+      }
+    },
+    "call_trace": {
+      "$ref": "https://foundry-rs.github.io/schemas/symbolic-result.v1.schema.json#/$defs/call_trace"
+    },
+    "calls": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/call" }
+    }
+  },
+  "$defs": {
+    "call": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "warp",
+        "roll",
+        "sender",
+        "target",
+        "calldata",
+        "value",
+        "contract_name",
+        "function_name",
+        "signature",
+        "args",
+        "raw_args"
+      ],
+      "properties": {
+        "warp": {
+          "type": ["string", "null"],
+          "pattern": "^0x(0|[1-9a-fA-F][0-9a-fA-F]*)$"
+        },
+        "roll": {
+          "type": ["string", "null"],
+          "pattern": "^0x(0|[1-9a-fA-F][0-9a-fA-F]*)$"
+        },
+        "sender": {
+          "type": "string",
+          "pattern": "^0x[0-9a-fA-F]{40}$"
+        },
+        "target": {
+          "type": "string",
+          "pattern": "^0x[0-9a-fA-F]{40}$"
+        },
+        "calldata": {
+          "type": "string",
+          "pattern": "^0x([0-9a-fA-F]{2})*$"
+        },
+        "value": {
+          "type": ["string", "null"],
+          "pattern": "^0x(0|[1-9a-fA-F][0-9a-fA-F]*)$"
+        },
+        "contract_name": {
+          "type": ["string", "null"]
+        },
+        "function_name": {
+          "type": ["string", "null"]
+        },
+        "signature": {
+          "type": ["string", "null"]
+        },
+        "args": {
+          "type": ["string", "null"]
+        },
+        "raw_args": {
+          "type": ["string", "null"]
+        }
+      }
+    }
+  }
+}

--- a/crates/evm/symbolic/assets/symbolic-result.schema.json
+++ b/crates/evm/symbolic/assets/symbolic-result.schema.json
@@ -52,6 +52,9 @@
         { "type": "null" },
         { "$ref": "#/$defs/counterexample" }
       ]
+    },
+    "artifact": {
+      "$ref": "#/$defs/artifact_ref"
     }
   },
   "allOf": [
@@ -448,6 +451,21 @@
         },
         "value": {
           "type": ["string", "null"]
+        }
+      }
+    },
+    "artifact_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "path"],
+      "properties": {
+        "schema": {
+          "type": "string",
+          "const": "foundry:symbolic.counterexample@v1"
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
         }
       }
     }

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -307,8 +307,10 @@ impl CoverageArgs {
         evm_opts: EvmOpts,
     ) -> Result<()> {
         let filter = self.test.filter(&config)?;
-        let outcome =
-            self.test.run_tests(project_root, config, evm_opts, output, &filter, true).await?;
+        let outcome = self
+            .test
+            .run_tests(project_root, config, evm_opts, output, &filter, true, None)
+            .await?;
 
         let known_contracts = outcome.known_contracts.as_ref().unwrap().clone();
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -4,9 +4,14 @@ use crate::{
     decode::decode_console_logs,
     diagnostic::build::SOLC_ERROR,
     gas_report::GasReport,
-    multi_runner::{MultiNetworkConfig, ShowmapConfig, matches_artifact},
+    multi_runner::{
+        MultiNetworkConfig, ShowmapConfig, SymbolicArtifactReplayConfig, matches_artifact,
+    },
     mutation::{MutationRunConfig, run_mutation_testing},
-    result::{SuiteResult, TestKindReport, TestOutcome, TestResult, TestStatus},
+    result::{
+        SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA, SuiteResult, SymbolicCounterexampleArtifact,
+        TestKindReport, TestOutcome, TestResult, TestStatus,
+    },
     traces::{
         CallTraceDecoderBuilder, InternalTraceMode, TraceKind,
         debug::{ContractSources, DebugTraceIdentifier},
@@ -227,6 +232,29 @@ pub struct TestArgs {
     /// Run symbolic check*/prove*/invariant*/statefulFuzz* tests.
     #[arg(long, env = "FOUNDRY_SYMBOLIC")]
     pub symbolic: bool,
+
+    /// Replay a durable symbolic counterexample artifact emitted by `forge test --symbolic`.
+    #[arg(
+        long,
+        value_name = "PATH",
+        value_hint = ValueHint::FilePath,
+        conflicts_with_all = [
+            "debug",
+            "flamegraph",
+            "flamechart",
+            "rerun",
+            "fuzz_input_file",
+            "showmap_out",
+            "path",
+            "test_pattern",
+            "test_pattern_inverse",
+            "contract_pattern",
+            "contract_pattern_inverse",
+            "path_pattern",
+            "no-match-path",
+        ],
+    )]
+    pub replay_symbolic_artifact: Option<PathBuf>,
 
     /// Solver executable used for symbolic tests.
     #[arg(long, env = "FOUNDRY_SYMBOLIC_SOLVER", value_name = "PATH_OR_NAME")]
@@ -458,6 +486,58 @@ impl TestArgs {
         })
     }
 
+    fn load_symbolic_artifact_replay(&self) -> Result<Option<SymbolicArtifactReplayConfig>> {
+        let Some(path) = &self.replay_symbolic_artifact else {
+            return Ok(None);
+        };
+
+        if !self.filter.is_empty() || self.path.is_some() {
+            bail!(
+                "`--replay-symbolic-artifact` cannot be combined with test selection filters; \
+                 the artifact selects its original target"
+            );
+        }
+
+        let value = foundry_common::fs::read_json_file::<serde_json::Value>(path).wrap_err(
+            format!("failed to read symbolic counterexample artifact {}", path.display()),
+        )?;
+        let schema_version =
+            value.get("schema_version").and_then(serde_json::Value::as_u64).ok_or_else(|| {
+                eyre::eyre!(
+                    "symbolic counterexample artifact {} is missing numeric schema_version",
+                    path.display()
+                )
+            })?;
+        if schema_version != 1 {
+            bail!(
+                "unsupported symbolic counterexample artifact schema version {} in {}",
+                schema_version,
+                path.display()
+            );
+        }
+        let schema = value.get("schema").and_then(serde_json::Value::as_str).ok_or_else(|| {
+            eyre::eyre!(
+                "symbolic counterexample artifact {} is missing string schema",
+                path.display()
+            )
+        })?;
+        if schema != SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA {
+            bail!(
+                "unsupported symbolic counterexample artifact schema `{}` in {}",
+                schema,
+                path.display()
+            );
+        }
+        let artifact = serde_json::from_value::<SymbolicCounterexampleArtifact>(value).wrap_err(
+            format!("failed to parse symbolic counterexample artifact {}", path.display()),
+        )?;
+        if artifact.calls.is_empty() {
+            bail!("symbolic counterexample artifact {} has no calls", path.display());
+        }
+
+        Ok(Some(SymbolicArtifactReplayConfig { artifact, path: path.clone() }))
+    }
+
     /// Reject flags whose stdout shape conflicts with the NDJSON stream
     /// contract under `--machine`. Called from the binary entry point so
     /// `--watch` is also rejected.
@@ -612,7 +692,33 @@ impl TestArgs {
         // Set up the project.
         let project = config.project()?;
 
-        let filter = self.filter(&config)?;
+        let replay_symbolic_artifact = self.load_symbolic_artifact_replay()?;
+        if replay_symbolic_artifact.is_some() {
+            config.symbolic.enabled = true;
+        }
+
+        let mut filter = self.filter(&config)?;
+        if let Some(replay) = &replay_symbolic_artifact {
+            let filter_args = filter.args_mut();
+            filter_args.test_pattern_inverse = None;
+            filter_args.contract_pattern_inverse = None;
+            filter_args.path_pattern_inverse = None;
+            let (path, contract) = replay
+                .artifact
+                .test
+                .contract
+                .rsplit_once(':')
+                .map_or(("", replay.artifact.test.contract.as_str()), |(path, contract)| {
+                    (path, contract)
+                });
+            filter_args.test_pattern =
+                Some(Regex::new(&format!("^{}$", regex::escape(&replay.artifact.test.test)))?);
+            filter_args.contract_pattern =
+                Some(Regex::new(&format!("^{}$", regex::escape(contract)))?);
+            if !path.is_empty() {
+                filter_args.path_pattern = Some(path.parse::<GlobMatcher>()?);
+            }
+        }
         trace!(target: "forge::test", ?filter, "using filter");
 
         let mut compiler = ProjectCompiler::new()
@@ -630,12 +736,22 @@ impl TestArgs {
             emit_machine_compile_error(&output);
         }
 
-        self.run_tests(&project.paths.root, config, evm_opts, &output, &filter, false).await
+        self.run_tests(
+            &project.paths.root,
+            config,
+            evm_opts,
+            &output,
+            &filter,
+            false,
+            replay_symbolic_artifact,
+        )
+        .await
     }
 
     /// Executes all the tests in the project.
     ///
     /// See [`Self::compile_and_run`] for more details.
+    #[allow(clippy::too_many_arguments)]
     pub async fn run_tests(
         &mut self,
         project_root: &Path,
@@ -644,6 +760,7 @@ impl TestArgs {
         output: &ProjectCompileOutput,
         filter: &ProjectPathsAwareFilter,
         coverage: bool,
+        replay_symbolic_artifact: Option<SymbolicArtifactReplayConfig>,
     ) -> Result<TestOutcome> {
         if config.fuzz.run == Some(0) {
             bail!("`fuzz.run` must be greater than 0");
@@ -678,6 +795,9 @@ impl TestArgs {
             }
             if self.showmap_out.is_some() {
                 conflicts.push("--showmap-out");
+            }
+            if self.replay_symbolic_artifact.is_some() {
+                conflicts.push("--replay-symbolic-artifact");
             }
             if !conflicts.is_empty() {
                 bail!(
@@ -764,6 +884,7 @@ impl TestArgs {
                 should_debug,
                 decode_internal,
                 MultiNetworkConfig::default(),
+                replay_symbolic_artifact.clone(),
             )
             .await?
         } else {
@@ -786,6 +907,7 @@ impl TestArgs {
                         all_override_networks: all_override_networks.clone(),
                         pass_network: None,
                     },
+                    replay_symbolic_artifact.clone(),
                 )
                 .await?;
 
@@ -807,6 +929,7 @@ impl TestArgs {
                             all_override_networks: all_override_networks.clone(),
                             pass_network: Some(network),
                         },
+                        replay_symbolic_artifact.clone(),
                     )
                     .await?;
                 merge_outcomes(&mut outcome, pass_outcome);
@@ -824,6 +947,25 @@ impl TestArgs {
 
             (libraries, outcome)
         };
+
+        if let Some(replay) = &replay_symbolic_artifact {
+            let replayed = outcome.tests().count();
+            if replayed == 0 {
+                bail!(
+                    "symbolic artifact target `{}::{}` was not found",
+                    replay.artifact.test.contract,
+                    replay.artifact.test.test
+                );
+            }
+            if replayed > 1 {
+                bail!(
+                    "symbolic artifact target `{}::{}` matched {} tests; replay requires exactly one target",
+                    replay.artifact.test.contract,
+                    replay.artifact.test.test,
+                    replayed
+                );
+            }
+        }
 
         if should_draw {
             let (suite_name, test_name, mut test_result) =
@@ -1148,6 +1290,7 @@ impl TestArgs {
         should_debug: bool,
         decode_internal: InternalTraceMode,
         multi_network: MultiNetworkConfig,
+        replay_symbolic_artifact: Option<SymbolicArtifactReplayConfig>,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
         let verbosity = evm_opts.verbosity;
         let (evm_env, tx_env, fork_block) =
@@ -1166,6 +1309,7 @@ impl TestArgs {
             .set_coverage(coverage)
             .with_multi_network(multi_network)
             .with_showmap(showmap)
+            .with_symbolic_artifact_replay(replay_symbolic_artifact)
             .build::<FEN, MultiCompiler>(output, evm_env, tx_env, evm_opts)?;
 
         let libraries = runner.libraries.clone();
@@ -1186,6 +1330,7 @@ impl TestArgs {
         should_debug: bool,
         decode_internal: InternalTraceMode,
         multi_network: MultiNetworkConfig,
+        replay_symbolic_artifact: Option<SymbolicArtifactReplayConfig>,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
         if dispatch_opts.networks.is_tempo() {
             self.build_and_run_tests::<TempoEvmNetwork>(
@@ -1197,6 +1342,7 @@ impl TestArgs {
                 should_debug,
                 decode_internal,
                 multi_network,
+                replay_symbolic_artifact,
             )
             .await
         } else {
@@ -1212,6 +1358,7 @@ impl TestArgs {
                         should_debug,
                         decode_internal,
                         multi_network,
+                        replay_symbolic_artifact,
                     )
                     .await;
             }
@@ -1224,6 +1371,7 @@ impl TestArgs {
                 should_debug,
                 decode_internal,
                 multi_network,
+                replay_symbolic_artifact,
             )
             .await
         }
@@ -1449,6 +1597,9 @@ impl TestArgs {
                     !self.suppress_successful_traces || result.status == TestStatus::Failure;
                 if !silent {
                     sh_println!("{}", result.short_result_with_suite(name, &contract_name))?;
+                    for artifact in &result.counterexample_artifacts {
+                        sh_warn!("Counterexample artifact: {}", artifact.path.display())?;
+                    }
 
                     // Display invariant metrics if invariant kind.
                     if let TestKind::Invariant { metrics, .. } = &result.kind

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -730,7 +730,7 @@ impl TestArgs {
             filter_args.contract_pattern =
                 Some(Regex::new(&format!("^{}$", regex::escape(contract)))?);
             if !path.is_empty() {
-                filter_args.path_pattern = Some(path.parse::<GlobMatcher>()?);
+                filter_args.path_pattern = Some(globset::escape(path).parse::<GlobMatcher>()?);
             }
         }
         trace!(target: "forge::test", ?filter, "using filter");

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     mutation::{MutationRunConfig, run_mutation_testing},
     result::{
         SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA, SuiteResult, SymbolicCounterexampleArtifact,
-        TestKindReport, TestOutcome, TestResult, TestStatus,
+        SymbolicReplayStatus, TestKindReport, TestOutcome, TestResult, TestStatus,
     },
     traces::{
         CallTraceDecoderBuilder, InternalTraceMode, TraceKind,
@@ -533,6 +533,13 @@ impl TestArgs {
         )?;
         if artifact.calls.is_empty() {
             bail!("symbolic counterexample artifact {} has no calls", path.display());
+        }
+        if artifact.replay.status != SymbolicReplayStatus::Confirmed {
+            bail!(
+                "symbolic counterexample artifact {} replay status must be confirmed, got {:?}",
+                path.display(),
+                artifact.replay.status,
+            );
         }
         let Some((artifact_path, contract_name)) = artifact.test.contract.rsplit_once(':') else {
             bail!(

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -534,6 +534,20 @@ impl TestArgs {
         if artifact.calls.is_empty() {
             bail!("symbolic counterexample artifact {} has no calls", path.display());
         }
+        let Some((artifact_path, contract_name)) = artifact.test.contract.rsplit_once(':') else {
+            bail!(
+                "symbolic counterexample artifact {} test.contract must be `path:Contract`, got `{}`",
+                path.display(),
+                artifact.test.contract,
+            );
+        };
+        if artifact_path.is_empty() || contract_name.is_empty() {
+            bail!(
+                "symbolic counterexample artifact {} test.contract must be `path:Contract`, got `{}`",
+                path.display(),
+                artifact.test.contract,
+            );
+        }
 
         Ok(Some(SymbolicArtifactReplayConfig { artifact, path: path.clone() }))
     }

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -3,7 +3,7 @@
 use crate::{
     ContractRunner, TestFilter,
     progress::TestsProgress,
-    result::SuiteResult,
+    result::{SuiteResult, SymbolicCounterexampleArtifact},
     runner::{
         ContractRunnerContext, InvariantCampaignScope, LIBRARY_DEPLOYER,
         count_runnable_invariant_campaign_anchors, is_symbolic_entrypoint,
@@ -363,6 +363,15 @@ pub struct ShowmapConfig {
     pub corpus_dir: Option<PathBuf>,
 }
 
+/// CLI-only options for replaying a durable symbolic counterexample artifact.
+#[derive(Clone, Debug)]
+pub struct SymbolicArtifactReplayConfig {
+    /// Artifact payload to replay.
+    pub artifact: SymbolicCounterexampleArtifact,
+    /// Path the artifact was loaded from, used in diagnostics.
+    pub path: PathBuf,
+}
+
 /// Configuration for the test runner.
 ///
 /// This is modified after instantiation through inline config.
@@ -401,6 +410,9 @@ pub struct TestRunnerConfig<FEN: FoundryEvmNetwork> {
     /// When set, fuzz/invariant tests run in corpus replay mode and emit
     /// AFL-`afl-showmap`-style files instead of running a campaign.
     pub showmap: Option<ShowmapConfig>,
+
+    /// When set, run only the matching test and replay this artifact's concrete payload.
+    pub symbolic_artifact_replay: Option<SymbolicArtifactReplayConfig>,
 }
 
 impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
@@ -518,6 +530,8 @@ pub struct MultiContractRunnerBuilder {
     pub multi_network: MultiNetworkConfig,
     /// Showmap replay mode (CLI-only, off by default).
     pub showmap: Option<ShowmapConfig>,
+    /// Symbolic artifact replay mode (CLI-only, off by default).
+    pub symbolic_artifact_replay: Option<SymbolicArtifactReplayConfig>,
 }
 
 impl MultiContractRunnerBuilder {
@@ -534,11 +548,20 @@ impl MultiContractRunnerBuilder {
             fail_fast: false,
             multi_network: Default::default(),
             showmap: None,
+            symbolic_artifact_replay: None,
         }
     }
 
     pub fn with_showmap(mut self, showmap: Option<ShowmapConfig>) -> Self {
         self.showmap = showmap;
+        self
+    }
+
+    pub fn with_symbolic_artifact_replay(
+        mut self,
+        replay: Option<SymbolicArtifactReplayConfig>,
+    ) -> Self {
+        self.symbolic_artifact_replay = replay;
         self
     }
 
@@ -706,6 +729,7 @@ impl MultiContractRunnerBuilder {
                 early_exit: EarlyExit::new(self.fail_fast),
                 multi_network: self.multi_network,
                 showmap: self.showmap,
+                symbolic_artifact_replay: self.symbolic_artifact_replay,
                 config: self.config,
             },
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1938,6 +1938,21 @@ impl TestResult {
         self.counterexample = Some(CounterExample::Sequence(call_sequence.len(), call_sequence));
     }
 
+    /// Returns the success result for a replayed invariant test.
+    pub fn invariant_replay_success(&mut self, call_count: usize) {
+        self.kind = TestKind::Invariant {
+            runs: 1,
+            calls: call_count,
+            reverts: 0,
+            workers: default_invariant_workers(),
+            metrics: HashMap::default(),
+            failed_corpus_replays: 0,
+            optimization_best_value: None,
+        };
+        self.status = TestStatus::Success;
+        self.reason = None;
+    }
+
     /// Returns the fail result for invariant test setup.
     pub fn invariant_setup_fail(&mut self, e: Report) {
         self.kind = TestKind::Invariant {

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1916,12 +1916,14 @@ impl TestResult {
         replayed_entirely: bool,
         invariant_name: &String,
         replay_reason: Option<String>,
+        calls: usize,
+        reverts: usize,
         call_sequence: Vec<BaseCounterExample>,
     ) {
         self.kind = TestKind::Invariant {
             runs: 1,
-            calls: 1,
-            reverts: 1,
+            calls,
+            reverts,
             workers: default_invariant_workers(),
             metrics: HashMap::default(),
             failed_corpus_replays: 0,

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1939,11 +1939,11 @@ impl TestResult {
     }
 
     /// Returns the success result for a replayed invariant test.
-    pub fn invariant_replay_success(&mut self, call_count: usize) {
+    pub fn invariant_replay_success(&mut self, call_count: usize, reverts: usize) {
         self.kind = TestKind::Invariant {
             runs: 1,
             calls: call_count,
-            reverts: 0,
+            reverts,
             workers: default_invariant_workers(),
             metrics: HashMap::default(),
             failed_corpus_replays: 0,

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -510,6 +510,40 @@ mod tests {
         assert_eq!(value["calls"][0]["value"], "0x9");
         assert_counterexample_artifact_shape(&value);
     }
+
+    #[test]
+    fn symbolic_counterexample_artifact_serializes_zero_quantities_compactly() {
+        let symbolic = SymbolicResult::pass(&SymbolicConfig::default(), SymbolicStats::default());
+        let call = SymbolicCounterexampleCall {
+            warp: Some(U256::ZERO),
+            roll: Some(U256::ZERO),
+            sender: Address::ZERO,
+            target: Address::ZERO,
+            calldata: Bytes::from_static(&[0x12, 0x34, 0x56, 0x78]),
+            value: Some(U256::ZERO),
+            contract_name: Some("Target".to_string()),
+            function_name: Some("step".to_string()),
+            signature: Some("step()".to_string()),
+            args: Some(String::new()),
+            raw_args: Some(String::new()),
+        };
+        let artifact = SymbolicCounterexampleArtifact::new(
+            SymbolicCounterexampleArtifactKind::Sequence,
+            SymbolicCounterexampleTestIdentity {
+                contract: "InvariantTest".to_string(),
+                test: "invariant_counter()".to_string(),
+            },
+            &symbolic,
+            SymbolicCounterexampleReplaySemantics { fail_on_revert: false },
+            vec![call],
+        );
+
+        let value = serde_json::to_value(artifact).unwrap();
+        assert_eq!(value["calls"][0]["warp"], "0x0");
+        assert_eq!(value["calls"][0]["roll"], "0x0");
+        assert_eq!(value["calls"][0]["value"], "0x0");
+        assert_counterexample_artifact_shape(&value);
+    }
 }
 
 /// A set of test results for a single test suite, which is all the tests in a single contract.
@@ -1134,6 +1168,7 @@ pub enum SymbolicReplayStatus {
 
 /// Replay metadata for symbolic counterexample candidates.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SymbolicReplayMetadata {
     /// Whether the symbolic outcome required concrete replay.
     pub required: bool,
@@ -1196,6 +1231,7 @@ impl From<&BaseCounterExample> for SymbolicCounterexample {
 
 /// Durable symbolic counterexample artifact.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SymbolicCounterexampleArtifact {
     /// Artifact schema version.
     pub schema_version: u32,
@@ -1248,6 +1284,7 @@ impl SymbolicCounterexampleArtifact {
 
 /// Concrete replay semantics captured when a symbolic artifact is confirmed.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SymbolicCounterexampleReplaySemantics {
     /// Whether an invariant sequence replay treats any target-call revert as a failure.
     pub fail_on_revert: bool,
@@ -1265,6 +1302,7 @@ pub enum SymbolicCounterexampleArtifactKind {
 
 /// Test identity for a symbolic counterexample artifact.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SymbolicCounterexampleTestIdentity {
     /// Contract identifier as reported by Forge.
     pub contract: String,
@@ -1274,6 +1312,7 @@ pub struct SymbolicCounterexampleTestIdentity {
 
 /// One concrete call in a symbolic counterexample artifact.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SymbolicCounterexampleCall {
     /// Amount to increase block timestamp before executing the call.
     pub warp: Option<U256>,
@@ -1403,7 +1442,10 @@ pub struct TestResult {
     /// Minimal reproduction test case for failing test
     pub counterexample: Option<CounterExample>,
 
-    /// Durable replay artifact for the top-level counterexample, when one was written.
+    /// Legacy durable replay artifact for the top-level counterexample, when one was written.
+    ///
+    /// Prefer [`Self::counterexample_artifacts`] for new consumers; this compatibility field is
+    /// maintained by [`Self::add_counterexample_artifact`] for older JSON readers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub counterexample_artifact: Option<SymbolicArtifactRef>,
 

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -362,6 +362,7 @@ mod tests {
             "kind",
             "test",
             "replay",
+            "replay_semantics",
             "bounds",
             "solver",
             "assumptions",
@@ -373,6 +374,7 @@ mod tests {
         assert_eq!(value["schema_version"], 1);
         assert_eq!(value["schema"], SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA);
         assert!(matches!(value["kind"].as_str(), Some("single_call" | "sequence")));
+        assert!(value["replay_semantics"].is_object());
         assert!(!value["calls"].as_array().expect("calls array").is_empty());
         for call in value["calls"].as_array().unwrap() {
             let call = call.as_object().expect("call object");
@@ -492,6 +494,7 @@ mod tests {
                 test: "invariant_counter()".to_string(),
             },
             &symbolic,
+            SymbolicCounterexampleReplaySemantics { fail_on_revert: false },
             vec![call.clone(), call],
         );
 
@@ -499,6 +502,7 @@ mod tests {
         assert_eq!(value["schema_version"], 1);
         assert_eq!(value["schema"], SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA);
         assert_eq!(value["kind"], "sequence");
+        assert_eq!(value["replay_semantics"]["fail_on_revert"], false);
         assert_eq!(value["calls"].as_array().unwrap().len(), 2);
         assert_eq!(value["calls"][0]["calldata"], "0x12345678");
         assert_eq!(value["calls"][0]["warp"], "0xc");
@@ -1203,6 +1207,8 @@ pub struct SymbolicCounterexampleArtifact {
     pub test: SymbolicCounterexampleTestIdentity,
     /// Concrete replay metadata for the counterexample candidate.
     pub replay: SymbolicReplayMetadata,
+    /// Replay semantics that must remain stable when this artifact is replayed.
+    pub replay_semantics: SymbolicCounterexampleReplaySemantics,
     /// Effective bounds used by this symbolic run.
     pub bounds: SymbolicBounds,
     /// Solver identity and counters collected during this run.
@@ -1221,6 +1227,7 @@ impl SymbolicCounterexampleArtifact {
         kind: SymbolicCounterexampleArtifactKind,
         test: SymbolicCounterexampleTestIdentity,
         symbolic: &SymbolicResult,
+        replay_semantics: SymbolicCounterexampleReplaySemantics,
         calls: Vec<SymbolicCounterexampleCall>,
     ) -> Self {
         Self {
@@ -1229,6 +1236,7 @@ impl SymbolicCounterexampleArtifact {
             kind,
             test,
             replay: symbolic.replay.clone(),
+            replay_semantics,
             bounds: symbolic.bounds.clone(),
             solver: symbolic.solver.clone(),
             assumptions: symbolic.assumptions.clone(),
@@ -1236,6 +1244,13 @@ impl SymbolicCounterexampleArtifact {
             calls,
         }
     }
+}
+
+/// Concrete replay semantics captured when a symbolic artifact is confirmed.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct SymbolicCounterexampleReplaySemantics {
+    /// Whether an invariant sequence replay treats any target-call revert as a failure.
+    pub fail_on_revert: bool,
 }
 
 /// Symbolic counterexample artifact shape.

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1,6 +1,9 @@
 //! Test outcomes.
 
-use crate::{fuzz::BaseCounterExample, gas_report::GasReport};
+use crate::{
+    fuzz::{BaseCounterExample, BasicTxDetails},
+    gas_report::GasReport,
+};
 use alloy_primitives::{
     Address, Bytes, I256, Log, Selector, U256,
     map::{AddressHashMap, HashMap},
@@ -13,7 +16,7 @@ use foundry_evm::{
     coverage::HitMaps,
     decode::SkipReason,
     executors::{RawCallResult, invariant::InvariantMetrics},
-    fuzz::{CounterExample, FuzzCase, FuzzFixtures, FuzzTestResult},
+    fuzz::{CallDetails, CounterExample, FuzzCase, FuzzFixtures, FuzzTestResult},
     traces::{CallTraceArena, CallTraceDecoder, TraceKind, Traces},
 };
 use foundry_evm_symbolic::{PortfolioDiagnostics, SymbolicStats, SymbolicStopReason};
@@ -32,6 +35,8 @@ pub(crate) fn invariant_campaign_display_name(contract_name: &str) -> String {
 
 const INVARIANT_CAMPAIGN_FALLBACK_NAME: &str = "Invariant campaign";
 const SYMBOLIC_RESULT_SCHEMA_VERSION: u32 = 1;
+pub const SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA: &str = "foundry:symbolic.counterexample@v1";
+pub const SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA_VERSION: u32 = 1;
 
 const fn symbolic_result_schema_version() -> u32 {
     SYMBOLIC_RESULT_SCHEMA_VERSION
@@ -294,6 +299,115 @@ fn test_failure_exit_code() -> i32 {
 mod tests {
     use super::*;
 
+    const SYMBOLIC_RESULT_SCHEMA_JSON: &str =
+        include_str!("../../evm/symbolic/assets/symbolic-result.schema.json");
+    const SYMBOLIC_COUNTEREXAMPLE_SCHEMA_JSON: &str =
+        include_str!("../../evm/symbolic/assets/symbolic-counterexample.schema.json");
+
+    fn schema_defs(schema: &serde_json::Value) -> &serde_json::Map<String, serde_json::Value> {
+        schema["$defs"].as_object().expect("schema $defs object")
+    }
+
+    fn assert_counterexample_schema_refs_resolve_offline() {
+        let counterexample_schema: serde_json::Value =
+            serde_json::from_str(SYMBOLIC_COUNTEREXAMPLE_SCHEMA_JSON).unwrap();
+        let result_schema: serde_json::Value =
+            serde_json::from_str(SYMBOLIC_RESULT_SCHEMA_JSON).unwrap();
+        let result_defs = schema_defs(&result_schema);
+        let counterexample_defs = schema_defs(&counterexample_schema);
+
+        fn visit_refs(
+            value: &serde_json::Value,
+            result_defs: &serde_json::Map<String, serde_json::Value>,
+            counterexample_defs: &serde_json::Map<String, serde_json::Value>,
+        ) {
+            match value {
+                serde_json::Value::Object(map) => {
+                    if let Some(reference) = map.get("$ref").and_then(serde_json::Value::as_str) {
+                        if let Some(name) = reference.strip_prefix(
+                            "https://foundry-rs.github.io/schemas/symbolic-result.v1.schema.json#/$defs/",
+                        ) {
+                            assert!(result_defs.contains_key(name), "unresolved ref {reference}");
+                        } else if let Some(name) = reference.strip_prefix("#/$defs/") {
+                            assert!(
+                                counterexample_defs.contains_key(name),
+                                "unresolved ref {reference}"
+                            );
+                        } else {
+                            panic!("unexpected schema ref {reference}");
+                        }
+                    }
+                    for child in map.values() {
+                        visit_refs(child, result_defs, counterexample_defs);
+                    }
+                }
+                serde_json::Value::Array(values) => {
+                    for child in values {
+                        visit_refs(child, result_defs, counterexample_defs);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        visit_refs(&counterexample_schema, result_defs, counterexample_defs);
+    }
+
+    fn assert_counterexample_artifact_shape(value: &serde_json::Value) {
+        assert_counterexample_schema_refs_resolve_offline();
+        let object = value.as_object().expect("artifact object");
+        for key in [
+            "schema_version",
+            "schema",
+            "kind",
+            "test",
+            "replay",
+            "bounds",
+            "solver",
+            "assumptions",
+            "call_trace",
+            "calls",
+        ] {
+            assert!(object.contains_key(key), "missing required artifact key {key}");
+        }
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["schema"], SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA);
+        assert!(matches!(value["kind"].as_str(), Some("single_call" | "sequence")));
+        assert!(!value["calls"].as_array().expect("calls array").is_empty());
+        for call in value["calls"].as_array().unwrap() {
+            let call = call.as_object().expect("call object");
+            for key in [
+                "warp",
+                "roll",
+                "sender",
+                "target",
+                "calldata",
+                "value",
+                "contract_name",
+                "function_name",
+                "signature",
+                "args",
+                "raw_args",
+            ] {
+                assert!(call.contains_key(key), "missing required call key {key}");
+            }
+            for key in ["warp", "roll", "value"] {
+                let Some(encoded) = call[key].as_str() else { continue };
+                let Some(hex) = encoded.strip_prefix("0x") else {
+                    panic!("{key} must be 0x-prefixed hex quantity: {encoded}");
+                };
+                assert!(
+                    hex == "0" || !hex.starts_with('0'),
+                    "{key} must be compact hex quantity without leading zeros: {encoded}"
+                );
+                assert!(
+                    hex.bytes().all(|byte| byte.is_ascii_hexdigit()),
+                    "{key} must be hex quantity: {encoded}"
+                );
+            }
+        }
+    }
+
     fn outcome_with_failed_invariant_workers(workers: &[usize]) -> TestOutcome {
         let test_results = workers
             .iter()
@@ -353,6 +467,44 @@ mod tests {
         .unwrap();
 
         assert_eq!(kind.invariant_workers(), Some(1));
+    }
+
+    #[test]
+    fn symbolic_counterexample_artifact_serializes_sequence_calls() {
+        let symbolic = SymbolicResult::pass(&SymbolicConfig::default(), SymbolicStats::default());
+        let call = SymbolicCounterexampleCall {
+            warp: Some(U256::from(12)),
+            roll: Some(U256::from(3)),
+            sender: Address::ZERO,
+            target: Address::ZERO,
+            calldata: Bytes::from_static(&[0x12, 0x34, 0x56, 0x78]),
+            value: Some(U256::from(9)),
+            contract_name: Some("Target".to_string()),
+            function_name: Some("step".to_string()),
+            signature: Some("step()".to_string()),
+            args: Some(String::new()),
+            raw_args: Some(String::new()),
+        };
+        let artifact = SymbolicCounterexampleArtifact::new(
+            SymbolicCounterexampleArtifactKind::Sequence,
+            SymbolicCounterexampleTestIdentity {
+                contract: "InvariantTest".to_string(),
+                test: "invariant_counter()".to_string(),
+            },
+            &symbolic,
+            vec![call.clone(), call],
+        );
+
+        let value = serde_json::to_value(artifact).unwrap();
+        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["schema"], SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA);
+        assert_eq!(value["kind"], "sequence");
+        assert_eq!(value["calls"].as_array().unwrap().len(), 2);
+        assert_eq!(value["calls"][0]["calldata"], "0x12345678");
+        assert_eq!(value["calls"][0]["warp"], "0xc");
+        assert_eq!(value["calls"][0]["roll"], "0x3");
+        assert_eq!(value["calls"][0]["value"], "0x9");
+        assert_counterexample_artifact_shape(&value);
     }
 }
 
@@ -537,6 +689,9 @@ pub enum InvariantFailure {
         /// Counterexample sequence, when one is available.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         counterexample: Option<CounterExample>,
+        /// Durable replay artifact for this counterexample, when one was written.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        artifact: Option<SymbolicArtifactRef>,
         /// Path where the counterexample was persisted for re-running and shrinking.
         persisted_path: std::path::PathBuf,
         /// Whether this failure is the stable campaign anchor.
@@ -559,6 +714,9 @@ pub enum InvariantFailure {
         /// Counterexample sequence leading up to (and including) the failing call.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         counterexample: Option<CounterExample>,
+        /// Durable replay artifact for this counterexample, when one was written.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        artifact: Option<SymbolicArtifactRef>,
     },
 }
 
@@ -591,6 +749,13 @@ impl InvariantFailure {
             Self::Predicate { counterexample, .. } | Self::Handler { counterexample, .. } => {
                 counterexample.as_ref()
             }
+        }
+    }
+
+    /// Durable replay artifact for this failure, when one was written.
+    pub const fn artifact(&self) -> Option<&SymbolicArtifactRef> {
+        match self {
+            Self::Predicate { artifact, .. } | Self::Handler { artifact, .. } => artifact.as_ref(),
         }
     }
 }
@@ -629,6 +794,9 @@ pub struct SymbolicResult {
     pub replay: SymbolicReplayMetadata,
     /// Concrete counterexample data, when the solver produced a candidate.
     pub counterexample: Option<SymbolicCounterexample>,
+    /// Durable counterexample artifact, when one was written.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<SymbolicArtifactRef>,
 }
 
 impl SymbolicResult {
@@ -703,7 +871,30 @@ impl SymbolicResult {
             call_trace,
             replay,
             counterexample,
+            artifact: None,
         }
+    }
+
+    /// Attaches a durable replay artifact reference to this symbolic result.
+    pub fn with_artifact(mut self, artifact: SymbolicArtifactRef) -> Self {
+        self.artifact = Some(artifact);
+        self
+    }
+}
+
+/// Reference to a durable symbolic counterexample artifact.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SymbolicArtifactRef {
+    /// Artifact schema id.
+    pub schema: String,
+    /// Path to the artifact file.
+    pub path: std::path::PathBuf,
+}
+
+impl SymbolicArtifactRef {
+    /// Creates a reference to a symbolic counterexample artifact.
+    pub fn new(path: impl Into<std::path::PathBuf>) -> Self {
+        Self { schema: SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA.to_string(), path: path.into() }
     }
 }
 
@@ -999,6 +1190,157 @@ impl From<&BaseCounterExample> for SymbolicCounterexample {
     }
 }
 
+/// Durable symbolic counterexample artifact.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicCounterexampleArtifact {
+    /// Artifact schema version.
+    pub schema_version: u32,
+    /// Artifact schema id.
+    pub schema: String,
+    /// Whether this counterexample is a single test call or a stateful sequence.
+    pub kind: SymbolicCounterexampleArtifactKind,
+    /// Test identity that produced this counterexample.
+    pub test: SymbolicCounterexampleTestIdentity,
+    /// Concrete replay metadata for the counterexample candidate.
+    pub replay: SymbolicReplayMetadata,
+    /// Effective bounds used by this symbolic run.
+    pub bounds: SymbolicBounds,
+    /// Solver identity and counters collected during this run.
+    pub solver: SymbolicSolverMetadata,
+    /// Soundness assumptions that bound what a `pass` proves.
+    pub assumptions: Vec<SymbolicAssumption>,
+    /// Where an agent can find the concrete replay trace, when one was produced.
+    pub call_trace: SymbolicCallTrace,
+    /// Concrete replay calls.
+    pub calls: Vec<SymbolicCounterexampleCall>,
+}
+
+impl SymbolicCounterexampleArtifact {
+    /// Creates a durable symbolic counterexample artifact from a symbolic result and call list.
+    pub fn new(
+        kind: SymbolicCounterexampleArtifactKind,
+        test: SymbolicCounterexampleTestIdentity,
+        symbolic: &SymbolicResult,
+        calls: Vec<SymbolicCounterexampleCall>,
+    ) -> Self {
+        Self {
+            schema_version: SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA_VERSION,
+            schema: SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA.to_string(),
+            kind,
+            test,
+            replay: symbolic.replay.clone(),
+            bounds: symbolic.bounds.clone(),
+            solver: symbolic.solver.clone(),
+            assumptions: symbolic.assumptions.clone(),
+            call_trace: symbolic.call_trace.clone(),
+            calls,
+        }
+    }
+}
+
+/// Symbolic counterexample artifact shape.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolicCounterexampleArtifactKind {
+    /// A single stateless symbolic test call.
+    SingleCall,
+    /// A stateful sequence of calls.
+    Sequence,
+}
+
+/// Test identity for a symbolic counterexample artifact.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicCounterexampleTestIdentity {
+    /// Contract identifier as reported by Forge.
+    pub contract: String,
+    /// Test function signature.
+    pub test: String,
+}
+
+/// One concrete call in a symbolic counterexample artifact.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SymbolicCounterexampleCall {
+    /// Amount to increase block timestamp before executing the call.
+    pub warp: Option<U256>,
+    /// Amount to increase block number before executing the call.
+    pub roll: Option<U256>,
+    /// Sender used for the call.
+    pub sender: Address,
+    /// Target address called.
+    pub target: Address,
+    /// ABI-encoded calldata for replay.
+    pub calldata: Bytes,
+    /// Ether value sent with the call, when any.
+    pub value: Option<U256>,
+    /// Human-readable contract identifier, when known.
+    pub contract_name: Option<String>,
+    /// ABI function name, when known.
+    pub function_name: Option<String>,
+    /// ABI function signature, when known.
+    pub signature: Option<String>,
+    /// Pretty-formatted ABI arguments, when decoded.
+    pub args: Option<String>,
+    /// Raw ABI arguments, when decoded.
+    pub raw_args: Option<String>,
+}
+
+impl SymbolicCounterexampleCall {
+    /// Creates an artifact call from Foundry's base counterexample shape.
+    pub fn from_base_counterexample(
+        counterexample: &BaseCounterExample,
+        default_sender: Address,
+        default_target: Address,
+    ) -> Self {
+        Self {
+            warp: counterexample.warp,
+            roll: counterexample.roll,
+            sender: counterexample.sender.unwrap_or(default_sender),
+            target: counterexample.addr.unwrap_or(default_target),
+            calldata: counterexample.calldata.clone(),
+            value: counterexample.value,
+            contract_name: counterexample.contract_name.clone(),
+            function_name: counterexample.func_name.clone(),
+            signature: counterexample.signature.clone(),
+            args: counterexample.args.clone(),
+            raw_args: counterexample.raw_args.clone(),
+        }
+    }
+
+    /// Creates Foundry's display counterexample shape from an artifact call.
+    pub fn to_base_counterexample(&self) -> BaseCounterExample {
+        BaseCounterExample {
+            warp: self.warp,
+            roll: self.roll,
+            sender: Some(self.sender),
+            addr: Some(self.target),
+            calldata: self.calldata.clone(),
+            value: self.value,
+            contract_name: self.contract_name.clone(),
+            func_name: self.function_name.clone(),
+            signature: self.signature.clone(),
+            args: self.args.clone(),
+            raw_args: self.raw_args.clone(),
+            traces: None,
+            show_solidity: false,
+            fuzz: Default::default(),
+        }
+    }
+
+    /// Converts an artifact call into Foundry's invariant replay transaction shape.
+    pub fn to_basic_tx_details(&self) -> BasicTxDetails {
+        BasicTxDetails {
+            warp: self.warp,
+            roll: self.roll,
+            sender: self.sender,
+            call_details: CallDetails {
+                target: self.target,
+                calldata: self.calldata.clone(),
+                value: self.value,
+            },
+        }
+    }
+}
+
 /// The result of an executed test.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct TestResult {
@@ -1045,6 +1387,14 @@ pub struct TestResult {
 
     /// Minimal reproduction test case for failing test
     pub counterexample: Option<CounterExample>,
+
+    /// Durable replay artifact for the top-level counterexample, when one was written.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub counterexample_artifact: Option<SymbolicArtifactRef>,
+
+    /// All durable replay artifacts produced for this test result, normalized for JSON consumers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub counterexample_artifacts: Vec<SymbolicArtifactRef>,
 
     /// Any captured & parsed as strings logs along the test's execution which should
     /// be printed to the user.
@@ -1111,6 +1461,16 @@ impl fmt::Display for TestResult {
 }
 
 impl TestResult {
+    /// Adds a durable replay artifact to the normalized list and legacy top-level field.
+    pub fn add_counterexample_artifact(&mut self, artifact: SymbolicArtifactRef) {
+        if !self.counterexample_artifacts.contains(&artifact) {
+            self.counterexample_artifacts.push(artifact.clone());
+        }
+        if self.counterexample_artifact.is_none() {
+            self.counterexample_artifact = Some(artifact);
+        }
+    }
+
     fn render_status_block(
         &self,
         user_facing: bool,
@@ -1622,6 +1982,16 @@ impl TestResult {
         // sequence" rendered on success). Invariant check-mode failures live entirely in
         // `invariant_failures`; `reason`/`counterexample` stay `None` for invariant tests.
         self.counterexample = counterexample;
+        let artifacts = self
+            .invariant_failures
+            .iter()
+            .chain(&self.invariant_handler_failures)
+            .filter_map(InvariantFailure::artifact)
+            .cloned()
+            .collect::<Vec<_>>();
+        for artifact in artifacts {
+            self.add_counterexample_artifact(artifact);
+        }
         self.gas_report_traces = gas_report_traces;
     }
 
@@ -1675,6 +2045,9 @@ impl TestResult {
         self.status = status;
         self.reason = reason;
         self.counterexample = counterexample;
+        if let Some(artifact) = symbolic.artifact.clone() {
+            self.add_counterexample_artifact(artifact);
+        }
         self.symbolic = Some(symbolic);
         self.duration = Duration::default();
     }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -741,6 +741,9 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 .collect::<Vec<_>>();
 
             if replay_functions.is_empty() {
+                if !self.mcr.tcfg.multi_network.all_override_networks.is_empty() {
+                    return SuiteResult::new(start.elapsed(), BTreeMap::new(), warnings);
+                }
                 return SuiteResult::new(
                     start.elapsed(),
                     [(
@@ -1413,6 +1416,51 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     .iter()
                     .map(SymbolicCounterexampleCall::to_basic_tx_details)
                     .collect::<Vec<_>>();
+                let setup_contracts = load_contracts(
+                    self.setup.traces.iter().map(|(_, trace)| &trace.arena),
+                    &self.cr.mcr.known_contracts,
+                );
+                let mut evm = InvariantExecutor::new_with_fuzz_seed(
+                    self.clone_executor(),
+                    self.invariant_runner(),
+                    self.config.fuzz.seed,
+                    self.config.invariant.clone(),
+                    &setup_contracts,
+                    &self.cr.mcr.known_contracts,
+                    self.cr.num_invariant_campaign_anchors,
+                );
+                if let Err(err) = evm.select_contract_artifacts(self.address) {
+                    self.result.invariant_setup_fail(err);
+                    return self.result;
+                }
+                let targeted = match evm.select_contracts_and_senders(self.address) {
+                    Ok((_, targeted)) => targeted,
+                    Err(err) => {
+                        self.result.invariant_setup_fail(err);
+                        return self.result;
+                    }
+                };
+                {
+                    let targets = targeted.targets();
+                    for (idx, tx) in txes.iter().enumerate() {
+                        let Some(selector) = tx.call_details.calldata.get(..4) else {
+                            self.result.single_fail(Some(format!(
+                                "sequence symbolic artifact call {} has calldata shorter than a selector",
+                                idx + 1
+                            )));
+                            return self.result;
+                        };
+                        if !targets.can_replay(tx) {
+                            self.result.single_fail(Some(format!(
+                                "sequence symbolic artifact call {} targets unknown function {} on {}",
+                                idx + 1,
+                                hex::encode_prefixed(selector),
+                                tx.call_details.target
+                            )));
+                            return self.result;
+                        }
+                    }
+                }
                 match check_sequence(
                     self.clone_executor(),
                     &txes,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1430,9 +1430,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         rd: Some(self.revert_decoder()),
                     },
                 ) {
-                    Ok((success, replayed_entirely, reason)) => {
+                    Ok((success, replayed_entirely, reason, reverts)) => {
                         if success {
-                            self.result.invariant_replay_success(txes.len());
+                            self.result.invariant_replay_success(txes.len(), reverts);
                         } else {
                             self.result.invariant_replay_fail(
                                 replayed_entirely,
@@ -1801,7 +1801,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 &mut call_sequence,
                 assertion_failure,
             );
-            if let Ok((success, replayed_entirely, replay_reason)) = replay
+            if let Ok((success, replayed_entirely, replay_reason, _)) = replay
                 && !success
             {
                 let warn =
@@ -2587,8 +2587,9 @@ struct InvariantPersistedFailure {
     assertion_failure: bool,
 }
 
-/// Mirrors `check_sequence`'s return: `(success, replayed_entirely, optional_reason)`.
-type CheckSequenceResult = eyre::Result<(bool, bool, Option<String>)>;
+/// Mirrors `check_sequence`'s return:
+/// `(success, replayed_entirely, optional_reason, reverts)`.
+type CheckSequenceResult = eyre::Result<(bool, bool, Option<String>, usize)>;
 
 /// Borrowed context shared by primary-invariant and handler-side replay helpers.
 struct ReplayContext<'a> {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1455,7 +1455,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                             )));
                             return self.result;
                         };
-                        if !targeted.targets().can_replay(tx) {
+                        if !targeted.targets().has_abi_function(tx) {
                             self.result.single_fail(Some(format!(
                                 "sequence symbolic artifact call {} targets unknown function {} on {}",
                                 idx + 1,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -11,8 +11,8 @@ use crate::{
         SymbolicCallTrace, SymbolicCounterexample, SymbolicCounterexampleArtifact,
         SymbolicCounterexampleArtifactKind, SymbolicCounterexampleCall,
         SymbolicCounterexampleReplaySemantics, SymbolicCounterexampleTestIdentity,
-        SymbolicReplayMetadata, SymbolicResult, TestResult, TestSetup, TestStatus,
-        invariant_campaign_display_name,
+        SymbolicReplayMetadata, SymbolicReplayStatus, SymbolicResult, TestResult, TestSetup,
+        TestStatus, invariant_campaign_display_name,
     },
 };
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
@@ -31,7 +31,7 @@ use foundry_evm::{
         fuzz::FuzzedExecutor,
         invariant::{
             CheckSequenceOptions, HandlerAssertionFailure, InvariantExecutor, InvariantFuzzError,
-            check_sequence, execute_tx, execute_tx_and_register_created, replay_error,
+            check_sequence, execute_tx_and_register_created, replay_error,
             replay_handler_failure_sequence, replay_run,
         },
         replay_corpus_to_showmap,
@@ -1351,6 +1351,13 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
 
         match artifact.kind {
             SymbolicCounterexampleArtifactKind::SingleCall => {
+                if artifact.replay.status != SymbolicReplayStatus::Confirmed {
+                    self.result.single_fail(Some(format!(
+                        "single-call symbolic artifact replay status must be confirmed, got {:?}",
+                        artifact.replay.status
+                    )));
+                    return self.result;
+                }
                 let Some(call) = artifact.calls.first() else {
                     self.result.single_fail(Some("symbolic artifact has no calls".to_string()));
                     return self.result;
@@ -1367,27 +1374,53 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     self.result.single_fail(Some(err));
                     return self.result;
                 }
+                if call.warp.is_some() || call.roll.is_some() {
+                    self.result.single_fail(Some(
+                        "single-call symbolic artifact replay does not support warp or roll"
+                            .to_string(),
+                    ));
+                    return self.result;
+                }
 
                 if self.prepare_test(func).is_err() {
                     return self.result;
                 }
 
-                let mut executor = self.clone_executor();
-                match execute_tx(&mut executor, &call.to_basic_tx_details()) {
-                    Ok(mut raw_call_result) => {
-                        let replay_still_fails = !executor.is_raw_call_mut_success(
+                let executor = self.clone_executor();
+                match executor.call_raw(
+                    call.sender,
+                    call.target,
+                    call.calldata.clone(),
+                    call.value.unwrap_or(U256::ZERO),
+                ) {
+                    Ok(raw_call_result) => {
+                        let replay_success = executor.is_raw_call_success(
                             self.address,
-                            &mut raw_call_result,
+                            Cow::Borrowed(&raw_call_result.state_changeset),
+                            &raw_call_result,
                             false,
                         );
-                        self.result.single_result(
-                            !replay_still_fails,
-                            if replay_still_fails { artifact.replay.reason.clone() } else { None },
-                            raw_call_result,
-                        );
-                        if replay_still_fails {
-                            self.result.counterexample =
-                                Some(CounterExample::Single(call.to_base_counterexample()));
+                        if replay_success {
+                            self.result.single_result(true, None, raw_call_result);
+                        } else {
+                            match raw_call_result.into_evm_error(Some(self.revert_decoder())) {
+                                EvmError::Execution(err) => {
+                                    let reason = if err.reason.is_empty() {
+                                        artifact.replay.reason.clone()
+                                    } else {
+                                        Some(err.reason.clone())
+                                    };
+                                    self.result.single_result(false, reason, err.raw);
+                                    self.result.counterexample =
+                                        Some(CounterExample::Single(call.to_base_counterexample()));
+                                }
+                                EvmError::Skip(reason) => self.result.single_skip(reason),
+                                err => {
+                                    self.result.counterexample =
+                                        Some(CounterExample::Single(call.to_base_counterexample()));
+                                    self.result.single_fail(Some(err.to_string()));
+                                }
+                            }
                         }
                     }
                     Err(err) => {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -7,14 +7,16 @@ use crate::{
     multi_runner::{TestContract, TestRunnerConfig},
     progress::{TestsProgress, start_fuzz_progress},
     result::{
-        InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicCallTrace,
-        SymbolicCounterexample, SymbolicReplayMetadata, SymbolicResult, TestResult, TestSetup,
-        TestStatus, invariant_campaign_display_name,
+        InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicArtifactRef,
+        SymbolicCallTrace, SymbolicCounterexample, SymbolicCounterexampleArtifact,
+        SymbolicCounterexampleArtifactKind, SymbolicCounterexampleCall,
+        SymbolicCounterexampleTestIdentity, SymbolicReplayMetadata, SymbolicResult, TestResult,
+        TestSetup, TestStatus, invariant_campaign_display_name,
     },
 };
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::{Function, JsonAbi};
-use alloy_primitives::{Address, Bytes, Selector, U256, address, map::HashMap};
+use alloy_primitives::{Address, Bytes, Selector, U256, address, hex, keccak256, map::HashMap};
 use eyre::Result;
 use foundry_common::{TestFunctionExt, TestFunctionKind, contracts::ContractsByAddress};
 use foundry_compilers::utils::canonicalized;
@@ -28,7 +30,7 @@ use foundry_evm::{
         fuzz::FuzzedExecutor,
         invariant::{
             CheckSequenceOptions, HandlerAssertionFailure, InvariantExecutor, InvariantFuzzError,
-            check_sequence, replay_error, replay_handler_failure_sequence, replay_run,
+            check_sequence, execute_tx, replay_error, replay_handler_failure_sequence, replay_run,
         },
         replay_corpus_to_showmap,
     },
@@ -42,7 +44,7 @@ use foundry_evm::{
 };
 use foundry_evm_networks::NetworkVariant;
 use foundry_evm_symbolic::{
-    SymbolicExecutor, SymbolicRunInput, SymbolicRunResult, SymbolicStopReason,
+    SymbolicExecutor, SymbolicRunInput, SymbolicRunResult, SymbolicStats, SymbolicStopReason,
 };
 use itertools::Itertools;
 use proptest::test_runner::{RngAlgorithm, TestError, TestRng, TestRunner};
@@ -729,6 +731,87 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             load_contracts(setup.traces.iter().map(|(_, t)| &t.arena), &self.mcr.known_contracts)
         });
 
+        if let Some(replay) = &self.mcr.tcfg.symbolic_artifact_replay {
+            let artifact = &replay.artifact;
+            let replay_functions = functions
+                .iter()
+                .filter(|func| func.signature() == artifact.test.test)
+                .copied()
+                .collect::<Vec<_>>();
+
+            if replay_functions.is_empty() {
+                return SuiteResult::new(
+                    start.elapsed(),
+                    [(
+                        artifact.test.test.clone(),
+                        TestResult::fail(format!(
+                            "symbolic artifact target `{}` was not found in `{}`",
+                            artifact.test.test, artifact.test.contract,
+                        )),
+                    )]
+                    .into(),
+                    warnings,
+                );
+            }
+            if replay_functions.len() > 1 {
+                return SuiteResult::new(
+                    start.elapsed(),
+                    [(
+                        artifact.test.test.clone(),
+                        TestResult::fail(format!(
+                            "symbolic artifact target `{}` matched {} functions in `{}`",
+                            artifact.test.test,
+                            replay_functions.len(),
+                            artifact.test.contract,
+                        )),
+                    )]
+                    .into(),
+                    warnings,
+                );
+            }
+
+            let test_results = replay_functions
+                .into_iter()
+                .map(|func| {
+                    let start = Instant::now();
+                    let kind = match artifact.kind {
+                        SymbolicCounterexampleArtifactKind::SingleCall => {
+                            TestFunctionKind::SymbolicTest
+                        }
+                        SymbolicCounterexampleArtifactKind::Sequence => func.test_function_kind(),
+                    };
+                    if artifact.kind == SymbolicCounterexampleArtifactKind::Sequence
+                        && !kind.is_invariant_test()
+                    {
+                        return (
+                            func.signature(),
+                            TestResult::fail(format!(
+                                "sequence symbolic artifact must target an invariant test, but matched {} function `{}`",
+                                kind.name(),
+                                func.signature(),
+                            )),
+                        );
+                    }
+                    let invariants =
+                        if artifact.kind == SymbolicCounterexampleArtifactKind::Sequence {
+                            std::slice::from_ref(&func)
+                        } else {
+                            &[][..]
+                        };
+                    let mut res = FunctionRunner::new(&self, &setup).run_symbolic_artifact_replay(
+                        func,
+                        invariants,
+                        call_after_invariant,
+                    );
+                    res.duration = start.elapsed();
+                    debug!(%kind, path = %replay.path.display(), "replayed symbolic artifact");
+                    (func.signature(), res)
+                })
+                .collect::<BTreeMap<_, _>>();
+
+            return SuiteResult::new(start.elapsed(), test_results, warnings);
+        }
+
         let test_fail_functions =
             functions.iter().filter(|func| func.test_function_kind().is_any_test_fail());
         if test_fail_functions.clone().next().is_some() {
@@ -890,6 +973,85 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         self.cr.progress.is_some() && self.config.symbolic.dump_smt
     }
 
+    fn persist_symbolic_counterexample_artifact(
+        &self,
+        test_name: &str,
+        artifact_file_name: &str,
+        symbolic: &SymbolicResult,
+        kind: SymbolicCounterexampleArtifactKind,
+        calls: Vec<SymbolicCounterexampleCall>,
+    ) -> Option<SymbolicArtifactRef> {
+        let dir = self
+            .config
+            .cache_path
+            .join("symbolic")
+            .join(sanitize_symbolic_artifact_component(self.cr.name));
+        // Use a stable per-test artifact path so the latest counterexample replaces older ones.
+        let path = dir.join(symbolic_artifact_file_name(artifact_file_name));
+        let artifact = SymbolicCounterexampleArtifact::new(
+            kind,
+            SymbolicCounterexampleTestIdentity {
+                contract: self.cr.name.to_string(),
+                test: test_name.to_string(),
+            },
+            symbolic,
+            calls,
+        );
+
+        if let Err(err) = foundry_common::fs::create_dir_all(&dir) {
+            tracing::error!(%err, path = %dir.display(), "Failed to create symbolic artifact dir");
+            return None;
+        }
+        if let Err(err) = foundry_common::fs::write_json_file(&path, &artifact) {
+            tracing::error!(%err, path = %path.display(), "Failed to write symbolic artifact");
+            return None;
+        }
+
+        Some(SymbolicArtifactRef::new(path))
+    }
+
+    fn persist_invariant_sequence_counterexample_artifact(
+        &self,
+        test_name: &str,
+        artifact_file_name: &str,
+        call_sequence: &[BaseCounterExample],
+    ) -> Option<SymbolicArtifactRef> {
+        if call_sequence.is_empty() {
+            return None;
+        }
+        if !self.config.symbolic.enabled {
+            return None;
+        }
+
+        let symbolic_result = SymbolicResult::incomplete(
+            &self.config.symbolic,
+            SymbolicStopReason::Error,
+            "concrete replay confirmed stateful counterexample",
+            SymbolicStats::default(),
+            SymbolicReplayMetadata::confirmed(),
+            SymbolicCallTrace::none(),
+            None,
+        );
+        let calls = call_sequence
+            .iter()
+            .map(|counterexample| {
+                SymbolicCounterexampleCall::from_base_counterexample(
+                    counterexample,
+                    CALLER,
+                    self.address,
+                )
+            })
+            .collect();
+
+        self.persist_symbolic_counterexample_artifact(
+            test_name,
+            artifact_file_name,
+            &symbolic_result,
+            SymbolicCounterexampleArtifactKind::Sequence,
+            calls,
+        )
+    }
+
     /// Configures this runner with the inline configuration for the contract.
     fn apply_function_inline_config(&mut self, func: &Function) -> Result<()> {
         if self.inline_config.contains_function(self.cr.name, &func.name) {
@@ -1037,9 +1199,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 );
             }
             SymbolicRunResult::Counterexample { args, calldata, stats } => {
-                let symbolic_counterexample = SymbolicCounterexample::from(
-                    &BaseCounterExample::from_fuzz_call(calldata.clone(), args.clone(), None),
-                );
+                let candidate_counterexample =
+                    BaseCounterExample::from_fuzz_call(calldata.clone(), args.clone(), None);
+                let symbolic_counterexample =
+                    SymbolicCounterexample::from(&candidate_counterexample);
                 let (mut raw_call_result, reason) = match self.executor.call(
                     self.sender,
                     self.address,
@@ -1052,19 +1215,20 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
                     Err(EvmError::Skip(reason)) => {
                         let replay_reason = format!("vm.skip during concrete replay: {reason}");
+                        let symbolic_result = SymbolicResult::incomplete(
+                            &self.config.symbolic,
+                            SymbolicStopReason::Error,
+                            "concrete replay skipped the symbolic counterexample",
+                            stats,
+                            SymbolicReplayMetadata::skipped(replay_reason),
+                            SymbolicCallTrace::none(),
+                            Some(symbolic_counterexample),
+                        );
                         self.result.symbolic_result(
                             TestStatus::Skipped,
                             reason.0,
                             None,
-                            SymbolicResult::incomplete(
-                                &self.config.symbolic,
-                                SymbolicStopReason::Error,
-                                "concrete replay skipped the symbolic counterexample",
-                                stats,
-                                SymbolicReplayMetadata::skipped(replay_reason),
-                                SymbolicCallTrace::none(),
-                                Some(symbolic_counterexample),
-                            ),
+                            symbolic_result,
                         );
                         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
                         self.result.symbolic_diagnostics = symbolic_diagnostics;
@@ -1072,19 +1236,20 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     }
                     Err(err) => {
                         let reason = err.to_string();
+                        let symbolic_result = SymbolicResult::incomplete(
+                            &self.config.symbolic,
+                            SymbolicStopReason::Error,
+                            reason.clone(),
+                            stats,
+                            SymbolicReplayMetadata::error(reason.clone()),
+                            SymbolicCallTrace::none(),
+                            Some(symbolic_counterexample),
+                        );
                         self.result.symbolic_result(
                             TestStatus::Failure,
-                            Some(reason.clone()),
+                            Some(reason),
                             None,
-                            SymbolicResult::incomplete(
-                                &self.config.symbolic,
-                                SymbolicStopReason::Error,
-                                reason.clone(),
-                                stats,
-                                SymbolicReplayMetadata::error(reason),
-                                SymbolicCallTrace::none(),
-                                Some(symbolic_counterexample),
-                            ),
+                            symbolic_result,
                         );
                         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
                         self.result.symbolic_diagnostics = symbolic_diagnostics;
@@ -1107,33 +1272,48 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 self.result.extend(raw_call_result);
                 if success {
                     let reason = "symbolic counterexample did not replay".to_string();
+                    let symbolic_result = SymbolicResult::incomplete(
+                        &self.config.symbolic,
+                        SymbolicStopReason::Error,
+                        reason.clone(),
+                        stats,
+                        SymbolicReplayMetadata::mismatch(reason.clone()),
+                        call_trace,
+                        Some(symbolic_counterexample),
+                    );
                     let counterexample = CounterExample::Single(base_counterexample);
                     self.result.symbolic_result(
                         TestStatus::Failure,
-                        Some(reason.clone()),
+                        Some(reason),
                         Some(counterexample),
-                        SymbolicResult::incomplete(
-                            &self.config.symbolic,
-                            SymbolicStopReason::Error,
-                            reason.clone(),
-                            stats,
-                            SymbolicReplayMetadata::mismatch(reason),
-                            call_trace,
-                            Some(symbolic_counterexample),
-                        ),
+                        symbolic_result,
                     );
                 } else {
+                    let mut symbolic_result = SymbolicResult::fail_counterexample(
+                        &self.config.symbolic,
+                        stats,
+                        call_trace,
+                        symbolic_counterexample,
+                    );
+                    if let Some(artifact) = self.persist_symbolic_counterexample_artifact(
+                        &func.signature(),
+                        &func.signature(),
+                        &symbolic_result,
+                        SymbolicCounterexampleArtifactKind::SingleCall,
+                        vec![SymbolicCounterexampleCall::from_base_counterexample(
+                            &base_counterexample,
+                            self.sender,
+                            self.address,
+                        )],
+                    ) {
+                        symbolic_result = symbolic_result.with_artifact(artifact);
+                    }
                     let counterexample = CounterExample::Single(base_counterexample);
                     self.result.symbolic_result(
                         TestStatus::Failure,
                         reason,
                         Some(counterexample),
-                        SymbolicResult::fail_counterexample(
-                            &self.config.symbolic,
-                            stats,
-                            call_trace,
-                            symbolic_counterexample,
-                        ),
+                        symbolic_result,
                     );
                 }
             }
@@ -1141,6 +1321,133 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
 
         self.result.symbolic_portfolio_diagnostics = portfolio_diagnostics;
         self.result.symbolic_diagnostics = symbolic_diagnostics;
+        self.result
+    }
+
+    /// Replays a durable symbolic counterexample artifact against this freshly set up test.
+    fn run_symbolic_artifact_replay(
+        mut self,
+        func: &Function,
+        invariants: &[&Function],
+        call_after_invariant: bool,
+    ) -> TestResult {
+        let Some(replay) = &self.cr.mcr.tcfg.symbolic_artifact_replay else {
+            self.result.single_fail(Some("missing symbolic artifact replay config".to_string()));
+            return self.result;
+        };
+        let artifact = &replay.artifact;
+        if let Err(e) = self.apply_function_inline_config(func) {
+            self.result.single_fail(Some(e.to_string()));
+            return self.result;
+        }
+
+        match artifact.kind {
+            SymbolicCounterexampleArtifactKind::SingleCall => {
+                let Some(call) = artifact.calls.first() else {
+                    self.result.single_fail(Some("symbolic artifact has no calls".to_string()));
+                    return self.result;
+                };
+                if artifact.calls.len() != 1 {
+                    self.result.single_fail(Some(
+                        "single-call symbolic artifact must contain exactly one call".to_string(),
+                    ));
+                    return self.result;
+                }
+                if let Err(err) = validate_single_call_symbolic_replay(func, call, self.address) {
+                    self.result.single_fail(Some(err));
+                    return self.result;
+                }
+
+                if self.prepare_test(func).is_err() {
+                    return self.result;
+                }
+
+                let mut executor = self.clone_executor();
+                match execute_tx(&mut executor, &call.to_basic_tx_details()) {
+                    Ok(mut raw_call_result) => {
+                        let replay_still_fails = !executor.is_raw_call_mut_success(
+                            self.address,
+                            &mut raw_call_result,
+                            false,
+                        );
+                        self.result.single_result(
+                            !replay_still_fails,
+                            if replay_still_fails { artifact.replay.reason.clone() } else { None },
+                            raw_call_result,
+                        );
+                        if replay_still_fails {
+                            self.result.counterexample =
+                                Some(CounterExample::Single(call.to_base_counterexample()));
+                        }
+                    }
+                    Err(err) => {
+                        self.result.counterexample =
+                            Some(CounterExample::Single(call.to_base_counterexample()));
+                        self.result.single_fail(Some(err.to_string()));
+                    }
+                }
+            }
+            SymbolicCounterexampleArtifactKind::Sequence => {
+                let Some(invariant) = invariants.first() else {
+                    self.result.single_fail(Some(
+                        "sequence symbolic artifact must target an invariant test".to_string(),
+                    ));
+                    return self.result;
+                };
+                if artifact.calls.is_empty() {
+                    self.result.single_fail(Some("symbolic artifact has no calls".to_string()));
+                    return self.result;
+                }
+
+                let calls = artifact
+                    .calls
+                    .iter()
+                    .map(SymbolicCounterexampleCall::to_base_counterexample)
+                    .collect::<Vec<_>>();
+                let txes = artifact
+                    .calls
+                    .iter()
+                    .map(SymbolicCounterexampleCall::to_basic_tx_details)
+                    .collect::<Vec<_>>();
+                match check_sequence(
+                    self.clone_executor(),
+                    &txes,
+                    (0..txes.len()).collect(),
+                    self.setup.address,
+                    invariant.selector().to_vec().into(),
+                    CheckSequenceOptions {
+                        // Artifact replay executes every stored call in order, so each call's
+                        // warp/roll delta is applied directly. Accumulation is only needed when a
+                        // shrink candidate skips calls and must fold removed delays forward.
+                        accumulate_warp_roll: false,
+                        fail_on_revert: self.config.invariant.fail_on_revert,
+                        expect_assertion_failure: false,
+                        call_after_invariant,
+                        rd: Some(self.revert_decoder()),
+                    },
+                ) {
+                    Ok((success, replayed_entirely, reason)) => {
+                        if success {
+                            self.result.status = TestStatus::Success;
+                            self.result.reason = None;
+                        } else {
+                            self.result.invariant_replay_fail(
+                                replayed_entirely,
+                                &invariant.signature(),
+                                reason.or_else(|| artifact.replay.reason.clone()),
+                                calls,
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        self.result.counterexample =
+                            Some(CounterExample::Sequence(calls.len(), calls));
+                        self.result.single_fail(Some(err.to_string()));
+                    }
+                }
+            }
+        }
+
         self.result
     }
 
@@ -1547,8 +1854,15 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     replayed_entirely,
                     &invariant_contract.anchor().name,
                     replay_reason,
-                    call_sequence,
+                    call_sequence.clone(),
                 );
+                if let Some(artifact) = self.persist_invariant_sequence_counterexample_artifact(
+                    &invariant_contract.anchor().signature(),
+                    &format!("{}-replay", invariant_contract.anchor().signature()),
+                    &call_sequence,
+                ) {
+                    self.result.add_counterexample_artifact(artifact);
+                }
                 return self.result;
             }
         }
@@ -1684,7 +1998,14 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                                     case_data.assertion_failure,
                                 );
                                 any_failure_persisted = true;
+                                let artifact = self
+                                    .persist_invariant_sequence_counterexample_artifact(
+                                        &invariant_contract.anchor().signature(),
+                                        &invariant_contract.anchor().signature(),
+                                        &call_sequence,
+                                    );
                                 Some(CounterExample::Sequence(calls.len(), call_sequence))
+                                    .map(|counterexample| (counterexample, artifact))
                             }
                             Ok(_) => None,
                             Err(err) => {
@@ -1697,10 +2018,15 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     // Handler bugs live in `handler_errors`; defensive None here.
                     InvariantFuzzError::HandlerAssertion(_) => None,
                 };
+                let (anchor_counterexample, artifact) = match anchor_counterexample {
+                    Some((counterexample, artifact)) => (Some(counterexample), artifact),
+                    None => (None, None),
+                };
                 invariant_failures.push(InvariantFailure::Predicate {
                     name: invariant_contract.anchor().name.clone(),
                     reason: error.revert_reason().unwrap_or_default(),
                     counterexample: anchor_counterexample,
+                    artifact,
                     persisted_path: primary_failure_file,
                     is_anchor: true,
                 });
@@ -1791,7 +2117,16 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                                     case_data.assertion_failure,
                                 );
                                 any_failure_persisted = true;
-                                Some(CounterExample::Sequence(original_seq_len, call_sequence))
+                                let artifact = self
+                                    .persist_invariant_sequence_counterexample_artifact(
+                                        &invariant.signature(),
+                                        &invariant.signature(),
+                                        &call_sequence,
+                                    );
+                                Some((
+                                    CounterExample::Sequence(original_seq_len, call_sequence),
+                                    artifact,
+                                ))
                             }
                             Ok(_) => None,
                             Err(err) => {
@@ -1800,10 +2135,15 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                             }
                         }
                     };
+                    let (secondary_counterexample, artifact) = match secondary_counterexample {
+                        Some((counterexample, artifact)) => (Some(counterexample), artifact),
+                        None => (None, None),
+                    };
                     invariant_failures.push(InvariantFailure::Predicate {
                         name: invariant.name.clone(),
                         reason: error.revert_reason().unwrap_or_default(),
                         counterexample: secondary_counterexample,
+                        artifact,
                         persisted_path: persisted_failure.clone(),
                         is_anchor: false,
                     });
@@ -1899,6 +2239,11 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         &current_settings,
                     );
                 }
+                let artifact = self.persist_invariant_sequence_counterexample_artifact(
+                    &invariant_contract.anchor().signature(),
+                    &format!("handler-{reverter}-{selector}"),
+                    &counterexample_calls,
+                );
 
                 let counterexample = if counterexample_calls.is_empty() {
                     None
@@ -1916,6 +2261,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     selector,
                     reason: failure.revert_reason.clone(),
                     counterexample,
+                    artifact,
                 }
             })
             .collect::<Vec<_>>();
@@ -2393,6 +2739,45 @@ fn invariant_failure_dir(persist_dir: PathBuf, contract_name: &str) -> PathBuf {
 /// Returns the invariant test contract name without the file path prefix.
 fn invariant_contract_name(contract_name: &str) -> &str {
     contract_name.split(':').next_back().unwrap()
+}
+
+fn sanitize_symbolic_artifact_component(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' { ch } else { '_' })
+        .collect::<String>();
+    if sanitized.is_empty() { "_".to_string() } else { sanitized }
+}
+
+fn symbolic_artifact_file_name(value: &str) -> String {
+    let hash = keccak256(value.as_bytes());
+    let hash = hex::encode(&hash[..4]);
+    format!("{}-{hash}.json", sanitize_symbolic_artifact_component(value))
+}
+
+fn validate_single_call_symbolic_replay(
+    func: &Function,
+    call: &SymbolicCounterexampleCall,
+    test_address: Address,
+) -> Result<(), String> {
+    if call.target != test_address {
+        return Err(format!(
+            "single-call symbolic artifact target {} does not match test contract {}",
+            call.target, test_address
+        ));
+    }
+    if call.value.is_some_and(|value| !value.is_zero()) {
+        return Err(
+            "single-call symbolic artifact replay does not support non-zero value".to_string()
+        );
+    }
+    if !call.calldata.get(..4).is_some_and(|selector| func.selector() == selector) {
+        return Err(format!(
+            "single-call symbolic artifact calldata does not match `{}` selector",
+            func.signature()
+        ));
+    }
+    Ok(())
 }
 
 /// Helper function to persist invariant failure.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1512,14 +1512,16 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         rd: Some(self.revert_decoder()),
                     },
                 ) {
-                    Ok((success, replayed_entirely, reason, reverts)) => {
+                    Ok((success, replayed_entirely, reason, calls_count, reverts)) => {
                         if success {
-                            self.result.invariant_replay_success(txes.len(), reverts);
+                            self.result.invariant_replay_success(calls_count, reverts);
                         } else {
                             self.result.invariant_replay_fail(
                                 replayed_entirely,
                                 &invariant.signature(),
                                 reason.or_else(|| artifact.replay.reason.clone()),
+                                calls_count,
+                                reverts,
                                 calls,
                             );
                         }
@@ -1883,7 +1885,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 &mut call_sequence,
                 assertion_failure,
             );
-            if let Ok((success, replayed_entirely, replay_reason, _)) = replay
+            if let Ok((success, replayed_entirely, replay_reason, calls_count, reverts)) = replay
                 && !success
             {
                 let warn =
@@ -1939,6 +1941,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     replayed_entirely,
                     &invariant_contract.anchor().name,
                     replay_reason,
+                    calls_count,
+                    reverts,
                     call_sequence.clone(),
                 );
                 if let Some(artifact) = self.persist_invariant_sequence_counterexample_artifact(
@@ -2670,8 +2674,8 @@ struct InvariantPersistedFailure {
 }
 
 /// Mirrors `check_sequence`'s return:
-/// `(success, replayed_entirely, optional_reason, reverts)`.
-type CheckSequenceResult = eyre::Result<(bool, bool, Option<String>, usize)>;
+/// `(success, replayed_entirely, optional_reason, calls, reverts)`.
+type CheckSequenceResult = eyre::Result<(bool, bool, Option<String>, usize, usize)>;
 
 /// Borrowed context shared by primary-invariant and handler-side replay helpers.
 struct ReplayContext<'a> {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1455,7 +1455,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                             )));
                             return self.result;
                         };
-                        if !targeted.targets().has_abi_function(tx) {
+                        if !targeted.targets().can_replay(tx) {
                             self.result.single_fail(Some(format!(
                                 "sequence symbolic artifact call {} targets unknown function {} on {}",
                                 idx + 1,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1466,8 +1466,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         }
                         if (!sender_filters.targeted.is_empty()
                             && !sender_filters.targeted.contains(&tx.sender))
-                            || (tx.sender != Address::ZERO
-                                && sender_filters.excluded.contains(&tx.sender))
+                            || sender_filters.excluded.contains(&tx.sender)
                         {
                             self.result.single_fail(Some(format!(
                                 "sequence symbolic artifact call {} uses forbidden sender {}",

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1432,8 +1432,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 ) {
                     Ok((success, replayed_entirely, reason)) => {
                         if success {
-                            self.result.status = TestStatus::Success;
-                            self.result.reason = None;
+                            self.result.invariant_replay_success(txes.len());
                         } else {
                             self.result.invariant_replay_fail(
                                 replayed_entirely,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -10,8 +10,9 @@ use crate::{
         InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicArtifactRef,
         SymbolicCallTrace, SymbolicCounterexample, SymbolicCounterexampleArtifact,
         SymbolicCounterexampleArtifactKind, SymbolicCounterexampleCall,
-        SymbolicCounterexampleTestIdentity, SymbolicReplayMetadata, SymbolicResult, TestResult,
-        TestSetup, TestStatus, invariant_campaign_display_name,
+        SymbolicCounterexampleReplaySemantics, SymbolicCounterexampleTestIdentity,
+        SymbolicReplayMetadata, SymbolicResult, TestResult, TestSetup, TestStatus,
+        invariant_campaign_display_name,
     },
 };
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
@@ -995,6 +996,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 test: test_name.to_string(),
             },
             symbolic,
+            SymbolicCounterexampleReplaySemantics {
+                fail_on_revert: self.config.invariant.fail_on_revert,
+            },
             calls,
         );
 
@@ -1420,7 +1424,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         // warp/roll delta is applied directly. Accumulation is only needed when a
                         // shrink candidate skips calls and must fold removed delays forward.
                         accumulate_warp_roll: false,
-                        fail_on_revert: self.config.invariant.fail_on_revert,
+                        fail_on_revert: artifact.replay_semantics.fail_on_revert,
                         expect_assertion_failure: false,
                         call_after_invariant,
                         rd: Some(self.revert_decoder()),

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -31,7 +31,8 @@ use foundry_evm::{
         fuzz::FuzzedExecutor,
         invariant::{
             CheckSequenceOptions, HandlerAssertionFailure, InvariantExecutor, InvariantFuzzError,
-            check_sequence, execute_tx, replay_error, replay_handler_failure_sequence, replay_run,
+            check_sequence, execute_tx, execute_tx_and_register_created, replay_error,
+            replay_handler_failure_sequence, replay_run,
         },
         replay_corpus_to_showmap,
     },
@@ -1442,7 +1443,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         }
                     };
                 {
-                    let targets = targeted.targets();
+                    let dynamic_target_ctx = evm.dynamic_target_ctx();
+                    let mut validation_executor =
+                        targeted.is_updatable.then(|| self.clone_executor());
+                    let mut validation_created_contracts = Vec::new();
                     for (idx, tx) in txes.iter().enumerate() {
                         let Some(selector) = tx.call_details.calldata.get(..4) else {
                             self.result.single_fail(Some(format!(
@@ -1451,7 +1455,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                             )));
                             return self.result;
                         };
-                        if !targets.can_replay(tx) {
+                        if !targeted.targets().can_replay(tx) {
                             self.result.single_fail(Some(format!(
                                 "sequence symbolic artifact call {} targets unknown function {} on {}",
                                 idx + 1,
@@ -1471,6 +1475,24 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                                 tx.sender
                             )));
                             return self.result;
+                        }
+                        if let Some(validation_executor) = validation_executor.as_mut() {
+                            match execute_tx_and_register_created(
+                                validation_executor,
+                                tx,
+                                &targeted,
+                                &dynamic_target_ctx,
+                                &mut validation_created_contracts,
+                            ) {
+                                Ok(()) => {}
+                                Err(err) => {
+                                    self.result.single_fail(Some(format!(
+                                        "sequence symbolic artifact call {} failed during target validation: {err}",
+                                        idx + 1
+                                    )));
+                                    return self.result;
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1361,7 +1361,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     ));
                     return self.result;
                 }
-                if let Err(err) = validate_single_call_symbolic_replay(func, call, self.address) {
+                if let Err(err) =
+                    validate_single_call_symbolic_replay(func, call, self.address, self.sender)
+                {
                     self.result.single_fail(Some(err));
                     return self.result;
                 }
@@ -2849,11 +2851,18 @@ fn validate_single_call_symbolic_replay(
     func: &Function,
     call: &SymbolicCounterexampleCall,
     test_address: Address,
+    expected_sender: Address,
 ) -> Result<(), String> {
     if call.target != test_address {
         return Err(format!(
             "single-call symbolic artifact target {} does not match test contract {}",
             call.target, test_address
+        ));
+    }
+    if call.sender != expected_sender {
+        return Err(format!(
+            "single-call symbolic artifact sender {} does not match configured sender {}",
+            call.sender, expected_sender
         ));
     }
     if call.value.is_some_and(|value| !value.is_zero()) {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1887,7 +1887,13 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 &mut call_sequence,
                 assertion_failure,
             );
-            if let Ok((success, replayed_entirely, replay_reason, calls_count, reverts)) = replay
+            if let Ok((
+                success,
+                mut replayed_entirely,
+                mut replay_reason,
+                mut calls_count,
+                mut reverts,
+            )) = replay
                 && !success
             {
                 let warn =
@@ -1924,6 +1930,25 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 ) {
                     Ok(replayed_call_sequence) if !replayed_call_sequence.is_empty() => {
                         call_sequence = replayed_call_sequence;
+                        let (_txes, replay) = replay_persisted_call_sequence(
+                            &replay_ctx,
+                            self.clone_executor(),
+                            &mut call_sequence,
+                            assertion_failure,
+                        );
+                        if let Ok((
+                            _success,
+                            updated_replayed_entirely,
+                            updated_replay_reason,
+                            updated_calls_count,
+                            updated_reverts,
+                        )) = replay
+                        {
+                            replayed_entirely = updated_replayed_entirely;
+                            replay_reason = updated_replay_reason;
+                            calls_count = updated_calls_count;
+                            reverts = updated_reverts;
+                        }
                         // Persist error in invariant failure dir.
                         record_invariant_failure(
                             failure_dir.as_path(),

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -239,6 +239,34 @@ mod tests {
 
     const CONTRACT_NAME: &str = "src/Test.t.sol:InvariantTest";
 
+    #[test]
+    fn symbolic_artifact_file_name_hashes_full_identity() {
+        let single = symbolic_artifact_file_name(
+            "src/A.t.sol:Contract",
+            "test_collision()",
+            SymbolicCounterexampleArtifactKind::SingleCall,
+        );
+        let same_file_component_different_contract = symbolic_artifact_file_name(
+            "src/B.t.sol:Contract",
+            "test_collision()",
+            SymbolicCounterexampleArtifactKind::SingleCall,
+        );
+        let same_contract_different_kind = symbolic_artifact_file_name(
+            "src/A.t.sol:Contract",
+            "test_collision()",
+            SymbolicCounterexampleArtifactKind::Sequence,
+        );
+
+        assert_ne!(single, same_file_component_different_contract);
+        assert_ne!(single, same_contract_different_kind);
+
+        let hash = single
+            .strip_prefix("test_collision__-")
+            .and_then(|value| value.strip_suffix(".json"))
+            .expect("file name should include sanitized value prefix and json suffix");
+        assert_eq!(hash.len(), 32);
+    }
+
     fn count_anchors(abi: &JsonAbi, inline_config: &InlineConfig) -> usize {
         let config = Config::default();
         count_runnable_invariant_campaign_anchors(
@@ -992,7 +1020,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             .join("symbolic")
             .join(sanitize_symbolic_artifact_component(self.cr.name));
         // Use a stable per-test artifact path so the latest counterexample replaces older ones.
-        let path = dir.join(symbolic_artifact_file_name(artifact_file_name));
+        let path = dir.join(symbolic_artifact_file_name(self.cr.name, artifact_file_name, kind));
         let artifact = SymbolicCounterexampleArtifact::new(
             kind,
             SymbolicCounterexampleTestIdentity {
@@ -2898,9 +2926,14 @@ fn sanitize_symbolic_artifact_component(value: &str) -> String {
     if sanitized.is_empty() { "_".to_string() } else { sanitized }
 }
 
-fn symbolic_artifact_file_name(value: &str) -> String {
-    let hash = keccak256(value.as_bytes());
-    let hash = hex::encode(&hash[..4]);
+fn symbolic_artifact_file_name(
+    contract_id: &str,
+    value: &str,
+    kind: SymbolicCounterexampleArtifactKind,
+) -> String {
+    let identity = format!("{contract_id}\0{value}\0{kind:?}");
+    let hash = keccak256(identity.as_bytes());
+    let hash = hex::encode(&hash[..16]);
     format!("{}-{hash}.json", sanitize_symbolic_artifact_component(value))
 }
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1433,13 +1433,14 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     self.result.invariant_setup_fail(err);
                     return self.result;
                 }
-                let targeted = match evm.select_contracts_and_senders(self.address) {
-                    Ok((_, targeted)) => targeted,
-                    Err(err) => {
-                        self.result.invariant_setup_fail(err);
-                        return self.result;
-                    }
-                };
+                let (sender_filters, targeted) =
+                    match evm.select_contracts_and_senders(self.address) {
+                        Ok(selected) => selected,
+                        Err(err) => {
+                            self.result.invariant_setup_fail(err);
+                            return self.result;
+                        }
+                    };
                 {
                     let targets = targeted.targets();
                     for (idx, tx) in txes.iter().enumerate() {
@@ -1456,6 +1457,18 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                                 idx + 1,
                                 hex::encode_prefixed(selector),
                                 tx.call_details.target
+                            )));
+                            return self.result;
+                        }
+                        if (!sender_filters.targeted.is_empty()
+                            && !sender_filters.targeted.contains(&tx.sender))
+                            || (tx.sender != Address::ZERO
+                                && sender_filters.excluded.contains(&tx.sender))
+                        {
+                            self.result.single_fail(Some(format!(
+                                "sequence symbolic artifact call {} uses forbidden sender {}",
+                                idx + 1,
+                                tx.sender
                             )));
                             return self.result;
                         }

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -478,7 +478,7 @@ Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSeque
 		sender=[..] addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
 		sender=[..] addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
 		sender=[..] addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=setNumber(uint256) args=[284406551521730736391345481857560031052359183671404042152984097777 [2.844e65]]
- invariant_increment() (runs: 1, calls: 1, reverts: 1)
+ invariant_increment() (runs: 1, calls: 3, reverts: 0)
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -1712,7 +1712,7 @@ Ran 1 test for test/CounterTest.t.sol:CounterTest
 [FAIL: condition 3 met]
 	[Sequence] (original: 5, shrunk: 5)
 ...
- invariant_cond3() (runs: 1, calls: 1, reverts: [..])
+ invariant_cond3() (runs: 1, calls: 5, reverts: 0)
 ...
 "#
     ]]);

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -330,6 +330,19 @@ args=[42]
     );
     std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
 
+    let mut invalid_artifact = artifact.clone();
+    invalid_artifact["calls"][0]["sender"] =
+        serde_json::json!("0x0000000000000000000000000000000000000001");
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&invalid_artifact).unwrap()).unwrap();
+    let invalid_stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", &artifact_path])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(invalid_stdout.contains("single-call symbolic artifact sender"), "{invalid_stdout}");
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
+
     prj.add_test(
         "SymbolicJsonCounterexample.t.sol",
         r#"

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1462,6 +1462,153 @@ contract SymbolicArtifactForbiddenSender is Test {
     assert!(stdout.contains("uses forbidden sender"), "{stdout}");
 });
 
+forgetest_init!(symbolic_artifact_replay_accepts_created_sequence_target, |prj, cmd| {
+    prj.add_test(
+        "SymbolicArtifactCreatedTarget.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract CreatedTarget {
+    SymbolicArtifactCreatedTarget invariantTest;
+
+    constructor(SymbolicArtifactCreatedTarget _invariantTest) {
+        invariantTest = _invariantTest;
+    }
+
+    function step() external {
+        invariantTest.trip();
+    }
+}
+
+contract Spawner {
+    SymbolicArtifactCreatedTarget invariantTest;
+
+    constructor(SymbolicArtifactCreatedTarget _invariantTest) {
+        invariantTest = _invariantTest;
+    }
+
+    function step() external {
+        new CreatedTarget(invariantTest);
+    }
+}
+
+contract SymbolicArtifactCreatedTarget is Test {
+    bool tripped;
+
+    function setUp() public {
+        new Spawner(this);
+    }
+
+    function trip() external {
+        tripped = true;
+    }
+
+    function invariant_notTripped() public view {
+        assert(!tripped);
+    }
+}
+"#,
+    );
+
+    let artifact_path = prj.root().join("created-sequence-target-artifact.json");
+    let artifact = serde_json::json!({
+        "schema_version": 1,
+        "schema": "foundry:symbolic.counterexample@v1",
+        "kind": "sequence",
+        "test": {
+            "contract": "test/SymbolicArtifactCreatedTarget.t.sol:SymbolicArtifactCreatedTarget",
+            "test": "invariant_notTripped()"
+        },
+        "replay": {
+            "required": true,
+            "status": "confirmed",
+            "reason": null
+        },
+        "replay_semantics": {
+            "fail_on_revert": false
+        },
+        "bounds": {
+            "timeout_seconds": null,
+            "loop_bound": null,
+            "max_depth": 0,
+            "max_paths": 0,
+            "invariant_depth": 2,
+            "exploration_order": "bfs",
+            "max_solver_queries": 0,
+            "default_dynamic_length": 0,
+            "max_dynamic_length": 0,
+            "array_lengths": [],
+            "dynamic_lengths": {},
+            "default_array_lengths": [],
+            "default_bytes_lengths": [],
+            "max_calldata_bytes": 0,
+            "symbolic_call_targets": false,
+            "storage_layout": "solidity"
+        },
+        "solver": {
+            "name": "manual",
+            "command": null,
+            "portfolio": [],
+            "stats": {
+                "paths": 0,
+                "solver_queries": 0,
+                "smt_queries": 0,
+                "sat_queries": 0,
+                "model_queries": 0,
+                "sat_cache_hits": 0,
+                "model_cache_hits": 0,
+                "heuristic_witnesses": 0,
+                "solver_time_ms": 0
+            }
+        },
+        "assumptions": [],
+        "call_trace": {
+            "available": false,
+            "source": null,
+            "format": null
+        },
+        "calls": [
+            {
+                "warp": null,
+                "roll": null,
+                "sender": "0x0000000000000000000000000000000000000b0b",
+                "target": "0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f",
+                "calldata": "0xe25fe175",
+                "value": null,
+                "contract_name": "Spawner",
+                "function_name": "step",
+                "signature": "step()",
+                "args": "",
+                "raw_args": ""
+            },
+            {
+                "warp": null,
+                "roll": null,
+                "sender": "0x0000000000000000000000000000000000000b0b",
+                "target": "0x104fBc016F4bb334D775a19E8A6510109AC63E00",
+                "calldata": "0xe25fe175",
+                "value": null,
+                "contract_name": "CreatedTarget",
+                "function_name": "step",
+                "signature": "step()",
+                "args": "",
+                "raw_args": ""
+            }
+        ]
+    });
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(stdout.contains("panic: assertion failed"), "{stdout}");
+    assert!(!stdout.contains("targets unknown function"), "{stdout}");
+});
+
 forgetest_init!(symbolic_artifact_replay_ignores_non_target_network_passes, |prj, cmd| {
     prj.add_test(
         "SymbolicArtifactNetworkReplay.t.sol",

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1088,6 +1088,107 @@ args=[7]
     );
 });
 
+forgetest_init!(symbolic_artifact_replay_uses_stored_fail_on_revert, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.fail_on_revert = false;
+    });
+    prj.add_test(
+        "SymbolicArtifactFailOnRevert.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicArtifactFailOnRevert is Test {
+    function setUp() public {
+        targetContract(address(this));
+    }
+
+    function step() external pure {
+        revert("boom");
+    }
+
+    function invariant_noop() public pure {}
+}
+"#,
+    );
+
+    let artifact_path = prj.root().join("fail-on-revert-artifact.json");
+    let artifact = serde_json::json!({
+        "schema_version": 1,
+        "schema": "foundry:symbolic.counterexample@v1",
+        "kind": "sequence",
+        "test": {
+            "contract": "test/SymbolicArtifactFailOnRevert.t.sol:SymbolicArtifactFailOnRevert",
+            "test": "invariant_noop()"
+        },
+        "replay": {
+            "required": true,
+            "status": "confirmed",
+            "reason": "boom"
+        },
+        "replay_semantics": {
+            "fail_on_revert": true
+        },
+        "bounds": {
+            "timeout_seconds": null,
+            "loop_bound": null,
+            "max_depth": 0,
+            "max_paths": 0,
+            "invariant_depth": 1,
+            "exploration_order": "bfs",
+            "max_solver_queries": 0,
+            "default_dynamic_length": 0,
+            "max_dynamic_length": 0,
+            "array_lengths": [],
+            "dynamic_lengths": {},
+            "default_array_lengths": [],
+            "default_bytes_lengths": [],
+            "max_calldata_bytes": 0,
+            "symbolic_call_targets": false,
+            "storage_layout": "solidity"
+        },
+        "solver": {
+            "name": "manual",
+            "command": null,
+            "portfolio": [],
+            "stats": {
+                "paths": 0,
+                "solver_queries": 0,
+                "smt_queries": 0,
+                "sat_queries": 0,
+                "model_queries": 0,
+                "sat_cache_hits": 0,
+                "model_cache_hits": 0,
+                "heuristic_witnesses": 0,
+                "solver_time_ms": 0
+            }
+        },
+        "assumptions": [],
+        "call_trace": {
+            "available": false,
+            "source": null,
+            "format": null
+        },
+        "calls": [{
+            "warp": null,
+            "roll": null,
+            "sender": "0x0000000000000000000000000000000000000000",
+            "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+            "calldata": "0xe25fe175",
+            "value": null,
+            "contract_name": "SymbolicArtifactFailOnRevert",
+            "function_name": "step",
+            "signature": "step()",
+            "args": "",
+            "raw_args": ""
+        }]
+    });
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
+
+    cmd.forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
+        .assert_failure();
+});
+
 forgetest_init!(symbolic_invariant_respects_sequence_depth, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1274,6 +1274,111 @@ contract SymbolicArtifactFailOnRevert is Test {
     assert!(result["kind"].get("Unit").is_none(), "{result}");
 });
 
+forgetest_init!(symbolic_artifact_replay_matches_bracketed_path, |prj, cmd| {
+    prj.add_test(
+        "SymbolicArtifact[Replay].t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicArtifactBracketPath is Test {
+    function setUp() public {
+        targetContract(address(this));
+    }
+
+    function step() external {
+        revert("boom");
+    }
+
+    function invariant_noop() public pure {}
+}
+"#,
+    );
+
+    let artifact_path = prj.root().join("bracketed-path-artifact.json");
+    let artifact = serde_json::json!({
+        "schema_version": 1,
+        "schema": "foundry:symbolic.counterexample@v1",
+        "kind": "sequence",
+        "test": {
+            "contract": "test/SymbolicArtifact[Replay].t.sol:SymbolicArtifactBracketPath",
+            "test": "invariant_noop()"
+        },
+        "replay": {
+            "required": true,
+            "status": "confirmed",
+            "reason": "boom"
+        },
+        "replay_semantics": {
+            "fail_on_revert": true
+        },
+        "bounds": {
+            "timeout_seconds": null,
+            "loop_bound": null,
+            "max_depth": 0,
+            "max_paths": 0,
+            "invariant_depth": 1,
+            "exploration_order": "bfs",
+            "max_solver_queries": 0,
+            "default_dynamic_length": 0,
+            "max_dynamic_length": 0,
+            "array_lengths": [],
+            "dynamic_lengths": {},
+            "default_array_lengths": [],
+            "default_bytes_lengths": [],
+            "max_calldata_bytes": 0,
+            "symbolic_call_targets": false,
+            "storage_layout": "solidity"
+        },
+        "solver": {
+            "name": "manual",
+            "command": null,
+            "portfolio": [],
+            "stats": {
+                "paths": 0,
+                "solver_queries": 0,
+                "smt_queries": 0,
+                "sat_queries": 0,
+                "model_queries": 0,
+                "sat_cache_hits": 0,
+                "model_cache_hits": 0,
+                "heuristic_witnesses": 0,
+                "solver_time_ms": 0
+            }
+        },
+        "assumptions": [],
+        "call_trace": {
+            "available": false,
+            "source": null,
+            "format": null
+        },
+        "calls": [
+            {
+                "warp": null,
+                "roll": null,
+                "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
+                "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+                "calldata": "0xe25fe175",
+                "value": null,
+                "contract_name": "SymbolicArtifactBracketPath",
+                "function_name": "step",
+                "signature": "step()",
+                "args": "",
+                "raw_args": ""
+            }
+        ]
+    });
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("invariant_noop()"), "{stdout}");
+    assert!(stdout.contains("boom"), "{stdout}");
+});
+
 forgetest_init!(symbolic_artifact_replay_rejects_stale_sequence_target, |prj, cmd| {
     prj.add_test(
         "SymbolicArtifactStaleTarget.t.sol",

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1187,6 +1187,31 @@ contract SymbolicArtifactFailOnRevert is Test {
     cmd.forge_fuse()
         .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
         .assert_failure();
+
+    let fixed_artifact_path = prj.root().join("fixed-artifact.json");
+    let mut fixed_artifact = artifact;
+    fixed_artifact["replay_semantics"]["fail_on_revert"] = serde_json::json!(false);
+    std::fs::write(&fixed_artifact_path, serde_json::to_vec_pretty(&fixed_artifact).unwrap())
+        .unwrap();
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--json",
+            "--replay-symbolic-artifact",
+            fixed_artifact_path.to_str().unwrap(),
+        ])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+    let result = json_test_result(&output, "invariant_noop()");
+    assert_eq!(result["status"], "Success");
+    assert!(result["kind"].get("Invariant").is_some(), "{result}");
+    assert_eq!(result["kind"]["Invariant"]["runs"], 1);
+    assert_eq!(result["kind"]["Invariant"]["calls"], 1);
+    assert!(result["kind"].get("Unit").is_none(), "{result}");
 });
 
 forgetest_init!(symbolic_invariant_respects_sequence_depth, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1219,6 +1219,19 @@ contract SymbolicArtifactFailOnRevert is Test {
     });
     std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
 
+    let mut bare_contract_artifact = artifact.clone();
+    bare_contract_artifact["test"]["contract"] = serde_json::json!("SymbolicArtifactFailOnRevert");
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&bare_contract_artifact).unwrap())
+        .unwrap();
+    let stderr = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+    assert!(stderr.contains("test.contract must be `path:Contract`"), "{stderr}");
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
+
     let output = cmd
         .forge_fuse()
         .args(["test", "--json", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1106,6 +1106,10 @@ contract SymbolicArtifactFailOnRevert is Test {
         revert("boom");
     }
 
+    function skip() external {
+        vm.assume(false);
+    }
+
     function invariant_noop() public pure {}
 }
 "#,
@@ -1168,19 +1172,34 @@ contract SymbolicArtifactFailOnRevert is Test {
             "source": null,
             "format": null
         },
-        "calls": [{
-            "warp": null,
-            "roll": null,
-            "sender": "0x0000000000000000000000000000000000000000",
-            "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
-            "calldata": "0xe25fe175",
-            "value": null,
-            "contract_name": "SymbolicArtifactFailOnRevert",
-            "function_name": "step",
-            "signature": "step()",
-            "args": "",
-            "raw_args": ""
-        }]
+        "calls": [
+            {
+                "warp": null,
+                "roll": null,
+                "sender": "0x0000000000000000000000000000000000000000",
+                "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+                "calldata": "0x1d2aa5b3",
+                "value": null,
+                "contract_name": "SymbolicArtifactFailOnRevert",
+                "function_name": "skip",
+                "signature": "skip()",
+                "args": "",
+                "raw_args": ""
+            },
+            {
+                "warp": null,
+                "roll": null,
+                "sender": "0x0000000000000000000000000000000000000000",
+                "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+                "calldata": "0xe25fe175",
+                "value": null,
+                "contract_name": "SymbolicArtifactFailOnRevert",
+                "function_name": "step",
+                "signature": "step()",
+                "args": "",
+                "raw_args": ""
+            }
+        ]
     });
     std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
 
@@ -1210,9 +1229,230 @@ contract SymbolicArtifactFailOnRevert is Test {
     assert_eq!(result["status"], "Success");
     assert!(result["kind"].get("Invariant").is_some(), "{result}");
     assert_eq!(result["kind"]["Invariant"]["runs"], 1);
-    assert_eq!(result["kind"]["Invariant"]["calls"], 1);
+    assert_eq!(result["kind"]["Invariant"]["calls"], 2);
     assert_eq!(result["kind"]["Invariant"]["reverts"], 1);
     assert!(result["kind"].get("Unit").is_none(), "{result}");
+});
+
+forgetest_init!(symbolic_artifact_replay_rejects_stale_sequence_target, |prj, cmd| {
+    prj.add_test(
+        "SymbolicArtifactStaleTarget.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicArtifactStaleTarget is Test {
+    function setUp() public {
+        targetContract(address(this));
+    }
+
+    function step() external {}
+
+    function invariant_noop() public pure {}
+}
+"#,
+    );
+
+    let artifact_path = prj.root().join("stale-sequence-selector-artifact.json");
+    let mut artifact = serde_json::json!({
+        "schema_version": 1,
+        "schema": "foundry:symbolic.counterexample@v1",
+        "kind": "sequence",
+        "test": {
+            "contract": "test/SymbolicArtifactStaleTarget.t.sol:SymbolicArtifactStaleTarget",
+            "test": "invariant_noop()"
+        },
+        "replay": {
+            "required": true,
+            "status": "confirmed",
+            "reason": null
+        },
+        "replay_semantics": {
+            "fail_on_revert": false
+        },
+        "bounds": {
+            "timeout_seconds": null,
+            "loop_bound": null,
+            "max_depth": 0,
+            "max_paths": 0,
+            "invariant_depth": 1,
+            "exploration_order": "bfs",
+            "max_solver_queries": 0,
+            "default_dynamic_length": 0,
+            "max_dynamic_length": 0,
+            "array_lengths": [],
+            "dynamic_lengths": {},
+            "default_array_lengths": [],
+            "default_bytes_lengths": [],
+            "max_calldata_bytes": 0,
+            "symbolic_call_targets": false,
+            "storage_layout": "solidity"
+        },
+        "solver": {
+            "name": "manual",
+            "command": null,
+            "portfolio": [],
+            "stats": {
+                "paths": 0,
+                "solver_queries": 0,
+                "smt_queries": 0,
+                "sat_queries": 0,
+                "model_queries": 0,
+                "sat_cache_hits": 0,
+                "model_cache_hits": 0,
+                "heuristic_witnesses": 0,
+                "solver_time_ms": 0
+            }
+        },
+        "assumptions": [],
+        "call_trace": {
+            "available": false,
+            "source": null,
+            "format": null
+        },
+        "calls": [{
+            "warp": null,
+            "roll": null,
+            "sender": "0x0000000000000000000000000000000000000000",
+            "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+            "calldata": "0xffffffff",
+            "value": null,
+            "contract_name": "SymbolicArtifactStaleTarget",
+            "function_name": "step",
+            "signature": "step()",
+            "args": "",
+            "raw_args": ""
+        }]
+    });
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(stdout.contains("targets unknown function"), "{stdout}");
+
+    let stale_target_artifact_path = prj.root().join("stale-sequence-target-artifact.json");
+    artifact["calls"][0]["target"] =
+        serde_json::json!("0x0000000000000000000000000000000000000000");
+    artifact["calls"][0]["calldata"] = serde_json::json!("0xe25fe175");
+    std::fs::write(&stale_target_artifact_path, serde_json::to_vec_pretty(&artifact).unwrap())
+        .unwrap();
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", stale_target_artifact_path.to_str().unwrap()])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(stdout.contains("targets unknown function"), "{stdout}");
+});
+
+forgetest_init!(symbolic_artifact_replay_ignores_non_target_network_passes, |prj, cmd| {
+    prj.add_test(
+        "SymbolicArtifactNetworkReplay.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicArtifactNetworkReplay is Test {
+    function setUp() public {
+        targetContract(address(this));
+    }
+
+    function step() external {}
+
+    function invariant_noop() public pure {}
+
+    /// forge-config: default.networks.network = "tempo"
+    function test_tempo_marker() public pure {}
+}
+"#,
+    );
+
+    let artifact_path = prj.root().join("network-replay-artifact.json");
+    let artifact = serde_json::json!({
+        "schema_version": 1,
+        "schema": "foundry:symbolic.counterexample@v1",
+        "kind": "sequence",
+        "test": {
+            "contract": "test/SymbolicArtifactNetworkReplay.t.sol:SymbolicArtifactNetworkReplay",
+            "test": "invariant_noop()"
+        },
+        "replay": {
+            "required": true,
+            "status": "confirmed",
+            "reason": null
+        },
+        "replay_semantics": {
+            "fail_on_revert": false
+        },
+        "bounds": {
+            "timeout_seconds": null,
+            "loop_bound": null,
+            "max_depth": 0,
+            "max_paths": 0,
+            "invariant_depth": 1,
+            "exploration_order": "bfs",
+            "max_solver_queries": 0,
+            "default_dynamic_length": 0,
+            "max_dynamic_length": 0,
+            "array_lengths": [],
+            "dynamic_lengths": {},
+            "default_array_lengths": [],
+            "default_bytes_lengths": [],
+            "max_calldata_bytes": 0,
+            "symbolic_call_targets": false,
+            "storage_layout": "solidity"
+        },
+        "solver": {
+            "name": "manual",
+            "command": null,
+            "portfolio": [],
+            "stats": {
+                "paths": 0,
+                "solver_queries": 0,
+                "smt_queries": 0,
+                "sat_queries": 0,
+                "model_queries": 0,
+                "sat_cache_hits": 0,
+                "model_cache_hits": 0,
+                "heuristic_witnesses": 0,
+                "solver_time_ms": 0
+            }
+        },
+        "assumptions": [],
+        "call_trace": {
+            "available": false,
+            "source": null,
+            "format": null
+        },
+        "calls": [{
+            "warp": null,
+            "roll": null,
+            "sender": "0x0000000000000000000000000000000000000000",
+            "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+            "calldata": "0xe25fe175",
+            "value": null,
+            "contract_name": "SymbolicArtifactNetworkReplay",
+            "function_name": "step",
+            "signature": "step()",
+            "args": "",
+            "raw_args": ""
+        }]
+    });
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("[PASS] invariant_noop()"), "{stdout}");
+    assert!(!stdout.contains("was not found"), "{stdout}");
 });
 
 forgetest_init!(symbolic_invariant_respects_sequence_depth, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1351,6 +1351,117 @@ contract SymbolicArtifactStaleTarget is Test {
     assert!(stdout.contains("targets unknown function"), "{stdout}");
 });
 
+forgetest_init!(symbolic_artifact_replay_rejects_forbidden_sequence_sender, |prj, cmd| {
+    prj.add_test(
+        "SymbolicArtifactForbiddenSender.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicArtifactForbiddenSender is Test {
+    bool drained;
+    address constant BOB = address(0xB0B);
+
+    function setUp() public {
+        targetContract(address(this));
+        excludeSender(BOB);
+    }
+
+    function step() external {
+        if (msg.sender == BOB) {
+            drained = true;
+        }
+    }
+
+    function invariant_notDrained() public view {
+        assert(!drained);
+    }
+}
+"#,
+    );
+
+    let artifact_path = prj.root().join("forbidden-sequence-sender-artifact.json");
+    let artifact = serde_json::json!({
+        "schema_version": 1,
+        "schema": "foundry:symbolic.counterexample@v1",
+        "kind": "sequence",
+        "test": {
+            "contract": "test/SymbolicArtifactForbiddenSender.t.sol:SymbolicArtifactForbiddenSender",
+            "test": "invariant_notDrained()"
+        },
+        "replay": {
+            "required": true,
+            "status": "confirmed",
+            "reason": null
+        },
+        "replay_semantics": {
+            "fail_on_revert": false
+        },
+        "bounds": {
+            "timeout_seconds": null,
+            "loop_bound": null,
+            "max_depth": 0,
+            "max_paths": 0,
+            "invariant_depth": 1,
+            "exploration_order": "bfs",
+            "max_solver_queries": 0,
+            "default_dynamic_length": 0,
+            "max_dynamic_length": 0,
+            "array_lengths": [],
+            "dynamic_lengths": {},
+            "default_array_lengths": [],
+            "default_bytes_lengths": [],
+            "max_calldata_bytes": 0,
+            "symbolic_call_targets": false,
+            "storage_layout": "solidity"
+        },
+        "solver": {
+            "name": "manual",
+            "command": null,
+            "portfolio": [],
+            "stats": {
+                "paths": 0,
+                "solver_queries": 0,
+                "smt_queries": 0,
+                "sat_queries": 0,
+                "model_queries": 0,
+                "sat_cache_hits": 0,
+                "model_cache_hits": 0,
+                "heuristic_witnesses": 0,
+                "solver_time_ms": 0
+            }
+        },
+        "assumptions": [],
+        "call_trace": {
+            "available": false,
+            "source": null,
+            "format": null
+        },
+        "calls": [{
+            "warp": null,
+            "roll": null,
+            "sender": "0x0000000000000000000000000000000000000b0b",
+            "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+            "calldata": "0xe25fe175",
+            "value": null,
+            "contract_name": "SymbolicArtifactForbiddenSender",
+            "function_name": "step",
+            "signature": "step()",
+            "args": "",
+            "raw_args": ""
+        }]
+    });
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(stdout.contains("uses forbidden sender"), "{stdout}");
+});
+
 forgetest_init!(symbolic_artifact_replay_ignores_non_target_network_passes, |prj, cmd| {
     prj.add_test(
         "SymbolicArtifactNetworkReplay.t.sol",

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1211,6 +1211,7 @@ contract SymbolicArtifactFailOnRevert is Test {
     assert!(result["kind"].get("Invariant").is_some(), "{result}");
     assert_eq!(result["kind"]["Invariant"]["runs"], 1);
     assert_eq!(result["kind"]["Invariant"]["calls"], 1);
+    assert_eq!(result["kind"]["Invariant"]["reverts"], 1);
     assert!(result["kind"].get("Unit").is_none(), "{result}");
 });
 

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1179,7 +1179,7 @@ contract SymbolicArtifactFailOnRevert is Test {
             {
                 "warp": null,
                 "roll": null,
-                "sender": "0x0000000000000000000000000000000000000000",
+                "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
                 "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
                 "calldata": "0x1d2aa5b3",
                 "value": null,
@@ -1192,7 +1192,7 @@ contract SymbolicArtifactFailOnRevert is Test {
             {
                 "warp": null,
                 "roll": null,
-                "sender": "0x0000000000000000000000000000000000000000",
+                "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
                 "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
                 "calldata": "0xe25fe175",
                 "value": null,
@@ -1315,7 +1315,7 @@ contract SymbolicArtifactStaleTarget is Test {
         "calls": [{
             "warp": null,
             "roll": null,
-            "sender": "0x0000000000000000000000000000000000000000",
+            "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
             "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
             "calldata": "0xffffffff",
             "value": null,
@@ -1458,6 +1458,25 @@ contract SymbolicArtifactForbiddenSender is Test {
     let stdout = cmd
         .forge_fuse()
         .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+
+    assert!(stdout.contains("uses forbidden sender"), "{stdout}");
+
+    let zero_sender_artifact_path = prj.root().join("zero-sequence-sender-artifact.json");
+    let mut zero_sender_artifact = artifact;
+    zero_sender_artifact["calls"][0]["sender"] =
+        serde_json::json!("0x0000000000000000000000000000000000000000");
+    std::fs::write(
+        &zero_sender_artifact_path,
+        serde_json::to_vec_pretty(&zero_sender_artifact).unwrap(),
+    )
+    .unwrap();
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", zero_sender_artifact_path.to_str().unwrap()])
         .assert_failure()
         .get_output()
         .stdout_lossy();
@@ -1693,7 +1712,7 @@ contract SymbolicArtifactNetworkReplay is Test {
         "calls": [{
             "warp": null,
             "roll": null,
-            "sender": "0x0000000000000000000000000000000000000000",
+            "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
             "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
             "calldata": "0xe25fe175",
             "value": null,

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1,7 +1,7 @@
 use foundry_common::sh_eprintln;
 use foundry_test_utils::{forgetest_init, str, util::OutputExt};
 use serde_json::Value;
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
 
 use super::symbolic_helpers::{assert_relevant_lines, assert_symbolic};
 
@@ -18,6 +18,18 @@ fn json_test_result(stdout: &[u8], signature: &str) -> Value {
         }
     }
     panic!("missing JSON test result for {signature}: {json}");
+}
+
+fn read_artifact_ref(artifact_ref: &Value) -> Value {
+    let artifact_path = artifact_ref["path"].as_str().expect("symbolic artifact path");
+    let artifact_path = PathBuf::from(artifact_path);
+    let artifact = std::fs::read_to_string(&artifact_path)
+        .unwrap_or_else(|err| panic!("failed to read artifact {}: {err}", artifact_path.display()));
+    serde_json::from_str(&artifact).expect("symbolic counterexample artifact")
+}
+
+fn read_artifact(symbolic: &Value) -> Value {
+    read_artifact_ref(&symbolic["artifact"])
 }
 
 forgetest_init!(symbolic_tests_are_ignored_without_flag, |prj, cmd| {
@@ -176,11 +188,13 @@ contract SymbolicAssert {
 "#,
     );
 
-    let stdout = cmd
+    let output = cmd
         .args(["test", "--symbolic", "--match-test", "checkRejectsFortyTwo"])
         .assert_failure()
         .get_output()
-        .stdout_lossy();
+        .clone();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
 
     assert_relevant_lines(
         &stdout,
@@ -206,6 +220,8 @@ checkRejectsFortyTwo(uint256)
 args=[42]
 "#]],
     );
+    assert!(stderr.contains("Counterexample artifact:"), "{stderr}");
+    assert!(stderr.contains("cache/symbolic/"), "{stderr}");
 });
 
 forgetest_init!(symbolic_json_schema_reports_replayed_counterexample, |prj, cmd| {
@@ -226,9 +242,25 @@ contract SymbolicJsonCounterexample {
 }
 "#,
     );
+    prj.add_test(
+        "SymbolicJsonCounterexampleDuplicate.t.sol",
+        r#"
+contract SymbolicJsonCounterexample {
+    function checkRejectsFortyTwo(uint256) public pure {}
+}
+"#,
+    );
 
     let output = cmd
-        .args(["test", "--symbolic", "--json", "--match-test", "checkRejectsFortyTwo"])
+        .args([
+            "test",
+            "--symbolic",
+            "--json",
+            "--match-test",
+            "checkRejectsFortyTwo",
+            "--match-path",
+            "test/SymbolicJsonCounterexample.t.sol",
+        ])
         .assert_failure()
         .get_output()
         .stdout
@@ -243,7 +275,90 @@ contract SymbolicJsonCounterexample {
     assert!(symbolic["counterexample"]["calldata"].as_str().unwrap().starts_with("0x"));
     assert_eq!(symbolic["counterexample"]["args"], "42");
     assert_eq!(symbolic["counterexample"]["raw_args"], "42");
+    assert_eq!(symbolic["artifact"]["schema"], "foundry:symbolic.counterexample@v1");
+    assert_eq!(result["counterexample_artifacts"].as_array().unwrap().len(), 1);
+    assert_eq!(result["counterexample_artifacts"][0], symbolic["artifact"]);
+    let artifact_path = symbolic["artifact"]["path"].as_str().unwrap().to_string();
+    let artifact = read_artifact(symbolic);
+    assert_eq!(artifact["schema_version"], 1);
+    assert_eq!(artifact["schema"], "foundry:symbolic.counterexample@v1");
+    assert_eq!(artifact["kind"], "single_call");
+    assert_eq!(artifact["test"]["test"], "checkRejectsFortyTwo(uint256)");
+    assert_eq!(artifact["replay"]["status"], "confirmed");
+    assert_eq!(artifact["calls"].as_array().unwrap().len(), 1);
+    assert!(artifact["calls"][0]["calldata"].as_str().unwrap().starts_with("0x"));
+    assert_eq!(artifact["calls"][0]["args"], "42");
+    assert_eq!(artifact["calls"][0]["raw_args"], "42");
     assert!(symbolic["solver"]["stats"]["model_queries"].as_u64().unwrap() >= 1);
+
+    let replay_stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", &artifact_path])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert_relevant_lines(
+        &replay_stdout,
+        foundry_test_utils::str![[r#"
+[FAIL;
+"#]],
+    );
+    assert_relevant_lines(
+        &replay_stdout,
+        foundry_test_utils::str![[r#"
+args=[42]
+"#]],
+    );
+    assert!(
+        !replay_stdout.contains("SymbolicJsonCounterexampleDuplicate.t.sol"),
+        "{replay_stdout}"
+    );
+
+    let mut invalid_artifact = artifact.clone();
+    invalid_artifact["calls"][0]["value"] = serde_json::json!("0x1");
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&invalid_artifact).unwrap()).unwrap();
+    let invalid_stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", &artifact_path])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(
+        invalid_stdout
+            .contains("single-call symbolic artifact replay does not support non-zero value"),
+        "{invalid_stdout}"
+    );
+    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
+
+    prj.add_test(
+        "SymbolicJsonCounterexample.t.sol",
+        r#"
+contract SymbolicJsonCounterexample {
+    function checkRejectsFortyTwo(uint256) public pure {}
+}
+"#,
+    );
+    cmd.forge_fuse().args(["test", "--replay-symbolic-artifact", &artifact_path]).assert_success();
+
+    prj.add_test(
+        "SymbolicJsonCounterexample.t.sol",
+        r#"
+contract SymbolicJsonCounterexample {
+    function checkRenamed(uint256) public pure {}
+}
+"#,
+    );
+    let stale_stderr = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", &artifact_path])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+    assert!(stale_stderr.contains("symbolic artifact target"), "{stale_stderr}");
+    assert!(
+        stale_stderr.contains("checkRejectsFortyTwo(uint256)` was not found"),
+        "{stale_stderr}"
+    );
 });
 
 forgetest_init!(symbolic_json_schema_reports_replay_skip, |prj, cmd| {
@@ -291,6 +406,7 @@ contract SymbolicJsonReplaySkip is Test {
         symbolic["replay"]["reason"].as_str().unwrap().contains("vm.skip during concrete replay")
     );
     assert_eq!(symbolic["counterexample"]["args"], "42");
+    assert!(symbolic["artifact"].is_null());
 });
 
 forgetest_init!(symbolic_json_schema_reports_incomplete, |prj, cmd| {
@@ -846,11 +962,13 @@ contract SymbolicInvariantSingle is Test {
 "#,
     );
 
-    let stdout = cmd
+    let output = cmd
         .args(["test", "--symbolic", "--match-test", "invariant_counterNeverEleven"])
         .assert_failure()
         .get_output()
-        .stdout_lossy();
+        .clone();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
 
     assert_relevant_lines(
         &stdout,
@@ -876,7 +994,98 @@ set(uint256)
 args=[7]
 "#]],
     );
+    assert!(stderr.contains("Counterexample artifact:"), "{stderr}");
+    assert!(stderr.contains("cache/symbolic/"), "{stderr}");
     assert!(!stdout.contains("No contracts to fuzz"), "{stdout}");
+});
+
+forgetest_init!(symbolic_json_reports_sequence_counterexample_artifact, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_json_reports_sequence_counterexample_artifact because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicInvariantSequenceArtifact.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicArtifactTarget {
+    uint256 public value;
+
+    function set(uint256 x) external {
+        if (x == 7) {
+            value = 11;
+        }
+    }
+}
+
+contract SymbolicInvariantSequenceArtifact is Test {
+    SymbolicArtifactTarget target;
+
+    function setUp() public {
+        target = new SymbolicArtifactTarget();
+        targetContract(address(target));
+    }
+
+    function invariant_counterNeverEleven() public view {
+        assert(target.value() != 11);
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--json", "--match-test", "invariant_counterNeverEleven"])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let result = json_test_result(&output, "invariant_counterNeverEleven()");
+    let failures = result["invariant_failures"].as_array().expect("invariant failures");
+    let failure = failures.first().expect("invariant failure");
+    assert_eq!(failure["artifact"]["schema"], "foundry:symbolic.counterexample@v1");
+    assert_eq!(result["counterexample_artifacts"].as_array().unwrap().len(), 1);
+    assert_eq!(result["counterexample_artifacts"][0], failure["artifact"]);
+    let artifact_path = failure["artifact"]["path"].as_str().unwrap().to_string();
+
+    let artifact = read_artifact_ref(&failure["artifact"]);
+    assert_eq!(artifact["schema_version"], 1);
+    assert_eq!(artifact["schema"], "foundry:symbolic.counterexample@v1");
+    assert_eq!(artifact["kind"], "sequence");
+    assert_eq!(artifact["test"]["test"], "invariant_counterNeverEleven()");
+    assert_eq!(artifact["replay"]["status"], "confirmed");
+    assert_eq!(artifact["calls"].as_array().unwrap().len(), 1);
+    assert_eq!(artifact["calls"][0]["function_name"], "set");
+    assert_eq!(artifact["calls"][0]["args"], "7");
+
+    let replay_stdout = cmd
+        .forge_fuse()
+        .args(["test", "--replay-symbolic-artifact", &artifact_path])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert_relevant_lines(
+        &replay_stdout,
+        foundry_test_utils::str![[r#"
+[FAIL:
+"#]],
+    );
+    assert_relevant_lines(
+        &replay_stdout,
+        foundry_test_utils::str![[r#"
+invariant_counterNeverEleven()
+"#]],
+    );
+    assert_relevant_lines(
+        &replay_stdout,
+        foundry_test_utils::str![[r#"
+args=[7]
+"#]],
+    );
 });
 
 forgetest_init!(symbolic_invariant_respects_sequence_depth, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1206,9 +1206,20 @@ contract SymbolicArtifactFailOnRevert is Test {
     });
     std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
 
-    cmd.forge_fuse()
-        .args(["test", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
-        .assert_failure();
+    let output = cmd
+        .forge_fuse()
+        .args(["test", "--json", "--replay-symbolic-artifact", artifact_path.to_str().unwrap()])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+    let result = json_test_result(&output, "invariant_noop()");
+    assert_eq!(result["status"], "Failure");
+    assert!(result["kind"].get("Invariant").is_some(), "{result}");
+    assert_eq!(result["kind"]["Invariant"]["runs"], 1);
+    assert_eq!(result["kind"]["Invariant"]["calls"], 2);
+    assert_eq!(result["kind"]["Invariant"]["reverts"], 1);
+    assert!(result["kind"].get("Unit").is_none(), "{result}");
 
     let fixed_artifact_path = prj.root().join("fixed-artifact.json");
     let mut fixed_artifact = artifact;

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1098,11 +1098,14 @@ forgetest_init!(symbolic_artifact_replay_uses_stored_fail_on_revert, |prj, cmd| 
 import "forge-std/Test.sol";
 
 contract SymbolicArtifactFailOnRevert is Test {
+    uint256 ignored;
+
     function setUp() public {
         targetContract(address(this));
     }
 
-    function step() external pure {
+    function step() external {
+        ignored = 1;
         revert("boom");
     }
 


### PR DESCRIPTION
## Description

Closes OSS-349

Adds symbolic counterexample artifacts that can be replayed independently from the original symbolic run. When `forge test --symbolic` confirms a counterexample, Forge writes a schema-versioned JSON artifact under the project cache and surfaces its path in JSON output and non-JSON test output.

Artifacts can be replayed with:

```bash
forge test --replay-symbolic-artifact <path>
```

Replay supports both single-call symbolic counterexamples and invariant/stateful sequence counterexamples.

**What changed**

- Persist confirmed symbolic counterexamples as `foundry:symbolic.counterexample@v1` artifacts.
- Add `--replay-symbolic-artifact <PATH>` to reconstruct the target contract/test/path and replay the stored calls.
- Add normalized JSON references via `counterexample_artifacts`.
- Surface artifact paths in human output as warnings.
- Validate replay artifacts before execution, including schema header, empty calls, target/function matching, and single-call value constraints.
- Make replay CI-friendly:
  - still-reproducing counterexample fails
  - fixed counterexample passes
  - stale or ambiguous target fails
- Cover single-call, invariant sequence, replay skip, stale target, fixed bug, and schema behavior in tests.
## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
