### PR TITLE
fix(evm): use system call for beacon roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5501,6 +5501,7 @@ version = "1.7.2"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
+ "alloy-evm",
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-rpc-types",

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -7,7 +7,7 @@ use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{BlockResponse, TransactionResponse};
 use alloy_primitives::{
-    Address, Bytes, U256,
+    Address, B256, Bytes, U256,
     map::{AddressHashMap, AddressSet},
 };
 use alloy_provider::{Provider, ext::DebugApi};
@@ -265,8 +265,8 @@ impl RunArgs {
 
         let spec_id = (*evm_env.cfg_env.spec()).into();
 
-        if spec_id.is_enabled_in(SpecId::CANCUN)
-            && let Some(parent_beacon_block_root) = parent_beacon_block_root
+        if let Some(parent_beacon_block_root) =
+            parent_beacon_block_root_for_spec(spec_id, parent_beacon_block_root)?
         {
             executor.apply_beacon_root(parent_beacon_block_root)?;
         }
@@ -410,6 +410,21 @@ impl RunArgs {
     }
 }
 
+fn parent_beacon_block_root_for_spec(
+    spec_id: SpecId,
+    parent_beacon_block_root: Option<B256>,
+) -> Result<Option<B256>> {
+    if !spec_id.is_enabled_in(SpecId::CANCUN) {
+        return Ok(None);
+    }
+
+    parent_beacon_block_root.map(Some).ok_or_else(|| {
+        eyre::eyre!(
+            "MissingParentBeaconBlockRoot: missing parent beacon block root for Cancun block"
+        )
+    })
+}
+
 pub fn fetch_contracts_bytecode_from_trace<FEN: FoundryEvmNetwork>(
     executor: &Executor<FEN>,
     result: &TraceResult,
@@ -466,5 +481,24 @@ impl figment::Provider for RunArgs {
         }
 
         Ok(Map::from([(Config::selected_profile(), map)]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parent_beacon_block_root_is_required_for_cancun() {
+        let err = parent_beacon_block_root_for_spec(SpecId::CANCUN, None).unwrap_err();
+        assert!(err.to_string().contains("MissingParentBeaconBlockRoot"));
+
+        let root = B256::repeat_byte(0x42);
+        assert_eq!(
+            parent_beacon_block_root_for_spec(SpecId::CANCUN, Some(root)).unwrap(),
+            Some(root),
+        );
+        assert_eq!(parent_beacon_block_root_for_spec(SpecId::SHANGHAI, Some(root)).unwrap(), None);
+        assert_eq!(parent_beacon_block_root_for_spec(SpecId::SHANGHAI, None).unwrap(), None);
     }
 }

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -27,8 +27,9 @@ foundry-evm-networks.workspace = true
 foundry-evm-traces.workspace = true
 
 alloy-dyn-abi = { workspace = true, features = ["arbitrary", "eip712"] }
-alloy-json-abi.workspace = true
 alloy-eips.workspace = true
+alloy-evm.workspace = true
+alloy-json-abi.workspace = true
 alloy-primitives = { workspace = true, features = [
     "serde",
     "getrandom",

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -11,6 +11,8 @@ use crate::inspectors::{
     cheatcodes::BroadcastableTransactions,
 };
 use alloy_dyn_abi::{DynSolValue, FunctionExt, JsonAbiExt};
+use alloy_eips::eip4788::{BEACON_ROOTS_ADDRESS, SYSTEM_ADDRESS};
+use alloy_evm::Evm;
 use alloy_json_abi::Function;
 use alloy_primitives::{
     Address, Bytes, Log, TxKind, U256, keccak256,
@@ -29,8 +31,8 @@ use foundry_evm_core::{
     },
     decode::{RevertDecoder, SkipReason},
     evm::{
-        EthEvmNetwork, EvmEnvFor, FoundryEvmNetwork, HaltReasonFor, IntoInstructionResult, SpecFor,
-        TxEnvFor,
+        EthEvmNetwork, EvmEnvFor, FoundryEvmFactory, FoundryEvmNetwork, HaltReasonFor,
+        IntoInstructionResult, SpecFor, TxEnvFor,
     },
     utils::StateChangeset,
 };
@@ -584,12 +586,26 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         &mut self,
         parent_beacon_block_root: alloy_primitives::B256,
     ) -> eyre::Result<()> {
-        let _ = self.transact_raw(
-            alloy_eips::eip4788::SYSTEM_ADDRESS,
-            alloy_eips::eip4788::BEACON_ROOTS_ADDRESS,
-            Bytes::copy_from_slice(parent_beacon_block_root.as_slice()),
-            U256::ZERO,
-        )?;
+        let calldata = Bytes::copy_from_slice(parent_beacon_block_root.as_slice());
+        let mut evm_env = self.evm_env.clone();
+        let inspector = self.inspector().clone();
+        let mut state = {
+            let mut backend = CowBackend::new_borrowed(self.backend());
+            let mut evm = FEN::EvmFactory::default().create_foundry_evm_with_inspector(
+                &mut backend,
+                evm_env.clone(),
+                inspector,
+            );
+            let result =
+                evm.transact_system_call(SYSTEM_ADDRESS, BEACON_ROOTS_ADDRESS, calldata)?;
+            evm_env = evm.finish().1;
+            result.state
+        };
+        state.retain(|address, _| *address == BEACON_ROOTS_ADDRESS);
+
+        self.backend_mut().commit(state);
+        self.inspector_mut().set_block(evm_env.block_env);
+
         Ok(())
     }
 
@@ -1603,6 +1619,25 @@ mod tests {
             &revm::context_interface::cfg::GasParams::new_spec(SpecId::AMSTERDAM),
         );
         assert!(executor.evm_env().cfg_env.is_amsterdam_eip8037_enabled());
+    }
+
+    #[test]
+    fn beacon_root_system_call_does_not_persist_system_address() {
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().spec_id(SpecId::CANCUN).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+        );
+        let before = executor.backend().basic_ref(SYSTEM_ADDRESS).unwrap();
+
+        executor.apply_beacon_root(B256::repeat_byte(0x11)).unwrap();
+
+        assert_eq!(
+            executor.backend().basic_ref(SYSTEM_ADDRESS).unwrap(),
+            before,
+            "EIP-4788 system calls must not persist the system caller account",
+        );
     }
 
     /// Regression test for `pre_override_blob_hashes` restoration.


### PR DESCRIPTION
## Motivation

This follows up on https://github.com/foundry-rs/foundry/pull/15371#pullrequestreview-4592704265 by routing the EIP-4788 beacon-root write through the EVM system-call path instead of the normal transaction path. The helper now executes the system call against an isolated backend and commits only the beacon roots contract state, avoiding caller or beneficiary side effects from the system address.

`cast run` now also treats a missing `parent_beacon_block_root` as a setup error once the resolved spec is Cancun or later, instead of silently skipping the beacon-root write and replaying with incomplete pre-block state.
