### PR TITLE
fix(invariant): preserve terminal input for optimization sequences

### DIFF
--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1145,17 +1145,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run.depth += 1;
                 }
 
-                // Only generate the next input if another iteration will execute it. On
-                // discarded/popped iterations `depth` isn't incremented, so the replacement
-                // is still generated.
-                if current_run.depth < config.depth {
-                    current_run.inputs.push(corpus_manager.generate_next_input(
-                        &mut invariant_test.test_data.branch_runner,
-                        &initial_seq,
-                        discarded,
-                        current_run.depth as usize,
-                    )?);
-                }
+                current_run.inputs.push(corpus_manager.generate_next_input(
+                    &mut invariant_test.test_data.branch_runner,
+                    &initial_seq,
+                    discarded,
+                    current_run.depth as usize,
+                )?);
             }
 
             // Extend corpus with current run data.


### PR DESCRIPTION
Restores terminal input generation for invariant runs so optimization best-sequence reporting keeps the same sequence shape expected by warp-aware shrinking tests. The empty-input corpus guard added in #15247 is left intact, so the original panic case remains covered.

Prompted by: @grandizzy

Verification:
- cargo test -p forge --test cli invariant_optimization_with_warp -- --nocapture
- cargo test -p foundry-evm empty_input_sequence_with_new_coverage_does_not_panic_or_insert -- --nocapture
- cargo fmt --check