### PR TITLE
chore: fix `large_stack_frames` clippy warning in `run_script`

### DIFF
--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -347,30 +347,39 @@ impl ScriptArgs {
             eyre::bail!("--tempo.session/TEMPO_SESSION_ID cannot be combined with --unlocked");
         }
 
+        // Box each branch's future to keep its large async state off `run_script`'s future;
+        // otherwise `run_command` trips `clippy::large_stack_frames` by a small margin.
         if is_tempo {
             let batch = self.batch;
-            let bundled = match self.prepare_bundled::<TempoEvmNetwork>(config, evm_opts).await? {
-                Some(bundled) => bundled,
-                None => return Ok(()),
-            };
-            // batch mode owns its own pending recovery inside broadcast_batch(); running the
-            // generic wait_for_pending() first would race with that and could double-process
-            // an already-confirmed batch hash.
-            let bundled = if batch { bundled } else { bundled.wait_for_pending().await? };
-            let broadcasted =
-                if batch { bundled.broadcast_batch().await? } else { bundled.broadcast().await? };
-            if broadcasted.args.verify {
-                broadcasted.verify().await?;
-            }
-            return Ok(());
+            return Box::pin(async move {
+                let bundled =
+                    match self.prepare_bundled::<TempoEvmNetwork>(config, evm_opts).await? {
+                        Some(bundled) => bundled,
+                        None => return Ok(()),
+                    };
+                // batch mode owns its own pending recovery inside broadcast_batch(); running the
+                // generic wait_for_pending() first would race with that and could double-process
+                // an already-confirmed batch hash.
+                let bundled = if batch { bundled } else { bundled.wait_for_pending().await? };
+                let broadcasted = if batch {
+                    bundled.broadcast_batch().await?
+                } else {
+                    bundled.broadcast().await?
+                };
+                if broadcasted.args.verify {
+                    broadcasted.verify().await?;
+                }
+                Ok(())
+            })
+            .await;
         }
 
         #[cfg(feature = "optimism")]
         if evm_opts.networks.is_optimism() {
-            return self.run_generic_script::<OpEvmNetwork>(config, evm_opts).await;
+            return Box::pin(self.run_generic_script::<OpEvmNetwork>(config, evm_opts)).await;
         }
 
-        self.run_generic_script::<EthEvmNetwork>(config, evm_opts).await
+        Box::pin(self.run_generic_script::<EthEvmNetwork>(config, evm_opts)).await
     }
 
     /// Prepares the bundled state (compile, simulate, bundle) and returns it


### PR DESCRIPTION
Box per-branch futures in `run_script` to keep large async state off `run_command`'s frame, fixing `clippy::large_stack_frames`.