### PR TITLE
perf(fuzz): skip empty fuzzer value drain

### DIFF
--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -134,6 +134,10 @@ impl InvariantFuzzState {
     }
 
     pub fn collect_fuzzer_values(&self, fuzzer: &mut Fuzzer) {
+        if fuzzer.collected_values.is_empty() {
+            return;
+        }
+
         let mut dict = self.inner.borrow_mut();
         for value in fuzzer.collected_values.drain(..) {
             dict.insert_value(value);


### PR DESCRIPTION
Return before borrowing the invariant fuzz dictionary when the fuzzer has no staged values to drain. This keeps the per-call invariant worker path out of RefCell borrow machinery for empty collections.