### PR TITLE
refactor(traces): remove trace mode

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -336,7 +336,7 @@ impl CallArgs {
                 }
             }
 
-            let trace_requirements = TraceRequirements::empty()
+            let trace_requirements = TraceRequirements::none()
                 .with_calls(true)
                 .with_debug(debug)
                 .with_decode_internal(if decode_internal {

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -42,7 +42,7 @@ use foundry_evm::{
     },
     executors::TracingExecutor,
     opts::EvmOpts,
-    traces::{InternalTraceMode, TraceMode},
+    traces::{InternalTraceMode, TraceRequirements},
 };
 use foundry_wallets::WalletOpts;
 use regex::Regex;
@@ -336,7 +336,8 @@ impl CallArgs {
                 }
             }
 
-            let trace_mode = TraceMode::Call
+            let trace_requirements = TraceRequirements::default()
+                .with_calls(true)
                 .with_debug(debug)
                 .with_decode_internal(if decode_internal {
                     InternalTraceMode::Full
@@ -348,7 +349,7 @@ impl CallArgs {
                 (evm_env, tx_env),
                 fork,
                 evm_version,
-                trace_mode,
+                trace_requirements,
                 networks,
                 create2_deployer,
                 state_overrides,

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -336,7 +336,7 @@ impl CallArgs {
                 }
             }
 
-            let trace_requirements = TraceRequirements::default()
+            let trace_requirements = TraceRequirements::empty()
                 .with_calls(true)
                 .with_debug(debug)
                 .with_decode_internal(if decode_internal {

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -240,7 +240,7 @@ impl RunArgs {
             );
         }
 
-        let trace_requirements = TraceRequirements::default()
+        let trace_requirements = TraceRequirements::empty()
             .with_calls(true)
             .with_debug(self.debug)
             .with_decode_internal(if self.decode_internal {

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -42,7 +42,7 @@ use foundry_evm::{
     executors::{EvmError, Executor, TracingExecutor},
     hardforks::FoundryHardfork,
     opts::EvmOpts,
-    traces::{InternalTraceMode, TraceMode, Traces},
+    traces::{InternalTraceMode, TraceRequirements, Traces},
 };
 use futures::TryFutureExt;
 use revm::{DatabaseRef, context::Block};
@@ -240,7 +240,8 @@ impl RunArgs {
             );
         }
 
-        let trace_mode = TraceMode::Call
+        let trace_requirements = TraceRequirements::default()
+            .with_calls(true)
             .with_debug(self.debug)
             .with_decode_internal(if self.decode_internal {
                 InternalTraceMode::Full
@@ -252,7 +253,7 @@ impl RunArgs {
             (evm_env.clone(), tx_env),
             fork,
             evm_version,
-            trace_mode,
+            trace_requirements,
             networks,
             create2_deployer,
             None,

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -240,7 +240,7 @@ impl RunArgs {
             );
         }
 
-        let trace_requirements = TraceRequirements::empty()
+        let trace_requirements = TraceRequirements::none()
             .with_calls(true)
             .with_debug(self.debug)
             .with_decode_internal(if self.decode_internal {

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1354,7 +1354,7 @@ impl Cheatcode for startDebugTraceRecordingCall {
 
         // turn on tracer debug configuration for recording
         *tracer.config_mut() =
-            TraceRequirements::empty().with_debug(true).into_config().expect("cannot be None");
+            TraceRequirements::none().with_debug(true).into_config().expect("cannot be None");
 
         // track where the recording starts
         if let Some(last_node) = tracer.traces().nodes().last() {

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1354,7 +1354,7 @@ impl Cheatcode for startDebugTraceRecordingCall {
 
         // turn on tracer debug configuration for recording
         *tracer.config_mut() =
-            TraceRequirements::default().with_debug(true).into_config().expect("cannot be None");
+            TraceRequirements::empty().with_debug(true).into_config().expect("cannot be None");
 
         // track where the recording starts
         if let Some(last_node) = tracer.traces().nodes().last() {

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -31,7 +31,7 @@ use foundry_evm_core::{
     evm::{FoundryEvmNetwork, TxEnvFor, TxEnvelopeFor},
     utils::get_blob_base_fee_update_fraction_by_spec_id,
 };
-use foundry_evm_traces::TraceMode;
+use foundry_evm_traces::TraceRequirements;
 use itertools::Itertools;
 use rand::Rng;
 use revm::{
@@ -1353,7 +1353,8 @@ impl Cheatcode for startDebugTraceRecordingCall {
         };
 
         // turn on tracer debug configuration for recording
-        *tracer.config_mut() = TraceMode::Debug.into_config().expect("cannot be None");
+        *tracer.config_mut() =
+            TraceRequirements::default().with_debug(true).into_config().expect("cannot be None");
 
         // track where the recording starts
         if let Some(last_node) = tracer.traces().nodes().last() {

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -14,7 +14,7 @@ use foundry_evm::{
     decode::decode_console_logs,
     executors::ExecutorBuilder,
     inspectors::CheatsConfig,
-    traces::TraceMode,
+    traces::TraceRequirements,
 };
 use solar::{
     ast::{ElementaryType, LitKind, StrKind, UnOpKind},
@@ -195,7 +195,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                 stack
                     .logs(self.config.foundry_config.live_logs)
                     .chisel_state(final_pc)
-                    .trace_mode(TraceMode::Call)
+                    .trace_requirements(TraceRequirements::default().with_calls(true))
                     .cheatcodes(
                         CheatsConfig::new(
                             &self.config.foundry_config,

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -195,7 +195,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                 stack
                     .logs(self.config.foundry_config.live_logs)
                     .chisel_state(final_pc)
-                    .trace_requirements(TraceRequirements::default().with_calls(true))
+                    .trace_requirements(TraceRequirements::empty().with_calls(true))
                     .cheatcodes(
                         CheatsConfig::new(
                             &self.config.foundry_config,

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -195,7 +195,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
                 stack
                     .logs(self.config.foundry_config.live_logs)
                     .chisel_state(final_pc)
-                    .trace_requirements(TraceRequirements::empty().with_calls(true))
+                    .trace_requirements(TraceRequirements::none().with_calls(true))
                     .cheatcodes(
                         CheatsConfig::new(
                             &self.config.foundry_config,

--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -46,7 +46,7 @@ pub fn replay_run<FEN: FoundryEvmNetwork>(
 ) -> Result<Vec<BaseCounterExample>> {
     // We want traces for a failed case.
     if executor.inspector().tracer.is_none() {
-        executor.set_trace_requirements(TraceRequirements::default().with_calls(true));
+        executor.set_trace_requirements(TraceRequirements::empty().with_calls(true));
     }
 
     let mut counterexample_sequence = vec![];

--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -46,7 +46,7 @@ pub fn replay_run<FEN: FoundryEvmNetwork>(
 ) -> Result<Vec<BaseCounterExample>> {
     // We want traces for a failed case.
     if executor.inspector().tracer.is_none() {
-        executor.set_trace_requirements(TraceRequirements::empty().with_calls(true));
+        executor.set_trace_requirements(TraceRequirements::none().with_calls(true));
     }
 
     let mut counterexample_sequence = vec![];

--- a/crates/evm/evm/src/executors/invariant/replay.rs
+++ b/crates/evm/evm/src/executors/invariant/replay.rs
@@ -17,7 +17,7 @@ use foundry_config::InvariantConfig;
 use foundry_evm_core::{decode::RevertDecoder, evm::FoundryEvmNetwork};
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::{BaseCounterExample, BasicTxDetails, invariant::InvariantContract};
-use foundry_evm_traces::{TraceKind, TraceMode, Traces, load_contracts};
+use foundry_evm_traces::{TraceKind, TraceRequirements, Traces, load_contracts};
 use indicatif::ProgressBar;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -46,7 +46,7 @@ pub fn replay_run<FEN: FoundryEvmNetwork>(
 ) -> Result<Vec<BaseCounterExample>> {
     // We want traces for a failed case.
     if executor.inspector().tracer.is_none() {
-        executor.set_tracing(TraceMode::Call);
+        executor.set_trace_requirements(TraceRequirements::default().with_calls(true));
     }
 
     let mut counterexample_sequence = vec![];

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -36,7 +36,7 @@ use foundry_evm_core::{
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::ObservedCall;
-use foundry_evm_traces::{SparsedTraceArena, TraceMode};
+use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     bytecode::Bytecode,
     context::Transaction,
@@ -365,8 +365,8 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
     }
 
     #[inline]
-    pub fn set_tracing(&mut self, mode: TraceMode) -> &mut Self {
-        self.inspector_mut().tracing(mode);
+    pub fn set_trace_requirements(&mut self, requirements: TraceRequirements) -> &mut Self {
+        self.inspector_mut().tracing_requirements(requirements);
         self
     }
 

--- a/crates/evm/evm/src/executors/trace.rs
+++ b/crates/evm/evm/src/executors/trace.rs
@@ -12,7 +12,7 @@ use foundry_evm_core::{
 };
 use foundry_evm_hardforks::TempoHardfork;
 use foundry_evm_networks::NetworkConfigs;
-use foundry_evm_traces::TraceMode;
+use foundry_evm_traces::TraceRequirements;
 use revm::{context::Transaction, state::Bytecode};
 use std::ops::{Deref, DerefMut};
 
@@ -26,7 +26,7 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         env: (EvmEnvFor<FEN>, TxEnvFor<FEN>),
         fork: CreateFork,
         version: Option<EvmVersion>,
-        trace_mode: TraceMode,
+        trace_requirements: TraceRequirements,
         networks: NetworkConfigs,
         create2_deployer: Address,
         state_overrides: Option<StateOverride>,
@@ -36,7 +36,10 @@ impl<FEN: FoundryEvmNetwork> TracingExecutor<FEN> {
         // is enabled, tracing will be enabled only for the targeted transaction
         let mut executor = ExecutorBuilder::default()
             .inspectors(|stack| {
-                stack.trace_mode(trace_mode).networks(networks).create2_deployer(create2_deployer)
+                stack
+                    .trace_requirements(trace_requirements)
+                    .networks(networks)
+                    .create2_deployer(create2_deployer)
             })
             .spec_id_opt(version.map(evm_spec_id::<SpecFor<FEN>>))
             .build(env.0, env.1, db);

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -96,7 +96,7 @@ impl<BLOCK: Clone> Default for InspectorStackBuilder<BLOCK> {
             gas_price: None,
             cheatcodes: None,
             fuzzer: None,
-            trace_requirements: TraceRequirements::default(),
+            trace_requirements: TraceRequirements::empty(),
             logs: None,
             line_coverage: None,
             print: None,

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -96,7 +96,7 @@ impl<BLOCK: Clone> Default for InspectorStackBuilder<BLOCK> {
             gas_price: None,
             cheatcodes: None,
             fuzzer: None,
-            trace_requirements: TraceRequirements::empty(),
+            trace_requirements: TraceRequirements::none(),
             logs: None,
             line_coverage: None,
             print: None,

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -23,7 +23,7 @@ use foundry_evm_core::{
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_networks::NetworkConfigs;
-use foundry_evm_traces::{SparsedTraceArena, TraceMode, TraceRequirements};
+use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     Inspector,
     context::{
@@ -186,16 +186,9 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
         self
     }
 
-    /// Set whether to enable the tracer.
-    /// Revert diagnostic inspector is activated when `mode != TraceMode::None`
-    #[inline]
-    pub fn trace_mode(self, mode: TraceMode) -> Self {
-        self.trace_requirements(TraceRequirements::from(mode))
-    }
-
     /// Set trace data requirements.
     #[inline]
-    pub fn trace_requirements(mut self, requirements: TraceRequirements) -> Self {
+    pub const fn trace_requirements(mut self, requirements: TraceRequirements) -> Self {
         self.trace_requirements = self.trace_requirements.merge(requirements);
         self
     }
@@ -634,13 +627,6 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
     #[inline]
     pub fn print(&mut self, yes: bool) {
         self.printer = yes.then(Default::default);
-    }
-
-    /// Set whether to enable the tracer.
-    /// Revert diagnostic inspector is activated when `mode != TraceMode::None`
-    #[inline]
-    pub fn tracing(&mut self, mode: TraceMode) {
-        self.tracing_requirements(TraceRequirements::from(mode));
     }
 
     /// Set trace data requirements.

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -23,7 +23,7 @@ use foundry_evm_core::{
 };
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_networks::NetworkConfigs;
-use foundry_evm_traces::{SparsedTraceArena, TraceMode};
+use foundry_evm_traces::{SparsedTraceArena, TraceMode, TraceRequirements};
 use revm::{
     Inspector,
     context::{
@@ -64,7 +64,7 @@ pub struct InspectorStackBuilder<BLOCK: Clone> {
     /// The fuzzer inspector and its state, if it exists.
     pub fuzzer: Option<Fuzzer>,
     /// Whether to enable tracing and revert diagnostics.
-    pub trace_mode: TraceMode,
+    pub trace_requirements: TraceRequirements,
     /// Whether logs should be collected.
     /// - None for no log collection.
     /// - Some(true) for realtime console.log-ing.
@@ -96,7 +96,7 @@ impl<BLOCK: Clone> Default for InspectorStackBuilder<BLOCK> {
             gas_price: None,
             cheatcodes: None,
             fuzzer: None,
-            trace_mode: TraceMode::None,
+            trace_requirements: TraceRequirements::default(),
             logs: None,
             line_coverage: None,
             print: None,
@@ -189,10 +189,14 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
     /// Set whether to enable the tracer.
     /// Revert diagnostic inspector is activated when `mode != TraceMode::None`
     #[inline]
-    pub fn trace_mode(mut self, mode: TraceMode) -> Self {
-        if self.trace_mode < mode {
-            self.trace_mode = mode
-        }
+    pub fn trace_mode(self, mode: TraceMode) -> Self {
+        self.trace_requirements(TraceRequirements::from(mode))
+    }
+
+    /// Set trace data requirements.
+    #[inline]
+    pub fn trace_requirements(mut self, requirements: TraceRequirements) -> Self {
+        self.trace_requirements = self.trace_requirements.merge(requirements);
         self
     }
 
@@ -227,7 +231,7 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
             gas_price,
             cheatcodes,
             fuzzer,
-            trace_mode,
+            trace_requirements,
             logs,
             line_coverage,
             print,
@@ -263,7 +267,7 @@ impl<BLOCK: Clone> InspectorStackBuilder<BLOCK> {
         stack.collect_line_coverage(line_coverage.unwrap_or(false));
         stack.collect_logs(logs);
         stack.print(print.unwrap_or(false));
-        stack.tracing(trace_mode);
+        stack.tracing_requirements(trace_requirements);
 
         stack.enable_isolation(enable_isolation);
         stack.networks(networks);
@@ -636,9 +640,16 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
     /// Revert diagnostic inspector is activated when `mode != TraceMode::None`
     #[inline]
     pub fn tracing(&mut self, mode: TraceMode) {
-        self.revert_diag = (!mode.is_none()).then(RevertDiagnostic::default).map(Into::into);
+        self.tracing_requirements(TraceRequirements::from(mode));
+    }
 
-        if let Some(config) = mode.into_config() {
+    /// Set trace data requirements.
+    #[inline]
+    pub fn tracing_requirements(&mut self, requirements: TraceRequirements) {
+        let config = requirements.into_config();
+        self.revert_diag = config.is_some().then(RevertDiagnostic::default).map(Into::into);
+
+        if let Some(config) = config {
             *self.tracer.get_or_insert_with(Default::default).config_mut() = config;
         } else {
             self.tracer = None;

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -395,7 +395,7 @@ pub struct TraceRequirements {
 }
 
 impl TraceRequirements {
-    pub const fn empty() -> Self {
+    pub const fn none() -> Self {
         Self {
             calls: false,
             steps: StepRecording::None,
@@ -538,18 +538,18 @@ mod tests {
     fn verbosity_0_through_2_is_noop() {
         for v in 0..=2 {
             assert_eq!(
-                TraceRequirements::empty().with_verbosity(v),
-                TraceRequirements::empty(),
+                TraceRequirements::none().with_verbosity(v),
+                TraceRequirements::none(),
                 "v={v}"
             );
             assert_eq!(
-                TraceRequirements::empty().with_calls(true).with_verbosity(v),
-                TraceRequirements::empty().with_calls(true),
+                TraceRequirements::none().with_calls(true).with_verbosity(v),
+                TraceRequirements::none().with_calls(true),
                 "v={v}"
             );
             assert_eq!(
-                TraceRequirements::empty().with_debug(true).with_verbosity(v),
-                TraceRequirements::empty().with_debug(true),
+                TraceRequirements::none().with_debug(true).with_verbosity(v),
+                TraceRequirements::none().with_debug(true),
                 "v={v}"
             );
         }
@@ -559,18 +559,18 @@ mod tests {
     fn verbosity_3_and_4_raises_to_call() {
         for v in 3..=4 {
             assert_eq!(
-                TraceRequirements::empty().with_verbosity(v),
-                TraceRequirements::empty().with_calls(true),
+                TraceRequirements::none().with_verbosity(v),
+                TraceRequirements::none().with_calls(true),
                 "v={v}"
             );
             assert_eq!(
-                TraceRequirements::empty().with_debug(true).with_verbosity(v),
-                TraceRequirements::empty().with_debug(true),
+                TraceRequirements::none().with_debug(true).with_verbosity(v),
+                TraceRequirements::none().with_debug(true),
                 "v={v}"
             );
             assert_eq!(
-                TraceRequirements::empty().with_state_changes(true).with_verbosity(v),
-                TraceRequirements::empty().with_state_changes(true),
+                TraceRequirements::none().with_state_changes(true).with_verbosity(v),
+                TraceRequirements::none().with_state_changes(true),
                 "v={v}"
             );
         }
@@ -578,11 +578,11 @@ mod tests {
 
     #[test]
     fn verbosity_5_raises_to_record_state_diff() {
-        let state_changes = TraceRequirements::empty().with_state_changes(true);
+        let state_changes = TraceRequirements::none().with_state_changes(true);
 
-        assert_eq!(TraceRequirements::empty().with_verbosity(5), state_changes);
-        assert_eq!(TraceRequirements::empty().with_calls(true).with_verbosity(5), state_changes);
-        let cfg = TraceRequirements::empty()
+        assert_eq!(TraceRequirements::none().with_verbosity(5), state_changes);
+        assert_eq!(TraceRequirements::none().with_calls(true).with_verbosity(5), state_changes);
+        let cfg = TraceRequirements::none()
             .with_calls(true)
             .with_steps(StepRecording::Jumps)
             .with_verbosity(5)
@@ -591,23 +591,23 @@ mod tests {
         assert!(cfg.record_state_diff);
         assert!(cfg.record_opcodes_filter.is_none());
         assert_eq!(
-            TraceRequirements::empty().with_debug(true).with_verbosity(5),
-            TraceRequirements::empty().with_debug(true)
+            TraceRequirements::none().with_debug(true).with_verbosity(5),
+            TraceRequirements::none().with_debug(true)
         );
         assert_eq!(
-            TraceRequirements::empty().with_state_changes(true).with_verbosity(5),
+            TraceRequirements::none().with_state_changes(true).with_verbosity(5),
             state_changes
         );
     }
 
     #[test]
     fn config_at_verbosity_0_is_none() {
-        assert!(TraceRequirements::empty().with_verbosity(0).into_config().is_none());
+        assert!(TraceRequirements::none().with_verbosity(0).into_config().is_none());
     }
 
     #[test]
     fn config_at_verbosity_3_records_calls_only() {
-        let cfg = TraceRequirements::empty().with_verbosity(3).into_config().unwrap();
+        let cfg = TraceRequirements::none().with_verbosity(3).into_config().unwrap();
         assert!(!cfg.record_steps, "verbosity 3 should not record steps");
         assert!(!cfg.record_state_diff, "verbosity 3 should not record state diff");
         assert!(cfg.record_logs, "verbosity 3 should record logs");
@@ -615,7 +615,7 @@ mod tests {
 
     #[test]
     fn config_at_verbosity_5_records_steps_and_state_diff() {
-        let cfg = TraceRequirements::empty().with_verbosity(5).into_config().unwrap();
+        let cfg = TraceRequirements::none().with_verbosity(5).into_config().unwrap();
         assert!(cfg.record_steps, "verbosity 5 must record steps for backtraces");
         assert!(cfg.record_state_diff, "verbosity 5 must record state diff");
         assert!(cfg.record_logs, "verbosity 5 must record logs");
@@ -636,7 +636,7 @@ mod tests {
     #[test]
     fn config_debug_mode_unchanged() {
         // Debug mode must still enable full recording for the debugger.
-        let cfg = TraceRequirements::empty().with_debug(true).into_config().unwrap();
+        let cfg = TraceRequirements::none().with_debug(true).into_config().unwrap();
         assert!(cfg.record_steps);
         assert!(cfg.record_memory_snapshots, "Debug must record memory snapshots");
         assert_eq!(
@@ -652,7 +652,7 @@ mod tests {
 
     #[test]
     fn requirements_preserve_internal_decode_with_state_diff() {
-        let cfg = TraceRequirements::empty()
+        let cfg = TraceRequirements::none()
             .with_decode_internal(InternalTraceMode::Full)
             .with_state_changes(true)
             .into_config()
@@ -671,11 +671,8 @@ mod tests {
 
     #[test]
     fn requirements_all_steps_avoid_debug_snapshots() {
-        let cfg = TraceRequirements::empty()
-            .with_all_steps(true)
-            .with_verbosity(5)
-            .into_config()
-            .unwrap();
+        let cfg =
+            TraceRequirements::none().with_all_steps(true).with_verbosity(5).into_config().unwrap();
 
         assert!(cfg.record_steps, "all steps must record opcode steps");
         assert!(cfg.record_opcodes_filter.is_none(), "all steps must record every opcode step");

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -350,7 +350,7 @@ pub fn load_contracts<'a>(
 }
 
 /// Different kinds of internal functions tracing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum InternalTraceMode {
     #[default]
     None,
@@ -360,49 +360,8 @@ pub enum InternalTraceMode {
     Full,
 }
 
-impl From<InternalTraceMode> for TraceMode {
-    fn from(mode: InternalTraceMode) -> Self {
-        match mode {
-            InternalTraceMode::None => Self::None,
-            InternalTraceMode::Simple => Self::JumpSimple,
-            InternalTraceMode::Full => Self::Jump,
-        }
-    }
-}
-
-// Different kinds of traces used by different foundry components.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum TraceMode {
-    /// Disabled tracing.
-    #[default]
-    None,
-    /// Simple call trace, no steps tracing required.
-    Call,
-    /// Call trace with steps tracing for JUMP and JUMPDEST opcodes.
-    ///
-    /// Does not enable tracking memory or stack snapshots.
-    Steps,
-    /// Call trace with tracing for JUMP and JUMPDEST opcode steps.
-    ///
-    /// Used for internal functions identification. Does not track memory snapshots.
-    JumpSimple,
-    /// Call trace with tracing for JUMP and JUMPDEST opcode steps.
-    ///
-    /// Same as `JumpSimple`, but tracks memory snapshots as well.
-    Jump,
-    /// Call trace with complete steps tracing.
-    ///
-    /// Used by debugger.
-    Debug,
-    /// Step trace with storage change recording.
-    ///
-    /// Records JUMP/JUMPDEST steps (like `Steps`) plus storage diffs on SLOAD/SSTORE.
-    /// Does not enable memory/stack snapshots or unfiltered opcode recording.
-    RecordStateDiff,
-}
-
 /// Opcode step recording granularity.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum StepRecording {
     /// No opcode steps.
     #[default]
@@ -411,6 +370,16 @@ pub enum StepRecording {
     Jumps,
     /// Record all opcode steps.
     All,
+}
+
+impl StepRecording {
+    const fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::All, _) | (_, Self::All) => Self::All,
+            (Self::Jumps, _) | (_, Self::Jumps) => Self::Jumps,
+            (Self::None, Self::None) => Self::None,
+        }
+    }
 }
 
 /// Trace data requirements composed across independent feature axes.
@@ -431,9 +400,9 @@ impl TraceRequirements {
         self
     }
 
-    pub fn merge(mut self, other: Self) -> Self {
+    pub const fn merge(mut self, other: Self) -> Self {
         self.calls |= other.calls;
-        self.steps = std::cmp::max(self.steps, other.steps);
+        self.steps = self.steps.merge(other.steps);
         self.memory_snapshots |= other.memory_snapshots;
         self.stack_snapshots |= other.stack_snapshots;
         self.returndata_snapshots |= other.returndata_snapshots;
@@ -442,8 +411,8 @@ impl TraceRequirements {
         self
     }
 
-    pub fn with_steps(mut self, steps: StepRecording) -> Self {
-        self.steps = std::cmp::max(self.steps, steps);
+    pub const fn with_steps(mut self, steps: StepRecording) -> Self {
+        self.steps = self.steps.merge(steps);
         self
     }
 
@@ -470,7 +439,7 @@ impl TraceRequirements {
         self
     }
 
-    pub fn with_decode_internal(self, mode: InternalTraceMode) -> Self {
+    pub const fn with_decode_internal(self, mode: InternalTraceMode) -> Self {
         match mode {
             InternalTraceMode::None => self,
             InternalTraceMode::Simple => {
@@ -484,7 +453,7 @@ impl TraceRequirements {
         }
     }
 
-    pub fn with_all_steps(self, yes: bool) -> Self {
+    pub const fn with_all_steps(self, yes: bool) -> Self {
         if yes { self.with_calls(true).with_steps(StepRecording::All) } else { self }
     }
 
@@ -500,6 +469,7 @@ impl TraceRequirements {
         match verbosity {
             0..3 => self,
             3..=4 => self.with_calls(true),
+            _ if matches!(self.steps, StepRecording::All) => self.with_calls(true),
             _ => self.with_state_changes(true),
         }
     }
@@ -534,84 +504,6 @@ impl TraceRequirements {
     }
 }
 
-impl From<TraceMode> for TraceRequirements {
-    fn from(mode: TraceMode) -> Self {
-        match mode {
-            TraceMode::None => Self::default(),
-            TraceMode::Call => Self::default().with_calls(true),
-            TraceMode::Steps => Self::default().with_calls(true).with_steps(StepRecording::Jumps),
-            TraceMode::JumpSimple => Self::default()
-                .with_calls(true)
-                .with_steps(StepRecording::Jumps)
-                .with_stack_snapshots(true),
-            TraceMode::Jump => Self::default()
-                .with_calls(true)
-                .with_steps(StepRecording::Jumps)
-                .with_memory_snapshots(true)
-                .with_stack_snapshots(true),
-            TraceMode::Debug => Self::default().with_debug(true),
-            TraceMode::RecordStateDiff => Self::default().with_state_changes(true),
-        }
-    }
-}
-
-impl TraceMode {
-    pub const fn is_none(self) -> bool {
-        matches!(self, Self::None)
-    }
-
-    pub const fn is_call(self) -> bool {
-        matches!(self, Self::Call)
-    }
-
-    pub const fn is_steps(self) -> bool {
-        matches!(self, Self::Steps)
-    }
-
-    pub const fn is_jump_simple(self) -> bool {
-        matches!(self, Self::JumpSimple)
-    }
-
-    pub const fn is_jump(self) -> bool {
-        matches!(self, Self::Jump)
-    }
-
-    pub const fn record_state_diff(self) -> bool {
-        matches!(self, Self::RecordStateDiff)
-    }
-
-    pub const fn is_debug(self) -> bool {
-        matches!(self, Self::Debug)
-    }
-
-    pub fn with_debug(self, yes: bool) -> Self {
-        if yes { std::cmp::max(self, Self::Debug) } else { self }
-    }
-
-    pub fn with_decode_internal(self, mode: InternalTraceMode) -> Self {
-        std::cmp::max(self, mode.into())
-    }
-
-    pub fn with_state_changes(self, yes: bool) -> Self {
-        if yes && !self.is_debug() { std::cmp::max(self, Self::RecordStateDiff) } else { self }
-    }
-
-    pub fn with_verbosity(self, verbosity: u8) -> Self {
-        match verbosity {
-            0..3 => self,
-            3..=4 => std::cmp::max(self, Self::Call),
-            // Enable step recording and state diff recording when verbosity is 5 or higher.
-            // This includes backtraces (JUMP/JUMPDEST steps) and storage changes.
-            _ if self.is_debug() => self,
-            _ => std::cmp::max(self, Self::RecordStateDiff),
-        }
-    }
-
-    pub fn into_config(self) -> Option<TracingInspectorConfig> {
-        TraceRequirements::from(self).into_config()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -630,26 +522,43 @@ mod tests {
         );
     }
 
-    // -- TraceMode::with_verbosity level tests --
-
     #[test]
     fn verbosity_0_through_2_is_noop() {
         for v in 0..=2 {
-            assert_eq!(TraceMode::None.with_verbosity(v), TraceMode::None, "v={v}");
-            assert_eq!(TraceMode::Call.with_verbosity(v), TraceMode::Call, "v={v}");
-            assert_eq!(TraceMode::Debug.with_verbosity(v), TraceMode::Debug, "v={v}");
+            assert_eq!(
+                TraceRequirements::default().with_verbosity(v),
+                TraceRequirements::default(),
+                "v={v}"
+            );
+            assert_eq!(
+                TraceRequirements::default().with_calls(true).with_verbosity(v),
+                TraceRequirements::default().with_calls(true),
+                "v={v}"
+            );
+            assert_eq!(
+                TraceRequirements::default().with_debug(true).with_verbosity(v),
+                TraceRequirements::default().with_debug(true),
+                "v={v}"
+            );
         }
     }
 
     #[test]
     fn verbosity_3_and_4_raises_to_call() {
         for v in 3..=4 {
-            assert_eq!(TraceMode::None.with_verbosity(v), TraceMode::Call, "v={v}");
-            // Already above Call — must not downgrade.
-            assert_eq!(TraceMode::Debug.with_verbosity(v), TraceMode::Debug, "v={v}");
             assert_eq!(
-                TraceMode::RecordStateDiff.with_verbosity(v),
-                TraceMode::RecordStateDiff,
+                TraceRequirements::default().with_verbosity(v),
+                TraceRequirements::default().with_calls(true),
+                "v={v}"
+            );
+            assert_eq!(
+                TraceRequirements::default().with_debug(true).with_verbosity(v),
+                TraceRequirements::default().with_debug(true),
+                "v={v}"
+            );
+            assert_eq!(
+                TraceRequirements::default().with_state_changes(true).with_verbosity(v),
+                TraceRequirements::default().with_state_changes(true),
                 "v={v}"
             );
         }
@@ -657,27 +566,36 @@ mod tests {
 
     #[test]
     fn verbosity_5_raises_to_record_state_diff() {
-        assert_eq!(TraceMode::None.with_verbosity(5), TraceMode::RecordStateDiff);
-        assert_eq!(TraceMode::Call.with_verbosity(5), TraceMode::RecordStateDiff);
-        assert_eq!(TraceMode::Steps.with_verbosity(5), TraceMode::RecordStateDiff);
-        // Debug mode already records full steps; it must not be downgraded to the lightweight
-        // RecordStateDiff mode when high verbosity is also requested.
-        assert_eq!(TraceMode::Debug.with_verbosity(5), TraceMode::Debug);
-        // Already at the top — stays the same.
-        assert_eq!(TraceMode::RecordStateDiff.with_verbosity(5), TraceMode::RecordStateDiff);
-    }
+        let state_changes = TraceRequirements::default().with_state_changes(true);
 
-    // -- into_config at each verbosity level --
+        assert_eq!(TraceRequirements::default().with_verbosity(5), state_changes);
+        assert_eq!(TraceRequirements::default().with_calls(true).with_verbosity(5), state_changes);
+        let cfg = TraceRequirements::default()
+            .with_calls(true)
+            .with_steps(StepRecording::Jumps)
+            .with_verbosity(5)
+            .into_config()
+            .unwrap();
+        assert!(cfg.record_state_diff);
+        assert!(cfg.record_opcodes_filter.is_none());
+        assert_eq!(
+            TraceRequirements::default().with_debug(true).with_verbosity(5),
+            TraceRequirements::default().with_debug(true)
+        );
+        assert_eq!(
+            TraceRequirements::default().with_state_changes(true).with_verbosity(5),
+            state_changes
+        );
+    }
 
     #[test]
     fn config_at_verbosity_0_is_none() {
-        let mode = TraceMode::None.with_verbosity(0);
-        assert!(mode.into_config().is_none());
+        assert!(TraceRequirements::default().with_verbosity(0).into_config().is_none());
     }
 
     #[test]
     fn config_at_verbosity_3_records_calls_only() {
-        let cfg = TraceMode::None.with_verbosity(3).into_config().unwrap();
+        let cfg = TraceRequirements::default().with_verbosity(3).into_config().unwrap();
         assert!(!cfg.record_steps, "verbosity 3 should not record steps");
         assert!(!cfg.record_state_diff, "verbosity 3 should not record state diff");
         assert!(cfg.record_logs, "verbosity 3 should record logs");
@@ -685,7 +603,7 @@ mod tests {
 
     #[test]
     fn config_at_verbosity_5_records_steps_and_state_diff() {
-        let cfg = TraceMode::None.with_verbosity(5).into_config().unwrap();
+        let cfg = TraceRequirements::default().with_verbosity(5).into_config().unwrap();
         assert!(cfg.record_steps, "verbosity 5 must record steps for backtraces");
         assert!(cfg.record_state_diff, "verbosity 5 must record state diff");
         assert!(cfg.record_logs, "verbosity 5 must record logs");
@@ -706,7 +624,7 @@ mod tests {
     #[test]
     fn config_debug_mode_unchanged() {
         // Debug mode must still enable full recording for the debugger.
-        let cfg = TraceMode::Debug.into_config().unwrap();
+        let cfg = TraceRequirements::default().with_debug(true).into_config().unwrap();
         assert!(cfg.record_steps);
         assert!(cfg.record_memory_snapshots, "Debug must record memory snapshots");
         assert_eq!(
@@ -741,7 +659,11 @@ mod tests {
 
     #[test]
     fn requirements_all_steps_avoid_debug_snapshots() {
-        let cfg = TraceRequirements::default().with_all_steps(true).into_config().unwrap();
+        let cfg = TraceRequirements::default()
+            .with_all_steps(true)
+            .with_verbosity(5)
+            .into_config()
+            .unwrap();
 
         assert!(cfg.record_steps, "all steps must record opcode steps");
         assert!(cfg.record_opcodes_filter.is_none(), "all steps must record every opcode step");

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -395,6 +395,18 @@ pub struct TraceRequirements {
 }
 
 impl TraceRequirements {
+    pub const fn empty() -> Self {
+        Self {
+            calls: false,
+            steps: StepRecording::None,
+            memory_snapshots: false,
+            stack_snapshots: false,
+            returndata_snapshots: false,
+            immediate_bytes: false,
+            state_diff: false,
+        }
+    }
+
     pub const fn with_calls(mut self, yes: bool) -> Self {
         self.calls |= yes;
         self
@@ -526,18 +538,18 @@ mod tests {
     fn verbosity_0_through_2_is_noop() {
         for v in 0..=2 {
             assert_eq!(
-                TraceRequirements::default().with_verbosity(v),
-                TraceRequirements::default(),
+                TraceRequirements::empty().with_verbosity(v),
+                TraceRequirements::empty(),
                 "v={v}"
             );
             assert_eq!(
-                TraceRequirements::default().with_calls(true).with_verbosity(v),
-                TraceRequirements::default().with_calls(true),
+                TraceRequirements::empty().with_calls(true).with_verbosity(v),
+                TraceRequirements::empty().with_calls(true),
                 "v={v}"
             );
             assert_eq!(
-                TraceRequirements::default().with_debug(true).with_verbosity(v),
-                TraceRequirements::default().with_debug(true),
+                TraceRequirements::empty().with_debug(true).with_verbosity(v),
+                TraceRequirements::empty().with_debug(true),
                 "v={v}"
             );
         }
@@ -547,18 +559,18 @@ mod tests {
     fn verbosity_3_and_4_raises_to_call() {
         for v in 3..=4 {
             assert_eq!(
-                TraceRequirements::default().with_verbosity(v),
-                TraceRequirements::default().with_calls(true),
+                TraceRequirements::empty().with_verbosity(v),
+                TraceRequirements::empty().with_calls(true),
                 "v={v}"
             );
             assert_eq!(
-                TraceRequirements::default().with_debug(true).with_verbosity(v),
-                TraceRequirements::default().with_debug(true),
+                TraceRequirements::empty().with_debug(true).with_verbosity(v),
+                TraceRequirements::empty().with_debug(true),
                 "v={v}"
             );
             assert_eq!(
-                TraceRequirements::default().with_state_changes(true).with_verbosity(v),
-                TraceRequirements::default().with_state_changes(true),
+                TraceRequirements::empty().with_state_changes(true).with_verbosity(v),
+                TraceRequirements::empty().with_state_changes(true),
                 "v={v}"
             );
         }
@@ -566,11 +578,11 @@ mod tests {
 
     #[test]
     fn verbosity_5_raises_to_record_state_diff() {
-        let state_changes = TraceRequirements::default().with_state_changes(true);
+        let state_changes = TraceRequirements::empty().with_state_changes(true);
 
-        assert_eq!(TraceRequirements::default().with_verbosity(5), state_changes);
-        assert_eq!(TraceRequirements::default().with_calls(true).with_verbosity(5), state_changes);
-        let cfg = TraceRequirements::default()
+        assert_eq!(TraceRequirements::empty().with_verbosity(5), state_changes);
+        assert_eq!(TraceRequirements::empty().with_calls(true).with_verbosity(5), state_changes);
+        let cfg = TraceRequirements::empty()
             .with_calls(true)
             .with_steps(StepRecording::Jumps)
             .with_verbosity(5)
@@ -579,23 +591,23 @@ mod tests {
         assert!(cfg.record_state_diff);
         assert!(cfg.record_opcodes_filter.is_none());
         assert_eq!(
-            TraceRequirements::default().with_debug(true).with_verbosity(5),
-            TraceRequirements::default().with_debug(true)
+            TraceRequirements::empty().with_debug(true).with_verbosity(5),
+            TraceRequirements::empty().with_debug(true)
         );
         assert_eq!(
-            TraceRequirements::default().with_state_changes(true).with_verbosity(5),
+            TraceRequirements::empty().with_state_changes(true).with_verbosity(5),
             state_changes
         );
     }
 
     #[test]
     fn config_at_verbosity_0_is_none() {
-        assert!(TraceRequirements::default().with_verbosity(0).into_config().is_none());
+        assert!(TraceRequirements::empty().with_verbosity(0).into_config().is_none());
     }
 
     #[test]
     fn config_at_verbosity_3_records_calls_only() {
-        let cfg = TraceRequirements::default().with_verbosity(3).into_config().unwrap();
+        let cfg = TraceRequirements::empty().with_verbosity(3).into_config().unwrap();
         assert!(!cfg.record_steps, "verbosity 3 should not record steps");
         assert!(!cfg.record_state_diff, "verbosity 3 should not record state diff");
         assert!(cfg.record_logs, "verbosity 3 should record logs");
@@ -603,7 +615,7 @@ mod tests {
 
     #[test]
     fn config_at_verbosity_5_records_steps_and_state_diff() {
-        let cfg = TraceRequirements::default().with_verbosity(5).into_config().unwrap();
+        let cfg = TraceRequirements::empty().with_verbosity(5).into_config().unwrap();
         assert!(cfg.record_steps, "verbosity 5 must record steps for backtraces");
         assert!(cfg.record_state_diff, "verbosity 5 must record state diff");
         assert!(cfg.record_logs, "verbosity 5 must record logs");
@@ -624,7 +636,7 @@ mod tests {
     #[test]
     fn config_debug_mode_unchanged() {
         // Debug mode must still enable full recording for the debugger.
-        let cfg = TraceRequirements::default().with_debug(true).into_config().unwrap();
+        let cfg = TraceRequirements::empty().with_debug(true).into_config().unwrap();
         assert!(cfg.record_steps);
         assert!(cfg.record_memory_snapshots, "Debug must record memory snapshots");
         assert_eq!(
@@ -640,7 +652,7 @@ mod tests {
 
     #[test]
     fn requirements_preserve_internal_decode_with_state_diff() {
-        let cfg = TraceRequirements::default()
+        let cfg = TraceRequirements::empty()
             .with_decode_internal(InternalTraceMode::Full)
             .with_state_changes(true)
             .into_config()
@@ -659,7 +671,7 @@ mod tests {
 
     #[test]
     fn requirements_all_steps_avoid_debug_snapshots() {
-        let cfg = TraceRequirements::default()
+        let cfg = TraceRequirements::empty()
             .with_all_steps(true)
             .with_verbosity(5)
             .into_config()

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -401,6 +401,160 @@ pub enum TraceMode {
     RecordStateDiff,
 }
 
+/// Opcode step recording granularity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum StepRecording {
+    /// No opcode steps.
+    #[default]
+    None,
+    /// Record only JUMP/JUMPDEST steps.
+    Jumps,
+    /// Record all opcode steps.
+    All,
+}
+
+/// Trace data requirements composed across independent feature axes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TraceRequirements {
+    calls: bool,
+    steps: StepRecording,
+    memory_snapshots: bool,
+    stack_snapshots: bool,
+    returndata_snapshots: bool,
+    immediate_bytes: bool,
+    state_diff: bool,
+}
+
+impl TraceRequirements {
+    pub const fn with_calls(mut self, yes: bool) -> Self {
+        self.calls |= yes;
+        self
+    }
+
+    pub fn merge(mut self, other: Self) -> Self {
+        self.calls |= other.calls;
+        self.steps = std::cmp::max(self.steps, other.steps);
+        self.memory_snapshots |= other.memory_snapshots;
+        self.stack_snapshots |= other.stack_snapshots;
+        self.returndata_snapshots |= other.returndata_snapshots;
+        self.immediate_bytes |= other.immediate_bytes;
+        self.state_diff |= other.state_diff;
+        self
+    }
+
+    pub fn with_steps(mut self, steps: StepRecording) -> Self {
+        self.steps = std::cmp::max(self.steps, steps);
+        self
+    }
+
+    pub const fn with_memory_snapshots(mut self, yes: bool) -> Self {
+        self.memory_snapshots |= yes;
+        self
+    }
+
+    pub const fn with_stack_snapshots(mut self, yes: bool) -> Self {
+        self.stack_snapshots |= yes;
+        self
+    }
+
+    pub const fn with_debug(mut self, yes: bool) -> Self {
+        if yes {
+            self.calls = true;
+            self.steps = StepRecording::All;
+            self.memory_snapshots = true;
+            self.stack_snapshots = true;
+            self.returndata_snapshots = true;
+            self.immediate_bytes = true;
+            self.state_diff = true;
+        }
+        self
+    }
+
+    pub fn with_decode_internal(self, mode: InternalTraceMode) -> Self {
+        match mode {
+            InternalTraceMode::None => self,
+            InternalTraceMode::Simple => {
+                self.with_calls(true).with_steps(StepRecording::Jumps).with_stack_snapshots(true)
+            }
+            InternalTraceMode::Full => self
+                .with_calls(true)
+                .with_steps(StepRecording::Jumps)
+                .with_memory_snapshots(true)
+                .with_stack_snapshots(true),
+        }
+    }
+
+    pub fn with_all_steps(self, yes: bool) -> Self {
+        if yes { self.with_calls(true).with_steps(StepRecording::All) } else { self }
+    }
+
+    pub const fn with_state_changes(mut self, yes: bool) -> Self {
+        self.state_diff |= yes;
+        if yes {
+            self.calls = true;
+        }
+        self
+    }
+
+    pub const fn with_verbosity(self, verbosity: u8) -> Self {
+        match verbosity {
+            0..3 => self,
+            3..=4 => self.with_calls(true),
+            _ => self.with_state_changes(true),
+        }
+    }
+
+    pub fn into_config(self) -> Option<TracingInspectorConfig> {
+        if !self.calls && self.steps == StepRecording::None && !self.state_diff {
+            return None;
+        }
+
+        let steps = if self.state_diff { StepRecording::All } else { self.steps };
+        TracingInspectorConfig {
+            record_steps: steps != StepRecording::None,
+            record_memory_snapshots: self.memory_snapshots,
+            record_stack_snapshots: if self.stack_snapshots {
+                StackSnapshotType::Full
+            } else {
+                StackSnapshotType::None
+            },
+            record_logs: true,
+            record_state_diff: self.state_diff,
+            record_returndata_snapshots: self.returndata_snapshots,
+            record_opcodes_filter: match steps {
+                StepRecording::None | StepRecording::All => None,
+                StepRecording::Jumps => {
+                    Some(OpcodeFilter::new().enabled(OpCode::JUMP).enabled(OpCode::JUMPDEST))
+                }
+            },
+            exclude_precompile_calls: false,
+            record_immediate_bytes: self.immediate_bytes,
+        }
+        .into()
+    }
+}
+
+impl From<TraceMode> for TraceRequirements {
+    fn from(mode: TraceMode) -> Self {
+        match mode {
+            TraceMode::None => Self::default(),
+            TraceMode::Call => Self::default().with_calls(true),
+            TraceMode::Steps => Self::default().with_calls(true).with_steps(StepRecording::Jumps),
+            TraceMode::JumpSimple => Self::default()
+                .with_calls(true)
+                .with_steps(StepRecording::Jumps)
+                .with_stack_snapshots(true),
+            TraceMode::Jump => Self::default()
+                .with_calls(true)
+                .with_steps(StepRecording::Jumps)
+                .with_memory_snapshots(true)
+                .with_stack_snapshots(true),
+            TraceMode::Debug => Self::default().with_debug(true),
+            TraceMode::RecordStateDiff => Self::default().with_state_changes(true),
+        }
+    }
+}
+
 impl TraceMode {
     pub const fn is_none(self) -> bool {
         matches!(self, Self::None)
@@ -454,40 +608,7 @@ impl TraceMode {
     }
 
     pub fn into_config(self) -> Option<TracingInspectorConfig> {
-        if self.is_none() {
-            None
-        } else {
-            // RecordStateDiff is Steps + state diff recording, not Debug + state diff.
-            // It should not enable memory/stack snapshots.
-            // State diff recording requires all opcodes (no filter) since it needs
-            // SLOAD/SSTORE steps, not just JUMP/JUMPDEST.
-            let record_state_diff = self.record_state_diff() || self.is_debug();
-            let effective = if self.record_state_diff() { Self::Steps } else { self };
-            TracingInspectorConfig {
-                record_steps: self >= Self::Steps,
-                record_memory_snapshots: effective >= Self::Jump,
-                record_stack_snapshots: if effective > Self::Steps {
-                    StackSnapshotType::Full
-                } else {
-                    StackSnapshotType::None
-                },
-                record_logs: true,
-                record_state_diff,
-                record_returndata_snapshots: effective.is_debug(),
-                // State diff needs all opcodes recorded to capture SLOAD/SSTORE.
-                record_opcodes_filter: if record_state_diff {
-                    None
-                } else {
-                    (effective.is_steps() || effective.is_jump() || effective.is_jump_simple())
-                        .then(|| {
-                            OpcodeFilter::new().enabled(OpCode::JUMP).enabled(OpCode::JUMPDEST)
-                        })
-                },
-                exclude_precompile_calls: false,
-                record_immediate_bytes: effective.is_debug(),
-            }
-            .into()
-        }
+        TraceRequirements::from(self).into_config()
     }
 }
 
@@ -597,5 +718,41 @@ mod tests {
         assert!(cfg.record_immediate_bytes, "Debug must record immediate bytes");
         assert!(cfg.record_opcodes_filter.is_none(), "Debug must record all opcodes (no filter)");
         assert!(cfg.record_state_diff, "Debug should record storage accesses for the debugger");
+    }
+
+    #[test]
+    fn requirements_preserve_internal_decode_with_state_diff() {
+        let cfg = TraceRequirements::default()
+            .with_decode_internal(InternalTraceMode::Full)
+            .with_state_changes(true)
+            .into_config()
+            .unwrap();
+
+        assert!(cfg.record_steps, "requirements should record opcode steps");
+        assert!(cfg.record_memory_snapshots, "Full internal decoding needs memory snapshots");
+        assert_eq!(
+            cfg.record_stack_snapshots,
+            StackSnapshotType::Full,
+            "internal decoding needs stack snapshots"
+        );
+        assert!(cfg.record_state_diff, "state changes should be recorded");
+        assert!(cfg.record_opcodes_filter.is_none(), "state diff needs unfiltered opcodes");
+    }
+
+    #[test]
+    fn requirements_all_steps_avoid_debug_snapshots() {
+        let cfg = TraceRequirements::default().with_all_steps(true).into_config().unwrap();
+
+        assert!(cfg.record_steps, "all steps must record opcode steps");
+        assert!(cfg.record_opcodes_filter.is_none(), "all steps must record every opcode step");
+        assert!(!cfg.record_memory_snapshots, "all steps should not record memory snapshots");
+        assert_eq!(
+            cfg.record_stack_snapshots,
+            StackSnapshotType::None,
+            "all steps should not record stack snapshots"
+        );
+        assert!(!cfg.record_returndata_snapshots, "all steps should not record returndata");
+        assert!(!cfg.record_immediate_bytes, "all steps should not record immediate bytes");
+        assert!(!cfg.record_state_diff, "all steps should not record state diffs");
     }
 }

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -30,7 +30,7 @@ use foundry_evm::{
     fuzz::strategies::{EnumBounds, LiteralsDictionary},
     inspectors::CheatsConfig,
     opts::EvmOpts,
-    traces::{InternalTraceMode, TraceMode},
+    traces::{InternalTraceMode, TraceRequirements},
 };
 use foundry_evm_networks::NetworkVariant;
 
@@ -471,7 +471,7 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
             cheatcodes.config =
                 Arc::new(cheatcodes.config.clone_with(&self.config, self.evm_opts.clone()));
         }
-        inspector.tracing(self.trace_mode());
+        inspector.tracing_requirements(self.trace_requirements());
         inspector.collect_line_coverage(self.line_coverage);
         inspector.enable_isolation(self.isolation);
         inspector.networks(self.evm_opts.networks);
@@ -504,7 +504,7 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
                 stack
                     .logs(self.config.live_logs)
                     .cheatcodes(cheats_config)
-                    .trace_mode(self.trace_mode())
+                    .trace_requirements(self.trace_requirements())
                     .line_coverage(self.line_coverage)
                     .enable_isolation(self.isolation)
                     .networks(self.evm_opts.networks)
@@ -517,8 +517,8 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
             .build(self.evm_env.clone(), self.tx_env.clone(), db)
     }
 
-    fn trace_mode(&self) -> TraceMode {
-        TraceMode::default()
+    fn trace_requirements(&self) -> TraceRequirements {
+        TraceRequirements::default()
             .with_debug(self.debug)
             .with_decode_internal(self.decode_internal)
             .with_verbosity(self.evm_opts.verbosity)

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -517,8 +517,8 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
             .build(self.evm_env.clone(), self.tx_env.clone(), db)
     }
 
-    fn trace_requirements(&self) -> TraceRequirements {
-        TraceRequirements::default()
+    const fn trace_requirements(&self) -> TraceRequirements {
+        TraceRequirements::empty()
             .with_debug(self.debug)
             .with_decode_internal(self.decode_internal)
             .with_verbosity(self.evm_opts.verbosity)

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -518,7 +518,7 @@ impl<FEN: FoundryEvmNetwork> TestRunnerConfig<FEN> {
     }
 
     const fn trace_requirements(&self) -> TraceRequirements {
-        TraceRequirements::empty()
+        TraceRequirements::none()
             .with_debug(self.debug)
             .with_decode_internal(self.decode_internal)
             .with_verbosity(self.evm_opts.verbosity)

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -766,7 +766,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
         let prev_tracer = should_override_setup_tracing.then(|| {
             let prev_tracer = self.executor.inspector_mut().tracer.take();
-            self.executor.set_trace_requirements(TraceRequirements::default().with_calls(true));
+            self.executor.set_trace_requirements(TraceRequirements::empty().with_calls(true));
             prev_tracer
         });
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -46,7 +46,7 @@ use foundry_evm::{
         strategies::EvmFuzzState,
     },
     revm::primitives::hardfork::SpecId,
-    traces::{TraceKind, TraceMode, load_contracts},
+    traces::{TraceKind, TraceRequirements, load_contracts},
 };
 use foundry_evm_networks::NetworkVariant;
 use foundry_evm_symbolic::{
@@ -766,7 +766,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
         let prev_tracer = should_override_setup_tracing.then(|| {
             let prev_tracer = self.executor.inspector_mut().tracer.take();
-            self.executor.set_tracing(TraceMode::Call);
+            self.executor.set_trace_requirements(TraceRequirements::default().with_calls(true));
             prev_tracer
         });
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -766,7 +766,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
         let prev_tracer = should_override_setup_tracing.then(|| {
             let prev_tracer = self.executor.inspector_mut().tracer.take();
-            self.executor.set_trace_requirements(TraceRequirements::empty().with_calls(true));
+            self.executor.set_trace_requirements(TraceRequirements::none().with_calls(true));
             prev_tracer
         });
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -870,7 +870,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
                 stack
                     .logs(self.config.live_logs)
                     .trace_requirements(
-                        TraceRequirements::empty().with_calls(true).with_debug(debug),
+                        TraceRequirements::none().with_calls(true).with_debug(debug),
                     )
                     .networks(self.evm_opts.networks)
                     .create2_deployer(self.evm_opts.create2_deployer)

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -61,7 +61,7 @@ use foundry_evm::{
     },
     opts::EvmOpts,
     revm::interpreter::InstructionResult,
-    traces::{TraceMode, Traces},
+    traces::{TraceRequirements, Traces},
 };
 use foundry_evm_networks::NetworkConfigs;
 use foundry_wallets::MultiWalletOpts;
@@ -869,7 +869,9 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
             .inspectors(|stack| {
                 stack
                     .logs(self.config.live_logs)
-                    .trace_mode(if debug { TraceMode::Debug } else { TraceMode::Call })
+                    .trace_requirements(
+                        TraceRequirements::default().with_calls(true).with_debug(debug),
+                    )
                     .networks(self.evm_opts.networks)
                     .create2_deployer(self.evm_opts.create2_deployer)
             })

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -870,7 +870,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
                 stack
                     .logs(self.config.live_logs)
                     .trace_requirements(
-                        TraceRequirements::default().with_calls(true).with_debug(debug),
+                        TraceRequirements::empty().with_calls(true).with_debug(debug),
                     )
                     .networks(self.evm_opts.networks)
                     .create2_deployer(self.evm_opts.create2_deployer)

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -311,7 +311,7 @@ where
         (evm_env.clone(), tx_env.clone()),
         fork,
         Some(fork_config.evm_version),
-        TraceRequirements::empty().with_calls(true),
+        TraceRequirements::none().with_calls(true),
         networks,
         create2_deployer,
         None,

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -311,7 +311,7 @@ where
         (evm_env.clone(), tx_env.clone()),
         fork,
         Some(fork_config.evm_version),
-        TraceRequirements::default().with_calls(true),
+        TraceRequirements::empty().with_calls(true),
         networks,
         create2_deployer,
         None,

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -27,7 +27,7 @@ use foundry_evm::{
     },
     executors::TracingExecutor,
     opts::EvmOpts,
-    traces::TraceMode,
+    traces::TraceRequirements,
     utils::{apply_chain_and_block_specific_env_changes, block_env_from_header},
 };
 use foundry_evm_networks::NetworkConfigs;
@@ -311,7 +311,7 @@ where
         (evm_env.clone(), tx_env.clone()),
         fork,
         Some(fork_config.evm_version),
-        TraceMode::Call,
+        TraceRequirements::default().with_calls(true),
         networks,
         create2_deployer,
         None,


### PR DESCRIPTION
Replace the old TraceMode ordering with TraceRequirements as the tracing API. Callers now compose calls, step granularity, snapshots, state diffs, verbosity, and internal decode needs from TraceRequirements::none().with_* instead of selecting from a linear mode enum.

This keeps independent trace requirements independent: all-step recording can be requested without enabling debugger snapshots, internal function decoding can request only the jump data it needs, and high verbosity can add call or state-diff data without downgrading richer requirements.
