### PR TITLE
feat(anvil): support block access list by number

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -109,6 +109,12 @@ pub enum EthRequest {
         bool,
     ),
 
+    #[serde(
+        rename = "eth_getBlockAccessListByBlockNumber",
+        deserialize_with = "lenient_block_number::lenient_block_number_seq"
+    )]
+    EthGetBlockAccessListByBlockNumber(BlockNumber),
+
     #[serde(rename = "eth_getTransactionCount")]
     EthGetTransactionCount(Address, Option<BlockId>),
 
@@ -1457,6 +1463,13 @@ mod tests {
     #[test]
     fn test_eth_block_tx_count_by_block_hash() {
         let s = r#"{"jsonrpc":"2.0","method":"eth_getBlockTransactionCountByHash","params":["0x4a3b0fce2cb9707b0baa68640cf2fe858c8bb4121b2a8cb904ff369d38a560ff"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_eth_get_block_access_list_by_block_number() {
+        let s = r#"{"jsonrpc":"2.0","method":"eth_getBlockAccessListByBlockNumber","params":["latest"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1553,6 +1553,9 @@ impl EthApi<FoundryNetwork> {
                     self.block_by_number(num).await.to_rpc_result()
                 }
             }
+            EthRequest::EthGetBlockAccessListByBlockNumber(block_number) => {
+                self.block_access_list_by_number(block_number).await.to_rpc_result()
+            }
             EthRequest::EthGetTransactionCount(addr, block) => {
                 self.transaction_count(addr, block).await.to_rpc_result()
             }
@@ -2085,6 +2088,26 @@ impl EthApi<FoundryNetwork> {
             return Ok(self.pending_block_full().await);
         }
         self.backend.block_by_number_full(number).await
+    }
+
+    /// Returns the EIP-7928 block access list for a block number.
+    ///
+    /// Handler for ETH RPC call: `eth_getBlockAccessListByBlockNumber`
+    pub async fn block_access_list_by_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<serde_json::Value>> {
+        node_info!("eth_getBlockAccessListByBlockNumber");
+        let block_request = self.block_request(Some(block_number.into())).await?;
+        let BlockRequest::Number(number) = block_request else { return Ok(None) };
+
+        if let Some(fork) = self.get_fork()
+            && fork.predates_fork_inclusive(number)
+        {
+            return Ok(fork.block_access_list_by_number(block_number).await?);
+        }
+
+        Ok(None)
     }
 
     /// Returns the number of transactions sent from given address at given time (block number).

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -138,6 +138,16 @@ impl<N: Network> ClientFork<N> {
         self.provider().get_proof(address, keys).block_id(block_number.unwrap_or_default()).await
     }
 
+    /// Sends `eth_getBlockAccessListByBlockNumber`
+    pub async fn block_access_list_by_number(
+        &self,
+        block_number: BlockNumber,
+    ) -> Result<Option<serde_json::Value>, TransportError> {
+        self.provider()
+            .raw_request("eth_getBlockAccessListByBlockNumber".into(), (block_number,))
+            .await
+    }
+
     pub async fn storage_at(
         &self,
         address: Address,

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -145,6 +145,20 @@ async fn can_get_block_by_number() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_get_block_access_list_by_number() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let block_access_list: Option<serde_json::Value> = provider
+        .client()
+        .request("eth_getBlockAccessListByBlockNumber", (BlockNumberOrTag::Latest,))
+        .await
+        .unwrap();
+
+    assert_eq!(block_access_list, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_resolve_safe_and_finalized_block_tags_with_configured_epoch_slots() {
     let slots_in_an_epoch = 3;
     let (api, handle) = spawn(NodeConfig::test().with_slots_in_an_epoch(slots_in_an_epoch)).await;


### PR DESCRIPTION
Adds Anvil support for the reth-compatible `eth_getBlockAccessListByBlockNumber` endpoint. The endpoint accepts the same lenient block number and tag forms as Anvil's other block-number RPCs, forwards pre-fork requests to the upstream provider, and returns `null` for local Anvil blocks because Anvil does not currently store EIP-7928 block access list payloads.

This keeps the by-number RPC surface compatible while leaving the raw and future stored-BAL behavior for separate scoped follow-ups.

Authored with AI assistance.
