### PR TITLE
feat(anvil): support eth_baseFee

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -68,6 +68,9 @@ pub enum EthRequest {
     #[serde(rename = "eth_gasPrice", with = "empty_params")]
     EthGasPrice(()),
 
+    #[serde(rename = "eth_baseFee", with = "empty_params")]
+    EthBaseFee(()),
+
     #[serde(rename = "eth_maxPriorityFeePerGas", with = "empty_params")]
     EthMaxPriorityFeePerGas(()),
 
@@ -841,6 +844,13 @@ mod tests {
     #[test]
     fn test_eth_max_priority_fee() {
         let s = r#"{"method": "eth_maxPriorityFeePerGas", "params":[]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_eth_base_fee() {
+        let s = r#"{"method": "eth_baseFee", "params":[]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -821,6 +821,14 @@ impl<N: Network> EthApi<N> {
         Ok(U256::from(self.gas_price()))
     }
 
+    /// Returns the base fee for the next block, or null before London.
+    ///
+    /// Handler for ETH RPC call: `eth_baseFee`
+    pub fn base_fee(&self) -> Result<Option<U256>> {
+        node_info!("eth_baseFee");
+        Ok(self.backend.fees().is_eip1559().then(|| U256::from(self.backend.base_fee())))
+    }
+
     /// Returns the excess blob gas and current blob gas price
     pub fn excess_blob_gas_and_price(&self) -> Result<Option<BlobExcessGasAndPrice>> {
         Ok(self.backend.excess_blob_gas_and_price())
@@ -1526,6 +1534,7 @@ impl EthApi<FoundryNetwork> {
             EthRequest::NetListening(_) => self.net_listening().to_rpc_result(),
             EthRequest::EthHashrate(()) => self.hashrate().to_rpc_result(),
             EthRequest::EthGasPrice(_) => self.eth_gas_price().to_rpc_result(),
+            EthRequest::EthBaseFee(_) => self.base_fee().to_rpc_result(),
             EthRequest::EthMaxPriorityFeePerGas(_) => {
                 self.gas_max_priority_fee_per_gas().to_rpc_result()
             }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -826,7 +826,7 @@ impl<N: Network> EthApi<N> {
     /// Handler for ETH RPC call: `eth_baseFee`
     pub fn base_fee(&self) -> Result<Option<U256>> {
         node_info!("eth_baseFee");
-        Ok(self.backend.fees().is_eip1559().then(|| U256::from(self.backend.base_fee())))
+        Ok(self.backend.is_eip1559().then(|| U256::from(self.backend.base_fee())))
     }
 
     /// Returns the excess blob gas and current blob gas price

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -63,6 +63,32 @@ async fn can_get_price() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_get_base_fee() {
+    let (api, handle) =
+        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::London.into()))).await;
+    let provider = handle.http_provider();
+
+    let base_fee: Option<U256> = provider.client().request("eth_baseFee", ()).await.unwrap();
+    assert_eq!(base_fee, api.base_fee().unwrap());
+
+    let expected = U256::from(1234);
+    api.anvil_set_next_block_base_fee_per_gas(expected).await.unwrap();
+
+    let base_fee: Option<U256> = provider.client().request("eth_baseFee", ()).await.unwrap();
+    assert_eq!(base_fee, Some(expected));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_null_base_fee_before_london() {
+    let (_api, handle) =
+        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Berlin.into()))).await;
+    let provider = handle.http_provider();
+
+    let base_fee: Option<U256> = provider.client().request("eth_baseFee", ()).await.unwrap();
+    assert_eq!(base_fee, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_get_accounts() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -812,6 +812,16 @@ async fn test_fork_base_fee() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fork_pre_london_base_fee_is_null() {
+    let (_api, handle) = spawn(fork_config().with_fork_block_number(Some(12_000_000u64))).await;
+
+    let provider = handle.http_provider();
+
+    let base_fee: Option<U256> = provider.client().request("eth_baseFee", ()).await.unwrap();
+    assert_eq!(base_fee, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fork_init_base_fee() {
     let (api, handle) = spawn(fork_config().with_fork_block_number(Some(13184859u64))).await;
 


### PR DESCRIPTION
Adds the missing Reth-compatible `eth_baseFee` RPC method to Anvil. The handler returns the next block base fee when EIP-1559 is active and `null` before London, matching Reth's contract, and wires request deserialization, dispatch, and endpoint coverage for London and pre-London nodes.

Authored with AI assistance.
