### PR TITLE
feat(anvil): support debug trace chain

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -325,6 +325,10 @@ pub enum EthRequest {
     #[serde(rename = "debug_dbGet")]
     DebugDbGet(String),
 
+    /// reth's `debug_traceChain` endpoint.
+    #[serde(rename = "debug_traceChain")]
+    DebugTraceChain(BlockNumber, BlockNumber),
+
     /// geth's `debug_traceBlockByHash` endpoint
     #[serde(rename = "debug_traceBlockByHash")]
     DebugTraceBlockByHash(B256, #[serde(default)] GethDebugTracingOptions),
@@ -1561,6 +1565,13 @@ true}]}"#;
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
 
         let s = r#"{"method": "debug_traceCall", "params": [{"data":"0xcfae3217","from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d"}, { "blockNumber": "0x0" }, {"disableStorage": true}]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_debug_trace_chain() {
+        let s = r#"{"method": "debug_traceChain", "params": ["earliest", "latest"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1679,6 +1679,9 @@ impl EthApi<FoundryNetwork> {
                 self.debug_code_by_hash(hash, block).await.to_rpc_result()
             }
             EthRequest::DebugDbGet(key) => self.debug_db_get(key).await.to_rpc_result(),
+            EthRequest::DebugTraceChain(start, end) => {
+                self.debug_trace_chain(start, end).to_rpc_result()
+            }
             EthRequest::DebugTraceBlockByHash(block_hash, opts) => {
                 self.debug_trace_block_by_hash(block_hash, opts).await.to_rpc_result()
             }
@@ -2867,6 +2870,18 @@ impl EthApi<FoundryNetwork> {
     ) -> Result<GethTrace> {
         node_info!("debug_traceTransaction");
         self.backend.debug_trace_transaction(tx_hash, opts).await
+    }
+
+    /// Returns reth's current explicit unimplemented error for block range tracing.
+    ///
+    /// Handler for RPC call: `debug_traceChain`
+    pub fn debug_trace_chain(
+        &self,
+        _start_exclusive: BlockNumber,
+        _end_inclusive: BlockNumber,
+    ) -> Result<()> {
+        node_info!("debug_traceChain");
+        Err(BlockchainError::RpcError(RpcError::internal_error_with("unimplemented")))
     }
 
     /// Returns traces for all transactions in a block by hash.

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -85,6 +85,18 @@ async fn can_get_client_version() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_debug_trace_chain() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let result: std::result::Result<serde_json::Value, _> =
+        provider.raw_request("debug_traceChain".into(), ("earliest", "latest")).await;
+
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("unimplemented"), "{err}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_get_chain_id() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
This adds Anvil support for reth's `debug_traceChain` RPC endpoint. Reth exposes this block-range endpoint but currently returns an explicit internal `unimplemented` error, so Anvil now parses the same request and returns that error instead of method-not-found.

The change is limited to the request parser, RPC dispatch, and endpoint coverage through an HTTP JSON-RPC integration test.

Authored with AI assistance.
