### PR TITLE
feat(anvil): support debug raw receipts

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -305,6 +305,10 @@ pub enum EthRequest {
     #[serde(rename = "debug_getRawTransaction", with = "sequence")]
     DebugGetRawTransaction(TxHash),
 
+    /// reth's `debug_getRawReceipts` endpoint.
+    #[serde(rename = "debug_getRawReceipts", with = "sequence")]
+    DebugGetRawReceipts(BlockId),
+
     /// geth's `debug_traceTransaction`  endpoint
     #[serde(rename = "debug_traceTransaction")]
     DebugTraceTransaction(B256, #[serde(default)] GethDebugTracingOptions),
@@ -1519,6 +1523,17 @@ mod tests {
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
         let s = r#"{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockNumberAndIndex","params":["0x3ed3a89b",0],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_debug_raw_receipts() {
+        let s = r#"{"jsonrpc":"2.0","method":"debug_getRawReceipts","params":["latest"],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"jsonrpc":"2.0","method":"debug_getRawReceipts","params":["0x3ed3a89bc10115a321aee238c02de214009f8532a65368e5df5eaf732ee7167c"],"id":1}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1667,6 +1667,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::DebugGetRawTransaction(hash) => {
                 self.raw_transaction(hash).await.to_rpc_result()
             }
+            EthRequest::DebugGetRawReceipts(block) => {
+                self.raw_receipts(block).await.to_rpc_result()
+            }
             // non eth-standard rpc calls
             EthRequest::DebugTraceTransaction(tx, opts) => {
                 self.debug_trace_transaction(tx, opts).await.to_rpc_result()
@@ -2825,6 +2828,19 @@ impl EthApi<FoundryNetwork> {
     pub async fn raw_transaction(&self, hash: B256) -> Result<Option<Bytes>> {
         node_info!("debug_getRawTransaction");
         self.inner_raw_transaction(hash).await
+    }
+
+    /// Returns EIP-2718 encoded raw receipts for the block.
+    ///
+    /// Handler for RPC call: `debug_getRawReceipts`.
+    pub async fn raw_receipts(&self, block: BlockId) -> Result<Vec<Bytes>> {
+        node_info!("debug_getRawReceipts");
+        let block = self.backend.get_block(block).ok_or(BlockchainError::BlockNotFound)?;
+        let receipts = self
+            .backend
+            .mined_receipts(block.header.hash_slow())
+            .ok_or(BlockchainError::BlockNotFound)?;
+        Ok(receipts.into_iter().map(|receipt| receipt.encoded_2718().into()).collect())
     }
 
     /// Returns EIP-2718 encoded raw transaction by block hash and index

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2835,6 +2835,21 @@ impl EthApi<FoundryNetwork> {
     /// Handler for RPC call: `debug_getRawReceipts`.
     pub async fn raw_receipts(&self, block: BlockId) -> Result<Vec<Bytes>> {
         node_info!("debug_getRawReceipts");
+
+        // In fork mode, serve pre-fork blocks from the upstream provider.
+        if let BlockRequest::Number(number) = self.block_request(Some(block)).await?
+            && let Some(fork) = self.get_fork()
+            && fork.predates_fork_inclusive(number)
+        {
+            let receipts = fork.block_receipts(number).await?.unwrap_or_default();
+            return Ok(receipts
+                .into_iter()
+                .map(|receipt| {
+                    receipt.0.inner.inner.map_logs(|log| log.inner).encoded_2718().into()
+                })
+                .collect());
+        }
+
         let block = self.backend.get_block(block).ok_or(BlockchainError::BlockNotFound)?;
         let receipts = self
             .backend

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use alloy_chains::NamedChain;
 use alloy_eips::{
+    eip2718::Decodable2718,
     eip7840::BlobParams,
     eip7910::{EthConfig, SystemContract},
 };
@@ -24,7 +25,7 @@ use anvil::{EthereumHardfork, NodeConfig, NodeHandle, PrecompileFactory, eth::Et
 use foundry_common::provider::get_http_provider;
 use foundry_config::Config;
 use foundry_evm_networks::NetworkConfigs;
-use foundry_primitives::FoundryNetwork;
+use foundry_primitives::{FoundryNetwork, FoundryReceiptEnvelope};
 use foundry_test_utils::rpc::{self, next_http_rpc_endpoint, next_rpc_endpoint};
 use futures::StreamExt;
 use revm::precompile::PrecompileStatus;
@@ -101,6 +102,40 @@ async fn test_fork_gas_limit_disabled_from_config() {
         .from(handle.dev_wallets().next().unwrap().address());
     let tx = WithOtherFields::new(tx);
     let _ = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+}
+
+// `debug_getRawReceipts` must serve pre-fork blocks from the upstream provider.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_debug_get_raw_receipts() {
+    let (_api, handle) = spawn(fork_config()).await;
+    let provider = handle.http_provider();
+
+    // A pre-fork block known to contain transactions.
+    let block_number = BLOCK_NUMBER - 1;
+    let rpc_receipts =
+        provider.get_block_receipts(BlockId::number(block_number)).await.unwrap().unwrap();
+    assert!(!rpc_receipts.is_empty());
+
+    let block = provider.get_block(BlockId::number(block_number)).await.unwrap().unwrap();
+    let raw_by_number: Vec<Bytes> = provider
+        .client()
+        .request("debug_getRawReceipts", (BlockId::number(block_number),))
+        .await
+        .unwrap();
+    let raw_by_hash: Vec<Bytes> = provider
+        .client()
+        .request("debug_getRawReceipts", (BlockId::hash(block.header.hash),))
+        .await
+        .unwrap();
+
+    assert_eq!(raw_by_number, raw_by_hash);
+    assert_eq!(raw_by_number.len(), rpc_receipts.len());
+
+    // Each entry decodes back into a receipt envelope matching the RPC receipt.
+    for (raw, rpc) in raw_by_number.iter().zip(rpc_receipts.iter()) {
+        let decoded = FoundryReceiptEnvelope::decode_2718(&mut raw.as_ref()).unwrap();
+        assert_eq!(decoded.status(), rpc.status());
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -5,6 +5,7 @@ use crate::{
 use alloy_consensus::Transaction;
 use alloy_network::{
     AnyRpcTransaction, EthereumWallet, ReceiptResponse, TransactionBuilder, TransactionResponse,
+    eip2718::Decodable2718,
 };
 use alloy_primitives::{
     Address, Bytes, FixedBytes, TxHash, U64, U256, address, hex, map::B256HashSet,
@@ -20,6 +21,7 @@ use alloy_sol_types::SolValue;
 use anvil::{NodeConfig, spawn};
 use eyre::Ok;
 use foundry_evm::hardfork::EthereumHardfork;
+use foundry_primitives::FoundryReceiptEnvelope;
 use futures::{FutureExt, StreamExt, future::join_all};
 use revm::primitives::eip7825::TX_GAS_LIMIT_CAP;
 use std::{
@@ -869,6 +871,57 @@ async fn can_get_raw_transaction() {
     let res2 = api.raw_transaction(*tx.tx_hash()).await;
 
     assert_eq!(res1.unwrap(), res2.unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_raw_receipts() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let provider = handle.http_provider();
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let first = TransactionRequest::default()
+        .from(accounts[0].address())
+        .value(U256::from(1))
+        .to(Address::random());
+    let second = TransactionRequest::default()
+        .from(accounts[1].address())
+        .value(U256::from(2))
+        .to(Address::random());
+
+    let first = provider.send_transaction(WithOtherFields::new(first)).await.unwrap();
+    let second = provider.send_transaction(WithOtherFields::new(second)).await.unwrap();
+
+    api.mine_one().await;
+    let first_receipt = first.get_receipt().await.unwrap();
+    let second_receipt = second.get_receipt().await.unwrap();
+    assert_eq!(first_receipt.block_number, Some(1));
+    assert_eq!(second_receipt.block_number, Some(1));
+
+    let block = provider.get_block(BlockId::number(1)).await.unwrap().unwrap();
+    let raw_by_number: Vec<Bytes> =
+        provider.client().request("debug_getRawReceipts", (BlockId::number(1),)).await.unwrap();
+    let raw_by_hash: Vec<Bytes> = provider
+        .client()
+        .request("debug_getRawReceipts", (BlockId::hash(block.header.hash),))
+        .await
+        .unwrap();
+    let missing: Result<Vec<Bytes>, _> =
+        provider.client().request("debug_getRawReceipts", (BlockId::number(999),)).await;
+
+    assert_eq!(raw_by_number, raw_by_hash);
+    assert_eq!(raw_by_number.len(), 2);
+    assert!(missing.is_err());
+
+    let mut first_raw = raw_by_number[0].as_ref();
+    let first_decoded = FoundryReceiptEnvelope::decode_2718(&mut first_raw).unwrap();
+    let mut second_raw = raw_by_number[1].as_ref();
+    let second_decoded = FoundryReceiptEnvelope::decode_2718(&mut second_raw).unwrap();
+
+    assert!(first_decoded.status());
+    assert!(second_decoded.status());
+    assert_eq!(first_decoded.cumulative_gas_used(), 21_000);
+    assert_eq!(second_decoded.cumulative_gas_used(), 42_000);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Adds Anvil support for reth's `debug_getRawReceipts` endpoint. The RPC request accepts a block id, resolves the local block, and returns the block's receipts as EIP-2718 encoded bytes.

This fills another raw debug API compatibility gap for tooling that needs canonical receipt bytes by block. The integration coverage mines two transactions into one block, fetches receipts by number and hash, decodes the returned bytes back into Foundry receipt envelopes, and checks the unresolved-block error path.

Authored with AI assistance.
