### PR TITLE
feat(anvil): support debug clear txpool

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -305,6 +305,10 @@ pub enum EthRequest {
     #[serde(rename = "debug_getRawTransaction", with = "sequence")]
     DebugGetRawTransaction(TxHash),
 
+    /// geth's `debug_clearTxpool` endpoint
+    #[serde(rename = "debug_clearTxpool", with = "empty_params")]
+    DebugClearTxpool(()),
+
     /// geth's `debug_traceTransaction`  endpoint
     #[serde(rename = "debug_traceTransaction")]
     DebugTraceTransaction(B256, #[serde(default)] GethDebugTracingOptions),
@@ -1519,6 +1523,13 @@ mod tests {
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
         let s = r#"{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockNumberAndIndex","params":["0x3ed3a89b",0],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_debug_clear_txpool() {
+        let s = r#"{"jsonrpc":"2.0","method":"debug_clearTxpool","params":[],"id":1}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -294,6 +294,15 @@ impl<N: Network> EthApi<N> {
         Ok(())
     }
 
+    /// Clears all transactions from the pool.
+    ///
+    /// Handler for RPC call: `debug_clearTxpool`
+    pub async fn debug_clear_txpool(&self) -> Result<()> {
+        node_info!("debug_clearTxpool");
+        self.pool.clear();
+        Ok(())
+    }
+
     pub async fn anvil_set_chain_id(&self, chain_id: u64) -> Result<()> {
         node_info!("anvil_setChainId");
         self.backend.set_chain_id(chain_id);
@@ -1667,6 +1676,8 @@ impl EthApi<FoundryNetwork> {
             EthRequest::DebugGetRawTransaction(hash) => {
                 self.raw_transaction(hash).await.to_rpc_result()
             }
+            // non eth-standard rpc calls
+            EthRequest::DebugClearTxpool(_) => self.debug_clear_txpool().await.to_rpc_result(),
             // non eth-standard rpc calls
             EthRequest::DebugTraceTransaction(tx, opts) => {
                 self.debug_trace_transaction(tx, opts).await.to_rpc_result()

--- a/crates/anvil/tests/it/txpool.rs
+++ b/crates/anvil/tests/it/txpool.rs
@@ -123,6 +123,45 @@ async fn geth_txpool_separates_queued_transactions() {
     assert!(!queued.contains_key("0"));
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn can_debug_clear_txpool() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let account = accounts[0].address();
+    let recipient = accounts[1].address();
+    let gas_price = 221435145689u128;
+
+    let pending_tx = TransactionRequest::default()
+        .with_to(recipient)
+        .with_from(account)
+        .with_value(U256::from(42))
+        .with_gas_price(gas_price)
+        .with_nonce(0);
+    let queued_tx = TransactionRequest::default()
+        .with_to(recipient)
+        .with_from(account)
+        .with_value(U256::from(84))
+        .with_gas_price(gas_price)
+        .with_nonce(2);
+
+    let _ = provider.send_transaction(WithOtherFields::new(pending_tx)).await.unwrap();
+    let _ = provider.send_transaction(WithOtherFields::new(queued_tx)).await.unwrap();
+
+    let status = provider.txpool_status().await.unwrap();
+    assert_eq!(status.pending, 1);
+    assert_eq!(status.queued, 1);
+
+    let _: () = provider.client().request("debug_clearTxpool", ()).await.unwrap();
+
+    let status = provider.txpool_status().await.unwrap();
+    assert_eq!(status.pending, 0);
+    assert_eq!(status.queued, 0);
+}
+
 // Cf. https://github.com/foundry-rs/foundry/issues/11239
 #[tokio::test(flavor = "multi_thread")]
 async fn accepts_spend_after_funding_when_pool_checks_disabled() {


### PR DESCRIPTION
This adds `debug_clearTxpool` support to Anvil. The method clears the same transaction pool as `anvil_dropAllTransactions` while exposing the geth/reth debug RPC spelling and response shape.

The integration coverage queues both ready and nonce-gapped transactions, calls `debug_clearTxpool`, and verifies the txpool status is empty afterward.

Authored with AI assistance.
