### PR TITLE
feat(debugger): show storage accesses

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -524,11 +524,17 @@ impl TUIContext<'_> {
         }
 
         // `revm-inspectors` records `storage_change` from journal entries, so warm `SLOAD`s do not
-        // get one. Debug traces already include the stack before execution and pushed stack values
-        // after execution, which is enough to display the accessed slot and loaded value.
+        // get one. Debug mode records full stack snapshots before each opcode; the following step's
+        // stack contains the loaded value after this `SLOAD` executes.
         if step.op.get() == opcode::SLOAD {
             let key = step.stack.as_deref()?.last().copied()?;
-            let value = step.push_stack.as_deref()?.last().copied()?;
+            let value = self
+                .debug_steps()
+                .get(self.current_step.checked_add(1)?)?
+                .stack
+                .as_deref()?
+                .last()
+                .copied()?;
             return Some(sload_storage_access_line(key, value));
         }
 
@@ -1479,12 +1485,12 @@ mod tests {
     }
 
     #[test]
-    fn current_storage_access_line_falls_back_for_warm_sload() {
+    fn current_storage_access_line_uses_next_stack_snapshot_for_warm_sload() {
         let mut step = trace_step(vec![U256::from(1)]);
         step.op = OpCode::SLOAD;
-        step.push_stack = Some(vec![U256::from(42)].into_boxed_slice());
         step.storage_change = None;
-        let mut context = context_with_arena(vec![debug_node(0, 0, vec![step])]);
+        let next_step = trace_step(vec![U256::from(42)]);
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![step, next_step])]);
         let tui = TUIContext::new(&mut context);
 
         assert_eq!(

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -18,7 +18,8 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
 use revm_inspectors::tracing::types::{
-    CallKind, CallTraceStep, DecodedInternalCall, DecodedTraceStep,
+    CallKind, CallTraceStep, DecodedInternalCall, DecodedTraceStep, StorageChange,
+    StorageChangeReason,
 };
 use std::{collections::VecDeque, fmt::Write};
 
@@ -486,25 +487,37 @@ impl TUIContext<'_> {
 
     fn draw_variables(&mut self, f: &mut Frame<'_>, area: Rect) {
         let variables = self.scope_variables();
+        let storage_access = self.current_storage_access_line();
         let known = variables.iter().filter(|variable| variable.value.is_some()).count();
-        let title = if variables.is_empty() {
+        let title = if variables.is_empty() && storage_access.is_none() {
             "Variables".to_string()
         } else {
-            format!("Variables: {known}/{}", variables.len())
+            let storage_suffix = if storage_access.is_some() { " | Storage" } else { "" };
+            format!("Variables: {known}/{}{storage_suffix}", variables.len())
         };
 
-        let text = if variables.is_empty() {
-            vec![Line::from(Span::styled(
+        let mut text = variables.into_iter().map(scope_variable_line).collect::<Vec<_>>();
+        if let Some(storage_access) = storage_access {
+            if !text.is_empty() {
+                text.push(Line::from(""));
+            }
+            text.push(storage_access);
+        }
+
+        if text.is_empty() {
+            text.push(Line::from(Span::styled(
                 "No variables in current scope",
                 Style::new().add_modifier(Modifier::DIM),
-            ))]
-        } else {
-            variables.into_iter().map(scope_variable_line).collect()
-        };
+            )));
+        }
 
         let block = Block::default().title(title).borders(Borders::ALL);
         let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
         f.render_widget(paragraph, area);
+    }
+
+    fn current_storage_access_line(&self) -> Option<Line<'static>> {
+        self.current_step().storage_change.as_deref().map(storage_access_line)
     }
 
     fn draw_buffer(&self, f: &mut Frame<'_>, area: Rect) {
@@ -880,6 +893,29 @@ fn scope_variable_line(variable: ScopeVariable) -> Line<'static> {
     Line::from(spans)
 }
 
+fn storage_access_line(change: &StorageChange) -> Line<'static> {
+    let op = match change.reason {
+        StorageChangeReason::SLOAD => "SLOAD",
+        StorageChangeReason::SSTORE => "SSTORE",
+    };
+
+    let text = match (change.reason, change.had_value) {
+        (StorageChangeReason::SSTORE, Some(previous)) => format!(
+            "storage {op} slot {}: {} -> {}",
+            hex_u256(change.key),
+            hex_u256(previous),
+            hex_u256(change.value)
+        ),
+        _ => format!("storage {op} slot {} = {}", hex_u256(change.key), hex_u256(change.value)),
+    };
+
+    Line::from(Span::styled(text, Style::new().fg(Color::Yellow)))
+}
+
+fn hex_u256(value: U256) -> String {
+    format!("{value:#x}")
+}
+
 fn variable_name(variable: &DebugVariable, index: usize, fallback_prefix: &str) -> String {
     variable
         .name
@@ -1084,7 +1120,7 @@ mod tests {
     use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
     use revm_inspectors::tracing::types::{
         CallKind, CallTraceStep, DecodedCallData, DecodedCallTrace, DecodedInternalCall,
-        DecodedTraceStep,
+        DecodedTraceStep, StorageChange, StorageChangeReason,
     };
 
     fn line_text(line: &Line<'_>) -> String {
@@ -1388,6 +1424,36 @@ mod tests {
         };
 
         assert_eq!(line_text(&super::scope_variable_line(variable)), "local sum = <unavailable>");
+    }
+
+    #[test]
+    fn storage_access_line_formats_sload() {
+        let change = StorageChange {
+            key: U256::from(1),
+            value: U256::from(42),
+            had_value: None,
+            reason: StorageChangeReason::SLOAD,
+        };
+
+        assert_eq!(
+            line_text(&super::storage_access_line(&change)),
+            "storage SLOAD slot 0x1 = 0x2a"
+        );
+    }
+
+    #[test]
+    fn storage_access_line_formats_sstore_with_previous_value() {
+        let change = StorageChange {
+            key: U256::from(1),
+            value: U256::from(42),
+            had_value: Some(U256::from(7)),
+            reason: StorageChangeReason::SSTORE,
+        };
+
+        assert_eq!(
+            line_text(&super::storage_access_line(&change)),
+            "storage SSTORE slot 0x1: 0x7 -> 0x2a"
+        );
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -17,6 +17,7 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
+use revm::bytecode::opcode;
 use revm_inspectors::tracing::types::{
     CallKind, CallTraceStep, DecodedInternalCall, DecodedTraceStep, StorageChange,
     StorageChangeReason,
@@ -517,7 +518,21 @@ impl TUIContext<'_> {
     }
 
     fn current_storage_access_line(&self) -> Option<Line<'static>> {
-        self.current_step().storage_change.as_deref().map(storage_access_line)
+        let step = self.current_step();
+        if let Some(change) = step.storage_change.as_deref() {
+            return Some(storage_access_line(change));
+        }
+
+        // `revm-inspectors` records `storage_change` from journal entries, so warm `SLOAD`s do not
+        // get one. Debug traces already include the stack before execution and pushed stack values
+        // after execution, which is enough to display the accessed slot and loaded value.
+        if step.op.get() == opcode::SLOAD {
+            let key = step.stack.as_deref()?.last().copied()?;
+            let value = step.push_stack.as_deref()?.last().copied()?;
+            return Some(sload_storage_access_line(key, value));
+        }
+
+        None
     }
 
     fn draw_buffer(&self, f: &mut Frame<'_>, area: Rect) {
@@ -910,6 +925,13 @@ fn storage_access_line(change: &StorageChange) -> Line<'static> {
     };
 
     Line::from(Span::styled(text, Style::new().fg(Color::Yellow)))
+}
+
+fn sload_storage_access_line(key: U256, value: U256) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("storage SLOAD slot {} = {}", hex_u256(key), hex_u256(value)),
+        Style::new().fg(Color::Yellow),
+    ))
 }
 
 fn hex_u256(value: U256) -> String {
@@ -1453,6 +1475,21 @@ mod tests {
         assert_eq!(
             line_text(&super::storage_access_line(&change)),
             "storage SSTORE slot 0x1: 0x7 -> 0x2a"
+        );
+    }
+
+    #[test]
+    fn current_storage_access_line_falls_back_for_warm_sload() {
+        let mut step = trace_step(vec![U256::from(1)]);
+        step.op = OpCode::SLOAD;
+        step.push_stack = Some(vec![U256::from(42)].into_boxed_slice());
+        step.storage_change = None;
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![step])]);
+        let tui = TUIContext::new(&mut context);
+
+        assert_eq!(
+            line_text(&tui.current_storage_access_line().unwrap()),
+            "storage SLOAD slot 0x1 = 0x2a"
         );
     }
 

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -439,7 +439,7 @@ impl TraceMode {
     }
 
     pub fn with_state_changes(self, yes: bool) -> Self {
-        if yes { std::cmp::max(self, Self::RecordStateDiff) } else { self }
+        if yes && !self.is_debug() { std::cmp::max(self, Self::RecordStateDiff) } else { self }
     }
 
     pub fn with_verbosity(self, verbosity: u8) -> Self {
@@ -448,6 +448,7 @@ impl TraceMode {
             3..=4 => std::cmp::max(self, Self::Call),
             // Enable step recording and state diff recording when verbosity is 5 or higher.
             // This includes backtraces (JUMP/JUMPDEST steps) and storage changes.
+            _ if self.is_debug() => self,
             _ => std::cmp::max(self, Self::RecordStateDiff),
         }
     }
@@ -460,6 +461,7 @@ impl TraceMode {
             // It should not enable memory/stack snapshots.
             // State diff recording requires all opcodes (no filter) since it needs
             // SLOAD/SSTORE steps, not just JUMP/JUMPDEST.
+            let record_state_diff = self.record_state_diff() || self.is_debug();
             let effective = if self.record_state_diff() { Self::Steps } else { self };
             TracingInspectorConfig {
                 record_steps: self >= Self::Steps,
@@ -470,10 +472,10 @@ impl TraceMode {
                     StackSnapshotType::None
                 },
                 record_logs: true,
-                record_state_diff: self.record_state_diff(),
+                record_state_diff,
                 record_returndata_snapshots: effective.is_debug(),
                 // State diff needs all opcodes recorded to capture SLOAD/SSTORE.
-                record_opcodes_filter: if self.record_state_diff() {
+                record_opcodes_filter: if record_state_diff {
                     None
                 } else {
                     (effective.is_steps() || effective.is_jump() || effective.is_jump_simple())
@@ -537,7 +539,9 @@ mod tests {
         assert_eq!(TraceMode::None.with_verbosity(5), TraceMode::RecordStateDiff);
         assert_eq!(TraceMode::Call.with_verbosity(5), TraceMode::RecordStateDiff);
         assert_eq!(TraceMode::Steps.with_verbosity(5), TraceMode::RecordStateDiff);
-        assert_eq!(TraceMode::Debug.with_verbosity(5), TraceMode::RecordStateDiff);
+        // Debug mode already records full steps; it must not be downgraded to the lightweight
+        // RecordStateDiff mode when high verbosity is also requested.
+        assert_eq!(TraceMode::Debug.with_verbosity(5), TraceMode::Debug);
         // Already at the top — stays the same.
         assert_eq!(TraceMode::RecordStateDiff.with_verbosity(5), TraceMode::RecordStateDiff);
     }
@@ -592,6 +596,6 @@ mod tests {
         assert!(cfg.record_returndata_snapshots, "Debug must record returndata");
         assert!(cfg.record_immediate_bytes, "Debug must record immediate bytes");
         assert!(cfg.record_opcodes_filter.is_none(), "Debug must record all opcodes (no filter)");
-        assert!(!cfg.record_state_diff, "Debug alone should not record state diff");
+        assert!(cfg.record_state_diff, "Debug should record storage accesses for the debugger");
     }
 }

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -81,6 +81,30 @@ fn collect_debug_dump_internal_calls<'a>(
     }
 }
 
+fn collect_debug_dump_storage_changes<'a>(
+    value: &'a serde_json::Value,
+    changes: &mut Vec<&'a serde_json::Value>,
+) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_debug_dump_storage_changes(value, changes);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            if let Some(change) = map.get("storage_change")
+                && !change.is_null()
+            {
+                changes.push(change);
+            }
+            for value in map.values() {
+                collect_debug_dump_storage_changes(value, changes);
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Contracts excluded from the main `testdata` run because they depend on flaky external RPCs.
 /// These are run separately by the `flaky_testdata` test below.
 /// Format: pipe-separated regex alternation, e.g. `"Foo|Bar|Baz"`.
@@ -2754,6 +2778,45 @@ contract DebugVarsTest {
     assert_eq!(
         address_call["return_data"],
         serde_json::json!(["0x000000000000000000000000000000000000bEEF"])
+    );
+});
+
+// Progresses <https://github.com/foundry-rs/foundry/issues/927>: debugger storage view.
+forgetest!(debug_dump_includes_storage_changes, |prj, cmd| {
+    prj.add_source(
+        "DebugStorage",
+        r"
+contract DebugStorageTest {
+    uint256 value;
+    uint256 untouched;
+
+    function testStorage() public {
+        value = 42;
+        uint256 loaded = value;
+        uint256 coldLoaded = untouched;
+        require(loaded == 42 && coldLoaded == 0);
+    }
+}
+",
+    );
+
+    let dump_path = prj.root().join("storage_dump.json");
+
+    cmd.args(["test", "--mt", "testStorage", "--debug", "--dump", dump_path.to_str().unwrap()]);
+    cmd.assert_success();
+
+    let dump: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dump_path).unwrap()).unwrap();
+    let mut storage_changes = Vec::new();
+    collect_debug_dump_storage_changes(&dump, &mut storage_changes);
+
+    assert!(
+        storage_changes.iter().any(|change| change["reason"] == "SSTORE"),
+        "debugger dump should include an SSTORE storage change: {storage_changes:#?}"
+    );
+    assert!(
+        storage_changes.iter().any(|change| change["reason"] == "SLOAD"),
+        "debugger dump should include an SLOAD storage access: {storage_changes:#?}"
     );
 });
 

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -2793,9 +2793,8 @@ contract DebugStorageTest {
     function testStorage() public {
         value = 42;
         uint256 loaded = value;
-        uint256 loadedAgain = value;
         uint256 coldLoaded = untouched;
-        require(loaded == 42 && loadedAgain == 42 && coldLoaded == 0);
+        require(loaded == 42 && coldLoaded == 0);
     }
 }
 ",

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -2793,8 +2793,9 @@ contract DebugStorageTest {
     function testStorage() public {
         value = 42;
         uint256 loaded = value;
+        uint256 loadedAgain = value;
         uint256 coldLoaded = untouched;
-        require(loaded == 42 && coldLoaded == 0);
+        require(loaded == 42 && loadedAgain == 42 && coldLoaded == 0);
     }
 }
 ",


### PR DESCRIPTION
## Motivation

Progresses #927. The debugger has memory/stack/source views, but no immediate indication when the current opcode touches contract storage. That makes storage-related debugging require manually interpreting SLOAD/SSTORE steps and stack values.

## Solution

- Record storage diffs/accesses in `TraceMode::Debug` while preserving full debugger memory/stack/returndata snapshots.
- Avoid downgrading `Debug` to the lightweight `RecordStateDiff` mode when high verbosity or explicit state changes are requested.
- Show the current `SLOAD`/`SSTORE` slot/value in the debugger Variables pane.
- Add unit coverage for trace config and storage access line formatting, plus a debugger dump integration test that verifies both SSTORE and SLOAD entries.
