### PR TITLE
fix: make Windows test assertions portable

### DIFF
--- a/crates/evm/evm/src/executors/showmap.rs
+++ b/crates/evm/evm/src/executors/showmap.rs
@@ -623,7 +623,7 @@ mod tests {
         let mut evm = EvmShowmap::new();
         evm.insert((h, 7u32), 5u64);
         let err = write_showmap_file(&path, &evm, &[]).unwrap_err();
-        assert!(err.to_string().contains("File exists"), "{err:?}");
+        assert!(err.to_string().contains("pick a different --showmap-trial"), "{err:?}");
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "keep me");
     }
 

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -801,7 +801,11 @@ forgetest_init!(forge_fuzz_corpus_subcommands_dedup_worker_entries, |prj, cmd| {
 
     let show = cmd.args(["fuzz", "show", "corpus"]).assert_success();
     let stdout = String::from_utf8(show.get_output().stdout.clone()).unwrap();
-    assert_eq!(stdout.matches("corpus/worker").count(), 1, "{stdout}");
+    assert_eq!(
+        stdout.matches(&format!("corpus{}worker", std::path::MAIN_SEPARATOR)).count(),
+        1,
+        "{stdout}"
+    );
 });
 
 forgetest_init!(forge_fuzz_replay_error_on_zero_replay, |prj, cmd| {
@@ -1012,10 +1016,9 @@ contract ForgeFuzzGeneratedCorpusTest is Test {
 
     let show = cmd.forge_fuse().args(["fuzz", "show", "fuzz_corpus"]).assert_success();
     let show_stdout = String::from_utf8(show.get_output().stdout.clone()).unwrap();
-    assert!(
-        show_stdout.contains("fuzz_corpus/ForgeFuzzGeneratedCorpusTest/testFuzz_SetNumber"),
-        "{show_stdout}"
-    );
+    let fuzz_corpus_path = ["fuzz_corpus", "ForgeFuzzGeneratedCorpusTest", "testFuzz_SetNumber"]
+        .join(std::path::MAIN_SEPARATOR_STR);
+    assert!(show_stdout.contains(&fuzz_corpus_path), "{show_stdout}");
 
     let replay = cmd
         .forge_fuse()
@@ -1041,10 +1044,10 @@ contract ForgeFuzzGeneratedCorpusTest is Test {
     let invariant_show =
         cmd.forge_fuse().args(["fuzz", "show", "invariant_corpus"]).assert_success();
     let invariant_stdout = String::from_utf8(invariant_show.get_output().stdout.clone()).unwrap();
-    assert!(
-        invariant_stdout.contains("invariant_corpus/ForgeFuzzGeneratedCorpusTest/worker0/corpus"),
-        "{invariant_stdout}"
-    );
+    let invariant_corpus_path =
+        ["invariant_corpus", "ForgeFuzzGeneratedCorpusTest", "worker0", "corpus"]
+            .join(std::path::MAIN_SEPARATOR_STR);
+    assert!(invariant_stdout.contains(&invariant_corpus_path), "{invariant_stdout}");
 });
 
 forgetest_init!(forge_fuzz_replay_scopes_generated_corpus_root_to_target, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/showmap.rs
+++ b/crates/forge/tests/cli/test_cmd/showmap.rs
@@ -233,7 +233,7 @@ contract ShowmapCounterTest is Test {
         ])
         .assert_failure();
     let stdout = String::from_utf8(retry.get_output().stdout.clone()).unwrap();
-    assert!(stdout.contains("File exists"), "{stdout}");
+    assert!(stdout.contains("pick a different --showmap-trial"), "{stdout}");
     assert_eq!(std::fs::read_to_string(&t1).unwrap(), before);
 });
 

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -97,8 +97,8 @@ pub fn build_project(
 
     if args.contract.path.is_some() {
         let contract = PathOrContractInfo::ContractInfo(args.contract.clone());
-        let target_path = project.root().join(contract.path().unwrap()).canonicalize()?;
-        let mut output = compiler.files([target_path.clone()]).compile(&project)?;
+        let target_path = project.root().join(contract.path().unwrap());
+        let mut output = compiler.files([target_path.canonicalize()?]).compile(&project)?;
         let artifact =
             find_matching_contract_artifact(&mut output, &target_path, Some(&args.contract.name))?;
         return Ok(artifact.into_contract_bytecode());


### PR DESCRIPTION
## Summary
- preserve project-root joined contract paths for verify artifact lookup while compiling the canonical file path
- make affected fuzz/showmap assertions use native path separators
- assert stable showmap overwrite guidance instead of platform-specific OS error text

## CI Failure
- https://github.com/foundry-rs/foundry/actions/runs/28393310128/job/84125614664

## Testing
- cargo fmt --check
- cargo test -p foundry-evm executors::showmap::tests::write_showmap_file_does_not_overwrite_existing_file
- cargo test -p forge-verify utils::tests::build_project_finds_artifact_by_relative_contract_path
- cargo test -p forge --test cli forge_fuzz_corpus_subcommands_dedup_worker_entries
- cargo test -p forge --test cli forge_fuzz_commands_read_generated_corpus_roots
- cargo test -p forge --test cli showmap_replay_distinct_trials_accumulate

Prompted by: @grandizzy