### PR TITLE
perf(anvil): filter txpool_contentFrom before conversion

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3653,10 +3653,17 @@ impl EthApi<FoundryNetwork> {
     /// Handler for ETH RPC call: `txpool_content`
     pub async fn txpool_content(&self) -> Result<TxpoolContent<AnyRpcTransaction>> {
         node_info!("txpool_content");
-        self.build_txpool_content()
+        self.build_txpool_content(None)
     }
 
-    fn build_txpool_content(&self) -> Result<TxpoolContent<AnyRpcTransaction>> {
+    /// Builds the txpool content, optionally filtered to a single sender.
+    ///
+    /// When `filter` is `Some`, only transactions from that sender are converted, avoiding the
+    /// cost of building RPC transactions for unrelated senders.
+    fn build_txpool_content(
+        &self,
+        filter: Option<Address>,
+    ) -> Result<TxpoolContent<AnyRpcTransaction>> {
         let mut content = TxpoolContent::<AnyRpcTransaction>::default();
         fn convert(tx: Arc<PoolTransaction<FoundryTxEnvelope>>) -> Result<AnyRpcTransaction> {
             let from = *tx.pending_transaction.sender();
@@ -3680,12 +3687,20 @@ impl EthApi<FoundryNetwork> {
         }
 
         for pending in self.pool.ready_transactions() {
-            let entry = content.pending.entry(*pending.pending_transaction.sender()).or_default();
+            let sender = *pending.pending_transaction.sender();
+            if filter.is_some_and(|from| from != sender) {
+                continue;
+            }
+            let entry = content.pending.entry(sender).or_default();
             let key = txpool_transaction_key(&pending.pending_transaction);
             entry.insert(key, convert(pending)?);
         }
         for queued in self.pool.pending_transactions() {
-            let entry = content.queued.entry(*queued.pending_transaction.sender()).or_default();
+            let sender = *queued.pending_transaction.sender();
+            if filter.is_some_and(|from| from != sender) {
+                continue;
+            }
+            let entry = content.queued.entry(sender).or_default();
             let key = txpool_transaction_key(&queued.pending_transaction);
             entry.insert(key, convert(queued)?);
         }
@@ -3705,7 +3720,7 @@ impl EthApi<FoundryNetwork> {
         from: Address,
     ) -> Result<TxpoolContentFrom<AnyRpcTransaction>> {
         node_info!("txpool_contentFrom");
-        let mut content = self.build_txpool_content()?;
+        let mut content = self.build_txpool_content(Some(from))?;
         Ok(content.remove_from(&from))
     }
 }


### PR DESCRIPTION
`txpool_contentFrom` built the whole txpool then dropped all but the requested sender. This filters by sender first, so only that sender's transactions get converted.
