### PR TITLE
perf(invariant): precompute selector -> function map for O(1) lookup

### DIFF
--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -90,6 +90,7 @@ impl FuzzRunIdentifiedContracts {
             created_contracts.push(*address);
             let contract = TargetedContract {
                 identifier: artifact.name.clone(),
+                function_by_selector: build_function_index(&contract.abi),
                 abi: contract.abi.clone(),
                 targeted_functions: functions,
                 excluded_functions: Vec::new(),
@@ -134,7 +135,7 @@ impl TargetedContracts {
                 tx.call_details
                     .calldata
                     .get(..4)
-                    .and_then(|selector| c.abi.functions().find(|f| f.selector() == selector)),
+                    .and_then(|selector| c.function_for_selector(selector)),
             ),
             None => (None, None),
         }
@@ -167,9 +168,7 @@ impl TargetedContracts {
         self.inner.get(&tx.call_details.target).and_then(|contract| {
             tx.call_details.calldata.get(..4).and_then(|selector| {
                 contract
-                    .abi
-                    .functions()
-                    .find(|f| f.selector() == selector)
+                    .function_for_selector(selector)
                     .map(|function| format!("{}.{}", contract.identifier.clone(), function.name))
             })
         })
@@ -213,17 +212,27 @@ pub struct TargetedContract {
     pub excluded_functions: Vec<Function>,
     /// The contract's storage layout, if available.
     pub storage_layout: Option<Arc<StorageLayout>>,
+    /// Selector -> ABI function map, precomputed from `abi` for O(1) lookup instead of scanning
+    /// `abi.functions()` on every call. Built once at construction; `abi` never changes after.
+    function_by_selector: HashMap<Selector, Function>,
+}
+
+/// Builds the selector -> function map used for O(1) function lookup by selector.
+fn build_function_index(abi: &JsonAbi) -> HashMap<Selector, Function> {
+    abi.functions().map(|func| (func.selector(), func.clone())).collect()
 }
 
 impl TargetedContract {
     /// Returns a new `TargetedContract` instance.
-    pub const fn new(identifier: String, abi: JsonAbi) -> Self {
+    pub fn new(identifier: String, abi: JsonAbi) -> Self {
+        let function_by_selector = build_function_index(&abi);
         Self {
             identifier,
             abi,
             targeted_functions: Vec::new(),
             excluded_functions: Vec::new(),
             storage_layout: None,
+            function_by_selector,
         }
     }
 
@@ -259,6 +268,13 @@ impl TargetedContract {
     /// Returns the function for the given selector.
     pub fn get_function(&self, selector: Selector) -> eyre::Result<&Function> {
         get_function(&self.identifier, selector, &self.abi)
+    }
+
+    /// O(1) lookup of the ABI function matching the given 4-byte selector prefix, or `None` if
+    /// the slice is not a known selector. Replaces a linear scan of `abi.functions()`.
+    fn function_for_selector(&self, selector: &[u8]) -> Option<&Function> {
+        let selector = Selector::try_from(selector).ok()?;
+        self.function_by_selector.get(&selector)
     }
 
     /// Adds the specified selectors to the targeted functions.


### PR DESCRIPTION
## Motivation

`TargetedContracts::fuzzed_artifacts` and `fuzzed_metric_key` resolve a transaction's 4-byte selector to its ABI `Function` with a linear `abi.functions().find(|f| f.selector() == selector)`. Both run on the hot invariant path:

- `fuzzed_artifacts` runs for every committed call (`collect_data` -> dictionary ingestion).
- `fuzzed_metric_key` runs per call when metrics are enabled.

For a `TargetedContract` with N functions this is O(N) per call, and the ABI is fixed once the contract is constructed — so the scan is redundant work repeated for the whole campaign.

## Change

Precompute a `HashMap<Selector, Function>` once per `TargetedContract` (in `new` and at the one struct-literal construction site) and look up in O(1) via a small `function_for_selector` helper. The map is an owned field — `FuzzRunIdentifiedContracts` is `Rc<RefCell<...>>` (single-threaded), so no synchronization is needed. Behavior is unchanged: the map returns the same `Function` the linear scan did.

`can_replay` is intentionally left alone: it scans `abi_fuzzed_functions()` (the targeted/mutable *subset*, which depends on the mutable `targeted_functions` / `excluded_functions`), so a precomputed full-ABI map doesn't directly apply. Happy to follow up on it separately.

## Status / verification

**Draft.** I couldn't build foundry locally to compile-check or benchmark on my machine, so this relies on CI to compile. The change is behavior-preserving and exercised by the existing invariant test suite (every invariant test decodes via `fuzzed_artifacts` / computes metric keys).

## Benchmark

foundry has no in-tree criterion harness, so here is a self-contained micro-benchmark for the selector->function resolution (drop into `crates/evm/fuzz/benches/` with `criterion` as a dev-dependency). It contrasts the previous linear scan against the map for an ABI with N functions:

```rust
// crates/evm/fuzz/benches/selector_lookup.rs
use alloy_json_abi::{Function, JsonAbi};
use alloy_primitives::{map::HashMap, Selector};
use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};

fn make_abi(n: usize) -> JsonAbi {
    let mut abi = JsonAbi::new();
    for i in 0..n {
        let f = Function::parse(&format!("f{i}(uint256)")).unwrap();
        abi.functions.entry(f.name.clone()).or_default().push(f);
    }
    abi
}

fn bench(c: &mut Criterion) {
    let mut g = c.benchmark_group("selector_lookup");
    for n in [4usize, 32, 128, 512] {
        let abi = make_abi(n);
        // last function's selector = worst case for the linear scan
        let target = abi.functions().last().unwrap().selector();
        let map: HashMap<Selector, Function> =
            abi.functions().map(|f| (f.selector(), f.clone())).collect();

        g.bench_with_input(BenchmarkId::new("linear", n), &n, |b, _| {
            b.iter(|| abi.functions().find(|f| f.selector() == target).unwrap().clone())
        });
        g.bench_with_input(BenchmarkId::new("map", n), &n, |b, _| {
            b.iter(|| map.get(&target).unwrap().clone())
        });
    }
    g.finish();
}

criterion_group!(benches, bench);
criterion_main!(benches);
```

Expected: `linear` grows ~linearly with N (worst-case selector at the tail), `map` stays flat. I haven't run it on my machine; end-to-end impact is best measured with the maintainers' fuzz benchmark (scfuzzbench). Happy to wire this bench into the tree if you'd like committed coverage.
