### PR TITLE
feat(cast): add tip403 command

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -964,6 +964,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         CastSubcommand::Erc20Token { command } => command.run().await?,
         CastSubcommand::Tip20Token { command } => command.run().await?,
         CastSubcommand::ReceivePolicy { command } => command.run().await?,
+        CastSubcommand::Tip403 { command } => command.run().await?,
         CastSubcommand::Keychain { command } => command.run().await?,
         CastSubcommand::KeyAuthorization { command } => command.run().await?,
         CastSubcommand::Tempo { command } => command.run().await?,

--- a/crates/cast/src/cmd/mod.rs
+++ b/crates/cast/src/cmd/mod.rs
@@ -33,6 +33,7 @@ pub mod storage;
 pub mod tempo;
 pub(crate) mod tempo_policy_args;
 pub mod tip20;
+pub mod tip403;
 pub mod trace;
 pub mod txpool;
 pub mod vaddr;

--- a/crates/cast/src/cmd/receive_policy.rs
+++ b/crates/cast/src/cmd/receive_policy.rs
@@ -27,6 +27,8 @@ use tempo_primitives::TempoAddressExt;
 #[derive(Debug, Parser, Clone)]
 pub enum ReceivePolicySubcommand {
     /// Set the caller's TIP-403 receive policy.
+    ///
+    /// Create the sender and token-filter policies referenced here with `cast tip403 create`.
     Set {
         /// Sender policy ID to evaluate for inbound transfer originators.
         sender_policy_id: u64,

--- a/crates/cast/src/cmd/tip403.rs
+++ b/crates/cast/src/cmd/tip403.rs
@@ -1,0 +1,355 @@
+use crate::{
+    cmd::tip20::{resolve_tip20_signer, send_tip20_transaction},
+    tx::{SendTxOpts, TxParams},
+};
+use alloy_ens::NameOrAddress;
+use alloy_primitives::Address;
+use clap::{Parser, ValueEnum};
+use eyre::Result;
+use foundry_cli::{
+    json::print_json_success,
+    opts::RpcOpts,
+    utils::{LoadConfig, get_provider},
+};
+use foundry_common::shell;
+use serde_json::{Value, json};
+use std::str::FromStr;
+use tempo_contracts::precompiles::{ITIP403Registry, TIP403_REGISTRY_ADDRESS};
+use tempo_primitives::TempoAddressExt;
+
+/// TIP-403 policy registry operations (Tempo).
+///
+/// Policies created here are referenced by ID from `cast receive-policy set` (sender policy and
+/// token filter) and by TIP-20 token compliance configuration.
+#[derive(Debug, Parser, Clone)]
+pub enum Tip403Subcommand {
+    /// Create a new simple (whitelist or blacklist) policy.
+    Create {
+        /// Policy type to create.
+        #[arg(value_enum)]
+        policy_type: PolicyKind,
+
+        /// Address authorized to modify the policy.
+        #[arg(long, value_parser = NameOrAddress::from_str)]
+        admin: NameOrAddress,
+
+        /// Initial member(s) to seed the policy with. Can be specified multiple times.
+        #[arg(long = "member", value_name = "ADDRESS", value_parser = NameOrAddress::from_str)]
+        accounts: Vec<NameOrAddress>,
+
+        #[command(flatten)]
+        send_tx: SendTxOpts,
+
+        #[command(flatten)]
+        tx: TxParams,
+    },
+
+    /// Add or remove an account from a whitelist policy.
+    Whitelist {
+        #[command(flatten)]
+        args: MembershipArgs,
+    },
+
+    /// Add or remove an account from a blacklist policy.
+    Blacklist {
+        #[command(flatten)]
+        args: MembershipArgs,
+    },
+
+    /// Show a policy's type and admin.
+    Info {
+        /// Policy ID to inspect.
+        policy_id: u64,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+
+    /// Check whether an address is authorized by a policy.
+    Check {
+        /// Policy ID to evaluate.
+        policy_id: u64,
+
+        /// Address to check.
+        #[arg(value_parser = NameOrAddress::from_str)]
+        address: NameOrAddress,
+
+        /// Role to evaluate (defaults to the transfer check). Role variants require T2+.
+        #[arg(long, value_enum)]
+        role: Option<PolicyRole>,
+
+        #[command(flatten)]
+        rpc: RpcOpts,
+    },
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct MembershipArgs {
+    /// Whether to add or remove the account.
+    #[arg(value_enum)]
+    pub action: MembershipAction,
+
+    /// Policy ID to modify.
+    pub policy_id: u64,
+
+    /// Account to add or remove.
+    #[arg(value_parser = NameOrAddress::from_str)]
+    pub account: NameOrAddress,
+
+    #[command(flatten)]
+    pub send_tx: SendTxOpts,
+
+    #[command(flatten)]
+    pub tx: TxParams,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum PolicyKind {
+    Whitelist,
+    Blacklist,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum MembershipAction {
+    Add,
+    Remove,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum PolicyRole {
+    Sender,
+    Recipient,
+    MintRecipient,
+}
+
+impl Tip403Subcommand {
+    pub async fn run(self) -> Result<()> {
+        match self {
+            Self::Create { policy_type, admin, accounts, send_tx, tx } => {
+                create(policy_type, admin, accounts, send_tx, tx).await
+            }
+            Self::Whitelist { args } => modify(PolicyKind::Whitelist, args).await,
+            Self::Blacklist { args } => modify(PolicyKind::Blacklist, args).await,
+            Self::Info { policy_id, rpc } => info(policy_id, rpc).await,
+            Self::Check { policy_id, address, role, rpc } => {
+                check(policy_id, address, role, rpc).await
+            }
+        }
+    }
+}
+
+async fn create(
+    policy_type: PolicyKind,
+    admin: NameOrAddress,
+    accounts: Vec<NameOrAddress>,
+    send_tx: SendTxOpts,
+    tx: TxParams,
+) -> Result<()> {
+    let config = send_tx.eth.rpc.load_config()?;
+    let provider = get_provider(&config)?;
+    let admin = admin.resolve(&provider).await?;
+
+    let mut members = Vec::with_capacity(accounts.len());
+    for account in accounts {
+        let account = account.resolve(&provider).await?;
+        warn_if_virtual(account)?;
+        members.push(account);
+    }
+
+    // Preview the policy ID the registry would assign. This is the next counter value, so it is
+    // only accurate if no other policy is created before this transaction lands.
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, &provider);
+    let policy_type_sol = policy_type.to_sol();
+    let expected_id = if members.is_empty() {
+        registry.createPolicy(admin, policy_type_sol).call().await?
+    } else {
+        registry.createPolicyWithAccounts(admin, policy_type_sol, members.clone()).call().await?
+    };
+    // Non-authoritative: the real ID is the one in the PolicyCreated event of this transaction.
+    sh_status!(
+        "Expected policy ID: {expected_id} (only if this tx is mined before any other policy \
+         creation; read the PolicyCreated event for the authoritative ID)"
+    )?;
+
+    let (signer, access_key) = resolve_tip20_signer(&send_tx, &tx).await?;
+    let type_arg = (policy_type_sol as u8).to_string();
+    let (sig, args) = if members.is_empty() {
+        ("createPolicy(address,uint8)", vec![admin.to_string(), type_arg])
+    } else {
+        (
+            "createPolicyWithAccounts(address,uint8,address[])",
+            vec![admin.to_string(), type_arg, address_array(&members)],
+        )
+    };
+    send_tip20_transaction(
+        NameOrAddress::Address(TIP403_REGISTRY_ADDRESS),
+        sig,
+        args,
+        send_tx,
+        tx,
+        signer,
+        access_key,
+    )
+    .await
+}
+
+async fn modify(kind: PolicyKind, args: MembershipArgs) -> Result<()> {
+    let MembershipArgs { action, policy_id, account, send_tx, tx } = args;
+    let config = send_tx.eth.rpc.load_config()?;
+    let provider = get_provider(&config)?;
+    let account = account.resolve(&provider).await?;
+    warn_if_virtual(account)?;
+
+    let flag = matches!(action, MembershipAction::Add);
+    let (signer, access_key) = resolve_tip20_signer(&send_tx, &tx).await?;
+    let sig = match kind {
+        PolicyKind::Whitelist => "modifyPolicyWhitelist(uint64,address,bool)",
+        PolicyKind::Blacklist => "modifyPolicyBlacklist(uint64,address,bool)",
+    };
+    send_tip20_transaction(
+        NameOrAddress::Address(TIP403_REGISTRY_ADDRESS),
+        sig,
+        vec![policy_id.to_string(), account.to_string(), flag.to_string()],
+        send_tx,
+        tx,
+        signer,
+        access_key,
+    )
+    .await
+}
+
+async fn info(policy_id: u64, rpc: RpcOpts) -> Result<()> {
+    let config = rpc.load_config()?;
+    let provider = get_provider(&config)?;
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, provider);
+    let builtin = builtin_label(policy_id);
+
+    if !registry.policyExists(policy_id).call().await? {
+        let payload = json!({ "policy_id": policy_id, "exists": false, "builtin": builtin });
+        return print_payload(payload, |_| sh_println!("Policy {policy_id} does not exist"));
+    }
+
+    let data = registry.policyData(policy_id).call().await?;
+    let payload = json!({
+        "policy_id": policy_id,
+        "exists": true,
+        "builtin": builtin,
+        "policy_type": policy_type_label(data.policyType),
+        "admin": format!("{}", data.admin),
+    });
+    print_payload(payload, |payload| {
+        sh_println!(
+            "Policy ID: {}\n\
+             Built-in:  {}\n\
+             Type:      {}\n\
+             Admin:     {}",
+            payload["policy_id"],
+            payload["builtin"].as_str().unwrap_or("no"),
+            payload["policy_type"].as_str().unwrap_or_default(),
+            payload["admin"].as_str().unwrap_or_default(),
+        )
+    })
+}
+
+async fn check(
+    policy_id: u64,
+    address: NameOrAddress,
+    role: Option<PolicyRole>,
+    rpc: RpcOpts,
+) -> Result<()> {
+    let config = rpc.load_config()?;
+    let provider = get_provider(&config)?;
+    let address = address.resolve(&provider).await?;
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, provider);
+    let authorized = match role {
+        None => registry.isAuthorized(policy_id, address).call().await?,
+        Some(PolicyRole::Sender) => registry.isAuthorizedSender(policy_id, address).call().await?,
+        Some(PolicyRole::Recipient) => {
+            registry.isAuthorizedRecipient(policy_id, address).call().await?
+        }
+        Some(PolicyRole::MintRecipient) => {
+            registry.isAuthorizedMintRecipient(policy_id, address).call().await?
+        }
+    };
+
+    let payload = json!({
+        "policy_id": policy_id,
+        "address": format!("{address}"),
+        "role": role_label(role),
+        "authorized": authorized,
+    });
+    print_payload(payload, |payload| {
+        sh_println!(
+            "Policy ID:  {}\n\
+             Address:    {}\n\
+             Role:       {}\n\
+             Authorized: {}",
+            payload["policy_id"],
+            payload["address"].as_str().unwrap_or_default(),
+            payload["role"].as_str().unwrap_or_default(),
+            payload["authorized"].as_bool().unwrap_or_default(),
+        )
+    })
+}
+
+/// Warn (but don't fail) on virtual members; only T3+ chains reject them on-chain.
+fn warn_if_virtual(account: Address) -> Result<()> {
+    if account.is_virtual() {
+        sh_warn!(
+            "{account} looks like a TIP-1022 virtual address; on T3+ chains it is rejected as a \
+             literal policy member. Resolve it to its master with `cast vaddr resolve {account}`."
+        )?;
+    }
+    Ok(())
+}
+
+fn address_array(accounts: &[Address]) -> String {
+    format!("[{}]", accounts.iter().map(Address::to_string).collect::<Vec<_>>().join(","))
+}
+
+fn print_payload<F>(payload: Value, human: F) -> Result<()>
+where
+    F: FnOnce(&Value) -> Result<()>,
+{
+    if shell::is_json() {
+        print_json_success(payload)?;
+    } else {
+        human(&payload)?;
+    }
+    Ok(())
+}
+
+impl PolicyKind {
+    const fn to_sol(self) -> ITIP403Registry::PolicyType {
+        match self {
+            Self::Whitelist => ITIP403Registry::PolicyType::WHITELIST,
+            Self::Blacklist => ITIP403Registry::PolicyType::BLACKLIST,
+        }
+    }
+}
+
+const fn policy_type_label(policy_type: ITIP403Registry::PolicyType) -> &'static str {
+    match policy_type {
+        ITIP403Registry::PolicyType::WHITELIST => "whitelist",
+        ITIP403Registry::PolicyType::BLACKLIST => "blacklist",
+        ITIP403Registry::PolicyType::COMPOUND => "compound",
+        _ => "unknown",
+    }
+}
+
+const fn builtin_label(policy_id: u64) -> Option<&'static str> {
+    match policy_id {
+        0 => Some("reject-all"),
+        1 => Some("allow-all"),
+        _ => None,
+    }
+}
+
+const fn role_label(role: Option<PolicyRole>) -> &'static str {
+    match role {
+        None => "transfer",
+        Some(PolicyRole::Sender) => "sender",
+        Some(PolicyRole::Recipient) => "recipient",
+        Some(PolicyRole::MintRecipient) => "mint-recipient",
+    }
+}

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -25,6 +25,7 @@ use crate::cmd::{
     storage::StorageArgs,
     tempo::TempoSubcommand,
     tip20::Tip20Subcommand,
+    tip403::Tip403Subcommand,
     trace::TraceArgs,
     txpool::TxPoolSubcommands,
     vaddr::VaddrSubcommand,
@@ -1263,6 +1264,13 @@ pub enum CastSubcommand {
     ReceivePolicy {
         #[command(subcommand)]
         command: ReceivePolicySubcommand,
+    },
+
+    /// TIP-403 policy registry operations (Tempo).
+    #[command(name = "tip403")]
+    Tip403 {
+        #[command(subcommand)]
+        command: Tip403Subcommand,
     },
 
     /// Tempo keychain (access key) management.

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -226,6 +226,281 @@ casttest!(receive_policy_receipt_json_and_claim_flow, async |_prj, cmd| {
     assert_eq!(claimed_balance_output["delivery_state"], "not_held");
 });
 
+// Exercises the full TIP-403 policy lifecycle: create, inspect, check, and modify membership.
+casttest!(tip403_policy_lifecycle, async |_prj, cmd| {
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let rpc = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = format!("0x{}", hex::encode(wallet.credential().to_bytes()));
+    let admin = wallet.address();
+    let member = handle.dev_wallets().nth(1).unwrap().address();
+
+    // IDs 0 and 1 are reserved, so the first user policy on a fresh node is ID 2.
+    let create_err = cmd
+        .cast_fuse()
+        .args([
+            "tip403",
+            "create",
+            "whitelist",
+            "--admin",
+            &admin.to_string(),
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success()
+        .get_output()
+        .stderr_lossy();
+    assert!(create_err.contains("Expected policy ID: 2"), "{create_err}");
+
+    let info = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "info", "2", "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let info = json_success_data(&info);
+    assert_eq!(info["exists"], true);
+    assert_eq!(info["policy_type"], "whitelist");
+    assert_eq!(info["admin"], admin.to_string());
+
+    // Non-member is not authorized by a whitelist policy until added.
+    let before = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "check", "2", &member.to_string(), "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert_eq!(json_success_data(&before)["authorized"], false);
+
+    cmd.cast_fuse()
+        .args([
+            "tip403",
+            "whitelist",
+            "add",
+            "2",
+            &member.to_string(),
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+
+    let after = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "check", "2", &member.to_string(), "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert_eq!(json_success_data(&after)["authorized"], true);
+
+    // Built-in policies are labeled.
+    let allow_all = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "info", "1", "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert_eq!(json_success_data(&allow_all)["builtin"], "allow-all");
+});
+
+casttest!(tip403_create_warns_on_virtual_member, async |_prj, cmd| {
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let rpc = handle.http_endpoint();
+    let pk =
+        format!("0x{}", hex::encode(handle.dev_wallets().next().unwrap().credential().to_bytes()));
+
+    // A TIP-1022 virtual address (bytes [4:14] == 0xFD) is rejected on-chain on T3+; cast warns
+    // and lets the chain enforce rather than hard-failing client-side.
+    let virtual_addr = "0x12345678fdfdfdfdfdfdfdfdfdfdaabbccdd0011";
+    let err = cmd
+        .cast_fuse()
+        .args([
+            "tip403",
+            "create",
+            "whitelist",
+            "--admin",
+            "0x0000000000000000000000000000000000000001",
+            "--member",
+            virtual_addr,
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+    assert!(err.contains("looks like a TIP-1022 virtual address"), "{err}");
+});
+
+casttest!(tip403_blacklist_semantics, async |_prj, cmd| {
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let rpc = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = format!("0x{}", hex::encode(wallet.credential().to_bytes()));
+    let admin = wallet.address();
+    let member = handle.dev_wallets().nth(1).unwrap().address();
+
+    cmd.cast_fuse()
+        .args([
+            "tip403",
+            "create",
+            "blacklist",
+            "--admin",
+            &admin.to_string(),
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+
+    // A blacklist authorizes everyone until they are explicitly added.
+    let before = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "check", "2", &member.to_string(), "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert_eq!(json_success_data(&before)["authorized"], true);
+
+    cmd.cast_fuse()
+        .args([
+            "tip403",
+            "blacklist",
+            "add",
+            "2",
+            &member.to_string(),
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+    let blocked = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "check", "2", &member.to_string(), "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert_eq!(json_success_data(&blocked)["authorized"], false);
+
+    cmd.cast_fuse()
+        .args([
+            "tip403",
+            "blacklist",
+            "remove",
+            "2",
+            &member.to_string(),
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+    let restored = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "check", "2", &member.to_string(), "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert_eq!(json_success_data(&restored)["authorized"], true);
+});
+
+casttest!(tip403_create_with_members, async |_prj, cmd| {
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T6.into()))).await;
+    let rpc = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = format!("0x{}", hex::encode(wallet.credential().to_bytes()));
+    let admin = wallet.address();
+    let member = handle.dev_wallets().nth(1).unwrap().address();
+
+    // `--member` seeds the whitelist via createPolicyWithAccounts, so the member is authorized
+    // immediately without a follow-up modify.
+    cmd.cast_fuse()
+        .args([
+            "tip403",
+            "create",
+            "whitelist",
+            "--admin",
+            &admin.to_string(),
+            "--member",
+            &member.to_string(),
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+    let check = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "check", "2", &member.to_string(), "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert_eq!(json_success_data(&check)["authorized"], true);
+});
+
+casttest!(tip403_works_pre_t6, async |_prj, cmd| {
+    // TIP-403 is a Genesis precompile, so the base policy commands work before T6 activates.
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T5.into()))).await;
+    let rpc = handle.http_endpoint();
+    let wallet = handle.dev_wallets().next().unwrap();
+    let pk = format!("0x{}", hex::encode(wallet.credential().to_bytes()));
+    let admin = wallet.address();
+    let member = handle.dev_wallets().nth(1).unwrap().address();
+
+    cmd.cast_fuse()
+        .args([
+            "tip403",
+            "create",
+            "whitelist",
+            "--admin",
+            &admin.to_string(),
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+    let info = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "info", "2", "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert_eq!(json_success_data(&info)["policy_type"], "whitelist");
+
+    cmd.cast_fuse()
+        .args([
+            "tip403",
+            "whitelist",
+            "add",
+            "2",
+            &member.to_string(),
+            "--private-key",
+            &pk,
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success();
+    let check = cmd
+        .cast_fuse()
+        .args(["--json", "tip403", "check", "2", &member.to_string(), "--rpc-url", &rpc])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert_eq!(json_success_data(&check)["authorized"], true);
+});
+
 casttest!(tip20_logo_create_help_includes_logo_uri, |_prj, cmd| {
     let output = cmd
         .cast_fuse()


### PR DESCRIPTION
Adds `cast tip403` to create and manage TIP-403 whitelist/blacklist policies (create, whitelist, blacklist, info, check), so the policy IDs that `cast receive-policy set` requires can be created from cast.