### PR TITLE
fix(verify): preserve chain id for bytecode forks

### DIFF
--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -3,7 +3,7 @@ use crate::{
     etherscan::EtherscanVerificationProvider,
     utils::{
         BytecodeType, JsonResult, check_and_encode_args, check_explorer_args, configure_env_block,
-        maybe_predeploy_contract,
+        load_fork_config_and_evm_opts, maybe_predeploy_contract,
     },
     verify::VerifierArgs,
 };
@@ -290,7 +290,7 @@ impl VerifyBytecodeArgs {
 
             // Deploy at genesis
             let gen_blk_num = 0_u64;
-            let (mut fork_config, evm_opts) = config.clone().load_config_and_evm_opts()?;
+            let (mut fork_config, evm_opts) = load_fork_config_and_evm_opts(&config)?;
             let (mut evm_env, _, mut executor) = crate::utils::get_tracing_executor::<FEN>(
                 &mut fork_config,
                 gen_blk_num,
@@ -497,7 +497,7 @@ impl VerifyBytecodeArgs {
             };
 
             // Fork the chain at `simulation_block`.
-            let (mut fork_config, evm_opts) = config.clone().load_config_and_evm_opts()?;
+            let (mut fork_config, evm_opts) = load_fork_config_and_evm_opts(&config)?;
             let (mut evm_env, _tx_env, mut executor) = crate::utils::get_tracing_executor::<FEN>(
                 &mut fork_config,
                 simulation_block - 1, // env.fork_block_number

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -10,6 +10,7 @@ use foundry_block_explorers::{
     errors::EtherscanError,
     utils::lookup_compiler_version,
 };
+use foundry_cli::utils::LoadConfig;
 use foundry_common::{
     abi::encode_args,
     compile::{PathOrContractInfo, ProjectCompiler},
@@ -276,6 +277,20 @@ pub fn check_args_len(
     Ok(())
 }
 
+pub fn load_fork_config_and_evm_opts(config: &Config) -> Result<(Config, EvmOpts)> {
+    let chain = config.chain;
+    let mut fork_config = config.clone();
+    fork_config.chain = None;
+
+    let (mut fork_config, mut evm_opts) = fork_config.load_config_and_evm_opts()?;
+    fork_config.chain = chain;
+    if let Some(chain) = chain {
+        evm_opts.env.chain_id = Some(chain.id());
+    }
+
+    Ok((fork_config, evm_opts))
+}
+
 pub async fn get_tracing_executor<FEN>(
     fork_config: &mut Config,
     fork_blk_num: u64,
@@ -466,6 +481,7 @@ mod tests {
     use crate::verify::VerifierArgs;
     use foundry_cli::opts::EtherscanOpts;
     use foundry_compilers::PathStyle;
+    use foundry_config::NamedChain;
     use foundry_test_utils::TestProject;
 
     #[test]
@@ -502,6 +518,16 @@ contract Counter {
         let artifact = build_project(&args, &config).unwrap();
 
         assert!(artifact.bytecode.and_then(|bytecode| bytecode.into_bytes()).is_some());
+    }
+
+    #[test]
+    fn load_fork_config_and_evm_opts_serializes_chain_as_id() {
+        let config = Config { chain: Some(NamedChain::Mainnet.into()), ..Default::default() };
+
+        let (fork_config, evm_opts) = load_fork_config_and_evm_opts(&config).unwrap();
+
+        assert_eq!(fork_config.chain, Some(NamedChain::Mainnet.into()));
+        assert_eq!(evm_opts.env.chain_id, Some(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes `forge verify-bytecode` runtime verification when a named chain is present in config.

`verify-bytecode` was reloading fork EVM opts from `Config`, but named chains like `mainnet` were serialized as strings while `EvmOpts.env.chain_id` expects a numeric chain id. This caused runtime bytecode verification to fail after creation bytecode matched.

This preserves the configured chain on the fork config while explicitly passing its numeric chain id into `EvmOpts`.

Closes #15338
