### PR TITLE
test(lint): cover nonReentrant fallback and receive modifiers

### DIFF
--- a/crates/lint/testdata/NonReentrantNotFirst.sol
+++ b/crates/lint/testdata/NonReentrantNotFirst.sol
@@ -43,6 +43,22 @@ contract NonReentrantNotFirst {
     receive() external payable nonReentrant onlyOwner {}
 }
 
+contract FallbackReceiveNonReentrantNotFirst {
+    modifier nonReentrant() {
+        _;
+    }
+
+    modifier onlyOwner() {
+        _;
+    }
+
+    receive() external payable onlyOwner nonReentrant { //~WARN: `nonReentrant` should be the first modifier
+    }
+
+    fallback() external payable onlyOwner nonReentrant { //~WARN: `nonReentrant` should be the first modifier
+    }
+}
+
 contract BaseReentrancyGuard {
     modifier nonReentrant() {
         _;

--- a/crates/lint/testdata/NonReentrantNotFirst.stderr
+++ b/crates/lint/testdata/NonReentrantNotFirst.stderr
@@ -25,6 +25,22 @@ LL │     function badDuplicate(uint256 amount) external nonReentrant onlyOwner
 warning[non-reentrant-not-first]: `nonReentrant` should be the first modifier
    ╭▸ ROOT/testdata/NonReentrantNotFirst.sol:LL:CC
    │
+LL │     receive() external payable onlyOwner nonReentrant {
+   │                                          ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/non-reentrant-not-first
+
+warning[non-reentrant-not-first]: `nonReentrant` should be the first modifier
+   ╭▸ ROOT/testdata/NonReentrantNotFirst.sol:LL:CC
+   │
+LL │     fallback() external payable onlyOwner nonReentrant {
+   │                                           ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/non-reentrant-not-first
+
+warning[non-reentrant-not-first]: `nonReentrant` should be the first modifier
+   ╭▸ ROOT/testdata/NonReentrantNotFirst.sol:LL:CC
+   │
 LL │     function badInherited() external onlyOwner nonReentrant {
    │                                                ━━━━━━━━━━━━
    │


### PR DESCRIPTION
## Summary
- Adds UI coverage for `non-reentrant-not-first` on `receive` and `fallback` functions.
- Keeps the lint implementation unchanged.
- Follows up on #15248 by covering the non-standard function kinds that the detector already handles.

## Why
The detector checks regular functions, fallback functions, and receive functions. The fixture already had regular function cases and a valid `receive` ordering case, but it did not lock in the warning path for `receive`/`fallback` when `nonReentrant` is not first.

## Validation
- `git diff --check HEAD~1..HEAD`
- `cargo test -p forge --test ui -- NonReentrantNotFirst`
