### PR TITLE
feat(forge): share shrink attempt accounting

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1254,14 +1254,14 @@ impl WorkerCorpus {
             let cmp_values = corpus.cmp_seq.first().map_or(&[][..], Vec::as_slice);
             match weighted_arg_mutation(test_runner.rng(), self.arg_mutation_distribution.as_ref())
             {
-                Some(true) => {
+                Some(true)
                     if !Self::cmp_mutate(&mut tx, function, cmp_values, test_runner)?
                         && self.mutation_weights.mutation_weight_abi > 0
-                        && !function.inputs.is_empty()
-                    {
-                        self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
-                    }
+                        && !function.inputs.is_empty() =>
+                {
+                    self.abi_mutate(&mut tx, function, test_runner, fuzz_state)?;
                 }
+                Some(true) => {}
                 Some(false)
                     if self.mutation_weights.mutation_weight_abi > 0
                         && !function.inputs.is_empty() =>

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -76,8 +76,8 @@ pub use result::InvariantFuzzTestResult;
 mod shrink;
 pub use shrink::{
     CheckSequenceFailureSite, CheckSequenceOptions, CheckSequenceOutcome, HandlerReplayOutcome,
-    SequenceShrink, ShrinkRun, ShrinkRunStats, check_sequence, check_sequence_value,
-    replay_handler_failure_sequence, shrink_sequence_by_removing,
+    SequenceShrink, ShrinkCandidateKeys, ShrinkRun, ShrinkRunStats, check_sequence,
+    check_sequence_value, replay_handler_failure_sequence, shrink_sequence_by_removing,
 };
 
 /// Minimum number of logical runs assigned to each auto invariant worker at the default invariant

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -76,8 +76,8 @@ pub use result::InvariantFuzzTestResult;
 mod shrink;
 pub use shrink::{
     CheckSequenceFailureSite, CheckSequenceOptions, CheckSequenceOutcome, HandlerReplayOutcome,
-    ShrinkRun, ShrinkRunStats, check_sequence, check_sequence_value,
-    replay_handler_failure_sequence,
+    SequenceShrink, ShrinkRun, ShrinkRunStats, check_sequence, check_sequence_value,
+    replay_handler_failure_sequence, shrink_sequence_by_removing,
 };
 
 /// Minimum number of logical runs assigned to each auto invariant worker at the default invariant

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -76,7 +76,8 @@ pub use result::InvariantFuzzTestResult;
 mod shrink;
 pub use shrink::{
     CheckSequenceFailureSite, CheckSequenceOptions, CheckSequenceOutcome, HandlerReplayOutcome,
-    check_sequence, check_sequence_value, replay_handler_failure_sequence,
+    ShrinkRun, ShrinkRunStats, check_sequence, check_sequence_value,
+    replay_handler_failure_sequence,
 };
 
 /// Minimum number of logical runs assigned to each auto invariant worker at the default invariant

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -18,7 +18,7 @@ use foundry_evm_fuzz::{BasicTxDetails, invariant::InvariantContract};
 use indicatif::ProgressBar;
 use proptest::bits::{BitSetLike, VarBitSet};
 use revm::context::Block;
-use std::cell::Cell;
+use std::{cell::Cell, collections::HashSet, hash::Hash};
 
 /// Shrinker for a call sequence failure.
 /// Iterates sequence call sequence top down and removes calls one by one.
@@ -157,6 +157,22 @@ impl ShrinkRun {
             self.stats.accepted += 1;
         }
         Some(accepted)
+    }
+}
+
+/// Shared key set for shrinkers that need to skip duplicate concrete replays.
+#[derive(Clone, Debug)]
+pub struct ShrinkCandidateKeys<K> {
+    seen: HashSet<K>,
+}
+
+impl<K: Eq + Hash> ShrinkCandidateKeys<K> {
+    pub fn new(initial: K) -> Self {
+        Self { seen: HashSet::from([initial]) }
+    }
+
+    pub fn insert(&mut self, key: K) -> bool {
+        self.seen.insert(key)
     }
 }
 
@@ -972,8 +988,8 @@ pub fn check_sequence_value<FEN: FoundryEvmNetwork>(
 #[cfg(test)]
 mod tests {
     use super::{
-        SequenceShrink, ShrinkErrorPolicy, ShrinkRun, build_shrunk_sequence, run_shrink_loop,
-        shrink_sequence_by_removing,
+        SequenceShrink, ShrinkCandidateKeys, ShrinkErrorPolicy, ShrinkRun, build_shrunk_sequence,
+        run_shrink_loop, shrink_sequence_by_removing,
     };
     use crate::executors::EarlyExit;
     use alloy_primitives::{Address, Bytes, U256};
@@ -1039,6 +1055,16 @@ mod tests {
         let stats = run.finish();
         assert_eq!(stats.attempts, 2);
         assert_eq!(stats.accepted, 1);
+    }
+
+    #[test]
+    fn shrink_candidate_keys_skip_duplicates() {
+        let mut candidates = ShrinkCandidateKeys::new("initial");
+
+        assert!(!candidates.insert("initial"));
+        assert!(candidates.insert("first"));
+        assert!(!candidates.insert("first"));
+        assert!(candidates.insert("second"));
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -57,6 +57,65 @@ enum ShrinkErrorPolicy {
     RestoreRemoved,
 }
 
+/// Attempt counters collected while trying shrink candidates.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ShrinkRunStats {
+    pub attempts: usize,
+    pub accepted: usize,
+}
+
+/// Shared shrink attempt driver.
+///
+/// Candidate generation stays with each shrinker; this type only centralizes limit enforcement
+/// and the "accept when the candidate still reproduces the bug" accounting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ShrinkRun {
+    max_attempts: usize,
+    stats: ShrinkRunStats,
+}
+
+impl ShrinkRun {
+    pub const fn new(max_attempts: usize) -> Self {
+        Self { max_attempts, stats: ShrinkRunStats { attempts: 0, accepted: 0 } }
+    }
+
+    pub const fn can_try(&self) -> bool {
+        self.stats.attempts < self.max_attempts
+    }
+
+    pub const fn remaining_attempts(&self) -> usize {
+        self.max_attempts - self.stats.attempts
+    }
+
+    pub const fn finish(self) -> ShrinkRunStats {
+        self.stats
+    }
+
+    pub fn try_candidate(&mut self, still_fails: impl FnOnce() -> bool) -> bool {
+        if !self.can_try() {
+            return false;
+        }
+
+        self.stats.attempts += 1;
+        if still_fails() {
+            self.stats.accepted += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn try_fallible_candidate<P>(&mut self, error_policy: ShrinkErrorPolicy, predicate: P) -> bool
+    where
+        P: FnOnce() -> eyre::Result<bool>,
+    {
+        self.try_candidate(|| match predicate() {
+            Ok(bug_still_present) => bug_still_present,
+            Err(_) => matches!(error_policy, ShrinkErrorPolicy::KeepRemoved),
+        })
+    }
+}
+
 /// Per-call decision returned by callbacks driving `replay_sequence`. `Continue` hands
 /// the result back so non-reverted calls auto-commit; `Stop` short-circuits.
 #[expect(clippy::large_enum_variant)]
@@ -212,10 +271,14 @@ where
     P: FnMut(&CallSequenceShrinker) -> eyre::Result<bool>,
 {
     let mut shrinker = CallSequenceShrinker::new(calls_len);
+    let mut run = ShrinkRun::new(config.shrink_run_limit as usize);
     let mut call_idx = 0;
 
-    for _ in 0..config.shrink_run_limit {
+    while run.can_try() {
         if early_exit.should_stop() {
+            break;
+        }
+        if shrinker.included_calls.count() == 0 {
             break;
         }
 
@@ -227,10 +290,7 @@ where
 
         shrinker.included_calls.clear(call_idx);
 
-        let bug_still_present = match predicate(&shrinker) {
-            Ok(b) => b,
-            Err(_) => matches!(error_policy, ShrinkErrorPolicy::KeepRemoved),
-        };
+        let bug_still_present = run.try_fallible_candidate(error_policy, || predicate(&shrinker));
         if bug_still_present {
             if shrinker.included_calls.count() == 1 {
                 break;
@@ -846,7 +906,9 @@ pub fn check_sequence_value<FEN: FoundryEvmNetwork>(
 
 #[cfg(test)]
 mod tests {
-    use super::{CallSequenceShrinker, ShrinkErrorPolicy, build_shrunk_sequence, run_shrink_loop};
+    use super::{
+        CallSequenceShrinker, ShrinkErrorPolicy, ShrinkRun, build_shrunk_sequence, run_shrink_loop,
+    };
     use crate::executors::EarlyExit;
     use alloy_primitives::{Address, Bytes, U256};
     use foundry_config::InvariantConfig;
@@ -895,6 +957,26 @@ mod tests {
     }
 
     #[test]
+    fn shrink_run_counts_attempts_and_accepts() {
+        let mut run = ShrinkRun::new(2);
+
+        assert_eq!(run.remaining_attempts(), 2);
+        assert!(!run.try_candidate(|| false));
+        assert!(run.try_candidate(|| true));
+
+        let mut called_after_limit = false;
+        assert!(!run.try_candidate(|| {
+            called_after_limit = true;
+            true
+        }));
+
+        assert!(!called_after_limit);
+        let stats = run.finish();
+        assert_eq!(stats.attempts, 2);
+        assert_eq!(stats.accepted, 1);
+    }
+
+    #[test]
     fn shrink_loop_keep_removed_treats_candidate_error_as_still_failing() {
         let config = InvariantConfig { shrink_run_limit: 1, ..Default::default() };
         let early_exit = EarlyExit::new(false);
@@ -905,5 +987,27 @@ mod tests {
             });
 
         assert_eq!(shrinker.current().collect::<Vec<_>>(), vec![1]);
+    }
+
+    #[test]
+    fn shrink_loop_limit_counts_candidate_replays_not_skipped_indices() {
+        let config = InvariantConfig { shrink_run_limit: 4, ..Default::default() };
+        let early_exit = EarlyExit::new(false);
+        let mut replay_attempts = 0;
+
+        let shrinker = run_shrink_loop(
+            &config,
+            3,
+            None,
+            &early_exit,
+            ShrinkErrorPolicy::RestoreRemoved,
+            |_| {
+                replay_attempts += 1;
+                Ok(matches!(replay_attempts, 1 | 4))
+            },
+        );
+
+        assert_eq!(replay_attempts, 4);
+        assert_eq!(shrinker.current().collect::<Vec<_>>(), vec![2]);
     }
 }

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -50,6 +50,40 @@ impl SequenceShrink {
         self.included_calls.count()
     }
 
+    pub fn apply<T: Clone>(&self, calls: &[T]) -> Vec<T> {
+        self.current().map(|idx| calls[idx].clone()).collect()
+    }
+
+    pub fn apply_with_accumulated_delay<T, D, A>(
+        &self,
+        calls: &[T],
+        mut delay: D,
+        mut apply_delay: A,
+    ) -> Vec<T>
+    where
+        T: Clone,
+        D: FnMut(&T) -> (Option<U256>, Option<U256>),
+        A: FnMut(T, U256, U256) -> T,
+    {
+        let mut result = Vec::new();
+        let mut accumulated_warp = U256::ZERO;
+        let mut accumulated_roll = U256::ZERO;
+
+        for (idx, call) in calls.iter().enumerate() {
+            let (warp, roll) = delay(call);
+            accumulated_warp += warp.unwrap_or(U256::ZERO);
+            accumulated_roll += roll.unwrap_or(U256::ZERO);
+
+            if self.contains(idx) {
+                result.push(apply_delay(call.clone(), accumulated_warp, accumulated_roll));
+                accumulated_warp = U256::ZERO;
+                accumulated_roll = U256::ZERO;
+            }
+        }
+
+        result
+    }
+
     fn remove(&mut self, call_idx: usize) {
         self.included_calls.clear(call_idx);
     }
@@ -199,8 +233,7 @@ pub(crate) fn reset_shrink_progress(
 }
 
 /// Applies accumulated warp/roll to a call, returning a modified copy.
-fn apply_warp_roll(call: &BasicTxDetails, warp: U256, roll: U256) -> BasicTxDetails {
-    let mut result = call.clone();
+fn apply_warp_roll(mut result: BasicTxDetails, warp: U256, roll: U256) -> BasicTxDetails {
     if warp > U256::ZERO {
         result.warp = Some(warp);
     }
@@ -246,25 +279,10 @@ fn build_shrunk_sequence(
     accumulate_warp_roll: bool,
 ) -> Vec<BasicTxDetails> {
     if !accumulate_warp_roll {
-        return shrinker.current().map(|idx| calls[idx].clone()).collect();
+        return shrinker.apply(calls);
     }
 
-    let mut result = Vec::new();
-    let mut accumulated_warp = U256::ZERO;
-    let mut accumulated_roll = U256::ZERO;
-
-    for (idx, call) in calls.iter().enumerate() {
-        accumulated_warp += call.warp.unwrap_or(U256::ZERO);
-        accumulated_roll += call.roll.unwrap_or(U256::ZERO);
-
-        if shrinker.contains(idx) {
-            result.push(apply_warp_roll(call, accumulated_warp, accumulated_roll));
-            accumulated_warp = U256::ZERO;
-            accumulated_roll = U256::ZERO;
-        }
-    }
-
-    result
+    shrinker.apply_with_accumulated_delay(calls, |call| (call.warp, call.roll), apply_warp_roll)
 }
 
 /// Shared sequence shrinker. Tries to drop each call; `predicate` decides whether the candidate
@@ -494,7 +512,7 @@ where
         }
         seq_iter.next();
 
-        let executed = apply_warp_roll(tx, accumulated_warp, accumulated_roll);
+        let executed = apply_warp_roll(tx.clone(), accumulated_warp, accumulated_roll);
         let call_result = execute_tx(executor, &executed)?;
 
         match on_call(idx, call_result)? {
@@ -923,7 +941,8 @@ pub fn check_sequence_value<FEN: FoundryEvmNetwork>(
         if seq_iter.peek() == Some(&&idx) {
             seq_iter.next();
 
-            let tx_with_accumulated = apply_warp_roll(tx, accumulated_warp, accumulated_roll);
+            let tx_with_accumulated =
+                apply_warp_roll(tx.clone(), accumulated_warp, accumulated_roll);
             let mut call_result = execute_tx(&mut executor, &tx_with_accumulated)?;
 
             if !call_result.reverted {

--- a/crates/evm/evm/src/executors/invariant/shrink.rs
+++ b/crates/evm/evm/src/executors/invariant/shrink.rs
@@ -18,27 +18,44 @@ use foundry_evm_fuzz::{BasicTxDetails, invariant::InvariantContract};
 use indicatif::ProgressBar;
 use proptest::bits::{BitSetLike, VarBitSet};
 use revm::context::Block;
+use std::cell::Cell;
 
 /// Shrinker for a call sequence failure.
 /// Iterates sequence call sequence top down and removes calls one by one.
 /// If the failure is still reproducible with removed call then moves to the next one.
 /// If the failure is not reproducible then restore removed call and moves to next one.
 #[derive(Debug)]
-struct CallSequenceShrinker {
+pub struct SequenceShrink {
     /// Length of call sequence to be shrunk.
     call_sequence_len: usize,
     /// Call ids contained in current shrunk sequence.
     included_calls: VarBitSet,
 }
 
-impl CallSequenceShrinker {
-    fn new(call_sequence_len: usize) -> Self {
+impl SequenceShrink {
+    pub fn new(call_sequence_len: usize) -> Self {
         Self { call_sequence_len, included_calls: VarBitSet::saturated(call_sequence_len) }
     }
 
     /// Return candidate shrink sequence to be tested, by removing ids from original sequence.
-    fn current(&self) -> impl Iterator<Item = usize> + '_ {
+    pub fn current(&self) -> impl Iterator<Item = usize> + '_ {
         (0..self.call_sequence_len).filter(|&call_id| self.included_calls.test(call_id))
+    }
+
+    pub fn contains(&self, call_idx: usize) -> bool {
+        self.included_calls.test(call_idx)
+    }
+
+    pub fn included_count(&self) -> usize {
+        self.included_calls.count()
+    }
+
+    fn remove(&mut self, call_idx: usize) {
+        self.included_calls.clear(call_idx);
+    }
+
+    fn restore(&mut self, call_idx: usize) {
+        self.included_calls.set(call_idx);
     }
 
     /// Advance to the next call index, wrapping around to 0 at the end.
@@ -92,27 +109,20 @@ impl ShrinkRun {
     }
 
     pub fn try_candidate(&mut self, still_fails: impl FnOnce() -> bool) -> bool {
-        if !self.can_try() {
-            return false;
-        }
-
-        self.stats.attempts += 1;
-        if still_fails() {
-            self.stats.accepted += 1;
-            true
-        } else {
-            false
-        }
+        self.try_candidate_decision(|| Some(still_fails())).unwrap_or(false)
     }
 
-    fn try_fallible_candidate<P>(&mut self, error_policy: ShrinkErrorPolicy, predicate: P) -> bool
-    where
-        P: FnOnce() -> eyre::Result<bool>,
-    {
-        self.try_candidate(|| match predicate() {
-            Ok(bug_still_present) => bug_still_present,
-            Err(_) => matches!(error_policy, ShrinkErrorPolicy::KeepRemoved),
-        })
+    fn try_candidate_decision(&mut self, decide: impl FnOnce() -> Option<bool>) -> Option<bool> {
+        if !self.can_try() {
+            return None;
+        }
+
+        let accepted = decide()?;
+        self.stats.attempts += 1;
+        if accepted {
+            self.stats.accepted += 1;
+        }
+        Some(accepted)
     }
 }
 
@@ -232,7 +242,7 @@ fn apply_warp_roll_to_env<FEN: FoundryEvmNetwork>(
 /// kept call so the final sequence remains reproducible.
 fn build_shrunk_sequence(
     calls: &[BasicTxDetails],
-    shrinker: &CallSequenceShrinker,
+    shrinker: &SequenceShrink,
     accumulate_warp_roll: bool,
 ) -> Vec<BasicTxDetails> {
     if !accumulate_warp_roll {
@@ -247,7 +257,7 @@ fn build_shrunk_sequence(
         accumulated_warp += call.warp.unwrap_or(U256::ZERO);
         accumulated_roll += call.roll.unwrap_or(U256::ZERO);
 
-        if shrinker.included_calls.test(idx) {
+        if shrinker.contains(idx) {
             result.push(apply_warp_roll(call, accumulated_warp, accumulated_roll));
             accumulated_warp = U256::ZERO;
             accumulated_roll = U256::ZERO;
@@ -255,6 +265,64 @@ fn build_shrunk_sequence(
     }
 
     result
+}
+
+/// Shared sequence shrinker. Tries to drop each call; `predicate` decides whether the candidate
+/// should be accepted, rejected, or skipped without spending a replay attempt.
+pub fn shrink_sequence_by_removing<P, S, A>(
+    calls_len: usize,
+    run: &mut ShrinkRun,
+    mut should_stop: S,
+    mut on_attempt: A,
+    mut predicate: P,
+) -> SequenceShrink
+where
+    P: FnMut(&SequenceShrink) -> Option<bool>,
+    S: FnMut() -> bool,
+    A: FnMut(),
+{
+    let mut shrinker = SequenceShrink::new(calls_len);
+    let mut call_idx = 0;
+    let mut skipped_candidates = 0usize;
+
+    while run.can_try() {
+        if should_stop() {
+            break;
+        }
+        let included_count = shrinker.included_count();
+        if included_count == 0 || skipped_candidates >= included_count {
+            break;
+        }
+
+        // Already-removed indices have nothing to drop.
+        if !shrinker.contains(call_idx) {
+            call_idx = shrinker.next_index(call_idx);
+            continue;
+        }
+
+        shrinker.remove(call_idx);
+
+        let Some(accepted) = run.try_candidate_decision(|| predicate(&shrinker)) else {
+            shrinker.restore(call_idx);
+            skipped_candidates += 1;
+            call_idx = shrinker.next_index(call_idx);
+            continue;
+        };
+
+        on_attempt();
+        skipped_candidates = 0;
+        if accepted {
+            if shrinker.included_count() == 1 {
+                break;
+            }
+        } else {
+            shrinker.restore(call_idx);
+        }
+
+        call_idx = shrinker.next_index(call_idx);
+    }
+
+    shrinker
 }
 
 /// Shared shrink loop driver. Tries to drop each call; `predicate` returns whether the
@@ -266,46 +334,25 @@ fn run_shrink_loop<P>(
     early_exit: &EarlyExit,
     error_policy: ShrinkErrorPolicy,
     mut predicate: P,
-) -> CallSequenceShrinker
+) -> SequenceShrink
 where
-    P: FnMut(&CallSequenceShrinker) -> eyre::Result<bool>,
+    P: FnMut(&SequenceShrink) -> eyre::Result<bool>,
 {
-    let mut shrinker = CallSequenceShrinker::new(calls_len);
     let mut run = ShrinkRun::new(config.shrink_run_limit as usize);
-    let mut call_idx = 0;
-
-    while run.can_try() {
-        if early_exit.should_stop() {
-            break;
-        }
-        if shrinker.included_calls.count() == 0 {
-            break;
-        }
-
-        // Already-removed indices have nothing to drop.
-        if !shrinker.included_calls.test(call_idx) {
-            call_idx = shrinker.next_index(call_idx);
-            continue;
-        }
-
-        shrinker.included_calls.clear(call_idx);
-
-        let bug_still_present = run.try_fallible_candidate(error_policy, || predicate(&shrinker));
-        if bug_still_present {
-            if shrinker.included_calls.count() == 1 {
-                break;
+    shrink_sequence_by_removing(
+        calls_len,
+        &mut run,
+        || early_exit.should_stop(),
+        || {
+            if let Some(progress) = progress {
+                progress.inc(1);
             }
-        } else {
-            shrinker.included_calls.set(call_idx);
-        }
-
-        if let Some(progress) = progress {
-            progress.inc(1);
-        }
-        call_idx = shrinker.next_index(call_idx);
-    }
-
-    shrinker
+        },
+        |shrinker| match predicate(shrinker) {
+            Ok(bug_still_present) => Some(bug_still_present),
+            Err(_) => Some(matches!(error_policy, ShrinkErrorPolicy::KeepRemoved)),
+        },
+    )
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -697,37 +744,36 @@ pub(crate) fn shrink_sequence_value<FEN: FoundryEvmNetwork>(
         return Ok(vec![]);
     }
 
-    let mut call_idx = 0;
-    let mut shrinker = CallSequenceShrinker::new(calls.len());
-
-    for _ in 0..config.shrink_run_limit {
-        if early_exit.should_stop() {
-            break;
-        }
-
-        shrinker.included_calls.clear(call_idx);
-
-        let keeps_target = check_sequence_value(
+    let replay_failed = Cell::new(false);
+    let mut replay_error = None;
+    let mut run = ShrinkRun::new(config.shrink_run_limit as usize);
+    let shrinker = shrink_sequence_by_removing(
+        calls.len(),
+        &mut run,
+        || early_exit.should_stop() || replay_failed.get(),
+        || {
+            if let Some(progress) = progress {
+                progress.inc(1);
+            }
+        },
+        |shrinker| match check_sequence_value(
             executor.clone(),
             calls,
             shrinker.current().collect(),
             target_address,
             calldata.clone(),
-        )? == Some(target_value);
-
-        if keeps_target {
-            if shrinker.included_calls.count() == 1 {
-                break;
+        ) {
+            Ok(Some(value)) => Some(value == target_value),
+            Ok(None) => Some(false),
+            Err(err) => {
+                replay_error = Some(err);
+                replay_failed.set(true);
+                None
             }
-        } else {
-            shrinker.included_calls.set(call_idx);
-        }
-
-        if let Some(progress) = progress {
-            progress.inc(1);
-        }
-
-        call_idx = shrinker.next_index(call_idx);
+        },
+    );
+    if let Some(err) = replay_error {
+        return Err(err);
     }
 
     Ok(build_shrunk_sequence(calls, &shrinker, true))
@@ -907,13 +953,13 @@ pub fn check_sequence_value<FEN: FoundryEvmNetwork>(
 #[cfg(test)]
 mod tests {
     use super::{
-        CallSequenceShrinker, ShrinkErrorPolicy, ShrinkRun, build_shrunk_sequence, run_shrink_loop,
+        SequenceShrink, ShrinkErrorPolicy, ShrinkRun, build_shrunk_sequence, run_shrink_loop,
+        shrink_sequence_by_removing,
     };
     use crate::executors::EarlyExit;
     use alloy_primitives::{Address, Bytes, U256};
     use foundry_config::InvariantConfig;
     use foundry_evm_fuzz::{BasicTxDetails, CallDetails};
-    use proptest::bits::BitSetLike;
 
     fn tx(warp: Option<u64>, roll: Option<u64>) -> BasicTxDetails {
         BasicTxDetails {
@@ -931,8 +977,8 @@ mod tests {
     #[test]
     fn build_shrunk_sequence_accumulates_removed_delay_into_next_kept_call() {
         let calls = vec![tx(Some(3), Some(5)), tx(Some(7), Some(11)), tx(Some(13), Some(17))];
-        let mut shrinker = CallSequenceShrinker::new(calls.len());
-        shrinker.included_calls.clear(0);
+        let mut shrinker = SequenceShrink::new(calls.len());
+        shrinker.remove(0);
 
         let shrunk = build_shrunk_sequence(&calls, &shrinker, true);
 
@@ -946,8 +992,8 @@ mod tests {
     #[test]
     fn build_shrunk_sequence_does_not_move_trailing_delay_backward() {
         let calls = vec![tx(Some(3), Some(5)), tx(Some(7), Some(11))];
-        let mut shrinker = CallSequenceShrinker::new(calls.len());
-        shrinker.included_calls.clear(1);
+        let mut shrinker = SequenceShrink::new(calls.len());
+        shrinker.remove(1);
 
         let shrunk = build_shrunk_sequence(&calls, &shrinker, true);
 
@@ -1009,5 +1055,32 @@ mod tests {
 
         assert_eq!(replay_attempts, 4);
         assert_eq!(shrinker.current().collect::<Vec<_>>(), vec![2]);
+    }
+
+    #[test]
+    fn sequence_shrinker_skips_duplicate_candidates_without_spending_attempts() {
+        let mut run = ShrinkRun::new(2);
+        let mut seen = Vec::new();
+
+        let shrinker = shrink_sequence_by_removing(
+            2,
+            &mut run,
+            || false,
+            || {},
+            |shrinker| {
+                let candidate = shrinker.current().collect::<Vec<_>>();
+                if seen.contains(&candidate) {
+                    None
+                } else {
+                    seen.push(candidate);
+                    Some(false)
+                }
+            },
+        );
+
+        assert_eq!(shrinker.current().collect::<Vec<_>>(), vec![0, 1]);
+        let stats = run.finish();
+        assert_eq!(stats.attempts, 2);
+        assert_eq!(stats.accepted, 0);
     }
 }

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -2,9 +2,10 @@ use crate::result::SymbolicCounterexampleCall;
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_primitives::{Address, B256, Bytes, Function as SolFunction, I256, U256};
-use foundry_evm::executors::invariant::{SequenceShrink, ShrinkRun, shrink_sequence_by_removing};
+use foundry_evm::executors::invariant::{
+    SequenceShrink, ShrinkCandidateKeys, ShrinkRun, shrink_sequence_by_removing,
+};
 use itertools::Itertools;
-use std::collections::HashSet;
 
 const MAX_SUBSET_CANDIDATES_PER_PASS: usize = 256;
 
@@ -104,7 +105,7 @@ pub(crate) fn minimize_sequence_counterexample(
 
 struct SequenceMinimizer<'a> {
     current_calls: Vec<SymbolicCounterexampleCall>,
-    tried_candidates: HashSet<Vec<ReplayCallKey>>,
+    tried_candidates: ShrinkCandidateKeys<Vec<ReplayCallKey>>,
     run: ShrinkRun,
     still_fails: &'a mut dyn FnMut(&[SymbolicCounterexampleCall]) -> bool,
 }
@@ -115,7 +116,7 @@ impl<'a> SequenceMinimizer<'a> {
         max_attempts: usize,
         still_fails: &'a mut dyn FnMut(&[SymbolicCounterexampleCall]) -> bool,
     ) -> Self {
-        let tried_candidates = HashSet::from([replay_sequence_key(&current_calls)]);
+        let tried_candidates = ShrinkCandidateKeys::new(replay_sequence_key(&current_calls));
         Self { current_calls, tried_candidates, run: ShrinkRun::new(max_attempts), still_fails }
     }
 
@@ -136,6 +137,7 @@ impl<'a> SequenceMinimizer<'a> {
         if !self.can_try() || candidate_calls == self.current_calls {
             return false;
         }
+
         if !self.tried_candidates.insert(replay_sequence_key(&candidate_calls)) {
             return false;
         }
@@ -165,9 +167,11 @@ impl<'a> SequenceMinimizer<'a> {
             || {},
             |shrinker| {
                 let candidate_calls = sequence_from_shrink(&base_calls, shrinker);
-                if candidate_calls == *current_calls
-                    || !tried_candidates.insert(replay_sequence_key(&candidate_calls))
-                {
+                if candidate_calls == *current_calls {
+                    return None;
+                }
+
+                if !tried_candidates.insert(replay_sequence_key(&candidate_calls)) {
                     return None;
                 }
 
@@ -303,7 +307,7 @@ pub(crate) fn minimize_single_call_counterexample(
     let mut current_args = original_args;
     let mut current_call = call_with_args(function, call, &current_args)?;
     let mut run = ShrinkRun::new(max_attempts);
-    let mut tried_calldata = HashSet::from([current_call.calldata.clone()]);
+    let mut tried_calldata = ShrinkCandidateKeys::new(current_call.calldata.clone());
 
     let mut try_args = |candidate_args: &[DynSolValue]| {
         if !run.can_try() {
@@ -312,9 +316,11 @@ pub(crate) fn minimize_single_call_counterexample(
         let Some(candidate_call) = call_with_args(function, call, candidate_args) else {
             return false;
         };
-        if candidate_call.calldata == current_call.calldata
-            || !tried_calldata.insert(candidate_call.calldata.clone())
-        {
+        if candidate_call.calldata == current_call.calldata {
+            return false;
+        }
+
+        if !tried_calldata.insert(candidate_call.calldata.clone()) {
             return false;
         }
 
@@ -1380,6 +1386,7 @@ fn accept_candidate(
 mod tests {
     use super::*;
     use alloy_json_abi::JsonAbi;
+    use std::collections::HashSet;
 
     const TEST_MAX_MINIMIZATION_ATTEMPTS: usize = 5000;
 

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -270,34 +270,19 @@ fn sequence_from_shrink(
     calls: &[SymbolicCounterexampleCall],
     shrinker: &SequenceShrink,
 ) -> Vec<SymbolicCounterexampleCall> {
-    let mut candidate = Vec::new();
-    let mut accumulated_warp = U256::ZERO;
-    let mut accumulated_roll = U256::ZERO;
-
-    for (idx, call) in calls.iter().enumerate() {
-        if shrinker.contains(idx) {
-            let mut kept = call.clone();
-            if !accumulated_warp.is_zero() {
-                kept.warp = add_optional_u256(Some(accumulated_warp), kept.warp);
+    shrinker.apply_with_accumulated_delay(
+        calls,
+        |call| (call.warp, call.roll),
+        |mut call, warp, roll| {
+            if !warp.is_zero() {
+                call.warp = Some(warp);
             }
-            if !accumulated_roll.is_zero() {
-                kept.roll = add_optional_u256(Some(accumulated_roll), kept.roll);
+            if !roll.is_zero() {
+                call.roll = Some(roll);
             }
-            candidate.push(kept);
-            accumulated_warp = U256::ZERO;
-            accumulated_roll = U256::ZERO;
-        } else {
-            accumulated_warp += call.warp.unwrap_or_default();
-            accumulated_roll += call.roll.unwrap_or_default();
-        }
-    }
-
-    candidate
-}
-
-fn add_optional_u256(left: Option<U256>, right: Option<U256>) -> Option<U256> {
-    let sum = left.unwrap_or_default() + right.unwrap_or_default();
-    (!sum.is_zero()).then_some(sum)
+            call
+        },
+    )
 }
 
 /// Minimizes a stateless symbolic counterexample with ABI-valid candidates only.

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -2,7 +2,7 @@ use crate::result::SymbolicCounterexampleCall;
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_primitives::{Address, B256, Bytes, Function as SolFunction, I256, U256};
-use foundry_evm::executors::invariant::ShrinkRun;
+use foundry_evm::executors::invariant::{SequenceShrink, ShrinkRun, shrink_sequence_by_removing};
 use itertools::Itertools;
 use std::collections::HashSet;
 
@@ -149,26 +149,36 @@ impl<'a> SequenceMinimizer<'a> {
     }
 
     fn minimize_len(&mut self) {
-        loop {
-            if self.current_calls.len() <= 1 || !self.can_try() {
-                break;
-            }
-
-            let mut changed = false;
-            let mut idx = 0usize;
-            while idx < self.current_calls.len() && self.current_calls.len() > 1 && self.can_try() {
-                let candidate_calls = sequence_without_call(&self.current_calls, idx);
-                if self.try_candidate(candidate_calls) {
-                    changed = true;
-                } else {
-                    idx += 1;
-                }
-            }
-
-            if !changed {
-                break;
-            }
+        if self.current_calls.len() <= 1 || !self.can_try() {
+            return;
         }
+
+        let base_calls = self.current_calls.clone();
+        let current_calls = &mut self.current_calls;
+        let tried_candidates = &mut self.tried_candidates;
+        let still_fails = &mut self.still_fails;
+
+        shrink_sequence_by_removing(
+            base_calls.len(),
+            &mut self.run,
+            || false,
+            || {},
+            |shrinker| {
+                let candidate_calls = sequence_from_shrink(&base_calls, shrinker);
+                if candidate_calls == *current_calls
+                    || !tried_candidates.insert(replay_sequence_key(&candidate_calls))
+                {
+                    return None;
+                }
+
+                if (*still_fails)(&candidate_calls) {
+                    *current_calls = candidate_calls;
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            },
+        );
     }
 
     fn minimize_calldata(&mut self) {
@@ -256,16 +266,32 @@ impl<'a> SequenceMinimizer<'a> {
     }
 }
 
-fn sequence_without_call(
+fn sequence_from_shrink(
     calls: &[SymbolicCounterexampleCall],
-    idx: usize,
+    shrinker: &SequenceShrink,
 ) -> Vec<SymbolicCounterexampleCall> {
-    let mut candidate = calls.to_vec();
-    let removed = candidate.remove(idx);
-    if let Some(next) = candidate.get_mut(idx) {
-        next.warp = add_optional_u256(removed.warp, next.warp);
-        next.roll = add_optional_u256(removed.roll, next.roll);
+    let mut candidate = Vec::new();
+    let mut accumulated_warp = U256::ZERO;
+    let mut accumulated_roll = U256::ZERO;
+
+    for (idx, call) in calls.iter().enumerate() {
+        if shrinker.contains(idx) {
+            let mut kept = call.clone();
+            if !accumulated_warp.is_zero() {
+                kept.warp = add_optional_u256(Some(accumulated_warp), kept.warp);
+            }
+            if !accumulated_roll.is_zero() {
+                kept.roll = add_optional_u256(Some(accumulated_roll), kept.roll);
+            }
+            candidate.push(kept);
+            accumulated_warp = U256::ZERO;
+            accumulated_roll = U256::ZERO;
+        } else {
+            accumulated_warp += call.warp.unwrap_or_default();
+            accumulated_roll += call.roll.unwrap_or_default();
+        }
     }
+
     candidate
 }
 

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -2,6 +2,7 @@ use crate::result::SymbolicCounterexampleCall;
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::Function;
 use alloy_primitives::{Address, B256, Bytes, Function as SolFunction, I256, U256};
+use foundry_evm::executors::invariant::ShrinkRun;
 use itertools::Itertools;
 use std::collections::HashSet;
 
@@ -104,9 +105,7 @@ pub(crate) fn minimize_sequence_counterexample(
 struct SequenceMinimizer<'a> {
     current_calls: Vec<SymbolicCounterexampleCall>,
     tried_candidates: HashSet<Vec<ReplayCallKey>>,
-    max_attempts: usize,
-    attempts: usize,
-    accepted: usize,
+    run: ShrinkRun,
     still_fails: &'a mut dyn FnMut(&[SymbolicCounterexampleCall]) -> bool,
 }
 
@@ -117,26 +116,20 @@ impl<'a> SequenceMinimizer<'a> {
         still_fails: &'a mut dyn FnMut(&[SymbolicCounterexampleCall]) -> bool,
     ) -> Self {
         let tried_candidates = HashSet::from([replay_sequence_key(&current_calls)]);
-        Self {
-            current_calls,
-            tried_candidates,
-            max_attempts,
-            attempts: 0,
-            accepted: 0,
-            still_fails,
-        }
+        Self { current_calls, tried_candidates, run: ShrinkRun::new(max_attempts), still_fails }
     }
 
     const fn can_try(&self) -> bool {
-        self.attempts < self.max_attempts
+        self.run.can_try()
     }
 
     const fn remaining_attempts(&self) -> usize {
-        self.max_attempts - self.attempts
+        self.run.remaining_attempts()
     }
 
     fn finish(self) -> (Vec<SymbolicCounterexampleCall>, usize, usize) {
-        (self.current_calls, self.attempts, self.accepted)
+        let stats = self.run.finish();
+        (self.current_calls, stats.attempts, stats.accepted)
     }
 
     fn try_candidate(&mut self, candidate_calls: Vec<SymbolicCounterexampleCall>) -> bool {
@@ -147,10 +140,8 @@ impl<'a> SequenceMinimizer<'a> {
             return false;
         }
 
-        self.attempts += 1;
-        if (self.still_fails)(&candidate_calls) {
+        if self.run.try_candidate(|| (self.still_fails)(&candidate_calls)) {
             self.current_calls = candidate_calls;
-            self.accepted += 1;
             true
         } else {
             false
@@ -300,12 +291,11 @@ pub(crate) fn minimize_single_call_counterexample(
     let original_args = function.abi_decode_input(&call.calldata[4..]).ok()?;
     let mut current_args = original_args;
     let mut current_call = call_with_args(function, call, &current_args)?;
-    let mut attempts = 0usize;
-    let mut accepted = 0usize;
+    let mut run = ShrinkRun::new(max_attempts);
     let mut tried_calldata = HashSet::from([current_call.calldata.clone()]);
 
     let mut try_args = |candidate_args: &[DynSolValue]| {
-        if attempts >= max_attempts {
+        if !run.can_try() {
             return false;
         }
         let Some(candidate_call) = call_with_args(function, call, candidate_args) else {
@@ -317,10 +307,8 @@ pub(crate) fn minimize_single_call_counterexample(
             return false;
         }
 
-        attempts += 1;
-        if still_fails(&candidate_call) {
+        if run.try_candidate(|| still_fails(&candidate_call)) {
             current_call = candidate_call;
-            accepted += 1;
             true
         } else {
             false
@@ -332,12 +320,13 @@ pub(crate) fn minimize_single_call_counterexample(
     minimize_values(&mut current_args, &mut try_args);
 
     current_call = with_formatted_args(current_call, &current_args);
+    let stats = run.finish();
 
     Some(MinimizedSingleCall {
         original_call: call.clone(),
         minimized_call: current_call,
-        attempts,
-        accepted,
+        attempts: stats.attempts,
+        accepted: stats.accepted,
     })
 }
 


### PR DESCRIPTION
## Summary

- add a shared `shrink_sequence_by_removing` deletion minimizer in invariant shrinking
- use the shared sequence minimizer from concrete invariant check shrinking, handler assertion shrinking, optimization shrinking, and concretized symbolic stateful length minimization
- share shrunk-sequence materialization, including removed `warp`/`roll` accumulation into the next kept call
- keep symbolic-only ABI calldata/sender/value minimization layered on top of the shared sequence shrinker
- keep duplicate symbolic candidates as skipped candidates so they do not spend replay attempts
- make concrete shrink limits count actual candidate replays rather than skipped already-removed indices
