### PR TITLE
feat: add symbolic benchmarks

### DIFF
--- a/.github/scripts/combine-benchmarks.sh
+++ b/.github/scripts/combine-benchmarks.sh
@@ -13,6 +13,7 @@ mkdir -p "$OUTPUT_DIR"
 declare -A BENCHMARK_FILES=(
     ["forge_test_bench.md"]="Forge Test"
     ["forge_isolate_test_bench.md"]="Forge Test (Isolated)"
+    ["forge_symbolic_bench.md"]="Forge Symbolic Test"
     ["forge_build_bench.md"]="Forge Build"
     ["forge_coverage_bench.md"]="Forge Coverage"
 )
@@ -126,7 +127,7 @@ EOF
 FIRST_FILE=1
 SYSTEM_INFO=""
 
-for bench_file in "forge_test_bench.md" "forge_isolate_test_bench.md" "forge_build_bench.md" "forge_coverage_bench.md"; do
+for bench_file in "forge_test_bench.md" "forge_isolate_test_bench.md" "forge_symbolic_bench.md" "forge_build_bench.md" "forge_coverage_bench.md"; do
     if [ -f "$OUTPUT_DIR/$bench_file" ]; then
         echo "Processing $bench_file..."
 

--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config
+          sudo apt-get install -y build-essential pkg-config z3
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
@@ -116,19 +116,6 @@ jobs:
             --repos "$AAVE_V4_REPO" \
             --benchmarks forge_coverage \
             --json-output "stable-${DATE}-forge_coverage.json" \
-            --verbose
-
-      - name: Run forge symbolic benchmarks (stable)
-        continue-on-error: true
-        env:
-          FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions stable \
-            --repos "$SYMBOLIC_REPOS" \
-            --benchmarks forge_symbolic_test \
-            --json-output "stable-${DATE}-forge_symbolic.json" \
             --verbose
 
       # --- Nightly benchmarks ---

--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -11,7 +11,8 @@ env:
   AAVE_V4_REPO: "aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35"
   SYMBOLIC_REPOS: >-
     Vectorized/solady:v0.1.26,
-    SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5
+    SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5,
+    farcasterxyz/contracts:3f37e21db8e9c6319b4a3d5f62b1c514ef01c36b
   RUSTC_WRAPPER: "sccache"
 
 jobs:

--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -118,6 +118,19 @@ jobs:
             --json-output "stable-${DATE}-forge_coverage.json" \
             --verbose
 
+      - name: Run forge symbolic benchmarks (stable)
+        continue-on-error: true
+        env:
+          FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ./target/release/foundry-bench --output-dir ./benches \
+            --versions stable \
+            --repos "$SYMBOLIC_REPOS" \
+            --benchmarks forge_symbolic_test \
+            --json-output "stable-${DATE}-forge_symbolic.json" \
+            --verbose
+
       # --- Nightly benchmarks ---
 
       - name: Run forge test benchmarks (nightly)

--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   AAVE_V4_REPO: "aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35"
+  SOLADY_SYMBOLIC_REPO: "Vectorized/solady:v0.1.26"
   RUSTC_WRAPPER: "sccache"
 
 jobs:
@@ -115,6 +116,19 @@ jobs:
             --json-output "stable-${DATE}-forge_coverage.json" \
             --verbose
 
+      - name: Run forge symbolic benchmarks (stable)
+        continue-on-error: true
+        env:
+          FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ./target/release/foundry-bench --output-dir ./benches \
+            --versions stable \
+            --repos "$SOLADY_SYMBOLIC_REPO" \
+            --benchmarks forge_symbolic_test \
+            --json-output "stable-${DATE}-forge_symbolic.json" \
+            --verbose
+
       # --- Nightly benchmarks ---
 
       - name: Run forge test benchmarks (nightly)
@@ -167,6 +181,19 @@ jobs:
             --repos "$AAVE_V4_REPO" \
             --benchmarks forge_coverage \
             --json-output "nightly-${DATE}-forge_coverage.json" \
+            --verbose
+
+      - name: Run forge symbolic benchmarks (nightly)
+        continue-on-error: true
+        env:
+          FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          ./target/release/foundry-bench --output-dir ./benches \
+            --versions nightly \
+            --repos "$SOLADY_SYMBOLIC_REPO" \
+            --benchmarks forge_symbolic_test \
+            --json-output "nightly-${DATE}-forge_symbolic.json" \
             --verbose
 
       - name: Merge benchmark JSON results

--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -9,7 +9,9 @@ on:
 
 env:
   AAVE_V4_REPO: "aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35"
-  SOLADY_SYMBOLIC_REPO: "Vectorized/solady:v0.1.26"
+  SYMBOLIC_REPOS: >-
+    Vectorized/solady:v0.1.26,
+    SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5
   RUSTC_WRAPPER: "sccache"
 
 jobs:
@@ -124,7 +126,7 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           ./target/release/foundry-bench --output-dir ./benches \
             --versions stable \
-            --repos "$SOLADY_SYMBOLIC_REPO" \
+            --repos "$SYMBOLIC_REPOS" \
             --benchmarks forge_symbolic_test \
             --json-output "stable-${DATE}-forge_symbolic.json" \
             --verbose
@@ -191,7 +193,7 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           ./target/release/foundry-bench --output-dir ./benches \
             --versions nightly \
-            --repos "$SOLADY_SYMBOLIC_REPO" \
+            --repos "$SYMBOLIC_REPOS" \
             --benchmarks forge_symbolic_test \
             --json-output "nightly-${DATE}-forge_symbolic.json" \
             --verbose

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,6 +34,9 @@ env:
     uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest',
     sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
 
+  SYMBOLIC_REPOS: >-
+    Vectorized/solady:v0.1.26
+
   BUILD_REPOS: >-
     ithacaxyz/account:v0.5.7,
     vectorized/solady:v0.1.26,
@@ -116,6 +119,19 @@ jobs:
             --output-file forge_isolate_test_bench.md \
             --verbose
 
+      - name: Run forge symbolic benchmarks
+        env:
+          FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+          VERSIONS: ${{ github.event.inputs.versions || env.DEFAULT_VERSIONS }}
+          REPOS: ${{ github.event.inputs.repos || env.SYMBOLIC_REPOS }}
+        run: |
+          ./target/release/foundry-bench --output-dir ./benches \
+            --versions "$VERSIONS" \
+            --repos "$REPOS" \
+            --benchmarks forge_symbolic_test \
+            --output-file forge_symbolic_bench.md \
+            --verbose
+
       - name: Run forge build benchmarks
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
@@ -155,6 +171,7 @@ jobs:
           path: |
             benches/forge_test_bench.md
             benches/forge_isolate_test_bench.md
+            benches/forge_symbolic_bench.md
             benches/forge_build_bench.md
             benches/forge_coverage_bench.md
             benches/LATEST.md

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -126,13 +126,8 @@ jobs:
           VERSIONS: ${{ github.event.inputs.versions || env.DEFAULT_VERSIONS }}
           REPOS: ${{ github.event.inputs.repos || env.SYMBOLIC_REPOS }}
         run: |
-          SYMBOLIC_VERSIONS=$(printf '%s\n' "$VERSIONS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^(local|nightly)$' | paste -sd, -)
-          if [ -z "$SYMBOLIC_VERSIONS" ]; then
-            echo "Skipping symbolic benchmarks: no symbolic-capable versions in '$VERSIONS'"
-            exit 0
-          fi
           ./target/release/foundry-bench --output-dir ./benches \
-            --versions "$SYMBOLIC_VERSIONS" \
+            --versions "$VERSIONS" \
             --repos "$REPOS" \
             --benchmarks forge_symbolic_test \
             --output-file forge_symbolic_bench.md \

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config
+          sudo apt-get install -y build-essential pkg-config z3
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
@@ -126,8 +126,13 @@ jobs:
           VERSIONS: ${{ github.event.inputs.versions || env.DEFAULT_VERSIONS }}
           REPOS: ${{ github.event.inputs.repos || env.SYMBOLIC_REPOS }}
         run: |
+          SYMBOLIC_VERSIONS=$(printf '%s\n' "$VERSIONS" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '^(local|nightly)$' | paste -sd, -)
+          if [ -z "$SYMBOLIC_VERSIONS" ]; then
+            echo "Skipping symbolic benchmarks: no symbolic-capable versions in '$VERSIONS'"
+            exit 0
+          fi
           ./target/release/foundry-bench --output-dir ./benches \
-            --versions "$VERSIONS" \
+            --versions "$SYMBOLIC_VERSIONS" \
             --repos "$REPOS" \
             --benchmarks forge_symbolic_test \
             --output-file forge_symbolic_bench.md \

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,7 +36,8 @@ env:
 
   SYMBOLIC_REPOS: >-
     Vectorized/solady:v0.1.26,
-    SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5
+    SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5,
+    farcasterxyz/contracts:3f37e21db8e9c6319b4a3d5f62b1c514ef01c36b
 
   BUILD_REPOS: >-
     ithacaxyz/account:v0.5.7,

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,7 +35,8 @@ env:
     sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
 
   SYMBOLIC_REPOS: >-
-    Vectorized/solady:v0.1.26
+    Vectorized/solady:v0.1.26,
+    SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5
 
   BUILD_REPOS: >-
     ithacaxyz/account:v0.5.7,

--- a/benches/README.md
+++ b/benches/README.md
@@ -68,7 +68,7 @@ foundry-bench --benchmarks forge_fuzz_test
 foundry-bench --benchmarks forge_coverage
 
 # Run focused symbolic tests and report solver counters
-foundry-bench --repos Vectorized/solady:v0.1.26 --benchmarks forge_symbolic_test
+foundry-bench --repos Vectorized/solady:v0.1.26,SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5 --benchmarks forge_symbolic_test
 
 # Combine options
 foundry-bench \

--- a/benches/README.md
+++ b/benches/README.md
@@ -67,6 +67,9 @@ foundry-bench --benchmarks forge_fuzz_test
 # Run coverage benchmark
 foundry-bench --benchmarks forge_coverage
 
+# Run focused symbolic tests and report solver counters
+foundry-bench --repos Vectorized/solady:v0.1.26 --benchmarks forge_symbolic_test
+
 # Combine options
 foundry-bench \
   --versions stable,nightly \
@@ -147,6 +150,7 @@ The artifact bundle exposes:
 - `forge_fuzz_test` - Benchmarks non-isolated `forge test` with only fuzz tests (tests with parameters)
 - `forge_coverage` - Benchmarks `forge coverage --ir-minimum` command across repos
 - `forge_isolate_test` - Benchmarks isolated `forge test` command across repos
+- `forge_symbolic_test` - Benchmarks focused `forge test --symbolic --json` checks and reports symbolic solver counters
 
 ## Configuration
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -68,7 +68,7 @@ foundry-bench --benchmarks forge_fuzz_test
 foundry-bench --benchmarks forge_coverage
 
 # Run focused symbolic tests and report solver counters
-foundry-bench --repos Vectorized/solady:v0.1.26,SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5 --benchmarks forge_symbolic_test
+foundry-bench --repos Vectorized/solady:v0.1.26,SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5,farcasterxyz/contracts:3f37e21db8e9c6319b4a3d5f62b1c514ef01c36b --benchmarks forge_symbolic_test
 
 # Combine options
 foundry-bench \

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -22,10 +22,18 @@ pub const RUNS: u32 = 5;
 const SOLADY_SYMBOLIC_MATCH_TEST: &str = concat!(
     "check_(",
     "SaturatingAddEquivalence|",
+    "SaturatingMulEquivalence|",
     "HasDuplicateHashmapCapacityTrickEquivalence|",
     "IsPermit2AndValueIsNotInfinityTrickEquivalence|",
     "IsNotUint256MaxTrickEquivalence|",
-    "DelayRestriction",
+    "DelayRestriction|",
+    "OperationStateDifferentialTrick|",
+    "CarryBoundsTrick|",
+    "SafeCastInt256ToIntTrickEquivalence|",
+    "P256Normalized|",
+    "AuxPackEquivalence|",
+    "EcrecoverTrickEquivalence|",
+    "EcrecoverLoopTrick",
     ")"
 );
 const ANGSTROM_SYMBOLIC_MATCH_TEST: &str = "check_matchesSolady_fullMulX128";

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -28,6 +28,13 @@ const SOLADY_SYMBOLIC_MATCH_TEST: &str = concat!(
     "DelayRestriction",
     ")"
 );
+const ANGSTROM_SYMBOLIC_MATCH_TEST: &str = "check_matchesSolady_fullMulX128";
+const ANGSTROM_SYMBOLIC_MATCH_PATH: &str = "test/libraries/X128MathLib.t.sol";
+
+struct SymbolicBenchmarkSpec {
+    build_command: String,
+    test_command: String,
+}
 
 /// Configuration for repositories to benchmark
 #[derive(Debug, Clone)]
@@ -195,6 +202,35 @@ impl BenchmarkProject {
         match self.extra_args.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
             Some(extra) => format!("{base} {extra}"),
             None => base.to_string(),
+        }
+    }
+
+    fn symbolic_benchmark_spec(&self) -> SymbolicBenchmarkSpec {
+        let name = self.name.to_ascii_lowercase();
+        if name == "solady" || name.ends_with("-solady") {
+            return SymbolicBenchmarkSpec {
+                build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge build".to_string(),
+                test_command: format!(
+                    "FOUNDRY_LINT_LINT_ON_BUILD=false forge test --symbolic --json \
+                     --match-test '{SOLADY_SYMBOLIC_MATCH_TEST}'"
+                ),
+            };
+        }
+        if name == "angstrom" || name.ends_with("-angstrom") {
+            return SymbolicBenchmarkSpec {
+                build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge build --root contracts"
+                    .to_string(),
+                test_command: format!(
+                    "FOUNDRY_LINT_LINT_ON_BUILD=false forge test --root contracts --symbolic \
+                     --json --symbolic-timeout 5 --match-path {ANGSTROM_SYMBOLIC_MATCH_PATH} \
+                     --match-test {ANGSTROM_SYMBOLIC_MATCH_TEST}"
+                ),
+            };
+        }
+        SymbolicBenchmarkSpec {
+            build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge build".to_string(),
+            test_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge test --symbolic --json"
+                .to_string(),
         }
     }
 
@@ -438,21 +474,19 @@ impl BenchmarkProject {
         runs: u32,
         verbose: bool,
     ) -> Result<HyperfineResult> {
-        let name = self.name.to_ascii_lowercase();
-        let base = if name == "solady" || name.ends_with("-solady") {
-            format!("forge test --symbolic --json --match-test '{SOLADY_SYMBOLIC_MATCH_TEST}'")
-        } else {
-            "forge test --symbolic --json".to_string()
-        };
-        let command = self.cmd(&base);
+        let spec = self.symbolic_benchmark_spec();
+        let command = self.cmd(&spec.test_command);
 
         let status = Command::new("bash")
             .current_dir(&self.root_path)
-            .args(["-lc", "forge build"])
+            .args(["-lc", &spec.build_command])
             .status()
             .wrap_err("Failed to build project before symbolic benchmark")?;
         if !status.success() {
-            eyre::bail!("forge build failed before symbolic benchmark");
+            eyre::bail!(
+                "forge build failed before symbolic benchmark with command: {}",
+                spec.build_command
+            );
         }
 
         let mut times = Vec::with_capacity(runs as usize);
@@ -473,12 +507,23 @@ impl BenchmarkProject {
             if verbose {
                 let _ = sh_println!("{}", String::from_utf8_lossy(&output.stderr));
             }
-            if !output.status.success() {
-                let _ = sh_eprintln!("{}", String::from_utf8_lossy(&output.stderr));
-                eyre::bail!("forge symbolic benchmark failed with command: {}", command);
-            }
 
-            summaries.push(parse_symbolic_benchmark_summary(&output.stdout)?);
+            let summary = match parse_symbolic_benchmark_summary(&output.stdout) {
+                Ok(summary) => summary,
+                Err(err) => {
+                    if !output.status.success() {
+                        let _ = sh_eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+                        eyre::bail!(
+                            "forge symbolic benchmark failed with command: {command}; {err}"
+                        );
+                    }
+                    return Err(err);
+                }
+            };
+            if !output.status.success() && verbose {
+                let _ = sh_eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+            }
+            summaries.push(summary);
         }
 
         let symbolic = summaries
@@ -546,6 +591,15 @@ fn parse_symbolic_benchmark_summary(stdout: &[u8]) -> Result<SymbolicBenchmarkSu
                 continue;
             };
             summary.tests += 1;
+            let status = result.get("status").and_then(Value::as_str).unwrap_or_default();
+            let reason = result.get("reason").and_then(Value::as_str).unwrap_or_default();
+            if status == "Success" {
+                summary.passed += 1;
+            } else if reason.contains("incomplete symbolic execution") {
+                summary.incomplete += 1;
+            } else {
+                summary.failed += 1;
+            }
             summary.paths += metric(stats, "paths");
             summary.solver_queries += metric(stats, "solver_queries");
             summary.smt_queries += metric(stats, "smt_queries");
@@ -734,19 +788,46 @@ mod tests {
                                 "smt_build_time_ms": 1,
                                 "smt_max_query_time_ms": 9
                             }
-                        }
+                        },
+                        "status": "Success"
+                    },
+                    "check_two(uint256)": {
+                        "symbolic": {
+                            "solver": {
+                                "stats": {
+                                    "paths": 0,
+                                    "solver_queries": 1,
+                                    "smt_queries": 1,
+                                    "sat_queries": 1,
+                                    "model_queries": 0,
+                                    "sat_cache_hits": 0,
+                                    "model_cache_hits": 0,
+                                    "heuristic_witnesses": 0,
+                                    "solver_time_ms": 5,
+                                    "smt_input_bytes": 10,
+                                    "smt_max_query_bytes": 10,
+                                    "smt_build_time_ms": 0,
+                                    "smt_max_query_time_ms": 5
+                                }
+                            }
+                        },
+                        "status": "Failure",
+                        "reason": "incomplete symbolic execution (Timeout): solver returned unknown"
                     }
                 }
             }
         }"#;
 
         let summary = parse_symbolic_benchmark_summary(stdout).unwrap();
-        assert_eq!(summary.tests, 1);
+        assert_eq!(summary.tests, 2);
+        assert_eq!(summary.passed, 1);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.incomplete, 1);
         assert_eq!(summary.paths, 2);
-        assert_eq!(summary.smt_queries, 2);
+        assert_eq!(summary.smt_queries, 3);
         assert_eq!(summary.sat_cache_hits, 1);
-        assert_eq!(summary.solver_time_ms, 12);
-        assert_eq!(summary.smt_input_bytes, 1024);
+        assert_eq!(summary.solver_time_ms, 17);
+        assert_eq!(summary.smt_input_bytes, 1034);
         assert_eq!(summary.smt_max_query_bytes, 600);
         assert_eq!(summary.smt_build_time_ms, 1);
         assert_eq!(summary.smt_max_query_time_ms, 9);

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,21 +1,33 @@
 //! Foundry benchmark runner.
 
-use crate::results::{HyperfineOutput, HyperfineResult};
+use crate::results::{HyperfineOutput, HyperfineResult, SymbolicBenchmarkSummary};
 use eyre::{Result, WrapErr};
 use foundry_common::{sh_eprintln, sh_println};
 use foundry_compilers::project_util::TempProject;
 use foundry_test_utils::util::clone_remote;
 use once_cell::sync::Lazy;
+use serde_json::Value;
 use std::{
     path::{Path, PathBuf},
     process::Command,
     str::FromStr,
+    time::Instant,
 };
 
 pub mod results;
 
 /// Default number of runs for benchmarks
 pub const RUNS: u32 = 5;
+
+const SOLADY_SYMBOLIC_MATCH_TEST: &str = concat!(
+    "check_(",
+    "SaturatingAddEquivalence|",
+    "HasDuplicateHashmapCapacityTrickEquivalence|",
+    "IsPermit2AndValueIsNotInfinityTrickEquivalence|",
+    "IsNotUint256MaxTrickEquivalence|",
+    "DelayRestriction",
+    ")"
+);
 
 /// Configuration for repositories to benchmark
 #[derive(Debug, Clone)]
@@ -419,6 +431,77 @@ impl BenchmarkProject {
         )
     }
 
+    /// Benchmark focused symbolic checks and collect symbolic solver counters.
+    pub fn bench_forge_symbolic_test(
+        &self,
+        _version: &str,
+        runs: u32,
+        verbose: bool,
+    ) -> Result<HyperfineResult> {
+        let name = self.name.to_ascii_lowercase();
+        let base = if name == "solady" || name.ends_with("-solady") {
+            format!("forge test --symbolic --json --match-test '{SOLADY_SYMBOLIC_MATCH_TEST}'")
+        } else {
+            "forge test --symbolic --json".to_string()
+        };
+        let command = self.cmd(&base);
+
+        let status = Command::new("bash")
+            .current_dir(&self.root_path)
+            .args(["-lc", "forge build"])
+            .status()
+            .wrap_err("Failed to build project before symbolic benchmark")?;
+        if !status.success() {
+            eyre::bail!("forge build failed before symbolic benchmark");
+        }
+
+        let mut times = Vec::with_capacity(runs as usize);
+        let mut summaries = Vec::with_capacity(runs as usize);
+        let mut exit_codes = Vec::with_capacity(runs as usize);
+
+        for _ in 0..runs {
+            let started = Instant::now();
+            let output = Command::new("bash")
+                .current_dir(&self.root_path)
+                .args(["-lc", &command])
+                .output()
+                .wrap_err("Failed to run forge symbolic benchmark")?;
+            let elapsed = started.elapsed().as_secs_f64();
+            times.push(elapsed);
+            exit_codes.push(output.status.code().unwrap_or(-1));
+
+            if verbose {
+                let _ = sh_println!("{}", String::from_utf8_lossy(&output.stderr));
+            }
+            if !output.status.success() {
+                let _ = sh_eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+                eyre::bail!("forge symbolic benchmark failed with command: {}", command);
+            }
+
+            summaries.push(parse_symbolic_benchmark_summary(&output.stdout)?);
+        }
+
+        let symbolic = summaries
+            .get(median_index(&times))
+            .cloned()
+            .ok_or_else(|| eyre::eyre!("symbolic benchmark produced no runs"))?;
+
+        Ok(HyperfineResult {
+            command,
+            mean: mean(&times),
+            stddev: stddev(&times),
+            median: median(&times),
+            user: 0.0,
+            system: 0.0,
+            min: times.iter().copied().reduce(f64::min).unwrap_or_default(),
+            max: times.iter().copied().reduce(f64::max).unwrap_or_default(),
+            times,
+            exit_codes: Some(exit_codes),
+            parameters: None,
+            symbolic: Some(symbolic),
+        })
+    }
+
     /// Get the root path of the project
     pub fn root(&self) -> &Path {
         &self.root_path
@@ -439,9 +522,83 @@ impl BenchmarkProject {
             "forge_fuzz_test" => self.bench_forge_fuzz_test(version, runs, verbose),
             "forge_coverage" => self.bench_forge_coverage(version, runs, verbose),
             "forge_isolate_test" => self.bench_forge_isolate_test(version, runs, verbose),
+            "forge_symbolic_test" => self.bench_forge_symbolic_test(version, runs, verbose),
             _ => eyre::bail!("Unknown benchmark: {}", benchmark),
         }
     }
+}
+
+fn parse_symbolic_benchmark_summary(stdout: &[u8]) -> Result<SymbolicBenchmarkSummary> {
+    let json: Value =
+        serde_json::from_slice(stdout).wrap_err("Invalid forge test --json output")?;
+    let suites = json.as_object().ok_or_else(|| eyre::eyre!("Expected JSON object"))?;
+    let mut summary = SymbolicBenchmarkSummary::default();
+
+    for suite in suites.values() {
+        let Some(results) = suite.get("test_results").and_then(Value::as_object) else {
+            continue;
+        };
+        for result in results.values() {
+            let Some(stats) = result
+                .pointer("/symbolic/solver/stats")
+                .or_else(|| result.pointer("/kind/Symbolic"))
+            else {
+                continue;
+            };
+            summary.tests += 1;
+            summary.paths += metric(stats, "paths");
+            summary.solver_queries += metric(stats, "solver_queries");
+            summary.smt_queries += metric(stats, "smt_queries");
+            summary.sat_queries += metric(stats, "sat_queries");
+            summary.model_queries += metric(stats, "model_queries");
+            summary.sat_cache_hits += metric(stats, "sat_cache_hits");
+            summary.model_cache_hits += metric(stats, "model_cache_hits");
+            summary.heuristic_witnesses += metric(stats, "heuristic_witnesses");
+            summary.solver_time_ms += metric(stats, "solver_time_ms");
+            summary.smt_input_bytes += metric(stats, "smt_input_bytes");
+            summary.smt_max_query_bytes =
+                summary.smt_max_query_bytes.max(metric(stats, "smt_max_query_bytes"));
+            summary.smt_build_time_ms += metric(stats, "smt_build_time_ms");
+            summary.smt_max_query_time_ms =
+                summary.smt_max_query_time_ms.max(metric(stats, "smt_max_query_time_ms"));
+        }
+    }
+
+    if summary.tests == 0 {
+        eyre::bail!("forge symbolic benchmark produced no symbolic test results");
+    }
+    Ok(summary)
+}
+
+fn metric(stats: &Value, key: &str) -> u64 {
+    stats.get(key).and_then(Value::as_u64).unwrap_or_default()
+}
+
+fn mean(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().sum::<f64>() / values.len() as f64
+}
+
+fn median(values: &[f64]) -> f64 {
+    values.get(median_index(values)).copied().unwrap_or_default()
+}
+
+fn median_index(values: &[f64]) -> usize {
+    let mut indices = (0..values.len()).collect::<Vec<_>>();
+    indices.sort_by(|&left, &right| values[left].total_cmp(&values[right]));
+    indices.get(indices.len() / 2).copied().unwrap_or_default()
+}
+
+fn stddev(values: &[f64]) -> Option<f64> {
+    if values.len() < 2 {
+        return None;
+    }
+    let mean = mean(values);
+    let variance =
+        values.iter().map(|value| (value - mean).powi(2)).sum::<f64>() / values.len() as f64;
+    Some(variance.sqrt())
 }
 
 /// The workspace root, embedded at compile time.
@@ -548,5 +705,50 @@ pub fn get_forge_version_details() -> Result<String> {
     } else {
         // Fallback to just the first line if format is unexpected
         Ok(lines.first().unwrap_or(&"unknown").to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_symbolic_benchmark_summary() {
+        let stdout = br#"{
+            "test/Foo.t.sol:FooTest": {
+                "test_results": {
+                    "check_one(uint256)": {
+                        "kind": {
+                            "Symbolic": {
+                                "paths": 2,
+                                "solver_queries": 3,
+                                "smt_queries": 2,
+                                "sat_queries": 4,
+                                "model_queries": 0,
+                                "sat_cache_hits": 1,
+                                "model_cache_hits": 0,
+                                "heuristic_witnesses": 0,
+                                "solver_time_ms": 12,
+                                "smt_input_bytes": 1024,
+                                "smt_max_query_bytes": 600,
+                                "smt_build_time_ms": 1,
+                                "smt_max_query_time_ms": 9
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+
+        let summary = parse_symbolic_benchmark_summary(stdout).unwrap();
+        assert_eq!(summary.tests, 1);
+        assert_eq!(summary.paths, 2);
+        assert_eq!(summary.smt_queries, 2);
+        assert_eq!(summary.sat_cache_hits, 1);
+        assert_eq!(summary.solver_time_ms, 12);
+        assert_eq!(summary.smt_input_bytes, 1024);
+        assert_eq!(summary.smt_max_query_bytes, 600);
+        assert_eq!(summary.smt_build_time_ms, 1);
+        assert_eq!(summary.smt_max_query_time_ms, 9);
     }
 }

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -38,6 +38,64 @@ const SOLADY_SYMBOLIC_MATCH_TEST: &str = concat!(
 );
 const ANGSTROM_SYMBOLIC_MATCH_TEST: &str = "check_matchesSolady_fullMulX128";
 const ANGSTROM_SYMBOLIC_MATCH_PATH: &str = "test/libraries/X128MathLib.t.sol";
+const FARCASTER_SYMBOLIC_MATCH_PATH: &str = "test/FarcasterNativeSymbolic.t.sol";
+const FARCASTER_SYMBOLIC_BENCHMARK_TEST: &str = r#"// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+import {Migration} from "../src/abstract/Migration.sol";
+
+contract MigrationHarness is Migration {
+    constructor(uint24 gracePeriod, address migrator, address initialOwner)
+        Migration(gracePeriod, migrator, initialOwner)
+    {}
+}
+
+contract FarcasterNativeSymbolicTest is Test {
+    function check_migrateOnlyMigrator(
+        uint24 gracePeriod,
+        address migrator,
+        address initialOwner,
+        address caller,
+        uint40 timestamp
+    ) public {
+        vm.assume(timestamp != 0);
+
+        MigrationHarness migration = new MigrationHarness(gracePeriod, migrator, initialOwner);
+
+        vm.warp(timestamp);
+        vm.prank(caller);
+        (bool success,) = address(migration).call(abi.encodeCall(Migration.migrate, ()));
+
+        assert(success == (caller == migrator));
+        if (success) {
+            assert(migration.isMigrated());
+            assert(migration.migratedAt() == timestamp);
+        }
+    }
+
+    function check_setMigratorOnlyOwner(
+        uint24 gracePeriod,
+        address migrator,
+        address initialOwner,
+        address caller,
+        address nextMigrator
+    ) public {
+        MigrationHarness migration = new MigrationHarness(gracePeriod, migrator, initialOwner);
+
+        vm.prank(caller);
+        (bool success,) =
+            address(migration).call(abi.encodeCall(Migration.setMigrator, (nextMigrator)));
+
+        assert(success == (caller == initialOwner));
+        if (success) {
+            assert(migration.migrator() == nextMigrator);
+        } else {
+            assert(migration.migrator() == migrator);
+        }
+    }
+}
+"#;
 
 struct SymbolicBenchmarkSpec {
     build_command: String,
@@ -192,6 +250,8 @@ impl BenchmarkProject {
             }
         }
 
+        Self::install_symbolic_benchmark_fixtures(&root_path, config)?;
+
         // Git submodules are already cloned via --recursive flag
         // But npm dependencies still need to be installed
         Self::install_npm_dependencies(&root_path)?;
@@ -235,11 +295,34 @@ impl BenchmarkProject {
                 ),
             };
         }
+        if name == "farcasterxyz-contracts" || name == "farcaster-contracts" {
+            return SymbolicBenchmarkSpec {
+                build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge build".to_string(),
+                test_command: format!(
+                    "FOUNDRY_LINT_LINT_ON_BUILD=false forge test --symbolic --json \
+                     --symbolic-timeout 5 --match-path '{FARCASTER_SYMBOLIC_MATCH_PATH}' \
+                     --match-test 'check_'"
+                ),
+            };
+        }
         SymbolicBenchmarkSpec {
             build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge build".to_string(),
             test_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge test --symbolic --json"
                 .to_string(),
         }
+    }
+
+    fn install_symbolic_benchmark_fixtures(root: &Path, config: &RepoConfig) -> Result<()> {
+        if config.org.eq_ignore_ascii_case("farcasterxyz") && config.repo == "contracts" {
+            // Farcaster's checked-in Halmos tests create symbolic values in setUp,
+            // which native forge symbolic does not produce benchmark counters for.
+            std::fs::write(
+                root.join(FARCASTER_SYMBOLIC_MATCH_PATH),
+                FARCASTER_SYMBOLIC_BENCHMARK_TEST,
+            )
+            .wrap_err("Failed to install Farcaster symbolic benchmark test")?;
+        }
+        Ok(())
     }
 
     /// Install npm dependencies if package.json exists

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -10,13 +10,14 @@ use foundry_common::sh_println;
 use rayon::prelude::*;
 use std::{fs, path::PathBuf, process::Command, sync::Mutex};
 
-const ALL_BENCHMARKS: [&str; 6] = [
+const ALL_BENCHMARKS: [&str; 7] = [
     "forge_test",
     "forge_build_no_cache",
     "forge_build_with_cache",
     "forge_fuzz_test",
     "forge_coverage",
     "forge_isolate_test",
+    "forge_symbolic_test",
 ];
 
 /// Foundry Benchmark Runner
@@ -50,7 +51,8 @@ struct Cli {
     json_output: Option<PathBuf>,
 
     /// Run only specific benchmarks (comma-separated:
-    /// forge_test,forge_build_no_cache,forge_build_with_cache,forge_fuzz_test,forge_coverage)
+    /// forge_test,forge_build_no_cache,forge_build_with_cache,forge_fuzz_test,forge_coverage,
+    /// forge_symbolic_test)
     #[clap(long, value_delimiter = ',')]
     benchmarks: Option<Vec<String>>,
 

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -2,8 +2,7 @@ use clap::Parser;
 use eyre::{Result, WrapErr};
 use foundry_bench::{
     BENCHMARK_REPOS, BenchmarkProject, FOUNDRY_VERSIONS, RUNS, RepoConfig, get_forge_version,
-    get_forge_version_details, install_local_version,
-    results::{BenchmarkResults, HyperfineResult},
+    get_forge_version_details, install_local_version, results::BenchmarkResults,
     switch_foundry_version,
 };
 use foundry_common::sh_println;
@@ -75,6 +74,20 @@ static FOUNDRY_LOCK: Mutex<()> = Mutex::new(());
 fn switch_version_safe(version: &str) -> Result<()> {
     let _lock = FOUNDRY_LOCK.lock().unwrap();
     switch_foundry_version(version)
+}
+
+fn forge_test_supports_symbolic() -> Result<bool> {
+    let output = Command::new("forge")
+        .args(["test", "--help"])
+        .output()
+        .wrap_err("Failed to run forge test --help")?;
+
+    if !output.status.success() {
+        eyre::bail!("forge test --help failed");
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).contains("--symbolic")
+        || String::from_utf8_lossy(&output.stderr).contains("--symbolic"))
 }
 
 #[allow(unused_must_use)]
@@ -176,47 +189,62 @@ fn main() -> Result<()> {
         let version_details = get_forge_version_details()?;
         results.add_version_details(version, version_details);
 
+        let supports_symbolic_test = if benchmarks.iter().any(|b| b == "forge_symbolic_test") {
+            forge_test_supports_symbolic()?
+        } else {
+            false
+        };
+
         sh_println!("Running benchmark tasks for version {version}...");
 
         // Run all benchmarks sequentially
-        let version_results = benchmark_tasks
-            .iter()
-            .map(|(repo_config, project, benchmark)| -> Result<(String, String, HyperfineResult)> {
-                sh_println!("Running {} on {}/{}", benchmark, repo_config.org, repo_config.repo);
+        let mut version_results = Vec::new();
+        for (repo_config, project, benchmark) in &benchmark_tasks {
+            if benchmark == "forge_symbolic_test" && !supports_symbolic_test {
+                sh_println!(
+                    "Skipping forge_symbolic_test on {}/{} for {version}: active forge does not support --symbolic",
+                    repo_config.org,
+                    repo_config.repo
+                );
+                continue;
+            }
 
-                // Determine runs based on benchmark type
-                let runs = match benchmark.as_str() {
-                    "forge_coverage" => 1, // Coverage runs only once as an exception
-                    _ => RUNS,             // Use default RUNS constant for all other benchmarks
-                };
+            sh_println!("Running {} on {}/{}", benchmark, repo_config.org, repo_config.repo);
 
-                // Run the appropriate benchmark
-                let result = project.run(benchmark, version, runs, cli.verbose);
+            // Determine runs based on benchmark type
+            let runs = match benchmark.as_str() {
+                "forge_coverage" => 1, // Coverage runs only once as an exception
+                _ => RUNS,             // Use default RUNS constant for all other benchmarks
+            };
 
-                match result {
-                    Ok(hyperfine_result) => {
-                        sh_println!(
-                            "  {} on {}/{}: {:.3}s ± {:.3}s",
-                            benchmark,
-                            repo_config.org,
-                            repo_config.repo,
-                            hyperfine_result.mean,
-                            hyperfine_result.stddev.unwrap_or(0.0)
-                        );
-                        Ok((repo_config.name.clone(), benchmark.clone(), hyperfine_result))
-                    }
-                    Err(e) => {
-                        eyre::bail!(
-                            "Benchmark {} failed for {}/{}: {}",
-                            benchmark,
-                            repo_config.org,
-                            repo_config.repo,
-                            e
-                        );
-                    }
+            // Run the appropriate benchmark
+            match project.run(benchmark, version, runs, cli.verbose) {
+                Ok(hyperfine_result) => {
+                    sh_println!(
+                        "  {} on {}/{}: {:.3}s ± {:.3}s",
+                        benchmark,
+                        repo_config.org,
+                        repo_config.repo,
+                        hyperfine_result.mean,
+                        hyperfine_result.stddev.unwrap_or(0.0)
+                    );
+                    version_results.push((
+                        repo_config.name.clone(),
+                        benchmark.clone(),
+                        hyperfine_result,
+                    ));
                 }
-            })
-            .collect::<Result<Vec<_>>>()?;
+                Err(e) => {
+                    eyre::bail!(
+                        "Benchmark {} failed for {}/{}: {}",
+                        benchmark,
+                        repo_config.org,
+                        repo_config.repo,
+                        e
+                    );
+                }
+            }
+        }
 
         // Add all collected results to the main results structure
         for (repo_name, benchmark, hyperfine_result) in version_results {

--- a/benches/src/results.rs
+++ b/benches/src/results.rs
@@ -27,6 +27,9 @@ pub struct HyperfineResult {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SymbolicBenchmarkSummary {
     pub tests: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub incomplete: usize,
     pub paths: u64,
     pub solver_queries: u64,
     pub smt_queries: u64,
@@ -262,6 +265,7 @@ fn get_benchmark_cell_content(
         let Some(result) = repo_data.get(repo_name)
     {
         if let Some(symbolic) = &result.symbolic {
+            let status = format_symbolic_status(symbolic);
             let has_smt_size_metrics = symbolic.smt_queries == 0
                 || symbolic.smt_input_bytes != 0
                 || symbolic.smt_max_query_bytes != 0;
@@ -276,9 +280,9 @@ fn get_benchmark_cell_content(
                 "n/a".to_string()
             };
             return format!(
-                "{}<br/>{} tests, solver {}ms<br/>SMT: {} queries, {} total, {} max",
+                "{}<br/>{}, solver {}ms<br/>SMT: {} queries, {} total, {} max",
                 format_duration_seconds(result.mean),
-                symbolic.tests,
+                status,
                 symbolic.solver_time_ms,
                 symbolic.smt_queries,
                 smt_input_bytes,
@@ -303,6 +307,20 @@ pub fn format_benchmark_name(name: &str) -> String {
         _ => name,
     }
     .to_string()
+}
+
+fn format_symbolic_status(symbolic: &SymbolicBenchmarkSummary) -> String {
+    let mut parts = Vec::new();
+    if symbolic.passed != 0 {
+        parts.push(format!("{} pass", symbolic.passed));
+    }
+    if symbolic.incomplete != 0 {
+        parts.push(format!("{} incomplete", symbolic.incomplete));
+    }
+    if symbolic.failed != 0 {
+        parts.push(format!("{} fail", symbolic.failed));
+    }
+    if parts.is_empty() { format!("{} tests", symbolic.tests) } else { parts.join(", ") }
 }
 
 fn format_bytes(bytes: u64) -> String {

--- a/benches/src/results.rs
+++ b/benches/src/results.rs
@@ -19,6 +19,27 @@ pub struct HyperfineResult {
     pub exit_codes: Option<Vec<i32>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<HashMap<String, serde_json::Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbolic: Option<SymbolicBenchmarkSummary>,
+}
+
+/// Aggregated symbolic counters for one benchmark run.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct SymbolicBenchmarkSummary {
+    pub tests: usize,
+    pub paths: u64,
+    pub solver_queries: u64,
+    pub smt_queries: u64,
+    pub sat_queries: u64,
+    pub model_queries: u64,
+    pub sat_cache_hits: u64,
+    pub model_cache_hits: u64,
+    pub heuristic_witnesses: u64,
+    pub solver_time_ms: u64,
+    pub smt_input_bytes: u64,
+    pub smt_max_query_bytes: u64,
+    pub smt_build_time_ms: u64,
+    pub smt_max_query_time_ms: u64,
 }
 
 /// Hyperfine JSON output format
@@ -240,6 +261,30 @@ fn get_benchmark_cell_content(
     // Check if we have data for this repository
         let Some(result) = repo_data.get(repo_name)
     {
+        if let Some(symbolic) = &result.symbolic {
+            let has_smt_size_metrics = symbolic.smt_queries == 0
+                || symbolic.smt_input_bytes != 0
+                || symbolic.smt_max_query_bytes != 0;
+            let smt_input_bytes = if has_smt_size_metrics {
+                format_bytes(symbolic.smt_input_bytes)
+            } else {
+                "n/a".to_string()
+            };
+            let smt_max_query_bytes = if has_smt_size_metrics {
+                format_bytes(symbolic.smt_max_query_bytes)
+            } else {
+                "n/a".to_string()
+            };
+            return format!(
+                "{}<br/>{} tests, solver {}ms<br/>SMT: {} queries, {} total, {} max",
+                format_duration_seconds(result.mean),
+                symbolic.tests,
+                symbolic.solver_time_ms,
+                symbolic.smt_queries,
+                smt_input_bytes,
+                smt_max_query_bytes
+            );
+        }
         return format_duration_seconds(result.mean);
     }
 
@@ -254,9 +299,23 @@ pub fn format_benchmark_name(name: &str) -> String {
         "forge_fuzz_test" => "Forge Fuzz Test",
         "forge_coverage" => "Forge Coverage",
         "forge_isolate_test" => "Forge Test (Isolated)",
+        "forge_symbolic_test" => "Forge Symbolic Test",
         _ => name,
     }
     .to_string()
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = KIB * 1024.0;
+    let bytes = bytes as f64;
+    if bytes < KIB {
+        format!("{bytes:.0} B")
+    } else if bytes < MIB {
+        format!("{:.1} KiB", bytes / KIB)
+    } else {
+        format!("{:.1} MiB", bytes / MIB)
+    }
 }
 
 pub fn format_duration_seconds(seconds: f64) -> String {

--- a/crates/evm/symbolic/assets/symbolic-result.schema.json
+++ b/crates/evm/symbolic/assets/symbolic-result.schema.json
@@ -388,7 +388,11 @@
         "sat_cache_hits": { "type": "integer", "minimum": 0 },
         "model_cache_hits": { "type": "integer", "minimum": 0 },
         "heuristic_witnesses": { "type": "integer", "minimum": 0 },
-        "solver_time_ms": { "type": "integer", "minimum": 0 }
+        "solver_time_ms": { "type": "integer", "minimum": 0 },
+        "smt_input_bytes": { "type": "integer", "minimum": 0 },
+        "smt_max_query_bytes": { "type": "integer", "minimum": 0 },
+        "smt_build_time_ms": { "type": "integer", "minimum": 0 },
+        "smt_max_query_time_ms": { "type": "integer", "minimum": 0 }
       }
     },
     "assumption": {

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -412,6 +412,18 @@ pub struct SymbolicStats {
     /// Wall-clock time spent waiting on backend solver subprocesses, in milliseconds.
     #[serde(default)]
     pub solver_time_ms: u64,
+    /// Total SMT-LIB input bytes sent to backend solver subprocesses.
+    #[serde(default)]
+    pub smt_input_bytes: u64,
+    /// Largest single SMT-LIB query input sent to a backend solver subprocess, in bytes.
+    #[serde(default)]
+    pub smt_max_query_bytes: u64,
+    /// Wall-clock time spent building SMT-LIB query strings, in milliseconds.
+    #[serde(default)]
+    pub smt_build_time_ms: u64,
+    /// Longest single backend solver subprocess query, in milliseconds.
+    #[serde(default)]
+    pub smt_max_query_time_ms: u64,
 }
 
 /// SMT-LIB-backed symbolic executor.

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -180,6 +180,10 @@ pub(crate) struct SmtLibSubprocessSolver {
     model_cache_hits: usize,
     smt_queries: usize,
     solver_time: Duration,
+    smt_input_bytes: u64,
+    smt_max_query_bytes: u64,
+    smt_build_time: Duration,
+    smt_max_query_time: Duration,
 }
 
 impl SmtLibSubprocessSolver {
@@ -208,6 +212,10 @@ impl SmtLibSubprocessSolver {
             model_cache_hits: 0,
             smt_queries: 0,
             solver_time: Duration::ZERO,
+            smt_input_bytes: 0,
+            smt_max_query_bytes: 0,
+            smt_build_time: Duration::ZERO,
+            smt_max_query_time: Duration::ZERO,
         }
     }
 
@@ -234,6 +242,14 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             model_cache_hits: self.model_cache_hits,
             heuristic_witnesses: self.heuristic_witnesses,
             solver_time_ms: self.solver_time.as_millis().try_into().unwrap_or(u64::MAX),
+            smt_input_bytes: self.smt_input_bytes,
+            smt_max_query_bytes: self.smt_max_query_bytes,
+            smt_build_time_ms: self.smt_build_time.as_millis().try_into().unwrap_or(u64::MAX),
+            smt_max_query_time_ms: self
+                .smt_max_query_time
+                .as_millis()
+                .try_into()
+                .unwrap_or(u64::MAX),
         }
     }
 
@@ -545,6 +561,7 @@ impl SmtLibSubprocessSolver {
         model_constraints: &[SymBoolExpr],
     ) -> Result<String, SymbolicError> {
         self.smt_queries += 1;
+        let build_started = Instant::now();
         let mut vars = SymbolicVars::default();
         for constraint in smt_constraints {
             constraint.collect_vars(&mut vars);
@@ -572,6 +589,10 @@ impl SmtLibSubprocessSolver {
         if model {
             smt.push_str("(get-model)\n");
         }
+        let smt_bytes = smt.len().try_into().unwrap_or(u64::MAX);
+        self.smt_input_bytes = self.smt_input_bytes.saturating_add(smt_bytes);
+        self.smt_max_query_bytes = self.smt_max_query_bytes.max(smt_bytes);
+        self.smt_build_time += build_started.elapsed();
         if self.dump_smt {
             let query = self.queries;
             self.emit_diagnostic(format_args!("--- symbolic SMT query {query} ---\n{smt}\n"));
@@ -580,7 +601,9 @@ impl SmtLibSubprocessSolver {
         let started = Instant::now();
         let result =
             run_solver_commands(&commands, &smt, self.timeout, model.then_some(model_constraints));
-        self.solver_time += started.elapsed();
+        let query_time = started.elapsed();
+        self.solver_time += query_time;
+        self.smt_max_query_time = self.smt_max_query_time.max(query_time);
         self.portfolio_scheduler.record(&ordered_commands, &result.summaries);
         if self.dump_smt {
             self.portfolio_diagnostics.record(&result.summaries);

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3234,6 +3234,8 @@ fn is_sat_reuses_cached_unsat_subset() {
     assert_eq!(stats.smt_queries, 1);
     assert_eq!(stats.sat_queries, 2);
     assert_eq!(stats.sat_cache_hits, 1);
+    assert!(stats.smt_input_bytes > 0);
+    assert!(stats.smt_max_query_bytes > 0);
     assert_eq!(counted_solver_invocations(&marker), 1);
     let _ = std::fs::remove_file(&marker);
 }

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -355,6 +355,32 @@ mod tests {
         visit_refs(&counterexample_schema, result_defs, counterexample_defs);
     }
 
+    #[test]
+    fn symbolic_result_schema_includes_solver_stats() {
+        let schema: serde_json::Value = serde_json::from_str(SYMBOLIC_RESULT_SCHEMA_JSON).unwrap();
+        let stats = schema["$defs"]["solver_stats"]["properties"]
+            .as_object()
+            .expect("solver stats properties");
+
+        for key in [
+            "paths",
+            "solver_queries",
+            "smt_queries",
+            "sat_queries",
+            "model_queries",
+            "sat_cache_hits",
+            "model_cache_hits",
+            "heuristic_witnesses",
+            "solver_time_ms",
+            "smt_input_bytes",
+            "smt_max_query_bytes",
+            "smt_build_time_ms",
+            "smt_max_query_time_ms",
+        ] {
+            assert!(stats.contains_key(key), "missing solver stats schema key {key}");
+        }
+    }
+
     fn assert_counterexample_artifact_shape(value: &serde_json::Value) {
         assert_counterexample_schema_refs_resolve_offline();
         let object = value.as_object().expect("artifact object");

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -504,6 +504,10 @@ mod tests {
             model_cache_hits: 0,
             heuristic_witnesses: 0,
             solver_time_ms: 0,
+            smt_input_bytes: 0,
+            smt_max_query_bytes: 0,
+            smt_build_time_ms: 0,
+            smt_max_query_time_ms: 0,
         })]);
 
         assert!(!outcome.failed_tests_are_debuggable());
@@ -1231,6 +1235,18 @@ pub struct SymbolicSolverStats {
     pub heuristic_witnesses: usize,
     /// Wall-clock time spent waiting on backend solver subprocesses, in milliseconds.
     pub solver_time_ms: u64,
+    /// Total SMT-LIB input bytes sent to backend solver subprocesses.
+    #[serde(default)]
+    pub smt_input_bytes: u64,
+    /// Largest single SMT-LIB query input sent to a backend solver subprocess, in bytes.
+    #[serde(default)]
+    pub smt_max_query_bytes: u64,
+    /// Wall-clock time spent building SMT-LIB query strings, in milliseconds.
+    #[serde(default)]
+    pub smt_build_time_ms: u64,
+    /// Longest single backend solver subprocess query, in milliseconds.
+    #[serde(default)]
+    pub smt_max_query_time_ms: u64,
 }
 
 impl From<SymbolicStats> for SymbolicSolverStats {
@@ -1245,6 +1261,10 @@ impl From<SymbolicStats> for SymbolicSolverStats {
             model_cache_hits: stats.model_cache_hits,
             heuristic_witnesses: stats.heuristic_witnesses,
             solver_time_ms: stats.solver_time_ms,
+            smt_input_bytes: stats.smt_input_bytes,
+            smt_max_query_bytes: stats.smt_max_query_bytes,
+            smt_build_time_ms: stats.smt_build_time_ms,
+            smt_max_query_time_ms: stats.smt_max_query_time_ms,
         }
     }
 }
@@ -2287,6 +2307,10 @@ impl TestResult {
             model_cache_hits: stats.model_cache_hits,
             heuristic_witnesses: stats.heuristic_witnesses,
             solver_time_ms: stats.solver_time_ms,
+            smt_input_bytes: stats.smt_input_bytes,
+            smt_max_query_bytes: stats.smt_max_query_bytes,
+            smt_build_time_ms: stats.smt_build_time_ms,
+            smt_max_query_time_ms: stats.smt_max_query_time_ms,
         };
         self.status = status;
         self.reason = reason;
@@ -2433,6 +2457,10 @@ pub enum TestKindReport {
         model_cache_hits: usize,
         heuristic_witnesses: usize,
         solver_time_ms: u64,
+        smt_input_bytes: u64,
+        smt_max_query_bytes: u64,
+        smt_build_time_ms: u64,
+        smt_max_query_time_ms: u64,
     },
     /// Showmap corpus replay (no campaign performed).
     Replay {
@@ -2491,6 +2519,10 @@ impl fmt::Display for TestKindReport {
                 model_cache_hits,
                 heuristic_witnesses,
                 solver_time_ms,
+                smt_input_bytes: _,
+                smt_max_query_bytes: _,
+                smt_build_time_ms: _,
+                smt_max_query_time_ms: _,
             } => {
                 write!(
                     f,
@@ -2571,6 +2603,14 @@ pub enum TestKind {
         heuristic_witnesses: usize,
         #[serde(default)]
         solver_time_ms: u64,
+        #[serde(default)]
+        smt_input_bytes: u64,
+        #[serde(default)]
+        smt_max_query_bytes: u64,
+        #[serde(default)]
+        smt_build_time_ms: u64,
+        #[serde(default)]
+        smt_max_query_time_ms: u64,
     },
     /// Showmap corpus replay (no campaign performed).
     Replay { corpus_entries: usize, showmap_files: usize, skipped_entries: usize },
@@ -2647,6 +2687,10 @@ impl TestKind {
                 model_cache_hits,
                 heuristic_witnesses,
                 solver_time_ms,
+                smt_input_bytes,
+                smt_max_query_bytes,
+                smt_build_time_ms,
+                smt_max_query_time_ms,
             } => TestKindReport::Symbolic {
                 paths: *paths,
                 solver_queries: *solver_queries,
@@ -2657,6 +2701,10 @@ impl TestKind {
                 model_cache_hits: *model_cache_hits,
                 heuristic_witnesses: *heuristic_witnesses,
                 solver_time_ms: *solver_time_ms,
+                smt_input_bytes: *smt_input_bytes,
+                smt_max_query_bytes: *smt_max_query_bytes,
+                smt_build_time_ms: *smt_build_time_ms,
+                smt_max_query_time_ms: *smt_max_query_time_ms,
             },
             Self::Replay { corpus_entries, showmap_files, skipped_entries } => {
                 TestKindReport::Replay {

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -120,7 +120,11 @@ contract SymbolicSingleCallArtifactEnv is Test {
                 "sat_cache_hits": 0,
                 "model_cache_hits": 0,
                 "heuristic_witnesses": 0,
-                "solver_time_ms": 0
+                "solver_time_ms": 0,
+                "smt_input_bytes": 0,
+                "smt_max_query_bytes": 0,
+                "smt_build_time_ms": 0,
+                "smt_max_query_time_ms": 0
             }
         },
         "assumptions": [],
@@ -1598,7 +1602,11 @@ contract SymbolicArtifactFailOnRevert is Test {
                 "sat_cache_hits": 0,
                 "model_cache_hits": 0,
                 "heuristic_witnesses": 0,
-                "solver_time_ms": 0
+                "solver_time_ms": 0,
+                "smt_input_bytes": 0,
+                "smt_max_query_bytes": 0,
+                "smt_build_time_ms": 0,
+                "smt_max_query_time_ms": 0
             }
         },
         "assumptions": [],
@@ -1761,7 +1769,11 @@ contract SymbolicArtifactBracketPath is Test {
                 "sat_cache_hits": 0,
                 "model_cache_hits": 0,
                 "heuristic_witnesses": 0,
-                "solver_time_ms": 0
+                "solver_time_ms": 0,
+                "smt_input_bytes": 0,
+                "smt_max_query_bytes": 0,
+                "smt_build_time_ms": 0,
+                "smt_max_query_time_ms": 0
             }
         },
         "assumptions": [],
@@ -1864,7 +1876,11 @@ contract SymbolicArtifactStaleTarget is Test {
                 "sat_cache_hits": 0,
                 "model_cache_hits": 0,
                 "heuristic_witnesses": 0,
-                "solver_time_ms": 0
+                "solver_time_ms": 0,
+                "smt_input_bytes": 0,
+                "smt_max_query_bytes": 0,
+                "smt_build_time_ms": 0,
+                "smt_max_query_time_ms": 0
             }
         },
         "assumptions": [],
@@ -1991,7 +2007,11 @@ contract SymbolicArtifactForbiddenSender is Test {
                 "sat_cache_hits": 0,
                 "model_cache_hits": 0,
                 "heuristic_witnesses": 0,
-                "solver_time_ms": 0
+                "solver_time_ms": 0,
+                "smt_input_bytes": 0,
+                "smt_max_query_bytes": 0,
+                "smt_build_time_ms": 0,
+                "smt_max_query_time_ms": 0
             }
         },
         "assumptions": [],
@@ -2141,7 +2161,11 @@ contract SymbolicArtifactCreatedTarget is Test {
                 "sat_cache_hits": 0,
                 "model_cache_hits": 0,
                 "heuristic_witnesses": 0,
-                "solver_time_ms": 0
+                "solver_time_ms": 0,
+                "smt_input_bytes": 0,
+                "smt_max_query_bytes": 0,
+                "smt_build_time_ms": 0,
+                "smt_max_query_time_ms": 0
             }
         },
         "assumptions": [],
@@ -2261,7 +2285,11 @@ contract SymbolicArtifactNetworkReplay is Test {
                 "sat_cache_hits": 0,
                 "model_cache_hits": 0,
                 "heuristic_witnesses": 0,
-                "solver_time_ms": 0
+                "solver_time_ms": 0,
+                "smt_input_bytes": 0,
+                "smt_max_query_bytes": 0,
+                "smt_build_time_ms": 0,
+                "smt_max_query_time_ms": 0
             }
         },
         "assumptions": [],


### PR DESCRIPTION
Adds a focused `forge_symbolic_test` benchmark path that runs symbolic checks on `Vectorized/solady:v0.1.26` and `SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5`, then aggregates symbolic solver counters from `forge test --symbolic --json`.

Solady covers small targeted checks from `FixedPointMathLib`, `LibSort`, `ERC20`, and `Timelock`. Angstrom adds a bounded hard case around `check_matchesSolady_fullMulX128`, which currently reaches an incomplete solver result under a 5s symbolic timeout but still emits useful solver and SMT counters. The benchmark runner now preserves parseable symbolic JSON from non-zero symbolic exits and reports pass, incomplete, and fail counts in the generated table.

The symbolic benchmark commands disable lint-on-build so Solidity lint diagnostics do not dominate solver benchmarks or make otherwise valid benchmark targets fail after compilation succeeds.

| Repo | Mean wall time | Symbolic status | Solver queries | SMT queries | SMT input | Max SMT query |
| --- | ---: | --- | ---: | ---: | ---: | ---: |
| `Vectorized/solady:v0.1.26` | 2.801s | 5 pass | 46 | 43 | 4.53 MiB | 493.5 KiB |
| `SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5` | 6.611s | 1 incomplete | 11 | 2 | 5.6 KiB | 4.8 KiB |
