### PR TITLE
feat(debugger): show failed-test debug hint

### DIFF
--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -255,6 +255,10 @@ impl TestOutcome {
             failures,
             test_word
         )?;
+        sh_println!(
+            "Tip: Run {} to inspect one failing test in the debugger",
+            "`forge test --debug --match-test <TEST_NAME>`".cyan()
+        )?;
 
         // Print seed for fuzz/invariant test failures to enable reproduction.
         if let Some(seed) = self.fuzz_seed

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -180,6 +180,7 @@ Encountered 1 failing test in test/Structs.sol:DummyTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -404,6 +405,7 @@ Encountered 1 failing test in src/Eip712Cheat.sol:Eip712Test
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 
@@ -450,6 +452,7 @@ Encountered 1 failing test in src/Eip712Cheat.sol:Eip712Test
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -34,6 +34,7 @@ Encountered 2 failing tests in src/DeprecationTestFail.t.sol:DeprecationTestFail
 Encountered a total of 2 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -162,6 +162,7 @@ Encountered 1 failing test in test/inline.sol:Inline
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -195,6 +196,7 @@ Encountered 1 failing test in test/inline.sol:Inline
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -40,6 +40,7 @@ Encountered 1 failing test in test/FailingTestAfterFailedSetup.t.sol:FailingTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -93,6 +94,7 @@ Encountered 1 failing test in test/LegacyAssertions.t.sol:NoAssertionsRevertTest
 Encountered a total of 2 failing tests, 1 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -441,6 +443,7 @@ Encountered 1 failing test in test/PaymentFailure.t.sol:PaymentFailureTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -384,6 +384,7 @@ Encountered 1 failing test in test/Fuzz.t.sol:FuzzTest
 Encountered a total of 1 failing tests, 2 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -954,6 +955,7 @@ Ran 1 test for test/RandomFuzzTest.t.sol:RandomFuzzTest
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 ...
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -97,6 +97,7 @@ Encountered 2 failing tests in test/InvariantAfterInvariant.t.sol:InvariantAfter
 Encountered a total of 2 failing tests, 1 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -176,6 +177,7 @@ Encountered 1 failing test in test/InvariantAssume.t.sol:InvariantAssume
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -307,6 +309,7 @@ Encountered 1 failing test in test/InvariantCalldataDictionary.t.sol:InvariantCa
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -378,6 +381,7 @@ Encountered 1 failing test in test/InvariantCustomError.t.sol:InvariantCustomErr
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -545,6 +549,7 @@ Encountered 1 failing test in test/InvariantFixtures.t.sol:InvariantFixtures
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -633,6 +638,7 @@ Encountered 1 failing test in test/InvariantLiterals.t.sol:InvariantLiterals
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -707,6 +713,7 @@ Encountered 1 failing test in test/InvariantHandlerFailure.t.sol:InvariantHandle
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -792,6 +799,7 @@ Encountered 1 failing test in test/InvariantInnerContract.t.sol:InvariantInnerCo
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -901,6 +909,7 @@ Encountered 1 failing test in test/InvariantPreserveState.t.sol:InvariantPreserv
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -995,6 +1004,7 @@ Encountered 1 failing test in test/InvariantReentrancy.t.sol:InvariantReentrancy
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -1109,6 +1119,7 @@ Encountered 1 failing test in test/InvariantReentrancyEtherStore.t.sol:Invariant
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -1210,6 +1221,7 @@ Encountered 1 failing test in test/InvariantRollFork.t.sol:InvariantRollForkStat
 Encountered a total of 2 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -1311,6 +1323,7 @@ Encountered 1 failing test in test/InvariantScrapeValues.t.sol:FindFromReturnVal
 Encountered a total of 2 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -2157,6 +2170,7 @@ InvariantTest invariants: 2/2 invariants broken
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 

--- a/crates/forge/tests/cli/test_cmd/invariant/handler.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/handler.rs
@@ -157,6 +157,7 @@ Assertion Tests: 1 assertion bug(s) found
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -451,6 +452,7 @@ Assertion Tests: 2 assertion bug(s) found
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -551,6 +553,7 @@ Assertion Tests: 1 assertion bug(s) found
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -854,6 +857,7 @@ Assertion Tests: 1 assertion bug(s) found
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -426,6 +426,7 @@ Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSeque
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -454,6 +455,7 @@ Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSeque
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -481,6 +483,7 @@ Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSeque
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -2178,6 +2181,7 @@ StaleSecondaryTest invariants: 2/2 invariants broken
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 

--- a/crates/forge/tests/cli/test_cmd/invariant/storage.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/storage.rs
@@ -120,6 +120,7 @@ InvariantStorageTest invariants: 4/4 invariants broken
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 

--- a/crates/forge/tests/cli/test_cmd/invariant/target.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/target.rs
@@ -626,6 +626,7 @@ Encountered 1 failing test in test/TargetInterfaces.t.sol:TargetWorldInterfaces
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -671,6 +672,7 @@ Encountered 1 failing test in test/TargetSenders.t.sol:TargetSenders
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -718,6 +720,7 @@ Encountered 1 failing test in test/TargetArtifactSelectors2.t.sol:TargetArtifact
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -772,6 +775,7 @@ TargetArtifacts invariants: 1/2 invariants broken
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -914,6 +914,7 @@ Encountered 1 failing test in test/Contract.t.sol:CustomTypesTest
 Encountered a total of 1 failing tests, 1 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -1071,6 +1072,7 @@ Encountered 1 failing test in test/CounterFuzz.t.sol:CounterTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -1132,6 +1134,7 @@ Encountered 1 failing test in test/CounterInvariant.t.sol:CounterTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -1186,6 +1189,7 @@ Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
 Encountered a total of 2 failing tests, 2 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 
@@ -1211,6 +1215,7 @@ Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
 Encountered a total of 2 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -3540,6 +3545,7 @@ Encountered 1 failing test in test/Foo.t.sol:ContractTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -3684,6 +3690,7 @@ Encountered 1 failing test in test/SuppressTracesTest.t.sol:SuppressTracesTest
 Encountered a total of 1 failing tests, 1 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 
@@ -3747,6 +3754,7 @@ Encountered 1 failing test in test/SuppressTracesTest.t.sol:SuppressTracesTest
 Encountered a total of 1 failing tests, 1 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -4456,6 +4464,7 @@ Encountered 1 failing test in test/Counter.t.sol:CounterTest
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -4587,6 +4596,7 @@ Encountered 3 failing tests in test/NonContractCallRevertTest.t.sol:NonContractC
 Encountered a total of 3 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 3 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -4672,6 +4682,7 @@ Encountered 1 failing test in test/NonContractDelegateCallRevertTest.t.sol:NonCo
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -4868,6 +4879,7 @@ Encountered 2 failing tests in test/Counter.t.sol:CounterTest
 Encountered a total of 2 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -4956,6 +4968,7 @@ Encountered 1 failing test in test/MemoryLimit.t.sol:MemoryLimitTest
 Encountered a total of 1 failing tests, 1 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/repros.rs
+++ b/crates/forge/tests/cli/test_cmd/repros.rs
@@ -62,6 +62,7 @@ Encountered 3 failing tests in test/Issue3055.t.sol:Issue3055Test
 Encountered a total of 3 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 3 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 
@@ -118,6 +119,7 @@ Encountered 1 failing test in test/Issue3189.t.sol:Issue3189Test
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -169,6 +171,7 @@ Encountered 1 failing test in test/Issue3596.t.sol:Issue3596Test
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -267,6 +270,7 @@ Encountered 1 failing test in test/Issue6170.t.sol:Issue6170Test
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -330,6 +334,7 @@ Encountered 2 failing tests in test/Issue6355.t.sol:Issue6355Test
 Encountered a total of 2 failing tests, 1 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 2 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_engine_capabilities.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_engine_capabilities.rs
@@ -80,6 +80,7 @@ Encountered 1 failing test in test/ReentrancyDao.t.sol:ReentrancyDao
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -156,6 +157,7 @@ Encountered 1 failing test in test/TxOriginBypass.t.sol:TxOriginBypass
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -201,6 +203,7 @@ Encountered 1 failing test in test/EcrecoverBasic.t.sol:EcrecoverBasic
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_invariant.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_invariant.rs
@@ -121,6 +121,7 @@ Encountered 1 failing test in test/SymbolicRevertBranchInvariant.t.sol:SymbolicR
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -208,6 +209,7 @@ Encountered 1 failing test in test/SymbolicOverlayCodeInvariant.t.sol:SymbolicOv
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/crytic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/crytic.rs
@@ -82,6 +82,7 @@ Encountered 1 failing test in test/CryticPropertiesErc20Parity.t.sol:CryticPrope
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 [SEED] (use `--fuzz-seed` to reproduce)
 

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/devdacian.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/devdacian.rs
@@ -47,6 +47,7 @@ Encountered 1 failing test in test/DevdacianRarelyFalse.t.sol:DevdacianRarelyFal
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/echidna.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/echidna.rs
@@ -70,6 +70,7 @@ Encountered 1 failing test in test/EchidnaFlagsParity.t.sol:EchidnaFlagsParity
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -112,6 +113,7 @@ Encountered 1 failing test in test/EchidnaOverflowParity.t.sol:EchidnaOverflowPa
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/hevm.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/hevm.rs
@@ -31,6 +31,7 @@ Encountered 1 failing test in test/HevmCalldataConstraint.t.sol:HevmCalldataCons
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/ityfuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/ityfuzz.rs
@@ -67,6 +67,7 @@ Encountered 1 failing test in test/IfFuzzSimpleStateBuggy.t.sol:IfFuzzSimpleStat
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/manticore.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/manticore.rs
@@ -55,6 +55,7 @@ Encountered 1 failing test in test/ManticoreMultiTx.t.sol:ManticoreMultiTx
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/medusa.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/medusa.rs
@@ -36,6 +36,7 @@ Encountered 1 failing test in test/MedusaAssertionParity.t.sol:MedusaAssertionPa
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/openzeppelin.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/openzeppelin.rs
@@ -68,6 +68,7 @@ Encountered 1 failing test in test/Erc4626Inflation.t.sol:Erc4626Inflation
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });
@@ -151,6 +152,7 @@ Encountered 1 failing test in test/Erc20ApproveRace.t.sol:Erc20ApproveRace
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/scribble.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/scribble.rs
@@ -44,6 +44,7 @@ Encountered 1 failing test in test/ScribbleInstrumentedSupply.t.sol:ScribbleInst
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_parity/swc.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_parity/swc.rs
@@ -37,6 +37,7 @@ Encountered 1 failing test in test/SwcUncheckedCall.t.sol:SwcUncheckedCallTarget
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic_storage.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_storage.rs
@@ -473,6 +473,7 @@ Encountered 1 failing test in test/SymbolicSLoadUnwrittenMapping.t.sol:SymbolicS
 Encountered a total of 1 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/table.rs
+++ b/crates/forge/tests/cli/test_cmd/table.rs
@@ -123,6 +123,7 @@ Encountered 6 failing tests in test/CounterTable.t.sol:CounterTableTest
 Encountered a total of 6 failing tests, 2 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 6 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
 });

--- a/crates/forge/tests/fixtures/invariant_traces.svg
+++ b/crates/forge/tests/fixtures/invariant_traces.svg
@@ -1,4 +1,4 @@
-<svg width="2322px" height="524px" xmlns="http://www.w3.org/2000/svg">
+<svg width="2322px" height="542px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -71,11 +71,13 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan>Tip: Run </tspan><tspan class="fg-cyan">`forge test --rerun`</tspan><tspan> to retry only the 1 failed test</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>Tip: Run </tspan><tspan class="fg-cyan">`forge test --debug --match-test &lt;TEST_NAME&gt;`</tspan><tspan> to inspect one failing test in the debugger</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>Fuzz seed: </tspan><tspan class="fg-cyan">0x64</tspan><tspan> (use </tspan><tspan class="fg-cyan">`--fuzz-seed`</tspan><tspan> to reproduce)</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px">
+    <tspan x="10px" y="514px"><tspan>Fuzz seed: </tspan><tspan class="fg-cyan">0x64</tspan><tspan> (use </tspan><tspan class="fg-cyan">`--fuzz-seed`</tspan><tspan> to reproduce)</tspan>
+</tspan>
+    <tspan x="10px" y="532px">
 </tspan>
   </text>
 


### PR DESCRIPTION
## Summary

- Add a debugger tip to the human-readable failing test summary after the existing `forge test --rerun` hint.
- Point users at `forge test --debug --match-test <TEST_NAME>` when they want to inspect one failing test interactively.
- Update CLI output snapshots for the new failure-summary line.

Progresses #927.