### PR TITLE
refactor(symbolic): use wait-timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5734,6 +5734,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -433,6 +433,7 @@ tikv-jemallocator = "0.7"
 auto_impl = "1"
 bytes = "1.11"
 walkdir = "2"
+wait-timeout = "0.2"
 prettyplease = "0.2"
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = [

--- a/crates/evm/symbolic/Cargo.toml
+++ b/crates/evm/symbolic/Cargo.toml
@@ -33,6 +33,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+wait-timeout.workspace = true
 
 [features]
 default = ["optimism"]

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -364,8 +364,7 @@ when symbolic tests run. This also applies when these values come from inline
 settings before running symbolic tests from untrusted projects.
 Timeouts and portfolio cancellation terminate only the direct solver child
 process. Wrapper commands should forward termination to any subprocesses they
-spawn and close inherited stdout/stderr so descendant solvers do not outlive the
-cancelled query.
+spawn so descendant solvers do not outlive the cancelled query.
 
 Halmos-style annotations are accepted as compatibility input and translated into
 the same internal config:

--- a/crates/evm/symbolic/src/consts.rs
+++ b/crates/evm/symbolic/src/consts.rs
@@ -28,9 +28,10 @@ pub(crate) const ERROR_DATA_MIN_LEN: usize = 68; // selector (4) + offset (32) +
 // Precompile address layout
 pub(crate) const PRECOMPILE_ADDRESS_LEADING_ZEROS: usize = 19;
 
-// Solver polling backoff
-pub(crate) const INITIAL_SOLVER_POLL_BACKOFF: Duration = Duration::from_micros(200);
-pub(crate) const MAX_SOLVER_POLL_BACKOFF: Duration = Duration::from_millis(50);
+// Solver subprocess supervision.
+pub(crate) const SOLVER_CANCEL_CHECK_INTERVAL: Duration = Duration::from_millis(50);
+
+// Portfolio scheduler launch delays.
 pub(crate) const SECOND_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(100);
 pub(crate) const RESCUE_PORTFOLIO_SOLVER_DELAY: Duration = Duration::from_millis(500);
 

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -37,7 +37,7 @@ use std::collections::BTreeMap;
 use std::{
     collections::VecDeque,
     fmt::{self, Write as _},
-    io::{Read, Write},
+    io::Write,
     num::NonZeroU32,
     ops::{ControlFlow, Deref, DerefMut},
     path::{Path, PathBuf},

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -1473,8 +1473,8 @@ fn run_solver_process(
         }
     };
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
         return SolverProcessOutcome::Error(solver_exit_error(
             command,
             output.status,

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -1,4 +1,6 @@
 use super::*;
+use std::process::{Child, Output};
+use wait_timeout::ChildExt;
 
 mod hard_arith_fallback;
 mod monotonic_product;
@@ -1418,7 +1420,7 @@ fn run_solver_process(
     timeout: Option<u32>,
     cancel: &AtomicBool,
 ) -> SolverProcessOutcome {
-    let mut child = match Command::new(&command.program)
+    let child = match Command::new(&command.program)
         .args(&command.args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -1433,89 +1435,89 @@ fn run_solver_process(
             ));
         }
     };
-    let stdout_reader = child.stdout.take().map(read_pipe_to_string);
-    let stderr_reader = child.stderr.take().map(read_pipe_to_string);
+    let mut child = SolverChild::new(child);
 
-    if let Some(mut stdin) = child.stdin.take()
+    if let Some(mut stdin) = child.child_mut().stdin.take()
         && let Err(err) = stdin.write_all(smt.as_bytes())
     {
-        kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
         return SolverProcessOutcome::Error(format!("failed to write solver query: {err}"));
     }
 
-    let deadline = timeout
-        .filter(|seconds| *seconds > 0)
-        .map(|seconds| Instant::now() + Duration::from_secs(seconds.into()));
-    let mut backoff = INITIAL_SOLVER_POLL_BACKOFF;
-    let status = loop {
+    let started_at = Instant::now();
+    let timeout =
+        timeout.filter(|seconds| *seconds > 0).map(|seconds| Duration::from_secs(seconds.into()));
+    loop {
         if cancel.load(Ordering::SeqCst) {
-            kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
             return SolverProcessOutcome::Cancelled;
         }
-        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
-            kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
-            return SolverProcessOutcome::Unknown;
-        }
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) => {
-                thread::sleep(backoff);
-                backoff = (backoff * 2).min(MAX_SOLVER_POLL_BACKOFF);
-            }
-            Err(err) => {
-                kill_and_reap_solver_process(&mut child, stdout_reader, stderr_reader);
-                return SolverProcessOutcome::Error(format!("failed to read solver output: {err}"));
-            }
-        }
-    };
 
-    let stdout = match join_pipe_output(stdout_reader, "stdout") {
-        Ok(stdout) => stdout,
-        Err(err) => return SolverProcessOutcome::Error(err),
+        let Some(wait) = solver_wait_duration(started_at.elapsed(), timeout) else {
+            return SolverProcessOutcome::Unknown;
+        };
+
+        match child.child_mut().wait_timeout(wait) {
+            Ok(Some(_)) => break,
+            Ok(None) => {}
+            Err(err) => {
+                return SolverProcessOutcome::Error(format!(
+                    "failed to wait for solver process: {err}"
+                ));
+            }
+        }
+    }
+
+    let output = match child.wait_with_output() {
+        Ok(output) => output,
+        Err(err) => {
+            return SolverProcessOutcome::Error(format!("failed to read solver output: {err}"));
+        }
     };
-    let stderr = match join_pipe_output(stderr_reader, "stderr") {
-        Ok(stderr) => stderr,
-        Err(err) => return SolverProcessOutcome::Error(err),
-    };
-    if !status.success() {
-        return SolverProcessOutcome::Error(solver_exit_error(command, status, &stdout, &stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if !output.status.success() {
+        return SolverProcessOutcome::Error(solver_exit_error(
+            command,
+            output.status,
+            &stdout,
+            &stderr,
+        ));
     }
     SolverProcessOutcome::Output(stdout)
 }
 
-fn read_pipe_to_string<R>(mut pipe: R) -> thread::JoinHandle<Result<String, String>>
-where
-    R: Read + Send + 'static,
-{
-    thread::spawn(move || {
-        let mut output = Vec::new();
-        pipe.read_to_end(&mut output)
-            .map_err(|err| format!("failed to read solver output: {err}"))?;
-        Ok(String::from_utf8_lossy(&output).to_string())
-    })
+fn solver_wait_duration(elapsed: Duration, timeout: Option<Duration>) -> Option<Duration> {
+    let Some(timeout) = timeout else {
+        return Some(SOLVER_CANCEL_CHECK_INTERVAL);
+    };
+    let remaining = timeout.checked_sub(elapsed)?;
+    if remaining.is_zero() { None } else { Some(remaining.min(SOLVER_CANCEL_CHECK_INTERVAL)) }
 }
 
-fn join_pipe_output(
-    reader: Option<thread::JoinHandle<Result<String, String>>>,
-    stream: &str,
-) -> Result<String, String> {
-    match reader {
-        Some(reader) => reader.join().map_err(|_| format!("solver {stream} reader panicked"))?,
-        None => Ok(String::new()),
+struct SolverChild {
+    child: Option<Child>,
+}
+
+impl SolverChild {
+    const fn new(child: Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    const fn child_mut(&mut self) -> &mut Child {
+        self.child.as_mut().expect("solver child exists")
+    }
+
+    fn wait_with_output(mut self) -> std::io::Result<Output> {
+        self.child.take().expect("solver child exists").wait_with_output()
     }
 }
 
-fn kill_and_reap_solver_process(
-    child: &mut std::process::Child,
-    stdout_reader: Option<thread::JoinHandle<Result<String, String>>>,
-    stderr_reader: Option<thread::JoinHandle<Result<String, String>>>,
-) {
-    // This only terminates the direct child. Wrapper commands should forward termination and close
-    // inherited pipes so descendant solver processes do not outlive cancelled queries.
-    let _ = child.kill();
-    let _ = child.wait();
-    let _ = join_pipe_output(stdout_reader, "stdout");
-    let _ = join_pipe_output(stderr_reader, "stderr");
+impl Drop for SolverChild {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
 }
 
 fn solver_exit_error(

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3616,6 +3616,25 @@ fn portfolio_sat_beats_early_unsat() {
 
 #[cfg(unix)]
 #[test]
+fn solver_process_timeout_returns_unknown() {
+    let commands = vec![
+        SolverCommand::new(
+            vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "cat >/dev/null; sleep 2; printf 'sat\n'".to_string(),
+            ],
+            false,
+        )
+        .unwrap(),
+    ];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(1), 1, false);
+
+    assert!(matches!(solver.is_sat(&[]), Err(SymbolicError::SolverUnknown)));
+}
+
+#[cfg(unix)]
+#[test]
 fn portfolio_scheduler_promotes_recent_sat_winner() {
     let marker = portfolio_test_marker("adaptive-slow-leader");
     let marker_arg = marker.display().to_string();


### PR DESCRIPTION
Replaces the symbolic solver subprocess timeout supervision with `wait-timeout` and a small owned child guard. The guard keeps cleanup scoped to solver runner exits, so timeout, cancellation, and early write failures kill and reap the direct solver child without custom pipe reader threads.

This also adds a regression test for solver subprocess timeout behavior and updates the symbolic README note around wrapper process cleanup.

AI assistance disclosure: This PR was written with Codex assistance.