### PR TITLE
fix(forge): clear history storage when etched

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -713,6 +713,16 @@ impl Cheatcode for etchCall {
         ccx.ecx.journal_mut().load_account(*target)?;
         let bytecode = Bytecode::new_raw_checked(newRuntimeBytecode.clone())
             .map_err(|e| fmt_err!("failed to create bytecode: {e}"))?;
+        if *target == HISTORY_STORAGE_ADDRESS
+            && bytecode.hash_slow() != keccak256(&HISTORY_STORAGE_CODE)
+        {
+            let account =
+                ccx.ecx.journal_mut().evm_state_mut().get_mut(target).expect("account is loaded");
+            if account.info.code_hash == keccak256(&HISTORY_STORAGE_CODE) {
+                account.storage.clear();
+                account.mark_created();
+            }
+        }
         ccx.ecx.journal_mut().set_code(*target, bytecode);
         Ok(Default::default())
     }

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -1126,6 +1126,15 @@ contract EIP2935Test is Test {
         assertEq(vm.load(HISTORY, bytes32(parent % 8191)), bytes32(0), "replaced history slot");
     }
 
+    function testRollDoesNotExposeSeededHistorySlotAfterEtch() public {
+        vm.etch(HISTORY, hex"00");
+
+        uint256 parent = 8191 * 1000 + 12;
+        vm.roll(parent + 1);
+
+        assertEq(vm.load(HISTORY, bytes32(parent % 8191)), bytes32(0), "replaced seeded history slot");
+    }
+
     function testSetBlockhashDoesNotPopulateReplacedHistoryContract() public {
         vm.etch(HISTORY, hex"00");
 


### PR DESCRIPTION
## Summary

- clear Foundry's synthetic EIP-2935 history storage when `vm.etch` replaces the canonical history contract bytecode
- add a Prague regression that etches the history address, rolls to a high block whose ring slot was pre-seeded, and verifies the slot remains zero

## Tests

- `cargo test -p forge eip2935_history_storage_in_prague_tests -- --nocapture`

Fixes #15479

Prompted by: @grandizzy