### PR TITLE
perf(fuzz): skip empty call artifact lookup

### DIFF
--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -147,9 +147,17 @@ impl InvariantFuzzState {
     ) {
         let mut dict = self.inner.borrow_mut();
         let targets = fuzzed_contracts.targets();
-        let (target_abi, target_function) = targets.fuzzed_artifacts(tx);
-        dict.insert_logs_values(target_abi, logs, run_depth);
-        dict.insert_result_values(target_function, result, run_depth);
+        let (target_abi, target_function) = if logs.is_empty() && result.is_empty() {
+            (None, None)
+        } else {
+            targets.fuzzed_artifacts(tx)
+        };
+        if !logs.is_empty() {
+            dict.insert_logs_values(target_abi, logs, run_depth);
+        }
+        if !result.is_empty() {
+            dict.insert_result_values(target_function, result, run_depth);
+        }
         // Get storage layouts for contracts in the state changeset
         let storage_layouts = targets.get_storage_layouts();
         dict.insert_new_state_values(state_changeset, &storage_layouts, mapping_slots);


### PR DESCRIPTION
`collect_values_from_call` runs on the hot path for every committed fuzzed call. It always called `fuzzed_artifacts(tx)` to resolve the target ABI and function, even when there were no logs and no return data to decode — and that lookup scans the contract's functions computing a keccak selector per function (alloy's `Function::selector()` is not cached).

Skip the lookup when both `logs` and `result` are empty (common for state-mutating calls that return nothing and emit no events), and only run each `insert_*` decode when its input is non-empty. Both inserts are already no-ops on empty input, so dictionary contents are unchanged.