### PR TITLE
feat(symbolic): minimize counterexample artifacts

### DIFF
--- a/crates/evm/symbolic/assets/symbolic-result.schema.json
+++ b/crates/evm/symbolic/assets/symbolic-result.schema.json
@@ -55,6 +55,9 @@
     },
     "artifact": {
       "$ref": "#/$defs/artifact_ref"
+    },
+    "minimization": {
+      "$ref": "#/$defs/minimization"
     }
   },
   "allOf": [
@@ -466,6 +469,42 @@
         "path": {
           "type": "string",
           "minLength": 1
+        }
+      }
+    },
+    "minimization": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original",
+        "minimized",
+        "attempts",
+        "accepted",
+        "original_calldata_bytes",
+        "minimized_calldata_bytes"
+      ],
+      "properties": {
+        "original": {
+          "$ref": "#/$defs/artifact_ref"
+        },
+        "minimized": {
+          "$ref": "#/$defs/artifact_ref"
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "accepted": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "original_calldata_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "minimized_calldata_bytes": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     }

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -515,8 +515,9 @@ impl SymbolicExecutor {
                         false_state.pc = fallthrough;
 
                         let true_feasible = self.take_loop_jump(&mut true_state, fallthrough, dest)
-                            && self.solver.is_sat(&true_state.constraints)?;
-                        let false_feasible = self.solver.is_sat(&false_state.constraints)?;
+                            && self.branch_is_sat_or_defer(&true_state.constraints)?;
+                        let false_feasible =
+                            self.branch_is_sat_or_defer(&false_state.constraints)?;
                         trace!(true_feasible, false_feasible, "JUMPI symbolic branch");
                         if true_feasible {
                             worklist.push_back(true_state);

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -15,12 +15,40 @@ impl SymbolicExecutor {
 
     /// Defers an incomplete result until all counterexample-producing modeled paths are explored.
     pub(super) fn defer_incomplete(&mut self, reason: &'static str) {
-        self.deferred_incomplete.get_or_insert(reason);
+        self.deferred_incomplete.get_or_insert(DeferredIncomplete::Unsupported(reason));
+    }
+
+    /// Defers a solver-unknown result while continuing with decidable sibling paths.
+    pub(super) fn defer_solver_unknown(&mut self) {
+        self.deferred_incomplete.get_or_insert(DeferredIncomplete::SolverUnknown);
+    }
+
+    /// Checks branch feasibility, recording solver-unknown as an incomplete proof path.
+    pub(super) fn branch_is_sat_or_defer(
+        &mut self,
+        constraints: &[BoolExpr],
+    ) -> Result<bool, SymbolicError> {
+        match self.solver.is_sat_branch(constraints) {
+            Ok(feasible) => Ok(feasible),
+            Err(SymbolicError::SolverUnknown) => {
+                self.defer_solver_unknown();
+                Ok(false)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Returns and clears any deferred incomplete reason.
-    const fn take_deferred_incomplete(&mut self) -> Option<&'static str> {
-        self.deferred_incomplete.take()
+    fn take_deferred_incomplete(&mut self) -> Option<(SymbolicStopReason, String)> {
+        match self.deferred_incomplete.take()? {
+            DeferredIncomplete::Unsupported(reason) => Some((
+                SymbolicStopReason::Stuck,
+                format!("unsupported symbolic execution feature: {reason}"),
+            )),
+            DeferredIncomplete::SolverUnknown => {
+                Some((SymbolicStopReason::Timeout, "solver returned unknown".to_string()))
+            }
+        }
     }
 
     /// Returns staged solver portfolio diagnostics collected by this executor.
@@ -265,10 +293,10 @@ impl SymbolicExecutor {
             });
         }
 
-        if let Some(reason) = self.take_deferred_incomplete() {
+        if let Some((kind, reason)) = self.take_deferred_incomplete() {
             return Ok(SymbolicRunResult::Incomplete {
-                kind: SymbolicStopReason::Stuck,
-                reason: format!("unsupported symbolic execution feature: {reason}"),
+                kind,
+                reason,
                 stats: self.stats_with_paths(completed_paths),
             });
         }
@@ -477,10 +505,10 @@ impl SymbolicExecutor {
             });
         }
 
-        if let Some(reason) = self.take_deferred_incomplete() {
+        if let Some((kind, reason)) = self.take_deferred_incomplete() {
             return Ok(SymbolicInvariantRunResult::Incomplete {
-                kind: SymbolicStopReason::Stuck,
-                reason: format!("unsupported symbolic execution feature: {reason}"),
+                kind,
+                reason,
                 stats: self.stats_with_paths(completed_paths),
             });
         }

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -237,7 +237,13 @@ pub struct SymbolicStats {
 pub struct SymbolicExecutor {
     config: SymbolicConfig,
     solver: Box<dyn runtime::SymbolicSolver>,
-    deferred_incomplete: Option<&'static str>,
+    deferred_incomplete: Option<DeferredIncomplete>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DeferredIncomplete {
+    Unsupported(&'static str),
+    SolverUnknown,
 }
 
 #[cfg(test)]

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -110,6 +110,11 @@ pub(crate) trait SymbolicSolver {
     /// [`SymbolicError::Solver`], as appropriate.
     fn is_sat(&mut self, constraints: &[BoolExpr]) -> Result<bool, SymbolicError>;
 
+    /// Returns branch satisfiability, allowing branch-only hard-arithmetic shortcuts.
+    fn is_sat_branch(&mut self, constraints: &[BoolExpr]) -> Result<bool, SymbolicError> {
+        self.is_sat(constraints)
+    }
+
     /// Returns a concrete model for all symbolic variables constrained by the path.
     ///
     /// The executor uses the returned variable assignments to materialize ABI
@@ -266,85 +271,12 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
 
     /// Returns whether `is_sat` holds.
     fn is_sat(&mut self, constraints: &[BoolExpr]) -> Result<bool, SymbolicError> {
-        self.sat_queries += 1;
-        if constraints.iter().any(bool_contains_gasleft) {
-            return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-        }
-        let smt_constraints = normalize_constraints_for_solver(constraints);
-        let cache_key = constraint_cache_key(&smt_constraints);
-        if let Some(result) = self.sat_cache.get(&cache_key) {
-            self.sat_cache_hits += 1;
-            trace!(result, "is_sat: normalized cache hit");
-            return Ok(*result);
-        }
-        if self.has_cached_unsat_subset(&cache_key) {
-            self.sat_cache_hits += 1;
-            trace!("is_sat: normalized unsat subset cache hit");
-            self.cache_sat_result(cache_key, false);
-            return Ok(false);
-        }
+        self.is_sat_inner(constraints, false)
+    }
 
-        self.reserve_query()?;
-        self.record_query();
-        let _span = trace_span!(
-            "solver_query",
-            query_id = self.queries,
-            constraint_count = constraints.len(),
-            kind = "is_sat"
-        )
-        .entered();
-        trace!(query_id = self.queries, constraint_count = constraints.len(), "solver is_sat");
-        if constraints_are_directly_unsat(&smt_constraints) {
-            trace!("is_sat: direct contradiction");
-            self.cache_sat_result(cache_key, false);
-            return Ok(false);
-        }
-        if product_monotonic_unsat_normalized(&smt_constraints) {
-            trace!("is_sat: monotonic product contradiction");
-            self.cache_sat_result(cache_key, false);
-            return Ok(false);
-        }
-        if constraints_prefer_hard_arith_fallback_first(&smt_constraints)
-            && validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some()
-        {
-            self.heuristic_witnesses += 1;
-            trace!("is_sat: validated hard arithmetic fallback model before solver");
-            self.cache_sat_result(cache_key, true);
-            return Ok(true);
-        }
-        let output = match self.query_normalized(&smt_constraints, false, constraints) {
-            Ok(output) => output,
-            Err(SymbolicError::SolverUnknown) => {
-                if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
-                    self.heuristic_witnesses += 1;
-                    trace!("is_sat: validated hard arithmetic fallback model after solver unknown");
-                    self.cache_sat_result(cache_key, true);
-                    return Ok(true);
-                }
-                return Err(SymbolicError::SolverUnknown);
-            }
-            Err(err) => return Err(err),
-        };
-        match output.lines().next().unwrap_or_default().trim() {
-            "sat" => {
-                self.cache_sat_result(cache_key, true);
-                Ok(true)
-            }
-            "unsat" => {
-                self.cache_sat_result(cache_key, false);
-                Ok(false)
-            }
-            "unknown" => {
-                if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
-                    self.heuristic_witnesses += 1;
-                    self.cache_sat_result(cache_key, true);
-                    Ok(true)
-                } else {
-                    Err(SymbolicError::SolverUnknown)
-                }
-            }
-            other => Err(SymbolicError::Solver(format!("unexpected solver response `{other}`"))),
-        }
+    /// Returns whether a branch is feasible.
+    fn is_sat_branch(&mut self, constraints: &[BoolExpr]) -> Result<bool, SymbolicError> {
+        self.is_sat_inner(constraints, true)
     }
 
     /// Implements the `model` solver helper.
@@ -448,6 +380,96 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
 }
 
 impl SmtLibSubprocessSolver {
+    /// Implements the `is_sat` solver helper.
+    fn is_sat_inner(
+        &mut self,
+        constraints: &[BoolExpr],
+        defer_hard_arith_without_witness: bool,
+    ) -> Result<bool, SymbolicError> {
+        self.sat_queries += 1;
+        if constraints.iter().any(bool_contains_gasleft) {
+            return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
+        }
+        let smt_constraints = normalize_constraints_for_solver(constraints);
+        let cache_key = constraint_cache_key(&smt_constraints);
+        if let Some(result) = self.sat_cache.get(&cache_key) {
+            self.sat_cache_hits += 1;
+            trace!(result, "is_sat: normalized cache hit");
+            return Ok(*result);
+        }
+        if self.has_cached_unsat_subset(&cache_key) {
+            self.sat_cache_hits += 1;
+            trace!("is_sat: normalized unsat subset cache hit");
+            self.cache_sat_result(cache_key, false);
+            return Ok(false);
+        }
+
+        self.reserve_query()?;
+        self.record_query();
+        let _span = trace_span!(
+            "solver_query",
+            query_id = self.queries,
+            constraint_count = constraints.len(),
+            kind = "is_sat"
+        )
+        .entered();
+        trace!(query_id = self.queries, constraint_count = constraints.len(), "solver is_sat");
+        if constraints_are_directly_unsat(&smt_constraints) {
+            trace!("is_sat: direct contradiction");
+            self.cache_sat_result(cache_key, false);
+            return Ok(false);
+        }
+        if product_monotonic_unsat_normalized(&smt_constraints) {
+            trace!("is_sat: monotonic product contradiction");
+            self.cache_sat_result(cache_key, false);
+            return Ok(false);
+        }
+        if constraints_prefer_hard_arith_fallback_first(&smt_constraints) {
+            if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
+                self.heuristic_witnesses += 1;
+                trace!("is_sat: validated hard arithmetic fallback model before solver");
+                self.cache_sat_result(cache_key, true);
+                return Ok(true);
+            }
+            if defer_hard_arith_without_witness {
+                trace!("is_sat: deferring hard arithmetic branch without local witness");
+                return Err(SymbolicError::SolverUnknown);
+            }
+        }
+        let output = match self.query_normalized(&smt_constraints, false, constraints) {
+            Ok(output) => output,
+            Err(SymbolicError::SolverUnknown) => {
+                if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
+                    self.heuristic_witnesses += 1;
+                    trace!("is_sat: validated hard arithmetic fallback model after solver unknown");
+                    self.cache_sat_result(cache_key, true);
+                    return Ok(true);
+                }
+                return Err(SymbolicError::SolverUnknown);
+            }
+            Err(err) => return Err(err),
+        };
+        match output.lines().next().unwrap_or_default().trim() {
+            "sat" => {
+                self.cache_sat_result(cache_key, true);
+                Ok(true)
+            }
+            "unsat" => {
+                self.cache_sat_result(cache_key, false);
+                Ok(false)
+            }
+            "unknown" => {
+                if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
+                    self.heuristic_witnesses += 1;
+                    self.cache_sat_result(cache_key, true);
+                    Ok(true)
+                } else {
+                    Err(SymbolicError::SolverUnknown)
+                }
+            }
+            other => Err(SymbolicError::Solver(format!("unexpected solver response `{other}`"))),
+        }
+    }
     /// Returns the resolved commands or the stored config error.
     pub(crate) fn commands(&self) -> Result<&[SolverCommand], SymbolicError> {
         self.commands

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -35,6 +35,7 @@ pub use runner::ContractRunner;
 
 mod progress;
 pub mod result;
+mod symbolic_minimizer;
 
 // TODO: remove
 pub use foundry_common::traits::TestFilter;

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -835,6 +835,9 @@ pub struct SymbolicResult {
     /// Durable counterexample artifact, when one was written.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact: Option<SymbolicArtifactRef>,
+    /// Deterministic concrete minimization details, when a replayed counterexample was minimized.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimization: Option<SymbolicCounterexampleMinimization>,
 }
 
 impl SymbolicResult {
@@ -910,12 +913,19 @@ impl SymbolicResult {
             replay,
             counterexample,
             artifact: None,
+            minimization: None,
         }
     }
 
     /// Attaches a durable replay artifact reference to this symbolic result.
     pub fn with_artifact(mut self, artifact: SymbolicArtifactRef) -> Self {
         self.artifact = Some(artifact);
+        self
+    }
+
+    /// Attaches deterministic minimization metadata to this symbolic result.
+    pub fn with_minimization(mut self, minimization: SymbolicCounterexampleMinimization) -> Self {
+        self.minimization = Some(minimization);
         self
     }
 }
@@ -933,6 +943,45 @@ impl SymbolicArtifactRef {
     /// Creates a reference to a symbolic counterexample artifact.
     pub fn new(path: impl Into<std::path::PathBuf>) -> Self {
         Self { schema: SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA.to_string(), path: path.into() }
+    }
+}
+
+/// Before/after artifact references and counters for concrete symbolic counterexample minimization.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SymbolicCounterexampleMinimization {
+    /// Original confirmed replay artifact before minimization.
+    pub original: SymbolicArtifactRef,
+    /// Minimized confirmed replay artifact after minimization.
+    pub minimized: SymbolicArtifactRef,
+    /// Number of concrete replay candidates tried.
+    pub attempts: usize,
+    /// Number of replay candidates accepted.
+    pub accepted: usize,
+    /// ABI calldata byte length before minimization.
+    pub original_calldata_bytes: usize,
+    /// ABI calldata byte length after minimization.
+    pub minimized_calldata_bytes: usize,
+}
+
+impl SymbolicCounterexampleMinimization {
+    /// Creates concrete minimization metadata.
+    pub const fn new(
+        original: SymbolicArtifactRef,
+        minimized: SymbolicArtifactRef,
+        attempts: usize,
+        accepted: usize,
+        original_calldata_bytes: usize,
+        minimized_calldata_bytes: usize,
+    ) -> Self {
+        Self {
+            original,
+            minimized,
+            attempts,
+            accepted,
+            original_calldata_bytes,
+            minimized_calldata_bytes,
+        }
     }
 }
 
@@ -2121,6 +2170,10 @@ impl TestResult {
         self.counterexample = counterexample;
         if let Some(artifact) = symbolic.artifact.clone() {
             self.add_counterexample_artifact(artifact);
+        }
+        if let Some(minimization) = symbolic.minimization.clone() {
+            self.add_counterexample_artifact(minimization.original);
+            self.add_counterexample_artifact(minimization.minimized);
         }
         self.symbolic = Some(symbolic);
         self.duration = Duration::default();

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1102,6 +1102,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         call: &SymbolicCounterexampleCall,
         expected_reason: Option<&str>,
     ) -> Result<(RawCallResult<FEN>, Option<String>), String> {
+        let Some(expected_reason) = expected_reason else {
+            return Err("candidate replay has no stable failure reason to compare".to_string());
+        };
+
         let mut executor = self.clone_executor();
         let raw_call_result = execute_tx(&mut executor, &call.to_basic_tx_details())
             .map_err(|err| err.to_string())?;
@@ -1115,10 +1119,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         }
 
         let reason = self.symbolic_raw_call_failure_reason(&raw_call_result)?;
-        if reason.as_deref() != expected_reason {
+        if reason.as_deref() != Some(expected_reason) {
             return Err(format!(
                 "candidate replay failed with different reason: expected `{}`, got `{}`",
-                expected_reason.unwrap_or(""),
+                expected_reason,
                 reason.as_deref().unwrap_or("")
             ));
         }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1398,18 +1398,19 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     let mut final_reason = reason;
                     let mut minimization = None;
 
-                    if let Some(candidate) = minimize_single_call_counterexample(
-                        func,
-                        &original_call,
-                        std::slice::from_ref(&self.sender),
-                        self.tcfg.config.invariant.shrink_run_limit as usize,
-                        |candidate| {
-                            self.symbolic_single_call_preserves_failure(
-                                candidate,
-                                final_reason.as_deref(),
-                            )
-                        },
-                    ) {
+                    if final_reason.is_some()
+                        && let Some(candidate) = minimize_single_call_counterexample(
+                            func,
+                            &original_call,
+                            self.tcfg.config.invariant.shrink_run_limit as usize,
+                            |candidate| {
+                                self.symbolic_single_call_preserves_failure(
+                                    candidate,
+                                    final_reason.as_deref(),
+                                )
+                            },
+                        )
+                    {
                         if candidate.changed() {
                             match self.replay_confirmed_symbolic_single_call(
                                 &candidate.minimized_call,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1454,7 +1454,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         &signature,
                         &symbolic_result,
                         SymbolicCounterexampleArtifactKind::SingleCall,
-                        vec![final_call.clone()],
+                        vec![final_call],
                     );
                     if let Some(artifact) = minimized_artifact.clone() {
                         symbolic_result = symbolic_result.with_artifact(artifact);
@@ -3079,7 +3079,7 @@ fn validate_single_call_symbolic_replay(
             call.target, test_address
         ));
     }
-    if !call.calldata.get(..4).is_some_and(|selector| func.selector() == selector) {
+    if call.calldata.get(..4).is_none_or(|selector| func.selector() != selector) {
         return Err(format!(
             "single-call symbolic artifact calldata does not match `{}` selector",
             func.signature()

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1115,11 +1115,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         }
 
         let reason = self.symbolic_raw_call_failure_reason(&raw_call_result)?;
-        if let Some(expected) = expected_reason
-            && reason.as_deref() != Some(expected)
-        {
+        if reason.as_deref() != expected_reason {
             return Err(format!(
-                "candidate replay failed with different reason: expected `{expected}`, got `{}`",
+                "candidate replay failed with different reason: expected `{}`, got `{}`",
+                expected_reason.unwrap_or(""),
                 reason.as_deref().unwrap_or("")
             ));
         }
@@ -1403,6 +1402,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         func,
                         &original_call,
                         std::slice::from_ref(&self.sender),
+                        self.tcfg.config.invariant.shrink_run_limit as usize,
                         |candidate| {
                             self.symbolic_single_call_preserves_failure(
                                 candidate,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -10,10 +10,11 @@ use crate::{
         InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicArtifactRef,
         SymbolicCallTrace, SymbolicCounterexample, SymbolicCounterexampleArtifact,
         SymbolicCounterexampleArtifactKind, SymbolicCounterexampleCall,
-        SymbolicCounterexampleReplaySemantics, SymbolicCounterexampleTestIdentity,
-        SymbolicReplayMetadata, SymbolicReplayStatus, SymbolicResult, TestResult, TestSetup,
-        TestStatus, invariant_campaign_display_name,
+        SymbolicCounterexampleMinimization, SymbolicCounterexampleReplaySemantics,
+        SymbolicCounterexampleTestIdentity, SymbolicReplayMetadata, SymbolicReplayStatus,
+        SymbolicResult, TestResult, TestSetup, TestStatus, invariant_campaign_display_name,
     },
+    symbolic_minimizer::minimize_single_call_counterexample,
 };
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::{Function, JsonAbi};
@@ -23,7 +24,7 @@ use foundry_common::{TestFunctionExt, TestFunctionKind, contracts::ContractsByAd
 use foundry_compilers::utils::canonicalized;
 use foundry_config::{Config, FuzzCorpusConfig, InlineConfig, InvariantConfig};
 use foundry_evm::{
-    constants::CALLER,
+    constants::{CALLER, CHEATCODE_ADDRESS},
     core::evm::FoundryEvmNetwork,
     decode::{RevertDecoder, SkipReason},
     executors::{
@@ -31,7 +32,7 @@ use foundry_evm::{
         fuzz::FuzzedExecutor,
         invariant::{
             CheckSequenceOptions, HandlerAssertionFailure, InvariantExecutor, InvariantFuzzError,
-            check_sequence, execute_tx_and_register_created, replay_error,
+            check_sequence, execute_tx, execute_tx_and_register_created, replay_error,
             replay_handler_failure_sequence, replay_run,
         },
         replay_corpus_to_showmap,
@@ -1088,6 +1089,65 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         )
     }
 
+    fn symbolic_single_call_preserves_failure(
+        &self,
+        call: &SymbolicCounterexampleCall,
+        expected_reason: Option<&str>,
+    ) -> bool {
+        self.replay_confirmed_symbolic_single_call(call, expected_reason).is_ok()
+    }
+
+    fn replay_confirmed_symbolic_single_call(
+        &self,
+        call: &SymbolicCounterexampleCall,
+        expected_reason: Option<&str>,
+    ) -> Result<(RawCallResult<FEN>, Option<String>), String> {
+        let mut executor = self.clone_executor();
+        let raw_call_result = execute_tx(&mut executor, &call.to_basic_tx_details())
+            .map_err(|err| err.to_string())?;
+        if executor.is_raw_call_success(
+            self.address,
+            Cow::Borrowed(&raw_call_result.state_changeset),
+            &raw_call_result,
+            false,
+        ) {
+            return Err("candidate replay succeeded".to_string());
+        }
+
+        let reason = self.symbolic_raw_call_failure_reason(&raw_call_result)?;
+        if let Some(expected) = expected_reason
+            && reason.as_deref() != Some(expected)
+        {
+            return Err(format!(
+                "candidate replay failed with different reason: expected `{expected}`, got `{}`",
+                reason.as_deref().unwrap_or("")
+            ));
+        }
+
+        Ok((raw_call_result, reason))
+    }
+
+    fn symbolic_raw_call_failure_reason(
+        &self,
+        raw_call_result: &RawCallResult<FEN>,
+    ) -> Result<Option<String>, String> {
+        if raw_call_result.reverter == Some(CHEATCODE_ADDRESS)
+            && let Some(reason) = SkipReason::decode(&raw_call_result.result)
+        {
+            return Err(format!("vm.skip during concrete replay: {reason}"));
+        }
+
+        if raw_call_result.reverted
+            || raw_call_result.exit_reason.is_some_and(|reason| !reason.is_ok())
+        {
+            Ok(Some(
+                self.revert_decoder().decode(&raw_call_result.result, raw_call_result.exit_reason),
+            ))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Configures this runner with the inline configuration for the contract.
     fn apply_function_inline_config(&mut self, func: &Function) -> Result<()> {
         if self.inline_config.contains_function(self.cr.name, &func.name) {
@@ -1239,7 +1299,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     BaseCounterExample::from_fuzz_call(calldata.clone(), args.clone(), None);
                 let symbolic_counterexample =
                     SymbolicCounterexample::from(&candidate_counterexample);
-                let (mut raw_call_result, reason) = match self.executor.call(
+                let (raw_call_result, reason) = match self.executor.call(
                     self.sender,
                     self.address,
                     func,
@@ -1293,9 +1353,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     }
                 };
 
-                let success = self.executor.is_raw_call_mut_success(
+                let success = self.executor.is_raw_call_success(
                     self.address,
-                    &mut raw_call_result,
+                    Cow::Borrowed(&raw_call_result.state_changeset),
+                    &raw_call_result,
                     false,
                 );
                 let call_trace =
@@ -1305,8 +1366,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     args,
                     raw_call_result.traces.clone(),
                 );
-                self.result.extend(raw_call_result);
                 if success {
+                    self.result.extend(raw_call_result);
                     let reason = "symbolic counterexample did not replay".to_string();
                     let symbolic_result = SymbolicResult::incomplete(
                         &self.config.symbolic,
@@ -1325,29 +1386,113 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         symbolic_result,
                     );
                 } else {
+                    let original_base_counterexample = base_counterexample;
+                    let original_call = SymbolicCounterexampleCall::from_base_counterexample(
+                        &original_base_counterexample,
+                        self.sender,
+                        self.address,
+                    );
+                    let original_symbolic_counterexample =
+                        SymbolicCounterexample::from(&original_base_counterexample);
+                    let mut final_call = original_call.clone();
+                    let mut final_raw_call_result = raw_call_result;
+                    let mut final_reason = reason;
+                    let mut minimization = None;
+
+                    if let Some(candidate) = minimize_single_call_counterexample(
+                        func,
+                        &original_call,
+                        std::slice::from_ref(&self.sender),
+                        |candidate| {
+                            self.symbolic_single_call_preserves_failure(
+                                candidate,
+                                final_reason.as_deref(),
+                            )
+                        },
+                    ) {
+                        if candidate.changed() {
+                            match self.replay_confirmed_symbolic_single_call(
+                                &candidate.minimized_call,
+                                final_reason.as_deref(),
+                            ) {
+                                Ok((raw_call_result, reason)) => {
+                                    final_call = candidate.minimized_call.clone();
+                                    final_raw_call_result = raw_call_result;
+                                    final_reason = reason;
+                                    minimization = Some(candidate);
+                                }
+                                Err(err) => {
+                                    warn!(
+                                        %err,
+                                        "discarding symbolic counterexample minimization result that no longer replays"
+                                    );
+                                }
+                            }
+                        } else {
+                            minimization = Some(candidate);
+                        }
+                    }
+
+                    let call_trace = SymbolicCallTrace::test_result_traces(
+                        final_raw_call_result.traces.is_some(),
+                    );
+                    let mut base_counterexample = final_call.to_base_counterexample();
+                    base_counterexample.traces = final_raw_call_result.traces.clone();
+                    let symbolic_counterexample =
+                        SymbolicCounterexample::from(&base_counterexample);
+                    self.result.extend(final_raw_call_result);
+
                     let mut symbolic_result = SymbolicResult::fail_counterexample(
                         &self.config.symbolic,
                         stats,
                         call_trace,
                         symbolic_counterexample,
                     );
-                    if let Some(artifact) = self.persist_symbolic_counterexample_artifact(
-                        &func.signature(),
-                        &func.signature(),
+                    let signature = func.signature();
+                    let minimized_artifact = self.persist_symbolic_counterexample_artifact(
+                        &signature,
+                        &signature,
                         &symbolic_result,
                         SymbolicCounterexampleArtifactKind::SingleCall,
-                        vec![SymbolicCounterexampleCall::from_base_counterexample(
-                            &base_counterexample,
-                            self.sender,
-                            self.address,
-                        )],
-                    ) {
+                        vec![final_call.clone()],
+                    );
+                    if let Some(artifact) = minimized_artifact.clone() {
                         symbolic_result = symbolic_result.with_artifact(artifact);
+                    }
+
+                    if let Some(minimization) = minimization {
+                        let original_symbolic_result = SymbolicResult::fail_counterexample(
+                            &self.config.symbolic,
+                            stats,
+                            SymbolicCallTrace::none(),
+                            original_symbolic_counterexample,
+                        );
+                        let original_artifact = self.persist_symbolic_counterexample_artifact(
+                            &signature,
+                            &format!("original__{signature}"),
+                            &original_symbolic_result,
+                            SymbolicCounterexampleArtifactKind::SingleCall,
+                            vec![minimization.original_call.clone()],
+                        );
+                        if let (Some(original), Some(minimized)) =
+                            (original_artifact, minimized_artifact)
+                        {
+                            symbolic_result = symbolic_result.with_minimization(
+                                SymbolicCounterexampleMinimization::new(
+                                    original,
+                                    minimized,
+                                    minimization.attempts,
+                                    minimization.accepted,
+                                    minimization.original_call.calldata.len(),
+                                    minimization.minimized_call.calldata.len(),
+                                ),
+                            );
+                        }
                     }
                     let counterexample = CounterExample::Single(base_counterexample);
                     self.result.symbolic_result(
                         TestStatus::Failure,
-                        reason,
+                        final_reason,
                         Some(counterexample),
                         symbolic_result,
                     );
@@ -1396,17 +1541,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     ));
                     return self.result;
                 }
-                if let Err(err) =
-                    validate_single_call_symbolic_replay(func, call, self.address, self.sender)
-                {
+                if let Err(err) = validate_single_call_symbolic_replay(func, call, self.address) {
                     self.result.single_fail(Some(err));
-                    return self.result;
-                }
-                if call.warp.is_some() || call.roll.is_some() {
-                    self.result.single_fail(Some(
-                        "single-call symbolic artifact replay does not support warp or roll"
-                            .to_string(),
-                    ));
                     return self.result;
                 }
 
@@ -1414,13 +1550,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     return self.result;
                 }
 
-                let executor = self.clone_executor();
-                match executor.call_raw(
-                    call.sender,
-                    call.target,
-                    call.calldata.clone(),
-                    call.value.unwrap_or(U256::ZERO),
-                ) {
+                let mut executor = self.clone_executor();
+                match execute_tx(&mut executor, &call.to_basic_tx_details()) {
                     Ok(raw_call_result) => {
                         let replay_success = executor.is_raw_call_success(
                             self.address,
@@ -2941,24 +3072,12 @@ fn validate_single_call_symbolic_replay(
     func: &Function,
     call: &SymbolicCounterexampleCall,
     test_address: Address,
-    expected_sender: Address,
 ) -> Result<(), String> {
     if call.target != test_address {
         return Err(format!(
             "single-call symbolic artifact target {} does not match test contract {}",
             call.target, test_address
         ));
-    }
-    if call.sender != expected_sender {
-        return Err(format!(
-            "single-call symbolic artifact sender {} does not match configured sender {}",
-            call.sender, expected_sender
-        ));
-    }
-    if call.value.is_some_and(|value| !value.is_zero()) {
-        return Err(
-            "single-call symbolic artifact replay does not support non-zero value".to_string()
-        );
     }
     if !call.calldata.get(..4).is_some_and(|selector| func.selector() == selector) {
         return Err(format!(

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -37,7 +37,7 @@ pub(crate) fn minimize_single_call_counterexample(
     configured_senders: &[Address],
     mut still_fails: impl FnMut(&SymbolicCounterexampleCall) -> bool,
 ) -> Option<MinimizedSingleCall> {
-    if !call.calldata.get(..4).is_some_and(|selector| selector == function.selector()) {
+    if call.calldata.get(..4).is_none_or(|selector| selector != function.selector()) {
         return None;
     }
 
@@ -446,16 +446,13 @@ fn same_call(left: &SymbolicCounterexampleCall, right: &SymbolicCounterexampleCa
         && left.value == right.value
 }
 
-fn minimize_values(
-    values: &mut Vec<DynSolValue>,
-    try_values: &mut dyn FnMut(&[DynSolValue]) -> bool,
-) {
+fn minimize_values(values: &mut [DynSolValue], try_values: &mut dyn FnMut(&[DynSolValue]) -> bool) {
     loop {
         let mut changed = false;
         for idx in 0..values.len() {
             let mut value = values[idx].clone();
             let value_changed = minimize_value(&mut value, &mut |candidate| {
-                let mut candidate_values = values.clone();
+                let mut candidate_values = values.to_vec();
                 candidate_values[idx] = candidate.clone();
                 try_values(&candidate_values)
             });
@@ -998,14 +995,14 @@ fn deletion_lengths(len: usize) -> Vec<usize> {
 }
 
 fn minimize_elements(
-    elements: &mut Vec<DynSolValue>,
+    elements: &mut [DynSolValue],
     rebuild: impl Fn(&[DynSolValue]) -> DynSolValue,
     try_value: &mut dyn FnMut(&DynSolValue) -> bool,
 ) -> Option<DynSolValue> {
     for idx in 0..elements.len() {
         let mut element = elements[idx].clone();
         let changed = minimize_value(&mut element, &mut |candidate| {
-            let mut candidate_elements = elements.clone();
+            let mut candidate_elements = elements.to_vec();
             candidate_elements[idx] = candidate.clone();
             try_value(&rebuild(&candidate_elements))
         });
@@ -1027,12 +1024,10 @@ fn minimize_elements_batch(
         return None;
     }
     let candidate = rebuild(&simple_elements);
-    if try_value(&candidate) {
+    try_value(&candidate).then(|| {
         *elements = simple_elements;
-        Some(candidate)
-    } else {
-        None
-    }
+        candidate
+    })
 }
 
 fn minimize_element_subsets(
@@ -1052,17 +1047,17 @@ fn minimize_element_subsets(
     }
 
     for subset_size in subset_sizes(shrinkable_idxs.len()) {
-        let mut subset = Vec::with_capacity(subset_size);
-        if let Some(candidate_elements) = try_element_subset(
+        let mut search = ElementSubsetSearch {
             elements,
-            &simple_elements,
-            &shrinkable_idxs,
-            subset_size,
-            0,
-            &mut subset,
-            &rebuild,
+            simple_elements: &simple_elements,
+            shrinkable_idxs: &shrinkable_idxs,
+            rebuild: &rebuild,
             try_value,
-        ) {
+        };
+        let mut subset = Vec::with_capacity(subset_size);
+        if let Some(candidate_elements) =
+            try_element_subset(&mut search, subset_size, 0, &mut subset)
+        {
             *elements = candidate_elements.clone();
             return Some(rebuild(&candidate_elements));
         }
@@ -1098,40 +1093,41 @@ fn bounded_combination_count(n: usize, k: usize, max: usize) -> Option<usize> {
     Some(count)
 }
 
-fn try_element_subset(
-    elements: &[DynSolValue],
-    simple_elements: &[DynSolValue],
-    shrinkable_idxs: &[usize],
+struct ElementSubsetSearch<'a, R>
+where
+    R: Fn(&[DynSolValue]) -> DynSolValue,
+{
+    elements: &'a [DynSolValue],
+    simple_elements: &'a [DynSolValue],
+    shrinkable_idxs: &'a [usize],
+    rebuild: &'a R,
+    try_value: &'a mut dyn FnMut(&DynSolValue) -> bool,
+}
+
+fn try_element_subset<R>(
+    search: &mut ElementSubsetSearch<'_, R>,
     subset_size: usize,
     start: usize,
     subset: &mut Vec<usize>,
-    rebuild: &impl Fn(&[DynSolValue]) -> DynSolValue,
-    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
-) -> Option<Vec<DynSolValue>> {
+) -> Option<Vec<DynSolValue>>
+where
+    R: Fn(&[DynSolValue]) -> DynSolValue,
+{
     if subset.len() == subset_size {
-        let mut candidate_elements = elements.to_vec();
+        let mut candidate_elements = search.elements.to_vec();
         for idx in subset.iter().copied() {
-            candidate_elements[idx] = simple_elements[idx].clone();
+            candidate_elements[idx] = search.simple_elements[idx].clone();
         }
-        if try_value(&rebuild(&candidate_elements)) {
+        if (search.try_value)(&(search.rebuild)(&candidate_elements)) {
             return Some(candidate_elements);
         }
         return None;
     }
 
     let remaining = subset_size - subset.len();
-    for choice_idx in start..=shrinkable_idxs.len() - remaining {
-        subset.push(shrinkable_idxs[choice_idx]);
-        if let Some(candidate) = try_element_subset(
-            elements,
-            simple_elements,
-            shrinkable_idxs,
-            subset_size,
-            choice_idx + 1,
-            subset,
-            rebuild,
-            try_value,
-        ) {
+    for choice_idx in start..=search.shrinkable_idxs.len() - remaining {
+        subset.push(search.shrinkable_idxs[choice_idx]);
+        if let Some(candidate) = try_element_subset(search, subset_size, choice_idx + 1, subset) {
             return Some(candidate);
         }
         subset.pop();
@@ -1287,6 +1283,129 @@ mod tests {
             vec![DynSolValue::Uint(U256::from(43), 8)]
         );
         assert!(minimized.attempts < MAX_MINIMIZATION_ATTEMPTS);
+    }
+
+    #[test]
+    fn matches_echidna_contiguous_slice_examples() {
+        let bytes_abi = JsonAbi::parse(["function check(bytes) external"]).unwrap();
+        let bytes_function = bytes_abi.functions().next().unwrap();
+        let bytes_start =
+            call(bytes_function, vec![DynSolValue::Bytes(vec![0x99, 0x41, 0x42, 0x88])]);
+        let bytes_minimized =
+            minimize_single_call_counterexample(bytes_function, &bytes_start, &[], |candidate| {
+                decoded(bytes_function, candidate) == vec![DynSolValue::Bytes(vec![0x41, 0x42])]
+            })
+            .unwrap();
+        assert_eq!(
+            decoded(bytes_function, &bytes_minimized.minimized_call),
+            vec![DynSolValue::Bytes(vec![0x41, 0x42])]
+        );
+
+        let string_abi = JsonAbi::parse(["function check(string) external"]).unwrap();
+        let string_function = string_abi.functions().next().unwrap();
+        let string_start = call(string_function, vec![DynSolValue::String("xOKy".to_string())]);
+        let string_minimized =
+            minimize_single_call_counterexample(string_function, &string_start, &[], |candidate| {
+                decoded(string_function, candidate) == vec![DynSolValue::String("OK".to_string())]
+            })
+            .unwrap();
+        assert_eq!(
+            decoded(string_function, &string_minimized.minimized_call),
+            vec![DynSolValue::String("OK".to_string())]
+        );
+
+        let array_abi = JsonAbi::parse(["function check(uint256[]) external"]).unwrap();
+        let array_function = array_abi.functions().next().unwrap();
+        let array_start = call(
+            array_function,
+            vec![DynSolValue::Array(vec![
+                DynSolValue::Uint(U256::from(9), 256),
+                DynSolValue::Uint(U256::from(4), 256),
+                DynSolValue::Uint(U256::from(2), 256),
+                DynSolValue::Uint(U256::from(8), 256),
+            ])],
+        );
+        let array_minimized =
+            minimize_single_call_counterexample(array_function, &array_start, &[], |candidate| {
+                let args = decoded(array_function, candidate);
+                matches!(&args[0], DynSolValue::Array(values) if values == &[
+                    DynSolValue::Uint(U256::from(4), 256),
+                    DynSolValue::Uint(U256::from(2), 256),
+                ])
+            })
+            .unwrap();
+        assert_eq!(
+            decoded(array_function, &array_minimized.minimized_call),
+            vec![DynSolValue::Array(vec![
+                DynSolValue::Uint(U256::from(4), 256),
+                DynSolValue::Uint(U256::from(2), 256),
+            ])]
+        );
+    }
+
+    #[test]
+    fn matches_echidna_address_deadbeef_and_bool_examples() {
+        let deadbeef = Address::from_word(B256::from(U256::from(0xdeadbeefu64)));
+
+        let address_abi = JsonAbi::parse(["function check(address) external"]).unwrap();
+        let address_function = address_abi.functions().next().unwrap();
+        let address_start =
+            call(address_function, vec![DynSolValue::Address(Address::from([0xaa; 20]))]);
+        let address_minimized = minimize_single_call_counterexample(
+            address_function,
+            &address_start,
+            &[],
+            |candidate| {
+                let args = decoded(address_function, candidate);
+                matches!(&args[..], [DynSolValue::Address(address)] if *address == deadbeef)
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            decoded(address_function, &address_minimized.minimized_call),
+            vec![DynSolValue::Address(deadbeef)]
+        );
+
+        let bool_abi = JsonAbi::parse(["function check(bool) external"]).unwrap();
+        let bool_function = bool_abi.functions().next().unwrap();
+        let bool_start = call(bool_function, vec![DynSolValue::Bool(true)]);
+        let bool_minimized =
+            minimize_single_call_counterexample(bool_function, &bool_start, &[], |candidate| {
+                decoded(bool_function, candidate) == vec![DynSolValue::Bool(false)]
+            })
+            .unwrap();
+        assert_eq!(
+            decoded(bool_function, &bool_minimized.minimized_call),
+            vec![DynSolValue::Bool(false)]
+        );
+    }
+
+    #[test]
+    fn minimizes_correlated_multi_arg_slice_examples() {
+        let abi = JsonAbi::parse(["function check(bytes,string) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(
+            function,
+            vec![
+                DynSolValue::Bytes(vec![0x99, 0x41, 0x42, 0x88]),
+                DynSolValue::String("xOKy".to_string()),
+            ],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[..], [
+                DynSolValue::Bytes(bytes),
+                DynSolValue::String(string),
+            ] if bytes == &[0x41, 0x42] && string.contains("OK"))
+        })
+        .unwrap();
+
+        assert_eq!(
+            decoded(function, &minimized.minimized_call),
+            vec![DynSolValue::Bytes(vec![0x41, 0x42]), DynSolValue::String("OK".to_string()),]
+        );
+        assert!(minimized.changed());
     }
 
     #[test]

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -4,7 +4,6 @@ use alloy_json_abi::Function;
 use alloy_primitives::{Address, B256, Bytes, Function as SolFunction, I256, U256};
 use itertools::Itertools;
 
-const MAX_MINIMIZATION_ATTEMPTS: usize = 5000;
 const MAX_SUBSET_CANDIDATES_PER_PASS: usize = 256;
 
 /// Result of deterministic single-call counterexample minimization.
@@ -35,6 +34,7 @@ pub(crate) fn minimize_single_call_counterexample(
     function: &Function,
     call: &SymbolicCounterexampleCall,
     configured_senders: &[Address],
+    max_attempts: usize,
     mut still_fails: impl FnMut(&SymbolicCounterexampleCall) -> bool,
 ) -> Option<MinimizedSingleCall> {
     if call.calldata.get(..4).is_none_or(|selector| selector != function.selector()) {
@@ -48,13 +48,13 @@ pub(crate) fn minimize_single_call_counterexample(
     let mut accepted = 0usize;
 
     let mut try_args = |candidate_args: &[DynSolValue]| {
+        if attempts >= max_attempts {
+            return false;
+        }
         let Some(candidate_call) = call_with_args(function, call, candidate_args) else {
             return false;
         };
         if candidate_call.calldata == current_call.calldata {
-            return false;
-        }
-        if attempts >= MAX_MINIMIZATION_ATTEMPTS {
             return false;
         }
 
@@ -74,6 +74,7 @@ pub(crate) fn minimize_single_call_counterexample(
     minimize_call_fields(
         &mut current_call,
         configured_senders,
+        max_attempts,
         &mut attempts,
         &mut accepted,
         &mut still_fails,
@@ -213,22 +214,28 @@ fn minimally_simple_value(mut value: DynSolValue) -> DynSolValue {
 fn minimize_call_fields(
     call: &mut SymbolicCounterexampleCall,
     configured_senders: &[Address],
+    max_attempts: usize,
     attempts: &mut usize,
     accepted: &mut usize,
     still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
 ) {
     loop {
-        let changed =
-            minimize_call_sender(call, configured_senders, attempts, accepted, still_fails)
-                || minimize_call_u256_field(
-                    call,
-                    attempts,
-                    accepted,
-                    still_fails,
-                    |call| call.value,
-                    |call, value| call.value = value,
-                )
-                || minimize_call_delay(call, attempts, accepted, still_fails);
+        let changed = minimize_call_sender(
+            call,
+            configured_senders,
+            max_attempts,
+            attempts,
+            accepted,
+            still_fails,
+        ) || minimize_call_u256_field(
+            call,
+            max_attempts,
+            attempts,
+            accepted,
+            still_fails,
+            |call| call.value,
+            |call, value| call.value = value,
+        ) || minimize_call_delay(call, max_attempts, attempts, accepted, still_fails);
         if !changed {
             break;
         }
@@ -238,6 +245,7 @@ fn minimize_call_fields(
 fn minimize_call_sender(
     call: &mut SymbolicCounterexampleCall,
     configured_senders: &[Address],
+    max_attempts: usize,
     attempts: &mut usize,
     accepted: &mut usize,
     still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
@@ -252,7 +260,14 @@ fn minimize_call_sender(
     for candidate in ordered_senders.into_iter().take(current_idx) {
         let mut candidate_call = call.clone();
         candidate_call.sender = candidate;
-        if accept_call_candidate(call, candidate_call, attempts, accepted, still_fails) {
+        if accept_call_candidate(
+            call,
+            candidate_call,
+            max_attempts,
+            attempts,
+            accepted,
+            still_fails,
+        ) {
             return true;
         }
     }
@@ -261,17 +276,25 @@ fn minimize_call_sender(
 
 fn minimize_call_delay(
     call: &mut SymbolicCounterexampleCall,
+    max_attempts: usize,
     attempts: &mut usize,
     accepted: &mut usize,
     still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
 ) -> bool {
     match (call.warp, call.roll) {
-        (Some(warp), Some(roll)) => {
-            minimize_call_delay_pair(call, warp, roll, attempts, accepted, still_fails)
-        }
+        (Some(warp), Some(roll)) => minimize_call_delay_pair(
+            call,
+            warp,
+            roll,
+            max_attempts,
+            attempts,
+            accepted,
+            still_fails,
+        ),
         _ => {
             minimize_call_u256_field(
                 call,
+                max_attempts,
                 attempts,
                 accepted,
                 still_fails,
@@ -279,6 +302,7 @@ fn minimize_call_delay(
                 |call, value| call.warp = value,
             ) || minimize_call_u256_field(
                 call,
+                max_attempts,
                 attempts,
                 accepted,
                 still_fails,
@@ -293,6 +317,7 @@ fn minimize_call_delay_pair(
     call: &mut SymbolicCounterexampleCall,
     current_warp: U256,
     current_roll: U256,
+    max_attempts: usize,
     attempts: &mut usize,
     accepted: &mut usize,
     still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
@@ -306,7 +331,7 @@ fn minimize_call_delay_pair(
         let mut candidate_call = call.clone();
         candidate_call.warp = Some(warp);
         candidate_call.roll = Some(roll);
-        accept_call_candidate(call, candidate_call, attempts, accepted, still_fails)
+        accept_call_candidate(call, candidate_call, max_attempts, attempts, accepted, still_fails)
     };
 
     (!current_roll.is_zero()
@@ -328,6 +353,7 @@ fn level_delay(warp: U256, roll: U256) -> (U256, U256) {
 
 fn minimize_call_u256_field(
     call: &mut SymbolicCounterexampleCall,
+    max_attempts: usize,
     attempts: &mut usize,
     accepted: &mut usize,
     still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
@@ -344,7 +370,7 @@ fn minimize_call_u256_field(
     minimize_u256_candidates(current, |candidate| {
         let mut candidate_call = call.clone();
         set(&mut candidate_call, Some(candidate));
-        accept_call_candidate(call, candidate_call, attempts, accepted, still_fails)
+        accept_call_candidate(call, candidate_call, max_attempts, attempts, accepted, still_fails)
     })
 }
 
@@ -420,11 +446,12 @@ fn minimize_u256_pair_candidates(
 fn accept_call_candidate(
     call: &mut SymbolicCounterexampleCall,
     candidate: SymbolicCounterexampleCall,
+    max_attempts: usize,
     attempts: &mut usize,
     accepted: &mut usize,
     still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
 ) -> bool {
-    if same_call(call, &candidate) || *attempts >= MAX_MINIMIZATION_ATTEMPTS {
+    if same_call(call, &candidate) || *attempts >= max_attempts {
         return false;
     }
 
@@ -1326,6 +1353,8 @@ mod tests {
     use super::*;
     use alloy_json_abi::JsonAbi;
 
+    const TEST_MAX_MINIMIZATION_ATTEMPTS: usize = 5000;
+
     fn call(function: &Function, args: Vec<DynSolValue>) -> SymbolicCounterexampleCall {
         SymbolicCounterexampleCall {
             warp: None,
@@ -1372,7 +1401,7 @@ mod tests {
         );
 
         let minimized =
-            minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            minimize_single_call_counterexample(function, &start, &[], TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
                 let args = decoded(function, candidate);
                 matches!(&args[0], DynSolValue::Uint(value, _) if *value & U256::from(0x2a) == U256::from(0x2a))
                     && matches!(&args[1], DynSolValue::Address(address) if address.as_slice()[19] == 0xaa)
@@ -1420,7 +1449,7 @@ mod tests {
             ],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+        let minimized = minimize_single_call_counterexample(function, &start, &[], TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
             let args = decoded(function, candidate);
             matches!(&args[0], DynSolValue::Uint(value, _) if *value > U256::from(42))
                 && matches!(&args[1], DynSolValue::Int(value, _) if *value < I256::try_from(-42).unwrap())
@@ -1446,17 +1475,23 @@ mod tests {
         let function = abi.functions().next().unwrap();
         let start = call(function, vec![DynSolValue::Uint(U256::from(246), 8)]);
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            let args = decoded(function, candidate);
-            matches!(&args[0], DynSolValue::Uint(value, 8) if *value > U256::from(42))
-        })
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[0], DynSolValue::Uint(value, 8) if *value > U256::from(42))
+            },
+        )
         .unwrap();
 
         assert_eq!(
             decoded(function, &minimized.minimized_call),
             vec![DynSolValue::Uint(U256::from(43), 8)]
         );
-        assert!(minimized.attempts < MAX_MINIMIZATION_ATTEMPTS);
+        assert!(minimized.attempts < TEST_MAX_MINIMIZATION_ATTEMPTS);
     }
 
     #[test]
@@ -1465,11 +1500,16 @@ mod tests {
         let bytes_function = bytes_abi.functions().next().unwrap();
         let bytes_start =
             call(bytes_function, vec![DynSolValue::Bytes(vec![0x99, 0x41, 0x42, 0x88])]);
-        let bytes_minimized =
-            minimize_single_call_counterexample(bytes_function, &bytes_start, &[], |candidate| {
+        let bytes_minimized = minimize_single_call_counterexample(
+            bytes_function,
+            &bytes_start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
                 decoded(bytes_function, candidate) == vec![DynSolValue::Bytes(vec![0x41, 0x42])]
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
         assert_eq!(
             decoded(bytes_function, &bytes_minimized.minimized_call),
             vec![DynSolValue::Bytes(vec![0x41, 0x42])]
@@ -1478,11 +1518,16 @@ mod tests {
         let string_abi = JsonAbi::parse(["function check(string) external"]).unwrap();
         let string_function = string_abi.functions().next().unwrap();
         let string_start = call(string_function, vec![DynSolValue::String("xOKy".to_string())]);
-        let string_minimized =
-            minimize_single_call_counterexample(string_function, &string_start, &[], |candidate| {
+        let string_minimized = minimize_single_call_counterexample(
+            string_function,
+            &string_start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
                 decoded(string_function, candidate) == vec![DynSolValue::String("OK".to_string())]
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
         assert_eq!(
             decoded(string_function, &string_minimized.minimized_call),
             vec![DynSolValue::String("OK".to_string())]
@@ -1499,15 +1544,20 @@ mod tests {
                 DynSolValue::Uint(U256::from(8), 256),
             ])],
         );
-        let array_minimized =
-            minimize_single_call_counterexample(array_function, &array_start, &[], |candidate| {
+        let array_minimized = minimize_single_call_counterexample(
+            array_function,
+            &array_start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
                 let args = decoded(array_function, candidate);
                 matches!(&args[0], DynSolValue::Array(values) if values == &[
                     DynSolValue::Uint(U256::from(4), 256),
                     DynSolValue::Uint(U256::from(2), 256),
                 ])
-            })
-            .unwrap();
+            },
+        )
+        .unwrap();
         assert_eq!(
             decoded(array_function, &array_minimized.minimized_call),
             vec![DynSolValue::Array(vec![
@@ -1529,6 +1579,7 @@ mod tests {
             address_function,
             &address_start,
             &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(address_function, candidate);
                 matches!(&args[..], [DynSolValue::Address(address)] if *address == deadbeef)
@@ -1543,11 +1594,14 @@ mod tests {
         let bool_abi = JsonAbi::parse(["function check(bool) external"]).unwrap();
         let bool_function = bool_abi.functions().next().unwrap();
         let bool_start = call(bool_function, vec![DynSolValue::Bool(true)]);
-        let bool_minimized =
-            minimize_single_call_counterexample(bool_function, &bool_start, &[], |candidate| {
-                decoded(bool_function, candidate) == vec![DynSolValue::Bool(false)]
-            })
-            .unwrap();
+        let bool_minimized = minimize_single_call_counterexample(
+            bool_function,
+            &bool_start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| decoded(bool_function, candidate) == vec![DynSolValue::Bool(false)],
+        )
+        .unwrap();
         assert_eq!(
             decoded(bool_function, &bool_minimized.minimized_call),
             vec![DynSolValue::Bool(false)]
@@ -1566,13 +1620,19 @@ mod tests {
             ],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            let args = decoded(function, candidate);
-            matches!(&args[..], [
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[..], [
                 DynSolValue::Bytes(bytes),
                 DynSolValue::String(string),
             ] if bytes == &[0x41, 0x42] && string.contains("OK"))
-        })
+            },
+        )
         .unwrap();
 
         assert_eq!(
@@ -1596,12 +1656,18 @@ mod tests {
             ])],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            let args = decoded(function, candidate);
-            matches!(&args[0], DynSolValue::Array(values) if values.iter().any(|value| {
-                matches!(value, DynSolValue::Address(candidate) if *candidate == target)
-            }))
-        })
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[0], DynSolValue::Array(values) if values.iter().any(|value| {
+                    matches!(value, DynSolValue::Address(candidate) if *candidate == target)
+                }))
+            },
+        )
         .unwrap();
 
         assert_eq!(
@@ -1624,15 +1690,21 @@ mod tests {
             ])],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            let args = decoded(function, candidate);
-            matches!(&args[0], DynSolValue::Tuple(values)
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[0], DynSolValue::Tuple(values)
                 if matches!(&values[..], [
                     DynSolValue::Uint(_, _),
                     DynSolValue::String(value),
                     DynSolValue::Address(_),
                 ] if value.contains("yolo")))
-        })
+            },
+        )
         .unwrap();
 
         assert_eq!(
@@ -1662,12 +1734,18 @@ mod tests {
             ],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            let args = decoded(function, candidate);
-            matches!(&args[0], DynSolValue::Tuple(outer)
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[0], DynSolValue::Tuple(outer)
                 if matches!(&outer[0], DynSolValue::Tuple(inner)
                     if matches!(&inner[0], DynSolValue::Bytes(bytes) if bytes.contains(&0x42))))
-        })
+            },
+        )
         .unwrap();
 
         assert_eq!(
@@ -1692,6 +1770,7 @@ mod tests {
             function,
             &start,
             &configured_senders,
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| configured_senders.contains(&candidate.sender),
         )
         .unwrap();
@@ -1708,9 +1787,13 @@ mod tests {
         start.warp = Some(U256::from(43));
         start.roll = Some(U256::from(42));
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            candidate.warp == Some(U256::ZERO) && candidate.roll == Some(U256::ZERO)
-        })
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| candidate.warp == Some(U256::ZERO) && candidate.roll == Some(U256::ZERO),
+        )
         .unwrap();
 
         assert_eq!(minimized.minimized_call.warp, Some(U256::ZERO));
@@ -1731,14 +1814,20 @@ mod tests {
             ],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            let args = decoded(function, candidate);
-            matches!(&args[..], [
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[..], [
                 DynSolValue::Uint(left, _),
                 DynSolValue::Uint(right, _),
                 DynSolValue::Bytes(bytes),
             ] if left.is_zero() && right.is_zero() && bytes.contains(&0x42))
-        })
+            },
+        )
         .unwrap();
 
         assert_eq!(
@@ -1765,15 +1854,21 @@ mod tests {
             ])],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            let args = decoded(function, candidate);
-            matches!(&args[0], DynSolValue::Tuple(values)
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[0], DynSolValue::Tuple(values)
                 if matches!(&values[..], [
                     DynSolValue::Uint(left, _),
                     DynSolValue::Uint(right, _),
                     DynSolValue::Bytes(bytes),
                 ] if left.is_zero() && right.is_zero() && bytes.contains(&0x42)))
-        })
+            },
+        )
         .unwrap();
 
         assert_eq!(
@@ -1800,15 +1895,21 @@ mod tests {
             ])],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            let args = decoded(function, candidate);
-            matches!(&args[0], DynSolValue::FixedArray(values)
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[0], DynSolValue::FixedArray(values)
                 if matches!(&values[..], [
                     DynSolValue::Uint(left, _),
                     DynSolValue::Uint(_, _),
                     DynSolValue::Uint(right, _),
                 ] if *left == *right + U256::from(1)))
-        })
+            },
+        )
         .unwrap();
 
         assert_eq!(
@@ -1839,7 +1940,7 @@ mod tests {
             ])],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+        let minimized = minimize_single_call_counterexample(function, &start, &[], TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
             let args = decoded(function, candidate);
             matches!(&args[0], DynSolValue::Array(values) if values.iter().tuple_combinations().any(|(left, right)| left == right))
         })
@@ -1871,7 +1972,7 @@ mod tests {
 
         let configured_senders = [Address::ZERO, start.sender];
         let minimized =
-            minimize_single_call_counterexample(function, &start, &configured_senders, |candidate| {
+            minimize_single_call_counterexample(function, &start, &configured_senders, TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
                 let args = decoded(function, candidate);
                 matches!(&args[..], [DynSolValue::Uint(left, _), DynSolValue::Uint(right, _)] if left.is_zero() && right.is_zero())
                     && candidate.value.is_some_and(|value| value > U256::from(42))
@@ -1909,12 +2010,18 @@ mod tests {
             ],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
-            let args = decoded(function, candidate);
-            matches!(&args[0], DynSolValue::Int(value, _) if *value == I256::MINUS_ONE)
-                && matches!(&args[1], DynSolValue::Bool(false))
-                && matches!(&args[2], DynSolValue::FixedBytes(bytes, 3) if bytes[2] == 0x42)
-        })
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &[],
+            TEST_MAX_MINIMIZATION_ATTEMPTS,
+            |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[0], DynSolValue::Int(value, _) if *value == I256::MINUS_ONE)
+                    && matches!(&args[1], DynSolValue::Bool(false))
+                    && matches!(&args[2], DynSolValue::FixedBytes(bytes, 3) if bytes[2] == 0x42)
+            },
+        )
         .unwrap();
 
         assert_eq!(decoded(function, &minimized.minimized_call), decoded(function, &start));

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -1176,6 +1176,10 @@ mod tests {
         function.abi_decode_input(&call.calldata[4..]).unwrap()
     }
 
+    fn address(value: u64) -> Address {
+        Address::from_word(B256::from(U256::from(value)))
+    }
+
     #[test]
     fn minimizes_common_abi_values_with_replay_predicate() {
         let abi =
@@ -1345,7 +1349,7 @@ mod tests {
 
     #[test]
     fn matches_echidna_address_deadbeef_and_bool_examples() {
-        let deadbeef = Address::from_word(B256::from(U256::from(0xdeadbeefu64)));
+        let deadbeef = address(0xdeadbeef);
 
         let address_abi = JsonAbi::parse(["function check(address) external"]).unwrap();
         let address_function = address_abi.functions().next().unwrap();
@@ -1405,6 +1409,142 @@ mod tests {
             decoded(function, &minimized.minimized_call),
             vec![DynSolValue::Bytes(vec![0x41, 0x42]), DynSolValue::String("OK".to_string()),]
         );
+        assert!(minimized.changed());
+    }
+
+    #[test]
+    fn adapts_echidna_values_darray_fixture() {
+        let abi = JsonAbi::parse(["function add_darray(address[]) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let target = address(0x123456);
+        let start = call(
+            function,
+            vec![DynSolValue::Array(vec![
+                DynSolValue::Address(address(0xaaaa)),
+                DynSolValue::Address(target),
+                DynSolValue::Address(address(0xbbbb)),
+            ])],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[0], DynSolValue::Array(values) if values.iter().any(|value| {
+                matches!(value, DynSolValue::Address(candidate) if *candidate == target)
+            }))
+        })
+        .unwrap();
+
+        assert_eq!(
+            decoded(function, &minimized.minimized_call),
+            vec![DynSolValue::Array(vec![DynSolValue::Address(target)])]
+        );
+        assert!(minimized.changed());
+    }
+
+    #[test]
+    fn adapts_echidna_abiv2_dynamic_struct_fixture() {
+        let abi = JsonAbi::parse(["function yolo((uint256,string,address)) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(
+            function,
+            vec![DynSolValue::Tuple(vec![
+                DynSolValue::Uint(U256::from(137), 256),
+                DynSolValue::String("xyoloy".to_string()),
+                DynSolValue::Address(Address::from([0xaa; 20])),
+            ])],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[0], DynSolValue::Tuple(values)
+                if matches!(&values[..], [
+                    DynSolValue::Uint(_, _),
+                    DynSolValue::String(value),
+                    DynSolValue::Address(_),
+                ] if value.contains("yolo")))
+        })
+        .unwrap();
+
+        assert_eq!(
+            decoded(function, &minimized.minimized_call),
+            vec![DynSolValue::Tuple(vec![
+                DynSolValue::Uint(U256::ZERO, 256),
+                DynSolValue::String("yolo".to_string()),
+                DynSolValue::Address(Address::ZERO),
+            ])]
+        );
+        assert!(minimized.changed());
+    }
+
+    #[test]
+    fn adapts_echidna_abiv2_multituple_fixture() {
+        let abi = JsonAbi::parse(["function f(((bytes)),((bytes))) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(
+            function,
+            vec![
+                DynSolValue::Tuple(vec![DynSolValue::Tuple(vec![DynSolValue::Bytes(vec![
+                    0x99, 0x42, 0x88,
+                ])])]),
+                DynSolValue::Tuple(vec![DynSolValue::Tuple(vec![DynSolValue::Bytes(vec![
+                    0xaa, 0xbb,
+                ])])]),
+            ],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[0], DynSolValue::Tuple(outer)
+                if matches!(&outer[0], DynSolValue::Tuple(inner)
+                    if matches!(&inner[0], DynSolValue::Bytes(bytes) if bytes.contains(&0x42))))
+        })
+        .unwrap();
+
+        assert_eq!(
+            decoded(function, &minimized.minimized_call),
+            vec![
+                DynSolValue::Tuple(vec![DynSolValue::Tuple(vec![DynSolValue::Bytes(vec![0x42])])]),
+                DynSolValue::Tuple(vec![DynSolValue::Tuple(vec![DynSolValue::Bytes(Vec::new())])]),
+            ]
+        );
+        assert!(minimized.changed());
+    }
+
+    #[test]
+    fn adapts_echidna_basic_multisender_fixture() {
+        let abi = JsonAbi::parse(["function s3() external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let mut start = call(function, Vec::new());
+        let configured_senders = [address(0x1), address(0x2), address(0x3)];
+        start.sender = configured_senders[2];
+
+        let minimized = minimize_single_call_counterexample(
+            function,
+            &start,
+            &configured_senders,
+            |candidate| configured_senders.contains(&candidate.sender),
+        )
+        .unwrap();
+
+        assert_eq!(minimized.minimized_call.sender, configured_senders[0]);
+        assert!(minimized.changed());
+    }
+
+    #[test]
+    fn adapts_echidna_basic_delay_fixture() {
+        let abi = JsonAbi::parse(["function g() external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let mut start = call(function, Vec::new());
+        start.warp = Some(U256::from(43));
+        start.roll = Some(U256::from(42));
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            candidate.warp == Some(U256::ZERO) && candidate.roll == Some(U256::ZERO)
+        })
+        .unwrap();
+
+        assert_eq!(minimized.minimized_call.warp, Some(U256::ZERO));
+        assert_eq!(minimized.minimized_call.roll, Some(U256::ZERO));
         assert!(minimized.changed());
     }
 

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -69,6 +69,7 @@ pub(crate) fn minimize_single_call_counterexample(
     };
     minimize_values_batch(&mut current_args, &mut try_args);
     minimize_value_subsets(&mut current_args, &mut try_args);
+    minimize_value_pairs(&mut current_args, &mut try_args);
     minimize_values(&mut current_args, &mut try_args);
     minimize_call_fields(
         &mut current_call,
@@ -467,6 +468,44 @@ fn minimize_values(values: &mut [DynSolValue], try_values: &mut dyn FnMut(&[DynS
     }
 }
 
+fn minimize_value_pairs(
+    values: &mut Vec<DynSolValue>,
+    try_values: &mut dyn FnMut(&[DynSolValue]) -> bool,
+) -> bool {
+    let mut changed = false;
+    loop {
+        let mut pass_changed = false;
+        for left_idx in 0..values.len() {
+            for right_idx in left_idx + 1..values.len() {
+                let left = values[left_idx].clone();
+                let right = values[right_idx].clone();
+                if minimize_numeric_value_pair(&left, &right, |left, right| {
+                    let mut candidate_values = values.clone();
+                    candidate_values[left_idx] = left;
+                    candidate_values[right_idx] = right;
+                    if try_values(&candidate_values) {
+                        *values = candidate_values;
+                        true
+                    } else {
+                        false
+                    }
+                }) {
+                    pass_changed = true;
+                    break;
+                }
+            }
+            if pass_changed {
+                break;
+            }
+        }
+        if !pass_changed {
+            break;
+        }
+        changed = true;
+    }
+    changed
+}
+
 fn minimize_value(
     value: &mut DynSolValue,
     try_value: &mut dyn FnMut(&DynSolValue) -> bool,
@@ -537,6 +576,14 @@ fn minimize_compound_value(
                 *value = candidate;
                 return true;
             }
+            if let Some(candidate) = minimize_element_pairs(
+                &mut elements,
+                |items| DynSolValue::Array(items.to_vec()),
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
             minimize_elements(&mut elements, |items| DynSolValue::Array(items.to_vec()), try_value)
                 .map(|candidate| {
                     *value = candidate;
@@ -554,6 +601,14 @@ fn minimize_compound_value(
                 return true;
             }
             if let Some(candidate) = minimize_element_subsets(
+                &mut elements,
+                |items| DynSolValue::FixedArray(items.to_vec()),
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            if let Some(candidate) = minimize_element_pairs(
                 &mut elements,
                 |items| DynSolValue::FixedArray(items.to_vec()),
                 try_value,
@@ -589,6 +644,14 @@ fn minimize_compound_value(
                 *value = candidate;
                 return true;
             }
+            if let Some(candidate) = minimize_element_pairs(
+                &mut elements,
+                |items| DynSolValue::Tuple(items.to_vec()),
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
             minimize_elements(&mut elements, |items| DynSolValue::Tuple(items.to_vec()), try_value)
                 .map(|candidate| {
                     *value = candidate;
@@ -610,6 +673,18 @@ fn minimize_compound_value(
                 return true;
             }
             if let Some(candidate) = minimize_element_subsets(
+                &mut tuple,
+                |items| DynSolValue::CustomStruct {
+                    name: name.clone(),
+                    prop_names: prop_names.clone(),
+                    tuple: items.to_vec(),
+                },
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            if let Some(candidate) = minimize_element_pairs(
                 &mut tuple,
                 |items| DynSolValue::CustomStruct {
                     name: name.clone(),
@@ -1030,6 +1105,33 @@ fn minimize_elements_batch(
     })
 }
 
+fn minimize_element_pairs(
+    elements: &mut Vec<DynSolValue>,
+    rebuild: impl Fn(&[DynSolValue]) -> DynSolValue,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> Option<DynSolValue> {
+    for left_idx in 0..elements.len() {
+        for right_idx in left_idx + 1..elements.len() {
+            let left = elements[left_idx].clone();
+            let right = elements[right_idx].clone();
+            if minimize_numeric_value_pair(&left, &right, |left, right| {
+                let mut candidate_elements = elements.clone();
+                candidate_elements[left_idx] = left;
+                candidate_elements[right_idx] = right;
+                if try_value(&rebuild(&candidate_elements)) {
+                    *elements = candidate_elements;
+                    true
+                } else {
+                    false
+                }
+            }) {
+                return Some(rebuild(elements));
+            }
+        }
+    }
+    None
+}
+
 fn minimize_element_subsets(
     elements: &mut Vec<DynSolValue>,
     rebuild: impl Fn(&[DynSolValue]) -> DynSolValue,
@@ -1063,6 +1165,74 @@ fn minimize_element_subsets(
         }
     }
     None
+}
+
+fn minimize_numeric_value_pair(
+    left: &DynSolValue,
+    right: &DynSolValue,
+    mut try_pair: impl FnMut(DynSolValue, DynSolValue) -> bool,
+) -> bool {
+    match (left, right) {
+        (DynSolValue::Uint(left, left_bits), DynSolValue::Uint(right, right_bits)) => {
+            let mut try_uint_pair = |left, right| {
+                try_pair(DynSolValue::Uint(left, *left_bits), DynSolValue::Uint(right, *right_bits))
+            };
+            minimize_u256_pair_delta_candidates(*left, *right, &mut try_uint_pair)
+        }
+        (DynSolValue::Int(left, left_bits), DynSolValue::Int(right, right_bits)) => {
+            minimize_i256_pair_candidates(*left, *right, |left, right| {
+                try_pair(DynSolValue::Int(left, *left_bits), DynSolValue::Int(right, *right_bits))
+            })
+        }
+        _ => false,
+    }
+}
+
+fn minimize_u256_pair_delta_candidates(
+    current_left: U256,
+    current_right: U256,
+    try_candidate: &mut impl FnMut(U256, U256) -> bool,
+) -> bool {
+    match current_left.cmp(&current_right) {
+        std::cmp::Ordering::Equal => {
+            !current_left.is_zero() && try_candidate(U256::ZERO, U256::ZERO)
+        }
+        std::cmp::Ordering::Greater => {
+            let delta = current_left - current_right;
+            !current_right.is_zero() && try_candidate(delta, U256::ZERO)
+        }
+        std::cmp::Ordering::Less => {
+            let delta = current_right - current_left;
+            !current_left.is_zero() && try_candidate(U256::ZERO, delta)
+        }
+    }
+}
+
+fn minimize_i256_pair_candidates(
+    current_left: I256,
+    current_right: I256,
+    mut try_candidate: impl FnMut(I256, I256) -> bool,
+) -> bool {
+    if current_left == I256::ZERO || current_right == I256::ZERO {
+        return false;
+    }
+    if current_left.is_negative() != current_right.is_negative() {
+        return false;
+    }
+
+    minimize_u256_pair_candidates(
+        current_left.unsigned_abs(),
+        current_right.unsigned_abs(),
+        |left_abs, right_abs| {
+            let left = signed_candidate_with_abs(current_left, left_abs);
+            let right = signed_candidate_with_abs(current_right, right_abs);
+            try_candidate(left, right)
+        },
+    )
+}
+
+fn signed_candidate_with_abs(current: I256, abs: U256) -> I256 {
+    if current.is_negative() { I256::from_raw(abs.wrapping_neg()) } else { I256::from_raw(abs) }
 }
 
 fn subset_sizes(shrinkable_len: usize) -> Vec<usize> {
@@ -1614,6 +1784,75 @@ mod tests {
                 DynSolValue::Bytes(vec![0x42]),
             ]),]
         );
+        assert!(minimized.accepted > 0);
+    }
+
+    #[test]
+    fn adapts_echidna_symbolic_fixed_array_relation_fixture() {
+        let abi = JsonAbi::parse(["function array(uint256[3]) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(
+            function,
+            vec![DynSolValue::FixedArray(vec![
+                DynSolValue::Uint(U256::from(4_370_001), 256),
+                DynSolValue::Uint(U256::from(1_524_785_991), 256),
+                DynSolValue::Uint(U256::from(4_370_000), 256),
+            ])],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[0], DynSolValue::FixedArray(values)
+                if matches!(&values[..], [
+                    DynSolValue::Uint(left, _),
+                    DynSolValue::Uint(_, _),
+                    DynSolValue::Uint(right, _),
+                ] if *left == *right + U256::from(1)))
+        })
+        .unwrap();
+
+        assert_eq!(
+            decoded(function, &minimized.minimized_call),
+            vec![DynSolValue::FixedArray(vec![
+                DynSolValue::Uint(U256::from(1), 256),
+                DynSolValue::Uint(U256::ZERO, 256),
+                DynSolValue::Uint(U256::ZERO, 256),
+            ])]
+        );
+        assert!(minimized.changed());
+        assert!(minimized.accepted > 0);
+    }
+
+    #[test]
+    fn adapts_echidna_addressarrayutils_duplicate_fixture() {
+        let abi = JsonAbi::parse(["function checkNoDuplicate(address[]) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(
+            function,
+            vec![DynSolValue::Array(vec![
+                DynSolValue::Address(address(0x20000)),
+                DynSolValue::Address(address(0xffff_ffff)),
+                DynSolValue::Address(Address::ZERO),
+                DynSolValue::Address(address(0x20000)),
+                DynSolValue::Address(address(0x1ffff_fffe)),
+                DynSolValue::Address(address(0x30000)),
+            ])],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[0], DynSolValue::Array(values) if values.iter().tuple_combinations().any(|(left, right)| left == right))
+        })
+        .unwrap();
+
+        assert_eq!(
+            decoded(function, &minimized.minimized_call),
+            vec![DynSolValue::Array(vec![
+                DynSolValue::Address(Address::ZERO),
+                DynSolValue::Address(Address::ZERO),
+            ])]
+        );
+        assert!(minimized.changed());
         assert!(minimized.accepted > 0);
     }
 

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -18,11 +18,6 @@ pub(crate) struct MinimizedSingleCall {
 impl MinimizedSingleCall {
     pub(crate) fn changed(&self) -> bool {
         self.original_call.calldata != self.minimized_call.calldata
-            || self.original_call.sender != self.minimized_call.sender
-            || self.original_call.target != self.minimized_call.target
-            || self.original_call.value != self.minimized_call.value
-            || self.original_call.warp != self.minimized_call.warp
-            || self.original_call.roll != self.minimized_call.roll
     }
 }
 
@@ -33,7 +28,6 @@ impl MinimizedSingleCall {
 pub(crate) fn minimize_single_call_counterexample(
     function: &Function,
     call: &SymbolicCounterexampleCall,
-    configured_senders: &[Address],
     max_attempts: usize,
     mut still_fails: impl FnMut(&SymbolicCounterexampleCall) -> bool,
 ) -> Option<MinimizedSingleCall> {
@@ -71,14 +65,6 @@ pub(crate) fn minimize_single_call_counterexample(
     minimize_value_subsets(&mut current_args, &mut try_args);
     minimize_value_pairs(&mut current_args, &mut try_args);
     minimize_values(&mut current_args, &mut try_args);
-    minimize_call_fields(
-        &mut current_call,
-        configured_senders,
-        max_attempts,
-        &mut attempts,
-        &mut accepted,
-        &mut still_fails,
-    );
 
     current_call = with_formatted_args(current_call, &current_args);
 
@@ -211,198 +197,6 @@ fn minimally_simple_value(mut value: DynSolValue) -> DynSolValue {
     value
 }
 
-fn minimize_call_fields(
-    call: &mut SymbolicCounterexampleCall,
-    configured_senders: &[Address],
-    max_attempts: usize,
-    attempts: &mut usize,
-    accepted: &mut usize,
-    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
-) {
-    loop {
-        let changed = minimize_call_sender(
-            call,
-            configured_senders,
-            max_attempts,
-            attempts,
-            accepted,
-            still_fails,
-        ) || minimize_call_u256_field(
-            call,
-            max_attempts,
-            attempts,
-            accepted,
-            still_fails,
-            |call| call.value,
-            |call, value| call.value = value,
-        ) || minimize_call_delay(call, max_attempts, attempts, accepted, still_fails);
-        if !changed {
-            break;
-        }
-    }
-}
-
-fn minimize_call_sender(
-    call: &mut SymbolicCounterexampleCall,
-    configured_senders: &[Address],
-    max_attempts: usize,
-    attempts: &mut usize,
-    accepted: &mut usize,
-    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
-) -> bool {
-    let mut ordered_senders = configured_senders.to_vec();
-    ordered_senders.sort_unstable();
-    ordered_senders.dedup();
-    let Some(current_idx) = ordered_senders.iter().position(|sender| *sender == call.sender) else {
-        return false;
-    };
-
-    for candidate in ordered_senders.into_iter().take(current_idx) {
-        let mut candidate_call = call.clone();
-        candidate_call.sender = candidate;
-        if accept_call_candidate(
-            call,
-            candidate_call,
-            max_attempts,
-            attempts,
-            accepted,
-            still_fails,
-        ) {
-            return true;
-        }
-    }
-    false
-}
-
-fn minimize_call_delay(
-    call: &mut SymbolicCounterexampleCall,
-    max_attempts: usize,
-    attempts: &mut usize,
-    accepted: &mut usize,
-    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
-) -> bool {
-    match (call.warp, call.roll) {
-        (Some(warp), Some(roll)) => minimize_call_delay_pair(
-            call,
-            warp,
-            roll,
-            max_attempts,
-            attempts,
-            accepted,
-            still_fails,
-        ),
-        _ => {
-            minimize_call_u256_field(
-                call,
-                max_attempts,
-                attempts,
-                accepted,
-                still_fails,
-                |call| call.warp,
-                |call, value| call.warp = value,
-            ) || minimize_call_u256_field(
-                call,
-                max_attempts,
-                attempts,
-                accepted,
-                still_fails,
-                |call| call.roll,
-                |call, value| call.roll = value,
-            )
-        }
-    }
-}
-
-fn minimize_call_delay_pair(
-    call: &mut SymbolicCounterexampleCall,
-    current_warp: U256,
-    current_roll: U256,
-    max_attempts: usize,
-    attempts: &mut usize,
-    accepted: &mut usize,
-    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
-) -> bool {
-    if current_warp.is_zero() && current_roll.is_zero() {
-        return false;
-    }
-
-    let mut try_delay = |call: &mut SymbolicCounterexampleCall, warp: U256, roll: U256| {
-        let (warp, roll) = level_delay(warp, roll);
-        let mut candidate_call = call.clone();
-        candidate_call.warp = Some(warp);
-        candidate_call.roll = Some(roll);
-        accept_call_candidate(call, candidate_call, max_attempts, attempts, accepted, still_fails)
-    };
-
-    (!current_roll.is_zero()
-        && minimize_u256_candidates(current_roll, |candidate| {
-            try_delay(call, current_warp, candidate)
-        }))
-        || (!current_warp.is_zero()
-            && minimize_u256_candidates(current_warp, |candidate| {
-                try_delay(call, candidate, current_roll)
-            }))
-        || minimize_u256_pair_candidates(current_warp, current_roll, |warp, roll| {
-            try_delay(call, warp, roll)
-        })
-}
-
-fn level_delay(warp: U256, roll: U256) -> (U256, U256) {
-    if warp.is_zero() || roll.is_zero() { (U256::ZERO, U256::ZERO) } else { (warp, roll) }
-}
-
-fn minimize_call_u256_field(
-    call: &mut SymbolicCounterexampleCall,
-    max_attempts: usize,
-    attempts: &mut usize,
-    accepted: &mut usize,
-    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
-    get: impl Fn(&SymbolicCounterexampleCall) -> Option<U256>,
-    set: impl Fn(&mut SymbolicCounterexampleCall, Option<U256>),
-) -> bool {
-    let Some(current) = get(call) else {
-        return false;
-    };
-    if current.is_zero() {
-        return false;
-    }
-
-    minimize_u256_candidates(current, |candidate| {
-        let mut candidate_call = call.clone();
-        set(&mut candidate_call, Some(candidate));
-        accept_call_candidate(call, candidate_call, max_attempts, attempts, accepted, still_fails)
-    })
-}
-
-fn minimize_u256_candidates(current: U256, mut try_candidate: impl FnMut(U256) -> bool) -> bool {
-    if !current.is_zero() && try_candidate(U256::ZERO) {
-        return true;
-    }
-    for bit in (0..256).rev() {
-        let mask: U256 = U256::from(1) << bit;
-        if current & mask == U256::ZERO {
-            continue;
-        }
-        if try_candidate(current & !mask) {
-            return true;
-        }
-    }
-
-    let mut accepted_value = current;
-    let mut rejected_value = U256::ZERO;
-    let mut changed = false;
-    while accepted_value > rejected_value + U256::from(1) {
-        let candidate = rejected_value + ((accepted_value - rejected_value) >> 1usize);
-        if try_candidate(candidate) {
-            accepted_value = candidate;
-            changed = true;
-        } else {
-            rejected_value = candidate;
-        }
-    }
-    changed
-}
-
 fn minimize_u256_pair_candidates(
     current_left: U256,
     current_right: U256,
@@ -441,37 +235,6 @@ fn minimize_u256_pair_candidates(
         }
     }
     changed
-}
-
-fn accept_call_candidate(
-    call: &mut SymbolicCounterexampleCall,
-    candidate: SymbolicCounterexampleCall,
-    max_attempts: usize,
-    attempts: &mut usize,
-    accepted: &mut usize,
-    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
-) -> bool {
-    if same_call(call, &candidate) || *attempts >= max_attempts {
-        return false;
-    }
-
-    *attempts += 1;
-    if still_fails(&candidate) {
-        *call = candidate;
-        *accepted += 1;
-        true
-    } else {
-        false
-    }
-}
-
-fn same_call(left: &SymbolicCounterexampleCall, right: &SymbolicCounterexampleCall) -> bool {
-    left.warp == right.warp
-        && left.roll == right.roll
-        && left.sender == right.sender
-        && left.target == right.target
-        && left.calldata == right.calldata
-        && left.value == right.value
 }
 
 fn minimize_values(values: &mut [DynSolValue], try_values: &mut dyn FnMut(&[DynSolValue]) -> bool) {
@@ -1401,7 +1164,7 @@ mod tests {
         );
 
         let minimized =
-            minimize_single_call_counterexample(function, &start, &[], TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
+            minimize_single_call_counterexample(function, &start, TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
                 let args = decoded(function, candidate);
                 matches!(&args[0], DynSolValue::Uint(value, _) if *value & U256::from(0x2a) == U256::from(0x2a))
                     && matches!(&args[1], DynSolValue::Address(address) if address.as_slice()[19] == 0xaa)
@@ -1449,7 +1212,7 @@ mod tests {
             ],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
+        let minimized = minimize_single_call_counterexample(function, &start, TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
             let args = decoded(function, candidate);
             matches!(&args[0], DynSolValue::Uint(value, _) if *value > U256::from(42))
                 && matches!(&args[1], DynSolValue::Int(value, _) if *value < I256::try_from(-42).unwrap())
@@ -1478,7 +1241,6 @@ mod tests {
         let minimized = minimize_single_call_counterexample(
             function,
             &start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(function, candidate);
@@ -1503,7 +1265,6 @@ mod tests {
         let bytes_minimized = minimize_single_call_counterexample(
             bytes_function,
             &bytes_start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 decoded(bytes_function, candidate) == vec![DynSolValue::Bytes(vec![0x41, 0x42])]
@@ -1521,7 +1282,6 @@ mod tests {
         let string_minimized = minimize_single_call_counterexample(
             string_function,
             &string_start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 decoded(string_function, candidate) == vec![DynSolValue::String("OK".to_string())]
@@ -1547,7 +1307,6 @@ mod tests {
         let array_minimized = minimize_single_call_counterexample(
             array_function,
             &array_start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(array_function, candidate);
@@ -1578,7 +1337,6 @@ mod tests {
         let address_minimized = minimize_single_call_counterexample(
             address_function,
             &address_start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(address_function, candidate);
@@ -1597,7 +1355,6 @@ mod tests {
         let bool_minimized = minimize_single_call_counterexample(
             bool_function,
             &bool_start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| decoded(bool_function, candidate) == vec![DynSolValue::Bool(false)],
         )
@@ -1623,7 +1380,6 @@ mod tests {
         let minimized = minimize_single_call_counterexample(
             function,
             &start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(function, candidate);
@@ -1659,7 +1415,6 @@ mod tests {
         let minimized = minimize_single_call_counterexample(
             function,
             &start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(function, candidate);
@@ -1693,7 +1448,6 @@ mod tests {
         let minimized = minimize_single_call_counterexample(
             function,
             &start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(function, candidate);
@@ -1737,7 +1491,6 @@ mod tests {
         let minimized = minimize_single_call_counterexample(
             function,
             &start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(function, candidate);
@@ -1759,49 +1512,6 @@ mod tests {
     }
 
     #[test]
-    fn adapts_echidna_basic_multisender_fixture() {
-        let abi = JsonAbi::parse(["function s3() external"]).unwrap();
-        let function = abi.functions().next().unwrap();
-        let mut start = call(function, Vec::new());
-        let configured_senders = [address(0x1), address(0x2), address(0x3)];
-        start.sender = configured_senders[2];
-
-        let minimized = minimize_single_call_counterexample(
-            function,
-            &start,
-            &configured_senders,
-            TEST_MAX_MINIMIZATION_ATTEMPTS,
-            |candidate| configured_senders.contains(&candidate.sender),
-        )
-        .unwrap();
-
-        assert_eq!(minimized.minimized_call.sender, configured_senders[0]);
-        assert!(minimized.changed());
-    }
-
-    #[test]
-    fn adapts_echidna_basic_delay_fixture() {
-        let abi = JsonAbi::parse(["function g() external"]).unwrap();
-        let function = abi.functions().next().unwrap();
-        let mut start = call(function, Vec::new());
-        start.warp = Some(U256::from(43));
-        start.roll = Some(U256::from(42));
-
-        let minimized = minimize_single_call_counterexample(
-            function,
-            &start,
-            &[],
-            TEST_MAX_MINIMIZATION_ATTEMPTS,
-            |candidate| candidate.warp == Some(U256::ZERO) && candidate.roll == Some(U256::ZERO),
-        )
-        .unwrap();
-
-        assert_eq!(minimized.minimized_call.warp, Some(U256::ZERO));
-        assert_eq!(minimized.minimized_call.roll, Some(U256::ZERO));
-        assert!(minimized.changed());
-    }
-
-    #[test]
     fn minimizes_correlated_top_level_abi_value_subsets() {
         let abi = JsonAbi::parse(["function check(uint256,uint256,bytes) external"]).unwrap();
         let function = abi.functions().next().unwrap();
@@ -1817,7 +1527,6 @@ mod tests {
         let minimized = minimize_single_call_counterexample(
             function,
             &start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(function, candidate);
@@ -1857,7 +1566,6 @@ mod tests {
         let minimized = minimize_single_call_counterexample(
             function,
             &start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(function, candidate);
@@ -1898,7 +1606,6 @@ mod tests {
         let minimized = minimize_single_call_counterexample(
             function,
             &start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(function, candidate);
@@ -1940,7 +1647,7 @@ mod tests {
             ])],
         );
 
-        let minimized = minimize_single_call_counterexample(function, &start, &[], TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
+        let minimized = minimize_single_call_counterexample(function, &start, TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
             let args = decoded(function, candidate);
             matches!(&args[0], DynSolValue::Array(values) if values.iter().tuple_combinations().any(|(left, right)| left == right))
         })
@@ -1953,44 +1660,6 @@ mod tests {
                 DynSolValue::Address(Address::ZERO),
             ])]
         );
-        assert!(minimized.changed());
-        assert!(minimized.accepted > 0);
-    }
-
-    #[test]
-    fn minimizes_correlated_args_and_call_env() {
-        let abi = JsonAbi::parse(["function check(uint256,uint256) external"]).unwrap();
-        let function = abi.functions().next().unwrap();
-        let mut start = call(
-            function,
-            vec![DynSolValue::Uint(U256::from(1), 256), DynSolValue::Uint(U256::from(1), 256)],
-        );
-        start.sender = Address::from([0xaa; 20]);
-        start.value = Some(U256::from(100));
-        start.warp = Some(U256::from(50));
-        start.roll = Some(U256::from(10));
-
-        let configured_senders = [Address::ZERO, start.sender];
-        let minimized =
-            minimize_single_call_counterexample(function, &start, &configured_senders, TEST_MAX_MINIMIZATION_ATTEMPTS, |candidate| {
-                let args = decoded(function, candidate);
-                matches!(&args[..], [DynSolValue::Uint(left, _), DynSolValue::Uint(right, _)] if left.is_zero() && right.is_zero())
-                    && candidate.value.is_some_and(|value| value > U256::from(42))
-                    && candidate.warp.is_some_and(|warp| warp > U256::from(4))
-                    && candidate.roll.is_some_and(|roll| roll > U256::from(2))
-                    && (candidate.sender == Address::ZERO || candidate.sender.as_slice()[19] == 0xaa)
-            })
-            .unwrap();
-
-        let args = decoded(function, &minimized.minimized_call);
-        assert_eq!(
-            args,
-            vec![DynSolValue::Uint(U256::ZERO, 256), DynSolValue::Uint(U256::ZERO, 256)]
-        );
-        assert_eq!(minimized.minimized_call.sender, Address::ZERO);
-        assert_eq!(minimized.minimized_call.value, Some(U256::from(43)));
-        assert_eq!(minimized.minimized_call.warp, Some(U256::from(5)));
-        assert_eq!(minimized.minimized_call.roll, Some(U256::from(3)));
         assert!(minimized.changed());
         assert!(minimized.accepted > 0);
     }
@@ -2013,7 +1682,6 @@ mod tests {
         let minimized = minimize_single_call_counterexample(
             function,
             &start,
-            &[],
             TEST_MAX_MINIMIZATION_ATTEMPTS,
             |candidate| {
                 let args = decoded(function, candidate);

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -1,0 +1,1426 @@
+use crate::result::SymbolicCounterexampleCall;
+use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
+use alloy_json_abi::Function;
+use alloy_primitives::{Address, B256, Bytes, Function as SolFunction, I256, U256};
+use itertools::Itertools;
+
+const MAX_MINIMIZATION_ATTEMPTS: usize = 5000;
+const MAX_SUBSET_CANDIDATES_PER_PASS: usize = 256;
+
+/// Result of deterministic single-call counterexample minimization.
+#[derive(Clone, Debug)]
+pub(crate) struct MinimizedSingleCall {
+    pub original_call: SymbolicCounterexampleCall,
+    pub minimized_call: SymbolicCounterexampleCall,
+    pub attempts: usize,
+    pub accepted: usize,
+}
+
+impl MinimizedSingleCall {
+    pub(crate) fn changed(&self) -> bool {
+        self.original_call.calldata != self.minimized_call.calldata
+            || self.original_call.sender != self.minimized_call.sender
+            || self.original_call.target != self.minimized_call.target
+            || self.original_call.value != self.minimized_call.value
+            || self.original_call.warp != self.minimized_call.warp
+            || self.original_call.roll != self.minimized_call.roll
+    }
+}
+
+/// Minimizes a stateless symbolic counterexample with ABI-valid candidates only.
+///
+/// `still_fails` must concretely replay the candidate and return `true` only when it preserves the
+/// already-confirmed failure.
+pub(crate) fn minimize_single_call_counterexample(
+    function: &Function,
+    call: &SymbolicCounterexampleCall,
+    configured_senders: &[Address],
+    mut still_fails: impl FnMut(&SymbolicCounterexampleCall) -> bool,
+) -> Option<MinimizedSingleCall> {
+    if !call.calldata.get(..4).is_some_and(|selector| selector == function.selector()) {
+        return None;
+    }
+
+    let original_args = function.abi_decode_input(&call.calldata[4..]).ok()?;
+    let mut current_args = original_args;
+    let mut current_call = call_with_args(function, call, &current_args)?;
+    let mut attempts = 0usize;
+    let mut accepted = 0usize;
+
+    let mut try_args = |candidate_args: &[DynSolValue]| {
+        let Some(candidate_call) = call_with_args(function, call, candidate_args) else {
+            return false;
+        };
+        if candidate_call.calldata == current_call.calldata {
+            return false;
+        }
+        if attempts >= MAX_MINIMIZATION_ATTEMPTS {
+            return false;
+        }
+
+        attempts += 1;
+        if still_fails(&candidate_call) {
+            current_call = candidate_call;
+            accepted += 1;
+            true
+        } else {
+            false
+        }
+    };
+    minimize_values_batch(&mut current_args, &mut try_args);
+    minimize_value_subsets(&mut current_args, &mut try_args);
+    minimize_values(&mut current_args, &mut try_args);
+    minimize_call_fields(
+        &mut current_call,
+        configured_senders,
+        &mut attempts,
+        &mut accepted,
+        &mut still_fails,
+    );
+
+    current_call = with_formatted_args(current_call, &current_args);
+
+    Some(MinimizedSingleCall {
+        original_call: call.clone(),
+        minimized_call: current_call,
+        attempts,
+        accepted,
+    })
+}
+
+fn call_with_args(
+    function: &Function,
+    template: &SymbolicCounterexampleCall,
+    args: &[DynSolValue],
+) -> Option<SymbolicCounterexampleCall> {
+    let calldata = Bytes::from(function.abi_encode_input(args).ok()?);
+    Some(SymbolicCounterexampleCall { calldata, args: None, raw_args: None, ..template.clone() })
+}
+
+fn with_formatted_args(
+    mut call: SymbolicCounterexampleCall,
+    args: &[DynSolValue],
+) -> SymbolicCounterexampleCall {
+    call.args = Some(foundry_common::fmt::format_tokens(args).format(", ").to_string());
+    call.raw_args = Some(foundry_common::fmt::format_tokens_raw(args).format(", ").to_string());
+    call
+}
+
+fn minimize_values_batch(
+    values: &mut Vec<DynSolValue>,
+    try_values: &mut dyn FnMut(&[DynSolValue]) -> bool,
+) -> bool {
+    let candidate_values = values.iter().cloned().map(minimally_simple_value).collect::<Vec<_>>();
+    if candidate_values == *values {
+        return false;
+    }
+    if try_values(&candidate_values) {
+        *values = candidate_values;
+        true
+    } else {
+        false
+    }
+}
+
+fn minimize_value_subsets(
+    values: &mut Vec<DynSolValue>,
+    try_values: &mut dyn FnMut(&[DynSolValue]) -> bool,
+) -> bool {
+    let mut changed = false;
+    loop {
+        let simple_values = values.iter().cloned().map(minimally_simple_value).collect::<Vec<_>>();
+        let shrinkable_idxs = values
+            .iter()
+            .zip(&simple_values)
+            .enumerate()
+            .filter_map(|(idx, (current, simple))| (current != simple).then_some(idx))
+            .collect::<Vec<_>>();
+        if shrinkable_idxs.len() < 2 {
+            break;
+        }
+
+        let mut pass_changed = false;
+        for subset_size in subset_sizes(shrinkable_idxs.len()) {
+            let mut subset = Vec::with_capacity(subset_size);
+            if try_value_subset(
+                values,
+                &simple_values,
+                &shrinkable_idxs,
+                subset_size,
+                0,
+                &mut subset,
+                try_values,
+            ) {
+                pass_changed = true;
+                break;
+            }
+        }
+
+        if !pass_changed {
+            break;
+        }
+        changed = true;
+    }
+    changed
+}
+
+fn try_value_subset(
+    values: &mut Vec<DynSolValue>,
+    simple_values: &[DynSolValue],
+    shrinkable_idxs: &[usize],
+    subset_size: usize,
+    start: usize,
+    subset: &mut Vec<usize>,
+    try_values: &mut dyn FnMut(&[DynSolValue]) -> bool,
+) -> bool {
+    if subset.len() == subset_size {
+        let mut candidate_values = values.clone();
+        for idx in subset.iter().copied() {
+            candidate_values[idx] = simple_values[idx].clone();
+        }
+        if try_values(&candidate_values) {
+            *values = candidate_values;
+            return true;
+        }
+        return false;
+    }
+
+    let remaining = subset_size - subset.len();
+    for choice_idx in start..=shrinkable_idxs.len() - remaining {
+        subset.push(shrinkable_idxs[choice_idx]);
+        if try_value_subset(
+            values,
+            simple_values,
+            shrinkable_idxs,
+            subset_size,
+            choice_idx + 1,
+            subset,
+            try_values,
+        ) {
+            return true;
+        }
+        subset.pop();
+    }
+    false
+}
+
+fn minimally_simple_value(mut value: DynSolValue) -> DynSolValue {
+    minimize_value(&mut value, &mut |_| true);
+    value
+}
+
+fn minimize_call_fields(
+    call: &mut SymbolicCounterexampleCall,
+    configured_senders: &[Address],
+    attempts: &mut usize,
+    accepted: &mut usize,
+    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
+) {
+    loop {
+        let changed =
+            minimize_call_sender(call, configured_senders, attempts, accepted, still_fails)
+                || minimize_call_u256_field(
+                    call,
+                    attempts,
+                    accepted,
+                    still_fails,
+                    |call| call.value,
+                    |call, value| call.value = value,
+                )
+                || minimize_call_delay(call, attempts, accepted, still_fails);
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn minimize_call_sender(
+    call: &mut SymbolicCounterexampleCall,
+    configured_senders: &[Address],
+    attempts: &mut usize,
+    accepted: &mut usize,
+    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
+) -> bool {
+    let mut ordered_senders = configured_senders.to_vec();
+    ordered_senders.sort_unstable();
+    ordered_senders.dedup();
+    let Some(current_idx) = ordered_senders.iter().position(|sender| *sender == call.sender) else {
+        return false;
+    };
+
+    for candidate in ordered_senders.into_iter().take(current_idx) {
+        let mut candidate_call = call.clone();
+        candidate_call.sender = candidate;
+        if accept_call_candidate(call, candidate_call, attempts, accepted, still_fails) {
+            return true;
+        }
+    }
+    false
+}
+
+fn minimize_call_delay(
+    call: &mut SymbolicCounterexampleCall,
+    attempts: &mut usize,
+    accepted: &mut usize,
+    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
+) -> bool {
+    match (call.warp, call.roll) {
+        (Some(warp), Some(roll)) => {
+            minimize_call_delay_pair(call, warp, roll, attempts, accepted, still_fails)
+        }
+        _ => {
+            minimize_call_u256_field(
+                call,
+                attempts,
+                accepted,
+                still_fails,
+                |call| call.warp,
+                |call, value| call.warp = value,
+            ) || minimize_call_u256_field(
+                call,
+                attempts,
+                accepted,
+                still_fails,
+                |call| call.roll,
+                |call, value| call.roll = value,
+            )
+        }
+    }
+}
+
+fn minimize_call_delay_pair(
+    call: &mut SymbolicCounterexampleCall,
+    current_warp: U256,
+    current_roll: U256,
+    attempts: &mut usize,
+    accepted: &mut usize,
+    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
+) -> bool {
+    if current_warp.is_zero() && current_roll.is_zero() {
+        return false;
+    }
+
+    let mut try_delay = |call: &mut SymbolicCounterexampleCall, warp: U256, roll: U256| {
+        let (warp, roll) = level_delay(warp, roll);
+        let mut candidate_call = call.clone();
+        candidate_call.warp = Some(warp);
+        candidate_call.roll = Some(roll);
+        accept_call_candidate(call, candidate_call, attempts, accepted, still_fails)
+    };
+
+    (!current_roll.is_zero()
+        && minimize_u256_candidates(current_roll, |candidate| {
+            try_delay(call, current_warp, candidate)
+        }))
+        || (!current_warp.is_zero()
+            && minimize_u256_candidates(current_warp, |candidate| {
+                try_delay(call, candidate, current_roll)
+            }))
+        || minimize_u256_pair_candidates(current_warp, current_roll, |warp, roll| {
+            try_delay(call, warp, roll)
+        })
+}
+
+fn level_delay(warp: U256, roll: U256) -> (U256, U256) {
+    if warp.is_zero() || roll.is_zero() { (U256::ZERO, U256::ZERO) } else { (warp, roll) }
+}
+
+fn minimize_call_u256_field(
+    call: &mut SymbolicCounterexampleCall,
+    attempts: &mut usize,
+    accepted: &mut usize,
+    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
+    get: impl Fn(&SymbolicCounterexampleCall) -> Option<U256>,
+    set: impl Fn(&mut SymbolicCounterexampleCall, Option<U256>),
+) -> bool {
+    let Some(current) = get(call) else {
+        return false;
+    };
+    if current.is_zero() {
+        return false;
+    }
+
+    minimize_u256_candidates(current, |candidate| {
+        let mut candidate_call = call.clone();
+        set(&mut candidate_call, Some(candidate));
+        accept_call_candidate(call, candidate_call, attempts, accepted, still_fails)
+    })
+}
+
+fn minimize_u256_candidates(current: U256, mut try_candidate: impl FnMut(U256) -> bool) -> bool {
+    if !current.is_zero() && try_candidate(U256::ZERO) {
+        return true;
+    }
+    for bit in (0..256).rev() {
+        let mask: U256 = U256::from(1) << bit;
+        if current & mask == U256::ZERO {
+            continue;
+        }
+        if try_candidate(current & !mask) {
+            return true;
+        }
+    }
+
+    let mut accepted_value = current;
+    let mut rejected_value = U256::ZERO;
+    let mut changed = false;
+    while accepted_value > rejected_value + U256::from(1) {
+        let candidate = rejected_value + ((accepted_value - rejected_value) >> 1usize);
+        if try_candidate(candidate) {
+            accepted_value = candidate;
+            changed = true;
+        } else {
+            rejected_value = candidate;
+        }
+    }
+    changed
+}
+
+fn minimize_u256_pair_candidates(
+    current_left: U256,
+    current_right: U256,
+    mut try_candidate: impl FnMut(U256, U256) -> bool,
+) -> bool {
+    if current_left.is_zero() || current_right.is_zero() {
+        return false;
+    }
+
+    let mut accepted_left = current_left;
+    let mut accepted_right = current_right;
+    let mut rejected_left = U256::ZERO;
+    let mut rejected_right = U256::ZERO;
+    let mut changed = false;
+    while accepted_left > rejected_left + U256::from(1)
+        || accepted_right > rejected_right + U256::from(1)
+    {
+        let candidate_left = if accepted_left > rejected_left + U256::from(1) {
+            rejected_left + ((accepted_left - rejected_left) >> 1usize)
+        } else {
+            accepted_left
+        };
+        let candidate_right = if accepted_right > rejected_right + U256::from(1) {
+            rejected_right + ((accepted_right - rejected_right) >> 1usize)
+        } else {
+            accepted_right
+        };
+
+        if try_candidate(candidate_left, candidate_right) {
+            accepted_left = candidate_left;
+            accepted_right = candidate_right;
+            changed = true;
+        } else {
+            rejected_left = candidate_left;
+            rejected_right = candidate_right;
+        }
+    }
+    changed
+}
+
+fn accept_call_candidate(
+    call: &mut SymbolicCounterexampleCall,
+    candidate: SymbolicCounterexampleCall,
+    attempts: &mut usize,
+    accepted: &mut usize,
+    still_fails: &mut impl FnMut(&SymbolicCounterexampleCall) -> bool,
+) -> bool {
+    if same_call(call, &candidate) || *attempts >= MAX_MINIMIZATION_ATTEMPTS {
+        return false;
+    }
+
+    *attempts += 1;
+    if still_fails(&candidate) {
+        *call = candidate;
+        *accepted += 1;
+        true
+    } else {
+        false
+    }
+}
+
+fn same_call(left: &SymbolicCounterexampleCall, right: &SymbolicCounterexampleCall) -> bool {
+    left.warp == right.warp
+        && left.roll == right.roll
+        && left.sender == right.sender
+        && left.target == right.target
+        && left.calldata == right.calldata
+        && left.value == right.value
+}
+
+fn minimize_values(
+    values: &mut Vec<DynSolValue>,
+    try_values: &mut dyn FnMut(&[DynSolValue]) -> bool,
+) {
+    loop {
+        let mut changed = false;
+        for idx in 0..values.len() {
+            let mut value = values[idx].clone();
+            let value_changed = minimize_value(&mut value, &mut |candidate| {
+                let mut candidate_values = values.clone();
+                candidate_values[idx] = candidate.clone();
+                try_values(&candidate_values)
+            });
+            if value_changed {
+                values[idx] = value;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+}
+
+fn minimize_value(
+    value: &mut DynSolValue,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    let mut changed = false;
+    loop {
+        let pass_changed =
+            minimize_scalar_value(value, try_value) || minimize_compound_value(value, try_value);
+        if !pass_changed {
+            break;
+        }
+        changed = true;
+    }
+    changed
+}
+
+fn minimize_scalar_value(
+    value: &mut DynSolValue,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    match value.clone() {
+        DynSolValue::Bool(true) => accept_candidate(value, DynSolValue::Bool(false), try_value),
+        DynSolValue::Bool(false) => false,
+        DynSolValue::Uint(current, bits) => minimize_uint(value, current, bits, try_value),
+        DynSolValue::Int(current, bits) => minimize_int(value, current, bits, try_value),
+        DynSolValue::Address(current) => minimize_address(value, current, try_value),
+        DynSolValue::FixedBytes(current, size) => {
+            minimize_fixed_bytes(value, current, size, try_value)
+        }
+        DynSolValue::Function(current) => {
+            if current == SolFunction::ZERO {
+                false
+            } else {
+                accept_candidate(value, DynSolValue::Function(SolFunction::ZERO), try_value)
+            }
+        }
+        DynSolValue::Bytes(current) => minimize_bytes(value, current, try_value),
+        DynSolValue::String(current) => minimize_string(value, current, try_value),
+        DynSolValue::Array(_)
+        | DynSolValue::FixedArray(_)
+        | DynSolValue::Tuple(_)
+        | DynSolValue::CustomStruct { .. } => false,
+    }
+}
+
+fn minimize_compound_value(
+    value: &mut DynSolValue,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    match value.clone() {
+        DynSolValue::Array(mut elements) => {
+            if minimize_array_len(value, &mut elements, try_value) {
+                return true;
+            }
+            if let Some(candidate) = minimize_elements_batch(
+                &mut elements,
+                |items| DynSolValue::Array(items.to_vec()),
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            if let Some(candidate) = minimize_element_subsets(
+                &mut elements,
+                |items| DynSolValue::Array(items.to_vec()),
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            minimize_elements(&mut elements, |items| DynSolValue::Array(items.to_vec()), try_value)
+                .map(|candidate| {
+                    *value = candidate;
+                    true
+                })
+                .unwrap_or(false)
+        }
+        DynSolValue::FixedArray(mut elements) => {
+            if let Some(candidate) = minimize_elements_batch(
+                &mut elements,
+                |items| DynSolValue::FixedArray(items.to_vec()),
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            if let Some(candidate) = minimize_element_subsets(
+                &mut elements,
+                |items| DynSolValue::FixedArray(items.to_vec()),
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            minimize_elements(
+                &mut elements,
+                |items| DynSolValue::FixedArray(items.to_vec()),
+                try_value,
+            )
+            .map(|candidate| {
+                *value = candidate;
+                true
+            })
+            .unwrap_or(false)
+        }
+        DynSolValue::Tuple(mut elements) => {
+            if let Some(candidate) = minimize_elements_batch(
+                &mut elements,
+                |items| DynSolValue::Tuple(items.to_vec()),
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            if let Some(candidate) = minimize_element_subsets(
+                &mut elements,
+                |items| DynSolValue::Tuple(items.to_vec()),
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            minimize_elements(&mut elements, |items| DynSolValue::Tuple(items.to_vec()), try_value)
+                .map(|candidate| {
+                    *value = candidate;
+                    true
+                })
+                .unwrap_or(false)
+        }
+        DynSolValue::CustomStruct { name, prop_names, mut tuple } => {
+            if let Some(candidate) = minimize_elements_batch(
+                &mut tuple,
+                |items| DynSolValue::CustomStruct {
+                    name: name.clone(),
+                    prop_names: prop_names.clone(),
+                    tuple: items.to_vec(),
+                },
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            if let Some(candidate) = minimize_element_subsets(
+                &mut tuple,
+                |items| DynSolValue::CustomStruct {
+                    name: name.clone(),
+                    prop_names: prop_names.clone(),
+                    tuple: items.to_vec(),
+                },
+                try_value,
+            ) {
+                *value = candidate;
+                return true;
+            }
+            minimize_elements(
+                &mut tuple,
+                |items| DynSolValue::CustomStruct {
+                    name: name.clone(),
+                    prop_names: prop_names.clone(),
+                    tuple: items.to_vec(),
+                },
+                try_value,
+            )
+            .map(|candidate| {
+                *value = candidate;
+                true
+            })
+            .unwrap_or(false)
+        }
+        _ => false,
+    }
+}
+
+fn minimize_uint(
+    value: &mut DynSolValue,
+    current: U256,
+    bits: usize,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    if !current.is_zero() && accept_candidate(value, DynSolValue::Uint(U256::ZERO, bits), try_value)
+    {
+        return true;
+    }
+
+    let bit_limit = bits.min(256);
+    for bit in (0..bit_limit).rev() {
+        let mask = U256::from(1) << bit;
+        if current & mask == U256::ZERO {
+            continue;
+        }
+        let candidate = current & !mask;
+        if accept_candidate(value, DynSolValue::Uint(candidate, bits), try_value) {
+            return true;
+        }
+    }
+
+    minimize_uint_by_search(value, current, bits, try_value)
+}
+
+fn minimize_uint_by_search(
+    value: &mut DynSolValue,
+    current: U256,
+    bits: usize,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    if current <= U256::from(1) {
+        return false;
+    }
+
+    let mut accepted = current;
+    let mut rejected = U256::ZERO;
+    let mut changed = false;
+    while accepted > rejected + U256::from(1) {
+        let candidate: U256 = rejected + ((accepted - rejected) >> 1usize);
+        if accept_candidate(value, DynSolValue::Uint(candidate, bits), try_value) {
+            accepted = candidate;
+            changed = true;
+        } else {
+            rejected = candidate;
+        }
+    }
+
+    changed
+}
+
+fn minimize_int(
+    value: &mut DynSolValue,
+    current: I256,
+    bits: usize,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    if current != I256::ZERO
+        && accept_candidate(value, DynSolValue::Int(I256::ZERO, bits), try_value)
+    {
+        return true;
+    }
+    if current.is_negative()
+        && current != I256::MINUS_ONE
+        && accept_candidate(value, DynSolValue::Int(I256::MINUS_ONE, bits), try_value)
+    {
+        return true;
+    }
+
+    minimize_int_by_search(value, current, bits, try_value)
+}
+
+fn minimize_int_by_search(
+    value: &mut DynSolValue,
+    current: I256,
+    bits: usize,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    let mut accepted_abs = current.unsigned_abs();
+    if accepted_abs <= U256::from(1) {
+        return false;
+    }
+
+    let mut rejected_abs = U256::ZERO;
+    let mut changed = false;
+    while accepted_abs > rejected_abs + U256::from(1) {
+        let candidate_abs: U256 = rejected_abs + ((accepted_abs - rejected_abs) >> 1usize);
+        let candidate = if current.is_negative() {
+            I256::from_raw(candidate_abs.wrapping_neg())
+        } else {
+            I256::from_raw(candidate_abs)
+        };
+        if accept_candidate(value, DynSolValue::Int(candidate, bits), try_value) {
+            accepted_abs = candidate_abs;
+            changed = true;
+        } else {
+            rejected_abs = candidate_abs;
+        }
+    }
+
+    changed
+}
+
+fn minimize_address(
+    value: &mut DynSolValue,
+    current: Address,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    for candidate in address_candidates(current) {
+        if accept_candidate(value, DynSolValue::Address(candidate), try_value) {
+            return true;
+        }
+    }
+    false
+}
+
+fn address_candidates(current: Address) -> Vec<Address> {
+    if current == Address::ZERO {
+        return Vec::new();
+    }
+
+    let mut candidates = Vec::new();
+    candidates.push(Address::ZERO);
+
+    let deadbeef = Address::from_word(B256::from(U256::from(0xdeadbeefu64)));
+    if current != deadbeef {
+        candidates.push(deadbeef);
+    }
+
+    let bytes = current.into_array();
+    for idx in 0..bytes.len() {
+        if bytes[idx] == 0 {
+            continue;
+        }
+        let mut candidate = bytes;
+        candidate[idx] = 0;
+        candidates.push(Address::from(candidate));
+    }
+
+    candidates
+}
+
+fn minimize_fixed_bytes(
+    value: &mut DynSolValue,
+    current: B256,
+    size: usize,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    if current != B256::ZERO
+        && accept_candidate(value, DynSolValue::FixedBytes(B256::ZERO, size), try_value)
+    {
+        return true;
+    }
+
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(current.as_slice());
+    for idx in (0..size.min(bytes.len())).rev() {
+        if bytes[idx] == 0 {
+            continue;
+        }
+        let mut candidate = bytes;
+        candidate[idx] = 0;
+        if accept_candidate(value, DynSolValue::FixedBytes(B256::from(candidate), size), try_value)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn minimize_bytes(
+    value: &mut DynSolValue,
+    current: Vec<u8>,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    for len in 0..current.len() {
+        if accept_candidate(value, DynSolValue::Bytes(current[..len].to_vec()), try_value) {
+            return true;
+        }
+    }
+    if try_delete_vec_range(&current, |candidate| {
+        accept_candidate(value, DynSolValue::Bytes(candidate), try_value)
+    }) {
+        return true;
+    }
+    if try_slice_vec_range(&current, |candidate| {
+        accept_candidate(value, DynSolValue::Bytes(candidate), try_value)
+    }) {
+        return true;
+    }
+
+    for idx in (0..current.len()).rev() {
+        if current[idx] == 0 {
+            continue;
+        }
+        let mut candidate = current.clone();
+        candidate[idx] = 0;
+        if accept_candidate(value, DynSolValue::Bytes(candidate), try_value) {
+            return true;
+        }
+    }
+    false
+}
+
+fn minimize_string(
+    value: &mut DynSolValue,
+    current: String,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    for len in 0..current.len() {
+        if current.is_char_boundary(len)
+            && accept_candidate(value, DynSolValue::String(current[..len].to_string()), try_value)
+        {
+            return true;
+        }
+    }
+    if try_delete_string_range(&current, |candidate| {
+        accept_candidate(value, DynSolValue::String(candidate), try_value)
+    }) {
+        return true;
+    }
+    if try_slice_string_range(&current, |candidate| {
+        accept_candidate(value, DynSolValue::String(candidate), try_value)
+    }) {
+        return true;
+    }
+
+    let current_bytes = current.as_bytes();
+    for idx in (0..current_bytes.len()).rev() {
+        if current_bytes[idx] == 0 {
+            continue;
+        }
+        let mut candidate = current_bytes.to_vec();
+        candidate[idx] = 0;
+        if let Ok(candidate) = String::from_utf8(candidate)
+            && accept_candidate(value, DynSolValue::String(candidate), try_value)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn minimize_array_len(
+    value: &mut DynSolValue,
+    current: &mut Vec<DynSolValue>,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    for len in 0..current.len() {
+        let candidate = DynSolValue::Array(current[..len].to_vec());
+        if accept_candidate(value, candidate, try_value) {
+            current.truncate(len);
+            return true;
+        }
+    }
+    if try_delete_vec_range(current, |candidate| {
+        accept_candidate(value, DynSolValue::Array(candidate), try_value)
+    }) {
+        return true;
+    }
+    if try_slice_vec_range(current, |candidate| {
+        accept_candidate(value, DynSolValue::Array(candidate), try_value)
+    }) {
+        return true;
+    }
+    false
+}
+
+fn try_delete_vec_range<T: Clone>(
+    current: &[T],
+    mut try_candidate: impl FnMut(Vec<T>) -> bool,
+) -> bool {
+    for range_len in deletion_lengths(current.len()) {
+        for start in 0..=current.len() - range_len {
+            let mut candidate = Vec::with_capacity(current.len() - range_len);
+            candidate.extend_from_slice(&current[..start]);
+            candidate.extend_from_slice(&current[start + range_len..]);
+            if try_candidate(candidate) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn try_delete_string_range(current: &str, mut try_candidate: impl FnMut(String) -> bool) -> bool {
+    let mut boundaries = current.char_indices().map(|(idx, _)| idx).collect::<Vec<_>>();
+    boundaries.push(current.len());
+
+    for range_len in deletion_lengths(boundaries.len().saturating_sub(1)) {
+        for start_idx in 0..=boundaries.len() - range_len - 1 {
+            let start = boundaries[start_idx];
+            let end = boundaries[start_idx + range_len];
+            let mut candidate = String::with_capacity(current.len() - (end - start));
+            candidate.push_str(&current[..start]);
+            candidate.push_str(&current[end..]);
+            if try_candidate(candidate) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn try_slice_vec_range<T: Clone>(
+    current: &[T],
+    mut try_candidate: impl FnMut(Vec<T>) -> bool,
+) -> bool {
+    for len in 1..current.len() {
+        for start in 1..=current.len() - len {
+            let candidate = current[start..start + len].to_vec();
+            if try_candidate(candidate) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn try_slice_string_range(current: &str, mut try_candidate: impl FnMut(String) -> bool) -> bool {
+    let mut boundaries = current.char_indices().map(|(idx, _)| idx).collect::<Vec<_>>();
+    boundaries.push(current.len());
+    let char_len = boundaries.len().saturating_sub(1);
+
+    for len in 1..char_len {
+        for start_idx in 1..=char_len - len {
+            let start = boundaries[start_idx];
+            let end = boundaries[start_idx + len];
+            if try_candidate(current[start..end].to_string()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn deletion_lengths(len: usize) -> Vec<usize> {
+    if len == 0 {
+        return Vec::new();
+    }
+
+    let mut lengths = Vec::new();
+    let mut range_len = len;
+    while range_len > 0 {
+        lengths.push(range_len);
+        range_len /= 2;
+    }
+    lengths.sort_unstable();
+    lengths.dedup();
+    lengths.reverse();
+    lengths
+}
+
+fn minimize_elements(
+    elements: &mut Vec<DynSolValue>,
+    rebuild: impl Fn(&[DynSolValue]) -> DynSolValue,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> Option<DynSolValue> {
+    for idx in 0..elements.len() {
+        let mut element = elements[idx].clone();
+        let changed = minimize_value(&mut element, &mut |candidate| {
+            let mut candidate_elements = elements.clone();
+            candidate_elements[idx] = candidate.clone();
+            try_value(&rebuild(&candidate_elements))
+        });
+        if changed {
+            elements[idx] = element;
+            return Some(rebuild(elements));
+        }
+    }
+    None
+}
+
+fn minimize_elements_batch(
+    elements: &mut Vec<DynSolValue>,
+    rebuild: impl Fn(&[DynSolValue]) -> DynSolValue,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> Option<DynSolValue> {
+    let simple_elements = elements.iter().cloned().map(minimally_simple_value).collect::<Vec<_>>();
+    if simple_elements == *elements {
+        return None;
+    }
+    let candidate = rebuild(&simple_elements);
+    if try_value(&candidate) {
+        *elements = simple_elements;
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
+fn minimize_element_subsets(
+    elements: &mut Vec<DynSolValue>,
+    rebuild: impl Fn(&[DynSolValue]) -> DynSolValue,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> Option<DynSolValue> {
+    let simple_elements = elements.iter().cloned().map(minimally_simple_value).collect::<Vec<_>>();
+    let shrinkable_idxs = elements
+        .iter()
+        .zip(&simple_elements)
+        .enumerate()
+        .filter_map(|(idx, (current, simple))| (current != simple).then_some(idx))
+        .collect::<Vec<_>>();
+    if shrinkable_idxs.len() < 2 {
+        return None;
+    }
+
+    for subset_size in subset_sizes(shrinkable_idxs.len()) {
+        let mut subset = Vec::with_capacity(subset_size);
+        if let Some(candidate_elements) = try_element_subset(
+            elements,
+            &simple_elements,
+            &shrinkable_idxs,
+            subset_size,
+            0,
+            &mut subset,
+            &rebuild,
+            try_value,
+        ) {
+            *elements = candidate_elements.clone();
+            return Some(rebuild(&candidate_elements));
+        }
+    }
+    None
+}
+
+fn subset_sizes(shrinkable_len: usize) -> Vec<usize> {
+    let mut sizes = Vec::new();
+    for subset_size in 2..shrinkable_len {
+        if bounded_combination_count(shrinkable_len, subset_size, MAX_SUBSET_CANDIDATES_PER_PASS)
+            .is_some()
+        {
+            sizes.push(subset_size);
+        }
+    }
+    sizes
+}
+
+fn bounded_combination_count(n: usize, k: usize, max: usize) -> Option<usize> {
+    if k > n {
+        return None;
+    }
+    let k = k.min(n - k);
+    let mut count = 1usize;
+    for step in 1..=k {
+        count = count.checked_mul(n + 1 - step)?;
+        count /= step;
+        if count > max {
+            return None;
+        }
+    }
+    Some(count)
+}
+
+fn try_element_subset(
+    elements: &[DynSolValue],
+    simple_elements: &[DynSolValue],
+    shrinkable_idxs: &[usize],
+    subset_size: usize,
+    start: usize,
+    subset: &mut Vec<usize>,
+    rebuild: &impl Fn(&[DynSolValue]) -> DynSolValue,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> Option<Vec<DynSolValue>> {
+    if subset.len() == subset_size {
+        let mut candidate_elements = elements.to_vec();
+        for idx in subset.iter().copied() {
+            candidate_elements[idx] = simple_elements[idx].clone();
+        }
+        if try_value(&rebuild(&candidate_elements)) {
+            return Some(candidate_elements);
+        }
+        return None;
+    }
+
+    let remaining = subset_size - subset.len();
+    for choice_idx in start..=shrinkable_idxs.len() - remaining {
+        subset.push(shrinkable_idxs[choice_idx]);
+        if let Some(candidate) = try_element_subset(
+            elements,
+            simple_elements,
+            shrinkable_idxs,
+            subset_size,
+            choice_idx + 1,
+            subset,
+            rebuild,
+            try_value,
+        ) {
+            return Some(candidate);
+        }
+        subset.pop();
+    }
+    None
+}
+
+fn accept_candidate(
+    value: &mut DynSolValue,
+    candidate: DynSolValue,
+    try_value: &mut dyn FnMut(&DynSolValue) -> bool,
+) -> bool {
+    if *value == candidate {
+        return false;
+    }
+    if try_value(&candidate) {
+        *value = candidate;
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_abi::JsonAbi;
+
+    fn call(function: &Function, args: Vec<DynSolValue>) -> SymbolicCounterexampleCall {
+        SymbolicCounterexampleCall {
+            warp: None,
+            roll: None,
+            sender: Address::ZERO,
+            target: Address::repeat_byte(0x11),
+            calldata: Bytes::from(function.abi_encode_input(&args).unwrap()),
+            value: Some(U256::ZERO),
+            contract_name: Some("Target".to_string()),
+            function_name: Some(function.name.clone()),
+            signature: Some(function.signature()),
+            args: Some(foundry_common::fmt::format_tokens(&args).format(", ").to_string()),
+            raw_args: Some(foundry_common::fmt::format_tokens_raw(&args).format(", ").to_string()),
+        }
+    }
+
+    fn decoded(function: &Function, call: &SymbolicCounterexampleCall) -> Vec<DynSolValue> {
+        function.abi_decode_input(&call.calldata[4..]).unwrap()
+    }
+
+    #[test]
+    fn minimizes_common_abi_values_with_replay_predicate() {
+        let abi =
+            JsonAbi::parse(["function check(uint256,address,bytes,string,uint256[]) external"])
+                .unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(
+            function,
+            vec![
+                DynSolValue::Uint(U256::from(0xff), 256),
+                DynSolValue::Address(Address::from([0xaa; 20])),
+                DynSolValue::Bytes(vec![0x99, 0x42, 0x88]),
+                DynSolValue::String("abc".to_string()),
+                DynSolValue::Array(vec![
+                    DynSolValue::Uint(U256::from(0), 256),
+                    DynSolValue::Uint(U256::from(7), 256),
+                    DynSolValue::Uint(U256::from(9), 256),
+                ]),
+            ],
+        );
+
+        let minimized =
+            minimize_single_call_counterexample(function, &start, &[], |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[0], DynSolValue::Uint(value, _) if *value & U256::from(0x2a) == U256::from(0x2a))
+                    && matches!(&args[1], DynSolValue::Address(address) if address.as_slice()[19] == 0xaa)
+                    && matches!(&args[2], DynSolValue::Bytes(bytes) if bytes.get(1) == Some(&0x42))
+                    && matches!(&args[3], DynSolValue::String(value) if value.starts_with('a'))
+                    && matches!(&args[4], DynSolValue::Array(values) if values.iter().any(|value| matches!(value, DynSolValue::Uint(uint, _) if *uint == U256::from(7))))
+            })
+            .unwrap();
+
+        let args = decoded(function, &minimized.minimized_call);
+        assert_eq!(args[0], DynSolValue::Uint(U256::from(0x2a), 256));
+        assert_eq!(
+            args[1],
+            DynSolValue::Address(Address::from([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xaa,
+            ]))
+        );
+        assert_eq!(args[2], DynSolValue::Bytes(vec![0, 0x42]));
+        assert_eq!(args[3], DynSolValue::String("a".to_string()));
+        assert_eq!(args[4], DynSolValue::Array(vec![DynSolValue::Uint(U256::from(7), 256)]));
+        assert!(minimized.changed());
+        assert!(minimized.attempts > minimized.accepted);
+        assert!(minimized.accepted > 0);
+    }
+
+    #[test]
+    fn minimizes_with_echidna_style_range_deletion_and_numeric_lowering() {
+        let abi =
+            JsonAbi::parse(["function check(uint256,int256,bytes,string,uint256[]) external"])
+                .unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(
+            function,
+            vec![
+                DynSolValue::Uint(U256::from(100), 256),
+                DynSolValue::Int(I256::try_from(-100).unwrap(), 256),
+                DynSolValue::Bytes(vec![1, 2, 3, 0x42, 4]),
+                DynSolValue::String("abcZ".to_string()),
+                DynSolValue::Array(vec![
+                    DynSolValue::Uint(U256::from(1), 256),
+                    DynSolValue::Uint(U256::from(2), 256),
+                    DynSolValue::Uint(U256::from(7), 256),
+                    DynSolValue::Uint(U256::from(3), 256),
+                ]),
+            ],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[0], DynSolValue::Uint(value, _) if *value > U256::from(42))
+                && matches!(&args[1], DynSolValue::Int(value, _) if *value < I256::try_from(-42).unwrap())
+                && matches!(&args[2], DynSolValue::Bytes(bytes) if bytes.contains(&0x42))
+                && matches!(&args[3], DynSolValue::String(value) if value.contains('Z'))
+                && matches!(&args[4], DynSolValue::Array(values) if values.iter().any(|value| matches!(value, DynSolValue::Uint(uint, _) if *uint == U256::from(7))))
+        })
+        .unwrap();
+
+        let args = decoded(function, &minimized.minimized_call);
+        assert_eq!(args[0], DynSolValue::Uint(U256::from(43), 256));
+        assert_eq!(args[1], DynSolValue::Int(I256::try_from(-43).unwrap(), 256));
+        assert_eq!(args[2], DynSolValue::Bytes(vec![0x42]));
+        assert_eq!(args[3], DynSolValue::String("Z".to_string()));
+        assert_eq!(args[4], DynSolValue::Array(vec![DynSolValue::Uint(U256::from(7), 256)]));
+        assert!(minimized.changed());
+        assert!(minimized.accepted > 0);
+    }
+
+    #[test]
+    fn matches_echidna_uint8_threshold_shrink_result() {
+        let abi = JsonAbi::parse(["function check(uint8) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(function, vec![DynSolValue::Uint(U256::from(246), 8)]);
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[0], DynSolValue::Uint(value, 8) if *value > U256::from(42))
+        })
+        .unwrap();
+
+        assert_eq!(
+            decoded(function, &minimized.minimized_call),
+            vec![DynSolValue::Uint(U256::from(43), 8)]
+        );
+        assert!(minimized.attempts < MAX_MINIMIZATION_ATTEMPTS);
+    }
+
+    #[test]
+    fn minimizes_correlated_top_level_abi_value_subsets() {
+        let abi = JsonAbi::parse(["function check(uint256,uint256,bytes) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(
+            function,
+            vec![
+                DynSolValue::Uint(U256::from(1), 256),
+                DynSolValue::Uint(U256::from(1), 256),
+                DynSolValue::Bytes(vec![0x99, 0x42, 0x88]),
+            ],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[..], [
+                DynSolValue::Uint(left, _),
+                DynSolValue::Uint(right, _),
+                DynSolValue::Bytes(bytes),
+            ] if left.is_zero() && right.is_zero() && bytes.contains(&0x42))
+        })
+        .unwrap();
+
+        assert_eq!(
+            decoded(function, &minimized.minimized_call),
+            vec![
+                DynSolValue::Uint(U256::ZERO, 256),
+                DynSolValue::Uint(U256::ZERO, 256),
+                DynSolValue::Bytes(vec![0x42]),
+            ]
+        );
+        assert!(minimized.accepted > 0);
+    }
+
+    #[test]
+    fn minimizes_correlated_nested_abi_value_subsets() {
+        let abi = JsonAbi::parse(["function check((uint256,uint256,bytes)) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let start = call(
+            function,
+            vec![DynSolValue::Tuple(vec![
+                DynSolValue::Uint(U256::from(1), 256),
+                DynSolValue::Uint(U256::from(1), 256),
+                DynSolValue::Bytes(vec![0x99, 0x42, 0x88]),
+            ])],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[0], DynSolValue::Tuple(values)
+                if matches!(&values[..], [
+                    DynSolValue::Uint(left, _),
+                    DynSolValue::Uint(right, _),
+                    DynSolValue::Bytes(bytes),
+                ] if left.is_zero() && right.is_zero() && bytes.contains(&0x42)))
+        })
+        .unwrap();
+
+        assert_eq!(
+            decoded(function, &minimized.minimized_call),
+            vec![DynSolValue::Tuple(vec![
+                DynSolValue::Uint(U256::ZERO, 256),
+                DynSolValue::Uint(U256::ZERO, 256),
+                DynSolValue::Bytes(vec![0x42]),
+            ]),]
+        );
+        assert!(minimized.accepted > 0);
+    }
+
+    #[test]
+    fn minimizes_correlated_args_and_call_env() {
+        let abi = JsonAbi::parse(["function check(uint256,uint256) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let mut start = call(
+            function,
+            vec![DynSolValue::Uint(U256::from(1), 256), DynSolValue::Uint(U256::from(1), 256)],
+        );
+        start.sender = Address::from([0xaa; 20]);
+        start.value = Some(U256::from(100));
+        start.warp = Some(U256::from(50));
+        start.roll = Some(U256::from(10));
+
+        let configured_senders = [Address::ZERO, start.sender];
+        let minimized =
+            minimize_single_call_counterexample(function, &start, &configured_senders, |candidate| {
+                let args = decoded(function, candidate);
+                matches!(&args[..], [DynSolValue::Uint(left, _), DynSolValue::Uint(right, _)] if left.is_zero() && right.is_zero())
+                    && candidate.value.is_some_and(|value| value > U256::from(42))
+                    && candidate.warp.is_some_and(|warp| warp > U256::from(4))
+                    && candidate.roll.is_some_and(|roll| roll > U256::from(2))
+                    && (candidate.sender == Address::ZERO || candidate.sender.as_slice()[19] == 0xaa)
+            })
+            .unwrap();
+
+        let args = decoded(function, &minimized.minimized_call);
+        assert_eq!(
+            args,
+            vec![DynSolValue::Uint(U256::ZERO, 256), DynSolValue::Uint(U256::ZERO, 256)]
+        );
+        assert_eq!(minimized.minimized_call.sender, Address::ZERO);
+        assert_eq!(minimized.minimized_call.value, Some(U256::from(43)));
+        assert_eq!(minimized.minimized_call.warp, Some(U256::from(5)));
+        assert_eq!(minimized.minimized_call.roll, Some(U256::from(3)));
+        assert!(minimized.changed());
+        assert!(minimized.accepted > 0);
+    }
+
+    #[test]
+    fn leaves_already_minimal_counterexample_replayable() {
+        let abi = JsonAbi::parse(["function check(int256,bool,bytes3) external"]).unwrap();
+        let function = abi.functions().next().unwrap();
+        let mut fixed_bytes = [0u8; 32];
+        fixed_bytes[2] = 0x42;
+        let start = call(
+            function,
+            vec![
+                DynSolValue::Int(I256::MINUS_ONE, 256),
+                DynSolValue::Bool(false),
+                DynSolValue::FixedBytes(B256::from(fixed_bytes), 3),
+            ],
+        );
+
+        let minimized = minimize_single_call_counterexample(function, &start, &[], |candidate| {
+            let args = decoded(function, candidate);
+            matches!(&args[0], DynSolValue::Int(value, _) if *value == I256::MINUS_ONE)
+                && matches!(&args[1], DynSolValue::Bool(false))
+                && matches!(&args[2], DynSolValue::FixedBytes(bytes, 3) if bytes[2] == 0x42)
+        })
+        .unwrap();
+
+        assert_eq!(decoded(function, &minimized.minimized_call), decoded(function, &start));
+        assert!(!minimized.changed());
+        assert_eq!(minimized.accepted, 0);
+    }
+}

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -1231,7 +1231,7 @@ fn minimize_i256_pair_candidates(
     )
 }
 
-fn signed_candidate_with_abs(current: I256, abs: U256) -> I256 {
+const fn signed_candidate_with_abs(current: I256, abs: U256) -> I256 {
     if current.is_negative() { I256::from_raw(abs.wrapping_neg()) } else { I256::from_raw(abs) }
 }
 
@@ -1834,7 +1834,7 @@ mod tests {
                 DynSolValue::Address(address(0xffff_ffff)),
                 DynSolValue::Address(Address::ZERO),
                 DynSolValue::Address(address(0x20000)),
-                DynSolValue::Address(address(0x1ffff_fffe)),
+                DynSolValue::Address(address(0x0001_ffff_fffe)),
                 DynSolValue::Address(address(0x30000)),
             ])],
         );

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -421,10 +421,10 @@ args=[42, 0x0042]
     );
 });
 
-forgetest_init!(symbolic_minimizer_preserves_failure_flag_reason, |prj, cmd| {
+forgetest_init!(symbolic_minimizer_skips_reasonless_failure_flag, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(
-            "skipping symbolic_minimizer_preserves_failure_flag_reason because z3 is not available"
+            "skipping symbolic_minimizer_skips_reasonless_failure_flag because z3 is not available"
         );
         return;
     }
@@ -455,18 +455,12 @@ contract SymbolicMinimizeFailureFlag is Test {
     assert_eq!(symbolic["status"], "fail_counterexample");
     assert_eq!(symbolic["replay"]["status"], "confirmed");
     assert_eq!(symbolic["counterexample"]["raw_args"], "42");
-    assert_eq!(symbolic["minimization"]["accepted"], 0);
-    assert_eq!(
-        symbolic["minimization"]["original_calldata_bytes"],
-        symbolic["minimization"]["minimized_calldata_bytes"]
-    );
+    assert!(symbolic["minimization"].is_null());
+    assert_eq!(result["counterexample_artifacts"].as_array().unwrap().len(), 1);
 
-    let original = read_artifact_ref(&symbolic["minimization"]["original"]);
-    let minimized = read_artifact(symbolic);
-    assert_eq!(original["replay"]["status"], "confirmed");
-    assert_eq!(minimized["replay"]["status"], "confirmed");
-    assert_eq!(original["calls"][0]["calldata"], minimized["calls"][0]["calldata"]);
-    assert_eq!(minimized["calls"][0]["raw_args"], "42");
+    let artifact = read_artifact(symbolic);
+    assert_eq!(artifact["replay"]["status"], "confirmed");
+    assert_eq!(artifact["calls"][0]["raw_args"], "42");
 
     let replay_stdout = cmd
         .forge_fuse()

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -421,6 +421,71 @@ args=[42, 0x0042]
     );
 });
 
+forgetest_init!(symbolic_minimizer_preserves_failure_flag_reason, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_minimizer_preserves_failure_flag_reason because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicMinimizeFailureFlag.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicMinimizeFailureFlag is Test {
+    function checkFailureFlag(uint256 x) public {
+        if (x == 0) revert("candidate-revert");
+        if (x == 42) fail();
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--json", "--match-test", "checkFailureFlag"])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let result = json_test_result(&output, "checkFailureFlag(uint256)");
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["status"], "fail_counterexample");
+    assert_eq!(symbolic["replay"]["status"], "confirmed");
+    assert_eq!(symbolic["counterexample"]["raw_args"], "42");
+    assert_eq!(symbolic["minimization"]["accepted"], 0);
+    assert_eq!(
+        symbolic["minimization"]["original_calldata_bytes"],
+        symbolic["minimization"]["minimized_calldata_bytes"]
+    );
+
+    let original = read_artifact_ref(&symbolic["minimization"]["original"]);
+    let minimized = read_artifact(symbolic);
+    assert_eq!(original["replay"]["status"], "confirmed");
+    assert_eq!(minimized["replay"]["status"], "confirmed");
+    assert_eq!(original["calls"][0]["calldata"], minimized["calls"][0]["calldata"]);
+    assert_eq!(minimized["calls"][0]["raw_args"], "42");
+
+    let replay_stdout = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--replay-symbolic-artifact",
+            symbolic["artifact"]["path"].as_str().unwrap(),
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert_relevant_lines(
+        &replay_stdout,
+        foundry_test_utils::str![[r#"
+args=[42]
+"#]],
+    );
+});
+
 forgetest_init!(symbolic_minimizes_echidna_address_array_duplicate_fixture, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -276,8 +276,14 @@ contract SymbolicJsonCounterexample {
     assert_eq!(symbolic["counterexample"]["args"], "42");
     assert_eq!(symbolic["counterexample"]["raw_args"], "42");
     assert_eq!(symbolic["artifact"]["schema"], "foundry:symbolic.counterexample@v1");
-    assert_eq!(result["counterexample_artifacts"].as_array().unwrap().len(), 1);
+    assert_eq!(result["counterexample_artifacts"].as_array().unwrap().len(), 2);
     assert_eq!(result["counterexample_artifacts"][0], symbolic["artifact"]);
+    assert_eq!(symbolic["minimization"]["minimized"], symbolic["artifact"]);
+    assert_eq!(symbolic["minimization"]["accepted"], 0);
+    assert_eq!(symbolic["minimization"]["original_calldata_bytes"], 36);
+    assert_eq!(symbolic["minimization"]["minimized_calldata_bytes"], 36);
+    let original_artifact = read_artifact_ref(&symbolic["minimization"]["original"]);
+    assert_eq!(original_artifact["calls"][0]["args"], "42");
     let artifact_path = symbolic["artifact"]["path"].as_str().unwrap().to_string();
     let artifact = read_artifact(symbolic);
     assert_eq!(artifact["schema_version"], 1);
@@ -286,6 +292,7 @@ contract SymbolicJsonCounterexample {
     assert_eq!(artifact["test"]["test"], "checkRejectsFortyTwo(uint256)");
     assert_eq!(artifact["replay"]["status"], "confirmed");
     assert_eq!(artifact["calls"].as_array().unwrap().len(), 1);
+    assert_eq!(original_artifact["calls"][0]["sender"], artifact["calls"][0]["sender"]);
     assert!(artifact["calls"][0]["calldata"].as_str().unwrap().starts_with("0x"));
     assert_eq!(artifact["calls"][0]["args"], "42");
     assert_eq!(artifact["calls"][0]["raw_args"], "42");
@@ -300,7 +307,7 @@ contract SymbolicJsonCounterexample {
     assert_relevant_lines(
         &replay_stdout,
         foundry_test_utils::str![[r#"
-[FAIL;
+[FAIL:
 "#]],
     );
     assert_relevant_lines(
@@ -313,35 +320,6 @@ args=[42]
         !replay_stdout.contains("SymbolicJsonCounterexampleDuplicate.t.sol"),
         "{replay_stdout}"
     );
-
-    let mut invalid_artifact = artifact.clone();
-    invalid_artifact["calls"][0]["value"] = serde_json::json!("0x1");
-    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&invalid_artifact).unwrap()).unwrap();
-    let invalid_stdout = cmd
-        .forge_fuse()
-        .args(["test", "--replay-symbolic-artifact", &artifact_path])
-        .assert_failure()
-        .get_output()
-        .stdout_lossy();
-    assert!(
-        invalid_stdout
-            .contains("single-call symbolic artifact replay does not support non-zero value"),
-        "{invalid_stdout}"
-    );
-    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
-
-    let mut invalid_artifact = artifact.clone();
-    invalid_artifact["calls"][0]["sender"] =
-        serde_json::json!("0x0000000000000000000000000000000000000001");
-    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&invalid_artifact).unwrap()).unwrap();
-    let invalid_stdout = cmd
-        .forge_fuse()
-        .args(["test", "--replay-symbolic-artifact", &artifact_path])
-        .assert_failure()
-        .get_output()
-        .stdout_lossy();
-    assert!(invalid_stdout.contains("single-call symbolic artifact sender"), "{invalid_stdout}");
-    std::fs::write(&artifact_path, serde_json::to_vec_pretty(&artifact).unwrap()).unwrap();
 
     prj.add_test(
         "SymbolicJsonCounterexample.t.sol",
@@ -371,6 +349,75 @@ contract SymbolicJsonCounterexample {
     assert!(
         stale_stderr.contains("checkRejectsFortyTwo(uint256)` was not found"),
         "{stale_stderr}"
+    );
+});
+
+forgetest_init!(symbolic_minimizes_replayed_counterexample_artifact, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_minimizes_replayed_counterexample_artifact because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicMinimizeCounterexample.t.sol",
+        r#"
+contract SymbolicMinimizeCounterexample {
+    /// forge-config: default.symbolic.array_lengths = [33]
+    function checkMinimize(uint256 x, bytes memory data) public pure {
+        if ((x & 0x2a) == 0x2a && data.length >= 2 && data[1] == 0x42) {
+            assert(false);
+        }
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--json", "--match-test", "checkMinimize"])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let result = json_test_result(&output, "checkMinimize(uint256,bytes)");
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["status"], "fail_counterexample");
+    assert_eq!(result["counterexample_artifacts"].as_array().unwrap().len(), 2);
+    assert_eq!(symbolic["minimization"]["minimized"], symbolic["artifact"]);
+    assert!(
+        symbolic["minimization"]["attempts"].as_u64().unwrap()
+            > symbolic["minimization"]["accepted"].as_u64().unwrap()
+    );
+    assert!(symbolic["minimization"]["accepted"].as_u64().unwrap() > 0);
+    assert!(
+        symbolic["minimization"]["minimized_calldata_bytes"].as_u64().unwrap()
+            < symbolic["minimization"]["original_calldata_bytes"].as_u64().unwrap()
+    );
+
+    let original = read_artifact_ref(&symbolic["minimization"]["original"]);
+    let minimized = read_artifact(symbolic);
+    assert_eq!(original["replay"]["status"], "confirmed");
+    assert_eq!(minimized["replay"]["status"], "confirmed");
+    assert_ne!(original["calls"][0]["calldata"], minimized["calls"][0]["calldata"]);
+    assert_eq!(minimized["calls"][0]["args"], "42, 0x0042");
+
+    let replay_stdout = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--replay-symbolic-artifact",
+            symbolic["artifact"]["path"].as_str().unwrap(),
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert_relevant_lines(
+        &replay_stdout,
+        foundry_test_utils::str![[r#"
+args=[42, 0x0042]
+"#]],
     );
 });
 

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -421,6 +421,80 @@ args=[42, 0x0042]
     );
 });
 
+forgetest_init!(symbolic_minimizes_echidna_address_array_duplicate_fixture, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_minimizes_echidna_address_array_duplicate_fixture because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicMinimizeAddressArrayDuplicate.t.sol",
+        r#"
+library AddressArrayUtilsBug {
+    function hasDuplicate(address[] memory xs) internal pure returns (bool) {
+        for (uint256 i = 0; i < xs.length; i++) {
+            for (uint256 j = i + 1; j < xs.length; j++) {
+                if (xs[i] == xs[j]) return true;
+            }
+        }
+        return false;
+    }
+}
+
+contract SymbolicMinimizeAddressArrayDuplicate {
+    /// forge-config: default.symbolic.array_lengths = [6]
+    function checkNoDuplicate(address[] memory xs) public pure {
+        assert(!AddressArrayUtilsBug.hasDuplicate(xs));
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--json", "--match-test", "checkNoDuplicate"])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+
+    let result = json_test_result(&output, "checkNoDuplicate(address[])");
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["status"], "fail_counterexample");
+    assert_eq!(result["counterexample_artifacts"].as_array().unwrap().len(), 2);
+    assert!(symbolic["minimization"]["accepted"].as_u64().unwrap() > 0);
+    assert_eq!(symbolic["minimization"]["original_calldata_bytes"], 260);
+    assert_eq!(symbolic["minimization"]["minimized_calldata_bytes"], 132);
+
+    let original = read_artifact_ref(&symbolic["minimization"]["original"]);
+    let minimized = read_artifact(symbolic);
+    assert_eq!(original["replay"]["status"], "confirmed");
+    assert_eq!(minimized["replay"]["status"], "confirmed");
+    assert_ne!(original["calls"][0]["calldata"], minimized["calls"][0]["calldata"]);
+    assert_eq!(
+        minimized["calls"][0]["args"],
+        "[0x0000000000000000000000000000000000000000, 0x0000000000000000000000000000000000000000]"
+    );
+
+    let replay_stdout = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--replay-symbolic-artifact",
+            symbolic["artifact"]["path"].as_str().unwrap(),
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert_relevant_lines(
+        &replay_stdout,
+        foundry_test_utils::str![[r#"
+args=[[0x0000000000000000000000000000000000000000, 0x0000000000000000000000000000000000000000]]
+"#]],
+    );
+});
+
 forgetest_init!(symbolic_json_schema_reports_replay_skip, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(


### PR DESCRIPTION
## Summary

Deterministic, replay-gated ABI-argument minimization for stateless single-call symbolic counterexamples. Emits original/minimized artifacts when the concrete replay has a stable failure reason; failure-flag-only counterexamples are replayed but not minimized because they lack enough failure identity to distinguish assertion sites.

Also keeps counterexample search moving past undecidable hard-arithmetic branch checks: replay-confirmed failures still win, while proof-only runs remain incomplete if an undecidable branch is the best result.

## Echidna Parity

Compared with `crytic/echidna@6d856e0` and `echidna 2.3.2`.

Matches applicable single-call ABI shrinking: numeric lowering, bool false, address zero/deadbeef, bytes/string/array deletion and contiguous slices, recursive array/tuple/struct shrinking.

Added unit/CLI examples adapted from Echidna fixture shapes that actually shrink: `values/darray.sol`, `abiv2/Dynamic.sol`, `abiv2/MultiTuple.sol`, `addressarrayutils/AddressArrayUtils_withHasDuplicateBug.sol`, and symbolic fixed-array/arithmetic relation fixtures.

Side-by-side rows below use single-call assertion harnesses, `--seq-len 1`, `--workers 1`, `--shrink-limit 5000`, pinned Echidna seed, and a Foundry release build. Speed delta is `(echidna_mean / foundry_mean - 1) * 100`. Rows with `minimized == original` are intentionally omitted.

| Fixture | Foundry minimized | Echidna minimized | Final result | Foundry | Echidna | Foundry faster |
| --- | --- | --- | --- | ---: | ---: | ---: |
| `AddressArrayUtils` duplicate | `[0x00, 0x00]` | `[0x0, 0x0]` | exact match, normalized | `211.7 ms +/- 9.4 ms` | `508.8 ms +/- 19.8 ms` | `2.4x` (`+140%`) |
| `uint256[3]`, `xs[0] == xs[2] + 1` | `[1, 0, 0]` | `[4370001, 112002286318682476054167386428588068701460580937039173544089718020404258470546, 4370000]` | Foundry smaller | `109.9 ms +/- 1.6 ms` | `389.6 ms +/- 16.8 ms` | `3.5x` (`+254%`) |
| `uint256`, `(x >> 5) / 7777 >= 2222` | `552975808` | `553425558` | Foundry smaller | `67.5 ms +/- 0.5 ms` | `373.8 ms +/- 10.6 ms` | `5.5x` (`+454%`) |

The `AddressArrayUtils` row shrinks calldata from 260 bytes to 132 bytes in Foundry and reaches the same final witness as Echidna. The numeric relation rows are not byte-identical parity: Foundry minimizes further under the same shrink limit.

Sequence/no-call shrinking is OSS-351. Call-environment shrinking for symbolic single calls is out of scope until symbolic execution models those values.
