### PR TITLE
feat(fuzz): seed invariant corpus from observed calls

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -41,14 +41,16 @@ use crate::{
 };
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, Bytes, I256};
+use alloy_primitives::{Address, Bytes, I256, U256};
 use eyre::{Result, eyre};
-use foundry_common::{ContractsByAddress, ContractsByArtifact, sh_warn};
+use foundry_common::{ContractsByAddress, ContractsByArtifact, TestFunctionExt, sh_warn};
 use foundry_config::FuzzCorpusConfig;
-use foundry_evm_core::{evm::FoundryEvmNetwork, utils::StateChangeset};
+use foundry_evm_core::{constants::CALLER, evm::FoundryEvmNetwork, utils::StateChangeset};
 use foundry_evm_fuzz::{
-    BasicTxDetails,
-    invariant::{ArtifactFilters, FuzzRunIdentifiedContracts},
+    BasicTxDetails, CallDetails, ObservedCall,
+    invariant::{
+        ArtifactFilters, FuzzRunIdentifiedContracts, InvariantContract, TargetedContracts,
+    },
     strategies::{
         EvmFuzzState, FuzzStateReader, InvariantFuzzState, generate_msg_value, mutate_param_value,
     },
@@ -189,6 +191,13 @@ impl CorpusEntry {
 pub(crate) struct CampaignCorpusEntry {
     tx_seq: Vec<BasicTxDetails>,
     dedupe_by_coverage: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CorpusInsertionMode {
+    Live,
+    Deferred,
+    MemoryOnly,
 }
 
 struct ReplayOutcome {
@@ -843,16 +852,16 @@ impl WorkerCorpus {
             }
         }
 
-        // Track in-memory corpus changes to update MasterWorker on sync.
-        let new_index = self.in_memory_corpus.len();
-        self.new_entry_indices.push(new_index);
-
-        // This includes reverting txs in the corpus and `can_continue` removes
-        // them. We want this as it is new coverage and may help reach the other branch.
-        self.metrics.corpus_count += 1;
-        self.in_memory_corpus.push(corpus);
+        self.push_corpus_entry(corpus);
 
         campaign_entry
+    }
+
+    fn push_corpus_entry(&mut self, corpus: CorpusEntry) {
+        let new_index = self.in_memory_corpus.len();
+        self.new_entry_indices.push(new_index);
+        self.metrics.corpus_count += 1;
+        self.in_memory_corpus.push(corpus);
     }
 
     /// Returns the previously persisted optimization best value and sequence (if any).
@@ -1122,6 +1131,150 @@ impl WorkerCorpus {
             .new_tree(test_runner)
             .map_err(|_| eyre!("Could not generate case"))?
             .current())
+    }
+
+    /// Converts replayable observed sub-calls into one normal multi-transaction corpus entry.
+    ///
+    /// This captures calls shaped by a handler or another target call and lets the existing corpus
+    /// machinery mutate, evict, sync, and persist them like any other interesting sequence.
+    pub fn hoist_observed_calls(
+        &mut self,
+        observed: &[ObservedCall],
+        parent_tx: &BasicTxDetails,
+        targeted_contracts: &FuzzRunIdentifiedContracts,
+        insertion_mode: CorpusInsertionMode,
+    ) -> Option<CampaignCorpusEntry> {
+        if !self.config.is_coverage_guided() || observed.is_empty() {
+            return None;
+        }
+
+        let targets = targeted_contracts.targets();
+        let mut tx_seq = Vec::with_capacity(observed.len());
+        let mut first_delay = Some((parent_tx.warp, parent_tx.roll));
+        for call in observed {
+            let (warp, roll) = first_delay.take().unwrap_or((None, None));
+            let tx = BasicTxDetails {
+                warp,
+                roll,
+                sender: call.caller,
+                call_details: CallDetails {
+                    target: call.target,
+                    calldata: call.calldata.clone(),
+                    value: call.value,
+                },
+            };
+            if targets.can_replay(&tx) {
+                tx_seq.push(tx);
+            }
+        }
+        drop(targets);
+
+        self.push_observed_sequence(tx_seq, insertion_mode)
+    }
+
+    /// Seeds the corpus from sibling zero-input unit tests by replaying them on a clone of the
+    /// post-setUp executor and keeping the direct replayable calls made by each test.
+    ///
+    /// Returns the number of test-derived corpus entries added.
+    pub fn seed_from_test_traces<FEN: FoundryEvmNetwork>(
+        &mut self,
+        invariant_contract: &InvariantContract<'_>,
+        targeted_contracts: &FuzzRunIdentifiedContracts,
+        executor: &Executor<FEN>,
+    ) -> Result<usize> {
+        if !self.config.is_coverage_guided() {
+            return Ok(0);
+        }
+
+        let mut added = 0;
+
+        for func in invariant_contract.abi.functions() {
+            if !func.is_unit_test() {
+                continue;
+            }
+            if invariant_contract
+                .invariant_fns
+                .iter()
+                .any(|(invariant_fn, _)| func.selector() == invariant_fn.selector())
+            {
+                continue;
+            }
+
+            let calldata = match func.abi_encode_input(&[]) {
+                Ok(calldata) => Bytes::from(calldata),
+                Err(_) => continue,
+            };
+
+            let mut exec = executor.clone();
+            if let Some(fuzzer) = exec.inspector_mut().fuzzer.as_mut() {
+                fuzzer.set_call_recording(true);
+                let _ = fuzzer.take_observed_calls();
+            }
+
+            let raw = match exec.call_raw(CALLER, invariant_contract.address, calldata, U256::ZERO)
+            {
+                Ok(raw) => raw,
+                Err(_) => continue,
+            };
+            if raw.reverted {
+                continue;
+            }
+
+            let observed = exec
+                .inspector_mut()
+                .fuzzer
+                .as_mut()
+                .map(|fuzzer| fuzzer.take_observed_calls())
+                .unwrap_or_default();
+            if observed.is_empty() {
+                continue;
+            }
+
+            let seq = {
+                let targets = targeted_contracts.targets();
+                sequence_from_observed(&observed, &targets)
+            };
+
+            let insertion_mode = if self.id == 0 {
+                CorpusInsertionMode::Live
+            } else {
+                CorpusInsertionMode::MemoryOnly
+            };
+            let len_before = self.in_memory_corpus.len();
+            let _ = self.push_observed_sequence(seq, insertion_mode);
+            if self.in_memory_corpus.len() > len_before {
+                debug!(target: "corpus", test = %func.name, "seeded corpus sequence from test trace");
+                added += 1;
+            }
+        }
+
+        Ok(added)
+    }
+
+    fn push_observed_sequence(
+        &mut self,
+        tx_seq: Vec<BasicTxDetails>,
+        insertion_mode: CorpusInsertionMode,
+    ) -> Option<CampaignCorpusEntry> {
+        if !self.config.is_coverage_guided() || tx_seq.is_empty() {
+            return None;
+        }
+
+        let campaign_entry = matches!(insertion_mode, CorpusInsertionMode::Deferred)
+            .then(|| CampaignCorpusEntry { tx_seq: tx_seq.clone(), dedupe_by_coverage: false });
+        let corpus = CorpusEntry::new(tx_seq);
+
+        if matches!(insertion_mode, CorpusInsertionMode::Live)
+            && let Some(worker_dir) = &self.worker_dir
+        {
+            let worker_corpus = worker_dir.join(CORPUS_DIR);
+            if let Err(err) = corpus.write_to_disk_in(&worker_corpus, self.config.corpus_gzip) {
+                debug!(target: "corpus", %err, "failed to persist corpus seed");
+            }
+        }
+
+        self.push_corpus_entry(corpus);
+        campaign_entry
     }
 
     /// Returns the next call to be used in call sequence.
@@ -1607,6 +1760,29 @@ impl WorkerCorpus {
     }
 }
 
+fn sequence_from_observed(
+    observed: &[ObservedCall],
+    targets: &TargetedContracts,
+) -> Vec<BasicTxDetails> {
+    observed
+        .iter()
+        .filter(|call| call.depth == 1)
+        .filter_map(|call| {
+            let tx = BasicTxDetails {
+                warp: None,
+                roll: None,
+                sender: call.caller,
+                call_details: CallDetails {
+                    target: call.target,
+                    calldata: call.calldata.clone(),
+                    value: call.value,
+                },
+            };
+            targets.can_replay(&tx).then_some(tx)
+        })
+        .collect()
+}
+
 fn prepare_campaign_output_dir(config: &FuzzCorpusConfig) {
     let Some(root) = &config.corpus_dir else {
         return;
@@ -1688,7 +1864,6 @@ fn unique_corpus_entries<'a>(
 mod tests {
     use super::*;
     use alloy_dyn_abi::DynSolValue;
-    use alloy_primitives::U256;
     use std::fs;
 
     fn basic_tx() -> BasicTxDetails {
@@ -1782,6 +1957,27 @@ mod tests {
         manager.current_mutated = Some(seed_uuid);
 
         (manager, seed_uuid)
+    }
+
+    fn targeted_contracts_with_selective_functions(
+        target: Address,
+        functions: Vec<Function>,
+        targeted_selectors: impl IntoIterator<Item = alloy_primitives::Selector>,
+    ) -> FuzzRunIdentifiedContracts {
+        use alloy_json_abi::JsonAbi;
+        use foundry_evm_fuzz::invariant::TargetedContract;
+
+        let mut abi = JsonAbi::new();
+        for function in functions {
+            abi.functions.entry(function.name.clone()).or_default().push(function);
+        }
+
+        let mut contract = TargetedContract::new("Target".to_string(), abi);
+        contract.add_selectors(targeted_selectors, false).unwrap();
+
+        let mut targets = TargetedContracts::new();
+        targets.inner.insert(target, contract);
+        FuzzRunIdentifiedContracts::new(targets, false)
     }
 
     #[test]
@@ -2003,6 +2199,266 @@ mod tests {
         assert!(shards.iter().all(|shard| shard.sancov_history_map == seed.sancov_history_map));
         assert!(shards.iter().all(|shard| shard.metrics.cumulative_edges_seen == 7));
         assert!(shards.iter().all(|shard| shard.metrics.cumulative_features_seen == 11));
+    }
+
+    #[test]
+    fn hoist_observed_calls_bundles_replayable_subcalls_into_one_corpus_entry() {
+        let target = Address::from([0x42; 20]);
+        let other = Address::from([0x43; 20]);
+        let sender = Address::from([0xaa; 20]);
+        let observed_caller = Address::from([0xbb; 20]);
+        let foo = Function::parse("foo(uint256)").unwrap();
+        let bar = Function::parse("bar()").unwrap();
+        let foo_selector = foo.selector();
+        let bar_selector = bar.selector();
+        let targeted_contracts = targeted_contracts_with_selective_functions(
+            target,
+            vec![foo, bar],
+            [foo_selector, bar_selector],
+        );
+
+        let mut foo_calldata = vec![0u8; 36];
+        foo_calldata[..4].copy_from_slice(&foo_selector[..]);
+        let bar_calldata = bar_selector.to_vec();
+        let mut unknown_selector = vec![0u8; 36];
+        unknown_selector[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        let value = U256::from(1);
+
+        let observed = vec![
+            ObservedCall {
+                depth: 1,
+                caller: observed_caller,
+                target,
+                calldata: Bytes::from(foo_calldata.clone()),
+                value: Some(value),
+            },
+            ObservedCall {
+                depth: 1,
+                caller: observed_caller,
+                target: other,
+                calldata: Bytes::from(foo_calldata),
+                value: None,
+            },
+            ObservedCall {
+                depth: 2,
+                caller: observed_caller,
+                target,
+                calldata: Bytes::from(bar_calldata),
+                value: None,
+            },
+            ObservedCall {
+                depth: 1,
+                caller: observed_caller,
+                target,
+                calldata: Bytes::from(unknown_selector),
+                value: None,
+            },
+            ObservedCall {
+                depth: 1,
+                caller: observed_caller,
+                target,
+                calldata: Bytes::from(vec![0u8; 3]),
+                value: None,
+            },
+        ];
+        let parent_tx = BasicTxDetails {
+            warp: Some(U256::from(123)),
+            roll: Some(U256::from(456)),
+            sender,
+            call_details: CallDetails {
+                target: Address::from([0x99; 20]),
+                calldata: Bytes::new(),
+                value: None,
+            },
+        };
+        let mut manager = empty_worker_corpus(0, temp_corpus_dir());
+
+        let campaign_entry = manager.hoist_observed_calls(
+            &observed,
+            &parent_tx,
+            &targeted_contracts,
+            CorpusInsertionMode::Live,
+        );
+
+        assert!(campaign_entry.is_none());
+        assert_eq!(manager.in_memory_corpus.len(), 1);
+        assert_eq!(manager.metrics.corpus_count, 1);
+
+        let entry = manager.in_memory_corpus.last().unwrap();
+        assert_eq!(entry.tx_seq.len(), 2);
+        let tx = &entry.tx_seq[0];
+        assert_eq!(tx.warp, parent_tx.warp);
+        assert_eq!(tx.roll, parent_tx.roll);
+        assert_eq!(tx.sender, observed_caller);
+        assert_eq!(tx.call_details.target, target);
+        assert_eq!(&tx.call_details.calldata[..4], &foo_selector[..]);
+        assert_eq!(tx.call_details.value, Some(value));
+
+        let tx = &entry.tx_seq[1];
+        assert_eq!(tx.warp, None);
+        assert_eq!(tx.roll, None);
+        assert_eq!(tx.sender, observed_caller);
+        assert_eq!(tx.call_details.target, target);
+        assert_eq!(&tx.call_details.calldata[..4], &bar_selector[..]);
+        assert_eq!(tx.call_details.value, None);
+    }
+
+    #[test]
+    fn hoist_observed_calls_returns_deferred_campaign_entry_without_persisting() {
+        let target = Address::from([0x42; 20]);
+        let foo = Function::parse("foo()").unwrap();
+        let selector = foo.selector();
+        let targeted_contracts = targeted_contracts_with_selective_functions(target, vec![foo], []);
+        let observed = vec![ObservedCall {
+            depth: 1,
+            caller: Address::from([0xaa; 20]),
+            target,
+            calldata: Bytes::from(selector.to_vec()),
+            value: None,
+        }];
+        let corpus_root = temp_corpus_dir();
+        let worker_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
+        let mut manager = empty_worker_corpus(1, corpus_root);
+
+        let campaign_entry = manager.hoist_observed_calls(
+            &observed,
+            &basic_tx(),
+            &targeted_contracts,
+            CorpusInsertionMode::Deferred,
+        );
+
+        let campaign_entry = campaign_entry.expect("deferred hoist should return campaign entry");
+        assert!(!campaign_entry.dedupe_by_coverage);
+        assert_eq!(campaign_entry.tx_seq.len(), 1);
+        assert_eq!(manager.in_memory_corpus.len(), 1);
+        assert_eq!(read_corpus_dir(&worker_corpus_dir).count(), 0);
+    }
+
+    #[test]
+    fn hoist_observed_calls_skips_empty_or_non_coverage_guided_inputs() {
+        let target = Address::from([0x42; 20]);
+        let foo = Function::parse("foo()").unwrap();
+        let selector = foo.selector();
+        let targeted_contracts = targeted_contracts_with_selective_functions(target, vec![foo], []);
+        let observed = vec![ObservedCall {
+            depth: 1,
+            caller: Address::from([0xaa; 20]),
+            target,
+            calldata: Bytes::from(selector.to_vec()),
+            value: None,
+        }];
+
+        let mut no_corpus_config = corpus_config(temp_corpus_dir());
+        no_corpus_config.corpus_dir = None;
+        let mut manager = WorkerCorpus::from_seed(
+            0,
+            no_corpus_config,
+            Just(basic_tx()).boxed(),
+            WorkerCorpusSeed::default(),
+        );
+        assert!(
+            manager
+                .hoist_observed_calls(
+                    &observed,
+                    &basic_tx(),
+                    &targeted_contracts,
+                    CorpusInsertionMode::Live
+                )
+                .is_none()
+        );
+        assert!(manager.in_memory_corpus.is_empty());
+
+        let mut manager = empty_worker_corpus(0, temp_corpus_dir());
+        assert!(
+            manager
+                .hoist_observed_calls(
+                    &[],
+                    &basic_tx(),
+                    &targeted_contracts,
+                    CorpusInsertionMode::Live
+                )
+                .is_none()
+        );
+        assert!(manager.in_memory_corpus.is_empty());
+    }
+
+    #[test]
+    fn sequence_from_observed_keeps_only_direct_replayable_calls() {
+        let target = Address::from([0x42; 20]);
+        let other = Address::from([0x43; 20]);
+        let sender = Address::from([0xaa; 20]);
+        let nested_caller = Address::from([0xbb; 20]);
+        let foo = Function::parse("foo(uint256)").unwrap();
+        let bar = Function::parse("bar()").unwrap();
+        let foo_selector = foo.selector();
+        let bar_selector = bar.selector();
+        let targeted_contracts =
+            targeted_contracts_with_selective_functions(target, vec![foo, bar], [foo_selector]);
+        let targets = targeted_contracts.targets();
+
+        let mut foo_calldata = vec![0u8; 36];
+        foo_calldata[..4].copy_from_slice(&foo_selector[..]);
+        let bar_calldata = bar_selector.to_vec();
+        let observed = vec![
+            ObservedCall {
+                depth: 1,
+                caller: sender,
+                target,
+                calldata: Bytes::from(foo_calldata.clone()),
+                value: None,
+            },
+            ObservedCall {
+                depth: 2,
+                caller: nested_caller,
+                target,
+                calldata: Bytes::from(foo_calldata),
+                value: None,
+            },
+            ObservedCall {
+                depth: 1,
+                caller: sender,
+                target,
+                calldata: Bytes::from(bar_calldata),
+                value: None,
+            },
+            ObservedCall {
+                depth: 1,
+                caller: sender,
+                target: other,
+                calldata: Bytes::from(foo_selector.to_vec()),
+                value: None,
+            },
+        ];
+
+        let seq = sequence_from_observed(&observed, &targets);
+
+        assert_eq!(seq.len(), 1);
+        assert_eq!(seq[0].sender, sender);
+        assert_eq!(seq[0].call_details.target, target);
+        assert_eq!(&seq[0].call_details.calldata[..4], &foo_selector[..]);
+    }
+
+    #[test]
+    fn push_observed_sequence_live_persists_and_memory_only_does_not() {
+        let corpus_root = temp_corpus_dir();
+        let worker0_corpus_dir = corpus_root.join("worker0").join(CORPUS_DIR);
+        let mut manager = empty_worker_corpus(0, corpus_root.clone());
+
+        assert!(
+            manager.push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::Live).is_none()
+        );
+        assert_eq!(manager.in_memory_corpus.len(), 1);
+        assert_eq!(read_corpus_dir(&worker0_corpus_dir).count(), 1);
+
+        let mut manager = empty_worker_corpus(1, corpus_root.clone());
+        let worker1_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
+        assert!(
+            manager
+                .push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::MemoryOnly)
+                .is_none()
+        );
+        assert_eq!(manager.in_memory_corpus.len(), 1);
+        assert_eq!(read_corpus_dir(&worker1_corpus_dir).count(), 0);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1207,7 +1207,7 @@ impl WorkerCorpus {
                 Err(_) => continue,
             };
 
-            let mut exec = executor.clone();
+            let exec = executor.clone();
 
             let raw = match exec.call_raw(CALLER, invariant_contract.address, calldata, U256::ZERO)
             {
@@ -1218,12 +1218,7 @@ impl WorkerCorpus {
                 continue;
             }
 
-            let observed = exec
-                .inspector_mut()
-                .fuzzer
-                .as_mut()
-                .map(|fuzzer| fuzzer.take_observed_calls())
-                .unwrap_or_default();
+            let observed = raw.observed_calls;
             if observed.is_empty() {
                 continue;
             }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1763,10 +1763,9 @@ fn sequence_from_observed(
         .iter()
         .filter(|call| matches!(depth, ObservedCallDepth::All) || call.depth == 1)
         .filter_map(|call| {
-            let (warp, roll) = first_delay.take().unwrap_or((None, None));
-            let tx = BasicTxDetails {
-                warp,
-                roll,
+            let mut tx = BasicTxDetails {
+                warp: None,
+                roll: None,
                 sender: call.caller,
                 call_details: CallDetails {
                     target: call.target,
@@ -1774,7 +1773,12 @@ fn sequence_from_observed(
                     value: call.value,
                 },
             };
-            targets.can_replay(&tx).then_some(tx)
+            targets.can_replay(&tx).then(|| {
+                let (warp, roll) = first_delay.take().unwrap_or((None, None));
+                tx.warp = warp;
+                tx.roll = roll;
+                tx
+            })
         })
         .collect()
 }
@@ -2224,14 +2228,14 @@ mod tests {
             ObservedCall {
                 depth: 1,
                 caller: observed_caller,
-                target,
+                target: other,
                 calldata: Bytes::from(foo_calldata.clone()),
                 value: Some(value),
             },
             ObservedCall {
                 depth: 1,
                 caller: observed_caller,
-                target: other,
+                target,
                 calldata: Bytes::from(foo_calldata),
                 value: None,
             },
@@ -2288,7 +2292,7 @@ mod tests {
         assert_eq!(tx.sender, observed_caller);
         assert_eq!(tx.call_details.target, target);
         assert_eq!(&tx.call_details.calldata[..4], &foo_selector[..]);
-        assert_eq!(tx.call_details.value, Some(value));
+        assert_eq!(tx.call_details.value, None);
 
         let tx = &entry.tx_seq[1];
         assert_eq!(tx.warp, None);

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -831,14 +831,28 @@ impl WorkerCorpus {
         };
         let corpus_cmp_seq: Vec<Vec<CmpOperands>> =
             cmp_seq.iter().take(corpus_inputs.len()).cloned().collect();
-        let campaign_entry = (!persist_now).then(|| CampaignCorpusEntry {
-            tx_seq: corpus_inputs.clone(),
-            dedupe_by_coverage: new_coverage,
-        });
         let corpus = CorpusEntry::new_with_cmp(corpus_inputs, corpus_cmp_seq, Uuid::new_v4());
 
-        if persist_now && let Some(worker_corpus) = &self.worker_dir {
-            let worker_corpus = worker_corpus.join(CORPUS_DIR);
+        self.insert_corpus_entry(
+            corpus,
+            if persist_now { CorpusInsertionMode::Live } else { CorpusInsertionMode::Deferred },
+            new_coverage,
+        )
+    }
+
+    fn insert_corpus_entry(
+        &mut self,
+        corpus: CorpusEntry,
+        insertion_mode: CorpusInsertionMode,
+        dedupe_by_coverage: bool,
+    ) -> Option<CampaignCorpusEntry> {
+        let campaign_entry = matches!(insertion_mode, CorpusInsertionMode::Deferred)
+            .then(|| CampaignCorpusEntry { tx_seq: corpus.tx_seq.clone(), dedupe_by_coverage });
+
+        if matches!(insertion_mode, CorpusInsertionMode::Live)
+            && let Some(worker_dir) = &self.worker_dir
+        {
+            let worker_corpus = worker_dir.join(CORPUS_DIR);
             let write_result = corpus.write_to_disk_in(&worker_corpus, self.config.corpus_gzip);
             if let Err(err) = write_result {
                 debug!(target: "corpus", %err, "failed to record call sequence {:?}", corpus.tx_seq);
@@ -853,7 +867,6 @@ impl WorkerCorpus {
         }
 
         self.push_corpus_entry(corpus);
-
         campaign_entry
     }
 
@@ -1148,26 +1161,15 @@ impl WorkerCorpus {
             return None;
         }
 
-        let targets = targeted_contracts.targets();
-        let mut tx_seq = Vec::with_capacity(observed.len());
-        let mut first_delay = Some((parent_tx.warp, parent_tx.roll));
-        for call in observed {
-            let (warp, roll) = first_delay.take().unwrap_or((None, None));
-            let tx = BasicTxDetails {
-                warp,
-                roll,
-                sender: call.caller,
-                call_details: CallDetails {
-                    target: call.target,
-                    calldata: call.calldata.clone(),
-                    value: call.value,
-                },
-            };
-            if targets.can_replay(&tx) {
-                tx_seq.push(tx);
-            }
-        }
-        drop(targets);
+        let tx_seq = {
+            let targets = targeted_contracts.targets();
+            sequence_from_observed(
+                observed,
+                &targets,
+                ObservedCallDepth::All,
+                Some((parent_tx.warp, parent_tx.roll)),
+            )
+        };
 
         self.push_observed_sequence(tx_seq, insertion_mode)
     }
@@ -1206,10 +1208,6 @@ impl WorkerCorpus {
             };
 
             let mut exec = executor.clone();
-            if let Some(fuzzer) = exec.inspector_mut().fuzzer.as_mut() {
-                fuzzer.set_call_recording(true);
-                let _ = fuzzer.take_observed_calls();
-            }
 
             let raw = match exec.call_raw(CALLER, invariant_contract.address, calldata, U256::ZERO)
             {
@@ -1232,7 +1230,7 @@ impl WorkerCorpus {
 
             let seq = {
                 let targets = targeted_contracts.targets();
-                sequence_from_observed(&observed, &targets)
+                sequence_from_observed(&observed, &targets, ObservedCallDepth::DirectOnly, None)
             };
 
             let insertion_mode = if self.id == 0 {
@@ -1260,21 +1258,9 @@ impl WorkerCorpus {
             return None;
         }
 
-        let campaign_entry = matches!(insertion_mode, CorpusInsertionMode::Deferred)
-            .then(|| CampaignCorpusEntry { tx_seq: tx_seq.clone(), dedupe_by_coverage: false });
         let corpus = CorpusEntry::new(tx_seq);
 
-        if matches!(insertion_mode, CorpusInsertionMode::Live)
-            && let Some(worker_dir) = &self.worker_dir
-        {
-            let worker_corpus = worker_dir.join(CORPUS_DIR);
-            if let Err(err) = corpus.write_to_disk_in(&worker_corpus, self.config.corpus_gzip) {
-                debug!(target: "corpus", %err, "failed to persist corpus seed");
-            }
-        }
-
-        self.push_corpus_entry(corpus);
-        campaign_entry
+        self.insert_corpus_entry(corpus, insertion_mode, false)
     }
 
     /// Returns the next call to be used in call sequence.
@@ -1760,17 +1746,27 @@ impl WorkerCorpus {
     }
 }
 
+#[derive(Clone, Copy)]
+enum ObservedCallDepth {
+    DirectOnly,
+    All,
+}
+
 fn sequence_from_observed(
     observed: &[ObservedCall],
     targets: &TargetedContracts,
+    depth: ObservedCallDepth,
+    first_delay: Option<(Option<U256>, Option<U256>)>,
 ) -> Vec<BasicTxDetails> {
+    let mut first_delay = first_delay;
     observed
         .iter()
-        .filter(|call| call.depth == 1)
+        .filter(|call| matches!(depth, ObservedCallDepth::All) || call.depth == 1)
         .filter_map(|call| {
+            let (warp, roll) = first_delay.take().unwrap_or((None, None));
             let tx = BasicTxDetails {
-                warp: None,
-                roll: None,
+                warp,
+                roll,
                 sender: call.caller,
                 call_details: CallDetails {
                     target: call.target,
@@ -2430,7 +2426,7 @@ mod tests {
             },
         ];
 
-        let seq = sequence_from_observed(&observed, &targets);
+        let seq = sequence_from_observed(&observed, &targets, ObservedCallDepth::DirectOnly, None);
 
         assert_eq!(seq.len(), 1);
         assert_eq!(seq[0].sender, sender);

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -920,13 +920,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 if new_call_coverage {
                     current_run.new_coverage = true;
                 }
-                let observed_calls = current_run
-                    .executor
-                    .inspector_mut()
-                    .fuzzer
-                    .as_mut()
-                    .map(|fuzzer| fuzzer.take_observed_calls())
-                    .unwrap_or_default();
+                let observed_calls = std::mem::take(&mut call_result.observed_calls);
                 if new_call_coverage
                     && let Some(entry) = corpus_manager.hoist_observed_calls(
                         &observed_calls,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1,7 +1,9 @@
 use crate::{
     executors::{
         DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, RawCallResult,
-        corpus::{DynamicTargetCtx, ReplayTarget, WorkerCorpus, WorkerCorpusSeed},
+        corpus::{
+            CorpusInsertionMode, DynamicTargetCtx, ReplayTarget, WorkerCorpus, WorkerCorpusSeed,
+        },
     },
     inspectors::Fuzzer,
 };
@@ -914,8 +916,30 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     None
                 };
                 // Collect edge coverage and set the flag in the current run.
-                if corpus_manager.merge_edge_coverage(&mut call_result) {
+                let new_call_coverage = corpus_manager.merge_edge_coverage(&mut call_result);
+                if new_call_coverage {
                     current_run.new_coverage = true;
+                }
+                let observed_calls = current_run
+                    .executor
+                    .inspector_mut()
+                    .fuzzer
+                    .as_mut()
+                    .map(|fuzzer| fuzzer.take_observed_calls())
+                    .unwrap_or_default();
+                if new_call_coverage
+                    && let Some(entry) = corpus_manager.hoist_observed_calls(
+                        &observed_calls,
+                        current_run.inputs.last().expect("checked above"),
+                        &invariant_test.targeted_contracts,
+                        if corpus_persistence.is_deferred() {
+                            CorpusInsertionMode::Deferred
+                        } else {
+                            CorpusInsertionMode::Live
+                        },
+                    )
+                {
+                    corpus_entries.push(entry);
                 }
 
                 if discarded {
@@ -1380,13 +1404,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // Set up fuzzer WITHOUT call_generator initially.
         // We defer call_override until after the initial invariant check to avoid
         // injecting random calls during setup which would break the invariant assertion.
-        executor.inspector_mut().set_fuzzer(Fuzzer {
-            call_generator: None,
-            collected_values: Vec::new(),
-            max_collected_values: config.dictionary.max_fuzz_dictionary_values,
-            mapping_slots,
-            collect: true,
-        });
+        executor.inspector_mut().set_fuzzer(
+            Fuzzer::new(config.dictionary.max_fuzz_dictionary_values, mapping_slots)
+                .with_call_recording(config.corpus.is_coverage_guided()),
+        );
 
         // Let's make sure the invariant is sound before actually starting the run:
         // We'll assert the invariant in its initial state, and if it fails, we'll
@@ -1407,10 +1428,24 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         )?;
         if let Some(fuzzer) = executor.inspector_mut().fuzzer.as_mut() {
             fuzz_state.collect_values(fuzzer.drain_collected_values());
+            let _ = fuzzer.take_observed_calls();
         }
-        // NOW enable call_override after the initial invariant check has passed.
-        // This allows `override_call_strat` to inject calls during actual fuzz runs
-        // for reentrancy vulnerability detection.
+        let mut worker = WorkerCorpus::from_seed(
+            plan.worker_id as usize,
+            config.corpus.clone(),
+            strategy.boxed(),
+            corpus_seed,
+        );
+
+        if let Err(err) =
+            worker.seed_from_test_traces(invariant_contract, &targeted_contracts, executor)
+        {
+            debug!(target: "corpus", %err, "failed to seed corpus from test traces");
+        }
+
+        // NOW enable call_override after the initial invariant check and corpus trace seeding have
+        // passed. This allows `override_call_strat` to inject calls during actual fuzz runs for
+        // reentrancy vulnerability detection.
         if config.call_override {
             let target_contract_ref = Arc::new(RwLock::new(Address::ZERO));
 
@@ -1444,13 +1479,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 fuzzer.call_generator = Some(call_generator);
             }
         }
-
-        let worker = WorkerCorpus::from_seed(
-            plan.worker_id as usize,
-            config.corpus.clone(),
-            strategy.boxed(),
-            corpus_seed,
-        );
 
         let mut invariant_test =
             InvariantTest::new(fuzz_state, targeted_contracts, failures, runner.clone());

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -35,6 +35,7 @@ use foundry_evm_core::{
     utils::StateChangeset,
 };
 use foundry_evm_coverage::HitMaps;
+use foundry_evm_fuzz::ObservedCall;
 use foundry_evm_traces::{SparsedTraceArena, TraceMode};
 use revm::{
     bytecode::Bytecode,
@@ -1029,6 +1030,8 @@ pub struct RawCallResult<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     pub edge_coverage: Option<EdgeCoverage>,
     /// EVM comparison operands collected during the call.
     pub evm_cmp_values: Option<Vec<CmpOperands>>,
+    /// Observed sub-calls collected during the call.
+    pub observed_calls: Vec<ObservedCall>,
     /// Sancov edge coverage from instrumented native Rust crates (e.g. precompiles).
     /// Tracked separately from EVM edge coverage to avoid ID-space collisions.
     pub sancov_coverage: Option<Vec<u8>>,
@@ -1068,6 +1071,7 @@ impl<FEN: FoundryEvmNetwork> Default for RawCallResult<FEN> {
             line_coverage: None,
             edge_coverage: None,
             evm_cmp_values: None,
+            observed_calls: Vec::new(),
             sancov_coverage: None,
             sancov_cmp_values: None,
             transactions: None,
@@ -1288,7 +1292,7 @@ impl<T, FEN: FoundryEvmNetwork> std::ops::DerefMut for CallResult<T, FEN> {
 fn convert_executed_result<FEN: FoundryEvmNetwork>(
     evm_env: EvmEnvFor<FEN>,
     tx_env: TxEnvFor<FEN>,
-    inspector: InspectorStack<FEN>,
+    mut inspector: InspectorStack<FEN>,
     ResultAndState { result, state: state_changeset }: ResultAndState<HaltReasonFor<FEN>>,
     db: &dyn DatabaseRef<Error = DatabaseError>,
     has_state_snapshot_failure: bool,
@@ -1313,6 +1317,12 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
         Some(Output::Call(data)) => data.clone(),
         _ => Bytes::new(),
     };
+    let observed_calls = inspector
+        .inner
+        .fuzzer
+        .as_mut()
+        .map(|fuzzer| fuzzer.take_observed_calls())
+        .unwrap_or_default();
 
     let InspectorData {
         mut logs,
@@ -1351,6 +1361,7 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
         line_coverage,
         edge_coverage,
         evm_cmp_values,
+        observed_calls,
         sancov_coverage: None,
         sancov_cmp_values: None,
         transactions,

--- a/crates/evm/fuzz/src/inspector.rs
+++ b/crates/evm/fuzz/src/inspector.rs
@@ -1,5 +1,5 @@
 use crate::invariant::RandomCallGenerator;
-use alloy_primitives::{B256, map::AddressMap};
+use alloy_primitives::{Address, B256, Bytes, U256, map::AddressMap};
 use foundry_common::mapping_slots::{MappingSlots, step as mapping_step};
 use foundry_evm_core::constants::CHEATCODE_ADDRESS;
 use revm::{
@@ -7,6 +7,20 @@ use revm::{
     context::{ContextTr, JournalTr, Transaction},
     interpreter::{CallInput, CallInputs, CallOutcome, CallScheme, CallValue, Interpreter},
 };
+
+/// A sub-call observed by the [`Fuzzer`] inspector.
+///
+/// `depth` is 1-indexed relative to the top-level call: depth 1 is a direct call
+/// from the top-level callee, depth 2 is a sub-call of that call, and so on. The
+/// top-level call itself is never recorded.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObservedCall {
+    pub depth: u32,
+    pub caller: Address,
+    pub target: Address,
+    pub calldata: Bytes,
+    pub value: Option<U256>,
+}
 
 /// An inspector that can fuzz and collect data for that effect.
 #[derive(Clone, Debug)]
@@ -21,6 +35,12 @@ pub struct Fuzzer {
     pub max_collected_values: usize,
     /// Mapping accesses observed during execution, used for storage slot sampling.
     pub mapping_slots: Option<AddressMap<MappingSlots>>,
+    /// Whether sub-calls should be buffered for later corpus seeding.
+    record_calls: bool,
+    /// Sub-calls observed since the last drain.
+    observed_calls: Vec<ObservedCall>,
+    /// Current EVM call depth. 0 means no active call, 1 means top-level call.
+    call_depth: u32,
 }
 
 impl<CTX: ContextTr> Inspector<CTX> for Fuzzer {
@@ -41,6 +61,15 @@ impl<CTX: ContextTr> Inspector<CTX> for Fuzzer {
             self.override_call(ecx, inputs);
         }
 
+        self.call_depth = self.call_depth.saturating_add(1);
+        self.record_observed_call(
+            inputs.caller,
+            inputs.target_address,
+            inputs.input.bytes(ecx),
+            inputs.transfer_value().filter(|value| !value.is_zero()),
+            inputs.scheme,
+        );
+
         // We only collect `stack` and `memory` data before and after calls.
         // this will be turned off on the next `step`
         self.collect = true;
@@ -59,10 +88,64 @@ impl<CTX: ContextTr> Inspector<CTX> for Fuzzer {
         // We only collect `stack` and `memory` data before and after calls.
         // this will be turned off on the next `step`
         self.collect = true;
+
+        self.call_depth = self.call_depth.saturating_sub(1);
     }
 }
 
 impl Fuzzer {
+    /// Constructs a new `Fuzzer` inspector.
+    pub const fn new(
+        max_collected_values: usize,
+        mapping_slots: Option<AddressMap<MappingSlots>>,
+    ) -> Self {
+        Self {
+            collect: true,
+            call_generator: None,
+            collected_values: Vec::new(),
+            max_collected_values,
+            mapping_slots,
+            record_calls: false,
+            observed_calls: Vec::new(),
+            call_depth: 0,
+        }
+    }
+
+    /// Enables or disables sub-call buffering.
+    pub const fn with_call_recording(mut self, record_calls: bool) -> Self {
+        self.record_calls = record_calls;
+        self
+    }
+
+    /// Enables or disables sub-call buffering on an existing inspector.
+    pub const fn set_call_recording(&mut self, record_calls: bool) {
+        self.record_calls = record_calls;
+    }
+
+    /// Returns the buffered sub-calls observed since the last drain.
+    pub fn take_observed_calls(&mut self) -> Vec<ObservedCall> {
+        std::mem::take(&mut self.observed_calls)
+    }
+
+    fn record_observed_call(
+        &mut self,
+        caller: Address,
+        target: Address,
+        calldata: Bytes,
+        value: Option<U256>,
+        scheme: CallScheme,
+    ) {
+        if self.record_calls && self.call_depth > 1 && matches!(scheme, CallScheme::Call) {
+            self.observed_calls.push(ObservedCall {
+                depth: self.call_depth - 1,
+                caller,
+                target,
+                calldata,
+                value,
+            });
+        }
+    }
+
     /// Collects `stack` and `memory` values into the fuzz dictionary.
     #[cold]
     fn collect_data(&mut self, interpreter: &Interpreter) {
@@ -157,5 +240,95 @@ impl Fuzzer {
 
         // Track that we're inside an overridden call to avoid recursive overrides
         call_generator.override_depth = 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fuzzer(record_calls: bool) -> Fuzzer {
+        Fuzzer::new(16, None).with_call_recording(record_calls)
+    }
+
+    #[test]
+    fn observed_calls_are_disabled_by_default() {
+        let mut fuzzer = Fuzzer::new(16, None);
+        fuzzer.call_depth = 2;
+
+        fuzzer.record_observed_call(
+            Address::from([0xaa; 20]),
+            Address::from([0x11; 20]),
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+            Some(U256::from(1)),
+            CallScheme::Call,
+        );
+
+        assert!(fuzzer.take_observed_calls().is_empty());
+    }
+
+    #[test]
+    fn observed_calls_skip_top_level_call() {
+        let mut fuzzer = fuzzer(true);
+        fuzzer.call_depth = 1;
+
+        fuzzer.record_observed_call(
+            Address::from([0xaa; 20]),
+            Address::from([0x11; 20]),
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+            None,
+            CallScheme::Call,
+        );
+
+        assert!(fuzzer.take_observed_calls().is_empty());
+    }
+
+    #[test]
+    fn observed_calls_record_subcall_depth_target_calldata_and_value() {
+        let mut fuzzer = fuzzer(true);
+        let caller = Address::from([0x11; 20]);
+        let target = Address::from([0x22; 20]);
+        let calldata = Bytes::from_static(&[0xca, 0xfe, 0xba, 0xbe]);
+        let value = Some(U256::from(7));
+        fuzzer.call_depth = 3;
+
+        fuzzer.record_observed_call(caller, target, calldata.clone(), value, CallScheme::Call);
+
+        assert_eq!(
+            fuzzer.take_observed_calls(),
+            vec![ObservedCall { depth: 2, caller, target, calldata, value }]
+        );
+    }
+
+    #[test]
+    fn observed_calls_skip_non_call_schemes() {
+        let mut fuzzer = fuzzer(true);
+        fuzzer.call_depth = 2;
+
+        fuzzer.record_observed_call(
+            Address::from([0x11; 20]),
+            Address::from([0x22; 20]),
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+            None,
+            CallScheme::DelegateCall,
+        );
+
+        assert!(fuzzer.take_observed_calls().is_empty());
+    }
+
+    #[test]
+    fn take_observed_calls_drains_buffer() {
+        let mut fuzzer = fuzzer(true);
+        fuzzer.call_depth = 2;
+        fuzzer.record_observed_call(
+            Address::from([0xaa; 20]),
+            Address::from([0x33; 20]),
+            Bytes::from_static(&[0x12, 0x34, 0x56, 0x78]),
+            None,
+            CallScheme::Call,
+        );
+
+        assert_eq!(fuzzer.take_observed_calls().len(), 1);
+        assert!(fuzzer.take_observed_calls().is_empty());
     }
 }

--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -131,7 +131,10 @@ impl TargetedContracts {
         match self.inner.get(&tx.call_details.target) {
             Some(c) => (
                 Some(&c.abi),
-                c.abi.functions().find(|f| f.selector() == tx.call_details.calldata[..4]),
+                tx.call_details
+                    .calldata
+                    .get(..4)
+                    .and_then(|selector| c.abi.functions().find(|f| f.selector() == selector)),
             ),
             None => (None, None),
         }
@@ -149,7 +152,11 @@ impl TargetedContracts {
     /// Returns whether the given transaction can be replayed or not with known contracts.
     pub fn can_replay(&self, tx: &BasicTxDetails) -> bool {
         match self.inner.get(&tx.call_details.target) {
-            Some(c) => c.abi.functions().any(|f| f.selector() == tx.call_details.calldata[..4]),
+            Some(c) => {
+                tx.call_details.calldata.get(..4).is_some_and(|selector| {
+                    c.abi_fuzzed_functions().any(|f| f.selector() == selector)
+                })
+            }
             None => false,
         }
     }
@@ -158,11 +165,13 @@ impl TargetedContracts {
     /// key composed from contract identifier and function name.
     pub fn fuzzed_metric_key(&self, tx: &BasicTxDetails) -> Option<String> {
         self.inner.get(&tx.call_details.target).and_then(|contract| {
-            contract
-                .abi
-                .functions()
-                .find(|f| f.selector() == tx.call_details.calldata[..4])
-                .map(|function| format!("{}.{}", contract.identifier.clone(), function.name))
+            tx.call_details.calldata.get(..4).and_then(|selector| {
+                contract
+                    .abi
+                    .functions()
+                    .find(|f| f.selector() == selector)
+                    .map(|function| format!("{}.{}", contract.identifier.clone(), function.name))
+            })
         })
     }
 
@@ -434,5 +443,40 @@ impl fmt::Display for InvariantSettings {
             self.excluded_senders.len(),
             self.fail_on_revert,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CallDetails;
+    use alloy_primitives::Bytes;
+
+    fn targeted_contracts_with_function(target: Address, function: Function) -> TargetedContracts {
+        let mut abi = JsonAbi::new();
+        abi.functions.entry(function.name.clone()).or_default().push(function);
+        let mut targets = TargetedContracts::new();
+        targets.inner.insert(target, TargetedContract::new("Target".to_string(), abi));
+        targets
+    }
+
+    fn tx(target: Address, calldata: impl Into<Bytes>) -> BasicTxDetails {
+        BasicTxDetails {
+            warp: None,
+            roll: None,
+            sender: Address::ZERO,
+            call_details: CallDetails { target, calldata: calldata.into(), value: None },
+        }
+    }
+
+    #[test]
+    fn targeted_contracts_short_calldata_is_not_replayable_or_decodable() {
+        let target = Address::from([0x42; 20]);
+        let targets = targeted_contracts_with_function(target, Function::parse("foo()").unwrap());
+        let tx = tx(target, vec![0xde, 0xad, 0xbe]);
+
+        assert!(!targets.can_replay(&tx));
+        assert!(targets.fuzzed_artifacts(&tx).1.is_none());
+        assert!(targets.fuzzed_metric_key(&tx).is_none());
     }
 }

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -31,7 +31,7 @@ pub mod strategies;
 pub use strategies::LiteralMaps;
 
 mod inspector;
-pub use inspector::Fuzzer;
+pub use inspector::{Fuzzer, ObservedCall};
 
 /// Metadata needed to reproduce a fuzz run.
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
Towards OSS-189 , inspired by [#9](https://github.com/0xalpharush/foundry/pull/9)

The fuzzer now records replayable subcalls, returns them through the raw call result, and hoists them into the invariant corpus when they produce new coverage. It also seeds the corpus from sibling zero-input test traces, so existing hand-written test flows can help guide invariant fuzzing.

A couple of edge cases are handled too: short calldata no longer panics selector checks, and parent warp/roll delay is preserved on the first retained observed call.