### PR TITLE
perf(invariant): cache dynamic target matches

### DIFF
--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -1,5 +1,5 @@
 use alloy_json_abi::{Event, Function, JsonAbi};
-use alloy_primitives::{Address, B256, Selector, map::HashMap};
+use alloy_primitives::{Address, B256, Selector, keccak256, map::HashMap};
 use foundry_compilers::artifacts::StorageLayout;
 use itertools::Either;
 use serde::{Deserialize, Serialize};
@@ -36,12 +36,17 @@ pub struct FuzzRunIdentifiedContracts {
     pub targets: Rc<RefCell<TargetedContracts>>,
     /// Whether target contracts are updatable or not.
     pub is_updatable: bool,
+    artifact_matches: Rc<RefCell<HashMap<B256, Option<CachedTargetContract>>>>,
 }
 
 impl FuzzRunIdentifiedContracts {
     /// Creates a new `FuzzRunIdentifiedContracts` instance.
     pub fn new(targets: TargetedContracts, is_updatable: bool) -> Self {
-        Self { targets: Rc::new(RefCell::new(targets)), is_updatable }
+        Self {
+            targets: Rc::new(RefCell::new(targets)),
+            is_updatable,
+            artifact_matches: Rc::new(RefCell::new(HashMap::default())),
+        }
     }
 
     /// Borrows the current targeted contracts.
@@ -63,7 +68,6 @@ impl FuzzRunIdentifiedContracts {
             return Ok(());
         }
 
-        let mut targets = self.targets.borrow_mut();
         for (address, account) in state_changeset {
             if setup_contracts.contains_key(address) {
                 continue;
@@ -77,24 +81,54 @@ impl FuzzRunIdentifiedContracts {
             if code.is_empty() {
                 continue;
             }
-            let Some((artifact, contract_data)) =
-                project_contracts.find_by_deployed_code(code.original_byte_slice())
-            else {
-                continue;
+            let code = code.original_byte_slice();
+            let code_hash = if account.info.code_hash == B256::ZERO {
+                keccak256(code)
+            } else {
+                account.info.code_hash
             };
-            let Some(functions) =
-                artifact_filters.get_targeted_functions(artifact, &contract_data.abi)?
+            let Some(contract) = self.target_contract_for_code(
+                code_hash,
+                code,
+                project_contracts,
+                artifact_filters,
+            )?
             else {
                 continue;
             };
             created_contracts.push(*address);
-            let mut contract =
-                TargetedContract::new(artifact.name.clone(), contract_data.abi.clone());
-            contract.targeted_functions = functions;
-            contract.storage_layout = contract_data.storage_layout.as_ref().map(Arc::clone);
-            targets.insert(*address, contract);
+            self.targets.borrow_mut().insert(*address, contract.into_targeted_contract());
         }
         Ok(())
+    }
+
+    fn target_contract_for_code(
+        &self,
+        code_hash: B256,
+        code: &[u8],
+        project_contracts: &ContractsByArtifact,
+        artifact_filters: &ArtifactFilters,
+    ) -> eyre::Result<Option<CachedTargetContract>> {
+        if let Some(cached_match) = self.artifact_matches.borrow().get(&code_hash) {
+            return Ok(cached_match.clone());
+        }
+
+        let cached_match = if let Some((artifact, contract_data)) =
+            project_contracts.find_by_deployed_code(code)
+        {
+            artifact_filters.get_targeted_functions(artifact, &contract_data.abi)?.map(
+                |targeted_functions| CachedTargetContract {
+                    identifier: artifact.name.clone(),
+                    abi: contract_data.abi.clone(),
+                    targeted_functions,
+                    storage_layout: contract_data.storage_layout.as_ref().map(Arc::clone),
+                },
+            )
+        } else {
+            None
+        };
+        self.artifact_matches.borrow_mut().insert(code_hash, cached_match.clone());
+        Ok(cached_match)
     }
 
     /// Clears targeted contracts created during an invariant run.
@@ -105,6 +139,23 @@ impl FuzzRunIdentifiedContracts {
                 targets.remove(addr);
             }
         }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CachedTargetContract {
+    identifier: String,
+    abi: JsonAbi,
+    targeted_functions: Vec<Function>,
+    storage_layout: Option<Arc<StorageLayout>>,
+}
+
+impl CachedTargetContract {
+    fn into_targeted_contract(self) -> TargetedContract {
+        let mut contract = TargetedContract::new(self.identifier, self.abi);
+        contract.targeted_functions = self.targeted_functions;
+        contract.storage_layout = self.storage_layout;
+        contract
     }
 }
 
@@ -516,7 +567,14 @@ impl fmt::Display for InvariantSettings {
 mod tests {
     use super::*;
     use crate::CallDetails;
-    use alloy_primitives::Bytes;
+    use alloy_primitives::{Bytes, U256};
+    use foundry_compilers::{
+        ArtifactId,
+        artifacts::{
+            BytecodeObject, CompactBytecode, CompactContractBytecode, CompactDeployedBytecode,
+        },
+    };
+    use revm::{bytecode::Bytecode, state::Account};
 
     fn targeted_contracts_with_function(target: Address, function: Function) -> TargetedContracts {
         let mut abi = JsonAbi::new();
@@ -535,6 +593,42 @@ mod tests {
         }
     }
 
+    fn artifact_id(name: &str) -> ArtifactId {
+        ArtifactId {
+            path: format!("{name}.json").into(),
+            name: name.to_string(),
+            source: format!("{name}.sol").into(),
+            version: "0.8.30".parse().unwrap(),
+            build_id: "test".to_string(),
+            profile: "test".to_string(),
+        }
+    }
+
+    fn project_contracts_with_runtime_code(name: &str, code: Bytes) -> ContractsByArtifact {
+        let deployed_bytecode = CompactDeployedBytecode {
+            bytecode: Some(CompactBytecode {
+                object: BytecodeObject::Bytecode(code),
+                source_map: None,
+                link_references: Default::default(),
+            }),
+            immutable_references: Default::default(),
+        };
+        let artifact = CompactContractBytecode {
+            abi: Some(JsonAbi::new()),
+            bytecode: None,
+            deployed_bytecode: Some(deployed_bytecode),
+        };
+        ContractsByArtifact::new([(artifact_id(name), artifact)])
+    }
+
+    fn touched_account_with_code(code: Bytes) -> Account {
+        let mut account = Account::default();
+        account.info.balance = U256::ZERO;
+        account.info.code = Some(Bytecode::new_raw(code));
+        account.mark_touch();
+        account
+    }
+
     #[test]
     fn targeted_contracts_short_calldata_is_not_replayable_or_decodable() {
         let target = Address::from([0x42; 20]);
@@ -544,5 +638,65 @@ mod tests {
         assert!(!targets.can_replay(&tx));
         assert!(targets.fuzzed_artifacts(&tx).1.is_none());
         assert!(targets.fuzzed_metric_key(&tx).is_none());
+    }
+
+    #[test]
+    fn collect_created_contracts_caches_deployed_code_matches() {
+        let existing = Address::from([0x42; 20]);
+        let created = Address::from([0x43; 20]);
+        let setup = Address::from([0x44; 20]);
+        let untouched = Address::from([0x45; 20]);
+        let runtime_code = Bytes::from_static(&[0x60, 0x00, 0x56]);
+        let project_contracts =
+            project_contracts_with_runtime_code("DynamicTarget", runtime_code.clone());
+        let mut targets = TargetedContracts::new();
+        for address in [existing, setup, untouched] {
+            targets.inner.insert(
+                address,
+                TargetedContract::new("AlreadyTargeted".to_string(), JsonAbi::new()),
+            );
+        }
+        let identified = FuzzRunIdentifiedContracts::new(targets, true);
+
+        let mut state_changeset = StateChangeset::default();
+        state_changeset.insert(existing, touched_account_with_code(runtime_code.clone()));
+        state_changeset.insert(setup, touched_account_with_code(runtime_code.clone()));
+        state_changeset.insert(untouched, Account::default());
+        state_changeset.insert(created, touched_account_with_code(runtime_code));
+        let mut created_contracts = Vec::new();
+        let setup_contracts =
+            ContractsByAddress::from([(setup, ("Setup".to_string(), JsonAbi::new()))]);
+
+        identified
+            .collect_created_contracts(
+                &state_changeset,
+                &project_contracts,
+                &setup_contracts,
+                &ArtifactFilters::default(),
+                &mut created_contracts,
+            )
+            .unwrap();
+
+        created_contracts.sort_unstable();
+        assert_eq!(created_contracts, vec![existing, created]);
+        let targets = identified.targets();
+        assert_eq!(targets[&existing].identifier, "DynamicTarget");
+        assert_eq!(targets[&created].identifier, "DynamicTarget");
+        assert_eq!(targets[&setup].identifier, "AlreadyTargeted");
+        assert_eq!(targets[&untouched].identifier, "AlreadyTargeted");
+        drop(targets);
+
+        identified
+            .collect_created_contracts(
+                &state_changeset,
+                &Default::default(),
+                &setup_contracts,
+                &ArtifactFilters::default(),
+                &mut created_contracts,
+            )
+            .unwrap();
+
+        created_contracts.sort_unstable();
+        assert_eq!(created_contracts, vec![existing, existing, created, created]);
     }
 }

--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -1,5 +1,5 @@
 use alloy_json_abi::{Event, Function, JsonAbi};
-use alloy_primitives::{Address, B256, Selector, keccak256, map::HashMap};
+use alloy_primitives::{Address, B256, Selector, map::HashMap};
 use foundry_compilers::artifacts::StorageLayout;
 use itertools::Either;
 use serde::{Deserialize, Serialize};
@@ -20,6 +20,10 @@ pub use filters::{ArtifactFilters, SenderFilters};
 use foundry_common::{ContractsByAddress, ContractsByArtifact};
 use foundry_evm_core::utils::{StateChangeset, get_function};
 
+type DynamicTargetCacheKey = (Address, B256);
+type DynamicTargetArtifactMatchCache =
+    Rc<RefCell<HashMap<DynamicTargetCacheKey, Option<CachedTargetContract>>>>;
+
 /// Returns true if the function returns `int256`, indicating optimization mode.
 /// In optimization mode, the fuzzer maximizes the return value instead of checking invariants.
 pub fn is_optimization_invariant(func: &Function) -> bool {
@@ -36,7 +40,7 @@ pub struct FuzzRunIdentifiedContracts {
     pub targets: Rc<RefCell<TargetedContracts>>,
     /// Whether target contracts are updatable or not.
     pub is_updatable: bool,
-    artifact_matches: Rc<RefCell<HashMap<B256, Option<CachedTargetContract>>>>,
+    artifact_matches: DynamicTargetArtifactMatchCache,
 }
 
 impl FuzzRunIdentifiedContracts {
@@ -81,13 +85,10 @@ impl FuzzRunIdentifiedContracts {
             if code.is_empty() {
                 continue;
             }
+            let code_hash = code.hash_slow();
             let code = code.original_byte_slice();
-            let code_hash = if account.info.code_hash == B256::ZERO {
-                keccak256(code)
-            } else {
-                account.info.code_hash
-            };
             let Some(contract) = self.target_contract_for_code(
+                *address,
                 code_hash,
                 code,
                 project_contracts,
@@ -104,12 +105,14 @@ impl FuzzRunIdentifiedContracts {
 
     fn target_contract_for_code(
         &self,
+        address: Address,
         code_hash: B256,
         code: &[u8],
         project_contracts: &ContractsByArtifact,
         artifact_filters: &ArtifactFilters,
     ) -> eyre::Result<Option<CachedTargetContract>> {
-        if let Some(cached_match) = self.artifact_matches.borrow().get(&code_hash) {
+        let cache_key = (address, code_hash);
+        if let Some(cached_match) = self.artifact_matches.borrow().get(&cache_key) {
             return Ok(cached_match.clone());
         }
 
@@ -122,12 +125,13 @@ impl FuzzRunIdentifiedContracts {
                     abi: contract_data.abi.clone(),
                     targeted_functions,
                     storage_layout: contract_data.storage_layout.as_ref().map(Arc::clone),
+                    event_lookup: Arc::new(TargetedContractEvents::new(&contract_data.abi)),
                 },
             )
         } else {
             None
         };
-        self.artifact_matches.borrow_mut().insert(code_hash, cached_match.clone());
+        self.artifact_matches.borrow_mut().insert(cache_key, cached_match.clone());
         Ok(cached_match)
     }
 
@@ -148,14 +152,19 @@ struct CachedTargetContract {
     abi: JsonAbi,
     targeted_functions: Vec<Function>,
     storage_layout: Option<Arc<StorageLayout>>,
+    event_lookup: Arc<TargetedContractEvents>,
 }
 
 impl CachedTargetContract {
     fn into_targeted_contract(self) -> TargetedContract {
-        let mut contract = TargetedContract::new(self.identifier, self.abi);
-        contract.targeted_functions = self.targeted_functions;
-        contract.storage_layout = self.storage_layout;
-        contract
+        TargetedContract {
+            identifier: self.identifier,
+            abi: self.abi,
+            targeted_functions: self.targeted_functions,
+            excluded_functions: Vec::new(),
+            storage_layout: self.storage_layout,
+            event_lookup: self.event_lookup,
+        }
     }
 }
 


### PR DESCRIPTION
Avoid repeatedly walking all compiled artifacts for the same touched deployed bytecode during invariant dynamic target discovery.

Updatable invariant runs scan touched accounts and match deployed bytecode back to project artifacts. A factory-created target can be touched many times, so repeatedly calling `find_by_deployed_code` pays the full artifact scan for bytecode that has already been identified at that address.

This caches the deployed-bytecode match by touched address and `Bytecode::hash_slow()` while preserving the existing target refresh and `created_contracts` cleanup behavior.

### What changed

- Cache dynamic target artifact matches by touched address and bytecode hash.
- Share the cached ABI event lookup across refreshed target entries.
- Preserve setup-contract, untouched-account, target refresh, and cleanup semantics.
- Add regression coverage for cache reuse without a second project artifact lookup.

### Benchmarks

Release `forge` binaries were built from the same base commit (`cd5b4cf9a`). The fixture uses a factory-created dynamic target, repeated invariant calls that touch it, and 200 similar artifacts to make repeated rediscovery visible.

| Case | Baseline | This PR | Speedup |
| --- | ---: | ---: | ---: |
| Depth 20,000, `--threads 1` | `364.9ms ± 2.3ms` | `295.2ms ± 2.6ms` | `1.24x ± 0.01` |
| Depth 100,000, `--threads 1` | `1.592s ± 0.018s` | `1.235s ± 0.007s` | `1.29x ± 0.02` |
