### PR TITLE
feat(anvil): support trace replay transaction

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -1824,6 +1824,7 @@ true}]}"#;
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }
 
+    #[test]
     fn test_serde_trace_transaction_opcode_gas() {
         let s = r#"{"method": "trace_transactionOpcodeGas", "params": ["0x4a3b0fce2cb9707b0baa68640cf2fe858c8bb4121b2a8cb904ff369d38a560ff"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -443,6 +443,10 @@ pub enum EthRequest {
         HashSet<TraceType>,
     ),
 
+    /// Trace transaction endpoint for parity's `trace_replayTransaction`.
+    #[serde(rename = "trace_replayTransaction")]
+    TraceReplayTransaction(B256, HashSet<TraceType>),
+
     /// Trace raw transaction endpoint for parity's `trace_rawTransaction`.
     #[serde(rename = "trace_rawTransaction")]
     TraceRawTransaction(Bytes, HashSet<TraceType>, #[serde(default)] Option<BlockId>),
@@ -1812,6 +1816,13 @@ mod tests {
         let s = r#"{"method": "debug_traceTransaction", "params":
 ["0x4a3b0fce2cb9707b0baa68640cf2fe858c8bb4121b2a8cb904ff369d38a560ff", {"disableStorage":
 true}]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_trace_replay_transaction() {
+        let s = r#"{"method":"trace_replayTransaction","params":["0x4a3b0fce2cb9707b0baa68640cf2fe858c8bb4121b2a8cb904ff369d38a560ff",["trace","stateDiff"]]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1351,6 +1351,18 @@ impl<N: Network> EthApi<N> {
         node_info!("trace_replayBlockTransactions");
         self.backend.trace_replay_block_transactions(block, trace_types).await
     }
+
+    /// Replays a transaction returning the requested traces.
+    ///
+    /// Handler for RPC call: `trace_replayTransaction`.
+    pub async fn trace_replay_transaction(
+        &self,
+        transaction: B256,
+        trace_types: HashSet<TraceType>,
+    ) -> Result<TraceResults> {
+        node_info!("trace_replayTransaction");
+        self.backend.trace_replay_transaction(transaction, trace_types).await
+    }
 }
 
 impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> EthApi<N> {
@@ -1862,6 +1874,9 @@ impl EthApi<FoundryNetwork> {
             }
             EthRequest::TraceReplayBlockTransactions(block, trace_types) => {
                 self.trace_replay_block_transactions(block, trace_types).await.to_rpc_result()
+            }
+            EthRequest::TraceReplayTransaction(transaction, trace_types) => {
+                self.trace_replay_transaction(transaction, trace_types).await.to_rpc_result()
             }
             EthRequest::TraceRawTransaction(tx, trace_types, block_number) => {
                 self.trace_raw_transaction(tx, trace_types, block_number).await.to_rpc_result()

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -357,6 +357,14 @@ impl<N: Network> ClientFork<N> {
         self.provider().raw_request("trace_replayBlockTransactions".into(), params).await
     }
 
+    pub async fn trace_replay_transaction(
+        &self,
+        hash: B256,
+        trace_types: HashSet<TraceType>,
+    ) -> Result<TraceResults, TransportError> {
+        self.provider().raw_request("trace_replayTransaction".into(), (hash, trace_types)).await
+    }
+
     /// Reset the fork to a fresh forked state, and optionally update the fork config
     pub async fn reset(
         &self,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1898,14 +1898,27 @@ impl<N: Network> Backend<N> {
         let block_number =
             self.blockchain.storage.read().transactions.get(&hash).map(|tx| tx.block_number);
 
-        if let Some(block_number) = block_number
-            && let Some(results) =
-                self.mined_parity_trace_replay_block_transactions(block_number, &trace_types)
-            && let Some(result) = results.into_iter().find(|result| result.transaction_hash == hash)
-        {
-            return Ok(result.full_trace);
+        // If the transaction was mined locally, replay it locally. Do not fall
+        // through to the fork when the local replay fails; that would misreport
+        // a local data problem as an upstream transaction lookup.
+        if let Some(block_number) = block_number {
+            let results = self
+                .mined_parity_trace_replay_block_transactions(block_number, &trace_types)
+                .ok_or(BlockchainError::BlockNotFound)?;
+
+            return results
+                .into_iter()
+                .find(|result| result.transaction_hash == hash)
+                .map(|result| result.full_trace)
+                .ok_or_else(|| {
+                    BlockchainError::Internal(format!(
+                        "replayed block {block_number} for local transaction {hash:?}, \
+                         but its trace was missing"
+                    ))
+                });
         }
 
+        // Not known locally: forward to the fork if present.
         if let Some(fork) = self.get_fork() {
             return Ok(fork.trace_replay_transaction(hash, trace_types).await?);
         }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1887,6 +1887,30 @@ impl<N: Network> Backend<N> {
         Ok(vec![])
     }
 
+    /// Replays a mined transaction and returns the requested traces.
+    pub async fn trace_replay_transaction(
+        &self,
+        hash: B256,
+        trace_types: HashSet<TraceType>,
+    ) -> Result<TraceResults, BlockchainError> {
+        let block_number =
+            self.blockchain.storage.read().transactions.get(&hash).map(|tx| tx.block_number);
+
+        if let Some(block_number) = block_number
+            && let Some(results) =
+                self.mined_parity_trace_replay_block_transactions(block_number, &trace_types)
+            && let Some(result) = results.into_iter().find(|result| result.transaction_hash == hash)
+        {
+            return Ok(result.full_trace);
+        }
+
+        if let Some(fork) = self.get_fork() {
+            return Ok(fork.trace_replay_transaction(hash, trace_types).await?);
+        }
+
+        Err(BlockchainError::TransactionNotFound)
+    }
+
     /// Traces a raw transaction without committing it to the chain state or mempool.
     pub async fn trace_raw_transaction(
         &self,

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -1573,6 +1573,43 @@ async fn test_trace_replay_block_transactions_local() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_trace_replay_transaction() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let from = accounts[0].address();
+    let to = accounts[1].address();
+    let amount = U256::from(12345);
+
+    let tx = TransactionRequest::default().to(to).value(amount).from(from);
+    let tx = WithOtherFields::new(tx);
+    let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+
+    let result: TraceResults = provider
+        .client()
+        .request(
+            "trace_replayTransaction",
+            (receipt.transaction_hash, vec![TraceType::Trace, TraceType::StateDiff]),
+        )
+        .await
+        .unwrap();
+
+    assert!(!result.trace.is_empty());
+    match &result.trace[0].action {
+        Action::Call(call) => {
+            assert_eq!(call.from, from);
+            assert_eq!(call.to, to);
+        }
+        _ => panic!("Expected Call action, got {:?}", result.trace[0].action),
+    }
+
+    let ChangedType::<U256> { from, to } =
+        result.state_diff.as_ref().unwrap().get(&to).unwrap().balance.as_changed().unwrap();
+    assert_eq!(to.checked_sub(*from).unwrap(), amount);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_debug_trace_block_by_number() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
Adds Anvil support for the Parity-style `trace_replayTransaction` endpoint. For local mined transactions, Anvil finds the containing block, reuses the existing block replay inspector path, and returns the requested `TraceResults` for the matching transaction.

Forked Anvil instances forward the request to the upstream provider, matching the existing trace replay block forwarding behavior. This gives trace tooling a single-transaction replay path without changing the broader block replay implementation.

Authored with AI assistance.
