### PR TITLE
fix(lint): include info rules by default

### DIFF
--- a/crates/config/src/lint.rs
+++ b/crates/config/src/lint.rs
@@ -37,7 +37,7 @@ impl Default for LinterConfig {
     fn default() -> Self {
         Self {
             lint_on_build: true,
-            severity: vec![Severity::High, Severity::Med, Severity::Low],
+            severity: Vec::new(),
             exclude_lints: Vec::new(),
             ignore: Vec::new(),
             lint_specific: LintSpecificConfig::default(),

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -119,6 +119,14 @@ solc = "0.8.5"
 Warning: Found unknown config section in foundry.toml: [default]
 This notation for profiles has been deprecated and may result in the profile not being registered in future versions.
 Please use [profile.default] instead or run `forge config --fix`.
+note[could-be-constant]: state variable could be declared constant
+  [FILE]:6:17
+  │
+6 │     uint public value = 42;
+  │                 ━━━━━
+  │
+  ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
 
 "#]]);
     // `forge clear` should not warn

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -170,11 +170,7 @@ prefer_compact = "all"
 single_line_imports = false
 
 [lint]
-severity = [
-    "high",
-    "medium",
-    "low",
-]
+severity = []
 exclude_lints = []
 ignore = []
 lint_on_build = true
@@ -1580,11 +1576,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "single_line_imports": false
   },
   "lint": {
-    "severity": [
-      "high",
-      "medium",
-      "low"
-    ],
+    "severity": [],
     "exclude_lints": [],
     "ignore": [],
     "lint_on_build": true,

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -59,6 +59,24 @@ contract Dummy {
 }
 "#;
 
+const DEFAULT_INFO_LINTS_IMPORT: &str = r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract UnusedSymbol {}
+"#;
+
+const DEFAULT_INFO_LINTS: &str = r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { UnusedSymbol } from "./DefaultInfoLintsImport.sol";
+
+contract DefaultInfoLints {
+    function BAD_CASE() public {}
+}
+"#;
+
 const COUNTER_A: &str = r#"
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
@@ -248,10 +266,24 @@ note[mixed-case-function]: function names should use mixedCase
             ..Default::default()
         };
     });
-    cmd.arg("lint").assert_success().stderr_eq(str![[r#"
+    cmd.forge_fuse().arg("lint").assert_success().stderr_eq(str![[r#"
 nothing to lint
 
 "#]]);
+});
+
+forgetest!(default_lint_severity_includes_info, |prj, cmd| {
+    prj.add_source("DefaultInfoLintsImport", DEFAULT_INFO_LINTS_IMPORT);
+    prj.add_source("DefaultInfoLints", DEFAULT_INFO_LINTS);
+
+    let output = cmd.arg("lint").assert_success();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+
+    assert_eq!(stderr.matches("note[").count(), 2);
+    assert!(stderr.contains("note[unused-import]: unused imports should be removed"));
+    assert!(stderr.contains("import { UnusedSymbol } from \"./DefaultInfoLintsImport.sol\";"));
+    assert!(stderr.contains("note[mixed-case-function]: function names should use mixedCase"));
+    assert!(stderr.contains("function BAD_CASE() public {}"));
 });
 
 forgetest!(can_use_config_mixed_case_exception, |prj, cmd| {

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -276,14 +276,25 @@ forgetest!(default_lint_severity_includes_info, |prj, cmd| {
     prj.add_source("DefaultInfoLintsImport", DEFAULT_INFO_LINTS_IMPORT);
     prj.add_source("DefaultInfoLints", DEFAULT_INFO_LINTS);
 
-    let output = cmd.arg("lint").assert_success();
-    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    cmd.arg("lint").assert_success().stderr_eq(str![[r#"
+note[mixed-case-function]: function names should use mixedCase
+  [FILE]:8:14
+  │
+8 │     function BAD_CASE() public {}
+  │              ━━━━━━━━ help: consider using: `badCase`
+  │
+  ╰ help: https://getfoundry.sh/forge/linting/mixed-case-function
 
-    assert_eq!(stderr.matches("note[").count(), 2);
-    assert!(stderr.contains("note[unused-import]: unused imports should be removed"));
-    assert!(stderr.contains("import { UnusedSymbol } from \"./DefaultInfoLintsImport.sol\";"));
-    assert!(stderr.contains("note[mixed-case-function]: function names should use mixedCase"));
-    assert!(stderr.contains("function BAD_CASE() public {}"));
+note[unused-import]: unused imports should be removed
+  [FILE]:5:10
+  │
+5 │ import { UnusedSymbol } from "./DefaultInfoLintsImport.sol";
+  │          ━━━━━━━━━━━━
+  │
+  ╰ help: https://getfoundry.sh/forge/linting/unused-import
+
+
+"#]]);
 });
 
 forgetest!(can_use_config_mixed_case_exception, |prj, cmd| {

--- a/crates/lint/testdata/DivideBeforeMultiply.stderr
+++ b/crates/lint/testdata/DivideBeforeMultiply.stderr
@@ -1,3 +1,27 @@
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/DivideBeforeMultiply.sol:LL:CC
+   │
+LL │             revert("done");
+   │             ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/DivideBeforeMultiply.sol:LL:CC
+   │
+LL │         assembly {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/DivideBeforeMultiply.sol:LL:CC
+   │
+LL │         assembly {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
 warning[divide-before-multiply]: multiplication should occur before division to avoid loss of precision
    ╭▸ ROOT/testdata/DivideBeforeMultiply.sol:LL:CC
    │

--- a/crates/lint/testdata/IncorrectShift.stderr
+++ b/crates/lint/testdata/IncorrectShift.stderr
@@ -22,3 +22,19 @@ LL │             result := sar(add(result, 1), 8)
    │
    ╰ help: https://getfoundry.sh/forge/linting/incorrect-shift
 
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/IncorrectShift.sol:LL:CC
+   │
+LL │         assembly {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+
+note[inline-assembly]: inline assembly used; review for memory safety and side effects
+   ╭▸ ROOT/testdata/IncorrectShift.sol:LL:CC
+   │
+LL │         assembly {
+   │         ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inline-assembly
+

--- a/crates/lint/testdata/Rtlo.stderr
+++ b/crates/lint/testdata/Rtlo.stderr
@@ -190,3 +190,123 @@ LL │     string public marks = unicode"left‎right‏end";
    │
    ╰ help: https://getfoundry.sh/forge/linting/rtlo
 
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public lre = unicode"�_�";
+   │                   ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public rle = unicode"�_�";
+   │                   ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public pdf = unicode"��";
+   │                   ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public lro = unicode"�_�";
+   │                   ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public rlo = unicode"�_�";
+   │                   ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public lri = unicode"�_�";
+   │                   ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public rli = unicode"�_�";
+   │                   ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public fsi = unicode"�_�";
+   │                   ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public pdi = unicode"��";
+   │                   ━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public suppressedLine = unicode"�_�";
+   │                   ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public suppressedA = unicode"�_�";
+   │                   ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public suppressedB = unicode"�_�";
+   │                   ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public clean = "no bidi here";
+   │                   ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[could-be-constant]: state variable could be declared constant
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     string public marks = unicode"left‎right‏end";
+   │                   ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/could-be-constant
+
+note[unused-state-variables]: state variable is never used
+   ╭▸ ROOT/testdata/Rtlo.sol:LL:CC
+   │
+LL │     /* hidden� /* text � */ uint256 inBlockComment;
+   │                             ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-state-variables
+

--- a/crates/lint/testdata/SoloInterfaces.stderr
+++ b/crates/lint/testdata/SoloInterfaces.stderr
@@ -1,0 +1,40 @@
+note[interface-naming]: interface names should be prefixed with 'I'
+   ╭▸ ROOT/testdata/SoloInterfaces.sol:LL:CC
+   │
+LL │ interface SoloInterfaces {
+   │           ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/interface-naming
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/SoloInterfaces.sol:LL:CC
+   │
+LL │ interface SoloInterfaces {
+   │           ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/SoloInterfaces.sol:LL:CC
+   │
+LL │ interface I2 {
+   │           ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[multi-contract-file]: prefer having only one contract, interface or library per file
+   ╭▸ ROOT/testdata/SoloInterfaces.sol:LL:CC
+   │
+LL │ interface I3 {
+   │           ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/multi-contract-file
+
+note[interface-file-naming]: interface file names should be prefixed with 'I'
+   ╭▸ ROOT/testdata/SoloInterfaces.sol:LL:CC
+   │
+LL │ interface SoloInterfaces {
+   │           ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/interface-file-naming
+

--- a/crates/lint/testdata/TautologicalCompare.stderr
+++ b/crates/lint/testdata/TautologicalCompare.stderr
@@ -1,3 +1,75 @@
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
+   │
+LL │         require(x >= x);
+   │         ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
+   │
+LL │         require(y == y);
+   │         ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
+   │
+LL │         require(x <= (x));
+   │         ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
+   │
+LL │         require(x >= y); // different identifiers
+   │         ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
+   │
+LL │         require(pick(x) == pick(x)); // calls excluded: sides may differ
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
+   │
+LL │         require(x + 1 > x); // not a self-comparison
+   │         ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
+   │
+LL │         require(uint256(x) == uint256(y)); // same cast, different operand
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
+   │
+LL │         require(uint256(x) == uint8(x)); // casts to different types: uint8 can truncate, not tautological
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
+note[custom-errors]: prefer using custom errors on revert and require calls
+   ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
+   │
+LL │         require(w == w);
+   │         ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/custom-errors
+
 warning[tautological-compare]: comparing an expression with itself is always true or false
    ╭▸ ROOT/testdata/TautologicalCompare.sol:LL:CC
    │


### PR DESCRIPTION
Fixes #15329.

## Summary
- restore the documented default lint behavior so an unspecified severity filter runs all severities, including info-level rules
- add CLI coverage proving plain `forge lint` reports `unused-import` and `mixed-case-function`
- reset a reused lint test command before its second invocation