### PR TITLE
perf(invariant): drain fuzzer values in place

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -919,7 +919,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run.inputs.last().expect("checked above"),
                 )?;
                 if let Some(fuzzer) = current_run.executor.inspector_mut().fuzzer.as_mut() {
-                    invariant_test.fuzz_state.collect_values(fuzzer.drain_collected_values());
+                    invariant_test.fuzz_state.collect_fuzzer_values(fuzzer);
                 }
                 // Capture per-call EVM cmp operands for I2S corpus mutation. Kept parallel
                 // to `current_run.inputs`; populated unconditionally so dropped calls (magic
@@ -1457,7 +1457,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             &mut failures,
         )?;
         if let Some(fuzzer) = executor.inspector_mut().fuzzer.as_mut() {
-            fuzz_state.collect_values(fuzzer.drain_collected_values());
+            fuzz_state.collect_fuzzer_values(fuzzer);
             let _ = fuzzer.take_observed_calls();
         }
         let mut worker = WorkerCorpus::from_seed(

--- a/crates/evm/fuzz/src/inspector.rs
+++ b/crates/evm/fuzz/src/inspector.rs
@@ -164,11 +164,6 @@ impl Fuzzer {
         self.collect = false;
     }
 
-    /// Drains values observed by the inspector since the last call.
-    pub fn drain_collected_values(&mut self) -> Vec<B256> {
-        std::mem::take(&mut self.collected_values)
-    }
-
     /// Overrides an external call to simulate reentrancy attacks.
     ///
     /// This function detects reentrancy vulnerabilities by replacing external calls

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -1,5 +1,6 @@
 use crate::{
-    BasicTxDetails, invariant::FuzzRunIdentifiedContracts, strategies::literals::LiteralsDictionary,
+    BasicTxDetails, Fuzzer, invariant::FuzzRunIdentifiedContracts,
+    strategies::literals::LiteralsDictionary,
 };
 use alloy_dyn_abi::{DynSolType, DynSolValue, EventExt, FunctionExt};
 use alloy_json_abi::{Function, JsonAbi};
@@ -128,6 +129,13 @@ impl InvariantFuzzState {
     pub fn collect_values(&self, values: impl IntoIterator<Item = B256>) {
         let mut dict = self.inner.borrow_mut();
         for value in values {
+            dict.insert_value(value);
+        }
+    }
+
+    pub fn collect_fuzzer_values(&self, fuzzer: &mut Fuzzer) {
+        let mut dict = self.inner.borrow_mut();
+        for value in fuzzer.collected_values.drain(..) {
             dict.insert_value(value);
         }
     }


### PR DESCRIPTION
Drains the fuzzer's collected stack values into the dictionary in place instead of `mem::take`-ing the buffer each call. `mem::take` swapped in a fresh zero-capacity `Vec` and dropped the old allocation, forcing a realloc on the next collection; the new `InvariantFuzzState::collect_fuzzer_values` drains the values while retaining the buffer's capacity for reuse, removing per-call allocator churn in the hot invariant loop.

The now-unused `Fuzzer::drain_collected_values` is removed.