### PR TITLE
feat(anvil): support eth block access list

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -109,6 +109,9 @@ pub enum EthRequest {
         bool,
     ),
 
+    #[serde(rename = "eth_getBlockAccessList", with = "sequence")]
+    EthGetBlockAccessList(BlockId),
+
     #[serde(rename = "eth_getTransactionCount")]
     EthGetTransactionCount(Address, Option<BlockId>),
 
@@ -1457,6 +1460,13 @@ mod tests {
     #[test]
     fn test_eth_block_tx_count_by_block_hash() {
         let s = r#"{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByHash","params":["0x4a3b0fce2cb9707b0baa68640cf2fe858c8bb4121b2a8cb904ff369d38a560ff"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_eth_get_block_access_list() {
+        let s = r#"{"jsonrpc":"2.0","method":"eth_getBlockAccessList","params":["latest"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1553,6 +1553,9 @@ impl EthApi<FoundryNetwork> {
                     self.block_by_number(num).await.to_rpc_result()
                 }
             }
+            EthRequest::EthGetBlockAccessList(block_id) => {
+                self.block_access_list(block_id).await.to_rpc_result()
+            }
             EthRequest::EthGetTransactionCount(addr, block) => {
                 self.transaction_count(addr, block).await.to_rpc_result()
             }
@@ -2085,6 +2088,23 @@ impl EthApi<FoundryNetwork> {
             return Ok(self.pending_block_full().await);
         }
         self.backend.block_by_number_full(number).await
+    }
+
+    /// Returns the EIP-7928 block access list for a block.
+    ///
+    /// Handler for ETH RPC call: `eth_getBlockAccessList`
+    pub async fn block_access_list(&self, block_id: BlockId) -> Result<Option<serde_json::Value>> {
+        node_info!("eth_getBlockAccessList");
+        let block_request = self.block_request(Some(block_id)).await?;
+        let BlockRequest::Number(number) = block_request else { return Ok(None) };
+
+        if let Some(fork) = self.get_fork()
+            && fork.predates_fork_inclusive(number)
+        {
+            return Ok(fork.block_access_list(block_id).await?);
+        }
+
+        Ok(None)
     }
 
     /// Returns the number of transactions sent from given address at given time (block number).

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -138,6 +138,14 @@ impl<N: Network> ClientFork<N> {
         self.provider().get_proof(address, keys).block_id(block_number.unwrap_or_default()).await
     }
 
+    /// Sends `eth_getBlockAccessList`
+    pub async fn block_access_list(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<serde_json::Value>, TransportError> {
+        self.provider().raw_request("eth_getBlockAccessList".into(), (block_id,)).await
+    }
+
     pub async fn storage_at(
         &self,
         address: Address,

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -145,6 +145,17 @@ async fn can_get_block_by_number() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_get_block_access_list() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let block_access_list: Option<serde_json::Value> =
+        provider.client().request("eth_getBlockAccessList", (BlockId::latest(),)).await.unwrap();
+
+    assert_eq!(block_access_list, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_resolve_safe_and_finalized_block_tags_with_configured_epoch_slots() {
     let slots_in_an_epoch = 3;
     let (api, handle) = spawn(NodeConfig::test().with_slots_in_an_epoch(slots_in_an_epoch)).await;


### PR DESCRIPTION
Adds Anvil support for the reth-compatible `eth_getBlockAccessList` endpoint. The endpoint resolves the requested block, forwards pre-fork requests to the upstream provider, and returns `null` for local Anvil blocks because Anvil does not currently store EIP-7928 block access list payloads.

This keeps the RPC surface compatible while leaving the by-hash, by-number, raw, and future stored-BAL behavior for separate scoped follow-ups.

Authored with AI assistance.
