### PR TITLE
fix(traces): guard Tempo precompile labels by hardfork

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -118,34 +118,7 @@ impl CallTraceDecoderBuilder {
     #[inline]
     pub fn with_tempo_hardfork(mut self, hardfork: Option<TempoHardfork>) -> Self {
         self.decoder.tempo_hardfork = hardfork;
-        if hardfork.is_some_and(|hardfork| hardfork.is_t3()) {
-            self.decoder
-                .labels
-                .entry(ADDRESS_REGISTRY_ADDRESS)
-                .or_insert_with(|| "AddressRegistry".to_string());
-            self.decoder
-                .labels
-                .entry(SIGNATURE_VERIFIER_ADDRESS)
-                .or_insert_with(|| "SignatureVerifier".to_string());
-        }
-        if hardfork.is_some_and(|hardfork| hardfork.is_t5()) {
-            self.decoder
-                .labels
-                .entry(TIP20_CHANNEL_RESERVE_ADDRESS)
-                .or_insert_with(|| "TIP20ChannelReserve".to_string());
-        }
-        if hardfork.is_some_and(|hardfork| hardfork.is_t6()) {
-            self.decoder
-                .labels
-                .entry(RECEIVE_POLICY_GUARD_ADDRESS)
-                .or_insert_with(|| "ReceivePolicyGuard".to_string());
-        }
-        if hardfork.is_some_and(|hardfork| hardfork.is_t7()) {
-            self.decoder
-                .labels
-                .entry(STORAGE_CREDITS_ADDRESS)
-                .or_insert_with(|| "StorageCredits".to_string());
-        }
+        insert_tempo_hardfork_labels(&mut self.decoder.labels, hardfork);
         self
     }
 
@@ -160,6 +133,29 @@ impl CallTraceDecoderBuilder {
     #[inline]
     pub fn build(self) -> CallTraceDecoder {
         self.decoder
+    }
+}
+
+fn insert_label(labels: &mut HashMap<Address, String>, address: Address, label: &'static str) {
+    labels.entry(address).or_insert_with(|| label.to_string());
+}
+
+fn insert_tempo_hardfork_labels(
+    labels: &mut HashMap<Address, String>,
+    hardfork: Option<TempoHardfork>,
+) {
+    if hardfork.is_some_and(|hardfork| hardfork.is_t3()) {
+        insert_label(labels, ADDRESS_REGISTRY_ADDRESS, "AddressRegistry");
+        insert_label(labels, SIGNATURE_VERIFIER_ADDRESS, "SignatureVerifier");
+    }
+    if hardfork.is_some_and(|hardfork| hardfork.is_t5()) {
+        insert_label(labels, TIP20_CHANNEL_RESERVE_ADDRESS, "TIP20ChannelReserve");
+    }
+    if hardfork.is_some_and(|hardfork| hardfork.is_t6()) {
+        insert_label(labels, RECEIVE_POLICY_GUARD_ADDRESS, "ReceivePolicyGuard");
+    }
+    if hardfork.is_some_and(|hardfork| hardfork.is_t7()) {
+        insert_label(labels, STORAGE_CREDITS_ADDRESS, "StorageCredits");
     }
 }
 
@@ -345,6 +341,7 @@ impl CallTraceDecoder {
         let default_labels = &Self::new().labels;
         if self.labels.len() > default_labels.len() {
             self.labels.clone_from(default_labels);
+            insert_tempo_hardfork_labels(&mut self.labels, self.tempo_hardfork);
         }
 
         self.receive_contracts.clear();
@@ -2067,6 +2064,24 @@ mod tests {
             .build();
 
         assert_eq!(decoder.labels.get(&TIP20_CHANNEL_RESERVE_ADDRESS), Some(&reserve_label));
+    }
+
+    #[test]
+    fn test_clear_addresses_preserves_tempo_hardfork_labels() {
+        use foundry_evm_core::tempo::TIP20_CHANNEL_RESERVE_ADDRESS;
+
+        let transient = address!("0x0000000000000000000000000000000000000123");
+        let mut decoder =
+            CallTraceDecoderBuilder::new().with_tempo_hardfork(Some(TempoHardfork::T5)).build();
+        decoder.labels.insert(transient, "Transient".to_string());
+
+        decoder.clear_addresses();
+
+        assert_eq!(
+            decoder.labels.get(&TIP20_CHANNEL_RESERVE_ADDRESS),
+            Some(&"TIP20ChannelReserve".to_string())
+        );
+        assert!(!decoder.labels.contains_key(&transient));
     }
 
     #[tokio::test]

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -118,6 +118,16 @@ impl CallTraceDecoderBuilder {
     #[inline]
     pub fn with_tempo_hardfork(mut self, hardfork: Option<TempoHardfork>) -> Self {
         self.decoder.tempo_hardfork = hardfork;
+        if hardfork.is_some_and(|hardfork| hardfork.is_t3()) {
+            self.decoder
+                .labels
+                .entry(ADDRESS_REGISTRY_ADDRESS)
+                .or_insert_with(|| "AddressRegistry".to_string());
+            self.decoder
+                .labels
+                .entry(SIGNATURE_VERIFIER_ADDRESS)
+                .or_insert_with(|| "SignatureVerifier".to_string());
+        }
         if hardfork.is_some_and(|hardfork| hardfork.is_t5()) {
             self.decoder
                 .labels
@@ -129,6 +139,12 @@ impl CallTraceDecoderBuilder {
                 .labels
                 .entry(RECEIVE_POLICY_GUARD_ADDRESS)
                 .or_insert_with(|| "ReceivePolicyGuard".to_string());
+        }
+        if hardfork.is_some_and(|hardfork| hardfork.is_t7()) {
+            self.decoder
+                .labels
+                .entry(STORAGE_CREDITS_ADDRESS)
+                .or_insert_with(|| "StorageCredits".to_string());
         }
         self
     }
@@ -262,11 +278,6 @@ impl CallTraceDecoder {
                 (NONCE_PRECOMPILE_ADDRESS, "Nonce".to_string()),
                 (VALIDATOR_CONFIG_ADDRESS, "ValidatorConfig".to_string()),
                 (ACCOUNT_KEYCHAIN_ADDRESS, "AccountKeychain".to_string()),
-                (ADDRESS_REGISTRY_ADDRESS, "AddressRegistry".to_string()),
-                (TIP20_CHANNEL_RESERVE_ADDRESS, "TIP20ChannelReserve".to_string()),
-                (SIGNATURE_VERIFIER_ADDRESS, "SignatureVerifier".to_string()),
-                (RECEIVE_POLICY_GUARD_ADDRESS, "ReceivePolicyGuard".to_string()),
-                (STORAGE_CREDITS_ADDRESS, "StorageCredits".to_string()),
                 (PATH_USD_ADDRESS, "PathUSD".to_string()),
             ]),
             receive_contracts: Default::default(),
@@ -1762,8 +1773,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_t5_channel_reserve_call_and_event_decode() {
-        let mut decoder = CallTraceDecoder::new().clone();
-        decoder.chain_id = Some(4217);
+        let decoder = CallTraceDecoderBuilder::new()
+            .with_chain_id(Some(4217))
+            .with_tempo_hardfork(Some(TempoHardfork::T5))
+            .build();
 
         let open = ITIP20ChannelReserve::openCall {
             payee: address!("0x0000000000000000000000000000000000000abc"),
@@ -1936,6 +1949,18 @@ mod tests {
                 .precompile_labels()
         };
 
+        let t2_labels = labels_for_hardfork(TempoHardfork::T2);
+        assert!(!t2_labels.contains_key(&ADDRESS_REGISTRY_ADDRESS));
+        assert!(!t2_labels.contains_key(&SIGNATURE_VERIFIER_ADDRESS));
+
+        let t3_labels = labels_for_hardfork(TempoHardfork::T3);
+        assert_eq!(t3_labels.get(&ADDRESS_REGISTRY_ADDRESS), Some(&"AddressRegistry".to_string()));
+        assert_eq!(
+            t3_labels.get(&SIGNATURE_VERIFIER_ADDRESS),
+            Some(&"SignatureVerifier".to_string())
+        );
+        assert!(!t3_labels.contains_key(&TIP20_CHANNEL_RESERVE_ADDRESS));
+
         let t4_labels = labels_for_hardfork(TempoHardfork::T4);
         assert_eq!(t4_labels.get(&TIP_FEE_MANAGER_ADDRESS), Some(&"FeeManager".to_string()));
         assert!(!t4_labels.contains_key(&TIP20_CHANNEL_RESERVE_ADDRESS));
@@ -1968,6 +1993,36 @@ mod tests {
             Some(&"ReceivePolicyGuard".to_string())
         );
         assert_eq!(t7_labels.get(&STORAGE_CREDITS_ADDRESS), Some(&"StorageCredits".to_string()));
+    }
+
+    async fn decoded_label_at_tempo_hardfork(
+        address: Address,
+        hardfork: TempoHardfork,
+    ) -> Option<String> {
+        let decoder = CallTraceDecoderBuilder::new().with_tempo_hardfork(Some(hardfork)).build();
+        decoder
+            .decode_function(&CallTrace { address, success: true, ..Default::default() })
+            .await
+            .label
+    }
+
+    #[tokio::test]
+    async fn test_decoded_labels_follow_tempo_hardfork_activation_boundaries() {
+        for (address, hardfork, expected) in [
+            (ADDRESS_REGISTRY_ADDRESS, TempoHardfork::T2, None),
+            (ADDRESS_REGISTRY_ADDRESS, TempoHardfork::T3, Some("AddressRegistry")),
+            (SIGNATURE_VERIFIER_ADDRESS, TempoHardfork::T2, None),
+            (SIGNATURE_VERIFIER_ADDRESS, TempoHardfork::T3, Some("SignatureVerifier")),
+            (TIP20_CHANNEL_RESERVE_ADDRESS, TempoHardfork::T4, None),
+            (TIP20_CHANNEL_RESERVE_ADDRESS, TempoHardfork::T5, Some("TIP20ChannelReserve")),
+            (RECEIVE_POLICY_GUARD_ADDRESS, TempoHardfork::T5, None),
+            (RECEIVE_POLICY_GUARD_ADDRESS, TempoHardfork::T6, Some("ReceivePolicyGuard")),
+            (STORAGE_CREDITS_ADDRESS, TempoHardfork::T6, None),
+            (STORAGE_CREDITS_ADDRESS, TempoHardfork::T7, Some("StorageCredits")),
+        ] {
+            let label = decoded_label_at_tempo_hardfork(address, hardfork).await;
+            assert_eq!(label.as_deref(), expected);
+        }
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -19,6 +19,7 @@ use crate::{
         identifier::SignaturesIdentifier,
     },
 };
+use alloy_chains::Chain;
 use alloy_primitives::U256;
 use chrono::Utc;
 use clap::{Parser, ValueEnum, ValueHint};
@@ -42,7 +43,7 @@ use foundry_compilers::{
     utils::source_files_iter,
 };
 use foundry_config::{
-    Config, InlineConfig, InvariantDepthMode, InvariantWorkers, figment,
+    Config, ExecutionSpec, InlineConfig, InvariantDepthMode, InvariantWorkers, figment,
     figment::{
         Metadata, Profile, Provider,
         value::{Dict, Map, Value},
@@ -1633,7 +1634,7 @@ impl TestArgs {
             return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
         }
 
-        let remote_chain =
+        let remote_chain: Option<Chain> =
             if runner.fork.is_some() { runner.tx_env.chain_id().map(Into::into) } else { None };
         let known_contracts = runner.known_contracts.clone();
 
@@ -1643,7 +1644,12 @@ impl TestArgs {
         // In multi-pass mode the per-pass summary is suppressed; the merged summary is
         // printed once by the caller after all passes complete.
         let is_multi_pass = !runner.tcfg.multi_network.all_override_networks.is_empty();
-        let is_tempo_network = runner.tcfg.evm_opts.networks.is_tempo();
+        let tempo_hardfork =
+            runner.tcfg.spec_id.evm_version_name().parse::<TempoHardfork>().ok().or_else(|| {
+                remote_chain
+                    .is_some_and(|chain| chain.is_tempo())
+                    .then(|| config.evm_spec_id::<TempoHardfork>())
+            });
 
         // Run tests in a streaming fashion.
         let (tx, rx) = channel::<(String, SuiteResult)>();
@@ -1670,10 +1676,7 @@ impl TestArgs {
             .with_label_disabled(self.disable_labels)
             .with_verbosity(verbosity)
             .with_chain_id(remote_chain.map(|c| c.id()))
-            .with_tempo_hardfork(
-                (is_tempo_network || remote_chain.is_some_and(|chain| chain.is_tempo()))
-                    .then(|| config.evm_spec_id::<TempoHardfork>()),
-            );
+            .with_tempo_hardfork(tempo_hardfork);
         // Signatures are of no value for gas reports.
         if !self.gas_report {
             builder =

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -19,7 +19,6 @@ use crate::{
         identifier::SignaturesIdentifier,
     },
 };
-use alloy_chains::Chain;
 use alloy_primitives::U256;
 use chrono::Utc;
 use clap::{Parser, ValueEnum, ValueHint};
@@ -1634,7 +1633,7 @@ impl TestArgs {
             return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
         }
 
-        let remote_chain: Option<Chain> =
+        let remote_chain: Option<foundry_config::Chain> =
             if runner.fork.is_some() { runner.tx_env.chain_id().map(Into::into) } else { None };
         let known_contracts = runner.known_contracts.clone();
 

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -1334,8 +1334,7 @@ import "forge-std/Test.sol";
 contract SequenceNoReverts {
     uint256 public count;
 
-    function work(uint256 x) public {
-        require(x % 2 != 0);
+    function work() public {
         count++;
     }
 }


### PR DESCRIPTION
## Summary

- move hardfork-gated Tempo precompile labels out of the unconditional decoder label table
- add T3/T5/T6/T7 labels only through the Tempo hardfork-aware decoder builder
- cover both debugger precompile labels and generic decoded trace labels at the activation boundaries