### PR TITLE
fix(debugger): show command aliases in prompt help

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -620,23 +620,24 @@ impl TUIContext<'_> {
 
         let mut parts = input.split_whitespace();
         let command = parts.next().unwrap();
-        match command {
-            "pc" | "p" | "continue" | "cont" | "c" => {
-                let Some(pc) = parts.next() else {
-                    return self.set_error(command_usage(command, "<pc>"));
-                };
-                if parts.next().is_some() {
-                    return self.set_error(command_usage(command, "<pc>"));
-                }
-                self.goto_pc_from_input(pc);
+        if CONTINUE_COMMANDS.contains(&command) || PC_COMMANDS.contains(&command) {
+            let Some(pc) = parts.next() else {
+                return self.set_error(command_usage(command, "<pc>"));
+            };
+            if parts.next().is_some() {
+                return self.set_error(command_usage(command, "<pc>"));
             }
-            "mem" | "memory" => self.run_buffer_command(command, BufferKind::Memory, parts),
-            "calldata" | "cd" => self.run_buffer_command(command, BufferKind::Calldata, parts),
-            "returndata" | "ret" | "rd" => {
-                self.run_buffer_command(command, BufferKind::Returndata, parts);
-            }
-            "help" | "h" => self.set_info(command_help()),
-            _ => self.set_error(format!("Unknown command `{command}`; try `help`")),
+            self.goto_pc_from_input(pc);
+        } else if MEMORY_COMMANDS.contains(&command) {
+            self.run_buffer_command(command, BufferKind::Memory, parts);
+        } else if CALLDATA_COMMANDS.contains(&command) {
+            self.run_buffer_command(command, BufferKind::Calldata, parts);
+        } else if RETURNDATA_COMMANDS.contains(&command) {
+            self.run_buffer_command(command, BufferKind::Returndata, parts);
+        } else if HELP_COMMANDS.contains(&command) {
+            self.set_info(command_help());
+        } else {
+            self.set_error(format!("Unknown command `{command}`; try `help`"));
         }
     }
 
@@ -815,13 +816,30 @@ const fn buffer_name(buffer: &BufferKind) -> &'static str {
     }
 }
 
+const CONTINUE_COMMANDS: &[&str] = &["continue", "cont", "c"];
+const PC_COMMANDS: &[&str] = &["pc", "p"];
+const MEMORY_COMMANDS: &[&str] = &["mem", "memory"];
+const CALLDATA_COMMANDS: &[&str] = &["calldata", "cd"];
+const RETURNDATA_COMMANDS: &[&str] = &["returndata", "ret", "rd"];
+const HELP_COMMANDS: &[&str] = &["help", "h"];
+
 fn command_usage(command: &str, arg: &str) -> String {
     format!("Usage: :{command} {arg}")
 }
 
 fn command_help() -> String {
-    "Commands: :continue <pc>, :pc <pc>, :mem <offset>, :calldata <offset>, :returndata <offset>"
-        .to_string()
+    format!(
+        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>",
+        command_aliases(CONTINUE_COMMANDS),
+        command_aliases(PC_COMMANDS),
+        command_aliases(MEMORY_COMMANDS),
+        command_aliases(CALLDATA_COMMANDS),
+        command_aliases(RETURNDATA_COMMANDS)
+    )
+}
+
+fn command_aliases(commands: &[&str]) -> String {
+    commands.iter().map(|command| format!(":{command}")).collect::<Vec<_>>().join("/")
 }
 
 fn handle_prompt_input_key_event(
@@ -1640,7 +1658,16 @@ mod tests {
 
         tui.run_command_from_input("help");
         assert_eq!(tui.status.as_ref().unwrap().kind, StatusKind::Info);
-        assert!(tui.status.as_ref().unwrap().text.contains(":continue <pc>"));
+        let help = &tui.status.as_ref().unwrap().text;
+        for commands in [
+            CONTINUE_COMMANDS,
+            PC_COMMANDS,
+            MEMORY_COMMANDS,
+            CALLDATA_COMMANDS,
+            RETURNDATA_COMMANDS,
+        ] {
+            assert!(help.contains(&command_aliases(commands)));
+        }
 
         tui.run_command_from_input("mem");
         let status = tui.status.as_ref().unwrap();

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -1049,8 +1049,8 @@ const COMMAND_PROMPT_HINT: &str = "  Enter: run | Esc: cancel | help: command li
 fn command_prompt_line(input: &str, width: u16) -> Line<'static> {
     let width = width as usize;
     let fixed_width = 2;
-    let hint_width = COMMAND_PROMPT_HINT.chars().count();
-    let input_width = input.chars().count();
+    let hint_width = text_width(COMMAND_PROMPT_HINT);
+    let input_width = text_width(input);
     let include_hint = fixed_width + input_width + hint_width <= width;
     let input_width = if include_hint {
         width.saturating_sub(fixed_width + hint_width)
@@ -1069,9 +1069,13 @@ fn command_prompt_line(input: &str, width: u16) -> Line<'static> {
     Line::from(spans)
 }
 
+/// Returns the rendered display width of `text` in terminal cells.
+fn text_width(text: &str) -> usize {
+    Span::raw(text).width()
+}
+
 fn input_tail(input: &str, max_width: usize) -> String {
-    let len = input.chars().count();
-    if len <= max_width {
+    if text_width(input) <= max_width {
         return input.to_string();
     }
     if max_width == 0 {
@@ -1081,9 +1085,17 @@ fn input_tail(input: &str, max_width: usize) -> String {
         return "<".to_string();
     }
 
-    let mut tail = input.chars().rev().take(max_width - 1).collect::<Vec<_>>();
-    tail.reverse();
-    format!("<{}", tail.into_iter().collect::<String>())
+    // Reserve one cell for the leading `<` truncation indicator, then keep the widest
+    // suffix that fits in the remaining width.
+    let tail_width = max_width - 1;
+    let mut start = input.len();
+    for (idx, _) in input.char_indices().rev() {
+        if text_width(&input[idx..]) > tail_width {
+            break;
+        }
+        start = idx;
+    }
+    format!("<{}", &input[start..])
 }
 
 fn step_notice_title(line: &str) -> &'static str {
@@ -1517,6 +1529,16 @@ mod tests {
         assert!(line.width() <= 12);
         assert_eq!(text, ":<789abcdef█");
         assert!(!text.contains("Enter: run"));
+    }
+
+    #[test]
+    fn command_prompt_line_clips_wide_unicode_to_width() {
+        // Full-width characters render two cells each, so clipping must respect display
+        // width rather than character count.
+        let input = "界界界界界界界界";
+        let line = super::command_prompt_line(input, 8);
+
+        assert!(line.width() <= 8);
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -314,17 +314,9 @@ impl TUIContext<'_> {
             unreachable!()
         };
 
-        let prompt_line = Line::from(vec![
-            Span::styled(":", Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
-            Span::raw(input),
-            Span::styled("█", Style::new().fg(Color::Cyan)),
-            Span::styled(
-                "  Enter: run | Esc: cancel | help: command list",
-                Style::new().add_modifier(Modifier::DIM),
-            ),
-        ]);
+        let prompt_line = command_prompt_line(input, prompt.width.saturating_sub(2));
         let block = Block::default().title("Command").borders(Borders::ALL);
-        let paragraph = Paragraph::new(prompt_line).block(block).wrap(Wrap { trim: false });
+        let paragraph = Paragraph::new(prompt_line).block(block);
         f.render_widget(paragraph, prompt);
 
         if self.show_shortcuts {
@@ -1052,6 +1044,48 @@ fn shortcut_lines() -> Vec<Line<'static>> {
     ]
 }
 
+const COMMAND_PROMPT_HINT: &str = "  Enter: run | Esc: cancel | help: command list";
+
+fn command_prompt_line(input: &str, width: u16) -> Line<'static> {
+    let width = width as usize;
+    let fixed_width = 2;
+    let hint_width = COMMAND_PROMPT_HINT.chars().count();
+    let input_width = input.chars().count();
+    let include_hint = fixed_width + input_width + hint_width <= width;
+    let input_width = if include_hint {
+        width.saturating_sub(fixed_width + hint_width)
+    } else {
+        width.saturating_sub(fixed_width)
+    };
+
+    let mut spans = vec![
+        Span::styled(":", Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+        Span::raw(input_tail(input, input_width)),
+        Span::styled("█", Style::new().fg(Color::Cyan)),
+    ];
+    if include_hint {
+        spans.push(Span::styled(COMMAND_PROMPT_HINT, Style::new().add_modifier(Modifier::DIM)));
+    }
+    Line::from(spans)
+}
+
+fn input_tail(input: &str, max_width: usize) -> String {
+    let len = input.chars().count();
+    if len <= max_width {
+        return input.to_string();
+    }
+    if max_width == 0 {
+        return String::new();
+    }
+    if max_width == 1 {
+        return "<".to_string();
+    }
+
+    let mut tail = input.chars().rev().take(max_width - 1).collect::<Vec<_>>();
+    tail.reverse();
+    format!("<{}", tail.into_iter().collect::<String>())
+}
+
 fn step_notice_title(line: &str) -> &'static str {
     if line.starts_with(PRECOMPILE_NOTICE_PREFIX) { "precompile call" } else { "decoded step" }
 }
@@ -1472,6 +1506,17 @@ mod tests {
         assert!(screen.contains(":pc 0"));
         assert!(screen.contains("Enter: run"));
         assert!(screen.contains("[:] command"));
+    }
+
+    #[test]
+    fn command_prompt_line_clips_long_input_to_tail() {
+        let input = "continue 0123456789abcdef";
+        let line = super::command_prompt_line(input, 12);
+        let text = line_text(&line);
+
+        assert!(line.width() <= 12);
+        assert_eq!(text, ":<789abcdef█");
+        assert!(!text.contains("Enter: run"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

This follows up on #15485 by polishing the debugger command prompt after it landed.

The command aliases now live in shared groups used by both command dispatch and help rendering, so aliases like `:cont`, `:c`, `:p`, `:cd`, `:ret`, and `:rd` stay documented with the parser. Long prompt input now renders as a single-line tail view when space is tight, keeping the cursor visible instead of wrapping inside the prompt block.
