### PR TITLE
feat(anvil): support debug raw header

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -350,6 +350,10 @@ pub enum EthRequest {
     #[serde(rename = "debug_getRawTransactions", with = "sequence")]
     DebugGetRawTransactions(BlockId),
 
+    /// geth's `debug_getRawHeader` endpoint.
+    #[serde(rename = "debug_getRawHeader", with = "sequence")]
+    DebugGetRawHeader(BlockId),
+
     /// geth's `debug_clearTxpool` endpoint
     #[serde(rename = "debug_clearTxpool", with = "empty_params")]
     DebugClearTxpool(()),
@@ -1699,6 +1703,17 @@ mod tests {
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
         let s = r#"{"jsonrpc":"2.0","method":"debug_getRawTransactions","params":["0x3ed3a89bc10115a321aee238c02de214009f8532a65368e5df5eaf732ee7167c"],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_debug_raw_header() {
+        let s = r#"{"jsonrpc":"2.0","method":"debug_getRawHeader","params":["latest"],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"jsonrpc":"2.0","method":"debug_getRawHeader","params":["0x3ed3a89bc10115a321aee238c02de214009f8532a65368e5df5eaf732ee7167c"],"id":1}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1738,6 +1738,7 @@ impl EthApi<FoundryNetwork> {
             EthRequest::DebugGetRawTransactions(block) => {
                 self.raw_transactions(block).await.to_rpc_result()
             }
+            EthRequest::DebugGetRawHeader(block) => self.raw_header(block).await.to_rpc_result(),
             // non eth-standard rpc calls
             EthRequest::DebugClearTxpool(_) => self.debug_clear_txpool().await.to_rpc_result(),
             // non eth-standard rpc calls
@@ -3092,6 +3093,15 @@ impl EthApi<FoundryNetwork> {
             return Ok(Vec::new());
         };
         Ok(block.body.transactions.into_iter().map(|tx| tx.encoded_2718().into()).collect())
+    }
+
+    /// Returns RLP encoded raw block header.
+    ///
+    /// Handler for RPC call: `debug_getRawHeader`.
+    pub async fn raw_header(&self, block: BlockId) -> Result<Bytes> {
+        node_info!("debug_getRawHeader");
+        let block = self.backend.get_block(block).ok_or(BlockchainError::BlockNotFound)?;
+        Ok(alloy_rlp::encode(&block.header).into())
     }
 
     /// Returns EIP-2718 encoded raw transaction by block hash and index

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -2,7 +2,7 @@ use crate::{
     abi::{Greeter, Multicall, SimpleStorage},
     utils::{connect_pubsub, http_provider_with_signer},
 };
-use alloy_consensus::Transaction;
+use alloy_consensus::{Header, Transaction};
 use alloy_network::{
     AnyRpcTransaction, EthereumWallet, ReceiptResponse, TransactionBuilder, TransactionResponse,
     eip2718::Decodable2718,
@@ -11,6 +11,7 @@ use alloy_primitives::{
     Address, B256, Bytes, FixedBytes, TxHash, U64, U256, address, hex, map::B256HashSet,
 };
 use alloy_provider::{Provider, WsConnect};
+use alloy_rlp::Decodable;
 use alloy_rpc_types::{
     AccessList, AccessListItem, AccessListResult, BlockId, BlockNumberOrTag, BlockOverrides,
     BlockTransactions, TransactionRequest,
@@ -1012,6 +1013,32 @@ async fn can_get_raw_transactions() {
     let second_raw = api.raw_transaction(second_hash).await.unwrap().unwrap();
     assert!(raw_by_number.contains(&first_raw));
     assert!(raw_by_number.contains(&second_raw));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_raw_header() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let from = handle.dev_wallets().next().unwrap().address();
+    let tx = TransactionRequest::default().from(from).value(U256::from(1)).to(Address::random());
+    provider.send_transaction(WithOtherFields::new(tx)).await.unwrap().get_receipt().await.unwrap();
+
+    let block = provider.get_block(BlockId::number(1)).await.unwrap().unwrap();
+    let raw_by_number: Bytes =
+        provider.client().request("debug_getRawHeader", (BlockId::number(1),)).await.unwrap();
+    let raw_by_hash: Bytes = provider
+        .client()
+        .request("debug_getRawHeader", (BlockId::hash(block.header.hash),))
+        .await
+        .unwrap();
+
+    assert_eq!(raw_by_number, raw_by_hash);
+    assert!(!raw_by_number.is_empty());
+
+    let decoded = Header::decode(&mut raw_by_number.as_ref()).unwrap();
+    assert_eq!(decoded.number, 1);
+    assert_eq!(decoded.hash_slow(), block.header.hash);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Adds Anvil support for geth/reth's `debug_getRawHeader` endpoint. The RPC request now accepts a block id, resolves the matching local block, and returns the RLP-encoded header bytes.

This fills another small compatibility gap for tooling that asks debug APIs for raw chain data instead of expanded JSON block objects. The integration coverage exercises lookup by both block number and block hash and decodes the returned bytes back into an Alloy header.

Authored with AI assistance.
