### PR TITLE
feat(anvil): support debug trace block

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -363,6 +363,10 @@ pub enum EthRequest {
     #[serde(rename = "debug_freeOSMemory", with = "empty_params")]
     DebugFreeOsMemory(()),
 
+    /// geth's `debug_traceBlock` endpoint.
+    #[serde(rename = "debug_traceBlock")]
+    DebugTraceBlock(Bytes, #[serde(default)] GethDebugTracingOptions),
+
     /// geth's `debug_traceBlockByHash` endpoint
     #[serde(rename = "debug_traceBlockByHash")]
     DebugTraceBlockByHash(B256, #[serde(default)] GethDebugTracingOptions),
@@ -1739,6 +1743,13 @@ true}]}"#;
             EthRequest::DebugFreeOsMemory(()) => {}
             req => panic!("unexpected request: {req:?}"),
         }
+    }
+
+    #[test]
+    fn test_serde_debug_trace_block() {
+        let s = r#"{"method":"debug_traceBlock","params":["0xc0",{"tracer":"callTracer"}]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }
 
     #[test]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1741,6 +1741,9 @@ impl EthApi<FoundryNetwork> {
                 self.debug_get_modified_accounts_by_number(start_number, end_number).to_rpc_result()
             }
             EthRequest::DebugFreeOsMemory(()) => self.debug_free_os_memory().to_rpc_result(),
+            EthRequest::DebugTraceBlock(rlp_block, opts) => {
+                self.debug_trace_block(rlp_block, opts).await.to_rpc_result()
+            }
             EthRequest::DebugTraceBlockByHash(block_hash, opts) => {
                 self.debug_trace_block_by_hash(block_hash, opts).await.to_rpc_result()
             }
@@ -3040,6 +3043,18 @@ impl EthApi<FoundryNetwork> {
     ) -> Result<GethTrace> {
         node_info!("debug_traceTransaction");
         self.backend.debug_trace_transaction(tx_hash, opts).await
+    }
+
+    /// Returns traces for all transactions in an RLP-encoded block.
+    ///
+    /// Handler for RPC call: `debug_traceBlock`
+    pub async fn debug_trace_block(
+        &self,
+        rlp_block: Bytes,
+        opts: GethDebugTracingOptions,
+    ) -> Result<Vec<TraceResult>> {
+        node_info!("debug_traceBlock");
+        self.backend.debug_trace_block(rlp_block, opts).await
     }
 
     /// Returns traces for all transactions in a block by hash.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -63,6 +63,7 @@ use alloy_primitives::{
     Address, B256, Bloom, Bytes, TxHash, TxKind, U64, U256, hex, keccak256, logs_bloom,
     map::{AddressMap, HashMap, HashSet},
 };
+use alloy_rlp::Decodable;
 use alloy_rpc_types::{
     AccessList, Block as AlloyBlock, BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions,
     EIP1186AccountProofResponse as AccountProof, EIP1186StorageProof as StorageProof, Filter,
@@ -3578,6 +3579,27 @@ where
         }
 
         Ok(GethTrace::Default(Default::default()))
+    }
+
+    /// Returns geth-style traces for all transactions in an RLP-encoded block.
+    pub async fn debug_trace_block(
+        &self,
+        rlp_block: Bytes,
+        opts: GethDebugTracingOptions,
+    ) -> Result<Vec<TraceResult>, BlockchainError> {
+        let mut rlp = rlp_block.as_ref();
+        let block = Block::<FoundryTxEnvelope>::decode(&mut rlp).map_err(|err| {
+            BlockchainError::RpcError(RpcError::invalid_params(format!(
+                "failed to decode block: {err}"
+            )))
+        })?;
+        if !rlp.is_empty() {
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(
+                "failed to decode block: trailing bytes".to_string(),
+            )));
+        }
+
+        self.debug_trace_block_by_hash(block.header.hash_slow(), opts).await
     }
 
     /// Returns geth-style traces for all transactions in a block by hash.

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -15,6 +15,7 @@ use alloy_provider::{
     Provider,
     ext::{DebugApi, TraceApi},
 };
+use alloy_rlp::Encodable;
 use alloy_rpc_types::{
     BlockNumberOrTag, TransactionRequest,
     state::StateOverride,
@@ -1472,6 +1473,51 @@ async fn test_debug_trace_block_by_hash() {
         .backend
         .debug_trace_block_by_hash(
             block_hash,
+            GethDebugTracingOptions::default()
+                .with_tracer(GethDebugTracerType::from(GethDebugBuiltInTracerType::CallTracer)),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(traces.len(), 1);
+
+    match &traces[0] {
+        alloy_rpc_types::trace::geth::TraceResult::Success { result, .. } => match result {
+            GethTrace::CallTracer(call_frame) => {
+                assert_eq!(call_frame.from, from);
+                assert_eq!(call_frame.to.unwrap(), to);
+                assert_eq!(call_frame.value, Some(amount));
+            }
+            _ => unreachable!("expected CallTracer"),
+        },
+        alloy_rpc_types::trace::geth::TraceResult::Error { error, .. } => {
+            panic!("trace failed: {error}");
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_debug_trace_block() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let from = accounts[0].address();
+    let to = accounts[1].address();
+    let amount = U256::from(3000);
+
+    let tx = TransactionRequest::default().to(to).value(amount).from(from);
+    let tx = WithOtherFields::new(tx);
+    let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+    let block_hash = receipt.block_hash.unwrap();
+    let block = api.backend.get_block(BlockId::Hash(block_hash.into())).unwrap();
+
+    let mut rlp_block = Vec::new();
+    block.encode(&mut rlp_block);
+
+    let traces = provider
+        .debug_trace_block(
+            &rlp_block,
             GethDebugTracingOptions::default()
                 .with_tracer(GethDebugTracerType::from(GethDebugBuiltInTracerType::CallTracer)),
         )


### PR DESCRIPTION
Adds Anvil support for `debug_traceBlock` by accepting an RLP-encoded block, decoding it, and tracing the matching local block through the existing hash-based debug tracer.

Anvil stores executed local blocks rather than exposing a raw block import/replay pipeline, so this supports encoded blocks that are already present in the local chain and otherwise preserves the existing block-not-found behavior. This fills the compatibility path for tooling that retrieves a block from Anvil and then traces it through the raw block endpoint.

Authored with AI assistance.
