### PR TITLE
perf(invariant): cache metric selector keys

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -402,8 +402,10 @@ struct InvariantTestData {
     line_coverage: Option<HitMaps>,
     // Metrics for each fuzzed selector.
     metrics: Map<String, InvariantMetrics>,
-    // Cache from fuzzed target selector to the stable metric key.
-    metric_key_cache: Map<(Address, Selector), Option<String>>,
+    // Cache from fuzzed (target, selector) to its metric key. Only resolved keys are cached;
+    // entries are invalidated when targets are added/removed mid-campaign (see
+    // `invalidate_metric_key_cache`) so they cannot go stale.
+    metric_key_cache: Map<(Address, Selector), String>,
 
     // Proptest runner to query for random values.
     // The strategy only comes with the first `input`. We fill the rest of the `inputs`
@@ -486,34 +488,52 @@ impl InvariantTest {
         };
         let cache_key = (tx_details.call_details.target, selector);
 
-        if let Some(cached) = self.test_data.metric_key_cache.get(&cache_key) {
-            let Some(metric_key) = cached.as_deref() else { return };
+        if let Some(metric_key) = self.test_data.metric_key_cache.get(&cache_key) {
             if let Some(invariant_metrics) = self.test_data.metrics.get_mut(metric_key) {
                 invariant_metrics.record_call(reverted, discarded);
-                return;
+            } else {
+                self.test_data
+                    .metrics
+                    .entry(metric_key.to_owned())
+                    .or_default()
+                    .record_call(reverted, discarded);
             }
-
-            self.test_data
-                .metrics
-                .entry(metric_key.to_owned())
-                .or_default()
-                .record_call(reverted, discarded);
             return;
         }
 
-        let metric_key = self
+        // Not cached: resolve from the current target set. Unresolved keys are not cached so that
+        // a tx whose target isn't a known target yet (e.g. created later in a corpus-mutated
+        // sequence) is re-resolved once the target is added.
+        let Some(metric_key) = self
             .targeted_contracts
             .targets()
-            .fuzzed_metric_key_for_selector(tx_details.call_details.target, selector);
+            .fuzzed_metric_key_for_selector(tx_details.call_details.target, selector)
+        else {
+            return;
+        };
         self.test_data.metric_key_cache.insert(cache_key, metric_key.clone());
-        let Some(metric_key) = metric_key else { return };
         self.test_data.metrics.entry(metric_key).or_default().record_call(reverted, discarded);
+    }
+
+    /// Invalidates cached metric keys for the given target addresses.
+    ///
+    /// Must be called whenever targeted contracts are added or removed mid-campaign (e.g. via
+    /// `collect_created_contracts` / `clear_created_contracts`) so a cached key cannot outlive the
+    /// `(target, selector)` -> contract mapping it was derived from (an address can be reused for a
+    /// different artifact across runs).
+    fn invalidate_metric_key_cache(&mut self, addresses: &[Address]) {
+        if addresses.is_empty() {
+            return;
+        }
+        self.test_data.metric_key_cache.retain(|(addr, _), _| !addresses.contains(addr));
     }
 
     /// End invariant test run by collecting results, cleaning collected artifacts and reverting
     /// created fuzz state.
     fn end_run<FEN: FoundryEvmNetwork>(&mut self, run: InvariantTestRun<FEN>, gas_samples: usize) {
-        // We clear all the targeted contracts created during this run.
+        // We clear all the targeted contracts created during this run, dropping their cached metric
+        // keys as well so a reused address cannot resolve to a stale contract in a later run.
+        self.invalidate_metric_key_cache(&run.created_contracts);
         self.targeted_contracts.clear_created_contracts(run.created_contracts);
 
         if self.test_data.gas_report_traces.len() < gas_samples {
@@ -1045,6 +1065,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
                     // Collect created contracts and add to fuzz targets only if targeted contracts
                     // are updatable.
+                    let created_before = current_run.created_contracts.len();
                     if let Err(error) =
                         &invariant_test.targeted_contracts.collect_created_contracts(
                             &state_changeset,
@@ -1056,6 +1077,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     {
                         warn!(target: "forge::test", "{error}");
                     }
+                    // Drop cached metric keys for any newly added targets so a reused address can't
+                    // resolve to a previously cached (stale) contract.
+                    invariant_test.invalidate_metric_key_cache(
+                        &current_run.created_contracts[created_before..],
+                    );
                     current_run
                         .fuzz_runs
                         .push(FuzzCase { gas: call_result.gas_used, stipend: call_result.stipend });

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -155,7 +155,7 @@ pub struct InvariantMetrics {
 }
 
 impl InvariantMetrics {
-    fn record_call(&mut self, reverted: bool, discarded: bool) {
+    const fn record_call(&mut self, reverted: bool, discarded: bool) {
         self.calls += 1;
         if discarded {
             self.discards += 1;
@@ -402,9 +402,8 @@ struct InvariantTestData {
     line_coverage: Option<HitMaps>,
     // Metrics for each fuzzed selector.
     metrics: Map<String, InvariantMetrics>,
-    // Cache from fuzzed (target, selector) to its metric key. Only resolved keys are cached;
-    // entries are invalidated when targets are added/removed mid-campaign (see
-    // `invalidate_metric_key_cache`) so they cannot go stale.
+    // Cache from fuzzed (target, selector) to its metric key. Only resolved keys are cached and
+    // they are invalidated when targets change (see `invalidate_metric_key_cache`).
     metric_key_cache: Map<(Address, Selector), String>,
 
     // Proptest runner to query for random values.
@@ -501,9 +500,8 @@ impl InvariantTest {
             return;
         }
 
-        // Not cached: resolve from the current target set. Unresolved keys are not cached so that
-        // a tx whose target isn't a known target yet (e.g. created later in a corpus-mutated
-        // sequence) is re-resolved once the target is added.
+        // Not cached: resolve from the current target set. Unresolved keys aren't cached so a tx
+        // whose target isn't known yet is re-resolved once that target is added.
         let Some(metric_key) = self
             .targeted_contracts
             .targets()
@@ -515,12 +513,8 @@ impl InvariantTest {
         self.test_data.metrics.entry(metric_key).or_default().record_call(reverted, discarded);
     }
 
-    /// Invalidates cached metric keys for the given target addresses.
-    ///
-    /// Must be called whenever targeted contracts are added or removed mid-campaign (e.g. via
-    /// `collect_created_contracts` / `clear_created_contracts`) so a cached key cannot outlive the
-    /// `(target, selector)` -> contract mapping it was derived from (an address can be reused for a
-    /// different artifact across runs).
+    /// Drops cached metric keys for the given addresses, keeping the cache coherent when targets
+    /// are added or removed (an address can be reused for a different artifact across runs).
     fn invalidate_metric_key_cache(&mut self, addresses: &[Address]) {
         if addresses.is_empty() {
             return;
@@ -531,8 +525,8 @@ impl InvariantTest {
     /// End invariant test run by collecting results, cleaning collected artifacts and reverting
     /// created fuzz state.
     fn end_run<FEN: FoundryEvmNetwork>(&mut self, run: InvariantTestRun<FEN>, gas_samples: usize) {
-        // We clear all the targeted contracts created during this run, dropping their cached metric
-        // keys as well so a reused address cannot resolve to a stale contract in a later run.
+        // Clear contracts created during this run, dropping their cached metric keys so a reused
+        // address can't resolve to a stale contract in a later run.
         self.invalidate_metric_key_cache(&run.created_contracts);
         self.targeted_contracts.clear_created_contracts(run.created_contracts);
 
@@ -1077,8 +1071,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     {
                         warn!(target: "forge::test", "{error}");
                     }
-                    // Drop cached metric keys for any newly added targets so a reused address can't
-                    // resolve to a previously cached (stale) contract.
+                    // Drop cached metric keys for newly added targets (reused address).
                     invariant_test.invalidate_metric_key_cache(
                         &current_run.created_contracts[created_before..],
                     );

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -154,6 +154,17 @@ pub struct InvariantMetrics {
     pub discards: usize,
 }
 
+impl InvariantMetrics {
+    fn record_call(&mut self, reverted: bool, discarded: bool) {
+        self.calls += 1;
+        if discarded {
+            self.discards += 1;
+        } else if reverted {
+            self.reverts += 1;
+        }
+    }
+}
+
 /// Campaign-level throughput metrics for invariant progress reporting.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct InvariantThroughputMetrics {
@@ -391,6 +402,8 @@ struct InvariantTestData {
     line_coverage: Option<HitMaps>,
     // Metrics for each fuzzed selector.
     metrics: Map<String, InvariantMetrics>,
+    // Cache from fuzzed target selector to the stable metric key.
+    metric_key_cache: Map<(Address, Selector), Option<String>>,
 
     // Proptest runner to query for random values.
     // The strategy only comes with the first `input`. We fill the rest of the `inputs`
@@ -430,6 +443,7 @@ impl InvariantTest {
             gas_report_traces: vec![],
             line_coverage: None,
             metrics: Map::default(),
+            metric_key_cache: Map::default(),
             branch_runner,
             optimization_best_value: None,
             optimization_best_sequence: vec![],
@@ -461,16 +475,39 @@ impl InvariantTest {
     /// Always increments number of calls; discarded runs (through assume cheatcodes) are tracked
     /// separated from reverts.
     fn record_metrics(&mut self, tx_details: &BasicTxDetails, reverted: bool, discarded: bool) {
-        if let Some(metric_key) = self.targeted_contracts.targets().fuzzed_metric_key(tx_details) {
-            let test_metrics = &mut self.test_data.metrics;
-            let invariant_metrics = test_metrics.entry(metric_key).or_default();
-            invariant_metrics.calls += 1;
-            if discarded {
-                invariant_metrics.discards += 1;
-            } else if reverted {
-                invariant_metrics.reverts += 1;
+        let Some(selector) = tx_details
+            .call_details
+            .calldata
+            .get(..4)
+            .and_then(|selector| <[u8; 4]>::try_from(selector).ok())
+            .map(Selector::from)
+        else {
+            return;
+        };
+        let cache_key = (tx_details.call_details.target, selector);
+
+        if let Some(cached) = self.test_data.metric_key_cache.get(&cache_key) {
+            let Some(metric_key) = cached.as_deref() else { return };
+            if let Some(invariant_metrics) = self.test_data.metrics.get_mut(metric_key) {
+                invariant_metrics.record_call(reverted, discarded);
+                return;
             }
+
+            self.test_data
+                .metrics
+                .entry(metric_key.to_owned())
+                .or_default()
+                .record_call(reverted, discarded);
+            return;
         }
+
+        let metric_key = self
+            .targeted_contracts
+            .targets()
+            .fuzzed_metric_key_for_selector(tx_details.call_details.target, selector);
+        self.test_data.metric_key_cache.insert(cache_key, metric_key.clone());
+        let Some(metric_key) = metric_key else { return };
+        self.test_data.metrics.entry(metric_key).or_default().record_call(reverted, discarded);
     }
 
     /// End invariant test run by collecting results, cleaning collected artifacts and reverting

--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -164,14 +164,29 @@ impl TargetedContracts {
     /// Identifies fuzzed contract and function based on given tx details and returns unique metric
     /// key composed from contract identifier and function name.
     pub fn fuzzed_metric_key(&self, tx: &BasicTxDetails) -> Option<String> {
-        self.inner.get(&tx.call_details.target).and_then(|contract| {
-            tx.call_details.calldata.get(..4).and_then(|selector| {
-                contract
-                    .abi
-                    .functions()
-                    .find(|f| f.selector() == selector)
-                    .map(|function| format!("{}.{}", contract.identifier.clone(), function.name))
+        tx.call_details
+            .calldata
+            .get(..4)
+            .and_then(|selector| <[u8; 4]>::try_from(selector).ok())
+            .map(Selector::from)
+            .and_then(|selector| {
+                self.fuzzed_metric_key_for_selector(tx.call_details.target, selector)
             })
+    }
+
+    /// Identifies fuzzed contract and function from target and selector and returns unique metric
+    /// key composed from contract identifier and function name.
+    pub fn fuzzed_metric_key_for_selector(
+        &self,
+        target: Address,
+        selector: Selector,
+    ) -> Option<String> {
+        self.inner.get(&target).and_then(|contract| {
+            contract
+                .abi
+                .functions()
+                .find(|f| f.selector() == selector)
+                .map(|function| format!("{}.{}", contract.identifier.as_str(), function.name))
         })
     }
 


### PR DESCRIPTION
`record_metrics` runs once per executed tx during invariant campaigns and previously recomputed the metric key every time — looking up the target contract, scanning its ABI for the selector, and building a `format!("{identifier}.{function}")` String on every call.

This caches the resolved metric key per `(target, selector)` so the ABI scan and string build happen only once per distinct pair, adding `fuzzed_metric_key_for_selector` and parsing the selector once from calldata.

Since invariant targets are updatable (contracts deployed mid-run are added via `collect_created_contracts` and cleared at run end, and an address can be reused for a different artifact across runs), the cache is kept coherent: only resolved keys are cached, and entries are invalidated when targets are added or removed. Behavior is otherwise unchanged.