### PR TITLE
perf(fuzz): skip empty call value collection

### DIFF
--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -153,6 +153,10 @@ impl InvariantFuzzState {
         run_depth: u32,
         mapping_slots: Option<&AddressMap<MappingSlots>>,
     ) {
+        if logs.is_empty() && result.is_empty() && state_changeset.is_empty() {
+            return;
+        }
+
         let mut dict = self.inner.borrow_mut();
         let targets = fuzzed_contracts.targets();
         let (target_abi, target_function) = if logs.is_empty() && result.is_empty() {


### PR DESCRIPTION
Return before borrowing the invariant fuzz dictionary when a successful call produced no logs, return data, or state changes. This preserves collection semantics while trimming an empty per-call path in invariant campaigns.