### PR TITLE
fix(fuzz): bound enum inputs to valid variants

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -453,7 +453,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         let dictionary_weight = self.config.dictionary.dictionary_weight.min(100);
         let calldata_strategy = proptest::prop_oneof![
             100 - dictionary_weight => fuzz_calldata(func.clone(), fuzz_fixtures),
-            dictionary_weight => fuzz_calldata_from_state(func.clone(), &fuzz_state),
+            dictionary_weight => fuzz_calldata_from_state(func.clone(), &fuzz_state, fuzz_fixtures),
         ];
         let value_strategy = if func.state_mutability == alloy_json_abi::StateMutability::Payable {
             fuzz_msg_value(self.config.corpus.payable_value_weight).boxed()

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -470,11 +470,19 @@ impl FuzzedCases {
 #[derive(Clone, Default, Debug)]
 pub struct FuzzFixtures {
     inner: Arc<HashMap<String, DynSolValue>>,
+    /// Variant counts for project enums, used to constrain fuzzed enum inputs.
+    enum_bounds: strategies::EnumBounds,
 }
 
 impl FuzzFixtures {
     pub fn new(fixtures: HashMap<String, DynSolValue>) -> Self {
-        Self { inner: Arc::new(fixtures) }
+        Self { inner: Arc::new(fixtures), enum_bounds: strategies::EnumBounds::default() }
+    }
+
+    /// Attaches collected enum variant counts.
+    pub fn with_enum_bounds(mut self, enum_bounds: strategies::EnumBounds) -> Self {
+        self.enum_bounds = enum_bounds;
+        self
     }
 
     /// Returns configured fixtures for `param_name` fuzzed parameter.
@@ -484,6 +492,12 @@ impl FuzzFixtures {
         } else {
             None
         }
+    }
+
+    /// Returns the variant count for an enum identified by an optional contract qualifier and name
+    /// (as found in an ABI `internalType`), or `None` if unknown.
+    pub fn enum_variant_count(&self, contract: Option<&str>, name: &str) -> Option<usize> {
+        self.enum_bounds.variant_count(contract, name)
     }
 }
 

--- a/crates/evm/fuzz/src/strategies/calldata.rs
+++ b/crates/evm/fuzz/src/strategies/calldata.rs
@@ -2,10 +2,111 @@ use crate::{
     FuzzFixtures,
     strategies::{FuzzStateReader, fuzz_param_from_state, fuzz_param_with_fixtures},
 };
-use alloy_dyn_abi::JsonAbiExt;
-use alloy_json_abi::Function;
-use alloy_primitives::Bytes;
-use proptest::prelude::Strategy;
+use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
+use alloy_json_abi::{Function, Param};
+use alloy_primitives::{Bytes, U256};
+use proptest::{prelude::Strategy, strategy::BoxedStrategy};
+
+/// Plan for constraining the enum leaves of a fuzzed parameter into their valid `0..variant_count`
+/// range. Solidity enums are ABI-encoded as `uint8`, so without this the fuzzer can generate
+/// out-of-range values that the contract rejects with `Panic(0x21)` when decoding them.
+#[derive(Clone, Debug)]
+enum EnumClamp {
+    /// An enum (possibly nested in arrays); reduce every `uint8` leaf modulo the variant count.
+    Leaf(U256),
+    /// A tuple/struct; apply the per-component plans (`None` = no clamping needed).
+    Tuple(Vec<Option<Self>>),
+}
+
+impl EnumClamp {
+    /// Builds a clamp plan for `input`, returning `None` if it contains no enums to constrain.
+    fn for_param(input: &Param, fuzz_fixtures: &FuzzFixtures) -> Option<Self> {
+        // Direct enum, e.g. `EnumVal` or `EnumVal[2][]`; strip any array suffix.
+        if let Some((contract, ty)) = input.internal_type.as_ref().and_then(|it| it.as_enum()) {
+            let base = ty.split('[').next().unwrap_or(ty);
+            if let Some(count) = fuzz_fixtures.enum_variant_count(contract, base)
+                && count > 0
+            {
+                return Some(Self::Leaf(U256::from(count)));
+            }
+        }
+
+        // Struct/tuple (or `Struct[]`): recurse into components, keeping the plan only if any field
+        // needs clamping.
+        if input.components.is_empty() {
+            return None;
+        }
+        let fields = input
+            .components
+            .iter()
+            .map(|component| Self::for_param(component, fuzz_fixtures))
+            .collect::<Vec<_>>();
+        fields.iter().any(Option::is_some).then_some(Self::Tuple(fields))
+    }
+
+    /// Applies the plan to a generated value, reducing every enum leaf into its valid range.
+    fn apply(&self, value: DynSolValue) -> DynSolValue {
+        match self {
+            Self::Leaf(count) => clamp_enum_leaf(value, *count),
+            Self::Tuple(fields) => match value {
+                DynSolValue::Tuple(values) => DynSolValue::Tuple(self.apply_fields(fields, values)),
+                DynSolValue::CustomStruct { name, prop_names, tuple } => {
+                    DynSolValue::CustomStruct {
+                        name,
+                        prop_names,
+                        tuple: self.apply_fields(fields, tuple),
+                    }
+                }
+                // `Struct[]`/`Struct[N]`: apply the field plan to each element.
+                DynSolValue::Array(values) => {
+                    DynSolValue::Array(values.into_iter().map(|v| self.apply(v)).collect())
+                }
+                DynSolValue::FixedArray(values) => {
+                    DynSolValue::FixedArray(values.into_iter().map(|v| self.apply(v)).collect())
+                }
+                other => other,
+            },
+        }
+    }
+
+    fn apply_fields(&self, fields: &[Option<Self>], values: Vec<DynSolValue>) -> Vec<DynSolValue> {
+        values
+            .into_iter()
+            .enumerate()
+            .map(|(i, value)| match fields.get(i) {
+                Some(Some(plan)) => plan.apply(value),
+                _ => value,
+            })
+            .collect()
+    }
+}
+
+/// Wraps `strat` to constrain any enum leaves in `input` to their valid range; a no-op otherwise.
+fn bound_enum(
+    strat: BoxedStrategy<DynSolValue>,
+    input: &Param,
+    fuzz_fixtures: &FuzzFixtures,
+) -> BoxedStrategy<DynSolValue> {
+    match EnumClamp::for_param(input, fuzz_fixtures) {
+        Some(plan) => strat.prop_map(move |value| plan.apply(value)).boxed(),
+        None => strat,
+    }
+}
+
+/// Recursively reduces every `uint8` leaf in an enum value (possibly nested in arrays) modulo
+/// `count`.
+fn clamp_enum_leaf(value: DynSolValue, count: U256) -> DynSolValue {
+    match value {
+        DynSolValue::Uint(v, 8) => DynSolValue::Uint(v % count, 8),
+        DynSolValue::Array(values) => {
+            DynSolValue::Array(values.into_iter().map(|v| clamp_enum_leaf(v, count)).collect())
+        }
+        DynSolValue::FixedArray(values) => {
+            DynSolValue::FixedArray(values.into_iter().map(|v| clamp_enum_leaf(v, count)).collect())
+        }
+        other => other,
+    }
+}
 
 /// Given a function, it returns a strategy which generates valid calldata
 /// for that function's input types, following declared test fixtures.
@@ -19,11 +120,12 @@ pub fn fuzz_calldata(
         .inputs
         .iter()
         .map(|input| {
-            fuzz_param_with_fixtures(
+            let strat = fuzz_param_with_fixtures(
                 &input.selector_type().parse().unwrap(),
                 fuzz_fixtures.param_fixtures(&input.name),
                 &input.name,
-            )
+            );
+            bound_enum(strat, input, fuzz_fixtures)
         })
         .collect::<Vec<_>>();
     strats.prop_map(move |values| {
@@ -43,11 +145,15 @@ pub fn fuzz_calldata(
 pub fn fuzz_calldata_from_state<S: FuzzStateReader>(
     func: Function,
     state: &S,
+    fuzz_fixtures: &FuzzFixtures,
 ) -> impl Strategy<Value = Bytes> + use<S> {
     let strats = func
         .inputs
         .iter()
-        .map(|input| fuzz_param_from_state(&input.selector_type().parse().unwrap(), state))
+        .map(|input| {
+            let strat = fuzz_param_from_state(&input.selector_type().parse().unwrap(), state);
+            bound_enum(strat, input, fuzz_fixtures)
+        })
         .collect::<Vec<_>>();
     strats
         .prop_map(move |values| {

--- a/crates/evm/fuzz/src/strategies/invariants.rs
+++ b/crates/evm/fuzz/src/strategies/invariants.rs
@@ -184,7 +184,7 @@ pub fn fuzz_contract_with_calldata<S: FuzzStateReader>(
     // `prop_oneof!` / `TupleUnion` `Arc`s for cheap cloning.
     let calldata_strategy = prop_oneof![
         100 - dictionary_weight => fuzz_calldata(func.clone(), fuzz_fixtures),
-        dictionary_weight => fuzz_calldata_from_state(func, fuzz_state),
+        dictionary_weight => fuzz_calldata_from_state(func, fuzz_state, fuzz_fixtures),
     ];
 
     // For payable functions, generate random value using shared strategy.

--- a/crates/evm/fuzz/src/strategies/literals.rs
+++ b/crates/evm/fuzz/src/strategies/literals.rs
@@ -85,6 +85,90 @@ pub struct LiteralMaps {
     pub bytes: IndexSet<Bytes>,
 }
 
+/// Maps Solidity enum definitions to their variant counts, used to constrain fuzzed enum inputs
+/// to valid values (the ABI encodes enums as `uint8` without carrying the variant count).
+///
+/// Keys are `"<Contract>.<Enum>"` for enums declared inside a contract/library and the bare
+/// `"<Enum>"` for file-level enums, mirroring the qualifier in an ABI `internalType`.
+#[derive(Clone, Debug, Default)]
+pub struct EnumBounds {
+    inner: Arc<HashMap<String, usize>>,
+}
+
+impl EnumBounds {
+    /// Records the variant count of every enum declaration across all parsed sources (libraries
+    /// and dependencies included, as their enums may be used as test parameters). Keys with
+    /// conflicting counts are dropped, leaving ambiguous enums unbounded rather than bounded wrong.
+    pub fn collect(analysis: &Analysis) -> Self {
+        let bounds = analysis.enter(|compiler| {
+            let mut collector = EnumBoundsCollector::default();
+            for source in compiler.sources().iter() {
+                if let Some(ast) = &source.ast {
+                    let _ = collector.visit_source_unit(ast);
+                }
+            }
+            // Keep only unambiguous entries; ambiguous keys (`None`) are discarded.
+            collector
+                .bounds
+                .into_iter()
+                .filter_map(|(key, count)| count.map(|count| (key, count)))
+                .collect()
+        });
+        Self { inner: Arc::new(bounds) }
+    }
+
+    /// Returns the number of variants for an enum identified by an optional contract qualifier and
+    /// name, or `None` if it is unknown.
+    pub fn variant_count(&self, contract: Option<&str>, name: &str) -> Option<usize> {
+        let key = match contract {
+            Some(contract) => format!("{contract}.{name}"),
+            None => name.to_string(),
+        };
+        self.inner.get(&key).copied()
+    }
+}
+
+/// AST visitor that records enum variant counts, tracking the enclosing contract to build
+/// fully-qualified keys.
+#[derive(Default)]
+struct EnumBoundsCollector {
+    /// Name of the contract/library currently being visited, if any.
+    current_contract: Option<String>,
+    /// Collected `enum key -> variant count` entries. A value of `None` marks a key seen with
+    /// conflicting counts (ambiguous), which is later discarded.
+    bounds: HashMap<String, Option<usize>>,
+}
+
+impl<'ast> ast::Visit<'ast> for EnumBoundsCollector {
+    type BreakValue = ();
+
+    fn visit_item_contract(&mut self, contract: &'ast ast::ItemContract<'ast>) -> ControlFlow<()> {
+        let prev = self.current_contract.replace(contract.name.as_str().to_string());
+        let r = self.walk_item_contract(contract);
+        self.current_contract = prev;
+        r
+    }
+
+    fn visit_item_enum(&mut self, enum_: &'ast ast::ItemEnum<'ast>) -> ControlFlow<()> {
+        let name = enum_.name.as_str();
+        let count = enum_.variants.len();
+        let key = match &self.current_contract {
+            Some(contract) => format!("{contract}.{name}"),
+            None => name.to_string(),
+        };
+        self.bounds
+            .entry(key)
+            // Same key seen with a different count is ambiguous; mark it for removal.
+            .and_modify(|existing| {
+                if *existing != Some(count) {
+                    *existing = None;
+                }
+            })
+            .or_insert(Some(count));
+        self.walk_item_enum(enum_)
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct LiteralsCollector {
     max_values: usize,

--- a/crates/evm/fuzz/src/strategies/mod.rs
+++ b/crates/evm/fuzz/src/strategies/mod.rs
@@ -23,4 +23,4 @@ mod mutators;
 pub use mutators::BoundMutator;
 
 mod literals;
-pub use literals::{LiteralMaps, LiteralsCollector, LiteralsDictionary};
+pub use literals::{EnumBounds, LiteralMaps, LiteralsCollector, LiteralsDictionary};

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -582,7 +582,7 @@ mod tests {
         let state = EvmFuzzState::test();
         let strategy = proptest::prop_oneof![
             60 => fuzz_calldata(func.clone(), &FuzzFixtures::default()),
-            40 => fuzz_calldata_from_state(func, &state),
+            40 => fuzz_calldata_from_state(func, &state, &FuzzFixtures::default()),
         ];
         let cfg = proptest::test_runner::Config { failure_persistence: None, ..Default::default() };
         let mut runner = proptest::test_runner::TestRunner::new(cfg);

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -27,7 +27,7 @@ use foundry_evm::{
     decode::RevertDecoder,
     executors::{EarlyExit, Executor, ExecutorBuilder, ShowmapDomain},
     fork::CreateFork,
-    fuzz::strategies::LiteralsDictionary,
+    fuzz::strategies::{EnumBounds, LiteralsDictionary},
     inspectors::CheatsConfig,
     opts::EvmOpts,
     traces::{InternalTraceMode, TraceMode},
@@ -74,6 +74,8 @@ pub struct MultiContractRunner<FEN: FoundryEvmNetwork> {
     pub fuzz_literals: LiteralsDictionary,
     /// Literals dictionary for invariant fuzzing.
     pub invariant_literals: LiteralsDictionary,
+    /// Variant counts for project enums, used to constrain fuzzed enum inputs.
+    pub enum_bounds: EnumBounds,
 
     /// The fork to use at launch
     pub fork: Option<CreateFork>,
@@ -723,6 +725,8 @@ impl MultiContractRunnerBuilder {
         })?;
 
         let analysis = Arc::new(analysis);
+        // Enum variant counts used to constrain fuzzed enum inputs to valid values.
+        let enum_bounds = EnumBounds::collect(&analysis);
         let fuzz_max_literals = self.config.fuzz.dictionary.max_fuzz_dictionary_literals;
         let invariant_max_literals = self.config.invariant.dictionary.max_fuzz_dictionary_literals;
         let fuzz_literals = LiteralsDictionary::new(
@@ -749,6 +753,7 @@ impl MultiContractRunnerBuilder {
             analysis,
             fuzz_literals,
             invariant_literals,
+            enum_bounds,
 
             tcfg: TestRunnerConfig {
                 evm_opts,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -663,7 +663,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 fixtures.insert(fixture_name(func.name.clone()), DynSolValue::Array(vals));
             };
         }
-        FuzzFixtures::new(fixtures)
+        FuzzFixtures::new(fixtures).with_enum_bounds(self.mcr.enum_bounds.clone())
     }
 
     /// Runs all tests for a contract whose names match the provided regular expression

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1008,6 +1008,74 @@ Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing te
     assert_eq!(random_failure_reason(&stdout), reason, "{stdout}");
 });
 
+// Fuzzed enum inputs must stay within `0..variant_count`, else the contract rejects them with
+// `Panic(0x21)` when decoding, before the test body runs. https://github.com/foundry-rs/foundry/issues/6623
+forgetest_init!(fuzz_bounds_enum_inputs, |prj, cmd| {
+    // File-level enum in a non-test source, used as a struct field below, to exercise enum
+    // collection from outside the test file.
+    prj.add_source(
+        "LibEnum.sol",
+        r#"
+enum LibEnumVal { L0, L1 }
+   "#,
+    );
+
+    prj.add_test(
+        "FuzzEnum.t.sol",
+        r#"
+import "forge-std/Test.sol";
+import {LibEnumVal} from "src/LibEnum.sol";
+
+contract FuzzEnum is Test {
+    enum EnumVal { VAL_0, VAL_1, VAL_2 }
+
+    struct WithEnum {
+        EnumVal e;
+        uint8 raw;
+        LibEnumVal lib;
+    }
+
+    function testScalarEnum(EnumVal val) public pure {
+        assert(uint8(val) < 3);
+    }
+
+    function testEnumArray(EnumVal[] memory vals) public pure {
+        for (uint256 i; i < vals.length; ++i) {
+            assert(uint8(vals[i]) < 3);
+        }
+    }
+
+    function testEnumInStruct(WithEnum memory s) public pure {
+        assert(uint8(s.e) < 3);
+        assert(uint8(s.lib) < 2);
+    }
+
+    function testEnumInStructArray(WithEnum[] memory xs) public pure {
+        for (uint256 i; i < xs.length; ++i) {
+            assert(uint8(xs[i].e) < 3);
+            assert(uint8(xs[i].lib) < 2);
+        }
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mc", "FuzzEnum", "--fuzz-runs", "512"]).assert_success().stdout_eq(str![
+        [r#"
+...
+Ran 4 tests for test/FuzzEnum.t.sol:FuzzEnum
+[PASS] testEnumArray(uint8[]) (runs: 512, [AVG_GAS])
+[PASS] testEnumInStruct((uint8,uint8,uint8)) (runs: 512, [AVG_GAS])
+[PASS] testEnumInStructArray((uint8,uint8,uint8)[]) (runs: 512, [AVG_GAS])
+[PASS] testScalarEnum(uint8) (runs: 512, [AVG_GAS])
+Suite result: ok. 4 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 4 tests passed, 0 failed, 0 skipped (4 total tests)
+
+"#]
+    ]);
+});
+
 fn random_failure_reason(stdout: &str) -> String {
     Regex::new(r"\[FAIL: (Random\([^)]+\))")
         .unwrap()


### PR DESCRIPTION
Fixes #6623

Solidity enums are ABI-encoded as `uint8`, but the ABI doesn't carry the variant count, so the fuzzer generated out-of-range values that the contract rejects with `Panic(0x21)` — a false-positive failure.

This collects each enum's variant count from the AST at build time and clamps fuzzed enum inputs (scalars, arrays, and enum fields in structs/tuples) to `value % variant_count`.