### PR TITLE
perf(symbolic): centralize test matching

### DIFF
--- a/crates/common/src/traits.rs
+++ b/crates/common/src/traits.rs
@@ -19,15 +19,32 @@ pub trait TestFilter: Send + Sync {
     /// Returns whether the test should be included for the given contract.
     ///
     /// `contract_id` is the full artifact identifier (`path:Contract`).
-    fn matches_test_function_in_contract(&self, _contract_id: &str, func: &Function) -> bool {
-        func.is_any_test() && self.matches_test(&func.signature())
+    fn matches_test_function_kind_in_contract(
+        &self,
+        _contract_id: &str,
+        func: &Function,
+        kind: TestFunctionKind,
+    ) -> bool {
+        kind.is_any_test() && self.matches_test(&func.signature())
+    }
+
+    /// Returns whether the test should be included for the given contract.
+    ///
+    /// `contract_id` is the full artifact identifier (`path:Contract`).
+    fn matches_test_function_in_contract(&self, contract_id: &str, func: &Function) -> bool {
+        self.matches_test_function_kind_in_contract(contract_id, func, func.test_function_kind())
     }
 }
 
 impl<'a> dyn TestFilter + 'a {
+    /// Returns `true` if the function kind is runnable and matches the given filter.
+    pub fn matches_test_function_kind(&self, func: &Function, kind: TestFunctionKind) -> bool {
+        kind.is_any_test() && self.matches_test(&func.signature())
+    }
+
     /// Returns `true` if the function is a test function that matches the given filter.
     pub fn matches_test_function(&self, func: &Function) -> bool {
-        func.is_any_test() && self.matches_test(&func.signature())
+        self.matches_test_function_kind(func, func.test_function_kind())
     }
 }
 
@@ -52,7 +69,7 @@ impl TestFilter for EmptyTestFilter {
 pub trait TestFunctionExt {
     /// Returns the kind of test function.
     fn test_function_kind(&self) -> TestFunctionKind {
-        TestFunctionKind::classify(self.tfe_as_str(), self.tfe_has_inputs())
+        TestFunctionKind::classify(self.tfe_as_str(), self.tfe_has_inputs(), false)
     }
 
     /// Returns `true` if this function is a `setUp` function.
@@ -175,7 +192,7 @@ pub enum TestFunctionKind {
 
 impl TestFunctionKind {
     /// Classify a function.
-    pub fn classify(name: &str, has_inputs: bool) -> Self {
+    pub fn classify(name: &str, has_inputs: bool, symbolic_entrypoints: bool) -> Self {
         match () {
             _ if name.starts_with("test") => {
                 let should_fail = name.starts_with("testFail");
@@ -189,6 +206,11 @@ impl TestFunctionKind {
                 Self::InvariantTest
             }
             _ if name.starts_with("table") => Self::TableTest,
+            _ if symbolic_entrypoints
+                && (name.starts_with("check") || name.starts_with("prove")) =>
+            {
+                Self::SymbolicTest
+            }
             _ if name.eq_ignore_ascii_case("setup") && !has_inputs => Self::Setup,
             _ if name.eq_ignore_ascii_case("afterinvariant") => Self::AfterInvariant,
             _ if name.starts_with("fixture") => Self::Fixture,
@@ -318,10 +340,26 @@ mod tests {
     #[test]
     fn test_setup_classification() {
         // setUp() with no params should be classified as Setup
-        assert_eq!(TestFunctionKind::classify("setUp", false), TestFunctionKind::Setup);
+        assert_eq!(TestFunctionKind::classify("setUp", false, false), TestFunctionKind::Setup);
 
         // setUp(bytes memory) with params should NOT be classified as Setup
         // This is common in Gnosis Safe/Zodiac modules
-        assert_eq!(TestFunctionKind::classify("setUp", true), TestFunctionKind::Unknown);
+        assert_eq!(TestFunctionKind::classify("setUp", true, false), TestFunctionKind::Unknown);
+    }
+
+    #[test]
+    fn test_symbolic_classification() {
+        assert_eq!(
+            TestFunctionKind::classify("checkSymbolic", true, true),
+            TestFunctionKind::SymbolicTest
+        );
+        assert_eq!(
+            TestFunctionKind::classify("proveSymbolic", false, true),
+            TestFunctionKind::SymbolicTest
+        );
+        assert_eq!(
+            TestFunctionKind::classify("checkSymbolic", true, false),
+            TestFunctionKind::Unknown
+        );
     }
 }

--- a/crates/config/src/inline/mod.rs
+++ b/crates/config/src/inline/mod.rs
@@ -126,14 +126,36 @@ impl InlineConfig {
         contract: &str,
         function: &str,
     ) -> Option<NetworkVariant> {
-        let data = self.provide(contract, function).data().ok()?;
-        let dict = data.get(profile).or_else(|| data.get(&Profile::Default))?;
-        if let Some(Value::Dict(_, networks)) = dict.get("networks")
-            && let Some(Value::String(_, s)) = networks.get("network")
-        {
-            return s.parse().ok();
-        }
-        None
+        inline_value_for_profile(
+            profile,
+            &[self.get_function(contract, function), self.get_contract(contract)],
+            |dict| {
+                if let Some(Value::Dict(_, networks)) = dict.get("networks")
+                    && let Some(Value::String(_, s)) = networks.get("network")
+                {
+                    return s.parse().ok();
+                }
+                None
+            },
+        )
+    }
+
+    /// Returns whether contract-level inline config enables symbolic execution.
+    pub fn contract_symbolic_enabled(
+        &self,
+        profile: &Profile,
+        contract: &str,
+        default: bool,
+    ) -> bool {
+        inline_value_for_profile(profile, &[self.get_contract(contract)], |dict| {
+            if let Some(Value::Dict(_, symbolic)) = dict.get("symbolic")
+                && let Some(Value::Bool(_, enabled)) = symbolic.get("enabled")
+            {
+                return Some(*enabled);
+            }
+            None
+        })
+        .unwrap_or(default)
     }
 
     /// Returns all distinct [`NetworkVariant`]s referenced in any inline config annotation.
@@ -162,6 +184,26 @@ impl InlineConfig {
         let key = (contract.to_string(), function.to_string());
         self.fn_level.get(&key)
     }
+}
+
+fn inline_value_for_profile<T>(
+    profile: &Profile,
+    levels: &[Option<&DataMap>],
+    value_from_dict: impl Fn(&Dict) -> Option<T> + Copy,
+) -> Option<T> {
+    inline_value_for_exact_profile(profile, levels, value_from_dict).or_else(|| {
+        (profile != Profile::Default)
+            .then(|| inline_value_for_exact_profile(&Profile::Default, levels, value_from_dict))
+            .flatten()
+    })
+}
+
+fn inline_value_for_exact_profile<T>(
+    profile: &Profile,
+    levels: &[Option<&DataMap>],
+    value_from_dict: impl Fn(&Dict) -> Option<T> + Copy,
+) -> Option<T> {
+    levels.iter().find_map(|data| data.and_then(|data| data.get(profile)).and_then(value_from_dict))
 }
 
 fn parse_config_values<'a>(
@@ -322,5 +364,81 @@ forge-config: default.symbolic.default_dynamic_length = 4
 
         assert_eq!(config.symbolic.array_lengths, vec![3]);
         assert_eq!(config.symbolic.default_dynamic_length, 4);
+    }
+
+    #[test]
+    fn contract_symbolic_enabled_reads_contract_inline_config() {
+        let mut inline = InlineConfig::new();
+        inline
+            .insert(&NatSpec {
+                contract: "test/Symbolic.t.sol:Symbolic".to_string(),
+                function: None,
+                line: "10:5".to_string(),
+                docs: r#"
+forge-config: default.symbolic.enabled = true
+forge-config: ci.symbolic.enabled = false
+"#
+                .to_string(),
+            })
+            .unwrap();
+
+        assert!(inline.contract_symbolic_enabled(
+            &Profile::new("default"),
+            "test/Symbolic.t.sol:Symbolic",
+            false,
+        ));
+        assert!(!inline.contract_symbolic_enabled(
+            &Profile::new("ci"),
+            "test/Symbolic.t.sol:Symbolic",
+            true,
+        ));
+        assert!(inline.contract_symbolic_enabled(
+            &Profile::new("nightly"),
+            "test/Symbolic.t.sol:Symbolic",
+            false,
+        ));
+        assert!(!inline.contract_symbolic_enabled(
+            &Profile::new("default"),
+            "test/Other.t.sol:Other",
+            false,
+        ));
+    }
+
+    #[test]
+    fn network_for_preserves_profile_then_level_precedence() {
+        let mut inline = InlineConfig::new();
+        inline
+            .insert(&NatSpec {
+                contract: "test/Network.t.sol:Network".to_string(),
+                function: None,
+                line: "10:5".to_string(),
+                docs: r#"
+forge-config: default.networks.network = "optimism"
+forge-config: ci.networks.network = "tempo"
+"#
+                .to_string(),
+            })
+            .unwrap();
+        inline
+            .insert(&NatSpec {
+                contract: "test/Network.t.sol:Network".to_string(),
+                function: Some("testNetwork".to_string()),
+                line: "20:5".to_string(),
+                docs: r#"forge-config: default.networks.network = "ethereum""#.to_string(),
+            })
+            .unwrap();
+
+        assert_eq!(
+            inline.network_for(
+                &Profile::new("default"),
+                "test/Network.t.sol:Network",
+                "testNetwork"
+            ),
+            Some(NetworkVariant::Ethereum),
+        );
+        assert_eq!(
+            inline.network_for(&Profile::new("ci"), "test/Network.t.sol:Network", "testNetwork"),
+            Some(NetworkVariant::Tempo),
+        );
     }
 }

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -18,12 +18,17 @@ use foundry_compilers::{
     Artifact, ArtifactId, Project, ProjectCompileOutput, ProjectPathsConfig, VYPER_EXTENSIONS,
     artifacts::{CompactBytecode, CompactDeployedBytecode, sourcemap::SourceMap},
 };
-use foundry_config::{Config, CoverageConfig, CoverageReportKind, parse_lcov_version};
+use foundry_config::{
+    Config, CoverageConfig, CoverageReportKind, InlineConfig, parse_lcov_version,
+};
 use foundry_evm::{core::ic::IcPcMap, opts::EvmOpts};
 use globset::{Glob, GlobSetBuilder};
 use rayon::prelude::*;
 use semver::Version;
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::impl_figment_convert!(CoverageArgs, test);
@@ -311,6 +316,7 @@ impl CoverageArgs {
         evm_opts: EvmOpts,
     ) -> Result<()> {
         let filter = self.test.filter(&config)?;
+        let inline_config = Arc::new(InlineConfig::new_parsed(output, &config)?);
         let outcome = self
             .test
             .run_tests(
@@ -319,7 +325,7 @@ impl CoverageArgs {
                 evm_opts,
                 output,
                 &filter,
-                TestExecutionOptions::coverage(),
+                TestExecutionOptions::coverage(inline_config),
             )
             .await?;
 

--- a/crates/forge/src/cmd/test/filter.rs
+++ b/crates/forge/src/cmd/test/filter.rs
@@ -1,6 +1,6 @@
 use alloy_json_abi::Function;
 use clap::Parser;
-use foundry_common::{TestFilter, TestFunctionExt};
+use foundry_common::{TestFilter, TestFunctionKind};
 use foundry_compilers::{FileFilter, ProjectPathsConfig};
 use foundry_config::{Config, filter::GlobMatcher};
 use serde::{Deserialize, Serialize};
@@ -249,9 +249,14 @@ impl TestFilter for ProjectPathsAwareFilter {
         self.args_filter.matches_path(path) && !self.paths.has_library_ancestor(path)
     }
 
-    fn matches_test_function_in_contract(&self, contract_id: &str, func: &Function) -> bool {
+    fn matches_test_function_kind_in_contract(
+        &self,
+        contract_id: &str,
+        func: &Function,
+        kind: TestFunctionKind,
+    ) -> bool {
         if let Some(failures) = &self.rerun_failures {
-            if !func.is_any_test() || !self.args_filter.matches_test(&func.signature()) {
+            if !kind.is_any_test() || !self.args_filter.matches_test(&func.signature()) {
                 return false;
             }
             let signature = func.signature();
@@ -264,7 +269,7 @@ impl TestFilter for ProjectPathsAwareFilter {
             // TODO(@mablr): let exact bare-name fuzz filters such as `^testFoo$`
             // match `testFoo(uint256)` when running `forge fuzz`, while preserving signature
             // matching for overloaded tests.
-            func.is_any_test() && self.args_filter.matches_test(&func.signature())
+            kind.is_any_test() && self.args_filter.matches_test(&func.signature())
         }
     }
 }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -867,7 +867,7 @@ impl TestArgs {
     /// filter. We want to compile all non-test sources always because tests might depend on them
     /// dynamically through cheatcodes.
     #[instrument(target = "forge::test", skip_all)]
-    fn source_selection_for_filter(
+    fn get_sources_to_compile(
         &self,
         config: &Config,
         test_filter: &ProjectPathsAwareFilter,
@@ -1021,12 +1021,8 @@ impl TestArgs {
                 .compile(&project)
         };
 
-        let (files, inline_config) = self.source_selection_for_filter(
-            &config,
-            &filter,
-            None,
-            replay_symbolic_artifact.as_ref(),
-        )?;
+        let (files, inline_config) =
+            self.get_sources_to_compile(&config, &filter, None, replay_symbolic_artifact.as_ref())?;
         let output = compile(files)?;
         let inline_config = match inline_config {
             Some(inline_config) => inline_config,
@@ -1609,7 +1605,7 @@ impl TestArgs {
             apply_mutation_compiler_overrides(&mut config_for_mutation);
 
             let json_output = shell::is_json();
-            let (selected_sources, _) = self.source_selection_for_filter(
+            let (selected_sources, _) = self.get_sources_to_compile(
                 &config_for_mutation,
                 filter,
                 Some(execution.inline_config.clone()),

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     decode::decode_console_logs,
     gas_report::GasReport,
     multi_runner::{
-        MultiNetworkConfig, ShowmapConfig, SymbolicArtifactReplayConfig, matches_artifact,
+        MultiNetworkConfig, ShowmapConfig, SymbolicArtifactReplayConfig, TestFunctionMatcher,
     },
     mutation::{MutationRunConfig, run_mutation_testing},
     result::{
@@ -158,22 +158,48 @@ pub(crate) struct TestExecutionOptions {
     pub(crate) decode_internal: InternalTraceMode,
     pub(crate) multi_network: MultiNetworkConfig,
     pub(crate) replay_symbolic_artifact: Option<SymbolicArtifactReplayConfig>,
+    pub(crate) inline_config: Arc<InlineConfig>,
 }
 
 impl TestExecutionOptions {
-    pub(crate) fn default_run() -> Self {
+    pub(crate) fn default_run(inline_config: Arc<InlineConfig>) -> Self {
         Self {
             coverage: false,
             should_debug: false,
             decode_internal: InternalTraceMode::None,
             multi_network: MultiNetworkConfig::default(),
             replay_symbolic_artifact: None,
+            inline_config,
         }
     }
 
-    pub(crate) fn coverage() -> Self {
-        Self { coverage: true, ..Self::default_run() }
+    pub(crate) fn coverage(inline_config: Arc<InlineConfig>) -> Self {
+        Self { coverage: true, ..Self::default_run(inline_config) }
     }
+}
+
+fn sources_to_compile_from_artifacts(
+    config: &Config,
+    test_filter: &ProjectPathsAwareFilter,
+    artifacts: &ProjectCompileOutput,
+    test_matcher: &TestFunctionMatcher<'_>,
+) -> BTreeSet<PathBuf> {
+    // `MultiContractRunner::build` strips the root prefix from artifact source paths so the
+    // identifiers it constructs are project-relative. Match that here for the filter check
+    // (notably for the `--rerun` failure list, which is persisted relative) but return the
+    // original absolute source paths so downstream compilation can locate them.
+    artifacts
+        .artifact_ids()
+        .filter_map(|(id, artifact)| artifact.abi.as_ref().map(|abi| (id, abi)))
+        .filter(|(id, abi)| {
+            if id.source.starts_with(&config.src) {
+                return true;
+            }
+            let stripped = id.clone().with_stripped_file_prefixes(&config.root);
+            test_matcher.matches_contract(test_filter, &stripped, abi)
+        })
+        .map(|(id, _)| id.source)
+        .collect()
 }
 
 /// CLI arguments for `forge test`.
@@ -841,17 +867,22 @@ impl TestArgs {
     /// filter. We want to compile all non-test sources always because tests might depend on them
     /// dynamically through cheatcodes.
     #[instrument(target = "forge::test", skip_all)]
-    pub fn get_sources_to_compile(
+    fn source_selection_for_filter(
         &self,
         config: &Config,
         test_filter: &ProjectPathsAwareFilter,
-    ) -> Result<BTreeSet<PathBuf>> {
+        inline_config: Option<Arc<InlineConfig>>,
+        symbolic_artifact_replay: Option<&SymbolicArtifactReplayConfig>,
+    ) -> Result<(BTreeSet<PathBuf>, Option<Arc<InlineConfig>>)> {
         // An empty filter doesn't filter out anything.
         // We can still optimize slightly by excluding scripts.
         if test_filter.is_empty() {
-            return Ok(source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
-                .chain(source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS))
-                .collect());
+            return Ok((
+                source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
+                    .chain(source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS))
+                    .collect(),
+                None,
+            ));
         }
 
         let filter_args = test_filter.args();
@@ -860,12 +891,15 @@ impl TestArgs {
             || filter_args.contract_pattern.is_some()
             || filter_args.contract_pattern_inverse.is_some();
         if !has_contract_or_test_filter {
-            return Ok(source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
-                .chain(
-                    source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS)
-                        .filter(|path| test_filter.matches_path(path)),
-                )
-                .collect());
+            return Ok((
+                source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
+                    .chain(
+                        source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS)
+                            .filter(|path| test_filter.matches_path(path)),
+                    )
+                    .collect(),
+                None,
+            ));
         }
 
         let mut project = config.create_project(true, true)?;
@@ -878,30 +912,15 @@ impl TestArgs {
             eyre::bail!("Compilation failed");
         }
 
-        let symbolic_artifact_replay = self.load_symbolic_artifact_replay()?;
+        let inline_config = match inline_config {
+            Some(inline_config) => inline_config,
+            None => Arc::new(InlineConfig::new_parsed(&output, config)?),
+        };
+        let test_matcher =
+            TestFunctionMatcher::new(config, &inline_config, symbolic_artifact_replay);
+        let files = sources_to_compile_from_artifacts(config, test_filter, &output, &test_matcher);
 
-        // `MultiContractRunner::build` strips the root prefix from artifact source paths so the
-        // identifiers it constructs are project-relative. Match that here for the filter check
-        // (notably for the `--rerun` failure list, which is persisted relative) but return the
-        // original absolute source paths so downstream compilation can locate them.
-        Ok(output
-            .artifact_ids()
-            .filter_map(|(id, artifact)| artifact.abi.as_ref().map(|abi| (id, abi)))
-            .filter(|(id, abi)| {
-                if id.source.starts_with(&config.src) {
-                    return true;
-                }
-                let stripped = id.clone().with_stripped_file_prefixes(&config.root);
-                matches_artifact(
-                    test_filter,
-                    &stripped,
-                    abi,
-                    config.symbolic.enabled,
-                    symbolic_artifact_replay.as_ref(),
-                )
-            })
-            .map(|(id, _)| id.source)
-            .collect())
+        Ok((files, Some(inline_config)))
     }
 
     /// Executes all the tests in the project.
@@ -911,8 +930,15 @@ impl TestArgs {
     ///
     /// Returns the test results for all matching tests.
     pub async fn compile_and_run(&mut self) -> Result<TestOutcome> {
-        let (project_root, config, evm_opts, output, filter, replay_symbolic_artifact) =
-            self.compile_project().await?;
+        let (
+            project_root,
+            config,
+            evm_opts,
+            output,
+            filter,
+            inline_config,
+            replay_symbolic_artifact,
+        ) = self.compile_project().await?;
         self.run_tests(
             &project_root,
             config,
@@ -921,7 +947,7 @@ impl TestArgs {
             &filter,
             TestExecutionOptions {
                 replay_symbolic_artifact,
-                ..TestExecutionOptions::default_run()
+                ..TestExecutionOptions::default_run(inline_config)
             },
         )
         .await
@@ -935,6 +961,7 @@ impl TestArgs {
         EvmOpts,
         ProjectCompileOutput,
         ProjectPathsAwareFilter,
+        Arc<InlineConfig>,
         Option<SymbolicArtifactReplayConfig>,
     )> {
         // Merge all configs.
@@ -984,13 +1011,37 @@ impl TestArgs {
         }
         trace!(target: "forge::test", ?filter, "using filter");
 
-        let compiler = ProjectCompiler::new()
-            .dynamic_test_linking(config.dynamic_test_linking)
-            .quiet(shell::is_json() || self.junit)
-            .files(self.get_sources_to_compile(&config, &filter)?);
-        let output = compiler.compile(&project)?;
+        let dynamic_test_linking = config.dynamic_test_linking;
+        let quiet = shell::is_json() || self.junit;
+        let compile = |files| {
+            ProjectCompiler::new()
+                .dynamic_test_linking(dynamic_test_linking)
+                .quiet(quiet)
+                .files(files)
+                .compile(&project)
+        };
 
-        Ok((project_root, config, evm_opts, output, filter, replay_symbolic_artifact))
+        let (files, inline_config) = self.source_selection_for_filter(
+            &config,
+            &filter,
+            None,
+            replay_symbolic_artifact.as_ref(),
+        )?;
+        let output = compile(files)?;
+        let inline_config = match inline_config {
+            Some(inline_config) => inline_config,
+            None => Arc::new(InlineConfig::new_parsed(&output, &config)?),
+        };
+
+        Ok((
+            project_root,
+            config,
+            evm_opts,
+            output,
+            filter,
+            inline_config,
+            replay_symbolic_artifact,
+        ))
     }
 
     /// Executes all the tests in the project.
@@ -1105,9 +1156,9 @@ impl TestArgs {
         let config_for_mutation = config.clone();
         let evm_opts_for_mutation = evm_opts.clone();
 
-        // Parse inline config early to detect per-test network annotations.
-        let inline_config = InlineConfig::new_parsed(output, &config)?;
-        let override_networks = inline_config.referenced_override_networks(&config.profile);
+        // Detect per-test network annotations.
+        let override_networks =
+            execution.inline_config.referenced_override_networks(&config.profile);
 
         let (libraries, mut outcome) = if override_networks.is_empty() {
             // Single-pass: no per-test network overrides, use global network setting.
@@ -1558,8 +1609,13 @@ impl TestArgs {
             apply_mutation_compiler_overrides(&mut config_for_mutation);
 
             let json_output = shell::is_json();
-            let selected_sources_relative = self
-                .get_sources_to_compile(&config_for_mutation, filter)?
+            let (selected_sources, _) = self.source_selection_for_filter(
+                &config_for_mutation,
+                filter,
+                Some(execution.inline_config.clone()),
+                execution.replay_symbolic_artifact.as_ref(),
+            )?;
+            let selected_sources_relative = selected_sources
                 .into_iter()
                 .filter_map(|path| {
                     path.strip_prefix(&config_for_mutation.root).ok().map(PathBuf::from)
@@ -1627,7 +1683,7 @@ impl TestArgs {
 
         let config = Arc::new(config);
         let showmap = self.showmap_config()?;
-        let runner = MultiContractRunnerBuilder::new(config.clone())
+        let runner = MultiContractRunnerBuilder::new(config.clone(), execution.inline_config)
             .set_debug(execution.should_debug)
             .set_decode_internal(execution.decode_internal)
             .set_record_all_steps(self.evm_profile.is_some())

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -6,7 +6,7 @@ use crate::{
     result::{SuiteResult, SymbolicCounterexampleArtifact, SymbolicCounterexampleArtifactKind},
     runner::{
         ContractRunnerContext, InvariantCampaignScope, LIBRARY_DEPLOYER,
-        count_runnable_invariant_campaign_anchors, is_symbolic_entrypoint,
+        count_runnable_invariant_campaign_anchors,
     },
 };
 use alloy_json_abi::{Function, JsonAbi};
@@ -14,7 +14,8 @@ use alloy_primitives::{Address, Bytes, U256};
 use eyre::Result;
 use foundry_cli::opts::configure_pcx_from_compile_output;
 use foundry_common::{
-    ContractsByArtifact, ContractsByArtifactBuilder, TestFunctionExt, get_contract_name,
+    ContractsByArtifact, ContractsByArtifactBuilder, EmptyTestFilter, TestFunctionKind,
+    get_contract_name,
 };
 use foundry_compilers::{
     Artifact, ArtifactId, Compiler, ProjectCompileOutput,
@@ -99,34 +100,10 @@ impl<FEN: FoundryEvmNetwork> DerefMut for MultiContractRunner<FEN> {
 }
 
 impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
-    fn matches_test_function(
-        &self,
-        filter: &dyn TestFilter,
-        contract_id: &str,
-        func: &Function,
-    ) -> bool {
-        matches_test_function(
-            filter,
-            contract_id,
-            func,
-            symbolic_entrypoints_enabled(
-                self.contract_symbolic_enabled(contract_id),
-                self.tcfg.symbolic_artifact_replay.as_ref(),
-            ),
-        )
-    }
-
-    fn contract_symbolic_enabled(&self, contract_id: &str) -> bool {
-        contract_symbolic_enabled(&self.config, &self.inline_config, contract_id)
-    }
-
-    fn matches_artifact(&self, filter: &dyn TestFilter, id: &ArtifactId, abi: &JsonAbi) -> bool {
-        let identifier = id.identifier();
-        matches_artifact(
-            filter,
-            id,
-            abi,
-            self.contract_symbolic_enabled(&identifier),
+    fn test_function_matcher(&self) -> TestFunctionMatcher<'_> {
+        TestFunctionMatcher::new(
+            &self.config,
+            &self.inline_config,
             self.tcfg.symbolic_artifact_replay.as_ref(),
         )
     }
@@ -136,7 +113,8 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         &'a self,
         filter: &'b dyn TestFilter,
     ) -> impl Iterator<Item = (&'a ArtifactId, &'a TestContract)> + 'b {
-        self.contracts.iter().filter(|&(id, c)| self.matches_artifact(filter, id, &c.abi))
+        let matcher = self.test_function_matcher();
+        self.contracts.iter().filter(move |&(id, c)| matcher.matches_contract(filter, id, &c.abi))
     }
 
     /// Returns an iterator over all test functions that match the filter.
@@ -144,11 +122,12 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         &'a self,
         filter: &'b dyn TestFilter,
     ) -> impl Iterator<Item = &'a Function> + 'b {
+        let matcher = self.test_function_matcher();
         self.matching_contracts(filter).flat_map(move |(id, c)| {
             let identifier = id.identifier();
             c.abi
                 .functions()
-                .filter(move |func| self.matches_test_function(filter, &identifier, func))
+                .filter(move |func| matcher.matches_test_function(filter, &identifier, func))
         })
     }
 
@@ -157,24 +136,23 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         &'a self,
         filter: &'b dyn TestFilter,
     ) -> impl Iterator<Item = &'a Function> + 'b {
+        let matcher = self.test_function_matcher();
         self.contracts
             .iter()
             .filter(|(id, _)| filter.matches_path(&id.source) && filter.matches_contract(&id.name))
             .flat_map(move |(id, c)| {
-                let symbolic_enabled = symbolic_entrypoints_enabled(
-                    self.contract_symbolic_enabled(&id.identifier()),
-                    self.tcfg.symbolic_artifact_replay.as_ref(),
-                );
-                c.abi.functions().filter(move |func| {
-                    func.is_any_test() || (symbolic_enabled && is_symbolic_entrypoint(func))
-                })
+                let identifier = id.identifier();
+                c.abi
+                    .functions()
+                    .filter(move |func| matcher.test_function_kind(&identifier, func).is_any_test())
             })
     }
 
     /// Returns all matching tests grouped by contract grouped by file (file -> (contract -> tests))
     pub fn list(&self, filter: &dyn TestFilter) -> BTreeMap<String, BTreeMap<String, Vec<String>>> {
+        let matcher = self.test_function_matcher();
         self.matching_contracts(filter)
-            .map(|(id, c)| {
+            .map(move |(id, c)| {
                 let source = id.source.as_path().display().to_string();
                 let name = id.name.clone();
                 let identifier = id.identifier();
@@ -183,7 +161,7 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
                     .functions()
                     // TODO(@mablr): in fuzz-only mode, make `--list` mirror execution
                     // by hiding unit/table/symbolic tests that `forge fuzz run/replay` skips.
-                    .filter(|func| self.matches_test_function(filter, &identifier, func))
+                    .filter(|func| matcher.matches_test_function(filter, &identifier, func))
                     .map(|func| func.name.clone())
                     .collect::<Vec<_>>();
                 (source, name, tests)
@@ -558,6 +536,8 @@ pub struct MultiContractRunnerBuilder {
     pub fork: Option<CreateFork>,
     /// Project config.
     pub config: Arc<Config>,
+    /// Parsed inline configuration.
+    pub inline_config: Arc<InlineConfig>,
     /// Whether or not to collect line coverage info
     pub line_coverage: bool,
     /// Whether or not to collect debug info
@@ -583,9 +563,10 @@ pub struct MultiContractRunnerBuilder {
 }
 
 impl MultiContractRunnerBuilder {
-    pub fn new(config: Arc<Config>) -> Self {
+    pub fn new(config: Arc<Config>, inline_config: Arc<InlineConfig>) -> Self {
         Self {
             config,
+            inline_config,
             sender: Default::default(),
             initial_balance: Default::default(),
             fork: Default::default(),
@@ -707,25 +688,23 @@ impl MultiContractRunnerBuilder {
         )?;
 
         let linked_contracts = linker.get_linked_artifacts_cow(&libraries)?;
-        let inline_config = Arc::new(InlineConfig::new_parsed(output, &self.config)?);
+        let inline_config = self.inline_config;
 
         // Create a mapping of name => (abi, deployment code, Vec<library deployment code>)
         let mut deployable_contracts = DeployableContracts::default();
+        let test_matcher = TestFunctionMatcher::new(
+            &self.config,
+            &inline_config,
+            self.symbolic_artifact_replay.as_ref(),
+        );
+        let empty_filter = EmptyTestFilter::default();
 
         for (id, contract) in linked_contracts.iter() {
             let Some(abi) = contract.abi.as_ref() else { continue };
-            let symbolic_enabled =
-                contract_symbolic_enabled(&self.config, &inline_config, &id.identifier());
 
             // if it's a test, link it and add to deployable contracts
             if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true)
-                && abi.functions().any(|func| {
-                    func.name.is_any_test()
-                        || symbolic_entrypoints_enabled(
-                            symbolic_enabled,
-                            self.symbolic_artifact_replay.as_ref(),
-                        ) && is_symbolic_entrypoint(func)
-                })
+                && test_matcher.matches_contract(&empty_filter, id, abi.borrow())
             {
                 linker.ensure_linked(contract, id)?;
 
@@ -828,42 +807,68 @@ impl MultiContractRunnerBuilder {
     }
 }
 
-pub fn matches_artifact(
-    filter: &dyn TestFilter,
-    id: &ArtifactId,
-    abi: &JsonAbi,
-    symbolic_enabled: bool,
-    symbolic_artifact_replay: Option<&SymbolicArtifactReplayConfig>,
-) -> bool {
-    matches_contract(
-        filter,
-        &id.source,
-        &id.name,
-        &id.identifier(),
-        abi.functions(),
-        symbolic_entrypoints_enabled(symbolic_enabled, symbolic_artifact_replay),
-    )
+#[derive(Clone, Copy)]
+pub(crate) struct TestFunctionMatcher<'a> {
+    config: &'a Config,
+    inline_config: &'a InlineConfig,
+    symbolic_artifact_replay: Option<&'a SymbolicArtifactReplayConfig>,
 }
 
-pub fn symbolic_entrypoints_enabled(
-    symbolic_enabled: bool,
-    symbolic_artifact_replay: Option<&SymbolicArtifactReplayConfig>,
-) -> bool {
-    symbolic_enabled
-        || symbolic_artifact_replay.is_some_and(|artifact| {
+impl<'a> TestFunctionMatcher<'a> {
+    pub(crate) const fn new(
+        config: &'a Config,
+        inline_config: &'a InlineConfig,
+        symbolic_artifact_replay: Option<&'a SymbolicArtifactReplayConfig>,
+    ) -> Self {
+        Self { config, inline_config, symbolic_artifact_replay }
+    }
+
+    fn symbolic_tests_enabled(&self, contract_id: &str) -> bool {
+        self.symbolic_artifact_replay.is_some_and(|artifact| {
             artifact.artifact.kind == SymbolicCounterexampleArtifactKind::SingleCall
-        })
-}
+        }) || self.inline_config.contract_symbolic_enabled(
+            &self.config.profile,
+            contract_id,
+            self.config.symbolic.enabled,
+        )
+    }
 
-fn contract_symbolic_enabled(
-    config: &Config,
-    inline_config: &InlineConfig,
-    contract_id: &str,
-) -> bool {
-    config
-        .merge_inline_provider(inline_config.provide(contract_id, ""))
-        .map(|config| config.symbolic.enabled)
-        .unwrap_or(config.symbolic.enabled)
+    pub(crate) fn test_function_kind(
+        &self,
+        contract_id: &str,
+        func: &Function,
+    ) -> TestFunctionKind {
+        TestFunctionKind::classify(
+            func.name.as_str(),
+            !func.inputs.is_empty(),
+            self.symbolic_tests_enabled(contract_id),
+        )
+    }
+
+    pub(crate) fn matches_test_function(
+        &self,
+        filter: &dyn TestFilter,
+        contract_id: &str,
+        func: &Function,
+    ) -> bool {
+        filter.matches_test_function_kind_in_contract(
+            contract_id,
+            func,
+            self.test_function_kind(contract_id, func),
+        )
+    }
+
+    pub(crate) fn matches_contract(
+        &self,
+        filter: &dyn TestFilter,
+        id: &ArtifactId,
+        abi: &JsonAbi,
+    ) -> bool {
+        let identifier = id.identifier();
+        matches_contract(filter, &id.source, &id.name, &identifier, abi.functions(), |func| {
+            self.test_function_kind(&identifier, func)
+        })
+    }
 }
 
 pub(crate) fn matches_contract(
@@ -872,39 +877,35 @@ pub(crate) fn matches_contract(
     contract_name: &str,
     contract_id: &str,
     functions: impl IntoIterator<Item = impl std::borrow::Borrow<Function>>,
-    symbolic_enabled: bool,
+    test_function_kind: impl Fn(&Function) -> TestFunctionKind,
 ) -> bool {
     (filter.matches_path(path) && filter.matches_contract(contract_name))
-        && functions
-            .into_iter()
-            .any(|func| matches_test_function(filter, contract_id, func.borrow(), symbolic_enabled))
-}
-
-fn matches_test_function(
-    filter: &dyn TestFilter,
-    contract_id: &str,
-    func: &Function,
-    symbolic_enabled: bool,
-) -> bool {
-    if symbolic_enabled && is_symbolic_entrypoint(func) {
-        filter.matches_test(&func.signature())
-    } else {
-        filter.matches_test_function_in_contract(contract_id, func)
-    }
+        && functions.into_iter().any(|func| {
+            let func = func.borrow();
+            filter.matches_test_function_kind_in_contract(
+                contract_id,
+                func,
+                test_function_kind(func),
+            )
+        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use foundry_common::EmptyTestFilter;
+    use foundry_common::TestFunctionExt;
 
     #[test]
-    fn matches_contract_includes_symbolic_entrypoints_when_enabled() {
+    fn matches_contract_uses_provided_function_kind() {
         let filter = EmptyTestFilter::default();
         let path = Path::new("test/Symbolic.t.sol");
         let func = Function::parse("checkFilteredCompile(uint256)").unwrap();
 
-        assert!(matches_contract(&filter, path, "Symbolic", "Symbolic", [func.clone()], true));
-        assert!(!matches_contract(&filter, path, "Symbolic", "Symbolic", [func], false));
+        assert!(matches_contract(&filter, path, "Symbolic", "Symbolic", [func.clone()], |_| {
+            TestFunctionKind::SymbolicTest
+        },));
+        assert!(!matches_contract(&filter, path, "Symbolic", "Symbolic", [func], |func| {
+            func.test_function_kind()
+        }));
     }
 }

--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -20,7 +20,7 @@ use std::{
 use eyre::Result;
 use foundry_common::{compile::ProjectCompiler, sh_eprintln, sh_println};
 use foundry_compilers::compilers::multi::MultiCompiler;
-use foundry_config::Config;
+use foundry_config::{Config, InlineConfig};
 #[cfg(feature = "optimism")]
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
@@ -677,6 +677,7 @@ fn compile_and_test_inner<FEN: FoundryEvmNetwork>(
         .files(files);
 
     let compile_output = compiler.compile(&config.project()?)?;
+    let inline_config = Arc::new(InlineConfig::new_parsed(&compile_output, config)?);
 
     // Rebuild the per-mutant test filter so `--match-test`, `--match-contract`,
     // `--match-path`, ... are honored against the temp workspace's paths
@@ -701,7 +702,7 @@ fn compile_and_test_inner<FEN: FoundryEvmNetwork>(
         // isolation flag, same fail-fast semantics for mutation, and same
         // filter so kept/skipped tests stay consistent across baseline and
         // mutant runs.
-        let mut runner = MultiContractRunnerBuilder::new(config.clone())
+        let mut runner = MultiContractRunnerBuilder::new(config.clone(), inline_config)
             .set_debug(false)
             .initial_balance(evm_opts.initial_balance)
             .sender(evm_opts.sender)

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -4,7 +4,7 @@ use crate::{
     MultiContractRunner, TestFilter,
     coverage::HitMaps,
     fuzz::{BaseCounterExample, FuzzTestResult},
-    multi_runner::{TestContract, TestRunnerConfig, symbolic_entrypoints_enabled},
+    multi_runner::{TestContract, TestFunctionMatcher, TestRunnerConfig},
     progress::{TestsProgress, start_fuzz_progress},
     result::{
         InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicArtifactRef,
@@ -79,10 +79,6 @@ use tracing::Span;
 ///
 /// `address(uint160(uint256(keccak256("foundry library deployer"))))`
 pub const LIBRARY_DEPLOYER: Address = address!("0x1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
-
-pub(crate) fn is_symbolic_entrypoint(func: &Function) -> bool {
-    func.name.starts_with("check") || func.name.starts_with("prove")
-}
 
 fn should_symbolically_seed_fuzz_corpus(config: &Config, func: &Function) -> bool {
     config.symbolic.seed_corpus && func.test_function_kind().is_fuzz_test()
@@ -837,8 +833,9 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         // Filter out functions sequentially since it's very fast and there is no need to do it
         // in parallel.
         let find_timer = Instant::now();
-        let symbolic_enabled = symbolic_entrypoints_enabled(
-            self.config.symbolic.enabled,
+        let test_matcher = TestFunctionMatcher::new(
+            &self.config,
+            &self.mcr.inline_config,
             self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
         );
         let functions = self
@@ -846,11 +843,11 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             .abi
             .functions()
             .filter(|func| {
-                if symbolic_enabled && is_symbolic_entrypoint(func) {
-                    filter.matches_test(&func.signature())
-                } else {
-                    filter.matches_test_function_in_contract(self.name, func)
-                }
+                filter.matches_test_function_kind_in_contract(
+                    self.name,
+                    func,
+                    test_matcher.test_function_kind(self.name, func),
+                )
             })
             .filter(|func| self.function_matches_network_pass(func))
             .collect::<Vec<_>>();
@@ -1024,11 +1021,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 }
 
                 let sig = func.signature();
-                let kind = if symbolic_enabled && is_symbolic_entrypoint(func) {
-                    TestFunctionKind::SymbolicTest
-                } else {
-                    func.test_function_kind()
-                };
+                let kind = test_matcher.test_function_kind(self.name, func);
 
                 let _guard = debug_span!(
                     "test",


### PR DESCRIPTION
Centralizes symbolic test matching so `check*` and `prove*` classification is handled by `TestFunctionKind` and `TestFunctionMatcher` instead of local special cases. Inline config is parsed once during test setup and passed into coverage, mutation, and runner construction, with direct lookup helpers for contract-level symbolic and network overrides.

This improves the matching path by avoiding repeated inline config parsing and by reading the few needed inline values directly from the parsed data instead of round-tripping through Figment serde just to inspect symbolic and network settings. It keeps source filtering, test listing, runner build, and execution on the same function-kind path while preserving default-profile fallback behavior.

Prepared with AI assistance.


Before:
<img width="358" height="223" alt="image" src="https://github.com/user-attachments/assets/e4a81c63-4758-46ec-a6c8-f34a8ce3b654" />

After:
<img width="329" height="151" alt="image" src="https://github.com/user-attachments/assets/457c632d-0928-4059-8689-f0ba16aa88fe" />

