### PR TITLE
fix(cast): reject unclaimable receive-policy recovery authorities

### DIFF
--- a/crates/cast/src/cmd/receive_policy.rs
+++ b/crates/cast/src/cmd/receive_policy.rs
@@ -193,6 +193,12 @@ async fn set(
     send_tx: SendTxOpts,
     tx: TxParams,
 ) -> Result<()> {
+    // Reject authorities that can never satisfy `ReceivePolicyGuard.claim()` before doing
+    // anything else; `--force` only suppresses the softer originator-recovery warning below.
+    if let Some(message) = invalid_recovery_authority_message(recovery_authority) {
+        eyre::bail!("{message}");
+    }
+
     let warning = if force {
         None
     } else {
@@ -473,6 +479,32 @@ async fn recovery_warning(
         blocked.len(),
         blocked.iter().map(Address::to_string).collect::<Vec<_>>().join(", ")
     )))
+}
+
+/// Returns an error message when `recovery_authority` could never pass
+/// `ReceivePolicyGuard.claim()` and would leave held receipts unclaimable.
+///
+/// `address(0)` is the originator-recovery sentinel and a receiver's own address is valid
+/// (receiver recovery), so those pass. Virtual and TIP-20 addresses are always rejected. Fixed
+/// system precompiles are rejected conservatively against the full known list (a superset of the
+/// registry's spec-aware check), since a not-yet-active precompile is never a sound authority and
+/// becomes unclaimable once it activates.
+fn invalid_recovery_authority_message(recovery_authority: Address) -> Option<String> {
+    if recovery_authority == Address::ZERO {
+        return None;
+    }
+    if recovery_authority.is_virtual() {
+        return Some("recovery authority cannot be a TIP-1022 virtual address".to_string());
+    }
+    if recovery_authority.is_tip20() {
+        return Some("recovery authority cannot be a TIP-20 token address".to_string());
+    }
+    if TEMPO_PRECOMPILE_ADDRESSES.contains(&recovery_authority) {
+        return Some(format!(
+            "recovery authority cannot be a fixed Tempo system precompile: {recovery_authority}"
+        ));
+    }
+    None
 }
 
 fn decode_claim_receipt(receipt: &Bytes) -> Result<IReceivePolicyGuard::ClaimReceiptV1> {
@@ -798,6 +830,38 @@ mod tests {
         assert_eq!(payload["recovery_mode"], "originator");
         assert_eq!(payload["recipient_is_virtual"], true);
         assert_eq!(payload["claim_target"], Value::Null);
+    }
+
+    #[test]
+    fn rejects_unclaimable_recovery_authorities() {
+        // Originator recovery and a plain EOA authority are valid.
+        assert_eq!(invalid_recovery_authority_message(Address::ZERO), None);
+        assert_eq!(
+            invalid_recovery_authority_message(address!(
+                "1111111111111111111111111111111111111111"
+            )),
+            None
+        );
+
+        // Every fixed Tempo system precompile is unclaimable.
+        for authority in TEMPO_PRECOMPILE_ADDRESSES {
+            let err = invalid_recovery_authority_message(*authority).unwrap();
+            assert!(err.contains("fixed Tempo system precompile"));
+        }
+
+        // TIP-20 token and TIP-1022 virtual addresses are unclaimable too.
+        let err = invalid_recovery_authority_message(address!(
+            "20c0000000000000000000000000000000000001"
+        ))
+        .unwrap();
+        assert!(err.contains("TIP-20 token address"));
+
+        let virtual_address = Address::new_virtual(
+            MasterId::from([0x12, 0x34, 0x56, 0x78]),
+            UserTag::from([0xab, 0xcd, 0xef, 0x01, 0x23, 0x45]),
+        );
+        let err = invalid_recovery_authority_message(virtual_address).unwrap();
+        assert!(err.contains("TIP-1022 virtual address"));
     }
 
     #[test]

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -19,8 +19,9 @@ use std::collections::BTreeMap;
 use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, NONCE_PRECOMPILE_ADDRESS,
     RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS,
-    TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS,
-    TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
+    STORAGE_CREDITS_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS,
+    TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
+    VALIDATOR_CONFIG_V2_ADDRESS,
 };
 
 pub mod celo;
@@ -41,6 +42,7 @@ const TEMPO_PRECOMPILES: &[(&str, Address)] = &[
     ("AddressRegistry", ADDRESS_REGISTRY_ADDRESS),
     ("TIP20ChannelReserve", TIP20_CHANNEL_RESERVE_ADDRESS),
     ("ReceivePolicyGuard", RECEIVE_POLICY_GUARD_ADDRESS),
+    ("StorageCredits", STORAGE_CREDITS_ADDRESS),
 ];
 
 /// All well-known Tempo precompile addresses.
@@ -57,6 +59,7 @@ pub const TEMPO_PRECOMPILE_ADDRESSES: &[Address] = &[
     ADDRESS_REGISTRY_ADDRESS,
     TIP20_CHANNEL_RESERVE_ADDRESS,
     RECEIVE_POLICY_GUARD_ADDRESS,
+    STORAGE_CREDITS_ADDRESS,
 ];
 
 /// Returns whether a well-known Tempo precompile address is active at `hardfork`.
@@ -65,6 +68,8 @@ pub fn is_tempo_precompile_active_at(address: Address, hardfork: TempoHardfork) 
         hardfork.is_t5()
     } else if address == RECEIVE_POLICY_GUARD_ADDRESS {
         hardfork.is_t6()
+    } else if address == STORAGE_CREDITS_ADDRESS {
+        hardfork.is_t7()
     } else if address == ADDRESS_REGISTRY_ADDRESS || address == SIGNATURE_VERIFIER_ADDRESS {
         hardfork.is_t3()
     } else {
@@ -431,6 +436,18 @@ mod tests {
             cfg.precompiles_label(Some(TempoHardfork::T6))
                 .contains_key(&RECEIVE_POLICY_GUARD_ADDRESS)
         );
+    }
+
+    #[test]
+    fn storage_credits_precompile_activates_at_t7() {
+        assert!(!is_tempo_precompile_active_at(STORAGE_CREDITS_ADDRESS, TempoHardfork::T6));
+        assert!(is_tempo_precompile_active_at(STORAGE_CREDITS_ADDRESS, TempoHardfork::T7));
+        assert!(TEMPO_PRECOMPILE_ADDRESSES.contains(&STORAGE_CREDITS_ADDRESS));
+
+        // The hardfork-filtered precompile map must honor the same T7 activation.
+        let cfg = NetworkConfigs { network: Some(NetworkVariant::Tempo), ..Default::default() };
+        assert!(!cfg.precompiles(Some(TempoHardfork::T6)).contains_key("StorageCredits"));
+        assert!(cfg.precompiles(Some(TempoHardfork::T7)).contains_key("StorageCredits"));
     }
 
     // --- resolved() / active_network_name ---


### PR DESCRIPTION
`cast receive-policy set` now rejects recovery authorities that can never pass `ReceivePolicyGuard.claim()` (TIP-1022 virtual, TIP-20, and fixed system precompile addresses), so held TIP-1028 funds can't be stranded. Mirrors the protocol's onchain check (tempo v1.9.0). Also adds the T7 `StorageCredits` precompile to Foundry's Tempo precompile list.

Part of OSS-450