### PR TITLE
chore(deps): bump foundry core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5375,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=7610c7e6f88429caa400ec35606afd28270ecf9f#7610c7e6f88429caa400ec35606afd28270ecf9f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5406,7 +5406,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=7610c7e6f88429caa400ec35606afd28270ecf9f#7610c7e6f88429caa400ec35606afd28270ecf9f"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5415,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=7610c7e6f88429caa400ec35606afd28270ecf9f#7610c7e6f88429caa400ec35606afd28270ecf9f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5435,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=7610c7e6f88429caa400ec35606afd28270ecf9f#7610c7e6f88429caa400ec35606afd28270ecf9f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5448,7 +5448,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=7610c7e6f88429caa400ec35606afd28270ecf9f#7610c7e6f88429caa400ec35606afd28270ecf9f"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -5777,8 +5777,8 @@ dependencies = [
 
 [[package]]
 name = "foundry-fork-db"
-version = "0.26.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=ba6246789fc12cf8fe78aa74aadf31d663f08c1f#ba6246789fc12cf8fe78aa74aadf31d663f08c1f"
+version = "0.27.0"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=7610c7e6f88429caa400ec35606afd28270ecf9f#7610c7e6f88429caa400ec35606afd28270ecf9f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5884,7 +5884,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d79879c950c97737f80911e916bda3d7fd45fb13#d79879c950c97737f80911e916bda3d7fd45fb13"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=7610c7e6f88429caa400ec35606afd28270ecf9f#7610c7e6f88429caa400ec35606afd28270ecf9f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "d79879c950c97737f80911e916bda3d7fd45fb13", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "7610c7e6f88429caa400ec35606afd28270ecf9f", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -339,7 +339,7 @@ foundry-compilers = { version = "0.21.0", default-features = false, features = [
     "rustls",
     "svm-solc",
 ] }
-foundry-fork-db = { version = "0.26.0", features = ["zstd"] }
+foundry-fork-db = { version = "0.27.0", features = ["zstd"] }
 solar = { package = "solar-compiler", version = "=0.1.8", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
     "rustls",
@@ -534,7 +534,7 @@ idna_adapter = "=1.1.0"
 
 [patch.crates-io]
 ## Temporary dependency on foundry-rs/foundry-core#94 until foundry-compilers is released.
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "39f19b016c2ba793b24255bda83bd3822c8cb525" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "7610c7e6f88429caa400ec35606afd28270ecf9f" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
@@ -594,7 +594,7 @@ op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = 
 alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
 
 ## foundry-fork-db
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "ba6246789fc12cf8fe78aa74aadf31d663f08c1f" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "7610c7e6f88429caa400ec35606afd28270ecf9f" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
 tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "65185565b01bc9f406a06c522357954d75ce7cb7" }


### PR DESCRIPTION
Updates the foundry-core git dependencies to the latest main revision, 7610c7e6f88429caa400ec35606afd28270ecf9f. This covers foundry-compilers, foundry-fork-db, and foundry-wallets, and bumps the workspace foundry-fork-db requirement to 0.27.0 so the git patch resolves to the updated package.

Checked with `cargo check -p foundry-evm-core`.

AI assistance was used for this PR.

Prompted by: @DaniPopes
