### PR TITLE
feat(config): support solc --via-ssa-cfg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5375,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5385,7 +5385,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "path-slash",
  "rand 0.9.4",
  "rayon",
@@ -5406,7 +5406,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5415,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5435,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5448,7 +5448,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=39f19b016c2ba793b24255bda83bd3822c8cb525#39f19b016c2ba793b24255bda83bd3822c8cb525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
 dependencies = [
  "alloy-primitives",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5400,7 +5400,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "path-slash",
  "rand 0.9.4",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -533,8 +533,8 @@ snapbox = { version = "1.2", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-## Temporary dependency on foundry-rs/foundry-core#94 until foundry-compilers is released.
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "39f19b016c2ba793b24255bda83bd3822c8cb525" }
+## Temporary dependency on foundry-rs/foundry-core#104 until foundry-compilers is released.
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "3e01874cb1e7f43d2554dc05fb1823687bdc3ab8" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/crates/cli/src/opts/build/core.rs
+++ b/crates/cli/src/opts/build/core.rs
@@ -284,6 +284,10 @@ impl Provider for BuildOpts {
             dict.insert("experimental".to_string(), true.into());
         }
 
+        if self.compiler.via_ssa_cfg {
+            dict.insert("via_ssa_cfg".to_string(), true.into());
+        }
+
         if let Some(optimize) = self.compiler.optimize {
             dict.insert("optimizer".to_string(), optimize.into());
         }

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -43,7 +43,8 @@ pub struct CompilerOpts {
 
     /// Turn on SSA CFG-based code generation via the IR (experimental).
     ///
-    /// This passes `--via-ssa-cfg` to solc. Implies `--via-ir`. This is false by default.
+    /// This passes `--via-ssa-cfg` to solc. Implies `--via-ir`. Requires `--experimental` to be
+    /// set (as of Solidity 0.8.35+). This is false by default.
     #[arg(long, help_heading = "Compiler options")]
     #[serde(skip)]
     pub via_ssa_cfg: bool,

--- a/crates/cli/src/opts/build/mod.rs
+++ b/crates/cli/src/opts/build/mod.rs
@@ -41,6 +41,13 @@ pub struct CompilerOpts {
     #[serde(skip)]
     pub experimental: bool,
 
+    /// Turn on SSA CFG-based code generation via the IR (experimental).
+    ///
+    /// This passes `--via-ssa-cfg` to solc. Implies `--via-ir`. This is false by default.
+    #[arg(long, help_heading = "Compiler options")]
+    #[serde(skip)]
+    pub via_ssa_cfg: bool,
+
     /// The number of runs specifies roughly how often each opcode of the deployed code will be
     /// executed across the life-time of the contract. This means it is a trade-off parameter
     /// between code size (deploy cost) and code execution cost (cost after deployment).
@@ -92,6 +99,12 @@ mod tests {
     fn can_parse_experimental() {
         let args: CompilerOpts = CompilerOpts::parse_from(["foundry-cli", "--experimental"]);
         assert!(args.experimental);
+    }
+
+    #[test]
+    fn can_parse_via_ssa_cfg() {
+        let args: CompilerOpts = CompilerOpts::parse_from(["foundry-cli", "--via-ssa-cfg"]);
+        assert!(args.via_ssa_cfg);
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1890,7 +1890,8 @@ impl Config {
                 debug_info: Vec::new(),
             }),
             model_checker,
-            // via_ssa_cfg implies via_ir only when via_ir is omitted, so we need to set both flags to true if via_ssa_cfg is enabled.
+            // via_ssa_cfg implies via_ir only when via_ir is omitted, so we need to set both flags
+            // to true if via_ssa_cfg is enabled.
             via_ir: Some(self.via_ir || self.via_ssa_cfg),
             via_ssa_cfg: Some(self.via_ssa_cfg),
             experimental: Some(self.experimental),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -478,15 +478,15 @@ pub struct Config {
     /// If set to true, changes compilation pipeline to go through the Yul intermediate
     /// representation.
     pub via_ir: bool,
+    /// Whether to turn on SSA CFG-based code generation via the IR.
+    /// This is an experimental feature (as of 0.8.35) that requires `experimental` to be enabled.
+    /// Enabling this option will also enable `via_ir` if it is not already enabled.
+    pub via_ssa_cfg: bool,
     /// Whether to enable Solidity's experimental mode.
     ///
     /// This passes `--experimental` to solc, which is required by Solidity 0.8.35+ for
     /// experimental features.
     pub experimental: bool,
-    /// Whether to turn on SSA CFG-based code generation via the IR (experimental).
-    ///
-    /// This passes `--via-ssa-cfg` to solc. Implies `via_ir`. This is false by default.
-    pub via_ssa_cfg: bool,
     /// Whether to include the AST as JSON in the compiler output.
     pub ast: bool,
     /// RPC storage caching settings determines what chains and endpoints to cache
@@ -1890,9 +1890,10 @@ impl Config {
                 debug_info: Vec::new(),
             }),
             model_checker,
-            via_ir: Some(self.via_ir),
-            experimental: Some(self.experimental),
+            // via_ssa_cfg implies via_ir only when via_ir is omitted, so we need to set both flags to true if via_ssa_cfg is enabled.
+            via_ir: Some(self.via_ir || self.via_ssa_cfg),
             via_ssa_cfg: Some(self.via_ssa_cfg),
+            experimental: Some(self.experimental),
             // Not used.
             stop_after: None,
             // Set in project paths.
@@ -2818,8 +2819,8 @@ impl Default for Config {
             deny: DenyLevel::Never,
             deny_warnings: false,
             via_ir: false,
-            experimental: false,
             via_ssa_cfg: false,
+            experimental: false,
             ast: false,
             rpc_storage_caching: Default::default(),
             rpc_endpoints: Default::default(),

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -483,6 +483,10 @@ pub struct Config {
     /// This passes `--experimental` to solc, which is required by Solidity 0.8.35+ for
     /// experimental features.
     pub experimental: bool,
+    /// Whether to turn on SSA CFG-based code generation via the IR (experimental).
+    ///
+    /// This passes `--via-ssa-cfg` to solc. Implies `via_ir`. This is false by default.
+    pub via_ssa_cfg: bool,
     /// Whether to include the AST as JSON in the compiler output.
     pub ast: bool,
     /// RPC storage caching settings determines what chains and endpoints to cache
@@ -1888,6 +1892,7 @@ impl Config {
             model_checker,
             via_ir: Some(self.via_ir),
             experimental: Some(self.experimental),
+            via_ssa_cfg: Some(self.via_ssa_cfg),
             // Not used.
             stop_after: None,
             // Set in project paths.
@@ -2810,6 +2815,7 @@ impl Default for Config {
             deny_warnings: false,
             via_ir: false,
             experimental: false,
+            via_ssa_cfg: false,
             ast: false,
             rpc_storage_caching: Default::default(),
             rpc_endpoints: Default::default(),
@@ -5307,6 +5313,23 @@ mod tests {
         let settings = config.solc_settings().unwrap();
         assert_eq!(settings.settings.experimental, Some(false));
         assert_eq!(settings.cli_settings.extra_args, vec!["--experimental".to_string()]);
+    }
+
+    #[test]
+    fn solc_settings_include_via_ssa_cfg_setting() {
+        let config = Config { via_ssa_cfg: true, ..Config::default() };
+        let settings = config.solc_settings().unwrap();
+        assert_eq!(settings.settings.via_ssa_cfg, Some(true));
+        assert!(settings.cli_settings.extra_args.is_empty());
+
+        let config = Config {
+            via_ssa_cfg: false,
+            extra_args: vec!["--via-ssa-cfg".to_string()],
+            ..Config::default()
+        };
+        let settings = config.solc_settings().unwrap();
+        assert_eq!(settings.settings.via_ssa_cfg, Some(false));
+        assert_eq!(settings.cli_settings.extra_args, vec!["--via-ssa-cfg".to_string()]);
     }
 
     #[test]

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -4160,8 +4160,8 @@ forgetest_init!(can_inspect_standard_json, |prj, cmd| {
     },
     "evmVersion": "osaka",
     "viaIR": false,
-    "experimental": false,
     "viaSSACFG": false,
+    "experimental": false,
     "libraries": {}
   }
 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -4161,6 +4161,7 @@ forgetest_init!(can_inspect_standard_json, |prj, cmd| {
     "evmVersion": "osaka",
     "viaIR": false,
     "experimental": false,
+    "viaSSACFG": false,
     "libraries": {}
   }
 }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -99,6 +99,7 @@ names = false
 sizes = false
 via_ir = false
 experimental = false
+via_ssa_cfg = false
 ast = false
 no_storage_caching = false
 no_rpc_rate_limit = false
@@ -474,6 +475,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
         legacy_assertions: false,
         extra_args: vec![],
         experimental: false,
+        via_ssa_cfg: false,
         networks: Default::default(),
         transaction_timeout: 120,
         additional_compiler_profiles: Default::default(),
@@ -699,9 +701,11 @@ forgetest_init!(eth_rpc_url_env_does_not_set_fork_url, |prj, _cmd| {
 // checks that we can set various config values
 forgetest_init!(can_set_config_values, |prj, _cmd| {
     prj.initialize_default_contracts();
-    let config = prj.config_from_output(["--via-ir", "--experimental", "--no-metadata"]);
+    let config =
+        prj.config_from_output(["--via-ir", "--experimental", "--via-ssa-cfg", "--no-metadata"]);
     assert!(config.via_ir);
     assert!(config.experimental);
+    assert!(config.via_ssa_cfg);
     assert_eq!(config.cbor_metadata, false);
     assert_eq!(config.bytecode_hash, BytecodeHash::None);
 });
@@ -1588,6 +1592,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "sizes": false,
   "via_ir": false,
   "experimental": false,
+  "via_ssa_cfg": false,
   "ast": false,
   "rpc_storage_caching": {
     "chains": "all",

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -98,8 +98,8 @@ extra_output_files = []
 names = false
 sizes = false
 via_ir = false
-experimental = false
 via_ssa_cfg = false
+experimental = false
 ast = false
 no_storage_caching = false
 no_rpc_rate_limit = false
@@ -1591,8 +1591,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
   "names": false,
   "sizes": false,
   "via_ir": false,
-  "experimental": false,
   "via_ssa_cfg": false,
+  "experimental": false,
   "ast": false,
   "rpc_storage_caching": {
     "chains": "all",


### PR DESCRIPTION
This mirrors #15177 (commit f4ecc6a46599fc6e6ac23e403b69c21cdd11eea5), which added support for solc's `--experimental` flag, applying the same pattern to expose solc's `viaSSACFG` setting. It adds a `--via-ssa-cfg` CLI flag and a `via_ssa_cfg` config option that turn on SSA CFG-based code generation via the IR (experimental, implies `viaIR`), false by default.

The Foundry-side wiring is in place: the `CompilerOpts` flag, the `Config` field and its default, the `solc_settings()` plumbing, and the corresponding parse/config/snapshot tests. As with #15177, this depends on the setting being exposed on `foundry-compilers`' solc `Settings` struct, which the currently pinned revision does not yet expose, so the config crate does not build on its own. I'm working on the required changes in foundry-core and will follow up here with the dependency bump, the same way #15177 pinned a foundry-core revision. Opening as a draft until that lands.

This change was prepared with AI assistance.


Updated: now ready thanks to https://github.com/foundry-rs/foundry-core/pull/104