### PR TITLE
perf(invariant): skip terminal corpus input generation

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -834,12 +834,17 @@ impl WorkerCorpus {
         // When the run is interesting only because of optimization (no new coverage),
         // add the best prefix to the corpus instead of the full run — the prefix is
         // the sequence that actually achieved the best value.
-        assert!(!inputs.is_empty());
-        let corpus_inputs = if improved_optimization && !new_coverage {
+        //
+        // `inputs` can be empty when every call was discarded/popped but new coverage was
+        // still recorded; there's nothing to persist, so skip without inserting an entry.
+        let corpus_inputs = if improved_optimization && (!new_coverage || inputs.is_empty()) {
             self.optimization_best_sequence.clone()
         } else {
             inputs.to_vec()
         };
+        if corpus_inputs.is_empty() {
+            return None;
+        }
         let corpus_cmp_seq: Vec<Vec<CmpOperands>> =
             cmp_seq.iter().take(corpus_inputs.len()).cloned().collect();
         let corpus = CorpusEntry::new_with_cmp(corpus_inputs, corpus_cmp_seq, Uuid::new_v4());
@@ -1998,6 +2003,29 @@ mod tests {
         assert!(record.dedupe_by_coverage);
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert_eq!(manager.metrics.corpus_count, 1);
+        assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
+    }
+
+    #[test]
+    fn empty_input_sequence_with_new_coverage_does_not_panic_or_insert() {
+        // A run where every executed call was discarded (magic assume) or popped (reverts
+        // without `fail_on_revert`, handler assertions) leaves no surviving inputs, yet
+        // `new_coverage` can still be true because edge coverage is collected before the
+        // input is popped. Processing must not panic and must not persist an entry.
+        let corpus_root = temp_corpus_dir();
+        let worker_subdir = corpus_root.join("worker1");
+        let mut manager = empty_worker_corpus(1, corpus_root);
+
+        let record = manager.process_inputs_for_campaign(&[], &[], true, None);
+
+        assert!(record.is_none());
+        assert_eq!(manager.in_memory_corpus.len(), 0);
+        assert_eq!(manager.metrics.corpus_count, 0);
+        assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
+
+        // Live processing path must also tolerate the empty sequence.
+        manager.process_inputs(&[], &[], true, None);
+        assert_eq!(manager.in_memory_corpus.len(), 0);
         assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
     }
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1145,6 +1145,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run.depth += 1;
                 }
 
+                // Only generate the next input if another iteration will execute it. On
+                // discarded/popped iterations `depth` isn't incremented, so the replacement
+                // is still generated.
                 if current_run.depth < config.depth {
                     current_run.inputs.push(corpus_manager.generate_next_input(
                         &mut invariant_test.test_data.branch_runner,

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1145,17 +1145,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run.depth += 1;
                 }
 
-                // Only generate the next input if another iteration will execute it. On
-                // discarded/popped iterations `depth` isn't incremented, so the replacement
-                // is still generated.
-                if current_run.depth < config.depth {
-                    current_run.inputs.push(corpus_manager.generate_next_input(
-                        &mut invariant_test.test_data.branch_runner,
-                        &initial_seq,
-                        discarded,
-                        current_run.depth as usize,
-                    )?);
-                }
+                current_run.inputs.push(corpus_manager.generate_next_input(
+                    &mut invariant_test.test_data.branch_runner,
+                    &initial_seq,
+                    discarded,
+                    current_run.depth as usize,
+                )?);
             }
 
             // Extend corpus with current run data.

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1145,12 +1145,14 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run.depth += 1;
                 }
 
-                current_run.inputs.push(corpus_manager.generate_next_input(
-                    &mut invariant_test.test_data.branch_runner,
-                    &initial_seq,
-                    discarded,
-                    current_run.depth as usize,
-                )?);
+                if current_run.depth < config.depth {
+                    current_run.inputs.push(corpus_manager.generate_next_input(
+                        &mut invariant_test.test_data.branch_runner,
+                        &initial_seq,
+                        discarded,
+                        current_run.depth as usize,
+                    )?);
+                }
             }
 
             // Extend corpus with current run data.


### PR DESCRIPTION
Skips generating the terminal corpus input in the per-run invariant loop. The loop previously generated one input past the final depth that was never executed, wasting an RNG draw and leaking an unexecuted input into corpus processing. Generation is now guarded on `depth < config.depth`, so it only runs when another iteration will execute the input (discarded/popped iterations do not increment `depth`, so the replacement is still produced).

Corpus processing also handles empty input sequences: a run where every call is discarded (magic assume) or popped (reverts without `fail_on_revert`, handler assertions) can leave `inputs` empty while `new_coverage` is still set, since edge coverage is collected before the pop. `process_inputs_inner` now updates mutation/optimization state and skips persisting a corpus entry when no surviving inputs remain, instead of asserting non-empty.

## Tests

- Added `empty_input_sequence_with_new_coverage_does_not_panic_or_insert` covering the deferred and live processing paths.
- `cargo test -p foundry-evm --lib executors::corpus::tests` passes (20).