### PR TITLE
Use wait-timeout for symbolic solver waits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5734,6 +5734,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -490,6 +490,7 @@ vergen = { package = "vergen-gitcl", version = "10.0.0", default-features = fals
     "build",
     "cargo",
 ] }
+wait-timeout = "0.2"
 yansi = { version = "1.0", features = ["detect-tty", "detect-env"] }
 path-slash = "0.2"
 jiff = { version = "0.2", default-features = false, features = [

--- a/crates/evm/symbolic/Cargo.toml
+++ b/crates/evm/symbolic/Cargo.toml
@@ -33,6 +33,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+wait-timeout.workspace = true
 
 [features]
 default = ["optimism"]

--- a/crates/evm/symbolic/src/consts.rs
+++ b/crates/evm/symbolic/src/consts.rs
@@ -28,9 +28,7 @@ pub(crate) const ERROR_DATA_MIN_LEN: usize = 68; // selector (4) + offset (32) +
 // Precompile address layout
 pub(crate) const PRECOMPILE_ADDRESS_LEADING_ZEROS: usize = 19;
 
-// Solver polling backoff
-pub(crate) const INITIAL_SOLVER_POLL_BACKOFF: Duration = Duration::from_micros(200);
-pub(crate) const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
+pub(crate) const SOLVER_CANCEL_CHECK_INTERVAL: Duration = Duration::from_millis(50);
 pub(crate) const SECOND_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(100);
 pub(crate) const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
 

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -37,7 +37,7 @@ use std::collections::BTreeMap;
 use std::{
     collections::VecDeque,
     fmt::{self, Write as _},
-    io::{Read, Write},
+    io::Write,
     num::NonZeroU32,
     ops::{ControlFlow, Deref, DerefMut},
     path::{Path, PathBuf},

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -18,6 +18,7 @@ use opt::{
 };
 #[cfg(test)]
 pub(crate) use opt::{normalize_bool_for_solver, normalize_expr_for_solver};
+use wait_timeout::ChildExt;
 
 /// Errors that arise when parsing or constructing solver commands from configuration.
 #[derive(Debug, thiserror::Error)]
@@ -1433,89 +1434,81 @@ fn run_solver_process(
             ));
         }
     };
-    let stdout_reader = child.stdout.take().map(read_pipe_to_string);
-    let stderr_reader = child.stderr.take().map(read_pipe_to_string);
-
     if let Some(mut stdin) = child.stdin.take()
         && let Err(err) = stdin.write_all(smt.as_bytes())
     {
-        kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
+        let _ = child.kill();
+        let _ = child.wait();
         return SolverProcessOutcome::Error(format!("failed to write solver query: {err}"));
     }
 
-    let deadline = timeout
-        .filter(|seconds| *seconds > 0)
-        .map(|seconds| Instant::now() + Duration::from_secs(seconds.into()));
-    let mut backoff = INITIAL_SOLVER_POLL_BACKOFF;
-    let status = loop {
-        if cancel.load(Ordering::SeqCst) {
-            kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
-            return SolverProcessOutcome::Cancelled;
-        }
-        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
-            kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
+    let wait_timeout =
+        timeout.filter(|seconds| *seconds > 0).map(|seconds| Duration::from_secs(seconds.into()));
+    let status = match wait_for_solver_process(&mut child, wait_timeout, cancel) {
+        Ok(SolverWaitOutcome::Exited(status)) => status,
+        Ok(SolverWaitOutcome::TimedOut) => {
+            let _ = child.kill();
+            let _ = child.wait();
             return SolverProcessOutcome::Unknown;
         }
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) => {
-                thread::sleep(backoff);
-                backoff = (backoff * 2).min(MAX_SOLVER_POLL_BACKOFF);
-            }
-            Err(err) => {
-                kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
-                return SolverProcessOutcome::Error(format!("failed to read solver output: {err}"));
-            }
+        Ok(SolverWaitOutcome::Cancelled) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return SolverProcessOutcome::Cancelled;
+        }
+        Err(err) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return SolverProcessOutcome::Error(format!("failed to read solver output: {err}"));
         }
     };
 
-    let stdout = match join_pipe_output(stdout_reader, "stdout") {
-        Ok(stdout) => stdout,
-        Err(err) => return SolverProcessOutcome::Error(err),
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(err) => {
+            return SolverProcessOutcome::Error(format!("failed to read solver output: {err}"));
+        }
     };
-    let stderr = match join_pipe_output(stderr_reader, "stderr") {
-        Ok(stderr) => stderr,
-        Err(err) => return SolverProcessOutcome::Error(err),
-    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
     if !status.success() {
         return SolverProcessOutcome::Error(solver_exit_error(command, status, &stdout, &stderr));
     }
-    SolverProcessOutcome::Output(stdout)
+    SolverProcessOutcome::Output(stdout.into_owned())
 }
 
-fn read_pipe_to_string<R>(mut pipe: R) -> thread::JoinHandle<Result<String, String>>
-where
-    R: Read + Send + 'static,
-{
-    thread::spawn(move || {
-        let mut output = Vec::new();
-        pipe.read_to_end(&mut output)
-            .map_err(|err| format!("failed to read solver output: {err}"))?;
-        Ok(String::from_utf8_lossy(&output).to_string())
-    })
+enum SolverWaitOutcome {
+    Cancelled,
+    Exited(std::process::ExitStatus),
+    TimedOut,
 }
 
-fn join_pipe_output(
-    reader: Option<thread::JoinHandle<Result<String, String>>>,
-    stream: &str,
-) -> Result<String, String> {
-    match reader {
-        Some(reader) => reader.join().map_err(|_| format!("solver {stream} reader panicked"))?,
-        None => Ok(String::new()),
-    }
-}
-
-fn kill_and_reap_solver_process(
+fn wait_for_solver_process(
     child: &mut std::process::Child,
-    stdout_reader: Option<thread::JoinHandle<Result<String, String>>>,
-    stderr_reader: Option<thread::JoinHandle<Result<String, String>>>,
-) {
-    // This only terminates the direct child. Wrapper commands should forward termination and close
-    // inherited pipes so descendant solver processes do not outlive cancelled queries.
-    let _ = child.kill();
-    let _ = child.wait();
-    let _ = join_pipe_output(stdout_reader, "stdout");
-    let _ = join_pipe_output(stderr_reader, "stderr");
+    timeout: Option<Duration>,
+    cancel: &AtomicBool,
+) -> std::io::Result<SolverWaitOutcome> {
+    let deadline = timeout.map(|timeout| Instant::now() + timeout);
+
+    loop {
+        if cancel.load(Ordering::SeqCst) {
+            return Ok(SolverWaitOutcome::Cancelled);
+        }
+
+        let wait = deadline
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+            .map_or(SOLVER_CANCEL_CHECK_INTERVAL, |remaining| {
+                remaining.min(SOLVER_CANCEL_CHECK_INTERVAL)
+            });
+
+        if wait.is_zero() {
+            return Ok(SolverWaitOutcome::TimedOut);
+        }
+
+        if let Some(status) = child.wait_timeout(wait)? {
+            return Ok(SolverWaitOutcome::Exited(status));
+        }
+    }
 }
 
 fn solver_exit_error(


### PR DESCRIPTION
## Summary
- add wait-timeout as a symbolic crate dependency
- replace the symbolic solver process try_wait/sleep timeout loop with wait-timeout-based waits
- keep cooperative portfolio cancellation responsive and distinguish cancellation from timeout

## Testing
- cargo fmt --check
- cargo check -p foundry-evm-symbolic
- cargo test -p foundry-evm-symbolic portfolio

Prompted by: @DaniPopes