### PR TITLE
feat(anvil): support debug raw block

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -354,6 +354,10 @@ pub enum EthRequest {
     #[serde(rename = "debug_getRawHeader", with = "sequence")]
     DebugGetRawHeader(BlockId),
 
+    /// geth's `debug_getRawBlock` endpoint.
+    #[serde(rename = "debug_getRawBlock", with = "sequence")]
+    DebugGetRawBlock(BlockId),
+
     /// geth's `debug_clearTxpool` endpoint
     #[serde(rename = "debug_clearTxpool", with = "empty_params")]
     DebugClearTxpool(()),
@@ -1714,6 +1718,17 @@ mod tests {
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
         let s = r#"{"jsonrpc":"2.0","method":"debug_getRawHeader","params":["0x3ed3a89bc10115a321aee238c02de214009f8532a65368e5df5eaf732ee7167c"],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_debug_raw_block() {
+        let s = r#"{"jsonrpc":"2.0","method":"debug_getRawBlock","params":["latest"],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"jsonrpc":"2.0","method":"debug_getRawBlock","params":["0x3ed3a89bc10115a321aee238c02de214009f8532a65368e5df5eaf732ee7167c"],"id":1}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1739,6 +1739,7 @@ impl EthApi<FoundryNetwork> {
                 self.raw_transactions(block).await.to_rpc_result()
             }
             EthRequest::DebugGetRawHeader(block) => self.raw_header(block).await.to_rpc_result(),
+            EthRequest::DebugGetRawBlock(block) => self.raw_block(block).await.to_rpc_result(),
             // non eth-standard rpc calls
             EthRequest::DebugClearTxpool(_) => self.debug_clear_txpool().await.to_rpc_result(),
             // non eth-standard rpc calls
@@ -3102,6 +3103,15 @@ impl EthApi<FoundryNetwork> {
         node_info!("debug_getRawHeader");
         let block = self.backend.get_block(block).ok_or(BlockchainError::BlockNotFound)?;
         Ok(alloy_rlp::encode(&block.header).into())
+    }
+
+    /// Returns RLP encoded raw block.
+    ///
+    /// Handler for RPC call: `debug_getRawBlock`.
+    pub async fn raw_block(&self, block: BlockId) -> Result<Bytes> {
+        node_info!("debug_getRawBlock");
+        let block = self.backend.get_block(block).ok_or(BlockchainError::BlockNotFound)?;
+        Ok(alloy_rlp::encode(&block).into())
     }
 
     /// Returns EIP-2718 encoded raw transaction by block hash and index

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -20,6 +20,7 @@ use alloy_rpc_types::{
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::SolValue;
 use anvil::{NodeConfig, spawn};
+use anvil_core::eth::block::Block;
 use eyre::Ok;
 use foundry_evm::hardfork::EthereumHardfork;
 use foundry_primitives::FoundryReceiptEnvelope;
@@ -1039,6 +1040,33 @@ async fn can_get_raw_header() {
     let decoded = Header::decode(&mut raw_by_number.as_ref()).unwrap();
     assert_eq!(decoded.number, 1);
     assert_eq!(decoded.hash_slow(), block.header.hash);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_raw_block() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let from = handle.dev_wallets().next().unwrap().address();
+    let tx = TransactionRequest::default().from(from).value(U256::from(1)).to(Address::random());
+    provider.send_transaction(WithOtherFields::new(tx)).await.unwrap().get_receipt().await.unwrap();
+
+    let block = provider.get_block(BlockId::number(1)).await.unwrap().unwrap();
+    let raw_by_number: Bytes =
+        provider.client().request("debug_getRawBlock", (BlockId::number(1),)).await.unwrap();
+    let raw_by_hash: Bytes = provider
+        .client()
+        .request("debug_getRawBlock", (BlockId::hash(block.header.hash),))
+        .await
+        .unwrap();
+
+    assert_eq!(raw_by_number, raw_by_hash);
+    assert!(!raw_by_number.is_empty());
+
+    let decoded: Block = Block::decode(&mut raw_by_number.as_ref()).unwrap();
+    assert_eq!(decoded.header.hash_slow(), block.header.hash);
+    assert_eq!(decoded.header.number, 1);
+    assert_eq!(decoded.body.transactions.len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Adds Anvil support for geth/reth's `debug_getRawBlock` endpoint. The RPC request accepts a block id, resolves the local block, and returns the RLP-encoded block bytes.

This fills another raw debug API compatibility gap for tools that need canonical block bytes instead of expanded JSON block responses. The endpoint is covered by request parsing and an integration test that fetches by number and hash, then decodes the returned bytes back into Anvil's block type.

Authored with AI assistance.
