### PR TITLE
fix(traces): decode calldata bytes in internal traces

### DIFF
--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -1249,6 +1249,37 @@ mod tests {
     }
 
     #[test]
+    fn decode_internal_parameter_values_passes_calldata_to_fallback_decoder() {
+        let digest = U256::from(0x1234);
+        let offset = 0x44;
+        let mut calldata = vec![0; offset];
+        calldata.extend_from_slice(&[0x11, 0x22, 0x33]);
+
+        let mut entry_node =
+            debug_node(0, 1, vec![trace_step(vec![digest, U256::from(offset), U256::from(3)])]);
+        entry_node.calldata = Bytes::from(calldata);
+
+        let mut context = context_with_arena(vec![
+            debug_node(0, 0, vec![internal_call_step_without_args(2)]),
+            debug_node(1, 0, vec![trace_step(Vec::new())]),
+            entry_node,
+        ]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.draw_memory.inner_call_index = 2;
+
+        assert_eq!(
+            tui.decode_internal_parameter_values(&scope(
+                "foo",
+                "(bytes32 digest, bytes calldata signature)"
+            )),
+            Some(vec![
+                "0x0000000000000000000000000000000000000000000000000000000000001234".to_string(),
+                "0x112233".to_string(),
+            ])
+        );
+    }
+
+    #[test]
     fn decode_internal_parameter_values_accepts_matching_overload_args() {
         let mut context = context_with_arena(vec![debug_node(
             0,

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -17,9 +17,7 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
-use revm_inspectors::tracing::types::{
-    CallKind, CallTraceStep, DecodedInternalCall, DecodedTraceStep,
-};
+use revm_inspectors::tracing::types::{CallKind, DecodedInternalCall, DecodedTraceStep};
 use std::{collections::VecDeque, fmt::Write};
 
 impl TUIContext<'_> {
@@ -764,8 +762,13 @@ impl TUIContext<'_> {
         }
 
         let parameters = Parameters::parse(&scope.parameters_src).ok()?;
-        let step = self.step_by_absolute_index(trace_node_idx, entry_step)?;
-        decode_step_parameters(&parameters, step)
+        let node = self.debug_arena().iter().find(|node| {
+            node.trace_node_idx == trace_node_idx
+                && entry_step >= node.step_offset
+                && entry_step < node.step_offset.saturating_add(node.steps.len())
+        })?;
+        let step = node.steps.get(entry_step.checked_sub(node.step_offset)?)?;
+        decode_step_parameters(&parameters, step, Some(node.calldata.as_ref()))
     }
 
     fn active_internal_call(&mut self) -> Option<ActiveInternalCall<'_>> {
@@ -847,17 +850,6 @@ impl TUIContext<'_> {
             end_step: location.end_step,
             decoded,
         })
-    }
-
-    fn step_by_absolute_index(
-        &self,
-        trace_node_idx: usize,
-        absolute_step: usize,
-    ) -> Option<&CallTraceStep> {
-        self.debug_arena()
-            .iter()
-            .filter(|node| node.trace_node_idx == trace_node_idx)
-            .find_map(|node| node.steps.get(absolute_step.checked_sub(node.step_offset)?))
     }
 
     fn absolute_current_step(&self) -> usize {
@@ -1235,7 +1227,7 @@ mod tests {
     fn decode_step_parameters_reads_static_values_from_stack() {
         let step = trace_step(vec![U256::from(42), U256::from(1)]);
         let parameters = Parameters::parse("(uint256 amount, bool ok)").unwrap();
-        let values = super::decode_step_parameters(&parameters, &step).unwrap();
+        let values = super::decode_step_parameters(&parameters, &step, None).unwrap();
 
         assert_eq!(values, ["42", "true"]);
     }

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -336,7 +336,7 @@ pub fn decode_step_parameters(
     Some(decoded)
 }
 
-fn stack_slots(ty: &DynSolType, storage: Option<Storage>) -> usize {
+const fn stack_slots(ty: &DynSolType, storage: Option<Storage>) -> usize {
     match (ty, storage) {
         (
             DynSolType::String | DynSolType::Bytes | DynSolType::Array(_),

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -161,9 +161,13 @@ impl<'a> DebugStepsWalker<'a> {
 
                 Some((
                     inputs.and_then(|t| {
-                        decode_step_parameters(&t, &self.node.trace.steps[start_idx + 1])
+                        decode_step_parameters(
+                            &t,
+                            &self.node.trace.steps[start_idx + 1],
+                            Some(self.node.trace.data.as_ref()),
+                        )
                     }),
-                    outputs.and_then(|t| decode_step_parameters(&t, self.current_step())),
+                    outputs.and_then(|t| decode_step_parameters(&t, self.current_step(), None)),
                 ))
             })
             .unwrap_or_default();
@@ -276,54 +280,118 @@ fn parse_types(source: &str) -> (Option<Parameters<'_>>, Option<Parameters<'_>>)
     (inputs, outputs)
 }
 
-/// Given [Parameters] and [CallTraceStep], tries to decode parameters by using stack and memory.
-pub fn decode_step_parameters(args: &Parameters<'_>, step: &CallTraceStep) -> Option<Vec<String>> {
+/// Given [Parameters] and [CallTraceStep], tries to decode parameters by using stack, memory, and
+/// call data.
+pub fn decode_step_parameters(
+    args: &Parameters<'_>,
+    step: &CallTraceStep,
+    calldata: Option<&[u8]>,
+) -> Option<Vec<String>> {
     let params = &args.params;
 
     if params.is_empty() {
         return Some(vec![]);
     }
 
-    let types = params.iter().map(|p| p.resolve().ok().map(|t| (t, p.storage))).collect::<Vec<_>>();
+    let types = params
+        .iter()
+        .map(|p| {
+            p.resolve().ok().map(|t| {
+                let slots = stack_slots(&t, p.storage);
+                (t, p.storage, slots)
+            })
+        })
+        .collect::<Vec<_>>();
 
     let stack = step.stack.as_ref()?;
+    let stack_slots =
+        types.iter().map(|type_| type_.as_ref().map_or(1, |(_, _, slots)| *slots)).sum::<usize>();
 
-    if stack.len() < types.len() {
+    if stack.len() < stack_slots {
         return None;
     }
 
-    let inputs = &stack[stack.len() - types.len()..];
+    let inputs = &stack[stack.len() - stack_slots..];
+    let memory = step.memory.as_ref().map(|memory| memory.as_bytes().as_ref());
+    let mut input_idx = 0;
+    let mut decoded = Vec::with_capacity(types.len());
 
-    let decoded = inputs
-        .iter()
-        .zip(types.iter())
-        .map(|(input, type_and_storage)| {
-            type_and_storage
-                .as_ref()
-                .and_then(|(type_, storage)| {
-                    match (type_, storage) {
-                        // HACK: alloy parser treats user-defined types as uint8: https://github.com/alloy-rs/core/pull/386
-                        //
-                        // filter out `uint8` params which are marked as storage or memory as this
-                        // is not possible in Solidity and means that type is user-defined
-                        (DynSolType::Uint(8), Some(Storage::Memory | Storage::Storage)) => None,
-                        (_, Some(Storage::Storage)) => None,
-                        (_, Some(Storage::Memory)) => decode_from_memory(
-                            type_,
-                            step.memory.as_ref()?.as_bytes(),
-                            input.try_into().ok()?,
-                        ),
-                        // Read other types from stack
-                        _ => type_.abi_decode(&input.to_be_bytes::<32>()).ok(),
-                    }
-                })
+    for type_and_storage in &types {
+        let Some((type_, storage, slots)) = type_and_storage.as_ref() else {
+            input_idx += 1;
+            decoded.push("<unknown>".to_string());
+            continue;
+        };
+        let input = &inputs[input_idx..input_idx + *slots];
+        input_idx += *slots;
+
+        decoded.push(
+            decode_parameter(type_, *storage, input, memory, calldata)
                 .as_ref()
                 .map(format_token)
-                .unwrap_or_else(|| "<unknown>".to_string())
-        })
-        .collect();
+                .unwrap_or_else(|| "<unknown>".to_string()),
+        );
+    }
 
     Some(decoded)
+}
+
+fn stack_slots(ty: &DynSolType, storage: Option<Storage>) -> usize {
+    match (ty, storage) {
+        (
+            DynSolType::String | DynSolType::Bytes | DynSolType::Array(_),
+            Some(Storage::Calldata),
+        ) => 2,
+        _ => 1,
+    }
+}
+
+fn decode_parameter(
+    ty: &DynSolType,
+    storage: Option<Storage>,
+    stack_words: &[U256],
+    memory: Option<&[u8]>,
+    calldata: Option<&[u8]>,
+) -> Option<DynSolValue> {
+    let input = stack_words.first()?;
+
+    match (ty, storage) {
+        // HACK: alloy parser treats user-defined types as uint8: https://github.com/alloy-rs/core/pull/386
+        //
+        // filter out `uint8` params which are marked as storage, memory, or calldata as this
+        // is not possible in Solidity and means that type is user-defined
+        (DynSolType::Uint(8), Some(Storage::Memory | Storage::Storage | Storage::Calldata)) => None,
+        (_, Some(Storage::Storage)) => None,
+        (_, Some(Storage::Memory)) => decode_from_memory(ty, memory?, input.try_into().ok()?),
+        (_, Some(Storage::Calldata)) => decode_from_calldata(ty, calldata?, stack_words),
+        // Read other types from stack
+        _ => ty.abi_decode(&input.to_be_bytes::<32>()).ok(),
+    }
+}
+
+fn decode_from_calldata(
+    ty: &DynSolType,
+    calldata: &[u8],
+    stack_words: &[U256],
+) -> Option<DynSolValue> {
+    let offset: usize = stack_words.first()?.try_into().ok()?;
+
+    match ty {
+        // For calldata `string` and `bytes`, Solidity keeps the byte offset and length on stack.
+        DynSolType::String | DynSolType::Bytes => {
+            let length: usize = stack_words.get(1)?.try_into().ok()?;
+            let data = memory_range(calldata, offset, length)?;
+
+            match ty {
+                DynSolType::Bytes => Some(DynSolValue::Bytes(data.to_vec())),
+                DynSolType::String => {
+                    Some(DynSolValue::String(String::from_utf8_lossy(data).to_string()))
+                }
+                _ => unreachable!(),
+            }
+        }
+        _ => None,
+    }
 }
 
 /// Decodes given [DynSolType] from memory.
@@ -446,6 +514,38 @@ mod tests {
         let params = Parameters::parse("(uint256[] storage values)").unwrap();
         let step = trace_step(vec![U256::from(5)]);
 
-        assert_eq!(decode_step_parameters(&params, &step), Some(vec!["<unknown>".to_string()]));
+        assert_eq!(
+            decode_step_parameters(&params, &step, None),
+            Some(vec!["<unknown>".to_string()])
+        );
+    }
+
+    #[test]
+    fn decode_step_parameters_aligns_static_arg_before_calldata_bytes() {
+        let params = Parameters::parse("(bytes32 digest, bytes calldata signature)").unwrap();
+        let digest = U256::from(0x1234);
+        let offset = 0x44;
+        let mut calldata = vec![0; offset];
+        calldata.extend_from_slice(&[0x11, 0x22, 0x33]);
+        let step = trace_step(vec![digest, U256::from(offset), U256::from(3)]);
+
+        assert_eq!(
+            decode_step_parameters(&params, &step, Some(&calldata)),
+            Some(vec![
+                "0x0000000000000000000000000000000000000000000000000000000000001234".to_string(),
+                "0x112233".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn decode_step_parameters_marks_calldata_bytes_unknown_without_calldata() {
+        let params = Parameters::parse("(bytes calldata signature)").unwrap();
+        let step = trace_step(vec![U256::from(0x44), U256::from(3)]);
+
+        assert_eq!(
+            decode_step_parameters(&params, &step, None),
+            Some(vec!["<unknown>".to_string()])
+        );
     }
 }

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -548,4 +548,19 @@ mod tests {
             Some(vec!["<unknown>".to_string()])
         );
     }
+
+    #[test]
+    fn decode_step_parameters_aligns_static_arg_after_unsupported_calldata_array() {
+        let params = Parameters::parse("(uint256[] calldata values, bytes32 digest)").unwrap();
+        let digest = U256::from(0x1234);
+        let step = trace_step(vec![U256::from(0x44), U256::from(2), digest]);
+
+        assert_eq!(
+            decode_step_parameters(&params, &step, Some(&[])),
+            Some(vec![
+                "<unknown>".to_string(),
+                "0x0000000000000000000000000000000000000000000000000000000000001234".to_string(),
+            ])
+        );
+    }
 }

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -1584,6 +1584,61 @@ Traces:
 "#]]);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/15224>
+#[cfg(not(feature = "isolate-by-default"))]
+forgetest_init!(internal_functions_trace_calldata_bytes, |prj, cmd| {
+    prj.clear();
+
+    prj.add_test(
+        "DecodeInternalCalldata",
+        r#"
+contract DecodeInternalCalldataTraceTest {
+    function test_decodeInternalCalldataBytes() public {
+        DecodeInternalTarget target = new DecodeInternalTarget();
+
+        bytes[] memory wrappedSignatures = new bytes[](1);
+        wrappedSignatures[0] = hex"11223344556677889900";
+
+        bytes32 expectedDigest = keccak256("digest that should appear in the internal trace");
+
+        bool ok = target.outer(wrappedSignatures, expectedDigest);
+        require(ok, "target returned false");
+    }
+}
+
+contract DecodeInternalTarget {
+    function outer(bytes[] calldata signatures, bytes32 digest) external pure returns (bool) {
+        bytes calldata signature = signatures[0];
+        return _internalValidate(digest, signature);
+    }
+
+    function _internalValidate(bytes32 digest, bytes calldata signature)
+        internal
+        pure
+        returns (bool)
+    {
+        return digest == keccak256("digest that should appear in the internal trace")
+            && signature.length == 10;
+    }
+}
+     "#,
+    );
+
+    let stdout = cmd
+        .args(["test", "-vvvv", "--decode-internal"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(
+        stdout.contains(
+            "DecodeInternalTarget::_internalValidate(bytes32,bytes)(\
+             0x9a707a44f6e6038d2b03f3947e82f6403612c5d5b923868f6a759e9c38e16a28, \
+             0x11223344556677889900)"
+        ),
+        "{stdout}"
+    );
+});
+
 // tests that `forge test` with a seed produces deterministic random values for uint and addresses.
 forgetest_init!(deterministic_randomness_with_seed, |prj, cmd| {
     prj.add_test(


### PR DESCRIPTION
## Summary

Fixes #15224.

- account for calldata reference parameters that occupy multiple stack words when decoding internal trace arguments
- decode calldata `bytes`/`string` arguments from the call input when the trace step provides offset and length
- pass frame calldata through the Forge trace and debugger internal-parameter decode paths
- add a Forge CLI regression for `bytes32` followed by `bytes calldata`

## Root Cause

`decode_step_parameters` assumed each Solidity parameter maps to one EVM stack word. A `bytes calldata` internal parameter is represented by offset and length, so the decoder selected too small a stack window and shifted the preceding `bytes32` argument onto the calldata offset.
