### PR TITLE
ci(mpp): use a fresh wallet each run

### DIFF
--- a/.github/scripts/tempo-mpp.sh
+++ b/.github/scripts/tempo-mpp.sh
@@ -53,6 +53,28 @@ if ! command -v "$CHISEL" &>/dev/null; then
   exit 1
 fi
 
+# When TEMPO_ROTATE_WALLET=1, generate a fresh wallet and use it instead of the
+# configured one. The faucet funds it below (TEMPO_AUTO_FUND).
+TEMPO_ROTATE_WALLET="${TEMPO_ROTATE_WALLET:-0}"
+if [ "$TEMPO_ROTATE_WALLET" = "1" ]; then
+  echo "Rotating to a fresh ephemeral MPP wallet"
+  if ! command -v jq &>/dev/null; then
+    echo "ERROR: jq is required for TEMPO_ROTATE_WALLET=1"
+    exit 1
+  fi
+  NEW_WALLET_JSON=$("$CAST" wallet new --json)
+  TEMPO_PRIVATE_KEY=$(printf '%s' "$NEW_WALLET_JSON" | jq -r '(.data // .)[0].private_key')
+  if [ -z "$TEMPO_PRIVATE_KEY" ] || [ "$TEMPO_PRIVATE_KEY" = "null" ]; then
+    echo "ERROR: failed to parse private key from 'cast wallet new --json'"
+    exit 1
+  fi
+  export TEMPO_PRIVATE_KEY
+  # Drop any pre-seeded wallet/channel state so the fresh key is used as-is.
+  unset TEMPO_KEYS_TOML_B64 2>/dev/null || true
+  rm -f "${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml" 2>/dev/null || true
+  rm -f "${TEMPO_HOME:-$HOME/.tempo}/channels.db" 2>/dev/null || true
+fi
+
 KEYS_FILE="${TEMPO_HOME:-$HOME/.tempo}/wallet/keys.toml"
 if [ -n "${TEMPO_PRIVATE_KEY:-}" ]; then
   WALLET=$("$CAST" wallet address --private-key "$TEMPO_PRIVATE_KEY")
@@ -79,7 +101,12 @@ if [ "$BEFORE_RAW" -lt "$MIN_BALANCE" ] && [ "$TEMPO_AUTO_FUND" = "1" ]; then
   while [ "$BEFORE_RAW" -lt "$MIN_BALANCE" ] && [ "$ATTEMPT" -lt "$TEMPO_AUTO_FUND_ATTEMPTS" ]; do
     ATTEMPT=$((ATTEMPT + 1))
     echo "Faucet attempt $ATTEMPT/$TEMPO_AUTO_FUND_ATTEMPTS"
-    "$CAST" rpc tempo_fundAddress "$WALLET_LOWER" --rpc-url "$RPC" >/dev/null
+    # Retry on a transient faucet error instead of aborting (set -e).
+    if ! "$CAST" rpc tempo_fundAddress "$WALLET_LOWER" --rpc-url "$RPC" >/dev/null; then
+      echo "Faucet RPC failed on attempt $ATTEMPT, retrying..."
+      sleep 2
+      continue
+    fi
     sleep 2
     BEFORE=$("$CAST" erc20 balance "$TOKEN" "$WALLET" --rpc-url "$RPC")
     echo "$BEFORE"

--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -50,8 +50,15 @@ jobs:
           MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
           MPP_DEPOSIT: "1000000"
           TEMPO_AUTO_FUND: "1"
+          # Use a fresh, faucet-funded wallet each run.
+          TEMPO_ROTATE_WALLET: "1"
         run: |
-          if [ -n "${TEMPO_PRIVATE_KEY:-}" ]; then
+          if [ -z "${MPP_API_KEY:-}" ]; then
+            echo "::warning::MPP_API_KEY secret not set, skipping MPP e2e"
+            exit 0
+          elif [ "${TEMPO_ROTATE_WALLET:-0}" = "1" ]; then
+            echo "::notice::Rotating to a fresh ephemeral wallet for MPP e2e"
+          elif [ -n "${TEMPO_PRIVATE_KEY:-}" ]; then
             echo "::notice::Using TEMPO_PRIVATE_KEY for MPP e2e"
           elif [ -n "${TEMPO_KEYS_TOML_B64:-}" ]; then
             mkdir -p ~/.tempo/wallet


### PR DESCRIPTION
Generate a fresh, faucet-funded wallet each run (`TEMPO_ROTATE_WALLET=1`). A new wallet has no channel history, so the open succeeds.

Also skips cleanly when `MPP_API_KEY` is unset.

Closes OSS-459