### PR TITLE
feat(fuzz): use minset corpus culling

### DIFF
--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -126,9 +126,6 @@ pub struct FuzzCorpusConfig {
     pub frontier_limit: usize,
     // Whether corpus to use gzip file compression and decompression.
     pub corpus_gzip: bool,
-    // Number of mutations until entry marked as eligible to be flushed from in-memory corpus.
-    // Mutations will be performed at least `corpus_min_mutations` times.
-    pub corpus_min_mutations: usize,
     // Number of corpus that won't be evicted from memory.
     pub corpus_min_size: usize,
     /// Whether to collect and display edge coverage metrics.
@@ -241,7 +238,6 @@ impl Default for FuzzCorpusConfig {
             frontier_dir: None,
             frontier_limit: Self::DEFAULT_FRONTIER_LIMIT,
             corpus_gzip: true,
-            corpus_min_mutations: 5,
             corpus_min_size: 0,
             show_edge_coverage: false,
             evm_edge_coverage_collision_free: true,

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -127,9 +127,6 @@ pub struct FuzzCorpusConfig {
     pub frontier_limit: usize,
     // Whether corpus to use gzip file compression and decompression.
     pub corpus_gzip: bool,
-    // Number of mutations until entry marked as eligible to be flushed from in-memory corpus.
-    // Mutations will be performed at least `corpus_min_mutations` times.
-    pub corpus_min_mutations: usize,
     // Number of corpus that won't be evicted from memory.
     pub corpus_min_size: usize,
     /// Whether to collect and display edge coverage metrics.
@@ -242,7 +239,6 @@ impl Default for FuzzCorpusConfig {
             frontier_dir: None,
             frontier_limit: Self::DEFAULT_FRONTIER_LIMIT,
             corpus_gzip: true,
-            corpus_min_mutations: 5,
             corpus_min_size: 0,
             show_edge_coverage: false,
             evm_edge_coverage_collision_free: true,

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -59,7 +59,11 @@ use foundry_evm_fuzz::{
 };
 #[cfg(test)]
 use proptest::prelude::Strategy;
+#[cfg(test)]
+use proptest::test_runner::TestRng;
 use proptest::test_runner::TestRunner;
+#[cfg(test)]
+use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -192,7 +196,7 @@ impl CorpusEntry {
 struct CachedDiskCorpus {
     descriptors: Vec<CorpusDirEntry>,
     descriptor_indices: HashMap<Uuid, usize>,
-    cache: VecDeque<CorpusEntry>,
+    cache: VecDeque<Arc<CorpusEntry>>,
     cache_max_len: usize,
 }
 
@@ -217,7 +221,16 @@ impl CachedDiskCorpus {
         }
     }
 
-    fn cache_entry(&mut self, corpus: CorpusEntry) {
+    #[cfg(test)]
+    fn remove_descriptor_at(&mut self, index: usize) {
+        let removed = self.descriptors.swap_remove(index);
+        self.descriptor_indices.remove(&removed.uuid);
+        if let Some(moved) = self.descriptors.get(index) {
+            self.descriptor_indices.insert(moved.uuid, index);
+        }
+    }
+
+    fn cache_entry(&mut self, corpus: Arc<CorpusEntry>) {
         if self.cache_max_len == 0 {
             return;
         }
@@ -227,6 +240,71 @@ impl CachedDiskCorpus {
         self.cache.push_back(corpus);
         while self.cache.len() > self.cache_max_len {
             self.cache.pop_front();
+        }
+    }
+
+    fn retain_replayable(&mut self, is_replayable: impl Fn(&[BasicTxDetails]) -> bool) {
+        let cached_replayability = self
+            .cache
+            .iter()
+            .map(|entry| (entry.uuid, is_replayable(&entry.tx_seq)))
+            .collect::<HashMap<_, _>>();
+        self.cache.retain(|entry| is_replayable(&entry.tx_seq));
+        self.descriptors.retain(|descriptor| {
+            cached_replayability.get(&descriptor.uuid).copied().unwrap_or_else(|| {
+                descriptor
+                    .read_tx_seq()
+                    .is_ok_and(|tx_seq| !tx_seq.is_empty() && is_replayable(&tx_seq))
+            })
+        });
+        self.descriptor_indices.clear();
+        self.descriptor_indices
+            .extend(self.descriptors.iter().enumerate().map(|(index, entry)| (entry.uuid, index)));
+    }
+
+    #[cfg(test)]
+    fn random_entry(
+        &mut self,
+        rng: &mut TestRng,
+    ) -> foundry_common::fs::Result<Option<Arc<CorpusEntry>>> {
+        loop {
+            if self.cache.is_empty() && self.descriptors.is_empty() {
+                return Ok(None);
+            }
+
+            if self.descriptors.is_empty() {
+                let index = rng.random_range(0..self.cache.len());
+                return Ok(self.cache.get(index).cloned());
+            }
+
+            let descriptor_index = rng.random_range(0..self.descriptors.len());
+            let descriptor = self.descriptors[descriptor_index].clone();
+            if let Some(cached) = self.cache.iter().find(|entry| entry.uuid == descriptor.uuid) {
+                return Ok(Some(Arc::clone(cached)));
+            }
+
+            let tx_seq = match descriptor.read_tx_seq() {
+                Ok(tx_seq) if !tx_seq.is_empty() => tx_seq,
+                Ok(_) => {
+                    self.remove_descriptor_at(descriptor_index);
+                    continue;
+                }
+                Err(err) => {
+                    debug!(target: "corpus", path=%descriptor.path.display(), %err, "removing unreadable corpus donor");
+                    self.remove_descriptor_at(descriptor_index);
+                    continue;
+                }
+            };
+            let mut corpus = CorpusEntry::new_with_cmp_and_edges(
+                tx_seq,
+                Vec::new(),
+                Vec::new(),
+                descriptor.uuid,
+            );
+            corpus.timestamp = descriptor.timestamp;
+            let corpus = Arc::new(corpus);
+            self.cache_entry(Arc::clone(&corpus));
+            return Ok(Some(corpus));
         }
     }
 }
@@ -472,9 +550,17 @@ impl WorkerCorpusSeed {
         let is_replayable =
             |tx_seq: &[BasicTxDetails]| tx_seq.iter().all(|tx| targeted_contracts.can_replay(tx));
         self.in_memory_corpus.retain(|entry| is_replayable(&entry.tx_seq));
+        self.disk_corpus.retain_replayable(is_replayable);
+        self.top_rated.clear();
+        for entry in &self.in_memory_corpus {
+            WorkerCorpus::update_top_rated_in(&mut self.top_rated, entry);
+        }
         self.metrics.corpus_count = self.in_memory_corpus.len();
-        self.metrics.favored_items =
-            self.in_memory_corpus.iter().filter(|entry| entry.is_favored).count();
+        WorkerCorpus::recompute_favored_for_entries(
+            &self.top_rated,
+            &mut self.in_memory_corpus,
+            &mut self.metrics,
+        );
 
         if !self.optimization_best_sequence.is_empty()
             && !is_replayable(&self.optimization_best_sequence)
@@ -550,6 +636,7 @@ impl WorkerCorpusSeed {
                 continue;
             }
 
+            seed.disk_corpus.push_descriptor(entry.clone());
             seed.metrics.corpus_count += 1;
             debug!(
                 target: "corpus",
@@ -1384,12 +1471,21 @@ impl WorkerCorpus {
         let mut old_to_new = vec![None; self.in_memory_corpus.len()];
         let mut retained = Vec::with_capacity(self.in_memory_corpus.len());
         let mut evicted_uuids = HashSet::new();
+        let unsynced_uuids = self
+            .new_entry_indices
+            .iter()
+            .filter_map(|&index| self.in_memory_corpus.get(index).map(|entry| entry.uuid))
+            .collect::<HashSet<_>>();
 
         for (old_index, corpus) in self.in_memory_corpus.drain(..).enumerate() {
-            if !corpus.is_favored && remaining_removals > 0 {
+            if !corpus.is_favored
+                && !unsynced_uuids.contains(&corpus.uuid)
+                && remaining_removals > 0
+            {
                 trace!(target: "corpus", corpus=%serde_json::to_string(&corpus).unwrap(), "evict corpus");
-                self.disk_corpus.cache_entry(corpus.clone());
-                evicted_uuids.insert(corpus.uuid);
+                let uuid = corpus.uuid;
+                self.disk_corpus.cache_entry(Arc::new(corpus));
+                evicted_uuids.insert(uuid);
                 remaining_removals -= 1;
             } else {
                 old_to_new[old_index] = Some(retained.len());
@@ -2671,12 +2767,36 @@ mod tests {
         let foo_selector = foo.selector();
         let foo_tx = tx_for_function(target, &foo, &[]);
         let bar_tx = tx_for_function(target, &bar, &[]);
-        let mut foo_entry = CorpusEntry::new(vec![foo_tx.clone()]);
+        let mut foo_entry = CorpusEntry::new_with_cmp_and_edges(
+            vec![foo_tx.clone()],
+            Vec::new(),
+            vec![1],
+            Uuid::new_v4(),
+        );
         foo_entry.is_favored = true;
-        let mut bar_entry = CorpusEntry::new(vec![bar_tx.clone()]);
+        let mut bar_entry = CorpusEntry::new_with_cmp_and_edges(
+            vec![bar_tx.clone()],
+            Vec::new(),
+            vec![2],
+            Uuid::new_v4(),
+        );
         bar_entry.is_favored = true;
+        let foo_uuid = foo_entry.uuid;
+        let bar_uuid = bar_entry.uuid;
+        let corpus_dir = temp_corpus_dir();
+        let bar_path = corpus_dir.join(format!("{bar_uuid}-1.json"));
+        std::fs::write(&bar_path, serde_json::to_vec(&vec![bar_tx.clone()]).unwrap()).unwrap();
+        let mut disk_corpus = CachedDiskCorpus::default();
+        disk_corpus.push_descriptor(CorpusDirEntry {
+            path: bar_path,
+            uuid: bar_uuid,
+            timestamp: 1,
+        });
+        disk_corpus.cache_entry(Arc::new(bar_entry.clone()));
         let mut seed = WorkerCorpusSeed {
             in_memory_corpus: vec![foo_entry, bar_entry],
+            disk_corpus,
+            top_rated: HashMap::from([(1, (foo_uuid, 1)), (2, (bar_uuid, 1))]),
             metrics: CorpusMetrics { corpus_count: 2, favored_items: 2, ..Default::default() },
             optimization_best_value: Some(I256::try_from(17).unwrap()),
             optimization_best_sequence: vec![bar_tx],
@@ -2700,6 +2820,9 @@ mod tests {
         );
         assert_eq!(seed.metrics.corpus_count, 1);
         assert_eq!(seed.metrics.favored_items, 1);
+        assert!(seed.disk_corpus.descriptors.is_empty());
+        assert!(seed.disk_corpus.cache.is_empty());
+        assert_eq!(seed.top_rated, HashMap::from([(1, (foo_uuid, 1))]));
         assert!(seed.optimization_best_value.is_none());
         assert!(seed.optimization_best_sequence.is_empty());
     }
@@ -3047,6 +3170,28 @@ mod tests {
     }
 
     #[test]
+    fn culling_keeps_unsynced_entries_until_export() {
+        let mut favored = CorpusEntry::new_with_cmp_and_edges(
+            vec![basic_tx()],
+            Vec::new(),
+            vec![1],
+            Uuid::new_v4(),
+        );
+        favored.is_favored = true;
+        let unsynced = CorpusEntry::new(vec![basic_tx()]);
+        let unsynced_uuid = unsynced.uuid;
+        let mut manager = seeded_worker_corpus(1, temp_corpus_dir(), vec![favored, unsynced]);
+        manager.new_entry_indices.push(1);
+
+        manager.cull_corpus().unwrap();
+        assert!(manager.in_memory_corpus.iter().any(|entry| entry.uuid == unsynced_uuid));
+
+        manager.new_entry_indices.clear();
+        manager.cull_corpus().unwrap();
+        assert!(!manager.in_memory_corpus.iter().any(|entry| entry.uuid == unsynced_uuid));
+    }
+
+    #[test]
     fn cached_disk_corpus_bounds_evicted_entries() {
         let mut cache = CachedDiskCorpus { cache_max_len: 2, ..CachedDiskCorpus::default() };
 
@@ -3057,13 +3202,29 @@ mod tests {
         let second_uuid = second.uuid;
         let third_uuid = third.uuid;
 
-        cache.cache_entry(first);
-        cache.cache_entry(second);
-        cache.cache_entry(third);
+        cache.cache_entry(Arc::new(first));
+        cache.cache_entry(Arc::new(second));
+        cache.cache_entry(Arc::new(third));
 
         assert_eq!(cache.cache.len(), 2);
         assert!(!cache.cache.iter().any(|entry| entry.uuid == first_uuid));
         assert!(cache.cache.iter().any(|entry| entry.uuid == second_uuid));
         assert!(cache.cache.iter().any(|entry| entry.uuid == third_uuid));
+    }
+
+    #[test]
+    fn cached_disk_corpus_prunes_unreadable_descriptors() {
+        let uuid = Uuid::new_v4();
+        let mut cache = CachedDiskCorpus::default();
+        cache.push_descriptor(CorpusDirEntry {
+            path: temp_corpus_dir().join(format!("{uuid}-1.json")),
+            uuid,
+            timestamp: 1,
+        });
+
+        let mut runner = TestRunner::default();
+        assert!(cache.random_entry(runner.rng()).unwrap().is_none());
+        assert!(cache.descriptors.is_empty());
+        assert!(cache.descriptor_indices.is_empty());
     }
 }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -62,7 +62,7 @@ use proptest::prelude::Strategy;
 use proptest::test_runner::TestRunner;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet, VecDeque},
     fmt,
     path::{Path, PathBuf},
     sync::{
@@ -78,7 +78,8 @@ const CORPUS_DIR: &str = "corpus";
 const SYNC_DIR: &str = "sync";
 const OPTIMIZATION_BEST_FILE: &str = "optimization_best.json";
 
-const FAVORABILITY_THRESHOLD: f64 = 0.3;
+const SANCOV_EDGE_OFFSET: usize = usize::MAX / 2;
+const CACHED_DISK_CORPUS_MAX_LEN: usize = 128;
 
 /// Threshold for compressing corpus entries.
 /// 4KiB is usually the minimum file size on popular file systems.
@@ -96,10 +97,9 @@ struct OptimizationState {
 struct CorpusEntry {
     // Unique corpus identifier.
     uuid: Uuid,
-    // Total mutations of corpus as primary source.
-    total_mutations: usize,
-    // New coverage found as a result of mutating this corpus.
-    new_finds_produced: usize,
+    // Unique coverage indices this entry hits.
+    #[serde(skip_serializing)]
+    unique_edges_covered: Vec<usize>,
     // Corpus call sequence.
     #[serde(skip_serializing)]
     tx_seq: Vec<BasicTxDetails>,
@@ -107,8 +107,7 @@ struct CorpusEntry {
     // Parallel to `tx_seq`. Empty inner vec means "no cmp data for this call".
     #[serde(skip_serializing)]
     cmp_seq: Vec<Vec<ComparisonHint>>,
-    // Whether this corpus is favored, i.e. producing new finds more often than
-    // `FAVORABILITY_THRESHOLD`.
+    // Whether this corpus is favored (part of the top-rated coverage minset).
     is_favored: bool,
     /// Timestamp of when this entry was written to disk in seconds.
     #[serde(skip_serializing)]
@@ -121,19 +120,19 @@ struct CorpusEntry {
 impl CorpusEntry {
     /// Creates a corpus entry with a new UUID.
     pub fn new(tx_seq: Vec<BasicTxDetails>) -> Self {
-        Self::new_with_cmp(tx_seq, Vec::new(), Uuid::new_v4())
+        Self::new_with_cmp_and_edges(tx_seq, Vec::new(), Vec::new(), Uuid::new_v4())
     }
 
-    /// Creates a corpus entry with the given UUID and per-call cmp operand log.
-    pub fn new_with_cmp(
+    /// Creates a corpus entry with coverage and per-call cmp operand log.
+    pub fn new_with_cmp_and_edges(
         tx_seq: Vec<BasicTxDetails>,
         cmp_seq: Vec<Vec<ComparisonHint>>,
+        edges_covered: Vec<usize>,
         uuid: Uuid,
     ) -> Self {
-        Self {
+        let mut entry = Self {
             uuid,
-            total_mutations: 0,
-            new_finds_produced: 0,
+            unique_edges_covered: Vec::new(),
             tx_seq,
             cmp_seq,
             is_favored: false,
@@ -142,7 +141,15 @@ impl CorpusEntry {
                 .expect("time went backwards")
                 .as_secs(),
             persisted_file_name: None,
-        }
+        };
+        entry.set_edges(edges_covered);
+        entry
+    }
+
+    pub fn set_edges(&mut self, mut edges_covered: Vec<usize>) {
+        edges_covered.sort_unstable();
+        edges_covered.dedup();
+        self.unique_edges_covered = edges_covered;
     }
 
     fn write_to_disk_in(&self, dir: &Path, can_gzip: bool) -> foundry_common::fs::Result<PathBuf> {
@@ -178,6 +185,49 @@ impl CorpusEntry {
         }
         let size: usize = self.tx_seq.iter().map(|tx| tx.estimate_serialized_size()).sum();
         size > GZIP_THRESHOLD
+    }
+}
+
+#[derive(Clone)]
+struct CachedDiskCorpus {
+    descriptors: Vec<CorpusDirEntry>,
+    descriptor_indices: HashMap<Uuid, usize>,
+    cache: VecDeque<CorpusEntry>,
+    cache_max_len: usize,
+}
+
+impl Default for CachedDiskCorpus {
+    fn default() -> Self {
+        Self {
+            descriptors: Vec::new(),
+            descriptor_indices: HashMap::new(),
+            cache: VecDeque::new(),
+            cache_max_len: CACHED_DISK_CORPUS_MAX_LEN,
+        }
+    }
+}
+
+impl CachedDiskCorpus {
+    fn push_descriptor(&mut self, descriptor: CorpusDirEntry) {
+        if let Some(&index) = self.descriptor_indices.get(&descriptor.uuid) {
+            self.descriptors[index] = descriptor;
+        } else {
+            self.descriptor_indices.insert(descriptor.uuid, self.descriptors.len());
+            self.descriptors.push(descriptor);
+        }
+    }
+
+    fn cache_entry(&mut self, corpus: CorpusEntry) {
+        if self.cache_max_len == 0 {
+            return;
+        }
+        if let Some(index) = self.cache.iter().position(|entry| entry.uuid == corpus.uuid) {
+            self.cache.remove(index);
+        }
+        self.cache.push_back(corpus);
+        while self.cache.len() > self.cache_max_len {
+            self.cache.pop_front();
+        }
     }
 }
 
@@ -297,6 +347,7 @@ struct ReplayOutcome {
     new_coverage: bool,
     /// Whether replay hit a first-time edge (advances the per-worker "time since new edge" timer).
     new_edge: bool,
+    edges_covered: Vec<usize>,
     cmp_seq: Vec<Vec<ComparisonHint>>,
     failed_replays: usize,
 }
@@ -340,9 +391,11 @@ struct ReplayCoverage<'a> {
 #[derive(Clone, Default)]
 pub(crate) struct WorkerCorpusSeed {
     in_memory_corpus: Vec<CorpusEntry>,
+    disk_corpus: CachedDiskCorpus,
     history_map: Vec<u8>,
     edge_indices: EdgeIndexMap,
     sancov_history_map: Vec<u8>,
+    top_rated: HashMap<usize, (Uuid, usize)>,
     metrics: CorpusMetrics,
     replay_dirs: Option<Vec<PathBuf>>,
     failed_replays: usize,
@@ -401,9 +454,11 @@ impl WorkerCorpusSeed {
 
         Self {
             in_memory_corpus,
+            disk_corpus: self.disk_corpus.clone(),
             history_map: self.history_map.clone(),
             edge_indices: self.edge_indices.clone(),
             sancov_history_map: self.sancov_history_map.clone(),
+            top_rated: self.top_rated.clone(),
             metrics,
             replay_dirs: self.replay_dirs.clone(),
             failed_replays: self.failed_replays,
@@ -461,6 +516,7 @@ impl WorkerCorpusSeed {
         let mut seen_entries =
             seed.in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
         for entry in unique_corpus_entries(&replay_dirs, &mut seen_entries) {
+            seed.disk_corpus.push_descriptor(entry.clone());
             // A corrupt or truncated corpus file (e.g. a process killed mid-write, since entries
             // are persisted non-atomically) must not abort the whole campaign startup: skip it
             // and keep loading the rest of the corpus.
@@ -482,8 +538,9 @@ impl WorkerCorpusSeed {
                 sancov_history_map: &mut seed.sancov_history_map,
                 metrics: Some(&mut seed.metrics),
             };
-            let ReplayOutcome { keep_entry, new_edge, cmp_seq, failed_replays, .. } =
-                replay_corpus_sequence(&tx_seq, executor, target, coverage)?;
+            let ReplayOutcome {
+                keep_entry, new_edge, edges_covered, cmp_seq, failed_replays, ..
+            } = replay_corpus_sequence(&tx_seq, executor, target, coverage)?;
             seed.failed_replays += failed_replays;
             // Start the timer at the baseline load if replay hit a first-time edge.
             if new_edge {
@@ -500,8 +557,17 @@ impl WorkerCorpusSeed {
                 tx_seq.len(),
                 entry.path.display()
             );
-            seed.in_memory_corpus.push(CorpusEntry::new_with_cmp(tx_seq, cmp_seq, entry.uuid));
+            let corpus_entry =
+                CorpusEntry::new_with_cmp_and_edges(tx_seq, cmp_seq, edges_covered, entry.uuid);
+            WorkerCorpus::update_top_rated_in(&mut seed.top_rated, &corpus_entry);
+            seed.in_memory_corpus.push(corpus_entry);
         }
+
+        WorkerCorpus::recompute_favored_for_entries(
+            &seed.top_rated,
+            &mut seed.in_memory_corpus,
+            &mut seed.metrics,
+        );
 
         Ok(seed)
     }
@@ -613,15 +679,6 @@ impl CorpusMetrics {
             self.cumulative_features_seen += 1;
         }
     }
-
-    /// Updates campaign favored items.
-    pub const fn update_favored(&mut self, is_favored: bool, corpus_favored: bool) {
-        if is_favored && !corpus_favored {
-            self.favored_items += 1;
-        } else if !is_favored && corpus_favored {
-            self.favored_items -= 1;
-        }
-    }
 }
 
 /// Per-worker corpus manager.
@@ -631,12 +688,16 @@ pub struct WorkerCorpus {
     /// In-memory corpus entries populated from the persisted files and
     /// runs administered by this worker.
     in_memory_corpus: Vec<CorpusEntry>,
+    /// Disk-backed corpus entries plus a bounded decoded cache for non-favored mutation donors.
+    disk_corpus: CachedDiskCorpus,
     /// History of binned hitcount of edges seen during fuzzing
     history_map: Vec<u8>,
     /// Stable dense EVM edge IDs for this worker's history map.
     edge_indices: EdgeIndexMap,
     /// History of binned hitcount of sancov (native Rust) edges seen during fuzzing
     sancov_history_map: Vec<u8>,
+    /// Best corpus entry for each coverage index.
+    top_rated: HashMap<usize, (Uuid, usize)>,
     /// Number of failed replays from initial corpus
     pub(crate) failed_replays: usize,
     /// Worker Metrics
@@ -761,6 +822,7 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
     let mut new_coverage_for_entry = false;
     let mut new_edge_for_entry = false;
     let mut created: Vec<Address> = Vec::new();
+    let mut edges_covered = Vec::new();
 
     for tx in tx_seq {
         if WorkerCorpus::can_replay_tx(tx, target.stateless, target.fuzzed_contracts) {
@@ -774,10 +836,12 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
                     .map(|cmp| ComparisonHint { lhs: cmp.op1, rhs: cmp.op2 })
                     .collect(),
             );
-            let (new_coverage, is_edge) = call_result.merge_all_coverage(
+            let (new_coverage, is_edge) = call_result.merge_all_coverage_with_edges_into(
                 coverage.history_map,
                 coverage.edge_indices,
                 coverage.sancov_history_map,
+                SANCOV_EDGE_OFFSET,
+                &mut edges_covered,
             );
             if new_coverage {
                 new_coverage_for_entry = true;
@@ -817,6 +881,7 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
                     keep_entry: false,
                     new_coverage: new_coverage_for_entry,
                     new_edge: new_edge_for_entry,
+                    edges_covered,
                     cmp_seq,
                     failed_replays,
                 });
@@ -829,6 +894,7 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
         keep_entry: true,
         new_coverage: new_coverage_for_entry,
         new_edge: new_edge_for_entry,
+        edges_covered,
         cmp_seq,
         failed_replays,
     })
@@ -838,7 +904,7 @@ impl WorkerCorpus {
     /// Produces the next sequence for either execution mode.
     pub fn new_sequence(&mut self, test_runner: &mut TestRunner) -> Result<SequencePlan> {
         if self.config.is_coverage_guided() && !self.in_memory_corpus.is_empty() {
-            self.evict_oldest_corpus()?;
+            self.cull_corpus()?;
         }
         let corpus_len = self.in_memory_corpus.len();
         let plan = self.sequence_generator.start(
@@ -892,12 +958,14 @@ impl WorkerCorpus {
             worker_dir
         });
 
-        Ok(Self {
+        let mut corpus = Self {
             id,
             in_memory_corpus: seed.in_memory_corpus,
+            disk_corpus: seed.disk_corpus,
             history_map: seed.history_map,
             edge_indices: seed.edge_indices,
             sancov_history_map: seed.sancov_history_map,
+            top_rated: seed.top_rated,
             failed_replays: seed.failed_replays,
             metrics: seed.metrics,
             sequence_generator,
@@ -910,7 +978,11 @@ impl WorkerCorpus {
             optimization_best_value: seed.optimization_best_value,
             optimization_best_sequence: seed.optimization_best_sequence,
             last_new_edge_at: seed.last_new_edge_at,
-        })
+        };
+        if !corpus.top_rated.is_empty() {
+            corpus.cull_corpus()?;
+        }
+        Ok(corpus)
     }
 
     /// Updates stats for the given call sequence, if new coverage produced.
@@ -922,9 +994,17 @@ impl WorkerCorpus {
         inputs: &[BasicTxDetails],
         cmp_seq: &[Vec<CmpOperands>],
         new_coverage: bool,
+        edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
     ) {
-        let _ = self.process_inputs_inner(inputs, cmp_seq, new_coverage, optimization, true);
+        let _ = self.process_inputs_inner(
+            inputs,
+            cmp_seq,
+            new_coverage,
+            edges_covered,
+            optimization,
+            true,
+        );
     }
 
     /// Updates worker-local corpus state and returns any corpus entry to persist after the
@@ -935,9 +1015,10 @@ impl WorkerCorpus {
         inputs: &[BasicTxDetails],
         cmp_seq: &[Vec<CmpOperands>],
         new_coverage: bool,
+        edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
     ) -> Option<CampaignCorpusEntry> {
-        self.process_inputs_inner(inputs, cmp_seq, new_coverage, optimization, false)
+        self.process_inputs_inner(inputs, cmp_seq, new_coverage, edges_covered, optimization, false)
     }
 
     fn process_inputs_inner(
@@ -945,6 +1026,7 @@ impl WorkerCorpus {
         inputs: &[BasicTxDetails],
         cmp_seq: &[Vec<CmpOperands>],
         new_coverage: bool,
+        edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
         persist_now: bool,
     ) -> Option<CampaignCorpusEntry> {
@@ -953,26 +1035,7 @@ impl WorkerCorpus {
             self.optimization_best_value.is_none_or(|best| *value > best)
         });
 
-        // Update stats of current mutated primary corpus.
-        if let Some(index) = self.current_mutated_index.take() {
-            let should_credit = new_coverage || improved_optimization;
-            if let Some(corpus) = self.in_memory_corpus.get_mut(index) {
-                corpus.total_mutations += 1;
-                if should_credit {
-                    corpus.new_finds_produced += 1
-                }
-                let is_favored = (corpus.new_finds_produced as f64 / corpus.total_mutations as f64)
-                    > FAVORABILITY_THRESHOLD;
-                self.metrics.update_favored(is_favored, corpus.is_favored);
-                corpus.is_favored = is_favored;
-
-                trace!(
-                    target: "corpus",
-                    "updated corpus {}, total mutations: {}, new finds: {}",
-                    corpus.uuid, corpus.total_mutations, corpus.new_finds_produced
-                );
-            }
-        }
+        self.current_mutated_index.take();
         if let Some((value, best_seq)) = optimization
             && improved_optimization
         {
@@ -1013,7 +1076,13 @@ impl WorkerCorpus {
                 values.iter().map(|cmp| ComparisonHint { lhs: cmp.op1, rhs: cmp.op2 }).collect()
             })
             .collect();
-        let corpus = CorpusEntry::new_with_cmp(corpus_inputs, corpus_cmp_seq, Uuid::new_v4());
+        let corpus = CorpusEntry::new_with_cmp_and_edges(
+            corpus_inputs,
+            corpus_cmp_seq,
+            edges_covered,
+            Uuid::new_v4(),
+        );
+        self.update_top_rated(&corpus);
 
         self.insert_corpus_entry(
             corpus,
@@ -1035,10 +1104,16 @@ impl WorkerCorpus {
             && let Some(worker_dir) = &self.worker_dir
         {
             let worker_corpus = worker_dir.join(CORPUS_DIR);
+            let disk_entry = CorpusDirEntry {
+                path: worker_corpus.join(corpus.file_name(self.config.corpus_gzip)),
+                uuid: corpus.uuid,
+                timestamp: corpus.timestamp,
+            };
             let write_result = corpus.write_to_disk_in(&worker_corpus, self.config.corpus_gzip);
             if let Err(err) = write_result {
                 debug!(target: "corpus", %err, "failed to record call sequence {:?}", corpus.tx_seq);
             } else {
+                self.disk_corpus.push_descriptor(disk_entry);
                 trace!(
                     target: "corpus",
                     "persisted {} inputs for new coverage for {} corpus",
@@ -1057,6 +1132,9 @@ impl WorkerCorpus {
         self.new_entry_indices.push(new_index);
         self.metrics.corpus_count += 1;
         self.in_memory_corpus.push(corpus);
+        if let Err(err) = self.recompute_favored_and_cull_corpus() {
+            debug!(target: "corpus", %err, "failed to recompute minset corpus");
+        }
     }
 
     /// Returns the previously persisted optimization best value and sequence (if any).
@@ -1070,6 +1148,71 @@ impl WorkerCorpus {
             .optimization_best_value
             .map(|value| (value, self.optimization_best_sequence.as_slice()));
         Self::persist_campaign_outputs(&self.config, Vec::new(), optimization_best);
+    }
+
+    fn update_top_rated(&mut self, corpus: &CorpusEntry) {
+        Self::update_top_rated_in(&mut self.top_rated, corpus);
+    }
+
+    fn update_top_rated_in(top_rated: &mut HashMap<usize, (Uuid, usize)>, corpus: &CorpusEntry) {
+        let cost = corpus.tx_seq.len();
+        for &edge_idx in &corpus.unique_edges_covered {
+            match top_rated.get_mut(&edge_idx) {
+                Some((best_uuid, best_cost)) if cost < *best_cost => {
+                    *best_uuid = corpus.uuid;
+                    *best_cost = cost;
+                }
+                Some(_) => {}
+                None => {
+                    top_rated.insert(edge_idx, (corpus.uuid, cost));
+                }
+            }
+        }
+    }
+
+    fn recompute_top_rated_for_edge(&mut self, edge_idx: usize) {
+        let best = self
+            .in_memory_corpus
+            .iter()
+            .filter(|corpus| corpus.unique_edges_covered.binary_search(&edge_idx).is_ok())
+            .min_by_key(|corpus| corpus.tx_seq.len())
+            .map(|corpus| (corpus.uuid, corpus.tx_seq.len()));
+
+        if let Some(best) = best {
+            self.top_rated.insert(edge_idx, best);
+        } else {
+            self.top_rated.remove(&edge_idx);
+        }
+    }
+
+    fn recompute_favored_for_entries(
+        top_rated: &HashMap<usize, (Uuid, usize)>,
+        corpus_entries: &mut [CorpusEntry],
+        metrics: &mut CorpusMetrics,
+    ) {
+        let favored_uuids = top_rated.values().map(|&(uuid, _)| uuid).collect::<HashSet<_>>();
+        let mut favored_items = 0;
+        for corpus in corpus_entries {
+            corpus.is_favored = favored_uuids.contains(&corpus.uuid);
+            if corpus.is_favored {
+                favored_items += 1;
+            }
+        }
+        metrics.favored_items = favored_items;
+    }
+
+    fn recompute_favored_and_cull_corpus(&mut self) -> Result<()> {
+        if self.in_memory_corpus.is_empty() {
+            self.metrics.favored_items = 0;
+            return Ok(());
+        }
+
+        Self::recompute_favored_for_entries(
+            &self.top_rated,
+            &mut self.in_memory_corpus,
+            &mut self.metrics,
+        );
+        self.cull_corpus()
     }
 
     /// Persists logical-campaign corpus and optimization outputs after worker results have merged.
@@ -1090,19 +1233,21 @@ impl WorkerCorpus {
         persist_optimization_output(config, optimization_best);
     }
 
-    /// Collects EVM and sancov coverage from call result and updates metrics.
-    pub fn merge_edge_coverage<FEN: FoundryEvmNetwork>(
+    pub fn merge_edge_coverage_with_edges_into<FEN: FoundryEvmNetwork>(
         &mut self,
         call_result: &mut RawCallResult<FEN>,
+        edges_covered: &mut Vec<usize>,
     ) -> bool {
         if !self.config.collect_edge_coverage() {
             return false;
         }
 
-        let (new_coverage, is_edge) = call_result.merge_all_coverage(
+        let (new_coverage, is_edge) = call_result.merge_all_coverage_with_edges_into(
             &mut self.history_map,
             &mut self.edge_indices,
             &mut self.sancov_history_map,
+            SANCOV_EDGE_OFFSET,
+            edges_covered,
         );
         if new_coverage {
             self.metrics.update_seen(is_edge);
@@ -1231,31 +1376,56 @@ impl WorkerCorpus {
 
         self.insert_corpus_entry(corpus, insertion_mode, false)
     }
-    /// Flush the oldest corpus mutated more than configured max mutations unless they are
-    /// favored.
-    fn evict_oldest_corpus(&mut self) -> Result<()> {
-        if self.in_memory_corpus.len() > self.config.corpus_min_size.max(1)
-            && let Some(index) = self.in_memory_corpus.iter().position(|corpus| {
-                corpus.total_mutations > self.config.corpus_min_mutations && !corpus.is_favored
-            })
-        {
-            let corpus = &self.in_memory_corpus[index];
 
-            trace!(target: "corpus", corpus=%serde_json::to_string(&corpus).unwrap(), "evict corpus");
-
-            // Remove corpus from memory.
-            self.in_memory_corpus.remove(index);
-
-            // Adjust the tracked indices.
-            self.new_entry_indices.retain_mut(|i| {
-                if *i > index {
-                    *i -= 1; // Shift indices down.
-                    true // Keep this index.
-                } else {
-                    *i != index // Remove if it's the deleted index, keep otherwise.
-                }
-            });
+    /// Flush non-favored entries from memory when the corpus size exceeds the minimum.
+    fn cull_corpus(&mut self) -> Result<()> {
+        let min_size = self.config.corpus_min_size.max(1);
+        if self.in_memory_corpus.len() <= min_size {
+            return Ok(());
         }
+
+        let mut remaining_removals = self.in_memory_corpus.len() - min_size;
+        let mut old_to_new = vec![None; self.in_memory_corpus.len()];
+        let mut retained = Vec::with_capacity(self.in_memory_corpus.len());
+        let mut evicted_uuids = HashSet::new();
+
+        for (old_index, corpus) in self.in_memory_corpus.drain(..).enumerate() {
+            if !corpus.is_favored && remaining_removals > 0 {
+                trace!(target: "corpus", corpus=%serde_json::to_string(&corpus).unwrap(), "evict corpus");
+                self.disk_corpus.cache_entry(corpus.clone());
+                evicted_uuids.insert(corpus.uuid);
+                remaining_removals -= 1;
+            } else {
+                old_to_new[old_index] = Some(retained.len());
+                retained.push(corpus);
+            }
+        }
+
+        if evicted_uuids.is_empty() {
+            self.in_memory_corpus = retained;
+            return Ok(());
+        }
+
+        self.in_memory_corpus = retained;
+        self.new_entry_indices = self
+            .new_entry_indices
+            .iter()
+            .filter_map(|&i| old_to_new.get(i).copied().flatten())
+            .collect();
+
+        let impacted_edges = self
+            .top_rated
+            .iter()
+            .filter_map(|(&edge_idx, &(uuid, _))| evicted_uuids.contains(&uuid).then_some(edge_idx))
+            .collect::<Vec<_>>();
+        for edge_idx in impacted_edges {
+            self.recompute_top_rated_for_edge(edge_idx);
+        }
+        Self::recompute_favored_for_entries(
+            &self.top_rated,
+            &mut self.in_memory_corpus,
+            &mut self.metrics,
+        );
         Ok(())
     }
     // Sync Methods.
@@ -1347,7 +1517,9 @@ impl WorkerCorpus {
                 metrics: Some(&mut metrics),
             };
             let mut replay_executor = executor.clone();
-            let ReplayOutcome { keep_entry, new_coverage, new_edge, cmp_seq, .. } =
+            let ReplayOutcome {
+                keep_entry, new_coverage, new_edge, edges_covered, cmp_seq, ..
+            } =
                 replay_corpus_sequence_with_executor(
                     &tx_seq,
                     &mut replay_executor,
@@ -1380,12 +1552,23 @@ impl WorkerCorpus {
                     "moved synced corpus to corpus dir",
                 );
 
-                let corpus_entry = CorpusEntry::new_with_cmp(tx_seq.clone(), cmp_seq, entry.uuid);
+                let corpus_entry = CorpusEntry::new_with_cmp_and_edges(
+                    tx_seq.clone(),
+                    cmp_seq,
+                    edges_covered,
+                    entry.uuid,
+                );
+                self.update_top_rated(&corpus_entry);
                 self.push_synced_corpus_entry(
                     corpus_entry,
                     entry.timestamp,
                     entry.name().to_owned(),
                 );
+                self.disk_corpus.push_descriptor(CorpusDirEntry {
+                    path: corpus_path,
+                    uuid: entry.uuid,
+                    timestamp: entry.timestamp,
+                });
             } else {
                 // Remove the file as it did not generate new coverage.
                 if let Err(err) = std::fs::remove_file(&entry.path) {
@@ -1395,6 +1578,8 @@ impl WorkerCorpus {
                 trace!(target: "corpus", "removed synced corpus from {sync_path:?}");
             }
         }
+
+        self.recompute_favored_and_cull_corpus()?;
 
         Ok(())
     }
@@ -1816,7 +2001,6 @@ mod tests {
         FuzzCorpusConfig {
             corpus_dir: Some(corpus_dir),
             corpus_gzip: false,
-            corpus_min_mutations: 0,
             corpus_min_size: 0,
             ..Default::default()
         }
@@ -1854,15 +2038,6 @@ mod tests {
             WorkerCorpusSeed { in_memory_corpus: entries, ..Default::default() },
         )
     }
-    fn new_manager_with_single_corpus() -> (WorkerCorpus, Uuid) {
-        let corpus = CorpusEntry::new(vec![basic_tx()]);
-        let seed_uuid = corpus.uuid;
-        let mut manager = seeded_worker_corpus(0, temp_corpus_dir(), vec![corpus]);
-        manager.current_mutated_index = Some(0);
-
-        (manager, seed_uuid)
-    }
-
     fn targeted_contracts_with_selective_functions(
         target: Address,
         functions: Vec<Function>,
@@ -2140,7 +2315,7 @@ mod tests {
         let worker_subdir = corpus_root.join("worker1");
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        let record = manager.process_inputs_for_campaign(&[basic_tx()], &[], true, None);
+        let record = manager.process_inputs_for_campaign(&[basic_tx()], &[], true, vec![1], None);
 
         let record = record.unwrap();
         assert!(record.dedupe_by_coverage);
@@ -2170,12 +2345,12 @@ mod tests {
             EdgeKey { address: Address::ZERO, depth: None, pc: 0, jump_dest: U256::from(10) };
 
         // First-time edge starts the timer.
-        assert!(manager.merge_edge_coverage(&mut edge_call(edge, 1)));
+        assert!(manager.merge_edge_coverage_with_edges_into(&mut edge_call(edge, 1), &mut vec![]));
         let first = manager.last_new_edge_at.expect("timer set after first new edge");
         assert_eq!(manager.metrics.cumulative_edges_seen, 1);
 
         // Same edge, higher bucket = a feature, not an edge: timer must not advance.
-        assert!(manager.merge_edge_coverage(&mut edge_call(edge, 8)));
+        assert!(manager.merge_edge_coverage_with_edges_into(&mut edge_call(edge, 8), &mut vec![]));
         assert_eq!(manager.last_new_edge_at, Some(first));
         assert_eq!(manager.metrics.cumulative_edges_seen, 1);
         assert_eq!(manager.metrics.cumulative_features_seen, 1);
@@ -2183,7 +2358,7 @@ mod tests {
         // A distinct edge advances the timer.
         let other =
             EdgeKey { address: Address::ZERO, depth: None, pc: 1, jump_dest: U256::from(20) };
-        assert!(manager.merge_edge_coverage(&mut edge_call(other, 1)));
+        assert!(manager.merge_edge_coverage_with_edges_into(&mut edge_call(other, 1), &mut vec![]));
         let second = manager.last_new_edge_at.expect("timer present");
         assert!(second >= first);
         assert_eq!(manager.metrics.cumulative_edges_seen, 2);
@@ -2200,7 +2375,7 @@ mod tests {
         let worker_subdir = corpus_root.join("worker1");
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        let record = manager.process_inputs_for_campaign(&[], &[], true, None);
+        let record = manager.process_inputs_for_campaign(&[], &[], true, Vec::new(), None);
 
         assert!(record.is_none());
         assert_eq!(manager.in_memory_corpus.len(), 0);
@@ -2208,7 +2383,7 @@ mod tests {
         assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
 
         // Live processing path must also tolerate the empty sequence.
-        manager.process_inputs(&[], &[], true, None);
+        manager.process_inputs(&[], &[], true, Vec::new(), None);
         assert_eq!(manager.in_memory_corpus.len(), 0);
         assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
     }
@@ -2223,6 +2398,7 @@ mod tests {
                 &sequence,
                 &[],
                 false,
+                Vec::new(),
                 Some((I256::try_from(7).unwrap(), sequence.clone())),
             )
             .unwrap();
@@ -2333,6 +2509,7 @@ mod tests {
             &worse_sequence,
             &[],
             false,
+            Vec::new(),
             Some((I256::try_from(50).unwrap(), worse_sequence.clone())),
         );
         assert!(worse.is_none());
@@ -2342,6 +2519,7 @@ mod tests {
             &better_sequence,
             &[],
             false,
+            Vec::new(),
             Some((I256::try_from(150).unwrap(), better_sequence.clone())),
         );
         assert!(better.is_some());
@@ -2353,9 +2531,11 @@ mod tests {
         let tx_seq = vec![basic_tx()];
         let seed = WorkerCorpusSeed {
             in_memory_corpus: vec![CorpusEntry::new(tx_seq.clone())],
+            disk_corpus: CachedDiskCorpus::default(),
             history_map: vec![1, 2, 3],
             edge_indices: EdgeIndexMap::default(),
             sancov_history_map: vec![4, 5],
+            top_rated: HashMap::new(),
             metrics: CorpusMetrics {
                 cumulative_edges_seen: 7,
                 cumulative_features_seen: 11,
@@ -2398,9 +2578,11 @@ mod tests {
         let entry_ids = entries.iter().map(|entry| entry.uuid).collect::<Vec<_>>();
         let seed = WorkerCorpusSeed {
             in_memory_corpus: entries,
+            disk_corpus: CachedDiskCorpus::default(),
             history_map: vec![1, 2, 3],
             edge_indices: EdgeIndexMap::default(),
             sancov_history_map: vec![4, 5],
+            top_rated: HashMap::new(),
             metrics: CorpusMetrics {
                 cumulative_edges_seen: 7,
                 cumulative_features_seen: 11,
@@ -2468,9 +2650,10 @@ mod tests {
         };
         let entries = (0..2)
             .map(|_| {
-                CorpusEntry::new_with_cmp(
+                CorpusEntry::new_with_cmp_and_edges(
                     vec![basic_tx()],
                     vec![vec![ComparisonHint { lhs: cmp.op1, rhs: cmp.op2 }]],
+                    Vec::new(),
                     Uuid::new_v4(),
                 )
             })
@@ -2809,93 +2992,82 @@ mod tests {
     }
 
     #[test]
-    fn favored_sets_true_and_metrics_increment_when_ratio_gt_threshold() {
-        let (mut manager, uuid) = new_manager_with_single_corpus();
-        let corpus = manager.in_memory_corpus.iter_mut().find(|c| c.uuid == uuid).unwrap();
-        corpus.total_mutations = 4;
-        corpus.new_finds_produced = 2; // ratio currently 0.5 if both increment → 3/5 = 0.6 > 0.3.
-        corpus.is_favored = false;
-
-        // Ensure metrics start at 0.
-        assert_eq!(manager.metrics.favored_items, 0);
-
-        // Mark this as the currently mutated corpus and process a run with new coverage.
-        manager.current_mutated_index = Some(0);
-        manager.process_inputs(&[basic_tx()], &[], true, None);
-
-        let corpus = manager.in_memory_corpus.iter().find(|c| c.uuid == uuid).unwrap();
-        assert!(corpus.is_favored, "expected favored to be true when ratio > threshold");
-        assert_eq!(
-            manager.metrics.favored_items, 1,
-            "favored_items should increment on false→true"
+    fn minset_marks_smallest_covering_corpus_as_favored() {
+        let mut manager = empty_worker_corpus(0, temp_corpus_dir());
+        let large = CorpusEntry::new_with_cmp_and_edges(
+            vec![basic_tx(), basic_tx()],
+            Vec::new(),
+            vec![1],
+            Uuid::new_v4(),
         );
+        let large_uuid = large.uuid;
+        let small = CorpusEntry::new_with_cmp_and_edges(
+            vec![basic_tx()],
+            Vec::new(),
+            vec![1],
+            Uuid::new_v4(),
+        );
+        let small_uuid = small.uuid;
+
+        manager.update_top_rated(&large);
+        manager.update_top_rated(&small);
+        manager.in_memory_corpus.push(large);
+        manager.in_memory_corpus.push(small);
+
+        manager.recompute_favored_and_cull_corpus().unwrap();
+
+        let large = manager.in_memory_corpus.iter().find(|c| c.uuid == large_uuid);
+        let small = manager.in_memory_corpus.iter().find(|c| c.uuid == small_uuid).unwrap();
+        assert!(large.is_none(), "larger non-favored corpus should be culled");
+        assert!(small.is_favored, "smallest corpus covering the edge should be favored");
+        assert_eq!(manager.metrics.favored_items, 1);
     }
 
     #[test]
-    fn favored_sets_false_and_metrics_decrement_when_ratio_lt_threshold() {
-        let (mut manager, uuid) = new_manager_with_single_corpus();
-        let corpus = manager.in_memory_corpus.iter_mut().find(|c| c.uuid == uuid).unwrap();
-        corpus.total_mutations = 9;
-        corpus.new_finds_produced = 3; // 3/9 = 0.333.. > 0.3; after +1: 3/10 = 0.3 => not favored.
-        corpus.is_favored = true; // Start as favored.
-
-        manager.metrics.favored_items = 1;
-
-        // Next run does NOT produce coverage → only total_mutations increments, ratio drops.
-        manager.current_mutated_index = Some(0);
-        manager.process_inputs(&[basic_tx()], &[], false, None);
-
-        let corpus = manager.in_memory_corpus.iter().find(|c| c.uuid == uuid).unwrap();
-        assert!(!corpus.is_favored, "expected favored to be false when ratio < threshold");
-        assert_eq!(
-            manager.metrics.favored_items, 0,
-            "favored_items should decrement on true→false"
+    fn culling_keeps_favored_minset_entries() {
+        let mut favored = CorpusEntry::new_with_cmp_and_edges(
+            vec![basic_tx()],
+            Vec::new(),
+            vec![1],
+            Uuid::new_v4(),
         );
-    }
-
-    #[test]
-    fn favored_is_false_on_ratio_equal_threshold() {
-        let (mut manager, uuid) = new_manager_with_single_corpus();
-        let corpus = manager.in_memory_corpus.iter_mut().find(|c| c.uuid == uuid).unwrap();
-        // After this call with new_coverage=true, totals become 10 and 3 → 0.3.
-        corpus.total_mutations = 9;
-        corpus.new_finds_produced = 2;
-        corpus.is_favored = false;
-
-        manager.current_mutated_index = Some(0);
-        manager.process_inputs(&[basic_tx()], &[], true, None);
-
-        let corpus = manager.in_memory_corpus.iter().find(|c| c.uuid == uuid).unwrap();
-        assert!(
-            !(corpus.is_favored),
-            "with strict '>' comparison, favored must be false when ratio == threshold"
-        );
-    }
-
-    #[test]
-    fn eviction_skips_favored_and_evicts_non_favored() {
-        // Manager with two corpora.
-        let mut favored = CorpusEntry::new(vec![basic_tx()]);
-        favored.total_mutations = 2;
         favored.is_favored = true;
+        let favored_uuid = favored.uuid;
+        let favored_cost = favored.tx_seq.len();
 
         let mut non_favored = CorpusEntry::new(vec![basic_tx()]);
-        non_favored.total_mutations = 2;
         non_favored.is_favored = false;
         let non_favored_uuid = non_favored.uuid;
 
         let mut manager = seeded_worker_corpus(0, temp_corpus_dir(), vec![favored, non_favored]);
+        manager.top_rated = HashMap::from([(1, (favored_uuid, favored_cost))]);
 
-        // First eviction should remove the non-favored one.
-        manager.evict_oldest_corpus().unwrap();
+        manager.cull_corpus().unwrap();
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert!(manager.in_memory_corpus.iter().all(|c| c.is_favored));
-
-        // Attempt eviction again: only favored remains → should not remove.
-        manager.evict_oldest_corpus().unwrap();
-        assert_eq!(manager.in_memory_corpus.len(), 1, "favored corpus must not be evicted");
-
-        // Ensure the evicted one was the non-favored uuid.
         assert!(manager.in_memory_corpus.iter().all(|c| c.uuid != non_favored_uuid));
+        assert_eq!(manager.disk_corpus.cache.len(), 1);
+        assert_eq!(manager.disk_corpus.cache[0].uuid, non_favored_uuid);
+    }
+
+    #[test]
+    fn cached_disk_corpus_bounds_evicted_entries() {
+        let mut cache = CachedDiskCorpus { cache_max_len: 2, ..CachedDiskCorpus::default() };
+
+        let first = CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x01])]);
+        let second = CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x02])]);
+        let third = CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x03])]);
+        let first_uuid = first.uuid;
+        let second_uuid = second.uuid;
+        let third_uuid = third.uuid;
+
+        cache.cache_entry(first);
+        cache.cache_entry(second);
+        cache.cache_entry(third);
+
+        assert_eq!(cache.cache.len(), 2);
+        assert!(!cache.cache.iter().any(|entry| entry.uuid == first_uuid));
+        assert!(cache.cache.iter().any(|entry| entry.uuid == second_uuid));
+        assert!(cache.cache.iter().any(|entry| entry.uuid == third_uuid));
     }
 }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -705,7 +705,6 @@ pub struct WorkerCorpus {
     /// Shared transaction-sequence generator.
     sequence_generator: SequenceGenerator,
     /// Identifier of current mutated entry for this worker.
-    current_mutated_index: Option<usize>,
     /// Config
     config: Arc<FuzzCorpusConfig>,
     /// Indices of new entries added to [`WorkerCorpus::in_memory_corpus`] since last sync.
@@ -919,7 +918,6 @@ impl WorkerCorpus {
             },
             self.config.is_coverage_guided(),
         )?;
-        self.current_mutated_index = plan.source();
         Ok(plan)
     }
 
@@ -969,7 +967,6 @@ impl WorkerCorpus {
             failed_replays: seed.failed_replays,
             metrics: seed.metrics,
             sequence_generator,
-            current_mutated_index: None,
             config: config.into(),
             new_entry_indices: Default::default(),
             initial_export_dirs,
@@ -1035,7 +1032,6 @@ impl WorkerCorpus {
             self.optimization_best_value.is_none_or(|best| *value > best)
         });
 
-        self.current_mutated_index = None;
         if let Some((value, best_seq)) = optimization
             && improved_optimization
         {

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1035,7 +1035,7 @@ impl WorkerCorpus {
             self.optimization_best_value.is_none_or(|best| *value > best)
         });
 
-        self.current_mutated_index.take();
+        self.current_mutated_index = None;
         if let Some((value, best_seq)) = optimization
             && improved_optimization
         {

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -84,6 +84,9 @@ const OPTIMIZATION_BEST_FILE: &str = "optimization_best.json";
 
 const SANCOV_EDGE_OFFSET: usize = usize::MAX / 2;
 const CACHED_DISK_CORPUS_MAX_LEN: usize = 128;
+// Prefer decoded donors while periodically refreshing the bounded cache from disk.
+#[cfg(test)]
+const DISK_CORPUS_REFRESH_DENOMINATOR: u32 = 16;
 
 /// Threshold for compressing corpus entries.
 /// 4KiB is usually the minimum file size on popular file systems.
@@ -243,20 +246,9 @@ impl CachedDiskCorpus {
         }
     }
 
-    fn retain_replayable(&mut self, is_replayable: impl Fn(&[BasicTxDetails]) -> bool) {
-        let cached_replayability = self
-            .cache
-            .iter()
-            .map(|entry| (entry.uuid, is_replayable(&entry.tx_seq)))
-            .collect::<HashMap<_, _>>();
-        self.cache.retain(|entry| is_replayable(&entry.tx_seq));
-        self.descriptors.retain(|descriptor| {
-            cached_replayability.get(&descriptor.uuid).copied().unwrap_or_else(|| {
-                descriptor
-                    .read_tx_seq()
-                    .is_ok_and(|tx_seq| !tx_seq.is_empty() && is_replayable(&tx_seq))
-            })
-        });
+    fn retain_uuids(&mut self, retained: &HashSet<Uuid>) {
+        self.cache.retain(|entry| retained.contains(&entry.uuid));
+        self.descriptors.retain(|descriptor| retained.contains(&descriptor.uuid));
         self.descriptor_indices.clear();
         self.descriptor_indices
             .extend(self.descriptors.iter().enumerate().map(|(index, entry)| (entry.uuid, index)));
@@ -267,12 +259,24 @@ impl CachedDiskCorpus {
         &mut self,
         rng: &mut TestRng,
     ) -> foundry_common::fs::Result<Option<Arc<CorpusEntry>>> {
+        let refresh_disk = self.cache.is_empty()
+            || (!self.descriptors.is_empty()
+                && rng.random_ratio(1, DISK_CORPUS_REFRESH_DENOMINATOR));
+        self.random_entry_with_disk_refresh(rng, refresh_disk)
+    }
+
+    #[cfg(test)]
+    fn random_entry_with_disk_refresh(
+        &mut self,
+        rng: &mut TestRng,
+        refresh_disk: bool,
+    ) -> foundry_common::fs::Result<Option<Arc<CorpusEntry>>> {
         loop {
             if self.cache.is_empty() && self.descriptors.is_empty() {
                 return Ok(None);
             }
 
-            if self.descriptors.is_empty() {
+            if !self.cache.is_empty() && (!refresh_disk || self.descriptors.is_empty()) {
                 let index = rng.random_range(0..self.cache.len());
                 return Ok(self.cache.get(index).cloned());
             }
@@ -418,6 +422,7 @@ pub(crate) enum CorpusInsertionMode {
     Live,
     Deferred,
     MemoryOnly,
+    WorkerSync,
 }
 
 struct ReplayOutcome {
@@ -506,6 +511,19 @@ impl WorkerCorpusSeed {
         self
     }
 
+    fn rebuild_minset(&mut self) {
+        self.top_rated.clear();
+        for entry in &self.in_memory_corpus {
+            WorkerCorpus::update_top_rated_in(&mut self.top_rated, entry);
+        }
+        self.metrics.corpus_count = self.in_memory_corpus.len();
+        WorkerCorpus::recompute_favored_for_entries(
+            &self.top_rated,
+            &mut self.in_memory_corpus,
+            &mut self.metrics,
+        );
+    }
+
     pub(crate) fn clone_for_worker(
         &self,
         worker_id: usize,
@@ -526,41 +544,39 @@ impl WorkerCorpusSeed {
             })
             .collect::<Vec<_>>();
 
+        let retained_uuids =
+            in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
+        let mut disk_corpus = self.disk_corpus.clone();
+        disk_corpus.retain_uuids(&retained_uuids);
         let mut metrics = self.metrics.clone();
         metrics.corpus_count = in_memory_corpus.len();
-        metrics.favored_items = in_memory_corpus.iter().filter(|entry| entry.is_favored).count();
 
-        Self {
+        let mut seed = Self {
             in_memory_corpus,
-            disk_corpus: self.disk_corpus.clone(),
+            disk_corpus,
             history_map: self.history_map.clone(),
             edge_indices: self.edge_indices.clone(),
             sancov_history_map: self.sancov_history_map.clone(),
-            top_rated: self.top_rated.clone(),
+            top_rated: HashMap::new(),
             metrics,
             replay_dirs: self.replay_dirs.clone(),
             failed_replays: self.failed_replays,
             optimization_best_value: self.optimization_best_value,
             optimization_best_sequence: self.optimization_best_sequence.clone(),
             last_new_edge_at: self.last_new_edge_at,
-        }
+        };
+        seed.rebuild_minset();
+        seed
     }
 
     pub(crate) fn retain_replayable(&mut self, targeted_contracts: &TargetedContracts) {
         let is_replayable =
             |tx_seq: &[BasicTxDetails]| tx_seq.iter().all(|tx| targeted_contracts.can_replay(tx));
         self.in_memory_corpus.retain(|entry| is_replayable(&entry.tx_seq));
-        self.disk_corpus.retain_replayable(is_replayable);
-        self.top_rated.clear();
-        for entry in &self.in_memory_corpus {
-            WorkerCorpus::update_top_rated_in(&mut self.top_rated, entry);
-        }
-        self.metrics.corpus_count = self.in_memory_corpus.len();
-        WorkerCorpus::recompute_favored_for_entries(
-            &self.top_rated,
-            &mut self.in_memory_corpus,
-            &mut self.metrics,
-        );
+        let retained_uuids =
+            self.in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
+        self.disk_corpus.retain_uuids(&retained_uuids);
+        self.rebuild_minset();
 
         if !self.optimization_best_sequence.is_empty()
             && !is_replayable(&self.optimization_best_sequence)
@@ -798,6 +814,10 @@ pub struct WorkerCorpus {
     new_entry_indices: Vec<usize>,
     /// Corpus directories the master loaded at startup and still needs to distribute.
     initial_export_dirs: Option<Vec<PathBuf>>,
+    /// UUIDs of stateless-worker entries pending export at the next synchronization.
+    pending_sync_uuids: HashSet<Uuid>,
+    /// Last sync timestamp in seconds.
+    last_sync_timestamp: u64,
     /// Worker Dir
     /// corpus_dir/worker1/
     worker_dir: Option<PathBuf>,
@@ -1057,6 +1077,8 @@ impl WorkerCorpus {
             config: config.into(),
             new_entry_indices: Default::default(),
             initial_export_dirs,
+            pending_sync_uuids: Default::default(),
+            last_sync_timestamp: 0,
             worker_dir,
             last_sync_metrics: Default::default(),
             optimization_best_value: seed.optimization_best_value,
@@ -1087,7 +1109,27 @@ impl WorkerCorpus {
             new_coverage,
             edges_covered,
             optimization,
-            true,
+            CorpusInsertionMode::Live,
+        );
+    }
+
+    /// Updates a stateless worker's corpus and protects new entries until its next synchronization.
+    #[instrument(skip_all)]
+    pub(crate) fn process_inputs_for_worker_sync(
+        &mut self,
+        inputs: &[BasicTxDetails],
+        cmp_seq: &[Vec<CmpOperands>],
+        new_coverage: bool,
+        edges_covered: Vec<usize>,
+        optimization: Option<(I256, Vec<BasicTxDetails>)>,
+    ) {
+        let _ = self.process_inputs_inner(
+            inputs,
+            cmp_seq,
+            new_coverage,
+            edges_covered,
+            optimization,
+            CorpusInsertionMode::WorkerSync,
         );
     }
 
@@ -1102,7 +1144,14 @@ impl WorkerCorpus {
         edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
     ) -> Option<CampaignCorpusEntry> {
-        self.process_inputs_inner(inputs, cmp_seq, new_coverage, edges_covered, optimization, false)
+        self.process_inputs_inner(
+            inputs,
+            cmp_seq,
+            new_coverage,
+            edges_covered,
+            optimization,
+            CorpusInsertionMode::Deferred,
+        )
     }
 
     fn process_inputs_inner(
@@ -1112,8 +1161,10 @@ impl WorkerCorpus {
         new_coverage: bool,
         edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
-        persist_now: bool,
+        insertion_mode: CorpusInsertionMode,
     ) -> Option<CampaignCorpusEntry> {
+        let persist_now =
+            matches!(insertion_mode, CorpusInsertionMode::Live | CorpusInsertionMode::WorkerSync);
         // Check if this run improved the optimization value.
         let improved_optimization = optimization.as_ref().is_some_and(|(value, _)| {
             self.optimization_best_value.is_none_or(|best| *value > best)
@@ -1167,11 +1218,7 @@ impl WorkerCorpus {
         );
         self.update_top_rated(&corpus);
 
-        self.insert_corpus_entry(
-            corpus,
-            if persist_now { CorpusInsertionMode::Live } else { CorpusInsertionMode::Deferred },
-            new_coverage,
-        )
+        self.insert_corpus_entry(corpus, insertion_mode, new_coverage)
     }
 
     fn insert_corpus_entry(
@@ -1183,7 +1230,7 @@ impl WorkerCorpus {
         let campaign_entry = matches!(insertion_mode, CorpusInsertionMode::Deferred)
             .then(|| CampaignCorpusEntry { tx_seq: corpus.tx_seq.clone(), dedupe_by_coverage });
 
-        if matches!(insertion_mode, CorpusInsertionMode::Live)
+        if matches!(insertion_mode, CorpusInsertionMode::Live | CorpusInsertionMode::WorkerSync)
             && let Some(worker_dir) = &self.worker_dir
         {
             let worker_corpus = worker_dir.join(CORPUS_DIR);
@@ -1206,13 +1253,14 @@ impl WorkerCorpus {
             }
         }
 
-        self.push_corpus_entry(corpus);
+        self.push_corpus_entry(corpus, matches!(insertion_mode, CorpusInsertionMode::WorkerSync));
         campaign_entry
     }
 
-    fn push_corpus_entry(&mut self, corpus: CorpusEntry) {
-        let new_index = self.in_memory_corpus.len();
-        self.new_entry_indices.push(new_index);
+    fn push_corpus_entry(&mut self, corpus: CorpusEntry, track_for_worker_sync: bool) {
+        if track_for_worker_sync {
+            self.pending_sync_uuids.insert(corpus.uuid);
+        }
         self.metrics.corpus_count += 1;
         self.in_memory_corpus.push(corpus);
         if let Err(err) = self.recompute_favored_and_cull_corpus() {
@@ -1285,6 +1333,7 @@ impl WorkerCorpus {
     }
 
     fn recompute_favored_and_cull_corpus(&mut self) -> Result<()> {
+        self.metrics.corpus_count = self.in_memory_corpus.len();
         if self.in_memory_corpus.is_empty() {
             self.metrics.favored_items = 0;
             return Ok(());
@@ -1462,24 +1511,27 @@ impl WorkerCorpus {
 
     /// Flush non-favored entries from memory when the corpus size exceeds the minimum.
     fn cull_corpus(&mut self) -> Result<()> {
+        self.metrics.corpus_count = self.in_memory_corpus.len();
         let min_size = self.config.corpus_min_size.max(1);
         if self.in_memory_corpus.len() <= min_size {
             return Ok(());
         }
 
+        if !self
+            .in_memory_corpus
+            .iter()
+            .any(|corpus| !corpus.is_favored && !self.pending_sync_uuids.contains(&corpus.uuid))
+        {
+            return Ok(());
+        }
+
         let mut remaining_removals = self.in_memory_corpus.len() - min_size;
-        let mut old_to_new = vec![None; self.in_memory_corpus.len()];
         let mut retained = Vec::with_capacity(self.in_memory_corpus.len());
         let mut evicted_uuids = HashSet::new();
-        let unsynced_uuids = self
-            .new_entry_indices
-            .iter()
-            .filter_map(|&index| self.in_memory_corpus.get(index).map(|entry| entry.uuid))
-            .collect::<HashSet<_>>();
 
-        for (old_index, corpus) in self.in_memory_corpus.drain(..).enumerate() {
+        for corpus in self.in_memory_corpus.drain(..) {
             if !corpus.is_favored
-                && !unsynced_uuids.contains(&corpus.uuid)
+                && !self.pending_sync_uuids.contains(&corpus.uuid)
                 && remaining_removals > 0
             {
                 trace!(target: "corpus", corpus=%serde_json::to_string(&corpus).unwrap(), "evict corpus");
@@ -1488,7 +1540,6 @@ impl WorkerCorpus {
                 evicted_uuids.insert(uuid);
                 remaining_removals -= 1;
             } else {
-                old_to_new[old_index] = Some(retained.len());
                 retained.push(corpus);
             }
         }
@@ -1499,12 +1550,7 @@ impl WorkerCorpus {
         }
 
         self.in_memory_corpus = retained;
-        self.new_entry_indices = self
-            .new_entry_indices
-            .iter()
-            .filter_map(|&i| old_to_new.get(i).copied().flatten())
-            .collect();
-
+        self.metrics.corpus_count = self.in_memory_corpus.len();
         let impacted_edges = self
             .top_rated
             .iter()
@@ -1683,7 +1729,9 @@ impl WorkerCorpus {
         assert_ne!(self.id, 0, "non-master only");
 
         // Early return if no new entries or corpus dir not configured.
-        if self.new_entry_indices.is_empty() || self.worker_dir.is_none() {
+        if (self.pending_sync_uuids.is_empty() && self.new_entry_indices.is_empty())
+            || self.worker_dir.is_none()
+        {
             return Ok(());
         }
 
@@ -1697,15 +1745,24 @@ impl WorkerCorpus {
             return Ok(());
         };
 
-        let mut exported = 0;
+        let mut exported_uuids = HashSet::new();
+        let mut recovered_descriptors = Vec::new();
         let corpus_dir = worker_dir.join(CORPUS_DIR);
-        let mut delivered = HashSet::new();
+        let mut exported = 0;
+        let new_entry_uuids = self
+            .new_entry_indices
+            .iter()
+            .filter_map(|&index| self.in_memory_corpus.get(index).map(|corpus| corpus.uuid))
+            .collect::<HashSet<_>>();
 
-        for &index in &self.new_entry_indices {
-            let Some(corpus) = self.in_memory_corpus.get(index) else {
-                delivered.insert(index);
-                continue;
-            };
+        for corpus in self
+            .in_memory_corpus
+            .iter()
+            .filter(|entry| {
+                new_entry_uuids.contains(&entry.uuid)
+                    || self.pending_sync_uuids.contains(&entry.uuid)
+            })
+        {
             let file_name = corpus.file_name(self.config.corpus_gzip);
             let file_path = corpus_dir.join(&file_name);
             if !file_path.is_file()
@@ -1719,10 +1776,18 @@ impl WorkerCorpus {
                 continue;
             }
             exported += 1;
-            delivered.insert(index);
+            exported_uuids.insert(corpus.uuid);
         }
-        self.new_entry_indices.retain(|index| !delivered.contains(index));
+        self.new_entry_indices.retain(|&index| {
+            self.in_memory_corpus
+                .get(index)
+                .is_none_or(|corpus| !exported_uuids.contains(&corpus.uuid))
+        });
 
+        for descriptor in recovered_descriptors {
+            self.disk_corpus.push_descriptor(descriptor);
+        }
+        self.pending_sync_uuids.retain(|uuid| !exported_uuids.contains(uuid));
         debug!(target: "corpus", "exported {exported} new corpus entries");
 
         Ok(())
@@ -1894,11 +1959,17 @@ impl WorkerCorpus {
         self.calibrate(executor, target)?;
         if self.id == 0 {
             self.export_to_workers(num_workers)?;
+            self.pending_sync_uuids.clear();
         } else {
             self.export_to_master()?;
         }
 
-        debug!(target: "corpus", "synced");
+        let last_sync = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        self.last_sync_timestamp = last_sync;
+
+        self.cull_corpus()?;
+
+        debug!(target: "corpus", last_sync, "synced");
 
         Ok(())
     }
@@ -2662,24 +2733,29 @@ mod tests {
     fn clone_for_worker_shards_warmed_corpus_and_recomputes_metrics() {
         let entries = (0..10)
             .map(|idx| {
-                let mut entry = CorpusEntry::new(vec![basic_tx()]);
-                entry.is_favored = idx % 2 == 0;
-                entry
+                CorpusEntry::new_with_cmp_and_edges(
+                    vec![basic_tx()],
+                    Vec::new(),
+                    vec![idx % 3],
+                    Uuid::new_v4(),
+                )
             })
             .collect::<Vec<_>>();
         let entry_ids = entries.iter().map(|entry| entry.uuid).collect::<Vec<_>>();
+        let top_rated =
+            HashMap::from([(0, (entry_ids[0], 1)), (1, (entry_ids[1], 1)), (2, (entry_ids[2], 1))]);
         let seed = WorkerCorpusSeed {
             in_memory_corpus: entries,
             disk_corpus: CachedDiskCorpus::default(),
             history_map: vec![1, 2, 3],
             edge_indices: EdgeIndexMap::default(),
             sancov_history_map: vec![4, 5],
-            top_rated: HashMap::new(),
+            top_rated,
             metrics: CorpusMetrics {
                 cumulative_edges_seen: 7,
                 cumulative_features_seen: 11,
                 corpus_count: 10,
-                favored_items: 5,
+                favored_items: 3,
             },
             replay_dirs: None,
             failed_replays: 13,
@@ -2723,8 +2799,11 @@ mod tests {
         );
         assert_eq!(
             shards.iter().map(|shard| shard.metrics.favored_items).collect::<Vec<_>>(),
-            [2, 1, 2]
+            [1, 1, 1]
         );
+        assert_eq!(shards[0].top_rated, HashMap::from([(0, (entry_ids[0], 1))]));
+        assert_eq!(shards[1].top_rated, HashMap::from([(1, (entry_ids[1], 1))]));
+        assert_eq!(shards[2].top_rated, HashMap::from([(2, (entry_ids[2], 1))]));
         assert!(shards.iter().all(|shard| shard.history_map == seed.history_map));
         assert!(shards.iter().all(|shard| shard.sancov_history_map == seed.sancov_history_map));
         assert!(shards.iter().all(|shard| shard.metrics.cumulative_edges_seen == 7));
@@ -2760,39 +2839,38 @@ mod tests {
     }
 
     #[test]
-    fn retain_replayable_removes_off_target_corpus_entries() {
+    fn retain_replayable_filters_descriptors_without_rereading_files() {
         let target = Address::from([0x11; 20]);
         let foo = Function::parse("foo()").unwrap();
         let bar = Function::parse("bar()").unwrap();
         let foo_selector = foo.selector();
         let foo_tx = tx_for_function(target, &foo, &[]);
         let bar_tx = tx_for_function(target, &bar, &[]);
-        let mut foo_entry = CorpusEntry::new_with_cmp_and_edges(
+        let foo_entry = CorpusEntry::new_with_cmp_and_edges(
             vec![foo_tx.clone()],
             Vec::new(),
             vec![1],
             Uuid::new_v4(),
         );
-        foo_entry.is_favored = true;
-        let mut bar_entry = CorpusEntry::new_with_cmp_and_edges(
+        let bar_entry = CorpusEntry::new_with_cmp_and_edges(
             vec![bar_tx.clone()],
             Vec::new(),
             vec![2],
             Uuid::new_v4(),
         );
-        bar_entry.is_favored = true;
         let foo_uuid = foo_entry.uuid;
         let bar_uuid = bar_entry.uuid;
-        let corpus_dir = temp_corpus_dir();
-        let bar_path = corpus_dir.join(format!("{bar_uuid}-1.json"));
-        std::fs::write(&bar_path, serde_json::to_vec(&vec![bar_tx.clone()]).unwrap()).unwrap();
         let mut disk_corpus = CachedDiskCorpus::default();
         disk_corpus.push_descriptor(CorpusDirEntry {
-            path: bar_path,
-            uuid: bar_uuid,
+            path: PathBuf::from("foo.json"),
+            uuid: foo_uuid,
             timestamp: 1,
         });
-        disk_corpus.cache_entry(Arc::new(bar_entry.clone()));
+        disk_corpus.push_descriptor(CorpusDirEntry {
+            path: PathBuf::from("bar.json"),
+            uuid: bar_uuid,
+            timestamp: 2,
+        });
         let mut seed = WorkerCorpusSeed {
             in_memory_corpus: vec![foo_entry, bar_entry],
             disk_corpus,
@@ -2820,7 +2898,8 @@ mod tests {
         );
         assert_eq!(seed.metrics.corpus_count, 1);
         assert_eq!(seed.metrics.favored_items, 1);
-        assert!(seed.disk_corpus.descriptors.is_empty());
+        assert_eq!(seed.disk_corpus.descriptors.len(), 1);
+        assert_eq!(seed.disk_corpus.descriptors[0].uuid, foo_uuid);
         assert!(seed.disk_corpus.cache.is_empty());
         assert_eq!(seed.top_rated, HashMap::from([(1, (foo_uuid, 1))]));
         assert!(seed.optimization_best_value.is_none());
@@ -3170,25 +3249,92 @@ mod tests {
     }
 
     #[test]
-    fn culling_keeps_unsynced_entries_until_export() {
-        let mut favored = CorpusEntry::new_with_cmp_and_edges(
-            vec![basic_tx()],
-            Vec::new(),
-            vec![1],
-            Uuid::new_v4(),
-        );
-        favored.is_favored = true;
-        let unsynced = CorpusEntry::new(vec![basic_tx()]);
-        let unsynced_uuid = unsynced.uuid;
-        let mut manager = seeded_worker_corpus(1, temp_corpus_dir(), vec![favored, unsynced]);
-        manager.new_entry_indices.push(1);
+    fn invariant_insertions_do_not_disable_culling() {
+        let mut deferred = empty_worker_corpus(1, temp_corpus_dir());
+        let mut live = empty_worker_corpus(0, temp_corpus_dir());
+        let mut memory_only = empty_worker_corpus(1, temp_corpus_dir());
 
-        manager.cull_corpus().unwrap();
-        assert!(manager.in_memory_corpus.iter().any(|entry| entry.uuid == unsynced_uuid));
+        for idx in 0..32 {
+            let tx = basic_tx_with_calldata(vec![idx]);
+            let _ = deferred.process_inputs_for_campaign(
+                std::slice::from_ref(&tx),
+                &[],
+                true,
+                vec![1],
+                None,
+            );
+            live.process_inputs(std::slice::from_ref(&tx), &[], true, vec![1], None);
+            let _ = memory_only.push_observed_sequence(vec![tx], CorpusInsertionMode::MemoryOnly);
+        }
 
-        manager.new_entry_indices.clear();
+        for manager in [&deferred, &live, &memory_only] {
+            assert_eq!(manager.in_memory_corpus.len(), 1);
+            assert_eq!(manager.metrics.corpus_count, manager.in_memory_corpus.len());
+            assert!(manager.pending_sync_uuids.is_empty());
+        }
+    }
+
+    #[test]
+    fn stateless_insertions_are_protected_until_sync() {
+        let mut manager = empty_worker_corpus(1, temp_corpus_dir());
+
+        for idx in 0..4 {
+            let tx = basic_tx_with_calldata(vec![idx]);
+            manager.process_inputs_for_worker_sync(
+                std::slice::from_ref(&tx),
+                &[],
+                true,
+                vec![1],
+                None,
+            );
+        }
+
+        assert_eq!(manager.in_memory_corpus.len(), 4);
+        assert_eq!(manager.pending_sync_uuids.len(), 4);
+    }
+
+    #[test]
+    fn stateless_export_retries_failures_before_culling() {
+        let corpus_root = temp_corpus_dir();
+        let master_sync_dir = corpus_root.join("worker0").join(SYNC_DIR);
+        fs::create_dir_all(&master_sync_dir).unwrap();
+        let mut manager = empty_worker_corpus(1, corpus_root);
+
+        for idx in 0..2 {
+            let tx = basic_tx_with_calldata(vec![idx]);
+            manager.process_inputs_for_worker_sync(
+                std::slice::from_ref(&tx),
+                &[],
+                true,
+                vec![1],
+                None,
+            );
+        }
+        let blocked_uuid = manager.in_memory_corpus[1].uuid;
+        let worker_corpus_dir = manager.worker_dir.as_ref().unwrap().join(CORPUS_DIR);
+        let blocked_path = worker_corpus_dir.join(manager.in_memory_corpus[1].file_name(false));
+        fs::remove_file(&blocked_path).unwrap();
+        fs::create_dir(&blocked_path).unwrap();
+
+        manager.export_to_master().unwrap();
         manager.cull_corpus().unwrap();
-        assert!(!manager.in_memory_corpus.iter().any(|entry| entry.uuid == unsynced_uuid));
+
+        assert_eq!(manager.pending_sync_uuids, HashSet::from([blocked_uuid]));
+        assert!(manager.in_memory_corpus.iter().any(|entry| entry.uuid == blocked_uuid));
+        fs::remove_dir(blocked_path).unwrap();
+
+        manager.export_to_master().unwrap();
+        assert!(manager.pending_sync_uuids.is_empty());
+
+        // Repeating an acknowledged export is idempotent if the destination still exists.
+        manager.pending_sync_uuids.insert(blocked_uuid);
+        manager.export_to_master().unwrap();
+        manager.cull_corpus().unwrap();
+
+        assert!(manager.pending_sync_uuids.is_empty());
+        assert_eq!(manager.in_memory_corpus.len(), 1);
+        assert!(manager.in_memory_corpus.iter().all(|entry| entry.uuid != blocked_uuid));
+        assert_eq!(manager.metrics.corpus_count, manager.in_memory_corpus.len());
     }
 
     #[test]
@@ -3226,5 +3372,42 @@ mod tests {
         assert!(cache.random_entry(runner.rng()).unwrap().is_none());
         assert!(cache.descriptors.is_empty());
         assert!(cache.descriptor_indices.is_empty());
+    }
+
+    #[test]
+    fn cached_disk_corpus_selects_cache_only_donor_with_descriptors_present() {
+        let descriptor_uuid = Uuid::new_v4();
+        let cache_only = Arc::new(CorpusEntry::new(vec![basic_tx()]));
+        let cache_only_uuid = cache_only.uuid;
+        let mut cache = CachedDiskCorpus::default();
+        cache.push_descriptor(CorpusDirEntry {
+            path: PathBuf::from("descriptor.json"),
+            uuid: descriptor_uuid,
+            timestamp: 1,
+        });
+        cache.cache_entry(cache_only);
+        let mut runner = TestRunner::deterministic();
+
+        let selected = cache.random_entry_with_disk_refresh(runner.rng(), false).unwrap().unwrap();
+
+        assert_eq!(selected.uuid, cache_only_uuid);
+    }
+
+    #[test]
+    fn cached_disk_corpus_refreshes_from_descriptor() {
+        let root = temp_corpus_dir();
+        let corpus = CorpusEntry::new(vec![basic_tx()]);
+        let uuid = corpus.uuid;
+        let timestamp = corpus.timestamp;
+        let path = corpus.write_to_disk_in(&root, false).unwrap();
+        let mut cache = CachedDiskCorpus::default();
+        cache.push_descriptor(CorpusDirEntry { path, uuid, timestamp });
+        cache.cache_entry(Arc::new(CorpusEntry::new(vec![basic_tx()])));
+        let mut runner = TestRunner::deterministic();
+
+        let selected = cache.random_entry_with_disk_refresh(runner.rng(), true).unwrap().unwrap();
+
+        assert_eq!(selected.uuid, uuid);
+        assert!(cache.cache.iter().any(|entry| entry.uuid == uuid));
     }
 }

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1657,15 +1657,14 @@ impl WorkerCorpus {
             let mut replay_executor = executor.clone();
             let ReplayOutcome {
                 keep_entry, new_coverage, new_edge, edges_covered, cmp_seq, ..
-            } =
-                replay_corpus_sequence_with_executor(
-                    &tx_seq,
-                    &mut replay_executor,
-                    target,
-                    coverage,
-                    true,
-                    false,
-                )?;
+            } = replay_corpus_sequence_with_executor(
+                &tx_seq,
+                &mut replay_executor,
+                target,
+                coverage,
+                true,
+                false,
+            )?;
 
             let sync_path = &entry.path;
             if keep_entry && new_coverage {
@@ -1746,7 +1745,7 @@ impl WorkerCorpus {
         };
 
         let mut exported_uuids = HashSet::new();
-        let mut recovered_descriptors = Vec::new();
+        let recovered_descriptors = Vec::new();
         let corpus_dir = worker_dir.join(CORPUS_DIR);
         let mut exported = 0;
         let new_entry_uuids = self
@@ -1755,14 +1754,9 @@ impl WorkerCorpus {
             .filter_map(|&index| self.in_memory_corpus.get(index).map(|corpus| corpus.uuid))
             .collect::<HashSet<_>>();
 
-        for corpus in self
-            .in_memory_corpus
-            .iter()
-            .filter(|entry| {
-                new_entry_uuids.contains(&entry.uuid)
-                    || self.pending_sync_uuids.contains(&entry.uuid)
-            })
-        {
+        for corpus in self.in_memory_corpus.iter().filter(|entry| {
+            new_entry_uuids.contains(&entry.uuid) || self.pending_sync_uuids.contains(&entry.uuid)
+        }) {
             let file_name = corpus.file_name(self.config.corpus_gzip);
             let file_path = corpus_dir.join(&file_name);
             if !file_path.is_file()
@@ -2324,8 +2318,9 @@ mod tests {
         let corpus_root = temp_corpus_dir();
         let mut worker = empty_worker_corpus(1, corpus_root.clone());
         let corpus = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
+        let uuid = corpus.uuid;
         let name = corpus.file_name(false);
-        worker.push_corpus_entry(corpus);
+        worker.push_corpus_entry(corpus, true);
 
         let master_sync = corpus_root.join("worker0").join(SYNC_DIR);
         fs::create_dir_all(&master_sync).unwrap();
@@ -2334,13 +2329,13 @@ mod tests {
             .unwrap();
 
         worker.export_to_master().unwrap();
-        assert_eq!(worker.new_entry_indices, [0]);
+        assert_eq!(worker.pending_sync_uuids, HashSet::from([uuid]));
         assert!(corpus_root.join("worker1").join(CORPUS_DIR).join(&name).is_file());
 
         fs::remove_file(&destination).unwrap();
         worker.export_to_master().unwrap();
 
-        assert!(worker.new_entry_indices.is_empty());
+        assert!(worker.pending_sync_uuids.is_empty());
         let exported = read_corpus_dir(&master_sync).next().unwrap().read_tx_seq().unwrap();
         assert!(same_tx_sequence(&exported, &[basic_tx_with_calldata([1])]));
     }
@@ -2353,7 +2348,7 @@ mod tests {
         let corpus = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
         let name = corpus.file_name(false);
         corpus.write_to_disk_in(&corpus_root.join("worker0").join(CORPUS_DIR), false).unwrap();
-        master.push_corpus_entry(corpus);
+        master.push_synced_corpus_entry(corpus, 0, name.clone());
 
         let worker2_sync = corpus_root.join("worker2").join(SYNC_DIR);
         fs::create_dir_all(&worker2_sync).unwrap();
@@ -2437,7 +2432,7 @@ mod tests {
         let pending = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
         let pending_name = pending.file_name(false);
         pending.write_to_disk_in(&flat_root.join("worker0").join(CORPUS_DIR), false).unwrap();
-        flat_master.push_corpus_entry(pending);
+        flat_master.push_synced_corpus_entry(pending, 0, pending_name.clone());
 
         flat_master.export_to_workers(2).unwrap();
 
@@ -2451,9 +2446,9 @@ mod tests {
         let corpus_root = temp_corpus_dir();
         let mut master = empty_worker_corpus(0, corpus_root.clone());
         master.initial_export_dirs = None;
-        let mut evicted = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
-        evicted.total_mutations = 1;
-        let retained = CorpusEntry::new(vec![basic_tx_with_calldata([2])]);
+        let evicted = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
+        let mut retained = CorpusEntry::new(vec![basic_tx_with_calldata([2])]);
+        retained.is_favored = true;
         let evicted_name = evicted.file_name(false);
         let retained_name = retained.file_name(false);
         let evicted_timestamp = evicted.timestamp;
@@ -2464,7 +2459,7 @@ mod tests {
         master.push_synced_corpus_entry(evicted, evicted_timestamp, evicted_name.clone());
         master.push_synced_corpus_entry(retained, retained_timestamp, retained_name.clone());
 
-        master.evict_oldest_corpus().unwrap();
+        master.cull_corpus().unwrap();
         master.export_to_workers(2).unwrap();
 
         let worker_sync = corpus_root.join("worker1").join(SYNC_DIR);

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -58,7 +58,7 @@ use foundry_evm_fuzz::{
 use proptest::test_runner::TestRunner;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet, VecDeque},
     fmt,
     path::{Path, PathBuf},
     sync::{
@@ -69,12 +69,21 @@ use std::{
 };
 use uuid::Uuid;
 
+#[cfg(test)]
+use proptest::test_runner::TestRng;
+#[cfg(test)]
+use rand::Rng;
+
 const WORKER: &str = "worker";
 const CORPUS_DIR: &str = "corpus";
 const SYNC_DIR: &str = "sync";
 const OPTIMIZATION_BEST_FILE: &str = "optimization_best.json";
 
-const FAVORABILITY_THRESHOLD: f64 = 0.3;
+const SANCOV_EDGE_OFFSET: usize = usize::MAX / 2;
+const CACHED_DISK_CORPUS_MAX_LEN: usize = 128;
+// Prefer decoded donors while periodically refreshing the bounded cache from disk.
+#[cfg(test)]
+const DISK_CORPUS_REFRESH_DENOMINATOR: u32 = 16;
 
 /// Threshold for compressing corpus entries.
 /// 4KiB is usually the minimum file size on popular file systems.
@@ -92,10 +101,9 @@ struct OptimizationState {
 struct CorpusEntry {
     // Unique corpus identifier.
     uuid: Uuid,
-    // Total mutations of corpus as primary source.
-    total_mutations: usize,
-    // New coverage found as a result of mutating this corpus.
-    new_finds_produced: usize,
+    // Unique coverage indices this entry hits.
+    #[serde(skip_serializing)]
+    unique_edges_covered: Vec<usize>,
     // Corpus call sequence.
     #[serde(skip_serializing)]
     tx_seq: Vec<BasicTxDetails>,
@@ -103,8 +111,7 @@ struct CorpusEntry {
     // Parallel to `tx_seq`. Empty inner vec means "no cmp data for this call".
     #[serde(skip_serializing)]
     cmp_seq: Vec<Vec<ComparisonHint>>,
-    // Whether this corpus is favored, i.e. producing new finds more often than
-    // `FAVORABILITY_THRESHOLD`.
+    // Whether this corpus is favored (part of the top-rated coverage minset).
     is_favored: bool,
     /// Timestamp of when this entry was written to disk in seconds.
     #[serde(skip_serializing)]
@@ -117,19 +124,19 @@ struct CorpusEntry {
 impl CorpusEntry {
     /// Creates a corpus entry with a new UUID.
     pub fn new(tx_seq: Vec<BasicTxDetails>) -> Self {
-        Self::new_with_cmp(tx_seq, Vec::new(), Uuid::new_v4())
+        Self::new_with_cmp_and_edges(tx_seq, Vec::new(), Vec::new(), Uuid::new_v4())
     }
 
-    /// Creates a corpus entry with the given UUID and per-call cmp operand log.
-    pub fn new_with_cmp(
+    /// Creates a corpus entry with coverage and per-call cmp operand log.
+    pub fn new_with_cmp_and_edges(
         tx_seq: Vec<BasicTxDetails>,
         cmp_seq: Vec<Vec<ComparisonHint>>,
+        edges_covered: Vec<usize>,
         uuid: Uuid,
     ) -> Self {
-        Self {
+        let mut entry = Self {
             uuid,
-            total_mutations: 0,
-            new_finds_produced: 0,
+            unique_edges_covered: Vec::new(),
             tx_seq,
             cmp_seq,
             is_favored: false,
@@ -138,7 +145,15 @@ impl CorpusEntry {
                 .expect("time went backwards")
                 .as_secs(),
             persisted_file_name: None,
-        }
+        };
+        entry.set_edges(edges_covered);
+        entry
+    }
+
+    pub fn set_edges(&mut self, mut edges_covered: Vec<usize>) {
+        edges_covered.sort_unstable();
+        edges_covered.dedup();
+        self.unique_edges_covered = edges_covered;
     }
 
     fn write_to_disk_in(&self, dir: &Path, can_gzip: bool) -> foundry_common::fs::Result<PathBuf> {
@@ -179,6 +194,124 @@ impl CorpusEntry {
         }
         let size: usize = self.tx_seq.iter().map(|tx| tx.estimate_serialized_size()).sum();
         size > GZIP_THRESHOLD
+    }
+}
+
+#[derive(Clone)]
+struct CachedDiskCorpus {
+    descriptors: Vec<CorpusDirEntry>,
+    descriptor_indices: HashMap<Uuid, usize>,
+    cache: VecDeque<Arc<CorpusEntry>>,
+    cache_max_len: usize,
+}
+
+impl Default for CachedDiskCorpus {
+    fn default() -> Self {
+        Self {
+            descriptors: Vec::new(),
+            descriptor_indices: HashMap::new(),
+            cache: VecDeque::new(),
+            cache_max_len: CACHED_DISK_CORPUS_MAX_LEN,
+        }
+    }
+}
+
+impl CachedDiskCorpus {
+    fn push_descriptor(&mut self, descriptor: CorpusDirEntry) {
+        if let Some(&index) = self.descriptor_indices.get(&descriptor.uuid) {
+            self.descriptors[index] = descriptor;
+        } else {
+            self.descriptor_indices.insert(descriptor.uuid, self.descriptors.len());
+            self.descriptors.push(descriptor);
+        }
+    }
+
+    #[cfg(test)]
+    fn remove_descriptor_at(&mut self, index: usize) {
+        let removed = self.descriptors.swap_remove(index);
+        self.descriptor_indices.remove(&removed.uuid);
+        if let Some(moved) = self.descriptors.get(index) {
+            self.descriptor_indices.insert(moved.uuid, index);
+        }
+    }
+
+    fn cache_entry(&mut self, corpus: Arc<CorpusEntry>) {
+        if self.cache_max_len == 0 {
+            return;
+        }
+        if let Some(index) = self.cache.iter().position(|entry| entry.uuid == corpus.uuid) {
+            self.cache.remove(index);
+        }
+        self.cache.push_back(corpus);
+        while self.cache.len() > self.cache_max_len {
+            self.cache.pop_front();
+        }
+    }
+
+    fn retain_uuids(&mut self, retained: &HashSet<Uuid>) {
+        self.cache.retain(|entry| retained.contains(&entry.uuid));
+        self.descriptors.retain(|descriptor| retained.contains(&descriptor.uuid));
+        self.descriptor_indices.clear();
+        self.descriptor_indices
+            .extend(self.descriptors.iter().enumerate().map(|(index, entry)| (entry.uuid, index)));
+    }
+
+    #[cfg(test)]
+    fn random_entry(
+        &mut self,
+        rng: &mut TestRng,
+    ) -> foundry_common::fs::Result<Option<Arc<CorpusEntry>>> {
+        let refresh_disk = self.cache.is_empty()
+            || (!self.descriptors.is_empty()
+                && rng.random_ratio(1, DISK_CORPUS_REFRESH_DENOMINATOR));
+        self.random_entry_with_disk_refresh(rng, refresh_disk)
+    }
+
+    #[cfg(test)]
+    fn random_entry_with_disk_refresh(
+        &mut self,
+        rng: &mut TestRng,
+        refresh_disk: bool,
+    ) -> foundry_common::fs::Result<Option<Arc<CorpusEntry>>> {
+        loop {
+            if self.cache.is_empty() && self.descriptors.is_empty() {
+                return Ok(None);
+            }
+
+            if !self.cache.is_empty() && (!refresh_disk || self.descriptors.is_empty()) {
+                let index = rng.random_range(0..self.cache.len());
+                return Ok(self.cache.get(index).cloned());
+            }
+
+            let descriptor_index = rng.random_range(0..self.descriptors.len());
+            let descriptor = self.descriptors[descriptor_index].clone();
+            if let Some(cached) = self.cache.iter().find(|entry| entry.uuid == descriptor.uuid) {
+                return Ok(Some(Arc::clone(cached)));
+            }
+
+            let tx_seq = match descriptor.read_tx_seq() {
+                Ok(tx_seq) if !tx_seq.is_empty() => tx_seq,
+                Ok(_) => {
+                    self.remove_descriptor_at(descriptor_index);
+                    continue;
+                }
+                Err(err) => {
+                    debug!(target: "corpus", path=%descriptor.path.display(), %err, "removing unreadable corpus donor");
+                    self.remove_descriptor_at(descriptor_index);
+                    continue;
+                }
+            };
+            let mut corpus = CorpusEntry::new_with_cmp_and_edges(
+                tx_seq,
+                Vec::new(),
+                Vec::new(),
+                descriptor.uuid,
+            );
+            corpus.timestamp = descriptor.timestamp;
+            let corpus = Arc::new(corpus);
+            self.cache_entry(Arc::clone(&corpus));
+            return Ok(Some(corpus));
+        }
     }
 }
 
@@ -294,6 +427,7 @@ struct ReplayOutcome {
     new_coverage: bool,
     /// Whether replay hit a first-time edge (advances the per-worker "time since new edge" timer).
     new_edge: bool,
+    edges_covered: Vec<usize>,
     cmp_seq: Vec<Vec<ComparisonHint>>,
     failed_replays: usize,
 }
@@ -337,9 +471,11 @@ struct ReplayCoverage<'a> {
 #[derive(Clone, Default)]
 pub(crate) struct WorkerCorpusSeed {
     in_memory_corpus: Vec<CorpusEntry>,
+    disk_corpus: CachedDiskCorpus,
     history_map: Vec<u8>,
     edge_indices: EdgeIndexMap,
     sancov_history_map: Vec<u8>,
+    top_rated: HashMap<usize, (Uuid, usize)>,
     metrics: CorpusMetrics,
     replay_dirs: Option<Vec<PathBuf>>,
     failed_replays: usize,
@@ -372,6 +508,19 @@ impl WorkerCorpusSeed {
         self
     }
 
+    fn rebuild_minset(&mut self) {
+        self.top_rated.clear();
+        for entry in &self.in_memory_corpus {
+            WorkerCorpus::update_top_rated_in(&mut self.top_rated, entry);
+        }
+        self.metrics.corpus_count = self.in_memory_corpus.len();
+        WorkerCorpus::recompute_favored_for_entries(
+            &self.top_rated,
+            &mut self.in_memory_corpus,
+            &mut self.metrics,
+        );
+    }
+
     pub(crate) fn clone_for_worker(
         &self,
         worker_id: usize,
@@ -392,31 +541,39 @@ impl WorkerCorpusSeed {
             })
             .collect::<Vec<_>>();
 
+        let retained_uuids =
+            in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
+        let mut disk_corpus = self.disk_corpus.clone();
+        disk_corpus.retain_uuids(&retained_uuids);
         let mut metrics = self.metrics.clone();
         metrics.corpus_count = in_memory_corpus.len();
-        metrics.favored_items = in_memory_corpus.iter().filter(|entry| entry.is_favored).count();
 
-        Self {
+        let mut seed = Self {
             in_memory_corpus,
+            disk_corpus,
             history_map: self.history_map.clone(),
             edge_indices: self.edge_indices.clone(),
             sancov_history_map: self.sancov_history_map.clone(),
+            top_rated: HashMap::new(),
             metrics,
             replay_dirs: self.replay_dirs.clone(),
             failed_replays: self.failed_replays,
             optimization_best_value: self.optimization_best_value,
             optimization_best_sequence: self.optimization_best_sequence.clone(),
             last_new_edge_at: self.last_new_edge_at,
-        }
+        };
+        seed.rebuild_minset();
+        seed
     }
 
     pub(crate) fn retain_replayable(&mut self, targeted_contracts: &TargetedContracts) {
         let is_replayable =
             |tx_seq: &[BasicTxDetails]| tx_seq.iter().all(|tx| targeted_contracts.can_replay(tx));
         self.in_memory_corpus.retain(|entry| is_replayable(&entry.tx_seq));
-        self.metrics.corpus_count = self.in_memory_corpus.len();
-        self.metrics.favored_items =
-            self.in_memory_corpus.iter().filter(|entry| entry.is_favored).count();
+        let retained_uuids =
+            self.in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
+        self.disk_corpus.retain_uuids(&retained_uuids);
+        self.rebuild_minset();
 
         if !self.optimization_best_sequence.is_empty()
             && !is_replayable(&self.optimization_best_sequence)
@@ -480,8 +637,9 @@ impl WorkerCorpusSeed {
                 sancov_history_map: &mut seed.sancov_history_map,
                 metrics: Some(&mut seed.metrics),
             };
-            let ReplayOutcome { keep_entry, new_edge, cmp_seq, failed_replays, .. } =
-                replay_corpus_sequence(&tx_seq, executor, target, coverage)?;
+            let ReplayOutcome {
+                keep_entry, new_edge, edges_covered, cmp_seq, failed_replays, ..
+            } = replay_corpus_sequence(&tx_seq, executor, target, coverage)?;
             seed.failed_replays += failed_replays;
             // Start the timer at the baseline load if replay hit a first-time edge.
             if new_edge {
@@ -491,6 +649,7 @@ impl WorkerCorpusSeed {
                 continue;
             }
 
+            seed.disk_corpus.push_descriptor(entry.clone());
             seed.metrics.corpus_count += 1;
             debug!(
                 target: "corpus",
@@ -498,8 +657,17 @@ impl WorkerCorpusSeed {
                 tx_seq.len(),
                 entry.path.display()
             );
-            seed.in_memory_corpus.push(CorpusEntry::new_with_cmp(tx_seq, cmp_seq, entry.uuid));
+            let corpus_entry =
+                CorpusEntry::new_with_cmp_and_edges(tx_seq, cmp_seq, edges_covered, entry.uuid);
+            WorkerCorpus::update_top_rated_in(&mut seed.top_rated, &corpus_entry);
+            seed.in_memory_corpus.push(corpus_entry);
         }
+
+        WorkerCorpus::recompute_favored_for_entries(
+            &seed.top_rated,
+            &mut seed.in_memory_corpus,
+            &mut seed.metrics,
+        );
 
         Ok(seed)
     }
@@ -607,15 +775,6 @@ impl CorpusMetrics {
             self.cumulative_features_seen += 1;
         }
     }
-
-    /// Updates campaign favored items.
-    pub const fn update_favored(&mut self, is_favored: bool, corpus_favored: bool) {
-        if is_favored && !corpus_favored {
-            self.favored_items += 1;
-        } else if !is_favored && corpus_favored {
-            self.favored_items -= 1;
-        }
-    }
 }
 
 /// Per-worker corpus manager.
@@ -625,12 +784,16 @@ pub struct WorkerCorpus {
     /// In-memory corpus entries populated from the persisted files and
     /// runs administered by this worker.
     in_memory_corpus: Vec<CorpusEntry>,
+    /// Disk-backed corpus entries plus a bounded decoded cache for non-favored mutation donors.
+    disk_corpus: CachedDiskCorpus,
     /// History of binned hitcount of edges seen during fuzzing
     history_map: Vec<u8>,
     /// Stable dense EVM edge IDs for this worker's history map.
     edge_indices: EdgeIndexMap,
     /// History of binned hitcount of sancov (native Rust) edges seen during fuzzing
     sancov_history_map: Vec<u8>,
+    /// Best corpus entry for each coverage index.
+    top_rated: HashMap<usize, (Uuid, usize)>,
     /// Number of failed replays from initial corpus
     pub(crate) failed_replays: usize,
     /// Worker Metrics
@@ -638,7 +801,6 @@ pub struct WorkerCorpus {
     /// Shared transaction-sequence generator.
     sequence_generator: SequenceGenerator,
     /// Identifier of current mutated entry for this worker.
-    current_mutated_index: Option<usize>,
     /// Config
     config: Arc<FuzzCorpusConfig>,
     /// Whether this corpus participates in stateless worker synchronization.
@@ -647,6 +809,10 @@ pub struct WorkerCorpus {
     new_entry_indices: Vec<usize>,
     /// Corpus directories the master loaded at startup and still needs to distribute.
     initial_export_dirs: Option<Vec<PathBuf>>,
+    /// UUIDs of stateless-worker entries pending export at the next synchronization.
+    pending_sync_uuids: HashSet<Uuid>,
+    /// Last sync timestamp in seconds.
+    last_sync_timestamp: u64,
     /// Worker Dir
     /// corpus_dir/worker1/
     worker_dir: Option<PathBuf>,
@@ -759,6 +925,7 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
     let mut new_coverage_for_entry = false;
     let mut new_edge_for_entry = false;
     let mut created: Vec<Address> = Vec::new();
+    let mut edges_covered = Vec::new();
 
     for tx in tx_seq {
         if WorkerCorpus::can_replay_tx(tx, target.stateless, target.fuzzed_contracts) {
@@ -772,10 +939,12 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
                     .map(|cmp| ComparisonHint { lhs: cmp.op1, rhs: cmp.op2 })
                     .collect(),
             );
-            let (new_coverage, is_edge) = call_result.merge_all_coverage(
+            let (new_coverage, is_edge) = call_result.merge_all_coverage_with_edges_into(
                 coverage.history_map,
                 coverage.edge_indices,
                 coverage.sancov_history_map,
+                SANCOV_EDGE_OFFSET,
+                &mut edges_covered,
             );
             if new_coverage {
                 new_coverage_for_entry = true;
@@ -815,6 +984,7 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
                     keep_entry: false,
                     new_coverage: new_coverage_for_entry,
                     new_edge: new_edge_for_entry,
+                    edges_covered,
                     cmp_seq,
                     failed_replays,
                 });
@@ -827,6 +997,7 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
         keep_entry: true,
         new_coverage: new_coverage_for_entry,
         new_edge: new_edge_for_entry,
+        edges_covered,
         cmp_seq,
         failed_replays,
     })
@@ -836,7 +1007,7 @@ impl WorkerCorpus {
     /// Produces the next sequence for either execution mode.
     pub fn new_sequence(&mut self, test_runner: &mut TestRunner) -> Result<SequencePlan> {
         if self.config.is_coverage_guided() && !self.in_memory_corpus.is_empty() {
-            self.evict_oldest_corpus()?;
+            self.cull_corpus()?;
         }
         let corpus_len = self.in_memory_corpus.len();
         let plan = self.sequence_generator.start(
@@ -851,7 +1022,6 @@ impl WorkerCorpus {
             },
             self.config.is_coverage_guided(),
         )?;
-        self.current_mutated_index = plan.source();
         Ok(plan)
     }
 
@@ -895,27 +1065,34 @@ impl WorkerCorpus {
             None
         };
 
-        Ok(Self {
+        let mut corpus = Self {
             id,
             in_memory_corpus: seed.in_memory_corpus,
+            disk_corpus: seed.disk_corpus,
             history_map: seed.history_map,
             edge_indices: seed.edge_indices,
             sancov_history_map: seed.sancov_history_map,
+            top_rated: seed.top_rated,
             failed_replays: seed.failed_replays,
             metrics: seed.metrics,
             sequence_generator,
-            current_mutated_index: None,
             config: config.into(),
             worker_sync_enabled: false,
             new_entry_indices: Default::default(),
             initial_export_dirs,
+            pending_sync_uuids: Default::default(),
+            last_sync_timestamp: 0,
             worker_dir,
             warned_persistence_failure: false,
             last_sync_metrics: Default::default(),
             optimization_best_value: seed.optimization_best_value,
             optimization_best_sequence: seed.optimization_best_sequence,
             last_new_edge_at: seed.last_new_edge_at,
-        })
+        };
+        if !corpus.top_rated.is_empty() {
+            corpus.cull_corpus()?;
+        }
+        Ok(corpus)
     }
 
     /// Updates stats for the given call sequence, if new coverage produced.
@@ -927,12 +1104,14 @@ impl WorkerCorpus {
         inputs: &[BasicTxDetails],
         cmp_seq: &[Vec<CmpOperands>],
         new_coverage: bool,
+        edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
     ) {
         self.process_inputs_inner(
             inputs,
             cmp_seq,
             new_coverage,
+            edges_covered,
             optimization,
             CorpusInsertionMode::Live,
             true,
@@ -949,23 +1128,27 @@ impl WorkerCorpus {
         inputs: &[BasicTxDetails],
         cmp_seq: &[Vec<CmpOperands>],
         new_coverage: bool,
+        edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
     ) {
         self.process_inputs_inner(
             inputs,
             cmp_seq,
             new_coverage,
+            edges_covered,
             optimization,
             CorpusInsertionMode::Live,
             false,
         );
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn process_inputs_inner(
         &mut self,
         inputs: &[BasicTxDetails],
         cmp_seq: &[Vec<CmpOperands>],
         new_coverage: bool,
+        edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
         insertion_mode: CorpusInsertionMode,
         persist_optimization: bool,
@@ -975,26 +1158,6 @@ impl WorkerCorpus {
             self.optimization_best_value.is_none_or(|best| *value > best)
         });
 
-        // Update stats of current mutated primary corpus.
-        if let Some(index) = self.current_mutated_index.take() {
-            let should_credit = new_coverage || improved_optimization;
-            if let Some(corpus) = self.in_memory_corpus.get_mut(index) {
-                corpus.total_mutations += 1;
-                if should_credit {
-                    corpus.new_finds_produced += 1
-                }
-                let is_favored = (corpus.new_finds_produced as f64 / corpus.total_mutations as f64)
-                    > FAVORABILITY_THRESHOLD;
-                self.metrics.update_favored(is_favored, corpus.is_favored);
-                corpus.is_favored = is_favored;
-
-                trace!(
-                    target: "corpus",
-                    "updated corpus {}, total mutations: {}, new finds: {}",
-                    corpus.uuid, corpus.total_mutations, corpus.new_finds_produced
-                );
-            }
-        }
         if let Some((value, best_seq)) = optimization
             && improved_optimization
         {
@@ -1035,7 +1198,13 @@ impl WorkerCorpus {
                 values.iter().map(|cmp| ComparisonHint { lhs: cmp.op1, rhs: cmp.op2 }).collect()
             })
             .collect();
-        let corpus = CorpusEntry::new_with_cmp(corpus_inputs, corpus_cmp_seq, Uuid::new_v4());
+        let corpus = CorpusEntry::new_with_cmp_and_edges(
+            corpus_inputs,
+            corpus_cmp_seq,
+            edges_covered,
+            Uuid::new_v4(),
+        );
+        self.update_top_rated(&corpus);
 
         self.insert_corpus_entry(corpus, insertion_mode)
     }
@@ -1045,6 +1214,12 @@ impl WorkerCorpus {
             && let Some(worker_dir) = &self.worker_dir
         {
             let worker_corpus = worker_dir.join(CORPUS_DIR);
+            let disk_entry = CorpusDirEntry {
+                path: worker_corpus
+                    .join(corpus.file_name(corpus.should_gzip(self.config.corpus_gzip))),
+                uuid: corpus.uuid,
+                timestamp: corpus.timestamp,
+            };
             let write_result = corpus.write_to_disk_in(&worker_corpus, self.config.corpus_gzip);
             if let Err(err) = write_result {
                 if !self.warned_persistence_failure {
@@ -1057,6 +1232,7 @@ impl WorkerCorpus {
                 }
                 debug!(target: "corpus", %err, "failed to record call sequence {:?}", corpus.tx_seq);
             } else {
+                self.disk_corpus.push_descriptor(disk_entry);
                 trace!(
                     target: "corpus",
                     "persisted {} inputs for new coverage for {} corpus",
@@ -1073,9 +1249,13 @@ impl WorkerCorpus {
         let new_index = self.in_memory_corpus.len();
         if self.worker_sync_enabled {
             self.new_entry_indices.push(new_index);
+            self.pending_sync_uuids.insert(corpus.uuid);
         }
         self.metrics.corpus_count += 1;
         self.in_memory_corpus.push(corpus);
+        if let Err(err) = self.recompute_favored_and_cull_corpus() {
+            debug!(target: "corpus", %err, "failed to recompute minset corpus");
+        }
     }
 
     /// Returns the previously persisted optimization best value and sequence (if any).
@@ -1091,19 +1271,87 @@ impl WorkerCorpus {
         persist_optimization_output(&self.config, optimization_best);
     }
 
-    /// Collects EVM and sancov coverage from call result and updates metrics.
-    pub fn merge_edge_coverage<FEN: FoundryEvmNetwork>(
+    fn update_top_rated(&mut self, corpus: &CorpusEntry) {
+        Self::update_top_rated_in(&mut self.top_rated, corpus);
+    }
+
+    fn update_top_rated_in(top_rated: &mut HashMap<usize, (Uuid, usize)>, corpus: &CorpusEntry) {
+        let cost = corpus.tx_seq.len();
+        for &edge_idx in &corpus.unique_edges_covered {
+            match top_rated.get_mut(&edge_idx) {
+                Some((best_uuid, best_cost)) if cost < *best_cost => {
+                    *best_uuid = corpus.uuid;
+                    *best_cost = cost;
+                }
+                Some(_) => {}
+                None => {
+                    top_rated.insert(edge_idx, (corpus.uuid, cost));
+                }
+            }
+        }
+    }
+
+    fn recompute_top_rated_for_edge(&mut self, edge_idx: usize) {
+        let best = self
+            .in_memory_corpus
+            .iter()
+            .filter(|corpus| corpus.unique_edges_covered.binary_search(&edge_idx).is_ok())
+            .min_by_key(|corpus| corpus.tx_seq.len())
+            .map(|corpus| (corpus.uuid, corpus.tx_seq.len()));
+
+        if let Some(best) = best {
+            self.top_rated.insert(edge_idx, best);
+        } else {
+            self.top_rated.remove(&edge_idx);
+        }
+    }
+
+    fn recompute_favored_for_entries(
+        top_rated: &HashMap<usize, (Uuid, usize)>,
+        corpus_entries: &mut [CorpusEntry],
+        metrics: &mut CorpusMetrics,
+    ) {
+        let favored_uuids = top_rated.values().map(|&(uuid, _)| uuid).collect::<HashSet<_>>();
+        let mut favored_items = 0;
+        for corpus in corpus_entries {
+            corpus.is_favored = favored_uuids.contains(&corpus.uuid);
+            if corpus.is_favored {
+                favored_items += 1;
+            }
+        }
+        metrics.favored_items = favored_items;
+    }
+
+    fn recompute_favored_and_cull_corpus(&mut self) -> Result<()> {
+        self.metrics.corpus_count = self.in_memory_corpus.len();
+        if self.in_memory_corpus.is_empty() {
+            self.metrics.favored_items = 0;
+            return Ok(());
+        }
+
+        Self::recompute_favored_for_entries(
+            &self.top_rated,
+            &mut self.in_memory_corpus,
+            &mut self.metrics,
+        );
+        self.cull_corpus()
+    }
+
+    pub fn merge_edge_coverage_with_edges_into<FEN: FoundryEvmNetwork>(
         &mut self,
         call_result: &mut RawCallResult<FEN>,
+        edges_covered: &mut Vec<usize>,
     ) -> bool {
         if !self.config.collect_edge_coverage() {
             return false;
         }
 
-        let (new_coverage, is_edge) = call_result.merge_all_coverage(
+        let (new_coverage, is_edge) = call_result.merge_all_coverage_with_edges_into(
             &mut self.history_map,
             &mut self.edge_indices,
             &mut self.sancov_history_map,
+            SANCOV_EDGE_OFFSET,
+            edges_covered,
         );
         if new_coverage {
             self.metrics.update_seen(is_edge);
@@ -1232,34 +1480,73 @@ impl WorkerCorpus {
 
         self.insert_corpus_entry(corpus, insertion_mode)
     }
-    /// Flush the oldest corpus mutated more than configured max mutations unless it is favored
-    /// or pending synchronization.
-    fn evict_oldest_corpus(&mut self) -> Result<()> {
-        if self.in_memory_corpus.len() > self.config.corpus_min_size.max(1)
-            && let Some(index) =
-                self.in_memory_corpus.iter().enumerate().position(|(index, corpus)| {
-                    self.new_entry_indices.binary_search(&index).is_err()
-                        && corpus.total_mutations > self.config.corpus_min_mutations
-                        && !corpus.is_favored
-                })
-        {
-            let corpus = &self.in_memory_corpus[index];
 
-            trace!(target: "corpus", corpus=%serde_json::to_string(&corpus).unwrap(), "evict corpus");
-
-            // Remove corpus from memory.
-            self.in_memory_corpus.remove(index);
-
-            // Adjust the tracked indices.
-            self.new_entry_indices.retain_mut(|i| {
-                if *i > index {
-                    *i -= 1; // Shift indices down.
-                    true // Keep this index.
-                } else {
-                    *i != index // Remove if it's the deleted index, keep otherwise.
-                }
-            });
+    /// Flush non-favored entries from memory when the corpus size exceeds the minimum.
+    fn cull_corpus(&mut self) -> Result<()> {
+        self.metrics.corpus_count = self.in_memory_corpus.len();
+        let min_size = self.config.corpus_min_size.max(1);
+        if self.in_memory_corpus.len() <= min_size {
+            return Ok(());
         }
+
+        if !self
+            .in_memory_corpus
+            .iter()
+            .any(|corpus| !corpus.is_favored && !self.pending_sync_uuids.contains(&corpus.uuid))
+        {
+            return Ok(());
+        }
+
+        let queued_uuids = self
+            .new_entry_indices
+            .iter()
+            .filter_map(|&index| self.in_memory_corpus.get(index).map(|entry| entry.uuid))
+            .collect::<HashSet<_>>();
+        let mut remaining_removals = self.in_memory_corpus.len() - min_size;
+        let mut retained = Vec::with_capacity(self.in_memory_corpus.len());
+        let mut evicted_uuids = HashSet::new();
+
+        for corpus in self.in_memory_corpus.drain(..) {
+            if !corpus.is_favored
+                && !self.pending_sync_uuids.contains(&corpus.uuid)
+                && remaining_removals > 0
+            {
+                trace!(target: "corpus", corpus=%serde_json::to_string(&corpus).unwrap(), "evict corpus");
+                let uuid = corpus.uuid;
+                self.disk_corpus.cache_entry(Arc::new(corpus));
+                evicted_uuids.insert(uuid);
+                remaining_removals -= 1;
+            } else {
+                retained.push(corpus);
+            }
+        }
+
+        if evicted_uuids.is_empty() {
+            self.in_memory_corpus = retained;
+            return Ok(());
+        }
+
+        self.in_memory_corpus = retained;
+        self.new_entry_indices = self
+            .in_memory_corpus
+            .iter()
+            .enumerate()
+            .filter_map(|(index, entry)| queued_uuids.contains(&entry.uuid).then_some(index))
+            .collect();
+        self.metrics.corpus_count = self.in_memory_corpus.len();
+        let impacted_edges = self
+            .top_rated
+            .iter()
+            .filter_map(|(&edge_idx, &(uuid, _))| evicted_uuids.contains(&uuid).then_some(edge_idx))
+            .collect::<Vec<_>>();
+        for edge_idx in impacted_edges {
+            self.recompute_top_rated_for_edge(edge_idx);
+        }
+        Self::recompute_favored_for_entries(
+            &self.top_rated,
+            &mut self.in_memory_corpus,
+            &mut self.metrics,
+        );
         Ok(())
     }
     // Sync Methods.
@@ -1336,6 +1623,7 @@ impl WorkerCorpus {
         corpus.persisted_file_name = Some(file_name);
         if self.worker_sync_enabled && self.id == 0 {
             self.new_entry_indices.push(self.in_memory_corpus.len());
+            self.pending_sync_uuids.insert(corpus.uuid);
         }
         self.in_memory_corpus.push(corpus);
     }
@@ -1366,15 +1654,16 @@ impl WorkerCorpus {
                 metrics: Some(&mut metrics),
             };
             let mut replay_executor = executor.clone();
-            let ReplayOutcome { keep_entry, new_coverage, new_edge, cmp_seq, .. } =
-                replay_corpus_sequence_with_executor(
-                    &tx_seq,
-                    &mut replay_executor,
-                    target,
-                    coverage,
-                    true,
-                    false,
-                )?;
+            let ReplayOutcome {
+                keep_entry, new_coverage, new_edge, edges_covered, cmp_seq, ..
+            } = replay_corpus_sequence_with_executor(
+                &tx_seq,
+                &mut replay_executor,
+                target,
+                coverage,
+                true,
+                false,
+            )?;
 
             let sync_path = &entry.path;
             if keep_entry && new_coverage {
@@ -1402,12 +1691,23 @@ impl WorkerCorpus {
                     "moved synced corpus to corpus dir",
                 );
 
-                let corpus_entry = CorpusEntry::new_with_cmp(tx_seq.clone(), cmp_seq, entry.uuid);
+                let corpus_entry = CorpusEntry::new_with_cmp_and_edges(
+                    tx_seq.clone(),
+                    cmp_seq,
+                    edges_covered,
+                    entry.uuid,
+                );
+                self.update_top_rated(&corpus_entry);
                 self.push_synced_corpus_entry(
                     corpus_entry,
                     entry.timestamp,
                     entry.name().to_owned(),
                 );
+                self.disk_corpus.push_descriptor(CorpusDirEntry {
+                    path: corpus_path,
+                    uuid: entry.uuid,
+                    timestamp: entry.timestamp,
+                });
             } else {
                 // Remove the file as it did not generate new coverage.
                 if let Err(err) = std::fs::remove_file(&entry.path) {
@@ -1421,6 +1721,8 @@ impl WorkerCorpus {
             }
         }
 
+        self.recompute_favored_and_cull_corpus()?;
+
         Ok(())
     }
 
@@ -1431,7 +1733,9 @@ impl WorkerCorpus {
         assert_ne!(self.id, 0, "non-master only");
 
         // Early return if no new entries or corpus dir not configured.
-        if self.new_entry_indices.is_empty() || self.worker_dir.is_none() {
+        if (self.pending_sync_uuids.is_empty() && self.new_entry_indices.is_empty())
+            || self.worker_dir.is_none()
+        {
             return Ok(());
         }
 
@@ -1445,15 +1749,18 @@ impl WorkerCorpus {
             return Ok(());
         };
 
-        let mut exported = 0;
+        let mut exported_uuids = HashSet::new();
         let corpus_dir = worker_dir.join(CORPUS_DIR);
-        let mut delivered = HashSet::new();
+        let mut exported = 0;
+        let new_entry_uuids = self
+            .new_entry_indices
+            .iter()
+            .filter_map(|&index| self.in_memory_corpus.get(index).map(|corpus| corpus.uuid))
+            .collect::<HashSet<_>>();
 
-        for &index in &self.new_entry_indices {
-            let Some(corpus) = self.in_memory_corpus.get(index) else {
-                delivered.insert(index);
-                continue;
-            };
+        for corpus in self.in_memory_corpus.iter().filter(|entry| {
+            new_entry_uuids.contains(&entry.uuid) || self.pending_sync_uuids.contains(&entry.uuid)
+        }) {
             let file_name = corpus.file_name(corpus.should_gzip(self.config.corpus_gzip));
             let file_path = corpus_dir.join(&file_name);
             if !file_path.is_file()
@@ -1467,10 +1774,15 @@ impl WorkerCorpus {
                 continue;
             }
             exported += 1;
-            delivered.insert(index);
+            exported_uuids.insert(corpus.uuid);
         }
-        self.new_entry_indices.retain(|index| !delivered.contains(index));
+        self.new_entry_indices.retain(|&index| {
+            self.in_memory_corpus
+                .get(index)
+                .is_none_or(|corpus| !exported_uuids.contains(&corpus.uuid))
+        });
 
+        self.pending_sync_uuids.retain(|uuid| !exported_uuids.contains(uuid));
         debug!(target: "corpus", "exported {exported} new corpus entries");
 
         Ok(())
@@ -1565,6 +1877,11 @@ impl WorkerCorpus {
             }
         }
 
+        for &index in &delivered {
+            if let Some(entry) = self.in_memory_corpus.get(index) {
+                self.pending_sync_uuids.remove(&entry.uuid);
+            }
+        }
         self.new_entry_indices.retain(|index| !delivered.contains(index));
         if startup_delivered {
             self.initial_export_dirs = None;
@@ -1647,7 +1964,12 @@ impl WorkerCorpus {
             self.export_to_master()?;
         }
 
-        debug!(target: "corpus", "synced");
+        let last_sync = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        self.last_sync_timestamp = last_sync;
+
+        self.cull_corpus()?;
+
+        debug!(target: "corpus", last_sync, "synced");
 
         Ok(())
     }
@@ -1873,7 +2195,6 @@ mod tests {
         FuzzCorpusConfig {
             corpus_dir: Some(corpus_dir),
             corpus_gzip: false,
-            corpus_min_mutations: 0,
             corpus_min_size: 0,
             ..Default::default()
         }
@@ -1970,15 +2291,6 @@ mod tests {
             WorkerCorpusSeed { in_memory_corpus: entries, ..Default::default() },
         )
     }
-    fn new_manager_with_single_corpus() -> (WorkerCorpus, Uuid) {
-        let corpus = CorpusEntry::new(vec![basic_tx()]);
-        let seed_uuid = corpus.uuid;
-        let mut manager = seeded_worker_corpus(0, temp_corpus_dir(), vec![corpus]);
-        manager.current_mutated_index = Some(0);
-
-        (manager, seed_uuid)
-    }
-
     fn targeted_contracts_with_selective_functions(
         target: Address,
         functions: Vec<Function>,
@@ -2101,6 +2413,7 @@ mod tests {
         let corpus_root = temp_corpus_dir();
         let mut worker = empty_worker_corpus(1, corpus_root.clone());
         let corpus = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
+        let uuid = corpus.uuid;
         let name = corpus.file_name(false);
         worker.push_corpus_entry(corpus);
 
@@ -2111,13 +2424,13 @@ mod tests {
             .unwrap();
 
         worker.export_to_master().unwrap();
-        assert_eq!(worker.new_entry_indices, [0]);
+        assert_eq!(worker.pending_sync_uuids, HashSet::from([uuid]));
         assert!(corpus_root.join("worker1").join(CORPUS_DIR).join(&name).is_file());
 
         fs::remove_file(&destination).unwrap();
         worker.export_to_master().unwrap();
 
-        assert!(worker.new_entry_indices.is_empty());
+        assert!(worker.pending_sync_uuids.is_empty());
         let exported = read_corpus_dir(&master_sync).next().unwrap().read_tx_seq().unwrap();
         assert!(same_tx_sequence(&exported, &[basic_tx_with_calldata([1])]));
     }
@@ -2130,7 +2443,7 @@ mod tests {
         let corpus = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
         let name = corpus.file_name(false);
         corpus.write_to_disk_in(&corpus_root.join("worker0").join(CORPUS_DIR), false).unwrap();
-        master.push_corpus_entry(corpus);
+        master.push_synced_corpus_entry(corpus, 0, name.clone());
 
         let worker2_sync = corpus_root.join("worker2").join(SYNC_DIR);
         fs::create_dir_all(&worker2_sync).unwrap();
@@ -2330,7 +2643,7 @@ mod tests {
         let pending = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
         let pending_name = pending.file_name(false);
         pending.write_to_disk_in(&flat_root.join("worker0").join(CORPUS_DIR), false).unwrap();
-        flat_master.push_corpus_entry(pending);
+        flat_master.push_synced_corpus_entry(pending, 0, pending_name.clone());
 
         flat_master.export_to_workers(2).unwrap();
 
@@ -2344,8 +2657,7 @@ mod tests {
         let corpus_root = temp_corpus_dir();
         let mut master = empty_worker_corpus(0, corpus_root.clone());
         master.initial_export_dirs = None;
-        let mut pending = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
-        pending.total_mutations = 1;
+        let pending = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
         let retained = CorpusEntry::new(vec![basic_tx_with_calldata([2])]);
         let pending_name = pending.file_name(false);
         let retained_name = retained.file_name(false);
@@ -2357,7 +2669,7 @@ mod tests {
         master.push_synced_corpus_entry(pending, pending_timestamp, pending_name.clone());
         master.push_synced_corpus_entry(retained, retained_timestamp, retained_name.clone());
 
-        master.evict_oldest_corpus().unwrap();
+        master.cull_corpus().unwrap();
         master.export_to_workers(2).unwrap();
 
         let worker_sync = corpus_root.join("worker1").join(SYNC_DIR);
@@ -2371,7 +2683,7 @@ mod tests {
         let worker_subdir = corpus_root.join("worker1");
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        manager.process_inputs_for_campaign(&[basic_tx()], &[], true, None);
+        manager.process_inputs_for_campaign(&[basic_tx()], &[], true, vec![1], None);
 
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert_eq!(manager.metrics.corpus_count, 1);
@@ -2399,12 +2711,12 @@ mod tests {
             EdgeKey { address: Address::ZERO, depth: None, pc: 0, jump_dest: U256::from(10) };
 
         // First-time edge starts the timer.
-        assert!(manager.merge_edge_coverage(&mut edge_call(edge, 1)));
+        assert!(manager.merge_edge_coverage_with_edges_into(&mut edge_call(edge, 1), &mut vec![]));
         let first = manager.last_new_edge_at.expect("timer set after first new edge");
         assert_eq!(manager.metrics.cumulative_edges_seen, 1);
 
         // Same edge, higher bucket = a feature, not an edge: timer must not advance.
-        assert!(manager.merge_edge_coverage(&mut edge_call(edge, 8)));
+        assert!(manager.merge_edge_coverage_with_edges_into(&mut edge_call(edge, 8), &mut vec![]));
         assert_eq!(manager.last_new_edge_at, Some(first));
         assert_eq!(manager.metrics.cumulative_edges_seen, 1);
         assert_eq!(manager.metrics.cumulative_features_seen, 1);
@@ -2412,7 +2724,7 @@ mod tests {
         // A distinct edge advances the timer.
         let other =
             EdgeKey { address: Address::ZERO, depth: None, pc: 1, jump_dest: U256::from(20) };
-        assert!(manager.merge_edge_coverage(&mut edge_call(other, 1)));
+        assert!(manager.merge_edge_coverage_with_edges_into(&mut edge_call(other, 1), &mut vec![]));
         let second = manager.last_new_edge_at.expect("timer present");
         assert!(second >= first);
         assert_eq!(manager.metrics.cumulative_edges_seen, 2);
@@ -2429,14 +2741,14 @@ mod tests {
         let worker_subdir = corpus_root.join("worker1");
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        manager.process_inputs_for_campaign(&[], &[], true, None);
+        manager.process_inputs_for_campaign(&[], &[], true, Vec::new(), None);
 
         assert_eq!(manager.in_memory_corpus.len(), 0);
         assert_eq!(manager.metrics.corpus_count, 0);
         assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
 
         // Live processing path must also tolerate the empty sequence.
-        manager.process_inputs(&[], &[], true, None);
+        manager.process_inputs(&[], &[], true, Vec::new(), None);
         assert_eq!(manager.in_memory_corpus.len(), 0);
         assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
     }
@@ -2450,6 +2762,7 @@ mod tests {
             &sequence,
             &[],
             false,
+            Vec::new(),
             Some((I256::try_from(7).unwrap(), sequence.clone())),
         );
 
@@ -2561,6 +2874,7 @@ mod tests {
             &worse_sequence,
             &[],
             false,
+            Vec::new(),
             Some((I256::try_from(50).unwrap(), worse_sequence.clone())),
         );
 
@@ -2569,6 +2883,7 @@ mod tests {
             &better_sequence,
             &[],
             false,
+            Vec::new(),
             Some((I256::try_from(150).unwrap(), better_sequence.clone())),
         );
         assert_eq!(manager.optimization_best_value, Some(I256::try_from(150).unwrap()));
@@ -2580,9 +2895,11 @@ mod tests {
         let tx_seq = vec![basic_tx()];
         let seed = WorkerCorpusSeed {
             in_memory_corpus: vec![CorpusEntry::new(tx_seq.clone())],
+            disk_corpus: CachedDiskCorpus::default(),
             history_map: vec![1, 2, 3],
             edge_indices: EdgeIndexMap::default(),
             sancov_history_map: vec![4, 5],
+            top_rated: HashMap::new(),
             metrics: CorpusMetrics {
                 cumulative_edges_seen: 7,
                 cumulative_features_seen: 11,
@@ -2617,22 +2934,29 @@ mod tests {
     fn clone_for_worker_shards_warmed_corpus_and_recomputes_metrics() {
         let entries = (0..10)
             .map(|idx| {
-                let mut entry = CorpusEntry::new(vec![basic_tx()]);
-                entry.is_favored = idx % 2 == 0;
-                entry
+                CorpusEntry::new_with_cmp_and_edges(
+                    vec![basic_tx()],
+                    Vec::new(),
+                    vec![idx % 3],
+                    Uuid::new_v4(),
+                )
             })
             .collect::<Vec<_>>();
         let entry_ids = entries.iter().map(|entry| entry.uuid).collect::<Vec<_>>();
+        let top_rated =
+            HashMap::from([(0, (entry_ids[0], 1)), (1, (entry_ids[1], 1)), (2, (entry_ids[2], 1))]);
         let seed = WorkerCorpusSeed {
             in_memory_corpus: entries,
+            disk_corpus: CachedDiskCorpus::default(),
             history_map: vec![1, 2, 3],
             edge_indices: EdgeIndexMap::default(),
             sancov_history_map: vec![4, 5],
+            top_rated,
             metrics: CorpusMetrics {
                 cumulative_edges_seen: 7,
                 cumulative_features_seen: 11,
                 corpus_count: 10,
-                favored_items: 5,
+                favored_items: 3,
             },
             replay_dirs: None,
             failed_replays: 13,
@@ -2676,8 +3000,11 @@ mod tests {
         );
         assert_eq!(
             shards.iter().map(|shard| shard.metrics.favored_items).collect::<Vec<_>>(),
-            [2, 1, 2]
+            [1, 1, 1]
         );
+        assert_eq!(shards[0].top_rated, HashMap::from([(0, (entry_ids[0], 1))]));
+        assert_eq!(shards[1].top_rated, HashMap::from([(1, (entry_ids[1], 1))]));
+        assert_eq!(shards[2].top_rated, HashMap::from([(2, (entry_ids[2], 1))]));
         assert!(shards.iter().all(|shard| shard.history_map == seed.history_map));
         assert!(shards.iter().all(|shard| shard.sancov_history_map == seed.sancov_history_map));
         assert!(shards.iter().all(|shard| shard.metrics.cumulative_edges_seen == 7));
@@ -2695,9 +3022,10 @@ mod tests {
         };
         let entries = (0..2)
             .map(|_| {
-                CorpusEntry::new_with_cmp(
+                CorpusEntry::new_with_cmp_and_edges(
                     vec![basic_tx()],
                     vec![vec![ComparisonHint { lhs: cmp.op1, rhs: cmp.op2 }]],
+                    Vec::new(),
                     Uuid::new_v4(),
                 )
             })
@@ -2712,19 +3040,42 @@ mod tests {
     }
 
     #[test]
-    fn retain_replayable_removes_off_target_corpus_entries() {
+    fn retain_replayable_filters_descriptors_without_rereading_files() {
         let target = Address::from([0x11; 20]);
         let foo = Function::parse("foo()").unwrap();
         let bar = Function::parse("bar()").unwrap();
         let foo_selector = foo.selector();
         let foo_tx = tx_for_function(target, &foo, &[]);
         let bar_tx = tx_for_function(target, &bar, &[]);
-        let mut foo_entry = CorpusEntry::new(vec![foo_tx.clone()]);
-        foo_entry.is_favored = true;
-        let mut bar_entry = CorpusEntry::new(vec![bar_tx.clone()]);
-        bar_entry.is_favored = true;
+        let foo_entry = CorpusEntry::new_with_cmp_and_edges(
+            vec![foo_tx.clone()],
+            Vec::new(),
+            vec![1],
+            Uuid::new_v4(),
+        );
+        let bar_entry = CorpusEntry::new_with_cmp_and_edges(
+            vec![bar_tx.clone()],
+            Vec::new(),
+            vec![2],
+            Uuid::new_v4(),
+        );
+        let foo_uuid = foo_entry.uuid;
+        let bar_uuid = bar_entry.uuid;
+        let mut disk_corpus = CachedDiskCorpus::default();
+        disk_corpus.push_descriptor(CorpusDirEntry {
+            path: PathBuf::from("foo.json"),
+            uuid: foo_uuid,
+            timestamp: 1,
+        });
+        disk_corpus.push_descriptor(CorpusDirEntry {
+            path: PathBuf::from("bar.json"),
+            uuid: bar_uuid,
+            timestamp: 2,
+        });
         let mut seed = WorkerCorpusSeed {
             in_memory_corpus: vec![foo_entry, bar_entry],
+            disk_corpus,
+            top_rated: HashMap::from([(1, (foo_uuid, 1)), (2, (bar_uuid, 1))]),
             metrics: CorpusMetrics { corpus_count: 2, favored_items: 2, ..Default::default() },
             optimization_best_value: Some(I256::try_from(17).unwrap()),
             optimization_best_sequence: vec![bar_tx],
@@ -2748,6 +3099,10 @@ mod tests {
         );
         assert_eq!(seed.metrics.corpus_count, 1);
         assert_eq!(seed.metrics.favored_items, 1);
+        assert_eq!(seed.disk_corpus.descriptors.len(), 1);
+        assert_eq!(seed.disk_corpus.descriptors[0].uuid, foo_uuid);
+        assert!(seed.disk_corpus.cache.is_empty());
+        assert_eq!(seed.top_rated, HashMap::from([(1, (foo_uuid, 1))]));
         assert!(seed.optimization_best_value.is_none());
         assert!(seed.optimization_best_sequence.is_empty());
     }
@@ -3018,94 +3373,216 @@ mod tests {
     }
 
     #[test]
-    fn favored_sets_true_and_metrics_increment_when_ratio_gt_threshold() {
-        let (mut manager, uuid) = new_manager_with_single_corpus();
-        let corpus = manager.in_memory_corpus.iter_mut().find(|c| c.uuid == uuid).unwrap();
-        corpus.total_mutations = 4;
-        corpus.new_finds_produced = 2; // ratio currently 0.5 if both increment → 3/5 = 0.6 > 0.3.
-        corpus.is_favored = false;
-
-        // Ensure metrics start at 0.
-        assert_eq!(manager.metrics.favored_items, 0);
-
-        // Mark this as the currently mutated corpus and process a run with new coverage.
-        manager.current_mutated_index = Some(0);
-        manager.process_inputs(&[basic_tx()], &[], true, None);
-
-        let corpus = manager.in_memory_corpus.iter().find(|c| c.uuid == uuid).unwrap();
-        assert!(corpus.is_favored, "expected favored to be true when ratio > threshold");
-        assert_eq!(
-            manager.metrics.favored_items, 1,
-            "favored_items should increment on false→true"
+    fn minset_marks_smallest_covering_corpus_as_favored() {
+        let mut manager = empty_worker_corpus(0, temp_corpus_dir());
+        let large = CorpusEntry::new_with_cmp_and_edges(
+            vec![basic_tx(), basic_tx()],
+            Vec::new(),
+            vec![1],
+            Uuid::new_v4(),
         );
+        let large_uuid = large.uuid;
+        let small = CorpusEntry::new_with_cmp_and_edges(
+            vec![basic_tx()],
+            Vec::new(),
+            vec![1],
+            Uuid::new_v4(),
+        );
+        let small_uuid = small.uuid;
+
+        manager.update_top_rated(&large);
+        manager.update_top_rated(&small);
+        manager.in_memory_corpus.push(large);
+        manager.in_memory_corpus.push(small);
+
+        manager.recompute_favored_and_cull_corpus().unwrap();
+
+        let large = manager.in_memory_corpus.iter().find(|c| c.uuid == large_uuid);
+        let small = manager.in_memory_corpus.iter().find(|c| c.uuid == small_uuid).unwrap();
+        assert!(large.is_none(), "larger non-favored corpus should be culled");
+        assert!(small.is_favored, "smallest corpus covering the edge should be favored");
+        assert_eq!(manager.metrics.favored_items, 1);
     }
 
     #[test]
-    fn favored_sets_false_and_metrics_decrement_when_ratio_lt_threshold() {
-        let (mut manager, uuid) = new_manager_with_single_corpus();
-        let corpus = manager.in_memory_corpus.iter_mut().find(|c| c.uuid == uuid).unwrap();
-        corpus.total_mutations = 9;
-        corpus.new_finds_produced = 3; // 3/9 = 0.333.. > 0.3; after +1: 3/10 = 0.3 => not favored.
-        corpus.is_favored = true; // Start as favored.
-
-        manager.metrics.favored_items = 1;
-
-        // Next run does NOT produce coverage → only total_mutations increments, ratio drops.
-        manager.current_mutated_index = Some(0);
-        manager.process_inputs(&[basic_tx()], &[], false, None);
-
-        let corpus = manager.in_memory_corpus.iter().find(|c| c.uuid == uuid).unwrap();
-        assert!(!corpus.is_favored, "expected favored to be false when ratio < threshold");
-        assert_eq!(
-            manager.metrics.favored_items, 0,
-            "favored_items should decrement on true→false"
+    fn culling_keeps_favored_minset_entries() {
+        let mut favored = CorpusEntry::new_with_cmp_and_edges(
+            vec![basic_tx()],
+            Vec::new(),
+            vec![1],
+            Uuid::new_v4(),
         );
-    }
-
-    #[test]
-    fn favored_is_false_on_ratio_equal_threshold() {
-        let (mut manager, uuid) = new_manager_with_single_corpus();
-        let corpus = manager.in_memory_corpus.iter_mut().find(|c| c.uuid == uuid).unwrap();
-        // After this call with new_coverage=true, totals become 10 and 3 → 0.3.
-        corpus.total_mutations = 9;
-        corpus.new_finds_produced = 2;
-        corpus.is_favored = false;
-
-        manager.current_mutated_index = Some(0);
-        manager.process_inputs(&[basic_tx()], &[], true, None);
-
-        let corpus = manager.in_memory_corpus.iter().find(|c| c.uuid == uuid).unwrap();
-        assert!(
-            !(corpus.is_favored),
-            "with strict '>' comparison, favored must be false when ratio == threshold"
-        );
-    }
-
-    #[test]
-    fn eviction_skips_favored_and_evicts_non_favored() {
-        // Manager with two corpora.
-        let mut favored = CorpusEntry::new(vec![basic_tx()]);
-        favored.total_mutations = 2;
         favored.is_favored = true;
+        let favored_uuid = favored.uuid;
+        let favored_cost = favored.tx_seq.len();
 
         let mut non_favored = CorpusEntry::new(vec![basic_tx()]);
-        non_favored.total_mutations = 2;
         non_favored.is_favored = false;
         let non_favored_uuid = non_favored.uuid;
 
         let mut manager = seeded_worker_corpus(0, temp_corpus_dir(), vec![favored, non_favored]);
+        manager.top_rated = HashMap::from([(1, (favored_uuid, favored_cost))]);
 
-        // First eviction should remove the non-favored one.
-        manager.evict_oldest_corpus().unwrap();
+        manager.cull_corpus().unwrap();
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert!(manager.in_memory_corpus.iter().all(|c| c.is_favored));
-
-        // Attempt eviction again: only favored remains → should not remove.
-        manager.evict_oldest_corpus().unwrap();
-        assert_eq!(manager.in_memory_corpus.len(), 1, "favored corpus must not be evicted");
-
-        // Ensure the evicted one was the non-favored uuid.
         assert!(manager.in_memory_corpus.iter().all(|c| c.uuid != non_favored_uuid));
+        assert_eq!(manager.disk_corpus.cache.len(), 1);
+        assert_eq!(manager.disk_corpus.cache[0].uuid, non_favored_uuid);
+    }
+
+    #[test]
+    fn invariant_insertions_do_not_disable_culling() {
+        let mut campaign = empty_worker_corpus(1, temp_corpus_dir());
+        let mut live = empty_worker_corpus(0, temp_corpus_dir());
+        let mut memory_only = empty_worker_corpus(1, temp_corpus_dir());
+        campaign.worker_sync_enabled = false;
+        live.worker_sync_enabled = false;
+        memory_only.worker_sync_enabled = false;
+
+        for idx in 0..32 {
+            let tx = basic_tx_with_calldata(vec![idx]);
+            campaign.process_inputs_for_campaign(
+                std::slice::from_ref(&tx),
+                &[],
+                true,
+                vec![1],
+                None,
+            );
+            live.process_inputs(std::slice::from_ref(&tx), &[], true, vec![1], None);
+            memory_only.push_observed_sequence(vec![tx], CorpusInsertionMode::MemoryOnly);
+        }
+
+        for manager in [&campaign, &live, &memory_only] {
+            assert_eq!(manager.in_memory_corpus.len(), 1);
+            assert_eq!(manager.metrics.corpus_count, manager.in_memory_corpus.len());
+            assert!(manager.pending_sync_uuids.is_empty());
+        }
+    }
+
+    #[test]
+    fn stateless_insertions_are_protected_until_sync() {
+        let mut manager = empty_worker_corpus(1, temp_corpus_dir());
+
+        for idx in 0..4 {
+            let tx = basic_tx_with_calldata(vec![idx]);
+            manager.process_inputs(std::slice::from_ref(&tx), &[], true, vec![1], None);
+        }
+
+        assert_eq!(manager.in_memory_corpus.len(), 4);
+        assert_eq!(manager.pending_sync_uuids.len(), 4);
+    }
+
+    #[test]
+    fn stateless_export_retries_failures_before_culling() {
+        let corpus_root = temp_corpus_dir();
+        let master_sync_dir = corpus_root.join("worker0").join(SYNC_DIR);
+        fs::create_dir_all(&master_sync_dir).unwrap();
+        let mut manager = empty_worker_corpus(1, corpus_root);
+
+        for idx in 0..2 {
+            let tx = basic_tx_with_calldata(vec![idx]);
+            manager.process_inputs(std::slice::from_ref(&tx), &[], true, vec![1], None);
+        }
+        let blocked_uuid = manager.in_memory_corpus[1].uuid;
+        let worker_corpus_dir = manager.worker_dir.as_ref().unwrap().join(CORPUS_DIR);
+        let blocked_path = worker_corpus_dir.join(manager.in_memory_corpus[1].file_name(false));
+        fs::remove_file(&blocked_path).unwrap();
+        fs::create_dir(&blocked_path).unwrap();
+
+        manager.export_to_master().unwrap();
+        manager.cull_corpus().unwrap();
+
+        assert_eq!(manager.pending_sync_uuids, HashSet::from([blocked_uuid]));
+        assert!(manager.in_memory_corpus.iter().any(|entry| entry.uuid == blocked_uuid));
+        fs::remove_dir(blocked_path).unwrap();
+
+        manager.export_to_master().unwrap();
+        assert!(manager.pending_sync_uuids.is_empty());
+
+        // Repeating an acknowledged export is idempotent if the destination still exists.
+        manager.pending_sync_uuids.insert(blocked_uuid);
+        manager.export_to_master().unwrap();
+        manager.cull_corpus().unwrap();
+
+        assert!(manager.pending_sync_uuids.is_empty());
+        assert_eq!(manager.in_memory_corpus.len(), 1);
+        assert!(manager.in_memory_corpus.iter().all(|entry| entry.uuid != blocked_uuid));
+        assert_eq!(manager.metrics.corpus_count, manager.in_memory_corpus.len());
+    }
+
+    #[test]
+    fn cached_disk_corpus_bounds_evicted_entries() {
+        let mut cache = CachedDiskCorpus { cache_max_len: 2, ..CachedDiskCorpus::default() };
+
+        let first = CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x01])]);
+        let second = CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x02])]);
+        let third = CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x03])]);
+        let first_uuid = first.uuid;
+        let second_uuid = second.uuid;
+        let third_uuid = third.uuid;
+
+        cache.cache_entry(Arc::new(first));
+        cache.cache_entry(Arc::new(second));
+        cache.cache_entry(Arc::new(third));
+
+        assert_eq!(cache.cache.len(), 2);
+        assert!(!cache.cache.iter().any(|entry| entry.uuid == first_uuid));
+        assert!(cache.cache.iter().any(|entry| entry.uuid == second_uuid));
+        assert!(cache.cache.iter().any(|entry| entry.uuid == third_uuid));
+    }
+
+    #[test]
+    fn cached_disk_corpus_prunes_unreadable_descriptors() {
+        let uuid = Uuid::new_v4();
+        let mut cache = CachedDiskCorpus::default();
+        cache.push_descriptor(CorpusDirEntry {
+            path: temp_corpus_dir().join(format!("{uuid}-1.json")),
+            uuid,
+            timestamp: 1,
+        });
+
+        let mut runner = TestRunner::default();
+        assert!(cache.random_entry(runner.rng()).unwrap().is_none());
+        assert!(cache.descriptors.is_empty());
+        assert!(cache.descriptor_indices.is_empty());
+    }
+
+    #[test]
+    fn cached_disk_corpus_selects_cache_only_donor_with_descriptors_present() {
+        let descriptor_uuid = Uuid::new_v4();
+        let cache_only = Arc::new(CorpusEntry::new(vec![basic_tx()]));
+        let cache_only_uuid = cache_only.uuid;
+        let mut cache = CachedDiskCorpus::default();
+        cache.push_descriptor(CorpusDirEntry {
+            path: PathBuf::from("descriptor.json"),
+            uuid: descriptor_uuid,
+            timestamp: 1,
+        });
+        cache.cache_entry(cache_only);
+        let mut runner = TestRunner::deterministic();
+
+        let selected = cache.random_entry_with_disk_refresh(runner.rng(), false).unwrap().unwrap();
+
+        assert_eq!(selected.uuid, cache_only_uuid);
+    }
+
+    #[test]
+    fn cached_disk_corpus_refreshes_from_descriptor() {
+        let root = temp_corpus_dir();
+        let corpus = CorpusEntry::new(vec![basic_tx()]);
+        let uuid = corpus.uuid;
+        let timestamp = corpus.timestamp;
+        let path = corpus.write_to_disk_in(&root, false).unwrap();
+        let mut cache = CachedDiskCorpus::default();
+        cache.push_descriptor(CorpusDirEntry { path, uuid, timestamp });
+        cache.cache_entry(Arc::new(CorpusEntry::new(vec![basic_tx()])));
+        let mut runner = TestRunner::deterministic();
+
+        let selected = cache.random_entry_with_disk_refresh(runner.rng(), true).unwrap().unwrap();
+
+        assert_eq!(selected.uuid, uuid);
+        assert!(cache.cache.iter().any(|entry| entry.uuid == uuid));
     }
 
     #[test]
@@ -3116,13 +3593,12 @@ mod tests {
             test_sequence(&config, TxGenerator::from_strategy(Just(basic_tx()).boxed()));
         let mut manager =
             WorkerCorpus::from_seed(0, config, generator, WorkerCorpusSeed::default()).unwrap();
-        let mut evictable = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
-        evictable.total_mutations = 1;
+        let evictable = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
         let evictable_uuid = evictable.uuid;
         manager.push_corpus_entry(evictable);
         manager.push_corpus_entry(CorpusEntry::new(vec![basic_tx_with_calldata([2])]));
 
-        manager.evict_oldest_corpus().unwrap();
+        manager.cull_corpus().unwrap();
 
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert!(manager.in_memory_corpus.iter().all(|entry| entry.uuid != evictable_uuid));

--- a/crates/evm/evm/src/executors/corpus_io.rs
+++ b/crates/evm/evm/src/executors/corpus_io.rs
@@ -36,6 +36,7 @@ pub fn canonical_replay_dirs(root: &Path) -> Vec<PathBuf> {
 }
 
 /// A single corpus file on disk.
+#[derive(Clone)]
 pub struct CorpusDirEntry {
     pub path: PathBuf,
     pub uuid: Uuid,

--- a/crates/evm/evm/src/executors/corpus_io.rs
+++ b/crates/evm/evm/src/executors/corpus_io.rs
@@ -15,6 +15,7 @@ const MAX_CORPUS_TREE_DIRS: usize = 10_000;
 const MAX_CORPUS_ENTRIES: usize = 1_000_000;
 
 /// A single corpus file on disk.
+#[derive(Clone)]
 pub struct CorpusDirEntry {
     pub path: PathBuf,
     pub uuid: Uuid,

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -413,7 +413,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         let frontier_new_coverage =
             self.config.corpus.collect_edge_coverage().then_some(new_coverage);
         frontier_recorder.capture_stateless_call(fuzz_run, &tx, &cmp_values, frontier_new_coverage);
-        coverage_metrics.process_inputs(
+        coverage_metrics.process_inputs_for_worker_sync(
             &[tx.clone()],
             &[cmp_values],
             new_coverage,

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -405,13 +405,21 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             )
             .map_err(|e| TestCaseError::fail(e.to_string()))?;
         let cmp_values = call.evm_cmp_values.take().unwrap_or_default();
-        let new_coverage = coverage_metrics.merge_edge_coverage(&mut call);
+        let mut edges_covered = Vec::new();
+        let new_coverage =
+            coverage_metrics.merge_edge_coverage_with_edges_into(&mut call, &mut edges_covered);
         // `new_coverage` is only meaningful when edge coverage is collected; otherwise
         // `merge_edge_coverage` always returns `false`, so record it as unknown for frontiers.
         let frontier_new_coverage =
             self.config.corpus.collect_edge_coverage().then_some(new_coverage);
         frontier_recorder.capture_stateless_call(fuzz_run, &tx, &cmp_values, frontier_new_coverage);
-        coverage_metrics.process_inputs(&[tx.clone()], &[cmp_values], new_coverage, None);
+        coverage_metrics.process_inputs(
+            &[tx.clone()],
+            &[cmp_values],
+            new_coverage,
+            edges_covered,
+            None,
+        );
 
         // Handle `vm.assume`.
         if call.result.as_ref() == MAGIC_ASSUME {

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -456,15 +456,17 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         // Handle `vm.assume` before recording coverage or persisting the input.
         if kind == CampaignCallKind::AssumptionRejected {
             // Account for the attempted corpus mutation without retaining or crediting the input.
-            coverage_metrics.process_inputs(&[], &[], false, None);
+            coverage_metrics.process_inputs(&[], &[], false, Vec::new(), None);
             return Err(TestCaseError::reject(FuzzError::AssumeReject));
         }
 
         if call.skip_reason().is_some() {
             // Account for the attempted corpus mutation without retaining or crediting the input.
-            coverage_metrics.process_inputs(&[], &[], false, None);
+            coverage_metrics.process_inputs(&[], &[], false, Vec::new(), None);
         } else {
-            let new_coverage = coverage_metrics.merge_edge_coverage(&mut call);
+            let mut edges_covered = Vec::new();
+            let new_coverage =
+                coverage_metrics.merge_edge_coverage_with_edges_into(&mut call, &mut edges_covered);
             // `new_coverage` is only meaningful when edge coverage is collected; otherwise
             // `merge_edge_coverage` always returns `false`, so record it as unknown for frontiers.
             let frontier_new_coverage =
@@ -480,6 +482,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                 std::slice::from_ref(&tx),
                 &[cmp_values],
                 new_coverage,
+                edges_covered,
                 None,
             );
         }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -329,16 +329,22 @@ fn campaign_seed_and_corpus_seed_for_worker(
     include_cmp_seq: bool,
     focus_seed: Option<U256>,
 ) -> (InvariantCampaignSeed, WorkerCorpusSeed) {
-    let worker_corpus_seed =
-        corpus_seed.clone_for_worker(plan.worker_id as usize, worker_count, include_cmp_seq);
     let Some(worker_campaign_seed) =
         focused_campaign_seed_for_worker(campaign_seed, plan, worker_count, focus_seed)
     else {
-        return (campaign_seed.clone(), worker_corpus_seed);
+        return (
+            campaign_seed.clone(),
+            corpus_seed.clone_for_worker(plan.worker_id as usize, worker_count, include_cmp_seq),
+        );
     };
 
-    let mut worker_corpus_seed = worker_corpus_seed;
-    worker_corpus_seed.retain_replayable(&worker_campaign_seed.targeted_contracts);
+    let mut focused_corpus_seed = corpus_seed.clone();
+    focused_corpus_seed.retain_replayable(&worker_campaign_seed.targeted_contracts);
+    let worker_corpus_seed = focused_corpus_seed.clone_for_worker(
+        plan.worker_id as usize,
+        worker_count,
+        include_cmp_seq,
+    );
     (worker_campaign_seed, worker_corpus_seed)
 }
 
@@ -824,6 +830,20 @@ impl<FEN: FoundryEvmNetwork> InvariantTestRun<FEN> {
     }
 }
 
+fn finalize_call_corpus_metadata(
+    inputs_len: usize,
+    cmp_seq: &mut Vec<Vec<crate::inspectors::CmpOperands>>,
+    call_cmp_values: Vec<crate::inspectors::CmpOperands>,
+    corpus_edges: &mut Vec<usize>,
+    corpus_edges_len: usize,
+) {
+    if cmp_seq.len() < inputs_len {
+        cmp_seq.push(call_cmp_values);
+    } else {
+        corpus_edges.truncate(corpus_edges_len);
+    }
+}
+
 /// Wrapper around any [`Executor`] implementer which provides fuzzing support using [`proptest`].
 ///
 /// After instantiation, calling `invariant_fuzz` will proceed to hammer the deployed smart
@@ -1231,6 +1251,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     None
                 };
                 // Collect edge coverage and set the flag in the current run.
+                let corpus_edges_len = current_run.corpus_edges.len();
                 let new_call_coverage = corpus_manager.merge_edge_coverage_with_edges_into(
                     &mut call_result,
                     &mut current_run.corpus_edges,
@@ -1248,6 +1269,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
                 if discarded {
                     current_run.inputs.pop();
+                    finalize_call_corpus_metadata(
+                        current_run.inputs.len(),
+                        &mut current_run.cmp_seq,
+                        call_cmp_values,
+                        &mut current_run.corpus_edges,
+                        corpus_edges_len,
+                    );
                     current_run.rejects += 1;
                     if current_run.rejects > config.max_assume_rejects {
                         invariant_test.set_error(
@@ -1406,9 +1434,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
                     // Keep `cmp_seq` parallel to `inputs`: only push when the input survived the
                     // pop branch above.
-                    if current_run.cmp_seq.len() < current_run.inputs.len() {
-                        current_run.cmp_seq.push(call_cmp_values);
-                    }
+                    finalize_call_corpus_metadata(
+                        current_run.inputs.len(),
+                        &mut current_run.cmp_seq,
+                        call_cmp_values,
+                        &mut current_run.corpus_edges,
+                        corpus_edges_len,
+                    );
 
                     if !continues || current_run.depth == run_depth - 1 {
                         current_run.save_last_run_inputs = true;
@@ -2436,6 +2468,39 @@ mod tests {
 
     fn first_generated_u64(runner: &mut TestRunner) -> u64 {
         any::<u64>().new_tree(runner).unwrap().current()
+    }
+
+    #[test]
+    fn assumed_calls_do_not_retain_corpus_edges() {
+        let mut cmp_seq = vec![Vec::new()];
+        let mut corpus_edges = vec![1, 2, 3, 4];
+
+        finalize_call_corpus_metadata(1, &mut cmp_seq, Vec::new(), &mut corpus_edges, 2);
+
+        assert_eq!(cmp_seq.len(), 1);
+        assert_eq!(corpus_edges, [1, 2]);
+    }
+
+    #[test]
+    fn reverted_calls_do_not_retain_corpus_edges() {
+        let mut cmp_seq = vec![Vec::new(), Vec::new()];
+        let mut corpus_edges = vec![1, 2, 3, 4, 5];
+
+        finalize_call_corpus_metadata(2, &mut cmp_seq, Vec::new(), &mut corpus_edges, 3);
+
+        assert_eq!(cmp_seq.len(), 2);
+        assert_eq!(corpus_edges, [1, 2, 3]);
+    }
+
+    #[test]
+    fn retained_calls_append_cmp_metadata_without_truncating_edges() {
+        let mut cmp_seq = vec![Vec::new()];
+        let mut corpus_edges = vec![1, 2, 3, 4];
+
+        finalize_call_corpus_metadata(2, &mut cmp_seq, Vec::new(), &mut corpus_edges, 2);
+
+        assert_eq!(cmp_seq.len(), 2);
+        assert_eq!(corpus_edges, [1, 2, 3, 4]);
     }
 
     fn test_runner() -> TestRunner {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -749,6 +749,8 @@ struct InvariantTestRun<FEN: FoundryEvmNetwork> {
     inputs: Vec<BasicTxDetails>,
     // Per-call EVM comparison operands (parallel to `inputs`), captured for I2S corpus mutation.
     cmp_seq: Vec<Vec<crate::inspectors::CmpOperands>>,
+    // Coverage indices hit during this run.
+    corpus_edges: Vec<usize>,
     // Current invariant run executor.
     executor: Executor<FEN>,
     // Invariant run stat reports (eg. gas usage).
@@ -791,6 +793,7 @@ impl<FEN: FoundryEvmNetwork> InvariantTestRun<FEN> {
         Self {
             inputs,
             cmp_seq: Vec::with_capacity(depth),
+            corpus_edges: Vec::new(),
             executor,
             fuzz_runs: Vec::with_capacity(depth),
             created_contracts: vec![],
@@ -816,6 +819,8 @@ impl<FEN: FoundryEvmNetwork> InvariantTestRun<FEN> {
         self.inputs.shrink_to_fit();
         self.cmp_seq.clear();
         self.cmp_seq.shrink_to_fit();
+        self.corpus_edges.clear();
+        self.corpus_edges.shrink_to_fit();
     }
 }
 
@@ -1226,7 +1231,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     None
                 };
                 // Collect edge coverage and set the flag in the current run.
-                let new_call_coverage = corpus_manager.merge_edge_coverage(&mut call_result);
+                let new_call_coverage = corpus_manager.merge_edge_coverage_with_edges_into(
+                    &mut call_result,
+                    &mut current_run.corpus_edges,
+                );
                 if new_call_coverage {
                     current_run.new_coverage = true;
                 }
@@ -1506,6 +1514,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &current_run.inputs,
                     &current_run.cmp_seq,
                     current_run.new_coverage,
+                    std::mem::take(&mut current_run.corpus_edges),
                     optimization,
                 ) {
                     corpus_entries.push(input);
@@ -1515,6 +1524,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &current_run.inputs,
                     &current_run.cmp_seq,
                     current_run.new_coverage,
+                    std::mem::take(&mut current_run.corpus_edges),
                     optimization,
                 );
             }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -333,16 +333,22 @@ fn campaign_seed_and_corpus_seed_for_worker(
     include_cmp_seq: bool,
     focus_seed: Option<U256>,
 ) -> (InvariantCampaignSeed, WorkerCorpusSeed) {
-    let worker_corpus_seed =
-        corpus_seed.clone_for_worker(plan.worker_id as usize, worker_count, include_cmp_seq);
     let Some(worker_campaign_seed) =
         focused_campaign_seed_for_worker(campaign_seed, plan, worker_count, focus_seed)
     else {
-        return (campaign_seed.clone(), worker_corpus_seed);
+        return (
+            campaign_seed.clone(),
+            corpus_seed.clone_for_worker(plan.worker_id as usize, worker_count, include_cmp_seq),
+        );
     };
 
-    let mut worker_corpus_seed = worker_corpus_seed;
-    worker_corpus_seed.retain_replayable(&worker_campaign_seed.targeted_contracts);
+    let mut focused_corpus_seed = corpus_seed.clone();
+    focused_corpus_seed.retain_replayable(&worker_campaign_seed.targeted_contracts);
+    let worker_corpus_seed = focused_corpus_seed.clone_for_worker(
+        plan.worker_id as usize,
+        worker_count,
+        include_cmp_seq,
+    );
     (worker_campaign_seed, worker_corpus_seed)
 }
 
@@ -739,6 +745,8 @@ struct InvariantTestRun<FEN: FoundryEvmNetwork> {
     inputs: Vec<BasicTxDetails>,
     // Per-call EVM comparison operands (parallel to `inputs`), captured for I2S corpus mutation.
     cmp_seq: Vec<Vec<crate::inspectors::CmpOperands>>,
+    // Coverage indices hit during this run.
+    corpus_edges: Vec<usize>,
     // Current invariant run executor.
     executor: Executor<FEN>,
     // Invariant run stat reports (eg. gas usage).
@@ -788,6 +796,7 @@ impl<FEN: FoundryEvmNetwork> InvariantTestRun<FEN> {
         Self {
             inputs,
             cmp_seq: Vec::with_capacity(depth),
+            corpus_edges: Vec::new(),
             executor,
             fuzz_runs: Vec::with_capacity(depth),
             created_contracts: vec![],
@@ -813,6 +822,22 @@ impl<FEN: FoundryEvmNetwork> InvariantTestRun<FEN> {
         self.inputs.shrink_to_fit();
         self.cmp_seq.clear();
         self.cmp_seq.shrink_to_fit();
+        self.corpus_edges.clear();
+        self.corpus_edges.shrink_to_fit();
+    }
+}
+
+fn finalize_call_corpus_metadata(
+    inputs_len: usize,
+    cmp_seq: &mut Vec<Vec<crate::inspectors::CmpOperands>>,
+    call_cmp_values: Vec<crate::inspectors::CmpOperands>,
+    corpus_edges: &mut Vec<usize>,
+    corpus_edges_len: usize,
+) {
+    if cmp_seq.len() < inputs_len {
+        cmp_seq.push(call_cmp_values);
+    } else {
+        corpus_edges.truncate(corpus_edges_len);
     }
 }
 
@@ -1182,6 +1207,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             }
 
             let mut call_cmp_values = Vec::new();
+            let mut corpus_edges_len = 0;
             let mut assertion_failure = false;
             let mut pre_merge_edges_hash = None;
             let mut handler = None;
@@ -1232,7 +1258,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             pre_merge_edges_hash = assertion_failure
                                 .then(|| error::snapshot_edge_fingerprint(call_result))
                                 .flatten();
-                            let new_call_coverage = corpus_manager.merge_edge_coverage(call_result);
+                            corpus_edges_len = current_run.corpus_edges.len();
+                            let new_call_coverage = corpus_manager
+                                .merge_edge_coverage_with_edges_into(
+                                    call_result,
+                                    &mut current_run.corpus_edges,
+                                );
                             if new_call_coverage {
                                 current_run.new_coverage = true;
                             }
@@ -1246,6 +1277,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                                 result.take().expect("campaign check result is available");
                             if kind == CampaignCallKind::AssumptionRejected {
                                 current_run.inputs.pop();
+                                current_run.corpus_edges.truncate(corpus_edges_len);
                                 current_run.rejects += 1;
                                 if current_run.rejects > config.max_assume_rejects {
                                     invariant_test.set_error(
@@ -1374,9 +1406,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             if run_cancelled {
                                 return Ok(CampaignControl::Stop);
                             }
-                            if current_run.cmp_seq.len() < current_run.inputs.len() {
-                                current_run.cmp_seq.push(std::mem::take(&mut call_cmp_values));
-                            }
+                            finalize_call_corpus_metadata(
+                                current_run.inputs.len(),
+                                &mut current_run.cmp_seq,
+                                std::mem::take(&mut call_cmp_values),
+                                &mut current_run.corpus_edges,
+                                corpus_edges_len,
+                            );
                             if !continues || current_run.depth == run_depth - 1 {
                                 current_run.save_last_run_inputs = true;
                             }
@@ -1492,6 +1528,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &current_run.inputs,
                     &current_run.cmp_seq,
                     current_run.new_coverage,
+                    std::mem::take(&mut current_run.corpus_edges),
                     optimization,
                 );
             } else {
@@ -1499,6 +1536,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &current_run.inputs,
                     &current_run.cmp_seq,
                     current_run.new_coverage,
+                    std::mem::take(&mut current_run.corpus_edges),
                     optimization,
                 );
             }
@@ -2362,6 +2400,39 @@ mod tests {
 
     fn first_generated_u64(runner: &mut TestRunner) -> u64 {
         any::<u64>().new_tree(runner).unwrap().current()
+    }
+
+    #[test]
+    fn assumed_calls_do_not_retain_corpus_edges() {
+        let mut cmp_seq = vec![Vec::new()];
+        let mut corpus_edges = vec![1, 2, 3, 4];
+
+        finalize_call_corpus_metadata(1, &mut cmp_seq, Vec::new(), &mut corpus_edges, 2);
+
+        assert_eq!(cmp_seq.len(), 1);
+        assert_eq!(corpus_edges, [1, 2]);
+    }
+
+    #[test]
+    fn reverted_calls_do_not_retain_corpus_edges() {
+        let mut cmp_seq = vec![Vec::new(), Vec::new()];
+        let mut corpus_edges = vec![1, 2, 3, 4, 5];
+
+        finalize_call_corpus_metadata(2, &mut cmp_seq, Vec::new(), &mut corpus_edges, 3);
+
+        assert_eq!(cmp_seq.len(), 2);
+        assert_eq!(corpus_edges, [1, 2, 3]);
+    }
+
+    #[test]
+    fn retained_calls_append_cmp_metadata_without_truncating_edges() {
+        let mut cmp_seq = vec![Vec::new()];
+        let mut corpus_edges = vec![1, 2, 3, 4];
+
+        finalize_call_corpus_metadata(2, &mut cmp_seq, Vec::new(), &mut corpus_edges, 2);
+
+        assert_eq!(cmp_seq.len(), 2);
+        assert_eq!(corpus_edges, [1, 2, 3, 4]);
     }
 
     fn test_runner() -> TestRunner {

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1248,6 +1248,53 @@ impl<FEN: FoundryEvmNetwork> RawCallResult<FEN> {
         (new_coverage, is_edge)
     }
 
+    /// Update provided history map with edge coverage info collected during this call and append
+    /// every hit edge index to `edges_covered`.
+    pub fn merge_edge_coverage_with_edges_into(
+        &mut self,
+        history_map: &mut Vec<u8>,
+        edge_indices: &mut EdgeIndexMap,
+        edges_covered: &mut Vec<usize>,
+    ) -> (bool, bool) {
+        let mut new_coverage = false;
+        let mut is_edge = false;
+        if let Some(x) = &mut self.edge_coverage {
+            match x {
+                EdgeCoverage::Hash(x) => {
+                    if history_map.len() < x.len() {
+                        history_map.resize(x.len(), 0);
+                    }
+                    for (idx, (curr, hist)) in
+                        std::iter::zip(x.iter_mut(), history_map.iter_mut()).enumerate()
+                    {
+                        if *curr > 0 {
+                            edges_covered.push(idx);
+                        }
+                        Self::merge_edge_count(*curr, hist, &mut new_coverage, &mut is_edge);
+                        *curr = 0;
+                    }
+                }
+                EdgeCoverage::CollisionFree(hits) => {
+                    for hit in hits.drain(..) {
+                        let edge_index = edge_indices.edge_index(hit.edge);
+                        edges_covered.push(edge_index);
+                        if history_map.len() <= edge_index {
+                            debug_assert_eq!(history_map.len(), edge_index);
+                            history_map.push(0);
+                        }
+                        Self::merge_edge_count(
+                            hit.count,
+                            &mut history_map[edge_index],
+                            &mut new_coverage,
+                            &mut is_edge,
+                        );
+                    }
+                }
+            }
+        }
+        (new_coverage, is_edge)
+    }
+
     const fn merge_edge_count(
         curr: u8,
         hist: &mut u8,
@@ -1312,6 +1359,41 @@ impl<FEN: FoundryEvmNetwork> RawCallResult<FEN> {
         (new_coverage, is_edge)
     }
 
+    /// Update provided history map with sancov coverage info collected during this call and append
+    /// every hit native edge index to `edges_covered`.
+    pub fn merge_sancov_coverage_with_edges_into(
+        &mut self,
+        history_map: &mut Vec<u8>,
+        edge_offset: usize,
+        edges_covered: &mut Vec<usize>,
+    ) -> (bool, bool) {
+        let mut new_coverage = false;
+        let mut is_edge = false;
+        if let Some(x) = &mut self.sancov_coverage {
+            if history_map.len() < x.len() {
+                history_map.resize(x.len(), 0);
+            }
+            for (idx, (curr, hist)) in
+                std::iter::zip(x.iter_mut(), history_map.iter_mut()).enumerate()
+            {
+                if *curr > 0 {
+                    edges_covered.push(idx.saturating_add(edge_offset));
+                    if let Some(bucket) = Self::bin_count(*curr)
+                        && *hist < bucket
+                    {
+                        if *hist == 0 {
+                            is_edge = true;
+                        }
+                        *hist = bucket;
+                        new_coverage = true;
+                    }
+                    *curr = 0;
+                }
+            }
+        }
+        (new_coverage, is_edge)
+    }
+
     /// Merge both EVM and sancov coverage into their respective history maps.
     /// Returns `(new_coverage, is_edge)` — true if either domain produced new coverage.
     pub fn merge_all_coverage(
@@ -1322,6 +1404,25 @@ impl<FEN: FoundryEvmNetwork> RawCallResult<FEN> {
     ) -> (bool, bool) {
         let (new_evm, edge_evm) = self.merge_edge_coverage(evm_history, evm_edge_indices);
         let (new_san, edge_san) = self.merge_sancov_coverage(sancov_history);
+        (new_evm || new_san, edge_evm || edge_san)
+    }
+
+    /// Merge both EVM and sancov coverage and append every hit coverage index to `edges_covered`.
+    pub fn merge_all_coverage_with_edges_into(
+        &mut self,
+        evm_history: &mut Vec<u8>,
+        evm_edge_indices: &mut EdgeIndexMap,
+        sancov_history: &mut Vec<u8>,
+        sancov_edge_offset: usize,
+        edges_covered: &mut Vec<usize>,
+    ) -> (bool, bool) {
+        let (new_evm, edge_evm) =
+            self.merge_edge_coverage_with_edges_into(evm_history, evm_edge_indices, edges_covered);
+        let (new_san, edge_san) = self.merge_sancov_coverage_with_edges_into(
+            sancov_history,
+            sancov_edge_offset,
+            edges_covered,
+        );
         (new_evm || new_san, edge_evm || edge_san)
     }
 }

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1600,6 +1600,53 @@ impl<FEN: FoundryEvmNetwork> RawCallResult<FEN> {
         (new_coverage, is_edge)
     }
 
+    /// Update provided history map with edge coverage info collected during this call and append
+    /// every hit edge index to `edges_covered`.
+    pub fn merge_edge_coverage_with_edges_into(
+        &mut self,
+        history_map: &mut Vec<u8>,
+        edge_indices: &mut EdgeIndexMap,
+        edges_covered: &mut Vec<usize>,
+    ) -> (bool, bool) {
+        let mut new_coverage = false;
+        let mut is_edge = false;
+        if let Some(x) = &mut self.edge_coverage {
+            match x {
+                EdgeCoverage::Hash(x) => {
+                    if history_map.len() < x.len() {
+                        history_map.resize(x.len(), 0);
+                    }
+                    for (idx, (curr, hist)) in
+                        std::iter::zip(x.iter_mut(), history_map.iter_mut()).enumerate()
+                    {
+                        if *curr > 0 {
+                            edges_covered.push(idx);
+                        }
+                        Self::merge_edge_count(*curr, hist, &mut new_coverage, &mut is_edge);
+                        *curr = 0;
+                    }
+                }
+                EdgeCoverage::CollisionFree(hits) => {
+                    for hit in hits.drain(..) {
+                        let edge_index = edge_indices.edge_index(hit.edge);
+                        edges_covered.push(edge_index);
+                        if history_map.len() <= edge_index {
+                            debug_assert_eq!(history_map.len(), edge_index);
+                            history_map.push(0);
+                        }
+                        Self::merge_edge_count(
+                            hit.count,
+                            &mut history_map[edge_index],
+                            &mut new_coverage,
+                            &mut is_edge,
+                        );
+                    }
+                }
+            }
+        }
+        (new_coverage, is_edge)
+    }
+
     const fn merge_edge_count(
         curr: u8,
         hist: &mut u8,
@@ -1664,6 +1711,41 @@ impl<FEN: FoundryEvmNetwork> RawCallResult<FEN> {
         (new_coverage, is_edge)
     }
 
+    /// Update provided history map with sancov coverage info collected during this call and append
+    /// every hit native edge index to `edges_covered`.
+    pub fn merge_sancov_coverage_with_edges_into(
+        &mut self,
+        history_map: &mut Vec<u8>,
+        edge_offset: usize,
+        edges_covered: &mut Vec<usize>,
+    ) -> (bool, bool) {
+        let mut new_coverage = false;
+        let mut is_edge = false;
+        if let Some(x) = &mut self.sancov_coverage {
+            if history_map.len() < x.len() {
+                history_map.resize(x.len(), 0);
+            }
+            for (idx, (curr, hist)) in
+                std::iter::zip(x.iter_mut(), history_map.iter_mut()).enumerate()
+            {
+                if *curr > 0 {
+                    edges_covered.push(idx.saturating_add(edge_offset));
+                    if let Some(bucket) = Self::bin_count(*curr)
+                        && *hist < bucket
+                    {
+                        if *hist == 0 {
+                            is_edge = true;
+                        }
+                        *hist = bucket;
+                        new_coverage = true;
+                    }
+                    *curr = 0;
+                }
+            }
+        }
+        (new_coverage, is_edge)
+    }
+
     /// Merge both EVM and sancov coverage into their respective history maps.
     /// Returns `(new_coverage, is_edge)` — true if either domain produced new coverage.
     pub fn merge_all_coverage(
@@ -1674,6 +1756,25 @@ impl<FEN: FoundryEvmNetwork> RawCallResult<FEN> {
     ) -> (bool, bool) {
         let (new_evm, edge_evm) = self.merge_edge_coverage(evm_history, evm_edge_indices);
         let (new_san, edge_san) = self.merge_sancov_coverage(sancov_history);
+        (new_evm || new_san, edge_evm || edge_san)
+    }
+
+    /// Merge both EVM and sancov coverage and append every hit coverage index to `edges_covered`.
+    pub fn merge_all_coverage_with_edges_into(
+        &mut self,
+        evm_history: &mut Vec<u8>,
+        evm_edge_indices: &mut EdgeIndexMap,
+        sancov_history: &mut Vec<u8>,
+        sancov_edge_offset: usize,
+        edges_covered: &mut Vec<usize>,
+    ) -> (bool, bool) {
+        let (new_evm, edge_evm) =
+            self.merge_edge_coverage_with_edges_into(evm_history, evm_edge_indices, edges_covered);
+        let (new_san, edge_san) = self.merge_sancov_coverage_with_edges_into(
+            sancov_history,
+            sancov_edge_offset,
+            edges_covered,
+        );
         (new_evm || new_san, edge_evm || edge_san)
     }
 }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -194,7 +194,6 @@ max_fuzz_dictionary_literals = 6553600
 gas_report_samples = 256
 frontier_limit = 256
 corpus_gzip = true
-corpus_min_mutations = 5
 corpus_min_size = 0
 show_edge_coverage = false
 evm_edge_coverage_collision_free = true
@@ -232,7 +231,6 @@ max_assume_rejects = 65536
 gas_report_samples = 256
 frontier_limit = 256
 corpus_gzip = true
-corpus_min_mutations = 5
 corpus_min_size = 0
 show_edge_coverage = false
 evm_edge_coverage_collision_free = true
@@ -1747,7 +1745,6 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "frontier_dir": null,
     "frontier_limit": 256,
     "corpus_gzip": true,
-    "corpus_min_mutations": 5,
     "corpus_min_size": 0,
     "show_edge_coverage": false,
     "evm_edge_coverage_collision_free": true,
@@ -1788,7 +1785,6 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "frontier_dir": null,
     "frontier_limit": 256,
     "corpus_gzip": true,
-    "corpus_min_mutations": 5,
     "corpus_min_size": 0,
     "show_edge_coverage": false,
     "evm_edge_coverage_collision_free": true,

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -198,7 +198,6 @@ max_fuzz_dictionary_literals = 6553600
 gas_report_samples = 256
 frontier_limit = 256
 corpus_gzip = true
-corpus_min_mutations = 5
 corpus_min_size = 0
 show_edge_coverage = false
 evm_edge_coverage_collision_free = true
@@ -236,7 +235,6 @@ max_assume_rejects = 65536
 gas_report_samples = 256
 frontier_limit = 256
 corpus_gzip = true
-corpus_min_mutations = 5
 corpus_min_size = 0
 show_edge_coverage = false
 evm_edge_coverage_collision_free = true
@@ -2209,7 +2207,6 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "frontier_dir": null,
     "frontier_limit": 256,
     "corpus_gzip": true,
-    "corpus_min_mutations": 5,
     "corpus_min_size": 0,
     "show_edge_coverage": false,
     "evm_edge_coverage_collision_free": true,
@@ -2250,7 +2247,6 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "frontier_dir": null,
     "frontier_limit": 256,
     "corpus_gzip": true,
-    "corpus_min_mutations": 5,
     "corpus_min_size": 0,
     "show_edge_coverage": false,
     "evm_edge_coverage_collision_free": true,

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -434,24 +434,47 @@ contract ForgeFuzzReplayFailureTest {
         prj.root().join("cache/fuzz/failures/ForgeFuzzReplayFailureTest/testFuzz_reverts");
     let mut failure: Value =
         serde_json::from_str(&std::fs::read_to_string(&failure_path).unwrap()).unwrap();
+    let persisted_failure: BaseCounterExample = serde_json::from_value(failure.clone()).unwrap();
+    let persisted_value = U256::from_be_slice(&persisted_failure.calldata[4..]);
     let failure = failure.as_object_mut().unwrap();
     failure.remove("sender");
     failure.remove("addr");
     failure.remove("value");
     std::fs::write(&failure_path, serde_json::to_vec_pretty(failure).unwrap()).unwrap();
 
-    let replay = cmd
-        .forge_fuse()
-        .args(["fuzz", "replay", "--mc", "ForgeFuzzReplayFailureTest", "-vvv"])
-        .assert_failure();
-    let stdout = String::from_utf8(replay.get_output().stdout.clone()).unwrap();
-    assert!(
-        stdout.contains("[FAIL: EvmError: Revert; counterexample: calldata=0x")
-            && stdout.contains("args=[200]] testFuzz_reverts(uint256) (runs: 0,"),
-        "{stdout}"
+    let expected = format!(
+        r#"No files changed, compilation skipped
+
+Ran 2 tests for test/ForgeFuzzReplayFailure.t.sol:ForgeFuzzReplayFailureTest
+[FAIL: EvmError: Revert; counterexample: calldata=[..] args=[{persisted_value}]] testFuzz_reverts(uint256) (runs: 0, [AVG_GAS])
+Traces:
+  [..] ForgeFuzzReplayFailureTest::testFuzz_reverts({persisted_value})
+    └─ ← [Revert] EvmError: Revert
+
+Backtrace:
+  at ForgeFuzzReplayFailureTest.testFuzz_reverts
+
+[SKIP: not runnable in replay mode] test_unit() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 1 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 1 skipped (2 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/ForgeFuzzReplayFailure.t.sol:ForgeFuzzReplayFailureTest
+[FAIL: EvmError: Revert; counterexample: calldata=[..] args=[{persisted_value}]] testFuzz_reverts(uint256) (runs: 0, [AVG_GAS])
+
+Encountered a total of 1 failing tests, 0 tests succeeded
+
+Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
+
+[SEED] (use `--fuzz-seed` to reproduce)
+"#
     );
-    assert!(stdout.contains("ForgeFuzzReplayFailureTest::testFuzz_reverts(200)"), "{stdout}");
-    assert!(stdout.contains("[SKIP: not runnable in replay mode] test_unit()"), "{stdout}");
+    cmd.forge_fuse()
+        .args(["fuzz", "replay", "--mc", "ForgeFuzzReplayFailureTest", "-vvv"])
+        .assert_failure()
+        .stdout_eq(expected);
 });
 
 forgetest_init!(stateless_fuzz_preserves_payable_value, |prj, cmd| {
@@ -590,7 +613,7 @@ contract ForgeFuzzReplayAssumeRejectTest {
     Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     function testFuzz_reverts(uint256 value) public {
-        vm.assume(value != 200);
+        vm.assume(value > 200);
         require(false, "fresh unrelated failure");
     }
 }

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -952,24 +952,47 @@ contract ForgeFuzzReplayFailureTest {
         prj.root().join("cache/fuzz/failures/ForgeFuzzReplayFailureTest/testFuzz_reverts");
     let mut failure: Value =
         serde_json::from_str(&std::fs::read_to_string(&failure_path).unwrap()).unwrap();
+    let persisted_failure: BaseCounterExample = serde_json::from_value(failure.clone()).unwrap();
+    let persisted_value = U256::from_be_slice(&persisted_failure.calldata[4..]);
     let failure = failure.as_object_mut().unwrap();
     failure.remove("sender");
     failure.remove("addr");
     failure.remove("value");
     std::fs::write(&failure_path, serde_json::to_vec_pretty(failure).unwrap()).unwrap();
 
-    let replay = cmd
-        .forge_fuse()
-        .args(["fuzz", "replay", "--mc", "ForgeFuzzReplayFailureTest", "-vvv"])
-        .assert_failure();
-    let stdout = String::from_utf8(replay.get_output().stdout.clone()).unwrap();
-    assert!(
-        stdout.contains("[FAIL: EvmError: Revert; counterexample: calldata=0x")
-            && stdout.contains("args=[200]] testFuzz_reverts(uint256) (runs: 0,"),
-        "{stdout}"
+    let expected = format!(
+        r#"No files changed, compilation skipped
+
+Ran 2 tests for test/ForgeFuzzReplayFailure.t.sol:ForgeFuzzReplayFailureTest
+[FAIL: EvmError: Revert; counterexample: calldata=[..] args=[{persisted_value}]] testFuzz_reverts(uint256) (runs: 0, [AVG_GAS])
+Traces:
+  [..] ForgeFuzzReplayFailureTest::testFuzz_reverts({persisted_value})
+    └─ ← [Revert] EvmError: Revert
+
+Backtrace:
+  at ForgeFuzzReplayFailureTest.testFuzz_reverts
+
+[SKIP: not runnable in replay mode] test_unit() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 1 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 1 skipped (2 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/ForgeFuzzReplayFailure.t.sol:ForgeFuzzReplayFailureTest
+[FAIL: EvmError: Revert; counterexample: calldata=[..] args=[{persisted_value}]] testFuzz_reverts(uint256) (runs: 0, [AVG_GAS])
+
+Encountered a total of 1 failing tests, 0 tests succeeded
+
+Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
+
+[SEED] (use `--fuzz-seed` to reproduce)
+"#
     );
-    assert!(stdout.contains("ForgeFuzzReplayFailureTest::testFuzz_reverts(200)"), "{stdout}");
-    assert!(stdout.contains("[SKIP: not runnable in replay mode] test_unit()"), "{stdout}");
+    cmd.forge_fuse()
+        .args(["fuzz", "replay", "--mc", "ForgeFuzzReplayFailureTest", "-vvv"])
+        .assert_failure()
+        .stdout_eq(expected);
 });
 
 forgetest_init!(stateless_fuzz_does_not_persist_skips, |prj, cmd| {
@@ -1159,7 +1182,7 @@ contract ForgeFuzzReplayAssumeRejectTest {
     Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     function testFuzz_reverts(uint256 value) public {
-        vm.assume(value != 200);
+        vm.assume(value > 200);
         require(false, "fresh unrelated failure");
     }
 }


### PR DESCRIPTION
Replace mutation-count eviction with the existing top-rated minset culling proposal, favoring shorter representatives of covered edges. This refresh preserves current campaign execution, immediate persistence from #16065, pending worker synchronization and fan-out, and edge bookkeeping when calls are popped. It does not include new mutations, observed-call dictionaries, or scheduling.

Production generation still samples the in-memory corpus only: cache/disk donor selection remains test-only and is an explicit unresolved review item. This is a refresh of the existing proposal, not a claim that the donor design is complete. Derek comparison baseline: master `bfe6e9a17`; warmed-corpus effectiveness and memory/I/O assessment remain pending, as does the book update for removing corpus_min_mutations.

Originally prompted by @0xalpharush. AI assistance was used for the refresh, conflict resolution, test adaptation, and this description.
