### PR TITLE
perf(symbolic): avoid kind extraction

### DIFF
--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -733,7 +733,7 @@ impl SymbolicExecutor {
             if in_size < 4 {
                 return Err(SymbolicError::Unsupported("short cheatcode CALL"));
             }
-            let in_offset = in_offset.into_usize("symbolic cheatcode CALL input offset")?;
+            let in_offset = in_offset.as_usize_or("symbolic cheatcode CALL input offset")?;
             if !self.assume_expr_at_least(state, &in_size_word, 4)? {
                 return Ok(StepOutcome::AssumeRejected);
             }

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -1679,11 +1679,8 @@ impl SymbolicExecutor {
                     0,
                     "symbolic vm.rollFork block number",
                 )?;
-                let current = state
-                    .block
-                    .number
-                    .clone()
-                    .into_concrete("symbolic vm.rollFork current block")?;
+                let current =
+                    state.block.number.as_const_or("symbolic vm.rollFork current block")?;
                 if block_number == current {
                     return Ok(CheatcodeOutcome::Continue(Vec::new()));
                 }
@@ -1704,11 +1701,8 @@ impl SymbolicExecutor {
                     1,
                     "symbolic vm.rollFork block number",
                 )?;
-                let current = state
-                    .block
-                    .number
-                    .clone()
-                    .into_concrete("symbolic vm.rollFork current block")?;
+                let current =
+                    state.block.number.as_const_or("symbolic vm.rollFork current block")?;
                 if executor.backend().is_active_fork(id) && block_number == current {
                     return Ok(CheatcodeOutcome::Continue(Vec::new()));
                 }

--- a/crates/evm/symbolic/src/runtime/cheatcodes.rs
+++ b/crates/evm/symbolic/src/runtime/cheatcodes.rs
@@ -344,7 +344,7 @@ pub(crate) fn recorded_logs_json_return_data(
         }
         push_ascii(&mut bytes, "],\"data\":\"0x");
 
-        let len = data_len.into_concrete("symbolic vm.getRecordedLogsJson data length").and_then(
+        let len = data_len.as_const_or("symbolic vm.getRecordedLogsJson data length").and_then(
             |len| {
                 usize::try_from(len).map_err(|_| {
                     SymbolicError::Unsupported("symbolic vm.getRecordedLogsJson data length")
@@ -454,7 +454,7 @@ pub(crate) fn read_abi_concrete_word_arg(
     index: usize,
     reason: &'static str,
 ) -> Result<U256, SymbolicError> {
-    read_abi_word_arg(memory, args_offset, index)?.into_concrete(reason)
+    read_abi_word_arg(memory, args_offset, index)?.as_const_or(reason)
 }
 
 pub(crate) fn read_abi_constrained_word_arg(
@@ -551,7 +551,7 @@ pub(crate) fn read_abi_dynamic_bytes_arg(
         .map_err(|_| SymbolicError::Unsupported(reason))?;
     let len_offset = args_offset.checked_add(offset).ok_or(SymbolicError::Unsupported(reason))?;
     let data_offset = len_offset.checked_add(32).ok_or(SymbolicError::Unsupported(reason))?;
-    let len = memory.load_word(len_offset)?.into_usize(reason)?;
+    let len = memory.load_word(len_offset)?.as_usize_or(reason)?;
     memory.read_concrete(data_offset, len)
 }
 

--- a/crates/evm/symbolic/src/runtime/expressions.rs
+++ b/crates/evm/symbolic/src/runtime/expressions.rs
@@ -209,7 +209,7 @@ impl SymExpr {
 
     fn storage_layout_key(&self) -> Option<(Self, Self)> {
         match self.kind() {
-            SymExprKind::Keccak { .. } => Some((self.clone(), Self::constant(U256::ZERO))),
+            SymExprKind::Keccak { .. } => Some((self.clone(), Self::zero())),
             SymExprKind::Op(SymExprOp::Add, left, right) => {
                 if let Some((base, offset)) = left.storage_layout_key()
                     && !right.contains_keccak()
@@ -326,7 +326,7 @@ impl SymExpr {
     }
 
     pub(crate) fn zero() -> Self {
-        Self::constant(U256::ZERO)
+        Self(EXPR_ZERO.clone())
     }
 
     pub(super) fn kind(&self) -> &SymExprKind {
@@ -407,7 +407,7 @@ impl SymExpr {
             return expr;
         }
 
-        let mut expr = Self::constant(U256::ZERO);
+        let mut expr = Self::zero();
         for (idx, byte) in bytes.into_iter().take(32).enumerate() {
             let shift = (31 - idx) * 8;
             let byte = byte.low_byte();
@@ -524,7 +524,7 @@ impl SymExpr {
     }
 
     pub(crate) fn bool_word(value: SymBoolExpr) -> Self {
-        Self::ite(value, Self::constant(U256::from(1)), Self::constant(U256::ZERO))
+        Self::ite(value, Self::constant(U256::from(1)), Self::zero())
     }
 
     pub(crate) fn bool_word_condition(&self) -> Option<SymBoolExpr> {
@@ -559,21 +559,15 @@ impl SymExpr {
     }
 
     pub(crate) fn into_zero_bool(self) -> SymBoolExpr {
-        match self.into_kind() {
+        match self.kind() {
             SymExprKind::Const(value) => SymBoolExpr::constant(value.is_zero()),
             SymExprKind::Ite(condition, then_expr, else_expr) => {
-                if let Some(condition) =
-                    Self::bool_word_condition_from_parts(&condition, &then_expr, &else_expr)
-                {
-                    condition.not()
-                } else {
-                    SymBoolExpr::eq(
-                        Self::from_kind(SymExprKind::Ite(condition, then_expr, else_expr)),
-                        Self::constant(U256::ZERO),
-                    )
+                match Self::bool_word_condition_from_parts(condition, then_expr, else_expr) {
+                    Some(condition) => condition.not(),
+                    None => SymBoolExpr::eq(self, Self::zero()),
                 }
             }
-            expr => SymBoolExpr::eq(Self::from_kind(expr), Self::constant(U256::ZERO)),
+            _ => SymBoolExpr::eq(self, Self::zero()),
         }
     }
 
@@ -581,15 +575,12 @@ impl SymExpr {
         self.into_zero_bool().not()
     }
 
-    pub(crate) fn into_concrete(self, reason: &'static str) -> Result<U256, SymbolicError> {
-        match self.into_kind() {
-            SymExprKind::Const(value) => Ok(value),
-            _ => Err(SymbolicError::Unsupported(reason)),
-        }
+    pub(crate) fn as_const_or(&self, reason: &'static str) -> Result<U256, SymbolicError> {
+        self.as_const().ok_or(SymbolicError::Unsupported(reason))
     }
 
-    pub(crate) fn into_usize(self, reason: &'static str) -> Result<usize, SymbolicError> {
-        let value = self.into_concrete(reason)?;
+    pub(crate) fn as_usize_or(&self, reason: &'static str) -> Result<usize, SymbolicError> {
+        let value = self.as_const_or(reason)?;
         usize::try_from(value).map_err(|_| SymbolicError::Unsupported(reason))
     }
 
@@ -764,7 +755,7 @@ impl SymExpr {
                 SymExprOp::Shl => {
                     let shift = right.eval()?;
                     if shift >= U256::from(256) {
-                        return Some(Self::constant(U256::ZERO));
+                        return Some(Self::zero());
                     }
                     let shift = usize::try_from(shift).expect("checked byte shift");
                     if shift % 8 != 0 {
@@ -772,7 +763,7 @@ impl SymExpr {
                     }
                     let source_index = index + shift / 8;
                     if source_index >= 32 {
-                        Some(Self::constant(U256::ZERO))
+                        Some(Self::zero())
                     } else {
                         left.byte_term(source_index)
                     }
@@ -780,7 +771,7 @@ impl SymExpr {
                 SymExprOp::Shr => {
                     let shift = right.eval()?;
                     if shift >= U256::from(256) {
-                        return Some(Self::constant(U256::ZERO));
+                        return Some(Self::zero());
                     }
                     let shift = usize::try_from(shift).expect("checked byte shift");
                     if shift % 8 != 0 {
@@ -788,7 +779,7 @@ impl SymExpr {
                     }
                     let byte_shift = shift / 8;
                     if index < byte_shift {
-                        Some(Self::constant(U256::ZERO))
+                        Some(Self::zero())
                     } else {
                         left.byte_term(index - byte_shift)
                     }
@@ -928,15 +919,11 @@ impl SymExpr {
     }
 
     pub(crate) fn ite(cond: SymBoolExpr, then_expr: Self, else_expr: Self) -> Self {
-        match cond.into_kind() {
-            SymBoolExprKind::Const(true) => then_expr,
-            SymBoolExprKind::Const(false) => else_expr,
-            _ if then_expr == else_expr => then_expr,
-            cond => Self::from_kind(SymExprKind::Ite(
-                SymBoolExpr::from_kind(cond),
-                then_expr,
-                else_expr,
-            )),
+        match cond.as_const() {
+            Some(true) => then_expr,
+            Some(false) => else_expr,
+            None if then_expr == else_expr => then_expr,
+            None => Self::from_kind(SymExprKind::Ite(cond, then_expr, else_expr)),
         }
     }
 
@@ -944,21 +931,17 @@ impl SymExpr {
         if value.is_zero() {
             return expr;
         }
-        match expr.into_kind() {
+        match expr.kind() {
             SymExprKind::Const(expr) => Self::constant(expr.wrapping_add(value)),
-            expr => Self::from_kind(SymExprKind::Op(
-                SymExprOp::Add,
-                Self::from_kind(expr),
-                Self::constant(value),
-            )),
+            _ => Self::from_kind(SymExprKind::Op(SymExprOp::Add, expr, Self::constant(value))),
         }
     }
 
     pub(crate) fn not(value: Self) -> Self {
-        match value.into_kind() {
-            SymExprKind::Const(value) => Self::constant(!value),
-            SymExprKind::Not(value) => value,
-            value => Self::from_kind(SymExprKind::Not(Self::from_kind(value))),
+        match value.kind() {
+            SymExprKind::Const(value) => Self::constant(!*value),
+            SymExprKind::Not(value) => value.clone(),
+            _ => Self::from_kind(SymExprKind::Not(value)),
         }
     }
 
@@ -1048,162 +1031,151 @@ impl SymExpr {
     }
 
     pub(crate) fn op(op: SymExprOp, left: Self, right: Self) -> Self {
-        match (op, left.into_kind(), right.into_kind()) {
-            (op, SymExprKind::Const(left), SymExprKind::Const(right)) => {
-                Self::constant(op.eval(left, right))
-            }
-            (SymExprOp::Add, SymExprKind::Const(value), right) if value.is_zero() => {
-                Self::from_kind(right)
-            }
-            (SymExprOp::Add, left, SymExprKind::Const(value)) if value.is_zero() => {
-                Self::from_kind(left)
-            }
-            (SymExprOp::Sub, left, SymExprKind::Const(value)) if value.is_zero() => {
-                Self::from_kind(left)
-            }
-            (SymExprOp::Sub, left, right) if left == right => Self::constant(U256::ZERO),
-            (SymExprOp::Mul, SymExprKind::Const(value), _)
-            | (SymExprOp::Mul, _, SymExprKind::Const(value))
-                if value.is_zero() =>
-            {
-                Self::constant(U256::ZERO)
-            }
-            (SymExprOp::Mul, SymExprKind::Const(value), right) if value == U256::from(1) => {
-                Self::from_kind(right)
-            }
-            (SymExprOp::Mul, left, SymExprKind::Const(value)) if value == U256::from(1) => {
-                Self::from_kind(left)
-            }
-            (
-                SymExprOp::UDiv | SymExprOp::URem | SymExprOp::SDiv | SymExprOp::SRem,
-                _,
-                SymExprKind::Const(value),
-            ) if value.is_zero() => Self::constant(U256::ZERO),
-            (SymExprOp::UDiv | SymExprOp::SDiv, left, SymExprKind::Const(value))
-                if value == U256::from(1) =>
-            {
-                Self::from_kind(left)
-            }
-            (SymExprOp::URem | SymExprOp::SRem, _, SymExprKind::Const(value))
-                if value == U256::from(1) =>
-            {
-                Self::constant(U256::ZERO)
-            }
-            (SymExprOp::And, SymExprKind::Const(value), _)
-            | (SymExprOp::And, _, SymExprKind::Const(value))
-                if value.is_zero() =>
-            {
-                Self::constant(U256::ZERO)
-            }
-            (SymExprOp::And, SymExprKind::Const(value), right) if value == U256::MAX => {
-                Self::from_kind(right)
-            }
-            (SymExprOp::And, left, SymExprKind::Const(value)) if value == U256::MAX => {
-                Self::from_kind(left)
-            }
-            (SymExprOp::And, left, right) if left == right => Self::from_kind(left),
-            (SymExprOp::And, SymExprKind::Const(mask), right) => {
-                Self::and_const(Self::from_kind(right), mask)
-            }
-            (SymExprOp::And, left, SymExprKind::Const(mask)) => {
-                Self::and_const(Self::from_kind(left), mask)
-            }
-            (SymExprOp::Or | SymExprOp::Xor, SymExprKind::Const(value), right)
-                if value.is_zero() =>
-            {
-                Self::from_kind(right)
-            }
-            (SymExprOp::Or | SymExprOp::Xor, left, SymExprKind::Const(value))
-                if value.is_zero() =>
-            {
-                Self::from_kind(left)
-            }
-            (SymExprOp::Shl | SymExprOp::Shr | SymExprOp::Sar, left, SymExprKind::Const(value))
-                if value.is_zero() =>
-            {
-                Self::from_kind(left)
-            }
-            (SymExprOp::Shl | SymExprOp::Shr, SymExprKind::Const(value), _) if value.is_zero() => {
-                Self::constant(U256::ZERO)
-            }
-            (op, left, right) => {
-                Self::from_kind(SymExprKind::Op(op, Self::from_kind(left), Self::from_kind(right)))
-            }
+        if let Some(expr) = Self::peephole_op(op, &left, &right) {
+            return expr;
+        }
+        Self::from_kind(SymExprKind::Op(op, left, right))
+    }
+
+    fn peephole_op(op: SymExprOp, left: &Self, right: &Self) -> Option<Self> {
+        match op {
+            SymExprOp::Add => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Some(Self::constant(op.eval(*left_value, *right_value)))
+                }
+                (SymExprKind::Const(value), _) if value.is_zero() => Some(right.clone()),
+                (_, SymExprKind::Const(value)) if value.is_zero() => Some(left.clone()),
+                _ => None,
+            },
+            SymExprOp::Sub => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Some(Self::constant(op.eval(*left_value, *right_value)))
+                }
+                (_, SymExprKind::Const(value)) if value.is_zero() => Some(left.clone()),
+                _ if left == right => Some(Self::zero()),
+                _ => None,
+            },
+            SymExprOp::Mul => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Some(Self::constant(op.eval(*left_value, *right_value)))
+                }
+                (SymExprKind::Const(value), _) | (_, SymExprKind::Const(value))
+                    if value.is_zero() =>
+                {
+                    Some(Self::zero())
+                }
+                (SymExprKind::Const(value), _) if *value == U256::from(1) => Some(right.clone()),
+                (_, SymExprKind::Const(value)) if *value == U256::from(1) => Some(left.clone()),
+                _ => None,
+            },
+            SymExprOp::UDiv | SymExprOp::SDiv => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Some(Self::constant(op.eval(*left_value, *right_value)))
+                }
+                (_, SymExprKind::Const(value)) if value.is_zero() => Some(Self::zero()),
+                (_, SymExprKind::Const(value)) if *value == U256::from(1) => Some(left.clone()),
+                _ => None,
+            },
+            SymExprOp::URem | SymExprOp::SRem => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Some(Self::constant(op.eval(*left_value, *right_value)))
+                }
+                (_, SymExprKind::Const(value)) if value.is_zero() => Some(Self::zero()),
+                (_, SymExprKind::Const(value)) if *value == U256::from(1) => Some(Self::zero()),
+                _ => None,
+            },
+            SymExprOp::And => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Some(Self::constant(op.eval(*left_value, *right_value)))
+                }
+                (SymExprKind::Const(value), _) | (_, SymExprKind::Const(value))
+                    if value.is_zero() =>
+                {
+                    Some(Self::zero())
+                }
+                (SymExprKind::Const(value), _) if *value == U256::MAX => Some(right.clone()),
+                (_, SymExprKind::Const(value)) if *value == U256::MAX => Some(left.clone()),
+                _ if left == right => Some(left.clone()),
+                (SymExprKind::Const(mask), _) => Some(Self::and_const(right.clone(), *mask)),
+                (_, SymExprKind::Const(mask)) => Some(Self::and_const(left.clone(), *mask)),
+                _ => None,
+            },
+            SymExprOp::Or | SymExprOp::Xor => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Some(Self::constant(op.eval(*left_value, *right_value)))
+                }
+                (SymExprKind::Const(value), _) if value.is_zero() => Some(right.clone()),
+                (_, SymExprKind::Const(value)) if value.is_zero() => Some(left.clone()),
+                _ => None,
+            },
+            SymExprOp::Shl | SymExprOp::Shr => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Some(Self::constant(op.eval(*left_value, *right_value)))
+                }
+                (_, SymExprKind::Const(value)) if value.is_zero() => Some(left.clone()),
+                (SymExprKind::Const(value), _) if value.is_zero() => Some(Self::zero()),
+                _ => None,
+            },
+            SymExprOp::Sar => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Some(Self::constant(op.eval(*left_value, *right_value)))
+                }
+                (_, SymExprKind::Const(value)) if value.is_zero() => Some(left.clone()),
+                _ => None,
+            },
         }
     }
 
     /// Builds an exact EVM `ADDMOD` expression.
     pub(crate) fn addmod(left: Self, right: Self, modulus: Self) -> Self {
-        match (left.into_kind(), right.into_kind(), modulus.into_kind()) {
+        match (left.kind(), right.kind(), modulus.kind()) {
             (_, _, SymExprKind::Const(modulus))
-                if modulus.is_zero() || modulus == U256::from(1) =>
+                if modulus.is_zero() || *modulus == U256::from(1) =>
             {
-                Self::constant(U256::ZERO)
+                Self::zero()
             }
             (SymExprKind::Const(left), SymExprKind::Const(right), SymExprKind::Const(modulus)) => {
-                Self::constant(left.add_mod(right, modulus))
+                Self::constant(left.add_mod(*right, *modulus))
             }
-            (left, right, modulus) => Self::from_kind(SymExprKind::AddMod {
-                left: Self::from_kind(left),
-                right: Self::from_kind(right),
-                modulus: Self::from_kind(modulus),
-            }),
+            _ => Self::from_kind(SymExprKind::AddMod { left, right, modulus }),
         }
     }
 
     /// Builds an exact EVM `MULMOD` expression.
     pub(crate) fn mulmod(left: Self, right: Self, modulus: Self) -> Self {
-        match (left.into_kind(), right.into_kind(), modulus.into_kind()) {
+        match (left.kind(), right.kind(), modulus.kind()) {
             (_, _, SymExprKind::Const(modulus))
-                if modulus.is_zero() || modulus == U256::from(1) =>
+                if modulus.is_zero() || *modulus == U256::from(1) =>
             {
-                Self::constant(U256::ZERO)
+                Self::zero()
             }
             (SymExprKind::Const(left), SymExprKind::Const(right), SymExprKind::Const(modulus)) => {
-                Self::constant(left.mul_mod(right, modulus))
+                Self::constant(left.mul_mod(*right, *modulus))
             }
-            (left, right, modulus) => Self::from_kind(SymExprKind::MulMod {
-                left: Self::from_kind(left),
-                right: Self::from_kind(right),
-                modulus: Self::from_kind(modulus),
-            }),
+            _ => Self::from_kind(SymExprKind::MulMod { left, right, modulus }),
         }
     }
 
     fn and_const(expr: Self, mask: U256) -> Self {
         if mask.is_zero() {
-            return Self::constant(U256::ZERO);
+            return Self::zero();
         }
         if mask == U256::MAX {
             return expr;
         }
 
-        match expr.into_kind() {
-            SymExprKind::Op(SymExprOp::And, left, right) => {
-                match (left.into_kind(), right.into_kind()) {
-                    (SymExprKind::Const(value), right) if value == mask => {
-                        Self::and_const(Self::from_kind(right), mask)
-                    }
-                    (left, SymExprKind::Const(value)) if value == mask => {
-                        Self::and_const(Self::from_kind(left), mask)
-                    }
-                    (left, right) if left == right => Self::and_const(Self::from_kind(left), mask),
-                    (left, right) => Self::from_kind(SymExprKind::Op(
-                        SymExprOp::And,
-                        Self::from_kind(SymExprKind::Op(
-                            SymExprOp::And,
-                            Self::from_kind(left),
-                            Self::from_kind(right),
-                        )),
-                        Self::constant(mask),
-                    )),
+        match expr.kind() {
+            SymExprKind::Op(SymExprOp::And, left, right) => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(value), _) if *value == mask => {
+                    Self::and_const(right.clone(), mask)
                 }
-            }
-            expr => Self::from_kind(SymExprKind::Op(
-                SymExprOp::And,
-                Self::from_kind(expr),
-                Self::constant(mask),
-            )),
+                (_, SymExprKind::Const(value)) if *value == mask => {
+                    Self::and_const(left.clone(), mask)
+                }
+                _ if left == right => Self::and_const(left.clone(), mask),
+                _ => Self::from_kind(SymExprKind::Op(SymExprOp::And, expr, Self::constant(mask))),
+            },
+            _ => Self::from_kind(SymExprKind::Op(SymExprOp::And, expr, Self::constant(mask))),
         }
     }
 
@@ -1397,7 +1369,7 @@ impl SymBoolExpr {
     }
 
     pub(crate) fn constant(value: bool) -> Self {
-        Self(if value { BOOL_TRUE.clone() } else { BOOL_FALSE.clone() })
+        Self(if value { &*BOOL_TRUE } else { &*BOOL_FALSE }.clone())
     }
 
     pub(super) fn kind(&self) -> &SymBoolExprKind {
@@ -1624,34 +1596,32 @@ impl SymBoolExpr {
     }
 
     pub(crate) fn eq(left: SymExpr, right: SymExpr) -> Self {
-        match (left.into_kind(), right.into_kind()) {
-            (left, right) if left == right => Self::constant(true),
+        match (left.kind(), right.kind()) {
+            _ if left == right => Self::constant(true),
             (SymExprKind::Const(left), SymExprKind::Const(right)) => Self::constant(left == right),
-            (left, SymExprKind::Const(right_value)) => {
-                let left = SymExpr::from_kind(left);
-                if let Some(condition) = Self::bool_word_eq_const(&left, right_value) {
+            (_, SymExprKind::Const(right_value)) => {
+                if let Some(condition) = Self::bool_word_eq_const(&left, *right_value) {
                     return condition;
                 }
                 if let Some(left_value) = left.known_word() {
-                    return Self::constant(left_value == right_value);
+                    return Self::constant(left_value == *right_value);
                 }
-                Self::from_kind(SymBoolExprKind::Eq(left, SymExpr::constant(right_value)))
+                Self::from_kind(SymBoolExprKind::Eq(left, right))
             }
-            (SymExprKind::Const(left_value), right) => {
-                let right = SymExpr::from_kind(right);
-                if let Some(condition) = Self::bool_word_eq_const(&right, left_value) {
+            (SymExprKind::Const(left_value), _) => {
+                if let Some(condition) = Self::bool_word_eq_const(&right, *left_value) {
                     return condition;
                 }
                 if let Some(right_value) = right.known_word() {
-                    return Self::constant(left_value == right_value);
+                    return Self::constant(*left_value == right_value);
                 }
-                Self::from_kind(SymBoolExprKind::Eq(SymExpr::constant(left_value), right))
+                Self::from_kind(SymBoolExprKind::Eq(left, right))
             }
             (
                 SymExprKind::Keccak { len: left_len, bytes: left_bytes, .. },
                 SymExprKind::Keccak { len: right_len, bytes: right_bytes, .. },
             ) if left_bytes.len() == right_bytes.len() => {
-                let mut conditions = vec![Self::eq(left_len, right_len)];
+                let mut conditions = vec![Self::eq(left_len.clone(), right_len.clone())];
                 conditions.extend(
                     left_bytes
                         .iter()
@@ -1674,10 +1644,7 @@ impl SymBoolExpr {
                         .collect(),
                 )
             }
-            (left, right) => Self::from_kind(SymBoolExprKind::Eq(
-                SymExpr::from_kind(left),
-                SymExpr::from_kind(right),
-            )),
+            _ => Self::from_kind(SymBoolExprKind::Eq(left, right)),
         }
     }
 
@@ -1711,11 +1678,11 @@ impl SymBoolExpr {
     pub(crate) fn and(values: Vec<Self>) -> Self {
         let mut out = Vec::new();
         for value in values {
-            match value.into_kind() {
+            match value.kind() {
                 SymBoolExprKind::Const(true) => {}
                 SymBoolExprKind::Const(false) => return Self::constant(false),
                 SymBoolExprKind::And(values) => out.extend(values.iter().cloned()),
-                value => out.push(Self::from_kind(value)),
+                _ => out.push(value),
             }
         }
         if out.is_empty() {
@@ -1735,10 +1702,10 @@ impl SymBoolExpr {
     pub(crate) fn or(values: Vec<Self>) -> Self {
         let mut out = Vec::new();
         for value in values {
-            match value.into_kind() {
+            match value.kind() {
                 SymBoolExprKind::Const(false) => {}
                 SymBoolExprKind::Const(true) => return Self::constant(true),
-                value => out.push(Self::from_kind(value)),
+                _ => out.push(value),
             }
         }
         if out.is_empty() {
@@ -1751,12 +1718,12 @@ impl SymBoolExpr {
     }
 
     pub(crate) fn cmp(op: SymBoolExprOp, left: SymExpr, right: SymExpr) -> Self {
-        match (op, left.into_kind(), right.into_kind()) {
-            (op, left, right) if left == right => {
+        match (op, left.kind(), right.kind()) {
+            (op, _, _) if left == right => {
                 Self::constant(matches!(op, SymBoolExprOp::Ule | SymBoolExprOp::Uge))
             }
             (op, SymExprKind::Const(left), SymExprKind::Const(right)) => {
-                Self::constant(op.eval(left, right))
+                Self::constant(op.eval(*left, *right))
             }
             (SymBoolExprOp::Ugt, SymExprKind::Const(value), _) if value.is_zero() => {
                 Self::constant(false)
@@ -1770,23 +1737,19 @@ impl SymBoolExpr {
             (SymBoolExprOp::Uge, _, SymExprKind::Const(value)) if value.is_zero() => {
                 Self::constant(true)
             }
-            (SymBoolExprOp::Ult, SymExprKind::Const(value), _) if value == U256::MAX => {
+            (SymBoolExprOp::Ult, SymExprKind::Const(value), _) if *value == U256::MAX => {
                 Self::constant(false)
             }
-            (SymBoolExprOp::Uge, SymExprKind::Const(value), _) if value == U256::MAX => {
+            (SymBoolExprOp::Uge, SymExprKind::Const(value), _) if *value == U256::MAX => {
                 Self::constant(true)
             }
-            (SymBoolExprOp::Ugt, _, SymExprKind::Const(value)) if value == U256::MAX => {
+            (SymBoolExprOp::Ugt, _, SymExprKind::Const(value)) if *value == U256::MAX => {
                 Self::constant(false)
             }
-            (SymBoolExprOp::Ule, _, SymExprKind::Const(value)) if value == U256::MAX => {
+            (SymBoolExprOp::Ule, _, SymExprKind::Const(value)) if *value == U256::MAX => {
                 Self::constant(true)
             }
-            (op, left, right) => Self::from_kind(SymBoolExprKind::Cmp(
-                op,
-                SymExpr::from_kind(left),
-                SymExpr::from_kind(right),
-            )),
+            _ => Self::from_kind(SymBoolExprKind::Cmp(op, left, right)),
         }
     }
 
@@ -1803,10 +1766,10 @@ impl SymBoolExpr {
     }
 
     pub(crate) fn not(self) -> Self {
-        match self.into_kind() {
-            SymBoolExprKind::Const(value) => Self::constant(!value),
-            SymBoolExprKind::Not(value) => value,
-            value => Self::from_kind(SymBoolExprKind::Not(Self::from_kind(value))),
+        match self.kind() {
+            SymBoolExprKind::Const(value) => Self::constant(!*value),
+            SymBoolExprKind::Not(value) => value.clone(),
+            _ => Self::from_kind(SymBoolExprKind::Not(self)),
         }
     }
 

--- a/crates/evm/symbolic/src/runtime/precompiles.rs
+++ b/crates/evm/symbolic/src/runtime/precompiles.rs
@@ -104,7 +104,7 @@ pub(crate) fn execute_symbolic_precompile(
         Some(4) => Ok(Some(SymReturnData::from_bytes_with_len(input, input_len))),
         Some(5) => symbolic_modexp_precompile(&input, input_len),
         Some(6) => {
-            let input_len = input_len.into_usize("symbolic precompile input")?;
+            let input_len = input_len.as_usize_or("symbolic precompile input")?;
             if input_len > input.len() {
                 return Err(SymbolicError::Unsupported("out-of-bounds symbolic precompile input"));
             }
@@ -116,7 +116,7 @@ pub(crate) fn execute_symbolic_precompile(
             Ok(Some(symbolic_fixed_len_precompile_output("bn254_add", &input, input_len, 64)))
         }
         Some(7) => {
-            let input_len = input_len.into_usize("symbolic precompile input")?;
+            let input_len = input_len.as_usize_or("symbolic precompile input")?;
             if input_len > input.len() {
                 return Err(SymbolicError::Unsupported("out-of-bounds symbolic precompile input"));
             }
@@ -128,7 +128,7 @@ pub(crate) fn execute_symbolic_precompile(
             Ok(Some(symbolic_fixed_len_precompile_output("bn254_mul", &input, input_len, 64)))
         }
         Some(8) => {
-            let input_len = input_len.into_usize("symbolic precompile input")?;
+            let input_len = input_len.as_usize_or("symbolic precompile input")?;
             if input_len % 192 != 0 {
                 return Ok(None);
             }
@@ -143,7 +143,7 @@ pub(crate) fn execute_symbolic_precompile(
             Ok(Some(symbolic_fixed_len_precompile_output("bn254_pairing", &input, input_len, 32)))
         }
         Some(9) => {
-            let input_len = input_len.into_usize("symbolic precompile input")?;
+            let input_len = input_len.as_usize_or("symbolic precompile input")?;
             if input_len != 213 {
                 return Ok(None);
             }
@@ -164,7 +164,7 @@ pub(crate) fn execute_symbolic_precompile(
         }
         Some(10) => Err(SymbolicError::Unsupported("KZG handled by execute_kzg_precompile_call")),
         _ => {
-            let input_len = input_len.into_usize("symbolic precompile input")?;
+            let input_len = input_len.as_usize_or("symbolic precompile input")?;
             if input_len > input.len() {
                 return Err(SymbolicError::Unsupported("out-of-bounds symbolic precompile input"));
             }
@@ -183,7 +183,7 @@ pub(crate) fn symbolic_modexp_precompile(
     input: &SymBytes,
     input_len: SymExpr,
 ) -> Result<Option<SymReturnData>, SymbolicError> {
-    let input_len = input_len.into_usize("symbolic precompile input")?;
+    let input_len = input_len.as_usize_or("symbolic precompile input")?;
     if input_len > input.len() {
         return Err(SymbolicError::Unsupported("out-of-bounds symbolic precompile input"));
     }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -90,8 +90,8 @@ impl SymBoolExpr {
     }
 
     fn cache_key_node(expr: Self) -> Self {
-        match expr.into_kind() {
-            SymBoolExprKind::Not(value) => value.not(),
+        match expr.kind() {
+            SymBoolExprKind::Not(value) => value.clone().not(),
             SymBoolExprKind::And(values) => {
                 let mut conjuncts = Vec::new();
                 for value in values.iter().cloned() {
@@ -101,14 +101,14 @@ impl SymBoolExpr {
                 Self::and(conjuncts)
             }
             SymBoolExprKind::Eq(left, right) => {
-                let left = left.cache_key();
-                let right = right.cache_key();
+                let left = left.clone().cache_key();
+                let right = right.clone().cache_key();
                 if left <= right { Self::eq(left, right) } else { Self::eq(right, left) }
             }
             SymBoolExprKind::Cmp(op, left, right) => {
-                Self::cache_key_cmp(op, left.cache_key(), right.cache_key())
+                Self::cache_key_cmp(*op, left.clone().cache_key(), right.clone().cache_key())
             }
-            SymBoolExprKind::Const(value) => Self::constant(value),
+            SymBoolExprKind::Const(value) => Self::constant(*value),
         }
     }
 
@@ -155,37 +155,17 @@ impl SymExpr {
 
     fn cache_key_node(expr: Self) -> Self {
         match expr.kind() {
-            SymExprKind::Op(op, left, right) => {
-                if op.is_commutative() && right < left {
-                    let SymExprKind::Op(op, left, right) = expr.into_kind() else { unreachable!() };
-                    Self::op(op, right, left)
-                } else {
-                    expr
-                }
+            SymExprKind::Op(op, left, right) if op.is_commutative() && right < left => {
+                Self::op(*op, right.clone(), left.clone())
             }
-            SymExprKind::AddMod { left, right, .. } => {
-                if right < left {
-                    let SymExprKind::AddMod { left, right, modulus } = expr.into_kind() else {
-                        unreachable!()
-                    };
-                    Self::addmod(right, left, modulus)
-                } else {
-                    expr
-                }
+            SymExprKind::AddMod { left, right, modulus } if right < left => {
+                Self::addmod(right.clone(), left.clone(), modulus.clone())
             }
-            SymExprKind::MulMod { left, right, .. } => {
-                if right < left {
-                    let SymExprKind::MulMod { left, right, modulus } = expr.into_kind() else {
-                        unreachable!()
-                    };
-                    Self::mulmod(right, left, modulus)
-                } else {
-                    expr
-                }
+            SymExprKind::MulMod { left, right, modulus } if right < left => {
+                Self::mulmod(right.clone(), left.clone(), modulus.clone())
             }
-            SymExprKind::Ite(_, _, _) => {
-                let SymExprKind::Ite(cond, left, right) = expr.into_kind() else { unreachable!() };
-                Self::ite(cond.cache_key(), left, right)
+            SymExprKind::Ite(cond, left, right) => {
+                Self::ite(cond.clone().cache_key(), left.clone(), right.clone())
             }
             _ => expr,
         }
@@ -559,23 +539,25 @@ fn normalize_bool_node_for_solver(expr: SymBoolExpr) -> SymBoolExpr {
         return normalized;
     }
 
-    match expr.into_kind() {
-        SymBoolExprKind::Not(value) => value.not(),
+    match expr.kind() {
+        SymBoolExprKind::Not(value) => value.clone().not(),
         SymBoolExprKind::And(values) => SymBoolExpr::and(values.iter().cloned().collect()),
         SymBoolExprKind::Eq(left, right) => {
-            let normalized =
-                SymBoolExpr::eq(normalize_expr_for_solver(left), normalize_expr_for_solver(right));
+            let normalized = SymBoolExpr::eq(
+                normalize_expr_for_solver(left.clone()),
+                normalize_expr_for_solver(right.clone()),
+            );
             normalized.normalize_udiv_for_solver().unwrap_or(normalized)
         }
         SymBoolExprKind::Cmp(op, left, right) => {
             let normalized = SymBoolExpr::cmp(
-                op,
-                normalize_expr_for_solver(left),
-                normalize_expr_for_solver(right),
+                *op,
+                normalize_expr_for_solver(left.clone()),
+                normalize_expr_for_solver(right.clone()),
             );
             normalized.normalize_udiv_for_solver().unwrap_or(normalized)
         }
-        SymBoolExprKind::Const(value) => SymBoolExpr::constant(value),
+        SymBoolExprKind::Const(value) => SymBoolExpr::constant(*value),
     }
 }
 
@@ -704,18 +686,14 @@ fn normalize_expr_node_for_solver(expr: SymExpr) -> SymExpr {
     }
 
     match expr.kind() {
-        SymExprKind::Op(op, left, right)
-            if matches!(
-                op,
-                SymExprOp::Add | SymExprOp::Mul | SymExprOp::And | SymExprOp::Or | SymExprOp::Xor
-            ) && right < left =>
-        {
-            let SymExprKind::Op(op, left, right) = expr.into_kind() else { unreachable!() };
-            SymExpr::op(op, right, left)
-        }
-        SymExprKind::Ite(_, _, _) => {
-            let SymExprKind::Ite(cond, left, right) = expr.into_kind() else { unreachable!() };
-            normalize_ite_expr_for_solver(cond, left, right)
+        SymExprKind::Op(
+            op
+            @ (SymExprOp::Add | SymExprOp::Mul | SymExprOp::And | SymExprOp::Or | SymExprOp::Xor),
+            left,
+            right,
+        ) if right < left => SymExpr::op(*op, right.clone(), left.clone()),
+        SymExprKind::Ite(cond, left, right) => {
+            normalize_ite_expr_for_solver(cond.clone(), left.clone(), right.clone())
         }
         _ => expr,
     }

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -907,7 +907,7 @@ impl ExpectedCall {
         if self.gas.is_none() && self.min_gas.is_none() {
             return Ok(true);
         }
-        let mut gas = gas.clone().into_concrete("symbolic expected call gas")?;
+        let mut gas = gas.as_const_or("symbolic expected call gas")?;
         if value.is_some_and(|value| !value.is_zero()) {
             gas = gas.saturating_add(U256::from(CALL_VALUE_STIPEND));
         }
@@ -2007,8 +2007,7 @@ impl SymbolicBlock {
         block_number: U256,
         block_hash: SymExpr,
     ) -> Result<(), SymbolicError> {
-        let current =
-            self.number.clone().into_concrete("symbolic vm.setBlockhash current number")?;
+        let current = self.number.as_const_or("symbolic vm.setBlockhash current number")?;
         if block_number < current && current - block_number <= U256::from(256) {
             self.block_hashes.insert(block_number, block_hash);
         }
@@ -2020,7 +2019,7 @@ impl SymbolicBlock {
         executor: &Executor<FEN>,
         block_number: U256,
     ) -> Result<SymExpr, SymbolicError> {
-        let current = self.number.clone().into_concrete("symbolic BLOCKHASH current number")?;
+        let current = self.number.as_const_or("symbolic BLOCKHASH current number")?;
         if block_number >= current || current - block_number > U256::from(256) {
             return Ok(SymExpr::zero());
         }
@@ -2045,7 +2044,7 @@ impl SymbolicBlock {
         if let Some(block_number) = block_number.as_const() {
             return self.block_hash(executor, block_number);
         }
-        let current = self.number.clone().into_concrete("symbolic BLOCKHASH current number")?;
+        let current = self.number.as_const_or("symbolic BLOCKHASH current number")?;
         if current.is_zero() {
             return Ok(SymExpr::zero());
         }


### PR DESCRIPTION
This refactors symbolic expression constructors to inspect borrowed expression kinds for peephole simplification instead of consuming expressions with `into_kind` and rebuilding the same nodes. `SymExpr::op` now delegates to a borrowed `peephole_op` helper, and the solver normalization/cache-key paths avoid unwrapping expression kinds after already matching on borrowed nodes.

The fallible concrete accessors are renamed to `as_const_or` and `as_usize_or` so callers no longer clone expressions just to surface unsupported symbolic values.

Prepared with AI assistance.
