### PR TITLE
refactor(config): parse halmos args with shlex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5492,6 +5492,7 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "serde_json",
+ "shlex",
  "similar-asserts",
  "snapbox",
  "solar-compiler",
@@ -5732,6 +5733,7 @@ dependencies = [
  "inturn",
  "serde",
  "serde_json",
+ "shlex",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -472,6 +472,7 @@ rustls = "0.23"
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
+shlex = "1"
 similar-asserts = "2.0"
 soldeer-commands = "=0.11.0"
 soldeer-core = { version = "=0.11.0", features = ["serde"] }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -40,6 +40,7 @@ regex.workspace = true
 semver = { workspace = true, features = ["serde"] }
 serde_json.workspace = true
 serde.workspace = true
+shlex.workspace = true
 soldeer-core.workspace = true
 thiserror.workspace = true
 toml = { workspace = true, features = ["preserve_order"] }

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -1,5 +1,4 @@
 use super::{INLINE_CONFIG_PREFIX, InlineConfigError, InlineConfigErrorKind};
-use crate::split_quoted_args;
 use figment::Profile;
 use foundry_compilers::{
     ProjectCompileOutput,
@@ -149,67 +148,15 @@ fn translate_halmos_config(args: &str, values: &mut Vec<String>) -> Result<(), S
     let tokens = split_halmos_args(args)?;
     let mut idx = 0;
     while idx < tokens.len() {
-        let token = tokens[idx].as_str();
-        if token == "--array-lengths" {
-            idx += 1;
-            let Some(value) = tokens.get(idx) else {
-                return Err("missing value for --array-lengths".to_string());
+        let token = &tokens[idx];
+        if let Some((arg, value)) = halmos_arg(token) {
+            let value = if let Some(value) = value {
+                value
+            } else {
+                idx += 1;
+                tokens.get(idx).ok_or_else(|| format!("missing value for {}", arg.flag))?
             };
-            push_halmos_array_lengths(values, value)?;
-        } else if let Some(value) = token.strip_prefix("--array-lengths=") {
-            push_halmos_array_lengths(values, value)?;
-        } else if token == "--default-array-lengths" {
-            idx += 1;
-            let Some(value) = tokens.get(idx) else {
-                return Err("missing value for --default-array-lengths".to_string());
-            };
-            push_halmos_lengths(values, "default_array_lengths", value, "--default-array-lengths")?;
-        } else if let Some(value) = token.strip_prefix("--default-array-lengths=") {
-            push_halmos_lengths(values, "default_array_lengths", value, "--default-array-lengths")?;
-        } else if token == "--default-bytes-lengths" {
-            idx += 1;
-            let Some(value) = tokens.get(idx) else {
-                return Err("missing value for --default-bytes-lengths".to_string());
-            };
-            push_halmos_lengths(values, "default_bytes_lengths", value, "--default-bytes-lengths")?;
-        } else if let Some(value) = token.strip_prefix("--default-bytes-lengths=") {
-            push_halmos_lengths(values, "default_bytes_lengths", value, "--default-bytes-lengths")?;
-        } else if let Some(field) = halmos_numeric_symbolic_field(token) {
-            idx += 1;
-            let Some(value) = tokens.get(idx) else {
-                return Err(format!("missing value for {token}"));
-            };
-            push_halmos_u32(values, field, value, token)?;
-        } else if let Some(value) = token.strip_prefix("--invariant-depth=") {
-            push_halmos_u32(values, "invariant_depth", value, "--invariant-depth")?;
-        } else if let Some(value) = token.strip_prefix("--loop=") {
-            push_halmos_u32(values, "loop", value, "--loop")?;
-        } else if let Some(value) = token.strip_prefix("--width=") {
-            push_halmos_u32(values, "width", value, "--width")?;
-        } else if let Some(value) = token.strip_prefix("--depth=") {
-            push_halmos_u32(values, "depth", value, "--depth")?;
-        } else if let Some(value) = token.strip_prefix("--solver-timeout=") {
-            push_halmos_u32(values, "timeout", value, "--solver-timeout")?;
-        } else if let Some(value) = token.strip_prefix("--solver-timeout-branching=") {
-            push_halmos_u32(values, "timeout", value, "--solver-timeout-branching")?;
-        } else if let Some(value) = token.strip_prefix("--solver-timeout-assertion=") {
-            push_halmos_u32(values, "timeout", value, "--solver-timeout-assertion")?;
-        } else if token == "--solver" {
-            idx += 1;
-            let Some(value) = tokens.get(idx) else {
-                return Err("missing value for --solver".to_string());
-            };
-            push_halmos_string(values, "solver", value);
-        } else if let Some(value) = token.strip_prefix("--solver=") {
-            push_halmos_string(values, "solver", value);
-        } else if token == "--solver-command" {
-            idx += 1;
-            let Some(value) = tokens.get(idx) else {
-                return Err("missing value for --solver-command".to_string());
-            };
-            push_halmos_string(values, "solver_command", value);
-        } else if let Some(value) = token.strip_prefix("--solver-command=") {
-            push_halmos_string(values, "solver_command", value);
+            emit_halmos_arg(values, arg, value)?;
         } else if token.starts_with("--")
             && tokens.get(idx + 1).is_some_and(|next| !next.starts_with("--"))
         {
@@ -221,20 +168,85 @@ fn translate_halmos_config(args: &str, values: &mut Vec<String>) -> Result<(), S
 }
 
 fn split_halmos_args(args: &str) -> Result<Vec<String>, String> {
-    split_quoted_args(args)
-        .map_err(|quote_ch| format!("unterminated {quote_ch} quote in @custom:halmos config"))
+    shlex::split(args).ok_or_else(|| "invalid shell quoting in @custom:halmos config".to_string())
 }
 
-fn halmos_numeric_symbolic_field(flag: &str) -> Option<&'static str> {
-    match flag {
-        "--loop" => Some("loop"),
-        "--width" => Some("width"),
-        "--depth" => Some("depth"),
-        "--invariant-depth" => Some("invariant_depth"),
-        "--solver-timeout" | "--solver-timeout-branching" | "--solver-timeout-assertion" => {
-            Some("timeout")
+#[derive(Clone, Copy)]
+struct HalmosArg {
+    flag: &'static str,
+    parser: HalmosArgParser,
+    foundry_field: &'static str,
+}
+
+#[derive(Clone, Copy)]
+enum HalmosArgParser {
+    ArrayLengths,
+    Lengths,
+    U32,
+    String,
+}
+
+const HALMOS_ARGS: &[HalmosArg] = &[
+    HalmosArg {
+        flag: "--array-lengths",
+        parser: HalmosArgParser::ArrayLengths,
+        foundry_field: "array_lengths",
+    },
+    HalmosArg {
+        flag: "--default-array-lengths",
+        parser: HalmosArgParser::Lengths,
+        foundry_field: "default_array_lengths",
+    },
+    HalmosArg {
+        flag: "--default-bytes-lengths",
+        parser: HalmosArgParser::Lengths,
+        foundry_field: "default_bytes_lengths",
+    },
+    HalmosArg { flag: "--loop", parser: HalmosArgParser::U32, foundry_field: "loop" },
+    HalmosArg {
+        flag: "--invariant-depth",
+        parser: HalmosArgParser::U32,
+        foundry_field: "invariant_depth",
+    },
+    HalmosArg { flag: "--width", parser: HalmosArgParser::U32, foundry_field: "width" },
+    HalmosArg { flag: "--depth", parser: HalmosArgParser::U32, foundry_field: "depth" },
+    HalmosArg { flag: "--solver-timeout", parser: HalmosArgParser::U32, foundry_field: "timeout" },
+    HalmosArg {
+        flag: "--solver-timeout-branching",
+        parser: HalmosArgParser::U32,
+        foundry_field: "timeout",
+    },
+    HalmosArg {
+        flag: "--solver-timeout-assertion",
+        parser: HalmosArgParser::U32,
+        foundry_field: "timeout",
+    },
+    HalmosArg { flag: "--solver", parser: HalmosArgParser::String, foundry_field: "solver" },
+    HalmosArg {
+        flag: "--solver-command",
+        parser: HalmosArgParser::String,
+        foundry_field: "solver_command",
+    },
+];
+
+fn halmos_arg(token: &str) -> Option<(HalmosArg, Option<&str>)> {
+    let (flag, value) =
+        token.split_once('=').map_or((token, None), |(flag, value)| (flag, Some(value)));
+    HALMOS_ARGS.iter().copied().find(|arg| arg.flag == flag).map(|arg| (arg, value))
+}
+
+fn emit_halmos_arg(values: &mut Vec<String>, arg: HalmosArg, value: &str) -> Result<(), String> {
+    match arg.parser {
+        HalmosArgParser::ArrayLengths => push_halmos_array_lengths(values, value),
+        HalmosArgParser::Lengths => push_halmos_lengths(values, arg.foundry_field, value, arg.flag),
+        HalmosArgParser::U32 => {
+            push_halmos_u32(values, arg.foundry_field, parse_halmos_u32(value, arg.flag)?);
+            Ok(())
         }
-        _ => None,
+        HalmosArgParser::String => {
+            push_halmos_string(values, arg.foundry_field, value);
+            Ok(())
+        }
     }
 }
 
@@ -272,14 +284,8 @@ fn push_halmos_lengths(
     Ok(())
 }
 
-fn push_halmos_u32(
-    values: &mut Vec<String>,
-    field: &str,
-    value: &str,
-    flag: &str,
-) -> Result<(), String> {
-    values.push(format!("default.symbolic.{field} = {}", parse_halmos_u32(value, flag)?));
-    Ok(())
+fn push_halmos_u32(values: &mut Vec<String>, field: &str, value: u32) {
+    values.push(format!("default.symbolic.{field} = {value}"));
 }
 
 fn push_halmos_string(values: &mut Vec<String>, field: &str, value: &str) {
@@ -990,6 +996,22 @@ contract FuzzInlineConf is DSTest {
     }
 
     #[test]
+    fn ignores_unsupported_halmos_flags_while_translating_supported_ones() {
+        let natspec = NatSpec {
+            contract: "dir/TestContract.t.sol:SymbolicContract".to_string(),
+            function: Some("checkBytes".to_string()),
+            line: "10:1".to_string(),
+            docs: "@custom:halmos --unsupported value --loop 10 --another --array-lengths 2"
+                .to_string(),
+        };
+
+        assert_eq!(
+            natspec.halmos_config_values().unwrap(),
+            vec!["default.symbolic.loop = 10", "default.symbolic.array_lengths = [2]",]
+        );
+    }
+
+    #[test]
     fn parse_solar_legacy_halmos_only_config() {
         let src = r#"
 contract SymbolicHalmosLengths {
@@ -1017,6 +1039,6 @@ contract SymbolicHalmosLengths {
     #[test]
     fn split_halmos_args_rejects_unterminated_quote() {
         let err = split_halmos_args(r#"--width "unterm"#).unwrap_err();
-        assert_eq!(err, r#"unterminated " quote in @custom:halmos config"#);
+        assert_eq!(err, "invalid shell quoting in @custom:halmos config");
     }
 }

--- a/crates/config/src/utils.rs
+++ b/crates/config/src/utils.rs
@@ -118,69 +118,6 @@ pub fn to_array_value(val: &str) -> Result<Value, figment::Error> {
     Ok(value)
 }
 
-/// Splits a shell-like argument string into argv parts without invoking a shell.
-///
-/// This supports whitespace separation, single and double quotes, and backslash escaping. It is
-/// intentionally smaller than a shell parser: expansions, redirection, pipelines, and command
-/// separators are treated as plain argument text by callers.
-///
-/// Returns `Err(quote_char)` when the input contains an unterminated quote.
-pub fn split_quoted_args(args: &str) -> Result<Vec<String>, char> {
-    let mut parts = Vec::new();
-    let mut current = String::new();
-    let mut quote = None;
-    let mut escaped = false;
-    let mut token_started = false;
-
-    for ch in args.chars() {
-        if escaped {
-            current.push(ch);
-            escaped = false;
-            token_started = true;
-            continue;
-        }
-        if ch == '\\' {
-            escaped = true;
-            token_started = true;
-            continue;
-        }
-        if let Some(quote_ch) = quote {
-            if ch == quote_ch {
-                quote = None;
-            } else {
-                current.push(ch);
-            }
-            token_started = true;
-            continue;
-        }
-        if matches!(ch, '"' | '\'') {
-            quote = Some(ch);
-            token_started = true;
-        } else if ch.is_whitespace() {
-            if token_started {
-                parts.push(std::mem::take(&mut current));
-                token_started = false;
-            }
-        } else {
-            current.push(ch);
-            token_started = true;
-        }
-    }
-
-    if let Some(quote_ch) = quote {
-        return Err(quote_ch);
-    }
-    if escaped {
-        current.push('\\');
-        token_started = true;
-    }
-    if token_started {
-        parts.push(current);
-    }
-
-    Ok(parts)
-}
-
 /// Returns a list of _unique_ paths to all folders under `root` that contain a `foundry.toml` file
 ///
 /// This will also resolve symlinks

--- a/crates/evm/symbolic/Cargo.toml
+++ b/crates/evm/symbolic/Cargo.toml
@@ -31,6 +31,7 @@ base64.workspace = true
 inturn.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+shlex.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/evm/symbolic/src/lib.rs
+++ b/crates/evm/symbolic/src/lib.rs
@@ -16,9 +16,7 @@ use alloy_signer_local::{
 use alloy_sol_types::SolCall;
 use base64::prelude::*;
 use foundry_cheatcodes_spec::{SymbolicVm, Vm};
-use foundry_config::{
-    SymbolicConfig, SymbolicExplorationOrder, SymbolicStorageLayout, split_quoted_args,
-};
+use foundry_config::{SymbolicConfig, SymbolicExplorationOrder, SymbolicStorageLayout};
 use foundry_evm::{
     constants::{CHEATCODE_ADDRESS, DEFAULT_CREATE2_DEPLOYER, HARDHAT_CONSOLE_ADDRESS},
     core::{backend::DatabaseExt, evm::FoundryEvmNetwork},

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -25,9 +25,9 @@ pub(crate) enum SolverConfigError {
     /// The command string parsed to an empty argv.
     #[error("symbolic solver command is empty")]
     EmptyCommand,
-    /// The command string contains an unterminated quote character.
-    #[error("unterminated {0} quote in symbolic solver command")]
-    UnterminatedQuote(char),
+    /// The command string contains invalid shell quoting.
+    #[error("invalid shell quoting in symbolic solver command")]
+    InvalidShellQuoting,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -873,7 +873,7 @@ pub(crate) fn solver_command_for_portfolio_entry(
 
 /// Splits a shell-like solver command into argv parts.
 pub(crate) fn split_solver_command(command: &str) -> Result<Vec<String>, SolverConfigError> {
-    let parts = split_quoted_args(command).map_err(SolverConfigError::UnterminatedQuote)?;
+    let parts = shlex::split(command).ok_or(SolverConfigError::InvalidShellQuoting)?;
     if parts.is_empty() {
         return Err(SolverConfigError::EmptyCommand);
     }

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3002,25 +3002,25 @@ fn split_solver_command_preserves_empty_quoted_args() {
 }
 
 #[test]
-fn split_solver_command_rejects_unterminated_double_quote() {
+fn split_solver_command_rejects_invalid_double_quote() {
     let err = split_solver_command(r#"z3 "unterm"#).unwrap_err();
 
     assert!(
-        matches!(err, SolverConfigError::UnterminatedQuote('"')),
-        "expected UnterminatedQuote('\"'), got {err:?}"
+        matches!(err, SolverConfigError::InvalidShellQuoting),
+        "expected InvalidShellQuoting, got {err:?}"
     );
-    assert_eq!(err.to_string(), r#"unterminated " quote in symbolic solver command"#);
+    assert_eq!(err.to_string(), "invalid shell quoting in symbolic solver command");
 }
 
 #[test]
-fn split_solver_command_rejects_unterminated_single_quote() {
+fn split_solver_command_rejects_invalid_single_quote() {
     let err = split_solver_command("z3 'unterm").unwrap_err();
 
     assert!(
-        matches!(err, SolverConfigError::UnterminatedQuote('\'')),
-        "expected UnterminatedQuote('\\''), got {err:?}"
+        matches!(err, SolverConfigError::InvalidShellQuoting),
+        "expected InvalidShellQuoting, got {err:?}"
     );
-    assert_eq!(err.to_string(), "unterminated ' quote in symbolic solver command");
+    assert_eq!(err.to_string(), "invalid shell quoting in symbolic solver command");
 }
 
 #[test]


### PR DESCRIPTION
Refactors legacy @custom:halmos inline config translation to use shlex for shell-like argument splitting and a data table of supported Halmos flags to map into Foundry symbolic config.

This removes the bespoke split_quoted_args helper and reuses shlex for symbolic solver command splitting as well, so both paths rely on the same argv parsing behavior.

AI assistance was used to prepare this change.
