### PR TITLE
test(tempo): add T6 local regression coverage

### DIFF
--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -27,7 +27,7 @@ use alloy_rpc_types::{BlockId, BlockNumberOrTag, TransactionRequest, anvil::Fork
 use alloy_serde::WithOtherFields;
 use alloy_signer::Signer;
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::{SolValue, sol};
+use alloy_sol_types::{SolEvent, SolValue, sol};
 use anvil::{NodeConfig, spawn};
 use foundry_evm::core::tempo::{
     ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, ITIP20ChannelReserve, PATH_USD_ADDRESS,
@@ -39,7 +39,9 @@ use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, DEFAULT_FEE_TOKEN,
     RECEIVE_POLICY_GUARD_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
-    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS,
+    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    receive_policy_guard::{IReceivePolicyGuard, InboundKind},
+    tip403_registry::{ALLOW_ALL_POLICY_ID, ITIP403Registry, REJECT_ALL_POLICY_ID},
 };
 use tempo_primitives::{
     AASigned, TempoSignature, TempoTransaction,
@@ -459,6 +461,144 @@ async fn test_tempo_config_filters_hardfork_gated_precompiles() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_t6_receive_policy_blocks_and_claims_transfer() {
+    let (_api_t5, handle_t5) =
+        spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T5.into()))).await;
+    let provider_t5 = handle_t5.http_provider();
+    let registry_t5 = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &provider_t5);
+    let guard_t5 = IReceivePolicyGuard::new(RECEIVE_POLICY_GUARD_ADDRESS, &provider_t5);
+
+    assert!(
+        registry_t5.receivePolicy(Address::ZERO).call().await.is_err(),
+        "receive-policy selectors should be unavailable before T6"
+    );
+    assert!(
+        guard_t5.balanceOf(Bytes::default()).call().await.is_err(),
+        "ReceivePolicyGuard should be unavailable before T6"
+    );
+
+    let (api, handle) =
+        spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let provider = handle.http_provider();
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let sender = accounts[0];
+    let receiver = accounts[1];
+    let recovery = accounts[2];
+    let claim_target = accounts[3];
+    let amount = U256::from(123_456u64);
+
+    let code = api.get_code(RECEIVE_POLICY_GUARD_ADDRESS, None).await.unwrap();
+    assert!(!code.is_empty(), "ReceivePolicyGuard should have sentinel code at T6");
+
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &provider);
+    let set_policy_tx = TransactionRequest::default()
+        .from(receiver)
+        .to(TIP403_REGISTRY_ADDRESS)
+        .with_input(
+            registry
+                .setReceivePolicy(REJECT_ALL_POLICY_ID, ALLOW_ALL_POLICY_ID, recovery)
+                .calldata()
+                .clone(),
+        )
+        .with_gas_limit(T5_PRECOMPILE_GAS);
+    let receipt = provider
+        .send_transaction(WithOtherFields::new(set_policy_tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(receipt.status(), "setReceivePolicy should succeed at T6");
+
+    let validation =
+        registry.validateReceivePolicy(PATH_USD, sender, receiver).call().await.unwrap();
+    assert!(!validation.authorized, "REJECT_ALL sender policy should hold the transfer");
+    assert_eq!(validation.blockedReason, ITIP403Registry::BlockedReason::RECEIVE_POLICY);
+
+    let token = ITIP20T5Rpc::new(PATH_USD, &provider);
+    let receiver_balance_before = token.balanceOf(receiver).call().await.unwrap();
+    let guard_balance_before = token.balanceOf(RECEIVE_POLICY_GUARD_ADDRESS).call().await.unwrap();
+    let claim_target_balance_before = token.balanceOf(claim_target).call().await.unwrap();
+
+    let transfer_tx = TransactionRequest::default()
+        .from(sender)
+        .to(PATH_USD)
+        .with_input(token.transfer(receiver, amount).calldata().clone())
+        .with_gas_limit(T5_PRECOMPILE_GAS);
+    let transfer_receipt = provider
+        .send_transaction(WithOtherFields::new(transfer_tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(transfer_receipt.status(), "blocked transfers should still succeed");
+
+    let blocked = transfer_receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| IReceivePolicyGuard::TransferBlocked::decode_log(&log.inner).ok())
+        .expect("blocked transfer should emit TransferBlocked");
+    let decoded = IReceivePolicyGuard::ClaimReceiptV1::abi_decode(&blocked.receipt).unwrap();
+
+    assert_eq!(blocked.token, PATH_USD);
+    assert_eq!(blocked.receiver, receiver);
+    assert_eq!(blocked.amount, amount);
+    assert_eq!(blocked.receiptVersion, 1);
+    assert_eq!(decoded.version, 1);
+    assert_eq!(decoded.token, PATH_USD);
+    assert_eq!(decoded.recoveryAuthority, recovery);
+    assert_eq!(decoded.originator, sender);
+    assert_eq!(decoded.recipient, receiver);
+    assert_eq!(decoded.blockedNonce, blocked.blockedNonce);
+    assert_eq!(decoded.blockedReason, ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8);
+    assert_eq!(decoded.kind, InboundKind::TRANSFER);
+    assert_eq!(decoded.memo, B256::ZERO);
+
+    let guard = IReceivePolicyGuard::new(RECEIVE_POLICY_GUARD_ADDRESS, &provider);
+    assert_eq!(guard.balanceOf(blocked.receipt.clone()).call().await.unwrap(), amount);
+    assert_eq!(token.balanceOf(receiver).call().await.unwrap(), receiver_balance_before);
+    assert_eq!(
+        token.balanceOf(RECEIVE_POLICY_GUARD_ADDRESS).call().await.unwrap(),
+        guard_balance_before + amount
+    );
+
+    let claim_tx = TransactionRequest::default()
+        .from(recovery)
+        .to(RECEIVE_POLICY_GUARD_ADDRESS)
+        .with_input(guard.claim(claim_target, blocked.receipt.clone()).calldata().clone())
+        .with_gas_limit(T5_PRECOMPILE_GAS);
+    let claim_receipt = provider
+        .send_transaction(WithOtherFields::new(claim_tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(claim_receipt.status(), "recovery authority should be able to claim held funds");
+
+    let claimed = claim_receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| IReceivePolicyGuard::ReceiptClaimed::decode_log(&log.inner).ok())
+        .expect("claim should emit ReceiptClaimed");
+    assert_eq!(claimed.token, PATH_USD);
+    assert_eq!(claimed.receiver, receiver);
+    assert_eq!(claimed.blockedNonce, decoded.blockedNonce);
+    assert_eq!(claimed.caller, recovery);
+    assert_eq!(claimed.to, claim_target);
+    assert_eq!(claimed.amount, amount);
+
+    assert_eq!(guard.balanceOf(blocked.receipt.clone()).call().await.unwrap(), U256::ZERO);
+    assert_eq!(
+        token.balanceOf(claim_target).call().await.unwrap(),
+        claim_target_balance_before + amount
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_tempo_channel_reserve_compute_channel_id_call() {
     let (_api, handle) =
         spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T5.into()))).await;
@@ -584,6 +724,66 @@ async fn test_anvil_cli_tempo_t5_hardfork_precompile_smoke() {
 
     let reserve = ITIP20ChannelReserveT5Rpc::new(TIP20_CHANNEL_RESERVE_ADDRESS, &provider);
     assert_ne!(reserve.domainSeparator().call().await.unwrap(), B256::ZERO);
+}
+
+#[cfg(feature = "cli")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_cli_tempo_t6_hardfork_receive_policy_guard_smoke() {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    let port_arg = port.to_string();
+
+    let mut child = ChildGuard(
+        Command::new(anvil_binary())
+            .args([
+                "--network",
+                "tempo",
+                "--hardfork",
+                "tempo:T6",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                &port_arg,
+                "-q",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn anvil --hardfork tempo:T6"),
+    );
+
+    let endpoint = format!("http://127.0.0.1:{port}");
+    let provider = http_provider(&endpoint);
+    let mut ready = false;
+    for _ in 0..50 {
+        if provider.get_chain_id().await.is_ok() {
+            ready = true;
+            break;
+        }
+        if let Some(status) = child.0.try_wait().unwrap() {
+            panic!("anvil exited before serving RPC: {status}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(ready, "anvil --hardfork tempo:T6 should start serving RPC");
+
+    let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
+        PATH_USD,
+        address!("0x0000000000000000000000000000000000000002"),
+        address!("0x0000000000000000000000000000000000000003"),
+        address!("0x0000000000000000000000000000000000000004"),
+        1,
+        1,
+        ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8,
+        InboundKind::TRANSFER,
+        B256::ZERO,
+    )
+    .abi_encode()
+    .into();
+    let guard = IReceivePolicyGuard::new(RECEIVE_POLICY_GUARD_ADDRESS, &provider);
+    assert_eq!(guard.balanceOf(receipt).call().await.unwrap(), U256::ZERO);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -1,6 +1,25 @@
 //! CLI tests for shared Tempo transaction options.
 
+use alloy_network::{ReceiptResponse, TransactionBuilder};
+use alloy_primitives::{Address, B256, U256, hex};
+use alloy_provider::Provider;
+use alloy_rpc_types::TransactionRequest;
+use alloy_serde::WithOtherFields;
+use alloy_sol_types::{SolEvent, SolValue};
+use anvil::NodeConfig;
+use foundry_evm::core::tempo::PATH_USD_ADDRESS;
 use foundry_test_utils::util::OutputExt;
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_contracts::precompiles::{
+    IReceivePolicyGuard, ITIP20, ITIP403Registry, TIP403_REGISTRY_ADDRESS,
+};
+
+fn json_success_data(output: &str) -> serde_json::Value {
+    let envelope: serde_json::Value =
+        serde_json::from_str(output.trim()).expect("command emits JSON");
+    assert_eq!(envelope["success"], true, "unexpected JSON envelope: {envelope}");
+    envelope["data"].clone()
+}
 
 casttest!(tempo_state_changing_help_includes_expires, |_prj, cmd| {
     let cases: &[(&str, &[&str])] = &[
@@ -20,6 +39,191 @@ casttest!(tempo_state_changing_help_includes_expires, |_prj, cmd| {
             "expected {name} help to expose --tempo.expires, got:\n{output}",
         );
     }
+});
+
+casttest!(receive_policy_receipt_json_and_claim_flow, async |_prj, cmd| {
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let rpc = handle.http_endpoint();
+    let provider = handle.http_provider();
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let sender = accounts[0];
+    let receiver = accounts[1];
+    let recovery = accounts[2];
+    let claim_target = accounts[3];
+    let recovery_wallet = handle.dev_wallets().nth(2).unwrap();
+    assert_eq!(recovery_wallet.address(), recovery);
+    let recovery_pk = format!("0x{}", hex::encode(recovery_wallet.credential().to_bytes()));
+    let amount = U256::from(77_000u64);
+    let path_usd = PATH_USD_ADDRESS.to_string();
+    let sender_arg = sender.to_string();
+    let receiver_arg = receiver.to_string();
+    let recovery_arg = recovery.to_string();
+    let claim_target_arg = claim_target.to_string();
+
+    let warning_preview = cmd
+        .cast_fuse()
+        .args(["--json", "receive-policy", "set", "0", "1", "--preview", "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let warning_preview = json_success_data(&warning_preview);
+    let warning = warning_preview["warning"].as_str().expect("warning should be present");
+    assert!(warning.contains("originator recovery is enabled"), "{warning}");
+    assert!(warning.contains("system/precompile sender"), "{warning}");
+
+    let safe_preview = cmd
+        .cast_fuse()
+        .args([
+            "--json",
+            "receive-policy",
+            "set",
+            "0",
+            "1",
+            "--recovery-authority",
+            &recovery_arg,
+            "--preview",
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let safe_preview = json_success_data(&safe_preview);
+    assert_eq!(safe_preview["action"], "set_receive_policy");
+    assert_eq!(safe_preview["recovery_mode"], "authority");
+    assert!(safe_preview["calldata"].as_str().is_some_and(|s| s.starts_with("0x")));
+    assert!(safe_preview["warning"].is_null());
+
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &provider);
+    let set_policy_tx = TransactionRequest::default()
+        .from(receiver)
+        .to(TIP403_REGISTRY_ADDRESS)
+        .with_input(registry.setReceivePolicy(0, 1, recovery).calldata().clone())
+        .with_gas_limit(10_000_000);
+    let set_policy = provider
+        .send_transaction(WithOtherFields::new(set_policy_tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(set_policy.status(), "setReceivePolicy should succeed");
+
+    let validate = cmd
+        .cast_fuse()
+        .args([
+            "--json",
+            "receive-policy",
+            "validate",
+            &path_usd,
+            &sender_arg,
+            &receiver_arg,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let validate = json_success_data(&validate);
+    assert_eq!(validate["authorized"], false);
+    assert_eq!(validate["blocked_reason"], "receive_policy");
+    assert_eq!(validate["delivery_state"], "held");
+
+    let token = ITIP20::new(PATH_USD_ADDRESS, &provider);
+    let claim_target_before = token.balanceOf(claim_target).call().await.unwrap();
+    let transfer_tx = TransactionRequest::default()
+        .from(sender)
+        .to(PATH_USD_ADDRESS)
+        .with_input(token.transfer(receiver, amount).calldata().clone())
+        .with_gas_limit(10_000_000);
+    let transfer = provider
+        .send_transaction(WithOtherFields::new(transfer_tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(transfer.status(), "blocked transfer should still succeed");
+
+    let blocked = transfer
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| IReceivePolicyGuard::TransferBlocked::decode_log(&log.inner).ok())
+        .expect("transfer should emit TransferBlocked");
+    assert_eq!(blocked.token, PATH_USD_ADDRESS);
+    assert_eq!(blocked.receiver, receiver);
+    assert_eq!(blocked.amount, amount);
+    let decoded = IReceivePolicyGuard::ClaimReceiptV1::abi_decode(&blocked.receipt).unwrap();
+    assert_eq!(decoded.version, 1);
+    assert_eq!(decoded.recoveryAuthority, recovery);
+    assert_eq!(decoded.originator, sender);
+    assert_eq!(decoded.recipient, receiver);
+    assert_eq!(decoded.blockedReason, ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8);
+    assert_eq!(decoded.memo, B256::ZERO);
+
+    let receipt_arg = blocked.receipt.to_string();
+    let decoded_output = cmd
+        .cast_fuse()
+        .args(["--json", "receive-policy", "receipt", "decode", &receipt_arg])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let decoded_output = json_success_data(&decoded_output);
+    assert_eq!(decoded_output["receipt"], receipt_arg);
+    assert_eq!(decoded_output["token"], path_usd);
+    assert_eq!(decoded_output["recovery_mode"], "authority");
+    assert_eq!(decoded_output["originator"], sender_arg);
+    assert_eq!(decoded_output["recipient"], receiver_arg);
+    assert_eq!(decoded_output["blocked_reason"], "receive_policy");
+    assert_eq!(decoded_output["kind"], "transfer");
+    assert_eq!(decoded_output["delivery_state"], "unknown");
+    assert_eq!(decoded_output["claim_target"], receiver_arg);
+
+    let human_decode = cmd
+        .cast_fuse()
+        .args(["receive-policy", "receipt", "decode", &receipt_arg])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(human_decode.contains("cast receive-policy claim"), "{human_decode}");
+    assert!(human_decode.contains(&receipt_arg), "{human_decode}");
+
+    let balance_output = cmd
+        .cast_fuse()
+        .args(["--json", "receive-policy", "receipt", "balance", &receipt_arg, "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let balance_output = json_success_data(&balance_output);
+    assert_eq!(balance_output["held_balance"], amount.to_string());
+    assert_eq!(balance_output["delivery_state"], "held");
+
+    cmd.cast_fuse()
+        .args([
+            "receive-policy",
+            "claim",
+            &claim_target_arg,
+            &receipt_arg,
+            "--private-key",
+            &recovery_pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+
+    assert_eq!(token.balanceOf(claim_target).call().await.unwrap(), claim_target_before + amount);
+
+    let claimed_balance_output = cmd
+        .cast_fuse()
+        .args(["--json", "receive-policy", "receipt", "balance", &receipt_arg, "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let claimed_balance_output = json_success_data(&claimed_balance_output);
+    assert_eq!(claimed_balance_output["held_balance"], "0");
+    assert_eq!(claimed_balance_output["delivery_state"], "not_held");
 });
 
 casttest!(tip20_logo_create_help_includes_logo_uri, |_prj, cmd| {

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -454,6 +454,7 @@ pub fn ethereum_hardfork_from_block_tag(block: impl Into<BlockNumberOrTag>) -> E
 mod tests {
     use super::*;
     use alloy_hardforks::ethereum::mainnet::*;
+    use tempo_chainspec::constants::{mainnet::*, moderato::*};
 
     #[test]
     fn test_ethereum_spec_id_mapping() {
@@ -490,22 +491,20 @@ mod tests {
             Some(FoundryHardfork::Tempo(TempoHardfork::T6))
         );
 
-        const MAINNET_T6_TIMESTAMP: u64 = 1_782_223_200;
-        const MODERATO_T6_TIMESTAMP: u64 = 1_781_791_200;
         assert_eq!(
-            FoundryHardfork::from_chain_and_timestamp(4217, MAINNET_T6_TIMESTAMP - 1),
+            FoundryHardfork::from_chain_and_timestamp(MAINNET_CHAIN_ID, MAINNET_T6_TIMESTAMP - 1),
             Some(FoundryHardfork::Tempo(TempoHardfork::T5))
         );
         assert_eq!(
-            FoundryHardfork::from_chain_and_timestamp(4217, MAINNET_T6_TIMESTAMP),
+            FoundryHardfork::from_chain_and_timestamp(MAINNET_CHAIN_ID, MAINNET_T6_TIMESTAMP),
             Some(FoundryHardfork::Tempo(TempoHardfork::T6))
         );
         assert_eq!(
-            FoundryHardfork::from_chain_and_timestamp(42431, MODERATO_T6_TIMESTAMP - 1),
+            FoundryHardfork::from_chain_and_timestamp(MODERATO_CHAIN_ID, MODERATO_T6_TIMESTAMP - 1),
             Some(FoundryHardfork::Tempo(TempoHardfork::T5))
         );
         assert_eq!(
-            FoundryHardfork::from_chain_and_timestamp(42431, MODERATO_T6_TIMESTAMP),
+            FoundryHardfork::from_chain_and_timestamp(MODERATO_CHAIN_ID, MODERATO_T6_TIMESTAMP),
             Some(FoundryHardfork::Tempo(TempoHardfork::T6))
         );
     }

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -489,6 +489,25 @@ mod tests {
             FoundryHardfork::from_chain_and_timestamp(42431, u64::MAX),
             Some(FoundryHardfork::Tempo(TempoHardfork::T6))
         );
+
+        const MAINNET_T6_TIMESTAMP: u64 = 1_782_223_200;
+        const MODERATO_T6_TIMESTAMP: u64 = 1_781_791_200;
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(4217, MAINNET_T6_TIMESTAMP - 1),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T5))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(4217, MAINNET_T6_TIMESTAMP),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T6))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(42431, MODERATO_T6_TIMESTAMP - 1),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T5))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(42431, MODERATO_T6_TIMESTAMP),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T6))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds focused Foundry-side regression coverage for the T6 Tempo surfaces that are visible through local execution and Cast tooling, without duplicating the upstream Tempo precompile suite.

- Extends Tempo hardfork auto-detection tests to cover the T6 mainnet and Moderato timestamp boundaries.
- Adds Anvil T6 receive-policy smoke coverage for pre-T6 incompatibility, ReceivePolicyGuard registration, blocked TIP-20 transfer receipts, receipt decoding, held balance accounting, and recovery-authority claims.
- Adds an explicit local `anvil --network tempo --hardfork tempo:T6` execution smoke.
- Adds Cast CLI coverage for receive-policy JSON envelopes/payloads, warning preview output, decoded receipt recovery hints, held-balance output, and `cast receive-policy claim` against local Anvil.