### PR TITLE
feat(lint): add non-reentrant-not-first detector

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -34,6 +34,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `unsafe-typecast`: Typecasts that can truncate values should be checked.
   - `unused-return`: Return value of an external call is not used.
   - `locked-ether`: Contracts that can receive ETH but have no mechanism to send it out.
+  - `non-reentrant-not-first`: `nonReentrant` should be the first modifier on guarded entry points.
   - `weak-prng`: Flags randomness-like expressions derived from predictable on-chain values.
 - **Low Severity:**
   - `block-timestamp`: Warns when `block.timestamp` is used in a comparison, as it may be manipulated by validators.

--- a/crates/lint/docs/non-reentrant-not-first.md
+++ b/crates/lint/docs/non-reentrant-not-first.md
@@ -1,0 +1,40 @@
+# Non-reentrant modifier not first
+
+**Severity**: `Med`
+**ID**: `non-reentrant-not-first`
+
+Flags functions where an OpenZeppelin-style `nonReentrant` modifier is present but is not the first
+modifier in the modifier list.
+
+## What it does
+
+Reports a function, fallback, or receive function when `nonReentrant` appears after another
+modifier, for example `onlyOwner nonReentrant`.
+
+The lint is intentionally narrow: it only checks modifier ordering and only matches a modifier named
+`nonReentrant`.
+
+## Why is this bad?
+
+Solidity applies modifiers in the order they are written. If another modifier runs before
+`nonReentrant`, that modifier's pre-body logic executes before the reentrancy guard is entered. For
+guarded external entry points, placing `nonReentrant` first keeps the reentrancy lock as the first
+piece of modifier logic.
+
+## Example
+
+### Bad
+
+```solidity
+function withdraw(uint256 amount) external onlyOwner nonReentrant {
+    _withdraw(amount);
+}
+```
+
+### Good
+
+```solidity
+function withdraw(uint256 amount) external nonReentrant onlyOwner {
+    _withdraw(amount);
+}
+```

--- a/crates/lint/src/sol/med/mod.rs
+++ b/crates/lint/src/sol/med/mod.rs
@@ -36,6 +36,9 @@ use unused_return::UNUSED_RETURN;
 mod locked_ether;
 use locked_ether::LOCKED_ETHER;
 
+mod non_reentrant_not_first;
+use non_reentrant_not_first::NON_REENTRANT_NOT_FIRST;
+
 mod tautological_compare;
 use tautological_compare::TAUTOLOGICAL_COMPARE;
 
@@ -55,6 +58,7 @@ register_lints!(
     (UnsafeTypecast, late, (UNSAFE_TYPECAST)),
     (UnusedReturn, late, (UNUSED_RETURN)),
     (LockedEther, late, (LOCKED_ETHER)),
+    (NonReentrantNotFirst, late, (NON_REENTRANT_NOT_FIRST)),
     (WeakPrng, early, (WEAK_PRNG)),
     (TautologicalCompare, late, (TAUTOLOGICAL_COMPARE))
 );

--- a/crates/lint/src/sol/med/non_reentrant_not_first.rs
+++ b/crates/lint/src/sol/med/non_reentrant_not_first.rs
@@ -1,0 +1,51 @@
+use super::NonReentrantNotFirst;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::sema::{
+    Gcx,
+    hir::{self, FunctionKind},
+};
+
+declare_forge_lint!(
+    NON_REENTRANT_NOT_FIRST,
+    Severity::Med,
+    "non-reentrant-not-first",
+    "`nonReentrant` should be the first modifier"
+);
+
+impl<'hir> LateLintPass<'hir> for NonReentrantNotFirst {
+    fn check_function(
+        &mut self,
+        ctx: &LintContext,
+        _gcx: Gcx<'hir>,
+        hir: &'hir hir::Hir<'hir>,
+        func: &'hir hir::Function<'hir>,
+    ) {
+        if !matches!(
+            func.kind,
+            FunctionKind::Function | FunctionKind::Fallback | FunctionKind::Receive
+        ) {
+            return;
+        }
+
+        if let Some((index, modifier)) = func
+            .modifiers
+            .iter()
+            .enumerate()
+            .find(|(_, modifier)| modifier_is_named(hir, modifier, "nonReentrant"))
+            && index != 0
+        {
+            ctx.emit(&NON_REENTRANT_NOT_FIRST, modifier.span);
+        }
+    }
+}
+
+fn modifier_is_named(hir: &hir::Hir<'_>, modifier: &hir::Modifier<'_>, name: &str) -> bool {
+    modifier.id.as_function().is_some_and(|function_id| {
+        let modifier_fn = hir.function(function_id);
+        matches!(modifier_fn.kind, FunctionKind::Modifier)
+            && modifier_fn.name.is_some_and(|ident| ident.as_str() == name)
+    })
+}

--- a/crates/lint/src/sol/med/non_reentrant_not_first.rs
+++ b/crates/lint/src/sol/med/non_reentrant_not_first.rs
@@ -30,15 +30,13 @@ impl<'hir> LateLintPass<'hir> for NonReentrantNotFirst {
             return;
         }
 
-        if let Some((index, modifier)) = func
-            .modifiers
+        func.modifiers
             .iter()
             .enumerate()
-            .find(|(_, modifier)| modifier_is_named(hir, modifier, "nonReentrant"))
-            && index != 0
-        {
-            ctx.emit(&NON_REENTRANT_NOT_FIRST, modifier.span);
-        }
+            .filter(|(index, modifier)| {
+                *index != 0 && modifier_is_named(hir, modifier, "nonReentrant")
+            })
+            .for_each(|(_, modifier)| ctx.emit(&NON_REENTRANT_NOT_FIRST, modifier.span));
     }
 }
 

--- a/crates/lint/testdata/NonReentrantNotFirst.sol
+++ b/crates/lint/testdata/NonReentrantNotFirst.sol
@@ -1,0 +1,60 @@
+//@compile-flags: --only-lint non-reentrant-not-first
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract NonReentrantNotFirst {
+    modifier nonReentrant() {
+        _;
+    }
+
+    modifier onlyOwner() {
+        _;
+    }
+
+    modifier whenNotPaused() {
+        _;
+    }
+
+    function badSingle(uint256 amount) external onlyOwner nonReentrant { //~WARN: `nonReentrant` should be the first modifier
+        amount;
+    }
+
+    function badMultiple(uint256 amount) external onlyOwner whenNotPaused nonReentrant { //~WARN: `nonReentrant` should be the first modifier
+        amount;
+    }
+
+    function goodFirst(uint256 amount) external nonReentrant onlyOwner {
+        amount;
+    }
+
+    function goodOnly(uint256 amount) external nonReentrant {
+        amount;
+    }
+
+    function goodNoGuard(uint256 amount) external onlyOwner whenNotPaused {
+        amount;
+    }
+
+    receive() external payable nonReentrant onlyOwner {}
+}
+
+contract BaseReentrancyGuard {
+    modifier nonReentrant() {
+        _;
+    }
+}
+
+contract InheritedNonReentrantNotFirst is BaseReentrancyGuard {
+    modifier onlyOwner() {
+        _;
+    }
+
+    function badInherited() external onlyOwner nonReentrant { //~WARN: `nonReentrant` should be the first modifier
+        msg.sender;
+    }
+
+    function goodInherited() external nonReentrant onlyOwner {
+        msg.sender;
+    }
+}

--- a/crates/lint/testdata/NonReentrantNotFirst.sol
+++ b/crates/lint/testdata/NonReentrantNotFirst.sol
@@ -24,6 +24,10 @@ contract NonReentrantNotFirst {
         amount;
     }
 
+    function badDuplicate(uint256 amount) external nonReentrant onlyOwner nonReentrant { //~WARN: `nonReentrant` should be the first modifier
+        amount;
+    }
+
     function goodFirst(uint256 amount) external nonReentrant onlyOwner {
         amount;
     }

--- a/crates/lint/testdata/NonReentrantNotFirst.stderr
+++ b/crates/lint/testdata/NonReentrantNotFirst.stderr
@@ -17,6 +17,14 @@ LL │     function badMultiple(uint256 amount) external onlyOwner whenNotPaused
 warning[non-reentrant-not-first]: `nonReentrant` should be the first modifier
    ╭▸ ROOT/testdata/NonReentrantNotFirst.sol:LL:CC
    │
+LL │     function badDuplicate(uint256 amount) external nonReentrant onlyOwner nonReentrant {
+   │                                                                           ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/non-reentrant-not-first
+
+warning[non-reentrant-not-first]: `nonReentrant` should be the first modifier
+   ╭▸ ROOT/testdata/NonReentrantNotFirst.sol:LL:CC
+   │
 LL │     function badInherited() external onlyOwner nonReentrant {
    │                                                ━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/NonReentrantNotFirst.stderr
+++ b/crates/lint/testdata/NonReentrantNotFirst.stderr
@@ -1,0 +1,24 @@
+warning[non-reentrant-not-first]: `nonReentrant` should be the first modifier
+   ╭▸ ROOT/testdata/NonReentrantNotFirst.sol:LL:CC
+   │
+LL │     function badSingle(uint256 amount) external onlyOwner nonReentrant {
+   │                                                           ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/non-reentrant-not-first
+
+warning[non-reentrant-not-first]: `nonReentrant` should be the first modifier
+   ╭▸ ROOT/testdata/NonReentrantNotFirst.sol:LL:CC
+   │
+LL │     function badMultiple(uint256 amount) external onlyOwner whenNotPaused nonReentrant {
+   │                                                                           ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/non-reentrant-not-first
+
+warning[non-reentrant-not-first]: `nonReentrant` should be the first modifier
+   ╭▸ ROOT/testdata/NonReentrantNotFirst.sol:LL:CC
+   │
+LL │     function badInherited() external onlyOwner nonReentrant {
+   │                                                ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/non-reentrant-not-first
+


### PR DESCRIPTION
## Motivation

Part of #14381.

Solidity applies modifiers in the order they are written. When an OpenZeppelin-style `nonReentrant` modifier appears after another modifier, that modifier's pre-body logic runs before the reentrancy guard is entered.

This adds a focused `forge lint` detector for that ordering issue without trying to infer broader reentrancy behavior.

## Solution

- Add a medium-severity `non-reentrant-not-first` late lint.
- Inspect functions, fallback functions, and receive functions.
- Match HIR-resolved modifiers named `nonReentrant` and report when the first matching modifier is not first in the modifier list.
- Keep the detector intentionally narrow: ordering-only, no CFG requirements, and no attempt to infer custom guard semantics.
- Add lint docs, README registration, and UI coverage for local and inherited `nonReentrant` modifiers plus non-triggering cases.

## Testing

- `cargo +nightly fmt --check`
- `git diff --check`
- `cargo test -p forge --test ui -- NonReentrantNotFirst`
- `cargo test -p forge-lint registered_lints_have`

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [ ] Breaking changes
