### PR TITLE
fix(tempo): preserve non-creditable-slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,7 +1159,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1183,7 +1183,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2559,7 +2559,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3046,7 +3046,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3205,7 +3205,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4254,7 +4254,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4515,7 +4515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5562,6 +5562,8 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
  "alloy-sol-types",
  "anvil",
  "auto_impl",
@@ -5590,6 +5592,7 @@ dependencies = [
  "tempo-contracts",
  "tempo-evm",
  "tempo-precompiles",
+ "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.18",
  "tokio",
@@ -6863,7 +6866,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7667,7 +7670,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10386,7 +10389,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10445,7 +10448,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11169,7 +11172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11717,13 +11720,13 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=65185565b01bc9f406a06c522357954d75ce7cb7#65185565b01bc9f406a06c522357954d75ce7cb7"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11756,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.8.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=65185565b01bc9f406a06c522357954d75ce7cb7#65185565b01bc9f406a06c522357954d75ce7cb7"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -11779,7 +11782,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=65185565b01bc9f406a06c522357954d75ce7cb7#65185565b01bc9f406a06c522357954d75ce7cb7"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -11790,7 +11793,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=65185565b01bc9f406a06c522357954d75ce7cb7#65185565b01bc9f406a06c522357954d75ce7cb7"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -11802,7 +11805,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=65185565b01bc9f406a06c522357954d75ce7cb7#65185565b01bc9f406a06c522357954d75ce7cb7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11831,7 +11834,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=65185565b01bc9f406a06c522357954d75ce7cb7#65185565b01bc9f406a06c522357954d75ce7cb7"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -11852,7 +11855,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=65185565b01bc9f406a06c522357954d75ce7cb7#65185565b01bc9f406a06c522357954d75ce7cb7"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -11863,7 +11866,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.8.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=65185565b01bc9f406a06c522357954d75ce7cb7#65185565b01bc9f406a06c522357954d75ce7cb7"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11894,7 +11897,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.9.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96f913fb2094f0acdc65b7ca3b9190162837b626#96f913fb2094f0acdc65b7ca3b9190162837b626"
+source = "git+https://github.com/tempoxyz/tempo?rev=65185565b01bc9f406a06c522357954d75ce7cb7#65185565b01bc9f406a06c522357954d75ce7cb7"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11921,7 +11924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13143,7 +13146,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13281,7 +13284,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -507,17 +507,17 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6540a5ac3c6f3848684eb
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false, features = [
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7", default-features = false }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -594,9 +594,9 @@ alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = 
 foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "ba6246789fc12cf8fe78aa74aadf31d663f08c1f" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "96f913fb2094f0acdc65b7ca3b9190162837b626" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7" }
 
 # solar
 solar = { package = "solar-compiler", git = "https://github.com/paradigmxyz/solar", rev = "da6b0c3a8c0edd23f8b1414c61418ba78d6c4670" }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -159,7 +159,7 @@ impl<DB: Database, T> BackendInspector<DB> for T where
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use revm::{
     DatabaseCommit, Inspector,
-    context::{Block as RevmBlock, BlockEnv, Cfg, CfgEnv, TxEnv},
+    context::{Block as RevmBlock, BlockEnv, Cfg, TxEnv},
     context_interface::{
         block::BlobExcessGasAndPrice,
         result::{ExecutionResult, HaltReason, Output, ResultAndState},
@@ -171,13 +171,11 @@ use revm::{
     state::AccountInfo,
 };
 use std::{
-    cell::RefCell,
     collections::BTreeMap,
     fmt::{self, Debug},
     io::{Read, Write},
     ops::{Mul, Not},
     path::PathBuf,
-    rc::Rc,
     sync::Arc,
     time::Duration,
 };
@@ -187,7 +185,6 @@ use tempo_evm::evm::TempoEvmFactory;
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS, extend_tempo_precompiles,
     storage::{StorageActions, StorageCtx},
-    storage_credits::NonCreditableSlots,
     tip_fee_manager::{IFeeManager, TipFeeManager},
     tip20::{ISSUER_ROLE, ITIP20, TIP20Token},
 };
@@ -1188,17 +1185,20 @@ impl<N: Network> Backend<N> {
         }
     }
 
-    fn inject_tempo_precompiles(
-        &self,
-        precompiles: &mut PrecompilesMap,
-        cfg_env: &CfgEnv<TempoHardfork>,
-    ) {
-        self.inject_precompiles(precompiles);
+    fn inject_tempo_precompiles<DB, I>(&self, evm: &mut tempo_evm::evm::TempoEvm<DB, I>)
+    where
+        DB: Database,
+        I: Inspector<TempoContext<DB>>,
+    {
+        self.inject_precompiles(evm.precompiles_mut());
+        // Re-extend Tempo precompiles, preserving shared non-creditable slots.
+        let cfg = evm.ctx().cfg.clone();
+        let non_creditable_slots = evm.non_creditable_slots();
         extend_tempo_precompiles(
-            precompiles,
-            cfg_env,
+            evm.precompiles_mut(),
+            &cfg,
             StorageActions::disabled(),
-            Rc::new(RefCell::new(NonCreditableSlots::empty())),
+            non_creditable_slots,
         );
     }
 
@@ -1316,8 +1316,7 @@ impl<N: Network> Backend<N> {
             tempo_env,
             inspector,
         );
-        let cfg = evm.cfg.clone();
-        self.inject_tempo_precompiles(evm.precompiles_mut(), &cfg);
+        self.inject_tempo_precompiles(&mut evm);
         let result = evm.transact(tx_env)?;
         Ok(ResultAndState {
             result: result.result.map_haltreason(|h| match h {

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -79,8 +79,11 @@ url.workspace = true
 
 [dev-dependencies]
 alloy-serde.workspace = true
+alloy-signer.workspace = true
+alloy-signer-local.workspace = true
 anvil.workspace = true
 foundry-test-utils.workspace = true
+tempo-primitives.workspace = true
 
 [features]
 default = ["optimism"]

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -12,12 +12,10 @@ use revm::{
     interpreter::{FrameInput, SharedMemory, interpreter_action::FrameInit},
     state::Bytecode,
 };
-use std::{cell::RefCell, rc::Rc};
 use tempo_evm::{TempoBlockEnv, TempoEvmFactory, TempoHaltReason, evm::TempoEvm};
 use tempo_precompiles::{
     extend_tempo_precompiles,
     storage::{StorageActions, StorageCtx},
-    storage_credits::NonCreditableSlots,
 };
 use tempo_revm::{
     TempoInvalidTransaction, TempoTxEnv, evm::TempoContext, gas_params::tempo_gas_params,
@@ -102,12 +100,14 @@ impl FoundryEvmFactory for TempoEvmFactory {
 
         let networks = tempo_evm.inspector().get_networks();
         networks.inject_precompiles(tempo_evm.precompiles_mut());
+        // Re-extend Tempo precompiles, preserving shared non-creditable slots.
         let cfg = tempo_evm.cfg.clone();
+        let non_creditable_slots = tempo_evm.non_creditable_slots();
         extend_tempo_precompiles(
             tempo_evm.precompiles_mut(),
             &cfg,
             StorageActions::disabled(),
-            Rc::new(RefCell::new(NonCreditableSlots::empty())),
+            non_creditable_slots,
         );
 
         initialize_tempo_evm(&mut tempo_evm, is_forked);

--- a/crates/evm/core/tests/tempo.rs
+++ b/crates/evm/core/tests/tempo.rs
@@ -1,0 +1,192 @@
+use alloy_evm::{Evm, EvmEnv, FromRecoveredTx};
+use alloy_primitives::{Address, TxKind, U256};
+use alloy_signer::Signer;
+use alloy_signer_local::PrivateKeySigner;
+use alloy_sol_types::SolCall;
+use foundry_evm_core::{
+    backend::Backend,
+    evm::{FoundryEvmFactory, TempoEvmNetwork},
+    fork::MultiFork,
+};
+use revm::{Inspector, inspector::NoOpInspector, state::AccountInfo};
+use tempo_alloy::primitives::TempoTxEnvelope;
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_evm::{TempoBlockEnv, TempoEvmFactory};
+use tempo_precompiles::{
+    ACCOUNT_KEYCHAIN_ADDRESS, DEFAULT_FEE_TOKEN,
+    account_keychain::{
+        KeyRestrictions, SignatureType as KeychainSignatureType, TokenLimit as KeychainTokenLimit,
+        authorizeKeyCall,
+    },
+    storage::{StorageActions, StorageCtx},
+    storage_credits::StorageCredits,
+    tip20::{ITIP20, TIP20Token},
+};
+use tempo_primitives::{
+    AASigned, TempoSignature, TempoTransaction,
+    transaction::{Call, KeychainSignature, PrimitiveSignature, calc_gas_balance_spending},
+};
+use tempo_revm::{TempoTxEnv, gas_params::tempo_gas_params};
+
+const GAS_LIMIT: u64 = 500_000;
+const GAS_PRICE: u128 = 1_000_000_000_000;
+const TRANSFER_AMOUNT: u64 = 1_234;
+
+fn in_memory_tempo_backend() -> Backend<TempoEvmNetwork> {
+    let (forks, _fork_handler) = MultiFork::new();
+    Backend::new(forks, None).unwrap()
+}
+
+fn seed_fee_token_balances(
+    db: &mut Backend<TempoEvmNetwork>,
+    account: Address,
+    recipient: Address,
+) {
+    db.insert_account_info(
+        account,
+        AccountInfo { balance: U256::from(1_000_000_000_000_000_000u128), ..Default::default() },
+    );
+    let initial_balance =
+        calc_gas_balance_spending(GAS_LIMIT, GAS_PRICE) + U256::from(TRANSFER_AMOUNT);
+    let token = TIP20Token::from_address_unchecked(DEFAULT_FEE_TOKEN);
+    db.insert_account_storage(DEFAULT_FEE_TOKEN, token.balances[account].slot(), initial_balance)
+        .unwrap();
+    db.insert_account_storage(DEFAULT_FEE_TOKEN, token.balances[recipient].slot(), U256::ONE)
+        .unwrap();
+}
+
+fn storage_credit_balance<DB, I>(evm: &mut tempo_evm::evm::TempoEvm<DB, I>, owner: Address) -> u64
+where
+    DB: alloy_evm::Database,
+    I: Inspector<tempo_revm::evm::TempoContext<DB>>,
+{
+    let ctx = evm.ctx_mut();
+    StorageCtx::enter_evm(
+        &mut ctx.journaled_state,
+        &ctx.block,
+        &ctx.cfg,
+        &ctx.tx,
+        StorageActions::disabled(),
+        || StorageCredits::new().balance_of(owner).unwrap(),
+    )
+}
+
+async fn primitive_tx(account: &PrivateKeySigner, tx: TempoTransaction) -> TempoTxEnv {
+    let signature = account.sign_hash(&tx.signature_hash()).await.unwrap();
+    let envelope = TempoTxEnvelope::AA(AASigned::new_unhashed(
+        tx,
+        TempoSignature::Primitive(PrimitiveSignature::Secp256k1(signature)),
+    ));
+    TempoTxEnv::from_recovered_tx(&envelope, account.address())
+}
+
+async fn keychain_spend_setup() -> (Address, Address, TempoTxEnv, TempoTxEnv) {
+    let root = PrivateKeySigner::random();
+    let access_key = PrivateKeySigner::random();
+    let recipient = Address::repeat_byte(0xee);
+    let spending_limit =
+        calc_gas_balance_spending(GAS_LIMIT, GAS_PRICE) + U256::from(TRANSFER_AMOUNT);
+
+    let authorize = authorizeKeyCall {
+        keyId: access_key.address(),
+        signatureType: KeychainSignatureType::Secp256k1,
+        config: KeyRestrictions {
+            expiry: u64::MAX,
+            enforceLimits: true,
+            limits: vec![KeychainTokenLimit {
+                token: DEFAULT_FEE_TOKEN,
+                amount: spending_limit,
+                period: 0,
+            }],
+            allowAnyCalls: true,
+            allowedCalls: vec![],
+        },
+    };
+    let auth_tx = primitive_tx(
+        &root,
+        TempoTransaction {
+            chain_id: 1,
+            fee_token: Some(DEFAULT_FEE_TOKEN),
+            max_priority_fee_per_gas: 0,
+            max_fee_per_gas: 0,
+            gas_limit: 2_000_000,
+            calls: vec![Call {
+                to: TxKind::Call(ACCOUNT_KEYCHAIN_ADDRESS),
+                value: U256::ZERO,
+                input: authorize.abi_encode().into(),
+            }],
+            access_list: Default::default(),
+            nonce_key: U256::ZERO,
+            nonce: 0,
+            fee_payer_signature: None,
+            valid_before: None,
+            valid_after: None,
+            key_authorization: None,
+            tempo_authorization_list: vec![],
+        },
+    )
+    .await;
+
+    let spend_tx = TempoTransaction {
+        chain_id: 1,
+        fee_token: Some(DEFAULT_FEE_TOKEN),
+        max_priority_fee_per_gas: GAS_PRICE,
+        max_fee_per_gas: GAS_PRICE,
+        gas_limit: GAS_LIMIT,
+        calls: vec![Call {
+            to: TxKind::Call(DEFAULT_FEE_TOKEN),
+            value: U256::ZERO,
+            input: ITIP20::transferCall { to: recipient, amount: U256::from(TRANSFER_AMOUNT) }
+                .abi_encode()
+                .into(),
+        }],
+        access_list: Default::default(),
+        nonce_key: U256::ZERO,
+        nonce: 1,
+        fee_payer_signature: None,
+        valid_before: None,
+        valid_after: None,
+        key_authorization: None,
+        tempo_authorization_list: vec![],
+    };
+    let keychain_hash = KeychainSignature::signing_hash(spend_tx.signature_hash(), root.address());
+    let access_signature = access_key.sign_hash(&keychain_hash).await.unwrap();
+    let envelope = TempoTxEnvelope::AA(AASigned::new_unhashed(
+        spend_tx,
+        TempoSignature::Keychain(KeychainSignature::new(
+            root.address(),
+            PrimitiveSignature::Secp256k1(access_signature),
+        )),
+    ));
+    let spend_env = TempoTxEnv::from_recovered_tx(&envelope, root.address());
+    (spend_env.inner.caller, recipient, auth_tx, spend_env)
+}
+
+#[tokio::test]
+async fn foundry_factory_keychain_limit_refund_does_not_leak_storage_credit() {
+    let (account, recipient, auth_tx, spend_tx) = keychain_spend_setup().await;
+    let mut db = in_memory_tempo_backend();
+    seed_fee_token_balances(&mut db, account, recipient);
+
+    let evm_env = EvmEnv::new(
+        revm::context::CfgEnv::<TempoHardfork>::default()
+            .with_spec_and_gas_params(TempoHardfork::T7, tempo_gas_params(TempoHardfork::T7)),
+        TempoBlockEnv::default(),
+    );
+    let mut evm = TempoEvmFactory::default().create_foundry_evm_with_inspector(
+        &mut db,
+        evm_env,
+        NoOpInspector,
+    );
+
+    let auth_result = evm.transact_commit(auth_tx).expect("auth transaction executes");
+    assert!(auth_result.is_success(), "auth transaction should succeed: {auth_result:?}");
+
+    let spend_result = evm.transact_commit(spend_tx).expect("spend transaction executes");
+    assert!(spend_result.is_success(), "keychain spend should succeed: {spend_result:?}");
+    assert_eq!(
+        storage_credit_balance(&mut evm, ACCOUNT_KEYCHAIN_ADDRESS),
+        0,
+        "post-tx fee refund recreates the keychain spending-limit slot, so the same-tx clear credit must be canceled",
+    );
+}


### PR DESCRIPTION
this PR preserves Tempo’s transaction-local non-creditable slots when re-extending precompiles after custom injections, fixing TIP-1060 fee-bookkeeping in simulations and estimates.

## PR Checklist

- [X] Added Tests
- [X] Added Documentation
- [ ] Breaking changes
