### PR TITLE
feat(evm): decode T6 receive policy receipts

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -6,9 +6,10 @@ use crate::{
 use alloy_dyn_abi::{DecodedEvent, DynSolValue, EventExt, FunctionExt, JsonAbiExt};
 use alloy_json_abi::{Error, Event, Function, JsonAbi};
 use alloy_primitives::{
-    Address, B256, LogData, Selector,
+    Address, B256, LogData, Selector, U256,
     map::{HashMap, HashSet},
 };
+use alloy_sol_types::SolValue;
 use foundry_common::{
     ContractsByArtifact, SELECTOR_LEN, abi::get_indexed_event, fmt::format_token,
     get_contract_name, selectors::SelectorKind,
@@ -515,7 +516,8 @@ impl CallTraceDecoder {
         for node in traces {
             node.trace.decoded = Some(Box::new(self.decode_function(&node.trace).await));
             for log in &mut node.logs {
-                log.decoded = Some(Box::new(self.decode_event(&log.raw_log).await));
+                log.decoded =
+                    Some(Box::new(self.decode_event_with_address(log.address, &log.raw_log).await));
             }
 
             if let Some(debug) = self.debug_identifier.as_ref()
@@ -644,9 +646,23 @@ impl CallTraceDecoder {
             }
 
             if args.is_none()
-                && let Ok(v) = func.abi_decode_input(&trace.data[SELECTOR_LEN..])
+                && let Ok(decoded) = func.abi_decode_input(&trace.data[SELECTOR_LEN..])
             {
-                args = Some(v.iter().map(|value| self.format_value(value)).collect());
+                args = Some(
+                    decoded
+                        .iter()
+                        .zip(&func.inputs)
+                        .map(|(value, input)| {
+                            self.format_param_value(
+                                Some(trace.address),
+                                &func.name,
+                                &input.name,
+                                &input.ty,
+                                value,
+                            )
+                        })
+                        .collect(),
+                );
             }
         }
 
@@ -867,6 +883,19 @@ impl CallTraceDecoder {
 
     /// Decodes an event.
     pub async fn decode_event(&self, log: &LogData) -> DecodedCallLog {
+        self.decode_event_inner(None, log).await
+    }
+
+    /// Decodes an event emitted by a known address.
+    pub async fn decode_event_with_address(
+        &self,
+        address: Address,
+        log: &LogData,
+    ) -> DecodedCallLog {
+        self.decode_event_inner(Some(address), log).await
+    }
+
+    async fn decode_event_inner(&self, address: Option<Address>, log: &LogData) -> DecodedCallLog {
         let &[t0, ..] = log.topics() else { return DecodedCallLog { name: None, params: None } };
 
         let mut events = Vec::new();
@@ -893,7 +922,16 @@ impl CallTraceDecoder {
                             .map(|(param, input)| {
                                 // undo patched names
                                 let name = input.name.clone();
-                                (name, self.format_value(&param))
+                                (
+                                    name,
+                                    self.format_param_value(
+                                        address,
+                                        &event.name,
+                                        &input.name,
+                                        &input.ty,
+                                        &param,
+                                    ),
+                                )
                             })
                             .collect(),
                     ),
@@ -963,6 +1001,69 @@ impl CallTraceDecoder {
         }
         format_token(value)
     }
+
+    fn format_param_value(
+        &self,
+        address: Option<Address>,
+        context_name: &str,
+        input_name: &str,
+        input_ty: &str,
+        value: &DynSolValue,
+    ) -> String {
+        self.format_claim_receipt_bytes(address, context_name, input_name, input_ty, value)
+            .map(|value| self.format_value(&value))
+            .unwrap_or_else(|| self.format_value(value))
+    }
+
+    fn format_claim_receipt_bytes(
+        &self,
+        address: Option<Address>,
+        context_name: &str,
+        input_name: &str,
+        input_ty: &str,
+        value: &DynSolValue,
+    ) -> Option<DynSolValue> {
+        if !matches!(address, Some(RECEIVE_POLICY_GUARD_ADDRESS | TIP403_REGISTRY_ADDRESS)) {
+            return None;
+        }
+        if input_name != "receipt" || input_ty != "bytes" {
+            return None;
+        }
+        if !matches!(context_name, "balanceOf" | "claim" | "burnBlockedReceipt" | "TransferBlocked")
+        {
+            return None;
+        }
+        let DynSolValue::Bytes(bytes) = value else { return None };
+        let decoded = IReceivePolicyGuard::ClaimReceiptV1::abi_decode(bytes).ok()?;
+
+        Some(DynSolValue::CustomStruct {
+            name: "ClaimReceiptV1".to_string(),
+            prop_names: vec![
+                "version".to_string(),
+                "token".to_string(),
+                "recoveryAuthority".to_string(),
+                "originator".to_string(),
+                "recipient".to_string(),
+                "blockedAt".to_string(),
+                "blockedNonce".to_string(),
+                "blockedReason".to_string(),
+                "kind".to_string(),
+                "memo".to_string(),
+            ],
+            tuple: vec![
+                DynSolValue::Uint(U256::from(decoded.version), 8),
+                DynSolValue::Address(decoded.token),
+                DynSolValue::Address(decoded.recoveryAuthority),
+                DynSolValue::Address(decoded.originator),
+                DynSolValue::Address(decoded.recipient),
+                DynSolValue::Uint(U256::from(decoded.blockedAt), 64),
+                DynSolValue::Uint(U256::from(decoded.blockedNonce), 64),
+                DynSolValue::Uint(U256::from(decoded.blockedReason), 8),
+                DynSolValue::Uint(U256::from(decoded.kind as u8), 8),
+                DynSolValue::FixedBytes(decoded.memo, 32),
+            ],
+        })
+    }
 }
 
 /// Returns `true` if the given function calldata (including function selector) is ABI-encoded.
@@ -1017,7 +1118,7 @@ fn indexed_inputs(event: &Event) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{U256, address, aliases::U96, hex};
+    use alloy_primitives::{address, aliases::U96, hex};
     use alloy_sol_types::{SolCall, SolEvent};
 
     #[test]
@@ -1868,6 +1969,250 @@ mod tests {
 
         assert_eq!(decoded.label, Some("ReceivePolicyGuard".to_string()));
         assert_eq!(decoded.call_data.unwrap().signature, "claim(address,bytes)");
+    }
+
+    #[tokio::test]
+    async fn test_t6_receive_policy_calls_decode() {
+        let decoder = CallTraceDecoderBuilder::new()
+            .with_chain_id(Some(4217))
+            .with_tempo_hardfork(Some(TempoHardfork::T6))
+            .build();
+
+        let set_policy = ITIP403Registry::setReceivePolicyCall {
+            senderPolicyId: 7,
+            tokenFilterId: 9,
+            recoveryAuthority: address!("0x0000000000000000000000000000000000000abc"),
+        };
+        let decoded = decoder
+            .decode_function(&CallTrace {
+                address: TIP403_REGISTRY_ADDRESS,
+                data: set_policy.abi_encode().into(),
+                success: true,
+                ..Default::default()
+            })
+            .await;
+        let call_data = decoded.call_data.expect("setReceivePolicy should decode");
+        assert_eq!(decoded.label.as_deref(), Some("TIP403Registry"));
+        assert_eq!(call_data.signature, "setReceivePolicy(uint64,uint64,address)");
+        assert_eq!(call_data.args[0], "7");
+        assert_eq!(call_data.args[1], "9");
+
+        let validate = ITIP403Registry::validateReceivePolicyCall {
+            token: PATH_USD_ADDRESS,
+            sender: address!("0x0000000000000000000000000000000000000def"),
+            receiver: address!("0x0000000000000000000000000000000000000123"),
+        };
+        let decoded = decoder
+            .decode_function(&CallTrace {
+                address: TIP403_REGISTRY_ADDRESS,
+                data: validate.abi_encode().into(),
+                success: true,
+                ..Default::default()
+            })
+            .await;
+        let call_data = decoded.call_data.expect("validateReceivePolicy should decode");
+        assert_eq!(call_data.signature, "validateReceivePolicy(address,address,address)");
+        assert!(call_data.args[0].contains("PathUSD"));
+    }
+
+    #[tokio::test]
+    async fn test_t6_admin_key_calls_decode() {
+        let decoder = CallTraceDecoderBuilder::new()
+            .with_chain_id(Some(4217))
+            .with_tempo_hardfork(Some(TempoHardfork::T6))
+            .build();
+        let account = address!("0x0000000000000000000000000000000000000abc");
+        let key = address!("0x0000000000000000000000000000000000000def");
+        let signature = vec![0x04, 0xaa, 0xbb];
+
+        let cases = [
+            (
+                ACCOUNT_KEYCHAIN_ADDRESS,
+                IAccountKeychain::authorizeAdminKeyCall {
+                    keyId: key,
+                    signatureType: IAccountKeychain::SignatureType::Secp256k1,
+                    witness: B256::repeat_byte(0x11),
+                }
+                .abi_encode()
+                .into(),
+                "authorizeAdminKey(address,uint8,bytes32)",
+            ),
+            (
+                ACCOUNT_KEYCHAIN_ADDRESS,
+                IAccountKeychain::isAdminKeyCall { account, keyId: key }.abi_encode().into(),
+                "isAdminKey(address,address)",
+            ),
+            (
+                SIGNATURE_VERIFIER_ADDRESS,
+                ISignatureVerifier::verifyKeychainCall {
+                    account,
+                    hash: B256::repeat_byte(0x22),
+                    signature: signature.clone().into(),
+                }
+                .abi_encode()
+                .into(),
+                "verifyKeychain(address,bytes32,bytes)",
+            ),
+            (
+                SIGNATURE_VERIFIER_ADDRESS,
+                ISignatureVerifier::verifyKeychainAdminCall {
+                    account,
+                    hash: B256::repeat_byte(0x33),
+                    signature: signature.into(),
+                }
+                .abi_encode()
+                .into(),
+                "verifyKeychainAdmin(address,bytes32,bytes)",
+            ),
+        ];
+
+        for (address, data, signature) in cases {
+            let decoded = decoder
+                .decode_function(&CallTrace { address, data, success: true, ..Default::default() })
+                .await;
+            assert_eq!(
+                decoded.call_data.expect("T6 keychain call should decode").signature,
+                signature
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_t6_receive_policy_and_admin_events_decode() {
+        let decoder = CallTraceDecoder::new();
+        let account = address!("0x0000000000000000000000000000000000000abc");
+        let key = address!("0x0000000000000000000000000000000000000def");
+
+        let events = [
+            (
+                ITIP403Registry::ReceivePolicyUpdated {
+                    account,
+                    senderPolicyId: 7,
+                    tokenFilterId: 9,
+                    recoveryAuthority: key,
+                }
+                .encode_log_data(),
+                "ReceivePolicyUpdated",
+            ),
+            (
+                IAccountKeychain::AdminKeyAuthorized { account, publicKey: key }.encode_log_data(),
+                "AdminKeyAuthorized",
+            ),
+            (
+                IReceivePolicyGuard::ReceiptClaimed {
+                    token: PATH_USD_ADDRESS,
+                    receiver: account,
+                    blockedNonce: 11,
+                    blockedAt: 12,
+                    receiptVersion: 1,
+                    originator: key,
+                    recipient: account,
+                    recoveryAuthority: key,
+                    caller: key,
+                    to: account,
+                    amount: U256::from(123),
+                }
+                .encode_log_data(),
+                "ReceiptClaimed",
+            ),
+            (
+                IReceivePolicyGuard::ReceiptBurned {
+                    token: PATH_USD_ADDRESS,
+                    receiver: account,
+                    blockedNonce: 11,
+                    blockedAt: 12,
+                    receiptVersion: 1,
+                    originator: key,
+                    recipient: account,
+                    recoveryAuthority: key,
+                    caller: key,
+                    amount: U256::from(123),
+                }
+                .encode_log_data(),
+                "ReceiptBurned",
+            ),
+        ];
+
+        for (log, expected_name) in events {
+            let decoded = decoder.decode_event(&log).await;
+            assert_eq!(decoded.name.as_deref(), Some(expected_name));
+            assert!(decoded.params.expect("event params should decode").len() >= 2);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_t6_claim_receipt_bytes_decode_in_calls_and_transfer_blocked_event() {
+        let decoder = CallTraceDecoder::new();
+        let recovery = address!("0x0000000000000000000000000000000000000abc");
+        let originator = address!("0x0000000000000000000000000000000000000def");
+        let recipient = address!("0x0000000000000000000000000000000000000123");
+        let receipt = IReceivePolicyGuard::ClaimReceiptV1::new(
+            PATH_USD_ADDRESS,
+            recovery,
+            originator,
+            recipient,
+            12,
+            34,
+            ITIP403Registry::BlockedReason::RECEIVE_POLICY as u8,
+            IReceivePolicyGuard::InboundKind::TRANSFER,
+            B256::repeat_byte(0x44),
+        )
+        .abi_encode();
+
+        let claim =
+            IReceivePolicyGuard::claimCall { to: recipient, receipt: receipt.clone().into() };
+        let decoded = decoder
+            .decode_function(&CallTrace {
+                address: RECEIVE_POLICY_GUARD_ADDRESS,
+                data: claim.abi_encode().into(),
+                success: true,
+                ..Default::default()
+            })
+            .await;
+        let call_data = decoded.call_data.expect("claim should decode");
+        assert_eq!(call_data.signature, "claim(address,bytes)");
+        assert!(call_data.args[1].contains("ClaimReceiptV1"));
+        assert!(call_data.args[1].contains("blockedNonce: 34"));
+        assert!(call_data.args[1].contains(&originator.to_string()));
+
+        let decoded = decoder
+            .decode_function(&CallTrace {
+                address: Address::from([0x77; 20]),
+                data: claim.abi_encode().into(),
+                success: true,
+                ..Default::default()
+            })
+            .await;
+        let call_data = decoded.call_data.expect("matching claim selector should decode");
+        assert_eq!(call_data.signature, "claim(address,bytes)");
+        assert!(!call_data.args[1].contains("ClaimReceiptV1"));
+        assert!(call_data.args[1].starts_with("0x"));
+
+        let blocked = IReceivePolicyGuard::TransferBlocked {
+            token: PATH_USD_ADDRESS,
+            receiver: recipient,
+            blockedNonce: 34,
+            amount: U256::from(123),
+            receiptVersion: 1,
+            receipt: receipt.into(),
+        };
+        let blocked_log = blocked.encode_log_data();
+        let decoded =
+            decoder.decode_event_with_address(RECEIVE_POLICY_GUARD_ADDRESS, &blocked_log).await;
+        assert_eq!(decoded.name.as_deref(), Some("TransferBlocked"));
+        let params = decoded.params.expect("TransferBlocked params should decode");
+        let receipt = params.iter().find(|(name, _)| name == "receipt").unwrap();
+        assert!(receipt.1.contains("ClaimReceiptV1"));
+        assert!(receipt.1.contains("blockedReason: 2"));
+        assert!(receipt.1.contains("kind: 0"));
+
+        let decoded =
+            decoder.decode_event_with_address(Address::from([0x77; 20]), &blocked_log).await;
+        assert_eq!(decoded.name.as_deref(), Some("TransferBlocked"));
+        let params = decoded.params.expect("TransferBlocked params should decode");
+        let receipt = params.iter().find(|(name, _)| name == "receipt").unwrap();
+        assert!(!receipt.1.contains("ClaimReceiptV1"));
+        assert!(receipt.1.starts_with("0x"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes OSS-340

- Add trace decoding support for Tempo T6 precompiles and labels.
- Decode TIP-403 receive-policy/admin-key calls and events in traces.
- Pretty-print receive-policy `ClaimReceiptV1` bytes for known guard/registry addresses.
- Preserve unrelated matching `receipt` bytes params as raw bytes.
- Reuse generic `CustomStruct` formatting for decoded claim receipts.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
