### PR TITLE
fix(anvil): sync block number after load state

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3931,7 +3931,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
             let fork_num_and_hash = self.get_fork().map(|f| (f.block_number(), f.block_hash()));
 
             let best_number = state.best_block_number.unwrap_or(block.number.saturating_to());
-            if let Some((number, hash)) = fork_num_and_hash {
+            let selected_best_number = if let Some((number, hash)) = fork_num_and_hash {
                 trace!(target: "backend", state_block_number=?best_number, fork_block_number=?number);
                 // If the state.block_number is greater than the fork block number, set best number
                 // to the state block number.
@@ -3949,11 +3949,13 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
                             )))
                         })?;
                     self.blockchain.storage.write().best_hash = best_hash;
+                    best_number
                 } else {
                     // If loading state file on a fork, set best number to the fork block number.
                     // Ref: https://github.com/foundry-rs/foundry/pull/9215#issue-2618681838
                     self.blockchain.storage.write().best_number = number;
                     self.blockchain.storage.write().best_hash = hash;
+                    number
                 }
             } else {
                 self.blockchain.storage.write().best_number = best_number;
@@ -3971,6 +3973,13 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
                     })?;
 
                 self.blockchain.storage.write().best_hash = best_hash;
+                best_number
+            };
+
+            // Keep NUMBER aligned with the canonical local head chosen above. Arbitrum state dumps
+            // can intentionally keep BlockEnv.number distinct from the best L2 block number.
+            if !is_arbitrum(self.chain_id().to()) {
+                self.set_block_number(selected_best_number);
             }
         }
 

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -2,7 +2,7 @@
 
 use crate::abi::Greeter;
 use alloy_network::{ReceiptResponse, TransactionBuilder};
-use alloy_primitives::{B256, Bytes, U256, Uint, address, b256, utils::Unit};
+use alloy_primitives::{B256, Bytes, U256, Uint, address, b256, bytes, utils::Unit};
 use alloy_provider::Provider;
 use alloy_rpc_types::{
     BlockId, TransactionRequest,
@@ -312,6 +312,52 @@ async fn test_fork_load_state() {
     assert_eq!(nonce_bob + 1, latest_nonce_bob);
 
     assert_eq!(balance_alice + value, latest_balance_alice);
+}
+
+// <https://github.com/foundry-rs/foundry/issues/10501>
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_load_state_keeps_number_opcode_in_sync() {
+    let target = address!("0000000000000000000000000000000000010501");
+    let bob = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+    let (api, _handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(next_http_archive_rpc_url()))
+            .with_fork_block_number(Some(21070682u64)),
+    )
+    .await;
+
+    // Runtime code: NUMBER, PUSH0, SSTORE, STOP.
+    api.anvil_set_code(target, bytes!("435f5500")).await.unwrap();
+    api.mine_one().await;
+
+    let serialized_state = api.serialized_state(false).await.unwrap();
+
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(next_http_archive_rpc_url()))
+            .with_fork_block_number(Some(21070686u64))
+            .with_init_state(Some(serialized_state)),
+    )
+    .await;
+    let provider = handle.http_provider();
+
+    let current_block = api.block_number().unwrap().to::<u64>();
+    assert_eq!(current_block, 21070686u64);
+
+    let tx = TransactionRequest::default().with_to(target).with_from(bob);
+    let receipt = provider
+        .send_transaction(WithOtherFields::new(tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let mined_block = receipt.block_number.unwrap();
+
+    let stored = provider.get_storage_at(target, U256::ZERO).await.unwrap();
+    assert_eq!(stored, U256::from(mined_block));
+    assert_eq!(stored, U256::from(current_block + 1));
 }
 
 // <https://github.com/foundry-rs/foundry/issues/9539>


### PR DESCRIPTION
Closes #10501.

When Anvil loads a state dump while also forking from a newer head, it updates `storage.best_number` to the selected fork/head but leaves `evm_env.block_env.number` at the serialized snapshot number. That means the RPC layer reports and mines at the restored head while the `NUMBER` opcode executes against the old snapshot height.

This tracks the head chosen during `load_state` and syncs `BlockEnv.number` for non-Arbitrum chains, preserving Arbitrum's existing distinction between the serialized block env and best L2 block number. A regression test covers a fork state reload where a contract stores `NUMBER` after restart.

Authored with AI assistance.
