### PR TITLE
feat(debugger): show chain-aware precompile clues

### DIFF
--- a/crates/debugger/src/builder.rs
+++ b/crates/debugger/src/builder.rs
@@ -1,6 +1,8 @@
 //! Debugger builder.
 
-use crate::{Debugger, DebuggerLayout, debugger::DebuggerStats, node::flatten_call_trace};
+use crate::{
+    Debugger, DebuggerLayout, debugger::DebuggerStats, node::flatten_call_trace_with_precompiles,
+};
 use alloy_primitives::{Address, map::AddressHashMap};
 use foundry_common::get_contract_name;
 use foundry_evm_core::Breakpoints;
@@ -19,6 +21,8 @@ pub struct DebuggerBuilder {
     stats: DebuggerStats,
     /// Identified contracts.
     identified_contracts: AddressHashMap<String>,
+    /// Active precompile labels for the current trace context.
+    precompile_labels: AddressHashMap<String>,
     /// Map of source files.
     sources: ContractSources,
     /// Map of the debugger breakpoints.
@@ -67,9 +71,11 @@ impl DebuggerBuilder {
 
     /// Extends the identified contracts from a decoder.
     #[inline]
-    pub fn decoder(self, decoder: &CallTraceDecoder) -> Self {
+    pub fn decoder(mut self, decoder: &CallTraceDecoder) -> Self {
         let c = decoder.contracts.iter().map(|(k, v)| (*k, get_contract_name(v).to_string()));
-        self.identified_contracts(c)
+        self.identified_contracts.extend(c);
+        self.precompile_labels.extend(decoder.precompile_labels());
+        self
     }
 
     /// Extends the identified contracts.
@@ -106,12 +112,19 @@ impl DebuggerBuilder {
     /// Builds the debugger.
     #[inline]
     pub fn build(self) -> Debugger {
-        let Self { mut trace_arenas, stats, identified_contracts, sources, breakpoints, layout } =
-            self;
+        let Self {
+            mut trace_arenas,
+            stats,
+            identified_contracts,
+            precompile_labels,
+            sources,
+            breakpoints,
+            layout,
+        } = self;
         identify_internal_calls(&mut trace_arenas, &identified_contracts, &sources);
         let mut debug_arena = Vec::new();
         for arena in trace_arenas {
-            flatten_call_trace(arena, &mut debug_arena);
+            flatten_call_trace_with_precompiles(arena, &mut debug_arena, &precompile_labels);
         }
         Debugger::new_with_stats(
             debug_arena,

--- a/crates/debugger/src/node.rs
+++ b/crates/debugger/src/node.rs
@@ -7,6 +7,8 @@ use revm_inspectors::tracing::types::{
 };
 use serde::{Deserialize, Serialize};
 
+const PRECOMPILES_TRACE_LABEL: &str = "PRECOMPILES";
+
 /// Represents a part of the execution frame before the next call or end of the execution.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct DebugNode {
@@ -187,8 +189,6 @@ const fn is_call_like_op(op: OpCode) -> bool {
             | OpCode::CREATE2
     )
 }
-
-const PRECOMPILES_TRACE_LABEL: &str = "PRECOMPILES";
 
 fn precompile_call_notice(
     trace: &CallTrace,

--- a/crates/debugger/src/node.rs
+++ b/crates/debugger/src/node.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, Bytes, hex};
+use alloy_primitives::{Address, Bytes, hex, map::AddressHashMap};
 use foundry_evm_core::precompiles;
 use foundry_evm_traces::{CallKind, CallTrace, CallTraceArena};
 use revm::bytecode::opcode::OpCode;
@@ -60,7 +60,17 @@ impl DebugNode {
 ///
 /// This is done by recursively traversing the call tree and collecting the steps in-between the
 /// calls.
-pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
+#[cfg(test)]
+fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
+    flatten_call_trace_with_precompiles(arena, out, &AddressHashMap::default());
+}
+
+/// Flattens given [CallTraceArena] into a list of [DebugNode]s using active precompile labels.
+pub fn flatten_call_trace_with_precompiles(
+    arena: CallTraceArena,
+    out: &mut Vec<DebugNode>,
+    precompile_labels: &AddressHashMap<String>,
+) {
     #[derive(Debug, Clone, Copy)]
     struct PendingNode {
         node_idx: usize,
@@ -73,6 +83,7 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
         node_idx: usize,
         out: &mut Vec<PendingNode>,
         step_notices: &mut Vec<(usize, usize, String)>,
+        precompile_labels: &AddressHashMap<String>,
     ) {
         let mut pending = PendingNode { node_idx, steps_count: 0, step_offset: 0 };
         let mut next_step_offset = 0;
@@ -85,15 +96,17 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
                     if let Some(step_idx) = last_step_idx.take()
                         && let Some(step) = node.trace.steps.get(step_idx)
                         && is_call_like_op(step.op)
-                        && let Some(notice) =
-                            precompile_call_notice(&arena.nodes()[child_idx].trace)
+                        && let Some(notice) = precompile_call_notice(
+                            &arena.nodes()[child_idx].trace,
+                            precompile_labels,
+                        )
                     {
                         step_notices.push((node_idx, step_idx, notice));
                     }
                     out.push(pending);
                     pending =
                         PendingNode { node_idx, steps_count: 0, step_offset: next_step_offset };
-                    inner(arena, child_idx, out, step_notices);
+                    inner(arena, child_idx, out, step_notices, precompile_labels);
                 }
                 TraceMemberOrder::Step(step_idx) => {
                     if pending.steps_count == 0 {
@@ -112,7 +125,7 @@ pub fn flatten_call_trace(arena: CallTraceArena, out: &mut Vec<DebugNode>) {
     }
     let mut nodes = Vec::new();
     let mut step_notices = Vec::new();
-    inner(&arena, 0, &mut nodes, &mut step_notices);
+    inner(&arena, 0, &mut nodes, &mut step_notices, precompile_labels);
 
     let mut arena_nodes = arena.into_nodes();
     for (node_idx, step_idx, notice) in step_notices {
@@ -175,21 +188,35 @@ const fn is_call_like_op(op: OpCode) -> bool {
     )
 }
 
-fn precompile_call_notice(trace: &CallTrace) -> Option<String> {
-    decoded_precompile_call_notice(&trace.decoded).or_else(|| known_precompile_call_notice(trace))
+const PRECOMPILES_TRACE_LABEL: &str = "PRECOMPILES";
+
+fn precompile_call_notice(
+    trace: &CallTrace,
+    precompile_labels: &AddressHashMap<String>,
+) -> Option<String> {
+    decoded_precompile_call_notice(&trace.decoded, trace.maybe_precompile.unwrap_or(false))
+        .or_else(|| known_precompile_call_notice(trace))
+        .or_else(|| labeled_precompile_call_notice(trace, precompile_labels))
+        .or_else(|| marked_precompile_call_notice(trace))
 }
 
-fn decoded_precompile_call_notice(decoded: &Option<Box<DecodedCallTrace>>) -> Option<String> {
+fn decoded_precompile_call_notice(
+    decoded: &Option<Box<DecodedCallTrace>>,
+    is_precompile: bool,
+) -> Option<String> {
     let decoded = decoded.as_ref()?;
     let label = decoded.label.as_deref()?;
-    if label != "PRECOMPILES" {
+    if label != PRECOMPILES_TRACE_LABEL && !is_precompile {
         return None;
     }
 
-    let Some(call_data) = &decoded.call_data else {
-        return Some(format!("precompile: {label}"));
-    };
+    Some(decoded_call_notice(label, decoded))
+}
 
+fn decoded_call_notice(label: &str, decoded: &DecodedCallTrace) -> String {
+    let Some(call_data) = &decoded.call_data else {
+        return format!("precompile: {label}");
+    };
     let args = call_data.args.join(", ");
     let function_name =
         call_data.signature.split_once('(').map_or(call_data.signature.as_str(), |(name, _)| name);
@@ -198,12 +225,42 @@ fn decoded_precompile_call_notice(decoded: &Option<Box<DecodedCallTrace>>) -> Op
         notice.push_str(" -> ");
         notice.push_str(return_data);
     }
+    notice
+}
+
+fn labeled_precompile_call_notice(
+    trace: &CallTrace,
+    precompile_labels: &AddressHashMap<String>,
+) -> Option<String> {
+    let label = precompile_labels.get(&trace.address)?;
+    if let Some(decoded) = trace.decoded.as_ref() {
+        return Some(decoded_call_notice(
+            decoded.label.as_deref().unwrap_or(label.as_str()),
+            decoded,
+        ));
+    }
+
+    let mut notice = format!("precompile: {label} @ {}", trace.address);
+    append_raw_precompile_io(&mut notice, trace);
     Some(notice)
+}
+
+fn marked_precompile_call_notice(trace: &CallTrace) -> Option<String> {
+    trace.maybe_precompile.unwrap_or(false).then(|| {
+        let mut notice = format!("precompile: {}", trace.address);
+        append_raw_precompile_io(&mut notice, trace);
+        notice
+    })
 }
 
 fn known_precompile_call_notice(trace: &CallTrace) -> Option<String> {
     let name = known_precompile_name(trace.address)?;
     let mut notice = format!("precompile: {name} @ {}", trace.address);
+    append_raw_precompile_io(&mut notice, trace);
+    Some(notice)
+}
+
+fn append_raw_precompile_io(notice: &mut String, trace: &CallTrace) {
     if !trace.data.is_empty() {
         notice.push_str(" input=");
         notice.push_str(&hex::encode_prefixed(&trace.data));
@@ -212,9 +269,9 @@ fn known_precompile_call_notice(trace: &CallTrace) -> Option<String> {
         notice.push_str(" output=");
         notice.push_str(&hex::encode_prefixed(&trace.output));
     }
-    Some(notice)
 }
 
+// Standard EVM fallback for traces that have no decoded precompile metadata or execution marker.
 const fn known_precompile_name(address: Address) -> Option<&'static str> {
     match address {
         precompiles::EC_RECOVER => Some("ecrecover"),
@@ -287,6 +344,48 @@ mod tests {
         }
     }
 
+    fn arena_with_child_after_staticcall(child_trace: CallTrace) -> CallTraceArena {
+        let mut arena = CallTraceArena::default();
+
+        {
+            let root = &mut arena.nodes_mut()[0];
+            root.trace.steps =
+                vec![step_with_op(0, OpCode::STATICCALL), step_with_op(1, OpCode::STOP)];
+            root.ordering = vec![
+                TraceMemberOrder::Step(0),
+                TraceMemberOrder::Call(0),
+                TraceMemberOrder::Step(1),
+            ];
+            root.children.push(1);
+        }
+
+        arena.nodes_mut().push(CallTraceNode {
+            parent: Some(0),
+            idx: 1,
+            trace: child_trace,
+            ordering: Vec::new(),
+            ..Default::default()
+        });
+
+        arena
+    }
+
+    fn decoded_fee_manager_trace(maybe_precompile: Option<bool>) -> CallTrace {
+        CallTrace {
+            address: Address::from([0x42; 20]),
+            maybe_precompile,
+            decoded: Some(Box::new(DecodedCallTrace {
+                label: Some("FeeManager".to_string()),
+                call_data: Some(DecodedCallData {
+                    signature: "userTokens(address)".to_string(),
+                    args: vec!["0x0000000000000000000000000000000000000000".to_string()],
+                }),
+                return_data: Some("0x0000000000000000000000000000000000000000".to_string()),
+            })),
+            ..Default::default()
+        }
+    }
+
     fn assert_no_precompile_notice(step: &CallTraceStep) {
         assert!(
             !matches!(
@@ -296,6 +395,13 @@ mod tests {
             "unexpected precompile notice: {:?}",
             step.decoded
         );
+    }
+
+    fn assert_precompile_notice(step: &CallTraceStep) -> &str {
+        let Some(DecodedTraceStep::Line(notice)) = step.decoded.as_deref() else {
+            panic!("missing precompile notice");
+        };
+        notice
     }
 
     #[test]
@@ -427,6 +533,63 @@ mod tests {
             notice,
             "precompile: sha256 @ 0x0000000000000000000000000000000000000002 input=0x68656c6c6f output=0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         );
+    }
+
+    #[test]
+    fn flatten_annotates_marked_precompile_child_calls_with_decoded_label() {
+        let arena = arena_with_child_after_staticcall(decoded_fee_manager_trace(Some(true)));
+
+        let mut flattened = Vec::new();
+        flatten_call_trace(arena, &mut flattened);
+
+        assert_eq!(
+            assert_precompile_notice(&flattened[0].steps[0]),
+            "precompile: FeeManager::userTokens(0x0000000000000000000000000000000000000000) -> 0x0000000000000000000000000000000000000000"
+        );
+    }
+
+    #[test]
+    fn flatten_annotates_chain_labeled_precompile_child_calls_with_decoded_label() {
+        let address = Address::from([0x42; 20]);
+        let arena = arena_with_child_after_staticcall(decoded_fee_manager_trace(None));
+        let precompile_labels = AddressHashMap::from_iter([(address, "FeeManager".to_string())]);
+
+        let mut flattened = Vec::new();
+        flatten_call_trace_with_precompiles(arena, &mut flattened, &precompile_labels);
+
+        assert_eq!(
+            assert_precompile_notice(&flattened[0].steps[0]),
+            "precompile: FeeManager::userTokens(0x0000000000000000000000000000000000000000) -> 0x0000000000000000000000000000000000000000"
+        );
+    }
+
+    #[test]
+    fn flatten_marks_marked_precompile_child_calls_without_decoded_trace() {
+        let arena = arena_with_child_after_staticcall(CallTrace {
+            address: Address::from([0x99; 20]),
+            maybe_precompile: Some(true),
+            data: Bytes::from_static(&[0x12, 0x34]),
+            output: Bytes::from_static(&[0x56]),
+            ..Default::default()
+        });
+
+        let mut flattened = Vec::new();
+        flatten_call_trace(arena, &mut flattened);
+
+        assert_eq!(
+            assert_precompile_notice(&flattened[0].steps[0]),
+            "precompile: 0x9999999999999999999999999999999999999999 input=0x1234 output=0x56"
+        );
+    }
+
+    #[test]
+    fn flatten_skips_decoded_label_without_precompile_marker() {
+        let arena = arena_with_child_after_staticcall(decoded_fee_manager_trace(None));
+
+        let mut flattened = Vec::new();
+        flatten_call_trace(arena, &mut flattened);
+
+        assert_no_precompile_notice(&flattened[0].steps[0]);
     }
 
     #[test]

--- a/crates/debugger/src/node.rs
+++ b/crates/debugger/src/node.rs
@@ -194,19 +194,15 @@ fn precompile_call_notice(
     trace: &CallTrace,
     precompile_labels: &AddressHashMap<String>,
 ) -> Option<String> {
-    decoded_precompile_call_notice(&trace.decoded, trace.maybe_precompile.unwrap_or(false))
-        .or_else(|| known_precompile_call_notice(trace))
+    decoded_precompile_call_notice(&trace.decoded)
         .or_else(|| labeled_precompile_call_notice(trace, precompile_labels))
-        .or_else(|| marked_precompile_call_notice(trace))
+        .or_else(|| known_precompile_call_notice(trace))
 }
 
-fn decoded_precompile_call_notice(
-    decoded: &Option<Box<DecodedCallTrace>>,
-    is_precompile: bool,
-) -> Option<String> {
+fn decoded_precompile_call_notice(decoded: &Option<Box<DecodedCallTrace>>) -> Option<String> {
     let decoded = decoded.as_ref()?;
     let label = decoded.label.as_deref()?;
-    if label != PRECOMPILES_TRACE_LABEL && !is_precompile {
+    if label != PRECOMPILES_TRACE_LABEL {
         return None;
     }
 
@@ -245,14 +241,6 @@ fn labeled_precompile_call_notice(
     Some(notice)
 }
 
-fn marked_precompile_call_notice(trace: &CallTrace) -> Option<String> {
-    trace.maybe_precompile.unwrap_or(false).then(|| {
-        let mut notice = format!("precompile: {}", trace.address);
-        append_raw_precompile_io(&mut notice, trace);
-        notice
-    })
-}
-
 fn known_precompile_call_notice(trace: &CallTrace) -> Option<String> {
     let name = known_precompile_name(trace.address)?;
     let mut notice = format!("precompile: {name} @ {}", trace.address);
@@ -271,7 +259,7 @@ fn append_raw_precompile_io(notice: &mut String, trace: &CallTrace) {
     }
 }
 
-// Standard EVM fallback for traces that have no decoded precompile metadata or execution marker.
+// Standard EVM fallback for traces that have no decoded precompile metadata.
 const fn known_precompile_name(address: Address) -> Option<&'static str> {
     match address {
         precompiles::EC_RECOVER => Some("ecrecover"),
@@ -370,10 +358,9 @@ mod tests {
         arena
     }
 
-    fn decoded_fee_manager_trace(maybe_precompile: Option<bool>) -> CallTrace {
+    fn decoded_fee_manager_trace() -> CallTrace {
         CallTrace {
             address: Address::from([0x42; 20]),
-            maybe_precompile,
             decoded: Some(Box::new(DecodedCallTrace {
                 label: Some("FeeManager".to_string()),
                 call_data: Some(DecodedCallData {
@@ -536,22 +523,9 @@ mod tests {
     }
 
     #[test]
-    fn flatten_annotates_marked_precompile_child_calls_with_decoded_label() {
-        let arena = arena_with_child_after_staticcall(decoded_fee_manager_trace(Some(true)));
-
-        let mut flattened = Vec::new();
-        flatten_call_trace(arena, &mut flattened);
-
-        assert_eq!(
-            assert_precompile_notice(&flattened[0].steps[0]),
-            "precompile: FeeManager::userTokens(0x0000000000000000000000000000000000000000) -> 0x0000000000000000000000000000000000000000"
-        );
-    }
-
-    #[test]
     fn flatten_annotates_chain_labeled_precompile_child_calls_with_decoded_label() {
         let address = Address::from([0x42; 20]);
-        let arena = arena_with_child_after_staticcall(decoded_fee_manager_trace(None));
+        let arena = arena_with_child_after_staticcall(decoded_fee_manager_trace());
         let precompile_labels = AddressHashMap::from_iter([(address, "FeeManager".to_string())]);
 
         let mut flattened = Vec::new();
@@ -564,27 +538,8 @@ mod tests {
     }
 
     #[test]
-    fn flatten_marks_marked_precompile_child_calls_without_decoded_trace() {
-        let arena = arena_with_child_after_staticcall(CallTrace {
-            address: Address::from([0x99; 20]),
-            maybe_precompile: Some(true),
-            data: Bytes::from_static(&[0x12, 0x34]),
-            output: Bytes::from_static(&[0x56]),
-            ..Default::default()
-        });
-
-        let mut flattened = Vec::new();
-        flatten_call_trace(arena, &mut flattened);
-
-        assert_eq!(
-            assert_precompile_notice(&flattened[0].steps[0]),
-            "precompile: 0x9999999999999999999999999999999999999999 input=0x1234 output=0x56"
-        );
-    }
-
-    #[test]
-    fn flatten_skips_decoded_label_without_precompile_marker() {
-        let arena = arena_with_child_after_staticcall(decoded_fee_manager_trace(None));
+    fn flatten_skips_decoded_label_without_active_precompile_label() {
+        let arena = arena_with_child_after_staticcall(decoded_fee_manager_trace());
 
         let mut flattened = Vec::new();
         flatten_call_trace(arena, &mut flattened);

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -7,7 +7,7 @@ use alloy_dyn_abi::{DecodedEvent, DynSolValue, EventExt, FunctionExt, JsonAbiExt
 use alloy_json_abi::{Error, Event, Function, JsonAbi};
 use alloy_primitives::{
     Address, B256, LogData, Selector, U256,
-    map::{HashMap, HashSet},
+    map::{AddressHashMap, HashMap, HashSet},
 };
 use alloy_sol_types::SolValue;
 use foundry_common::{
@@ -338,6 +338,17 @@ impl CallTraceDecoder {
         self.fallback_contracts.clear();
         self.non_fallback_contracts.clear();
         self.functions_by_address.clear();
+    }
+
+    /// Returns labels for precompiles active in this decoder's chain context.
+    pub fn precompile_labels(&self) -> AddressHashMap<String> {
+        self.labels
+            .iter()
+            .filter(|(address, _)| {
+                precompiles::is_known_precompile(**address, self.chain_id, self.tempo_hardfork)
+            })
+            .map(|(address, label)| (*address, label.clone()))
+            .collect()
     }
 
     /// Identify unknown addresses in the specified call trace using the specified identifier.
@@ -1912,6 +1923,32 @@ mod tests {
 
         // On a Tempo chain, the Tempo precompile should be filtered out.
         assert_eq!(identifier.queried, vec![regular_addr]);
+    }
+
+    #[test]
+    fn test_precompile_labels_include_local_tempo_precompiles() {
+        let decoder =
+            CallTraceDecoderBuilder::new().with_tempo_hardfork(Some(TempoHardfork::T5)).build();
+
+        let labels = decoder.precompile_labels();
+        assert_eq!(labels.get(&TIP_FEE_MANAGER_ADDRESS), Some(&"FeeManager".to_string()));
+        assert_eq!(
+            labels.get(&TIP20_CHANNEL_RESERVE_ADDRESS),
+            Some(&"TIP20ChannelReserve".to_string())
+        );
+        assert!(!labels.contains_key(&RECEIVE_POLICY_GUARD_ADDRESS));
+    }
+
+    #[test]
+    fn test_precompile_labels_skip_tempo_precompiles_on_other_chains() {
+        let decoder = CallTraceDecoderBuilder::new()
+            .with_chain_id(Some(1))
+            .with_tempo_hardfork(Some(TempoHardfork::T6))
+            .build();
+
+        let labels = decoder.precompile_labels();
+        assert!(!labels.contains_key(&TIP_FEE_MANAGER_ADDRESS));
+        assert!(!labels.contains_key(&RECEIVE_POLICY_GUARD_ADDRESS));
     }
 
     #[test]

--- a/crates/evm/traces/src/decoder/precompiles.rs
+++ b/crates/evm/traces/src/decoder/precompiles.rs
@@ -91,9 +91,10 @@ pub(super) fn is_known_precompile(
         Some(hardfork) => active_tempo_precompile_addresses(hardfork).any(|addr| addr == address),
         None => TEMPO_PRECOMPILE_ADDRESSES.contains(&address),
     };
-    if chain_id.is_some_and(|id| Chain::from_id(id).is_tempo())
-        && (is_tempo_precompile || TEMPO_TIP20_TOKENS.contains(&address))
-    {
+    let is_tempo_context = chain_id
+        .map(|id| Chain::from_id(id).is_tempo())
+        .unwrap_or_else(|| tempo_hardfork.is_some());
+    if is_tempo_context && (is_tempo_precompile || TEMPO_TIP20_TOKENS.contains(&address)) {
         return true;
     }
     // Celo transfer precompile (only on Celo chains).

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1193,7 +1193,7 @@ impl TestArgs {
 
             // Prefer execution traces for normal debug runs, but when execution never starts
             // (for example if `setUp()` reverts), fall back to available setup/deployment traces.
-            let traces = {
+            let mut traces = {
                 let execution = test_result
                     .traces
                     .iter()
@@ -1202,6 +1202,11 @@ impl TestArgs {
                     .collect::<Vec<_>>();
                 if execution.is_empty() { test_result.traces.clone() } else { execution }
             };
+            if let Some(decoder) = &outcome.last_run_decoder {
+                for (_, arena) in &mut traces {
+                    decode_trace_arena(arena, decoder).await;
+                }
+            }
 
             // Run the debugger.
             let mut builder = Debugger::builder()

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -2804,9 +2804,55 @@ contract PrecompileDebugTest {
 
     assert!(
         lines.iter().any(|line| {
-            *line == "precompile: sha256 @ 0x0000000000000000000000000000000000000002 input=0x68656c6c6f output=0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+            *line == "precompile: PRECOMPILES::sha256(0x68656c6c6f) -> 0x2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
         }),
         "missing decoded precompile line in debugger dump: {lines:?}"
+    );
+});
+
+forgetest!(debug_dump_marks_tempo_precompile_call_steps, |prj, cmd| {
+    prj.update_config(|config| {
+        config.networks = foundry_evm_networks::NetworkConfigs::with_tempo();
+        config.hardfork = Some("tempo:T5".parse::<foundry_config::FoundryHardfork>().unwrap());
+    });
+
+    prj.add_test(
+        "TempoPrecompileDebug.t.sol",
+        r#"
+contract TempoPrecompileDebugTest {
+    address constant TIP_FEE_MANAGER = 0xfeEC000000000000000000000000000000000000;
+
+    function testTempoFeeManagerPrecompileDebug() public view {
+        (bool ok, bytes memory output) = TIP_FEE_MANAGER.staticcall(
+            abi.encodeWithSignature("userTokens(address)", address(0))
+        );
+        require(ok, "FeeManager precompile failed");
+        require(output.length == 32, "bad FeeManager output");
+    }
+}
+"#,
+    );
+
+    let dump_path = prj.root().join("tempo_precompile_dump.json");
+
+    cmd.args([
+        "test",
+        "--mt",
+        "testTempoFeeManagerPrecompileDebug",
+        "--debug",
+        "--dump",
+        dump_path.to_str().unwrap(),
+    ]);
+    cmd.assert_success();
+
+    let dump: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(dump_path).unwrap()).unwrap();
+    let mut lines = Vec::new();
+    collect_debug_dump_decoded_lines(&dump, &mut lines);
+
+    assert!(
+        lines.iter().any(|line| line.contains("precompile: FeeManager::userTokens(")),
+        "missing decoded Tempo precompile line in debugger dump: {lines:?}"
     );
 });
 


### PR DESCRIPTION
Follow-up to #15379.

This makes debugger precompile call clues use the decoder's active precompile labels, so chain-specific precompiles such as Tempo FeeManager can be annotated without adding Tempo address tables to the debugger. It also decodes selected debug traces before building the debugger dump so decoded call data is available in the notice.