### PR TITLE
perf(fuzz): avoid eager observed call calldata

### DIFF
--- a/crates/evm/fuzz/src/inspector.rs
+++ b/crates/evm/fuzz/src/inspector.rs
@@ -150,7 +150,7 @@ impl Fuzzer {
     }
 
     #[inline]
-    fn should_record_observed_call(&self, scheme: CallScheme) -> bool {
+    const fn should_record_observed_call(&self, scheme: CallScheme) -> bool {
         self.record_calls && self.call_depth > 1 && matches!(scheme, CallScheme::Call)
     }
 

--- a/crates/evm/fuzz/src/inspector.rs
+++ b/crates/evm/fuzz/src/inspector.rs
@@ -62,13 +62,15 @@ impl<CTX: ContextTr> Inspector<CTX> for Fuzzer {
         }
 
         self.call_depth = self.call_depth.saturating_add(1);
-        self.record_observed_call(
-            inputs.caller,
-            inputs.target_address,
-            inputs.input.bytes(ecx),
-            inputs.transfer_value().filter(|value| !value.is_zero()),
-            inputs.scheme,
-        );
+        if self.should_record_observed_call(inputs.scheme) {
+            self.observed_calls.push(ObservedCall {
+                depth: self.call_depth - 1,
+                caller: inputs.caller,
+                target: inputs.target_address,
+                calldata: inputs.input.bytes(ecx),
+                value: inputs.transfer_value().filter(|value| !value.is_zero()),
+            });
+        }
 
         // We only collect `stack` and `memory` data before and after calls.
         // this will be turned off on the next `step`
@@ -127,6 +129,7 @@ impl Fuzzer {
         std::mem::take(&mut self.observed_calls)
     }
 
+    #[cfg(test)]
     fn record_observed_call(
         &mut self,
         caller: Address,
@@ -135,7 +138,7 @@ impl Fuzzer {
         value: Option<U256>,
         scheme: CallScheme,
     ) {
-        if self.record_calls && self.call_depth > 1 && matches!(scheme, CallScheme::Call) {
+        if self.should_record_observed_call(scheme) {
             self.observed_calls.push(ObservedCall {
                 depth: self.call_depth - 1,
                 caller,
@@ -144,6 +147,11 @@ impl Fuzzer {
                 value,
             });
         }
+    }
+
+    #[inline]
+    fn should_record_observed_call(&self, scheme: CallScheme) -> bool {
+        self.record_calls && self.call_depth > 1 && matches!(scheme, CallScheme::Call)
     }
 
     /// Collects `stack` and `memory` values into the fuzz dictionary.


### PR DESCRIPTION
The `Fuzzer` inspector's `call` hook materialized observed-call calldata via `inputs.input.bytes(ecx)` on every EVM sub-call, then discarded it unless call recording was active. For `CallInput::SharedBuffer` that copies the calldata into a fresh `Bytes` on each call.

Gate on `should_record_observed_call(scheme)` first and only materialize calldata (and value) when the call will actually be recorded — i.e. when `record_calls` is set (coverage-guided invariant fuzzing), the call is nested, and the scheme is `CALL`. Behavior is unchanged; only the wasted allocation on non-recorded calls is removed.