### PR TITLE
chore(deps): bump tempo rev pins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3046,7 +3046,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3205,7 +3205,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4254,7 +4254,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4515,7 +4515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6863,7 +6863,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7667,7 +7667,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8778,7 +8778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8929,7 +8929,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10386,7 +10386,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10445,7 +10445,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11237,7 +11237,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11272,7 +11272,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.13.0",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11717,13 +11717,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=d6905c39c80a2b607965f71ef6a51c78acc78bf1#d6905c39c80a2b607965f71ef6a51c78acc78bf1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11756,7 +11756,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=d6905c39c80a2b607965f71ef6a51c78acc78bf1#d6905c39c80a2b607965f71ef6a51c78acc78bf1"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11779,7 +11779,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=d6905c39c80a2b607965f71ef6a51c78acc78bf1#d6905c39c80a2b607965f71ef6a51c78acc78bf1"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11790,7 +11790,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=d6905c39c80a2b607965f71ef6a51c78acc78bf1#d6905c39c80a2b607965f71ef6a51c78acc78bf1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11802,7 +11802,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=d6905c39c80a2b607965f71ef6a51c78acc78bf1#d6905c39c80a2b607965f71ef6a51c78acc78bf1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11831,7 +11831,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=d6905c39c80a2b607965f71ef6a51c78acc78bf1#d6905c39c80a2b607965f71ef6a51c78acc78bf1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11852,7 +11852,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=d6905c39c80a2b607965f71ef6a51c78acc78bf1#d6905c39c80a2b607965f71ef6a51c78acc78bf1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11863,7 +11863,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=d6905c39c80a2b607965f71ef6a51c78acc78bf1#d6905c39c80a2b607965f71ef6a51c78acc78bf1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11894,7 +11894,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=d6905c39c80a2b607965f71ef6a51c78acc78bf1#d6905c39c80a2b607965f71ef6a51c78acc78bf1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11921,7 +11921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13143,7 +13143,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13281,7 +13281,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,17 +507,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6540a5ac3c6f3848684eb
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -594,9 +594,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "ba6246789fc12cf8fe78aa74aadf31d663f08c1f" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "d6905c39c80a2b607965f71ef6a51c78acc78bf1" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }


### PR DESCRIPTION
## Summary

- Bump the `tempoxyz/tempo` git rev pins from `96f913fb2094f0acdc65b7ca3b9190162837b626` to `d6905c39c80a2b607965f71ef6a51c78acc78bf1`.
- Refresh `Cargo.lock` so all Tempo git packages resolve to the same updated revision.
- Leave `mpp-rs` unchanged because its current pin already matches upstream `main` HEAD.