### PR TITLE
refactor(forge): isolate symbolic artifact replay options

### DIFF
--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -1,4 +1,8 @@
-use super::{install, test::TestArgs, watch::WatchArgs};
+use super::{
+    install,
+    test::{TestArgs, TestExecutionOptions},
+    watch::WatchArgs,
+};
 use crate::coverage::{
     BytecodeReporter, ContractId, CoverageReport, CoverageReporter, CoverageSummaryReporter,
     DebugReporter, ItemAnchor, LcovReporter,
@@ -309,7 +313,14 @@ impl CoverageArgs {
         let filter = self.test.filter(&config)?;
         let outcome = self
             .test
-            .run_tests(project_root, config, evm_opts, output, &filter, true, None)
+            .run_tests(
+                project_root,
+                config,
+                evm_opts,
+                output,
+                &filter,
+                TestExecutionOptions::coverage(),
+            )
             .await?;
 
         let known_contracts = outcome.known_contracts.as_ref().unwrap().clone();

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -105,6 +105,31 @@ impl From<ShowmapDomainArg> for ShowmapDomain {
     }
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct TestExecutionOptions {
+    pub(crate) coverage: bool,
+    pub(crate) should_debug: bool,
+    pub(crate) decode_internal: InternalTraceMode,
+    pub(crate) multi_network: MultiNetworkConfig,
+    pub(crate) replay_symbolic_artifact: Option<SymbolicArtifactReplayConfig>,
+}
+
+impl TestExecutionOptions {
+    pub(crate) fn default_run() -> Self {
+        Self {
+            coverage: false,
+            should_debug: false,
+            decode_internal: InternalTraceMode::None,
+            multi_network: MultiNetworkConfig::default(),
+            replay_symbolic_artifact: None,
+        }
+    }
+
+    pub(crate) fn coverage() -> Self {
+        Self { coverage: true, ..Self::default_run() }
+    }
+}
+
 /// CLI arguments for `forge test`.
 #[derive(Clone, Debug, Parser)]
 #[command(next_help_heading = "Test options")]
@@ -660,6 +685,8 @@ impl TestArgs {
             eyre::bail!("Compilation failed");
         }
 
+        let symbolic_artifact_replay = self.load_symbolic_artifact_replay()?;
+
         // `MultiContractRunner::build` strips the root prefix from artifact source paths so the
         // identifiers it constructs are project-relative. Match that here for the filter check
         // (notably for the `--rerun` failure list, which is persisted relative) but return the
@@ -672,7 +699,13 @@ impl TestArgs {
                     return true;
                 }
                 let stripped = id.clone().with_stripped_file_prefixes(&config.root);
-                matches_artifact(test_filter, &stripped, abi, config.symbolic.enabled)
+                matches_artifact(
+                    test_filter,
+                    &stripped,
+                    abi,
+                    config.symbolic.enabled,
+                    symbolic_artifact_replay.as_ref(),
+                )
             })
             .map(|(id, _)| id.source)
             .collect())
@@ -722,9 +755,6 @@ impl TestArgs {
         let project = config.project()?;
 
         let replay_symbolic_artifact = self.load_symbolic_artifact_replay()?;
-        if replay_symbolic_artifact.is_some() {
-            config.symbolic.enabled = true;
-        }
 
         let mut filter = self.filter(&config)?;
         if let Some(replay) = &replay_symbolic_artifact {
@@ -771,8 +801,10 @@ impl TestArgs {
             evm_opts,
             &output,
             &filter,
-            false,
-            replay_symbolic_artifact,
+            TestExecutionOptions {
+                replay_symbolic_artifact,
+                ..TestExecutionOptions::default_run()
+            },
         )
         .await
     }
@@ -780,16 +812,14 @@ impl TestArgs {
     /// Executes all the tests in the project.
     ///
     /// See [`Self::compile_and_run`] for more details.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn run_tests(
+    pub(crate) async fn run_tests(
         &mut self,
         project_root: &Path,
         mut config: Config,
         mut evm_opts: EvmOpts,
         output: &ProjectCompileOutput,
         filter: &ProjectPathsAwareFilter,
-        coverage: bool,
-        replay_symbolic_artifact: Option<SymbolicArtifactReplayConfig>,
+        mut execution: TestExecutionOptions,
     ) -> Result<TestOutcome> {
         if config.fuzz.run == Some(0) {
             bail!("`fuzz.run` must be greater than 0");
@@ -819,7 +849,7 @@ impl TestArgs {
             if self.junit {
                 conflicts.push("--junit");
             }
-            if coverage {
+            if execution.coverage {
                 conflicts.push("coverage");
             }
             if self.showmap_out.is_some() {
@@ -853,7 +883,7 @@ impl TestArgs {
             .or_else(|| Some(U256::from_be_bytes(rand::rng().random::<[u8; 32]>())));
 
         // Create test options from general project settings and compiler output.
-        let should_debug = self.debug;
+        execution.should_debug = self.debug;
         let should_draw = self.flamegraph || self.flamechart;
 
         // Determine executor verbosity.
@@ -903,17 +933,15 @@ impl TestArgs {
 
         let (libraries, mut outcome) = if override_networks.is_empty() {
             // Single-pass: no per-test network overrides, use global network setting.
+            execution.decode_internal = decode_internal;
+            execution.multi_network = MultiNetworkConfig::default();
             self.dispatch_network(
                 &evm_opts,
                 config,
                 evm_opts.clone(),
                 output,
                 filter,
-                coverage,
-                should_debug,
-                decode_internal,
-                MultiNetworkConfig::default(),
-                replay_symbolic_artifact.clone(),
+                execution.clone(),
             )
             .await?
         } else {
@@ -929,14 +957,14 @@ impl TestArgs {
                     evm_opts.clone(),
                     output,
                     filter,
-                    coverage,
-                    should_debug,
-                    decode_internal,
-                    MultiNetworkConfig {
-                        all_override_networks: all_override_networks.clone(),
-                        pass_network: None,
+                    TestExecutionOptions {
+                        decode_internal,
+                        multi_network: MultiNetworkConfig {
+                            all_override_networks: all_override_networks.clone(),
+                            pass_network: None,
+                        },
+                        ..execution.clone()
                     },
-                    replay_symbolic_artifact.clone(),
                 )
                 .await?;
 
@@ -951,14 +979,14 @@ impl TestArgs {
                         pass_evm_opts.clone(),
                         output,
                         filter,
-                        coverage,
-                        should_debug,
-                        decode_internal,
-                        MultiNetworkConfig {
-                            all_override_networks: all_override_networks.clone(),
-                            pass_network: Some(network),
+                        TestExecutionOptions {
+                            decode_internal,
+                            multi_network: MultiNetworkConfig {
+                                all_override_networks: all_override_networks.clone(),
+                                pass_network: Some(network),
+                            },
+                            ..execution.clone()
                         },
-                        replay_symbolic_artifact.clone(),
                     )
                     .await?;
                 merge_outcomes(&mut outcome, pass_outcome);
@@ -977,7 +1005,7 @@ impl TestArgs {
             (libraries, outcome)
         };
 
-        if let Some(replay) = &replay_symbolic_artifact {
+        if let Some(replay) = &execution.replay_symbolic_artifact {
             let replayed = outcome.tests().count();
             if replayed == 0 {
                 bail!(
@@ -1037,7 +1065,7 @@ impl TestArgs {
             }
         }
 
-        if should_debug {
+        if execution.should_debug {
             // Get first non-empty suite result. We will have only one such entry.
             let (_, _, test_result) =
                 outcome.remove_first().ok_or_eyre("no tests were executed")?;
@@ -1311,18 +1339,13 @@ impl TestArgs {
     }
 
     /// Build the test runner and execute tests for a specific network type.
-    #[allow(clippy::too_many_arguments)]
     async fn build_and_run_tests<FEN: FoundryEvmNetwork>(
         &self,
         config: Config,
         evm_opts: EvmOpts,
         output: &ProjectCompileOutput,
         filter: &ProjectPathsAwareFilter,
-        coverage: bool,
-        should_debug: bool,
-        decode_internal: InternalTraceMode,
-        multi_network: MultiNetworkConfig,
-        replay_symbolic_artifact: Option<SymbolicArtifactReplayConfig>,
+        execution: TestExecutionOptions,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
         let verbosity = evm_opts.verbosity;
         let (evm_env, tx_env, fork_block) =
@@ -1331,17 +1354,17 @@ impl TestArgs {
         let config = Arc::new(config);
         let showmap = self.showmap_config();
         let runner = MultiContractRunnerBuilder::new(config.clone())
-            .set_debug(should_debug)
-            .set_decode_internal(decode_internal)
+            .set_debug(execution.should_debug)
+            .set_decode_internal(execution.decode_internal)
             .initial_balance(evm_opts.initial_balance)
             .sender(evm_opts.sender)
             .with_fork(evm_opts.get_fork(&config, evm_env.cfg_env.chain_id, fork_block))
             .enable_isolation(evm_opts.isolate)
             .fail_fast(self.fail_fast)
-            .set_coverage(coverage)
-            .with_multi_network(multi_network)
+            .set_coverage(execution.coverage)
+            .with_multi_network(execution.multi_network)
             .with_showmap(showmap)
-            .with_symbolic_artifact_replay(replay_symbolic_artifact)
+            .with_symbolic_artifact_replay(execution.replay_symbolic_artifact)
             .build::<FEN, MultiCompiler>(output, evm_env, tx_env, evm_opts)?;
 
         let libraries = runner.libraries.clone();
@@ -1350,7 +1373,6 @@ impl TestArgs {
     }
 
     /// Dispatches `build_and_run_tests` to the correct network type based on `evm_opts.networks`.
-    #[allow(clippy::too_many_arguments)]
     async fn dispatch_network(
         &self,
         dispatch_opts: &EvmOpts,
@@ -1358,54 +1380,22 @@ impl TestArgs {
         evm_opts: EvmOpts,
         output: &ProjectCompileOutput,
         filter: &ProjectPathsAwareFilter,
-        coverage: bool,
-        should_debug: bool,
-        decode_internal: InternalTraceMode,
-        multi_network: MultiNetworkConfig,
-        replay_symbolic_artifact: Option<SymbolicArtifactReplayConfig>,
+        execution: TestExecutionOptions,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
         if dispatch_opts.networks.is_tempo() {
-            self.build_and_run_tests::<TempoEvmNetwork>(
-                config,
-                evm_opts,
-                output,
-                filter,
-                coverage,
-                should_debug,
-                decode_internal,
-                multi_network,
-                replay_symbolic_artifact,
-            )
-            .await
+            self.build_and_run_tests::<TempoEvmNetwork>(config, evm_opts, output, filter, execution)
+                .await
         } else {
             #[cfg(feature = "optimism")]
             if dispatch_opts.networks.is_optimism() {
                 return self
                     .build_and_run_tests::<OpEvmNetwork>(
-                        config,
-                        evm_opts,
-                        output,
-                        filter,
-                        coverage,
-                        should_debug,
-                        decode_internal,
-                        multi_network,
-                        replay_symbolic_artifact,
+                        config, evm_opts, output, filter, execution,
                     )
                     .await;
             }
-            self.build_and_run_tests::<EthEvmNetwork>(
-                config,
-                evm_opts,
-                output,
-                filter,
-                coverage,
-                should_debug,
-                decode_internal,
-                multi_network,
-                replay_symbolic_artifact,
-            )
-            .await
+            self.build_and_run_tests::<EthEvmNetwork>(config, evm_opts, output, filter, execution)
+                .await
         }
     }
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -3,7 +3,7 @@
 use crate::{
     ContractRunner, TestFilter,
     progress::TestsProgress,
-    result::{SuiteResult, SymbolicCounterexampleArtifact},
+    result::{SuiteResult, SymbolicCounterexampleArtifact, SymbolicCounterexampleArtifactKind},
     runner::{
         ContractRunnerContext, InvariantCampaignScope, LIBRARY_DEPLOYER,
         count_runnable_invariant_campaign_anchors, is_symbolic_entrypoint,
@@ -101,11 +101,25 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         contract_id: &str,
         func: &Function,
     ) -> bool {
-        matches_test_function(filter, contract_id, func, self.config.symbolic.enabled)
+        matches_test_function(
+            filter,
+            contract_id,
+            func,
+            symbolic_entrypoints_enabled(
+                self.config.symbolic.enabled,
+                self.tcfg.symbolic_artifact_replay.as_ref(),
+            ),
+        )
     }
 
     fn matches_artifact(&self, filter: &dyn TestFilter, id: &ArtifactId, abi: &JsonAbi) -> bool {
-        matches_artifact(filter, id, abi, self.config.symbolic.enabled)
+        matches_artifact(
+            filter,
+            id,
+            abi,
+            self.config.symbolic.enabled,
+            self.tcfg.symbolic_artifact_replay.as_ref(),
+        )
     }
 
     /// Returns an iterator over all contracts that match the filter.
@@ -139,7 +153,11 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
             .filter(|(id, _)| filter.matches_path(&id.source) && filter.matches_contract(&id.name))
             .flat_map(|(_, c)| c.abi.functions())
             .filter(|func| {
-                func.is_any_test() || (self.config.symbolic.enabled && is_symbolic_entrypoint(func))
+                func.is_any_test()
+                    || (symbolic_entrypoints_enabled(
+                        self.config.symbolic.enabled,
+                        self.tcfg.symbolic_artifact_replay.as_ref(),
+                    ) && is_symbolic_entrypoint(func))
             })
     }
 
@@ -652,7 +670,10 @@ impl MultiContractRunnerBuilder {
             if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true)
                 && abi.functions().any(|func| {
                     func.name.is_any_test()
-                        || self.config.symbolic.enabled && is_symbolic_entrypoint(func)
+                        || symbolic_entrypoints_enabled(
+                            self.config.symbolic.enabled,
+                            self.symbolic_artifact_replay.as_ref(),
+                        ) && is_symbolic_entrypoint(func)
                 })
             {
                 linker.ensure_linked(contract, id)?;
@@ -743,6 +764,7 @@ pub fn matches_artifact(
     id: &ArtifactId,
     abi: &JsonAbi,
     symbolic_enabled: bool,
+    symbolic_artifact_replay: Option<&SymbolicArtifactReplayConfig>,
 ) -> bool {
     matches_contract(
         filter,
@@ -750,8 +772,18 @@ pub fn matches_artifact(
         &id.name,
         &id.identifier(),
         abi.functions(),
-        symbolic_enabled,
+        symbolic_entrypoints_enabled(symbolic_enabled, symbolic_artifact_replay),
     )
+}
+
+pub fn symbolic_entrypoints_enabled(
+    symbolic_enabled: bool,
+    symbolic_artifact_replay: Option<&SymbolicArtifactReplayConfig>,
+) -> bool {
+    symbolic_enabled
+        || symbolic_artifact_replay.is_some_and(|artifact| {
+            artifact.artifact.kind == SymbolicCounterexampleArtifactKind::SingleCall
+        })
 }
 
 pub(crate) fn matches_contract(

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -4,7 +4,7 @@ use crate::{
     MultiContractRunner, TestFilter,
     coverage::HitMaps,
     fuzz::{BaseCounterExample, FuzzTestResult},
-    multi_runner::{TestContract, TestRunnerConfig},
+    multi_runner::{TestContract, TestRunnerConfig, symbolic_entrypoints_enabled},
     progress::{TestsProgress, start_fuzz_progress},
     result::{
         InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicArtifactRef,
@@ -736,7 +736,10 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         // Filter out functions sequentially since it's very fast and there is no need to do it
         // in parallel.
         let find_timer = Instant::now();
-        let symbolic_enabled = self.config.symbolic.enabled;
+        let symbolic_enabled = symbolic_entrypoints_enabled(
+            self.config.symbolic.enabled,
+            self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
+        );
         let functions = self
             .contract
             .abi
@@ -921,7 +924,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 }
 
                 let sig = func.signature();
-                let kind = if self.config.symbolic.enabled && is_symbolic_entrypoint(func) {
+                let kind = if symbolic_enabled && is_symbolic_entrypoint(func) {
                     TestFunctionKind::SymbolicTest
                 } else {
                     func.test_function_kind()


### PR DESCRIPTION
## Description

Addresses follow-up feedback from #15217 around symbolic artifact replay orchestration.

This removes the need to globally enable `config.symbolic.enabled` when replaying symbolic artifacts and instead threads replay-specific execution state through a dedicated `TestExecutionOptions` struct. Single-call artifact replay can still opt into symbolic entrypoint discovery, while sequence replay avoids enabling symbolic mode and its solver-related side effects.

This also reduces the `run_tests` positional argument growth by grouping execution flags into `TestExecutionOptions`, replacing the previous `#[allow(clippy::too_many_arguments)]` workaround.

## What changed

- Add `TestExecutionOptions` for test execution flags.
- Pass replay configuration through execution options instead of standalone positional args.
- Stop forcing `config.symbolic.enabled = true` for all artifact replays.
- Add `symbolic_entrypoints_enabled(...)` to scope symbolic entrypoint discovery to:
  - normal symbolic runs
  - single-call symbolic artifact replay
- Update coverage test execution to use `TestExecutionOptions::coverage()`.
- Remove now-unneeded `too_many_arguments` allowances from the test execution path.