### PR TITLE
feat(corpus): add low-weight crossover mutators

### DIFF
--- a/.changelog/corpus-crossover-mutators.md
+++ b/.changelog/corpus-crossover-mutators.md
@@ -1,0 +1,6 @@
+---
+forge: minor
+foundry-config: minor
+foundry-evm-fuzz: minor
+---
+Add configurable crossover insertion and replacement mutations for invariant corpus sequences.

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -270,6 +270,10 @@ pub struct FuzzCorpusMutationWeights {
     pub mutation_weight_abi: u32,
     /// Weight for comparison-operand guided argument mutation.
     pub mutation_weight_cmp: u32,
+    /// Weight for inserting a transaction loaded from the persisted corpus.
+    pub mutation_weight_crossover_insert: u32,
+    /// Weight for replacing a transaction with one loaded from the persisted corpus.
+    pub mutation_weight_crossover_replace: u32,
 }
 
 impl FuzzCorpusMutationWeights {
@@ -281,6 +285,8 @@ impl FuzzCorpusMutationWeights {
             + self.mutation_weight_suffix as u64
             + self.mutation_weight_abi as u64
             + self.mutation_weight_cmp as u64
+            + self.mutation_weight_crossover_insert as u64
+            + self.mutation_weight_crossover_replace as u64
     }
 
     /// Returns defaults if every configured weight is zero.
@@ -292,13 +298,15 @@ impl FuzzCorpusMutationWeights {
 impl Default for FuzzCorpusMutationWeights {
     fn default() -> Self {
         Self {
-            mutation_weight_splice: 1,
-            mutation_weight_repeat: 1,
-            mutation_weight_interleave: 1,
-            mutation_weight_prefix: 1,
-            mutation_weight_suffix: 1,
-            mutation_weight_abi: 1,
-            mutation_weight_cmp: 1,
+            mutation_weight_splice: 4,
+            mutation_weight_repeat: 4,
+            mutation_weight_interleave: 4,
+            mutation_weight_prefix: 4,
+            mutation_weight_suffix: 4,
+            mutation_weight_abi: 4,
+            mutation_weight_cmp: 4,
+            mutation_weight_crossover_insert: 1,
+            mutation_weight_crossover_replace: 1,
         }
     }
 }

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -272,6 +272,10 @@ pub struct FuzzCorpusMutationWeights {
     pub mutation_weight_abi: u32,
     /// Weight for comparison-operand guided argument mutation.
     pub mutation_weight_cmp: u32,
+    /// Weight for inserting a transaction selected from the corpus.
+    pub mutation_weight_crossover_insert: u32,
+    /// Weight for replacing a transaction with one selected from the corpus.
+    pub mutation_weight_crossover_replace: u32,
 }
 
 impl FuzzCorpusMutationWeights {
@@ -283,6 +287,8 @@ impl FuzzCorpusMutationWeights {
             + self.mutation_weight_suffix as u64
             + self.mutation_weight_abi as u64
             + self.mutation_weight_cmp as u64
+            + self.mutation_weight_crossover_insert as u64
+            + self.mutation_weight_crossover_replace as u64
     }
 
     /// Returns defaults if every configured weight is zero.
@@ -294,13 +300,15 @@ impl FuzzCorpusMutationWeights {
 impl Default for FuzzCorpusMutationWeights {
     fn default() -> Self {
         Self {
-            mutation_weight_splice: 1,
-            mutation_weight_repeat: 1,
-            mutation_weight_interleave: 1,
-            mutation_weight_prefix: 1,
-            mutation_weight_suffix: 1,
-            mutation_weight_abi: 1,
-            mutation_weight_cmp: 1,
+            mutation_weight_splice: 4,
+            mutation_weight_repeat: 4,
+            mutation_weight_interleave: 4,
+            mutation_weight_prefix: 4,
+            mutation_weight_suffix: 4,
+            mutation_weight_abi: 4,
+            mutation_weight_cmp: 4,
+            mutation_weight_crossover_insert: 1,
+            mutation_weight_crossover_replace: 1,
         }
     }
 }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -101,7 +101,9 @@ fn weighted_mutation_type(rng: &mut impl Rng, distribution: &WeightedIndex<u32>)
         4 => MutationType::Suffix,
         5 => MutationType::Abi,
         6 => MutationType::Cmp,
-        _ => unreachable!("mutation distribution only has seven entries"),
+        7 => MutationType::CrossoverInsert,
+        8 => MutationType::CrossoverReplace,
+        _ => unreachable!("mutation distribution only has nine entries"),
     }
 }
 
@@ -138,6 +140,10 @@ enum MutationType {
     /// Replace input bytes using comparison operands observed for a corpus entry
     /// (input-to-state, LibAFL-style).
     Cmp,
+    /// Insert a transaction loaded from the persisted corpus into this sequence.
+    CrossoverInsert,
+    /// Replace a transaction in this sequence with one loaded from the persisted corpus.
+    CrossoverReplace,
 }
 
 /// Persisted optimization state: the best value found and the sequence that produced it.
@@ -849,6 +855,8 @@ impl WorkerCorpus {
             mutation_weights.mutation_weight_suffix,
             mutation_weights.mutation_weight_abi,
             mutation_weights.mutation_weight_cmp,
+            mutation_weights.mutation_weight_crossover_insert,
+            mutation_weights.mutation_weight_crossover_replace,
         ])
         .map_err(|err| eyre!("invalid corpus mutation weights: {err}"))?;
         let arg_mutation_distribution = if mutation_weights.mutation_weight_abi == 0
@@ -1294,6 +1302,38 @@ impl WorkerCorpus {
                         }
                     }
                 }
+                MutationType::CrossoverInsert => {
+                    let (corpus_index, corpus) = if rng.random::<bool>() {
+                        (primary_index, primary)
+                    } else {
+                        (secondary_index, secondary)
+                    };
+                    trace!(target: "corpus", "crossover insert into {}", corpus.uuid);
+
+                    self.current_mutated_index = Some(corpus_index);
+
+                    new_seq = corpus.tx_seq.clone();
+                    if let Some(tx) = self.load_random_disk_tx(rng) {
+                        let idx = rng.random_range(0..=new_seq.len());
+                        new_seq.insert(idx, tx);
+                    }
+                }
+                MutationType::CrossoverReplace => {
+                    let (corpus_index, corpus) = if rng.random::<bool>() {
+                        (primary_index, primary)
+                    } else {
+                        (secondary_index, secondary)
+                    };
+                    trace!(target: "corpus", "crossover replace in {}", corpus.uuid);
+
+                    self.current_mutated_index = Some(corpus_index);
+
+                    new_seq = corpus.tx_seq.clone();
+                    if let Some(tx) = self.load_random_disk_tx(rng) {
+                        let idx = rng.random_range(0..new_seq.len());
+                        new_seq[idx] = tx;
+                    }
+                }
             }
         }
 
@@ -1374,6 +1414,36 @@ impl WorkerCorpus {
             .new_tree(test_runner)
             .map_err(|_| eyre!("Could not generate case"))?
             .current())
+    }
+
+    fn load_random_disk_tx(&self, rng: &mut impl Rng) -> Option<BasicTxDetails> {
+        let worker_dir = self.worker_dir.as_ref()?;
+        let corpus_dir = worker_dir.join(CORPUS_DIR);
+        let entries: Vec<CorpusDirEntry> = read_corpus_dir(&corpus_dir).collect();
+        if entries.is_empty() {
+            return None;
+        }
+
+        let entry_idx = rng.random_range(0..entries.len());
+        let entry = &entries[entry_idx];
+        let tx_seq = match entry.read_tx_seq() {
+            Ok(seq) => seq,
+            Err(err) => {
+                debug!(
+                    target: "corpus",
+                    %err,
+                    "failed to load on-disk corpus entry {:?}",
+                    entry.path
+                );
+                return None;
+            }
+        };
+        if tx_seq.is_empty() {
+            return None;
+        }
+
+        let tx_idx = rng.random_range(0..tx_seq.len());
+        tx_seq.into_iter().nth(tx_idx)
     }
 
     /// Converts replayable observed sub-calls into one normal multi-transaction corpus entry.
@@ -2256,6 +2326,8 @@ mod tests {
             mutation_weight_suffix: 1,
             mutation_weight_abi: 0,
             mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
         };
         let generated = basic_tx_with_calldata(vec![0x44]);
         let seed = WorkerCorpusSeed {
@@ -2297,6 +2369,8 @@ mod tests {
             mutation_weight_suffix: 0,
             mutation_weight_abi: 0,
             mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
         };
 
         let err = WorkerCorpus::from_seed(
@@ -2329,6 +2403,8 @@ mod tests {
             mutation_weight_suffix: 0,
             mutation_weight_abi: 0,
             mutation_weight_cmp: 1,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
         };
         let mut manager = worker_corpus_with_config(0, config, basic_tx(), seed);
         let mut runner = TestRunner::default();
@@ -2405,6 +2481,90 @@ mod tests {
             }
         }
         assert_eq!((ok, err), (1, 1), "the corrupt file must read as Err, the valid one as Ok");
+    }
+
+    fn empty_targeted_contracts() -> FuzzRunIdentifiedContracts {
+        FuzzRunIdentifiedContracts::new(TargetedContracts::new(), false)
+    }
+
+    #[test]
+    fn invariant_crossover_insert_loads_tx_from_persisted_corpus() {
+        let corpus_root = temp_corpus_dir();
+        let mut config = corpus_config(corpus_root.clone());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 1,
+            mutation_weight_crossover_replace: 0,
+        };
+
+        let base = basic_tx_with_calldata(vec![0xaa]);
+        let donor = basic_tx_with_calldata(vec![0xbb]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![base.clone()])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, basic_tx(), seed);
+        let worker_corpus_dir = corpus_root.join(format!("{WORKER}0")).join(CORPUS_DIR);
+        CorpusEntry::new(vec![donor.clone()]).write_to_disk_in(&worker_corpus_dir, false).unwrap();
+
+        let mut runner = TestRunner::default();
+        let sequence = manager
+            .new_inputs(
+                &mut runner,
+                &empty_fuzz_state().into_invariant(),
+                &empty_targeted_contracts(),
+            )
+            .unwrap();
+
+        assert_eq!(sequence.len(), 2);
+        assert!(sequence.iter().any(|tx| tx.call_details.calldata == base.call_details.calldata));
+        assert!(sequence.iter().any(|tx| tx.call_details.calldata == donor.call_details.calldata));
+        assert_eq!(manager.current_mutated_index, Some(0));
+    }
+
+    #[test]
+    fn invariant_crossover_replace_loads_tx_from_persisted_corpus() {
+        let corpus_root = temp_corpus_dir();
+        let mut config = corpus_config(corpus_root.clone());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 1,
+        };
+
+        let donor = basic_tx_with_calldata(vec![0xcc]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![basic_tx_with_calldata(vec![0xdd])])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, basic_tx(), seed);
+        let worker_corpus_dir = corpus_root.join(format!("{WORKER}0")).join(CORPUS_DIR);
+        CorpusEntry::new(vec![donor.clone()]).write_to_disk_in(&worker_corpus_dir, false).unwrap();
+
+        let mut runner = TestRunner::default();
+        let sequence = manager
+            .new_inputs(
+                &mut runner,
+                &empty_fuzz_state().into_invariant(),
+                &empty_targeted_contracts(),
+            )
+            .unwrap();
+
+        assert_eq!(sequence.len(), 1);
+        assert_eq!(sequence[0].call_details.calldata, donor.call_details.calldata);
+        assert_eq!(manager.current_mutated_index, Some(0));
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -3013,6 +3013,8 @@ mod tests {
             mutation_weight_suffix: 1,
             mutation_weight_abi: 1,
             mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 1,
+            mutation_weight_crossover_replace: 1,
         };
         assert!(!invariant_worker_collects_evm_cmp_log(&config, 0, 1));
 
@@ -3025,6 +3027,8 @@ mod tests {
             mutation_weight_suffix: 0,
             mutation_weight_abi: 0,
             mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
         };
         assert!(invariant_worker_collects_evm_cmp_log(&config, 0, 1));
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -3069,6 +3069,8 @@ mod tests {
             mutation_weight_suffix: 1,
             mutation_weight_abi: 1,
             mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 1,
+            mutation_weight_crossover_replace: 1,
         };
         assert!(!invariant_worker_collects_evm_cmp_log(&config, 0, 1));
 
@@ -3081,6 +3083,8 @@ mod tests {
             mutation_weight_suffix: 0,
             mutation_weight_abi: 0,
             mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
         };
         assert!(invariant_worker_collects_evm_cmp_log(&config, 0, 1));
 

--- a/crates/evm/fuzz/src/sequence.rs
+++ b/crates/evm/fuzz/src/sequence.rs
@@ -132,6 +132,8 @@ enum MutationType {
     Suffix,
     Abi,
     Cmp,
+    CrossoverInsert,
+    CrossoverReplace,
 }
 
 impl SequenceGenerator {
@@ -192,6 +194,8 @@ impl SequenceGenerator {
             weights.mutation_weight_suffix,
             weights.mutation_weight_abi,
             weights.mutation_weight_cmp,
+            weights.mutation_weight_crossover_insert,
+            weights.mutation_weight_crossover_replace,
         ];
         let mutations =
             WeightedIndex::new(all).map_err(|e| eyre!("invalid corpus mutation weights: {e}"))?;
@@ -323,7 +327,9 @@ impl SequenceGenerator {
             3 => MutationType::Prefix,
             4 => MutationType::Suffix,
             5 => MutationType::Abi,
-            _ => MutationType::Cmp,
+            6 => MutationType::Cmp,
+            7 => MutationType::CrossoverInsert,
+            _ => MutationType::CrossoverReplace,
         };
         let a = runner.rng().random_range(0..corpus_len);
         let b = runner.rng().random_range(0..corpus_len);
@@ -415,6 +421,23 @@ impl SequenceGenerator {
                             )?
                         }
                     }
+                }
+                (seq, i)
+            }
+            MutationType::CrossoverInsert | MutationType::CrossoverReplace => {
+                let i = if runner.rng().random() { a } else { b };
+                let base = if i == a { primary } else { secondary };
+                let donor = if i == a { secondary } else { primary };
+                let mut seq = base.transactions.to_vec();
+                let donor = donor.transactions
+                    [runner.rng().random_range(0..donor.transactions.len())]
+                .clone();
+                if matches!(kind, MutationType::CrossoverInsert) {
+                    let index = runner.rng().random_range(0..=seq.len());
+                    seq.insert(index, donor);
+                } else {
+                    let index = runner.rng().random_range(0..seq.len());
+                    seq[index] = donor;
                 }
                 (seq, i)
             }
@@ -661,6 +684,8 @@ mod tests {
             mutation_weight_suffix: 0,
             mutation_weight_abi: 0,
             mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
         };
         match kind {
             0 => weights.mutation_weight_splice = 1,
@@ -669,7 +694,9 @@ mod tests {
             3 => weights.mutation_weight_prefix = 1,
             4 => weights.mutation_weight_suffix = 1,
             5 => weights.mutation_weight_abi = 1,
-            _ => weights.mutation_weight_cmp = 1,
+            6 => weights.mutation_weight_cmp = 1,
+            7 => weights.mutation_weight_crossover_insert = 1,
+            _ => weights.mutation_weight_crossover_replace = 1,
         }
         weights
     }
@@ -986,6 +1013,8 @@ mod tests {
             mutation_weight_suffix: 0,
             mutation_weight_abi: 0,
             mutation_weight_cmp: 1,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
         };
         let generator = SequenceGenerator::invariant(
             generator_tx(9),

--- a/crates/evm/fuzz/src/sequence.rs
+++ b/crates/evm/fuzz/src/sequence.rs
@@ -1084,4 +1084,54 @@ mod tests {
             .unwrap();
         assert_eq!(accesses, 2);
     }
+    #[test]
+    fn invariant_crossover_insert_uses_corpus_transactions() {
+        let mut config = config();
+        config.mutation_weights = forced_weights(7);
+        let generator = SequenceGenerator::invariant(
+            generator_tx(9),
+            state(),
+            FuzzRunIdentifiedContracts::new(TargetedContracts::new(), false),
+            &config,
+        )
+        .unwrap();
+        let base = [tx(1)];
+        let plan = generator
+            .start(&mut TestRunner::deterministic(), 1, |_| CorpusEntryView::new(&base, &[]), true)
+            .unwrap();
+        assert_eq!(plan.initial().len(), 2);
+        assert!(plan.initial().iter().all(|call| call.sender == base[0].sender));
+        assert_eq!(plan.source(), Some(0));
+    }
+
+    #[test]
+    fn invariant_crossover_replace_uses_corpus_transactions() {
+        let mut config = config();
+        config.mutation_weights = forced_weights(8);
+        let generator = SequenceGenerator::invariant(
+            generator_tx(9),
+            state(),
+            FuzzRunIdentifiedContracts::new(TargetedContracts::new(), false),
+            &config,
+        )
+        .unwrap();
+        let entries = [[tx(1)], [tx(2)]];
+        let mut runner = TestRunner::deterministic();
+        let mut replaced = false;
+        for _ in 0..100 {
+            let plan = generator
+                .start(
+                    &mut runner,
+                    entries.len(),
+                    |index| CorpusEntryView::new(&entries[index], &[]),
+                    true,
+                )
+                .unwrap();
+            assert_eq!(plan.initial().len(), 1);
+            let sender = plan.initial()[0].sender;
+            assert!(entries.iter().any(|entry| entry[0].sender == sender));
+            replaced |= sender != entries[plan.source().unwrap()][0].sender;
+        }
+        assert!(replaced, "crossover replacement never selected a distinct donor");
+    }
 }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -727,6 +727,14 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_CMP", value_name = "WEIGHT")]
     pub fuzz_mutation_weight_cmp: Option<u32>,
 
+    /// Corpus mutation weight for inserting persisted corpus transactions.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_CROSSOVER_INSERT", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_crossover_insert: Option<u32>,
+
+    /// Corpus mutation weight for replacing calls with persisted corpus transactions.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_CROSSOVER_REPLACE", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_crossover_replace: Option<u32>,
+
     /// File to rerun fuzz failures from.
     #[arg(long)]
     pub fuzz_input_file: Option<String>,
@@ -799,6 +807,18 @@ pub struct TestArgs {
     /// Corpus mutation weight for comparison-operand mutation.
     #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_CMP", value_name = "WEIGHT")]
     pub invariant_mutation_weight_cmp: Option<u32>,
+
+    /// Corpus mutation weight for inserting persisted corpus transactions.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_CROSSOVER_INSERT", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_crossover_insert: Option<u32>,
+
+    /// Corpus mutation weight for replacing calls with persisted corpus transactions.
+    #[arg(
+        long,
+        env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_CROSSOVER_REPLACE",
+        value_name = "WEIGHT"
+    )]
+    pub invariant_mutation_weight_crossover_replace: Option<u32>,
 
     /// Run symbolic check*/prove*/invariant*/statefulFuzz* tests.
     #[arg(long, env = "FOUNDRY_SYMBOLIC")]
@@ -3281,6 +3301,12 @@ impl Provider for TestArgs {
         if let Some(weight) = self.fuzz_mutation_weight_cmp {
             fuzz_dict.insert("mutation_weight_cmp".to_string(), weight.into());
         }
+        if let Some(weight) = self.fuzz_mutation_weight_crossover_insert {
+            fuzz_dict.insert("mutation_weight_crossover_insert".to_string(), weight.into());
+        }
+        if let Some(weight) = self.fuzz_mutation_weight_crossover_replace {
+            fuzz_dict.insert("mutation_weight_crossover_replace".to_string(), weight.into());
+        }
         if let Some(fuzz_input_file) = self.fuzz_input_file.clone() {
             fuzz_dict.insert("failure_persist_file".to_string(), fuzz_input_file.into());
         }
@@ -3368,6 +3394,12 @@ impl Provider for TestArgs {
         }
         if let Some(weight) = self.invariant_mutation_weight_cmp {
             invariant_dict.insert("mutation_weight_cmp".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_crossover_insert {
+            invariant_dict.insert("mutation_weight_crossover_insert".to_string(), weight.into());
+        }
+        if let Some(weight) = self.invariant_mutation_weight_crossover_replace {
+            invariant_dict.insert("mutation_weight_crossover_replace".to_string(), weight.into());
         }
         if !invariant_dict.is_empty() {
             dict.insert("invariant".to_string(), invariant_dict.into());
@@ -4338,6 +4370,10 @@ mod tests {
             "123,456",
             "--symbolic-frontier-selectors",
             "0x12345678,deadbeef",
+            "--fuzz-mutation-weight-crossover-insert",
+            "1",
+            "--fuzz-mutation-weight-crossover-replace",
+            "2",
             "--invariant-depth",
             "300",
             "--invariant-min-depth",
@@ -4364,6 +4400,10 @@ mod tests {
             "2",
             "--invariant-mutation-weight-cmp",
             "7",
+            "--invariant-mutation-weight-crossover-insert",
+            "1",
+            "--invariant-mutation-weight-crossover-replace",
+            "3",
         ]);
 
         let figment = figment::Figment::from(&args);
@@ -4405,6 +4445,14 @@ mod tests {
             figment.extract_inner::<Vec<String>>("symbolic.frontier_selectors").unwrap(),
             vec!["0x12345678", "deadbeef"]
         );
+        assert_eq!(
+            figment.extract_inner::<u32>("fuzz.mutation_weight_crossover_insert").unwrap(),
+            1
+        );
+        assert_eq!(
+            figment.extract_inner::<u32>("fuzz.mutation_weight_crossover_replace").unwrap(),
+            2
+        );
         assert_eq!(figment.extract_inner::<u32>("invariant.depth").unwrap(), 300);
         assert_eq!(figment.extract_inner::<u32>("invariant.min_depth").unwrap(), 20);
         assert_eq!(
@@ -4435,6 +4483,14 @@ mod tests {
         assert_eq!(figment.extract_inner::<u32>("invariant.payable_value_weight").unwrap(), 34);
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_splice").unwrap(), 2);
         assert_eq!(figment.extract_inner::<u32>("invariant.mutation_weight_cmp").unwrap(), 7);
+        assert_eq!(
+            figment.extract_inner::<u32>("invariant.mutation_weight_crossover_insert").unwrap(),
+            1
+        );
+        assert_eq!(
+            figment.extract_inner::<u32>("invariant.mutation_weight_crossover_replace").unwrap(),
+            3
+        );
 
         let config = Config::default().merge_inline_provider(&args).unwrap();
         assert_eq!(config.fuzz.dictionary.dictionary_weight, 35);
@@ -4454,6 +4510,8 @@ mod tests {
         assert_eq!(config.symbolic.frontier_ids, vec![4, 9]);
         assert_eq!(config.symbolic.frontier_pcs, vec![123, 456]);
         assert_eq!(config.symbolic.frontier_selectors, vec!["0x12345678", "deadbeef"]);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_crossover_insert, 1);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_crossover_replace, 2);
         assert_eq!(config.invariant.depth, 300);
         assert_eq!(config.invariant.min_depth, 20);
         assert_eq!(config.invariant.depth_mode, InvariantDepthMode::Random);
@@ -4472,6 +4530,8 @@ mod tests {
         assert_eq!(config.invariant.corpus.payable_value_weight, 34);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_splice, 2);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
+        assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_crossover_insert, 1);
+        assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_crossover_replace, 3);
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -718,6 +718,14 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_CMP", value_name = "WEIGHT")]
     pub fuzz_mutation_weight_cmp: Option<u32>,
 
+    /// Corpus mutation weight for inserting corpus transactions.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_CROSSOVER_INSERT", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_crossover_insert: Option<u32>,
+
+    /// Corpus mutation weight for replacing calls with corpus transactions.
+    #[arg(long, env = "FOUNDRY_FUZZ_MUTATION_WEIGHT_CROSSOVER_REPLACE", value_name = "WEIGHT")]
+    pub fuzz_mutation_weight_crossover_replace: Option<u32>,
+
     /// File to rerun fuzz failures from.
     #[arg(
         long,
@@ -803,6 +811,18 @@ pub struct TestArgs {
     /// Corpus mutation weight for comparison-operand mutation.
     #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_CMP", value_name = "WEIGHT")]
     pub invariant_mutation_weight_cmp: Option<u32>,
+
+    /// Corpus mutation weight for inserting corpus transactions.
+    #[arg(long, env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_CROSSOVER_INSERT", value_name = "WEIGHT")]
+    pub invariant_mutation_weight_crossover_insert: Option<u32>,
+
+    /// Corpus mutation weight for replacing calls with corpus transactions.
+    #[arg(
+        long,
+        env = "FOUNDRY_INVARIANT_MUTATION_WEIGHT_CROSSOVER_REPLACE",
+        value_name = "WEIGHT"
+    )]
+    pub invariant_mutation_weight_crossover_replace: Option<u32>,
 
     /// Run symbolic check*/prove*/invariant*/statefulFuzz* tests.
     #[arg(long, env = "FOUNDRY_SYMBOLIC")]
@@ -3009,6 +3029,8 @@ impl Provider for TestArgs {
             "mutation_weight_suffix" => self.fuzz_mutation_weight_suffix,
             "mutation_weight_abi" => self.fuzz_mutation_weight_abi,
             "mutation_weight_cmp" => self.fuzz_mutation_weight_cmp,
+            "mutation_weight_crossover_insert" => self.fuzz_mutation_weight_crossover_insert,
+            "mutation_weight_crossover_replace" => self.fuzz_mutation_weight_crossover_replace,
         };
         let invariant = dict! {
             "runs" => self.invariant_runs_override,
@@ -3035,6 +3057,8 @@ impl Provider for TestArgs {
             "mutation_weight_suffix" => self.invariant_mutation_weight_suffix,
             "mutation_weight_abi" => self.invariant_mutation_weight_abi,
             "mutation_weight_cmp" => self.invariant_mutation_weight_cmp,
+            "mutation_weight_crossover_insert" => self.invariant_mutation_weight_crossover_insert,
+            "mutation_weight_crossover_replace" => self.invariant_mutation_weight_crossover_replace,
         };
         let symbolic = dict! {
             "enabled" => self.symbolic.then_some(true),
@@ -3830,6 +3854,10 @@ mod tests {
             "123,456",
             "--symbolic-frontier-selectors",
             "0x12345678,deadbeef",
+            "--fuzz-mutation-weight-crossover-insert",
+            "1",
+            "--fuzz-mutation-weight-crossover-replace",
+            "2",
             "--invariant-depth",
             "300",
             "--invariant-min-depth",
@@ -3856,6 +3884,10 @@ mod tests {
             "2",
             "--invariant-mutation-weight-cmp",
             "7",
+            "--invariant-mutation-weight-crossover-insert",
+            "1",
+            "--invariant-mutation-weight-crossover-replace",
+            "3",
         ]);
 
         let config = Config::default().merge_inline_provider(&args).unwrap();
@@ -3877,6 +3909,8 @@ mod tests {
         assert_eq!(config.symbolic.frontier_ids, vec![4, 9]);
         assert_eq!(config.symbolic.frontier_pcs, vec![123, 456]);
         assert_eq!(config.symbolic.frontier_selectors, vec!["0x12345678", "deadbeef"]);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_crossover_insert, 1);
+        assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_crossover_replace, 2);
         assert_eq!(config.invariant.depth, 300);
         assert_eq!(config.invariant.min_depth, 20);
         assert_eq!(config.invariant.depth_mode, InvariantDepthMode::Random);
@@ -3895,5 +3929,7 @@ mod tests {
         assert_eq!(config.invariant.corpus.payable_value_weight, 34);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_splice, 2);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);
+        assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_crossover_insert, 1);
+        assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_crossover_replace, 3);
     }
 }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -470,6 +470,14 @@ pub struct CampaignArgs {
     #[arg(long, value_name = "WEIGHT")]
     pub mutation_weight_cmp: Option<u32>,
 
+    /// Corpus mutation weight for inserting corpus transactions.
+    #[arg(long, value_name = "WEIGHT")]
+    pub mutation_weight_crossover_insert: Option<u32>,
+
+    /// Corpus mutation weight for replacing calls with corpus transactions.
+    #[arg(long, value_name = "WEIGHT")]
+    pub mutation_weight_crossover_replace: Option<u32>,
+
     /// Directory for fuzz branch frontier artifacts.
     #[arg(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
     pub frontier_dir: Option<PathBuf>,
@@ -1403,6 +1411,10 @@ impl TestArgs {
             invariant_mutation_weight_abi: campaign.mutation_weight_abi,
             fuzz_mutation_weight_cmp: campaign.mutation_weight_cmp,
             invariant_mutation_weight_cmp: campaign.mutation_weight_cmp,
+            fuzz_mutation_weight_crossover_insert: campaign.mutation_weight_crossover_insert,
+            fuzz_mutation_weight_crossover_replace: campaign.mutation_weight_crossover_replace,
+            invariant_mutation_weight_crossover_insert: campaign.mutation_weight_crossover_insert,
+            invariant_mutation_weight_crossover_replace: campaign.mutation_weight_crossover_replace,
             fuzz_frontier_dir: campaign.frontier_dir.clone(),
             invariant_frontier_dir: campaign.frontier_dir,
             fuzz_frontier_limit: campaign.frontier_limit,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -203,13 +203,15 @@ sancov_edges = false
 sancov_trace_cmp = false
 corpus_random_sequence_weight = 10
 payable_value_weight = 0
-mutation_weight_splice = 1
-mutation_weight_repeat = 1
-mutation_weight_interleave = 1
-mutation_weight_prefix = 1
-mutation_weight_suffix = 1
-mutation_weight_abi = 1
-mutation_weight_cmp = 1
+mutation_weight_splice = 4
+mutation_weight_repeat = 4
+mutation_weight_interleave = 4
+mutation_weight_prefix = 4
+mutation_weight_suffix = 4
+mutation_weight_abi = 4
+mutation_weight_cmp = 4
+mutation_weight_crossover_insert = 1
+mutation_weight_crossover_replace = 1
 failure_persist_dir = "cache/fuzz"
 show_logs = false
 
@@ -241,13 +243,15 @@ sancov_edges = false
 sancov_trace_cmp = false
 corpus_random_sequence_weight = 10
 payable_value_weight = 15
-mutation_weight_splice = 1
-mutation_weight_repeat = 1
-mutation_weight_interleave = 1
-mutation_weight_prefix = 1
-mutation_weight_suffix = 1
-mutation_weight_abi = 1
-mutation_weight_cmp = 1
+mutation_weight_splice = 4
+mutation_weight_repeat = 4
+mutation_weight_interleave = 4
+mutation_weight_prefix = 4
+mutation_weight_suffix = 4
+mutation_weight_abi = 4
+mutation_weight_cmp = 4
+mutation_weight_crossover_insert = 1
+mutation_weight_crossover_replace = 1
 failure_persist_dir = "cache/invariant"
 show_metrics = true
 show_solidity = false
@@ -1501,13 +1505,15 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "sancov_trace_cmp": false,
     "corpus_random_sequence_weight": 10,
     "payable_value_weight": 0,
-    "mutation_weight_splice": 1,
-    "mutation_weight_repeat": 1,
-    "mutation_weight_interleave": 1,
-    "mutation_weight_prefix": 1,
-    "mutation_weight_suffix": 1,
-    "mutation_weight_abi": 1,
-    "mutation_weight_cmp": 1,
+    "mutation_weight_splice": 4,
+    "mutation_weight_repeat": 4,
+    "mutation_weight_interleave": 4,
+    "mutation_weight_prefix": 4,
+    "mutation_weight_suffix": 4,
+    "mutation_weight_abi": 4,
+    "mutation_weight_cmp": 4,
+    "mutation_weight_crossover_insert": 1,
+    "mutation_weight_crossover_replace": 1,
     "failure_persist_dir": "cache/fuzz",
     "show_logs": false,
     "timeout": null
@@ -1542,13 +1548,15 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "sancov_trace_cmp": false,
     "corpus_random_sequence_weight": 10,
     "payable_value_weight": 15,
-    "mutation_weight_splice": 1,
-    "mutation_weight_repeat": 1,
-    "mutation_weight_interleave": 1,
-    "mutation_weight_prefix": 1,
-    "mutation_weight_suffix": 1,
-    "mutation_weight_abi": 1,
-    "mutation_weight_cmp": 1,
+    "mutation_weight_splice": 4,
+    "mutation_weight_repeat": 4,
+    "mutation_weight_interleave": 4,
+    "mutation_weight_prefix": 4,
+    "mutation_weight_suffix": 4,
+    "mutation_weight_abi": 4,
+    "mutation_weight_cmp": 4,
+    "mutation_weight_crossover_insert": 1,
+    "mutation_weight_crossover_replace": 1,
     "failure_persist_dir": "cache/invariant",
     "show_metrics": true,
     "timeout": null,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -207,13 +207,15 @@ sancov_edges = false
 sancov_trace_cmp = false
 corpus_random_sequence_weight = 10
 payable_value_weight = 0
-mutation_weight_splice = 1
-mutation_weight_repeat = 1
-mutation_weight_interleave = 1
-mutation_weight_prefix = 1
-mutation_weight_suffix = 1
-mutation_weight_abi = 1
-mutation_weight_cmp = 1
+mutation_weight_splice = 4
+mutation_weight_repeat = 4
+mutation_weight_interleave = 4
+mutation_weight_prefix = 4
+mutation_weight_suffix = 4
+mutation_weight_abi = 4
+mutation_weight_cmp = 4
+mutation_weight_crossover_insert = 1
+mutation_weight_crossover_replace = 1
 failure_persist_dir = "cache/fuzz"
 show_logs = false
 
@@ -245,13 +247,15 @@ sancov_edges = false
 sancov_trace_cmp = false
 corpus_random_sequence_weight = 10
 payable_value_weight = 15
-mutation_weight_splice = 1
-mutation_weight_repeat = 1
-mutation_weight_interleave = 1
-mutation_weight_prefix = 1
-mutation_weight_suffix = 1
-mutation_weight_abi = 1
-mutation_weight_cmp = 1
+mutation_weight_splice = 4
+mutation_weight_repeat = 4
+mutation_weight_interleave = 4
+mutation_weight_prefix = 4
+mutation_weight_suffix = 4
+mutation_weight_abi = 4
+mutation_weight_cmp = 4
+mutation_weight_crossover_insert = 1
+mutation_weight_crossover_replace = 1
 failure_persist_dir = "cache/invariant"
 show_metrics = true
 show_solidity = false
@@ -2218,13 +2222,15 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "sancov_trace_cmp": false,
     "corpus_random_sequence_weight": 10,
     "payable_value_weight": 0,
-    "mutation_weight_splice": 1,
-    "mutation_weight_repeat": 1,
-    "mutation_weight_interleave": 1,
-    "mutation_weight_prefix": 1,
-    "mutation_weight_suffix": 1,
-    "mutation_weight_abi": 1,
-    "mutation_weight_cmp": 1,
+    "mutation_weight_splice": 4,
+    "mutation_weight_repeat": 4,
+    "mutation_weight_interleave": 4,
+    "mutation_weight_prefix": 4,
+    "mutation_weight_suffix": 4,
+    "mutation_weight_abi": 4,
+    "mutation_weight_cmp": 4,
+    "mutation_weight_crossover_insert": 1,
+    "mutation_weight_crossover_replace": 1,
     "failure_persist_dir": "cache/fuzz",
     "show_logs": false,
     "timeout": null
@@ -2259,13 +2265,15 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "sancov_trace_cmp": false,
     "corpus_random_sequence_weight": 10,
     "payable_value_weight": 15,
-    "mutation_weight_splice": 1,
-    "mutation_weight_repeat": 1,
-    "mutation_weight_interleave": 1,
-    "mutation_weight_prefix": 1,
-    "mutation_weight_suffix": 1,
-    "mutation_weight_abi": 1,
-    "mutation_weight_cmp": 1,
+    "mutation_weight_splice": 4,
+    "mutation_weight_repeat": 4,
+    "mutation_weight_interleave": 4,
+    "mutation_weight_prefix": 4,
+    "mutation_weight_suffix": 4,
+    "mutation_weight_abi": 4,
+    "mutation_weight_cmp": 4,
+    "mutation_weight_crossover_insert": 1,
+    "mutation_weight_crossover_replace": 1,
     "failure_persist_dir": "cache/invariant",
     "show_metrics": true,
     "timeout": null,


### PR DESCRIPTION
Add low-weight crossover insertion and replacement mutations. This refresh reuses the implementation from #15763 in the current SequenceGenerator: donor transactions come from the active corpus, including loaded seeds, rather than a separate per-mutation disk scan. The proposed weights are unchanged.

Based on master `bfe6e9a17`; #15367 adds structural mutations on top and should be compared against this PR head to measure its incremental effect. Derek assessment and the corresponding book configuration update remain pending.

Originally prompted by @0xalpharush. AI assistance was used for the refresh, API integration, tests, and this description.
