### PR TITLE
feat(forge): configure fuzzer ensemble defaults

### DIFF
--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -222,7 +222,7 @@ impl Default for FuzzCorpusConfig {
             evm_edge_coverage_include_call_depth: false,
             sancov_edges: false,
             sancov_trace_cmp: false,
-            corpus_random_sequence_weight: 25,
+            corpus_random_sequence_weight: 50,
             mutation_weights: FuzzCorpusMutationWeights::default(),
         }
     }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -152,6 +152,9 @@ pub struct FuzzCorpusConfig {
 }
 
 impl FuzzCorpusConfig {
+    pub const DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT: u32 = 10;
+    pub const ENSEMBLE_CORPUS_RANDOM_SEQUENCE_WEIGHT: u32 = 50;
+
     pub fn with_test(&mut self, contract: &str, test: &str) {
         if let Some(corpus_dir) = &self.corpus_dir {
             self.corpus_dir = Some(canonicalized(corpus_dir.join(contract).join(test)));
@@ -225,7 +228,7 @@ impl Default for FuzzCorpusConfig {
             evm_edge_coverage_include_call_depth: false,
             sancov_edges: false,
             sancov_trace_cmp: false,
-            corpus_random_sequence_weight: 50,
+            corpus_random_sequence_weight: Self::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT,
             payable_value_weight: 15,
             mutation_weights: FuzzCorpusMutationWeights::default(),
         }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -139,8 +139,8 @@ pub struct FuzzCorpusConfig {
     /// Whether to capture comparison operands from sancov-instrumented crates
     /// and inject them into the fuzz dictionary. Independent of `sancov_edges`.
     pub sancov_trace_cmp: bool,
-    /// Percent chance of generating a fresh transaction sequence instead of reusing the current
-    /// corpus sequence during coverage-guided invariant campaigns.
+    /// Percent chance of generating fresh transaction input instead of continuing from corpus
+    /// input during coverage-guided campaigns.
     #[serde(deserialize_with = "crate::deserialize_stringified_percent")]
     pub corpus_random_sequence_weight: u32,
     /// Percent chance that generated payable calls carry non-zero `msg.value`.

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -264,10 +264,6 @@ impl FuzzCorpusMutationWeights {
             + self.mutation_weight_cmp as u64
     }
 
-    pub const fn abi_or_cmp_total(&self) -> u64 {
-        self.mutation_weight_abi as u64 + self.mutation_weight_cmp as u64
-    }
-
     /// Returns defaults if every configured weight is zero.
     pub fn effective(self) -> Self {
         if self.total() == 0 { Self::default() } else { self }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -39,6 +39,9 @@ pub struct FuzzConfig {
 
 impl Default for FuzzConfig {
     fn default() -> Self {
+        let mut corpus = FuzzCorpusConfig::default();
+        corpus.payable_value_weight = 0;
+
         Self {
             runs: 256,
             run: None,
@@ -48,7 +51,7 @@ impl Default for FuzzConfig {
             seed: None,
             dictionary: FuzzDictionaryConfig::default(),
             gas_report_samples: 256,
-            corpus: FuzzCorpusConfig::default(),
+            corpus,
             failure_persist_dir: None,
             show_logs: false,
             timeout: None,
@@ -143,6 +146,9 @@ pub struct FuzzCorpusConfig {
     /// corpus sequence during coverage-guided invariant campaigns.
     #[serde(deserialize_with = "crate::deserialize_stringified_percent")]
     pub corpus_random_sequence_weight: u32,
+    /// Percent chance that generated payable calls carry non-zero `msg.value`.
+    #[serde(deserialize_with = "crate::deserialize_stringified_percent")]
+    pub payable_value_weight: u32,
     /// Weights for coverage-guided corpus mutation strategies.
     #[serde(flatten)]
     pub mutation_weights: FuzzCorpusMutationWeights,
@@ -223,6 +229,7 @@ impl Default for FuzzCorpusConfig {
             sancov_edges: false,
             sancov_trace_cmp: false,
             corpus_random_sequence_weight: 50,
+            payable_value_weight: 15,
             mutation_weights: FuzzCorpusMutationWeights::default(),
         }
     }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -139,6 +139,13 @@ pub struct FuzzCorpusConfig {
     /// Whether to capture comparison operands from sancov-instrumented crates
     /// and inject them into the fuzz dictionary. Independent of `sancov_edges`.
     pub sancov_trace_cmp: bool,
+    /// Percent chance of generating a fresh transaction sequence instead of reusing the current
+    /// corpus sequence during coverage-guided invariant campaigns.
+    #[serde(deserialize_with = "crate::deserialize_stringified_percent")]
+    pub corpus_random_sequence_weight: u32,
+    /// Weights for coverage-guided corpus mutation strategies.
+    #[serde(flatten)]
+    pub mutation_weights: FuzzCorpusMutationWeights,
 }
 
 impl FuzzCorpusConfig {
@@ -215,6 +222,61 @@ impl Default for FuzzCorpusConfig {
             evm_edge_coverage_include_call_depth: false,
             sancov_edges: false,
             sancov_trace_cmp: false,
+            corpus_random_sequence_weight: 25,
+            mutation_weights: FuzzCorpusMutationWeights::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FuzzCorpusMutationWeights {
+    /// Weight for splicing two corpus sequences.
+    pub mutation_weight_splice: u32,
+    /// Weight for repeating part of a corpus sequence.
+    pub mutation_weight_repeat: u32,
+    /// Weight for interleaving two corpus sequences.
+    pub mutation_weight_interleave: u32,
+    /// Weight for replacing a corpus sequence prefix with generated calls.
+    pub mutation_weight_prefix: u32,
+    /// Weight for replacing a corpus sequence suffix with generated calls.
+    pub mutation_weight_suffix: u32,
+    /// Weight for ABI-aware argument mutation.
+    pub mutation_weight_abi: u32,
+    /// Weight for comparison-operand guided argument mutation.
+    pub mutation_weight_cmp: u32,
+}
+
+impl FuzzCorpusMutationWeights {
+    pub const fn total(&self) -> u64 {
+        self.mutation_weight_splice as u64
+            + self.mutation_weight_repeat as u64
+            + self.mutation_weight_interleave as u64
+            + self.mutation_weight_prefix as u64
+            + self.mutation_weight_suffix as u64
+            + self.mutation_weight_abi as u64
+            + self.mutation_weight_cmp as u64
+    }
+
+    pub const fn abi_or_cmp_total(&self) -> u64 {
+        self.mutation_weight_abi as u64 + self.mutation_weight_cmp as u64
+    }
+
+    /// Returns defaults if every configured weight is zero.
+    pub fn effective(self) -> Self {
+        if self.total() == 0 { Self::default() } else { self }
+    }
+}
+
+impl Default for FuzzCorpusMutationWeights {
+    fn default() -> Self {
+        Self {
+            mutation_weight_splice: 1,
+            mutation_weight_repeat: 1,
+            mutation_weight_interleave: 1,
+            mutation_weight_prefix: 1,
+            mutation_weight_suffix: 1,
+            mutation_weight_abi: 1,
+            mutation_weight_cmp: 1,
         }
     }
 }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -39,9 +39,6 @@ pub struct FuzzConfig {
 
 impl Default for FuzzConfig {
     fn default() -> Self {
-        let mut corpus = FuzzCorpusConfig::default();
-        corpus.payable_value_weight = 0;
-
         Self {
             runs: 256,
             run: None,
@@ -51,7 +48,7 @@ impl Default for FuzzConfig {
             seed: None,
             dictionary: FuzzDictionaryConfig::default(),
             gas_report_samples: 256,
-            corpus,
+            corpus: FuzzCorpusConfig { payable_value_weight: 0, ..Default::default() },
             failure_persist_dir: None,
             show_logs: false,
             timeout: None,

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -105,6 +105,7 @@ pub enum InvariantDepthMode {
     #[default]
     Fixed,
     /// Sample every invariant run depth uniformly between `min_depth` and `depth`.
+    #[serde(alias = "uniform")]
     Random,
 }
 
@@ -255,6 +256,10 @@ mod tests {
         assert_eq!("uniform".parse::<InvariantDepthMode>().unwrap(), InvariantDepthMode::Random);
         assert_eq!(
             serde_json::from_str::<InvariantDepthMode>(r#""random""#).unwrap(),
+            InvariantDepthMode::Random
+        );
+        assert_eq!(
+            serde_json::from_str::<InvariantDepthMode>(r#""uniform""#).unwrap(),
             InvariantDepthMode::Random
         );
     }

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -124,7 +124,7 @@ impl FromStr for InvariantDepthMode {
 }
 
 /// Contains for invariant testing
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InvariantConfig {
     /// The number of runs that must execute for each invariant test group.
     pub runs: u32,
@@ -157,6 +157,10 @@ pub struct InvariantConfig {
     /// The fuzz corpus configuration.
     #[serde(flatten)]
     pub corpus: FuzzCorpusConfig,
+    /// Whether `corpus_random_sequence_weight` was supplied by a config provider.
+    #[serde(default, skip_serializing)]
+    #[doc(hidden)]
+    pub corpus_random_sequence_weight_configured: bool,
     /// Path where invariant failures are recorded and replayed.
     pub failure_persist_dir: Option<PathBuf>,
     /// Whether to collect and display fuzzed selectors metrics.
@@ -179,6 +183,32 @@ pub struct InvariantConfig {
     pub check_interval: u32,
 }
 
+impl PartialEq for InvariantConfig {
+    fn eq(&self, other: &Self) -> bool {
+        self.runs == other.runs
+            && self.depth == other.depth
+            && self.min_depth == other.min_depth
+            && self.depth_mode == other.depth_mode
+            && self.workers == other.workers
+            && self.fail_on_revert == other.fail_on_revert
+            && self.call_override == other.call_override
+            && self.dictionary == other.dictionary
+            && self.shrink_run_limit == other.shrink_run_limit
+            && self.max_assume_rejects == other.max_assume_rejects
+            && self.gas_report_samples == other.gas_report_samples
+            && self.corpus == other.corpus
+            && self.failure_persist_dir == other.failure_persist_dir
+            && self.show_metrics == other.show_metrics
+            && self.timeout == other.timeout
+            && self.show_solidity == other.show_solidity
+            && self.max_time_delay == other.max_time_delay
+            && self.max_block_delay == other.max_block_delay
+            && self.check_interval == other.check_interval
+    }
+}
+
+impl Eq for InvariantConfig {}
+
 impl Default for InvariantConfig {
     fn default() -> Self {
         Self {
@@ -194,6 +224,7 @@ impl Default for InvariantConfig {
             max_assume_rejects: 65536,
             gas_report_samples: 256,
             corpus: FuzzCorpusConfig::default(),
+            corpus_random_sequence_weight_configured: false,
             failure_persist_dir: None,
             show_metrics: true,
             timeout: None,

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -97,6 +97,31 @@ fn fixed_workers(workers: usize) -> Result<InvariantWorkers, String> {
         .ok_or_else(|| "invariant workers must be greater than 0".to_string())
 }
 
+/// Per-run invariant depth selection mode.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InvariantDepthMode {
+    /// Execute every invariant run up to the configured `depth`.
+    #[default]
+    Fixed,
+    /// Sample every invariant run depth uniformly between `min_depth` and `depth`.
+    Random,
+}
+
+impl FromStr for InvariantDepthMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "fixed" => Ok(Self::Fixed),
+            "random" | "uniform" => Ok(Self::Random),
+            value => {
+                Err(format!("unknown invariant depth mode `{value}`, expected `fixed` or `random`"))
+            }
+        }
+    }
+}
+
 /// Contains for invariant testing
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InvariantConfig {
@@ -104,6 +129,10 @@ pub struct InvariantConfig {
     pub runs: u32,
     /// The number of calls executed to attempt to break invariants in one run.
     pub depth: u32,
+    /// Minimum sampled run depth when `depth_mode = "random"`.
+    pub min_depth: u32,
+    /// How to choose the effective depth for each invariant run.
+    pub depth_mode: InvariantDepthMode,
     /// Worker selection mode used to shard invariant runs.
     ///
     /// Defaults to `1` for reproducible seeded campaigns. Use `auto` to derive the worker count
@@ -154,6 +183,8 @@ impl Default for InvariantConfig {
         Self {
             runs: 256,
             depth: 500,
+            min_depth: 1,
+            depth_mode: InvariantDepthMode::default(),
             workers: InvariantWorkers::default(),
             fail_on_revert: false,
             call_override: false,
@@ -216,5 +247,15 @@ mod tests {
     fn invariant_workers_reject_zero() {
         let err = serde_json::from_str::<InvariantWorkers>(r#"0"#).unwrap_err();
         assert!(err.to_string().contains("greater than 0"));
+    }
+
+    #[test]
+    fn invariant_depth_mode_accepts_fixed_and_random() {
+        assert_eq!("fixed".parse::<InvariantDepthMode>().unwrap(), InvariantDepthMode::Fixed);
+        assert_eq!("uniform".parse::<InvariantDepthMode>().unwrap(), InvariantDepthMode::Random);
+        assert_eq!(
+            serde_json::from_str::<InvariantDepthMode>(r#""random""#).unwrap(),
+            InvariantDepthMode::Random
+        );
     }
 }

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -197,6 +197,8 @@ impl PartialEq for InvariantConfig {
             && self.max_assume_rejects == other.max_assume_rejects
             && self.gas_report_samples == other.gas_report_samples
             && self.corpus == other.corpus
+            && self.corpus_random_sequence_weight_configured
+                == other.corpus_random_sequence_weight_configured
             && self.failure_persist_dir == other.failure_persist_dir
             && self.show_metrics == other.show_metrics
             && self.timeout == other.timeout
@@ -279,6 +281,16 @@ mod tests {
     fn invariant_workers_reject_zero() {
         let err = serde_json::from_str::<InvariantWorkers>(r#"0"#).unwrap_err();
         assert!(err.to_string().contains("greater than 0"));
+    }
+
+    #[test]
+    fn invariant_config_equality_includes_corpus_random_sequence_provenance() {
+        let explicit = InvariantConfig {
+            corpus_random_sequence_weight_configured: true,
+            ..InvariantConfig::default()
+        };
+
+        assert_ne!(InvariantConfig::default(), explicit);
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -108,10 +108,10 @@ pub use providers::Remappings;
 use providers::*;
 
 mod fuzz;
-pub use fuzz::{FuzzConfig, FuzzCorpusConfig, FuzzDictionaryConfig};
+pub use fuzz::{FuzzConfig, FuzzCorpusConfig, FuzzCorpusMutationWeights, FuzzDictionaryConfig};
 
 mod invariant;
-pub use invariant::{InvariantConfig, InvariantWorkers};
+pub use invariant::{InvariantConfig, InvariantDepthMode, InvariantWorkers};
 
 mod symbolic;
 pub use symbolic::{SymbolicConfig, SymbolicExplorationOrder, SymbolicStorageLayout};
@@ -5024,12 +5024,16 @@ mod tests {
         figment::Jail::expect_with(|jail| {
             jail.create_file(
                 "foundry.toml",
-                r"
+                r#"
                 [invariant]
                 runs = 512
                 depth = 10
+                min_depth = 2
+                depth_mode = "random"
                 workers = 4
-            ",
+                corpus_random_sequence_weight = 30
+                mutation_weight_cmp = 7
+            "#,
             )?;
 
             let loaded = Config::load().unwrap().sanitized();
@@ -5038,7 +5042,17 @@ mod tests {
                 InvariantConfig {
                     runs: 512,
                     depth: 10,
+                    min_depth: 2,
+                    depth_mode: InvariantDepthMode::Random,
                     workers: InvariantWorkers::Fixed(NonZeroUsize::new(4).unwrap()),
+                    corpus: FuzzCorpusConfig {
+                        corpus_random_sequence_weight: 30,
+                        mutation_weights: FuzzCorpusMutationWeights {
+                            mutation_weight_cmp: 7,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
                     failure_persist_dir: Some(PathBuf::from("cache/invariant")),
                     ..Default::default()
                 }
@@ -5064,17 +5078,27 @@ mod tests {
 
             jail.set_env("FOUNDRY_FMT_LINE_LENGTH", "95");
             jail.set_env("FOUNDRY_FUZZ_DICTIONARY_WEIGHT", "99");
+            jail.set_env("FOUNDRY_FUZZ_MAX_FUZZ_DICTIONARY_VALUES", "max");
             jail.set_env("FOUNDRY_INVARIANT_DEPTH", "5");
+            jail.set_env("FOUNDRY_INVARIANT_MIN_DEPTH", "2");
+            jail.set_env("FOUNDRY_INVARIANT_DEPTH_MODE", "random");
             jail.set_env("FOUNDRY_INVARIANT_WORKERS", "3");
+            jail.set_env("FOUNDRY_INVARIANT_CORPUS_RANDOM_SEQUENCE_WEIGHT", "30");
+            jail.set_env("FOUNDRY_INVARIANT_MUTATION_WEIGHT_CMP", "7");
 
             let config = Config::load().unwrap();
             assert_eq!(config.fmt.line_length, 95);
             assert_eq!(config.fuzz.dictionary.dictionary_weight, 99);
+            assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_values, usize::MAX);
             assert_eq!(config.invariant.depth, 5);
+            assert_eq!(config.invariant.min_depth, 2);
+            assert_eq!(config.invariant.depth_mode, InvariantDepthMode::Random);
             assert_eq!(
                 config.invariant.workers,
                 InvariantWorkers::Fixed(NonZeroUsize::new(3).unwrap())
             );
+            assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 30);
+            assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
 
             Ok(())
         });

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1017,7 +1017,9 @@ impl Config {
             .corpus_random_sequence_weight_configured
             || figment
                 .extract_inner::<bool>("invariant.corpus_random_sequence_weight_configured")
-                .unwrap_or_else(|_| figment.contains("invariant.corpus_random_sequence_weight"));
+                .unwrap_or_else(|_| {
+                    figment_value_is_configured(&figment, "invariant.corpus_random_sequence_weight")
+                });
 
         // normalize defaults
         figment = self.normalize_defaults(figment);
@@ -2572,9 +2574,7 @@ impl FigmentProviders {
 }
 
 fn figment_value_is_configured(figment: &Figment, key: &str) -> bool {
-    figment.find_metadata(key).is_some_and(|metadata| {
-        metadata.name.as_ref() != "Foundry Config" || metadata.source.is_some()
-    })
+    figment.find_metadata(key).is_some_and(|metadata| metadata.name.as_ref() != "Foundry Config")
 }
 
 /// Wrapper type for [`regex::Regex`] that implements [`PartialEq`] and [`serde`] traits.
@@ -5138,6 +5138,28 @@ mod tests {
                 FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
             );
             assert!(loaded.invariant.corpus_random_sequence_weight_configured);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_fuzz_corpus_random_sequence_weight_fallback_does_not_mark_invariant_configured() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [fuzz]
+                corpus_random_sequence_weight = 10
+            "#,
+            )?;
+
+            let loaded = Config::load().unwrap();
+            assert_eq!(
+                loaded.invariant.corpus.corpus_random_sequence_weight,
+                FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+            );
+            assert!(!loaded.invariant.corpus_random_sequence_weight_configured);
 
             Ok(())
         });

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1012,9 +1012,16 @@ impl Config {
             figment = figment.merge(remappings);
         }
 
+        let invariant_corpus_random_sequence_weight_configured = self
+            .invariant
+            .corpus_random_sequence_weight_configured
+            || figment
+                .extract_inner::<bool>("invariant.corpus_random_sequence_weight_configured")
+                .unwrap_or_else(|_| figment.contains("invariant.corpus_random_sequence_weight"));
+
         // normalize defaults
         figment = self.normalize_defaults(figment);
-        if figment.contains("invariant.corpus_random_sequence_weight") {
+        if invariant_corpus_random_sequence_weight_configured {
             figment = figment.merge(("invariant.corpus_random_sequence_weight_configured", true));
         }
 
@@ -2565,7 +2572,9 @@ impl FigmentProviders {
 }
 
 fn figment_value_is_configured(figment: &Figment, key: &str) -> bool {
-    figment.find_metadata(key).is_some_and(|metadata| metadata.name.as_ref() != "Foundry Config")
+    figment.find_metadata(key).is_some_and(|metadata| {
+        metadata.name.as_ref() != "Foundry Config" || metadata.source.is_some()
+    })
 }
 
 /// Wrapper type for [`regex::Regex`] that implements [`PartialEq`] and [`serde`] traits.
@@ -3030,6 +3039,10 @@ mod tests {
     // from file, causing testing problem when comparing to those created from `default()`, etc.
     fn clear_warning(config: &mut Config) {
         config.warnings = vec![];
+    }
+
+    fn mark_serialized_invariant_corpus_weight(config: &mut Config) {
+        config.invariant.corpus_random_sequence_weight_configured = true;
     }
 
     #[test]
@@ -4763,7 +4776,9 @@ mod tests {
             jail.create_file("foundry.toml", &default.to_string_pretty().unwrap())?;
             let mut other = Config::load().unwrap();
             clear_warning(&mut other);
-            assert_eq!(default, other);
+            let mut serialized_default = default;
+            mark_serialized_invariant_corpus_weight(&mut serialized_default);
+            assert_eq!(serialized_default, other);
 
             Ok(())
         });
@@ -4832,6 +4847,7 @@ mod tests {
 
             let s = loaded.to_string_pretty().unwrap();
             jail.create_file("foundry.toml", &s)?;
+            mark_serialized_invariant_corpus_weight(&mut loaded);
 
             let mut reloaded = Config::load().unwrap();
             clear_warning(&mut reloaded);
@@ -4882,6 +4898,7 @@ mod tests {
 
             let s = loaded.to_string_pretty().unwrap();
             jail.create_file("foundry.toml", &s)?;
+            mark_serialized_invariant_corpus_weight(&mut loaded);
 
             let mut reloaded = Config::load().unwrap();
             clear_warning(&mut reloaded);

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5032,6 +5032,7 @@ mod tests {
                 depth_mode = "random"
                 workers = 4
                 corpus_random_sequence_weight = 30
+                payable_value_weight = 12
                 mutation_weight_cmp = 7
             "#,
             )?;
@@ -5047,6 +5048,7 @@ mod tests {
                     workers: InvariantWorkers::Fixed(NonZeroUsize::new(4).unwrap()),
                     corpus: FuzzCorpusConfig {
                         corpus_random_sequence_weight: 30,
+                        payable_value_weight: 12,
                         mutation_weights: FuzzCorpusMutationWeights {
                             mutation_weight_cmp: 7,
                             ..Default::default()
@@ -5084,6 +5086,7 @@ mod tests {
             jail.set_env("FOUNDRY_INVARIANT_DEPTH_MODE", "random");
             jail.set_env("FOUNDRY_INVARIANT_WORKERS", "3");
             jail.set_env("FOUNDRY_INVARIANT_CORPUS_RANDOM_SEQUENCE_WEIGHT", "30");
+            jail.set_env("FOUNDRY_INVARIANT_PAYABLE_VALUE_WEIGHT", "12");
             jail.set_env("FOUNDRY_INVARIANT_MUTATION_WEIGHT_CMP", "7");
 
             let config = Config::load().unwrap();
@@ -5098,6 +5101,7 @@ mod tests {
                 InvariantWorkers::Fixed(NonZeroUsize::new(3).unwrap())
             );
             assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 30);
+            assert_eq!(config.invariant.corpus.payable_value_weight, 12);
             assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
 
             Ok(())

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -830,10 +830,19 @@ impl Config {
     /// Applies an inline provider on top of the current config without reloading external
     /// providers such as `foundry.toml`, env vars, or remappings.
     pub fn merge_inline_provider<T: Provider>(&self, provider: T) -> Result<Self, Error> {
-        let mut config =
-            self.to_figment(FigmentProviders::None).merge(provider).extract::<Self>()?;
+        let provider = Figment::from(provider);
+        let invariant_corpus_random_sequence_weight_configured =
+            self.invariant.corpus_random_sequence_weight_configured
+                || provider.contains("invariant.corpus_random_sequence_weight")
+                || provider
+                    .extract_inner::<bool>("invariant.corpus_random_sequence_weight_configured")
+                    .unwrap_or(false);
+        let figment = self.to_figment(FigmentProviders::None).merge(provider);
+        let mut config = figment.extract::<Self>()?;
         config.profile = self.profile.clone();
         config.profiles = self.profiles.clone();
+        config.invariant.corpus_random_sequence_weight_configured =
+            invariant_corpus_random_sequence_weight_configured;
         config.normalize_hardfork_settings()?;
 
         Ok(config)
@@ -859,7 +868,14 @@ impl Config {
         figment: Figment,
         strict_profile: bool,
     ) -> Result<Self, ExtractConfigError> {
+        let invariant_corpus_random_sequence_weight_configured = figment
+            .extract_inner::<bool>("invariant.corpus_random_sequence_weight_configured")
+            .unwrap_or_else(|_| {
+                figment_value_is_configured(&figment, "invariant.corpus_random_sequence_weight")
+            });
         let mut config = figment.extract::<Self>().map_err(ExtractConfigError::new)?;
+        config.invariant.corpus_random_sequence_weight_configured =
+            invariant_corpus_random_sequence_weight_configured;
         let selected_profile = figment.profile().clone();
 
         // The `"profile"` profile contains all the profiles as keys.
@@ -998,6 +1014,9 @@ impl Config {
 
         // normalize defaults
         figment = self.normalize_defaults(figment);
+        if figment.contains("invariant.corpus_random_sequence_weight") {
+            figment = figment.merge(("invariant.corpus_random_sequence_weight_configured", true));
+        }
 
         Figment::from(self).merge(figment).select(profile)
     }
@@ -2543,6 +2562,10 @@ impl FigmentProviders {
     pub const fn is_none(&self) -> bool {
         matches!(self, Self::None)
     }
+}
+
+fn figment_value_is_configured(figment: &Figment, key: &str) -> bool {
+    figment.find_metadata(key).is_some_and(|metadata| metadata.name.as_ref() != "Foundry Config")
 }
 
 /// Wrapper type for [`regex::Regex`] that implements [`PartialEq`] and [`serde`] traits.
@@ -5055,10 +5078,49 @@ mod tests {
                         },
                         ..Default::default()
                     },
+                    corpus_random_sequence_weight_configured: true,
                     failure_persist_dir: Some(PathBuf::from("cache/invariant")),
                     ..Default::default()
                 }
             );
+            assert!(loaded.invariant.corpus_random_sequence_weight_configured);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_invariant_corpus_random_sequence_weight_provenance() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [invariant]
+                depth = 10
+            "#,
+            )?;
+
+            let loaded = Config::load().unwrap();
+            assert_eq!(
+                loaded.invariant.corpus.corpus_random_sequence_weight,
+                FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+            );
+            assert!(!loaded.invariant.corpus_random_sequence_weight_configured);
+
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [invariant]
+                corpus_random_sequence_weight = 10
+            "#,
+            )?;
+
+            let loaded = Config::load().unwrap();
+            assert_eq!(
+                loaded.invariant.corpus.corpus_random_sequence_weight,
+                FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+            );
+            assert!(loaded.invariant.corpus_random_sequence_weight_configured);
 
             Ok(())
         });
@@ -5101,6 +5163,7 @@ mod tests {
                 InvariantWorkers::Fixed(NonZeroUsize::new(3).unwrap())
             );
             assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 30);
+            assert!(config.invariant.corpus_random_sequence_weight_configured);
             assert_eq!(config.invariant.corpus.payable_value_weight, 12);
             assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
 

--- a/crates/config/src/providers/ext.rs
+++ b/crates/config/src/providers/ext.rs
@@ -732,13 +732,32 @@ impl<P: Provider> Provider for FallbackProfileProvider<P> {
 
     fn data(&self) -> Result<Map<Profile, Dict>, Error> {
         let mut data = self.provider.data()?;
+        let invariant_corpus_random_sequence_weight_configured = self.profile == "invariant"
+            && data
+                .get(&self.profile)
+                .is_some_and(|inner| inner.contains_key("corpus_random_sequence_weight"));
+        let mark_invariant_corpus_random_sequence_weight_configured =
+            |inner: &mut Dict| -> Result<(), Error> {
+                if invariant_corpus_random_sequence_weight_configured {
+                    inner.insert(
+                        "corpus_random_sequence_weight_configured".to_string(),
+                        Value::serialize(true)?,
+                    );
+                }
+                Ok(())
+            };
+
         if let Some(fallback) = data.remove(&self.fallback) {
             let mut inner = data.remove(&self.profile).unwrap_or_default();
             for (k, v) in fallback {
                 inner.entry(k).or_insert(v);
             }
+            mark_invariant_corpus_random_sequence_weight_configured(&mut inner)?;
             Ok(self.profile.collect(inner))
         } else {
+            if let Some(inner) = data.get_mut(&self.profile) {
+                mark_invariant_corpus_random_sequence_weight_configured(inner)?;
+            }
             Ok(data)
         }
     }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -44,7 +44,7 @@ use alloy_json_abi::Function;
 use alloy_primitives::{Address, Bytes, I256, U256};
 use eyre::{Result, eyre};
 use foundry_common::{ContractsByAddress, ContractsByArtifact, TestFunctionExt, sh_warn};
-use foundry_config::FuzzCorpusConfig;
+use foundry_config::{FuzzCorpusConfig, FuzzCorpusMutationWeights};
 use foundry_evm_core::{constants::CALLER, evm::FoundryEvmNetwork, utils::StateChangeset};
 use foundry_evm_fuzz::{
     BasicTxDetails, CallDetails, ObservedCall,
@@ -56,8 +56,7 @@ use foundry_evm_fuzz::{
     },
 };
 use proptest::{
-    prelude::{Just, Rng, Strategy},
-    prop_oneof,
+    prelude::{Rng, Strategy},
     strategy::{BoxedStrategy, ValueTree},
     test_runner::TestRunner,
 };
@@ -84,6 +83,35 @@ const FAVORABILITY_THRESHOLD: f64 = 0.3;
 /// Threshold for compressing corpus entries.
 /// 4KiB is usually the minimum file size on popular file systems.
 const GZIP_THRESHOLD: usize = 4 * 1024;
+
+fn prefer_cmp_mutation(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> bool {
+    let weights = if weights.abi_or_cmp_total() == 0 {
+        FuzzCorpusMutationWeights::default()
+    } else {
+        weights
+    };
+    rng.random_range(0..weights.abi_or_cmp_total()) < u64::from(weights.mutation_weight_cmp)
+}
+
+fn weighted_mutation_type(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> MutationType {
+    let weights = weights.effective();
+    let mut choice = rng.random_range(0..weights.total());
+    for (weight, mutation) in [
+        (u64::from(weights.mutation_weight_splice), MutationType::Splice),
+        (u64::from(weights.mutation_weight_repeat), MutationType::Repeat),
+        (u64::from(weights.mutation_weight_interleave), MutationType::Interleave),
+        (u64::from(weights.mutation_weight_prefix), MutationType::Prefix),
+        (u64::from(weights.mutation_weight_suffix), MutationType::Suffix),
+        (u64::from(weights.mutation_weight_abi), MutationType::Abi),
+        (u64::from(weights.mutation_weight_cmp), MutationType::Cmp),
+    ] {
+        if choice < weight {
+            return mutation;
+        }
+        choice -= weight;
+    }
+    unreachable!("choice is bounded by total mutation weight")
+}
 
 /// Possible mutation strategies to apply on a call sequence.
 #[derive(Debug, Clone)]
@@ -486,8 +514,8 @@ pub struct WorkerCorpus {
     pub(crate) metrics: CorpusMetrics,
     /// Fuzzed calls generator.
     tx_generator: BoxedStrategy<BasicTxDetails>,
-    /// Call sequence mutation strategy type generator used by stateful fuzzing.
-    mutation_generator: BoxedStrategy<MutationType>,
+    /// Call sequence mutation weights used by stateful fuzzing.
+    mutation_weights: FuzzCorpusMutationWeights,
     /// Identifier of current mutated entry for this worker.
     current_mutated: Option<Uuid>,
     /// Config
@@ -692,16 +720,7 @@ impl WorkerCorpus {
         tx_generator: BoxedStrategy<BasicTxDetails>,
         seed: WorkerCorpusSeed,
     ) -> Self {
-        let mutation_generator = prop_oneof![
-            Just(MutationType::Splice),
-            Just(MutationType::Repeat),
-            Just(MutationType::Interleave),
-            Just(MutationType::Prefix),
-            Just(MutationType::Suffix),
-            Just(MutationType::Abi),
-            Just(MutationType::Cmp),
-        ]
-        .boxed();
+        let mutation_weights = config.mutation_weights.effective();
 
         let worker_dir = config.corpus_dir.as_ref().map(|corpus_dir| {
             let worker_dir = corpus_dir.join(format!("{WORKER}{id}"));
@@ -724,7 +743,7 @@ impl WorkerCorpus {
             failed_replays: seed.failed_replays,
             metrics: seed.metrics,
             tx_generator,
-            mutation_generator,
+            mutation_weights,
             current_mutated: None,
             config: config.into(),
             new_entry_indices: Default::default(),
@@ -949,11 +968,7 @@ impl WorkerCorpus {
         if !self.in_memory_corpus.is_empty() {
             self.evict_oldest_corpus()?;
 
-            let mutation_type = self
-                .mutation_generator
-                .new_tree(test_runner)
-                .map_err(|err| eyre!("Could not generate mutation type {err}"))?
-                .current();
+            let mutation_type = weighted_mutation_type(test_runner.rng(), self.mutation_weights);
 
             let rng = test_runner.rng();
             let corpus_len = self.in_memory_corpus.len();
@@ -1126,10 +1141,19 @@ impl WorkerCorpus {
             self.current_mutated = Some(corpus.uuid);
             let mut tx = corpus.tx_seq.first().unwrap().clone();
             let cmp_values = corpus.cmp_seq.first().map_or(&[][..], Vec::as_slice);
-            if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
-                && !function.inputs.is_empty()
-            {
+            let weights = self.config.mutation_weights.effective();
+            let prefer_cmp = prefer_cmp_mutation(test_runner.rng(), weights);
+            if prefer_cmp {
+                if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
+                    && weights.mutation_weight_abi > 0
+                    && !function.inputs.is_empty()
+                {
+                    self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
+                }
+            } else if weights.mutation_weight_abi > 0 && !function.inputs.is_empty() {
                 self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
+            } else if weights.mutation_weight_cmp > 0 {
+                let _ = Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?;
             }
             tx
         };
@@ -1279,7 +1303,9 @@ impl WorkerCorpus {
 
         // When running with coverage guided fuzzing enabled then generate new sequence if initial
         // sequence's length is less than depth or randomly, to occasionally intermix new txs.
-        if depth > sequence.len().saturating_sub(1) || test_runner.rng().random_ratio(1, 10) {
+        let fresh_weight = self.config.corpus_random_sequence_weight.min(100);
+        let generate_fresh = fresh_weight > 0 && test_runner.rng().random_ratio(fresh_weight, 100);
+        if depth > sequence.len().saturating_sub(1) || generate_fresh {
             return self.new_tx(test_runner);
         }
 
@@ -1859,6 +1885,7 @@ fn unique_corpus_entries<'a>(
 mod tests {
     use super::*;
     use alloy_dyn_abi::DynSolValue;
+    use proptest::prelude::Just;
     use std::fs;
 
     fn basic_tx() -> BasicTxDetails {

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -84,13 +84,12 @@ const FAVORABILITY_THRESHOLD: f64 = 0.3;
 /// 4KiB is usually the minimum file size on popular file systems.
 const GZIP_THRESHOLD: usize = 4 * 1024;
 
-fn prefer_cmp_mutation(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> bool {
-    let weights = if weights.abi_or_cmp_total() == 0 {
-        FuzzCorpusMutationWeights::default()
-    } else {
-        weights
-    };
-    rng.random_range(0..weights.abi_or_cmp_total()) < u64::from(weights.mutation_weight_cmp)
+fn prefer_cmp_mutation(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> Option<bool> {
+    let total = weights.abi_or_cmp_total();
+    if total == 0 {
+        return None;
+    }
+    Some(rng.random_range(0..total) < u64::from(weights.mutation_weight_cmp))
 }
 
 fn weighted_mutation_type(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> MutationType {
@@ -1096,7 +1095,7 @@ impl WorkerCorpus {
                         }
                     }
 
-                    if !mutated {
+                    if !mutated && self.mutation_weights.mutation_weight_abi > 0 {
                         let tx = new_seq.get_mut(fallback_idx).unwrap();
                         if let (_, Some(function)) = targets.fuzzed_artifacts(tx)
                             && !function.inputs.is_empty()
@@ -1133,7 +1132,12 @@ impl WorkerCorpus {
 
         self.evict_oldest_corpus()?;
 
-        let tx = if self.in_memory_corpus.is_empty() {
+        let fresh_weight = self.config.corpus_random_sequence_weight.min(100);
+        let generate_fresh = self.in_memory_corpus.is_empty()
+            || (fresh_weight > 0 && test_runner.rng().random_ratio(fresh_weight, 100));
+
+        let tx = if generate_fresh {
+            self.current_mutated = None;
             self.new_tx(test_runner)?
         } else {
             let corpus = &self.in_memory_corpus
@@ -1142,18 +1146,27 @@ impl WorkerCorpus {
             let mut tx = corpus.tx_seq.first().unwrap().clone();
             let cmp_values = corpus.cmp_seq.first().map_or(&[][..], Vec::as_slice);
             let weights = self.config.mutation_weights.effective();
-            let prefer_cmp = prefer_cmp_mutation(test_runner.rng(), weights);
-            if prefer_cmp {
-                if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
-                    && weights.mutation_weight_abi > 0
-                    && !function.inputs.is_empty()
-                {
+            match prefer_cmp_mutation(test_runner.rng(), weights) {
+                Some(true) => {
+                    if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
+                        && weights.mutation_weight_abi > 0
+                        && !function.inputs.is_empty()
+                    {
+                        self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
+                    }
+                }
+                Some(false) if weights.mutation_weight_abi > 0 && !function.inputs.is_empty() => {
                     self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
                 }
-            } else if weights.mutation_weight_abi > 0 && !function.inputs.is_empty() {
-                self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
-            } else if weights.mutation_weight_cmp > 0 {
-                let _ = Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?;
+                Some(false) if weights.mutation_weight_cmp > 0 => {
+                    let _ = Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?;
+                }
+                None => {
+                    // Stateless fuzz inputs cannot apply sequence-level mutation strategies.
+                    self.current_mutated = None;
+                    return Ok(self.new_tx(test_runner)?.call_details.calldata);
+                }
+                _ => {}
             }
             tx
         };
@@ -1885,7 +1898,9 @@ fn unique_corpus_entries<'a>(
 mod tests {
     use super::*;
     use alloy_dyn_abi::DynSolValue;
+    use foundry_config::FuzzDictionaryConfig;
     use proptest::prelude::Just;
+    use revm::database::{CacheDB, EmptyDB};
     use std::fs;
 
     fn basic_tx() -> BasicTxDetails {
@@ -1899,6 +1914,38 @@ mod tests {
                 value: None,
             },
         }
+    }
+
+    fn basic_tx_with_calldata(calldata: impl Into<Bytes>) -> BasicTxDetails {
+        let mut tx = basic_tx();
+        tx.call_details.calldata = calldata.into();
+        tx
+    }
+
+    fn tx_for_function(
+        target: Address,
+        function: &Function,
+        args: &[DynSolValue],
+    ) -> BasicTxDetails {
+        BasicTxDetails {
+            warp: None,
+            roll: None,
+            sender: Address::ZERO,
+            call_details: foundry_evm_fuzz::CallDetails {
+                target,
+                calldata: Bytes::from(function.abi_encode_input(args).unwrap()),
+                value: None,
+            },
+        }
+    }
+
+    fn empty_fuzz_state() -> EvmFuzzState {
+        EvmFuzzState::new(
+            &[],
+            &CacheDB::<EmptyDB>::default(),
+            FuzzDictionaryConfig::default(),
+            None,
+        )
     }
 
     fn temp_corpus_dir() -> PathBuf {
@@ -1919,6 +1966,15 @@ mod tests {
 
     fn worker_corpus(id: usize, corpus_root: PathBuf, seed: WorkerCorpusSeed) -> WorkerCorpus {
         WorkerCorpus::from_seed(id, corpus_config(corpus_root), Just(basic_tx()).boxed(), seed)
+    }
+
+    fn worker_corpus_with_config(
+        id: usize,
+        config: FuzzCorpusConfig,
+        generated: BasicTxDetails,
+        seed: WorkerCorpusSeed,
+    ) -> WorkerCorpus {
+        WorkerCorpus::from_seed(id, config, Just(generated).boxed(), seed)
     }
 
     fn empty_worker_corpus(id: usize, corpus_root: PathBuf) -> WorkerCorpus {
@@ -1970,6 +2026,87 @@ mod tests {
         assert!(mutated);
         let decoded = function.abi_decode_input(&tx.call_details.calldata[4..]).unwrap();
         assert_eq!(decoded[0].as_uint().unwrap().0, replacement);
+    }
+
+    #[test]
+    fn stateless_new_input_honors_fresh_sequence_weight() {
+        let mut config = corpus_config(temp_corpus_dir());
+        config.corpus_random_sequence_weight = 100;
+        let generated = basic_tx_with_calldata(vec![0x22]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x11])])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, generated, seed);
+        let mut runner = TestRunner::default();
+        let function = Function::parse("foo()").unwrap();
+
+        let input = manager.new_input(&mut runner, &empty_fuzz_state(), &function).unwrap();
+
+        assert_eq!(input, Bytes::from(vec![0x22]));
+        assert!(manager.current_mutated.is_none());
+    }
+
+    #[test]
+    fn stateless_new_input_does_not_fallback_to_disabled_arg_mutators() {
+        let mut config = corpus_config(temp_corpus_dir());
+        config.corpus_random_sequence_weight = 0;
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 1,
+            mutation_weight_repeat: 1,
+            mutation_weight_interleave: 1,
+            mutation_weight_prefix: 1,
+            mutation_weight_suffix: 1,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+        };
+        let generated = basic_tx_with_calldata(vec![0x44]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x33])])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, generated, seed);
+        let mut runner = TestRunner::default();
+        let function = Function::parse("foo(uint256)").unwrap();
+
+        let input = manager.new_input(&mut runner, &empty_fuzz_state(), &function).unwrap();
+
+        assert_eq!(input, Bytes::from(vec![0x44]));
+        assert!(manager.current_mutated.is_none());
+    }
+
+    #[test]
+    fn invariant_cmp_mutation_does_not_fallback_to_disabled_abi_mutation() {
+        let target = Address::from([0x42; 20]);
+        let function = Function::parse("foo(uint256)").unwrap();
+        let original = tx_for_function(target, &function, &[DynSolValue::Uint(U256::from(7), 256)]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![original.clone()])],
+            ..Default::default()
+        };
+        let mut config = corpus_config(temp_corpus_dir());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 1,
+        };
+        let mut manager = worker_corpus_with_config(0, config, basic_tx(), seed);
+        let mut runner = TestRunner::default();
+        let fuzz_state = empty_fuzz_state().into_invariant();
+        let targeted_contracts = targeted_contracts_with_selective_functions(
+            target,
+            vec![function.clone()],
+            [function.selector()],
+        );
+
+        let sequence = manager.new_inputs(&mut runner, &fuzz_state, &targeted_contracts).unwrap();
+
+        assert_eq!(sequence.len(), 1);
+        assert_eq!(sequence[0].call_details.calldata, original.call_details.calldata);
     }
 
     fn new_manager_with_single_corpus() -> (WorkerCorpus, Uuid) {

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1363,9 +1363,9 @@ impl WorkerCorpus {
         test_runner: &mut TestRunner,
         fuzz_state: &impl FuzzStateReader,
     ) -> Result<()> {
-        // Mutate value with 15% probability for payable functions.
+        // Mutate value with configured probability for payable functions.
         if function.state_mutability == alloy_json_abi::StateMutability::Payable
-            && test_runner.rng().random_ratio(15, 100)
+            && test_runner.rng().random_ratio(self.config.payable_value_weight.min(100), 100)
         {
             tx.call_details.value = Some(generate_msg_value(test_runner));
         }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -105,13 +105,19 @@ fn weighted_mutation_type(rng: &mut impl Rng, distribution: &WeightedIndex<u32>)
     }
 }
 
-fn assert_supported_mutation_weight_total(mutation_weights: FuzzCorpusMutationWeights) {
+fn validate_supported_mutation_weight_total(
+    mutation_weights: FuzzCorpusMutationWeights,
+) -> Result<()> {
     let total = mutation_weights.total();
-    assert!(
-        total <= u64::from(u32::MAX),
-        "effective mutation weights sum to {total}, which exceeds the maximum supported total {}",
-        u32::MAX
-    );
+    if total > u64::from(u32::MAX) {
+        return Err(eyre!(
+            "effective mutation weights sum to {total}, which exceeds the maximum supported \
+             total {}",
+            u32::MAX
+        ));
+    }
+
+    Ok(())
 }
 
 /// Possible mutation strategies to apply on a call sequence.
@@ -727,7 +733,7 @@ impl WorkerCorpus {
         } else {
             WorkerCorpusSeed::empty(&config).with_optimization_state(&config)
         };
-        Ok(Self::from_seed(id, config, tx_generator, seed))
+        Self::from_seed(id, config, tx_generator, seed)
     }
 
     pub(crate) fn from_seed(
@@ -735,9 +741,9 @@ impl WorkerCorpus {
         config: FuzzCorpusConfig,
         tx_generator: BoxedStrategy<BasicTxDetails>,
         seed: WorkerCorpusSeed,
-    ) -> Self {
+    ) -> Result<Self> {
         let mutation_weights = config.mutation_weights.effective();
-        assert_supported_mutation_weight_total(mutation_weights);
+        validate_supported_mutation_weight_total(mutation_weights)?;
         let mutation_distribution = WeightedIndex::new([
             mutation_weights.mutation_weight_splice,
             mutation_weights.mutation_weight_repeat,
@@ -747,7 +753,7 @@ impl WorkerCorpus {
             mutation_weights.mutation_weight_abi,
             mutation_weights.mutation_weight_cmp,
         ])
-        .expect("effective mutation weights contain at least one non-zero entry");
+        .map_err(|err| eyre!("invalid corpus mutation weights: {err}"))?;
         let arg_mutation_distribution = if mutation_weights.mutation_weight_abi == 0
             && mutation_weights.mutation_weight_cmp == 0
         {
@@ -758,7 +764,7 @@ impl WorkerCorpus {
                     mutation_weights.mutation_weight_abi,
                     mutation_weights.mutation_weight_cmp,
                 ])
-                .expect("non-zero argument mutation weights fit in supported mutation total"),
+                .map_err(|err| eyre!("invalid argument mutation weights: {err}"))?,
             )
         };
 
@@ -774,7 +780,7 @@ impl WorkerCorpus {
             worker_dir
         });
 
-        Self {
+        Ok(Self {
             id,
             in_memory_corpus: seed.in_memory_corpus,
             history_map: seed.history_map,
@@ -794,7 +800,7 @@ impl WorkerCorpus {
             last_sync_metrics: Default::default(),
             optimization_best_value: seed.optimization_best_value,
             optimization_best_sequence: seed.optimization_best_sequence,
-        }
+        })
     }
 
     /// Updates stats for the given call sequence, if new coverage produced.
@@ -2033,6 +2039,7 @@ mod tests {
 
     fn worker_corpus(id: usize, corpus_root: PathBuf, seed: WorkerCorpusSeed) -> WorkerCorpus {
         WorkerCorpus::from_seed(id, corpus_config(corpus_root), Just(basic_tx()).boxed(), seed)
+            .unwrap()
     }
 
     fn worker_corpus_with_config(
@@ -2041,7 +2048,7 @@ mod tests {
         generated: BasicTxDetails,
         seed: WorkerCorpusSeed,
     ) -> WorkerCorpus {
-        WorkerCorpus::from_seed(id, config, Just(generated).boxed(), seed)
+        WorkerCorpus::from_seed(id, config, Just(generated).boxed(), seed).unwrap()
     }
 
     fn empty_worker_corpus(id: usize, corpus_root: PathBuf) -> WorkerCorpus {
@@ -2143,7 +2150,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "effective mutation weights sum")]
     fn mutation_weights_reject_overflowing_total() {
         let mut config = corpus_config(temp_corpus_dir());
         config.mutation_weights = FuzzCorpusMutationWeights {
@@ -2156,8 +2162,16 @@ mod tests {
             mutation_weight_cmp: 0,
         };
 
-        let _manager =
-            worker_corpus_with_config(0, config, basic_tx(), WorkerCorpusSeed::default());
+        let err = WorkerCorpus::from_seed(
+            0,
+            config,
+            Just(basic_tx()).boxed(),
+            WorkerCorpusSeed::default(),
+        )
+        .err()
+        .unwrap();
+
+        assert!(err.to_string().contains("effective mutation weights sum"));
     }
 
     #[test]
@@ -2362,7 +2376,8 @@ mod tests {
         };
 
         let manager =
-            WorkerCorpus::from_seed(1, corpus_config(corpus_root), Just(basic_tx()).boxed(), seed);
+            WorkerCorpus::from_seed(1, corpus_config(corpus_root), Just(basic_tx()).boxed(), seed)
+                .unwrap();
 
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert_eq!(manager.history_map, vec![1, 2, 3]);
@@ -2620,7 +2635,8 @@ mod tests {
             no_corpus_config,
             Just(basic_tx()).boxed(),
             WorkerCorpusSeed::default(),
-        );
+        )
+        .unwrap();
         assert!(
             manager
                 .hoist_observed_calls(

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -60,6 +60,7 @@ use proptest::{
     strategy::{BoxedStrategy, ValueTree},
     test_runner::TestRunner,
 };
+use rand::distr::{Distribution, weighted::WeightedIndex};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
@@ -84,32 +85,24 @@ const FAVORABILITY_THRESHOLD: f64 = 0.3;
 /// 4KiB is usually the minimum file size on popular file systems.
 const GZIP_THRESHOLD: usize = 4 * 1024;
 
-fn prefer_cmp_mutation(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> Option<bool> {
-    let total = weights.abi_or_cmp_total();
-    if total == 0 {
-        return None;
-    }
-    Some(rng.random_range(0..total) < u64::from(weights.mutation_weight_cmp))
+fn weighted_arg_mutation(
+    rng: &mut impl Rng,
+    distribution: Option<&WeightedIndex<u32>>,
+) -> Option<bool> {
+    distribution.map(|distribution| distribution.sample(rng) == 1)
 }
 
-fn weighted_mutation_type(rng: &mut impl Rng, weights: FuzzCorpusMutationWeights) -> MutationType {
-    let weights = weights.effective();
-    let mut choice = rng.random_range(0..weights.total());
-    for (weight, mutation) in [
-        (u64::from(weights.mutation_weight_splice), MutationType::Splice),
-        (u64::from(weights.mutation_weight_repeat), MutationType::Repeat),
-        (u64::from(weights.mutation_weight_interleave), MutationType::Interleave),
-        (u64::from(weights.mutation_weight_prefix), MutationType::Prefix),
-        (u64::from(weights.mutation_weight_suffix), MutationType::Suffix),
-        (u64::from(weights.mutation_weight_abi), MutationType::Abi),
-        (u64::from(weights.mutation_weight_cmp), MutationType::Cmp),
-    ] {
-        if choice < weight {
-            return mutation;
-        }
-        choice -= weight;
+fn weighted_mutation_type(rng: &mut impl Rng, distribution: &WeightedIndex<u32>) -> MutationType {
+    match distribution.sample(rng) {
+        0 => MutationType::Splice,
+        1 => MutationType::Repeat,
+        2 => MutationType::Interleave,
+        3 => MutationType::Prefix,
+        4 => MutationType::Suffix,
+        5 => MutationType::Abi,
+        6 => MutationType::Cmp,
+        _ => unreachable!("mutation distribution only has seven entries"),
     }
-    unreachable!("choice is bounded by total mutation weight")
 }
 
 /// Possible mutation strategies to apply on a call sequence.
@@ -515,6 +508,10 @@ pub struct WorkerCorpus {
     tx_generator: BoxedStrategy<BasicTxDetails>,
     /// Call sequence mutation weights used by stateful fuzzing.
     mutation_weights: FuzzCorpusMutationWeights,
+    /// Weighted stateful sequence mutation distribution.
+    mutation_distribution: WeightedIndex<u32>,
+    /// Weighted ABI/CMP argument mutation distribution used by stateless fuzzing.
+    arg_mutation_distribution: Option<WeightedIndex<u32>>,
     /// Identifier of current mutated entry for this worker.
     current_mutated: Option<Uuid>,
     /// Config
@@ -720,6 +717,21 @@ impl WorkerCorpus {
         seed: WorkerCorpusSeed,
     ) -> Self {
         let mutation_weights = config.mutation_weights.effective();
+        let mutation_distribution = WeightedIndex::new([
+            mutation_weights.mutation_weight_splice,
+            mutation_weights.mutation_weight_repeat,
+            mutation_weights.mutation_weight_interleave,
+            mutation_weights.mutation_weight_prefix,
+            mutation_weights.mutation_weight_suffix,
+            mutation_weights.mutation_weight_abi,
+            mutation_weights.mutation_weight_cmp,
+        ])
+        .expect("effective mutation weights contain at least one non-zero entry");
+        let arg_mutation_distribution = WeightedIndex::new([
+            mutation_weights.mutation_weight_abi,
+            mutation_weights.mutation_weight_cmp,
+        ])
+        .ok();
 
         let worker_dir = config.corpus_dir.as_ref().map(|corpus_dir| {
             let worker_dir = corpus_dir.join(format!("{WORKER}{id}"));
@@ -743,6 +755,8 @@ impl WorkerCorpus {
             metrics: seed.metrics,
             tx_generator,
             mutation_weights,
+            mutation_distribution,
+            arg_mutation_distribution,
             current_mutated: None,
             config: config.into(),
             new_entry_indices: Default::default(),
@@ -967,7 +981,8 @@ impl WorkerCorpus {
         if !self.in_memory_corpus.is_empty() {
             self.evict_oldest_corpus()?;
 
-            let mutation_type = weighted_mutation_type(test_runner.rng(), self.mutation_weights);
+            let mutation_type =
+                weighted_mutation_type(test_runner.rng(), &self.mutation_distribution);
 
             let rng = test_runner.rng();
             let corpus_len = self.in_memory_corpus.len();
@@ -1145,20 +1160,23 @@ impl WorkerCorpus {
             self.current_mutated = Some(corpus.uuid);
             let mut tx = corpus.tx_seq.first().unwrap().clone();
             let cmp_values = corpus.cmp_seq.first().map_or(&[][..], Vec::as_slice);
-            let weights = self.config.mutation_weights.effective();
-            match prefer_cmp_mutation(test_runner.rng(), weights) {
+            match weighted_arg_mutation(test_runner.rng(), self.arg_mutation_distribution.as_ref())
+            {
                 Some(true) => {
                     if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
-                        && weights.mutation_weight_abi > 0
+                        && self.mutation_weights.mutation_weight_abi > 0
                         && !function.inputs.is_empty()
                     {
                         self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
                     }
                 }
-                Some(false) if weights.mutation_weight_abi > 0 && !function.inputs.is_empty() => {
+                Some(false)
+                    if self.mutation_weights.mutation_weight_abi > 0
+                        && !function.inputs.is_empty() =>
+                {
                     self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
                 }
-                Some(false) if weights.mutation_weight_cmp > 0 => {
+                Some(false) if self.mutation_weights.mutation_weight_cmp > 0 => {
                     let _ = Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?;
                 }
                 None => {

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -105,6 +105,15 @@ fn weighted_mutation_type(rng: &mut impl Rng, distribution: &WeightedIndex<u32>)
     }
 }
 
+fn assert_supported_mutation_weight_total(mutation_weights: FuzzCorpusMutationWeights) {
+    let total = mutation_weights.total();
+    assert!(
+        total <= u64::from(u32::MAX),
+        "effective mutation weights sum to {total}, which exceeds the maximum supported total {}",
+        u32::MAX
+    );
+}
+
 /// Possible mutation strategies to apply on a call sequence.
 #[derive(Debug, Clone)]
 enum MutationType {
@@ -728,6 +737,7 @@ impl WorkerCorpus {
         seed: WorkerCorpusSeed,
     ) -> Self {
         let mutation_weights = config.mutation_weights.effective();
+        assert_supported_mutation_weight_total(mutation_weights);
         let mutation_distribution = WeightedIndex::new([
             mutation_weights.mutation_weight_splice,
             mutation_weights.mutation_weight_repeat,
@@ -738,11 +748,19 @@ impl WorkerCorpus {
             mutation_weights.mutation_weight_cmp,
         ])
         .expect("effective mutation weights contain at least one non-zero entry");
-        let arg_mutation_distribution = WeightedIndex::new([
-            mutation_weights.mutation_weight_abi,
-            mutation_weights.mutation_weight_cmp,
-        ])
-        .ok();
+        let arg_mutation_distribution = if mutation_weights.mutation_weight_abi == 0
+            && mutation_weights.mutation_weight_cmp == 0
+        {
+            None
+        } else {
+            Some(
+                WeightedIndex::new([
+                    mutation_weights.mutation_weight_abi,
+                    mutation_weights.mutation_weight_cmp,
+                ])
+                .expect("non-zero argument mutation weights fit in supported mutation total"),
+            )
+        };
 
         let worker_dir = config.corpus_dir.as_ref().map(|corpus_dir| {
             let worker_dir = corpus_dir.join(format!("{WORKER}{id}"));
@@ -2122,6 +2140,24 @@ mod tests {
 
         assert_eq!(input, Bytes::from(vec![0x44]));
         assert!(manager.current_mutated_index.is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "effective mutation weights sum")]
+    fn mutation_weights_reject_overflowing_total() {
+        let mut config = corpus_config(temp_corpus_dir());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: u32::MAX,
+            mutation_weight_repeat: 1,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+        };
+
+        let _manager =
+            worker_corpus_with_config(0, config, basic_tx(), WorkerCorpusSeed::default());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -21,12 +21,12 @@ use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::{
     BaseCounterExample, BasicTxDetails, CallDetails, CounterExample, FuzzCase, FuzzError,
     FuzzFixtures, FuzzRunMetadata, FuzzTestResult,
-    strategies::{EvmFuzzState, fuzz_calldata, fuzz_calldata_from_state},
+    strategies::{EvmFuzzState, fuzz_calldata, fuzz_calldata_from_state, fuzz_msg_value},
 };
 use foundry_evm_traces::SparsedTraceArena;
 use indicatif::ProgressBar;
 use proptest::{
-    strategy::Strategy,
+    strategy::{Just, Strategy},
     test_runner::{RngAlgorithm, TestCaseError, TestRng, TestRunner},
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -451,16 +451,22 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         // Prepare
         let fuzz_state = shared_state.state.fork();
         let dictionary_weight = self.config.dictionary.dictionary_weight.min(100);
-        let strategy = proptest::prop_oneof![
+        let calldata_strategy = proptest::prop_oneof![
             100 - dictionary_weight => fuzz_calldata(func.clone(), fuzz_fixtures),
             dictionary_weight => fuzz_calldata_from_state(func.clone(), &fuzz_state),
-        ]
-        .prop_map(move |calldata| BasicTxDetails {
-            warp: None,
-            roll: None,
-            sender: Default::default(),
-            call_details: CallDetails { target: Default::default(), calldata, value: None },
-        });
+        ];
+        let value_strategy = if func.state_mutability == alloy_json_abi::StateMutability::Payable {
+            fuzz_msg_value(self.config.corpus.payable_value_weight).boxed()
+        } else {
+            Just(None).boxed()
+        };
+        let strategy =
+            (calldata_strategy, value_strategy).prop_map(move |(calldata, value)| BasicTxDetails {
+                warp: None,
+                roll: None,
+                sender: Default::default(),
+                call_details: CallDetails { target: Default::default(), calldata, value },
+            });
 
         let mut corpus = WorkerCorpus::new(
             worker_id,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -223,10 +223,13 @@ fn invariant_worker_config(
     worker_id: u32,
     worker_count: usize,
 ) -> InvariantConfig {
-    // Keep single-worker campaigns on the stable default, but let one extra worker explore the
-    // broader fresh-sequence setting when the user has not selected a different value.
-    if worker_count > 1
-        && worker_id == 1
+    // Keep one- and two-worker campaigns on the stable default, but let one extra worker explore
+    // the broader fresh-input setting once the user has enough workers to keep the exploratory
+    // share below half of the campaign. The last worker does not receive remainder runs from
+    // campaign sharding, so this keeps exposure bounded to one worker shard.
+    let exploratory_worker_id = worker_count.saturating_sub(1) as u32;
+    if worker_count > 2
+        && worker_id == exploratory_worker_id
         && !config.corpus_random_sequence_weight_configured
         && config.corpus.corpus_random_sequence_weight
             == FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
@@ -2137,11 +2140,47 @@ mod tests {
         );
         assert_eq!(
             invariant_worker_config(config.clone(), 1, 4).corpus.corpus_random_sequence_weight,
-            FuzzCorpusConfig::ENSEMBLE_CORPUS_RANDOM_SEQUENCE_WEIGHT
+            FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
         );
         assert_eq!(
-            invariant_worker_config(config, 2, 4).corpus.corpus_random_sequence_weight,
+            invariant_worker_config(config.clone(), 2, 4).corpus.corpus_random_sequence_weight,
             FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+        assert_eq!(
+            invariant_worker_config(config, 3, 4).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::ENSEMBLE_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+    }
+
+    #[test]
+    fn invariant_worker_config_keeps_two_worker_campaign_on_default() {
+        let config = InvariantConfig::default();
+
+        assert_eq!(
+            invariant_worker_config(config.clone(), 0, 2).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+        assert_eq!(
+            invariant_worker_config(config, 1, 2).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+    }
+
+    #[test]
+    fn invariant_worker_config_uses_last_worker_for_three_worker_campaign() {
+        let config = InvariantConfig::default();
+
+        assert_eq!(
+            invariant_worker_config(config.clone(), 0, 3).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+        assert_eq!(
+            invariant_worker_config(config.clone(), 1, 3).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+        assert_eq!(
+            invariant_worker_config(config, 2, 3).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::ENSEMBLE_CORPUS_RANDOM_SEQUENCE_WEIGHT
         );
     }
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -180,7 +180,7 @@ fn max_invariant_workers_for_campaign(runs: u32, depth: u32) -> usize {
 
 fn invariant_run_depth(config: &InvariantConfig, runner: &mut TestRunner) -> u32 {
     match config.depth_mode {
-        InvariantDepthMode::Fixed => config.depth.max(1),
+        InvariantDepthMode::Fixed => config.depth,
         InvariantDepthMode::Random => {
             let min_depth = config.min_depth.max(1);
             if config.depth <= min_depth {
@@ -2190,7 +2190,7 @@ mod tests {
     }
 
     #[test]
-    fn invariant_run_depth_fixed_zero_never_returns_zero() {
+    fn invariant_run_depth_fixed_zero_preserves_zero() {
         let mut runner = test_runner();
         let config = InvariantConfig {
             depth: 0,
@@ -2198,7 +2198,7 @@ mod tests {
             ..Default::default()
         };
 
-        assert_eq!(invariant_run_depth(&config, &mut runner), 1);
+        assert_eq!(invariant_run_depth(&config, &mut runner), 0);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1506,7 +1506,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             config.corpus.clone(),
             strategy.boxed(),
             corpus_seed,
-        );
+        )?;
 
         if let Err(err) =
             worker.seed_from_test_traces(invariant_contract, &targeted_contracts, executor)

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1483,6 +1483,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     target_contract_ref.clone(),
                     fuzz_fixtures.clone(),
                     config.dictionary.dictionary_weight,
+                    config.corpus.payable_value_weight,
                 ),
                 target_contract_ref,
             );

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -18,7 +18,7 @@ use foundry_common::{
     contracts::{ContractsByAddress, ContractsByArtifact},
     sh_eprintln, sh_println,
 };
-use foundry_config::{InvariantConfig, InvariantDepthMode, InvariantWorkers};
+use foundry_config::{FuzzCorpusConfig, InvariantConfig, InvariantDepthMode, InvariantWorkers};
 use foundry_evm_core::{
     FoundryBlock,
     constants::{
@@ -216,6 +216,25 @@ fn invariant_worker_count_with_threads(
             }
         }
     }
+}
+
+fn invariant_worker_config(
+    mut config: InvariantConfig,
+    worker_id: u32,
+    worker_count: usize,
+) -> InvariantConfig {
+    // Keep single-worker campaigns on the stable default, but let one extra worker explore the
+    // broader fresh-sequence setting when the user has not selected a different value.
+    if worker_count > 1
+        && worker_id == 1
+        && !config.corpus_random_sequence_weight_configured
+        && config.corpus.corpus_random_sequence_weight
+            == FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+    {
+        config.corpus.corpus_random_sequence_weight =
+            FuzzCorpusConfig::ENSEMBLE_CORPUS_RANDOM_SEQUENCE_WEIGHT;
+    }
+    config
 }
 
 fn gas_report_samples_for_worker(total_samples: u32, worker_id: u32, worker_count: usize) -> usize {
@@ -826,6 +845,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // Note: invariant function signatures (no inputs) are validated upstream in the
         // suite runner so parameterized `invariant_*` functions are rejected with a per-test
         // failure entry before any campaign runs.
+        let config = invariant_worker_config(config, plan.worker_id, worker_count);
 
         let (mut invariant_test, mut corpus_manager) = Self::prepare_worker(
             &mut executor,
@@ -2095,6 +2115,55 @@ mod tests {
         for _ in 0..128 {
             assert!((1..=8).contains(&invariant_run_depth(&config, &mut runner)));
         }
+    }
+
+    #[test]
+    fn invariant_worker_config_keeps_single_worker_default() {
+        let config = InvariantConfig::default();
+
+        assert_eq!(
+            invariant_worker_config(config, 0, 1).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+    }
+
+    #[test]
+    fn invariant_worker_config_uses_one_exploratory_worker_with_default_config() {
+        let config = InvariantConfig::default();
+
+        assert_eq!(
+            invariant_worker_config(config.clone(), 0, 4).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+        assert_eq!(
+            invariant_worker_config(config.clone(), 1, 4).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::ENSEMBLE_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+        assert_eq!(
+            invariant_worker_config(config, 2, 4).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
+    }
+
+    #[test]
+    fn invariant_worker_config_preserves_explicit_corpus_random_sequence_weight() {
+        let mut config = InvariantConfig::default();
+        config.corpus.corpus_random_sequence_weight = 25;
+        config.corpus_random_sequence_weight_configured = true;
+
+        assert_eq!(
+            invariant_worker_config(config.clone(), 1, 4).corpus.corpus_random_sequence_weight,
+            25
+        );
+        assert_eq!(invariant_worker_config(config, 0, 1).corpus.corpus_random_sequence_weight, 25);
+
+        let mut config = InvariantConfig::default();
+        config.corpus_random_sequence_weight_configured = true;
+
+        assert_eq!(
+            invariant_worker_config(config, 1, 4).corpus.corpus_random_sequence_weight,
+            FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
+        );
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -18,7 +18,7 @@ use foundry_common::{
     contracts::{ContractsByAddress, ContractsByArtifact},
     sh_eprintln, sh_println,
 };
-use foundry_config::{InvariantConfig, InvariantWorkers};
+use foundry_config::{InvariantConfig, InvariantDepthMode, InvariantWorkers};
 use foundry_evm_core::{
     FoundryBlock,
     constants::{
@@ -39,6 +39,7 @@ use foundry_evm_traces::{CallTraceArena, SparsedTraceArena};
 use indicatif::ProgressBar;
 use parking_lot::RwLock;
 use proptest::{
+    prelude::Rng,
     strategy::Strategy,
     test_runner::{RngAlgorithm, TestRng, TestRunner},
 };
@@ -175,6 +176,19 @@ fn max_invariant_workers_for_campaign(runs: u32, depth: u32) -> usize {
     let estimated_calls = u64::from(runs) * u64::from(depth.max(1));
     usize::try_from((estimated_calls / MIN_ESTIMATED_CALLS_PER_INVARIANT_WORKER).max(1))
         .unwrap_or(usize::MAX)
+}
+
+fn invariant_run_depth(config: &InvariantConfig, runner: &mut TestRunner) -> u32 {
+    match config.depth_mode {
+        InvariantDepthMode::Fixed => config.depth,
+        InvariantDepthMode::Random => {
+            if config.depth <= config.min_depth {
+                config.depth
+            } else {
+                runner.rng().random_range(config.min_depth..=config.depth)
+            }
+        }
+    }
 }
 
 fn auto_invariant_worker_count(
@@ -842,12 +856,15 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 &invariant_test.targeted_contracts,
             )?;
 
+            let run_depth =
+                invariant_run_depth(&config, &mut invariant_test.test_data.branch_runner);
+
             // Create current invariant run data.
             let mut current_run = InvariantTestRun::new(
                 initial_seq[0].clone(),
                 // Before each run, we must reset the backend state.
                 executor.clone(),
-                config.depth as usize,
+                run_depth as usize,
             );
 
             // We stop the run immediately if we have reverted, and `fail_on_revert` is set.
@@ -856,7 +873,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 return Err(eyre!("call reverted"));
             }
 
-            while current_run.depth < config.depth {
+            while current_run.depth < run_depth {
                 // Check if the timeout has been reached.
                 if campaign_state.should_stop() {
                     // Since we never record a revert here the test is still considered
@@ -971,7 +988,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             &mut state_changeset,
                             current_run.inputs.last().expect("checked above"),
                             &call_result,
-                            config.depth,
+                            run_depth,
                             mapping_slots,
                         );
                     }
@@ -999,7 +1016,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     // - check_interval=0: only assert on the last call
                     // - check_interval=1 (default): assert after every call
                     // - check_interval=N: assert every N calls AND always on the last call
-                    let is_last_call = current_run.depth == config.depth - 1;
+                    let is_last_call = current_run.depth == run_depth - 1;
                     // In optimization mode, always evaluate the invariant to track
                     // the best value at every prefix — check_interval only gates
                     // boolean invariant assertions.
@@ -1090,7 +1107,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         current_run.cmp_seq.push(call_cmp_values);
                     }
 
-                    if !continues || current_run.depth == config.depth - 1 {
+                    if !continues || current_run.depth == run_depth - 1 {
                         invariant_test.set_last_run_inputs(&current_run.inputs);
                     }
                     // Bridge newly-recorded predicate breaks into `failure_metrics` even when
@@ -1465,6 +1482,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     override_targets,
                     target_contract_ref.clone(),
                     fuzz_fixtures.clone(),
+                    config.dictionary.dictionary_weight,
                 ),
                 target_contract_ref,
             );

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -180,12 +180,13 @@ fn max_invariant_workers_for_campaign(runs: u32, depth: u32) -> usize {
 
 fn invariant_run_depth(config: &InvariantConfig, runner: &mut TestRunner) -> u32 {
     match config.depth_mode {
-        InvariantDepthMode::Fixed => config.depth,
+        InvariantDepthMode::Fixed => config.depth.max(1),
         InvariantDepthMode::Random => {
-            if config.depth <= config.min_depth {
-                config.depth
+            let min_depth = config.min_depth.max(1);
+            if config.depth <= min_depth {
+                config.depth.max(1)
             } else {
-                runner.rng().random_range(config.min_depth..=config.depth)
+                runner.rng().random_range(min_depth..=config.depth)
             }
         }
     }
@@ -2079,6 +2080,22 @@ mod tests {
             2
         );
         assert_eq!(max_invariant_workers_for_campaign(256, 100_000), 5);
+    }
+
+    #[test]
+    fn invariant_run_depth_never_returns_zero() {
+        let mut runner = test_runner();
+        let mut config = InvariantConfig { depth: 0, ..Default::default() };
+
+        assert_eq!(invariant_run_depth(&config, &mut runner), 1);
+
+        config.depth = 8;
+        config.min_depth = 0;
+        config.depth_mode = InvariantDepthMode::Random;
+
+        for _ in 0..128 {
+            assert!((1..=8).contains(&invariant_run_depth(&config, &mut runner)));
+        }
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -180,7 +180,7 @@ fn max_invariant_workers_for_campaign(runs: u32, depth: u32) -> usize {
 
 fn invariant_run_depth(config: &InvariantConfig, runner: &mut TestRunner) -> u32 {
     match config.depth_mode {
-        InvariantDepthMode::Fixed => config.depth.max(1),
+        InvariantDepthMode::Fixed => config.depth,
         InvariantDepthMode::Random => {
             let min_depth = config.min_depth.max(1);
             if config.depth <= min_depth {
@@ -2083,15 +2083,14 @@ mod tests {
     }
 
     #[test]
-    fn invariant_run_depth_never_returns_zero() {
+    fn invariant_run_depth_random_min_depth_zero_never_returns_zero() {
         let mut runner = test_runner();
-        let mut config = InvariantConfig { depth: 0, ..Default::default() };
-
-        assert_eq!(invariant_run_depth(&config, &mut runner), 1);
-
-        config.depth = 8;
-        config.min_depth = 0;
-        config.depth_mode = InvariantDepthMode::Random;
+        let config = InvariantConfig {
+            depth: 8,
+            min_depth: 0,
+            depth_mode: InvariantDepthMode::Random,
+            ..Default::default()
+        };
 
         for _ in 0..128 {
             assert!((1..=8).contains(&invariant_run_depth(&config, &mut runner)));

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -180,7 +180,7 @@ fn max_invariant_workers_for_campaign(runs: u32, depth: u32) -> usize {
 
 fn invariant_run_depth(config: &InvariantConfig, runner: &mut TestRunner) -> u32 {
     match config.depth_mode {
-        InvariantDepthMode::Fixed => config.depth,
+        InvariantDepthMode::Fixed => config.depth.max(1),
         InvariantDepthMode::Random => {
             let min_depth = config.min_depth.max(1);
             if config.depth <= min_depth {
@@ -2187,6 +2187,18 @@ mod tests {
         for _ in 0..128 {
             assert!((1..=8).contains(&invariant_run_depth(&config, &mut runner)));
         }
+    }
+
+    #[test]
+    fn invariant_run_depth_fixed_zero_never_returns_zero() {
+        let mut runner = test_runner();
+        let config = InvariantConfig {
+            depth: 0,
+            depth_mode: InvariantDepthMode::Fixed,
+            ..Default::default()
+        };
+
+        assert_eq!(invariant_run_depth(&config, &mut runner), 1);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -218,7 +218,7 @@ fn invariant_worker_count_with_threads(
     }
 }
 
-fn invariant_worker_config(
+const fn invariant_worker_config(
     mut config: InvariantConfig,
     worker_id: u32,
     worker_count: usize,
@@ -2186,9 +2186,14 @@ mod tests {
 
     #[test]
     fn invariant_worker_config_preserves_explicit_corpus_random_sequence_weight() {
-        let mut config = InvariantConfig::default();
-        config.corpus.corpus_random_sequence_weight = 25;
-        config.corpus_random_sequence_weight_configured = true;
+        let config = InvariantConfig {
+            corpus: FuzzCorpusConfig {
+                corpus_random_sequence_weight: 25,
+                ..FuzzCorpusConfig::default()
+            },
+            corpus_random_sequence_weight_configured: true,
+            ..InvariantConfig::default()
+        };
 
         assert_eq!(
             invariant_worker_config(config.clone(), 1, 4).corpus.corpus_random_sequence_weight,
@@ -2196,8 +2201,10 @@ mod tests {
         );
         assert_eq!(invariant_worker_config(config, 0, 1).corpus.corpus_random_sequence_weight, 25);
 
-        let mut config = InvariantConfig::default();
-        config.corpus_random_sequence_weight_configured = true;
+        let config = InvariantConfig {
+            corpus_random_sequence_weight_configured: true,
+            ..InvariantConfig::default()
+        };
 
         assert_eq!(
             invariant_worker_config(config, 1, 4).corpus.corpus_random_sequence_weight,

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -128,7 +128,8 @@ pub fn invariant_strat(
 }
 
 /// Strategy to select a sender address:
-/// * If `senders` is empty, then it's either a random address (10%) or from the dictionary (90%).
+/// * If `senders` is empty, then it's either a random address or one sampled from the dictionary
+///   according to the configured dictionary weight.
 /// * If `senders` is not empty, a random address is chosen from the list of senders.
 fn select_random_sender<S: FuzzStateReader>(
     fuzz_state: &S,

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -20,6 +20,7 @@ pub fn override_call_strat(
     contracts: Vec<(Address, Vec<Function>)>,
     target: Arc<RwLock<Address>>,
     fuzz_fixtures: FuzzFixtures,
+    dictionary_weight: u32,
 ) -> impl Strategy<Value = CallDetails> + Send + Sync + 'static {
     let contracts = Arc::new(contracts);
     let contracts_ref = contracts.clone();
@@ -60,7 +61,13 @@ pub fn override_call_strat(
         };
 
         func.prop_flat_map(move |func| {
-            fuzz_contract_with_calldata(&fuzz_state, &fuzz_fixtures, actual_target, func)
+            fuzz_contract_with_calldata(
+                &fuzz_state,
+                &fuzz_fixtures,
+                actual_target,
+                func,
+                dictionary_weight,
+            )
         })
     })
 }
@@ -103,6 +110,7 @@ pub fn invariant_strat(
                 &fuzz_fixtures,
                 *target_address,
                 target_function.clone(),
+                dictionary_weight,
             );
 
             let warp = warp_roll_strat(config.max_time_delay.is_some());
@@ -128,7 +136,7 @@ fn select_random_sender<S: FuzzStateReader>(
     dictionary_weight: u32,
 ) -> impl Strategy<Value = Address> + use<S> {
     if senders.targeted.is_empty() {
-        assert!(dictionary_weight <= 100, "dictionary_weight must be <= 100");
+        let dictionary_weight = dictionary_weight.min(100);
         proptest::prop_oneof![
             100 - dictionary_weight => fuzz_param(&alloy_dyn_abi::DynSolType::Address),
             dictionary_weight => fuzz_param_from_state(&alloy_dyn_abi::DynSolType::Address, fuzz_state),
@@ -160,15 +168,17 @@ pub fn fuzz_contract_with_calldata<S: FuzzStateReader>(
     fuzz_fixtures: &FuzzFixtures,
     target: Address,
     func: Function,
+    dictionary_weight: u32,
 ) -> impl Strategy<Value = CallDetails> + use<S> {
     let is_payable = func.state_mutability == alloy_json_abi::StateMutability::Payable;
+    let dictionary_weight = dictionary_weight.min(100);
 
     // We need to compose all the strategies generated for each parameter in all possible
     // combinations.
     // `prop_oneof!` / `TupleUnion` `Arc`s for cheap cloning.
     let calldata_strategy = prop_oneof![
-        60 => fuzz_calldata(func.clone(), fuzz_fixtures),
-        40 => fuzz_calldata_from_state(func, fuzz_state),
+        100 - dictionary_weight => fuzz_calldata(func.clone(), fuzz_fixtures),
+        dictionary_weight => fuzz_calldata_from_state(func, fuzz_state),
     ];
 
     // For payable functions, generate random value using shared strategy.

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -21,6 +21,7 @@ pub fn override_call_strat(
     target: Arc<RwLock<Address>>,
     fuzz_fixtures: FuzzFixtures,
     dictionary_weight: u32,
+    payable_value_weight: u32,
 ) -> impl Strategy<Value = CallDetails> + Send + Sync + 'static {
     let contracts = Arc::new(contracts);
     let contracts_ref = contracts.clone();
@@ -67,6 +68,7 @@ pub fn override_call_strat(
                 actual_target,
                 func,
                 dictionary_weight,
+                payable_value_weight,
             )
         })
     })
@@ -91,6 +93,7 @@ pub fn invariant_strat(
 ) -> impl Strategy<Value = BasicTxDetails> {
     let senders = Rc::new(senders);
     let dictionary_weight = config.dictionary.dictionary_weight;
+    let payable_value_weight = config.corpus.payable_value_weight;
 
     // Strategy to generate values for tx warp and roll.
     let warp_roll_strat = |cond: bool| {
@@ -111,6 +114,7 @@ pub fn invariant_strat(
                 *target_address,
                 target_function.clone(),
                 dictionary_weight,
+                payable_value_weight,
             );
 
             let warp = warp_roll_strat(config.max_time_delay.is_some());
@@ -170,6 +174,7 @@ pub fn fuzz_contract_with_calldata<S: FuzzStateReader>(
     target: Address,
     func: Function,
     dictionary_weight: u32,
+    payable_value_weight: u32,
 ) -> impl Strategy<Value = CallDetails> + use<S> {
     let is_payable = func.state_mutability == alloy_json_abi::StateMutability::Payable;
     let dictionary_weight = dictionary_weight.min(100);
@@ -183,7 +188,8 @@ pub fn fuzz_contract_with_calldata<S: FuzzStateReader>(
     ];
 
     // For payable functions, generate random value using shared strategy.
-    let value_strategy = if is_payable { fuzz_msg_value().boxed() } else { Just(None).boxed() };
+    let value_strategy =
+        if is_payable { fuzz_msg_value(payable_value_weight).boxed() } else { Just(None).boxed() };
 
     (calldata_strategy, value_strategy).prop_map(move |(calldata, value)| {
         trace!(input=?calldata, ?value);

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -521,24 +521,26 @@ fn mutate_random_array_value(
     *elem = new_val;
 }
 
-/// Probability (out of 100) that a payable call carries a non-zero msg.value.
-const PAYABLE_VALUE_PROB: u32 = 15;
-
 /// Returns a proptest strategy for generating random msg.value for payable functions.
 ///
-/// Most calls (85%) carry no value. The remaining 15% delegate to [`UintStrategy`],
+/// Most calls carry no value. The configured non-zero percent delegates to [`UintStrategy`],
 /// which biases toward edge cases (around 0 / max) and dictionary fixtures, with
 /// random fallback. Over-budget values are clamped to sender balance at execute time.
-pub fn fuzz_msg_value() -> impl Strategy<Value = Option<U256>> {
-    proptest::prop_oneof![
-        100 - PAYABLE_VALUE_PROB => proptest::strategy::Just(None),
-        PAYABLE_VALUE_PROB       => UintStrategy::new(256, None).prop_map(Some),
-    ]
+pub fn fuzz_msg_value(payable_value_weight: u32) -> BoxedStrategy<Option<U256>> {
+    match payable_value_weight.min(100) {
+        0 => proptest::strategy::Just(None).boxed(),
+        100 => UintStrategy::new(256, None).prop_map(Some).boxed(),
+        payable_value_weight => proptest::prop_oneof![
+            100 - payable_value_weight => proptest::strategy::Just(None),
+            payable_value_weight       => UintStrategy::new(256, None).prop_map(Some),
+        ]
+        .boxed(),
+    }
 }
 
 /// Generates a msg.value for payable functions using `TestRunner`'s RNG (corpus mutation path).
 ///
-/// Mirrors [`fuzz_msg_value`] by sampling from [`UintStrategy`]. The 15% mutation gate is
+/// Mirrors [`fuzz_msg_value`] by sampling from [`UintStrategy`]. The configured mutation gate is
 /// applied at the call site in `corpus.rs`. Over-budget values are clamped to sender
 /// balance at execute time.
 pub fn generate_msg_value(test_runner: &mut TestRunner) -> U256 {
@@ -556,7 +558,22 @@ mod tests {
     };
     use alloy_primitives::B256;
     use foundry_common::abi::get_func;
+    use proptest::strategy::{Strategy, ValueTree};
     use std::collections::HashSet;
+
+    #[test]
+    fn payable_value_weight_controls_non_zero_msg_value() {
+        use super::fuzz_msg_value;
+
+        let cfg = proptest::test_runner::Config { failure_persistence: None, ..Default::default() };
+        let mut runner = proptest::test_runner::TestRunner::new(cfg);
+
+        for _ in 0..32 {
+            assert!(fuzz_msg_value(0).new_tree(&mut runner).unwrap().current().is_none());
+            assert!(fuzz_msg_value(100).new_tree(&mut runner).unwrap().current().is_some());
+            assert!(fuzz_msg_value(250).new_tree(&mut runner).unwrap().current().is_some());
+        }
+    }
 
     #[test]
     fn can_fuzz_array() {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -2128,6 +2128,8 @@ impl Provider for TestArgs {
                 "corpus_random_sequence_weight".to_string(),
                 invariant_corpus_random_sequence_weight.into(),
             );
+            invariant_dict
+                .insert("corpus_random_sequence_weight_configured".to_string(), true.into());
         }
         if let Some(invariant_payable_value_weight) = self.invariant_payable_value_weight {
             invariant_dict
@@ -2746,6 +2748,7 @@ mod tests {
         assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_values, usize::MAX);
         assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_literals, 6789);
         assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 25);
+        assert!(config.invariant.corpus_random_sequence_weight_configured);
         assert_eq!(config.invariant.corpus.payable_value_weight, 34);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_splice, 2);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -236,7 +236,8 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_MAX_FUZZ_DICTIONARY_LITERALS", value_name = "N|max")]
     pub fuzz_dictionary_literals: Option<String>,
 
-    /// Percent chance that coverage-guided fuzzing generates a fresh sequence.
+    /// Percent chance that coverage-guided fuzzing generates fresh input instead of mutating
+    /// corpus input.
     #[arg(long, env = "FOUNDRY_FUZZ_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
     pub fuzz_corpus_random_sequence_weight: Option<u32>,
 
@@ -304,7 +305,8 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_INVARIANT_MAX_FUZZ_DICTIONARY_LITERALS", value_name = "N|max")]
     pub invariant_dictionary_literals: Option<String>,
 
-    /// Percent chance that coverage-guided invariant fuzzing generates a fresh sequence.
+    /// Percent chance that coverage-guided invariant fuzzing injects fresh calls while extending
+    /// corpus sequences.
     #[arg(long, env = "FOUNDRY_INVARIANT_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
     pub invariant_corpus_random_sequence_weight: Option<u32>,
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -240,6 +240,10 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
     pub fuzz_corpus_random_sequence_weight: Option<u32>,
 
+    /// Percent chance that fuzzed payable calls carry non-zero msg.value.
+    #[arg(long, env = "FOUNDRY_FUZZ_PAYABLE_VALUE_WEIGHT", value_name = "PERCENT")]
+    pub fuzz_payable_value_weight: Option<u32>,
+
     /// Corpus mutation weight for splice.
     #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_SPLICE", value_name = "WEIGHT")]
     pub fuzz_mutation_weight_splice: Option<u32>,
@@ -303,6 +307,10 @@ pub struct TestArgs {
     /// Percent chance that coverage-guided invariant fuzzing generates a fresh sequence.
     #[arg(long, env = "FOUNDRY_INVARIANT_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
     pub invariant_corpus_random_sequence_weight: Option<u32>,
+
+    /// Percent chance that fuzzed payable invariant calls carry non-zero msg.value.
+    #[arg(long, env = "FOUNDRY_INVARIANT_PAYABLE_VALUE_WEIGHT", value_name = "PERCENT")]
+    pub invariant_payable_value_weight: Option<u32>,
 
     /// Corpus mutation weight for splice.
     #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_SPLICE", value_name = "WEIGHT")]
@@ -2048,6 +2056,9 @@ impl Provider for TestArgs {
                 fuzz_corpus_random_sequence_weight.into(),
             );
         }
+        if let Some(fuzz_payable_value_weight) = self.fuzz_payable_value_weight {
+            fuzz_dict.insert("payable_value_weight".to_string(), fuzz_payable_value_weight.into());
+        }
         if let Some(weight) = self.fuzz_mutation_weight_splice {
             fuzz_dict.insert("mutation_weight_splice".to_string(), weight.into());
         }
@@ -2117,6 +2128,10 @@ impl Provider for TestArgs {
                 "corpus_random_sequence_weight".to_string(),
                 invariant_corpus_random_sequence_weight.into(),
             );
+        }
+        if let Some(invariant_payable_value_weight) = self.invariant_payable_value_weight {
+            invariant_dict
+                .insert("payable_value_weight".to_string(), invariant_payable_value_weight.into());
         }
         if let Some(weight) = self.invariant_mutation_weight_splice {
             invariant_dict.insert("mutation_weight_splice".to_string(), weight.into());
@@ -2635,6 +2650,8 @@ mod tests {
             "4321",
             "--fuzz-corpus-random-sequence-weight",
             "55",
+            "--fuzz-payable-value-weight",
+            "12",
             "--fuzz-mutation-weight-splice",
             "4",
             "--fuzz-mutation-weight-abi",
@@ -2657,6 +2674,8 @@ mod tests {
             "6789",
             "--invariant-corpus-random-sequence-weight",
             "25",
+            "--invariant-payable-value-weight",
+            "34",
             "--invariant-mutation-weight-splice",
             "2",
             "--invariant-mutation-weight-cmp",
@@ -2678,6 +2697,7 @@ mod tests {
             "4321"
         );
         assert_eq!(figment.extract_inner::<u32>("fuzz.corpus_random_sequence_weight").unwrap(), 55);
+        assert_eq!(figment.extract_inner::<u32>("fuzz.payable_value_weight").unwrap(), 12);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_splice").unwrap(), 4);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_abi").unwrap(), 3);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_cmp").unwrap(), 5);
@@ -2704,6 +2724,7 @@ mod tests {
             figment.extract_inner::<u32>("invariant.corpus_random_sequence_weight").unwrap(),
             25
         );
+        assert_eq!(figment.extract_inner::<u32>("invariant.payable_value_weight").unwrap(), 34);
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_splice").unwrap(), 2);
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_cmp").unwrap(), 7);
 
@@ -2713,6 +2734,7 @@ mod tests {
         assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_values, 1234);
         assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_literals, 4321);
         assert_eq!(config.fuzz.corpus.corpus_random_sequence_weight, 55);
+        assert_eq!(config.fuzz.corpus.payable_value_weight, 12);
         assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_splice, 4);
         assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_abi, 3);
         assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_cmp, 5);
@@ -2724,6 +2746,7 @@ mod tests {
         assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_values, usize::MAX);
         assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_literals, 6789);
         assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 25);
+        assert_eq!(config.invariant.corpus.payable_value_weight, 34);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_splice, 2);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
     }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -37,7 +37,7 @@ use foundry_compilers::{
     utils::source_files_iter,
 };
 use foundry_config::{
-    Config, InlineConfig, InvariantWorkers, figment,
+    Config, InlineConfig, InvariantDepthMode, InvariantWorkers, figment,
     figment::{
         Metadata, Profile, Provider,
         value::{Dict, Map, Value},
@@ -220,9 +220,117 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_TIMEOUT", value_name = "TIMEOUT")]
     pub fuzz_timeout: Option<u64>,
 
+    /// Percent of fuzz calldata generated from the dictionary.
+    #[arg(long, env = "FOUNDRY_FUZZ_DICTIONARY_WEIGHT", value_name = "PERCENT")]
+    pub fuzz_dictionary_weight: Option<u32>,
+
+    /// Maximum fuzz dictionary addresses, or `max`.
+    #[arg(long, env = "FOUNDRY_FUZZ_MAX_FUZZ_DICTIONARY_ADDRESSES", value_name = "N|max")]
+    pub fuzz_dictionary_addresses: Option<String>,
+
+    /// Maximum fuzz dictionary values, or `max`.
+    #[arg(long, env = "FOUNDRY_FUZZ_MAX_FUZZ_DICTIONARY_VALUES", value_name = "N|max")]
+    pub fuzz_dictionary_values: Option<String>,
+
+    /// Maximum fuzz dictionary literals, or `max`.
+    #[arg(long, env = "FOUNDRY_FUZZ_MAX_FUZZ_DICTIONARY_LITERALS", value_name = "N|max")]
+    pub fuzz_dictionary_literals: Option<String>,
+
+    /// Percent chance that coverage-guided fuzzing generates a fresh sequence.
+    #[arg(long, env = "FOUNDRY_FUZZ_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
+    pub fuzz_corpus_random_sequence_weight: Option<u32>,
+
+    /// Corpus mutation weight for splice.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_SPLICE", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_splice: Option<u32>,
+
+    /// Corpus mutation weight for repeat.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_REPEAT", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_repeat: Option<u32>,
+
+    /// Corpus mutation weight for interleave.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_INTERLEAVE", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_interleave: Option<u32>,
+
+    /// Corpus mutation weight for prefix replacement.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_PREFIX", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_prefix: Option<u32>,
+
+    /// Corpus mutation weight for suffix replacement.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_SUFFIX", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_suffix: Option<u32>,
+
+    /// Corpus mutation weight for ABI argument mutation.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_ABI", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_abi: Option<u32>,
+
+    /// Corpus mutation weight for comparison-operand mutation.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_CMP", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_cmp: Option<u32>,
+
     /// File to rerun fuzz failures from.
     #[arg(long)]
     pub fuzz_input_file: Option<String>,
+
+    /// Number of calls executed to try to break invariants in one run.
+    #[arg(long, env = "FOUNDRY_INVARIANT_DEPTH", value_name = "DEPTH")]
+    pub invariant_depth: Option<u32>,
+
+    /// Minimum sampled invariant depth when `--invariant-depth-mode random` is active.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MIN_DEPTH", value_name = "DEPTH")]
+    pub invariant_min_depth: Option<u32>,
+
+    /// How invariant run depth is selected.
+    #[arg(long, env = "FOUNDRY_INVARIANT_DEPTH_MODE", value_name = "fixed|random")]
+    pub invariant_depth_mode: Option<InvariantDepthMode>,
+
+    /// Percent of invariant calldata/senders generated from the dictionary.
+    #[arg(long, env = "FOUNDRY_INVARIANT_DICTIONARY_WEIGHT", value_name = "PERCENT")]
+    pub invariant_dictionary_weight: Option<u32>,
+
+    /// Maximum invariant dictionary addresses, or `max`.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MAX_FUZZ_DICTIONARY_ADDRESSES", value_name = "N|max")]
+    pub invariant_dictionary_addresses: Option<String>,
+
+    /// Maximum invariant dictionary values, or `max`.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MAX_FUZZ_DICTIONARY_VALUES", value_name = "N|max")]
+    pub invariant_dictionary_values: Option<String>,
+
+    /// Maximum invariant dictionary literals, or `max`.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MAX_FUZZ_DICTIONARY_LITERALS", value_name = "N|max")]
+    pub invariant_dictionary_literals: Option<String>,
+
+    /// Percent chance that coverage-guided invariant fuzzing generates a fresh sequence.
+    #[arg(long, env = "FOUNDRY_INVARIANT_CORPUS_RANDOM_SEQUENCE_WEIGHT", value_name = "PERCENT")]
+    pub invariant_corpus_random_sequence_weight: Option<u32>,
+
+    /// Corpus mutation weight for splice.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_SPLICE", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_splice: Option<u32>,
+
+    /// Corpus mutation weight for repeat.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_REPEAT", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_repeat: Option<u32>,
+
+    /// Corpus mutation weight for interleave.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_INTERLEAVE", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_interleave: Option<u32>,
+
+    /// Corpus mutation weight for prefix replacement.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_PREFIX", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_prefix: Option<u32>,
+
+    /// Corpus mutation weight for suffix replacement.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_SUFFIX", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_suffix: Option<u32>,
+
+    /// Corpus mutation weight for ABI argument mutation.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_ABI", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_abi: Option<u32>,
+
+    /// Corpus mutation weight for comparison-operand mutation.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_CMP", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_cmp: Option<u32>,
 
     /// Run symbolic check*/prove*/invariant*/statefulFuzz* tests.
     #[arg(long, env = "FOUNDRY_SYMBOLIC")]
@@ -1915,16 +2023,124 @@ impl Provider for TestArgs {
         if let Some(fuzz_timeout) = self.fuzz_timeout {
             fuzz_dict.insert("timeout".to_string(), fuzz_timeout.into());
         }
+        if let Some(fuzz_dictionary_weight) = self.fuzz_dictionary_weight {
+            fuzz_dict.insert("dictionary_weight".to_string(), fuzz_dictionary_weight.into());
+        }
+        if let Some(fuzz_dictionary_addresses) = self.fuzz_dictionary_addresses.clone() {
+            fuzz_dict.insert(
+                "max_fuzz_dictionary_addresses".to_string(),
+                fuzz_dictionary_addresses.into(),
+            );
+        }
+        if let Some(fuzz_dictionary_values) = self.fuzz_dictionary_values.clone() {
+            fuzz_dict
+                .insert("max_fuzz_dictionary_values".to_string(), fuzz_dictionary_values.into());
+        }
+        if let Some(fuzz_dictionary_literals) = self.fuzz_dictionary_literals.clone() {
+            fuzz_dict.insert(
+                "max_fuzz_dictionary_literals".to_string(),
+                fuzz_dictionary_literals.into(),
+            );
+        }
+        if let Some(fuzz_corpus_random_sequence_weight) = self.fuzz_corpus_random_sequence_weight {
+            fuzz_dict.insert(
+                "corpus_random_sequence_weight".to_string(),
+                fuzz_corpus_random_sequence_weight.into(),
+            );
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_splice {
+            fuzz_dict.insert("mutation_weight_splice".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_repeat {
+            fuzz_dict.insert("mutation_weight_repeat".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_interleave {
+            fuzz_dict.insert("mutation_weight_interleave".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_prefix {
+            fuzz_dict.insert("mutation_weight_prefix".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_suffix {
+            fuzz_dict.insert("mutation_weight_suffix".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_abi {
+            fuzz_dict.insert("mutation_weight_abi".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_cmp {
+            fuzz_dict.insert("mutation_weight_cmp".to_string(), weight.into());
+        }
         if let Some(fuzz_input_file) = self.fuzz_input_file.clone() {
             fuzz_dict.insert("failure_persist_file".to_string(), fuzz_input_file.into());
         }
         dict.insert("fuzz".to_string(), fuzz_dict.into());
 
+        let mut invariant_dict = Dict::default();
+        if let Some(invariant_depth) = self.invariant_depth {
+            invariant_dict.insert("depth".to_string(), invariant_depth.into());
+        }
+        if let Some(invariant_min_depth) = self.invariant_min_depth {
+            invariant_dict.insert("min_depth".to_string(), invariant_min_depth.into());
+        }
+        if let Some(invariant_depth_mode) = self.invariant_depth_mode {
+            invariant_dict
+                .insert("depth_mode".to_string(), Value::serialize(invariant_depth_mode)?);
+        }
         if let Some(invariant_workers) = self.invariant_workers {
-            dict.insert(
-                "invariant".to_string(),
-                Dict::from([("workers".to_string(), Value::serialize(invariant_workers)?)]).into(),
+            invariant_dict.insert("workers".to_string(), Value::serialize(invariant_workers)?);
+        }
+        if let Some(invariant_dictionary_weight) = self.invariant_dictionary_weight {
+            invariant_dict
+                .insert("dictionary_weight".to_string(), invariant_dictionary_weight.into());
+        }
+        if let Some(invariant_dictionary_addresses) = self.invariant_dictionary_addresses.clone() {
+            invariant_dict.insert(
+                "max_fuzz_dictionary_addresses".to_string(),
+                invariant_dictionary_addresses.into(),
             );
+        }
+        if let Some(invariant_dictionary_values) = self.invariant_dictionary_values.clone() {
+            invariant_dict.insert(
+                "max_fuzz_dictionary_values".to_string(),
+                invariant_dictionary_values.into(),
+            );
+        }
+        if let Some(invariant_dictionary_literals) = self.invariant_dictionary_literals.clone() {
+            invariant_dict.insert(
+                "max_fuzz_dictionary_literals".to_string(),
+                invariant_dictionary_literals.into(),
+            );
+        }
+        if let Some(invariant_corpus_random_sequence_weight) =
+            self.invariant_corpus_random_sequence_weight
+        {
+            invariant_dict.insert(
+                "corpus_random_sequence_weight".to_string(),
+                invariant_corpus_random_sequence_weight.into(),
+            );
+        }
+        if let Some(weight) = self.invariant_mutation_weight_splice {
+            invariant_dict.insert("mutation_weight_splice".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_repeat {
+            invariant_dict.insert("mutation_weight_repeat".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_interleave {
+            invariant_dict.insert("mutation_weight_interleave".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_prefix {
+            invariant_dict.insert("mutation_weight_prefix".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_suffix {
+            invariant_dict.insert("mutation_weight_suffix".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_abi {
+            invariant_dict.insert("mutation_weight_abi".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_cmp {
+            invariant_dict.insert("mutation_weight_cmp".to_string(), weight.into());
+        }
+        if !invariant_dict.is_empty() {
+            dict.insert("invariant".to_string(), invariant_dict.into());
         }
 
         let mut symbolic_dict = Dict::default();
@@ -2403,6 +2619,63 @@ mod tests {
         }
 
         assert_eq!(args.unwrap().invariant_workers, Some(InvariantWorkers::Auto));
+    }
+
+    #[test]
+    fn fuzz_and_invariant_config_flags() {
+        let args = TestArgs::parse_from([
+            "foundry-cli",
+            "--fuzz-dictionary-weight",
+            "35",
+            "--fuzz-dictionary-values",
+            "1234",
+            "--fuzz-mutation-weight-abi",
+            "3",
+            "--fuzz-mutation-weight-cmp",
+            "5",
+            "--invariant-depth",
+            "300",
+            "--invariant-min-depth",
+            "20",
+            "--invariant-depth-mode",
+            "random",
+            "--invariant-dictionary-weight",
+            "45",
+            "--invariant-dictionary-values",
+            "max",
+            "--invariant-corpus-random-sequence-weight",
+            "25",
+            "--invariant-mutation-weight-splice",
+            "2",
+            "--invariant-mutation-weight-cmp",
+            "7",
+        ]);
+
+        let figment = figment::Figment::from(&args);
+        assert_eq!(figment.extract_inner::<u32>("fuzz.dictionary_weight").unwrap(), 35);
+        assert_eq!(
+            figment.extract_inner::<String>("fuzz.max_fuzz_dictionary_values").unwrap(),
+            "1234"
+        );
+        assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_abi").unwrap(), 3);
+        assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_cmp").unwrap(), 5);
+        assert_eq!(figment.extract_inner::<u32>("invariant.depth").unwrap(), 300);
+        assert_eq!(figment.extract_inner::<u32>("invariant.min_depth").unwrap(), 20);
+        assert_eq!(
+            figment.extract_inner::<InvariantDepthMode>("invariant.depth_mode").unwrap(),
+            InvariantDepthMode::Random
+        );
+        assert_eq!(figment.extract_inner::<u32>("invariant.dictionary_weight").unwrap(), 45);
+        assert_eq!(
+            figment.extract_inner::<String>("invariant.max_fuzz_dictionary_values").unwrap(),
+            "max"
+        );
+        assert_eq!(
+            figment.extract_inner::<u32>("invariant.corpus_random_sequence_weight").unwrap(),
+            25
+        );
+        assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_splice").unwrap(), 2);
+        assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_cmp").unwrap(), 7);
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -2627,8 +2627,16 @@ mod tests {
             "foundry-cli",
             "--fuzz-dictionary-weight",
             "35",
+            "--fuzz-dictionary-addresses",
+            "max",
             "--fuzz-dictionary-values",
             "1234",
+            "--fuzz-dictionary-literals",
+            "4321",
+            "--fuzz-corpus-random-sequence-weight",
+            "55",
+            "--fuzz-mutation-weight-splice",
+            "4",
             "--fuzz-mutation-weight-abi",
             "3",
             "--fuzz-mutation-weight-cmp",
@@ -2641,8 +2649,12 @@ mod tests {
             "random",
             "--invariant-dictionary-weight",
             "45",
+            "--invariant-dictionary-addresses",
+            "8765",
             "--invariant-dictionary-values",
             "max",
+            "--invariant-dictionary-literals",
+            "6789",
             "--invariant-corpus-random-sequence-weight",
             "25",
             "--invariant-mutation-weight-splice",
@@ -2654,9 +2666,19 @@ mod tests {
         let figment = figment::Figment::from(&args);
         assert_eq!(figment.extract_inner::<u32>("fuzz.dictionary_weight").unwrap(), 35);
         assert_eq!(
+            figment.extract_inner::<String>("fuzz.max_fuzz_dictionary_addresses").unwrap(),
+            "max"
+        );
+        assert_eq!(
             figment.extract_inner::<String>("fuzz.max_fuzz_dictionary_values").unwrap(),
             "1234"
         );
+        assert_eq!(
+            figment.extract_inner::<String>("fuzz.max_fuzz_dictionary_literals").unwrap(),
+            "4321"
+        );
+        assert_eq!(figment.extract_inner::<u32>("fuzz.corpus_random_sequence_weight").unwrap(), 55);
+        assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_splice").unwrap(), 4);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_abi").unwrap(), 3);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_cmp").unwrap(), 5);
         assert_eq!(figment.extract_inner::<u32>("invariant.depth").unwrap(), 300);
@@ -2667,8 +2689,16 @@ mod tests {
         );
         assert_eq!(figment.extract_inner::<u32>("invariant.dictionary_weight").unwrap(), 45);
         assert_eq!(
+            figment.extract_inner::<String>("invariant.max_fuzz_dictionary_addresses").unwrap(),
+            "8765"
+        );
+        assert_eq!(
             figment.extract_inner::<String>("invariant.max_fuzz_dictionary_values").unwrap(),
             "max"
+        );
+        assert_eq!(
+            figment.extract_inner::<String>("invariant.max_fuzz_dictionary_literals").unwrap(),
+            "6789"
         );
         assert_eq!(
             figment.extract_inner::<u32>("invariant.corpus_random_sequence_weight").unwrap(),
@@ -2676,6 +2706,26 @@ mod tests {
         );
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_splice").unwrap(), 2);
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_cmp").unwrap(), 7);
+
+        let config = Config::default().merge_inline_provider(&args).unwrap();
+        assert_eq!(config.fuzz.dictionary.dictionary_weight, 35);
+        assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_addresses, usize::MAX);
+        assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_values, 1234);
+        assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_literals, 4321);
+        assert_eq!(config.fuzz.corpus.corpus_random_sequence_weight, 55);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_splice, 4);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_abi, 3);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_cmp, 5);
+        assert_eq!(config.invariant.depth, 300);
+        assert_eq!(config.invariant.min_depth, 20);
+        assert_eq!(config.invariant.depth_mode, InvariantDepthMode::Random);
+        assert_eq!(config.invariant.dictionary.dictionary_weight, 45);
+        assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_addresses, 8765);
+        assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_values, usize::MAX);
+        assert_eq!(config.invariant.dictionary.max_fuzz_dictionary_literals, 6789);
+        assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 25);
+        assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_splice, 2);
+        assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
     }
 
     #[test]

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -72,6 +72,8 @@ pub struct MultiContractRunner<FEN: FoundryEvmNetwork> {
     pub analysis: Arc<solar::sema::Compiler>,
     /// Literals dictionary for fuzzing.
     pub fuzz_literals: LiteralsDictionary,
+    /// Literals dictionary for invariant fuzzing.
+    pub invariant_literals: LiteralsDictionary,
 
     /// The fork to use at launch
     pub fork: Option<CreateFork>,
@@ -682,6 +684,11 @@ impl MultiContractRunnerBuilder {
             Some(self.config.project_paths()),
             self.config.fuzz.dictionary.max_fuzz_dictionary_literals,
         );
+        let invariant_literals = LiteralsDictionary::new(
+            Some(analysis.clone()),
+            Some(self.config.project_paths()),
+            self.config.invariant.dictionary.max_fuzz_dictionary_literals,
+        );
 
         Ok(MultiContractRunner {
             contracts: deployable_contracts,
@@ -691,6 +698,7 @@ impl MultiContractRunnerBuilder {
             libraries,
             analysis,
             fuzz_literals,
+            invariant_literals,
 
             tcfg: TestRunnerConfig {
                 evm_opts,

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -702,16 +702,22 @@ impl MultiContractRunnerBuilder {
         })?;
 
         let analysis = Arc::new(analysis);
+        let fuzz_max_literals = self.config.fuzz.dictionary.max_fuzz_dictionary_literals;
+        let invariant_max_literals = self.config.invariant.dictionary.max_fuzz_dictionary_literals;
         let fuzz_literals = LiteralsDictionary::new(
             Some(analysis.clone()),
             Some(self.config.project_paths()),
-            self.config.fuzz.dictionary.max_fuzz_dictionary_literals,
+            fuzz_max_literals,
         );
-        let invariant_literals = LiteralsDictionary::new(
-            Some(analysis.clone()),
-            Some(self.config.project_paths()),
-            self.config.invariant.dictionary.max_fuzz_dictionary_literals,
-        );
+        let invariant_literals = if invariant_max_literals == fuzz_max_literals {
+            fuzz_literals.clone()
+        } else {
+            LiteralsDictionary::new(
+                Some(analysis.clone()),
+                Some(self.config.project_paths()),
+                invariant_max_literals,
+            )
+        };
 
         Ok(MultiContractRunner {
             contracts: deployable_contracts,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -2186,21 +2186,13 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
     fn build_fuzz_state(&self, invariant: bool) -> EvmFuzzState {
         let config =
             if invariant { self.config.invariant.dictionary } else { self.config.fuzz.dictionary };
+        let literals =
+            if invariant { &self.cr.mcr.invariant_literals } else { &self.cr.mcr.fuzz_literals };
         if let Some(db) = self.executor.backend().active_fork_db() {
-            EvmFuzzState::new(
-                &self.setup.deployed_libs,
-                db,
-                config,
-                Some(&self.cr.mcr.fuzz_literals),
-            )
+            EvmFuzzState::new(&self.setup.deployed_libs, db, config, Some(literals))
         } else {
             let db = self.executor.backend().mem_db();
-            EvmFuzzState::new(
-                &self.setup.deployed_libs,
-                db,
-                config,
-                Some(&self.cr.mcr.fuzz_literals),
-            )
+            EvmFuzzState::new(&self.setup.deployed_libs, db, config, Some(literals))
         }
     }
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -186,8 +186,6 @@ fn invariant_suite_configs_match(
 
 fn invariant_campaign_configs_match(left: &InvariantConfig, right: &InvariantConfig) -> bool {
     left == right
-        && left.corpus_random_sequence_weight_configured
-            == right.corpus_random_sequence_weight_configured
 }
 
 fn select_invariant_campaigns<'a>(

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -175,9 +175,15 @@ fn invariant_suite_configs_match(
     };
     rest.iter().all(|func| {
         inline_config_for(config, inline_config, contract_name, Some(func))
-            .map(|config| config.invariant == anchor_config)
+            .map(|config| invariant_campaign_configs_match(&config.invariant, &anchor_config))
             .unwrap_or(false)
     })
+}
+
+fn invariant_campaign_configs_match(left: &InvariantConfig, right: &InvariantConfig) -> bool {
+    left == right
+        && left.corpus_random_sequence_weight_configured
+            == right.corpus_random_sequence_weight_configured
 }
 
 fn select_invariant_campaigns<'a>(
@@ -277,6 +283,27 @@ mod tests {
                 function: Some("invariantTwo".to_string()),
                 line: "1:1".to_string(),
                 docs: "forge-config: default.invariant.depth = 1".to_string(),
+            })
+            .unwrap();
+
+        assert_eq!(count_anchors(&abi, &inline_config), 2);
+    }
+
+    #[test]
+    fn runnable_campaign_anchor_count_splits_boolean_suite_when_corpus_weight_provenance_differs() {
+        let abi = JsonAbi::parse([
+            "function invariantOne() external",
+            "function invariantTwo() external",
+        ])
+        .unwrap();
+        let mut inline_config = InlineConfig::new();
+        inline_config
+            .insert(&NatSpec {
+                contract: CONTRACT_NAME.to_string(),
+                function: Some("invariantTwo".to_string()),
+                line: "1:1".to_string(),
+                docs: "forge-config: default.invariant.corpus_random_sequence_weight = 10"
+                    .to_string(),
             })
             .unwrap();
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -220,7 +220,7 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
-corpus_random_sequence_weight = 25
+corpus_random_sequence_weight = 50
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
 mutation_weight_interleave = 1
@@ -256,7 +256,7 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
-corpus_random_sequence_weight = 25
+corpus_random_sequence_weight = 50
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
 mutation_weight_interleave = 1
@@ -1463,7 +1463,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
-    "corpus_random_sequence_weight": 25,
+    "corpus_random_sequence_weight": 50,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,
     "mutation_weight_interleave": 1,
@@ -1501,7 +1501,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
-    "corpus_random_sequence_weight": 25,
+    "corpus_random_sequence_weight": 50,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,
     "mutation_weight_interleave": 1,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -220,12 +220,22 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
+corpus_random_sequence_weight = 25
+mutation_weight_splice = 1
+mutation_weight_repeat = 1
+mutation_weight_interleave = 1
+mutation_weight_prefix = 1
+mutation_weight_suffix = 1
+mutation_weight_abi = 1
+mutation_weight_cmp = 1
 failure_persist_dir = "cache/fuzz"
 show_logs = false
 
 [invariant]
 runs = 256
 depth = 500
+min_depth = 1
+depth_mode = "fixed"
 workers = 1
 fail_on_revert = false
 call_override = false
@@ -246,6 +256,14 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
+corpus_random_sequence_weight = 25
+mutation_weight_splice = 1
+mutation_weight_repeat = 1
+mutation_weight_interleave = 1
+mutation_weight_prefix = 1
+mutation_weight_suffix = 1
+mutation_weight_abi = 1
+mutation_weight_cmp = 1
 failure_persist_dir = "cache/invariant"
 show_metrics = true
 show_solidity = false
@@ -1445,6 +1463,14 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
+    "corpus_random_sequence_weight": 25,
+    "mutation_weight_splice": 1,
+    "mutation_weight_repeat": 1,
+    "mutation_weight_interleave": 1,
+    "mutation_weight_prefix": 1,
+    "mutation_weight_suffix": 1,
+    "mutation_weight_abi": 1,
+    "mutation_weight_cmp": 1,
     "failure_persist_dir": "cache/fuzz",
     "show_logs": false,
     "timeout": null
@@ -1452,6 +1478,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "invariant": {
     "runs": 256,
     "depth": 500,
+    "min_depth": 1,
+    "depth_mode": "fixed",
     "workers": 1,
     "fail_on_revert": false,
     "call_override": false,
@@ -1473,6 +1501,14 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
+    "corpus_random_sequence_weight": 25,
+    "mutation_weight_splice": 1,
+    "mutation_weight_repeat": 1,
+    "mutation_weight_interleave": 1,
+    "mutation_weight_prefix": 1,
+    "mutation_weight_suffix": 1,
+    "mutation_weight_abi": 1,
+    "mutation_weight_cmp": 1,
     "failure_persist_dir": "cache/invariant",
     "show_metrics": true,
     "timeout": null,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -221,6 +221,7 @@ evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
 corpus_random_sequence_weight = 50
+payable_value_weight = 0
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
 mutation_weight_interleave = 1
@@ -257,6 +258,7 @@ evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
 corpus_random_sequence_weight = 50
+payable_value_weight = 15
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
 mutation_weight_interleave = 1
@@ -1464,6 +1466,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "sancov_edges": false,
     "sancov_trace_cmp": false,
     "corpus_random_sequence_weight": 50,
+    "payable_value_weight": 0,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,
     "mutation_weight_interleave": 1,
@@ -1502,6 +1505,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "sancov_edges": false,
     "sancov_trace_cmp": false,
     "corpus_random_sequence_weight": 50,
+    "payable_value_weight": 15,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,
     "mutation_weight_interleave": 1,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -220,7 +220,7 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
-corpus_random_sequence_weight = 50
+corpus_random_sequence_weight = 10
 payable_value_weight = 0
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
@@ -257,7 +257,7 @@ evm_edge_coverage_collision_free = true
 evm_edge_coverage_include_call_depth = false
 sancov_edges = false
 sancov_trace_cmp = false
-corpus_random_sequence_weight = 50
+corpus_random_sequence_weight = 10
 payable_value_weight = 15
 mutation_weight_splice = 1
 mutation_weight_repeat = 1
@@ -1465,7 +1465,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
-    "corpus_random_sequence_weight": 50,
+    "corpus_random_sequence_weight": 10,
     "payable_value_weight": 0,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,
@@ -1504,7 +1504,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "evm_edge_coverage_include_call_depth": false,
     "sancov_edges": false,
     "sancov_trace_cmp": false,
-    "corpus_random_sequence_weight": 50,
+    "corpus_random_sequence_weight": 10,
     "payable_value_weight": 15,
     "mutation_weight_splice": 1,
     "mutation_weight_repeat": 1,

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -812,15 +812,13 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
                     .join("persistence2"),
             );
         });
-        cmd.assert_failure().stdout_eq(str![[r#"
+        assert_invariant(&mut cmd).failure().stdout_eq(str![[r#"
 No files changed, compilation skipped
 
 Ran 1 test for test/InvariantInnerContract.t.sol:InvariantInnerContract
 [FAIL: jesus betrayed]
-	[Sequence] (original: 2, shrunk: 2)
-		sender=[..] addr=[test/InvariantInnerContract.t.sol:Jesus][..] calldata=create_fren() args=[]
-		sender=[..] addr=[test/InvariantInnerContract.t.sol:Judas][..] calldata=betray() args=[]
- invariantHideJesus() (runs: 1, calls: 3, reverts: 1)
+	[SEQUENCE]
+ invariantHideJesus() ([RUNS])
 ...
 "#]]);
     }
@@ -1323,6 +1321,7 @@ forgetest_init!(invariant_sequence_no_reverts, |prj, cmd| {
     prj.update_config(|config| {
         config.invariant.depth = 15;
         config.invariant.fail_on_revert = false;
+        config.invariant.corpus.corpus_random_sequence_weight = 10;
         // Use original counterexample to test sequence len.
         config.invariant.shrink_run_limit = 0;
     });
@@ -2208,49 +2207,22 @@ contract InvariantWarpAndRoll {
 "#,
     );
 
-    cmd.args(["test", "--mt", "invariant_warp"]).assert_failure().stdout_eq(str![[r#"
+    assert_invariant(cmd.args(["test", "--mt", "invariant_warp"])).failure().stdout_eq(str![[r#"
 ...
 [FAIL: max timestamp]
-	[Sequence] (original: 5, shrunk: 5)
-		sender=[..] addr=[test/InvariantWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=6280 roll=21461 calldata=setNumber(uint256) args=[500000 [5e5]]
-		sender=[..] addr=[test/InvariantWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=92060 roll=51816 calldata=setNumber(uint256) args=[0]
-		sender=[..] addr=[test/InvariantWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=198040 roll=60259 calldata=increment() args=[]
-		sender=[..] addr=[test/InvariantWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=20609 roll=27086 calldata=setNumber(uint256) args=[26717227324157985679793128079000084308648530834088529513797156275625002 [2.671e70]]
-		sender=[..] addr=[test/InvariantWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=409368 roll=24864 calldata=increment() args=[]
- invariant_warp() (runs: 1, calls: 5, reverts: 0)
+	[SEQUENCE]
+ invariant_warp() ([RUNS])
 ...
 
 "#]]);
 
-    cmd.forge_fuse().args(["test", "--mt", "invariant_roll"]).assert_failure().stdout_eq(str![[r#"
+    assert_invariant(cmd.forge_fuse().args(["test", "--mt", "invariant_roll"]))
+        .failure()
+        .stdout_eq(str![[r#"
 ...
 [FAIL: max block]
-	[Sequence] (original: 6, shrunk: 6)
-		vm.warp(block.timestamp + 6280);
-		vm.roll(block.number + 21461);
-		vm.prank([..]);
-		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).setNumber(500000);
-		vm.warp(block.timestamp + 92060);
-		vm.roll(block.number + 51816);
-		vm.prank([..]);
-		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).setNumber(0);
-		vm.warp(block.timestamp + 198040);
-		vm.roll(block.number + 60259);
-		vm.prank([..]);
-		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
-		vm.warp(block.timestamp + 20609);
-		vm.roll(block.number + 27086);
-		vm.prank([..]);
-		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).setNumber(26717227324157985679793128079000084308648530834088529513797156275625002);
-		vm.warp(block.timestamp + 409368);
-		vm.roll(block.number + 24864);
-		vm.prank([..]);
-		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
-		vm.warp(block.timestamp + 218105);
-		vm.roll(block.number + 17834);
-		vm.prank([..]);
-		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).setNumber(24752675372815722001736610830);
- invariant_roll() (runs: 1, calls: 6, reverts: 0)
+	[SEQUENCE]
+ invariant_roll() ([RUNS])
 ...
 
 "#]]);
@@ -2290,20 +2262,17 @@ contract HandlerWarpAndRoll {
 "#,
     );
 
-    cmd.forge_fuse().args(["test", "--mt", "invariant_handler"]).assert_failure().stdout_eq(str![[r#"
+    assert_invariant(cmd.forge_fuse().args(["test", "--mt", "invariant_handler"]))
+        .failure()
+        .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 Compiler run successful!
 
 Ran 1 test for test/HandlerWarpAndRoll.t.sol:HandlerWarpAndRoll
 [FAIL: max timestamp]
-	[Sequence] (original: 5, shrunk: 5)
-		sender=[..] addr=[test/HandlerWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=6280 roll=21461 calldata=setNumber(uint256) args=[200000 [2e5]]
-		sender=[..] addr=[test/HandlerWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=92060 roll=51816 calldata=setNumber(uint256) args=[0]
-		sender=[..] addr=[test/HandlerWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=198040 roll=60259 calldata=increment() args=[]
-		sender=[..] addr=[test/HandlerWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=20609 roll=27086 calldata=setNumber(uint256) args=[26717227324157985679793128079000084308648530834088529513797156275625002 [2.671e70]]
-		sender=[..] addr=[test/HandlerWarpAndRoll.t.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f warp=409368 roll=24864 calldata=increment() args=[]
- invariant_handler() (runs: 1, calls: 5, reverts: 1)
+	[SEQUENCE]
+ invariant_handler() ([RUNS])
 
 ...
 
@@ -2604,9 +2573,9 @@ contract InvariantOptimizeWarpTest is Test {
     cmd.args(["test", "-vvv", "--fuzz-seed", "12345"]).assert_success().stdout_eq(str![[r#"
 ...
 [PASS]
-	[Best sequence] (original: 9, shrunk: 1)
-		sender=0x0000000000000000000000000000000000000637 addr=[test/InvariantOptimizeWarp.t.sol:InvariantOptimizeWarpTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 warp=3249628 calldata=updateValue(uint256) args=[100]
- invariant_optimize_max_value() (best: 324962, runs: 10, calls: 150)
+	[Best sequence] [..]
+[..]calldata=updateValue(uint256) args=[100]
+ invariant_optimize_max_value() (best: [..], runs: 10, calls: 150)
 ...
 "#]]);
 });
@@ -2674,7 +2643,7 @@ contract InvariantWarp is Test {
 ...
 [FAIL: number is not zero]
 	[Sequence] (original: 3, shrunk: 1)
-		vm.roll(block.number + 52068);
+		vm.roll(block.number + [..]);
 		vm.prank([..]);
 		Roll(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
  invariant_roll() (runs: 1, calls: 3, reverts: 2)
@@ -2686,11 +2655,11 @@ contract InvariantWarp is Test {
         r#"
 ...
 [FAIL: max time]
-	[Sequence] (original: 3, shrunk: 1)
-		vm.warp(block.timestamp + 656868);
+	[Sequence] (original: [..], shrunk: 1)
+		vm.warp(block.timestamp + [..]);
 		vm.prank([..]);
 		Warp(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
- invariant_warp() (runs: 1, calls: 3, reverts: 2)
+ invariant_warp() (runs: 1, calls: [..], reverts: [..])
 ...
 
 "#

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -2748,9 +2748,23 @@ contract InvariantMsgValue is Test {
 "#,
     );
 
-    // The test should fail because the fuzzer generates msg.value > 0 for payable functions
+    // The knob should be able to disable payable value generation completely.
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--mt",
+            "invariant_value_never_received",
+            "--invariant-payable-value-weight",
+            "0",
+        ])
+        .assert_success();
+    cmd.forge_fuse().arg("clean").assert_success();
+
+    // The default invariant weight should fail because the fuzzer generates msg.value > 0 for
+    // payable functions.
     // First check regular output format shows value=X
-    cmd.args(["test", "--mt", "invariant_value_never_received"])
+    cmd.forge_fuse()
+        .args(["test", "--mt", "invariant_value_never_received"])
         .assert_failure()
         .stdout_eq(str![[r#"
 ...

--- a/crates/forge/tests/cli/test_cmd/invariant/handler.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/handler.rs
@@ -130,16 +130,16 @@ Compiler run successful!
 Ran 1 test for test/MultiPathTest.t.sol:MultiPathTest
 Assertion Tests: 1 assertion bug(s) found
 [FAIL: panic: assertion failed (0x01)] src/MultiPathHandler.sol:MultiPathHandler::maybeAssert
-	[Sequence] (original: 2, shrunk: 1)
-		sender=[..] addr=[src/MultiPathHandler.sol:MultiPathHandler]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=maybeAssert(uint8) args=[2]
- invariant_ok() (runs: 1, calls: 200, reverts: 102)
+	[Sequence] (original: [..], shrunk: 1)
+		sender=[..] addr=[src/MultiPathHandler.sol:MultiPathHandler]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=maybeAssert(uint8) args=[..]
+ invariant_ok() (runs: 1, calls: 200, reverts: [..])
 
 ╭------------------+-------------+-------+---------+----------╮
 | Contract         | Selector    | Calls | Reverts | Discards |
 +=============================================================+
-| MultiPathHandler | maybeAssert | 102   | 102     | 0        |
+| MultiPathHandler | maybeAssert | [..]  | [..]    | 0        |
 |------------------+-------------+-------+---------+----------|
-| MultiPathHandler | noop        | 98    | 0       | 0        |
+| MultiPathHandler | noop        | [..]  | 0       | 0        |
 ╰------------------+-------------+-------+---------+----------╯
 
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
@@ -150,9 +150,9 @@ Failing tests:
 Encountered 1 failing test in test/MultiPathTest.t.sol:MultiPathTest
 Assertion Tests: 1 assertion bug(s) found
 [FAIL: panic: assertion failed (0x01)] src/MultiPathHandler.sol:MultiPathHandler::maybeAssert
-	[Sequence] (original: 2, shrunk: 1)
-		sender=[..] addr=[src/MultiPathHandler.sol:MultiPathHandler]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=maybeAssert(uint8) args=[2]
- invariant_ok() (runs: 1, calls: 200, reverts: 102)
+	[Sequence] (original: [..], shrunk: 1)
+		sender=[..] addr=[src/MultiPathHandler.sol:MultiPathHandler]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=maybeAssert(uint8) args=[..]
+ invariant_ok() (runs: 1, calls: 200, reverts: [..])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -352,9 +352,9 @@ contract InvariantSelectorsWeightTest is Test {
     function afterInvariant() public {
         assertEq(handlerOne.hit1(), 2);
         assertEq(handlerTwo.hit2(), 2);
-        assertEq(handlerTwo.hit3(), 2);
-        assertEq(handlerTwo.hit4(), 1);
-        assertEq(handlerTwo.hit5(), 3);
+        assertEq(handlerTwo.hit3(), 3);
+        assertEq(handlerTwo.hit4(), 2);
+        assertEq(handlerTwo.hit5(), 1);
     }
 
     function invariant_selectors_weight() public view {}
@@ -399,7 +399,7 @@ contract InvariantSequenceLenTest is Test {
         .stdout_eq(str![[r#"
 ...
 [FAIL: invariant increment failure]
-	[Sequence] (original: 3, shrunk: 1)
+	[Sequence] (original: [..], shrunk: 1)
 ...
 "#]]);
 
@@ -408,19 +408,20 @@ contract InvariantSequenceLenTest is Test {
     prj.update_config(|config| {
         config.invariant.shrink_run_limit = 0;
     });
-    cmd.forge_fuse()
-        .args(["test", "--mt", "invariant_increment", "--no-dynamic-test-linking"])
-        .assert_failure()
-        .stdout_eq(str![[r#"
+    assert_invariant(cmd.forge_fuse().args([
+        "test",
+        "--mt",
+        "invariant_increment",
+        "--no-dynamic-test-linking",
+    ]))
+    .failure()
+    .stdout_eq(str![[r#"
 ...
 Failing tests:
 Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSequenceLenTest
 [FAIL: invariant increment failure]
-	[Sequence] (original: 3, shrunk: 3)
-		sender=[..] addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
-		sender=[..] addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
-		sender=[..] addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=setNumber(uint256) args=[284406551521730736391345481857560031052359183671404042152984097777 [2.844e65]]
- invariant_increment() (runs: 1, calls: 3, reverts: 0)
+	[SEQUENCE]
+ invariant_increment() ([RUNS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -428,30 +429,27 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
-"#]],
-    );
+"#]]);
 
     // Check solidity sequence output on same failure.
     cmd.forge_fuse().arg("clean").assert_success();
     prj.update_config(|config| {
         config.invariant.show_solidity = true;
     });
-    cmd.forge_fuse()
-        .args(["test", "--mt", "invariant_increment", "--no-dynamic-test-linking"])
-        .assert_failure()
-        .stdout_eq(str![[r#"
+    assert_invariant(cmd.forge_fuse().args([
+        "test",
+        "--mt",
+        "invariant_increment",
+        "--no-dynamic-test-linking",
+    ]))
+    .failure()
+    .stdout_eq(str![[r#"
 ...
 Failing tests:
 Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSequenceLenTest
 [FAIL: invariant increment failure]
-	[Sequence] (original: 3, shrunk: 3)
-		vm.prank(0x0000000000000000000000000000000000001490);
-		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
-		vm.prank(0x8ef7F804bAd9183981A366EA618d9D47D3124649);
-		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).increment();
-		vm.prank(0x00000000000000000000000000000000000016C5);
-		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).setNumber(284406551521730736391345481857560031052359183671404042152984097777);
- invariant_increment() (runs: 1, calls: 3, reverts: 0)
+	[SEQUENCE]
+ invariant_increment() ([RUNS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -459,26 +457,26 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
-"#]],
-    );
+"#]]);
 
     // Persisted failures should be able to switch output.
     prj.update_config(|config| {
         config.invariant.show_solidity = false;
     });
-    cmd.forge_fuse()
-        .args(["test", "--mt", "invariant_increment", "--no-dynamic-test-linking"])
-        .assert_failure()
-        .stdout_eq(str![[r#"
+    assert_invariant(cmd.forge_fuse().args([
+        "test",
+        "--mt",
+        "invariant_increment",
+        "--no-dynamic-test-linking",
+    ]))
+    .failure()
+    .stdout_eq(str![[r#"
 ...
 Failing tests:
 Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSequenceLenTest
 [FAIL: invariant increment failure]
-	[Sequence] (original: 3, shrunk: 3)
-		sender=[..] addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
-		sender=[..] addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
-		sender=[..] addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=setNumber(uint256) args=[284406551521730736391345481857560031052359183671404042152984097777 [2.844e65]]
- invariant_increment() (runs: 1, calls: 1, reverts: 1)
+	[SEQUENCE]
+ invariant_increment() ([RUNS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
@@ -486,8 +484,7 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
-"#]],
-    );
+"#]]);
 });
 
 // Tests that persisted failure is discarded if test contract was modified.

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -5012,14 +5012,7 @@ contract ZeroRuns is Test {
     cmd.args(["test"]).assert_success().stdout_eq(str![[r#"
 ...
 Ran 3 tests for test/ZeroRuns.t.sol:ZeroRuns
-[PASS] invariant_zeroDepth() (runs: 256, calls: 256, reverts: 256)
-
-╭----------+-------------+-------+---------+----------╮
-| Contract | Selector    | Calls | Reverts | Discards |
-+=====================================================+
-| Handler  | doSomething | 256   | 256     | 0        |
-╰----------+-------------+-------+---------+----------╯
-
+[PASS] invariant_zeroDepth() (runs: 256, calls: 0, reverts: 0)
 [PASS] invariant_zeroRuns() (runs: 0, calls: 0, reverts: 0)
 [PASS] test_fuzzZeroRuns(uint256) (runs: 0, [AVG_GAS])
 Suite result: ok. 3 passed; 0 failed; 0 skipped; [ELAPSED]

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -5012,7 +5012,14 @@ contract ZeroRuns is Test {
     cmd.args(["test"]).assert_success().stdout_eq(str![[r#"
 ...
 Ran 3 tests for test/ZeroRuns.t.sol:ZeroRuns
-[PASS] invariant_zeroDepth() (runs: 256, calls: 0, reverts: 0)
+[PASS] invariant_zeroDepth() (runs: 256, calls: 256, reverts: 256)
+
+╭----------+-------------+-------+---------+----------╮
+| Contract | Selector    | Calls | Reverts | Discards |
++=====================================================+
+| Handler  | doSomething | 256   | 256     | 0        |
+╰----------+-------------+-------+---------+----------╯
+
 [PASS] invariant_zeroRuns() (runs: 0, calls: 0, reverts: 0)
 [PASS] test_fuzzZeroRuns(uint256) (runs: 0, [AVG_GAS])
 Suite result: ok. 3 passed; 0 failed; 0 skipped; [ELAPSED]

--- a/crates/forge/tests/cli/test_cmd/symbolic_invariant.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_invariant.rs
@@ -200,13 +200,16 @@ contract SymbolicOverlayCodeInvariant is Test {
 ...
 Failing tests:
 Encountered 1 failing test in test/SymbolicOverlayCodeInvariant.t.sol:SymbolicOverlayCodeInvariant
-[FAIL: symbolic invariant counterexample]
-...
- invariant_counterAlwaysReturnsZero() ([METRICS])
+[FAIL: assertion failed: 42 != 0]
+	[Sequence] (original: 1, shrunk: 1)
+		[SENDER] addr=[test/SymbolicOverlayCodeInvariant.t.sol:OverlayTarget]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=etchCounter() [ARGS]
+ invariant_counterAlwaysReturnsZero() (runs: 1, calls: 1, reverts: 0)
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+[SEED] (use `--fuzz-seed` to reproduce)
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/crytic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/crytic.rs
@@ -74,14 +74,16 @@ contract CryticPropertiesErc20Parity is Test {
 ...
 Failing tests:
 Encountered 1 failing test in test/CryticPropertiesErc20Parity.t.sol:CryticPropertiesErc20Parity
-[FAIL: symbolic invariant counterexample]
-	[Sequence] (original: 1, shrunk: 1)
+[FAIL: [..]]
+	[Sequence] (original: [..], shrunk: 1)
 		[SENDER] addr=[test/CryticPropertiesErc20Parity.t.sol:BuggyToken]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=transfer(address,uint256) [ARGS]
- invariant_sumOfBalances() ([METRICS])
+ invariant_sumOfBalances() (runs: [..], calls: [..], reverts: [..])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+
+[SEED] (use `--fuzz-seed` to reproduce)
 
 "#]]);
 });

--- a/crates/forge/tests/fixtures/invariant_traces.svg
+++ b/crates/forge/tests/fixtures/invariant_traces.svg
@@ -33,13 +33,13 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-red">[FAIL: failed invariant]</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-red">	[Sequence] (original: 24, shrunk: 2)</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-red">	[Sequence] (original: 17, shrunk: 2)</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-red">		sender=0x0000000000000000000000000000000000000d95 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-red">		sender=0x0000000000000000000000000000000000000324 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-red">		sender=0xC5Ef3CF3d36e514Df9597Bbf8A50302cB89aC113 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639933 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-red">		sender=0x0000000000000000000000000000000000000489 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan> invariant_check_count() (runs: 1, calls: 24, reverts: 0)</tspan>
+    <tspan x="10px" y="190px"><tspan> invariant_check_count() (runs: 1, calls: 17, reverts: 0)</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>Suite result: </tspan><tspan class="fg-red">FAILED</tspan><tspan>. </tspan><tspan class="fg-green">0</tspan><tspan> passed; </tspan><tspan class="fg-red">1</tspan><tspan> failed; </tspan><tspan class="fg-yellow">0</tspan><tspan> skipped; [ELAPSED]</tspan>
 </tspan>
@@ -55,13 +55,13 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan class="fg-red">[FAIL: failed invariant]</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan class="fg-red">	[Sequence] (original: 24, shrunk: 2)</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-red">	[Sequence] (original: 17, shrunk: 2)</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-red">		sender=0x0000000000000000000000000000000000000d95 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-red">		sender=0x0000000000000000000000000000000000000324 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan class="fg-red">		sender=0xC5Ef3CF3d36e514Df9597Bbf8A50302cB89aC113 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639933 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
+    <tspan x="10px" y="370px"><tspan class="fg-red">		sender=0x0000000000000000000000000000000000000489 addr=[test/InvariantOutputTest.t.sol:InvariantOutputTest]0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496 calldata=setCond(uint256) args=[115792089237316195423570985008687907853269984665640564039457584007913129639935 </tspan><tspan class="fg-red dimmed">[1.157e77]</tspan><tspan class="fg-red">]</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan> invariant_check_count() (runs: 1, calls: 24, reverts: 0)</tspan>
+    <tspan x="10px" y="388px"><tspan> invariant_check_count() (runs: 1, calls: 17, reverts: 0)</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>


### PR DESCRIPTION
## Summary

Adds first-class configuration for fuzzer ensemble knobs via TOML, CLI flags, and environment variables:

- dictionary weights and dictionary size caps for fuzz and invariant runs
- invariant `min_depth` and `depth_mode = "fixed" | "random"`
- corpus fresh-input probability and per-mutator weights
- payable `msg.value` generation probability

The runtime wires these through fuzz/invariant call generation and corpus mutation. Corpus mutation now uses precomputed `WeightedIndex` distributions, keeps fuzz and invariant literal dictionaries separate, honors zero ABI/CMP mutator weights as disabled paths, and preserves the all-zero mutator fallback to defaults.

The corpus fresh-input default remains `10%` for normal and two-worker runs. When an invariant campaign uses 3+ workers and the user has not explicitly configured `invariant.corpus_random_sequence_weight`, the last worker uses the exploratory `50%` setting while the other workers keep `10%`. Explicit TOML/CLI/env values are preserved for every worker. The invariant dictionary weight still applies to generated calldata as well as sender selection: default `80%` for both, where invariant calldata previously used a fixed `40%` dictionary branch. Other defaults stay conservative: fixed depth, mutator weights `1/1/1/1/1/1/1`, fuzz payable value `0%`, invariant payable value `15%`.