### PR TITLE
feat(cast): guard receive-policy T6

### DIFF
--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -3733,7 +3733,10 @@ struct AnvilNodeInfo {
     network: Option<String>,
 }
 
-async fn is_tempo_hardfork_active<P>(provider: &P, hardfork: TempoHardfork) -> Result<bool>
+pub(crate) async fn is_tempo_hardfork_active<P>(
+    provider: &P,
+    hardfork: TempoHardfork,
+) -> Result<bool>
 where
     P: Provider<TempoNetwork>,
 {

--- a/crates/cast/src/cmd/receive_policy.rs
+++ b/crates/cast/src/cmd/receive_policy.rs
@@ -1,9 +1,13 @@
 use crate::{
-    cmd::tip20::{resolve_tip20_signer, send_tip20_transaction},
+    cmd::{
+        keychain::is_tempo_hardfork_active,
+        tip20::{resolve_tip20_signer, send_tip20_transaction},
+    },
     tx::{SendTxOpts, TxParams},
 };
 use alloy_ens::NameOrAddress;
 use alloy_primitives::{Address, Bytes, U256, keccak256};
+use alloy_provider::Provider;
 use alloy_sol_types::{SolCall, SolValue};
 use clap::{Parser, Subcommand};
 use eyre::{Result, WrapErr, ensure};
@@ -13,6 +17,7 @@ use foundry_cli::{
     utils::{LoadConfig, get_provider},
 };
 use foundry_common::{provider::ProviderBuilder, shell};
+use foundry_evm::hardfork::TempoHardfork;
 use foundry_evm_networks::TEMPO_PRECOMPILE_ADDRESSES;
 use serde_json::{Value, json};
 use std::str::FromStr;
@@ -380,8 +385,29 @@ async fn receipt_balance(receipt: Bytes, rpc: RpcOpts) -> Result<()> {
     })
 }
 
+// The ReceivePolicyGuard precompile only has code from T6 onwards, so a pre-T6 call would
+// succeed as a silent no-op instead of reverting. Fail early with a clear message.
+async fn ensure_receive_policy_t6<P>(provider: &P, command: &str) -> Result<()>
+where
+    P: Provider<TempoNetwork>,
+{
+    // Prefer the hardfork query, but if it is unavailable (e.g. an older RPC without the method)
+    // fall back to checking whether the guard precompile has code.
+    let active = match is_tempo_hardfork_active(provider, TempoHardfork::T6).await {
+        Ok(active) => active,
+        Err(_) => !provider.get_code_at(RECEIVE_POLICY_GUARD_ADDRESS).await?.is_empty(),
+    };
+    if !active {
+        eyre::bail!("{command} requires a Tempo T6-capable ReceivePolicy RPC");
+    }
+    Ok(())
+}
+
 async fn burn_receipt(receipt: Bytes, send_tx: SendTxOpts, tx: TxParams) -> Result<()> {
     decode_claim_receipt(&receipt)?;
+    let config = send_tx.eth.rpc.load_config()?;
+    let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+    ensure_receive_policy_t6(&provider, "cast receive-policy receipt burn").await?;
     let (signer, access_key) = resolve_tip20_signer(&send_tx, &tx).await?;
     send_tip20_transaction(
         NameOrAddress::Address(RECEIVE_POLICY_GUARD_ADDRESS),
@@ -399,6 +425,7 @@ async fn claim(to: NameOrAddress, receipt: Bytes, send_tx: SendTxOpts, tx: TxPar
     decode_claim_receipt(&receipt)?;
     let config = send_tx.eth.rpc.load_config()?;
     let provider = ProviderBuilder::<TempoNetwork>::from_config(&config)?.build()?;
+    ensure_receive_policy_t6(&provider, "cast receive-policy claim").await?;
     let to = to.resolve(&provider).await?;
     let (signer, access_key) = resolve_tip20_signer(&send_tx, &tx).await?;
     send_tip20_transaction(

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -226,6 +226,73 @@ casttest!(receive_policy_receipt_json_and_claim_flow, async |_prj, cmd| {
     assert_eq!(claimed_balance_output["delivery_state"], "not_held");
 });
 
+// The ReceivePolicyGuard precompile is only active from T6, so claim/burn must fail early on a
+// pre-T6 RPC instead of submitting a transaction that would silently succeed as a no-op.
+casttest!(receive_policy_claim_and_burn_require_t6, async |_prj, cmd| {
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T5.into()))).await;
+    let rpc = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = format!("0x{}", hex::encode(wallet.credential().to_bytes()));
+
+    let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
+        PATH_USD_ADDRESS,
+        Address::ZERO,
+        wallet.address(),
+        Address::with_last_byte(0xbe),
+        1_780_000_000,
+        1,
+        ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8,
+        IReceivePolicyGuard::InboundKind::TRANSFER,
+        B256::ZERO,
+    )
+    .abi_encode();
+    let receipt_arg = format!("0x{}", hex::encode(&receipt));
+
+    let claim_err = cmd
+        .cast_fuse()
+        .args([
+            "receive-policy",
+            "claim",
+            &wallet.address().to_string(),
+            &receipt_arg,
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+    assert!(
+        claim_err
+            .contains("cast receive-policy claim requires a Tempo T6-capable ReceivePolicy RPC"),
+        "{claim_err}"
+    );
+
+    let burn_err = cmd
+        .cast_fuse()
+        .args([
+            "receive-policy",
+            "receipt",
+            "burn",
+            &receipt_arg,
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+    assert!(
+        burn_err.contains(
+            "cast receive-policy receipt burn requires a Tempo T6-capable ReceivePolicy RPC"
+        ),
+        "{burn_err}"
+    );
+});
+
 casttest!(tip20_logo_create_help_includes_logo_uri, |_prj, cmd| {
     let output = cmd
         .cast_fuse()


### PR DESCRIPTION
`cast receive-policy claim` and `receipt burn` send directly to the `ReceivePolicyGuard` precompile, which only has code from T6 onward — pre-T6 those txs silently succeed as no-ops. This adds a T6 preflight (hardfork check, falling back to `eth_getCode`) so both commands fail early with a clear message. Includes a CLI regression test.