### PR TITLE
feat(fuzz): capture branch frontier artifacts

### DIFF
--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -186,14 +186,15 @@ impl FuzzCorpusConfig {
 
     /// Whether EVM comparison operand capture is enabled.
     ///
-    /// EVM comparison operands are only useful for coverage-guided fuzzing, so they are derived
-    /// from corpus mode. Disabled when sancov edge coverage is active because sancov replaces EVM
-    /// bytecode coverage as the guidance signal.
+    /// EVM comparison operands for corpus mutation are only useful for coverage-guided fuzzing, so
+    /// they are derived from corpus mode and disabled when sancov edge coverage is active.
+    /// Frontier capture still records EVM comparison sites because those artifacts target
+    /// Solidity bytecode branches, not the active coverage guidance source.
     pub fn collect_evm_cmp_log(&self) -> bool {
-        !self.sancov_edges
-            && ((self.corpus_dir.is_some()
+        self.capture_branch_frontiers()
+            || (!self.sancov_edges
+                && self.corpus_dir.is_some()
                 && self.mutation_weights.effective().mutation_weight_cmp > 0)
-                || self.capture_branch_frontiers())
     }
 
     /// Whether fuzz branch frontier artifacts should be captured.

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -119,6 +119,10 @@ pub struct FuzzCorpusConfig {
     // Path to corpus directory, enabled coverage guided fuzzing mode.
     // If not set then sequences producing new coverage are not persisted and mutated.
     pub corpus_dir: Option<PathBuf>,
+    // Path to fuzz branch frontier artifacts for symbolic follow-up.
+    pub frontier_dir: Option<PathBuf>,
+    // Maximum number of branch frontier records to write for one fuzz test.
+    pub frontier_limit: usize,
     // Whether corpus to use gzip file compression and decompression.
     pub corpus_gzip: bool,
     // Number of mutations until entry marked as eligible to be flushed from in-memory corpus.
@@ -154,10 +158,14 @@ pub struct FuzzCorpusConfig {
 impl FuzzCorpusConfig {
     pub const DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT: u32 = 10;
     pub const ENSEMBLE_CORPUS_RANDOM_SEQUENCE_WEIGHT: u32 = 50;
+    pub const DEFAULT_FRONTIER_LIMIT: usize = 256;
 
     pub fn with_test(&mut self, contract: &str, test: &str) {
         if let Some(corpus_dir) = &self.corpus_dir {
             self.corpus_dir = Some(canonicalized(corpus_dir.join(contract).join(test)));
+        }
+        if let Some(frontier_dir) = &self.frontier_dir {
+            self.frontier_dir = Some(canonicalized(frontier_dir.join(contract).join(test)));
         }
     }
 
@@ -183,8 +191,14 @@ impl FuzzCorpusConfig {
     /// bytecode coverage as the guidance signal.
     pub fn collect_evm_cmp_log(&self) -> bool {
         !self.sancov_edges
-            && self.corpus_dir.is_some()
-            && self.mutation_weights.effective().mutation_weight_cmp > 0
+            && ((self.corpus_dir.is_some()
+                && self.mutation_weights.effective().mutation_weight_cmp > 0)
+                || self.capture_branch_frontiers())
+    }
+
+    /// Whether fuzz branch frontier artifacts should be captured.
+    pub const fn capture_branch_frontiers(&self) -> bool {
+        self.frontier_dir.is_some() && self.frontier_limit > 0
     }
 
     /// Whether EVM edge coverage should use collision-free dense IDs.
@@ -222,6 +236,8 @@ impl Default for FuzzCorpusConfig {
     fn default() -> Self {
         Self {
             corpus_dir: None,
+            frontier_dir: None,
+            frontier_limit: Self::DEFAULT_FRONTIER_LIMIT,
             corpus_gzip: true,
             corpus_min_mutations: 5,
             corpus_min_size: 0,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1408,6 +1408,7 @@ impl Config {
         };
         remove_test_dir(&self.fuzz.failure_persist_dir);
         remove_test_dir(&self.fuzz.corpus.corpus_dir);
+        remove_test_dir(&self.fuzz.corpus.frontier_dir);
         remove_test_dir(&self.invariant.corpus.corpus_dir);
         remove_test_dir(&self.invariant.failure_persist_dir);
 

--- a/crates/evm/evm/src/executors/fuzz/frontier.rs
+++ b/crates/evm/evm/src/executors/fuzz/frontier.rs
@@ -1,0 +1,268 @@
+use crate::inspectors::CmpOperands;
+use alloy_json_abi::Function;
+use alloy_primitives::{
+    Address, Bytes, I256, U256,
+    map::{Entry, HashMap},
+};
+use foundry_common::fs;
+use foundry_evm_fuzz::{BasicTxDetails, CallDetails, FuzzRunMetadata};
+use revm::bytecode::opcode;
+use serde::{Serialize, Serializer};
+use std::{
+    path::Path,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+const FRONTIER_SCHEMA: &str = "foundry:fuzz.branch-frontiers@v1";
+pub(super) const FRONTIER_FILE: &str = "branch-frontiers.json";
+
+#[derive(Debug, Serialize)]
+pub(super) struct FuzzBranchFrontierArtifact {
+    /// Stable artifact schema identifier for downstream symbolic consumers.
+    schema: &'static str,
+    /// Schema version for consumers that prefer numeric dispatch.
+    version: u32,
+    /// Unix timestamp, in seconds, when the artifact was written.
+    generated_at: u64,
+    /// Fuzz test signature that produced the frontier records.
+    test: String,
+    /// Configured maximum number of records retained for this test.
+    limit: usize,
+    /// Captured comparison frontiers.
+    frontiers: Vec<FuzzBranchFrontier>,
+}
+
+impl FuzzBranchFrontierArtifact {
+    pub(super) fn new(
+        func: &Function,
+        limit: usize,
+        mut frontiers: Vec<FuzzBranchFrontier>,
+    ) -> Self {
+        for (id, frontier) in frontiers.iter_mut().enumerate() {
+            frontier.id = id as u64;
+        }
+
+        Self {
+            schema: FRONTIER_SCHEMA,
+            version: 1,
+            generated_at: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("time went backwards")
+                .as_secs(),
+            test: func.signature(),
+            limit,
+            frontiers,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct FuzzBranchFrontier {
+    /// Unique record identifier.
+    id: u64,
+    /// Reproducible fuzz seed, if configured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<U256>,
+    /// 1-based fuzz run number, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run: Option<u32>,
+    /// Fuzz worker that produced the record, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    worker: Option<u32>,
+    /// Whether this call also expanded coverage from the worker's current map.
+    new_coverage: bool,
+    /// Index of the call in the recorded sequence. Stateless fuzzing records one call.
+    call_index: usize,
+    /// Concrete call sequence that reached the frontier.
+    #[serde(serialize_with = "serialize_sequence")]
+    sequence: Arc<[BasicTxDetails]>,
+    /// EVM comparison site to target symbolically.
+    site: FuzzBranchFrontierSite,
+    /// Concrete operands observed at the site.
+    operands: FuzzBranchFrontierOperands,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct FuzzBranchFrontierSite {
+    address: Address,
+    pc: usize,
+    opcode: u8,
+    opcode_name: &'static str,
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+struct FuzzBranchFrontierOperands {
+    lhs: U256,
+    rhs: U256,
+    /// Result of evaluating the captured comparison with these concrete operands.
+    result: bool,
+    /// Raw unsigned absolute operand delta, useful as a deterministic priority score.
+    operand_delta: U256,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct FuzzBranchFrontierKey {
+    address: Address,
+    pc: usize,
+    opcode: u8,
+    result: bool,
+}
+
+impl FuzzBranchFrontierKey {
+    const fn new(cmp: &CmpOperands, result: bool) -> Self {
+        Self { address: cmp.address, pc: cmp.pc, opcode: cmp.opcode, result }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct FuzzFrontierRecorder {
+    limit: usize,
+    frontiers: Vec<FuzzBranchFrontier>,
+    indexes: HashMap<FuzzBranchFrontierKey, usize>,
+}
+
+impl FuzzFrontierRecorder {
+    pub(super) fn new(limit: usize) -> Self {
+        Self { limit, frontiers: Vec::with_capacity(limit.min(32)), indexes: HashMap::default() }
+    }
+
+    pub(super) fn capture_stateless_call(
+        &mut self,
+        run: Option<&FuzzRunMetadata>,
+        sender: Address,
+        target: Address,
+        calldata: &Bytes,
+        cmp_values: &[CmpOperands],
+        new_coverage: bool,
+    ) {
+        if self.limit == 0 || cmp_values.is_empty() {
+            return;
+        }
+
+        let mut sequence = None;
+        let mut new_frontier = |cmp: &CmpOperands, result, operand_delta| {
+            let sequence = sequence.get_or_insert_with(|| {
+                let call = BasicTxDetails {
+                    warp: None,
+                    roll: None,
+                    sender,
+                    call_details: CallDetails { target, calldata: calldata.clone(), value: None },
+                };
+                Arc::from(Vec::from([call]).into_boxed_slice())
+            });
+            FuzzBranchFrontier::new(
+                run,
+                Arc::clone(sequence),
+                *cmp,
+                result,
+                operand_delta,
+                new_coverage,
+                0,
+            )
+        };
+
+        for cmp in cmp_values {
+            let result = comparison_result(cmp);
+            let key = FuzzBranchFrontierKey::new(cmp, result);
+            let operand_delta = operand_delta(cmp.op1, cmp.op2);
+
+            match self.indexes.entry(key) {
+                Entry::Occupied(entry) => {
+                    let index = *entry.get();
+                    if operand_delta < self.frontiers[index].operands.operand_delta {
+                        self.frontiers[index] = new_frontier(cmp, result, operand_delta);
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    if self.frontiers.len() < self.limit {
+                        entry.insert(self.frontiers.len());
+                        let frontier = new_frontier(cmp, result, operand_delta);
+                        self.frontiers.push(frontier);
+                    }
+                }
+            }
+        }
+    }
+
+    pub(super) fn into_frontiers(self) -> Vec<FuzzBranchFrontier> {
+        self.frontiers
+    }
+}
+
+impl FuzzBranchFrontier {
+    fn new(
+        run: Option<&FuzzRunMetadata>,
+        sequence: Arc<[BasicTxDetails]>,
+        cmp: CmpOperands,
+        result: bool,
+        operand_delta: U256,
+        new_coverage: bool,
+        call_index: usize,
+    ) -> Self {
+        Self {
+            id: 0,
+            seed: run.and_then(|run| run.seed),
+            run: run.and_then(|run| run.run),
+            worker: run.and_then(|run| run.worker),
+            new_coverage,
+            call_index,
+            sequence,
+            site: FuzzBranchFrontierSite {
+                address: cmp.address,
+                pc: cmp.pc,
+                opcode: cmp.opcode,
+                opcode_name: opcode_name(cmp.opcode),
+            },
+            operands: FuzzBranchFrontierOperands {
+                lhs: cmp.op1,
+                rhs: cmp.op2,
+                result,
+                operand_delta,
+            },
+        }
+    }
+}
+
+pub(super) fn write_frontier_artifact(
+    dir: &Path,
+    artifact: &FuzzBranchFrontierArtifact,
+) -> fs::Result<()> {
+    fs::create_dir_all(dir)?;
+    fs::write_json_file(&dir.join(FRONTIER_FILE), artifact)
+}
+
+fn serialize_sequence<S>(sequence: &Arc<[BasicTxDetails]>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    Serialize::serialize(sequence.as_ref(), serializer)
+}
+
+fn comparison_result(cmp: &CmpOperands) -> bool {
+    match cmp.opcode {
+        opcode::EQ => cmp.op1 == cmp.op2,
+        opcode::LT => cmp.op1 < cmp.op2,
+        opcode::GT => cmp.op1 > cmp.op2,
+        opcode::SLT => I256::from_raw(cmp.op1) < I256::from_raw(cmp.op2),
+        opcode::SGT => I256::from_raw(cmp.op1) > I256::from_raw(cmp.op2),
+        opcode::ISZERO => cmp.op1.is_zero(),
+        _ => false,
+    }
+}
+
+fn operand_delta(left: U256, right: U256) -> U256 {
+    if left >= right { left - right } else { right - left }
+}
+
+const fn opcode_name(op: u8) -> &'static str {
+    match op {
+        opcode::EQ => "EQ",
+        opcode::LT => "LT",
+        opcode::GT => "GT",
+        opcode::SLT => "SLT",
+        opcode::SGT => "SGT",
+        opcode::ISZERO => "ISZERO",
+        _ => "UNKNOWN",
+    }
+}

--- a/crates/evm/evm/src/executors/fuzz/frontier.rs
+++ b/crates/evm/evm/src/executors/fuzz/frontier.rs
@@ -97,7 +97,7 @@ struct FuzzBranchFrontierOperands {
     rhs: U256,
     /// Result of evaluating the captured comparison with these concrete operands.
     result: bool,
-    /// Raw unsigned absolute operand delta, useful as a deterministic priority score.
+    /// Absolute operand delta interpreted according to the comparison opcode's signedness.
     operand_delta: U256,
 }
 
@@ -165,7 +165,7 @@ impl FuzzFrontierRecorder {
         for cmp in cmp_values {
             let result = comparison_result(cmp);
             let key = FuzzBranchFrontierKey::new(cmp, result);
-            let operand_delta = operand_delta(cmp.op1, cmp.op2);
+            let operand_delta = operand_delta(cmp);
 
             match self.indexes.entry(key) {
                 Entry::Occupied(entry) => {
@@ -251,8 +251,32 @@ fn comparison_result(cmp: &CmpOperands) -> bool {
     }
 }
 
-fn operand_delta(left: U256, right: U256) -> U256 {
+fn operand_delta(cmp: &CmpOperands) -> U256 {
+    match cmp.opcode {
+        opcode::SLT | opcode::SGT => signed_operand_delta(cmp.op1, cmp.op2),
+        _ => unsigned_operand_delta(cmp.op1, cmp.op2),
+    }
+}
+
+fn unsigned_operand_delta(left: U256, right: U256) -> U256 {
     if left >= right { left - right } else { right - left }
+}
+
+fn signed_operand_delta(left: U256, right: U256) -> U256 {
+    let (left_negative, left_magnitude) = signed_magnitude(left);
+    let (right_negative, right_magnitude) = signed_magnitude(right);
+
+    if left_negative == right_negative {
+        unsigned_operand_delta(left_magnitude, right_magnitude)
+    } else {
+        left_magnitude + right_magnitude
+    }
+}
+
+fn signed_magnitude(value: U256) -> (bool, U256) {
+    let negative = I256::from_raw(value) < I256::ZERO;
+    let magnitude = if negative { U256::ZERO.wrapping_sub(value) } else { value };
+    (negative, magnitude)
 }
 
 const fn opcode_name(op: u8) -> &'static str {
@@ -264,5 +288,33 @@ const fn opcode_name(op: u8) -> &'static str {
         opcode::SGT => "SGT",
         opcode::ISZERO => "ISZERO",
         _ => "UNKNOWN",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operand_delta_uses_signed_distance_for_signed_comparisons() {
+        let unsigned = CmpOperands {
+            op1: U256::MAX,
+            op2: U256::from(1),
+            pc: 0,
+            address: Address::ZERO,
+            opcode: opcode::LT,
+        };
+        assert_eq!(operand_delta(&unsigned), U256::MAX - U256::from(1));
+
+        let signed = CmpOperands { opcode: opcode::SLT, ..unsigned };
+        assert_eq!(operand_delta(&signed), U256::from(2));
+    }
+
+    #[test]
+    fn signed_operand_delta_handles_full_int256_range() {
+        let min = I256::MIN.into_raw();
+        let max = I256::MAX.into_raw();
+
+        assert_eq!(signed_operand_delta(min, max), U256::MAX);
     }
 }

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -39,7 +39,9 @@ use std::{
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
+mod frontier;
 mod types;
+use frontier::{FuzzBranchFrontier, FuzzBranchFrontierArtifact, FuzzFrontierRecorder};
 pub use types::{CaseOutcome, CounterExampleOutcome, FuzzOutcome};
 
 /// Corpus syncs across workers every `SYNC_INTERVAL` runs.
@@ -84,6 +86,8 @@ struct WorkerState<FEN: FoundryEvmNetwork> {
     last_run_timestamp: u128,
     /// Failed corpus replays
     failed_corpus_replays: usize,
+    /// Branch frontiers captured for symbolic follow-up.
+    frontiers: Vec<FuzzBranchFrontier>,
 }
 
 impl<FEN: FoundryEvmNetwork> WorkerState<FEN> {
@@ -104,6 +108,7 @@ impl<FEN: FoundryEvmNetwork> WorkerState<FEN> {
             failure_run: None,
             last_run_timestamp: 0,
             failed_corpus_replays: 0,
+            frontiers: Vec::new(),
         }
     }
 }
@@ -369,12 +374,22 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         address: Address,
         calldata: Bytes,
         coverage_metrics: &mut WorkerCorpus,
+        frontier_recorder: &mut FuzzFrontierRecorder,
+        fuzz_run: Option<&FuzzRunMetadata>,
     ) -> Result<FuzzOutcome<FEN>, TestCaseError> {
         let mut call = executor
             .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
             .map_err(|e| TestCaseError::fail(e.to_string()))?;
         let cmp_values = call.evm_cmp_values.take().unwrap_or_default();
         let new_coverage = coverage_metrics.merge_edge_coverage(&mut call);
+        frontier_recorder.capture_stateless_call(
+            fuzz_run,
+            self.sender,
+            address,
+            &calldata,
+            &cmp_values,
+            new_coverage,
+        );
         coverage_metrics.process_inputs(
             &[BasicTxDetails {
                 warp: None,
@@ -439,6 +454,8 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         func: &Function,
         shared_state: &SharedFuzzState,
     ) -> FuzzTestResult {
+        self.write_branch_frontiers(&mut workers, func);
+
         let mut result = FuzzTestResult::default();
         if workers.is_empty() {
             result.success = true;
@@ -536,6 +553,32 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         result
     }
 
+    fn write_branch_frontiers(&self, workers: &mut [WorkerState<FEN>], func: &Function) {
+        let Some(frontier_dir) = &self.config.corpus.frontier_dir else {
+            return;
+        };
+        let limit = self.config.corpus.frontier_limit;
+        if limit == 0 {
+            return;
+        }
+
+        let mut frontiers = Vec::with_capacity(limit.min(32));
+        for worker in workers {
+            if frontiers.len() == limit {
+                break;
+            }
+            frontiers.extend(worker.frontiers.drain(..).take(limit - frontiers.len()));
+        }
+        if frontiers.is_empty() {
+            return;
+        }
+
+        let artifact = FuzzBranchFrontierArtifact::new(func, limit, frontiers);
+        if let Err(err) = frontier::write_frontier_artifact(frontier_dir, &artifact) {
+            warn!(%err, path = ?frontier_dir, "failed to write fuzz branch frontier artifact");
+        }
+    }
+
     /// Runs a single fuzz worker
     #[allow(clippy::too_many_arguments)]
     fn run_worker(
@@ -579,6 +622,12 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             None, // dynamic target ctx (invariant-only)
         )?;
         let mut executor = self.executor_f.clone();
+        let frontier_limit = if self.config.corpus.capture_branch_frontiers() {
+            self.config.corpus.frontier_limit
+        } else {
+            0
+        };
+        let mut frontier_recorder = FuzzFrontierRecorder::new(frontier_limit);
 
         let mut worker = WorkerState::new(worker_id);
         // We want to collect at least one trace which will be displayed to user.
@@ -709,7 +758,14 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             };
 
             worker.last_run_timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
-            match self.single_fuzz(&executor, address, input, &mut corpus) {
+            match self.single_fuzz(
+                &executor,
+                address,
+                input,
+                &mut corpus,
+                &mut frontier_recorder,
+                fuzz_run.as_ref(),
+            ) {
                 Ok(fuzz_outcome) => match fuzz_outcome {
                     FuzzOutcome::Case(case) => {
                         let total_runs = inc_runs();
@@ -820,6 +876,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         if worker_id == 0 {
             worker.failed_corpus_replays = corpus.failed_replays;
         }
+        worker.frontiers = frontier_recorder.into_frontiers();
 
         // Logs stats
         trace!("worker {worker_id} fuzz stats");

--- a/crates/evm/evm/src/inspectors/edge_cov.rs
+++ b/crates/evm/evm/src/inspectors/edge_cov.rs
@@ -166,6 +166,9 @@ pub struct EdgeCovInspector {
     hitcount: Vec<u8>,
     /// Configuration for edge ID generation.
     config: EdgeCovConfig,
+    /// Whether to collect edge hits. Comparison-only consumers keep this off to avoid affecting
+    /// the active coverage guidance source.
+    collect_edges: bool,
     /// Per-execution dense edge hitcounts. Stable IDs are assigned by the corpus history owner.
     dense_hitcount: HashMap<EdgeKey, u8>,
     hash_builder: DefaultHashBuilder,
@@ -180,6 +183,7 @@ impl fmt::Debug for EdgeCovInspector {
             .field("capacity", &self.hitcount.len())
             .field("edges", &self.edge_count())
             .field("config", &self.config)
+            .field("collect_edges", &self.collect_edges)
             .finish()
     }
 }
@@ -197,6 +201,14 @@ impl EdgeCovInspector {
         inspector
     }
 
+    /// Create a comparison-operand inspector without collecting EVM edge hits.
+    pub fn with_cmp_log_only() -> Self {
+        let mut inspector = Self::new();
+        inspector.collect_edges = false;
+        inspector.enable_cmp_log(true);
+        inspector
+    }
+
     /// Create a new `EdgeCovInspector` with the given configuration.
     ///
     /// [`EdgeCovKind::Hash`] preallocates a fixed-size bitmap;
@@ -209,6 +221,7 @@ impl EdgeCovInspector {
         Self {
             hitcount,
             config,
+            collect_edges: true,
             dense_hitcount: HashMap::default(),
             hash_builder: DefaultHashBuilder::default(),
             cmp_log: None,
@@ -259,6 +272,10 @@ impl EdgeCovInspector {
 
     /// Mark the edge `(address, depth, pc, jump_dest)` as hit.
     fn store_hit(&mut self, address: Address, depth: usize, pc: usize, jump_dest: U256) {
+        if !self.collect_edges {
+            return;
+        }
+
         let edge_id = match self.config.kind {
             EdgeCovKind::CollisionFree => {
                 self.store_dense_hit(address, depth, pc, jump_dest);
@@ -424,7 +441,7 @@ where
     #[inline]
     fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
         let op = interp.bytecode.opcode();
-        if matches!(op, opcode::JUMP | opcode::JUMPI) {
+        if self.collect_edges && matches!(op, opcode::JUMP | opcode::JUMPI) {
             self.do_step(interp, context);
         }
         if self.cmp_log.is_some()
@@ -487,6 +504,25 @@ mod tests {
         let (coverage, cmp_log) = inspector.into_parts();
         assert_eq!(coverage, EdgeCoverage::CollisionFree(Vec::new()));
         assert!(cmp_log.is_empty());
+    }
+
+    #[test]
+    fn cmp_log_only_does_not_collect_edges() {
+        let mut inspector = EdgeCovInspector::with_cmp_log_only();
+        let addr = Address::ZERO;
+
+        inspector.store_hit(addr, 0, 0, U256::from(1));
+        inspector.store_cmp(CmpOperands {
+            op1: U256::from(123),
+            op2: U256::from(456),
+            pc: 42,
+            address: addr,
+            opcode: opcode::EQ,
+        });
+
+        let (coverage, cmp_log) = inspector.into_parts();
+        assert_eq!(coverage, EdgeCoverage::CollisionFree(Vec::new()));
+        assert_eq!(cmp_log.len(), 1);
     }
 
     #[test]

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -589,7 +589,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
     pub fn collect_evm_cmp_log(&mut self, yes: bool) {
         if yes {
             self.edge_coverage
-                .get_or_insert_with(|| EdgeCovInspector::new().into())
+                .get_or_insert_with(|| EdgeCovInspector::with_cmp_log_only().into())
                 .enable_cmp_log(true);
         } else if let Some(edge_coverage) = &mut self.edge_coverage {
             edge_coverage.enable_cmp_log(false);

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -136,7 +136,7 @@ configured record limit, and a `frontiers` array. Each frontier contains:
 - the concrete one-call sequence that reached the site
 - the EVM comparison site (`address`, `pc`, `opcode`, `opcode_name`)
 - concrete operands (`lhs`, `rhs`), the comparison result, and an
-  `operand_delta` priority score
+  `operand_delta` priority score interpreted according to opcode signedness
 - whether the call also expanded the worker's coverage map
 
 Frontier capture is opt-in and bounded by `fuzz.frontier_limit` (default 256).

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -115,6 +115,33 @@ guide branch order; they do not prune feasible symbolic paths. JSON output
 records the per-test corpus directory, import counts, and seed files that
 matched a symbolic calldata variant under `symbolic.corpus_seeds.used`.
 
+Fuzzing can also record branch frontier artifacts for later targeted symbolic
+follow-up:
+
+```sh
+forge test --match-test test_hard_branch --fuzz-frontier-dir fuzz_frontiers
+```
+
+For example, a fuzz run may pass after reaching `feeMultiplier == 100` at a
+`feeMultiplier < 100` guard; the frontier gives symbolic execution the replay
+calldata and comparison site needed to solve the adjacent missed branch.
+
+Forge writes one bounded artifact per fuzz test at
+`<fuzz_frontier_dir>/<contract>/<test>/branch-frontiers.json`. The artifact
+uses schema `foundry:fuzz.branch-frontiers@v1` and records the test signature,
+configured record limit, and a `frontiers` array. Each frontier contains:
+
+- a stable record index (`id`) within the artifact
+- fuzz replay metadata (`seed`, `run`, `worker`) when available
+- the concrete one-call sequence that reached the site
+- the EVM comparison site (`address`, `pc`, `opcode`, `opcode_name`)
+- concrete operands (`lhs`, `rhs`), the comparison result, and an
+  `operand_delta` priority score
+- whether the call also expanded the worker's coverage map
+
+Frontier capture is opt-in and bounded by `fuzz.frontier_limit` (default 256).
+It reuses the fuzzer's comparison-operand inspector and does not store traces.
+
 > **Hash-model caveat:** `PASS` also assumes collision and preimage resistance
 > for symbolic `KECCAK256` and hash-like precompile terms. The executor may use
 > equal symbolic hashes to infer equal symbolic preimages or lengths in modeled

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -380,6 +380,14 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_CORPUS_DIR", value_name = "PATH", value_hint = ValueHint::DirPath)]
     pub fuzz_corpus_dir: Option<PathBuf>,
 
+    /// Directory for fuzz branch frontier artifacts.
+    #[arg(long, env = "FOUNDRY_FUZZ_FRONTIER_DIR", value_name = "PATH", value_hint = ValueHint::DirPath)]
+    pub fuzz_frontier_dir: Option<PathBuf>,
+
+    /// Maximum number of fuzz branch frontier records to write per test.
+    #[arg(long, env = "FOUNDRY_FUZZ_FRONTIER_LIMIT", value_name = "COUNT")]
+    pub fuzz_frontier_limit: Option<usize>,
+
     /// Percent chance that fuzzed payable calls carry non-zero msg.value.
     #[arg(long, env = "FOUNDRY_FUZZ_PAYABLE_VALUE_WEIGHT", value_name = "PERCENT")]
     pub fuzz_payable_value_weight: Option<u32>,
@@ -2335,6 +2343,15 @@ impl Provider for TestArgs {
                 fuzz_corpus_dir.to_string_lossy().to_string().into(),
             );
         }
+        if let Some(fuzz_frontier_dir) = self.fuzz_frontier_dir.clone() {
+            fuzz_dict.insert(
+                "frontier_dir".to_string(),
+                fuzz_frontier_dir.to_string_lossy().to_string().into(),
+            );
+        }
+        if let Some(fuzz_frontier_limit) = self.fuzz_frontier_limit {
+            fuzz_dict.insert("frontier_limit".to_string(), fuzz_frontier_limit.into());
+        }
         if let Some(fuzz_payable_value_weight) = self.fuzz_payable_value_weight {
             fuzz_dict.insert("payable_value_weight".to_string(), fuzz_payable_value_weight.into());
         }
@@ -3121,6 +3138,10 @@ mod tests {
             "55",
             "--fuzz-corpus-dir",
             "fuzz_corpus",
+            "--fuzz-frontier-dir",
+            "fuzz_frontiers",
+            "--fuzz-frontier-limit",
+            "7",
             "--fuzz-payable-value-weight",
             "12",
             "--fuzz-mutation-weight-splice",
@@ -3174,6 +3195,11 @@ mod tests {
             figment.extract_inner::<PathBuf>("fuzz.corpus_dir").unwrap(),
             PathBuf::from("fuzz_corpus")
         );
+        assert_eq!(
+            figment.extract_inner::<PathBuf>("fuzz.frontier_dir").unwrap(),
+            PathBuf::from("fuzz_frontiers")
+        );
+        assert_eq!(figment.extract_inner::<usize>("fuzz.frontier_limit").unwrap(), 7);
         assert_eq!(figment.extract_inner::<u32>("fuzz.payable_value_weight").unwrap(), 12);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_splice").unwrap(), 4);
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_abi").unwrap(), 3);
@@ -3216,6 +3242,8 @@ mod tests {
         assert_eq!(config.fuzz.dictionary.max_fuzz_dictionary_literals, 4321);
         assert_eq!(config.fuzz.corpus.corpus_random_sequence_weight, 55);
         assert_eq!(config.fuzz.corpus.corpus_dir, Some(PathBuf::from("fuzz_corpus")));
+        assert_eq!(config.fuzz.corpus.frontier_dir, Some(PathBuf::from("fuzz_frontiers")));
+        assert_eq!(config.fuzz.corpus.frontier_limit, 7);
         assert_eq!(config.fuzz.corpus.payable_value_weight, 12);
         assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_splice, 4);
         assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_abi, 3);

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1138,13 +1138,20 @@ forgetest_init!(can_clean_test_cache, |prj, cmd| {
     let _ = fs::create_dir(fuzz_cache_dir.clone());
     let invariant_cache_dir = prj.root().join("cache/invariant");
     let _ = fs::create_dir(invariant_cache_dir.clone());
+    let frontier_cache_dir = prj.root().join("cache/frontiers");
+    let _ = fs::create_dir(frontier_cache_dir.clone());
+    prj.update_config(|config| {
+        config.fuzz.corpus.frontier_dir = Some("cache/frontiers".into());
+    });
 
     assert!(fuzz_cache_dir.exists());
     assert!(invariant_cache_dir.exists());
+    assert!(frontier_cache_dir.exists());
 
     cmd.forge_fuse().arg("clean").assert_empty_stdout();
     assert!(!fuzz_cache_dir.exists());
     assert!(!invariant_cache_dir.exists());
+    assert!(!frontier_cache_dir.exists());
 });
 
 // checks that extra output works

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -211,6 +211,7 @@ max_fuzz_dictionary_addresses = 15728640
 max_fuzz_dictionary_values = 9830400
 max_fuzz_dictionary_literals = 6553600
 gas_report_samples = 256
+frontier_limit = 256
 corpus_gzip = true
 corpus_min_mutations = 5
 corpus_min_size = 0
@@ -248,6 +249,7 @@ max_fuzz_dictionary_literals = 6553600
 shrink_run_limit = 5000
 max_assume_rejects = 65536
 gas_report_samples = 256
+frontier_limit = 256
 corpus_gzip = true
 corpus_min_mutations = 5
 corpus_min_size = 0
@@ -1458,6 +1460,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "max_fuzz_dictionary_literals": 6553600,
     "gas_report_samples": 256,
     "corpus_dir": null,
+    "frontier_dir": null,
+    "frontier_limit": 256,
     "corpus_gzip": true,
     "corpus_min_mutations": 5,
     "corpus_min_size": 0,
@@ -1497,6 +1501,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "max_assume_rejects": 65536,
     "gas_report_samples": 256,
     "corpus_dir": null,
+    "frontier_dir": null,
+    "frontier_limit": 256,
     "corpus_gzip": true,
     "corpus_min_mutations": 5,
     "corpus_min_size": 0,

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1050,6 +1050,87 @@ contract ForgeFuzzGeneratedCorpusTest is Test {
     assert!(invariant_stdout.contains(&invariant_corpus_path), "{invariant_stdout}");
 });
 
+forgetest_init!(fuzz_branch_frontiers_capture_comparison_for_symbolic_followup, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzFrontier.t.sol",
+        r#"
+contract ForgeFuzzFrontierTest {
+    function testFuzz_frontier(uint64 amount, uint256 feeMultiplier) public pure {
+        uint256 credited;
+        unchecked {
+            credited = uint256(amount) + (feeMultiplier - 100);
+        }
+
+        if (feeMultiplier < 100) {
+            assert(credited <= amount);
+        }
+    }
+}
+   "#,
+    );
+
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--match-test",
+            "testFuzz_frontier",
+            "--fuzz-runs",
+            "8",
+            "--fuzz-seed",
+            "0x1234",
+            "--threads",
+            "1",
+            "--fuzz-frontier-dir",
+            "fuzz_frontiers",
+        ])
+        .assert_success();
+
+    let frontier_path = prj
+        .root()
+        .join("fuzz_frontiers")
+        .join("ForgeFuzzFrontierTest")
+        .join("testFuzz_frontier")
+        .join("branch-frontiers.json");
+    let artifact: Value = serde_json::from_slice(
+        &std::fs::read(&frontier_path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", frontier_path.display())),
+    )
+    .unwrap();
+    assert_eq!(artifact["schema"], "foundry:fuzz.branch-frontiers@v1");
+    assert_eq!(artifact["version"], 1);
+    assert_eq!(artifact["test"], "testFuzz_frontier(uint64,uint256)");
+    assert_eq!(artifact["limit"], 256);
+
+    let frontiers = artifact["frontiers"].as_array().unwrap();
+    let frontier = frontiers
+        .iter()
+        .find(|frontier| {
+            frontier["site"]["opcode_name"] == "LT"
+                && frontier["operands"]["lhs"] == "0x64"
+                && frontier["operands"]["rhs"] == "0x64"
+                && frontier["operands"]["result"] == false
+        })
+        .unwrap_or_else(|| panic!("missing missed fee multiplier frontier in {artifact:#}"));
+    assert!(frontier["id"].as_u64().is_some(), "{frontier:#}");
+    assert_eq!(frontier["call_index"], 0);
+    assert_eq!(frontier["site"]["opcode_name"], "LT");
+    assert!(frontier["site"]["pc"].as_u64().is_some(), "{frontier:#}");
+    assert_eq!(frontier["operands"]["operand_delta"], "0x0");
+    assert_eq!(frontier["operands"]["result"], false);
+
+    let sequence = frontier["sequence"].as_array().unwrap();
+    assert_eq!(sequence.len(), 1);
+    assert!(
+        sequence[0]["target"].as_str().unwrap().eq_ignore_ascii_case(DEFAULT_TEST_TARGET),
+        "{frontier:#}"
+    );
+    let calldata = sequence[0]["calldata"].as_str().unwrap();
+    let expected_selector =
+        hex::encode(&alloy_primitives::keccak256(b"testFuzz_frontier(uint64,uint256)")[..4]);
+    assert!(calldata.starts_with(&format!("0x{expected_selector}")), "{calldata}");
+    assert!(calldata.ends_with(&format!("{:064x}{:064x}", 100u64, 100u64)), "{calldata}");
+});
+
 forgetest_init!(forge_fuzz_replay_scopes_generated_corpus_root_to_target, |prj, cmd| {
     prj.add_test(
         "ForgeFuzzGeneratedRootScope.t.sol",

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1085,50 +1085,73 @@ contract ForgeFuzzFrontierTest {
         ])
         .assert_success();
 
-    let frontier_path = prj
-        .root()
-        .join("fuzz_frontiers")
-        .join("ForgeFuzzFrontierTest")
-        .join("testFuzz_frontier")
-        .join("branch-frontiers.json");
-    let artifact: Value = serde_json::from_slice(
-        &std::fs::read(&frontier_path)
-            .unwrap_or_else(|err| panic!("failed to read {}: {err}", frontier_path.display())),
-    )
-    .unwrap();
-    assert_eq!(artifact["schema"], "foundry:fuzz.branch-frontiers@v1");
-    assert_eq!(artifact["version"], 1);
-    assert_eq!(artifact["test"], "testFuzz_frontier(uint64,uint256)");
-    assert_eq!(artifact["limit"], 256);
+    let assert_frontier_artifact = |frontier_dir: &str| {
+        let frontier_path = prj
+            .root()
+            .join(frontier_dir)
+            .join("ForgeFuzzFrontierTest")
+            .join("testFuzz_frontier")
+            .join("branch-frontiers.json");
+        let artifact: Value = serde_json::from_slice(
+            &std::fs::read(&frontier_path)
+                .unwrap_or_else(|err| panic!("failed to read {}: {err}", frontier_path.display())),
+        )
+        .unwrap();
+        assert_eq!(artifact["schema"], "foundry:fuzz.branch-frontiers@v1");
+        assert_eq!(artifact["version"], 1);
+        assert_eq!(artifact["test"], "testFuzz_frontier(uint64,uint256)");
+        assert_eq!(artifact["limit"], 256);
 
-    let frontiers = artifact["frontiers"].as_array().unwrap();
-    let frontier = frontiers
-        .iter()
-        .find(|frontier| {
-            frontier["site"]["opcode_name"] == "LT"
-                && frontier["operands"]["lhs"] == "0x64"
-                && frontier["operands"]["rhs"] == "0x64"
-                && frontier["operands"]["result"] == false
-        })
-        .unwrap_or_else(|| panic!("missing missed fee multiplier frontier in {artifact:#}"));
-    assert!(frontier["id"].as_u64().is_some(), "{frontier:#}");
-    assert_eq!(frontier["call_index"], 0);
-    assert_eq!(frontier["site"]["opcode_name"], "LT");
-    assert!(frontier["site"]["pc"].as_u64().is_some(), "{frontier:#}");
-    assert_eq!(frontier["operands"]["operand_delta"], "0x0");
-    assert_eq!(frontier["operands"]["result"], false);
+        let frontiers = artifact["frontiers"].as_array().unwrap();
+        let frontier = frontiers
+            .iter()
+            .find(|frontier| {
+                frontier["site"]["opcode_name"] == "LT"
+                    && frontier["operands"]["lhs"] == "0x64"
+                    && frontier["operands"]["rhs"] == "0x64"
+                    && frontier["operands"]["result"] == false
+            })
+            .unwrap_or_else(|| panic!("missing missed fee multiplier frontier in {artifact:#}"));
+        assert!(frontier["id"].as_u64().is_some(), "{frontier:#}");
+        assert_eq!(frontier["call_index"], 0);
+        assert_eq!(frontier["site"]["opcode_name"], "LT");
+        assert!(frontier["site"]["pc"].as_u64().is_some(), "{frontier:#}");
+        assert_eq!(frontier["operands"]["operand_delta"], "0x0");
+        assert_eq!(frontier["operands"]["result"], false);
 
-    let sequence = frontier["sequence"].as_array().unwrap();
-    assert_eq!(sequence.len(), 1);
-    assert!(
-        sequence[0]["target"].as_str().unwrap().eq_ignore_ascii_case(DEFAULT_TEST_TARGET),
-        "{frontier:#}"
-    );
-    let calldata = sequence[0]["calldata"].as_str().unwrap();
-    let expected_selector =
-        hex::encode(&alloy_primitives::keccak256(b"testFuzz_frontier(uint64,uint256)")[..4]);
-    assert!(calldata.starts_with(&format!("0x{expected_selector}")), "{calldata}");
-    assert!(calldata.ends_with(&format!("{:064x}{:064x}", 100u64, 100u64)), "{calldata}");
+        let sequence = frontier["sequence"].as_array().unwrap();
+        assert_eq!(sequence.len(), 1);
+        assert!(
+            sequence[0]["target"].as_str().unwrap().eq_ignore_ascii_case(DEFAULT_TEST_TARGET),
+            "{frontier:#}"
+        );
+        let calldata = sequence[0]["calldata"].as_str().unwrap();
+        let expected_selector =
+            hex::encode(&alloy_primitives::keccak256(b"testFuzz_frontier(uint64,uint256)")[..4]);
+        assert!(calldata.starts_with(&format!("0x{expected_selector}")), "{calldata}");
+        assert!(calldata.ends_with(&format!("{:064x}{:064x}", 100u64, 100u64)), "{calldata}");
+    };
+    assert_frontier_artifact("fuzz_frontiers");
+
+    prj.update_config(|config| {
+        config.fuzz.corpus.sancov_edges = true;
+    });
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--match-test",
+            "testFuzz_frontier",
+            "--fuzz-runs",
+            "8",
+            "--fuzz-seed",
+            "0x1234",
+            "--threads",
+            "1",
+            "--fuzz-frontier-dir",
+            "sancov_fuzz_frontiers",
+        ])
+        .assert_success();
+    assert_frontier_artifact("sancov_fuzz_frontiers");
 });
 
 forgetest_init!(forge_fuzz_replay_scopes_generated_corpus_root_to_target, |prj, cmd| {


### PR DESCRIPTION
This adds opt-in fuzz branch frontier capture so fuzz runs can hand concrete comparison sites to later targeted symbolic execution work. When `fuzz.frontier_dir` is configured, Forge writes a bounded per-test `branch-frontiers.json` artifact under `<frontier_dir>/<contract>/<test>/`, including replay metadata, the concrete one-call sequence, the EVM comparison site, operands, comparison result, operand delta, and whether that run expanded coverage.

The implementation keeps capture off by default and bounded by `fuzz.frontier_limit`, documents the `foundry:fuzz.branch-frontiers@v1` format in the symbolic README, and includes config coverage plus a Forge integration test that models a missed `feeMultiplier < 100` arithmetic bug branch.

### Concrete example

The in-tree regression uses a Velocore-style `feeMultiplier - 100` underflow shape. A short fuzz run passes, but the frontier artifact records an adjacent `LT` comparison at the `feeMultiplier < 100` guard:

```text
opcode: LT
condition: feeMultiplier < 100
observed operands: lhs = 0x64, rhs = 0x64
observed result: false
replay calldata decodes to: amount = 100, feeMultiplier = 100
```

That is the intended handoff: fuzzing reached the boundary of a hard branch, and a later symbolic pass can replay that call and solve for the neighboring `feeMultiplier < 100` path.

I also smoke-tested this against `grandizzy/symbolic-bug-suite` with a temporary Velocore-style fuzz adapter. The short frontier run produced `LT` frontier artifacts, a longer 256-run fuzz pass found a concrete failing side (`args=[15, 0]`), and the existing symbolic Velocore test found a witness with z3 (`checkFeeRebateCannotExceedAmount`, `args=[0, 0]`).

### Review follow-up

This also addresses the first review pass:

- `forge clean` now removes configured `fuzz.frontier_dir` artifacts.
- `--fuzz-frontier-dir` still records EVM comparison frontiers when `sancov_edges = true`; this uses a cmp-only EVM inspector so frontier capture does not add EVM edge hits to sancov-guided campaigns.
- `operand_delta` now uses signed distance for `SLT`/`SGT` and unsigned distance for unsigned comparisons.

Local checks:
- `cargo +nightly fmt --all`
- `git diff --check`
- `cargo +1.95.0 check -p foundry-evm`
- `cargo +1.95.0 build -p forge`
- `cargo +1.95.0 test -p foundry-evm cmp_log_only_does_not_collect_edges -- --nocapture`
- `cargo +1.95.0 test -p foundry-evm operand_delta_uses_signed_distance_for_signed_comparisons -- --nocapture`
- `cargo +1.95.0 test -p foundry-evm signed_operand_delta_handles_full_int256_range -- --nocapture`
- `cargo +1.95.0 test -p forge fuzz_branch_frontiers_capture_comparison_for_symbolic_followup -- --nocapture`
- `cargo +1.95.0 test -p forge can_clean_test_cache -- --nocapture`
- `cargo +nightly clippy -p foundry-evm --all-targets --all-features --locked`
- `cargo +nightly clippy -p forge --all-targets --all-features --locked`
- `grandizzy/symbolic-bug-suite`: short frontier smoke test, 256-run fuzz failure check, `forge test --symbolic --match-test checkFeeRebateCannotExceedAmount`, and full `forge test --symbolic` expected-failure suite exit.