### PR TITLE
feat(debugger): show precompile call clues

### DIFF
--- a/crates/debugger/src/node.rs
+++ b/crates/debugger/src/node.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::{Address, Bytes, hex};
 use foundry_evm_core::precompiles;
 use foundry_evm_traces::{CallKind, CallTrace, CallTraceArena};
+use revm::bytecode::opcode::OpCode;
 use revm_inspectors::tracing::types::{
     CallTraceStep, DecodedCallTrace, DecodedTraceStep, TraceMemberOrder,
 };
@@ -75,16 +76,19 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
     ) {
         let mut pending = PendingNode { node_idx, steps_count: 0, step_offset: 0 };
         let mut next_step_offset = 0;
+        let mut last_step_idx: Option<usize> = None;
         let node = &arena.nodes()[node_idx];
         for order in &node.ordering {
             match order {
                 TraceMemberOrder::Call(idx) => {
                     let child_idx = node.children[*idx];
-                    if next_step_offset > 0
+                    if let Some(step_idx) = last_step_idx.take()
+                        && let Some(step) = node.trace.steps.get(step_idx)
+                        && is_call_like_op(step.op)
                         && let Some(notice) =
                             precompile_call_notice(&arena.nodes()[child_idx].trace)
                     {
-                        step_notices.push((node_idx, next_step_offset - 1, notice));
+                        step_notices.push((node_idx, step_idx, notice));
                     }
                     out.push(pending);
                     pending =
@@ -97,8 +101,11 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
                     }
                     pending.steps_count += 1;
                     next_step_offset = step_idx.saturating_add(1);
+                    last_step_idx = Some(*step_idx);
                 }
-                _ => {}
+                _ => {
+                    last_step_idx = None;
+                }
             }
         }
         out.push(pending);
@@ -112,7 +119,7 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
         if let Some(step) =
             arena_nodes.get_mut(node_idx).and_then(|node| node.trace.steps.get_mut(step_idx))
         {
-            step.decoded = Some(Box::new(DecodedTraceStep::Line(notice)));
+            set_step_notice(step, notice);
         }
     }
 
@@ -146,6 +153,26 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
 
         out.push(node);
     }
+}
+
+fn set_step_notice(step: &mut CallTraceStep, notice: String) {
+    match step.decoded.as_deref_mut() {
+        None => step.decoded = Some(Box::new(DecodedTraceStep::Line(notice))),
+        Some(DecodedTraceStep::Line(line)) if line.is_empty() => *line = notice,
+        Some(_) => {}
+    }
+}
+
+const fn is_call_like_op(op: OpCode) -> bool {
+    matches!(
+        op,
+        OpCode::CALL
+            | OpCode::STATICCALL
+            | OpCode::DELEGATECALL
+            | OpCode::CALLCODE
+            | OpCode::CREATE
+            | OpCode::CREATE2
+    )
 }
 
 fn precompile_call_notice(trace: &CallTrace) -> Option<String> {
@@ -216,8 +243,8 @@ const fn known_precompile_name(address: Address) -> Option<&'static str> {
 mod tests {
     use super::*;
     use foundry_evm_traces::CallTraceNode;
-    use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
-    use revm_inspectors::tracing::types::DecodedCallData;
+    use revm::interpreter::InstructionResult;
+    use revm_inspectors::tracing::types::{DecodedCallData, DecodedInternalCall};
 
     fn step(pc: usize) -> CallTraceStep {
         CallTraceStep {
@@ -240,6 +267,35 @@ mod tests {
 
     fn step_with_op(pc: usize, op: OpCode) -> CallTraceStep {
         CallTraceStep { op, ..step(pc) }
+    }
+
+    fn known_sha256_precompile_node() -> CallTraceNode {
+        CallTraceNode {
+            parent: Some(0),
+            idx: 1,
+            trace: CallTrace {
+                address: precompiles::SHA_256,
+                data: Bytes::from_static(b"hello"),
+                output: alloy_primitives::hex!(
+                    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+                )
+                .into(),
+                ..Default::default()
+            },
+            ordering: Vec::new(),
+            ..Default::default()
+        }
+    }
+
+    fn assert_no_precompile_notice(step: &CallTraceStep) {
+        assert!(
+            !matches!(
+                step.decoded.as_deref(),
+                Some(DecodedTraceStep::Line(line)) if line.starts_with("precompile:")
+            ),
+            "unexpected precompile notice: {:?}",
+            step.decoded
+        );
     }
 
     #[test]
@@ -359,21 +415,7 @@ mod tests {
             root.children.push(1);
         }
 
-        arena.nodes_mut().push(CallTraceNode {
-            parent: Some(0),
-            idx: 1,
-            trace: CallTrace {
-                address: precompiles::SHA_256,
-                data: Bytes::from_static(b"hello"),
-                output: alloy_primitives::hex!(
-                    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
-                )
-                .into(),
-                ..Default::default()
-            },
-            ordering: Vec::new(),
-            ..Default::default()
-        });
+        arena.nodes_mut().push(known_sha256_precompile_node());
 
         let mut flattened = Vec::new();
         flatten_call_trace(arena, &mut flattened);
@@ -385,5 +427,82 @@ mod tests {
             notice,
             "precompile: sha256 @ 0x0000000000000000000000000000000000000002 input=0x68656c6c6f output=0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         );
+    }
+
+    #[test]
+    fn flatten_preserves_existing_decoded_step_metadata_on_precompile_child_calls() {
+        let mut arena = CallTraceArena::default();
+
+        {
+            let root = &mut arena.nodes_mut()[0];
+            let mut call_step = step_with_op(0, OpCode::STATICCALL);
+            call_step.decoded = Some(Box::new(DecodedTraceStep::InternalCall(
+                DecodedInternalCall {
+                    func_name: "DebugMe::foo".to_string(),
+                    args: Some(vec!["1".to_string()]),
+                    return_data: Some(vec!["2".to_string()]),
+                },
+                1,
+            )));
+            root.trace.steps = vec![call_step, step_with_op(1, OpCode::STOP)];
+            root.ordering = vec![
+                TraceMemberOrder::Step(0),
+                TraceMemberOrder::Call(0),
+                TraceMemberOrder::Step(1),
+            ];
+            root.children.push(1);
+        }
+        arena.nodes_mut().push(known_sha256_precompile_node());
+
+        let mut flattened = Vec::new();
+        flatten_call_trace(arena, &mut flattened);
+
+        let Some(DecodedTraceStep::InternalCall(decoded, end_step)) =
+            flattened[0].steps[0].decoded.as_deref()
+        else {
+            panic!("expected existing internal call metadata to be preserved");
+        };
+        assert_eq!(decoded.func_name, "DebugMe::foo");
+        assert_eq!(*end_step, 1);
+    }
+
+    #[test]
+    fn flatten_skips_precompile_notice_without_preceding_step() {
+        let mut arena = CallTraceArena::default();
+
+        {
+            let root = &mut arena.nodes_mut()[0];
+            root.trace.steps = vec![step_with_op(0, OpCode::STOP)];
+            root.ordering = vec![TraceMemberOrder::Call(0), TraceMemberOrder::Step(0)];
+            root.children.push(1);
+        }
+        arena.nodes_mut().push(known_sha256_precompile_node());
+
+        let mut flattened = Vec::new();
+        flatten_call_trace(arena, &mut flattened);
+
+        assert_no_precompile_notice(&flattened[0].steps[0]);
+    }
+
+    #[test]
+    fn flatten_skips_precompile_notice_after_non_call_step() {
+        let mut arena = CallTraceArena::default();
+
+        {
+            let root = &mut arena.nodes_mut()[0];
+            root.trace.steps = vec![step_with_op(0, OpCode::STOP), step_with_op(1, OpCode::STOP)];
+            root.ordering = vec![
+                TraceMemberOrder::Step(0),
+                TraceMemberOrder::Call(0),
+                TraceMemberOrder::Step(1),
+            ];
+            root.children.push(1);
+        }
+        arena.nodes_mut().push(known_sha256_precompile_node());
+
+        let mut flattened = Vec::new();
+        flatten_call_trace(arena, &mut flattened);
+
+        assert_no_precompile_notice(&flattened[0].steps[0]);
     }
 }

--- a/crates/debugger/src/node.rs
+++ b/crates/debugger/src/node.rs
@@ -1,6 +1,9 @@
-use alloy_primitives::{Address, Bytes};
-use foundry_evm_traces::{CallKind, CallTraceArena};
-use revm_inspectors::tracing::types::{CallTraceStep, DecodedCallTrace, TraceMemberOrder};
+use alloy_primitives::{Address, Bytes, hex};
+use foundry_evm_core::precompiles;
+use foundry_evm_traces::{CallKind, CallTrace, CallTraceArena};
+use revm_inspectors::tracing::types::{
+    CallTraceStep, DecodedCallTrace, DecodedTraceStep, TraceMemberOrder,
+};
 use serde::{Deserialize, Serialize};
 
 /// Represents a part of the execution frame before the next call or end of the execution.
@@ -64,17 +67,29 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
         step_offset: usize,
     }
 
-    fn inner(arena: &CallTraceArena, node_idx: usize, out: &mut Vec<PendingNode>) {
+    fn inner(
+        arena: &CallTraceArena,
+        node_idx: usize,
+        out: &mut Vec<PendingNode>,
+        step_notices: &mut Vec<(usize, usize, String)>,
+    ) {
         let mut pending = PendingNode { node_idx, steps_count: 0, step_offset: 0 };
         let mut next_step_offset = 0;
         let node = &arena.nodes()[node_idx];
         for order in &node.ordering {
             match order {
                 TraceMemberOrder::Call(idx) => {
+                    let child_idx = node.children[*idx];
+                    if next_step_offset > 0
+                        && let Some(notice) =
+                            precompile_call_notice(&arena.nodes()[child_idx].trace)
+                    {
+                        step_notices.push((node_idx, next_step_offset - 1, notice));
+                    }
                     out.push(pending);
                     pending =
                         PendingNode { node_idx, steps_count: 0, step_offset: next_step_offset };
-                    inner(arena, node.children[*idx], out);
+                    inner(arena, child_idx, out, step_notices);
                 }
                 TraceMemberOrder::Step(step_idx) => {
                     if pending.steps_count == 0 {
@@ -89,9 +104,18 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
         out.push(pending);
     }
     let mut nodes = Vec::new();
-    inner(&arena, 0, &mut nodes);
+    let mut step_notices = Vec::new();
+    inner(&arena, 0, &mut nodes, &mut step_notices);
 
     let mut arena_nodes = arena.into_nodes();
+    for (node_idx, step_idx, notice) in step_notices {
+        if let Some(step) =
+            arena_nodes.get_mut(node_idx).and_then(|node| node.trace.steps.get_mut(step_idx))
+        {
+            step.decoded = Some(Box::new(DecodedTraceStep::Line(notice)));
+        }
+    }
+
     let trace_node_idx_offset =
         out.iter().map(|node| node.trace_node_idx).max().map_or(0, |idx| idx.saturating_add(1));
 
@@ -124,11 +148,76 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
     }
 }
 
+fn precompile_call_notice(trace: &CallTrace) -> Option<String> {
+    decoded_precompile_call_notice(&trace.decoded).or_else(|| known_precompile_call_notice(trace))
+}
+
+fn decoded_precompile_call_notice(decoded: &Option<Box<DecodedCallTrace>>) -> Option<String> {
+    let decoded = decoded.as_ref()?;
+    let label = decoded.label.as_deref()?;
+    if label != "PRECOMPILES" {
+        return None;
+    }
+
+    let Some(call_data) = &decoded.call_data else {
+        return Some(format!("precompile: {label}"));
+    };
+
+    let args = call_data.args.join(", ");
+    let function_name =
+        call_data.signature.split_once('(').map_or(call_data.signature.as_str(), |(name, _)| name);
+    let mut notice = format!("precompile: {label}::{function_name}({args})");
+    if let Some(return_data) = decoded.return_data.as_deref() {
+        notice.push_str(" -> ");
+        notice.push_str(return_data);
+    }
+    Some(notice)
+}
+
+fn known_precompile_call_notice(trace: &CallTrace) -> Option<String> {
+    let name = known_precompile_name(trace.address)?;
+    let mut notice = format!("precompile: {name} @ {}", trace.address);
+    if !trace.data.is_empty() {
+        notice.push_str(" input=");
+        notice.push_str(&hex::encode_prefixed(&trace.data));
+    }
+    if !trace.output.is_empty() {
+        notice.push_str(" output=");
+        notice.push_str(&hex::encode_prefixed(&trace.output));
+    }
+    Some(notice)
+}
+
+fn known_precompile_name(address: Address) -> Option<&'static str> {
+    match address {
+        precompiles::EC_RECOVER => Some("ecrecover"),
+        precompiles::SHA_256 => Some("sha256"),
+        precompiles::RIPEMD_160 => Some("ripemd"),
+        precompiles::IDENTITY => Some("identity"),
+        precompiles::MOD_EXP => Some("modexp"),
+        precompiles::EC_ADD => Some("ecadd"),
+        precompiles::EC_MUL => Some("ecmul"),
+        precompiles::EC_PAIRING => Some("ecpairing"),
+        precompiles::BLAKE_2F => Some("blake2f"),
+        precompiles::POINT_EVALUATION => Some("pointEvaluation"),
+        precompiles::BLS12_G1ADD => Some("bls12G1Add"),
+        precompiles::BLS12_G1MSM => Some("bls12G1Msm"),
+        precompiles::BLS12_G2ADD => Some("bls12G2Add"),
+        precompiles::BLS12_G2MSM => Some("bls12G2Msm"),
+        precompiles::BLS12_PAIRING_CHECK => Some("bls12PairingCheck"),
+        precompiles::BLS12_MAP_FP_TO_G1 => Some("bls12MapFpToG1"),
+        precompiles::BLS12_MAP_FP2_TO_G2 => Some("bls12MapFp2ToG2"),
+        precompiles::P256_VERIFY => Some("p256Verify"),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use foundry_evm_traces::{CallTrace, CallTraceNode};
+    use foundry_evm_traces::CallTraceNode;
     use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
+    use revm_inspectors::tracing::types::DecodedCallData;
 
     fn step(pc: usize) -> CallTraceStep {
         CallTraceStep {
@@ -147,6 +236,10 @@ mod tests {
             immediate_bytes: None,
             decoded: None,
         }
+    }
+
+    fn step_with_op(pc: usize, op: OpCode) -> CallTraceStep {
+        CallTraceStep { op, ..step(pc) }
     }
 
     #[test]
@@ -199,5 +292,98 @@ mod tests {
         flatten_call_trace(arena, &mut flattened);
 
         assert_eq!(flattened[1].trace_node_idx, 2);
+    }
+
+    #[test]
+    fn flatten_annotates_parent_step_for_precompile_child_calls() {
+        let mut arena = CallTraceArena::default();
+
+        {
+            let root = &mut arena.nodes_mut()[0];
+            root.trace.steps =
+                vec![step_with_op(0, OpCode::STATICCALL), step_with_op(1, OpCode::STOP)];
+            root.ordering = vec![
+                TraceMemberOrder::Step(0),
+                TraceMemberOrder::Call(0),
+                TraceMemberOrder::Step(1),
+            ];
+            root.children.push(1);
+        }
+
+        arena.nodes_mut().push(CallTraceNode {
+            parent: Some(0),
+            idx: 1,
+            trace: CallTrace {
+                decoded: Some(Box::new(DecodedCallTrace {
+                    label: Some("PRECOMPILES".to_string()),
+                    call_data: Some(DecodedCallData {
+                        signature: "sha256(bytes)".to_string(),
+                        args: vec!["0x68656c6c6f".to_string()],
+                    }),
+                    return_data: Some(
+                        "0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+                            .to_string(),
+                    ),
+                })),
+                ..Default::default()
+            },
+            ordering: Vec::new(),
+            ..Default::default()
+        });
+
+        let mut flattened = Vec::new();
+        flatten_call_trace(arena, &mut flattened);
+
+        let Some(DecodedTraceStep::Line(notice)) = flattened[0].steps[0].decoded.as_deref() else {
+            panic!("missing precompile notice");
+        };
+        assert_eq!(
+            notice,
+            "precompile: PRECOMPILES::sha256(0x68656c6c6f) -> 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+    }
+
+    #[test]
+    fn flatten_marks_known_precompile_child_calls_without_decoded_trace() {
+        let mut arena = CallTraceArena::default();
+
+        {
+            let root = &mut arena.nodes_mut()[0];
+            root.trace.steps =
+                vec![step_with_op(0, OpCode::STATICCALL), step_with_op(1, OpCode::STOP)];
+            root.ordering = vec![
+                TraceMemberOrder::Step(0),
+                TraceMemberOrder::Call(0),
+                TraceMemberOrder::Step(1),
+            ];
+            root.children.push(1);
+        }
+
+        arena.nodes_mut().push(CallTraceNode {
+            parent: Some(0),
+            idx: 1,
+            trace: CallTrace {
+                address: precompiles::SHA_256,
+                data: Bytes::from_static(b"hello"),
+                output: alloy_primitives::hex!(
+                    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+                )
+                .into(),
+                ..Default::default()
+            },
+            ordering: Vec::new(),
+            ..Default::default()
+        });
+
+        let mut flattened = Vec::new();
+        flatten_call_trace(arena, &mut flattened);
+
+        let Some(DecodedTraceStep::Line(notice)) = flattened[0].steps[0].decoded.as_deref() else {
+            panic!("missing precompile notice");
+        };
+        assert_eq!(
+            notice,
+            "precompile: sha256 @ 0x0000000000000000000000000000000000000002 input=0x68656c6c6f output=0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
     }
 }

--- a/crates/debugger/src/node.rs
+++ b/crates/debugger/src/node.rs
@@ -188,7 +188,7 @@ fn known_precompile_call_notice(trace: &CallTrace) -> Option<String> {
     Some(notice)
 }
 
-fn known_precompile_name(address: Address) -> Option<&'static str> {
+const fn known_precompile_name(address: Address) -> Option<&'static str> {
     match address {
         precompiles::EC_RECOVER => Some("ecrecover"),
         precompiles::SHA_256 => Some("sha256"),

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -282,10 +282,10 @@ impl TUIContext<'_> {
             CallKind::DelegateCall => "Contract delegatecall",
             CallKind::AuthCall => "Contract authcall",
         };
-        let title = format!(
-            "{} {} ",
+        let title = source_pane_title(
             call_kind_text,
-            source_name.map(|s| format!("| {s}")).unwrap_or_default()
+            source_name,
+            self.current_step_notice_text().map(step_notice_title),
         );
         let block = Block::default().title(title).borders(Borders::ALL);
         let paragraph = Paragraph::new(text_output).block(block).wrap(Wrap { trim: false });
@@ -436,6 +436,13 @@ impl TUIContext<'_> {
             .ok_or_else(|| format!("No source map for contract {contract_name}"))
     }
 
+    fn current_step_notice_text(&self) -> Option<&str> {
+        let DecodedTraceStep::Line(line) = self.current_step().decoded.as_deref()? else {
+            return None;
+        };
+        (!line.is_empty()).then_some(line.as_str())
+    }
+
     fn draw_op_list(&self, f: &mut Frame<'_>, area: Rect) {
         let debug_steps = self.debug_steps();
         let max_pc = debug_steps.iter().map(|step| step.pc).max().unwrap_or(0);
@@ -507,15 +514,22 @@ impl TUIContext<'_> {
     fn draw_variables(&mut self, f: &mut Frame<'_>, area: Rect) {
         let variables = self.scope_variables();
         let storage_access = self.current_storage_access_line();
+        let step_notice = self.current_step_notice_line();
         let known = variables.iter().filter(|variable| variable.value.is_some()).count();
-        let title = if variables.is_empty() && storage_access.is_none() {
-            "Variables".to_string()
-        } else {
-            let storage_suffix = if storage_access.is_some() { " | Storage" } else { "" };
-            format!("Variables: {known}/{}{storage_suffix}", variables.len())
-        };
+        let title = variables_title(
+            variables.len(),
+            known,
+            storage_access.is_some(),
+            step_notice.is_some(),
+        );
 
         let mut text = variables.into_iter().map(scope_variable_line).collect::<Vec<_>>();
+        if let Some(step_notice) = step_notice {
+            if !text.is_empty() {
+                text.push(Line::from(""));
+            }
+            text.push(step_notice);
+        }
         if let Some(storage_access) = storage_access {
             if !text.is_empty() {
                 text.push(Line::from(""));
@@ -533,6 +547,10 @@ impl TUIContext<'_> {
         let block = Block::default().title(title).borders(Borders::ALL);
         let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
         f.render_widget(paragraph, area);
+    }
+
+    fn current_step_notice_line(&self) -> Option<Line<'static>> {
+        self.current_step_notice_text().map(step_notice_line)
     }
 
     fn current_storage_access_line(&self) -> Option<Line<'static>> {
@@ -713,6 +731,8 @@ struct ActiveInternalCall<'a> {
     end_step: usize,
     decoded: &'a DecodedInternalCall,
 }
+
+const PRECOMPILE_NOTICE_PREFIX: &str = "precompile:";
 
 impl ScopeVariableKind {
     const fn label(self) -> &'static str {
@@ -909,6 +929,50 @@ impl TUIContext<'_> {
     fn absolute_current_step(&self) -> usize {
         self.debug_call().step_offset.saturating_add(self.current_step)
     }
+}
+
+fn source_pane_title(
+    call_kind_text: &str,
+    source_name: Option<&str>,
+    step_notice: Option<&str>,
+) -> String {
+    let mut title = call_kind_text.to_string();
+    if let Some(step_notice) = step_notice {
+        write!(title, " | {step_notice}").unwrap();
+    }
+    if let Some(source_name) = source_name {
+        write!(title, " | {source_name}").unwrap();
+    }
+    title.push(' ');
+    title
+}
+
+fn variables_title(
+    total_variables: usize,
+    known_variables: usize,
+    has_storage_access: bool,
+    has_step_notice: bool,
+) -> String {
+    if total_variables == 0 && !has_storage_access && !has_step_notice {
+        return "Variables".to_string();
+    }
+
+    let mut title = format!("Variables: {known_variables}/{total_variables}");
+    if has_step_notice {
+        title.push_str(" | Trace");
+    }
+    if has_storage_access {
+        title.push_str(" | Storage");
+    }
+    title
+}
+
+fn step_notice_title(line: &str) -> &'static str {
+    if line.starts_with(PRECOMPILE_NOTICE_PREFIX) { "precompile call" } else { "decoded step" }
+}
+
+fn step_notice_line(line: &str) -> Line<'static> {
+    Line::from(Span::styled(line.to_string(), Style::new().fg(Color::Magenta)))
 }
 
 fn scope_variable_line(variable: ScopeVariable) -> Line<'static> {
@@ -1569,6 +1633,49 @@ mod tests {
         let variable = DebugVariable { name: None, declaration: 0..1, scope: 0..2 };
 
         assert_eq!(super::variable_name(&variable, 2, "arg"), "arg2");
+    }
+
+    #[test]
+    fn current_step_notice_text_reads_decoded_line_steps() {
+        let mut step = trace_step(Vec::new());
+        step.decoded = Some(Box::new(DecodedTraceStep::Line(
+            "precompile: PRECOMPILES::sha256(0x68656c6c6f)".to_string(),
+        )));
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![step])]);
+        let tui = TUIContext::new(&mut context);
+
+        assert_eq!(
+            tui.current_step_notice_text(),
+            Some("precompile: PRECOMPILES::sha256(0x68656c6c6f)")
+        );
+    }
+
+    #[test]
+    fn source_pane_title_includes_precompile_notice_before_source() {
+        assert_eq!(
+            super::source_pane_title(
+                "Contract call",
+                Some("test/Precompile.t.sol"),
+                Some("precompile call")
+            ),
+            "Contract call | precompile call | test/Precompile.t.sol "
+        );
+    }
+
+    #[test]
+    fn variables_title_tracks_decoded_step_notices() {
+        assert_eq!(super::variables_title(0, 0, false, false), "Variables");
+        assert_eq!(super::variables_title(0, 0, false, true), "Variables: 0/0 | Trace");
+        assert_eq!(super::variables_title(2, 1, true, true), "Variables: 1/2 | Trace | Storage");
+    }
+
+    #[test]
+    fn step_notice_line_highlights_precompile_clue() {
+        let line = super::step_notice_line("precompile: PRECOMPILES::sha256(0x68656c6c6f)");
+
+        assert_eq!(line_text(&line), "precompile: PRECOMPILES::sha256(0x68656c6c6f)");
+        assert_eq!(line.spans[0].style, Style::new().fg(Color::Magenta));
+        assert_eq!(super::step_notice_title(&line_text(&line)), "precompile call");
     }
 
     #[test]

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -55,73 +55,61 @@ fn setup_testdata_cmd(cmd: &mut TestCommand) {
     drop(dotenv);
 }
 
-fn collect_debug_dump_internal_calls<'a>(
+fn collect_debug_dump_values<'a, T>(
     value: &'a serde_json::Value,
-    calls: &mut Vec<&'a serde_json::Value>,
+    collected: &mut Vec<T>,
+    collect_from_object: &mut impl FnMut(&'a serde_json::Map<String, serde_json::Value>, &mut Vec<T>),
 ) {
     match value {
         serde_json::Value::Array(values) => {
             for value in values {
-                collect_debug_dump_internal_calls(value, calls);
+                collect_debug_dump_values(value, collected, collect_from_object);
             }
         }
         serde_json::Value::Object(map) => {
-            if let Some(call) = map
-                .get("InternalCall")
-                .and_then(|value| value.as_array())
-                .and_then(|values| values.first())
-            {
-                calls.push(call);
-            }
+            collect_from_object(map, collected);
             for value in map.values() {
-                collect_debug_dump_internal_calls(value, calls);
+                collect_debug_dump_values(value, collected, collect_from_object);
             }
         }
         _ => {}
     }
 }
 
+fn collect_debug_dump_internal_calls<'a>(
+    value: &'a serde_json::Value,
+    calls: &mut Vec<&'a serde_json::Value>,
+) {
+    collect_debug_dump_values(value, calls, &mut |map, calls| {
+        if let Some(call) = map
+            .get("InternalCall")
+            .and_then(|value| value.as_array())
+            .and_then(|values| values.first())
+        {
+            calls.push(call);
+        }
+    });
+}
+
 fn collect_debug_dump_decoded_lines<'a>(value: &'a serde_json::Value, lines: &mut Vec<&'a str>) {
-    match value {
-        serde_json::Value::Array(values) => {
-            for value in values {
-                collect_debug_dump_decoded_lines(value, lines);
-            }
+    collect_debug_dump_values(value, lines, &mut |map, lines| {
+        if let Some(line) = map.get("Line").and_then(|value| value.as_str()) {
+            lines.push(line);
         }
-        serde_json::Value::Object(map) => {
-            if let Some(line) = map.get("Line").and_then(|value| value.as_str()) {
-                lines.push(line);
-            }
-            for value in map.values() {
-                collect_debug_dump_decoded_lines(value, lines);
-            }
-        }
-        _ => {}
-    }
+    });
 }
 
 fn collect_debug_dump_storage_changes<'a>(
     value: &'a serde_json::Value,
     changes: &mut Vec<&'a serde_json::Value>,
 ) {
-    match value {
-        serde_json::Value::Array(values) => {
-            for value in values {
-                collect_debug_dump_storage_changes(value, changes);
-            }
+    collect_debug_dump_values(value, changes, &mut |map, changes| {
+        if let Some(change) = map.get("storage_change")
+            && !change.is_null()
+        {
+            changes.push(change);
         }
-        serde_json::Value::Object(map) => {
-            if let Some(change) = map.get("storage_change")
-                && !change.is_null()
-            {
-                changes.push(change);
-            }
-            for value in map.values() {
-                collect_debug_dump_storage_changes(value, changes);
-            }
-        }
-        _ => {}
-    }
+    });
 }
 
 /// Contracts excluded from the main `testdata` run because they depend on flaky external RPCs.

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -81,6 +81,25 @@ fn collect_debug_dump_internal_calls<'a>(
     }
 }
 
+fn collect_debug_dump_decoded_lines<'a>(value: &'a serde_json::Value, lines: &mut Vec<&'a str>) {
+    match value {
+        serde_json::Value::Array(values) => {
+            for value in values {
+                collect_debug_dump_decoded_lines(value, lines);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            if let Some(line) = map.get("Line").and_then(|value| value.as_str()) {
+                lines.push(line);
+            }
+            for value in map.values() {
+                collect_debug_dump_decoded_lines(value, lines);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn collect_debug_dump_storage_changes<'a>(
     value: &'a serde_json::Value,
     changes: &mut Vec<&'a serde_json::Value>,
@@ -2762,6 +2781,45 @@ contract Dummy {
     cmd.assert_success();
 
     assert!(dump_path.exists());
+});
+
+forgetest!(debug_dump_marks_precompile_call_steps, |prj, cmd| {
+    prj.add_test(
+        "PrecompileDebug.t.sol",
+        r#"
+contract PrecompileDebugTest {
+    function testSha256PrecompileDebug() public {
+        (bool ok, bytes memory output) = address(0x02).staticcall(hex"68656c6c6f");
+        require(ok, "sha256 precompile failed");
+        require(output.length == 32, "bad sha256 output");
+    }
+}
+"#,
+    );
+
+    let dump_path = prj.root().join("precompile_dump.json");
+
+    cmd.args([
+        "test",
+        "--mt",
+        "testSha256PrecompileDebug",
+        "--debug",
+        "--dump",
+        dump_path.to_str().unwrap(),
+    ]);
+    cmd.assert_success();
+
+    let dump: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dump_path).unwrap()).unwrap();
+    let mut lines = Vec::new();
+    collect_debug_dump_decoded_lines(&dump, &mut lines);
+
+    assert!(
+        lines.iter().any(|line| {
+            *line == "precompile: sha256 @ 0x0000000000000000000000000000000000000002 input=0x68656c6c6f output=0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        }),
+        "missing decoded precompile line in debugger dump: {lines:?}"
+    );
 });
 
 forgetest!(debug_dump_disambiguates_overloaded_internal_functions, |prj, cmd| {


### PR DESCRIPTION
## Summary

- Annotate debugger call-op steps when the next child trace is a known precompile call.
- Show the decoded/precompile notice in the Variables pane and add a short `precompile call` clue to the source pane title.
- Cover both decoded precompile traces and debug-dump traces that only have the known precompile address/data/output.

Progresses #927.