### PR TITLE
fix(foundryup): resolve nightly via releases Atom feed to avoid API rate limit

### DIFF
--- a/foundryup/foundryup
+++ b/foundryup/foundryup
@@ -7,7 +7,7 @@ set -eo pipefail
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-FOUNDRYUP_INSTALLER_VERSION="1.8.6"
+FOUNDRYUP_INSTALLER_VERSION="1.8.7"
 
 BASE_DIR=${XDG_CONFIG_HOME:-$HOME}
 FOUNDRY_DIR=${FOUNDRY_DIR:-"$BASE_DIR/.foundry"}
@@ -691,21 +691,29 @@ resolve_version_and_tag() {
     say "resolved release tag: ${FOUNDRYUP_TAG}"
     FOUNDRYUP_VERSION="$FOUNDRYUP_TAG"
   elif [[ "$FOUNDRYUP_VERSION" == "nightly" ]]; then
-    # Resolve to the latest nightly (prerelease) release via the GitHub API.
-    # The GitHub API does not guarantee that releases are returned in
-    # chronological order, so we collect all matching nightlies along with
-    # their `published_at` timestamps and sort them ourselves.
-    say "fetching latest nightly release tags from ${FOUNDRYUP_REPO}..."
-    FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases" | awk '
-      /"tag_name"[[:space:]]*:/ { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); tag=$0 }
-      /"published_at"[[:space:]]*:[[:space:]]*"/ {
-        pub=$0
-        gsub(/.*"published_at"[[:space:]]*:[[:space:]]*"/, "", pub)
-        gsub(/".*/, "", pub)
-        if (tag ~ /^nightly-/) print pub "\t" tag
-        tag=""
-      }
-    ' | sort -r | awk -F '\t' 'NR==1 { print $2 }') || err "failed to fetch release tags from GitHub API"
+    # Nightlies are published as immutable `nightly-<sha>` releases. Resolve the
+    # most recent one from GitHub's public releases Atom feed, which lists
+    # releases newest-first, works unauthenticated, and is not subject to the
+    # `api.github.com` REST rate limit (60 req/hr per IP). Shared CI IPs exhaust
+    # that limit and fail with HTTP 403. Falls back to the API only when the
+    # feed cannot be parsed.
+    say "fetching latest nightly release tag from ${FOUNDRYUP_REPO}..."
+    FOUNDRYUP_TAG=$(resolve_nightly_tag_via_feed "$FOUNDRYUP_REPO")
+    if [ -z "$FOUNDRYUP_TAG" ]; then
+      # The GitHub API does not guarantee that releases are returned in
+      # chronological order, so we collect all matching nightlies along with
+      # their `published_at` timestamps and sort them ourselves.
+      FOUNDRYUP_TAG=$(fetch "https://api.github.com/repos/${FOUNDRYUP_REPO}/releases" | awk '
+        /"tag_name"[[:space:]]*:/ { gsub(/.*"tag_name"[[:space:]]*:[[:space:]]*"/, ""); gsub(/".*/, ""); tag=$0 }
+        /"published_at"[[:space:]]*:[[:space:]]*"/ {
+          pub=$0
+          gsub(/.*"published_at"[[:space:]]*:[[:space:]]*"/, "", pub)
+          gsub(/".*/, "", pub)
+          if (tag ~ /^nightly-/) print pub "\t" tag
+          tag=""
+        }
+      ' | sort -r | awk -F '\t' 'NR==1 { print $2 }') || err "failed to fetch release tags from GitHub API"
+    fi
     if [ -z "$FOUNDRYUP_TAG" ]; then
       err "could not find a nightly release tag for ${FOUNDRYUP_REPO}"
     fi
@@ -750,6 +758,38 @@ resolve_latest_tag_via_redirect() {
   case "$_tag" in
     *[!A-Za-z0-9._-]*) return 0 ;;
     v[0-9]*) printf '%s\n' "$_tag" ;;
+    *) return 0 ;;
+  esac
+}
+
+# Resolves the latest nightly tag for repo $1 from GitHub's public releases
+# Atom feed (`releases.atom`), which lists releases newest-first, works
+# unauthenticated, and is not subject to the api.github.com REST rate limit.
+# Prints `nightly-<sha>` for the most recent nightly, or nothing if it cannot
+# be resolved so the caller can fall back to the API.
+resolve_nightly_tag_via_feed() {
+  local _repo="$1"
+  local _url="https://github.com/${_repo}/releases.atom"
+  local _feed=""
+  if check_cmd curl; then
+    _feed=$(curl -fsSL \
+      --retry "$FOUNDRYUP_MAX_RETRIES" \
+      --retry-delay "$FOUNDRYUP_RETRY_DELAY" \
+      --retry-max-time "$FOUNDRYUP_RETRY_MAX_TIME" \
+      --retry-all-errors \
+      "$_url" 2>/dev/null) || return 0
+  else
+    _feed=$(wget --tries="$FOUNDRYUP_MAX_RETRIES" \
+      --waitretry="$FOUNDRYUP_RETRY_DELAY" \
+      --retry-on-http-error=403,408,429,500,502,503,504 \
+      -qO- "$_url" 2>/dev/null) || return 0
+  fi
+  # The feed is newest-first, so the first `nightly-<40-hex-sha>` reference is
+  # the most recent nightly release. Validate the SHA before returning it.
+  local _tag=""
+  _tag=$(printf '%s\n' "$_feed" | grep -oE 'nightly-[0-9a-f]{40}' | head -n1) || return 0
+  case "$_tag" in
+    nightly-*) printf '%s\n' "$_tag" ;;
     *) return 0 ;;
   esac
 }

--- a/foundryup/test.sh
+++ b/foundryup/test.sh
@@ -50,9 +50,41 @@ curl() { printf 'https://github.com/foundry-rs/foundry/releases/tag/not-a-versio
 check_eq "redirect with non-version tag returns empty" \
   "" "$(resolve_latest_tag_via_redirect foundry-rs/foundry)"
 
+# --- resolve_nightly_tag_via_feed ----------------------------------------
+
+NIGHTLY_SHA="bc3b7f1e90bb7a30903d7d1ae2c532e4fba5679d"
+OLDER_SHA="55210f8c412eac24e9318341efab1e27c5b03822"
+# Minimal Atom feed: newest nightly first, then an older one and a stable tag.
+FEED="<feed>
+  <entry><link href=\"https://github.com/foundry-rs/foundry/releases/tag/nightly-$NIGHTLY_SHA\"/></entry>
+  <entry><link href=\"https://github.com/foundry-rs/foundry/releases/tag/nightly-$OLDER_SHA\"/></entry>
+  <entry><link href=\"https://github.com/foundry-rs/foundry/releases/tag/v1.7.1\"/></entry>
+</feed>"
+
+curl() { printf '%s' "$FEED"; }
+check_eq "nightly feed returns newest nightly-<sha>" \
+  "nightly-$NIGHTLY_SHA" "$(resolve_nightly_tag_via_feed foundry-rs/foundry)"
+
+curl() { printf '<feed><entry><link href="https://github.com/foundry-rs/foundry/releases/tag/v1.7.1"/></entry></feed>'; }
+check_eq "nightly feed without nightly entry returns empty" \
+  "" "$(resolve_nightly_tag_via_feed foundry-rs/foundry)"
+
+curl() { return 1; }
+check_eq "nightly feed fetch failure returns empty" \
+  "" "$(resolve_nightly_tag_via_feed foundry-rs/foundry)"
+
 # --- resolve_version_and_tag (redirect + API fallback) --------------------
 
 API_JSON='{"tag_name": "v9.9.9", "name": "v9.9.9"}'
+# Minimal `releases` listing used for the nightly API fallback path. The awk
+# parser is line-oriented (it mirrors the real multi-line api.github.com JSON),
+# so `tag_name` and `published_at` must be on separate lines.
+NIGHTLY_API_JSON='[
+  {
+    "tag_name": "nightly-deadbeef",
+    "published_at": "2026-01-01T00:00:00Z"
+  }
+]'
 
 # `fetch` runs in a command-substitution subshell, so track calls via a file.
 api_marker="$(mktemp)"
@@ -72,6 +104,21 @@ FOUNDRYUP_VERSION="latest"
 resolve_version_and_tag
 check_eq "latest falls back to API tag" "v9.9.9" "$FOUNDRYUP_TAG"
 check_eq "latest calls API when redirect fails" "1" "$(wc -l < "$api_marker" | tr -d ' ')"
+
+: > "$api_marker"
+curl() { printf '%s' "$FEED"; }
+FOUNDRYUP_VERSION="nightly"
+resolve_version_and_tag
+check_eq "nightly resolves to nightly-<sha> via feed" "nightly-$NIGHTLY_SHA" "$FOUNDRYUP_TAG"
+check_eq "nightly does not call API when feed works" "0" "$(wc -l < "$api_marker" | tr -d ' ')"
+
+: > "$api_marker"
+curl() { return 1; }
+fetch() { echo called >> "$api_marker"; printf '%s' "$NIGHTLY_API_JSON"; }
+FOUNDRYUP_VERSION="nightly"
+resolve_version_and_tag
+check_eq "nightly falls back to API tag" "nightly-deadbeef" "$FOUNDRYUP_TAG"
+check_eq "nightly calls API when feed fails" "1" "$(wc -l < "$api_marker" | tr -d ' ')"
 
 # --- summary --------------------------------------------------------------
 


### PR DESCRIPTION
## Motivation

`foundryup --install nightly` resolves the tag by hitting `api.github.com/repos/<repo>/releases`, which is rate limited to **60 req/hr per IP** for unauthenticated requests. Shared CI IPs exhaust this and fail with:

```
foundryup: fetching latest nightly release tags from foundry-rs/foundry...
curl: (22) The requested URL returned error: 403
foundryup: failed to fetch release tags from GitHub API
```

#15148 fixed this for `latest`/`stable` via the `releases/latest` web redirect, but left the `nightly` path on the REST API, so nightly installs still 403 on busy CI runners. (Closes the same class of issue as #14836, for nightly.)

## Solution

Resolve the most recent `nightly-<sha>` release from GitHub's public **releases Atom feed** (`https://github.com/<repo>/releases.atom`):

- lists releases **newest-first**, so the first `nightly-<40-hex-sha>` entry is the latest nightly
- works **unauthenticated** and is **not** subject to the `api.github.com` REST rate limit (same risk profile as the #15148 redirect)
- resolves to the **immutable** `nightly-<sha>` tag, preserving the per-commit version directory the rest of foundryup expects
- falls back to the existing REST API path only when the feed cannot be parsed

The rolling `nightly` tag is intentionally **not** used: it can lag behind the latest nightly (it currently points at an April build while newer nightlies exist), so relying on it would install a stale toolchain.

`latest`/`stable` are deliberately left on the `releases/latest` redirect: that endpoint excludes prereleases (so it can't return a nightly) and honors the maintainer-designated "Latest" release, which is the correct semantic for stable.

## Testing

- `foundryup/test.sh` extended with mocked coverage for `resolve_nightly_tag_via_feed` and the feed→API fallback (no network). All pass; `shellcheck` clean.
- Verified end-to-end with `GITHUB_TOKEN`/`GH_TOKEN` unset: `foundryup --install nightly` resolves `nightly-bc3b7f1e90bb7a30903d7d1ae2c532e4fba5679d` (latest), passes attestation verification, installs into `versions/nightly-<sha>`, and makes **zero** `api.github.com` calls.