### PR TITLE
feat(anvil): support receipt subscriptions

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -53,6 +53,7 @@ use alloy_rpc_types::{
     anvil::{
         ForkedNetwork, Forking, Metadata, MineOptions, NodeEnvironment, NodeForkConfig, NodeInfo,
     },
+    pubsub::TransactionReceiptsParams,
     request::TransactionRequest,
     simulate::{SimulatePayload, SimulatedBlock},
     state::{AccountOverride, EvmOverrides, StateOverridesBuilder},
@@ -3481,6 +3482,42 @@ impl EthApi<FoundryNetwork> {
                 if let Ok(Some(txn)) = this.transaction_by_hash(hash).await
                     && tx.send(txn).is_err()
                 {
+                    break;
+                }
+            }
+        });
+
+        rx
+    }
+
+    /// Returns a listener for new block receipts.
+    pub fn transaction_receipts_subscription(
+        &self,
+        filter: TransactionReceiptsParams,
+    ) -> UnboundedReceiver<Vec<FoundryTxReceipt>> {
+        let (tx, rx) = unbounded_channel();
+        let mut blocks = self.new_block_notifications();
+        let this = self.clone();
+
+        tokio::spawn(async move {
+            while let Some(block) = blocks.next().await {
+                let Ok(Some(mut receipts)) =
+                    this.block_receipts(BlockId::Hash(block.hash.into())).await
+                else {
+                    continue;
+                };
+
+                if let Some(hashes) = &filter.transaction_hashes
+                    && !hashes.is_empty()
+                {
+                    receipts.retain(|receipt| hashes.contains(&receipt.transaction_hash()));
+                }
+
+                if receipts.is_empty() {
+                    continue;
+                }
+
+                if tx.send(receipts).is_err() {
                     break;
                 }
             }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3500,18 +3500,36 @@ impl EthApi<FoundryNetwork> {
         let this = self.clone();
 
         tokio::spawn(async move {
-            while let Some(block) = blocks.next().await {
-                let Ok(Some(mut receipts)) =
-                    this.block_receipts(BlockId::Hash(block.hash.into())).await
-                else {
-                    continue;
+            // Precompute the hash filter once.
+            let hash_filter = filter
+                .transaction_hashes
+                .filter(|hashes| !hashes.is_empty())
+                .map(|hashes| hashes.into_iter().collect::<std::collections::HashSet<_>>());
+
+            loop {
+                let block = tokio::select! {
+                    biased;
+                    // Exit when the subscriber unsubscribes, even while awaiting the next block.
+                    _ = tx.closed() => break,
+                    maybe_block = blocks.next() => match maybe_block {
+                        Some(block) => block,
+                        None => break,
+                    },
                 };
 
-                if let Some(hashes) = &filter.transaction_hashes
-                    && !hashes.is_empty()
-                {
-                    receipts.retain(|receipt| hashes.contains(&receipt.transaction_hash()));
-                }
+                let receipts = match this.block_receipts(BlockId::Hash(block.hash.into())).await {
+                    Ok(Some(mut receipts)) => {
+                        if let Some(hashes) = &hash_filter {
+                            receipts.retain(|receipt| hashes.contains(&receipt.transaction_hash()));
+                        }
+                        receipts
+                    }
+                    Ok(None) => continue,
+                    Err(err) => {
+                        trace!(target: "node", %err, "failed to build block receipts for subscription");
+                        continue;
+                    }
+                };
 
                 if receipts.is_empty() {
                     continue;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -818,7 +818,7 @@ impl<N: Network> Backend<N> {
     }
 
     /// Returns the number of new-block listeners. Closed listeners are pruned lazily on the next
-    /// [`Self::notify_on_new_block`].
+    /// new block notification.
     pub fn new_block_listeners_count(&self) -> usize {
         self.new_block_listeners.lock().len()
     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -817,6 +817,12 @@ impl<N: Network> Backend<N> {
         rx
     }
 
+    /// Returns the number of new-block listeners. Closed listeners are pruned lazily on the next
+    /// [`Self::notify_on_new_block`].
+    pub fn new_block_listeners_count(&self) -> usize {
+        self.new_block_listeners.lock().len()
+    }
+
     /// Notifies all `new_block_listeners` about the new block
     fn notify_on_new_block(&self, header: Header, hash: B256) {
         // cleanup closed notification streams first, if the channel is closed we can remove the

--- a/crates/anvil/src/pubsub.rs
+++ b/crates/anvil/src/pubsub.rs
@@ -8,6 +8,7 @@ use alloy_primitives::{B256, TxHash};
 use alloy_rpc_types::{FilteredParams, Log, Transaction, pubsub::SubscriptionResult};
 use anvil_core::eth::{block::Block, subscription::SubscriptionId};
 use anvil_rpc::{request::Version, response::ResponseResult};
+use foundry_primitives::FoundryTxReceipt;
 use futures::{Stream, StreamExt, channel::mpsc::Receiver, ready};
 use serde::Serialize;
 use std::{
@@ -100,6 +101,7 @@ pub enum EthSubscription<N: Network> {
     Header(NewBlockNotifications, StorageInfo<N>, SubscriptionId),
     PendingTransactions(Receiver<TxHash>, SubscriptionId),
     FullPendingTransactions(UnboundedReceiver<AnyRpcTransaction>, SubscriptionId),
+    TransactionReceipts(UnboundedReceiver<Vec<FoundryTxReceipt>>, SubscriptionId),
 }
 
 impl<N: Network> std::fmt::Debug for EthSubscription<N> {
@@ -109,6 +111,7 @@ impl<N: Network> std::fmt::Debug for EthSubscription<N> {
             Self::Header(..) => f.debug_tuple("Header").finish(),
             Self::PendingTransactions(..) => f.debug_tuple("PendingTransactions").finish(),
             Self::FullPendingTransactions(..) => f.debug_tuple("FullPendingTransactions").finish(),
+            Self::TransactionReceipts(..) => f.debug_tuple("TransactionReceipts").finish(),
         }
     }
 }
@@ -150,6 +153,13 @@ where
             }
             Self::FullPendingTransactions(tx, id) => {
                 let res = ready!(tx.poll_recv(cx)).map(to_rpc_result).map(|result| {
+                    let params = EthSubscriptionParams { subscription: id.clone(), result };
+                    EthSubscriptionResponse::new(params)
+                });
+                Poll::Ready(res)
+            }
+            Self::TransactionReceipts(receipts, id) => {
+                let res = ready!(receipts.poll_recv(cx)).map(to_rpc_result).map(|result| {
                     let params = EthSubscriptionParams { subscription: id.clone(), result };
                     EthSubscriptionResponse::new(params)
                 });

--- a/crates/anvil/src/server/rpc_handlers.rs
+++ b/crates/anvil/src/server/rpc_handlers.rs
@@ -114,7 +114,24 @@ impl PubSubEthRpcHandler {
                         }
                     }
                     SubscriptionKind::TransactionReceipts => {
-                        return RpcError::internal_error_with("Not implemented").into();
+                        trace!(target: "rpc::ws", "received transaction receipts subscription");
+                        match *raw_params {
+                            Params::None => EthSubscription::TransactionReceipts(
+                                self.api.transaction_receipts_subscription(Default::default()),
+                                id.clone(),
+                            ),
+                            Params::TransactionReceipts(filter) => {
+                                EthSubscription::TransactionReceipts(
+                                    self.api.transaction_receipts_subscription(filter),
+                                    id.clone(),
+                                )
+                            }
+                            _ => {
+                                return ResponseResult::Error(RpcError::invalid_params(
+                                    "Expected transactionReceipts params",
+                                ));
+                            }
+                        }
                     }
                     SubscriptionKind::Syncing => {
                         return RpcError::internal_error_with("Not implemented").into();

--- a/crates/anvil/tests/it/pubsub.rs
+++ b/crates/anvil/tests/it/pubsub.rs
@@ -1,15 +1,19 @@
 //! tests for subscriptions
 
 use crate::utils::{connect_pubsub, connect_pubsub_with_wallet};
-use alloy_network::{EthereumWallet, TransactionBuilder};
+use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
 use alloy_pubsub::Subscription;
-use alloy_rpc_types::{Block as AlloyBlock, Filter, TransactionRequest};
+use alloy_rpc_types::{
+    Block as AlloyBlock, Filter, TransactionRequest, pubsub::TransactionReceiptsParams,
+};
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::sol;
 use anvil::{NodeConfig, spawn};
+use foundry_primitives::FoundryTxReceipt;
 use futures::StreamExt;
+use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sub_new_heads() {
@@ -245,6 +249,66 @@ async fn test_subscriptions() {
         .collect::<Vec<_>>();
 
     assert_eq!(blocks, vec![1, 2, 3])
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sub_transaction_receipts() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let ws_provider = connect_pubsub(&handle.ws_endpoint()).await;
+    let http_provider = handle.http_provider();
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let accounts = http_provider.get_accounts().await.unwrap();
+    let from = accounts[0];
+    let to = accounts[1];
+
+    let tx = TransactionRequest::default()
+        .with_from(from)
+        .with_to(to)
+        .with_value(U256::from(1))
+        .with_nonce(0);
+    let first = http_provider.send_transaction(WithOtherFields::new(tx)).await.unwrap();
+
+    let tx = TransactionRequest::default()
+        .with_from(from)
+        .with_to(to)
+        .with_value(U256::from(2))
+        .with_nonce(1);
+    let second = http_provider.send_transaction(WithOtherFields::new(tx)).await.unwrap();
+
+    let all_id =
+        ws_provider.raw_request("eth_subscribe".into(), ["transactionReceipts"]).await.unwrap();
+    let all_stream: Subscription<Vec<FoundryTxReceipt>> =
+        ws_provider.get_subscription(all_id).await.unwrap();
+    let mut all_stream = all_stream.into_stream();
+
+    let filter = TransactionReceiptsParams { transaction_hashes: Some(vec![*second.tx_hash()]) };
+    let filtered_id = ws_provider
+        .raw_request("eth_subscribe".into(), ("transactionReceipts", filter))
+        .await
+        .unwrap();
+    let filtered_stream: Subscription<Vec<FoundryTxReceipt>> =
+        ws_provider.get_subscription(filtered_id).await.unwrap();
+    let mut filtered_stream = filtered_stream.into_stream();
+
+    api.mine_one().await;
+
+    let all_receipts = tokio::time::timeout(Duration::from_secs(5), all_stream.next())
+        .await
+        .expect("timed out waiting for transaction receipts")
+        .expect("subscription ended unexpectedly");
+    let filtered_receipts = tokio::time::timeout(Duration::from_secs(5), filtered_stream.next())
+        .await
+        .expect("timed out waiting for filtered transaction receipts")
+        .expect("subscription ended unexpectedly");
+
+    assert_eq!(all_receipts.len(), 2);
+    assert_eq!(all_receipts[0].transaction_hash(), *first.tx_hash());
+    assert_eq!(all_receipts[1].transaction_hash(), *second.tx_hash());
+
+    assert_eq!(filtered_receipts.len(), 1);
+    assert_eq!(filtered_receipts[0].transaction_hash(), *second.tx_hash());
 }
 
 #[expect(clippy::disallowed_macros)]

--- a/crates/anvil/tests/it/pubsub.rs
+++ b/crates/anvil/tests/it/pubsub.rs
@@ -2,7 +2,7 @@
 
 use crate::utils::{connect_pubsub, connect_pubsub_with_wallet};
 use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder};
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::Provider;
 use alloy_pubsub::Subscription;
 use alloy_rpc_types::{
@@ -309,6 +309,34 @@ async fn test_sub_transaction_receipts() {
 
     assert_eq!(filtered_receipts.len(), 1);
     assert_eq!(filtered_receipts[0].transaction_hash(), *second.tx_hash());
+}
+
+// A receipt subscription must drop its block listener once the subscriber unsubscribes, even if its
+// filter never matched any transaction.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sub_transaction_receipts_cleanup_on_unsubscribe() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let baseline = api.backend.new_block_listeners_count();
+
+    // Filter on a hash that never gets mined, so the task can only exit via the dropped receiver.
+    let filter = TransactionReceiptsParams { transaction_hashes: Some(vec![B256::random()]) };
+    let rx = api.transaction_receipts_subscription(filter);
+    assert_eq!(api.backend.new_block_listeners_count(), baseline + 1);
+
+    drop(rx);
+
+    // Let the task observe the closed channel, then mine to trigger listener pruning.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    api.mine_one().await;
+    api.mine_one().await;
+
+    assert_eq!(
+        api.backend.new_block_listeners_count(),
+        baseline,
+        "subscription task should terminate after unsubscribe"
+    );
 }
 
 #[expect(clippy::disallowed_macros)]


### PR DESCRIPTION
This adds `eth_subscribe` support for `transactionReceipts`. The subscription listens for new Anvil blocks, reuses the existing `eth_getBlockReceipts` receipt shape, and emits receipt vectors for blocks that contain matching transactions.

The optional `transactionHashes` filter is supported as well, so clients can subscribe to receipts for all transactions or only selected transaction hashes.

Authored with AI assistance.
