### PR TITLE
perf(invariant): skip zero-value balance lookup

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1968,9 +1968,12 @@ pub(crate) fn execute_tx<FEN: FoundryEvmNetwork>(
 
     // Bound requested value by sender's available balance so payable paths still get
     // exercised when the requested value exceeds balance, instead of collapsing to zero.
-    let requested_value = tx.call_details.value.unwrap_or(U256::ZERO);
-    let sender_balance = executor.get_balance(tx.sender)?;
-    let value = requested_value.min(sender_balance);
+    let value = match tx.call_details.value {
+        Some(requested_value) if !requested_value.is_zero() => {
+            requested_value.min(executor.get_balance(tx.sender)?)
+        }
+        _ => U256::ZERO,
+    };
     executor
         .call_raw(tx.sender, tx.call_details.target, tx.call_details.calldata.clone(), value)
         .map_err(|e| eyre!(format!("Could not make raw evm call: {e}")))


### PR DESCRIPTION
`execute_tx` runs once per invariant tx and always read the sender's balance to cap the requested call value, even though most generated calls carry no value (non-payable functions emit `None`, and `fuzz_msg_value` is ~85% `None`).

This skips the balance lookup unless the requested value is `Some(> 0)`, avoiding a per-tx backend/journal read (and remote account fetches on forks) in the common case. When a positive value is requested it's still capped to the sender's balance, so over-budget fuzzed values keep exercising payable paths. The computed value is otherwise unchanged.