### PR TITLE
feat(anvil): support debug bad blocks

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -305,6 +305,10 @@ pub enum EthRequest {
     #[serde(rename = "debug_getRawTransaction", with = "sequence")]
     DebugGetRawTransaction(TxHash),
 
+    /// reth's `debug_getBadBlocks` endpoint.
+    #[serde(rename = "debug_getBadBlocks", with = "empty_params")]
+    DebugGetBadBlocks(()),
+
     /// geth's `debug_traceTransaction`  endpoint
     #[serde(rename = "debug_traceTransaction")]
     DebugTraceTransaction(B256, #[serde(default)] GethDebugTracingOptions),
@@ -1519,6 +1523,13 @@ mod tests {
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
         let s = r#"{"jsonrpc":"2.0","method":"eth_getRawTransactionByBlockNumberAndIndex","params":["0x3ed3a89b",0],"id":1}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_debug_get_bad_blocks() {
+        let s = r#"{"jsonrpc":"2.0","method":"debug_getBadBlocks","params":[],"id":1}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1218,6 +1218,14 @@ impl<N: Network> EthApi<N> {
         self.backend.debug_db_get(key).await
     }
 
+    /// Returns invalid blocks known to the node.
+    ///
+    /// Handler for RPC call: `debug_getBadBlocks`.
+    pub fn bad_blocks(&self) -> Result<Vec<serde_json::Value>> {
+        node_info!("debug_getBadBlocks");
+        Ok(Vec::new())
+    }
+
     /// Returns traces for the transaction hash via parity's tracing endpoint
     ///
     /// Handler for RPC call: `trace_transaction`
@@ -1667,6 +1675,7 @@ impl EthApi<FoundryNetwork> {
             EthRequest::DebugGetRawTransaction(hash) => {
                 self.raw_transaction(hash).await.to_rpc_result()
             }
+            EthRequest::DebugGetBadBlocks(_) => self.bad_blocks().to_rpc_result(),
             // non eth-standard rpc calls
             EthRequest::DebugTraceTransaction(tx, opts) => {
                 self.debug_trace_transaction(tx, opts).await.to_rpc_result()

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -529,6 +529,17 @@ async fn can_get_code_by_hash() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_get_bad_blocks() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let bad_blocks: Vec<serde_json::Value> =
+        provider.client().request("debug_getBadBlocks", ()).await.unwrap();
+
+    assert!(bad_blocks.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fill_transaction_fills_chain_id() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let wallet = handle.dev_wallets().next().unwrap();


### PR DESCRIPTION
Adds Anvil support for reth's `debug_getBadBlocks` endpoint. Anvil does not maintain a bad-block store, so the endpoint returns an empty list for the local development node.

This fills a debug API compatibility gap for tooling that probes the bad-block endpoint before deciding which client features are available. The coverage includes request parsing and an HTTP-level integration test that asserts the endpoint exists and returns an empty array.

Authored with AI assistance.
