### PR TITLE
feat(forge): configure fuzzer ensemble defaults

### DIFF
--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -222,7 +222,7 @@ impl Default for FuzzCorpusConfig {
             evm_edge_coverage_include_call_depth: false,
             sancov_edges: false,
             sancov_trace_cmp: false,
-            corpus_random_sequence_weight: 25,
+            corpus_random_sequence_weight: 50,
             mutation_weights: FuzzCorpusMutationWeights::default(),
         }
     }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -264,10 +264,6 @@ impl FuzzCorpusMutationWeights {
             + self.mutation_weight_cmp as u64
     }
 
-    pub const fn abi_or_cmp_total(&self) -> u64 {
-        self.mutation_weight_abi as u64 + self.mutation_weight_cmp as u64
-    }
-
     /// Returns defaults if every configured weight is zero.
     pub fn effective(self) -> Self {
         if self.total() == 0 { Self::default() } else { self }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -39,6 +39,9 @@ pub struct FuzzConfig {
 
 impl Default for FuzzConfig {
     fn default() -> Self {
+        let mut corpus = FuzzCorpusConfig::default();
+        corpus.payable_value_weight = 0;
+
         Self {
             runs: 256,
             run: None,
@@ -48,7 +51,7 @@ impl Default for FuzzConfig {
             seed: None,
             dictionary: FuzzDictionaryConfig::default(),
             gas_report_samples: 256,
-            corpus: FuzzCorpusConfig::default(),
+            corpus,
             failure_persist_dir: None,
             show_logs: false,
             timeout: None,
@@ -143,6 +146,9 @@ pub struct FuzzCorpusConfig {
     /// corpus sequence during coverage-guided invariant campaigns.
     #[serde(deserialize_with = "crate::deserialize_stringified_percent")]
     pub corpus_random_sequence_weight: u32,
+    /// Percent chance that generated payable calls carry non-zero `msg.value`.
+    #[serde(deserialize_with = "crate::deserialize_stringified_percent")]
+    pub payable_value_weight: u32,
     /// Weights for coverage-guided corpus mutation strategies.
     #[serde(flatten)]
     pub mutation_weights: FuzzCorpusMutationWeights,
@@ -223,6 +229,7 @@ impl Default for FuzzCorpusConfig {
             sancov_edges: false,
             sancov_trace_cmp: false,
             corpus_random_sequence_weight: 50,
+            payable_value_weight: 15,
             mutation_weights: FuzzCorpusMutationWeights::default(),
         }
     }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -139,6 +139,13 @@ pub struct FuzzCorpusConfig {
     /// Whether to capture comparison operands from sancov-instrumented crates
     /// and inject them into the fuzz dictionary. Independent of `sancov_edges`.
     pub sancov_trace_cmp: bool,
+    /// Percent chance of generating a fresh transaction sequence instead of reusing the current
+    /// corpus sequence during coverage-guided invariant campaigns.
+    #[serde(deserialize_with = "crate::deserialize_stringified_percent")]
+    pub corpus_random_sequence_weight: u32,
+    /// Weights for coverage-guided corpus mutation strategies.
+    #[serde(flatten)]
+    pub mutation_weights: FuzzCorpusMutationWeights,
 }
 
 impl FuzzCorpusConfig {
@@ -215,6 +222,61 @@ impl Default for FuzzCorpusConfig {
             evm_edge_coverage_include_call_depth: false,
             sancov_edges: false,
             sancov_trace_cmp: false,
+            corpus_random_sequence_weight: 25,
+            mutation_weights: FuzzCorpusMutationWeights::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzCorpusMutationWeights {
+    /// Weight for splicing two corpus sequences.
+    pub mutation_weight_splice: u32,
+    /// Weight for repeating part of a corpus sequence.
+    pub mutation_weight_repeat: u32,
+    /// Weight for interleaving two corpus sequences.
+    pub mutation_weight_interleave: u32,
+    /// Weight for replacing a corpus sequence prefix with generated calls.
+    pub mutation_weight_prefix: u32,
+    /// Weight for replacing a corpus sequence suffix with generated calls.
+    pub mutation_weight_suffix: u32,
+    /// Weight for ABI-aware argument mutation.
+    pub mutation_weight_abi: u32,
+    /// Weight for comparison-operand guided argument mutation.
+    pub mutation_weight_cmp: u32,
+}
+
+impl FuzzCorpusMutationWeights {
+    pub const fn total(&self) -> u64 {
+        self.mutation_weight_splice as u64
+            + self.mutation_weight_repeat as u64
+            + self.mutation_weight_interleave as u64
+            + self.mutation_weight_prefix as u64
+            + self.mutation_weight_suffix as u64
+            + self.mutation_weight_abi as u64
+            + self.mutation_weight_cmp as u64
+    }
+
+    pub const fn abi_or_cmp_total(&self) -> u64 {
+        self.mutation_weight_abi as u64 + self.mutation_weight_cmp as u64
+    }
+
+    /// Returns defaults if every configured weight is zero.
+    pub fn effective(self) -> Self {
+        if self.total() == 0 { Self::default() } else { self }
+    }
+}
+
+impl Default for FuzzCorpusMutationWeights {
+    fn default() -> Self {
+        Self {
+            mutation_weight_splice: 1,
+            mutation_weight_repeat: 1,
+            mutation_weight_interleave: 1,
+            mutation_weight_prefix: 1,
+            mutation_weight_suffix: 1,
+            mutation_weight_abi: 1,
+            mutation_weight_cmp: 1,
         }
     }
 }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -39,9 +39,6 @@ pub struct FuzzConfig {
 
 impl Default for FuzzConfig {
     fn default() -> Self {
-        let mut corpus = FuzzCorpusConfig::default();
-        corpus.payable_value_weight = 0;
-
         Self {
             runs: 256,
             run: None,
@@ -51,7 +48,7 @@ impl Default for FuzzConfig {
             seed: None,
             dictionary: FuzzDictionaryConfig::default(),
             gas_report_samples: 256,
-            corpus,
+            corpus: FuzzCorpusConfig { payable_value_weight: 0, ..Default::default() },
             failure_persist_dir: None,
             show_logs: false,
             timeout: None,

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -105,6 +105,7 @@ pub enum InvariantDepthMode {
     #[default]
     Fixed,
     /// Sample every invariant run depth uniformly between `min_depth` and `depth`.
+    #[serde(alias = "uniform")]
     Random,
 }
 
@@ -255,6 +256,10 @@ mod tests {
         assert_eq!("uniform".parse::<InvariantDepthMode>().unwrap(), InvariantDepthMode::Random);
         assert_eq!(
             serde_json::from_str::<InvariantDepthMode>(r#""random""#).unwrap(),
+            InvariantDepthMode::Random
+        );
+        assert_eq!(
+            serde_json::from_str::<InvariantDepthMode>(r#""uniform""#).unwrap(),
             InvariantDepthMode::Random
         );
     }

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -97,6 +97,31 @@ fn fixed_workers(workers: usize) -> Result<InvariantWorkers, String> {
         .ok_or_else(|| "invariant workers must be greater than 0".to_string())
 }
 
+/// Per-run invariant depth selection mode.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InvariantDepthMode {
+    /// Execute every invariant run up to the configured `depth`.
+    #[default]
+    Fixed,
+    /// Sample every invariant run depth uniformly between `min_depth` and `depth`.
+    Random,
+}
+
+impl FromStr for InvariantDepthMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "fixed" => Ok(Self::Fixed),
+            "random" | "uniform" => Ok(Self::Random),
+            value => {
+                Err(format!("unknown invariant depth mode `{value}`, expected `fixed` or `random`"))
+            }
+        }
+    }
+}
+
 /// Contains for invariant testing
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InvariantConfig {
@@ -104,6 +129,10 @@ pub struct InvariantConfig {
     pub runs: u32,
     /// The number of calls executed to attempt to break invariants in one run.
     pub depth: u32,
+    /// Minimum sampled run depth when `depth_mode = "random"`.
+    pub min_depth: u32,
+    /// How to choose the effective depth for each invariant run.
+    pub depth_mode: InvariantDepthMode,
     /// Worker selection mode used to shard invariant runs.
     ///
     /// Defaults to `1` for reproducible seeded campaigns. Use `auto` to derive the worker count
@@ -154,6 +183,8 @@ impl Default for InvariantConfig {
         Self {
             runs: 256,
             depth: 500,
+            min_depth: 1,
+            depth_mode: InvariantDepthMode::default(),
             workers: InvariantWorkers::default(),
             fail_on_revert: false,
             call_override: false,
@@ -216,5 +247,15 @@ mod tests {
     fn invariant_workers_reject_zero() {
         let err = serde_json::from_str::<InvariantWorkers>(r#"0"#).unwrap_err();
         assert!(err.to_string().contains("greater than 0"));
+    }
+
+    #[test]
+    fn invariant_depth_mode_accepts_fixed_and_random() {
+        assert_eq!("fixed".parse::<InvariantDepthMode>().unwrap(), InvariantDepthMode::Fixed);
+        assert_eq!("uniform".parse::<InvariantDepthMode>().unwrap(), InvariantDepthMode::Random);
+        assert_eq!(
+            serde_json::from_str::<InvariantDepthMode>(r#""random""#).unwrap(),
+            InvariantDepthMode::Random
+        );
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -108,10 +108,10 @@ pub use providers::Remappings;
 use providers::*;
 
 mod fuzz;
-pub use fuzz::{FuzzConfig, FuzzCorpusConfig, FuzzDictionaryConfig};
+pub use fuzz::{FuzzConfig, FuzzCorpusConfig, FuzzCorpusMutationWeights, FuzzDictionaryConfig};
 
 mod invariant;
-pub use invariant::{InvariantConfig, InvariantWorkers};
+pub use invariant::{InvariantConfig, InvariantDepthMode, InvariantWorkers};
 
 mod symbolic;
 pub use symbolic::{SymbolicConfig, SymbolicExplorationOrder, SymbolicStorageLayout};
@@ -5024,12 +5024,16 @@ mod tests {
         figment::Jail::expect_with(|jail| {
             jail.create_file(
                 "foundry.toml",
-                r"
+                r#"
                 [invariant]
                 runs = 512
                 depth = 10
+                min_depth = 2
+                depth_mode = "random"
                 workers = 4
-            ",
+                corpus_random_sequence_weight = 30
+                mutation_weight_cmp = 7
+            "#,
             )?;
 
             let loaded = Config::load().unwrap().sanitized();
@@ -5038,7 +5042,17 @@ mod tests {
                 InvariantConfig {
                     runs: 512,
                     depth: 10,
+                    min_depth: 2,
+                    depth_mode: InvariantDepthMode::Random,
                     workers: InvariantWorkers::Fixed(NonZeroUsize::new(4).unwrap()),
+                    corpus: FuzzCorpusConfig {
+                        corpus_random_sequence_weight: 30,
+                        mutation_weights: FuzzCorpusMutationWeights {
+                            mutation_weight_cmp: 7,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
                     failure_persist_dir: Some(PathBuf::from("cache/invariant")),
                     ..Default::default()
                 }
@@ -5064,17 +5078,27 @@ mod tests {
 
             jail.set_env("FOUNDRY_FMT_LINE_LENGTH", "95");
             jail.set_env("FOUNDRY_FUZZ_DICTIONARY_WEIGHT", "99");
+            jail.set_env("FOUNDRY_FUZZ_MAX_FUZZ_DICTIONARY_VALUES", "max");
             jail.set_env("FOUNDRY_INVARIANT_DEPTH", "5");
+            jail.set_env("FOUNDRY_INVARIANT_MIN_DEPTH", "2");
+            jail.set_env("FOUNDRY_INVARIANT_DEPTH_MODE", "random");
             jail.set_env("FOUNDRY_INVARIANT_WORKERS", "3");
+            jail.set_env("FOUNDRY_INVARIANT_CORPUS_RANDOM_SEQUENCE_WEIGHT", "30");
+            jail.set_env("FOUNDRY_INVARIANT_MUTATION_WEIGHT_CMP", "7");
 
             let config = Config::load().unwrap();
             assert_eq!(config.fmt.line_length, 95);
             assert_eq!(config.fuzz.dictionary.dictionary_weight, 99);
+            assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_values, usize::MAX);
             assert_eq!(config.invariant.depth, 5);
+            assert_eq!(config.invariant.min_depth, 2);
+            assert_eq!(config.invariant.depth_mode, InvariantDepthMode::Random);
             assert_eq!(
                 config.invariant.workers,
                 InvariantWorkers::Fixed(NonZeroUsize::new(3).unwrap())
             );
+            assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 30);
+            assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
 
             Ok(())
         });

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5032,6 +5032,7 @@ mod tests {
                 depth_mode = "random"
                 workers = 4
                 corpus_random_sequence_weight = 30
+                payable_value_weight = 12
                 mutation_weight_cmp = 7
             "#,
             )?;
@@ -5047,6 +5048,7 @@ mod tests {
                     workers: InvariantWorkers::Fixed(NonZeroUsize::new(4).unwrap()),
                     corpus: FuzzCorpusConfig {
                         corpus_random_sequence_weight: 30,
+                        payable_value_weight: 12,
                         mutation_weights: FuzzCorpusMutationWeights {
                             mutation_weight_cmp: 7,
                             ..Default::default()
@@ -5084,6 +5086,7 @@ mod tests {
             jail.set_env("FOUNDRY_INVARIANT_DEPTH_MODE", "random");
             jail.set_env("FOUNDRY_INVARIANT_WORKERS", "3");
             jail.set_env("FOUNDRY_INVARIANT_CORPUS_RANDOM_SEQUENCE_WEIGHT", "30");
+            jail.set_env("FOUNDRY_INVARIANT_PAYABLE_VALUE_WEIGHT", "12");
             jail.set_env("FOUNDRY_INVARIANT_MUTATION_WEIGHT_CMP", "7");
 
             let config = Config::load().unwrap();
@@ -5098,6 +5101,7 @@ mod tests {
                 InvariantWorkers::Fixed(NonZeroUsize::new(3).unwrap())
             );
             assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 30);
+            assert_eq!(config.invariant.corpus.payable_value_weight, 12);
             assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
 
             Ok(())

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -44,7 +44,7 @@ use alloy_json_abi::Function;
 use alloy_primitives::{Address, Bytes, I256, U256};
 use eyre::{Result, eyre};
 use foundry_common::{ContractsByAddress, ContractsByArtifact, TestFunctionExt, sh_warn};
-use foundry_config::FuzzCorpusConfig;
+use foundry_config::{FuzzCorpusConfig, FuzzCorpusMutationWeights};
 use foundry_evm_core::{constants::CALLER, evm::FoundryEvmNetwork, utils::StateChangeset};
 use foundry_evm_fuzz::{
     BasicTxDetails, CallDetails, ObservedCall,
@@ -56,8 +56,7 @@ use foundry_evm_fuzz::{
     },
 };
 use proptest::{
-    prelude::{Just, Rng, Strategy},
-    prop_oneof,
+    prelude::{Rng, Strategy},
     strategy::{BoxedStrategy, ValueTree},
     test_runner::TestRunner,
 };
@@ -84,6 +83,35 @@ const FAVORABILITY_THRESHOLD: f64 = 0.3;
 /// Threshold for compressing corpus entries.
 /// 4KiB is usually the minimum file size on popular file systems.
 const GZIP_THRESHOLD: usize = 4 * 1024;
+
+fn prefer_cmp_mutation(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> bool {
+    let weights = if weights.abi_or_cmp_total() == 0 {
+        FuzzCorpusMutationWeights::default()
+    } else {
+        weights
+    };
+    rng.random_range(0..weights.abi_or_cmp_total()) < u64::from(weights.mutation_weight_cmp)
+}
+
+fn weighted_mutation_type(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> MutationType {
+    let weights = weights.effective();
+    let mut choice = rng.random_range(0..weights.total());
+    for (weight, mutation) in [
+        (u64::from(weights.mutation_weight_splice), MutationType::Splice),
+        (u64::from(weights.mutation_weight_repeat), MutationType::Repeat),
+        (u64::from(weights.mutation_weight_interleave), MutationType::Interleave),
+        (u64::from(weights.mutation_weight_prefix), MutationType::Prefix),
+        (u64::from(weights.mutation_weight_suffix), MutationType::Suffix),
+        (u64::from(weights.mutation_weight_abi), MutationType::Abi),
+        (u64::from(weights.mutation_weight_cmp), MutationType::Cmp),
+    ] {
+        if choice < weight {
+            return mutation;
+        }
+        choice -= weight;
+    }
+    unreachable!("choice is bounded by total mutation weight")
+}
 
 /// Possible mutation strategies to apply on a call sequence.
 #[derive(Debug, Clone)]
@@ -486,8 +514,8 @@ pub struct WorkerCorpus {
     pub(crate) metrics: CorpusMetrics,
     /// Fuzzed calls generator.
     tx_generator: BoxedStrategy<BasicTxDetails>,
-    /// Call sequence mutation strategy type generator used by stateful fuzzing.
-    mutation_generator: BoxedStrategy<MutationType>,
+    /// Call sequence mutation weights used by stateful fuzzing.
+    mutation_weights: FuzzCorpusMutationWeights,
     /// Identifier of current mutated entry for this worker.
     current_mutated: Option<Uuid>,
     /// Config
@@ -692,16 +720,7 @@ impl WorkerCorpus {
         tx_generator: BoxedStrategy<BasicTxDetails>,
         seed: WorkerCorpusSeed,
     ) -> Self {
-        let mutation_generator = prop_oneof![
-            Just(MutationType::Splice),
-            Just(MutationType::Repeat),
-            Just(MutationType::Interleave),
-            Just(MutationType::Prefix),
-            Just(MutationType::Suffix),
-            Just(MutationType::Abi),
-            Just(MutationType::Cmp),
-        ]
-        .boxed();
+        let mutation_weights = config.mutation_weights.effective();
 
         let worker_dir = config.corpus_dir.as_ref().map(|corpus_dir| {
             let worker_dir = corpus_dir.join(format!("{WORKER}{id}"));
@@ -724,7 +743,7 @@ impl WorkerCorpus {
             failed_replays: seed.failed_replays,
             metrics: seed.metrics,
             tx_generator,
-            mutation_generator,
+            mutation_weights,
             current_mutated: None,
             config: config.into(),
             new_entry_indices: Default::default(),
@@ -949,11 +968,7 @@ impl WorkerCorpus {
         if !self.in_memory_corpus.is_empty() {
             self.evict_oldest_corpus()?;
 
-            let mutation_type = self
-                .mutation_generator
-                .new_tree(test_runner)
-                .map_err(|err| eyre!("Could not generate mutation type {err}"))?
-                .current();
+            let mutation_type = weighted_mutation_type(test_runner.rng(), self.mutation_weights);
 
             let rng = test_runner.rng();
             let corpus_len = self.in_memory_corpus.len();
@@ -1126,10 +1141,19 @@ impl WorkerCorpus {
             self.current_mutated = Some(corpus.uuid);
             let mut tx = corpus.tx_seq.first().unwrap().clone();
             let cmp_values = corpus.cmp_seq.first().map_or(&[][..], Vec::as_slice);
-            if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
-                && !function.inputs.is_empty()
-            {
+            let weights = self.config.mutation_weights.effective();
+            let prefer_cmp = prefer_cmp_mutation(test_runner.rng(), weights);
+            if prefer_cmp {
+                if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
+                    && weights.mutation_weight_abi > 0
+                    && !function.inputs.is_empty()
+                {
+                    self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
+                }
+            } else if weights.mutation_weight_abi > 0 && !function.inputs.is_empty() {
                 self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
+            } else if weights.mutation_weight_cmp > 0 {
+                let _ = Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?;
             }
             tx
         };
@@ -1279,7 +1303,9 @@ impl WorkerCorpus {
 
         // When running with coverage guided fuzzing enabled then generate new sequence if initial
         // sequence's length is less than depth or randomly, to occasionally intermix new txs.
-        if depth > sequence.len().saturating_sub(1) || test_runner.rng().random_ratio(1, 10) {
+        let fresh_weight = self.config.corpus_random_sequence_weight.min(100);
+        let generate_fresh = fresh_weight > 0 && test_runner.rng().random_ratio(fresh_weight, 100);
+        if depth > sequence.len().saturating_sub(1) || generate_fresh {
             return self.new_tx(test_runner);
         }
 
@@ -1859,6 +1885,7 @@ fn unique_corpus_entries<'a>(
 mod tests {
     use super::*;
     use alloy_dyn_abi::DynSolValue;
+    use proptest::prelude::Just;
     use std::fs;
 
     fn basic_tx() -> BasicTxDetails {

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -84,13 +84,12 @@ const FAVORABILITY_THRESHOLD: f64 = 0.3;
 /// 4KiB is usually the minimum file size on popular file systems.
 const GZIP_THRESHOLD: usize = 4 * 1024;
 
-fn prefer_cmp_mutation(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> bool {
-    let weights = if weights.abi_or_cmp_total() == 0 {
-        FuzzCorpusMutationWeights::default()
-    } else {
-        weights
-    };
-    rng.random_range(0..weights.abi_or_cmp_total()) < u64::from(weights.mutation_weight_cmp)
+fn prefer_cmp_mutation(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> Option<bool> {
+    let total = weights.abi_or_cmp_total();
+    if total == 0 {
+        return None;
+    }
+    Some(rng.random_range(0..total) < u64::from(weights.mutation_weight_cmp))
 }
 
 fn weighted_mutation_type(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> MutationType {
@@ -1096,7 +1095,7 @@ impl WorkerCorpus {
                         }
                     }
 
-                    if !mutated {
+                    if !mutated && self.mutation_weights.mutation_weight_abi > 0 {
                         let tx = new_seq.get_mut(fallback_idx).unwrap();
                         if let (_, Some(function)) = targets.fuzzed_artifacts(tx)
                             && !function.inputs.is_empty()
@@ -1133,7 +1132,12 @@ impl WorkerCorpus {
 
         self.evict_oldest_corpus()?;
 
-        let tx = if self.in_memory_corpus.is_empty() {
+        let fresh_weight = self.config.corpus_random_sequence_weight.min(100);
+        let generate_fresh = self.in_memory_corpus.is_empty()
+            || (fresh_weight > 0 && test_runner.rng().random_ratio(fresh_weight, 100));
+
+        let tx = if generate_fresh {
+            self.current_mutated = None;
             self.new_tx(test_runner)?
         } else {
             let corpus = &self.in_memory_corpus
@@ -1142,18 +1146,27 @@ impl WorkerCorpus {
             let mut tx = corpus.tx_seq.first().unwrap().clone();
             let cmp_values = corpus.cmp_seq.first().map_or(&[][..], Vec::as_slice);
             let weights = self.config.mutation_weights.effective();
-            let prefer_cmp = prefer_cmp_mutation(test_runner.rng(), weights);
-            if prefer_cmp {
-                if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
-                    && weights.mutation_weight_abi > 0
-                    && !function.inputs.is_empty()
-                {
+            match prefer_cmp_mutation(test_runner.rng(), weights) {
+                Some(true) => {
+                    if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
+                        && weights.mutation_weight_abi > 0
+                        && !function.inputs.is_empty()
+                    {
+                        self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
+                    }
+                }
+                Some(false) if weights.mutation_weight_abi > 0 && !function.inputs.is_empty() => {
                     self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
                 }
-            } else if weights.mutation_weight_abi > 0 && !function.inputs.is_empty() {
-                self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
-            } else if weights.mutation_weight_cmp > 0 {
-                let _ = Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?;
+                Some(false) if weights.mutation_weight_cmp > 0 => {
+                    let _ = Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?;
+                }
+                None => {
+                    // Stateless fuzz inputs cannot apply sequence-level mutation strategies.
+                    self.current_mutated = None;
+                    return Ok(self.new_tx(test_runner)?.call_details.calldata);
+                }
+                _ => {}
             }
             tx
         };
@@ -1885,7 +1898,9 @@ fn unique_corpus_entries<'a>(
 mod tests {
     use super::*;
     use alloy_dyn_abi::DynSolValue;
+    use foundry_config::FuzzDictionaryConfig;
     use proptest::prelude::Just;
+    use revm::database::{CacheDB, EmptyDB};
     use std::fs;
 
     fn basic_tx() -> BasicTxDetails {
@@ -1899,6 +1914,38 @@ mod tests {
                 value: None,
             },
         }
+    }
+
+    fn basic_tx_with_calldata(calldata: impl Into<Bytes>) -> BasicTxDetails {
+        let mut tx = basic_tx();
+        tx.call_details.calldata = calldata.into();
+        tx
+    }
+
+    fn tx_for_function(
+        target: Address,
+        function: &Function,
+        args: &[DynSolValue],
+    ) -> BasicTxDetails {
+        BasicTxDetails {
+            warp: None,
+            roll: None,
+            sender: Address::ZERO,
+            call_details: foundry_evm_fuzz::CallDetails {
+                target,
+                calldata: Bytes::from(function.abi_encode_input(args).unwrap()),
+                value: None,
+            },
+        }
+    }
+
+    fn empty_fuzz_state() -> EvmFuzzState {
+        EvmFuzzState::new(
+            &[],
+            &CacheDB::<EmptyDB>::default(),
+            FuzzDictionaryConfig::default(),
+            None,
+        )
     }
 
     fn temp_corpus_dir() -> PathBuf {
@@ -1919,6 +1966,15 @@ mod tests {
 
     fn worker_corpus(id: usize, corpus_root: PathBuf, seed: WorkerCorpusSeed) -> WorkerCorpus {
         WorkerCorpus::from_seed(id, corpus_config(corpus_root), Just(basic_tx()).boxed(), seed)
+    }
+
+    fn worker_corpus_with_config(
+        id: usize,
+        config: FuzzCorpusConfig,
+        generated: BasicTxDetails,
+        seed: WorkerCorpusSeed,
+    ) -> WorkerCorpus {
+        WorkerCorpus::from_seed(id, config, Just(generated).boxed(), seed)
     }
 
     fn empty_worker_corpus(id: usize, corpus_root: PathBuf) -> WorkerCorpus {
@@ -1970,6 +2026,87 @@ mod tests {
         assert!(mutated);
         let decoded = function.abi_decode_input(&tx.call_details.calldata[4..]).unwrap();
         assert_eq!(decoded[0].as_uint().unwrap().0, replacement);
+    }
+
+    #[test]
+    fn stateless_new_input_honors_fresh_sequence_weight() {
+        let mut config = corpus_config(temp_corpus_dir());
+        config.corpus_random_sequence_weight = 100;
+        let generated = basic_tx_with_calldata(vec![0x22]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x11])])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, generated, seed);
+        let mut runner = TestRunner::default();
+        let function = Function::parse("foo()").unwrap();
+
+        let input = manager.new_input(&mut runner, &empty_fuzz_state(), &function).unwrap();
+
+        assert_eq!(input, Bytes::from(vec![0x22]));
+        assert!(manager.current_mutated.is_none());
+    }
+
+    #[test]
+    fn stateless_new_input_does_not_fallback_to_disabled_arg_mutators() {
+        let mut config = corpus_config(temp_corpus_dir());
+        config.corpus_random_sequence_weight = 0;
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 1,
+            mutation_weight_repeat: 1,
+            mutation_weight_interleave: 1,
+            mutation_weight_prefix: 1,
+            mutation_weight_suffix: 1,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+        };
+        let generated = basic_tx_with_calldata(vec![0x44]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x33])])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, generated, seed);
+        let mut runner = TestRunner::default();
+        let function = Function::parse("foo(uint256)").unwrap();
+
+        let input = manager.new_input(&mut runner, &empty_fuzz_state(), &function).unwrap();
+
+        assert_eq!(input, Bytes::from(vec![0x44]));
+        assert!(manager.current_mutated.is_none());
+    }
+
+    #[test]
+    fn invariant_cmp_mutation_does_not_fallback_to_disabled_abi_mutation() {
+        let target = Address::from([0x42; 20]);
+        let function = Function::parse("foo(uint256)").unwrap();
+        let original = tx_for_function(target, &function, &[DynSolValue::Uint(U256::from(7), 256)]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![original.clone()])],
+            ..Default::default()
+        };
+        let mut config = corpus_config(temp_corpus_dir());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 1,
+        };
+        let mut manager = worker_corpus_with_config(0, config, basic_tx(), seed);
+        let mut runner = TestRunner::default();
+        let fuzz_state = empty_fuzz_state().into_invariant();
+        let targeted_contracts = targeted_contracts_with_selective_functions(
+            target,
+            vec![function.clone()],
+            [function.selector()],
+        );
+
+        let sequence = manager.new_inputs(&mut runner, &fuzz_state, &targeted_contracts).unwrap();
+
+        assert_eq!(sequence.len(), 1);
+        assert_eq!(sequence[0].call_details.calldata, original.call_details.calldata);
     }
 
     fn new_manager_with_single_corpus() -> (WorkerCorpus, Uuid) {

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1363,9 +1363,9 @@ impl WorkerCorpus {
         test_runner: &mut TestRunner,
         fuzz_state: &impl FuzzStateReader,
     ) -> Result<()> {
-        // Mutate value with 15% probability for payable functions.
+        // Mutate value with configured probability for payable functions.
         if function.state_mutability == alloy_json_abi::StateMutability::Payable
-            && test_runner.rng().random_ratio(15, 100)
+            && test_runner.rng().random_ratio(self.config.payable_value_weight.min(100), 100)
         {
             tx.call_details.value = Some(generate_msg_value(test_runner));
         }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -60,6 +60,7 @@ use proptest::{
     strategy::{BoxedStrategy, ValueTree},
     test_runner::TestRunner,
 };
+use rand::distr::{Distribution, weighted::WeightedIndex};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
@@ -84,32 +85,24 @@ const FAVORABILITY_THRESHOLD: f64 = 0.3;
 /// 4KiB is usually the minimum file size on popular file systems.
 const GZIP_THRESHOLD: usize = 4 * 1024;
 
-fn prefer_cmp_mutation(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> Option<bool> {
-    let total = weights.abi_or_cmp_total();
-    if total == 0 {
-        return None;
-    }
-    Some(rng.random_range(0..total) < u64::from(weights.mutation_weight_cmp))
+fn weighted_arg_mutation(
+    rng: &mut impl Rng,
+    distribution: Option<&WeightedIndex<u32>>,
+) -> Option<bool> {
+    distribution.map(|distribution| distribution.sample(rng) == 1)
 }
 
-fn weighted_mutation_type(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> MutationType {
-    let weights = weights.effective();
-    let mut choice = rng.random_range(0..weights.total());
-    for (weight, mutation) in [
-        (u64::from(weights.mutation_weight_splice), MutationType::Splice),
-        (u64::from(weights.mutation_weight_repeat), MutationType::Repeat),
-        (u64::from(weights.mutation_weight_interleave), MutationType::Interleave),
-        (u64::from(weights.mutation_weight_prefix), MutationType::Prefix),
-        (u64::from(weights.mutation_weight_suffix), MutationType::Suffix),
-        (u64::from(weights.mutation_weight_abi), MutationType::Abi),
-        (u64::from(weights.mutation_weight_cmp), MutationType::Cmp),
-    ] {
-        if choice < weight {
-            return mutation;
-        }
-        choice -= weight;
+fn weighted_mutation_type(rng: &mut impl Rng, distribution: &WeightedIndex<u32>) -> MutationType {
+    match distribution.sample(rng) {
+        0 => MutationType::Splice,
+        1 => MutationType::Repeat,
+        2 => MutationType::Interleave,
+        3 => MutationType::Prefix,
+        4 => MutationType::Suffix,
+        5 => MutationType::Abi,
+        6 => MutationType::Cmp,
+        _ => unreachable!("mutation distribution only has seven entries"),
     }
-    unreachable!("choice is bounded by total mutation weight")
 }
 
 /// Possible mutation strategies to apply on a call sequence.
@@ -515,6 +508,10 @@ pub struct WorkerCorpus {
     tx_generator: BoxedStrategy<BasicTxDetails>,
     /// Call sequence mutation weights used by stateful fuzzing.
     mutation_weights: FuzzCorpusMutationWeights,
+    /// Weighted stateful sequence mutation distribution.
+    mutation_distribution: WeightedIndex<u32>,
+    /// Weighted ABI/CMP argument mutation distribution used by stateless fuzzing.
+    arg_mutation_distribution: Option<WeightedIndex<u32>>,
     /// Identifier of current mutated entry for this worker.
     current_mutated: Option<Uuid>,
     /// Config
@@ -720,6 +717,21 @@ impl WorkerCorpus {
         seed: WorkerCorpusSeed,
     ) -> Self {
         let mutation_weights = config.mutation_weights.effective();
+        let mutation_distribution = WeightedIndex::new([
+            mutation_weights.mutation_weight_splice,
+            mutation_weights.mutation_weight_repeat,
+            mutation_weights.mutation_weight_interleave,
+            mutation_weights.mutation_weight_prefix,
+            mutation_weights.mutation_weight_suffix,
+            mutation_weights.mutation_weight_abi,
+            mutation_weights.mutation_weight_cmp,
+        ])
+        .expect("effective mutation weights contain at least one non-zero entry");
+        let arg_mutation_distribution = WeightedIndex::new([
+            mutation_weights.mutation_weight_abi,
+            mutation_weights.mutation_weight_cmp,
+        ])
+        .ok();
 
         let worker_dir = config.corpus_dir.as_ref().map(|corpus_dir| {
             let worker_dir = corpus_dir.join(format!("{WORKER}{id}"));
@@ -743,6 +755,8 @@ impl WorkerCorpus {
             metrics: seed.metrics,
             tx_generator,
             mutation_weights,
+            mutation_distribution,
+            arg_mutation_distribution,
             current_mutated: None,
             config: config.into(),
             new_entry_indices: Default::default(),
@@ -967,7 +981,8 @@ impl WorkerCorpus {
         if !self.in_memory_corpus.is_empty() {
             self.evict_oldest_corpus()?;
 
-            let mutation_type = weighted_mutation_type(test_runner.rng(), self.mutation_weights);
+            let mutation_type =
+                weighted_mutation_type(test_runner.rng(), &self.mutation_distribution);
 
             let rng = test_runner.rng();
             let corpus_len = self.in_memory_corpus.len();
@@ -1145,20 +1160,23 @@ impl WorkerCorpus {
             self.current_mutated = Some(corpus.uuid);
             let mut tx = corpus.tx_seq.first().unwrap().clone();
             let cmp_values = corpus.cmp_seq.first().map_or(&[][..], Vec::as_slice);
-            let weights = self.config.mutation_weights.effective();
-            match prefer_cmp_mutation(test_runner.rng(), weights) {
+            match weighted_arg_mutation(test_runner.rng(), self.arg_mutation_distribution.as_ref())
+            {
                 Some(true) => {
                     if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
-                        && weights.mutation_weight_abi > 0
+                        && self.mutation_weights.mutation_weight_abi > 0
                         && !function.inputs.is_empty()
                     {
                         self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
                     }
                 }
-                Some(false) if weights.mutation_weight_abi > 0 && !function.inputs.is_empty() => {
+                Some(false)
+                    if self.mutation_weights.mutation_weight_abi > 0
+                        && !function.inputs.is_empty() =>
+                {
                     self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
                 }
-                Some(false) if weights.mutation_weight_cmp > 0 => {
+                Some(false) if self.mutation_weights.mutation_weight_cmp > 0 => {
                     let _ = Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?;
                 }
                 None => {

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -21,12 +21,12 @@ use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::{
     BaseCounterExample, BasicTxDetails, CallDetails, CounterExample, FuzzCase, FuzzError,
     FuzzFixtures, FuzzRunMetadata, FuzzTestResult,
-    strategies::{EvmFuzzState, fuzz_calldata, fuzz_calldata_from_state},
+    strategies::{EvmFuzzState, fuzz_calldata, fuzz_calldata_from_state, fuzz_msg_value},
 };
 use foundry_evm_traces::SparsedTraceArena;
 use indicatif::ProgressBar;
 use proptest::{
-    strategy::Strategy,
+    strategy::{Just, Strategy},
     test_runner::{RngAlgorithm, TestCaseError, TestRng, TestRunner},
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -451,16 +451,22 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         // Prepare
         let fuzz_state = shared_state.state.fork();
         let dictionary_weight = self.config.dictionary.dictionary_weight.min(100);
-        let strategy = proptest::prop_oneof![
+        let calldata_strategy = proptest::prop_oneof![
             100 - dictionary_weight => fuzz_calldata(func.clone(), fuzz_fixtures),
             dictionary_weight => fuzz_calldata_from_state(func.clone(), &fuzz_state),
-        ]
-        .prop_map(move |calldata| BasicTxDetails {
-            warp: None,
-            roll: None,
-            sender: Default::default(),
-            call_details: CallDetails { target: Default::default(), calldata, value: None },
-        });
+        ];
+        let value_strategy = if func.state_mutability == alloy_json_abi::StateMutability::Payable {
+            fuzz_msg_value(self.config.corpus.payable_value_weight).boxed()
+        } else {
+            Just(None).boxed()
+        };
+        let strategy =
+            (calldata_strategy, value_strategy).prop_map(move |(calldata, value)| BasicTxDetails {
+                warp: None,
+                roll: None,
+                sender: Default::default(),
+                call_details: CallDetails { target: Default::default(), calldata, value },
+            });
 
         let mut corpus = WorkerCorpus::new(
             worker_id,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1483,6 +1483,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     target_contract_ref.clone(),
                     fuzz_fixtures.clone(),
                     config.dictionary.dictionary_weight,
+                    config.corpus.payable_value_weight,
                 ),
                 target_contract_ref,
             );

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -18,7 +18,7 @@ use foundry_common::{
     contracts::{ContractsByAddress, ContractsByArtifact},
     sh_eprintln, sh_println,
 };
-use foundry_config::{InvariantConfig, InvariantWorkers};
+use foundry_config::{InvariantConfig, InvariantDepthMode, InvariantWorkers};
 use foundry_evm_core::{
     FoundryBlock,
     constants::{
@@ -39,6 +39,7 @@ use foundry_evm_traces::{CallTraceArena, SparsedTraceArena};
 use indicatif::ProgressBar;
 use parking_lot::RwLock;
 use proptest::{
+    prelude::Rng,
     strategy::Strategy,
     test_runner::{RngAlgorithm, TestRng, TestRunner},
 };
@@ -175,6 +176,19 @@ fn max_invariant_workers_for_campaign(runs: u32, depth: u32) -> usize {
     let estimated_calls = u64::from(runs) * u64::from(depth.max(1));
     usize::try_from((estimated_calls / MIN_ESTIMATED_CALLS_PER_INVARIANT_WORKER).max(1))
         .unwrap_or(usize::MAX)
+}
+
+fn invariant_run_depth(config: &InvariantConfig, runner: &mut TestRunner) -> u32 {
+    match config.depth_mode {
+        InvariantDepthMode::Fixed => config.depth,
+        InvariantDepthMode::Random => {
+            if config.depth <= config.min_depth {
+                config.depth
+            } else {
+                runner.rng().random_range(config.min_depth..=config.depth)
+            }
+        }
+    }
 }
 
 fn auto_invariant_worker_count(
@@ -842,12 +856,15 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 &invariant_test.targeted_contracts,
             )?;
 
+            let run_depth =
+                invariant_run_depth(&config, &mut invariant_test.test_data.branch_runner);
+
             // Create current invariant run data.
             let mut current_run = InvariantTestRun::new(
                 initial_seq[0].clone(),
                 // Before each run, we must reset the backend state.
                 executor.clone(),
-                config.depth as usize,
+                run_depth as usize,
             );
 
             // We stop the run immediately if we have reverted, and `fail_on_revert` is set.
@@ -856,7 +873,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 return Err(eyre!("call reverted"));
             }
 
-            while current_run.depth < config.depth {
+            while current_run.depth < run_depth {
                 // Check if the timeout has been reached.
                 if campaign_state.should_stop() {
                     // Since we never record a revert here the test is still considered
@@ -971,7 +988,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             &mut state_changeset,
                             current_run.inputs.last().expect("checked above"),
                             &call_result,
-                            config.depth,
+                            run_depth,
                             mapping_slots,
                         );
                     }
@@ -999,7 +1016,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     // - check_interval=0: only assert on the last call
                     // - check_interval=1 (default): assert after every call
                     // - check_interval=N: assert every N calls AND always on the last call
-                    let is_last_call = current_run.depth == config.depth - 1;
+                    let is_last_call = current_run.depth == run_depth - 1;
                     // In optimization mode, always evaluate the invariant to track
                     // the best value at every prefix — check_interval only gates
                     // boolean invariant assertions.
@@ -1090,7 +1107,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         current_run.cmp_seq.push(call_cmp_values);
                     }
 
-                    if !continues || current_run.depth == config.depth - 1 {
+                    if !continues || current_run.depth == run_depth - 1 {
                         invariant_test.set_last_run_inputs(&current_run.inputs);
                     }
                     // Bridge newly-recorded predicate breaks into `failure_metrics` even when
@@ -1465,6 +1482,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     override_targets,
                     target_contract_ref.clone(),
                     fuzz_fixtures.clone(),
+                    config.dictionary.dictionary_weight,
                 ),
                 target_contract_ref,
             );

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -128,7 +128,8 @@ pub fn invariant_strat(
 }
 
 /// Strategy to select a sender address:
-/// * If `senders` is empty, then it's either a random address (10%) or from the dictionary (90%).
+/// * If `senders` is empty, then it's either a random address or one sampled from the dictionary
+///   according to the configured dictionary weight.
 /// * If `senders` is not empty, a random address is chosen from the list of senders.
 fn select_random_sender<S: FuzzStateReader>(
     fuzz_state: &S,

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -20,6 +20,7 @@ pub fn override_call_strat(
     contracts: Vec<(Address, Vec<Function>)>,
     target: Arc<RwLock<Address>>,
     fuzz_fixtures: FuzzFixtures,
+    dictionary_weight: u32,
 ) -> impl Strategy<Value = CallDetails> + Send + Sync + 'static {
     let contracts = Arc::new(contracts);
     let contracts_ref = contracts.clone();
@@ -60,7 +61,13 @@ pub fn override_call_strat(
         };
 
         func.prop_flat_map(move |func| {
-            fuzz_contract_with_calldata(&fuzz_state, &fuzz_fixtures, actual_target, func)
+            fuzz_contract_with_calldata(
+                &fuzz_state,
+                &fuzz_fixtures,
+                actual_target,
+                func,
+                dictionary_weight,
+            )
         })
     })
 }
@@ -103,6 +110,7 @@ pub fn invariant_strat(
                 &fuzz_fixtures,
                 *target_address,
                 target_function.clone(),
+                dictionary_weight,
             );
 
             let warp = warp_roll_strat(config.max_time_delay.is_some());
@@ -128,7 +136,7 @@ fn select_random_sender<S: FuzzStateReader>(
     dictionary_weight: u32,
 ) -> impl Strategy<Value = Address> + use<S> {
     if senders.targeted.is_empty() {
-        assert!(dictionary_weight <= 100, "dictionary_weight must be <= 100");
+        let dictionary_weight = dictionary_weight.min(100);
         proptest::prop_oneof![
             100 - dictionary_weight => fuzz_param(&alloy_dyn_abi::DynSolType::Address),
             dictionary_weight => fuzz_param_from_state(&alloy_dyn_abi::DynSolType::Address, fuzz_state),
@@ -160,15 +168,17 @@ pub fn fuzz_contract_with_calldata<S: FuzzStateReader>(
     fuzz_fixtures: &FuzzFixtures,
     target: Address,
     func: Function,
+    dictionary_weight: u32,
 ) -> impl Strategy<Value = CallDetails> + use<S> {
     let is_payable = func.state_mutability == alloy_json_abi::StateMutability::Payable;
+    let dictionary_weight = dictionary_weight.min(100);
 
     // We need to compose all the strategies generated for each parameter in all possible
     // combinations.
     // `prop_oneof!` / `TupleUnion` `Arc`s for cheap cloning.
     let calldata_strategy = prop_oneof![
-        60 => fuzz_calldata(func.clone(), fuzz_fixtures),
-        40 => fuzz_calldata_from_state(func, fuzz_state),
+        100 - dictionary_weight => fuzz_calldata(func.clone(), fuzz_fixtures),
+        dictionary_weight => fuzz_calldata_from_state(func, fuzz_state),
     ];
 
     // For payable functions, generate random value using shared strategy.

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -21,6 +21,7 @@ pub fn override_call_strat(
     target: Arc<RwLock<Address>>,
     fuzz_fixtures: FuzzFixtures,
     dictionary_weight: u32,
+    payable_value_weight: u32,
 ) -> impl Strategy<Value = CallDetails> + Send + Sync + 'static {
     let contracts = Arc::new(contracts);
     let contracts_ref = contracts.clone();
@@ -67,6 +68,7 @@ pub fn override_call_strat(
                 actual_target,
                 func,
                 dictionary_weight,
+                payable_value_weight,
             )
         })
     })
@@ -91,6 +93,7 @@ pub fn invariant_strat(
 ) -> impl Strategy<Value = BasicTxDetails> {
     let senders = Rc::new(senders);
     let dictionary_weight = config.dictionary.dictionary_weight;
+    let payable_value_weight = config.corpus.payable_value_weight;
 
     // Strategy to generate values for tx warp and roll.
     let warp_roll_strat = |cond: bool| {
@@ -111,6 +114,7 @@ pub fn invariant_strat(
                 *target_address,
                 target_function.clone(),
                 dictionary_weight,
+                payable_value_weight,
             );
 
             let warp = warp_roll_strat(config.max_time_delay.is_some());
@@ -170,6 +174,7 @@ pub fn fuzz_contract_with_calldata<S: FuzzStateReader>(
     target: Address,
     func: Function,
     dictionary_weight: u32,
+    payable_value_weight: u32,
 ) -> impl Strategy<Value = CallDetails> + use<S> {
     let is_payable = func.state_mutability == alloy_json_abi::StateMutability::Payable;
     let dictionary_weight = dictionary_weight.min(100);
@@ -183,7 +188,8 @@ pub fn fuzz_contract_with_calldata<S: FuzzStateReader>(
     ];
 
     // For payable functions, generate random value using shared strategy.
-    let value_strategy = if is_payable { fuzz_msg_value().boxed() } else { Just(None).boxed() };
+    let value_strategy =
+        if is_payable { fuzz_msg_value(payable_value_weight).boxed() } else { Just(None).boxed() };
 
     (calldata_strategy, value_strategy).prop_map(move |(calldata, value)| {
         trace!(input=?calldata, ?value);

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -521,24 +521,26 @@ fn mutate_random_array_value(
     *elem = new_val;
 }
 
-/// Probability (out of 100) that a payable call carries a non-zero msg.value.
-const PAYABLE_VALUE_PROB: u32 = 15;
-
 /// Returns a proptest strategy for generating random msg.value for payable functions.
 ///
-/// Most calls (85%) carry no value. The remaining 15% delegate to [`UintStrategy`],
+/// Most calls carry no value. The configured non-zero percent delegates to [`UintStrategy`],
 /// which biases toward edge cases (around 0 / max) and dictionary fixtures, with
 /// random fallback. Over-budget values are clamped to sender balance at execute time.
-pub fn fuzz_msg_value() -> impl Strategy<Value = Option<U256>> {
-    proptest::prop_oneof![
-        100 - PAYABLE_VALUE_PROB => proptest::strategy::Just(None),
-        PAYABLE_VALUE_PROB       => UintStrategy::new(256, None).prop_map(Some),
-    ]
+pub fn fuzz_msg_value(payable_value_weight: u32) -> BoxedStrategy<Option<U256>> {
+    match payable_value_weight.min(100) {
+        0 => proptest::strategy::Just(None).boxed(),
+        100 => UintStrategy::new(256, None).prop_map(Some).boxed(),
+        payable_value_weight => proptest::prop_oneof![
+            100 - payable_value_weight => proptest::strategy::Just(None),
+            payable_value_weight       => UintStrategy::new(256, None).prop_map(Some),
+        ]
+        .boxed(),
+    }
 }
 
 /// Generates a msg.value for payable functions using `TestRunner`'s RNG (corpus mutation path).
 ///
-/// Mirrors [`fuzz_msg_value`] by sampling from [`UintStrategy`]. The 15% mutation gate is
+/// Mirrors [`fuzz_msg_value`] by sampling from [`UintStrategy`]. The configured mutation gate is
 /// applied at the call site in `corpus.rs`. Over-budget values are clamped to sender
 /// balance at execute time.
 pub fn generate_msg_value(test_runner: &mut TestRunner) -> U256 {
@@ -556,7 +558,22 @@ mod tests {
     };
     use alloy_primitives::B256;
     use foundry_common::abi::get_func;
+    use proptest::strategy::{Strategy, ValueTree};
     use std::collections::HashSet;
+
+    #[test]
+    fn payable_value_weight_controls_non_zero_msg_value() {
+        use super::fuzz_msg_value;
+
+        let cfg = proptest::test_runner::Config { failure_persistence: None, ..Default::default() };
+        let mut runner = proptest::test_runner::TestRunner::new(cfg);
+
+        for _ in 0..32 {
+            assert!(fuzz_msg_value(0).new_tree(&mut runner).unwrap().current().is_none());
+            assert!(fuzz_msg_value(100).new_tree(&mut runner).unwrap().current().is_some());
+            assert!(fuzz_msg_value(250).new_tree(&mut runner).unwrap().current().is_some());
+        }
+    }
 
     #[test]
     fn can_fuzz_array() {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -240,6 +240,10 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
     pub fuzz_corpus_random_sequence_weight: Option<u32>,
 
+    /// Percent chance that fuzzed payable calls carry non-zero msg.value.
+    #[arg(long, env = "FOUNDRY_FUZZ_PAYABLE_VALUE_WEIGHT", value_name = "PERCENT")]
+    pub fuzz_payable_value_weight: Option<u32>,
+
     /// Corpus mutation weight for splice.
     #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_SPLICE", value_name = "WEIGHT")]
     pub fuzz_mutation_weight_splice: Option<u32>,
@@ -303,6 +307,10 @@ pub struct TestArgs {
     /// Percent chance that coverage-guided invariant fuzzing generates a fresh sequence.
     #[arg(long, env = "FOUNDRY_INVARIANT_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
     pub invariant_corpus_random_sequence_weight: Option<u32>,
+
+    /// Percent chance that fuzzed payable invariant calls carry non-zero msg.value.
+    #[arg(long, env = "FOUNDRY_INVARIANT_PAYABLE_VALUE_WEIGHT", value_name = "PERCENT")]
+    pub invariant_payable_value_weight: Option<u32>,
 
     /// Corpus mutation weight for splice.
     #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_SPLICE", value_name = "WEIGHT")]
@@ -2048,6 +2056,9 @@ impl Provider for TestArgs {
                 fuzz_corpus_random_sequence_weight.into(),
             );
         }
+        if let Some(fuzz_payable_value_weight) = self.fuzz_payable_value_weight {
+            fuzz_dict.insert("payable_value_weight".to_string(), fuzz_payable_value_weight.into());
+        }
         if let Some(weight) = self.fuzz_mutation_weight_splice {
             fuzz_dict.insert("mutation_weight_splice".to_string(), weight.into());
         }
@@ -2117,6 +2128,10 @@ impl Provider for TestArgs {
                 "corpus_random_sequence_weight".to_string(),
                 invariant_corpus_random_sequence_weight.into(),
             );
+        }
+        if let Some(invariant_payable_value_weight) = self.invariant_payable_value_weight {
+            invariant_dict
+                .insert("payable_value_weight".to_string(), invariant_payable_value_weight.into());
         }
         if let Some(weight) = self.invariant_mutation_weight_splice {
             invariant_dict.insert("mutation_weight_splice".to_string(), weight.into());
@@ -2635,6 +2650,8 @@ mod tests {
             "4321",
             "--fuzz-corpus-random-sequence-weight",
             "55",
+            "--fuzz-payable-value-weight",
+            "12",
             "--fuzz-mutation-weight-splice",
             "4",
             "--fuzz-mutation-weight-abi",
@@ -2657,6 +2674,8 @@ mod tests {
             "6789",
             "--invariant-corpus-random-sequence-weight",
             "25",
+            "--invariant-payable-value-weight",
+            "34",
             "--invariant-mutation-weight-splice",
             "2",
             "--invariant-mutation-weight-cmp",
@@ -2678,6 +2697,7 @@ mod tests {
             "4321"
         );
         assert_eq!(figment.extract_inner::<u32>("fuzz.corpus_random_sequence_weight").unwrap(), 55);
+        assert_eq!(figment.extract_inner::<u32>("fuzz.payable_value_weight").unwrap(), 12);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_splice").unwrap(), 4);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_abi").unwrap(), 3);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_cmp").unwrap(), 5);
@@ -2704,6 +2724,7 @@ mod tests {
             figment.extract_inner::<u32>("invariant.corpus_random_sequence_weight").unwrap(),
             25
         );
+        assert_eq!(figment.extract_inner::<u32>("invariant.payable_value_weight").unwrap(), 34);
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_splice").unwrap(), 2);
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_cmp").unwrap(), 7);
 
@@ -2713,6 +2734,7 @@ mod tests {
         assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_values, 1234);
         assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_literals, 4321);
         assert_eq!(config.fuzz.corpus.corpus_random_sequence_weight, 55);
+        assert_eq!(config.fuzz.corpus.payable_value_weight, 12);
         assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_splice, 4);
         assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_abi, 3);
         assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_cmp, 5);
@@ -2724,6 +2746,7 @@ mod tests {
         assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_values, usize::MAX);
         assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_literals, 6789);
         assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 25);
+        assert_eq!(config.invariant.corpus.payable_value_weight, 34);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_splice, 2);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
     }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -37,7 +37,7 @@ use foundry_compilers::{
     utils::source_files_iter,
 };
 use foundry_config::{
-    Config, InlineConfig, InvariantWorkers, figment,
+    Config, InlineConfig, InvariantDepthMode, InvariantWorkers, figment,
     figment::{
         Metadata, Profile, Provider,
         value::{Dict, Map, Value},
@@ -220,9 +220,117 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_TIMEOUT", value_name = "TIMEOUT")]
     pub fuzz_timeout: Option<u64>,
 
+    /// Percent of fuzz calldata generated from the dictionary.
+    #[arg(long, env = "FOUNDRY_FUZZ_DICTIONARY_WEIGHT", value_name = "PERCENT")]
+    pub fuzz_dictionary_weight: Option<u32>,
+
+    /// Maximum fuzz dictionary addresses, or `max`.
+    #[arg(long, env = "FOUNDRY_FUZZ_MAX_FUZZ_DICTIONARY_ADDRESSES", value_name = "N|max")]
+    pub fuzz_dictionary_addresses: Option<String>,
+
+    /// Maximum fuzz dictionary values, or `max`.
+    #[arg(long, env = "FOUNDRY_FUZZ_MAX_FUZZ_DICTIONARY_VALUES", value_name = "N|max")]
+    pub fuzz_dictionary_values: Option<String>,
+
+    /// Maximum fuzz dictionary literals, or `max`.
+    #[arg(long, env = "FOUNDRY_FUZZ_MAX_FUZZ_DICTIONARY_LITERALS", value_name = "N|max")]
+    pub fuzz_dictionary_literals: Option<String>,
+
+    /// Percent chance that coverage-guided fuzzing generates a fresh sequence.
+    #[arg(long, env = "FOUNDRY_FUZZ_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
+    pub fuzz_corpus_random_sequence_weight: Option<u32>,
+
+    /// Corpus mutation weight for splice.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_SPLICE", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_splice: Option<u32>,
+
+    /// Corpus mutation weight for repeat.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_REPEAT", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_repeat: Option<u32>,
+
+    /// Corpus mutation weight for interleave.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_INTERLEAVE", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_interleave: Option<u32>,
+
+    /// Corpus mutation weight for prefix replacement.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_PREFIX", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_prefix: Option<u32>,
+
+    /// Corpus mutation weight for suffix replacement.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_SUFFIX", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_suffix: Option<u32>,
+
+    /// Corpus mutation weight for ABI argument mutation.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_ABI", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_abi: Option<u32>,
+
+    /// Corpus mutation weight for comparison-operand mutation.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_CMP", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_cmp: Option<u32>,
+
     /// File to rerun fuzz failures from.
     #[arg(long)]
     pub fuzz_input_file: Option<String>,
+
+    /// Number of calls executed to try to break invariants in one run.
+    #[arg(long, env = "FOUNDRY_INVARIANT_DEPTH", value_name = "DEPTH")]
+    pub invariant_depth: Option<u32>,
+
+    /// Minimum sampled invariant depth when `--invariant-depth-mode random` is active.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MIN_DEPTH", value_name = "DEPTH")]
+    pub invariant_min_depth: Option<u32>,
+
+    /// How invariant run depth is selected.
+    #[arg(long, env = "FOUNDRY_INVARIANT_DEPTH_MODE", value_name = "fixed|random")]
+    pub invariant_depth_mode: Option<InvariantDepthMode>,
+
+    /// Percent of invariant calldata/senders generated from the dictionary.
+    #[arg(long, env = "FOUNDRY_INVARIANT_DICTIONARY_WEIGHT", value_name = "PERCENT")]
+    pub invariant_dictionary_weight: Option<u32>,
+
+    /// Maximum invariant dictionary addresses, or `max`.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MAX_FUZZ_DICTIONARY_ADDRESSES", value_name = "N|max")]
+    pub invariant_dictionary_addresses: Option<String>,
+
+    /// Maximum invariant dictionary values, or `max`.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MAX_FUZZ_DICTIONARY_VALUES", value_name = "N|max")]
+    pub invariant_dictionary_values: Option<String>,
+
+    /// Maximum invariant dictionary literals, or `max`.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MAX_FUZZ_DICTIONARY_LITERALS", value_name = "N|max")]
+    pub invariant_dictionary_literals: Option<String>,
+
+    /// Percent chance that coverage-guided invariant fuzzing generates a fresh sequence.
+    #[arg(long, env = "FOUNDRY_INVARIANT_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
+    pub invariant_corpus_random_sequence_weight: Option<u32>,
+
+    /// Corpus mutation weight for splice.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_SPLICE", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_splice: Option<u32>,
+
+    /// Corpus mutation weight for repeat.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_REPEAT", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_repeat: Option<u32>,
+
+    /// Corpus mutation weight for interleave.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_INTERLEAVE", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_interleave: Option<u32>,
+
+    /// Corpus mutation weight for prefix replacement.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_PREFIX", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_prefix: Option<u32>,
+
+    /// Corpus mutation weight for suffix replacement.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_SUFFIX", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_suffix: Option<u32>,
+
+    /// Corpus mutation weight for ABI argument mutation.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_ABI", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_abi: Option<u32>,
+
+    /// Corpus mutation weight for comparison-operand mutation.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_CMP", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_cmp: Option<u32>,
 
     /// Run symbolic check*/prove*/invariant*/statefulFuzz* tests.
     #[arg(long, env = "FOUNDRY_SYMBOLIC")]
@@ -1915,16 +2023,124 @@ impl Provider for TestArgs {
         if let Some(fuzz_timeout) = self.fuzz_timeout {
             fuzz_dict.insert("timeout".to_string(), fuzz_timeout.into());
         }
+        if let Some(fuzz_dictionary_weight) = self.fuzz_dictionary_weight {
+            fuzz_dict.insert("dictionary_weight".to_string(), fuzz_dictionary_weight.into());
+        }
+        if let Some(fuzz_dictionary_addresses) = self.fuzz_dictionary_addresses.clone() {
+            fuzz_dict.insert(
+                "max_fuzz_dictionary_addresses".to_string(),
+                fuzz_dictionary_addresses.into(),
+            );
+        }
+        if let Some(fuzz_dictionary_values) = self.fuzz_dictionary_values.clone() {
+            fuzz_dict
+                .insert("max_fuzz_dictionary_values".to_string(), fuzz_dictionary_values.into());
+        }
+        if let Some(fuzz_dictionary_literals) = self.fuzz_dictionary_literals.clone() {
+            fuzz_dict.insert(
+                "max_fuzz_dictionary_literals".to_string(),
+                fuzz_dictionary_literals.into(),
+            );
+        }
+        if let Some(fuzz_corpus_random_sequence_weight) = self.fuzz_corpus_random_sequence_weight {
+            fuzz_dict.insert(
+                "corpus_random_sequence_weight".to_string(),
+                fuzz_corpus_random_sequence_weight.into(),
+            );
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_splice {
+            fuzz_dict.insert("mutation_weight_splice".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_repeat {
+            fuzz_dict.insert("mutation_weight_repeat".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_interleave {
+            fuzz_dict.insert("mutation_weight_interleave".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_prefix {
+            fuzz_dict.insert("mutation_weight_prefix".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_suffix {
+            fuzz_dict.insert("mutation_weight_suffix".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_abi {
+            fuzz_dict.insert("mutation_weight_abi".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_cmp {
+            fuzz_dict.insert("mutation_weight_cmp".to_string(), weight.into());
+        }
         if let Some(fuzz_input_file) = self.fuzz_input_file.clone() {
             fuzz_dict.insert("failure_persist_file".to_string(), fuzz_input_file.into());
         }
         dict.insert("fuzz".to_string(), fuzz_dict.into());
 
+        let mut invariant_dict = Dict::default();
+        if let Some(invariant_depth) = self.invariant_depth {
+            invariant_dict.insert("depth".to_string(), invariant_depth.into());
+        }
+        if let Some(invariant_min_depth) = self.invariant_min_depth {
+            invariant_dict.insert("min_depth".to_string(), invariant_min_depth.into());
+        }
+        if let Some(invariant_depth_mode) = self.invariant_depth_mode {
+            invariant_dict
+                .insert("depth_mode".to_string(), Value::serialize(invariant_depth_mode)?);
+        }
         if let Some(invariant_workers) = self.invariant_workers {
-            dict.insert(
-                "invariant".to_string(),
-                Dict::from([("workers".to_string(), Value::serialize(invariant_workers)?)]).into(),
+            invariant_dict.insert("workers".to_string(), Value::serialize(invariant_workers)?);
+        }
+        if let Some(invariant_dictionary_weight) = self.invariant_dictionary_weight {
+            invariant_dict
+                .insert("dictionary_weight".to_string(), invariant_dictionary_weight.into());
+        }
+        if let Some(invariant_dictionary_addresses) = self.invariant_dictionary_addresses.clone() {
+            invariant_dict.insert(
+                "max_fuzz_dictionary_addresses".to_string(),
+                invariant_dictionary_addresses.into(),
             );
+        }
+        if let Some(invariant_dictionary_values) = self.invariant_dictionary_values.clone() {
+            invariant_dict.insert(
+                "max_fuzz_dictionary_values".to_string(),
+                invariant_dictionary_values.into(),
+            );
+        }
+        if let Some(invariant_dictionary_literals) = self.invariant_dictionary_literals.clone() {
+            invariant_dict.insert(
+                "max_fuzz_dictionary_literals".to_string(),
+                invariant_dictionary_literals.into(),
+            );
+        }
+        if let Some(invariant_corpus_random_sequence_weight) =
+            self.invariant_corpus_random_sequence_weight
+        {
+            invariant_dict.insert(
+                "corpus_random_sequence_weight".to_string(),
+                invariant_corpus_random_sequence_weight.into(),
+            );
+        }
+        if let Some(weight) = self.invariant_mutation_weight_splice {
+            invariant_dict.insert("mutation_weight_splice".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_repeat {
+            invariant_dict.insert("mutation_weight_repeat".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_interleave {
+            invariant_dict.insert("mutation_weight_interleave".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_prefix {
+            invariant_dict.insert("mutation_weight_prefix".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_suffix {
+            invariant_dict.insert("mutation_weight_suffix".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_abi {
+            invariant_dict.insert("mutation_weight_abi".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_cmp {
+            invariant_dict.insert("mutation_weight_cmp".to_string(), weight.into());
+        }
+        if !invariant_dict.is_empty() {
+            dict.insert("invariant".to_string(), invariant_dict.into());
         }
 
         let mut symbolic_dict = Dict::default();
@@ -2403,6 +2619,63 @@ mod tests {
         }
 
         assert_eq!(args.unwrap().invariant_workers, Some(InvariantWorkers::Auto));
+    }
+
+    #[test]
+    fn fuzz_and_invariant_config_flags() {
+        let args = TestArgs::parse_from([
+            "foundry-cli",
+            "--fuzz-dictionary-weight",
+            "35",
+            "--fuzz-dictionary-values",
+            "1234",
+            "--fuzz-mutation-weight-abi",
+            "3",
+            "--fuzz-mutation-weight-cmp",
+            "5",
+            "--invariant-depth",
+            "300",
+            "--invariant-min-depth",
+            "20",
+            "--invariant-depth-mode",
+            "random",
+            "--invariant-dictionary-weight",
+            "45",
+            "--invariant-dictionary-values",
+            "max",
+            "--invariant-corpus-random-sequence-weight",
+            "25",
+            "--invariant-mutation-weight-splice",
+            "2",
+            "--invariant-mutation-weight-cmp",
+            "7",
+        ]);
+
+        let figment = figment::Figment::from(&args);
+        assert_eq!(figment.extract_inner::<u32>("fuzz.dictionary_weight").unwrap(), 35);
+        assert_eq!(
+            figment.extract_inner::<String>("fuzz.max_fuzz_dictionary_values").unwrap(),
+            "1234"
+        );
+        assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_abi").unwrap(), 3);
+        assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_cmp").unwrap(), 5);
+        assert_eq!(figment.extract_inner::<u32>("invariant.depth").unwrap(), 300);
+        assert_eq!(figment.extract_inner::<u32>("invariant.min_depth").unwrap(), 20);
+        assert_eq!(
+            figment.extract_inner::<InvariantDepthMode>("invariant.depth_mode").unwrap(),
+            InvariantDepthMode::Random
+        );
+        assert_eq!(figment.extract_inner::<u32>("invariant.dictionary_weight").unwrap(), 45);
+        assert_eq!(
+            figment.extract_inner::<String>("invariant.max_fuzz_dictionary_values").unwrap(),
+            "max"
+        );
+        assert_eq!(
+            figment.extract_inner::<u32>("invariant.corpus_random_sequence_weight").unwrap(),
+            25
+        );
+        assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_splice").unwrap(), 2);
+        assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_cmp").unwrap(), 7);
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -2627,8 +2627,16 @@ mod tests {
             "foundry-cli",
             "--fuzz-dictionary-weight",
             "35",
+            "--fuzz-dictionary-addresses",
+            "max",
             "--fuzz-dictionary-values",
             "1234",
+            "--fuzz-dictionary-literals",
+            "4321",
+            "--fuzz-corpus-random-sequence-weight",
+            "55",
+            "--fuzz-mutation-weight-splice",
+            "4",
             "--fuzz-mutation-weight-abi",
             "3",
             "--fuzz-mutation-weight-cmp",
@@ -2641,8 +2649,12 @@ mod tests {
             "random",
             "--invariant-dictionary-weight",
             "45",
+            "--invariant-dictionary-addresses",
+            "8765",
             "--invariant-dictionary-values",
             "max",
+            "--invariant-dictionary-literals",
+            "6789",
             "--invariant-corpus-random-sequence-weight",
             "25",
             "--invariant-mutation-weight-splice",
@@ -2654,9 +2666,19 @@ mod tests {
         let figment = figment::Figment::from(&args);
         assert_eq!(figment.extract_inner::<u32>("fuzz.dictionary_weight").unwrap(), 35);
         assert_eq!(
+            figment.extract_inner::<String>("fuzz.max_fuzz_dictionary_addresses").unwrap(),
+            "max"
+        );
+        assert_eq!(
             figment.extract_inner::<String>("fuzz.max_fuzz_dictionary_values").unwrap(),
             "1234"
         );
+        assert_eq!(
+            figment.extract_inner::<String>("fuzz.max_fuzz_dictionary_literals").unwrap(),
+            "4321"
+        );
+        assert_eq!(figment.extract_inner::<u32>("fuzz.corpus_random_sequence_weight").unwrap(), 55);
+        assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_splice").unwrap(), 4);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_abi").unwrap(), 3);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_cmp").unwrap(), 5);
         assert_eq!(figment.extract_inner::<u32>("invariant.depth").unwrap(), 300);
@@ -2667,8 +2689,16 @@ mod tests {
         );
         assert_eq!(figment.extract_inner::<u32>("invariant.dictionary_weight").unwrap(), 45);
         assert_eq!(
+            figment.extract_inner::<String>("invariant.max_fuzz_dictionary_addresses").unwrap(),
+            "8765"
+        );
+        assert_eq!(
             figment.extract_inner::<String>("invariant.max_fuzz_dictionary_values").unwrap(),
             "max"
+        );
+        assert_eq!(
+            figment.extract_inner::<String>("invariant.max_fuzz_dictionary_literals").unwrap(),
+            "6789"
         );
         assert_eq!(
             figment.extract_inner::<u32>("invariant.corpus_random_sequence_weight").unwrap(),
@@ -2676,6 +2706,26 @@ mod tests {
         );
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_splice").unwrap(), 2);
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_cmp").unwrap(), 7);
+
+        let config = Config::default().merge_inline_provider(&args).unwrap();
+        assert_eq!(config.fuzz.dictionary.dictionary_weight, 35);
+        assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_addresses, usize::MAX);
+        assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_values, 1234);
+        assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_literals, 4321);
+        assert_eq!(config.fuzz.corpus.corpus_random_sequence_weight, 55);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_splice, 4);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_abi, 3);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_cmp, 5);
+        assert_eq!(config.invariant.depth, 300);
+        assert_eq!(config.invariant.min_depth, 20);
+        assert_eq!(config.invariant.depth_mode, InvariantDepthMode::Random);
+        assert_eq!(config.invariant.dictionary.dictionary_weight, 45);
+        assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_addresses, 8765);
+        assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_values, usize::MAX);
+        assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_literals, 6789);
+        assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 25);
+        assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_splice, 2);
+        assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
     }
 
     #[test]

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -72,6 +72,8 @@ pub struct MultiContractRunner<FEN: FoundryEvmNetwork> {
     pub analysis: Arc<solar::sema::Compiler>,
     /// Literals dictionary for fuzzing.
     pub fuzz_literals: LiteralsDictionary,
+    /// Literals dictionary for invariant fuzzing.
+    pub invariant_literals: LiteralsDictionary,
 
     /// The fork to use at launch
     pub fork: Option<CreateFork>,
@@ -682,6 +684,11 @@ impl MultiContractRunnerBuilder {
             Some(self.config.project_paths()),
             self.config.fuzz.dictionary.max_fuzz_dictionary_literals,
         );
+        let invariant_literals = LiteralsDictionary::new(
+            Some(analysis.clone()),
+            Some(self.config.project_paths()),
+            self.config.invariant.dictionary.max_fuzz_dictionary_literals,
+        );
 
         Ok(MultiContractRunner {
             contracts: deployable_contracts,
@@ -691,6 +698,7 @@ impl MultiContractRunnerBuilder {
             libraries,
             analysis,
             fuzz_literals,
+            invariant_literals,
 
             tcfg: TestRunnerConfig {
                 evm_opts,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -2186,21 +2186,13 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
     fn build_fuzz_state(&self, invariant: bool) -> EvmFuzzState {
         let config =
             if invariant { self.config.invariant.dictionary } else { self.config.fuzz.dictionary };
+        let literals =
+            if invariant { &self.cr.mcr.invariant_literals } else { &self.cr.mcr.fuzz_literals };
         if let Some(db) = self.executor.backend().active_fork_db() {
-            EvmFuzzState::new(
-                &self.setup.deployed_libs,
-                db,
-                config,
-                Some(&self.cr.mcr.fuzz_literals),
-            )
+            EvmFuzzState::new(&self.setup.deployed_libs, db, config, Some(literals))
         } else {
             let db = self.executor.backend().mem_db();
-            EvmFuzzState::new(
-                &self.setup.deployed_libs,
-                db,
-                config,
-                Some(&self.cr.mcr.fuzz_literals),
-            )
+            EvmFuzzState::new(&self.setup.deployed_libs, db, config, Some(literals))
         }
     }
 }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -220,7 +220,7 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
-corpus_random_sequence_weight = 25
+corpus_random_sequence_weight = 50
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
 mutation_weight_interleave = 1
@@ -256,7 +256,7 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
-corpus_random_sequence_weight = 25
+corpus_random_sequence_weight = 50
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
 mutation_weight_interleave = 1
@@ -1463,7 +1463,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
-    "corpus_random_sequence_weight": 25,
+    "corpus_random_sequence_weight": 50,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,
     "mutation_weight_interleave": 1,
@@ -1501,7 +1501,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
-    "corpus_random_sequence_weight": 25,
+    "corpus_random_sequence_weight": 50,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,
     "mutation_weight_interleave": 1,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -220,12 +220,22 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
+corpus_random_sequence_weight = 25
+mutation_weight_splice = 1
+mutation_weight_repeat = 1
+mutation_weight_interleave = 1
+mutation_weight_prefix = 1
+mutation_weight_suffix = 1
+mutation_weight_abi = 1
+mutation_weight_cmp = 1
 failure_persist_dir = "cache/fuzz"
 show_logs = false
 
 [invariant]
 runs = 256
 depth = 500
+min_depth = 1
+depth_mode = "fixed"
 workers = 1
 fail_on_revert = false
 call_override = false
@@ -246,6 +256,14 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
+corpus_random_sequence_weight = 25
+mutation_weight_splice = 1
+mutation_weight_repeat = 1
+mutation_weight_interleave = 1
+mutation_weight_prefix = 1
+mutation_weight_suffix = 1
+mutation_weight_abi = 1
+mutation_weight_cmp = 1
 failure_persist_dir = "cache/invariant"
 show_metrics = true
 show_solidity = false
@@ -1445,6 +1463,14 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
+    "corpus_random_sequence_weight": 25,
+    "mutation_weight_splice": 1,
+    "mutation_weight_repeat": 1,
+    "mutation_weight_interleave": 1,
+    "mutation_weight_prefix": 1,
+    "mutation_weight_suffix": 1,
+    "mutation_weight_abi": 1,
+    "mutation_weight_cmp": 1,
     "failure_persist_dir": "cache/fuzz",
     "show_logs": false,
     "timeout": null
@@ -1452,6 +1478,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "invariant": {
     "runs": 256,
     "depth": 500,
+    "min_depth": 1,
+    "depth_mode": "fixed",
     "workers": 1,
     "fail_on_revert": false,
     "call_override": false,
@@ -1473,6 +1501,14 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
+    "corpus_random_sequence_weight": 25,
+    "mutation_weight_splice": 1,
+    "mutation_weight_repeat": 1,
+    "mutation_weight_interleave": 1,
+    "mutation_weight_prefix": 1,
+    "mutation_weight_suffix": 1,
+    "mutation_weight_abi": 1,
+    "mutation_weight_cmp": 1,
     "failure_persist_dir": "cache/invariant",
     "show_metrics": true,
     "timeout": null,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -221,6 +221,7 @@ evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
 corpus_random_sequence_weight = 50
+payable_value_weight = 0
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
 mutation_weight_interleave = 1
@@ -257,6 +258,7 @@ evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
 corpus_random_sequence_weight = 50
+payable_value_weight = 15
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
 mutation_weight_interleave = 1
@@ -1464,6 +1466,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "sancov_edges": false,
     "sancov_trace_cmp": false,
     "corpus_random_sequence_weight": 50,
+    "payable_value_weight": 0,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,
     "mutation_weight_interleave": 1,
@@ -1502,6 +1505,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "sancov_edges": false,
     "sancov_trace_cmp": false,
     "corpus_random_sequence_weight": 50,
+    "payable_value_weight": 15,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,
     "mutation_weight_interleave": 1,

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -2748,9 +2748,23 @@ contract InvariantMsgValue is Test {
 "#,
     );
 
-    // The test should fail because the fuzzer generates msg.value > 0 for payable functions
+    // The knob should be able to disable payable value generation completely.
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--mt",
+            "invariant_value_never_received",
+            "--invariant-payable-value-weight",
+            "0",
+        ])
+        .assert_success();
+    cmd.forge_fuse().arg("clean").assert_success();
+
+    // The default invariant weight should fail because the fuzzer generates msg.value > 0 for
+    // payable functions.
     // First check regular output format shows value=X
-    cmd.args(["test", "--mt", "invariant_value_never_received"])
+    cmd.forge_fuse()
+        .args(["test", "--mt", "invariant_value_never_received"])
         .assert_failure()
         .stdout_eq(str![[r#"
 ...


### PR DESCRIPTION
## Summary

Adds first-class configuration for fuzzer ensemble knobs via TOML, CLI flags, and environment variables:

- dictionary weights and dictionary size caps for fuzz and invariant runs
- invariant `min_depth` and `depth_mode = "fixed" | "random"`
- corpus fresh-sequence probability and per-mutator weights
- payable `msg.value` generation probability

The runtime wires these through fuzz/invariant call generation and corpus mutation. Corpus mutation now uses precomputed `WeightedIndex` distributions, keeps fuzz and invariant literal dictionaries separate, honors zero ABI/CMP mutator weights as disabled paths, and preserves the all-zero mutator fallback to defaults.

The only default changed by the benchmark data is corpus fresh-sequence probability: `10% -> 50%`. Other defaults stay conservative or preserve existing behavior: fixed depth, invariant dictionary weight `80%`, mutator weights `1/1/1/1/1/1/1`, fuzz payable value `0%`, invariant payable value `15%`.

## Benchmark Summary

Benchmarks focused on `crytic/echidna-parade` `examples/justlen.sol` plus synthetic dictionary/depth targets.

- One-hour `echidna-parade` run produced broad `justlen` coverage: `test_long_64()` and `test_long_128()` failed in all 98 outputs; `test_long_8()` failed in 45 outputs.
- Foundry fixed-budget `justlen` corpus campaigns improved with fresh-sequence `50%`: mean `2.880s` versus old `10%` mean `38.177s`.
- Time-to-counterexample on `JustLen128InvariantTest` did not regress: fresh `10%`, `25%`, and `50%` all measured around `0.714s` mean.
- Heavier ABI/CMP/structural mutator weights did not beat the all-ones default on the current matrix.
- Dictionary and depth sweeps supported keeping invariant dictionary weight high and depth mode fixed by default; random depth remains available as an autoresearch knob.