### PR TITLE
feat(debugger): jump to active buffer offsets

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -68,6 +68,8 @@ pub(crate) struct TUIContext<'a> {
     pub(crate) key_buffer: String,
     /// Current goto program counter prompt contents, if the prompt is active.
     pub(crate) pc_input: Option<String>,
+    /// Current active-buffer byte offset prompt contents, if the prompt is active.
+    pub(crate) buffer_offset_input: Option<String>,
     /// Current opcode search prompt contents, if the prompt is active.
     pub(crate) opcode_search_input: Option<String>,
     /// Last opcode search term, used by repeat-search shortcuts.
@@ -95,6 +97,7 @@ impl<'a> TUIContext<'a> {
 
             key_buffer: String::with_capacity(64),
             pc_input: None,
+            buffer_offset_input: None,
             opcode_search_input: None,
             last_opcode_search: None,
             status: None,
@@ -164,9 +167,17 @@ impl<'a> TUIContext<'a> {
 
     fn active_buffer(&self) -> &[u8] {
         match self.active_buffer {
-            BufferKind::Memory => self.current_step().memory.as_ref().unwrap().as_bytes(),
+            BufferKind::Memory => self.current_step().memory.as_ref().map_or(&[], |m| m.as_bytes()),
             BufferKind::Calldata => &self.debug_call().calldata,
             BufferKind::Returndata => &self.current_step().returndata,
+        }
+    }
+
+    pub(crate) const fn active_buffer_name(&self) -> &'static str {
+        match self.active_buffer {
+            BufferKind::Memory => "memory",
+            BufferKind::Calldata => "calldata",
+            BufferKind::Returndata => "returndata",
         }
     }
 }
@@ -191,6 +202,11 @@ impl TUIContext<'_> {
 
         if self.pc_input.is_some() {
             self.handle_pc_input_key_event(event);
+            return ControlFlow::Continue(());
+        }
+
+        if self.buffer_offset_input.is_some() {
+            self.handle_buffer_offset_input_key_event(event);
             return ControlFlow::Continue(());
         }
 
@@ -325,6 +341,13 @@ impl TUIContext<'_> {
                 self.pc_input = Some(String::new());
             }
 
+            // Go to byte offset in the active buffer
+            KeyCode::Char('o') => {
+                self.key_buffer.clear();
+                self.status = None;
+                self.buffer_offset_input = Some(String::new());
+            }
+
             // Search opcodes in the current call
             KeyCode::Char('/') => {
                 self.key_buffer.clear();
@@ -377,9 +400,34 @@ impl TUIContext<'_> {
                 }
             }
             KeyCode::Char(c)
-                if !event.modifiers.contains(KeyModifiers::CONTROL) && is_pc_input_char(c) =>
+                if !event.modifiers.contains(KeyModifiers::CONTROL) && is_numeric_input_char(c) =>
             {
                 if let Some(input) = &mut self.pc_input {
+                    input.push(c);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_buffer_offset_input_key_event(&mut self, event: KeyEvent) {
+        match event.code {
+            KeyCode::Esc => {
+                self.buffer_offset_input = None;
+            }
+            KeyCode::Enter => {
+                let input = self.buffer_offset_input.take().unwrap_or_default();
+                self.goto_buffer_offset_from_input(&input);
+            }
+            KeyCode::Backspace => {
+                if let Some(input) = &mut self.buffer_offset_input {
+                    input.pop();
+                }
+            }
+            KeyCode::Char(c)
+                if !event.modifiers.contains(KeyModifiers::CONTROL) && is_numeric_input_char(c) =>
+            {
+                if let Some(input) = &mut self.buffer_offset_input {
                     input.push(c);
                 }
             }
@@ -461,7 +509,7 @@ impl TUIContext<'_> {
                 self.debug_arena(),
                 self.draw_memory.inner_call_index,
                 self.current_step,
-                candidate.pc,
+                candidate.value,
             ) {
                 found.push((candidate, target));
             }
@@ -471,10 +519,10 @@ impl TUIContext<'_> {
             [] => {
                 let current = self.debug_call();
                 let outside = candidates.iter().any(|candidate| {
-                    pc_exists_outside_code_context(self.debug_arena(), current, candidate.pc)
+                    pc_exists_outside_code_context(self.debug_arena(), current, candidate.value)
                 });
                 let pc = if let [candidate] = candidates.as_slice() {
-                    let pc = candidate.pc;
+                    let pc = candidate.value;
                     format!("PC 0x{pc:x} ({pc})")
                 } else {
                     format!("PC `{}`", input.trim())
@@ -511,13 +559,70 @@ impl TUIContext<'_> {
         self.scroll_memory_to_current_write();
         self.key_buffer.clear();
 
-        let pc = candidate.pc;
+        let pc = candidate.value;
         let scope = match target.scope {
             PcTargetScope::CurrentNode => "current trace",
             PcTargetScope::SameCodeContext => "same contract",
         };
         let action = if already_at_target { "Already at" } else { "Jumped to" };
         self.set_info(format!("{action} PC 0x{pc:x} ({pc}) in {scope}"));
+    }
+
+    fn goto_buffer_offset_from_input(&mut self, input: &str) {
+        let candidates = match parse_buffer_offset_candidates(input) {
+            Ok(candidates) => candidates,
+            Err(err) => {
+                self.set_error(err);
+                return;
+            }
+        };
+
+        let buffer_name = self.active_buffer_name();
+        let buffer_len = self.active_buffer().len();
+        if buffer_len == 0 {
+            self.set_error(format!("Current {buffer_name} buffer is empty"));
+            return;
+        }
+
+        let mut found = Vec::new();
+        for &candidate in &candidates {
+            if candidate.value < buffer_len {
+                found.push(candidate);
+            }
+        }
+
+        match found.as_slice() {
+            [] => {
+                let offset = if let [candidate] = candidates.as_slice() {
+                    format!("0x{:x} ({})", candidate.value, candidate.value)
+                } else {
+                    format!("`{}`", input.trim())
+                };
+                self.set_error(format!(
+                    "{buffer_name} offset {offset} is outside the {buffer_len}-byte buffer"
+                ));
+            }
+            [candidate] => self.apply_buffer_offset(*candidate),
+            _ => {
+                let input = input.trim();
+                let options = found
+                    .iter()
+                    .map(|candidate| candidate.describe())
+                    .collect::<Vec<_>>()
+                    .join(" and ");
+                self.set_error(format!(
+                    "Ambiguous buffer offset `{input}`: {options} both exist; use d:<offset> or 0x<offset>"
+                ));
+            }
+        }
+    }
+
+    fn apply_buffer_offset(&mut self, candidate: NumericCandidate) {
+        let offset = candidate.value;
+        self.draw_memory.current_buf_startline = offset / 32;
+        self.key_buffer.clear();
+        let buffer_name = self.active_buffer_name();
+        self.set_info(format!("Jumped to {buffer_name} offset 0x{offset:x} ({offset})"));
     }
 
     fn set_info(&mut self, text: String) {
@@ -547,7 +652,10 @@ impl TUIContext<'_> {
     }
 
     fn handle_mouse_event(&mut self, event: MouseEvent) -> ControlFlow<ExitReason> {
-        if self.pc_input.is_some() || self.opcode_search_input.is_some() {
+        if self.pc_input.is_some()
+            || self.buffer_offset_input.is_some()
+            || self.opcode_search_input.is_some()
+        {
             return ControlFlow::Continue(());
         }
 
@@ -643,7 +751,7 @@ fn buffer_as_number(s: &str) -> usize {
     s.parse().unwrap_or(MIN).clamp(MIN, MAX)
 }
 
-const fn is_pc_input_char(c: char) -> bool {
+const fn is_numeric_input_char(c: char) -> bool {
     c.is_ascii_hexdigit() || matches!(c, 'x' | 'X' | ':')
 }
 
@@ -660,19 +768,21 @@ enum PcBase {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct PcCandidate {
-    pc: usize,
+struct NumericCandidate {
+    value: usize,
     base: PcBase,
 }
 
-impl PcCandidate {
+impl NumericCandidate {
     fn describe(self) -> String {
         match self.base {
-            PcBase::Hex => format!("hex 0x{:x}", self.pc),
-            PcBase::Decimal => format!("decimal {}", self.pc),
+            PcBase::Hex => format!("hex 0x{:x}", self.value),
+            PcBase::Decimal => format!("decimal {}", self.value),
         }
     }
 }
+
+type PcCandidate = NumericCandidate;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PcTargetScope {
@@ -688,53 +798,93 @@ struct PcTarget {
 }
 
 fn parse_pc_candidates(input: &str) -> Result<Vec<PcCandidate>, String> {
+    parse_numeric_candidates(input, NumericInputKind::ProgramCounter)
+}
+
+fn parse_buffer_offset_candidates(input: &str) -> Result<Vec<NumericCandidate>, String> {
+    parse_numeric_candidates(input, NumericInputKind::BufferOffset)
+}
+
+#[derive(Clone, Copy)]
+enum NumericInputKind {
+    ProgramCounter,
+    BufferOffset,
+}
+
+impl NumericInputKind {
+    const fn empty_message(self) -> &'static str {
+        match self {
+            Self::ProgramCounter => "Enter a program counter",
+            Self::BufferOffset => "Enter a buffer offset",
+        }
+    }
+
+    fn invalid_message(self, input: &str) -> String {
+        match self {
+            Self::ProgramCounter => format!("Invalid PC `{input}`; use 0x2a, 2a, or d:42"),
+            Self::BufferOffset => {
+                format!("Invalid buffer offset `{input}`; use 0x20 or d:32")
+            }
+        }
+    }
+}
+
+fn parse_numeric_candidates(
+    input: &str,
+    kind: NumericInputKind,
+) -> Result<Vec<NumericCandidate>, String> {
     let input = input.trim();
     if input.is_empty() {
-        return Err("Enter a program counter".to_string());
+        return Err(kind.empty_message().to_string());
     }
 
     if let Some(rest) = input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")) {
-        return parse_pc_candidate(rest, 16, PcBase::Hex, input);
+        return parse_numeric_candidate(rest, 16, PcBase::Hex, input, kind);
     }
 
     if let Some(rest) = input.strip_prefix("d:").or_else(|| input.strip_prefix("dec:")) {
-        return parse_pc_candidate(rest, 10, PcBase::Decimal, input);
+        return parse_numeric_candidate(rest, 10, PcBase::Decimal, input, kind);
     }
 
     if input.chars().any(|c| c.is_ascii_hexdigit() && c.is_ascii_alphabetic()) {
-        return parse_pc_candidate(input, 16, PcBase::Hex, input);
+        return parse_numeric_candidate(input, 16, PcBase::Hex, input, kind);
     }
 
     if input.chars().all(|c| c.is_ascii_digit()) {
-        let decimal = parse_pc(input, 10, input)?;
-        let hex = parse_pc(input, 16, input)?;
+        let decimal = parse_number(input, 10, input, kind)?;
+        let hex = parse_number(input, 16, input, kind)?;
         if decimal == hex {
-            return Ok(vec![PcCandidate { pc: decimal, base: PcBase::Decimal }]);
+            return Ok(vec![NumericCandidate { value: decimal, base: PcBase::Decimal }]);
         }
         return Ok(vec![
-            PcCandidate { pc: decimal, base: PcBase::Decimal },
-            PcCandidate { pc: hex, base: PcBase::Hex },
+            NumericCandidate { value: decimal, base: PcBase::Decimal },
+            NumericCandidate { value: hex, base: PcBase::Hex },
         ]);
     }
 
-    Err(format!("Invalid PC `{input}`; use 0x2a, 2a, or d:42"))
+    Err(kind.invalid_message(input))
 }
 
-fn parse_pc_candidate(
+fn parse_numeric_candidate(
     input: &str,
     radix: u32,
     base: PcBase,
     original: &str,
-) -> Result<Vec<PcCandidate>, String> {
-    Ok(vec![PcCandidate { pc: parse_pc(input, radix, original)?, base }])
+    kind: NumericInputKind,
+) -> Result<Vec<NumericCandidate>, String> {
+    Ok(vec![NumericCandidate { value: parse_number(input, radix, original, kind)?, base }])
 }
 
-fn parse_pc(input: &str, radix: u32, original: &str) -> Result<usize, String> {
+fn parse_number(
+    input: &str,
+    radix: u32,
+    original: &str,
+    kind: NumericInputKind,
+) -> Result<usize, String> {
     if input.is_empty() {
-        return Err(format!("Invalid PC `{original}`; use 0x2a, 2a, or d:42"));
+        return Err(kind.invalid_message(original));
     }
-    usize::from_str_radix(input, radix)
-        .map_err(|_| format!("Invalid PC `{original}`; use 0x2a, 2a, or d:42"))
+    usize::from_str_radix(input, radix).map_err(|_| kind.invalid_message(original))
 }
 
 fn find_pc_target(
@@ -965,11 +1115,11 @@ mod tests {
     fn parses_prefixed_hex_pc() {
         assert_eq!(
             parse_pc_candidates("0x2a").unwrap(),
-            vec![PcCandidate { pc: 42, base: PcBase::Hex }]
+            vec![PcCandidate { value: 42, base: PcBase::Hex }]
         );
         assert_eq!(
             parse_pc_candidates("0X2A").unwrap(),
-            vec![PcCandidate { pc: 42, base: PcBase::Hex }]
+            vec![PcCandidate { value: 42, base: PcBase::Hex }]
         );
     }
 
@@ -977,7 +1127,7 @@ mod tests {
     fn parses_bare_hex_pc_with_letters() {
         assert_eq!(
             parse_pc_candidates("2a").unwrap(),
-            vec![PcCandidate { pc: 42, base: PcBase::Hex }]
+            vec![PcCandidate { value: 42, base: PcBase::Hex }]
         );
     }
 
@@ -985,11 +1135,11 @@ mod tests {
     fn parses_explicit_decimal_pc() {
         assert_eq!(
             parse_pc_candidates("d:42").unwrap(),
-            vec![PcCandidate { pc: 42, base: PcBase::Decimal }]
+            vec![PcCandidate { value: 42, base: PcBase::Decimal }]
         );
         assert_eq!(
             parse_pc_candidates("dec:42").unwrap(),
-            vec![PcCandidate { pc: 42, base: PcBase::Decimal }]
+            vec![PcCandidate { value: 42, base: PcBase::Decimal }]
         );
     }
 
@@ -998,13 +1148,13 @@ mod tests {
         assert_eq!(
             parse_pc_candidates("10").unwrap(),
             vec![
-                PcCandidate { pc: 10, base: PcBase::Decimal },
-                PcCandidate { pc: 16, base: PcBase::Hex },
+                PcCandidate { value: 10, base: PcBase::Decimal },
+                PcCandidate { value: 16, base: PcBase::Hex },
             ]
         );
         assert_eq!(
             parse_pc_candidates("9").unwrap(),
-            vec![PcCandidate { pc: 9, base: PcBase::Decimal }]
+            vec![PcCandidate { value: 9, base: PcBase::Decimal }]
         );
     }
 
@@ -1014,6 +1164,31 @@ mod tests {
         assert!(parse_pc_candidates("0x").is_err());
         assert!(parse_pc_candidates("xyz").is_err());
         assert!(parse_pc_candidates("184467440737095516160").is_err());
+    }
+
+    #[test]
+    fn parses_buffer_offsets_like_program_counters_with_offset_errors() {
+        assert_eq!(
+            parse_buffer_offset_candidates("0x20").unwrap(),
+            vec![NumericCandidate { value: 32, base: PcBase::Hex }]
+        );
+        assert_eq!(
+            parse_buffer_offset_candidates("d:32").unwrap(),
+            vec![NumericCandidate { value: 32, base: PcBase::Decimal }]
+        );
+        assert_eq!(
+            parse_buffer_offset_candidates("20").unwrap(),
+            vec![
+                NumericCandidate { value: 20, base: PcBase::Decimal },
+                NumericCandidate { value: 32, base: PcBase::Hex },
+            ]
+        );
+
+        assert_eq!(parse_buffer_offset_candidates("").unwrap_err(), "Enter a buffer offset");
+        assert_eq!(
+            parse_buffer_offset_candidates("0x").unwrap_err(),
+            "Invalid buffer offset `0x`; use 0x20 or d:32"
+        );
     }
 
     #[test]
@@ -1167,6 +1342,111 @@ mod tests {
         assert_eq!(tui.pc_input, None);
         assert_eq!(tui.current_step, 0);
         assert_eq!(tui.status, None);
+    }
+
+    #[test]
+    fn buffer_offset_input_mode_handles_calldata_offsets_and_blocks_normal_commands() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![step(1)],
+            Bytes::from(vec![0; 96]),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.active_buffer = BufferKind::Calldata;
+
+        assert!(matches!(tui.handle_key_event(key(KeyCode::Char('o'))), ControlFlow::Continue(())));
+        assert_eq!(tui.buffer_offset_input.as_deref(), Some(""));
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('q')));
+        assert_eq!(tui.buffer_offset_input.as_deref(), Some(""));
+        assert_eq!(tui.draw_memory.current_buf_startline, 0);
+
+        for c in "0x40".chars() {
+            let _ = tui.handle_key_event(key(KeyCode::Char(c)));
+        }
+        let _ = tui.handle_key_event(key(KeyCode::Enter));
+
+        assert_eq!(tui.buffer_offset_input, None);
+        assert_eq!(tui.draw_memory.current_buf_startline, 2);
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Info);
+        assert_eq!(status.text, "Jumped to calldata offset 0x40 (64)");
+    }
+
+    #[test]
+    fn buffer_offset_jumps_in_active_calldata_buffer() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![step(1)],
+            Bytes::from(vec![0; 96]),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.active_buffer = BufferKind::Calldata;
+
+        tui.goto_buffer_offset_from_input("0x20");
+
+        assert_eq!(tui.draw_memory.current_buf_startline, 1);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Jumped to calldata offset 0x20 (32)");
+    }
+
+    #[test]
+    fn buffer_offset_reports_ambiguous_and_out_of_range_offsets_without_moving() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![step(1)],
+            Bytes::from(vec![0; 64]),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.active_buffer = BufferKind::Calldata;
+        tui.draw_memory.current_buf_startline = 1;
+
+        tui.goto_buffer_offset_from_input("20");
+        assert_eq!(tui.draw_memory.current_buf_startline, 1);
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert!(status.text.contains("Ambiguous buffer offset `20`"));
+
+        tui.goto_buffer_offset_from_input("0x80");
+        assert_eq!(tui.draw_memory.current_buf_startline, 1);
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "calldata offset 0x80 (128) is outside the 64-byte buffer");
+    }
+
+    #[test]
+    fn buffer_offset_escape_cancels_and_empty_buffer_reports_error() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('o')));
+        let _ = tui.handle_key_event(key(KeyCode::Char('2')));
+        let _ = tui.handle_key_event(key(KeyCode::Esc));
+
+        assert_eq!(tui.buffer_offset_input, None);
+        assert_eq!(tui.draw_memory.current_buf_startline, 0);
+        assert_eq!(tui.status, None);
+
+        tui.goto_buffer_offset_from_input("0");
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "Current memory buffer is empty");
     }
 
     #[test]

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -400,7 +400,7 @@ impl TUIContext<'_> {
                 }
             }
             KeyCode::Char(c)
-                if !event.modifiers.contains(KeyModifiers::CONTROL) && is_numeric_input_char(c) =>
+                if !event.modifiers.contains(KeyModifiers::CONTROL) && is_pc_input_char(c) =>
             {
                 if let Some(input) = &mut self.pc_input {
                     input.push(c);
@@ -425,7 +425,8 @@ impl TUIContext<'_> {
                 }
             }
             KeyCode::Char(c)
-                if !event.modifiers.contains(KeyModifiers::CONTROL) && is_numeric_input_char(c) =>
+                if !event.modifiers.contains(KeyModifiers::CONTROL)
+                    && (c.is_ascii_hexdigit() || matches!(c, 'x' | 'X' | ':')) =>
             {
                 if let Some(input) = &mut self.buffer_offset_input {
                     input.push(c);
@@ -509,7 +510,7 @@ impl TUIContext<'_> {
                 self.debug_arena(),
                 self.draw_memory.inner_call_index,
                 self.current_step,
-                candidate.value,
+                candidate.pc,
             ) {
                 found.push((candidate, target));
             }
@@ -519,10 +520,10 @@ impl TUIContext<'_> {
             [] => {
                 let current = self.debug_call();
                 let outside = candidates.iter().any(|candidate| {
-                    pc_exists_outside_code_context(self.debug_arena(), current, candidate.value)
+                    pc_exists_outside_code_context(self.debug_arena(), current, candidate.pc)
                 });
                 let pc = if let [candidate] = candidates.as_slice() {
-                    let pc = candidate.value;
+                    let pc = candidate.pc;
                     format!("PC 0x{pc:x} ({pc})")
                 } else {
                     format!("PC `{}`", input.trim())
@@ -559,7 +560,7 @@ impl TUIContext<'_> {
         self.scroll_memory_to_current_write();
         self.key_buffer.clear();
 
-        let pc = candidate.value;
+        let pc = candidate.pc;
         let scope = match target.scope {
             PcTargetScope::CurrentNode => "current trace",
             PcTargetScope::SameCodeContext => "same contract",
@@ -569,8 +570,8 @@ impl TUIContext<'_> {
     }
 
     fn goto_buffer_offset_from_input(&mut self, input: &str) {
-        let candidates = match parse_buffer_offset_candidates(input) {
-            Ok(candidates) => candidates,
+        let offset = match parse_buffer_offset(input) {
+            Ok(offset) => offset,
             Err(err) => {
                 self.set_error(err);
                 return;
@@ -584,41 +585,17 @@ impl TUIContext<'_> {
             return;
         }
 
-        let mut found = Vec::new();
-        for &candidate in &candidates {
-            if candidate.value < buffer_len {
-                found.push(candidate);
-            }
+        if offset >= buffer_len {
+            self.set_error(format!(
+                "{buffer_name} offset 0x{offset:x} ({offset}) is outside the {buffer_len}-byte buffer"
+            ));
+            return;
         }
 
-        match found.as_slice() {
-            [] => {
-                let offset = if let [candidate] = candidates.as_slice() {
-                    format!("0x{:x} ({})", candidate.value, candidate.value)
-                } else {
-                    format!("`{}`", input.trim())
-                };
-                self.set_error(format!(
-                    "{buffer_name} offset {offset} is outside the {buffer_len}-byte buffer"
-                ));
-            }
-            [candidate] => self.apply_buffer_offset(*candidate),
-            _ => {
-                let input = input.trim();
-                let options = found
-                    .iter()
-                    .map(|candidate| candidate.describe())
-                    .collect::<Vec<_>>()
-                    .join(" and ");
-                self.set_error(format!(
-                    "Ambiguous buffer offset `{input}`: {options} both exist; use d:<offset> or 0x<offset>"
-                ));
-            }
-        }
+        self.apply_buffer_offset(offset);
     }
 
-    fn apply_buffer_offset(&mut self, candidate: NumericCandidate) {
-        let offset = candidate.value;
+    fn apply_buffer_offset(&mut self, offset: usize) {
         self.draw_memory.current_buf_startline = offset / 32;
         self.key_buffer.clear();
         let buffer_name = self.active_buffer_name();
@@ -751,7 +728,7 @@ fn buffer_as_number(s: &str) -> usize {
     s.parse().unwrap_or(MIN).clamp(MIN, MAX)
 }
 
-const fn is_numeric_input_char(c: char) -> bool {
+const fn is_pc_input_char(c: char) -> bool {
     c.is_ascii_hexdigit() || matches!(c, 'x' | 'X' | ':')
 }
 
@@ -768,21 +745,19 @@ enum PcBase {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct NumericCandidate {
-    value: usize,
+struct PcCandidate {
+    pc: usize,
     base: PcBase,
 }
 
-impl NumericCandidate {
+impl PcCandidate {
     fn describe(self) -> String {
         match self.base {
-            PcBase::Hex => format!("hex 0x{:x}", self.value),
-            PcBase::Decimal => format!("decimal {}", self.value),
+            PcBase::Hex => format!("hex 0x{:x}", self.pc),
+            PcBase::Decimal => format!("decimal {}", self.pc),
         }
     }
 }
-
-type PcCandidate = NumericCandidate;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PcTargetScope {
@@ -798,93 +773,79 @@ struct PcTarget {
 }
 
 fn parse_pc_candidates(input: &str) -> Result<Vec<PcCandidate>, String> {
-    parse_numeric_candidates(input, NumericInputKind::ProgramCounter)
-}
-
-fn parse_buffer_offset_candidates(input: &str) -> Result<Vec<NumericCandidate>, String> {
-    parse_numeric_candidates(input, NumericInputKind::BufferOffset)
-}
-
-#[derive(Clone, Copy)]
-enum NumericInputKind {
-    ProgramCounter,
-    BufferOffset,
-}
-
-impl NumericInputKind {
-    const fn empty_message(self) -> &'static str {
-        match self {
-            Self::ProgramCounter => "Enter a program counter",
-            Self::BufferOffset => "Enter a buffer offset",
-        }
-    }
-
-    fn invalid_message(self, input: &str) -> String {
-        match self {
-            Self::ProgramCounter => format!("Invalid PC `{input}`; use 0x2a, 2a, or d:42"),
-            Self::BufferOffset => {
-                format!("Invalid buffer offset `{input}`; use 0x20 or d:32")
-            }
-        }
-    }
-}
-
-fn parse_numeric_candidates(
-    input: &str,
-    kind: NumericInputKind,
-) -> Result<Vec<NumericCandidate>, String> {
     let input = input.trim();
     if input.is_empty() {
-        return Err(kind.empty_message().to_string());
+        return Err("Enter a program counter".to_string());
     }
 
     if let Some(rest) = input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")) {
-        return parse_numeric_candidate(rest, 16, PcBase::Hex, input, kind);
+        return parse_pc_candidate(rest, 16, PcBase::Hex, input);
     }
 
     if let Some(rest) = input.strip_prefix("d:").or_else(|| input.strip_prefix("dec:")) {
-        return parse_numeric_candidate(rest, 10, PcBase::Decimal, input, kind);
+        return parse_pc_candidate(rest, 10, PcBase::Decimal, input);
     }
 
     if input.chars().any(|c| c.is_ascii_hexdigit() && c.is_ascii_alphabetic()) {
-        return parse_numeric_candidate(input, 16, PcBase::Hex, input, kind);
+        return parse_pc_candidate(input, 16, PcBase::Hex, input);
     }
 
     if input.chars().all(|c| c.is_ascii_digit()) {
-        let decimal = parse_number(input, 10, input, kind)?;
-        let hex = parse_number(input, 16, input, kind)?;
+        let decimal = parse_pc(input, 10, input)?;
+        let hex = parse_pc(input, 16, input)?;
         if decimal == hex {
-            return Ok(vec![NumericCandidate { value: decimal, base: PcBase::Decimal }]);
+            return Ok(vec![PcCandidate { pc: decimal, base: PcBase::Decimal }]);
         }
         return Ok(vec![
-            NumericCandidate { value: decimal, base: PcBase::Decimal },
-            NumericCandidate { value: hex, base: PcBase::Hex },
+            PcCandidate { pc: decimal, base: PcBase::Decimal },
+            PcCandidate { pc: hex, base: PcBase::Hex },
         ]);
     }
 
-    Err(kind.invalid_message(input))
+    Err(format!("Invalid PC `{input}`; use 0x2a, 2a, or d:42"))
 }
 
-fn parse_numeric_candidate(
+fn parse_pc_candidate(
     input: &str,
     radix: u32,
     base: PcBase,
     original: &str,
-    kind: NumericInputKind,
-) -> Result<Vec<NumericCandidate>, String> {
-    Ok(vec![NumericCandidate { value: parse_number(input, radix, original, kind)?, base }])
+) -> Result<Vec<PcCandidate>, String> {
+    Ok(vec![PcCandidate { pc: parse_pc(input, radix, original)?, base }])
 }
 
-fn parse_number(
-    input: &str,
-    radix: u32,
-    original: &str,
-    kind: NumericInputKind,
-) -> Result<usize, String> {
+fn parse_pc(input: &str, radix: u32, original: &str) -> Result<usize, String> {
     if input.is_empty() {
-        return Err(kind.invalid_message(original));
+        return Err(format!("Invalid PC `{original}`; use 0x2a, 2a, or d:42"));
     }
-    usize::from_str_radix(input, radix).map_err(|_| kind.invalid_message(original))
+    usize::from_str_radix(input, radix)
+        .map_err(|_| format!("Invalid PC `{original}`; use 0x2a, 2a, or d:42"))
+}
+
+fn parse_buffer_offset(input: &str) -> Result<usize, String> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Err("Enter a buffer offset".to_string());
+    }
+
+    let (digits, radix) =
+        if let Some(rest) = input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")) {
+            (rest, 16)
+        } else if let Some(rest) = input.strip_prefix("d:").or_else(|| input.strip_prefix("dec:")) {
+            (rest, 10)
+        } else {
+            (input, 10)
+        };
+
+    if digits.is_empty() {
+        return Err(invalid_buffer_offset(input));
+    }
+
+    usize::from_str_radix(digits, radix).map_err(|_| invalid_buffer_offset(input))
+}
+
+fn invalid_buffer_offset(input: &str) -> String {
+    format!("Invalid buffer offset `{input}`; use 0x20 or d:32")
 }
 
 fn find_pc_target(
@@ -1115,11 +1076,11 @@ mod tests {
     fn parses_prefixed_hex_pc() {
         assert_eq!(
             parse_pc_candidates("0x2a").unwrap(),
-            vec![PcCandidate { value: 42, base: PcBase::Hex }]
+            vec![PcCandidate { pc: 42, base: PcBase::Hex }]
         );
         assert_eq!(
             parse_pc_candidates("0X2A").unwrap(),
-            vec![PcCandidate { value: 42, base: PcBase::Hex }]
+            vec![PcCandidate { pc: 42, base: PcBase::Hex }]
         );
     }
 
@@ -1127,7 +1088,7 @@ mod tests {
     fn parses_bare_hex_pc_with_letters() {
         assert_eq!(
             parse_pc_candidates("2a").unwrap(),
-            vec![PcCandidate { value: 42, base: PcBase::Hex }]
+            vec![PcCandidate { pc: 42, base: PcBase::Hex }]
         );
     }
 
@@ -1135,11 +1096,11 @@ mod tests {
     fn parses_explicit_decimal_pc() {
         assert_eq!(
             parse_pc_candidates("d:42").unwrap(),
-            vec![PcCandidate { value: 42, base: PcBase::Decimal }]
+            vec![PcCandidate { pc: 42, base: PcBase::Decimal }]
         );
         assert_eq!(
             parse_pc_candidates("dec:42").unwrap(),
-            vec![PcCandidate { value: 42, base: PcBase::Decimal }]
+            vec![PcCandidate { pc: 42, base: PcBase::Decimal }]
         );
     }
 
@@ -1148,13 +1109,13 @@ mod tests {
         assert_eq!(
             parse_pc_candidates("10").unwrap(),
             vec![
-                PcCandidate { value: 10, base: PcBase::Decimal },
-                PcCandidate { value: 16, base: PcBase::Hex },
+                PcCandidate { pc: 10, base: PcBase::Decimal },
+                PcCandidate { pc: 16, base: PcBase::Hex },
             ]
         );
         assert_eq!(
             parse_pc_candidates("9").unwrap(),
-            vec![PcCandidate { value: 9, base: PcBase::Decimal }]
+            vec![PcCandidate { pc: 9, base: PcBase::Decimal }]
         );
     }
 
@@ -1167,27 +1128,20 @@ mod tests {
     }
 
     #[test]
-    fn parses_buffer_offsets_like_program_counters_with_offset_errors() {
-        assert_eq!(
-            parse_buffer_offset_candidates("0x20").unwrap(),
-            vec![NumericCandidate { value: 32, base: PcBase::Hex }]
-        );
-        assert_eq!(
-            parse_buffer_offset_candidates("d:32").unwrap(),
-            vec![NumericCandidate { value: 32, base: PcBase::Decimal }]
-        );
-        assert_eq!(
-            parse_buffer_offset_candidates("20").unwrap(),
-            vec![
-                NumericCandidate { value: 20, base: PcBase::Decimal },
-                NumericCandidate { value: 32, base: PcBase::Hex },
-            ]
-        );
+    fn parses_buffer_offsets_without_changing_pc_candidate_shape() {
+        assert_eq!(parse_buffer_offset("0x20").unwrap(), 32);
+        assert_eq!(parse_buffer_offset("d:32").unwrap(), 32);
+        assert_eq!(parse_buffer_offset("dec:32").unwrap(), 32);
+        assert_eq!(parse_buffer_offset("20").unwrap(), 20);
 
-        assert_eq!(parse_buffer_offset_candidates("").unwrap_err(), "Enter a buffer offset");
+        assert_eq!(parse_buffer_offset("").unwrap_err(), "Enter a buffer offset");
         assert_eq!(
-            parse_buffer_offset_candidates("0x").unwrap_err(),
+            parse_buffer_offset("0x").unwrap_err(),
             "Invalid buffer offset `0x`; use 0x20 or d:32"
+        );
+        assert_eq!(
+            parse_buffer_offset("2a").unwrap_err(),
+            "Invalid buffer offset `2a`; use 0x20 or d:32"
         );
     }
 
@@ -1400,7 +1354,7 @@ mod tests {
     }
 
     #[test]
-    fn buffer_offset_reports_ambiguous_and_out_of_range_offsets_without_moving() {
+    fn buffer_offset_reports_out_of_range_offsets_without_moving() {
         let address = Address::repeat_byte(1);
         let mut context = context_with_arena(vec![DebugNode::new(
             address,
@@ -1416,11 +1370,12 @@ mod tests {
         tui.draw_memory.current_buf_startline = 1;
 
         tui.goto_buffer_offset_from_input("20");
-        assert_eq!(tui.draw_memory.current_buf_startline, 1);
+        assert_eq!(tui.draw_memory.current_buf_startline, 0);
         let status = tui.status.as_ref().unwrap();
-        assert_eq!(status.kind, StatusKind::Error);
-        assert!(status.text.contains("Ambiguous buffer offset `20`"));
+        assert_eq!(status.kind, StatusKind::Info);
+        assert_eq!(status.text, "Jumped to calldata offset 0x14 (20)");
 
+        tui.draw_memory.current_buf_startline = 1;
         tui.goto_buffer_offset_from_input("0x80");
         assert_eq!(tui.draw_memory.current_buf_startline, 1);
         let status = tui.status.as_ref().unwrap();

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -232,7 +232,7 @@ impl TUIContext<'_> {
             }),
             // Scroll down the memory buffer
             KeyCode::Char('j') | KeyCode::Down if control => self.repeat(|this| {
-                let max_buf = (this.active_buffer().len() / 32).saturating_sub(1);
+                let max_buf = this.active_buffer().len().div_ceil(32).saturating_sub(1);
                 if this.draw_memory.current_buf_startline < max_buf {
                     this.draw_memory.current_buf_startline += 1;
                 }
@@ -386,53 +386,20 @@ impl TUIContext<'_> {
     }
 
     fn handle_pc_input_key_event(&mut self, event: KeyEvent) {
-        match event.code {
-            KeyCode::Esc => {
-                self.pc_input = None;
-            }
-            KeyCode::Enter => {
-                let input = self.pc_input.take().unwrap_or_default();
-                self.goto_pc_from_input(&input);
-            }
-            KeyCode::Backspace => {
-                if let Some(input) = &mut self.pc_input {
-                    input.pop();
-                }
-            }
-            KeyCode::Char(c)
-                if !event.modifiers.contains(KeyModifiers::CONTROL) && is_pc_input_char(c) =>
-            {
-                if let Some(input) = &mut self.pc_input {
-                    input.push(c);
-                }
-            }
-            _ => {}
+        if let Some(input) =
+            handle_prompt_input_key_event(&mut self.pc_input, event, |_, c| is_pc_input_char(c))
+        {
+            self.goto_pc_from_input(&input);
         }
     }
 
     fn handle_buffer_offset_input_key_event(&mut self, event: KeyEvent) {
-        match event.code {
-            KeyCode::Esc => {
-                self.buffer_offset_input = None;
-            }
-            KeyCode::Enter => {
-                let input = self.buffer_offset_input.take().unwrap_or_default();
-                self.goto_buffer_offset_from_input(&input);
-            }
-            KeyCode::Backspace => {
-                if let Some(input) = &mut self.buffer_offset_input {
-                    input.pop();
-                }
-            }
-            KeyCode::Char(c)
-                if !event.modifiers.contains(KeyModifiers::CONTROL)
-                    && (c.is_ascii_hexdigit() || matches!(c, 'x' | 'X' | ':')) =>
-            {
-                if let Some(input) = &mut self.buffer_offset_input {
-                    input.push(c);
-                }
-            }
-            _ => {}
+        if let Some(input) = handle_prompt_input_key_event(
+            &mut self.buffer_offset_input,
+            event,
+            is_buffer_offset_input_char,
+        ) {
+            self.goto_buffer_offset_from_input(&input);
         }
     }
 
@@ -728,8 +695,63 @@ fn buffer_as_number(s: &str) -> usize {
     s.parse().unwrap_or(MIN).clamp(MIN, MAX)
 }
 
+fn handle_prompt_input_key_event(
+    input: &mut Option<String>,
+    event: KeyEvent,
+    is_input_char: impl Fn(&str, char) -> bool,
+) -> Option<String> {
+    match event.code {
+        KeyCode::Esc => {
+            *input = None;
+        }
+        KeyCode::Enter => {
+            return Some(input.take().unwrap_or_default());
+        }
+        KeyCode::Backspace => {
+            if let Some(input) = input {
+                input.pop();
+            }
+        }
+        KeyCode::Char(c) if !event.modifiers.contains(KeyModifiers::CONTROL) => {
+            if let Some(input) = input
+                && is_input_char(input, c)
+            {
+                input.push(c);
+            }
+        }
+        _ => {}
+    }
+
+    None
+}
+
 const fn is_pc_input_char(c: char) -> bool {
     c.is_ascii_hexdigit() || matches!(c, 'x' | 'X' | ':')
+}
+
+fn is_buffer_offset_input_char(input: &str, c: char) -> bool {
+    if !(c.is_ascii_hexdigit() || matches!(c, 'x' | 'X' | ':')) {
+        return false;
+    }
+
+    let mut next = String::with_capacity(input.len() + c.len_utf8());
+    next.push_str(input);
+    next.push(c);
+    is_buffer_offset_input_prefix(&next)
+}
+
+fn is_buffer_offset_input_prefix(input: &str) -> bool {
+    if let Some(rest) = input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")) {
+        return rest.chars().all(|c| c.is_ascii_hexdigit());
+    }
+
+    if let Some(rest) = input.strip_prefix("d:").or_else(|| input.strip_prefix("dec:")) {
+        return rest.chars().all(|c| c.is_ascii_digit());
+    }
+
+    input.chars().all(|c| c.is_ascii_hexdigit())
+        || "d:".starts_with(input)
+        || "dec:".starts_with(input)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -834,7 +856,7 @@ fn parse_buffer_offset(input: &str) -> Result<usize, String> {
         } else if let Some(rest) = input.strip_prefix("d:").or_else(|| input.strip_prefix("dec:")) {
             (rest, 10)
         } else {
-            (input, 10)
+            (input, 16)
         };
 
     if digits.is_empty() {
@@ -845,7 +867,7 @@ fn parse_buffer_offset(input: &str) -> Result<usize, String> {
 }
 
 fn invalid_buffer_offset(input: &str) -> String {
-    format!("Invalid buffer offset `{input}`; use 0x20 or d:32")
+    format!("Invalid buffer offset `{input}`; use hex 0x20/20 or decimal d:32")
 }
 
 fn find_pc_target(
@@ -1050,6 +1072,10 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::empty())
     }
 
+    fn ctrl_key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::CONTROL)
+    }
+
     #[test]
     fn layout_shortcut_cycles_only_concrete_layouts() {
         let address = Address::repeat_byte(1);
@@ -1128,21 +1154,40 @@ mod tests {
     }
 
     #[test]
-    fn parses_buffer_offsets_without_changing_pc_candidate_shape() {
+    fn parses_buffer_offsets_as_visible_hex_labels() {
         assert_eq!(parse_buffer_offset("0x20").unwrap(), 32);
         assert_eq!(parse_buffer_offset("d:32").unwrap(), 32);
         assert_eq!(parse_buffer_offset("dec:32").unwrap(), 32);
-        assert_eq!(parse_buffer_offset("20").unwrap(), 20);
+        assert_eq!(parse_buffer_offset("20").unwrap(), 32);
+        assert_eq!(parse_buffer_offset("2a").unwrap(), 42);
+        assert_eq!(parse_buffer_offset("a").unwrap(), 10);
 
         assert_eq!(parse_buffer_offset("").unwrap_err(), "Enter a buffer offset");
         assert_eq!(
             parse_buffer_offset("0x").unwrap_err(),
-            "Invalid buffer offset `0x`; use 0x20 or d:32"
+            "Invalid buffer offset `0x`; use hex 0x20/20 or decimal d:32"
         );
         assert_eq!(
-            parse_buffer_offset("2a").unwrap_err(),
-            "Invalid buffer offset `2a`; use 0x20 or d:32"
+            parse_buffer_offset("2x3").unwrap_err(),
+            "Invalid buffer offset `2x3`; use hex 0x20/20 or decimal d:32"
         );
+    }
+
+    #[test]
+    fn filters_buffer_offset_input_to_parser_prefixes() {
+        assert!(is_buffer_offset_input_char("", '0'));
+        assert!(is_buffer_offset_input_char("0", 'x'));
+        assert!(is_buffer_offset_input_char("0x", '2'));
+        assert!(is_buffer_offset_input_char("2", 'a'));
+        assert!(is_buffer_offset_input_char("d", ':'));
+        assert!(is_buffer_offset_input_char("dec", ':'));
+        assert!(is_buffer_offset_input_char("dec:", '3'));
+
+        assert!(!is_buffer_offset_input_char("", 'x'));
+        assert!(!is_buffer_offset_input_char("2", 'x'));
+        assert!(!is_buffer_offset_input_char("1", ':'));
+        assert!(!is_buffer_offset_input_char("DEC", ':'));
+        assert!(!is_buffer_offset_input_char("d:", 'a'));
     }
 
     #[test]
@@ -1320,7 +1365,7 @@ mod tests {
         assert_eq!(tui.buffer_offset_input.as_deref(), Some(""));
         assert_eq!(tui.draw_memory.current_buf_startline, 0);
 
-        for c in "0x40".chars() {
+        for c in "40".chars() {
             let _ = tui.handle_key_event(key(KeyCode::Char(c)));
         }
         let _ = tui.handle_key_event(key(KeyCode::Enter));
@@ -1347,10 +1392,31 @@ mod tests {
         tui.init();
         tui.active_buffer = BufferKind::Calldata;
 
-        tui.goto_buffer_offset_from_input("0x20");
+        tui.goto_buffer_offset_from_input("20");
 
         assert_eq!(tui.draw_memory.current_buf_startline, 1);
         assert_eq!(tui.status.as_ref().unwrap().text, "Jumped to calldata offset 0x20 (32)");
+    }
+
+    #[test]
+    fn buffer_offset_jumps_to_visible_hex_label_on_partial_last_line() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![step(1)],
+            Bytes::from(vec![0; 65]),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.active_buffer = BufferKind::Calldata;
+
+        tui.goto_buffer_offset_from_input("40");
+
+        assert_eq!(tui.draw_memory.current_buf_startline, 2);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Jumped to calldata offset 0x40 (64)");
     }
 
     #[test]
@@ -1370,14 +1436,14 @@ mod tests {
         tui.draw_memory.current_buf_startline = 1;
 
         tui.goto_buffer_offset_from_input("20");
-        assert_eq!(tui.draw_memory.current_buf_startline, 0);
+        assert_eq!(tui.draw_memory.current_buf_startline, 1);
         let status = tui.status.as_ref().unwrap();
         assert_eq!(status.kind, StatusKind::Info);
-        assert_eq!(status.text, "Jumped to calldata offset 0x14 (20)");
+        assert_eq!(status.text, "Jumped to calldata offset 0x20 (32)");
 
-        tui.draw_memory.current_buf_startline = 1;
+        tui.draw_memory.current_buf_startline = 0;
         tui.goto_buffer_offset_from_input("0x80");
-        assert_eq!(tui.draw_memory.current_buf_startline, 1);
+        assert_eq!(tui.draw_memory.current_buf_startline, 0);
         let status = tui.status.as_ref().unwrap();
         assert_eq!(status.kind, StatusKind::Error);
         assert_eq!(status.text, "calldata offset 0x80 (128) is outside the 64-byte buffer");
@@ -1402,6 +1468,29 @@ mod tests {
         let status = tui.status.as_ref().unwrap();
         assert_eq!(status.kind, StatusKind::Error);
         assert_eq!(status.text, "Current memory buffer is empty");
+    }
+
+    #[test]
+    fn buffer_scroll_reaches_partial_last_line() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![step(1)],
+            Bytes::from(vec![0; 65]),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.active_buffer = BufferKind::Calldata;
+
+        let _ = tui.handle_key_event(ctrl_key(KeyCode::Char('j')));
+        assert_eq!(tui.draw_memory.current_buf_startline, 1);
+        let _ = tui.handle_key_event(ctrl_key(KeyCode::Char('j')));
+        assert_eq!(tui.draw_memory.current_buf_startline, 2);
+        let _ = tui.handle_key_event(ctrl_key(KeyCode::Char('j')));
+        assert_eq!(tui.draw_memory.current_buf_startline, 2);
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -231,7 +231,7 @@ impl TUIContext<'_> {
                 Span::raw(input.as_str()),
                 Span::styled("█", Style::new().fg(Color::Cyan)),
                 Span::styled(
-                    "  Enter: jump | Esc: cancel | hex: 0x20 | decimal: d:32",
+                    "  Enter: jump | Esc: cancel | hex: 0x20/20 | decimal: d:32",
                     Style::new().add_modifier(Modifier::DIM),
                 ),
             ]));
@@ -562,8 +562,8 @@ impl TUIContext<'_> {
     fn draw_buffer(&self, f: &mut Frame<'_>, area: Rect) {
         let call = self.debug_call();
         let step = self.current_step();
-        let buf = match self.active_buffer {
-            BufferKind::Memory => step.memory.as_ref().unwrap().as_ref(),
+        let buf: &[u8] = match self.active_buffer {
+            BufferKind::Memory => step.memory.as_ref().map_or(&[], |memory| memory.as_ref()),
             BufferKind::Calldata => call.calldata.as_ref(),
             BufferKind::Returndata => step.returndata.as_ref(),
         };
@@ -1154,6 +1154,9 @@ mod tests {
     use foundry_evm_core::Breakpoints;
     use foundry_evm_traces::debug::{ContractSources, DebugSourceScope, DebugVariable};
     use ratatui::{
+        Terminal,
+        backend::TestBackend,
+        layout::Rect,
         style::{Color, Style},
         text::Line,
     };
@@ -1255,6 +1258,25 @@ mod tests {
 
     fn abi_word(value: U256) -> [u8; 32] {
         value.to_be_bytes::<32>()
+    }
+
+    #[test]
+    fn draw_buffer_handles_missing_memory_snapshot() {
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![trace_step(Vec::new())])]);
+        let tui = TUIContext::new(&mut context);
+        let backend = TestBackend::new(80, 4);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|f| tui.draw_buffer(f, Rect::new(0, 0, 80, 4))).unwrap();
+
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(screen.contains("Memory (max expansion: 0 bytes)"));
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -197,9 +197,12 @@ impl TUIContext<'_> {
 
     fn footer_height(&self) -> u16 {
         let status_or_input = u16::from(
-            self.pc_input.is_some() || self.opcode_search_input.is_some() || self.status.is_some(),
+            self.pc_input.is_some()
+                || self.buffer_offset_input.is_some()
+                || self.opcode_search_input.is_some()
+                || self.status.is_some(),
         );
-        let shortcuts = if self.show_shortcuts { 2 } else { 0 };
+        let shortcuts = if self.show_shortcuts { 3 } else { 0 };
         status_or_input + shortcuts
     }
 
@@ -216,6 +219,19 @@ impl TUIContext<'_> {
                 Span::styled("█", Style::new().fg(Color::Cyan)),
                 Span::styled(
                     "  Enter: jump | Esc: cancel | hex: 0x2a/2a | decimal: d:42",
+                    Style::new().add_modifier(Modifier::DIM),
+                ),
+            ]));
+        } else if let Some(input) = &self.buffer_offset_input {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("Goto {} offset: ", self.active_buffer_name()),
+                    Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(input.as_str()),
+                Span::styled("█", Style::new().fg(Color::Cyan)),
+                Span::styled(
+                    "  Enter: jump | Esc: cancel | hex: 0x20 | decimal: d:32",
                     Style::new().add_modifier(Modifier::DIM),
                 ),
             ]));
@@ -240,12 +256,15 @@ impl TUIContext<'_> {
             lines.push(Line::from(Span::styled(status.text.as_str(), style)));
         }
 
-        let l1 = "[q]: quit | [k/j]: prev/next op | [a/s]: prev/next jump | [c/C]: prev/next call | [g/G]: start/end | [p]: goto PC | [/]: search opcodes | [n/N]: next/prev search";
-        let l2 = "[l]: layout | [b]: cycle buffer | [t]: stack labels | [m]: buffer decoding | [shift + j/k]: scroll stack | [ctrl + j/k]: scroll buffer | ['<char>]: goto breakpoint | [h] toggle help";
+        let l1 =
+            "[q] quit | [j/k] op | [a/s] jump | [c/C] call | [g/G] start/end | [p] PC | [o] offset";
+        let l2 = "[/] search | [n/N] repeat | [l] layout | [b] buffer | [t] labels | [m] decode | [h] help";
+        let l3 = "[J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint";
         let dimmed = Style::new().add_modifier(Modifier::DIM);
         if self.show_shortcuts {
             lines.push(Line::from(Span::styled(l1, dimmed)));
             lines.push(Line::from(Span::styled(l2, dimmed)));
+            lines.push(Line::from(Span::styled(l3, dimmed)));
         }
 
         let paragraph =


### PR DESCRIPTION
## Summary
- Add an `o` shortcut in the debugger TUI to jump the active memory/calldata/returndata pane to a byte offset.
- Keep the existing program-counter parser and terminology intact while parsing buffer offsets separately.
- Compact the debugger footer into three non-wrapping shortcut lines and add coverage for offset parsing, prompt handling, empty buffers, and calldata jumps.

Refs #927.
