### PR TITLE
fix(script): invalidate fork cache after state-mutating vm.rpc

### DIFF
--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -5,7 +5,7 @@ use crate::{
 use alloy_dyn_abi::DynSolValue;
 use alloy_evm::EvmEnv;
 use alloy_network::AnyNetwork;
-use alloy_primitives::{B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
@@ -216,7 +216,9 @@ impl Cheatcode for rpc_0Call {
         let Self { method, params } = self;
         let url =
             ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
-        rpc_call(&url, method, params)
+        let result = rpc_call(&url, method, params)?;
+        invalidate_active_fork_cache(ccx, method, params);
+        Ok(result)
     }
 }
 
@@ -233,7 +235,9 @@ impl Cheatcode for rpcJson_0Call {
         let Self { method, params } = self;
         let url =
             ccx.ecx.db().active_fork_url().ok_or_else(|| fmt_err!("no active fork URL found"))?;
-        rpc_json_call(&url, method, params)
+        let result = rpc_json_call(&url, method, params)?;
+        invalidate_active_fork_cache(ccx, method, params);
+        Ok(result)
     }
 }
 
@@ -451,6 +455,52 @@ fn rpc_call(url: &str, method: &str, params: &str) -> Result {
 fn rpc_json_call(url: &str, method: &str, params: &str) -> Result {
     let result = rpc_result(url, method, params)?;
     Ok(serde_json::to_string(&result)?.abi_encode())
+}
+
+/// Invalidates the fork DB cache after a `vm.rpc` call on the active fork that mutates the node
+/// directly (bypassing the cache), so later DB reads (e.g. the broadcast simulation runner)
+/// re-fetch the new value. Only well-known Anvil/Hardhat account/storage setters are handled;
+/// chain-advancing methods (e.g. `eth_sendTransaction`) need re-forking, not eviction.
+fn invalidate_active_fork_cache<FEN: FoundryEvmNetwork>(
+    ccx: &mut CheatsCtxt<'_, '_, FEN>,
+    method: &str,
+    params: &str,
+) {
+    const ACCOUNT_SETTERS: &[&str] = &[
+        "anvil_setBalance",
+        "hardhat_setBalance",
+        "tenderly_setBalance",
+        "anvil_addBalance",
+        "hardhat_addBalance",
+        "tenderly_addBalance",
+        "anvil_setNonce",
+        "hardhat_setNonce",
+        "evm_setAccountNonce",
+        "anvil_setCode",
+        "hardhat_setCode",
+    ];
+    let is_storage_setter = matches!(method, "anvil_setStorageAt" | "hardhat_setStorageAt");
+    if !is_storage_setter && !ACCOUNT_SETTERS.contains(&method) {
+        return;
+    }
+
+    let Ok(params) = serde_json::from_str::<serde_json::Value>(params) else { return };
+    let Some(address) =
+        params.get(0).and_then(|v| v.as_str()).and_then(|s| s.parse::<Address>().ok())
+    else {
+        return;
+    };
+
+    if is_storage_setter {
+        let Some(slot) =
+            params.get(1).and_then(|v| v.as_str()).and_then(|s| s.parse::<U256>().ok())
+        else {
+            return;
+        };
+        ccx.ecx.db_mut().invalidate_fork_cache_storage(address, slot);
+    } else {
+        ccx.ecx.db_mut().invalidate_fork_cache_account(address);
+    }
 }
 
 fn rpc_result(url: &str, method: &str, params: &str) -> Result<serde_json::Value> {

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -275,6 +275,14 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN
         self.backend.is_persistent(acc)
     }
 
+    fn invalidate_fork_cache_account(&mut self, address: Address) {
+        self.backend.to_mut().invalidate_fork_cache_account(address)
+    }
+
+    fn invalidate_fork_cache_storage(&mut self, address: Address, slot: U256) {
+        self.backend.to_mut().invalidate_fork_cache_storage(address, slot)
+    }
+
     fn remove_persistent_account(&mut self, account: &Address) -> bool {
         self.backend.to_mut().remove_persistent_account(account)
     }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -27,7 +27,7 @@ use revm::{
     bytecode::Bytecode,
     context::{Block, BlockEnv, CfgEnv, ContextTr, JournalInner, Transaction},
     context_interface::{journaled_state::account::JournaledAccountTr, result::ResultAndState},
-    database::{CacheDB, DatabaseRef, EmptyDB},
+    database::{AccountState, CacheDB, DatabaseRef, EmptyDB},
     primitives::{AddressMap, HashMap as Map, KECCAK_EMPTY, Log},
     state::{Account, AccountInfo, EvmState, EvmStorageSlot, TransactionId},
 };
@@ -308,6 +308,14 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
 
     /// Returns true if the given account is currently marked as persistent.
     fn is_persistent(&self, acc: &Address) -> bool;
+
+    /// Drops cached account info for `address` on the active fork so the next read re-fetches it
+    /// from the node (used after out-of-band mutations like `anvil_setBalance` via `vm.rpc`).
+    fn invalidate_fork_cache_account(&mut self, address: Address);
+
+    /// Like [`invalidate_fork_cache_account`](Self::invalidate_fork_cache_account), but for a
+    /// single storage slot.
+    fn invalidate_fork_cache_storage(&mut self, address: Address, slot: U256);
 
     /// Revokes persistent status from the given account.
     fn remove_persistent_account(&mut self, account: &Address) -> bool;
@@ -1541,6 +1549,35 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
     fn add_persistent_account(&mut self, account: Address) -> bool {
         trace!(?account, "add persistent account");
         self.inner.persistent_accounts.insert(account)
+    }
+
+    fn invalidate_fork_cache_account(&mut self, address: Address) {
+        let Some(fork_db) = self.active_fork_db_mut() else { return };
+        trace!(?address, "invalidate fork cache account");
+        fork_db.db.data().accounts.write().remove(&address);
+        // Keep the local entry if it holds in-script modifications (e.g. `vm.deal`).
+        if fork_db
+            .cache
+            .accounts
+            .get(&address)
+            .is_some_and(|account| account.account_state == AccountState::None)
+        {
+            fork_db.cache.accounts.remove(&address);
+        }
+    }
+
+    fn invalidate_fork_cache_storage(&mut self, address: Address, slot: U256) {
+        let Some(fork_db) = self.active_fork_db_mut() else { return };
+        trace!(?address, ?slot, "invalidate fork cache storage");
+        if let Some(storage) = fork_db.db.data().storage.write().get_mut(&address) {
+            storage.remove(&slot);
+        }
+        // Keep the local slot if the account holds in-script modifications.
+        if let Some(account) = fork_db.cache.accounts.get_mut(&address)
+            && account.account_state == AccountState::None
+        {
+            account.storage.remove(&slot);
+        }
     }
 
     fn remove_persistent_account(&mut self, account: &Address) -> bool {

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use alloy_hardforks::EthereumHardfork;
 use alloy_network::Ethereum;
-use alloy_primitives::{Address, Bytes, address, hex};
+use alloy_primitives::{Address, Bytes, U256, address, hex};
 use anvil::{NodeConfig, spawn};
 use forge_script_sequence::ScriptSequence;
 use foundry_test_utils::{
@@ -4011,4 +4011,61 @@ forgetest_async!(script_check_contract_sizes_honors_config_limit, |prj, cmd| {
     cmd.args(["script", "DeployLarge", "--rpc-url", &handle.http_endpoint()])
         .assert_success()
         .stderr_eq(str![[r#""#]]);
+});
+
+// Regression test for https://github.com/foundry-rs/foundry/issues/15207: the broadcast simulation
+// must observe an `anvil_setBalance` done via `vm.rpc` earlier in the same script.
+forgetest_async!(can_broadcast_with_vm_rpc_set_balance_on_fork, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+
+    // Default genesis balance is 100 ETH; fund above the broadcast amount so the send only succeeds
+    // if the simulation observes the mutation.
+    prj.add_script(
+        "FundViaRpc.s.sol",
+        r#"
+import {Script} from "forge-std/Script.sol";
+
+contract FundViaRpc is Script {
+    address constant SENDER = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
+    address constant RECIPIENT = 0x000000000000000000000000000000000000dEaD;
+
+    function run() external {
+        uint256 fundedAmount = 1000 ether;
+        uint256 sendAmount = 500 ether;
+
+        vm.deal(SENDER, fundedAmount);
+
+        // Fund the account on the forked node directly, bypassing the fork cache.
+        vm.rpc(
+            "anvil_setBalance",
+            string.concat("[\"", vm.toString(SENDER), "\", \"", vm.toString(fundedAmount), "\"]")
+        );
+
+        vm.startBroadcast(SENDER);
+        (bool ok,) = RECIPIENT.call{value: sendAmount}("");
+        require(ok, "send failed");
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    cmd.arg("script")
+        .args([
+            "FundViaRpc",
+            "--rpc-url",
+            &handle.http_endpoint(),
+            "--sender",
+            "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+            "--broadcast",
+            "--unlocked",
+        ])
+        .assert_success();
+
+    // The broadcast transaction must actually have landed on-chain.
+    let recipient = address!("0x000000000000000000000000000000000000dEaD");
+    let balance = api.balance(recipient, None).await.unwrap();
+    assert_eq!(balance, U256::from(500) * U256::from(10).pow(U256::from(18)));
 });


### PR DESCRIPTION
Fixes #15207. 

`vm.rpc("anvil_setBalance", ...)` mutates the forked node directly but not Foundry's fork cache, so `forge script --broadcast` replayed the pre-broadcast simulation against stale state and failed with "lack of funds". Now a state-mutating active-fork `vm.rpc`/`vm.rpcJson` evicts the affected account/slot from the fork cache so the simulation re-fetches the new value.