### PR TITLE
fix(tempo): avoid receive-policy recipient collisions

### DIFF
--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -8,13 +8,23 @@ import {StdPrecompiles} from "tempo-std/StdPrecompiles.sol";
 import {StdTokens} from "tempo-std/StdTokens.sol";
 import {Mail} from "../src/Mail.sol";
 
+interface ITIP403Registry {
+    function validateReceivePolicy(address token, address sender, address receiver)
+        external
+        view
+        returns (bool authorized, uint8 blockedReason);
+}
+
 /// @notice Tests for direct mail sending (no signature verification).
 contract MailTest is Test {
+    address internal constant TIP403_REGISTRY = address(0x403c000000000000000000000000000000000000);
+
     ITIP20 public token;
     Mail public mail;
 
     address public constant ALICE = address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
-    address public constant BOB = address(0x70997970C51812dc3A010C7d01b50e0d17dc79C8);
+    address public BOB;
+    uint256 internal BOB_PK;
 
     function setUp() public virtual {
         address feeToken = vm.envOr("TEMPO_FEE_TOKEN", StdTokens.PATH_USD_ADDRESS);
@@ -26,6 +36,8 @@ contract MailTest is Test {
         );
 
         ITIP20RolesAuth(address(token)).grantRole(token.ISSUER_ROLE(), address(this));
+
+        (BOB, BOB_PK) = _selectRecipient();
 
         mail = new Mail(token);
     }
@@ -61,13 +73,31 @@ contract MailTest is Test {
         assertEq(token.balanceOf(BOB), sendAmount);
         assertEq(token.balanceOf(ALICE), mintAmount - sendAmount);
     }
+
+    function _selectRecipient() internal returns (address recipient, uint256 privateKey) {
+        for (uint256 i; i < 16; i++) {
+            (recipient, privateKey) = makeAddrAndKey(string.concat("tempo-mail-bob-", vm.toString(i)));
+            if (_isRecipientAllowed(recipient)) return (recipient, privateKey);
+        }
+
+        revert("no receive-policy-safe recipient");
+    }
+
+    function _isRecipientAllowed(address recipient) internal view returns (bool) {
+        (bool ok, bytes memory data) = TIP403_REGISTRY.staticcall(
+            abi.encodeCall(ITIP403Registry.validateReceivePolicy, (address(token), ALICE, recipient))
+        );
+        if (!ok || data.length < 64) return true;
+
+        (bool authorized,) = abi.decode(data, (bool, uint8));
+        return authorized;
+    }
 }
 
 /// @notice Tests for relayed mail using the TIP-1020 SignatureVerifier precompile (requires T3+).
 contract MailRelayTest is MailTest {
     // secp256k1 keys (used by vm.sign / vm.addr)
     uint256 internal constant ALICE_PK = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
-    uint256 internal constant BOB_PK = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
 
     // P256 key (used by vm.signP256 / vm.publicKeyP256)
     uint256 internal constant CAROL_P256_PK = 0x1;

--- a/crates/forge/assets/tempo/MailTemplate.t.sol
+++ b/crates/forge/assets/tempo/MailTemplate.t.sol
@@ -8,23 +8,13 @@ import {StdPrecompiles} from "tempo-std/StdPrecompiles.sol";
 import {StdTokens} from "tempo-std/StdTokens.sol";
 import {Mail} from "../src/Mail.sol";
 
-interface ITIP403Registry {
-    function validateReceivePolicy(address token, address sender, address receiver)
-        external
-        view
-        returns (bool authorized, uint8 blockedReason);
-}
-
 /// @notice Tests for direct mail sending (no signature verification).
 contract MailTest is Test {
-    address internal constant TIP403_REGISTRY = address(0x403c000000000000000000000000000000000000);
-
     ITIP20 public token;
     Mail public mail;
 
     address public constant ALICE = address(0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266);
     address public BOB;
-    uint256 internal BOB_PK;
 
     function setUp() public virtual {
         address feeToken = vm.envOr("TEMPO_FEE_TOKEN", StdTokens.PATH_USD_ADDRESS);
@@ -37,7 +27,7 @@ contract MailTest is Test {
 
         ITIP20RolesAuth(address(token)).grantRole(token.ISSUER_ROLE(), address(this));
 
-        (BOB, BOB_PK) = _selectRecipient();
+        BOB = address(uint160(uint256(keccak256(abi.encodePacked("tempo-mail-bob", address(token))))));
 
         mail = new Mail(token);
     }
@@ -73,31 +63,13 @@ contract MailTest is Test {
         assertEq(token.balanceOf(BOB), sendAmount);
         assertEq(token.balanceOf(ALICE), mintAmount - sendAmount);
     }
-
-    function _selectRecipient() internal returns (address recipient, uint256 privateKey) {
-        for (uint256 i; i < 16; i++) {
-            (recipient, privateKey) = makeAddrAndKey(string.concat("tempo-mail-bob-", vm.toString(i)));
-            if (_isRecipientAllowed(recipient)) return (recipient, privateKey);
-        }
-
-        revert("no receive-policy-safe recipient");
-    }
-
-    function _isRecipientAllowed(address recipient) internal view returns (bool) {
-        (bool ok, bytes memory data) = TIP403_REGISTRY.staticcall(
-            abi.encodeCall(ITIP403Registry.validateReceivePolicy, (address(token), ALICE, recipient))
-        );
-        if (!ok || data.length < 64) return true;
-
-        (bool authorized,) = abi.decode(data, (bool, uint8));
-        return authorized;
-    }
 }
 
 /// @notice Tests for relayed mail using the TIP-1020 SignatureVerifier precompile (requires T3+).
 contract MailRelayTest is MailTest {
     // secp256k1 keys (used by vm.sign / vm.addr)
     uint256 internal constant ALICE_PK = 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80;
+    uint256 internal constant BAD_SIGNER_PK = 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d;
 
     // P256 key (used by vm.signP256 / vm.publicKeyP256)
     uint256 internal constant CAROL_P256_PK = 0x1;
@@ -183,13 +155,13 @@ contract MailRelayTest is MailTest {
         mail.sendMail(ALICE, BOB, message, attachment, sig);
     }
 
-    /// @notice Submitting Bob's signature as Alice's fails.
+    /// @notice Submitting a different account's signature as Alice's fails.
     function test_WrongSignerReverts() public {
         Mail.Attachment memory attachment = Mail.Attachment({amount: 100, memo: "fake"});
 
         string memory message = "spoofed";
         bytes32 digest = mail.getDigest(ALICE, BOB, message, attachment);
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(BOB_PK, digest);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(BAD_SIGNER_PK, digest);
 
         vm.expectRevert("invalid signature");
         mail.sendMail(ALICE, BOB, message, attachment, abi.encodePacked(r, s, v));


### PR DESCRIPTION
## Summary
- derive the Tempo template recipient from the freshly-created token address instead of the canonical Anvil BOB address
- remove TIP403 probe/retry logic from the starter template
- use a separate bad signer key for the negative signature test now that `BOB` is token-derived

## Why this failed
The scheduled Tempo testnet CI was failing because the generated template used the canonical Anvil `BOB` address, `0x70997970C51812dc3A010C7d01b50e0d17dc79C8`, as the TIP20 recipient.

That address now has a receive policy on public Moderato. The live TIP403 registry rejects direct receipt for the freshly-created template token with `validateReceivePolicy(PATH_USD, ALICE, BOB) -> (false, 2)`, where `2` is `TOKEN_FILTER`. The transfer path succeeds, but the token is routed to the receive-policy guard instead of being credited to `BOB`, so assertions like `balanceOf(BOB) == amount` fail.

## Fix
The template now derives `BOB` during `setUp()` from the generated token address:

```solidity
BOB = address(uint160(uint256(keccak256(abi.encodePacked("tempo-mail-bob", address(token))))));
```

Because the token address is fresh for each template test setup, the recipient is not a reusable public dev address that can be preconfigured on Moderato. This keeps the starter template simple and chain-agnostic while avoiding the public-state collision.

`test_WrongSignerReverts` now signs with an unrelated `BAD_SIGNER_PK` instead of a Bob private key, since Bob is no longer derived from a fixed key.

Closes #15342
Successful run: https://github.com/foundry-rs/foundry/actions/runs/28081824800

## Tests
- `forge fmt crates/forge/assets/tempo/MailTemplate.t.sol`
- generated template direct tests on Moderato: `forge test --fork-url https://rpc.moderato.tempo.xyz --mc MailTest -vv`
- `cargo test -p forge --test cli tempo --no-fail-fast`

Prompted by: @grandizzy
