### PR TITLE
perf: gate mapping slot recording by opcode

### DIFF
--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -30,7 +30,9 @@ use alloy_rpc_types::AccessList;
 use alloy_sol_types::{SolCall, SolInterface, SolValue};
 use foundry_common::{
     FoundryTransactionBuilder, SELECTOR_LEN, TransactionMaybeSigned,
-    mapping_slots::{MappingSlots, step as mapping_step},
+    mapping_slots::{
+        MappingSlots, observes_opcode as observes_mapping_opcode, step as mapping_step,
+    },
 };
 use foundry_evm_core::{
     Breakpoints, EvmEnv, FoundryTransaction, InspectorExt,
@@ -1395,7 +1397,10 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
 
         // `startMappingRecording`: record SSTORE and KECCAK256.
         if let Some(mapping_slots) = &mut self.mapping_slots {
-            mapping_step(mapping_slots, interpreter);
+            let op = interpreter.bytecode.opcode();
+            if observes_mapping_opcode(op) {
+                mapping_step(mapping_slots, interpreter, op);
+            }
         }
 
         // `snapshotGas*`: take a snapshot of the current gas.

--- a/crates/common/src/mapping_slots.rs
+++ b/crates/common/src/mapping_slots.rs
@@ -2,10 +2,7 @@ use alloy_primitives::{
     B256, U256, keccak256,
     map::{AddressHashMap, B256HashMap},
 };
-use revm::{
-    bytecode::opcode,
-    interpreter::Interpreter,
-};
+use revm::{bytecode::opcode, interpreter::Interpreter};
 
 /// Recorded mapping slots.
 #[derive(Clone, Debug, Default)]

--- a/crates/common/src/mapping_slots.rs
+++ b/crates/common/src/mapping_slots.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{
 };
 use revm::{
     bytecode::opcode,
-    interpreter::{Interpreter, interpreter_types::Jumps},
+    interpreter::Interpreter,
 };
 
 /// Recorded mapping slots.
@@ -44,11 +44,17 @@ impl MappingSlots {
     }
 }
 
+/// Returns whether the opcode can update recorded mapping slot metadata.
+#[inline]
+pub const fn observes_opcode(op: u8) -> bool {
+    matches!(op, opcode::KECCAK256 | opcode::SSTORE)
+}
+
 /// Function to be used in Inspector::step to record mapping slots and keys
 #[cold]
-pub fn step(mapping_slots: &mut AddressHashMap<MappingSlots>, interpreter: &Interpreter) {
+pub fn step(mapping_slots: &mut AddressHashMap<MappingSlots>, interpreter: &Interpreter, op: u8) {
     #[allow(clippy::collapsible_match)]
-    match interpreter.bytecode.opcode() {
+    match op {
         opcode::KECCAK256 if interpreter.stack.peek(1) == Ok(U256::from(0x40)) => {
             let address = interpreter.input.target_address;
             let offset = interpreter.stack.peek(0).expect("stack size > 1").saturating_to();

--- a/crates/evm/fuzz/src/inspector.rs
+++ b/crates/evm/fuzz/src/inspector.rs
@@ -1,11 +1,16 @@
 use crate::invariant::RandomCallGenerator;
 use alloy_primitives::{Address, B256, Bytes, U256, map::AddressMap};
-use foundry_common::mapping_slots::{MappingSlots, step as mapping_step};
+use foundry_common::mapping_slots::{
+    MappingSlots, observes_opcode as observes_mapping_opcode, step as mapping_step,
+};
 use foundry_evm_core::constants::CHEATCODE_ADDRESS;
 use revm::{
     Inspector,
     context::{ContextTr, JournalTr, Transaction},
-    interpreter::{CallInput, CallInputs, CallOutcome, CallScheme, CallValue, Interpreter},
+    interpreter::{
+        CallInput, CallInputs, CallOutcome, CallScheme, CallValue, Interpreter,
+        interpreter_types::Jumps,
+    },
 };
 
 /// A sub-call observed by the [`Fuzzer`] inspector.
@@ -50,7 +55,10 @@ impl<CTX: ContextTr> Inspector<CTX> for Fuzzer {
         if self.collect {
             self.collect_data(interp);
             if let Some(mapping_slots) = &mut self.mapping_slots {
-                mapping_step(mapping_slots, interp);
+                let op = interp.bytecode.opcode();
+                if observes_mapping_opcode(op) {
+                    mapping_step(mapping_slots, interp, op);
+                }
             }
         }
     }


### PR DESCRIPTION
Add a small opcode predicate for mapping slot recording and pass the loaded opcode into the recorder.

This avoids calling the cold mapping recorder on interpreter steps that cannot observe KECCAK256 or SSTORE while preserving the existing recording behavior for relevant opcodes.