### PR TITLE
feat(symbolic): import fuzz corpus seeds

### DIFF
--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -50,6 +50,8 @@ const DOC_KEYS: &[&str] = &["out", "title", "book", "homepage", "repository", "p
 const SYMBOLIC_KEYS: &[&str] = &[
     "enabled",
     "seed_corpus",
+    "use_fuzz_corpus",
+    "corpus_seed_limit",
     "solver",
     "solver_command",
     "solver_portfolio",

--- a/crates/config/src/symbolic.rs
+++ b/crates/config/src/symbolic.rs
@@ -34,6 +34,10 @@ pub struct SymbolicConfig {
     pub enabled: bool,
     /// Whether fuzz tests should be symbolically concretized into fuzz corpus seeds.
     pub seed_corpus: bool,
+    /// Whether fuzz corpus seeds should guide symbolic fuzz-test exploration.
+    pub use_fuzz_corpus: bool,
+    /// Maximum number of fuzz corpus seeds to import for one symbolic run.
+    pub corpus_seed_limit: usize,
     /// Solver executable to invoke.
     pub solver: String,
     /// Exact solver command to invoke. When set, this overrides `solver`.
@@ -94,6 +98,8 @@ impl Default for SymbolicConfig {
         Self {
             enabled: false,
             seed_corpus: false,
+            use_fuzz_corpus: false,
+            corpus_seed_limit: 32,
             solver: "z3".to_string(),
             solver_command: None,
             solver_portfolio: Vec::new(),
@@ -147,6 +153,8 @@ mod tests {
         let value = serde_json::json!({
             "enabled": false,
             "seed_corpus": false,
+            "use_fuzz_corpus": false,
+            "corpus_seed_limit": 32,
             "solver": "z3",
             "timeout": 30,
             "max_depth": 10000,

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -112,8 +112,8 @@ forge test --symbolic-use-fuzz-corpus --fuzz-corpus-dir fuzz_corpus
 
 Imported corpus entries are bounded by `symbolic.corpus_seed_limit` and only
 guide branch order; they do not prune feasible symbolic paths. JSON output
-records the per-test corpus directory, import counts, and exact seed files under
-`symbolic.corpus_seeds`.
+records the per-test corpus directory, import counts, and seed files that
+matched a symbolic calldata variant under `symbolic.corpus_seeds.used`.
 
 > **Hash-model caveat:** `PASS` also assumes collision and preimage resistance
 > for symbolic `KECCAK256` and hash-like precompile terms. The executor may use

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -103,6 +103,18 @@ forge test --symbolic-seed-corpus --fuzz-corpus-dir fuzz_corpus
 Forge symbolically executes matching fuzz tests, reuses their normal corpus
 layout, and writes a successful concrete input as a seed for later fuzz runs.
 
+Symbolic execution can import the same Foundry fuzz corpus as path-priority
+hints for fuzz tests:
+
+```sh
+forge test --symbolic-use-fuzz-corpus --fuzz-corpus-dir fuzz_corpus
+```
+
+Imported corpus entries are bounded by `symbolic.corpus_seed_limit` and only
+guide branch order; they do not prune feasible symbolic paths. JSON output
+records the per-test corpus directory, import counts, and exact seed files under
+`symbolic.corpus_seeds`.
+
 > **Hash-model caveat:** `PASS` also assumes collision and preimage resistance
 > for symbolic `KECCAK256` and hash-like precompile terms. The executor may use
 > equal symbolic hashes to infer equal symbolic preimages or lengths in modeled

--- a/crates/evm/symbolic/assets/symbolic-result.schema.json
+++ b/crates/evm/symbolic/assets/symbolic-result.schema.json
@@ -53,6 +53,9 @@
         { "$ref": "#/$defs/counterexample" }
       ]
     },
+    "corpus_seeds": {
+      "$ref": "#/$defs/corpus_seeds"
+    },
     "artifact": {
       "$ref": "#/$defs/artifact_ref"
     },
@@ -458,6 +461,47 @@
         },
         "value": {
           "type": ["string", "null"]
+        }
+      }
+    },
+    "corpus_seeds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["corpus_dir", "limit", "loaded", "skipped", "used"],
+      "properties": {
+        "corpus_dir": {
+          "type": ["string", "null"]
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "loaded": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skipped": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "used": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/corpus_seed" }
+        }
+      }
+    },
+    "corpus_seed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "calldata"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "calldata": {
+          "type": "string",
+          "pattern": "^0x([0-9a-fA-F]{2})*$"
         }
       }
     },

--- a/crates/evm/symbolic/src/abi.rs
+++ b/crates/evm/symbolic/src/abi.rs
@@ -98,6 +98,28 @@ impl SymbolicCalldata {
     ) -> Result<Vec<DynSolValue>, SymbolicError> {
         self.inputs.iter().map(|input| input.value.model_value(model)).collect()
     }
+
+    pub(super) fn seed_model(&self, seed: &SymbolicConcreteInput) -> Option<SymbolicModel> {
+        if seed.args.len() != self.inputs.len() {
+            return None;
+        }
+
+        let mut model = SymbolicModel::default();
+        for (input, arg) in self.inputs.iter().zip(&seed.args) {
+            if !input.value.seed_model_value(&mut model, arg) {
+                return None;
+            }
+        }
+
+        for constraint in &self.constraints {
+            if constraint.eval_model_if_complete(&model).ok().flatten() != Some(true) {
+                return None;
+            }
+        }
+
+        let calldata = self.bytes.eval_model(&model).ok()?;
+        (calldata.as_slice() == seed.calldata.as_ref()).then_some(model)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -700,6 +722,68 @@ impl SymbolicAbiValue {
             ),
         })
     }
+
+    pub(super) fn seed_model_value(&self, model: &mut SymbolicModel, value: &DynSolValue) -> bool {
+        match (self, value) {
+            (Self::Bool { word }, DynSolValue::Bool(value)) => {
+                word.assign_model_value(model, U256::from(*value as u8))
+            }
+            (Self::Uint { bits, word }, DynSolValue::Uint(value, value_bits))
+                if bits == value_bits =>
+            {
+                word.assign_model_value(model, *value)
+            }
+            (Self::Int { bits, word }, DynSolValue::Int(value, value_bits))
+                if bits == value_bits =>
+            {
+                word.assign_model_value(model, value.into_raw())
+            }
+            (Self::FixedBytes { bytes, size }, DynSolValue::FixedBytes(value, value_size))
+                if size == value_size =>
+            {
+                seed_model_bytes(model, bytes, &value.as_slice()[..*size])
+            }
+            (Self::Address { word }, DynSolValue::Address(value)) => {
+                word.assign_model_value(model, address_word(*value))
+            }
+            (Self::Bytes { len, bytes }, DynSolValue::Bytes(value)) => {
+                len.assign_model_value(model, U256::from(value.len()))
+                    && seed_model_bytes(model, bytes, value)
+            }
+            (Self::String { bytes }, DynSolValue::String(value)) => {
+                seed_model_bytes(model, bytes, value.as_bytes())
+            }
+            (Self::Array { elements }, DynSolValue::Array(values))
+            | (Self::FixedArray { elements }, DynSolValue::FixedArray(values))
+            | (Self::Tuple { elements }, DynSolValue::Tuple(values)) => {
+                seed_model_elements(model, elements, values)
+            }
+            (Self::Tuple { elements }, DynSolValue::CustomStruct { tuple, .. }) => {
+                seed_model_elements(model, elements, tuple)
+            }
+            _ => false,
+        }
+    }
+}
+
+fn seed_model_elements(
+    model: &mut SymbolicModel,
+    elements: &[SymbolicAbiValue],
+    values: &[DynSolValue],
+) -> bool {
+    elements.len() == values.len()
+        && elements
+            .iter()
+            .zip(values)
+            .all(|(element, value)| element.seed_model_value(model, value))
+}
+
+fn seed_model_bytes(model: &mut SymbolicModel, bytes: &SymBytes, value: &[u8]) -> bool {
+    bytes.len() == value.len()
+        && value
+            .iter()
+            .enumerate()
+            .all(|(idx, byte)| bytes.byte(idx).assign_model_value(model, U256::from(*byte)))
 }
 
 pub(super) fn encode_sequence<'a>(

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -467,22 +467,15 @@ impl SymbolicExecutor {
                             self.branch_is_sat_or_defer(&false_state.constraints)?;
                         trace!(true_feasible, false_feasible, "JUMPI symbolic branch");
                         match (true_feasible, false_feasible) {
-                            (true, true)
-                                if false_state.corpus_seed_model_count()
-                                    > true_state.corpus_seed_model_count() =>
-                            {
-                                push_preferred_branch(
-                                    worklist,
-                                    false_state,
-                                    true_state,
-                                    self.config.exploration_order,
-                                );
-                            }
                             (true, true) => {
-                                push_preferred_branch(
+                                let true_seed_count = true_state.corpus_seed_model_count();
+                                let false_seed_count = false_state.corpus_seed_model_count();
+                                push_seed_ordered_branches(
                                     worklist,
                                     true_state,
+                                    true_seed_count,
                                     false_state,
+                                    false_seed_count,
                                     self.config.exploration_order,
                                 );
                             }
@@ -778,10 +771,32 @@ impl SymbolicExecutor {
     }
 }
 
-fn push_preferred_branch(
-    worklist: &mut VecDeque<PathState>,
-    preferred: PathState,
-    secondary: PathState,
+fn push_seed_ordered_branches<T>(
+    worklist: &mut VecDeque<T>,
+    true_branch: T,
+    true_seed_count: usize,
+    false_branch: T,
+    false_seed_count: usize,
+    order: SymbolicExplorationOrder,
+) {
+    match false_seed_count.cmp(&true_seed_count) {
+        std::cmp::Ordering::Greater => {
+            push_preferred_branch(worklist, false_branch, true_branch, order);
+        }
+        std::cmp::Ordering::Less => {
+            push_preferred_branch(worklist, true_branch, false_branch, order);
+        }
+        std::cmp::Ordering::Equal => {
+            worklist.push_back(true_branch);
+            worklist.push_back(false_branch);
+        }
+    }
+}
+
+fn push_preferred_branch<T>(
+    worklist: &mut VecDeque<T>,
+    preferred: T,
+    secondary: T,
     order: SymbolicExplorationOrder,
 ) {
     match order {
@@ -793,5 +808,72 @@ fn push_preferred_branch(
             worklist.push_back(secondary);
             worklist.push_back(preferred);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_ordered_branches_preserve_equal_count_order() {
+        let mut bfs_worklist = VecDeque::new();
+        push_seed_ordered_branches(
+            &mut bfs_worklist,
+            "true",
+            0,
+            "false",
+            0,
+            SymbolicExplorationOrder::Bfs,
+        );
+        assert_eq!(
+            super::super::pop_worklist(&mut bfs_worklist, SymbolicExplorationOrder::Bfs),
+            Some("true")
+        );
+
+        let mut dfs_worklist = VecDeque::new();
+        push_seed_ordered_branches(
+            &mut dfs_worklist,
+            "true",
+            0,
+            "false",
+            0,
+            SymbolicExplorationOrder::Dfs,
+        );
+        assert_eq!(
+            super::super::pop_worklist(&mut dfs_worklist, SymbolicExplorationOrder::Dfs),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn seed_ordered_branches_prefer_strict_seed_count() {
+        let mut bfs_worklist = VecDeque::new();
+        push_seed_ordered_branches(
+            &mut bfs_worklist,
+            "true",
+            0,
+            "false",
+            1,
+            SymbolicExplorationOrder::Bfs,
+        );
+        assert_eq!(
+            super::super::pop_worklist(&mut bfs_worklist, SymbolicExplorationOrder::Bfs),
+            Some("false")
+        );
+
+        let mut dfs_worklist = VecDeque::new();
+        push_seed_ordered_branches(
+            &mut dfs_worklist,
+            "true",
+            1,
+            "false",
+            0,
+            SymbolicExplorationOrder::Dfs,
+        );
+        assert_eq!(
+            super::super::pop_worklist(&mut dfs_worklist, SymbolicExplorationOrder::Dfs),
+            Some("true")
+        );
     }
 }

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -454,11 +454,11 @@ impl SymbolicExecutor {
                             state.split_corpus_seed_models(&true_cond);
                         let mut true_state = state.clone();
                         true_state.constraints.push(true_cond);
-                        true_state.corpus_seed_models = true_seed_models;
+                        true_state.set_corpus_seed_models(true_seed_models);
                         true_state.pc = dest;
                         let mut false_state = state.clone();
                         false_state.constraints.push(false_cond);
-                        false_state.corpus_seed_models = false_seed_models;
+                        false_state.set_corpus_seed_models(false_seed_models);
                         false_state.pc = fallthrough;
 
                         let true_feasible = self.take_loop_jump(&mut true_state, fallthrough, dest)
@@ -468,8 +468,8 @@ impl SymbolicExecutor {
                         trace!(true_feasible, false_feasible, "JUMPI symbolic branch");
                         match (true_feasible, false_feasible) {
                             (true, true)
-                                if false_state.corpus_seed_models.len()
-                                    > true_state.corpus_seed_models.len() =>
+                                if false_state.corpus_seed_model_count()
+                                    > true_state.corpus_seed_model_count() =>
                             {
                                 push_preferred_branch(
                                     worklist,

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -450,11 +450,15 @@ impl SymbolicExecutor {
                         let true_cond = cond.nonzero_bool();
                         let false_cond = true_cond.clone().not();
                         let fallthrough = state.pc;
+                        let (true_seed_models, false_seed_models) =
+                            state.split_corpus_seed_models(&true_cond);
                         let mut true_state = state.clone();
                         true_state.constraints.push(true_cond);
+                        true_state.corpus_seed_models = true_seed_models;
                         true_state.pc = dest;
                         let mut false_state = state.clone();
                         false_state.constraints.push(false_cond);
+                        false_state.corpus_seed_models = false_seed_models;
                         false_state.pc = fallthrough;
 
                         let true_feasible = self.take_loop_jump(&mut true_state, fallthrough, dest)
@@ -462,11 +466,29 @@ impl SymbolicExecutor {
                         let false_feasible =
                             self.branch_is_sat_or_defer(&false_state.constraints)?;
                         trace!(true_feasible, false_feasible, "JUMPI symbolic branch");
-                        if true_feasible {
-                            worklist.push_back(true_state);
-                        }
-                        if false_feasible {
-                            worklist.push_back(false_state);
+                        match (true_feasible, false_feasible) {
+                            (true, true)
+                                if false_state.corpus_seed_models.len()
+                                    > true_state.corpus_seed_models.len() =>
+                            {
+                                push_preferred_branch(
+                                    worklist,
+                                    false_state,
+                                    true_state,
+                                    self.config.exploration_order,
+                                );
+                            }
+                            (true, true) => {
+                                push_preferred_branch(
+                                    worklist,
+                                    true_state,
+                                    false_state,
+                                    self.config.exploration_order,
+                                );
+                            }
+                            (true, false) => worklist.push_back(true_state),
+                            (false, true) => worklist.push_back(false_state),
+                            (false, false) => {}
                         }
                         return Ok(StepOutcome::Forked);
                     }
@@ -752,6 +774,24 @@ impl SymbolicExecutor {
             StepOutcome::Failure
         } else {
             StepOutcome::Revert
+        }
+    }
+}
+
+fn push_preferred_branch(
+    worklist: &mut VecDeque<PathState>,
+    preferred: PathState,
+    secondary: PathState,
+    order: SymbolicExplorationOrder,
+) {
+    match order {
+        SymbolicExplorationOrder::Bfs => {
+            worklist.push_back(preferred);
+            worklist.push_back(secondary);
+        }
+        SymbolicExplorationOrder::Dfs => {
+            worklist.push_back(secondary);
+            worklist.push_back(preferred);
         }
     }
 }

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -470,14 +470,28 @@ impl SymbolicExecutor {
                             (true, true) => {
                                 let true_seed_count = true_state.corpus_seed_model_count();
                                 let false_seed_count = false_state.corpus_seed_model_count();
-                                push_seed_ordered_branches(
-                                    worklist,
-                                    true_state,
-                                    true_seed_count,
-                                    false_state,
-                                    false_seed_count,
+                                match (
+                                    false_seed_count.cmp(&true_seed_count),
                                     self.config.exploration_order,
-                                );
+                                ) {
+                                    (
+                                        std::cmp::Ordering::Greater,
+                                        SymbolicExplorationOrder::Bfs,
+                                    )
+                                    | (std::cmp::Ordering::Less, SymbolicExplorationOrder::Dfs) => {
+                                        worklist.push_back(false_state);
+                                        worklist.push_back(true_state);
+                                    }
+                                    (
+                                        std::cmp::Ordering::Greater,
+                                        SymbolicExplorationOrder::Dfs,
+                                    )
+                                    | (std::cmp::Ordering::Less, SymbolicExplorationOrder::Bfs)
+                                    | (std::cmp::Ordering::Equal, _) => {
+                                        worklist.push_back(true_state);
+                                        worklist.push_back(false_state);
+                                    }
+                                }
                             }
                             (true, false) => worklist.push_back(true_state),
                             (false, true) => worklist.push_back(false_state),
@@ -768,112 +782,5 @@ impl SymbolicExecutor {
         } else {
             StepOutcome::Revert
         }
-    }
-}
-
-fn push_seed_ordered_branches<T>(
-    worklist: &mut VecDeque<T>,
-    true_branch: T,
-    true_seed_count: usize,
-    false_branch: T,
-    false_seed_count: usize,
-    order: SymbolicExplorationOrder,
-) {
-    match false_seed_count.cmp(&true_seed_count) {
-        std::cmp::Ordering::Greater => {
-            push_preferred_branch(worklist, false_branch, true_branch, order);
-        }
-        std::cmp::Ordering::Less => {
-            push_preferred_branch(worklist, true_branch, false_branch, order);
-        }
-        std::cmp::Ordering::Equal => {
-            worklist.push_back(true_branch);
-            worklist.push_back(false_branch);
-        }
-    }
-}
-
-fn push_preferred_branch<T>(
-    worklist: &mut VecDeque<T>,
-    preferred: T,
-    secondary: T,
-    order: SymbolicExplorationOrder,
-) {
-    match order {
-        SymbolicExplorationOrder::Bfs => {
-            worklist.push_back(preferred);
-            worklist.push_back(secondary);
-        }
-        SymbolicExplorationOrder::Dfs => {
-            worklist.push_back(secondary);
-            worklist.push_back(preferred);
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn seed_ordered_branches_preserve_equal_count_order() {
-        let mut bfs_worklist = VecDeque::new();
-        push_seed_ordered_branches(
-            &mut bfs_worklist,
-            "true",
-            0,
-            "false",
-            0,
-            SymbolicExplorationOrder::Bfs,
-        );
-        assert_eq!(
-            super::super::pop_worklist(&mut bfs_worklist, SymbolicExplorationOrder::Bfs),
-            Some("true")
-        );
-
-        let mut dfs_worklist = VecDeque::new();
-        push_seed_ordered_branches(
-            &mut dfs_worklist,
-            "true",
-            0,
-            "false",
-            0,
-            SymbolicExplorationOrder::Dfs,
-        );
-        assert_eq!(
-            super::super::pop_worklist(&mut dfs_worklist, SymbolicExplorationOrder::Dfs),
-            Some("false")
-        );
-    }
-
-    #[test]
-    fn seed_ordered_branches_prefer_strict_seed_count() {
-        let mut bfs_worklist = VecDeque::new();
-        push_seed_ordered_branches(
-            &mut bfs_worklist,
-            "true",
-            0,
-            "false",
-            1,
-            SymbolicExplorationOrder::Bfs,
-        );
-        assert_eq!(
-            super::super::pop_worklist(&mut bfs_worklist, SymbolicExplorationOrder::Bfs),
-            Some("false")
-        );
-
-        let mut dfs_worklist = VecDeque::new();
-        push_seed_ordered_branches(
-            &mut dfs_worklist,
-            "true",
-            1,
-            "false",
-            0,
-            SymbolicExplorationOrder::Dfs,
-        );
-        assert_eq!(
-            super::super::pop_worklist(&mut dfs_worklist, SymbolicExplorationOrder::Dfs),
-            Some("true")
-        );
     }
 }

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -1,4 +1,23 @@
 use super::*;
+use std::cmp::Reverse;
+
+fn order_roots_by_corpus_seed_count(roots: &mut [PathState], order: SymbolicExplorationOrder) {
+    let Some((first, rest)) = roots.split_first() else {
+        return;
+    };
+    if rest.iter().all(|root| root.corpus_seed_model_count() == first.corpus_seed_model_count()) {
+        return;
+    }
+
+    match order {
+        SymbolicExplorationOrder::Bfs => {
+            roots.sort_by_key(|root| Reverse(root.corpus_seed_model_count()));
+        }
+        SymbolicExplorationOrder::Dfs => {
+            roots.sort_by_key(PathState::corpus_seed_model_count);
+        }
+    }
+}
 
 impl SymbolicExecutor {
     /// Creates a symbolic executor from Foundry's symbolic configuration.
@@ -108,6 +127,28 @@ impl SymbolicExecutor {
         }
     }
 
+    /// Returns corpus seed indexes that can be modeled by at least one symbolic calldata variant.
+    pub fn modeled_corpus_seed_indexes(
+        config: &SymbolicConfig,
+        function: &Function,
+        corpus_seeds: &[SymbolicConcreteInput],
+    ) -> Result<Vec<usize>, SymbolicError> {
+        let variants = SymbolicCalldata::variants(function, config)?;
+        let mut modeled = vec![false; corpus_seeds.len()];
+        for calldata in &variants {
+            for (idx, seed) in corpus_seeds.iter().enumerate() {
+                if !modeled[idx] && calldata.seed_model(seed).is_some() {
+                    modeled[idx] = true;
+                }
+            }
+        }
+        Ok(modeled
+            .into_iter()
+            .enumerate()
+            .filter_map(|(idx, modeled)| modeled.then_some(idx))
+            .collect())
+    }
+
     /// Executes a bounded symbolic invariant call sequence.
     ///
     /// Each sequence step chooses from the concrete target functions and senders supplied by
@@ -153,7 +194,7 @@ impl SymbolicExecutor {
             .ok_or(SymbolicError::MissingAccount(input.target))?;
         let bytecode = account.code.ok_or(SymbolicError::MissingCode(input.target))?;
         let code = SymCode::from_bytecode(&bytecode);
-        let mut worklist = VecDeque::new();
+        let mut roots = Vec::new();
         for calldata in SymbolicCalldata::variants(input.function, &self.config)? {
             let corpus_seed_models = input
                 .corpus_seeds
@@ -171,8 +212,10 @@ impl SymbolicExecutor {
             root.apply_executor_env(input.executor);
             root.world.set_storage_layout(self.config.storage_layout);
             root.world.clear_transaction_scoped_state();
-            worklist.push_back(root);
+            roots.push(root);
         }
+        order_roots_by_corpus_seed_count(&mut roots, self.config.exploration_order);
+        let mut worklist = roots.into_iter().collect::<VecDeque<_>>();
         let mut completed_paths = 0usize;
         let mut reverted_paths = 0usize;
         let mut normal_paths = 0usize;

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -155,6 +155,8 @@ impl SymbolicExecutor {
         let code = SymCode::from_bytecode(&bytecode);
         let mut worklist = VecDeque::new();
         for calldata in SymbolicCalldata::variants(input.function, &self.config)? {
+            let corpus_seed_models =
+                input.corpus_seeds.iter().filter_map(|seed| calldata.seed_model(seed)).collect();
             let mut root = PathState::new(
                 input.target,
                 input.sender,
@@ -162,6 +164,7 @@ impl SymbolicExecutor {
                 calldata,
                 input.ffi_enabled,
             );
+            root.corpus_seed_models = corpus_seed_models;
             root.apply_executor_env(input.executor);
             root.world.set_storage_layout(self.config.storage_layout);
             root.world.clear_transaction_scoped_state();

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -155,8 +155,11 @@ impl SymbolicExecutor {
         let code = SymCode::from_bytecode(&bytecode);
         let mut worklist = VecDeque::new();
         for calldata in SymbolicCalldata::variants(input.function, &self.config)? {
-            let corpus_seed_models =
-                input.corpus_seeds.iter().filter_map(|seed| calldata.seed_model(seed)).collect();
+            let corpus_seed_models = input
+                .corpus_seeds
+                .iter()
+                .filter_map(|seed| calldata.seed_model(seed).map(Arc::new))
+                .collect();
             let mut root = PathState::new(
                 input.target,
                 input.sender,
@@ -164,7 +167,7 @@ impl SymbolicExecutor {
                 calldata,
                 input.ffi_enabled,
             );
-            root.corpus_seed_models = corpus_seed_models;
+            root.set_corpus_seed_models(corpus_seed_models);
             root.apply_executor_env(input.executor);
             root.world.set_storage_layout(self.config.storage_layout);
             root.world.clear_transaction_scoped_state();

--- a/crates/evm/symbolic/src/runtime.rs
+++ b/crates/evm/symbolic/src/runtime.rs
@@ -52,6 +52,8 @@ pub struct SymbolicRunInput<'a, FEN: FoundryEvmNetwork> {
     pub ffi_enabled: bool,
     /// Whether to return one successful concrete input when execution is safe.
     pub collect_success_input: bool,
+    /// Concrete fuzz corpus entries used as path-priority hints.
+    pub corpus_seeds: Vec<SymbolicConcreteInput>,
 }
 
 /// Error returned by the internal symbolic executor.

--- a/crates/evm/symbolic/src/runtime/expressions.rs
+++ b/crates/evm/symbolic/src/runtime/expressions.rs
@@ -504,6 +504,21 @@ impl SymExpr {
         })
     }
 
+    pub(crate) fn assign_model_value(&self, model: &mut SymbolicModel, value: U256) -> bool {
+        match self.kind() {
+            SymExprKind::Const(existing) => *existing == value,
+            SymExprKind::Var(var) => {
+                if let Some(existing) = model.get(var) {
+                    *existing == value
+                } else {
+                    model.insert(*var, value);
+                    true
+                }
+            }
+            _ => false,
+        }
+    }
+
     pub(crate) fn from_bool(value: SymBoolExpr) -> Self {
         Self::bool_word(value)
     }
@@ -1532,6 +1547,19 @@ impl SymBoolExpr {
         })
     }
 
+    pub(crate) fn eval_model_if_complete<M: SymbolicModelLookup + ?Sized>(
+        &self,
+        model: &M,
+    ) -> Result<Option<bool>, SymbolicError> {
+        let mut vars = SymbolicVars::default();
+        self.collect_eval_vars(&mut vars);
+        if vars.iter().copied().all(|var| model.contains_name(var)) {
+            self.eval_model(model).map(Some)
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Visits all word expressions contained in this boolean expression.
     pub(crate) fn visit_exprs<B>(
         &self,
@@ -1788,6 +1816,18 @@ impl SymBoolExpr {
                 SymExprKind::Var(var)
                 | SymExprKind::Keccak { name: var, .. }
                 | SymExprKind::Hash { name: var, .. } => {
+                    vars.insert(*var);
+                }
+                _ => {}
+            }
+            ControlFlow::<()>::Continue(())
+        });
+    }
+
+    pub(crate) fn collect_eval_vars(&self, vars: &mut SymbolicVars) {
+        let _ = self.visit_exprs(&mut |expr| {
+            match expr.kind() {
+                SymExprKind::Var(var) | SymExprKind::Hash { name: var, .. } => {
                     vars.insert(*var);
                 }
                 _ => {}

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -17,7 +17,7 @@ pub(crate) struct PathState {
     pub(crate) recorded_logs: Option<Vec<SymbolicLog>>,
     pub(crate) access_record: Option<AccessRecord>,
     pub(crate) root_calldata: Option<SymbolicCalldata>,
-    pub(crate) corpus_seed_models: Vec<SymbolicModel>,
+    corpus_seed_models: Vec<Arc<SymbolicModel>>,
     pub(crate) loop_jumps: HashMap<usize, u32>,
     pub(crate) expected_revert: Option<ExpectedRevert>,
     pub(crate) assume_no_revert_next_call: Option<AssumeNoRevert>,
@@ -242,20 +242,28 @@ impl PathState {
     pub(crate) fn split_corpus_seed_models(
         &self,
         condition: &SymBoolExpr,
-    ) -> (Vec<SymbolicModel>, Vec<SymbolicModel>) {
+    ) -> (Vec<Arc<SymbolicModel>>, Vec<Arc<SymbolicModel>>) {
         let mut true_models = Vec::new();
         let mut false_models = Vec::new();
         for model in &self.corpus_seed_models {
-            match condition.eval_model_if_complete(model) {
-                Ok(Some(true)) => true_models.push(model.clone()),
-                Ok(Some(false)) => false_models.push(model.clone()),
+            match condition.eval_model_if_complete(model.as_ref()) {
+                Ok(Some(true)) => true_models.push(Arc::clone(model)),
+                Ok(Some(false)) => false_models.push(Arc::clone(model)),
                 Ok(None) | Err(_) => {
-                    true_models.push(model.clone());
-                    false_models.push(model.clone());
+                    true_models.push(Arc::clone(model));
+                    false_models.push(Arc::clone(model));
                 }
             }
         }
         (true_models, false_models)
+    }
+
+    pub(crate) fn set_corpus_seed_models(&mut self, models: Vec<Arc<SymbolicModel>>) {
+        self.corpus_seed_models = models;
+    }
+
+    pub(crate) const fn corpus_seed_model_count(&self) -> usize {
+        self.corpus_seed_models.len()
     }
 
     pub(crate) fn expr_upper_bound_usize(&self, expr: &SymExpr) -> Option<usize> {

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -17,6 +17,7 @@ pub(crate) struct PathState {
     pub(crate) recorded_logs: Option<Vec<SymbolicLog>>,
     pub(crate) access_record: Option<AccessRecord>,
     pub(crate) root_calldata: Option<SymbolicCalldata>,
+    pub(crate) corpus_seed_models: Vec<SymbolicModel>,
     pub(crate) loop_jumps: HashMap<usize, u32>,
     pub(crate) expected_revert: Option<ExpectedRevert>,
     pub(crate) assume_no_revert_next_call: Option<AssumeNoRevert>,
@@ -64,6 +65,7 @@ impl PathState {
             recorded_logs: None,
             access_record: None,
             root_calldata: Some(calldata),
+            corpus_seed_models: Vec::new(),
             loop_jumps: HashMap::default(),
             expected_revert: None,
             assume_no_revert_next_call: None,
@@ -103,6 +105,7 @@ impl PathState {
             recorded_logs: None,
             access_record: None,
             root_calldata: None,
+            corpus_seed_models: Vec::new(),
             loop_jumps: HashMap::default(),
             expected_revert: None,
             assume_no_revert_next_call: None,
@@ -234,6 +237,25 @@ impl PathState {
         }
 
         expr.eval_model(&model).ok()
+    }
+
+    pub(crate) fn split_corpus_seed_models(
+        &self,
+        condition: &SymBoolExpr,
+    ) -> (Vec<SymbolicModel>, Vec<SymbolicModel>) {
+        let mut true_models = Vec::new();
+        let mut false_models = Vec::new();
+        for model in &self.corpus_seed_models {
+            match condition.eval_model_if_complete(model) {
+                Ok(Some(true)) => true_models.push(model.clone()),
+                Ok(Some(false)) => false_models.push(model.clone()),
+                Ok(None) | Err(_) => {
+                    true_models.push(model.clone());
+                    false_models.push(model.clone());
+                }
+            }
+        }
+        (true_models, false_models)
     }
 
     pub(crate) fn expr_upper_bound_usize(&self, expr: &SymExpr) -> Option<usize> {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -405,6 +405,43 @@ fn dynamic_calldata_encodes_bounded_bytes() {
 }
 
 #[test]
+fn calldata_seed_model_round_trips_common_abi_values() {
+    let function = Function::parse(
+        "check(bool,uint256,int128,address,bytes3,bytes,string,uint256[],(uint256,bool))",
+    )
+    .unwrap();
+    let config = SymbolicConfig {
+        default_array_lengths: vec![2],
+        default_bytes_lengths: vec![2],
+        ..Default::default()
+    };
+    let mut fixed = [0u8; 32];
+    fixed[..3].copy_from_slice(&[0xaa, 0xbb, 0xcc]);
+    let args = vec![
+        DynSolValue::Bool(true),
+        DynSolValue::Uint(U256::from(42), 256),
+        DynSolValue::Int(I256::try_from(-5i64).unwrap(), 128),
+        DynSolValue::Address(Address::from([0x11; 20])),
+        DynSolValue::FixedBytes(B256::from(fixed), 3),
+        DynSolValue::Bytes(vec![1, 2]),
+        DynSolValue::String("ok".to_string()),
+        DynSolValue::Array(vec![
+            DynSolValue::Uint(U256::from(1), 256),
+            DynSolValue::Uint(U256::from(2), 256),
+        ]),
+        DynSolValue::Tuple(vec![DynSolValue::Uint(U256::from(9), 256), DynSolValue::Bool(false)]),
+    ];
+    let seed = SymbolicConcreteInput {
+        calldata: Bytes::from(function.abi_encode_input(&args).unwrap()),
+        args: args.clone(),
+    };
+    let calldata = SymbolicCalldata::variants(&function, &config).unwrap().remove(0);
+    let model = calldata.seed_model(&seed).unwrap();
+
+    assert_eq!(calldata.model_to_args(&model).unwrap(), args);
+}
+
+#[test]
 fn calldata_word_loads_preserve_structural_words() {
     let function = Function::parse("check(uint256,bool,address)").unwrap();
     let calldata =

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -490,6 +490,14 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_SYMBOLIC_SEED_CORPUS")]
     pub symbolic_seed_corpus: bool,
 
+    /// Run fuzz tests symbolically using existing fuzz corpus entries as path-priority hints.
+    #[arg(long, env = "FOUNDRY_SYMBOLIC_USE_FUZZ_CORPUS")]
+    pub symbolic_use_fuzz_corpus: bool,
+
+    /// Maximum number of fuzz corpus entries to import for one symbolic test.
+    #[arg(long, env = "FOUNDRY_SYMBOLIC_CORPUS_SEED_LIMIT", value_name = "COUNT")]
+    pub symbolic_corpus_seed_limit: Option<usize>,
+
     /// Solver executable used for symbolic tests.
     #[arg(long, env = "FOUNDRY_SYMBOLIC_SOLVER", value_name = "PATH_OR_NAME")]
     pub symbolic_solver: Option<String>,
@@ -2374,6 +2382,12 @@ impl Provider for TestArgs {
         }
         if self.symbolic_seed_corpus {
             symbolic_dict.insert("seed_corpus".to_string(), true.into());
+        }
+        if self.symbolic_use_fuzz_corpus {
+            symbolic_dict.insert("use_fuzz_corpus".to_string(), true.into());
+        }
+        if let Some(corpus_seed_limit) = self.symbolic_corpus_seed_limit {
+            symbolic_dict.insert("corpus_seed_limit".to_string(), corpus_seed_limit.into());
         }
         if let Some(solver) = self.symbolic_solver.clone() {
             symbolic_dict.insert("solver".to_string(), solver.into());

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1067,11 +1067,11 @@ pub struct SymbolicCorpusSeedMetadata {
     pub loaded: usize,
     /// Number of corpus files skipped because they were unreadable or not a matching single call.
     pub skipped: usize,
-    /// Seeds passed to symbolic execution as path-priority hints.
+    /// Seeds modeled by symbolic execution as path-priority hints.
     pub used: Vec<SymbolicCorpusSeedRef>,
 }
 
-/// One fuzz corpus seed passed to symbolic execution.
+/// One fuzz corpus seed modeled by symbolic execution.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SymbolicCorpusSeedRef {
     /// Corpus file path.

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -948,6 +948,9 @@ pub struct SymbolicResult {
     pub replay: SymbolicReplayMetadata,
     /// Concrete counterexample data, when the solver produced a candidate.
     pub counterexample: Option<SymbolicCounterexample>,
+    /// Fuzz corpus seeds imported into symbolic execution, when enabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corpus_seeds: Option<SymbolicCorpusSeedMetadata>,
     /// Durable counterexample artifact, when one was written.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub artifact: Option<SymbolicArtifactRef>,
@@ -1028,9 +1031,16 @@ impl SymbolicResult {
             call_trace,
             replay,
             counterexample,
+            corpus_seeds: None,
             artifact: None,
             minimization: None,
         }
+    }
+
+    /// Attaches fuzz corpus import metadata to this symbolic result.
+    pub fn with_corpus_seeds(mut self, corpus_seeds: SymbolicCorpusSeedMetadata) -> Self {
+        self.corpus_seeds = Some(corpus_seeds);
+        self
     }
 
     /// Attaches a durable replay artifact reference to this symbolic result.
@@ -1044,6 +1054,30 @@ impl SymbolicResult {
         self.minimization = Some(minimization);
         self
     }
+}
+
+/// Fuzz corpus import metadata for a symbolic run.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SymbolicCorpusSeedMetadata {
+    /// Corpus root used for the current test, after contract/test path expansion.
+    pub corpus_dir: Option<std::path::PathBuf>,
+    /// Maximum imported seeds allowed by configuration.
+    pub limit: usize,
+    /// Number of corpus files considered.
+    pub loaded: usize,
+    /// Number of corpus files skipped because they were unreadable or not a matching single call.
+    pub skipped: usize,
+    /// Seeds passed to symbolic execution as path-priority hints.
+    pub used: Vec<SymbolicCorpusSeedRef>,
+}
+
+/// One fuzz corpus seed passed to symbolic execution.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SymbolicCorpusSeedRef {
+    /// Corpus file path.
+    pub path: std::path::PathBuf,
+    /// ABI-encoded calldata imported from the corpus file.
+    pub calldata: Bytes,
 }
 
 /// Reference to a durable symbolic counterexample artifact.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -96,14 +96,11 @@ struct ImportedSymbolicCorpusSeeds {
     metadata: Option<SymbolicCorpusSeedMetadata>,
 }
 
-impl ImportedSymbolicCorpusSeeds {
-    fn attach_to(&self, result: SymbolicResult) -> SymbolicResult {
-        if let Some(metadata) = self.metadata.clone() {
-            result.with_corpus_seeds(metadata)
-        } else {
-            result
-        }
-    }
+fn attach_imported_symbolic_corpus_seeds(
+    metadata: &Option<SymbolicCorpusSeedMetadata>,
+    result: SymbolicResult,
+) -> SymbolicResult {
+    if let Some(metadata) = metadata.clone() { result.with_corpus_seeds(metadata) } else { result }
 }
 
 pub(crate) struct InvariantCampaignScope<'a> {
@@ -1779,7 +1776,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             return self.result;
         }
 
-        let imported_corpus = self.import_symbolic_fuzz_corpus(func);
+        let ImportedSymbolicCorpusSeeds { inputs: corpus_seeds, metadata: corpus_seed_metadata } =
+            self.import_symbolic_fuzz_corpus(func);
         let mut symbolic = SymbolicExecutor::new(self.config.symbolic.clone());
         if self.should_defer_symbolic_diagnostics() {
             symbolic.capture_diagnostics();
@@ -1792,7 +1790,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             value: U256::ZERO,
             ffi_enabled: self.config.ffi,
             collect_success_input: false,
-            corpus_seeds: imported_corpus.inputs.clone(),
+            corpus_seeds,
         });
         let portfolio_diagnostics = symbolic.portfolio_diagnostics();
         let symbolic_diagnostics = symbolic.take_diagnostics();
@@ -1803,7 +1801,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     TestStatus::Success,
                     None,
                     None,
-                    imported_corpus.attach_to(SymbolicResult::pass(&self.config.symbolic, stats)),
+                    attach_imported_symbolic_corpus_seeds(
+                        &corpus_seed_metadata,
+                        SymbolicResult::pass(&self.config.symbolic, stats),
+                    ),
                 );
             }
             SymbolicRunResult::Incomplete { kind, reason, stats } => {
@@ -1812,15 +1813,18 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     TestStatus::Failure,
                     Some(display_reason),
                     None,
-                    imported_corpus.attach_to(SymbolicResult::incomplete(
-                        &self.config.symbolic,
-                        kind,
-                        reason,
-                        stats,
-                        SymbolicReplayMetadata::not_required(),
-                        SymbolicCallTrace::none(),
-                        None,
-                    )),
+                    attach_imported_symbolic_corpus_seeds(
+                        &corpus_seed_metadata,
+                        SymbolicResult::incomplete(
+                            &self.config.symbolic,
+                            kind,
+                            reason,
+                            stats,
+                            SymbolicReplayMetadata::not_required(),
+                            SymbolicCallTrace::none(),
+                            None,
+                        ),
+                    ),
                 );
             }
             SymbolicRunResult::Counterexample { args, calldata, stats } => {
@@ -1840,8 +1844,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
                     Err(EvmError::Skip(reason)) => {
                         let replay_reason = format!("vm.skip during concrete replay: {reason}");
-                        let symbolic_result =
-                            imported_corpus.attach_to(SymbolicResult::incomplete(
+                        let symbolic_result = attach_imported_symbolic_corpus_seeds(
+                            &corpus_seed_metadata,
+                            SymbolicResult::incomplete(
                                 &self.config.symbolic,
                                 SymbolicStopReason::Error,
                                 "concrete replay skipped the symbolic counterexample",
@@ -1849,7 +1854,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                                 SymbolicReplayMetadata::skipped(replay_reason),
                                 SymbolicCallTrace::none(),
                                 Some(symbolic_counterexample),
-                            ));
+                            ),
+                        );
                         self.result.symbolic_result(
                             TestStatus::Skipped,
                             reason.0,
@@ -1862,8 +1868,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     }
                     Err(err) => {
                         let reason = err.to_string();
-                        let symbolic_result =
-                            imported_corpus.attach_to(SymbolicResult::incomplete(
+                        let symbolic_result = attach_imported_symbolic_corpus_seeds(
+                            &corpus_seed_metadata,
+                            SymbolicResult::incomplete(
                                 &self.config.symbolic,
                                 SymbolicStopReason::Error,
                                 reason.clone(),
@@ -1871,7 +1878,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                                 SymbolicReplayMetadata::error(reason.clone()),
                                 SymbolicCallTrace::none(),
                                 Some(symbolic_counterexample),
-                            ));
+                            ),
+                        );
                         self.result.symbolic_result(
                             TestStatus::Failure,
                             Some(reason),
@@ -1900,15 +1908,18 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 if success {
                     self.result.extend(raw_call_result);
                     let reason = "symbolic counterexample did not replay".to_string();
-                    let symbolic_result = imported_corpus.attach_to(SymbolicResult::incomplete(
-                        &self.config.symbolic,
-                        SymbolicStopReason::Error,
-                        reason.clone(),
-                        stats,
-                        SymbolicReplayMetadata::mismatch(reason.clone()),
-                        call_trace,
-                        Some(symbolic_counterexample),
-                    ));
+                    let symbolic_result = attach_imported_symbolic_corpus_seeds(
+                        &corpus_seed_metadata,
+                        SymbolicResult::incomplete(
+                            &self.config.symbolic,
+                            SymbolicStopReason::Error,
+                            reason.clone(),
+                            stats,
+                            SymbolicReplayMetadata::mismatch(reason.clone()),
+                            call_trace,
+                            Some(symbolic_counterexample),
+                        ),
+                    );
                     let counterexample = CounterExample::Single(base_counterexample);
                     self.result.symbolic_result(
                         TestStatus::Failure,
@@ -2027,7 +2038,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         TestStatus::Failure,
                         final_reason,
                         Some(counterexample),
-                        imported_corpus.attach_to(symbolic_result),
+                        attach_imported_symbolic_corpus_seeds(
+                            &corpus_seed_metadata,
+                            symbolic_result,
+                        ),
                     );
                 }
             }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -8,11 +8,12 @@ use crate::{
     progress::{TestsProgress, start_fuzz_progress},
     result::{
         InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicArtifactRef,
-        SymbolicCallTrace, SymbolicCounterexample, SymbolicCounterexampleArtifact,
-        SymbolicCounterexampleArtifactKind, SymbolicCounterexampleCall,
-        SymbolicCounterexampleMinimization, SymbolicCounterexampleReplaySemantics,
-        SymbolicCounterexampleTestIdentity, SymbolicReplayMetadata, SymbolicReplayStatus,
-        SymbolicResult, TestResult, TestSetup, TestStatus, invariant_campaign_display_name,
+        SymbolicCallTrace, SymbolicCorpusSeedMetadata, SymbolicCorpusSeedRef,
+        SymbolicCounterexample, SymbolicCounterexampleArtifact, SymbolicCounterexampleArtifactKind,
+        SymbolicCounterexampleCall, SymbolicCounterexampleMinimization,
+        SymbolicCounterexampleReplaySemantics, SymbolicCounterexampleTestIdentity,
+        SymbolicReplayMetadata, SymbolicReplayStatus, SymbolicResult, TestResult, TestSetup,
+        TestStatus, invariant_campaign_display_name,
     },
     symbolic_minimizer::{
         MinimizedSequence, minimize_sequence_counterexample, minimize_single_call_counterexample,
@@ -31,7 +32,7 @@ use foundry_evm::{
     decode::{RevertDecoder, SkipReason},
     executors::{
         CallResult, EvmError, Executor, ITest, InvariantReplayOptions, RawCallResult, ShowmapOpts,
-        ShowmapReplayTarget,
+        ShowmapReplayTarget, canonical_replay_dirs,
         fuzz::FuzzedExecutor,
         invariant::{
             CheckSequenceFailureSite, CheckSequenceOptions, CheckSequenceOutcome,
@@ -39,7 +40,7 @@ use foundry_evm::{
             execute_tx, execute_tx_and_register_created, replay_error,
             replay_handler_failure_sequence, replay_run,
         },
-        persist_corpus_seed, replay_corpus_to_showmap,
+        persist_corpus_seed, read_corpus_dir, replay_corpus_to_showmap,
     },
     fuzz::{
         BasicTxDetails, CallDetails, CounterExample, FuzzFixtures, fixture_name,
@@ -83,6 +84,26 @@ pub(crate) fn is_symbolic_entrypoint(func: &Function) -> bool {
 
 fn should_symbolically_seed_fuzz_corpus(config: &Config, func: &Function) -> bool {
     config.symbolic.seed_corpus && func.test_function_kind().is_fuzz_test()
+}
+
+fn should_symbolically_import_fuzz_corpus(config: &Config, func: &Function) -> bool {
+    config.symbolic.use_fuzz_corpus && func.test_function_kind().is_fuzz_test()
+}
+
+#[derive(Default)]
+struct ImportedSymbolicCorpusSeeds {
+    inputs: Vec<SymbolicConcreteInput>,
+    metadata: Option<SymbolicCorpusSeedMetadata>,
+}
+
+impl ImportedSymbolicCorpusSeeds {
+    fn attach_to(&self, result: SymbolicResult) -> SymbolicResult {
+        if let Some(metadata) = self.metadata.clone() {
+            result.with_corpus_seeds(metadata)
+        } else {
+            result
+        }
+    }
 }
 
 pub(crate) struct InvariantCampaignScope<'a> {
@@ -1004,7 +1025,9 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 }
 
                 let sig = func.signature();
-                let kind = if symbolic_enabled && is_symbolic_entrypoint(func) {
+                let kind = if (symbolic_enabled && is_symbolic_entrypoint(func))
+                    || should_symbolically_import_fuzz_corpus(&self.config, func)
+                {
                     TestFunctionKind::SymbolicTest
                 } else {
                     func.test_function_kind()
@@ -1654,12 +1677,109 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         self.result
     }
 
+    fn import_symbolic_fuzz_corpus(&self, func: &Function) -> ImportedSymbolicCorpusSeeds {
+        let mut imported = ImportedSymbolicCorpusSeeds::default();
+        if !should_symbolically_import_fuzz_corpus(&self.config, func) {
+            return imported;
+        }
+
+        let mut fuzz_config = self.config.fuzz.clone();
+        let _ = test_paths(
+            &mut fuzz_config.corpus,
+            fuzz_config.failure_persist_dir.clone().unwrap(),
+            self.cr.name,
+            &func.name,
+        );
+        let limit = self.config.symbolic.corpus_seed_limit;
+        let mut metadata = SymbolicCorpusSeedMetadata {
+            corpus_dir: fuzz_config.corpus.corpus_dir.clone(),
+            limit,
+            loaded: 0,
+            skipped: 0,
+            used: Vec::new(),
+        };
+        let Some(corpus_dir) = fuzz_config.corpus.corpus_dir.clone() else {
+            let _ = sh_warn!(
+                "`--symbolic-use-fuzz-corpus` requires `--fuzz-corpus-dir` or `fuzz.corpus_dir`; \
+                 running without imported corpus seeds"
+            );
+            imported.metadata = Some(metadata);
+            return imported;
+        };
+
+        if limit == 0 {
+            imported.metadata = Some(metadata);
+            return imported;
+        }
+
+        'dirs: for replay_dir in canonical_replay_dirs(&corpus_dir) {
+            let mut entries = read_corpus_dir(&replay_dir).collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.path.cmp(&right.path));
+            for entry in entries {
+                if imported.inputs.len() >= limit {
+                    break 'dirs;
+                }
+                metadata.loaded += 1;
+                let tx_seq = match entry.read_tx_seq() {
+                    Ok(tx_seq) => tx_seq,
+                    Err(err) => {
+                        metadata.skipped += 1;
+                        debug!(%err, path = %entry.path.display(), "failed to read symbolic corpus seed");
+                        continue;
+                    }
+                };
+                let Some(input) = self.symbolic_corpus_seed_input(func, &tx_seq) else {
+                    metadata.skipped += 1;
+                    continue;
+                };
+                metadata.used.push(SymbolicCorpusSeedRef {
+                    path: entry.path,
+                    calldata: input.calldata.clone(),
+                });
+                imported.inputs.push(input);
+            }
+        }
+
+        debug!(
+            test = %func.signature(),
+            corpus_dir = %corpus_dir.display(),
+            loaded = metadata.loaded,
+            skipped = metadata.skipped,
+            used = metadata.used.len(),
+            "imported symbolic fuzz corpus seeds"
+        );
+        imported.metadata = Some(metadata);
+        imported
+    }
+
+    fn symbolic_corpus_seed_input(
+        &self,
+        func: &Function,
+        tx_seq: &[BasicTxDetails],
+    ) -> Option<SymbolicConcreteInput> {
+        let [tx] = tx_seq else {
+            return None;
+        };
+        if tx.call_details.target != self.address
+            || !tx.call_details.value.unwrap_or_default().is_zero()
+        {
+            return None;
+        }
+        let calldata = &tx.call_details.calldata;
+        if calldata.get(..4) != Some(func.selector().as_slice()) {
+            return None;
+        }
+        let args = func.abi_decode_input(&calldata[4..]).ok()?;
+        Some(SymbolicConcreteInput { args, calldata: calldata.clone() })
+    }
+
     /// Runs a symbolic test and replays any discovered counterexample concretely.
     fn run_symbolic_test(mut self, func: &Function) -> TestResult {
         if self.prepare_test(func).is_err() {
             return self.result;
         }
 
+        let imported_corpus = self.import_symbolic_fuzz_corpus(func);
         let mut symbolic = SymbolicExecutor::new(self.config.symbolic.clone());
         if self.should_defer_symbolic_diagnostics() {
             symbolic.capture_diagnostics();
@@ -1672,6 +1792,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             value: U256::ZERO,
             ffi_enabled: self.config.ffi,
             collect_success_input: false,
+            corpus_seeds: imported_corpus.inputs.clone(),
         });
         let portfolio_diagnostics = symbolic.portfolio_diagnostics();
         let symbolic_diagnostics = symbolic.take_diagnostics();
@@ -1682,7 +1803,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     TestStatus::Success,
                     None,
                     None,
-                    SymbolicResult::pass(&self.config.symbolic, stats),
+                    imported_corpus.attach_to(SymbolicResult::pass(&self.config.symbolic, stats)),
                 );
             }
             SymbolicRunResult::Incomplete { kind, reason, stats } => {
@@ -1691,7 +1812,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     TestStatus::Failure,
                     Some(display_reason),
                     None,
-                    SymbolicResult::incomplete(
+                    imported_corpus.attach_to(SymbolicResult::incomplete(
                         &self.config.symbolic,
                         kind,
                         reason,
@@ -1699,7 +1820,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         SymbolicReplayMetadata::not_required(),
                         SymbolicCallTrace::none(),
                         None,
-                    ),
+                    )),
                 );
             }
             SymbolicRunResult::Counterexample { args, calldata, stats } => {
@@ -1719,15 +1840,16 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     Err(EvmError::Execution(err)) => (err.raw, Some(err.reason)),
                     Err(EvmError::Skip(reason)) => {
                         let replay_reason = format!("vm.skip during concrete replay: {reason}");
-                        let symbolic_result = SymbolicResult::incomplete(
-                            &self.config.symbolic,
-                            SymbolicStopReason::Error,
-                            "concrete replay skipped the symbolic counterexample",
-                            stats,
-                            SymbolicReplayMetadata::skipped(replay_reason),
-                            SymbolicCallTrace::none(),
-                            Some(symbolic_counterexample),
-                        );
+                        let symbolic_result =
+                            imported_corpus.attach_to(SymbolicResult::incomplete(
+                                &self.config.symbolic,
+                                SymbolicStopReason::Error,
+                                "concrete replay skipped the symbolic counterexample",
+                                stats,
+                                SymbolicReplayMetadata::skipped(replay_reason),
+                                SymbolicCallTrace::none(),
+                                Some(symbolic_counterexample),
+                            ));
                         self.result.symbolic_result(
                             TestStatus::Skipped,
                             reason.0,
@@ -1740,15 +1862,16 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     }
                     Err(err) => {
                         let reason = err.to_string();
-                        let symbolic_result = SymbolicResult::incomplete(
-                            &self.config.symbolic,
-                            SymbolicStopReason::Error,
-                            reason.clone(),
-                            stats,
-                            SymbolicReplayMetadata::error(reason.clone()),
-                            SymbolicCallTrace::none(),
-                            Some(symbolic_counterexample),
-                        );
+                        let symbolic_result =
+                            imported_corpus.attach_to(SymbolicResult::incomplete(
+                                &self.config.symbolic,
+                                SymbolicStopReason::Error,
+                                reason.clone(),
+                                stats,
+                                SymbolicReplayMetadata::error(reason.clone()),
+                                SymbolicCallTrace::none(),
+                                Some(symbolic_counterexample),
+                            ));
                         self.result.symbolic_result(
                             TestStatus::Failure,
                             Some(reason),
@@ -1777,7 +1900,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 if success {
                     self.result.extend(raw_call_result);
                     let reason = "symbolic counterexample did not replay".to_string();
-                    let symbolic_result = SymbolicResult::incomplete(
+                    let symbolic_result = imported_corpus.attach_to(SymbolicResult::incomplete(
                         &self.config.symbolic,
                         SymbolicStopReason::Error,
                         reason.clone(),
@@ -1785,7 +1908,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         SymbolicReplayMetadata::mismatch(reason.clone()),
                         call_trace,
                         Some(symbolic_counterexample),
-                    );
+                    ));
                     let counterexample = CounterExample::Single(base_counterexample);
                     self.result.symbolic_result(
                         TestStatus::Failure,
@@ -1904,7 +2027,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         TestStatus::Failure,
                         final_reason,
                         Some(counterexample),
-                        symbolic_result,
+                        imported_corpus.attach_to(symbolic_result),
                     );
                 }
             }
@@ -2167,6 +2290,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             value: U256::ZERO,
             ffi_enabled: self.config.ffi,
             collect_success_input: true,
+            corpus_seeds: Vec::new(),
         });
 
         let input = match result {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -93,7 +93,6 @@ fn should_symbolically_import_fuzz_corpus(config: &Config, func: &Function) -> b
 #[derive(Default)]
 struct ImportedSymbolicCorpusSeeds {
     inputs: Vec<SymbolicConcreteInput>,
-    refs: Vec<SymbolicCorpusSeedRef>,
     metadata: Option<SymbolicCorpusSeedMetadata>,
 }
 
@@ -1733,7 +1732,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     metadata.skipped += 1;
                     continue;
                 };
-                imported.refs.push(SymbolicCorpusSeedRef {
+                metadata.used.push(SymbolicCorpusSeedRef {
                     path: entry.path,
                     calldata: input.calldata.clone(),
                 });
@@ -1782,7 +1781,6 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
 
         let ImportedSymbolicCorpusSeeds {
             inputs: corpus_seeds,
-            refs: corpus_seed_refs,
             metadata: mut corpus_seed_metadata,
         } = self.import_symbolic_fuzz_corpus(func);
         if let Some(metadata) = corpus_seed_metadata.as_mut() {
@@ -1792,9 +1790,17 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 &corpus_seeds,
             ) {
                 Ok(indexes) => {
-                    metadata.used = indexes
+                    let mut indexes = indexes.into_iter().peekable();
+                    metadata.used = std::mem::take(&mut metadata.used)
                         .into_iter()
-                        .filter_map(|idx| corpus_seed_refs.get(idx).cloned())
+                        .enumerate()
+                        .filter_map(|(idx, seed)| match indexes.peek().copied() {
+                            Some(used_idx) if used_idx == idx => {
+                                indexes.next();
+                                Some(seed)
+                            }
+                            _ => None,
+                        })
                         .collect();
                 }
                 Err(err) => {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -93,6 +93,7 @@ fn should_symbolically_import_fuzz_corpus(config: &Config, func: &Function) -> b
 #[derive(Default)]
 struct ImportedSymbolicCorpusSeeds {
     inputs: Vec<SymbolicConcreteInput>,
+    refs: Vec<SymbolicCorpusSeedRef>,
     metadata: Option<SymbolicCorpusSeedMetadata>,
 }
 
@@ -1022,9 +1023,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 }
 
                 let sig = func.signature();
-                let kind = if (symbolic_enabled && is_symbolic_entrypoint(func))
-                    || should_symbolically_import_fuzz_corpus(&self.config, func)
-                {
+                let kind = if symbolic_enabled && is_symbolic_entrypoint(func) {
                     TestFunctionKind::SymbolicTest
                 } else {
                     func.test_function_kind()
@@ -1584,6 +1583,11 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             self.result.single_fail(Some(e.to_string()));
             return self.result;
         }
+        let kind = if should_symbolically_import_fuzz_corpus(&self.config, func) {
+            TestFunctionKind::SymbolicTest
+        } else {
+            kind
+        };
 
         // In showmap replay mode and `forge fuzz`, only fuzz/invariant tests are runnable.
         if (self.cr.mcr.tcfg.showmap.is_some() || self.cr.mcr.tcfg.fuzz_only)
@@ -1729,7 +1733,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     metadata.skipped += 1;
                     continue;
                 };
-                metadata.used.push(SymbolicCorpusSeedRef {
+                imported.refs.push(SymbolicCorpusSeedRef {
                     path: entry.path,
                     calldata: input.calldata.clone(),
                 });
@@ -1742,7 +1746,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             corpus_dir = %corpus_dir.display(),
             loaded = metadata.loaded,
             skipped = metadata.skipped,
-            used = metadata.used.len(),
+            imported = imported.inputs.len(),
             "imported symbolic fuzz corpus seeds"
         );
         imported.metadata = Some(metadata);
@@ -1776,8 +1780,32 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             return self.result;
         }
 
-        let ImportedSymbolicCorpusSeeds { inputs: corpus_seeds, metadata: corpus_seed_metadata } =
-            self.import_symbolic_fuzz_corpus(func);
+        let ImportedSymbolicCorpusSeeds {
+            inputs: corpus_seeds,
+            refs: corpus_seed_refs,
+            metadata: mut corpus_seed_metadata,
+        } = self.import_symbolic_fuzz_corpus(func);
+        if let Some(metadata) = corpus_seed_metadata.as_mut() {
+            match SymbolicExecutor::modeled_corpus_seed_indexes(
+                &self.config.symbolic,
+                func,
+                &corpus_seeds,
+            ) {
+                Ok(indexes) => {
+                    metadata.used = indexes
+                        .into_iter()
+                        .filter_map(|idx| corpus_seed_refs.get(idx).cloned())
+                        .collect();
+                }
+                Err(err) => {
+                    debug!(
+                        %err,
+                        test = %func.signature(),
+                        "failed to model imported symbolic corpus seeds"
+                    );
+                }
+            }
+        }
         let mut symbolic = SymbolicExecutor::new(self.config.symbolic.clone());
         if self.should_defer_symbolic_diagnostics() {
             symbolic.capture_diagnostics();

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -125,6 +125,8 @@ script_execution_protection = true
 [profile.default.symbolic]
 enabled = false
 seed_corpus = false
+use_fuzz_corpus = false
+corpus_seed_limit = 32
 solver = "z3"
 timeout = 30
 max_depth = 10000
@@ -365,6 +367,8 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         symbolic: SymbolicConfig {
             enabled: true,
             seed_corpus: true,
+            use_fuzz_corpus: true,
+            corpus_seed_limit: 17,
             solver: "custom-z3".to_string(),
             solver_command: None,
             solver_portfolio: Vec::new(),
@@ -1521,6 +1525,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "symbolic": {
     "enabled": false,
     "seed_corpus": false,
+    "use_fuzz_corpus": false,
+    "corpus_seed_limit": 32,
     "solver": "z3",
     "timeout": 30,
     "max_depth": 10000,

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1838,6 +1838,164 @@ contract SymbolicImportFuzzCorpus {
     assert_eq!(std::path::PathBuf::from(used[0]["path"].as_str().unwrap()), seed_path);
 });
 
+forgetest_init!(symbolic_import_fuzz_corpus_prioritizes_seeded_calldata_variant, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_import_fuzz_corpus_prioritizes_seeded_calldata_variant because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicImportFuzzCorpusVariants.t.sol",
+        r#"
+contract SymbolicImportFuzzCorpusVariants {
+    /// forge-config: default.symbolic.default_bytes_lengths = [1, 2]
+    function testGuidedBytes(bytes memory data) public pure {
+        if (data.length == 1) {
+            if (data[0] == 0x11) return;
+            return;
+        }
+        if (data.length != 2) return;
+        assert(false);
+    }
+}
+"#,
+    );
+
+    let selector = &keccak256(b"testGuidedBytes(bytes)")[..4];
+    let calldata = format!(
+        "0x{}{:064x}{:064x}{:0<64}",
+        hex::encode(selector),
+        32,
+        2,
+        hex::encode([0xaa, 0xbb])
+    );
+    let unmodeled_calldata = format!(
+        "0x{}{:064x}{:064x}{:0<64}",
+        hex::encode(selector),
+        32,
+        3,
+        hex::encode([0xcc, 0xdd, 0xee])
+    );
+    let corpus_dir = prj
+        .root()
+        .join("fuzz_corpus")
+        .join("SymbolicImportFuzzCorpusVariants")
+        .join("testGuidedBytes")
+        .join("worker0")
+        .join("corpus");
+    std::fs::create_dir_all(&corpus_dir).unwrap();
+    let seed_path = corpus_dir.join("00000000-0000-0000-0000-000000000001-1.json");
+    let unmodeled_seed_path = corpus_dir.join("00000000-0000-0000-0000-000000000002-1.json");
+    for (path, calldata) in
+        [(&seed_path, calldata.as_str()), (&unmodeled_seed_path, unmodeled_calldata.as_str())]
+    {
+        let seed = serde_json::json!([
+            {
+                "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
+                "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+                "calldata": calldata
+            }
+        ]);
+        std::fs::write(path, serde_json::to_vec_pretty(&seed).unwrap()).unwrap();
+    }
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--match-test",
+            "testGuidedBytes",
+            "--symbolic-use-fuzz-corpus",
+            "--fuzz-corpus-dir",
+            "fuzz_corpus",
+            "--symbolic-width",
+            "2",
+            "--json",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+    let result = json_test_result(&output, "testGuidedBytes(bytes)");
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["status"], "fail_counterexample");
+    assert_eq!(symbolic["corpus_seeds"]["loaded"], 2);
+    assert_eq!(symbolic["corpus_seeds"]["skipped"], 0);
+    let used = symbolic["corpus_seeds"]["used"].as_array().unwrap();
+    assert_eq!(used.len(), 1);
+    assert_eq!(used[0]["calldata"], calldata);
+    assert_eq!(std::path::PathBuf::from(used[0]["path"].as_str().unwrap()), seed_path);
+});
+
+forgetest_init!(symbolic_import_fuzz_corpus_honors_function_inline_config, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_import_fuzz_corpus_honors_function_inline_config because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicInlineImportFuzzCorpus.t.sol",
+        r#"
+contract SymbolicInlineImportFuzzCorpus {
+    /// forge-config: default.symbolic.use_fuzz_corpus = true
+    function testFuzz_inline(uint256 x) public pure {
+        if (x != 7) return;
+        assert(false);
+    }
+}
+"#,
+    );
+
+    let selector = &keccak256(b"testFuzz_inline(uint256)")[..4];
+    let calldata = format!("0x{}{:064x}", hex::encode(selector), 7);
+    let corpus_dir = prj
+        .root()
+        .join("fuzz_corpus")
+        .join("SymbolicInlineImportFuzzCorpus")
+        .join("testFuzz_inline")
+        .join("worker0")
+        .join("corpus");
+    std::fs::create_dir_all(&corpus_dir).unwrap();
+    let seed_path = corpus_dir.join("00000000-0000-0000-0000-000000000001-1.json");
+    let seed = serde_json::json!([
+        {
+            "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
+            "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+            "calldata": calldata
+        }
+    ]);
+    std::fs::write(&seed_path, serde_json::to_vec_pretty(&seed).unwrap()).unwrap();
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--match-test",
+            "testFuzz_inline",
+            "--fuzz-corpus-dir",
+            "fuzz_corpus",
+            "--symbolic-width",
+            "1",
+            "--json",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+    let result = json_test_result(&output, "testFuzz_inline(uint256)");
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["status"], "fail_counterexample");
+    assert_eq!(symbolic["counterexample"]["raw_args"], "7");
+    assert_eq!(symbolic["corpus_seeds"]["loaded"], 1);
+    let used = symbolic["corpus_seeds"]["used"].as_array().unwrap();
+    assert_eq!(used.len(), 1);
+    assert_eq!(used[0]["calldata"], calldata);
+});
+
 forgetest_init!(symbolic_seed_corpus_warns_without_corpus_dir, |prj, cmd| {
     prj.add_test(
         "SymbolicFuzzCorpusNoDir.t.sol",

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1747,6 +1747,97 @@ contract SymbolicFuzzCorpusBestEffort {
     assert!(stdout.contains("[PASS] testFuzz_symbolicHostile(uint256)"), "{stdout}");
 });
 
+forgetest_init!(symbolic_import_fuzz_corpus_guides_bounded_symbolic_path, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_import_fuzz_corpus_guides_bounded_symbolic_path because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicImportFuzzCorpus.t.sol",
+        r#"
+contract SymbolicImportFuzzCorpus {
+    function testGuided(uint256 x) public pure {
+        if (x != 7) return;
+        assert(false);
+    }
+}
+"#,
+    );
+
+    let empty_output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--match-test",
+            "testGuided",
+            "--symbolic-use-fuzz-corpus",
+            "--fuzz-corpus-dir",
+            "empty_fuzz_corpus",
+            "--symbolic-width",
+            "1",
+            "--json",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+    let empty_result = json_test_result(&empty_output, "testGuided(uint256)");
+    let empty_symbolic = &empty_result["symbolic"];
+    assert_eq!(empty_symbolic["status"], "incomplete");
+    assert_eq!(empty_symbolic["corpus_seeds"]["used"].as_array().unwrap().len(), 0);
+
+    let selector = &keccak256(b"testGuided(uint256)")[..4];
+    let calldata = format!("0x{}{:064x}", hex::encode(selector), 7);
+    let corpus_dir = prj
+        .root()
+        .join("fuzz_corpus")
+        .join("SymbolicImportFuzzCorpus")
+        .join("testGuided")
+        .join("worker0")
+        .join("corpus");
+    std::fs::create_dir_all(&corpus_dir).unwrap();
+    let seed_path = corpus_dir.join("00000000-0000-0000-0000-000000000001-1.json");
+    let seed = serde_json::json!([
+        {
+            "sender": "0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38",
+            "target": "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496",
+            "calldata": calldata
+        }
+    ]);
+    std::fs::write(&seed_path, serde_json::to_vec_pretty(&seed).unwrap()).unwrap();
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--match-test",
+            "testGuided",
+            "--symbolic-use-fuzz-corpus",
+            "--fuzz-corpus-dir",
+            "fuzz_corpus",
+            "--symbolic-width",
+            "1",
+            "--json",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+    let result = json_test_result(&output, "testGuided(uint256)");
+    let symbolic = &result["symbolic"];
+    assert_eq!(symbolic["status"], "fail_counterexample");
+    assert_eq!(symbolic["counterexample"]["raw_args"], "7");
+    assert_eq!(symbolic["corpus_seeds"]["loaded"], 1);
+    assert_eq!(symbolic["corpus_seeds"]["skipped"], 0);
+    let used = symbolic["corpus_seeds"]["used"].as_array().unwrap();
+    assert_eq!(used.len(), 1);
+    assert_eq!(used[0]["calldata"], calldata);
+    assert_eq!(std::path::PathBuf::from(used[0]["path"].as_str().unwrap()), seed_path);
+});
+
 forgetest_init!(symbolic_seed_corpus_warns_without_corpus_dir, |prj, cmd| {
     prj.add_test(
         "SymbolicFuzzCorpusNoDir.t.sol",


### PR DESCRIPTION
## Summary
- add `--symbolic-use-fuzz-corpus` and bounded `symbolic.corpus_seed_limit` config
- import matching single-call fuzz corpus entries into symbolic fuzz-test runs as branch-priority hints
- emit imported seed metadata in symbolic JSON output and document the import path