### PR TITLE
ci: bump cross for musl release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
         run: |
           cargo install cross --locked \
             --git https://github.com/cross-rs/cross \
-            --rev baf457efc2555225af47963475bd70e8d2f5993f
+            --rev 64b5bb4d3d34de062552b9a2093affe77b4ad16a
 
       - name: Build binaries
         env:


### PR DESCRIPTION
## Summary

- bump the release workflow's pinned `cross` revision to cross-rs/cross@64b5bb4d3d34de062552b9a2093affe77b4ad16a
- pick up the newer `cross` main images based on Ubuntu 24.04 for musl release builds

## Context

The nightly release failed in both musl matrix jobs while compiling `aws-lc-sys v0.42.0`; its build script rejected the container `cc` due to the GCC memcmp bug check. The existing `cross` pin uses older Ubuntu 20.04-based images, while this newer cross commit moves provided Docker images to Ubuntu 24.04.

The musl target toolchain remains musl-cross-make GCC 9.2.0, but the observed failure was on the host/build-script compiler path (`x86_64-unknown-linux-gnu`), so moving the cross image base should give `aws-lc-sys` a newer host `cc` without introducing custom image ownership.

## Validation

- Not run locally: release validation requires the GitHub Actions musl matrix with Depot/cross containers.

Prompted by: @grandizzy

Closes #15508
