### PR TITLE
feat(anvil): support empty tx conditionals

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -174,6 +174,9 @@ pub enum EthRequest {
     #[serde(rename = "eth_sendRawTransaction", with = "sequence")]
     EthSendRawTransaction(Bytes),
 
+    #[serde(rename = "eth_sendRawTransactionConditional")]
+    EthSendRawTransactionConditional(Bytes, serde_json::Value),
+
     #[serde(rename = "eth_sendRawTransactionSync", with = "sequence")]
     EthSendRawTransactionSync(Bytes),
 
@@ -1471,6 +1474,14 @@ mod tests {
     #[test]
     fn test_eth_new_filter() {
         let s = r#"{"method": "eth_newFilter", "params": [{"topics":["0x000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b"]}],"id":73}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_raw_transaction_conditional() {
+        let s = r#"{"method": "eth_sendRawTransactionConditional", "params":
+["0x4a3b0fce2cb9707b0baa68640cf2fe858c8bb4121b2a8cb904ff369d38a560ff", {"knownAccounts":{}}]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1593,6 +1593,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::EthSendRawTransaction(tx) => {
                 self.send_raw_transaction(tx).await.to_rpc_result()
             }
+            EthRequest::EthSendRawTransactionConditional(tx, condition) => {
+                self.send_raw_transaction_conditional(tx, condition).await.to_rpc_result()
+            }
             EthRequest::EthSendRawTransactionSync(tx) => {
                 self.send_raw_transaction_sync(tx).await.to_rpc_result()
             }
@@ -2381,6 +2384,24 @@ impl EthApi<FoundryNetwork> {
         Ok(*tx.hash())
     }
 
+    /// Sends a signed transaction with an empty transaction condition.
+    ///
+    /// Handler for ETH RPC call: `eth_sendRawTransactionConditional`
+    pub async fn send_raw_transaction_conditional(
+        &self,
+        tx: Bytes,
+        condition: serde_json::Value,
+    ) -> Result<TxHash> {
+        node_info!("eth_sendRawTransactionConditional");
+        if !is_empty_transaction_condition(&condition) {
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(
+                "transaction conditions are not supported",
+            )));
+        }
+
+        self.send_raw_transaction(tx).await
+    }
+
     /// Classifies a raw transaction with the active Anvil Tempo/T5 payment-lane classifier.
     pub fn anvil_classify_transaction(&self, tx: Bytes) -> Result<PaymentLaneClassification> {
         node_info!("anvil_classifyTransaction");
@@ -2916,6 +2937,18 @@ impl EthApi<FoundryNetwork> {
             self.backend.call_with_tracing(request, fees, Some(block_request), opts).await;
         result
     }
+}
+
+fn is_empty_transaction_condition(condition: &serde_json::Value) -> bool {
+    let Some(condition) = condition.as_object() else {
+        return false;
+    };
+
+    condition.iter().all(|(key, value)| match key.as_str() {
+        "knownAccounts" => value.as_object().is_some_and(|accounts| accounts.is_empty()),
+        "blockNumberMin" | "blockNumberMax" | "timestampMin" | "timestampMax" => value.is_null(),
+        _ => false,
+    })
 }
 
 // == impl EthApi anvil endpoints ==

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -15,7 +15,7 @@ use alloy_primitives::{
     Address, B256, ChainId, U256, b256, bytes,
     map::{AddressHashMap, B256HashMap, HashMap},
 };
-use alloy_provider::Provider;
+use alloy_provider::{PendingTransactionConfig, Provider};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, BlockTransactions, request::TransactionRequest,
     state::AccountOverride,
@@ -494,6 +494,67 @@ async fn can_send_raw_tx_sync() {
     let receipt = api.send_raw_transaction_sync(encoded.into()).await.unwrap();
     assert_eq!(receipt.from(), wallets[1].address());
     assert_eq!(receipt.to(), tx.to());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_send_raw_transaction_conditional() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()));
+    let (_api, handle) = spawn(node_config).await;
+    let provider = http_provider(&handle.http_endpoint());
+
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let eip1559_est = provider.estimate_eip1559_fees().await.unwrap();
+
+    let from = wallets[0].address();
+    let mut tx = TxEip1559 {
+        max_fee_per_gas: eip1559_est.max_fee_per_gas,
+        max_priority_fee_per_gas: eip1559_est.max_priority_fee_per_gas,
+        gas_limit: 100000,
+        chain_id: 31337,
+        to: alloy_primitives::TxKind::Call(from),
+        input: bytes!("11112222"),
+        ..Default::default()
+    };
+    let signature = wallets[1].sign_transaction_sync(&mut tx).unwrap();
+
+    let tx = tx.into_signed(signature);
+    let mut encoded = Vec::new();
+    tx.eip2718_encode(&mut encoded);
+
+    let tx_hash = provider
+        .raw_request(
+            "eth_sendRawTransactionConditional".into(),
+            (alloy_primitives::Bytes::from(encoded), serde_json::json!({"knownAccounts": {}})),
+        )
+        .await
+        .unwrap();
+
+    let tx_hash = provider
+        .watch_pending_transaction(PendingTransactionConfig::new(tx_hash))
+        .await
+        .unwrap()
+        .await
+        .unwrap();
+
+    let receipt = provider.get_transaction_receipt(tx_hash).await.unwrap().unwrap();
+    assert_eq!(receipt.from(), wallets[1].address());
+    assert_eq!(receipt.to(), tx.to());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_raw_transaction_conditional_prestate() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let result: std::result::Result<serde_json::Value, _> = provider
+        .raw_request(
+            "eth_sendRawTransactionConditional".into(),
+            (alloy_primitives::Bytes::default(), serde_json::json!({"blockNumberMin": "0x2"})),
+        )
+        .await;
+
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("transaction conditions are not supported"), "{err}");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This adds Anvil parsing and dispatch for reth's exported `eth_sendRawTransactionConditional` eth extension endpoint. Empty/default transaction conditions are equivalent to `eth_sendRawTransaction`, so Anvil now accepts those and reuses the existing raw transaction path.

Non-empty preconditions are rejected explicitly instead of being silently ignored, because Anvil does not currently preserve conditional metadata in its transaction pool. That keeps the endpoint compatible for default condition callers while making the remaining semantic gap visible.

Authored with AI assistance.
