### PR TITLE
test: allow vm.load on precompiles

### DIFF
--- a/testdata/default/cheats/Load.t.sol
+++ b/testdata/default/cheats/Load.t.sol
@@ -24,9 +24,8 @@ contract LoadTest is Test {
         assertEq(val, 20, "load failed");
     }
 
-    function testLoadNotAvailableOnPrecompiles() public {
-        vm._expectCheatcodeRevert("cannot use precompile 0x0000000000000000000000000000000000000001 as an argument");
-        vm.load(address(1), bytes32(0));
+    function testLoadAvailableOnPrecompiles() public {
+        assertEq(vm.load(address(1), bytes32(0)), bytes32(0));
     }
 
     function testLoadOtherStorage() public {


### PR DESCRIPTION
## Summary
- follow-up to #15231, which intentionally allowed read-only `vm.load` calls on precompile accounts
- update the Load cheatcode testdata fixture to reflect that `vm.load` can read precompile storage
- keep mutation cheatcode behavior covered by the existing precompile regression test

## Test
- `cargo test -p forge --test cli precompile_cheatcode_load_is_read_only`
- `cargo test -p forge --test cli test_cmd::testdata` *(blocked locally: sandbox has no Vyper compiler, fails before reaching the changed Solidity fixture with `Found Vyper sources, but no compiler versions are available for it`)*

Prompted by: @grandizzy