### PR TITLE
ci(release): skip duplicate immutable nightly releases

### DIFF
--- a/.github/scripts/create-tag.js
+++ b/.github/scripts/create-tag.js
@@ -7,9 +7,17 @@ module.exports = async ({ github, context }, tagName) => {
             sha: context.sha,
         });
     } catch (err) {
-        if (err.status === 422 && String(err.message).includes("Reference already exists")) {
-            console.log(`Tag already exists: ${tagName}`);
-            return;
+        if (err.status === 422) {
+            const { data: existingRef } = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tagName}`,
+            });
+            if (existingRef.object.sha === context.sha) {
+                console.log(`Tag already exists at ${context.sha}: ${tagName}`);
+                return;
+            }
+            console.error(`Tag ${tagName} already exists at ${existingRef.object.sha}, expected ${context.sha}`);
         }
         throw err;
     }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       tag_name: ${{ steps.release_info.outputs.tag_name }}
       release_name: ${{ steps.release_info.outputs.release_name }}
       changelog: ${{ steps.build_changelog.outputs.changelog }}
+      skip_release: ${{ steps.existing_release.outputs.skip_release || 'false' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -55,12 +56,33 @@ jobs:
             printf 'from_tag=%s\n' "$PREV_STABLE" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Check existing nightly release
+        id: existing_release
+        if: ${{ env.IS_NIGHTLY == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          skip_release=false
+          if is_draft="$(gh release view "$TAG_NAME" --json isDraft --jq .isDraft 2>/dev/null)"; then
+            if [[ "$is_draft" == "true" ]]; then
+              echo "Draft nightly release $TAG_NAME already exists; continuing so assets can be uploaded."
+            else
+              echo "Published nightly release $TAG_NAME already exists; skipping duplicate nightly release."
+              skip_release=true
+            fi
+          fi
+          printf 'skip_release=%s\n' "$skip_release" >> "$GITHUB_OUTPUT"
+
       # Creates a `nightly-SHA` tag for this specific nightly
       # This tag is used for this specific nightly version's release
       # which allows users to roll back. It is also used to build
       # the changelog.
       - name: Create build-specific nightly tag
-        if: ${{ env.IS_NIGHTLY == 'true' }}
+        if: ${{ env.IS_NIGHTLY == 'true' && steps.existing_release.outputs.skip_release != 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
@@ -71,6 +93,7 @@ jobs:
 
       - name: Build changelog
         id: build_changelog
+        if: ${{ steps.existing_release.outputs.skip_release != 'true' }}
         uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
         with:
           configuration: "./.github/changelog.json"
@@ -86,6 +109,7 @@ jobs:
       # a draft for a maintainer to publish manually; nightlies are auto-
       # published by the `publish-nightly` job at the end of the workflow.
       - name: Create draft release
+        if: ${{ steps.existing_release.outputs.skip_release != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -115,6 +139,7 @@ jobs:
   release-docker:
     name: Release Docker
     needs: prepare
+    if: ${{ needs.prepare.outputs.skip_release != 'true' }}
     uses: ./.github/workflows/docker-publish.yml
     permissions:
       attestations: write
@@ -139,6 +164,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 240
     needs: prepare
+    if: ${{ needs.prepare.outputs.skip_release != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -404,7 +430,7 @@ jobs:
     name: Publish nightly release
     runs-on: ubuntu-latest
     needs: [prepare, release-docker, release]
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.prepare.outputs.skip_release != 'true' }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

- Skip nightly release work when the computed immutable nightly release is already published for the current SHA.
- Gate the downstream Docker, binary release, and publish jobs on the new `prepare` skip output.
- Make `create-tag.js` idempotent for existing tags that already point at the current commit, independent of GitHub's 422 message text.

## Root cause

Nightlies are now immutable `nightly-${GITHUB_SHA}` releases. When `master` does not move between two scheduled runs, the second run computes the same tag as the previous successful nightly. The release is already published, so the workflow cannot upload more assets to it.
