### PR TITLE
fix(cast): parse hex call values before calldata

### DIFF
--- a/crates/cast/src/call_spec.rs
+++ b/crates/cast/src/call_spec.rs
@@ -67,10 +67,13 @@ impl CallSpec {
         // Pattern: to:value:sig:args or to::sig:args (empty value) or to:value:0xdata
         let mut idx = 1;
 
-        // Check for value (non-empty, not starting with 0x unless it's a number)
+        // Check for value. Hex-looking parts are ambiguous with raw calldata, so only treat them
+        // as values when a following sig/data field makes this the value position.
         if idx < parts.len() {
             let part = parts[idx];
-            if !part.is_empty() && !part.starts_with("0x") && !part.contains('(') {
+            let is_hex_like = part.starts_with("0x") || part.starts_with("0X");
+            let has_following_field = idx + 1 < parts.len();
+            if !part.is_empty() && !part.contains('(') && (!is_hex_like || has_following_field) {
                 // This looks like a value
                 value = parse_ether_or_wei(part)?;
                 idx += 1;
@@ -215,5 +218,14 @@ mod tests {
         assert_eq!(spec.value, U256::ZERO);
         assert!(spec.sig.is_none());
         assert_eq!(spec.data, Some(Bytes::from(hex::decode("abcdef").unwrap())));
+    }
+
+    #[test]
+    fn test_parse_with_hex_value_and_raw_data() {
+        let spec =
+            CallSpec::parse("0x1234567890123456789012345678901234567890:0x0:0x1234").unwrap();
+        assert_eq!(spec.value, U256::ZERO);
+        assert!(spec.sig.is_none());
+        assert_eq!(spec.data, Some(Bytes::from(hex::decode("1234").unwrap())));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`CallSpec::parse` already supports hex values through `parse_ether_or_wei`, but the outer parser skipped value parsing for fields starting with `0x`. As a result, a spec such as `address:0x0:0x1234` was interpreted as raw calldata `0x0`, and the actual calldata field was ignored.

This matters for batch call specs that combine a hex value with raw calldata or another call payload.




## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Treat a hex-looking field in the value position as a value when a following sig/data field makes the field order unambiguous.
- Keep `to::0xdata` as the explicit form for raw calldata with no value.
- Add a regression test for `address:0x0:0x1234`.



## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
