### PR TITLE
feat(debugger): add storage command

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -1,6 +1,6 @@
 //! Debugger context and event handler implementation.
 
-use super::storage::{find_storage_access, hex_u256};
+use super::storage::{StorageAccess, hex_u256, storage_access_at};
 use crate::{DebugNode, DebuggerLayout, ExitReason, debugger::DebuggerContext};
 use alloy_primitives::{Address, U256, hex};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
@@ -678,13 +678,23 @@ impl TUIContext<'_> {
             }
         };
 
-        let Some(access) = find_storage_access(self.debug_steps(), self.current_step, slot) else {
+        let Some(target) = find_storage_target(
+            self.debug_arena(),
+            self.draw_memory.inner_call_index,
+            self.current_step,
+            slot,
+        ) else {
             self.set_error(format!("Storage slot {} not accessed in current call", hex_u256(slot)));
             return;
         };
 
+        let access = target.access;
+        self.draw_memory.inner_call_index = target.node_index;
         self.current_step = access.step_index();
+        self.draw_memory.current_buf_startline = 0;
+        self.draw_memory.current_stack_startline = 0;
         self.scroll_memory_to_current_write();
+        self.key_buffer.clear();
         self.set_info(format!(
             "Jumped to {} at PC 0x{:x} ({})",
             access.describe(),
@@ -980,6 +990,12 @@ struct PcTarget {
     scope: PcTargetScope,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StorageTarget {
+    node_index: usize,
+    access: StorageAccess,
+}
+
 fn parse_pc_candidates(input: &str) -> Result<Vec<PcCandidate>, String> {
     let input = input.trim();
     if input.is_empty() {
@@ -1080,6 +1096,105 @@ fn parse_storage_slot(input: &str) -> Result<U256, String> {
 
 fn invalid_storage_slot(input: &str) -> String {
     format!("Invalid storage slot `{input}`; use hex 0x20/20 or decimal d:32")
+}
+
+fn find_storage_target(
+    arena: &[DebugNode],
+    current_node_index: usize,
+    current_step: usize,
+    slot: U256,
+) -> Option<StorageTarget> {
+    let current_node = arena.get(current_node_index)?;
+    let trace_node_idx = current_node.trace_node_idx;
+    let current_absolute_step = current_node.step_offset.saturating_add(current_step);
+
+    storage_target_at(arena, current_node_index, current_step, slot)
+        .or_else(|| find_storage_target_after(arena, trace_node_idx, current_absolute_step, slot))
+        .or_else(|| find_storage_target_before(arena, trace_node_idx, current_absolute_step, slot))
+}
+
+fn storage_target_at(
+    arena: &[DebugNode],
+    node_index: usize,
+    step_index: usize,
+    slot: U256,
+) -> Option<StorageTarget> {
+    let node = arena.get(node_index)?;
+    storage_access_at(&node.steps, step_index)
+        .filter(|access| access.slot() == slot)
+        .map(|access| StorageTarget { node_index, access })
+}
+
+fn find_storage_target_after(
+    arena: &[DebugNode],
+    trace_node_idx: usize,
+    current_absolute_step: usize,
+    slot: U256,
+) -> Option<StorageTarget> {
+    let mut best = None;
+
+    for (node_index, node) in arena.iter().enumerate() {
+        if node.trace_node_idx != trace_node_idx {
+            continue;
+        }
+
+        for step_index in 0..node.steps.len() {
+            let absolute_step = node.step_offset.saturating_add(step_index);
+            if absolute_step <= current_absolute_step {
+                continue;
+            }
+
+            let Some(access) =
+                storage_access_at(&node.steps, step_index).filter(|access| access.slot() == slot)
+            else {
+                continue;
+            };
+
+            match best {
+                Some((best_absolute_step, _, _)) if absolute_step >= best_absolute_step => {}
+                _ => best = Some((absolute_step, node_index, access)),
+            }
+            break;
+        }
+    }
+
+    best.map(|(_, node_index, access)| StorageTarget { node_index, access })
+}
+
+fn find_storage_target_before(
+    arena: &[DebugNode],
+    trace_node_idx: usize,
+    current_absolute_step: usize,
+    slot: U256,
+) -> Option<StorageTarget> {
+    let mut best = None;
+
+    for (node_index, node) in arena.iter().enumerate() {
+        if node.trace_node_idx != trace_node_idx {
+            continue;
+        }
+
+        for step_index in (0..node.steps.len()).rev() {
+            let absolute_step = node.step_offset.saturating_add(step_index);
+            if absolute_step >= current_absolute_step {
+                continue;
+            }
+
+            let Some(access) =
+                storage_access_at(&node.steps, step_index).filter(|access| access.slot() == slot)
+            else {
+                continue;
+            };
+
+            match best {
+                Some((best_absolute_step, _, _)) if absolute_step <= best_absolute_step => {}
+                _ => best = Some((absolute_step, node_index, access)),
+            }
+            break;
+        }
+    }
+
+    best.map(|(_, node_index, access)| StorageTarget { node_index, access })
 }
 
 fn find_pc_target(
@@ -1753,6 +1868,52 @@ mod tests {
     }
 
     #[test]
+    fn command_prompt_searches_storage_across_split_call_segments() {
+        let address = Address::repeat_byte(1);
+        let mut store = step(42);
+        store.storage_change = Some(Box::new(StorageChange {
+            key: U256::from(1),
+            value: U256::from(42),
+            had_value: None,
+            reason: StorageChangeReason::SSTORE,
+        }));
+
+        let mut first =
+            DebugNode::new(address, CallKind::Call, vec![step(1)], Bytes::new(), 0, None);
+        first.trace_node_idx = 7;
+        first.step_offset = 0;
+
+        let mut child = DebugNode::new(
+            Address::repeat_byte(2),
+            CallKind::Call,
+            vec![step(2)],
+            Bytes::new(),
+            0,
+            None,
+        );
+        child.trace_node_idx = 8;
+        child.step_offset = 1;
+
+        let mut second =
+            DebugNode::new(address, CallKind::Call, vec![store], Bytes::new(), 0, None);
+        second.trace_node_idx = 7;
+        second.step_offset = 2;
+
+        let mut context = context_with_arena(vec![first, child, second]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("storage 1");
+
+        assert_eq!(tui.draw_memory.inner_call_index, 2);
+        assert_eq!(tui.current_step, 0);
+        assert_eq!(
+            tui.status.as_ref().unwrap().text,
+            "Jumped to storage SSTORE slot 0x1 = 0x2a at PC 0x2a (42)"
+        );
+    }
+
+    #[test]
     fn command_prompt_finds_warm_sload_from_stack_snapshots() {
         let address = Address::repeat_byte(1);
         let steps =
@@ -1774,6 +1935,30 @@ mod tests {
         assert_eq!(
             tui.status.as_ref().unwrap().text,
             "Jumped to storage SLOAD slot 0x1 = 0x2a at PC 0x1 (1)"
+        );
+    }
+
+    #[test]
+    fn command_prompt_finds_warm_sstore_from_stack_snapshot() {
+        let address = Address::repeat_byte(1);
+        let steps = vec![step_with_stack(42, OpCode::SSTORE, &[42, 1])];
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            steps,
+            Bytes::new(),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("slot 1");
+
+        assert_eq!(tui.current_step, 0);
+        assert_eq!(
+            tui.status.as_ref().unwrap().text,
+            "Jumped to storage SSTORE slot 0x1 = 0x2a at PC 0x2a (42)"
         );
     }
 

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -1,13 +1,13 @@
 //! Debugger context and event handler implementation.
 
 use crate::{DebugNode, DebuggerLayout, ExitReason, debugger::DebuggerContext};
-use alloy_primitives::{Address, hex};
+use alloy_primitives::{Address, U256, hex};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use foundry_evm_core::buffer::{BufferKind, get_buffer_accesses};
 use foundry_tui::TuiApp;
 use ratatui::Frame;
-use revm::bytecode::opcode::OpCode;
-use revm_inspectors::tracing::types::{CallKind, CallTraceStep};
+use revm::bytecode::opcode::{self, OpCode};
+use revm_inspectors::tracing::types::{CallKind, CallTraceStep, StorageChangeReason};
 use std::ops::ControlFlow;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -634,6 +634,8 @@ impl TUIContext<'_> {
             self.run_buffer_command(command, BufferKind::Calldata, parts);
         } else if RETURNDATA_COMMANDS.contains(&command) {
             self.run_buffer_command(command, BufferKind::Returndata, parts);
+        } else if STORAGE_COMMANDS.contains(&command) {
+            self.run_storage_command(command, parts);
         } else if HELP_COMMANDS.contains(&command) {
             self.set_info(command_help());
         } else {
@@ -654,6 +656,40 @@ impl TUIContext<'_> {
             return self.set_error(command_usage(command, "<offset>"));
         }
         self.goto_buffer_offset(buffer, offset);
+    }
+
+    fn run_storage_command<'a>(&mut self, command: &str, mut args: impl Iterator<Item = &'a str>) {
+        let Some(slot) = args.next() else {
+            return self.set_error(command_usage(command, "<slot>"));
+        };
+        if args.next().is_some() {
+            return self.set_error(command_usage(command, "<slot>"));
+        }
+        self.goto_storage_slot_from_input(slot);
+    }
+
+    fn goto_storage_slot_from_input(&mut self, input: &str) {
+        let slot = match parse_storage_slot(input) {
+            Ok(slot) => slot,
+            Err(err) => {
+                self.set_error(err);
+                return;
+            }
+        };
+
+        let Some(access) = find_storage_access(self.debug_steps(), self.current_step, slot) else {
+            self.set_error(format!("Storage slot {} not accessed in current call", hex_u256(slot)));
+            return;
+        };
+
+        self.current_step = access.step_index;
+        self.scroll_memory_to_current_write();
+        self.set_info(format!(
+            "Jumped to {} at PC 0x{:x} ({})",
+            access.describe(),
+            access.pc,
+            access.pc
+        ));
     }
 
     fn apply_buffer_offset(&mut self, offset: usize) {
@@ -821,6 +857,7 @@ const PC_COMMANDS: &[&str] = &["pc", "p"];
 const MEMORY_COMMANDS: &[&str] = &["mem", "memory"];
 const CALLDATA_COMMANDS: &[&str] = &["calldata", "cd"];
 const RETURNDATA_COMMANDS: &[&str] = &["returndata", "ret", "rd"];
+const STORAGE_COMMANDS: &[&str] = &["storage", "store", "slot"];
 const HELP_COMMANDS: &[&str] = &["help", "h"];
 
 fn command_usage(command: &str, arg: &str) -> String {
@@ -829,12 +866,13 @@ fn command_usage(command: &str, arg: &str) -> String {
 
 fn command_help() -> String {
     format!(
-        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>",
+        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>",
         command_aliases(CONTINUE_COMMANDS),
         command_aliases(PC_COMMANDS),
         command_aliases(MEMORY_COMMANDS),
         command_aliases(CALLDATA_COMMANDS),
-        command_aliases(RETURNDATA_COMMANDS)
+        command_aliases(RETURNDATA_COMMANDS),
+        command_aliases(STORAGE_COMMANDS)
     )
 }
 
@@ -941,6 +979,41 @@ struct PcTarget {
     scope: PcTargetScope,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StorageAccessKind {
+    Sload,
+    Sstore,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StorageAccess {
+    step_index: usize,
+    pc: usize,
+    kind: StorageAccessKind,
+    slot: U256,
+    value: U256,
+    previous: Option<U256>,
+}
+
+impl StorageAccess {
+    fn describe(self) -> String {
+        let op = match self.kind {
+            StorageAccessKind::Sload => "SLOAD",
+            StorageAccessKind::Sstore => "SSTORE",
+        };
+
+        match (self.kind, self.previous) {
+            (StorageAccessKind::Sstore, Some(previous)) => format!(
+                "storage {op} slot {}: {} -> {}",
+                hex_u256(self.slot),
+                hex_u256(previous),
+                hex_u256(self.value)
+            ),
+            _ => format!("storage {op} slot {} = {}", hex_u256(self.slot), hex_u256(self.value)),
+        }
+    }
+}
+
 fn parse_pc_candidates(input: &str) -> Result<Vec<PcCandidate>, String> {
     let input = input.trim();
     if input.is_empty() {
@@ -1015,6 +1088,91 @@ fn parse_buffer_offset(input: &str) -> Result<usize, String> {
 
 fn invalid_buffer_offset(input: &str) -> String {
     format!("Invalid buffer offset `{input}`; use hex 0x20/20 or decimal d:32")
+}
+
+fn parse_storage_slot(input: &str) -> Result<U256, String> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Err("Enter a storage slot".to_string());
+    }
+
+    let (digits, radix) =
+        if let Some(rest) = input.strip_prefix("0x").or_else(|| input.strip_prefix("0X")) {
+            (rest, 16)
+        } else if let Some(rest) = input.strip_prefix("d:").or_else(|| input.strip_prefix("dec:")) {
+            (rest, 10)
+        } else {
+            (input, 16)
+        };
+
+    if digits.is_empty() {
+        return Err(invalid_storage_slot(input));
+    }
+
+    U256::from_str_radix(digits, radix).map_err(|_| invalid_storage_slot(input))
+}
+
+fn invalid_storage_slot(input: &str) -> String {
+    format!("Invalid storage slot `{input}`; use hex 0x20/20 or decimal d:32")
+}
+
+fn find_storage_access(
+    steps: &[CallTraceStep],
+    current_step: usize,
+    slot: U256,
+) -> Option<StorageAccess> {
+    if steps.is_empty() {
+        return None;
+    }
+
+    let current = current_step.min(steps.len() - 1);
+    storage_access_at(steps, current).filter(|access| access.slot == slot).or_else(|| {
+        steps
+            .iter()
+            .enumerate()
+            .skip(current.saturating_add(1))
+            .find_map(|(i, _)| storage_access_at(steps, i).filter(|access| access.slot == slot))
+            .or_else(|| {
+                steps[..current].iter().enumerate().rev().find_map(|(i, _)| {
+                    storage_access_at(steps, i).filter(|access| access.slot == slot)
+                })
+            })
+    })
+}
+
+fn storage_access_at(steps: &[CallTraceStep], step_index: usize) -> Option<StorageAccess> {
+    let step = steps.get(step_index)?;
+    if let Some(change) = step.storage_change.as_deref() {
+        let kind = match change.reason {
+            StorageChangeReason::SLOAD => StorageAccessKind::Sload,
+            StorageChangeReason::SSTORE => StorageAccessKind::Sstore,
+        };
+        return Some(StorageAccess {
+            step_index,
+            pc: step.pc,
+            kind,
+            slot: change.key,
+            value: change.value,
+            previous: change.had_value,
+        });
+    }
+
+    if step.op.get() == opcode::SLOAD {
+        return Some(StorageAccess {
+            step_index,
+            pc: step.pc,
+            kind: StorageAccessKind::Sload,
+            slot: step.stack.as_deref()?.last().copied()?,
+            value: steps.get(step_index.checked_add(1)?)?.stack.as_deref()?.last().copied()?,
+            previous: None,
+        });
+    }
+
+    None
+}
+
+fn hex_u256(value: U256) -> String {
+    format!("{value:#x}")
 }
 
 fn find_pc_target(
@@ -1156,10 +1314,11 @@ fn is_jump(step: &CallTraceStep, prev: &CallTraceStep) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{Bytes, U256};
+    use alloy_primitives::Bytes;
     use foundry_evm_core::Breakpoints;
     use foundry_evm_traces::debug::ContractSources;
     use revm::interpreter::InstructionResult;
+    use revm_inspectors::tracing::types::StorageChange;
 
     fn step(pc: usize) -> CallTraceStep {
         step_with_stack(pc, OpCode::STOP, &[])
@@ -1419,6 +1578,26 @@ mod tests {
     }
 
     #[test]
+    fn parses_storage_slots_as_visible_hex_labels() {
+        assert_eq!(parse_storage_slot("0x20").unwrap(), U256::from(32));
+        assert_eq!(parse_storage_slot("d:32").unwrap(), U256::from(32));
+        assert_eq!(parse_storage_slot("dec:32").unwrap(), U256::from(32));
+        assert_eq!(parse_storage_slot("20").unwrap(), U256::from(32));
+        assert_eq!(parse_storage_slot("2a").unwrap(), U256::from(42));
+        assert_eq!(parse_storage_slot("a").unwrap(), U256::from(10));
+
+        assert_eq!(parse_storage_slot("").unwrap_err(), "Enter a storage slot");
+        assert_eq!(
+            parse_storage_slot("0x").unwrap_err(),
+            "Invalid storage slot `0x`; use hex 0x20/20 or decimal d:32"
+        );
+        assert_eq!(
+            parse_storage_slot("2x3").unwrap_err(),
+            "Invalid storage slot `2x3`; use hex 0x20/20 or decimal d:32"
+        );
+    }
+
+    #[test]
     fn filters_buffer_offset_input_to_parser_prefixes() {
         assert!(is_buffer_offset_input_char("", '0'));
         assert!(is_buffer_offset_input_char("0", 'x'));
@@ -1637,6 +1816,61 @@ mod tests {
     }
 
     #[test]
+    fn command_prompt_jumps_to_storage_slot_access() {
+        let address = Address::repeat_byte(1);
+        let mut store = step(42);
+        store.storage_change = Some(Box::new(StorageChange {
+            key: U256::from(1),
+            value: U256::from(42),
+            had_value: Some(U256::from(7)),
+            reason: StorageChangeReason::SSTORE,
+        }));
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![step(1), store],
+            Bytes::new(),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("storage 1");
+
+        assert_eq!(tui.current_step, 1);
+        assert_eq!(
+            tui.status.as_ref().unwrap().text,
+            "Jumped to storage SSTORE slot 0x1: 0x7 -> 0x2a at PC 0x2a (42)"
+        );
+    }
+
+    #[test]
+    fn command_prompt_finds_warm_sload_from_stack_snapshots() {
+        let address = Address::repeat_byte(1);
+        let steps =
+            vec![step_with_stack(1, OpCode::SLOAD, &[1]), step_with_stack(2, OpCode::STOP, &[42])];
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            steps,
+            Bytes::new(),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("store 1");
+
+        assert_eq!(tui.current_step, 0);
+        assert_eq!(
+            tui.status.as_ref().unwrap().text,
+            "Jumped to storage SLOAD slot 0x1 = 0x2a at PC 0x1 (1)"
+        );
+    }
+
+    #[test]
     fn command_prompt_accepts_optional_leading_colon() {
         let address = Address::repeat_byte(1);
         let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1, 42])]);
@@ -1665,6 +1899,7 @@ mod tests {
             MEMORY_COMMANDS,
             CALLDATA_COMMANDS,
             RETURNDATA_COMMANDS,
+            STORAGE_COMMANDS,
         ] {
             assert!(help.contains(&command_aliases(commands)));
         }
@@ -1673,6 +1908,11 @@ mod tests {
         let status = tui.status.as_ref().unwrap();
         assert_eq!(status.kind, StatusKind::Error);
         assert_eq!(status.text, "Usage: :mem <offset>");
+
+        tui.run_command_from_input("store");
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "Usage: :store <slot>");
     }
 
     #[test]

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -2008,6 +2008,36 @@ mod tests {
     }
 
     #[test]
+    fn command_prompt_ignores_failed_sstore_storage_change() {
+        let address = Address::repeat_byte(1);
+        let mut store = step_with_stack(42, OpCode::SSTORE, &[42, 1]);
+        store.storage_change = Some(Box::new(StorageChange {
+            key: U256::from(1),
+            value: U256::from(42),
+            had_value: Some(U256::ZERO),
+            reason: StorageChangeReason::SSTORE,
+        }));
+        store.status = Some(InstructionResult::OutOfGas);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![store],
+            Bytes::new(),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("slot 1");
+
+        assert_eq!(tui.current_step, 0);
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "Storage slot 0x1 not accessed in current call");
+    }
+
+    #[test]
     fn command_prompt_accepts_optional_leading_colon() {
         let address = Address::repeat_byte(1);
         let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1, 42])]);

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -1,13 +1,14 @@
 //! Debugger context and event handler implementation.
 
+use super::storage::{find_storage_access, hex_u256};
 use crate::{DebugNode, DebuggerLayout, ExitReason, debugger::DebuggerContext};
 use alloy_primitives::{Address, U256, hex};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use foundry_evm_core::buffer::{BufferKind, get_buffer_accesses};
 use foundry_tui::TuiApp;
 use ratatui::Frame;
-use revm::bytecode::opcode::{self, OpCode};
-use revm_inspectors::tracing::types::{CallKind, CallTraceStep, StorageChangeReason};
+use revm::bytecode::opcode::OpCode;
+use revm_inspectors::tracing::types::{CallKind, CallTraceStep};
 use std::ops::ControlFlow;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -682,13 +683,13 @@ impl TUIContext<'_> {
             return;
         };
 
-        self.current_step = access.step_index;
+        self.current_step = access.step_index();
         self.scroll_memory_to_current_write();
         self.set_info(format!(
             "Jumped to {} at PC 0x{:x} ({})",
             access.describe(),
-            access.pc,
-            access.pc
+            access.pc(),
+            access.pc()
         ));
     }
 
@@ -979,41 +980,6 @@ struct PcTarget {
     scope: PcTargetScope,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum StorageAccessKind {
-    Sload,
-    Sstore,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct StorageAccess {
-    step_index: usize,
-    pc: usize,
-    kind: StorageAccessKind,
-    slot: U256,
-    value: U256,
-    previous: Option<U256>,
-}
-
-impl StorageAccess {
-    fn describe(self) -> String {
-        let op = match self.kind {
-            StorageAccessKind::Sload => "SLOAD",
-            StorageAccessKind::Sstore => "SSTORE",
-        };
-
-        match (self.kind, self.previous) {
-            (StorageAccessKind::Sstore, Some(previous)) => format!(
-                "storage {op} slot {}: {} -> {}",
-                hex_u256(self.slot),
-                hex_u256(previous),
-                hex_u256(self.value)
-            ),
-            _ => format!("storage {op} slot {} = {}", hex_u256(self.slot), hex_u256(self.value)),
-        }
-    }
-}
-
 fn parse_pc_candidates(input: &str) -> Result<Vec<PcCandidate>, String> {
     let input = input.trim();
     if input.is_empty() {
@@ -1114,65 +1080,6 @@ fn parse_storage_slot(input: &str) -> Result<U256, String> {
 
 fn invalid_storage_slot(input: &str) -> String {
     format!("Invalid storage slot `{input}`; use hex 0x20/20 or decimal d:32")
-}
-
-fn find_storage_access(
-    steps: &[CallTraceStep],
-    current_step: usize,
-    slot: U256,
-) -> Option<StorageAccess> {
-    if steps.is_empty() {
-        return None;
-    }
-
-    let current = current_step.min(steps.len() - 1);
-    storage_access_at(steps, current).filter(|access| access.slot == slot).or_else(|| {
-        steps
-            .iter()
-            .enumerate()
-            .skip(current.saturating_add(1))
-            .find_map(|(i, _)| storage_access_at(steps, i).filter(|access| access.slot == slot))
-            .or_else(|| {
-                steps[..current].iter().enumerate().rev().find_map(|(i, _)| {
-                    storage_access_at(steps, i).filter(|access| access.slot == slot)
-                })
-            })
-    })
-}
-
-fn storage_access_at(steps: &[CallTraceStep], step_index: usize) -> Option<StorageAccess> {
-    let step = steps.get(step_index)?;
-    if let Some(change) = step.storage_change.as_deref() {
-        let kind = match change.reason {
-            StorageChangeReason::SLOAD => StorageAccessKind::Sload,
-            StorageChangeReason::SSTORE => StorageAccessKind::Sstore,
-        };
-        return Some(StorageAccess {
-            step_index,
-            pc: step.pc,
-            kind,
-            slot: change.key,
-            value: change.value,
-            previous: change.had_value,
-        });
-    }
-
-    if step.op.get() == opcode::SLOAD {
-        return Some(StorageAccess {
-            step_index,
-            pc: step.pc,
-            kind: StorageAccessKind::Sload,
-            slot: step.stack.as_deref()?.last().copied()?,
-            value: steps.get(step_index.checked_add(1)?)?.stack.as_deref()?.last().copied()?,
-            previous: None,
-        });
-    }
-
-    None
-}
-
-fn hex_u256(value: U256) -> String {
-    format!("{value:#x}")
 }
 
 fn find_pc_target(
@@ -1318,7 +1225,7 @@ mod tests {
     use foundry_evm_core::Breakpoints;
     use foundry_evm_traces::debug::ContractSources;
     use revm::interpreter::InstructionResult;
-    use revm_inspectors::tracing::types::StorageChange;
+    use revm_inspectors::tracing::types::{StorageChange, StorageChangeReason};
 
     fn step(pc: usize) -> CallTraceStep {
         step_with_stack(pc, OpCode::STOP, &[])

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -1087,7 +1087,12 @@ fn parse_storage_slot(input: &str) -> Result<U256, String> {
             (input, 16)
         };
 
-    if digits.is_empty() {
+    let valid_digits = match radix {
+        10 => digits.bytes().all(|b| b.is_ascii_digit()),
+        16 => digits.bytes().all(|b| b.is_ascii_hexdigit()),
+        _ => unreachable!(),
+    };
+    if digits.is_empty() || !valid_digits {
         return Err(invalid_storage_slot(input));
     }
 
@@ -1617,6 +1622,22 @@ mod tests {
             parse_storage_slot("2x3").unwrap_err(),
             "Invalid storage slot `2x3`; use hex 0x20/20 or decimal d:32"
         );
+        assert_eq!(
+            parse_storage_slot("1_0").unwrap_err(),
+            "Invalid storage slot `1_0`; use hex 0x20/20 or decimal d:32"
+        );
+        assert_eq!(
+            parse_storage_slot("_").unwrap_err(),
+            "Invalid storage slot `_`; use hex 0x20/20 or decimal d:32"
+        );
+        assert_eq!(
+            parse_storage_slot("0x_").unwrap_err(),
+            "Invalid storage slot `0x_`; use hex 0x20/20 or decimal d:32"
+        );
+        assert_eq!(
+            parse_storage_slot("d:_").unwrap_err(),
+            "Invalid storage slot `d:_`; use hex 0x20/20 or decimal d:32"
+        );
     }
 
     #[test]
@@ -1960,6 +1981,30 @@ mod tests {
             tui.status.as_ref().unwrap().text,
             "Jumped to storage SSTORE slot 0x1 = 0x2a at PC 0x2a (42)"
         );
+    }
+
+    #[test]
+    fn command_prompt_ignores_failed_sstore_stack_snapshot() {
+        let address = Address::repeat_byte(1);
+        let mut store = step_with_stack(42, OpCode::SSTORE, &[42, 1]);
+        store.status = Some(InstructionResult::StateChangeDuringStaticCall);
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![store],
+            Bytes::new(),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("slot 1");
+
+        assert_eq!(tui.current_step, 0);
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "Storage slot 0x1 not accessed in current call");
     }
 
     #[test]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -1,6 +1,9 @@
 //! TUI draw implementation.
 
-use super::context::{ActiveInternalCallCache, ActiveInternalCallLocation, StatusKind, TUIContext};
+use super::{
+    context::{ActiveInternalCallCache, ActiveInternalCallLocation, StatusKind, TUIContext},
+    storage::{StorageAccess, storage_access_at},
+};
 use crate::{DebuggerLayout, debugger::DebuggerStats, op::OpcodeParam};
 use alloy_dyn_abi::{DynSolType, Specifier, parser::Parameters};
 use alloy_primitives::{Address, U256, keccak256};
@@ -17,10 +20,7 @@ use ratatui::{
     text::{Line, Span, Text},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
 };
-use revm::bytecode::opcode;
-use revm_inspectors::tracing::types::{
-    CallKind, DecodedInternalCall, DecodedTraceStep, StorageChange, StorageChangeReason,
-};
+use revm_inspectors::tracing::types::{CallKind, DecodedInternalCall, DecodedTraceStep};
 use std::{collections::VecDeque, fmt::Write};
 
 impl TUIContext<'_> {
@@ -613,27 +613,7 @@ impl TUIContext<'_> {
     }
 
     fn current_storage_access_line(&self) -> Option<Line<'static>> {
-        let step = self.current_step();
-        if let Some(change) = step.storage_change.as_deref() {
-            return Some(storage_access_line(change));
-        }
-
-        // `revm-inspectors` records `storage_change` from journal entries, so warm `SLOAD`s do not
-        // get one. Debug mode records full stack snapshots before each opcode; the following step's
-        // stack contains the loaded value after this `SLOAD` executes.
-        if step.op.get() == opcode::SLOAD {
-            let key = step.stack.as_deref()?.last().copied()?;
-            let value = self
-                .debug_steps()
-                .get(self.current_step.checked_add(1)?)?
-                .stack
-                .as_deref()?
-                .last()
-                .copied()?;
-            return Some(sload_storage_access_line(key, value));
-        }
-
-        None
+        storage_access_at(self.debug_steps(), self.current_step).map(storage_access_line)
     }
 
     fn draw_buffer(&self, f: &mut Frame<'_>, area: Rect) {
@@ -1121,34 +1101,8 @@ fn scope_variable_line(variable: ScopeVariable) -> Line<'static> {
     Line::from(spans)
 }
 
-fn storage_access_line(change: &StorageChange) -> Line<'static> {
-    let op = match change.reason {
-        StorageChangeReason::SLOAD => "SLOAD",
-        StorageChangeReason::SSTORE => "SSTORE",
-    };
-
-    let text = match (change.reason, change.had_value) {
-        (StorageChangeReason::SSTORE, Some(previous)) => format!(
-            "storage {op} slot {}: {} -> {}",
-            hex_u256(change.key),
-            hex_u256(previous),
-            hex_u256(change.value)
-        ),
-        _ => format!("storage {op} slot {} = {}", hex_u256(change.key), hex_u256(change.value)),
-    };
-
-    Line::from(Span::styled(text, Style::new().fg(Color::Yellow)))
-}
-
-fn sload_storage_access_line(key: U256, value: U256) -> Line<'static> {
-    Line::from(Span::styled(
-        format!("storage SLOAD slot {} = {}", hex_u256(key), hex_u256(value)),
-        Style::new().fg(Color::Yellow),
-    ))
-}
-
-fn hex_u256(value: U256) -> String {
-    format!("{value:#x}")
+fn storage_access_line(access: StorageAccess) -> Line<'static> {
+    Line::from(Span::styled(access.describe(), Style::new().fg(Color::Yellow)))
 }
 
 fn variable_name(variable: &DebugVariable, index: usize, fallback_prefix: &str) -> String {
@@ -1783,30 +1737,33 @@ mod tests {
 
     #[test]
     fn storage_access_line_formats_sload() {
-        let change = StorageChange {
+        let mut step = trace_step(Vec::new());
+        step.storage_change = Some(Box::new(StorageChange {
             key: U256::from(1),
             value: U256::from(42),
             had_value: None,
             reason: StorageChangeReason::SLOAD,
-        };
+        }));
+        let steps = [step];
+        let access = super::storage_access_at(&steps, 0).unwrap();
 
-        assert_eq!(
-            line_text(&super::storage_access_line(&change)),
-            "storage SLOAD slot 0x1 = 0x2a"
-        );
+        assert_eq!(line_text(&super::storage_access_line(access)), "storage SLOAD slot 0x1 = 0x2a");
     }
 
     #[test]
     fn storage_access_line_formats_sstore_with_previous_value() {
-        let change = StorageChange {
+        let mut step = trace_step(Vec::new());
+        step.storage_change = Some(Box::new(StorageChange {
             key: U256::from(1),
             value: U256::from(42),
             had_value: Some(U256::from(7)),
             reason: StorageChangeReason::SSTORE,
-        };
+        }));
+        let steps = [step];
+        let access = super::storage_access_at(&steps, 0).unwrap();
 
         assert_eq!(
-            line_text(&super::storage_access_line(&change)),
+            line_text(&super::storage_access_line(access)),
             "storage SSTORE slot 0x1: 0x7 -> 0x2a"
         );
     }

--- a/crates/debugger/src/tui/mod.rs
+++ b/crates/debugger/src/tui/mod.rs
@@ -8,6 +8,7 @@ use crate::debugger::DebuggerContext;
 use context::TUIContext;
 
 mod draw;
+mod storage;
 
 /// Debugger exit reason.
 #[derive(Debug)]

--- a/crates/debugger/src/tui/storage.rs
+++ b/crates/debugger/src/tui/storage.rs
@@ -1,8 +1,7 @@
 //! Storage access helpers for debugger TUI views and commands.
 
 use alloy_primitives::U256;
-use revm::bytecode::opcode;
-use revm::interpreter::InstructionResult;
+use revm::{bytecode::opcode, interpreter::InstructionResult};
 use revm_inspectors::tracing::types::{CallTraceStep, StorageChangeReason};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/debugger/src/tui/storage.rs
+++ b/crates/debugger/src/tui/storage.rs
@@ -2,6 +2,7 @@
 
 use alloy_primitives::U256;
 use revm::bytecode::opcode;
+use revm::interpreter::InstructionResult;
 use revm_inspectors::tracing::types::{CallTraceStep, StorageChangeReason};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -82,7 +83,7 @@ pub(super) fn storage_access_at(
         });
     }
 
-    if step.op.get() == opcode::SSTORE {
+    if step.op.get() == opcode::SSTORE && step.status.is_none_or(InstructionResult::is_ok) {
         let mut stack = step.stack.as_deref()?.iter().rev();
         let slot = stack.next().copied()?;
         let value = stack.next().copied()?;

--- a/crates/debugger/src/tui/storage.rs
+++ b/crates/debugger/src/tui/storage.rs
@@ -29,6 +29,10 @@ impl StorageAccess {
         self.pc
     }
 
+    pub(super) const fn slot(self) -> U256 {
+        self.slot
+    }
+
     pub(super) fn describe(self) -> String {
         let op = match self.kind {
             StorageAccessKind::Sload => "SLOAD",
@@ -45,27 +49,6 @@ impl StorageAccess {
             _ => format!("storage {op} slot {} = {}", hex_u256(self.slot), hex_u256(self.value)),
         }
     }
-}
-
-pub(super) fn find_storage_access(
-    steps: &[CallTraceStep],
-    current_step: usize,
-    slot: U256,
-) -> Option<StorageAccess> {
-    if steps.is_empty() {
-        return None;
-    }
-
-    let current = current_step.min(steps.len() - 1);
-    storage_access_at(steps, current).filter(|access| access.slot == slot).or_else(|| {
-        (current.saturating_add(1)..steps.len())
-            .find_map(|i| storage_access_at(steps, i).filter(|access| access.slot == slot))
-            .or_else(|| {
-                (0..current)
-                    .rev()
-                    .find_map(|i| storage_access_at(steps, i).filter(|access| access.slot == slot))
-            })
-    })
 }
 
 pub(super) fn storage_access_at(
@@ -95,6 +78,20 @@ pub(super) fn storage_access_at(
             kind: StorageAccessKind::Sload,
             slot: step.stack.as_deref()?.last().copied()?,
             value: steps.get(step_index.checked_add(1)?)?.stack.as_deref()?.last().copied()?,
+            previous: None,
+        });
+    }
+
+    if step.op.get() == opcode::SSTORE {
+        let mut stack = step.stack.as_deref()?.iter().rev();
+        let slot = stack.next().copied()?;
+        let value = stack.next().copied()?;
+        return Some(StorageAccess {
+            step_index,
+            pc: step.pc,
+            kind: StorageAccessKind::Sstore,
+            slot,
+            value,
             previous: None,
         });
     }

--- a/crates/debugger/src/tui/storage.rs
+++ b/crates/debugger/src/tui/storage.rs
@@ -1,0 +1,107 @@
+//! Storage access helpers for debugger TUI views and commands.
+
+use alloy_primitives::U256;
+use revm::bytecode::opcode;
+use revm_inspectors::tracing::types::{CallTraceStep, StorageChangeReason};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StorageAccessKind {
+    Sload,
+    Sstore,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct StorageAccess {
+    step_index: usize,
+    pc: usize,
+    kind: StorageAccessKind,
+    slot: U256,
+    value: U256,
+    previous: Option<U256>,
+}
+
+impl StorageAccess {
+    pub(super) const fn step_index(self) -> usize {
+        self.step_index
+    }
+
+    pub(super) const fn pc(self) -> usize {
+        self.pc
+    }
+
+    pub(super) fn describe(self) -> String {
+        let op = match self.kind {
+            StorageAccessKind::Sload => "SLOAD",
+            StorageAccessKind::Sstore => "SSTORE",
+        };
+
+        match (self.kind, self.previous) {
+            (StorageAccessKind::Sstore, Some(previous)) => format!(
+                "storage {op} slot {}: {} -> {}",
+                hex_u256(self.slot),
+                hex_u256(previous),
+                hex_u256(self.value)
+            ),
+            _ => format!("storage {op} slot {} = {}", hex_u256(self.slot), hex_u256(self.value)),
+        }
+    }
+}
+
+pub(super) fn find_storage_access(
+    steps: &[CallTraceStep],
+    current_step: usize,
+    slot: U256,
+) -> Option<StorageAccess> {
+    if steps.is_empty() {
+        return None;
+    }
+
+    let current = current_step.min(steps.len() - 1);
+    storage_access_at(steps, current).filter(|access| access.slot == slot).or_else(|| {
+        (current.saturating_add(1)..steps.len())
+            .find_map(|i| storage_access_at(steps, i).filter(|access| access.slot == slot))
+            .or_else(|| {
+                (0..current)
+                    .rev()
+                    .find_map(|i| storage_access_at(steps, i).filter(|access| access.slot == slot))
+            })
+    })
+}
+
+pub(super) fn storage_access_at(
+    steps: &[CallTraceStep],
+    step_index: usize,
+) -> Option<StorageAccess> {
+    let step = steps.get(step_index)?;
+    if let Some(change) = step.storage_change.as_deref() {
+        let kind = match change.reason {
+            StorageChangeReason::SLOAD => StorageAccessKind::Sload,
+            StorageChangeReason::SSTORE => StorageAccessKind::Sstore,
+        };
+        return Some(StorageAccess {
+            step_index,
+            pc: step.pc,
+            kind,
+            slot: change.key,
+            value: change.value,
+            previous: change.had_value,
+        });
+    }
+
+    if step.op.get() == opcode::SLOAD {
+        return Some(StorageAccess {
+            step_index,
+            pc: step.pc,
+            kind: StorageAccessKind::Sload,
+            slot: step.stack.as_deref()?.last().copied()?,
+            value: steps.get(step_index.checked_add(1)?)?.stack.as_deref()?.last().copied()?,
+            previous: None,
+        });
+    }
+
+    None
+}
+
+pub(super) fn hex_u256(value: U256) -> String {
+    format!("{value:#x}")
+}

--- a/crates/debugger/src/tui/storage.rs
+++ b/crates/debugger/src/tui/storage.rs
@@ -56,6 +56,10 @@ pub(super) fn storage_access_at(
     step_index: usize,
 ) -> Option<StorageAccess> {
     let step = steps.get(step_index)?;
+    if step.op.get() == opcode::SSTORE && !step.status.is_none_or(InstructionResult::is_ok) {
+        return None;
+    }
+
     if let Some(change) = step.storage_change.as_deref() {
         let kind = match change.reason {
             StorageChangeReason::SLOAD => StorageAccessKind::Sload,
@@ -82,7 +86,7 @@ pub(super) fn storage_access_at(
         });
     }
 
-    if step.op.get() == opcode::SSTORE && step.status.is_none_or(InstructionResult::is_ok) {
+    if step.op.get() == opcode::SSTORE {
         let mut stack = step.stack.as_deref()?.iter().rev();
         let slot = stack.next().copied()?;
         let value = stack.next().copied()?;


### PR DESCRIPTION
This adds `:storage`, `:store`, and `:slot` debugger commands that jump to the next matching `SLOAD` or `SSTORE` for a storage slot in the current call. The command path reuses the same private storage-access helper as the Variables panel, so recorded storage changes and warm `SLOAD` stack snapshots are interpreted and formatted consistently.

Refs #927
