### PR TITLE
feat(debugger): add command prompt

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -70,6 +70,8 @@ pub(crate) struct TUIContext<'a> {
     pub(crate) pc_input: Option<String>,
     /// Current active-buffer byte offset prompt contents, if the prompt is active.
     pub(crate) buffer_offset_input: Option<String>,
+    /// Current debugger command prompt contents, if the prompt is active.
+    pub(crate) command_input: Option<String>,
     /// Current opcode search prompt contents, if the prompt is active.
     pub(crate) opcode_search_input: Option<String>,
     /// Last opcode search term, used by repeat-search shortcuts.
@@ -87,7 +89,6 @@ pub(crate) struct TUIContext<'a> {
     pub(crate) buf_utf: bool,
     pub(crate) show_shortcuts: bool,
     pub(crate) show_source: bool,
-    pub(crate) show_variables: bool,
     /// The currently active buffer (memory, calldata, returndata) to be drawn.
     pub(crate) active_buffer: BufferKind,
 }
@@ -100,6 +101,7 @@ impl<'a> TUIContext<'a> {
             key_buffer: String::with_capacity(64),
             pc_input: None,
             buffer_offset_input: None,
+            command_input: None,
             opcode_search_input: None,
             last_opcode_search: None,
             status: None,
@@ -112,7 +114,6 @@ impl<'a> TUIContext<'a> {
             buf_utf: false,
             show_shortcuts: true,
             show_source: true,
-            show_variables: true,
             active_buffer: BufferKind::Memory,
         }
     }
@@ -170,7 +171,11 @@ impl<'a> TUIContext<'a> {
     }
 
     fn active_buffer(&self) -> &[u8] {
-        match self.active_buffer {
+        self.buffer(&self.active_buffer)
+    }
+
+    fn buffer(&self, buffer: &BufferKind) -> &[u8] {
+        match buffer {
             BufferKind::Memory => self.current_step().memory.as_ref().map_or(&[], |m| m.as_bytes()),
             BufferKind::Calldata => &self.debug_call().calldata,
             BufferKind::Returndata => &self.current_step().returndata,
@@ -178,11 +183,7 @@ impl<'a> TUIContext<'a> {
     }
 
     pub(crate) const fn active_buffer_name(&self) -> &'static str {
-        match self.active_buffer {
-            BufferKind::Memory => "memory",
-            BufferKind::Calldata => "calldata",
-            BufferKind::Returndata => "returndata",
-        }
+        buffer_name(&self.active_buffer)
     }
 }
 
@@ -211,6 +212,11 @@ impl TUIContext<'_> {
 
         if self.buffer_offset_input.is_some() {
             self.handle_buffer_offset_input_key_event(event);
+            return ControlFlow::Continue(());
+        }
+
+        if self.command_input.is_some() {
+            self.handle_command_input_key_event(event);
             return ControlFlow::Continue(());
         }
 
@@ -352,13 +358,6 @@ impl TUIContext<'_> {
                 self.set_info(format!("Source pane: {state}"));
             }
 
-            // Toggle variables pane
-            KeyCode::Char('V') => {
-                self.show_variables = !self.show_variables;
-                let state = if self.show_variables { "shown" } else { "hidden" };
-                self.set_info(format!("Variables pane: {state}"));
-            }
-
             // Go to program counter
             KeyCode::Char('p') => {
                 self.key_buffer.clear();
@@ -371,6 +370,13 @@ impl TUIContext<'_> {
                 self.key_buffer.clear();
                 self.status = None;
                 self.buffer_offset_input = Some(String::new());
+            }
+
+            // Run debugger command
+            KeyCode::Char(':') => {
+                self.key_buffer.clear();
+                self.status = None;
+                self.command_input = Some(String::new());
             }
 
             // Search opcodes in the current call
@@ -429,6 +435,14 @@ impl TUIContext<'_> {
             is_buffer_offset_input_char,
         ) {
             self.goto_buffer_offset_from_input(&input);
+        }
+    }
+
+    fn handle_command_input_key_event(&mut self, event: KeyEvent) {
+        if let Some(input) =
+            handle_prompt_input_key_event(&mut self.command_input, event, |_, c| !c.is_control())
+        {
+            self.run_command_from_input(&input);
         }
     }
 
@@ -566,6 +580,10 @@ impl TUIContext<'_> {
     }
 
     fn goto_buffer_offset_from_input(&mut self, input: &str) {
+        self.goto_buffer_offset(buffer_kind(&self.active_buffer), input);
+    }
+
+    fn goto_buffer_offset(&mut self, buffer: BufferKind, input: &str) {
         let offset = match parse_buffer_offset(input) {
             Ok(offset) => offset,
             Err(err) => {
@@ -574,8 +592,8 @@ impl TUIContext<'_> {
             }
         };
 
-        let buffer_name = self.active_buffer_name();
-        let buffer_len = self.active_buffer().len();
+        let buffer_name = buffer_name(&buffer);
+        let buffer_len = self.buffer(&buffer).len();
         if buffer_len == 0 {
             self.set_error(format!("Current {buffer_name} buffer is empty"));
             return;
@@ -588,7 +606,52 @@ impl TUIContext<'_> {
             return;
         }
 
+        self.active_buffer = buffer;
         self.apply_buffer_offset(offset);
+    }
+
+    fn run_command_from_input(&mut self, input: &str) {
+        let input = input.trim();
+        if input.is_empty() {
+            self.set_error("Enter a debugger command".to_string());
+            return;
+        }
+
+        let mut parts = input.split_whitespace();
+        let command = parts.next().unwrap();
+        match command {
+            "pc" | "p" | "continue" | "cont" | "c" => {
+                let Some(pc) = parts.next() else {
+                    return self.set_error(command_usage(command, "<pc>"));
+                };
+                if parts.next().is_some() {
+                    return self.set_error(command_usage(command, "<pc>"));
+                }
+                self.goto_pc_from_input(pc);
+            }
+            "mem" | "memory" => self.run_buffer_command(command, BufferKind::Memory, parts),
+            "calldata" | "cd" => self.run_buffer_command(command, BufferKind::Calldata, parts),
+            "returndata" | "ret" | "rd" => {
+                self.run_buffer_command(command, BufferKind::Returndata, parts);
+            }
+            "help" | "h" => self.set_info(command_help()),
+            _ => self.set_error(format!("Unknown command `{command}`; try `help`")),
+        }
+    }
+
+    fn run_buffer_command<'a>(
+        &mut self,
+        command: &str,
+        buffer: BufferKind,
+        mut args: impl Iterator<Item = &'a str>,
+    ) {
+        let Some(offset) = args.next() else {
+            return self.set_error(command_usage(command, "<offset>"));
+        };
+        if args.next().is_some() {
+            return self.set_error(command_usage(command, "<offset>"));
+        }
+        self.goto_buffer_offset(buffer, offset);
     }
 
     fn apply_buffer_offset(&mut self, offset: usize) {
@@ -641,6 +704,7 @@ impl TUIContext<'_> {
     fn handle_mouse_event(&mut self, event: MouseEvent) -> ControlFlow<ExitReason> {
         if self.pc_input.is_some()
             || self.buffer_offset_input.is_some()
+            || self.command_input.is_some()
             || self.opcode_search_input.is_some()
         {
             return ControlFlow::Continue(());
@@ -740,6 +804,31 @@ fn buffer_as_number(s: &str) -> usize {
 
 const fn toggle_state(enabled: bool) -> &'static str {
     if enabled { "on" } else { "off" }
+}
+
+const fn buffer_name(buffer: &BufferKind) -> &'static str {
+    match buffer {
+        BufferKind::Memory => "memory",
+        BufferKind::Calldata => "calldata",
+        BufferKind::Returndata => "returndata",
+    }
+}
+
+const fn buffer_kind(buffer: &BufferKind) -> BufferKind {
+    match buffer {
+        BufferKind::Memory => BufferKind::Memory,
+        BufferKind::Calldata => BufferKind::Calldata,
+        BufferKind::Returndata => BufferKind::Returndata,
+    }
+}
+
+fn command_usage(command: &str, arg: &str) -> String {
+    format!("Usage: :{command} {arg}")
+}
+
+fn command_help() -> String {
+    "Commands: :continue <pc>, :pc <pc>, :mem <offset>, :calldata <offset>, :returndata <offset>"
+        .to_string()
 }
 
 fn handle_prompt_input_key_event(
@@ -1178,13 +1267,6 @@ mod tests {
         assert!(tui.show_source);
         assert_eq!(tui.status.as_ref().unwrap().text, "Source pane: shown");
 
-        let _ = tui.handle_key_event(key(KeyCode::Char('V')));
-        assert!(!tui.show_variables);
-        assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: hidden");
-        let _ = tui.handle_key_event(key(KeyCode::Char('V')));
-        assert!(tui.show_variables);
-        assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: shown");
-
         let _ = tui.handle_key_event(key(KeyCode::Char('h')));
         assert!(!tui.show_shortcuts);
         assert_eq!(tui.status.as_ref().unwrap().text, "Shortcut help: hidden");
@@ -1493,6 +1575,71 @@ mod tests {
         assert_eq!(tui.pc_input, None);
         assert_eq!(tui.current_step, 0);
         assert_eq!(tui.status, None);
+    }
+
+    #[test]
+    fn command_input_mode_handles_keys_and_blocks_normal_commands() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1, 42])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        assert!(matches!(tui.handle_key_event(key(KeyCode::Char(':'))), ControlFlow::Continue(())));
+        assert_eq!(tui.command_input.as_deref(), Some(""));
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('q')));
+        assert_eq!(tui.command_input.as_deref(), Some("q"));
+        assert_eq!(tui.current_step, 0);
+
+        let _ = tui.handle_key_event(key(KeyCode::Backspace));
+        for c in "continue 2a".chars() {
+            let _ = tui.handle_key_event(key(KeyCode::Char(c)));
+        }
+        let _ = tui.handle_key_event(key(KeyCode::Enter));
+
+        assert_eq!(tui.command_input, None);
+        assert_eq!(tui.current_step, 1);
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Info);
+        assert_eq!(status.text, "Jumped to PC 0x2a (42) in current trace");
+    }
+
+    #[test]
+    fn command_prompt_jumps_to_named_buffer_offset() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![step(1)],
+            Bytes::from(vec![0; 96]),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("calldata 40");
+
+        assert_eq!(tui.active_buffer, BufferKind::Calldata);
+        assert_eq!(tui.draw_memory.current_buf_startline, 2);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Jumped to calldata offset 0x40 (64)");
+    }
+
+    #[test]
+    fn command_prompt_reports_help_and_usage_errors() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("help");
+        assert_eq!(tui.status.as_ref().unwrap().kind, StatusKind::Info);
+        assert!(tui.status.as_ref().unwrap().text.contains(":continue <pc>"));
+
+        tui.run_command_from_input("mem");
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "Usage: :mem <offset>");
     }
 
     #[test]

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -580,7 +580,7 @@ impl TUIContext<'_> {
     }
 
     fn goto_buffer_offset_from_input(&mut self, input: &str) {
-        self.goto_buffer_offset(buffer_kind(&self.active_buffer), input);
+        self.goto_buffer_offset(self.active_buffer, input);
     }
 
     fn goto_buffer_offset(&mut self, buffer: BufferKind, input: &str) {
@@ -812,14 +812,6 @@ const fn buffer_name(buffer: &BufferKind) -> &'static str {
         BufferKind::Memory => "memory",
         BufferKind::Calldata => "calldata",
         BufferKind::Returndata => "returndata",
-    }
-}
-
-const fn buffer_kind(buffer: &BufferKind) -> BufferKind {
-    match buffer {
-        BufferKind::Memory => BufferKind::Memory,
-        BufferKind::Calldata => BufferKind::Calldata,
-        BufferKind::Returndata => BufferKind::Returndata,
     }
 }
 

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -87,6 +87,7 @@ pub(crate) struct TUIContext<'a> {
     pub(crate) buf_utf: bool,
     pub(crate) show_shortcuts: bool,
     pub(crate) show_source: bool,
+    pub(crate) show_variables: bool,
     /// The currently active buffer (memory, calldata, returndata) to be drawn.
     pub(crate) active_buffer: BufferKind,
 }
@@ -111,6 +112,7 @@ impl<'a> TUIContext<'a> {
             buf_utf: false,
             show_shortcuts: true,
             show_source: true,
+            show_variables: true,
             active_buffer: BufferKind::Memory,
         }
     }
@@ -348,6 +350,13 @@ impl TUIContext<'_> {
                 self.show_source = !self.show_source;
                 let state = if self.show_source { "shown" } else { "hidden" };
                 self.set_info(format!("Source pane: {state}"));
+            }
+
+            // Toggle variables pane
+            KeyCode::Char('V') => {
+                self.show_variables = !self.show_variables;
+                let state = if self.show_variables { "shown" } else { "hidden" };
+                self.set_info(format!("Variables pane: {state}"));
             }
 
             // Go to program counter
@@ -1168,6 +1177,13 @@ mod tests {
         let _ = tui.handle_key_event(key(KeyCode::Char('v')));
         assert!(tui.show_source);
         assert_eq!(tui.status.as_ref().unwrap().text, "Source pane: shown");
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('V')));
+        assert!(!tui.show_variables);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: hidden");
+        let _ = tui.handle_key_event(key(KeyCode::Char('V')));
+        assert!(tui.show_variables);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: shown");
 
         let _ = tui.handle_key_event(key(KeyCode::Char('h')));
         assert!(!tui.show_shortcuts);

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -612,6 +612,7 @@ impl TUIContext<'_> {
 
     fn run_command_from_input(&mut self, input: &str) {
         let input = input.trim();
+        let input = input.strip_prefix(':').unwrap_or(input).trim_start();
         if input.is_empty() {
             self.set_error("Enter a debugger command".to_string());
             return;
@@ -1623,6 +1624,19 @@ mod tests {
         assert_eq!(tui.active_buffer, BufferKind::Calldata);
         assert_eq!(tui.draw_memory.current_buf_startline, 2);
         assert_eq!(tui.status.as_ref().unwrap().text, "Jumped to calldata offset 0x40 (64)");
+    }
+
+    #[test]
+    fn command_prompt_accepts_optional_leading_colon() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1, 42])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input(":pc 2a");
+
+        assert_eq!(tui.current_step, 1);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Jumped to PC 0x2a (42) in current trace");
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -226,18 +226,26 @@ impl TUIContext<'_> {
     }
 
     fn footer_height(&self) -> u16 {
-        let status_or_input = u16::from(
-            self.pc_input.is_some()
-                || self.buffer_offset_input.is_some()
-                || self.command_input.is_some()
-                || self.opcode_search_input.is_some()
-                || self.status.is_some(),
-        );
+        let status_or_input = if self.command_input.is_some() {
+            3
+        } else {
+            u16::from(
+                self.pc_input.is_some()
+                    || self.buffer_offset_input.is_some()
+                    || self.opcode_search_input.is_some()
+                    || self.status.is_some(),
+            )
+        };
         let shortcuts = if self.show_shortcuts { 3 } else { 0 };
         status_or_input + shortcuts
     }
 
     fn draw_footer(&self, f: &mut Frame<'_>, area: Rect) {
+        if let Some(input) = &self.command_input {
+            self.draw_command_prompt(f, area, input);
+            return;
+        }
+
         let mut lines = Vec::with_capacity(self.footer_height() as usize);
 
         if let Some(input) = &self.pc_input {
@@ -266,19 +274,6 @@ impl TUIContext<'_> {
                     Style::new().add_modifier(Modifier::DIM),
                 ),
             ]));
-        } else if let Some(input) = &self.command_input {
-            lines.push(Line::from(vec![
-                Span::styled(
-                    "Command: ",
-                    Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-                ),
-                Span::raw(input.as_str()),
-                Span::styled("█", Style::new().fg(Color::Cyan)),
-                Span::styled(
-                    "  Enter: run | Esc: cancel | help: command list",
-                    Style::new().add_modifier(Modifier::DIM),
-                ),
-            ]));
         } else if let Some(input) = &self.opcode_search_input {
             lines.push(Line::from(vec![
                 Span::styled(
@@ -300,19 +295,47 @@ impl TUIContext<'_> {
             lines.push(Line::from(Span::styled(status.text.as_str(), style)));
         }
 
-        let l1 =
-            "[q] quit | [j/k] op | [a/s] jump | [c/C] call | [g/G] start/end | [p] PC | [o] offset";
-        let l2 = "[/] search | [:] command | [n/N] repeat | [l] layout | [b] buffer | [v] source";
-        let l3 = "[t] labels | [m] decode | [h] help | [J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint";
-        let dimmed = Style::new().add_modifier(Modifier::DIM);
         if self.show_shortcuts {
-            lines.push(Line::from(Span::styled(l1, dimmed)));
-            lines.push(Line::from(Span::styled(l2, dimmed)));
-            lines.push(Line::from(Span::styled(l3, dimmed)));
+            lines.extend(shortcut_lines());
         }
 
         let paragraph =
             Paragraph::new(lines).alignment(Alignment::Center).wrap(Wrap { trim: false });
+        f.render_widget(paragraph, area);
+    }
+
+    fn draw_command_prompt(&self, f: &mut Frame<'_>, area: Rect, input: &str) {
+        let shortcuts = if self.show_shortcuts { 3 } else { 0 };
+        let [prompt, shortcuts_area] = Layout::new(
+            Direction::Vertical,
+            [Constraint::Length(3), Constraint::Length(shortcuts)],
+        )
+        .split(area)[..] else {
+            unreachable!()
+        };
+
+        let prompt_line = Line::from(vec![
+            Span::styled(":", Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::raw(input),
+            Span::styled("█", Style::new().fg(Color::Cyan)),
+            Span::styled(
+                "  Enter: run | Esc: cancel | help: command list",
+                Style::new().add_modifier(Modifier::DIM),
+            ),
+        ]);
+        let block = Block::default().title("Command").borders(Borders::ALL);
+        let paragraph = Paragraph::new(prompt_line).block(block).wrap(Wrap { trim: false });
+        f.render_widget(paragraph, prompt);
+
+        if self.show_shortcuts {
+            self.draw_shortcuts(f, shortcuts_area);
+        }
+    }
+
+    fn draw_shortcuts(&self, f: &mut Frame<'_>, area: Rect) {
+        let paragraph = Paragraph::new(shortcut_lines())
+            .alignment(Alignment::Center)
+            .wrap(Wrap { trim: false });
         f.render_widget(paragraph, area);
     }
 
@@ -1011,6 +1034,24 @@ fn variables_title(
     title
 }
 
+fn shortcut_lines() -> Vec<Line<'static>> {
+    let dimmed = Style::new().add_modifier(Modifier::DIM);
+    vec![
+        Line::from(Span::styled(
+            "[q] quit | [j/k] op | [a/s] jump | [c/C] call | [g/G] start/end | [p] PC | [o] offset",
+            dimmed,
+        )),
+        Line::from(Span::styled(
+            "[/] search | [:] command | [n/N] repeat | [l] layout | [b] buffer | [v] source",
+            dimmed,
+        )),
+        Line::from(Span::styled(
+            "[t] labels | [m] decode | [h] help | [J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint",
+            dimmed,
+        )),
+    ]
+}
+
 fn step_notice_title(line: &str) -> &'static str {
     if line.starts_with(PRECOMPILE_NOTICE_PREFIX) { "precompile call" } else { "decoded step" }
 }
@@ -1408,6 +1449,29 @@ mod tests {
             .collect::<String>();
         assert!(!screen.contains("Contract call"));
         assert!(screen.contains("Memory (max expansion: 0 bytes)"));
+    }
+
+    #[test]
+    fn command_prompt_draws_in_bordered_block() {
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![trace_step(Vec::new())])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.command_input = Some("pc 0".to_string());
+        let backend = TestBackend::new(120, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|f| tui.draw_footer(f, Rect::new(0, 0, 120, 6))).unwrap();
+
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(screen.contains("Command"));
+        assert!(screen.contains(":pc 0"));
+        assert!(screen.contains("Enter: run"));
+        assert!(screen.contains("[:] command"));
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -269,7 +269,7 @@ impl TUIContext<'_> {
         } else if let Some(input) = &self.command_input {
             lines.push(Line::from(vec![
                 Span::styled(
-                    "Command: :",
+                    "Command: ",
                     Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
                 ),
                 Span::raw(input.as_str()),

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -113,45 +113,43 @@ impl TUIContext<'_> {
             self.draw_footer(f, footer);
         }
 
+        let source_weight = if self.show_source { 3 } else { 0 };
+        let variables_weight = if self.show_variables { 1 } else { 0 };
+        let memory_weight = if self.show_source { 1 } else { 2 };
+        let total_weight = 1 + variables_weight + 1 + memory_weight + source_weight;
+        let mut constraints = Vec::with_capacity(5);
+        constraints.push(Constraint::Ratio(1, total_weight));
+        if self.show_variables {
+            constraints.push(Constraint::Ratio(variables_weight, total_weight));
+        }
+        constraints.push(Constraint::Ratio(1, total_weight));
+        constraints.push(Constraint::Ratio(memory_weight, total_weight));
         if self.show_source {
-            // Split the app vertically to construct all the panes.
-            let [op_pane, variables_pane, stack_pane, memory_pane, src_pane] = Layout::new(
-                Direction::Vertical,
-                [
-                    Constraint::Ratio(1, 7),
-                    Constraint::Ratio(1, 7),
-                    Constraint::Ratio(1, 7),
-                    Constraint::Ratio(1, 7),
-                    Constraint::Ratio(3, 7),
-                ],
-            )
-            .split(app)[..] else {
-                unreachable!()
-            };
-
-            self.draw_src(f, src_pane);
-            self.draw_op_list(f, op_pane);
-            self.draw_variables(f, variables_pane);
-            self.draw_stack(f, stack_pane);
-            self.draw_buffer(f, memory_pane);
-            return;
+            constraints.push(Constraint::Ratio(source_weight, total_weight));
         }
 
-        let [op_pane, variables_pane, stack_pane, memory_pane] = Layout::new(
-            Direction::Vertical,
-            [
-                Constraint::Ratio(1, 5),
-                Constraint::Ratio(1, 5),
-                Constraint::Ratio(1, 5),
-                Constraint::Ratio(2, 5),
-            ],
-        )
-        .split(app)[..] else {
-            unreachable!()
-        };
+        let panes = Layout::new(Direction::Vertical, constraints).split(app);
+        let mut pane_idx = 0;
+        let op_pane = panes[pane_idx];
+        pane_idx += 1;
+        let variables_pane = self.show_variables.then(|| {
+            let pane = panes[pane_idx];
+            pane_idx += 1;
+            pane
+        });
+        let stack_pane = panes[pane_idx];
+        pane_idx += 1;
+        let memory_pane = panes[pane_idx];
+        pane_idx += 1;
+        let src_pane = self.show_source.then(|| panes[pane_idx]);
 
+        if let Some(src_pane) = src_pane {
+            self.draw_src(f, src_pane);
+        }
         self.draw_op_list(f, op_pane);
-        self.draw_variables(f, variables_pane);
+        if let Some(variables_pane) = variables_pane {
+            self.draw_variables(f, variables_pane);
+        }
         self.draw_stack(f, stack_pane);
         self.draw_buffer(f, memory_pane);
     }
@@ -205,13 +203,25 @@ impl TUIContext<'_> {
         };
 
         // Split right pane vertically to construct variables, stack and memory.
-        let [variables_pane, stack_pane, memory_pane] = Layout::new(
-            Direction::Vertical,
-            [Constraint::Ratio(1, 4), Constraint::Ratio(1, 4), Constraint::Ratio(2, 4)],
-        )
-        .split(app_right)[..] else {
-            unreachable!()
-        };
+        let variables_weight = if self.show_variables { 1 } else { 0 };
+        let total_weight = variables_weight + 1 + 2;
+        let mut constraints = Vec::with_capacity(3);
+        if self.show_variables {
+            constraints.push(Constraint::Ratio(variables_weight, total_weight));
+        }
+        constraints.push(Constraint::Ratio(1, total_weight));
+        constraints.push(Constraint::Ratio(2, total_weight));
+
+        let panes = Layout::new(Direction::Vertical, constraints).split(app_right);
+        let mut pane_idx = 0;
+        let variables_pane = self.show_variables.then(|| {
+            let pane = panes[pane_idx];
+            pane_idx += 1;
+            pane
+        });
+        let stack_pane = panes[pane_idx];
+        pane_idx += 1;
+        let memory_pane = panes[pane_idx];
 
         if footer_height > 0 {
             self.draw_footer(f, footer);
@@ -220,7 +230,9 @@ impl TUIContext<'_> {
             self.draw_src(f, src_pane);
         }
         self.draw_op_list(f, op_pane);
-        self.draw_variables(f, variables_pane);
+        if let Some(variables_pane) = variables_pane {
+            self.draw_variables(f, variables_pane);
+        }
         self.draw_stack(f, stack_pane);
         self.draw_buffer(f, memory_pane);
     }
@@ -288,7 +300,7 @@ impl TUIContext<'_> {
 
         let l1 =
             "[q] quit | [j/k] op | [a/s] jump | [c/C] call | [g/G] start/end | [p] PC | [o] offset";
-        let l2 = "[/] search | [n/N] repeat | [l] layout | [b] buffer | [v] source | [t] labels | [m] decode | [h] help";
+        let l2 = "[/] search | [n/N] repeat | [l] layout | [v/V] source/vars | [b] buffer | [t] labels | [m] decode | [h] help";
         let l3 = "[J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint";
         let dimmed = Style::new().add_modifier(Modifier::DIM);
         if self.show_shortcuts {
@@ -1393,6 +1405,32 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(!screen.contains("Contract call"));
+        assert!(screen.contains("Memory (max expansion: 0 bytes)"));
+    }
+
+    #[test]
+    fn hidden_variables_pane_omits_variables_panel() {
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![trace_step(Vec::new())])]);
+        context.layout = DebuggerLayout::Vertical;
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.show_source = false;
+        tui.show_variables = false;
+        let backend = TestBackend::new(220, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|f| tui.draw_layout(f)).unwrap();
+
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(!screen.contains("Variables"));
+        assert!(!screen.contains("Contract call"));
+        assert!(screen.contains("Stack: 0"));
         assert!(screen.contains("Memory (max expansion: 0 bytes)"));
     }
 

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -113,43 +113,45 @@ impl TUIContext<'_> {
             self.draw_footer(f, footer);
         }
 
-        let source_weight = if self.show_source { 3 } else { 0 };
-        let variables_weight = if self.show_variables { 1 } else { 0 };
-        let memory_weight = if self.show_source { 1 } else { 2 };
-        let total_weight = 1 + variables_weight + 1 + memory_weight + source_weight;
-        let mut constraints = Vec::with_capacity(5);
-        constraints.push(Constraint::Ratio(1, total_weight));
-        if self.show_variables {
-            constraints.push(Constraint::Ratio(variables_weight, total_weight));
-        }
-        constraints.push(Constraint::Ratio(1, total_weight));
-        constraints.push(Constraint::Ratio(memory_weight, total_weight));
         if self.show_source {
-            constraints.push(Constraint::Ratio(source_weight, total_weight));
-        }
+            // Split the app vertically to construct all the panes.
+            let [op_pane, variables_pane, stack_pane, memory_pane, src_pane] = Layout::new(
+                Direction::Vertical,
+                [
+                    Constraint::Ratio(1, 7),
+                    Constraint::Ratio(1, 7),
+                    Constraint::Ratio(1, 7),
+                    Constraint::Ratio(1, 7),
+                    Constraint::Ratio(3, 7),
+                ],
+            )
+            .split(app)[..] else {
+                unreachable!()
+            };
 
-        let panes = Layout::new(Direction::Vertical, constraints).split(app);
-        let mut pane_idx = 0;
-        let op_pane = panes[pane_idx];
-        pane_idx += 1;
-        let variables_pane = self.show_variables.then(|| {
-            let pane = panes[pane_idx];
-            pane_idx += 1;
-            pane
-        });
-        let stack_pane = panes[pane_idx];
-        pane_idx += 1;
-        let memory_pane = panes[pane_idx];
-        pane_idx += 1;
-        let src_pane = self.show_source.then(|| panes[pane_idx]);
-
-        if let Some(src_pane) = src_pane {
             self.draw_src(f, src_pane);
-        }
-        self.draw_op_list(f, op_pane);
-        if let Some(variables_pane) = variables_pane {
+            self.draw_op_list(f, op_pane);
             self.draw_variables(f, variables_pane);
+            self.draw_stack(f, stack_pane);
+            self.draw_buffer(f, memory_pane);
+            return;
         }
+
+        let [op_pane, variables_pane, stack_pane, memory_pane] = Layout::new(
+            Direction::Vertical,
+            [
+                Constraint::Ratio(1, 5),
+                Constraint::Ratio(1, 5),
+                Constraint::Ratio(1, 5),
+                Constraint::Ratio(2, 5),
+            ],
+        )
+        .split(app)[..] else {
+            unreachable!()
+        };
+
+        self.draw_op_list(f, op_pane);
+        self.draw_variables(f, variables_pane);
         self.draw_stack(f, stack_pane);
         self.draw_buffer(f, memory_pane);
     }
@@ -203,25 +205,13 @@ impl TUIContext<'_> {
         };
 
         // Split right pane vertically to construct variables, stack and memory.
-        let variables_weight = if self.show_variables { 1 } else { 0 };
-        let total_weight = variables_weight + 1 + 2;
-        let mut constraints = Vec::with_capacity(3);
-        if self.show_variables {
-            constraints.push(Constraint::Ratio(variables_weight, total_weight));
-        }
-        constraints.push(Constraint::Ratio(1, total_weight));
-        constraints.push(Constraint::Ratio(2, total_weight));
-
-        let panes = Layout::new(Direction::Vertical, constraints).split(app_right);
-        let mut pane_idx = 0;
-        let variables_pane = self.show_variables.then(|| {
-            let pane = panes[pane_idx];
-            pane_idx += 1;
-            pane
-        });
-        let stack_pane = panes[pane_idx];
-        pane_idx += 1;
-        let memory_pane = panes[pane_idx];
+        let [variables_pane, stack_pane, memory_pane] = Layout::new(
+            Direction::Vertical,
+            [Constraint::Ratio(1, 4), Constraint::Ratio(1, 4), Constraint::Ratio(2, 4)],
+        )
+        .split(app_right)[..] else {
+            unreachable!()
+        };
 
         if footer_height > 0 {
             self.draw_footer(f, footer);
@@ -230,9 +220,7 @@ impl TUIContext<'_> {
             self.draw_src(f, src_pane);
         }
         self.draw_op_list(f, op_pane);
-        if let Some(variables_pane) = variables_pane {
-            self.draw_variables(f, variables_pane);
-        }
+        self.draw_variables(f, variables_pane);
         self.draw_stack(f, stack_pane);
         self.draw_buffer(f, memory_pane);
     }
@@ -241,6 +229,7 @@ impl TUIContext<'_> {
         let status_or_input = u16::from(
             self.pc_input.is_some()
                 || self.buffer_offset_input.is_some()
+                || self.command_input.is_some()
                 || self.opcode_search_input.is_some()
                 || self.status.is_some(),
         );
@@ -277,6 +266,19 @@ impl TUIContext<'_> {
                     Style::new().add_modifier(Modifier::DIM),
                 ),
             ]));
+        } else if let Some(input) = &self.command_input {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "Command: :",
+                    Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(input.as_str()),
+                Span::styled("█", Style::new().fg(Color::Cyan)),
+                Span::styled(
+                    "  Enter: run | Esc: cancel | help: command list",
+                    Style::new().add_modifier(Modifier::DIM),
+                ),
+            ]));
         } else if let Some(input) = &self.opcode_search_input {
             lines.push(Line::from(vec![
                 Span::styled(
@@ -300,8 +302,8 @@ impl TUIContext<'_> {
 
         let l1 =
             "[q] quit | [j/k] op | [a/s] jump | [c/C] call | [g/G] start/end | [p] PC | [o] offset";
-        let l2 = "[/] search | [n/N] repeat | [l] layout | [v/V] source/vars | [b] buffer | [t] labels | [m] decode | [h] help";
-        let l3 = "[J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint";
+        let l2 = "[/] search | [:] command | [n/N] repeat | [l] layout | [b] buffer | [v] source";
+        let l3 = "[t] labels | [m] decode | [h] help | [J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint";
         let dimmed = Style::new().add_modifier(Modifier::DIM);
         if self.show_shortcuts {
             lines.push(Line::from(Span::styled(l1, dimmed)));
@@ -1405,32 +1407,6 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(!screen.contains("Contract call"));
-        assert!(screen.contains("Memory (max expansion: 0 bytes)"));
-    }
-
-    #[test]
-    fn hidden_variables_pane_omits_variables_panel() {
-        let mut context = context_with_arena(vec![debug_node(0, 0, vec![trace_step(Vec::new())])]);
-        context.layout = DebuggerLayout::Vertical;
-        let mut tui = TUIContext::new(&mut context);
-        tui.init();
-        tui.show_source = false;
-        tui.show_variables = false;
-        let backend = TestBackend::new(220, 30);
-        let mut terminal = Terminal::new(backend).unwrap();
-
-        terminal.draw(|f| tui.draw_layout(f)).unwrap();
-
-        let screen = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(|cell| cell.symbol())
-            .collect::<String>();
-        assert!(!screen.contains("Variables"));
-        assert!(!screen.contains("Contract call"));
-        assert!(screen.contains("Stack: 0"));
         assert!(screen.contains("Memory (max expansion: 0 bytes)"));
     }
 

--- a/crates/evm/core/src/buffer.rs
+++ b/crates/evm/core/src/buffer.rs
@@ -2,7 +2,7 @@ use alloy_primitives::U256;
 use revm::bytecode::opcode;
 
 /// Used to keep track of which buffer is currently active to be drawn by the debugger.
-#[derive(Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BufferKind {
     Memory,
     Calldata,

--- a/crates/evm/core/src/buffer.rs
+++ b/crates/evm/core/src/buffer.rs
@@ -2,7 +2,7 @@ use alloy_primitives::U256;
 use revm::bytecode::opcode;
 
 /// Used to keep track of which buffer is currently active to be drawn by the debugger.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Copy, Debug, PartialEq, Eq)]
 pub enum BufferKind {
     Memory,
     Calldata,


### PR DESCRIPTION
## Summary
- add `:` command mode to the debugger TUI
- support `:continue <pc>` / `:pc <pc>` for PC jumps
- support `:mem <offset>`, `:calldata <offset>`, and `:returndata <offset>` for buffer jumps
- expose the command prompt in the footer

Refs #927