### PR TITLE
feat(anvil): support eth call many

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -4,7 +4,7 @@ use alloy_primitives::{
     map::{HashMap, HashSet},
 };
 use alloy_rpc_types::{
-    BlockId, BlockNumberOrTag as BlockNumber, BlockOverrides, Filter, Index,
+    BlockId, BlockNumberOrTag as BlockNumber, BlockOverrides, Bundle, Filter, Index, StateContext,
     anvil::{Forking, MineOptions},
     pubsub::{Params as SubscriptionParams, SubscriptionKind},
     request::TransactionRequest,
@@ -186,6 +186,13 @@ pub enum EthRequest {
         #[serde(default)] Option<BlockId>,
         #[serde(default)] Option<StateOverride>,
         #[serde(default)] Option<Box<BlockOverrides>>,
+    ),
+
+    #[serde(rename = "eth_callMany")]
+    EthCallMany(
+        Vec<Bundle<WithOtherFields<TransactionRequest>>>,
+        #[serde(default)] Option<StateContext>,
+        #[serde(default)] Option<StateOverride>,
     ),
 
     #[serde(rename = "eth_simulateV1")]
@@ -1591,6 +1598,12 @@ true}]}"#;
         let _req = serde_json::from_str::<EthRequest>(s).unwrap();
 
         let s = r#"{"method": "eth_call", "params":[{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}, { "blockHash":"0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3" }]}"#;
+        let _req = serde_json::from_str::<EthRequest>(s).unwrap();
+    }
+
+    #[test]
+    fn test_eth_call_many() {
+        let s = r#"{"method":"eth_callMany","params":[[{"transactions":[{"from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d","data":"0xcfae3217"}]}],{"blockNumber":"latest"},{"0x0000000000000000000000000000000000000001":{"balance":"0x1"}}]}"#;
         let _req = serde_json::from_str::<EthRequest>(s).unwrap();
     }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -55,7 +55,7 @@ use alloy_rpc_types::{
     },
     request::TransactionRequest,
     simulate::{SimulatePayload, SimulatedBlock},
-    state::{AccountOverride, EvmOverrides, StateOverridesBuilder},
+    state::{AccountOverride, EvmOverrides, StateOverride, StateOverridesBuilder},
     trace::{
         filter::TraceFilter,
         geth::{GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult},
@@ -63,7 +63,7 @@ use alloy_rpc_types::{
     },
     txpool::{TxpoolContent, TxpoolInspect, TxpoolInspectSummary, TxpoolStatus},
 };
-use alloy_rpc_types_eth::FillTransaction;
+use alloy_rpc_types_eth::{Bundle, EthCallResponse, FillTransaction, StateContext};
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::{SolCall, SolValue, sol};
 use alloy_transport::TransportErrorKind;
@@ -1603,6 +1603,9 @@ impl EthApi<FoundryNetwork> {
                 .call(call, block, EvmOverrides::new(state_override, block_overrides))
                 .await
                 .to_rpc_result(),
+            EthRequest::EthCallMany(bundles, state_context, state_override) => {
+                self.call_many(bundles, state_context, state_override).await.to_rpc_result()
+            }
             EthRequest::EthSimulateV1(simulation, block) => {
                 self.simulate_v1(simulation, block).await.to_rpc_result()
             }
@@ -2461,6 +2464,40 @@ impl EthApi<FoundryNetwork> {
             trace!(target : "node", "Call status {:?}, gas {}", exit, gas);
 
             ensure_return_ok(exit, &out)
+        })
+        .await
+    }
+
+    pub async fn call_many(
+        &self,
+        bundles: Vec<Bundle<WithOtherFields<TransactionRequest>>>,
+        state_context: Option<StateContext>,
+        state_override: Option<StateOverride>,
+    ) -> Result<Vec<Vec<EthCallResponse>>> {
+        node_info!("eth_callMany");
+        let StateContext { transaction_index, block_number } = state_context.unwrap_or_default();
+        if transaction_index.is_some_and(|index| index.index().is_some()) {
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(
+                "transactionIndex is not supported for eth_callMany yet".to_string(),
+            )));
+        }
+
+        let block_request = self.block_request(block_number).await?;
+        if let BlockRequest::Number(number) = block_request
+            && let Some(fork) = self.get_fork()
+            && fork.predates_fork(number)
+        {
+            return Ok(fork
+                .call_many(
+                    bundles,
+                    Some(StateContext { transaction_index, block_number: Some(number.into()) }),
+                    state_override,
+                )
+                .await?);
+        }
+
+        self.on_blocking_task(|this| async move {
+            this.backend.call_many(bundles, Some(block_request), state_override).await
         })
         .await
     }

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -18,12 +18,16 @@ use alloy_provider::{
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions, EIP1186AccountProofResponse,
     FeeHistory, Filter, Log,
+    request::TransactionRequest,
     simulate::{SimulatePayload, SimulatedBlock},
+    state::StateOverride,
     trace::{
         geth::{GethDebugTracingOptions, GethTrace, TraceResult},
         parity::{LocalizedTransactionTrace as Trace, TraceResultsWithTransactionHash, TraceType},
     },
 };
+use alloy_rpc_types_eth::{Bundle, EthCallResponse, StateContext};
+use alloy_serde::WithOtherFields;
 use alloy_transport::TransportError;
 use foundry_common::provider::{ProviderBuilder, RetryProvider};
 use foundry_evm::hardfork::FoundryHardfork;
@@ -357,6 +361,18 @@ impl<N: Network> ClientFork<N> {
         let res = self.provider().call(request.clone()).block(block.into()).await?;
 
         Ok(res)
+    }
+
+    /// Sends `eth_callMany`
+    pub async fn call_many(
+        &self,
+        bundles: Vec<Bundle<WithOtherFields<TransactionRequest>>>,
+        state_context: Option<StateContext>,
+        state_override: Option<StateOverride>,
+    ) -> Result<Vec<Vec<EthCallResponse>>, TransportError> {
+        self.provider()
+            .raw_request("eth_callMany".into(), (bundles, state_context, state_override))
+            .await
     }
 
     /// Sends `eth_simulateV1`

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -82,6 +82,7 @@ use alloy_rpc_types::{
         parity::{LocalizedTransactionTrace, TraceResultsWithTransactionHash, TraceType},
     },
 };
+use alloy_rpc_types_eth::{Bundle, EthCallResponse};
 use alloy_serde::{OtherFields, WithOtherFields};
 use alloy_trie::{HashBuilder, Nibbles, proof::ProofRetainer};
 use anvil_core::eth::{
@@ -4054,6 +4055,76 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
 }
 
 impl Backend<FoundryNetwork> {
+    /// Executes bundles of call requests and returns each call output.
+    pub async fn call_many(
+        &self,
+        bundles: Vec<Bundle<WithOtherFields<TransactionRequest>>>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
+        state_override: Option<alloy_rpc_types::state::StateOverride>,
+    ) -> Result<Vec<Vec<EthCallResponse>>, BlockchainError> {
+        if bundles.is_empty() {
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(
+                "bundles are empty.".to_string(),
+            )));
+        }
+
+        self.with_database_at(block_request, |state, block_env| {
+            let mut cache_db = CacheDB::new(state);
+            if let Some(state_override) = state_override {
+                apply_state_overrides(state_override, &mut cache_db)?;
+            }
+
+            let mut results = Vec::with_capacity(bundles.len());
+            for bundle in bundles {
+                let Bundle { transactions, block_override } = bundle;
+                let mut bundle_block_env = block_env.clone();
+                if let Some(block_override) = block_override {
+                    cache_db.apply_block_overrides(block_override, &mut bundle_block_env);
+                }
+
+                let mut bundle_results = Vec::with_capacity(transactions.len());
+                for request in transactions {
+                    let fee_details = FeeDetails::new(
+                        request.gas_price,
+                        request.max_fee_per_gas,
+                        request.max_priority_fee_per_gas,
+                        request.max_fee_per_blob_gas,
+                    )?
+                    .or_zero_fees();
+                    let (evm_env, tx_env, op_deposit) =
+                        self.build_call_env(request, fee_details, bundle_block_env.clone());
+
+                    let mut inspector = self.build_inspector();
+                    let ResultAndState { result, state } = self.transact_with_inspector_ref(
+                        &cache_db,
+                        &evm_env,
+                        &mut inspector,
+                        tx_env,
+                        op_deposit,
+                    )?;
+
+                    let output = result.output().cloned().unwrap_or_default();
+                    let response = if result.is_success() {
+                        EthCallResponse { value: Some(output), error: None }
+                    } else {
+                        let error = RevertDecoder::new()
+                            .maybe_decode(&output, None)
+                            .unwrap_or_else(|| "execution failed".to_string());
+                        EthCallResponse { value: None, error: Some(error) }
+                    };
+
+                    cache_db.commit(state);
+                    bundle_results.push(response);
+                }
+
+                results.push(bundle_results);
+            }
+
+            Ok(results)
+        })
+        .await?
+    }
+
     /// Simulates the payload by executing the calls in request.
     pub async fn simulate(
         &self,

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -20,6 +20,7 @@ use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, BlockTransactions, request::TransactionRequest,
     state::AccountOverride,
 };
+use alloy_rpc_types_eth::{Bundle, EthCallResponse};
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::SolCall;
 use anvil::{CHAIN_ID, EthereumHardfork, NodeConfig, eth::api::CLIENT_VERSION, spawn};
@@ -435,6 +436,56 @@ async fn can_call_with_state_override() {
     let value = simple_storage_contract.getValue().state(overrides).call().await.unwrap();
     // `value` *is* changed with state
     assert_eq!(value, "");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_call_many() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let wallet = handle.dev_wallets().next().unwrap();
+    let signer: EthereumWallet = wallet.clone().into();
+    let from = wallet.address();
+
+    let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
+
+    let simple_storage_contract =
+        SimpleStorage::deploy(&provider, "initial".to_string()).await.unwrap();
+
+    let set_value = simple_storage_contract.setValue("updated".to_string());
+    let get_value = simple_storage_contract.getValue();
+    let transactions = vec![
+        WithOtherFields::new(
+            TransactionRequest::default()
+                .with_from(from)
+                .with_to(*simple_storage_contract.address())
+                .with_input(set_value.calldata().clone()),
+        ),
+        WithOtherFields::new(
+            TransactionRequest::default()
+                .with_from(from)
+                .with_to(*simple_storage_contract.address())
+                .with_input(get_value.calldata().clone()),
+        ),
+    ];
+
+    let response: Vec<Vec<EthCallResponse>> = provider
+        .client()
+        .request(
+            "eth_callMany",
+            (vec![
+                Bundle { transactions, block_override: None },
+                Bundle { transactions: Vec::new(), block_override: None },
+            ],),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.len(), 2);
+    assert_eq!(response[0].len(), 2);
+    assert!(response[1].is_empty());
+    assert_eq!(response[0][0].error, None);
+    let output = response[0][1].clone().ensure_ok().unwrap();
+    let value = SimpleStorage::getValueCall::abi_decode_returns(&output).unwrap();
+    assert_eq!(value, "updated");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Adds Anvil support for reth's `eth_callMany` endpoint. The implementation accepts call bundles, applies the optional state override once, runs calls sequentially with call-style EVM settings, and commits each call into the next call's state before returning `EthCallResponse` values.

This covers the main bundle execution path for local Anvil state and forwards forked historical requests to the upstream provider. Concrete `transactionIndex` state contexts are left for a separate parameter-specific follow-up because they require replaying partial block state.

Authored with AI assistance.
