### PR TITLE
feat(create): pass license type to verification

### DIFF
--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -89,7 +89,8 @@ pub struct CreateArgs {
     #[arg(long, requires = "verify")]
     show_standard_json_input: bool,
 
-    /// The Etherscan license type code or SPDX identifier to include with the verification request.
+    /// The Etherscan license type code or SPDX identifier to include with the verification
+    /// request.
     ///
     /// Accepts either an Etherscan numeric license code or a common SPDX identifier such as `MIT`.
     /// This is only used for Etherscan-style verifiers when `--verify` is enabled.

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -89,6 +89,13 @@ pub struct CreateArgs {
     #[arg(long, requires = "verify")]
     show_standard_json_input: bool,
 
+    /// The Etherscan license type code to include with the verification request.
+    ///
+    /// See Etherscan's supported `licenseType` values. This is only used for Etherscan-style
+    /// verifiers when `--verify` is enabled.
+    #[arg(long, requires = "verify", value_name = "CODE", help_heading = "Verifier options")]
+    license_type: Option<String>,
+
     /// Timeout to use for broadcasting transactions.
     #[arg(long, env = "ETH_TIMEOUT")]
     pub timeout: Option<u64>,
@@ -356,7 +363,7 @@ impl CreateArgs {
             root: None,
             verifier: self.verifier.clone(),
             via_ir: self.build.via_ir,
-            license_type: None,
+            license_type: self.license_type.clone(),
             evm_version: self.build.compiler.evm_version,
             show_standard_json_input: self.show_standard_json_input,
             guess_constructor_args: false,
@@ -697,7 +704,7 @@ impl CreateArgs {
             root: None,
             verifier: self.verifier,
             via_ir: self.build.via_ir,
-            license_type: None,
+            license_type: self.license_type,
             evm_version: self.build.compiler.evm_version,
             show_standard_json_input: self.show_standard_json_input,
             guess_constructor_args: false,
@@ -920,9 +927,12 @@ mod tests {
             "10",
             "--delay",
             "30",
+            "--license-type",
+            "13",
         ]);
         assert_eq!(args.retry.retries, 10);
         assert_eq!(args.retry.delay, 30);
+        assert_eq!(args.license_type.as_deref(), Some("13"));
     }
     #[test]
     fn can_parse_chain_id() {

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -10,7 +10,7 @@ use alloy_signer::{Signature, Signer};
 use alloy_transport::TransportError;
 use clap::{Parser, ValueHint};
 use eyre::{Context, ContextCompat, Result};
-use forge_verify::{RetryArgs, VerifierArgs, VerifyArgs};
+use forge_verify::{RetryArgs, VerifierArgs, VerifyArgs, parse_etherscan_license_type};
 use foundry_cli::{
     opts::{BuildOpts, EthereumOpts, EtherscanOpts, TransactionOpts},
     utils::{
@@ -89,11 +89,17 @@ pub struct CreateArgs {
     #[arg(long, requires = "verify")]
     show_standard_json_input: bool,
 
-    /// The Etherscan license type code to include with the verification request.
+    /// The Etherscan license type code or SPDX identifier to include with the verification request.
     ///
-    /// See Etherscan's supported `licenseType` values. This is only used for Etherscan-style
-    /// verifiers when `--verify` is enabled.
-    #[arg(long, requires = "verify", value_name = "CODE", help_heading = "Verifier options")]
+    /// Accepts either an Etherscan numeric license code or a common SPDX identifier such as `MIT`.
+    /// This is only used for Etherscan-style verifiers when `--verify` is enabled.
+    #[arg(
+        long,
+        requires = "verify",
+        value_name = "LICENSE",
+        help_heading = "Verifier options",
+        value_parser = parse_etherscan_license_type,
+    )]
     license_type: Option<String>,
 
     /// Timeout to use for broadcasting transactions.
@@ -934,6 +940,32 @@ mod tests {
         assert_eq!(args.retry.delay, 30);
         assert_eq!(args.license_type.as_deref(), Some("13"));
     }
+
+    #[test]
+    fn can_parse_create_license_type_spdx() {
+        let args: CreateArgs = CreateArgs::parse_from([
+            "foundry-cli",
+            "src/Domains.sol:Domains",
+            "--verify",
+            "--license-type",
+            "MIT",
+        ]);
+        assert_eq!(args.license_type.as_deref(), Some("3"));
+    }
+
+    #[test]
+    fn errors_on_invalid_create_license_type() {
+        let err = CreateArgs::try_parse_from([
+            "foundry-cli",
+            "src/Domains.sol:Domains",
+            "--verify",
+            "--license-type",
+            "definitely-not-a-license",
+        ])
+        .unwrap_err();
+        assert!(err.to_string().contains("unsupported Etherscan license type"));
+    }
+
     #[test]
     fn can_parse_chain_id() {
         let args: CreateArgs = CreateArgs::parse_from([

--- a/crates/verify/src/lib.rs
+++ b/crates/verify/src/lib.rs
@@ -22,7 +22,7 @@ pub use retry::RetryArgs;
 pub mod sourcify;
 
 pub mod verify;
-pub use verify::{VerifierArgs, VerifyArgs, VerifyCheckArgs};
+pub use verify::{VerifierArgs, VerifyArgs, VerifyCheckArgs, parse_etherscan_license_type};
 
 mod types;
 

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -431,7 +431,7 @@ pub struct VerifyArgs {
     pub language: Option<ContractLanguage>,
 }
 
-fn parse_etherscan_license_type(value: &str) -> Result<String, String> {
+pub fn parse_etherscan_license_type(value: &str) -> Result<String, String> {
     let value = value.trim();
     if value.is_empty() {
         return Err("license type cannot be empty".into());


### PR DESCRIPTION
## Motivation

Follow-up to #14975. `forge verify-contract` can now pass an Etherscan `licenseType`, but the one-step `forge create --verify` path still built `VerifyArgs` with `license_type: None` in both verification call sites.

That means users who deploy and verify in one command cannot include the same license metadata unless they split the flow and call `forge verify-contract` manually afterward.

This intentionally does not overlap with #15162's SPDX parsing and validation work. This PR only forwards the raw Etherscan code through the existing create-and-verify path.

Refs #14475.

## Solution

- Add `--license-type <CODE>` to `forge create`, gated behind `--verify`.
- Pass the value into the preflight verification request.
- Pass the same value into the final verification request after deployment.
- Extend the existing `can_parse_create` parser test so the flag is covered without adding a broader integration fixture.

## Validation

- `cargo +nightly fmt --check`
- `git diff --check`
- `git diff --cached --check`
- `cargo test -p forge can_parse_create`
- `cargo check -p forge`

## AI assistance disclosure

I used ChatGPT/Codex to inspect the related issue/PR history, prepare the patch, and run local validation.
