### PR TITLE
feat(anvil): support debug modified accounts by hash

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -325,6 +325,10 @@ pub enum EthRequest {
     #[serde(rename = "debug_dbGet")]
     DebugDbGet(String),
 
+    /// reth's `debug_getModifiedAccountsByHash` endpoint.
+    #[serde(rename = "debug_getModifiedAccountsByHash")]
+    DebugGetModifiedAccountsByHash(B256, B256),
+
     /// geth's `debug_traceBlockByHash` endpoint
     #[serde(rename = "debug_traceBlockByHash")]
     DebugTraceBlockByHash(B256, #[serde(default)] GethDebugTracingOptions),
@@ -1563,6 +1567,16 @@ true}]}"#;
         let s = r#"{"method": "debug_traceCall", "params": [{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}, { "blockNumber": "0x0" }, {"disableStorage": true}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_debug_get_modified_accounts_by_hash() {
+        let s = r#"{"method": "debug_getModifiedAccountsByHash", "params": ["0x0000000000000000000000000000000000000000000000000000000000000000", "0x0000000000000000000000000000000000000000000000000000000000000001"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        match serde_json::from_value::<EthRequest>(value).unwrap() {
+            EthRequest::DebugGetModifiedAccountsByHash(_, _) => {}
+            req => panic!("unexpected request: {req:?}"),
+        }
     }
 
     #[test]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1218,6 +1218,16 @@ impl<N: Network> EthApi<N> {
         self.backend.debug_db_get(key).await
     }
 
+    /// Handles reth's no-op `debug_getModifiedAccountsByHash` endpoint.
+    pub fn debug_get_modified_accounts_by_hash(
+        &self,
+        _start_hash: B256,
+        _end_hash: B256,
+    ) -> Result<()> {
+        node_info!("debug_getModifiedAccountsByHash");
+        Ok(())
+    }
+
     /// Returns traces for the transaction hash via parity's tracing endpoint
     ///
     /// Handler for RPC call: `trace_transaction`
@@ -1679,6 +1689,9 @@ impl EthApi<FoundryNetwork> {
                 self.debug_code_by_hash(hash, block).await.to_rpc_result()
             }
             EthRequest::DebugDbGet(key) => self.debug_db_get(key).await.to_rpc_result(),
+            EthRequest::DebugGetModifiedAccountsByHash(start_hash, end_hash) => {
+                self.debug_get_modified_accounts_by_hash(start_hash, end_hash).to_rpc_result()
+            }
             EthRequest::DebugTraceBlockByHash(block_hash, opts) => {
                 self.debug_trace_block_by_hash(block_hash, opts).await.to_rpc_result()
             }

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -529,6 +529,24 @@ async fn can_get_code_by_hash() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_debug_get_modified_accounts_by_hash() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let response: serde_json::Value = provider
+        .raw_request(
+            "debug_getModifiedAccountsByHash".into(),
+            (
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
+            ),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response, serde_json::Value::Null);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fill_transaction_fills_chain_id() {
     let (api, handle) = spawn(NodeConfig::test()).await;
     let wallet = handle.dev_wallets().next().unwrap();


### PR DESCRIPTION
This adds Anvil support for reth's `debug_getModifiedAccountsByHash` RPC endpoint. Reth exposes this two-hash endpoint and currently returns success with no result payload, so Anvil now parses the same request and returns JSON `null` instead of method-not-found.

The change is limited to the request parser, RPC dispatch, and endpoint coverage through an HTTP JSON-RPC integration test.

Authored with AI assistance.
