### PR TITLE
fix(cheatcodes): avoid warming recorded cold accesses

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1936,7 +1936,8 @@ fn get_recorded_state_diffs<FEN: FoundryEvmNetwork>(
             .filter(|account_access| {
                 !account_access.storageAccesses.is_empty()
                     || account_access.oldBalance != account_access.newBalance
-                    || account_access.oldNonce != account_access.newNonce
+                    || (!account_access.reverted
+                        && account_access.oldNonce != account_access.newNonce)
             })
             .for_each(|account_access| {
                 // Record account balance diffs.
@@ -1961,7 +1962,7 @@ fn get_recorded_state_diffs<FEN: FoundryEvmNetwork>(
                 }
 
                 // Record account nonce diffs.
-                if account_access.oldNonce != account_access.newNonce {
+                if account_access.oldNonce != account_access.newNonce && !account_access.reverted {
                     let account_diff =
                         state_diffs.entry(account_access.account).or_insert_with(|| {
                             AccountStateDiffs {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2594,19 +2594,16 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             op::SSTORE => {
                 let Some(last) = account_accesses.last_mut() else { return };
 
-                // TODO: avoid warming cold SSTORE slots while recording state diffs.
                 let key = try_or_return!(interpreter.stack.peek(0));
                 let value = try_or_return!(interpreter.stack.peek(1));
                 let address = interpreter.input.target_address;
                 // Try to load the account and the slot's previous value, otherwise, assume it's
-                // not set (zero value)
-                let previous_value = if ecx.journal_mut().load_account(address).is_ok()
-                    && let Some(previous) = ecx.sload(address, key)
-                {
-                    previous.data
-                } else {
-                    U256::ZERO
-                };
+                // not set (zero value). Revert the checkpoint so this read does not warm the slot
+                // for the actual SSTORE opcode.
+                let checkpoint = ecx.journal_mut().checkpoint();
+                let previous_value =
+                    ecx.sload(address, key).map(|previous| previous.data).unwrap_or_default();
+                ecx.journal_mut().checkpoint_revert(checkpoint);
 
                 let access = crate::Vm::StorageAccess {
                     account: address,
@@ -2623,7 +2620,6 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
 
             // Record account accesses via the EXT family of opcodes
             op::EXTCODECOPY | op::EXTCODESIZE | op::EXTCODEHASH | op::BALANCE => {
-                // TODO: avoid warming cold accounts while recording EXT*/BALANCE state diffs.
                 let kind = match interpreter.bytecode.opcode() {
                     op::EXTCODECOPY => crate::Vm::AccountAccessKind::Extcodecopy,
                     op::EXTCODESIZE => crate::Vm::AccountAccessKind::Extcodesize,
@@ -2633,12 +2629,13 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                 };
                 let address =
                     Address::from_word(B256::from(try_or_return!(interpreter.stack.peek(0))));
-                let (initialized, balance, nonce) =
-                    if let Ok(acc) = ecx.journal_mut().load_account(address) {
-                        (acc.data.info.exists(), acc.data.info.balance, acc.data.info.nonce)
-                    } else {
-                        (false, U256::ZERO, 0)
-                    };
+                let checkpoint = ecx.journal_mut().checkpoint();
+                let (initialized, balance, nonce) = ecx
+                    .journal_mut()
+                    .load_account(address)
+                    .map(|acc| (acc.data.info.exists(), acc.data.info.balance, acc.data.info.nonce))
+                    .unwrap_or_default();
+                ecx.journal_mut().checkpoint_revert(checkpoint);
                 let curr_depth =
                     ecx.journal().depth().try_into().expect("journaled state depth exceeds u64");
                 let account_access = crate::Vm::AccountAccess {

--- a/testdata/paris/cheats/LastCallGas.t.sol
+++ b/testdata/paris/cheats/LastCallGas.t.sol
@@ -36,9 +36,40 @@ contract StorageGasTarget {
         }
     }
 
+    function writeAll() public {
+        for (uint256 i; i < 256; ++i) {
+            slots[i] = i + 2;
+        }
+    }
+
     function sum() public view returns (uint256 s) {
         for (uint256 i; i < 256; ++i) {
             s += slots[i];
+        }
+    }
+}
+
+contract AccountGasTarget {
+    function balanceOf(address account) public view returns (uint256) {
+        return account.balance;
+    }
+
+    function codeSizeOf(address account) public view returns (uint256 size) {
+        assembly {
+            size := extcodesize(account)
+        }
+    }
+
+    function codeHashOf(address account) public view returns (bytes32 hash) {
+        assembly {
+            hash := extcodehash(account)
+        }
+    }
+
+    function copyCodeOf(address account) public view returns (bytes32 word) {
+        assembly {
+            extcodecopy(account, 0, 0, 0x20)
+            word := mload(0)
         }
     }
 }
@@ -239,6 +270,76 @@ contract LastCallGasIsolatedTest is LastCallGasFixture {
         recordingOn.fill();
         vm.startStateDiffRecording();
         recordingOn.sum();
+
+        assertEq(vm.lastCallGas().gasTotalUsed, gasRecordingOff);
+    }
+
+    function testStateDiffRecordingDoesNotWarmStorageWrites() public {
+        StorageGasTarget recordingOff = new StorageGasTarget();
+        recordingOff.fill();
+        recordingOff.writeAll();
+        uint64 gasRecordingOff = vm.lastCallGas().gasTotalUsed;
+
+        StorageGasTarget recordingOn = new StorageGasTarget();
+        recordingOn.fill();
+        vm.startStateDiffRecording();
+        recordingOn.writeAll();
+
+        assertEq(vm.lastCallGas().gasTotalUsed, gasRecordingOff);
+    }
+
+    function testStateDiffRecordingDoesNotWarmBalanceReads() public {
+        AccountGasTarget recordingOff = new AccountGasTarget();
+        Target accountOff = new Target();
+        recordingOff.balanceOf(address(accountOff));
+        uint64 gasRecordingOff = vm.lastCallGas().gasTotalUsed;
+
+        AccountGasTarget recordingOn = new AccountGasTarget();
+        Target accountOn = new Target();
+        vm.startStateDiffRecording();
+        recordingOn.balanceOf(address(accountOn));
+
+        assertEq(vm.lastCallGas().gasTotalUsed, gasRecordingOff);
+    }
+
+    function testStateDiffRecordingDoesNotWarmExtcodesizeReads() public {
+        AccountGasTarget recordingOff = new AccountGasTarget();
+        Target accountOff = new Target();
+        recordingOff.codeSizeOf(address(accountOff));
+        uint64 gasRecordingOff = vm.lastCallGas().gasTotalUsed;
+
+        AccountGasTarget recordingOn = new AccountGasTarget();
+        Target accountOn = new Target();
+        vm.startStateDiffRecording();
+        recordingOn.codeSizeOf(address(accountOn));
+
+        assertEq(vm.lastCallGas().gasTotalUsed, gasRecordingOff);
+    }
+
+    function testStateDiffRecordingDoesNotWarmExtcodehashReads() public {
+        AccountGasTarget recordingOff = new AccountGasTarget();
+        Target accountOff = new Target();
+        recordingOff.codeHashOf(address(accountOff));
+        uint64 gasRecordingOff = vm.lastCallGas().gasTotalUsed;
+
+        AccountGasTarget recordingOn = new AccountGasTarget();
+        Target accountOn = new Target();
+        vm.startStateDiffRecording();
+        recordingOn.codeHashOf(address(accountOn));
+
+        assertEq(vm.lastCallGas().gasTotalUsed, gasRecordingOff);
+    }
+
+    function testStateDiffRecordingDoesNotWarmExtcodecopyReads() public {
+        AccountGasTarget recordingOff = new AccountGasTarget();
+        Target accountOff = new Target();
+        recordingOff.copyCodeOf(address(accountOff));
+        uint64 gasRecordingOff = vm.lastCallGas().gasTotalUsed;
+
+        AccountGasTarget recordingOn = new AccountGasTarget();
+        Target accountOn = new Target();
+        vm.startStateDiffRecording();
+        recordingOn.copyCodeOf(address(accountOn));
 
         assertEq(vm.lastCallGas().gasTotalUsed, gasRecordingOff);
     }


### PR DESCRIPTION
## Motivation

Fixes the remaining state-diff recording follow-ups from #15382. Recording now observes cold `SSTORE` slot values and cold `BALANCE`/`EXTCODE*` account metadata through reverted journal checkpoints, so the recorder can keep the same diff metadata without warming those slots or accounts before the real opcode executes.

This also keeps `getStateDiff` from reporting nonce diffs for reverted account accesses, matching the existing reverted-call state-diff behavior, and adds isolated `lastCallGas` regressions for cold storage writes plus `BALANCE`, `EXTCODESIZE`, `EXTCODEHASH`, and `EXTCODECOPY`.
