### PR TITLE
feat(anvil): support full pending filters

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -305,8 +305,8 @@ pub enum EthRequest {
 
     /// Creates a filter in the node, to notify when new pending transactions arrive.
     /// To check if the state has changed, call `eth_getFilterChanges`.
-    #[serde(rename = "eth_newPendingTransactionFilter", with = "empty_params")]
-    EthNewPendingTransactionFilter(()),
+    #[serde(rename = "eth_newPendingTransactionFilter", with = "optional_sequence")]
+    EthNewPendingTransactionFilter(Option<bool>),
 
     /// Returns an array of all logs matching filter with given id.
     #[serde(rename = "eth_getFilterLogs", with = "sequence")]
@@ -1626,6 +1626,29 @@ mod tests {
 ["0x4a3b0fce2cb9707b0baa68640cf2fe858c8bb4121b2a8cb904ff369d38a560ff", {"knownAccounts":{}}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_eth_new_pending_transaction_filter() {
+        let s = r#"{"method": "eth_newPendingTransactionFilter", "params":[],"id":73}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let req = serde_json::from_value::<EthRequest>(value).unwrap();
+        assert!(matches!(req, EthRequest::EthNewPendingTransactionFilter(None)));
+
+        let s = r#"{"method": "eth_newPendingTransactionFilter", "params":[null],"id":73}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let req = serde_json::from_value::<EthRequest>(value).unwrap();
+        assert!(matches!(req, EthRequest::EthNewPendingTransactionFilter(None)));
+
+        let s = r#"{"method": "eth_newPendingTransactionFilter", "params":[false],"id":73}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let req = serde_json::from_value::<EthRequest>(value).unwrap();
+        assert!(matches!(req, EthRequest::EthNewPendingTransactionFilter(Some(false))));
+
+        let s = r#"{"method": "eth_newPendingTransactionFilter", "params":[true],"id":73}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let req = serde_json::from_value::<EthRequest>(value).unwrap();
+        assert!(matches!(req, EthRequest::EthNewPendingTransactionFilter(Some(true))));
     }
 
     #[test]

--- a/crates/anvil/core/src/eth/serde_helpers.rs
+++ b/crates/anvil/core/src/eth/serde_helpers.rs
@@ -31,6 +31,26 @@ pub mod sequence {
     }
 }
 
+/// A module that deserializes an optional single-item sequence.
+pub mod optional_sequence {
+    use serde::{Deserialize, Deserializer, de::DeserializeOwned};
+
+    pub fn deserialize<'de, T, D>(d: D) -> Result<Option<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+        T: DeserializeOwned,
+    {
+        let mut seq = Option::<Vec<Option<T>>>::deserialize(d)?.unwrap_or_default();
+        if seq.len() > 1 {
+            return Err(serde::de::Error::custom(format!(
+                "expected params sequence with length 0 or 1 but got {}",
+                seq.len()
+            )));
+        }
+        Ok(seq.pop().flatten())
+    }
+}
+
 /// A module that deserializes `[]` optionally
 pub mod empty_params {
     use serde::{Deserialize, Deserializer};

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1886,8 +1886,8 @@ impl EthApi<FoundryNetwork> {
             EthRequest::EthNewFilter(filter) => self.new_filter(filter).await.to_rpc_result(),
             EthRequest::EthGetFilterChanges(id) => self.get_filter_changes(&id).await,
             EthRequest::EthNewBlockFilter(_) => self.new_block_filter().await.to_rpc_result(),
-            EthRequest::EthNewPendingTransactionFilter(_) => {
-                self.new_pending_transaction_filter().await.to_rpc_result()
+            EthRequest::EthNewPendingTransactionFilter(full) => {
+                self.new_pending_transaction_filter(full.unwrap_or(false)).await.to_rpc_result()
             }
             EthRequest::EthGetFilterLogs(id) => self.get_filter_logs(&id).await.to_rpc_result(),
             EthRequest::EthUninstallFilter(id) => self.uninstall_filter(&id).await.to_rpc_result(),
@@ -3012,9 +3012,13 @@ impl EthApi<FoundryNetwork> {
     /// Creates a filter in the node, to notify when new pending transactions arrive.
     ///
     /// Handler for ETH RPC call: `eth_newPendingTransactionFilter`
-    pub async fn new_pending_transaction_filter(&self) -> Result<String> {
+    pub async fn new_pending_transaction_filter(&self, full: bool) -> Result<String> {
         node_info!("eth_newPendingTransactionFilter");
-        let filter = EthFilter::PendingTransactions(self.new_ready_transactions());
+        let filter = if full {
+            EthFilter::FullPendingTransactions(self.full_pending_transactions())
+        } else {
+            EthFilter::PendingTransactions(self.new_ready_transactions())
+        };
         Ok(self.filters.add_filter(filter).await)
     }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -104,7 +104,7 @@ use revm::{
 use std::{sync::Arc, time::Duration};
 use tempo_chainspec::hardfork::TempoHardfork;
 use tokio::{
-    sync::mpsc::{UnboundedReceiver, unbounded_channel},
+    sync::mpsc::{self, UnboundedReceiver, unbounded_channel},
     try_join,
 };
 
@@ -3015,7 +3015,7 @@ impl EthApi<FoundryNetwork> {
     pub async fn new_pending_transaction_filter(&self, full: bool) -> Result<String> {
         node_info!("eth_newPendingTransactionFilter");
         let filter = if full {
-            EthFilter::FullPendingTransactions(self.full_pending_transactions())
+            EthFilter::FullPendingTransactions(self.full_pending_transactions_filter())
         } else {
             EthFilter::PendingTransactions(self.new_ready_transactions())
         };
@@ -3769,6 +3769,29 @@ impl EthApi<FoundryNetwork> {
             while let Some(hash) = hashes.next().await {
                 if let Ok(Some(txn)) = this.transaction_by_hash(hash).await
                     && tx.send(txn).is_err()
+                {
+                    break;
+                }
+            }
+        });
+
+        rx
+    }
+
+    /// Returns a bounded stream of full pending transactions for poll-based filters.
+    ///
+    /// Unlike [`Self::full_pending_transactions`], this applies backpressure via a bounded channel,
+    /// so an unpolled filter cannot buffer transactions without bound.
+    pub fn full_pending_transactions_filter(&self) -> mpsc::Receiver<AnyRpcTransaction> {
+        // Mirror the pool's ready-listener buffer so a full filter is bounded like a hash filter.
+        let (tx, rx) = mpsc::channel(2048);
+        let mut hashes = self.new_ready_transactions();
+        let this = self.clone();
+
+        tokio::spawn(async move {
+            while let Some(hash) = hashes.next().await {
+                if let Ok(Some(txn)) = this.transaction_by_hash(hash).await
+                    && tx.send(txn).await.is_err()
                 {
                     break;
                 }

--- a/crates/anvil/src/filter.rs
+++ b/crates/anvil/src/filter.rs
@@ -20,7 +20,7 @@ use std::{
     task::{Context, Poll},
     time::{Duration, Instant},
 };
-use tokio::sync::{Mutex, mpsc::UnboundedReceiver};
+use tokio::sync::{Mutex, mpsc};
 
 /// Type alias for filters identified by their id and their expiration timestamp
 type FilterMap<N> = Arc<Mutex<HashMap<String, (EthFilter<N>, Instant)>>>;
@@ -142,7 +142,7 @@ pub enum EthFilter<N: Network> {
     Logs(Box<LogsFilter<N>>),
     Blocks(NewBlockNotifications),
     PendingTransactions(Receiver<TxHash>),
-    FullPendingTransactions(UnboundedReceiver<AnyRpcTransaction>),
+    FullPendingTransactions(mpsc::Receiver<AnyRpcTransaction>),
 }
 
 impl<N: Network> std::fmt::Debug for EthFilter<N> {

--- a/crates/anvil/src/filter.rs
+++ b/crates/anvil/src/filter.rs
@@ -5,7 +5,7 @@ use crate::{
     pubsub::filter_logs,
 };
 use alloy_consensus::TxReceipt;
-use alloy_network::Network;
+use alloy_network::{AnyRpcTransaction, Network};
 use alloy_primitives::{TxHash, map::HashMap};
 use alloy_rpc_types::{Filter, FilteredParams, Log};
 use anvil_core::eth::subscription::SubscriptionId;
@@ -20,7 +20,7 @@ use std::{
     task::{Context, Poll},
     time::{Duration, Instant},
 };
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc::UnboundedReceiver};
 
 /// Type alias for filters identified by their id and their expiration timestamp
 type FilterMap<N> = Arc<Mutex<HashMap<String, (EthFilter<N>, Instant)>>>;
@@ -142,6 +142,7 @@ pub enum EthFilter<N: Network> {
     Logs(Box<LogsFilter<N>>),
     Blocks(NewBlockNotifications),
     PendingTransactions(Receiver<TxHash>),
+    FullPendingTransactions(UnboundedReceiver<AnyRpcTransaction>),
 }
 
 impl<N: Network> std::fmt::Debug for EthFilter<N> {
@@ -150,6 +151,7 @@ impl<N: Network> std::fmt::Debug for EthFilter<N> {
             Self::Logs(_) => f.debug_tuple("Logs").finish(),
             Self::Blocks(_) => f.debug_tuple("Blocks").finish(),
             Self::PendingTransactions(_) => f.debug_tuple("PendingTransactions").finish(),
+            Self::FullPendingTransactions(_) => f.debug_tuple("FullPendingTransactions").finish(),
         }
     }
 }
@@ -175,6 +177,13 @@ where
                 let mut new_txs = Vec::new();
                 while let Poll::Ready(Some(tx_hash)) = tx.poll_next_unpin(cx) {
                     new_txs.push(tx_hash);
+                }
+                Poll::Ready(Some(Ok(new_txs).to_rpc_result()))
+            }
+            Self::FullPendingTransactions(tx) => {
+                let mut new_txs = Vec::new();
+                while let Poll::Ready(Some(tx)) = tx.poll_recv(cx) {
+                    new_txs.push(tx);
                 }
                 Poll::Ready(Some(Ok(new_txs).to_rpc_result()))
             }

--- a/crates/anvil/tests/it/txpool.rs
+++ b/crates/anvil/tests/it/txpool.rs
@@ -1,11 +1,14 @@
 //! txpool related tests
 
-use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
-use alloy_primitives::U256;
+use alloy_consensus::Transaction;
+use alloy_network::{AnyRpcTransaction, ReceiptResponse, TransactionBuilder, TransactionResponse};
+use alloy_primitives::{TxHash, U256};
 use alloy_provider::{Provider, ext::TxPoolApi};
 use alloy_rpc_types::TransactionRequest;
 use alloy_serde::WithOtherFields;
 use anvil::{NodeConfig, spawn};
+use std::time::Duration;
+use tokio::time::sleep;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn geth_txpool() {
@@ -228,6 +231,62 @@ async fn geth_txpool_content_from_filters_sender() {
     let empty_content = provider.txpool_content_from(empty_sender).await.unwrap();
     assert!(empty_content.pending.is_empty());
     assert!(empty_content.queued.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_filter_full_pending_transactions() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let account = provider.get_accounts().await.unwrap().remove(0);
+    let value = U256::from(42);
+    let tx = TransactionRequest::default().with_to(account).with_from(account).with_value(value);
+    let tx = WithOtherFields::new(tx);
+
+    let hash_filter: String =
+        provider.client().request("eth_newPendingTransactionFilter", (false,)).await.unwrap();
+    let full_filter: String =
+        provider.client().request("eth_newPendingTransactionFilter", (true,)).await.unwrap();
+
+    let pending = provider.send_transaction(tx).await.unwrap();
+    let tx_hash = *pending.tx_hash();
+
+    let mut hash_changes = Vec::new();
+    for _ in 0..100 {
+        let changes: Vec<TxHash> = provider
+            .client()
+            .request("eth_getFilterChanges", (hash_filter.clone(),))
+            .await
+            .unwrap();
+        if !changes.is_empty() {
+            hash_changes = changes;
+            break;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+
+    let mut full_changes = Vec::new();
+    for _ in 0..100 {
+        let changes: Vec<AnyRpcTransaction> = provider
+            .client()
+            .request("eth_getFilterChanges", (full_filter.clone(),))
+            .await
+            .unwrap();
+        if !changes.is_empty() {
+            full_changes = changes;
+            break;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+
+    assert_eq!(hash_changes, vec![tx_hash]);
+    assert_eq!(full_changes.len(), 1);
+
+    let full_tx = &full_changes[0];
+    assert_eq!(full_tx.inner.tx_hash(), tx_hash);
+    assert_eq!(full_tx.inner.value(), value);
 }
 
 // Cf. https://github.com/foundry-rs/foundry/issues/11239


### PR DESCRIPTION
This adds support for the optional boolean parameter on `eth_newPendingTransactionFilter`. The default and `false` behavior continues to return pending transaction hashes, while `true` installs a full-pending-transaction filter backed by Anvil's existing full pending transaction stream.

The parser now accepts omitted, null, false, and true parameter forms, matching the boolean wire shape used by upstream clients.

Authored with AI assistance.
