### PR TITLE
feat(anvil): support block opcode gas

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -451,6 +451,10 @@ pub enum EthRequest {
     #[serde(rename = "trace_transactionOpcodeGas", with = "sequence")]
     TraceTransactionOpcodeGas(B256),
 
+    /// Opcode gas trace endpoint for reth's `trace_blockOpcodeGas`.
+    #[serde(rename = "trace_blockOpcodeGas", with = "sequence")]
+    TraceBlockOpcodeGas(BlockId),
+
     /// Trace raw transaction endpoint for parity's `trace_rawTransaction`.
     #[serde(rename = "trace_rawTransaction")]
     TraceRawTransaction(Bytes, HashSet<TraceType>, #[serde(default)] Option<BlockId>),
@@ -1834,6 +1838,17 @@ true}]}"#;
     #[test]
     fn test_serde_trace_replay_transaction() {
         let s = r#"{"method":"trace_replayTransaction","params":["0x4a3b0fce2cb9707b0baa68640cf2fe858c8bb4121b2a8cb904ff369d38a560ff",["trace","stateDiff"]]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_trace_block_opcode_gas() {
+        let s = r#"{"method": "trace_blockOpcodeGas", "params": ["0x1"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+
+        let s = r#"{"method": "trace_blockOpcodeGas", "params": [{"blockHash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -60,7 +60,7 @@ use alloy_rpc_types::{
     trace::{
         filter::TraceFilter,
         geth::{GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult},
-        opcode::TransactionOpcodeGas,
+        opcode::{BlockOpcodeGas, TransactionOpcodeGas},
         parity::{
             LocalizedTransactionTrace, TraceResults, TraceResultsWithTransactionHash, TraceType,
         },
@@ -1428,6 +1428,17 @@ impl EthApi<FoundryNetwork> {
         self.backend.trace_transaction_opcode_gas(tx_hash).await
     }
 
+    /// Returns opcode gas usage for all transactions in a block.
+    ///
+    /// Handler for RPC call: `trace_blockOpcodeGas`.
+    pub async fn trace_block_opcode_gas(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<BlockOpcodeGas>> {
+        node_info!("trace_blockOpcodeGas");
+        self.backend.trace_block_opcode_gas(block_id).await
+    }
+
     /// Traces a raw signed transaction without importing it into the mempool.
     ///
     /// Handler for RPC call: `trace_rawTransaction`.
@@ -1892,6 +1903,9 @@ impl EthApi<FoundryNetwork> {
             }
             EthRequest::TraceTransactionOpcodeGas(tx_hash) => {
                 self.trace_transaction_opcode_gas(tx_hash).await.to_rpc_result()
+            }
+            EthRequest::TraceBlockOpcodeGas(block_id) => {
+                self.trace_block_opcode_gas(block_id).await.to_rpc_result()
             }
             EthRequest::TraceRawTransaction(tx, trace_types, block_number) => {
                 self.trace_raw_transaction(tx, trace_types, block_number).await.to_rpc_result()

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -23,7 +23,7 @@ use alloy_rpc_types::{
     state::StateOverride,
     trace::{
         geth::{GethDebugTracingOptions, GethTrace, TraceResult},
-        opcode::TransactionOpcodeGas,
+        opcode::{BlockOpcodeGas, TransactionOpcodeGas},
         parity::{
             LocalizedTransactionTrace as Trace, TraceResults, TraceResultsWithTransactionHash,
             TraceType,
@@ -371,6 +371,13 @@ impl<N: Network> ClientFork<N> {
         trace_types: HashSet<TraceType>,
     ) -> Result<TraceResults, TransportError> {
         self.provider().raw_request("trace_replayTransaction".into(), (hash, trace_types)).await
+    }
+
+    pub async fn trace_block_opcode_gas(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<BlockOpcodeGas>, TransportError> {
+        self.provider().raw_request("trace_blockOpcodeGas".into(), (block_id,)).await
     }
 
     /// Reset the fork to a fresh forked state, and optionally update the fork config

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3699,12 +3699,12 @@ where
         &self,
         block_id: BlockId,
     ) -> Result<Option<BlockOpcodeGas>, BlockchainError> {
-        if let Some((block, block_hash)) = self.get_block_with_hash(block_id.clone()) {
+        if let Some((block, block_hash)) = self.get_block_with_hash(block_id) {
             return self.mined_block_opcode_gas(&block, block_hash).map(Some);
         }
 
         if let Some(fork) = self.get_fork() {
-            let number = self.ensure_block_number(Some(block_id.clone())).await?;
+            let number = self.ensure_block_number(Some(block_id)).await?;
             if fork.predates_fork_inclusive(number) {
                 return Ok(fork.trace_block_opcode_gas(block_id).await?);
             }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3718,6 +3718,14 @@ where
         block: &Block,
         block_hash: B256,
     ) -> Result<BlockOpcodeGas, BlockchainError> {
+        if block.body.transactions.is_empty() {
+            return Ok(BlockOpcodeGas {
+                block_hash,
+                block_number: block.header.number(),
+                transactions: Vec::new(),
+            });
+        }
+
         let parent_hash = block.header.parent_hash;
 
         let trace = |parent_state: &StateDb| -> Result<Vec<TransactionOpcodeGas>, BlockchainError> {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -80,7 +80,7 @@ use alloy_rpc_types::{
             GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
             NoopFrame, TraceResult,
         },
-        opcode::TransactionOpcodeGas,
+        opcode::{BlockOpcodeGas, TransactionOpcodeGas},
         parity::{
             LocalizedTransactionTrace, TraceResults, TraceResultsWithTransactionHash, TraceType,
         },
@@ -3692,6 +3692,75 @@ where
             }
             Err(err) => Err(err),
         }
+    }
+
+    /// Returns opcode gas usage for all transactions in the given block.
+    pub async fn trace_block_opcode_gas(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<BlockOpcodeGas>, BlockchainError> {
+        if let Some((block, block_hash)) = self.get_block_with_hash(block_id.clone()) {
+            return self.mined_block_opcode_gas(&block, block_hash).map(Some);
+        }
+
+        if let Some(fork) = self.get_fork() {
+            let number = self.ensure_block_number(Some(block_id.clone())).await?;
+            if fork.predates_fork_inclusive(number) {
+                return Ok(fork.trace_block_opcode_gas(block_id).await?);
+            }
+        }
+
+        Err(BlockchainError::BlockNotFound)
+    }
+
+    fn mined_block_opcode_gas(
+        &self,
+        block: &Block,
+        block_hash: B256,
+    ) -> Result<BlockOpcodeGas, BlockchainError> {
+        let parent_hash = block.header.parent_hash;
+
+        let trace = |parent_state: &StateDb| -> Result<Vec<TransactionOpcodeGas>, BlockchainError> {
+            let mut cache_db = CacheDB::new(Box::new(parent_state));
+            let mut transactions = Vec::with_capacity(block.body.transactions.len());
+
+            let mut evm_env = self.evm_env.read().clone();
+            evm_env.block_env = block_env_from_header(&block.header);
+
+            for tx_envelope in &block.body.transactions {
+                let mut inspector = OpcodeGasInspector::default();
+                let pending_tx = PendingTransaction::from_maybe_impersonated(tx_envelope.clone())?;
+                let (result, _) = self.transact_envelope_with_inspector_ref(
+                    &cache_db,
+                    &evm_env,
+                    &mut inspector,
+                    pending_tx.transaction.as_ref(),
+                    *pending_tx.sender(),
+                )?;
+
+                transactions.push(TransactionOpcodeGas {
+                    transaction_hash: tx_envelope.hash(),
+                    opcode_gas: inspector.opcode_gas_iter().collect(),
+                });
+
+                cache_db.commit(result.state);
+            }
+
+            Ok(transactions)
+        };
+
+        let read_guard = self.states.upgradable_read();
+        let transactions = if let Some(state) = read_guard.get_state(&parent_hash) {
+            trace(state)?
+        } else {
+            let mut write_guard = RwLockUpgradableReadGuard::upgrade(read_guard);
+            let state = write_guard
+                .get_on_disk_state(&parent_hash)
+                .ok_or(BlockchainError::BlockNotFound)?;
+            trace(state)?
+        };
+
+        Ok(BlockOpcodeGas { block_hash, block_number: block.header.number(), transactions })
     }
 
     /// Rollback the chain to a common height.

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -26,7 +26,7 @@ use alloy_rpc_types::{
             GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, PreStateConfig,
             PreStateFrame,
         },
-        opcode::TransactionOpcodeGas,
+        opcode::{BlockOpcodeGas, TransactionOpcodeGas},
         parity::{Action, ChangedType, LocalizedTransactionTrace, TraceResults, TraceType},
     },
 };
@@ -80,7 +80,6 @@ async fn test_trace_transaction_opcode_gas_local() {
     let storage = SimpleStorage::deploy(&provider, "init value".to_string()).await.unwrap();
     let receipt =
         storage.setValue("bar".to_string()).send().await.unwrap().get_receipt().await.unwrap();
-
     let opcode_gas: Option<TransactionOpcodeGas> = handle
         .http_provider()
         .raw_request("trace_transactionOpcodeGas".into(), (receipt.transaction_hash,))
@@ -90,6 +89,46 @@ async fn test_trace_transaction_opcode_gas_local() {
 
     assert_eq!(opcode_gas.transaction_hash, receipt.transaction_hash);
     assert!(opcode_gas.contains("SSTORE"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_trace_block_opcode_gas_local() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let signer: EthereumWallet = wallets[0].clone().into();
+    let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
+
+    let storage = SimpleStorage::deploy(&provider, "init value".to_string()).await.unwrap();
+    let receipt =
+        storage.setValue("bar".to_string()).send().await.unwrap().get_receipt().await.unwrap();
+    let block_number = receipt.block_number.unwrap();
+    let block_hash = receipt.block_hash.unwrap();
+
+    let by_number: Option<BlockOpcodeGas> = handle
+        .http_provider()
+        .raw_request("trace_blockOpcodeGas".into(), (BlockId::number(block_number),))
+        .await
+        .unwrap();
+    let by_hash: Option<BlockOpcodeGas> = handle
+        .http_provider()
+        .raw_request("trace_blockOpcodeGas".into(), (BlockId::Hash(block_hash.into()),))
+        .await
+        .unwrap();
+
+    let by_number = by_number.unwrap();
+    let by_hash = by_hash.unwrap();
+
+    assert_eq!(by_number.block_hash, block_hash);
+    assert_eq!(by_number.block_number, block_number);
+    assert_eq!(by_number.transactions.len(), 1);
+    assert_eq!(by_number.transactions[0].transaction_hash, receipt.transaction_hash);
+    assert!(by_number.contains("SSTORE"));
+
+    assert_eq!(by_hash.block_hash, block_hash);
+    assert_eq!(by_hash.block_number, block_number);
+    assert_eq!(by_hash.transactions.len(), 1);
+    assert_eq!(by_hash.transactions[0].transaction_hash, receipt.transaction_hash);
+    assert!(by_hash.contains("SSTORE"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -98,6 +98,20 @@ async fn test_trace_block_opcode_gas_local() {
     let signer: EthereumWallet = wallets[0].clone().into();
     let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
 
+    let genesis = provider.get_block(BlockId::number(0)).await.unwrap().unwrap();
+    for block_id in [BlockId::number(0), BlockId::hash(genesis.header.hash), BlockId::earliest()] {
+        let opcode_gas: Option<BlockOpcodeGas> = handle
+            .http_provider()
+            .raw_request("trace_blockOpcodeGas".into(), (block_id,))
+            .await
+            .unwrap();
+        let opcode_gas = opcode_gas.unwrap();
+
+        assert_eq!(opcode_gas.block_hash, genesis.header.hash);
+        assert_eq!(opcode_gas.block_number, genesis.header.number);
+        assert!(opcode_gas.transactions.is_empty());
+    }
+
     let storage = SimpleStorage::deploy(&provider, "init value".to_string()).await.unwrap();
     let receipt =
         storage.setValue("bar".to_string()).send().await.unwrap().get_receipt().await.unwrap();


### PR DESCRIPTION
This adds Anvil support for reth's `trace_blockOpcodeGas` RPC endpoint. Local mined blocks are replayed from their parent state with a fresh `OpcodeGasInspector` for each transaction, and forked historical blocks can be delegated upstream through the same raw RPC method.

The request parser accepts reth-style `BlockId` parameters, and integration coverage verifies number and hash lookups for a block containing a storage-writing transaction.

Authored with AI assistance.
