### PR TITLE
fix(ci): benchmarks for 1.8 release

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -48,7 +48,7 @@ env:
   COVERAGE_REPOS: >-
     ithacaxyz/account:v0.5.7 --nmc SimulateExecuteTest,
     uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
-    sparkdotfi/spark-psm:v1.0.0
+    sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
 
   RUSTC_WRAPPER: "sccache"
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -121,18 +121,20 @@ jobs:
             --output-file forge_isolate_test_bench.md \
             --verbose
 
-      - name: Run forge symbolic benchmarks
-        env:
-          FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-          VERSIONS: ${{ github.event.inputs.versions || env.DEFAULT_VERSIONS }}
-          REPOS: ${{ github.event.inputs.repos || env.SYMBOLIC_REPOS }}
-        run: |
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions "$VERSIONS" \
-            --repos "$REPOS" \
-            --benchmarks forge_symbolic_test \
-            --output-file forge_symbolic_bench.md \
-            --verbose
+      # Temporarily disabled as long as the previous stable benchmark baseline
+      # does not support symbolic execution.
+      # - name: Run forge symbolic benchmarks
+      #   env:
+      #     FOUNDRY_DIR: ${{ github.workspace }}/.foundry
+      #     VERSIONS: ${{ github.event.inputs.versions || env.DEFAULT_VERSIONS }}
+      #     REPOS: ${{ github.event.inputs.repos || env.SYMBOLIC_REPOS }}
+      #   run: |
+      #     ./target/release/foundry-bench --output-dir ./benches \
+      #       --versions "$VERSIONS" \
+      #       --repos "$REPOS" \
+      #       --benchmarks forge_symbolic_test \
+      #       --output-file forge_symbolic_bench.md \
+      #       --verbose
 
       - name: Run forge build benchmarks
         env:
@@ -170,10 +172,10 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-results
+          # The symbolic benchmark artifact is omitted while the symbolic step is disabled.
           path: |
             benches/forge_test_bench.md
             benches/forge_isolate_test_bench.md
-            benches/forge_symbolic_bench.md
             benches/forge_build_bench.md
             benches/forge_coverage_bench.md
             benches/LATEST.md

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -277,38 +277,45 @@ impl BenchmarkProject {
         let name = self.name.to_ascii_lowercase();
         if name == "solady" || name.ends_with("-solady") {
             return SymbolicBenchmarkSpec {
-                build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge build".to_string(),
+                build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build"
+                    .to_string(),
                 test_command: format!(
-                    "FOUNDRY_LINT_LINT_ON_BUILD=false forge test --symbolic --json \
+                    "FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge test \
+                     --symbolic --json \
                      --match-test '{SOLADY_SYMBOLIC_MATCH_TEST}'"
                 ),
             };
         }
         if name == "angstrom" || name.ends_with("-angstrom") {
             return SymbolicBenchmarkSpec {
-                build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge build --root contracts"
-                    .to_string(),
+                build_command:
+                    "FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build --root contracts"
+                        .to_string(),
                 test_command: format!(
-                    "FOUNDRY_LINT_LINT_ON_BUILD=false forge test --root contracts --symbolic \
-                     --json --symbolic-timeout 5 --match-path {ANGSTROM_SYMBOLIC_MATCH_PATH} \
-                     --match-test {ANGSTROM_SYMBOLIC_MATCH_TEST}"
+                    "FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge test \
+                     --root contracts --symbolic --json --symbolic-timeout 5 --match-path \
+                     {ANGSTROM_SYMBOLIC_MATCH_PATH} --match-test {ANGSTROM_SYMBOLIC_MATCH_TEST}"
                 ),
             };
         }
         if name == "farcasterxyz-contracts" || name == "farcaster-contracts" {
             return SymbolicBenchmarkSpec {
-                build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge build".to_string(),
+                build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build"
+                    .to_string(),
                 test_command: format!(
-                    "FOUNDRY_LINT_LINT_ON_BUILD=false forge test --symbolic --json \
+                    "FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge test \
+                     --symbolic --json \
                      --symbolic-timeout 5 --match-path '{FARCASTER_SYMBOLIC_MATCH_PATH}' \
                      --match-test 'check_'"
                 ),
             };
         }
         SymbolicBenchmarkSpec {
-            build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge build".to_string(),
-            test_command: "FOUNDRY_LINT_LINT_ON_BUILD=false forge test --symbolic --json"
+            build_command: "FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build"
                 .to_string(),
+            test_command:
+                "FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge test --symbolic --json"
+                    .to_string(),
         }
     }
 
@@ -451,7 +458,7 @@ impl BenchmarkProject {
             version,
             &self.cmd("FOUNDRY_ISOLATE=false forge test"),
             runs,
-            Some("forge build"),
+            Some("FOUNDRY_ISOLATE=false forge build"),
             None,
             None,
             verbose,
@@ -468,10 +475,10 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_build_with_cache",
             version,
-            &self.cmd("FOUNDRY_LINT_LINT_ON_BUILD=false forge build"),
+            &self.cmd("FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build"),
             runs,
             None,
-            Some("forge build"),
+            Some("FOUNDRY_ISOLATE=false forge build"),
             None,
             verbose,
         )
@@ -488,11 +495,11 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_build_no_cache",
             version,
-            &self.cmd("FOUNDRY_LINT_LINT_ON_BUILD=false forge build"),
+            &self.cmd("FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build"),
             runs,
-            Some("forge clean"),
+            Some("FOUNDRY_ISOLATE=false forge clean"),
             None,
-            Some("forge clean"),
+            Some("FOUNDRY_ISOLATE=false forge clean"),
             verbose,
         )
     }
@@ -510,7 +517,7 @@ impl BenchmarkProject {
             version,
             &self.cmd(r#"FOUNDRY_ISOLATE=false forge test --match-test "test[^(]*\([^)]+\)""#),
             runs,
-            Some("forge build"),
+            Some("FOUNDRY_ISOLATE=false forge build"),
             None,
             None,
             verbose,
@@ -529,7 +536,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_coverage",
             version,
-            &self.cmd("forge coverage --ir-minimum"),
+            &self.cmd("FOUNDRY_ISOLATE=false forge coverage --ir-minimum"),
             runs,
             None,
             None,
@@ -549,9 +556,9 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_isolate_test",
             version,
-            &self.cmd("forge test --isolate"),
+            &self.cmd("FOUNDRY_ISOLATE=true forge test --isolate"),
             runs,
-            Some("forge build"),
+            Some("FOUNDRY_ISOLATE=true forge build"),
             None,
             None,
             verbose,


### PR DESCRIPTION
## Description

- Skips the known failing Spark invariant in coverage benchmarks to match the existing test benchmark exclusions.
- Temporarily pins benchmark isolate mode explicitly so only `forge_isolate_test` runs isolated and the other benchmarks run non-isolated (as isolate mode becomes default on v1.8.0)
- Temporarily disables symbolic benchmarks because the v1.7.1 baseline does not support native symbolic execution.

