### PR TITLE
perf(evm): skip empty revert diagnostic calls

### DIFF
--- a/crates/evm/evm/src/inspectors/revert_diagnostic.rs
+++ b/crates/evm/evm/src/inspectors/revert_diagnostic.rs
@@ -171,6 +171,10 @@ impl<CTX: ContextTr> Inspector<CTX> for RevertDiagnostic {
     /// Tracks the first call with non-zero calldata that targets a non-contract address. Excludes
     /// precompiles and test addresses.
     fn call(&mut self, ctx: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        if inputs.input.is_empty() {
+            return None;
+        }
+
         let target = self.code_target_address(inputs);
 
         if IGNORE.contains(&target) || ctx.journal_ref().precompile_addresses().contains(&target) {
@@ -179,7 +183,6 @@ impl<CTX: ContextTr> Inspector<CTX> for RevertDiagnostic {
 
         if let Ok(state) = ctx.journal_mut().code(target)
             && state.is_empty()
-            && !inputs.input.is_empty()
         {
             self.non_contract_call = Some((target, inputs.scheme, ctx.journal_ref().depth()));
         }


### PR DESCRIPTION
Short-circuit `RevertDiagnostic::call` for calls with empty calldata.

The non-contract-call diagnostic only records a target when `!inputs.input.is_empty()`, so calls with empty calldata (e.g. plain value transfers) can never set `non_contract_call`. Returning early for them skips target resolution, the `IGNORE`/precompile checks, and the `journal.code(target)` load on that path.

Behavior is unchanged: the recorded diagnostic is identical, and the CALL itself still warms the target for gas accounting, so this only avoids redundant work.