### PR TITLE
ci: skip rust-cache for no-default-features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
           toolchain: stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo build --workspace --no-default-features --locked
 
   typos:


### PR DESCRIPTION
## Summary
- remove `Swatinem/rust-cache` from the `no-default-features` CI job
- keep `sccache` in place so rustc compile output caching remains enabled
- leave other workflow rust-cache uses unchanged

## Rationale
The `no-default-features` job can fail before `cargo build` starts when the rust-cache restore exhausts runner disk space. This job only needs to build with no default features, and `sccache` already covers the high-value rustc compilation cache.

## Test
- not run locally; workflow-only change

Prompted by: @grandizzy