### PR TITLE
fix(evm): preserve `CreatedLocal` across isolated `SELFDESTRUCT` flows

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1084,17 +1084,14 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
         interpreter: &mut Interpreter,
         ecx: &mut FoundryContextFor<'_, FEN>,
     ) {
-        if let Some(inner_context) = &self.inner_context_data {
-            let address = interpreter.input.target_address();
-            if inner_context.locally_created_accounts.contains(&address)
-                && let Some(account) = ecx.journal_mut().evm_state_mut().get_mut(&address)
-            {
-                account.mark_created_locally();
-            }
-        }
-        if self.locally_created_accounts.contains(&interpreter.input.target_address())
-            && let Some(account) =
-                ecx.journal_mut().evm_state_mut().get_mut(&interpreter.input.target_address())
+        let address = interpreter.input.target_address();
+        let should_mark_created_locally = self.locally_created_accounts.contains(&address)
+            || self
+                .inner_context_data
+                .as_ref()
+                .is_some_and(|ctx| ctx.locally_created_accounts.contains(&address));
+        if should_mark_created_locally
+            && let Some(account) = ecx.journal_mut().evm_state_mut().get_mut(&address)
         {
             account.mark_created_locally();
         }
@@ -1441,17 +1438,16 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
         call: &CreateInputs,
         outcome: &mut CreateOutcome,
     ) {
-        if self.in_inner_context
-            && outcome.result.result.is_ok()
-            && let Some(address) = outcome.address
-            && let Some(inner_context) = &mut self.inner_context_data
-        {
-            inner_context.locally_created_accounts.insert(address);
-        }
         if outcome.result.result.is_ok()
             && let Some(address) = outcome.address
         {
             self.locally_created_accounts.insert(address);
+
+            if self.in_inner_context
+                && let Some(inner_context) = &mut self.inner_context_data
+            {
+                inner_context.locally_created_accounts.insert(address);
+            }
         }
 
         // We are processing inner context outputs in the outer context, so need to avoid processing

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -853,8 +853,10 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
                     let mut state = journal.state.clone();
 
                     for (addr, acc_mut) in &mut state {
-                        // mark all accounts cold, besides preloaded addresses
-                        if journal.warm_addresses.is_cold(addr) {
+                        // Preserve revm's per-transaction creation flag for accounts created in
+                        // the parent context. A cold load in the nested context clears local
+                        // flags, which would incorrectly disable EIP-6780 cleanup.
+                        if journal.warm_addresses.is_cold(addr) && !acc_mut.is_created_locally() {
                             acc_mut.mark_cold();
                         }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -385,6 +385,8 @@ pub struct InspectorStackInner {
     /// Flag marking if we are in the inner EVM context.
     pub in_inner_context: bool,
     pub inner_context_data: Option<InnerContextData>,
+    /// Accounts that should retain the per-transaction creation marker in the current context.
+    pub locally_created_accounts: AddressHashSet,
     pub top_frame_journal: AddressMap<Account>,
     /// Address that reverted the call, if any.
     pub reverter: Option<Address>,
@@ -992,6 +994,8 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
 
     /// Invoked at the beginning of a new top-level (0 depth) frame.
     fn top_level_frame_start(&mut self, ecx: &mut FoundryContextFor<'_, FEN>) {
+        self.locally_created_accounts.clear();
+
         if self.enable_isolation {
             // If we're in isolation mode, we need to keep track of the state at the beginning of
             // the frame to be able to roll back on revert
@@ -1087,6 +1091,12 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             {
                 account.mark_created_locally();
             }
+        }
+        if self.locally_created_accounts.contains(&interpreter.input.target_address())
+            && let Some(account) =
+                ecx.journal_mut().evm_state_mut().get_mut(&interpreter.input.target_address())
+        {
+            account.mark_created_locally();
         }
 
         call_inspectors!(
@@ -1431,6 +1441,19 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
         call: &CreateInputs,
         outcome: &mut CreateOutcome,
     ) {
+        if self.in_inner_context
+            && outcome.result.result.is_ok()
+            && let Some(address) = outcome.address
+            && let Some(inner_context) = &mut self.inner_context_data
+        {
+            inner_context.locally_created_accounts.insert(address);
+        }
+        if outcome.result.result.is_ok()
+            && let Some(address) = outcome.address
+        {
+            self.locally_created_accounts.insert(address);
+        }
+
         // We are processing inner context outputs in the outer context, so need to avoid processing
         // twice.
         if self.in_inner_context && ecx.journal().depth() == 1 {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use alloy_primitives::{
     Address, B256, Bytes, Log, TxKind, U256, keccak256,
-    map::{AddressHashMap, AddressMap},
+    map::{AddressHashMap, AddressHashSet, AddressMap},
 };
 
 use foundry_cheatcodes::{CheatcodeAnalysis, CheatcodesExecutor, NestedEvmClosure, Wallets};
@@ -34,7 +34,7 @@ use revm::{
     handler::FrameResult,
     interpreter::{
         CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, FrameInput, Gas,
-        InstructionResult, Interpreter, InterpreterResult, return_ok,
+        InstructionResult, Interpreter, InterpreterResult, interpreter_types::InputsTr, return_ok,
     },
     primitives::KECCAK_EMPTY,
     state::{Account, AccountStatus},
@@ -331,6 +331,8 @@ pub struct InspectorData<FEN: FoundryEvmNetwork> {
 pub struct InnerContextData {
     /// Origin of the transaction in the outer EVM context.
     original_origin: Address,
+    /// Accounts that were created locally before entering the nested EVM context.
+    locally_created_accounts: AddressHashSet,
 }
 
 /// An inspector that calls multiple inspectors in sequence.
@@ -480,6 +482,7 @@ impl<FEN: FoundryEvmNetwork> CheatcodesExecutor<FEN> for InspectorStackInner {
         self.in_inner_context = enabled;
         self.inner_context_data = enabled.then(|| InnerContextData {
             original_origin: original_origin.expect("origin required when enabling inner ctx"),
+            locally_created_accounts: AddressHashSet::default(),
         });
     }
 }
@@ -826,8 +829,16 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
             ecx.tx_mut().set_blob_hashes(Vec::new());
         }
 
-        self.inner_context_data =
-            Some(InnerContextData { original_origin: cached_tx_env.caller() });
+        let locally_created_accounts = ecx
+            .journal()
+            .evm_state()
+            .iter()
+            .filter_map(|(addr, acc)| acc.is_created_locally().then_some(*addr))
+            .collect();
+        self.inner_context_data = Some(InnerContextData {
+            original_origin: cached_tx_env.caller(),
+            locally_created_accounts,
+        });
         self.in_inner_context = true;
 
         // Tell cheatcodes we're entering the synthetic inner transaction so
@@ -854,9 +865,10 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
 
                     for (addr, acc_mut) in &mut state {
                         // Preserve revm's per-transaction creation flag for accounts created in
-                        // the parent context. A cold load in the nested context clears local
-                        // flags, which would incorrectly disable EIP-6780 cleanup.
-                        if journal.warm_addresses.is_cold(addr) && !acc_mut.is_created_locally() {
+                        // the parent context in initialize_interp. A cold load in the nested
+                        // context clears local flags, but keeping accounts cold preserves gas
+                        // accounting for isolated calls.
+                        if journal.warm_addresses.is_cold(addr) {
                             acc_mut.mark_cold();
                         }
 
@@ -1068,6 +1080,15 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
         interpreter: &mut Interpreter,
         ecx: &mut FoundryContextFor<'_, FEN>,
     ) {
+        if let Some(inner_context) = &self.inner_context_data {
+            let address = interpreter.input.target_address();
+            if inner_context.locally_created_accounts.contains(&address)
+                && let Some(account) = ecx.journal_mut().evm_state_mut().get_mut(&address)
+            {
+                account.mark_created_locally();
+            }
+        }
+
         call_inspectors!(
             [
                 &mut self.line_coverage,

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -975,6 +975,10 @@ forgetest_init!(setup_selfdestruct_deletes_same_tx_created_contracts, |prj, cmd|
 import {Test} from "forge-std/Test.sol";
 
 contract A {
+    function codeLength() public view returns (uint256) {
+        return address(this).code.length;
+    }
+
     function kill() public {
         selfdestruct(payable(address(0)));
     }
@@ -1010,6 +1014,10 @@ contract SetupSelfdestructTest is Test {
     function setUp() public {
         factory = new Factory{salt: keccak256(abi.encode("evil"))}();
         a = A(factory.helloA());
+
+        (bool success, bytes memory data) = address(a).staticcall(abi.encodeCall(A.codeLength, ()));
+        assertTrue(success);
+        assertEq(abi.decode(data, (uint256)), address(a).code.length);
 
         a.kill();
         factory.kill();

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -968,6 +968,106 @@ contract TransientTest is Test {
     cmd.args(["test", "-vvvv", "--isolate", "--evm-version", "cancun"]).assert_success();
 });
 
+forgetest_init!(setup_selfdestruct_deletes_same_tx_created_contracts, |prj, cmd| {
+    prj.add_test(
+        "SetupSelfdestruct.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract A {
+    function kill() public {
+        selfdestruct(payable(address(0)));
+    }
+}
+
+contract B {
+    uint256 private x;
+
+    constructor(uint256 x_) {
+        x = x_;
+    }
+}
+
+contract Factory {
+    function helloA() public returns (address) {
+        return address(new A());
+    }
+
+    function helloB() public returns (address) {
+        return address(new B(1337));
+    }
+
+    function kill() public {
+        selfdestruct(payable(address(0)));
+    }
+}
+
+contract SetupSelfdestructTest is Test {
+    A private a;
+    B private b;
+    Factory private factory;
+
+    function setUp() public {
+        factory = new Factory{salt: keccak256(abi.encode("evil"))}();
+        a = A(factory.helloA());
+
+        a.kill();
+        factory.kill();
+    }
+
+    function testMorphingContract() public {
+        assertEq(address(a).code.length, 0);
+        assertEq(address(factory).code.length, 0);
+
+        factory = new Factory{salt: keccak256(abi.encode("evil"))}();
+        b = B(factory.helloB());
+        assertEq(address(a), address(b));
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--match-path", "test/SetupSelfdestruct.t.sol", "--evm-version", "cancun"])
+        .assert_success();
+});
+
+forgetest_init!(selfdestruct_keeps_setup_created_contract_in_test_body, |prj, cmd| {
+    prj.add_test(
+        "SetupThenTestSelfdestruct.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract A {
+    function kill() public {
+        selfdestruct(payable(address(0)));
+    }
+}
+
+contract SetupThenTestSelfdestructTest is Test {
+    A private a;
+
+    function setUp() public {
+        a = new A();
+    }
+
+    function testCodePersistsAcrossSetupBoundary() public {
+        a.kill();
+        assertGt(address(a).code.length, 0);
+    }
+}
+   "#,
+    );
+
+    cmd.args([
+        "test",
+        "--match-path",
+        "test/SetupThenTestSelfdestruct.t.sol",
+        "--evm-version",
+        "cancun",
+    ])
+    .assert_success();
+});
+
 forgetest_init!(
     #[ignore = "Too slow"]
     can_disable_block_gas_limit,


### PR DESCRIPTION
## Motivation

Close #15384

Preserves revm's per-transaction `CreatedLocal` marker across Foundry's isolated/nested execution paths without changing account warmth.

This fixes post-Cancun `SELFDESTRUCT` cleanup for contracts created and destroyed in the same logical test transaction, including when a `STATICCALL` happens between creation and destruction.
