### PR TITLE
fix: clippy lints

### DIFF
--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -381,10 +381,9 @@ impl FuzzDictionary {
                 for &topic in log.topics() {
                     self.insert_value(topic);
                 }
-                let chunks = log.data.data.chunks_exact(32);
-                let rem = chunks.remainder();
+                let (chunks, rem) = log.data.data.as_chunks::<32>();
                 for chunk in chunks {
-                    self.insert_value(chunk.try_into().unwrap());
+                    self.insert_value((*chunk).into());
                 }
                 if !rem.is_empty() {
                     self.insert_value(B256::right_padding_from(rem));

--- a/crates/evm/traces/src/decoder/precompiles.rs
+++ b/crates/evm/traces/src/decoder/precompiles.rs
@@ -365,8 +365,7 @@ impl Precompile for Blake2f {
 fn decode_blake2f<'a>(data: &'a [u8]) -> alloy_sol_types::Result<Vec<String>> {
     let mut decoder = abi::Decoder::new(data);
     let rounds = u32::from_be_bytes(decoder.take_slice(4)?.try_into().unwrap());
-    let u64_le_list =
-        |x: &'a [u8]| x.chunks_exact(8).map(|x| u64::from_le_bytes(x.try_into().unwrap()));
+    let u64_le_list = |x: &'a [u8]| x.as_chunks::<8>().0.iter().map(|x| u64::from_le_bytes(*x));
     let h = u64_le_list(decoder.take_slice(64)?);
     let m = u64_le_list(decoder.take_slice(128)?);
     let t = u64_le_list(decoder.take_slice(16)?);

--- a/crates/forge/src/mutation/mutators/unary_op_mutator.rs
+++ b/crates/forge/src/mutation/mutators/unary_op_mutator.rs
@@ -19,14 +19,8 @@ impl Mutator for UnaryOpMutator {
 
         let expr = context.expr.unwrap();
 
-        let op;
-        let target_span;
-
-        match &expr.kind {
-            ExprKind::Unary(un_op, target) => {
-                op = un_op.kind;
-                target_span = target.span;
-            }
+        let (op, target_span) = match &expr.kind {
+            ExprKind::Unary(un_op, target) => (un_op.kind, target.span),
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
Nightly clippy's `chunks_exact_to_as_chunks` and `needless_late_init` lints fail on master. Use `as_chunks()` in `decode_blake2f` and fuzz `state`, and collapse the late init in `unary_op_mutator`.