### PR TITLE
feat(debugger): toggle source pane

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -86,6 +86,7 @@ pub(crate) struct TUIContext<'a> {
     /// Whether to decode active buffer as utf8 or not.
     pub(crate) buf_utf: bool,
     pub(crate) show_shortcuts: bool,
+    pub(crate) show_source: bool,
     /// The currently active buffer (memory, calldata, returndata) to be drawn.
     pub(crate) active_buffer: BufferKind,
 }
@@ -109,6 +110,7 @@ impl<'a> TUIContext<'a> {
             stack_labels: false,
             buf_utf: false,
             show_shortcuts: true,
+            show_source: true,
             active_buffer: BufferKind::Memory,
         }
     }
@@ -339,6 +341,13 @@ impl TUIContext<'_> {
             KeyCode::Char('m') => {
                 self.buf_utf = !self.buf_utf;
                 self.set_info(format!("UTF-8 decoding: {}", toggle_state(self.buf_utf)));
+            }
+
+            // Toggle source pane
+            KeyCode::Char('v') => {
+                self.show_source = !self.show_source;
+                let state = if self.show_source { "shown" } else { "hidden" };
+                self.set_info(format!("Source pane: {state}"));
             }
 
             // Go to program counter
@@ -1152,6 +1161,13 @@ mod tests {
         let _ = tui.handle_key_event(key(KeyCode::Char('m')));
         assert!(!tui.buf_utf);
         assert_eq!(tui.status.as_ref().unwrap().text, "UTF-8 decoding: off");
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('v')));
+        assert!(!tui.show_source);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Source pane: hidden");
+        let _ = tui.handle_key_event(key(KeyCode::Char('v')));
+        assert!(tui.show_source);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Source pane: shown");
 
         let _ = tui.handle_key_event(key(KeyCode::Char('h')));
         assert!(!tui.show_shortcuts);

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -109,25 +109,47 @@ impl TUIContext<'_> {
             unreachable!()
         };
 
-        // Split the app vertically to construct all the panes.
-        let [op_pane, variables_pane, stack_pane, memory_pane, src_pane] = Layout::new(
+        if footer_height > 0 {
+            self.draw_footer(f, footer);
+        }
+
+        if self.show_source {
+            // Split the app vertically to construct all the panes.
+            let [op_pane, variables_pane, stack_pane, memory_pane, src_pane] = Layout::new(
+                Direction::Vertical,
+                [
+                    Constraint::Ratio(1, 7),
+                    Constraint::Ratio(1, 7),
+                    Constraint::Ratio(1, 7),
+                    Constraint::Ratio(1, 7),
+                    Constraint::Ratio(3, 7),
+                ],
+            )
+            .split(app)[..] else {
+                unreachable!()
+            };
+
+            self.draw_src(f, src_pane);
+            self.draw_op_list(f, op_pane);
+            self.draw_variables(f, variables_pane);
+            self.draw_stack(f, stack_pane);
+            self.draw_buffer(f, memory_pane);
+            return;
+        }
+
+        let [op_pane, variables_pane, stack_pane, memory_pane] = Layout::new(
             Direction::Vertical,
             [
-                Constraint::Ratio(1, 7),
-                Constraint::Ratio(1, 7),
-                Constraint::Ratio(1, 7),
-                Constraint::Ratio(1, 7),
-                Constraint::Ratio(3, 7),
+                Constraint::Ratio(1, 5),
+                Constraint::Ratio(1, 5),
+                Constraint::Ratio(1, 5),
+                Constraint::Ratio(2, 5),
             ],
         )
         .split(app)[..] else {
             unreachable!()
         };
 
-        if footer_height > 0 {
-            self.draw_footer(f, footer);
-        }
-        self.draw_src(f, src_pane);
         self.draw_op_list(f, op_pane);
         self.draw_variables(f, variables_pane);
         self.draw_stack(f, stack_pane);
@@ -168,12 +190,18 @@ impl TUIContext<'_> {
             unreachable!()
         };
 
-        // Split left pane in 2 vertically to opcode list and source.
-        let [op_pane, src_pane] =
-            Layout::new(Direction::Vertical, [Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)])
-                .split(app_left)[..]
-        else {
-            unreachable!()
+        let (op_pane, src_pane) = if self.show_source {
+            // Split left pane in 2 vertically to opcode list and source.
+            let [op_pane, src_pane] = Layout::new(
+                Direction::Vertical,
+                [Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)],
+            )
+            .split(app_left)[..] else {
+                unreachable!()
+            };
+            (op_pane, Some(src_pane))
+        } else {
+            (app_left, None)
         };
 
         // Split right pane vertically to construct variables, stack and memory.
@@ -188,7 +216,9 @@ impl TUIContext<'_> {
         if footer_height > 0 {
             self.draw_footer(f, footer);
         }
-        self.draw_src(f, src_pane);
+        if let Some(src_pane) = src_pane {
+            self.draw_src(f, src_pane);
+        }
         self.draw_op_list(f, op_pane);
         self.draw_variables(f, variables_pane);
         self.draw_stack(f, stack_pane);
@@ -258,7 +288,7 @@ impl TUIContext<'_> {
 
         let l1 =
             "[q] quit | [j/k] op | [a/s] jump | [c/C] call | [g/G] start/end | [p] PC | [o] offset";
-        let l2 = "[/] search | [n/N] repeat | [l] layout | [b] buffer | [t] labels | [m] decode | [h] help";
+        let l2 = "[/] search | [n/N] repeat | [l] layout | [b] buffer | [v] source | [t] labels | [m] decode | [h] help";
         let l3 = "[J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint";
         let dimmed = Style::new().add_modifier(Modifier::DIM);
         if self.show_shortcuts {
@@ -1209,7 +1239,7 @@ fn hex_digits(n: usize) -> usize {
 mod tests {
     use super::TUIContext;
     use crate::{
-        DebugNode,
+        DebugNode, DebuggerLayout,
         debugger::{DebuggerContext, DebuggerStats},
         op::OpcodeParam,
     };
@@ -1340,6 +1370,29 @@ mod tests {
             .iter()
             .map(|cell| cell.symbol())
             .collect::<String>();
+        assert!(screen.contains("Memory (max expansion: 0 bytes)"));
+    }
+
+    #[test]
+    fn hidden_source_pane_omits_source_panel() {
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![trace_step(Vec::new())])]);
+        context.layout = DebuggerLayout::Horizontal;
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.show_source = false;
+        let backend = TestBackend::new(220, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|f| tui.draw_layout(f)).unwrap();
+
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(!screen.contains("Contract call"));
         assert!(screen.contains("Memory (max expansion: 0 bytes)"));
     }
 


### PR DESCRIPTION
## Summary
- add a `v` debugger shortcut to hide/show the source pane
- give the remaining panes the freed space in both vertical and horizontal layouts
- report the source-pane state through the debugger status line and footer shortcut help

## Why
This covers a small piece of #927 by making the debugger layout more flexible without changing the default view. It helps when source context is unavailable or less useful and the user needs more room for opcodes, stack, variables, or memory.

## Testing
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p foundry-debugger`
- `cargo +1.95.0 clippy -p foundry-debugger --all-targets -- -D warnings`

Refs #927