### PR TITLE
fix(config): preserve inline config root

### DIFF
--- a/crates/config/src/inline/mod.rs
+++ b/crates/config/src/inline/mod.rs
@@ -367,6 +367,50 @@ forge-config: default.symbolic.default_dynamic_length = 4
     }
 
     #[test]
+    fn merge_inline_provider_uses_selected_profile() {
+        let mut inline = InlineConfig::new();
+        inline
+            .insert(&natspec(
+                r#"
+forge-config: default.fuzz.runs = 1
+forge-config: ci.fuzz.runs = 2
+"#,
+            ))
+            .unwrap();
+
+        let profile = Profile::new("ci");
+        let config = Config {
+            profile: profile.clone(),
+            profiles: vec![Profile::Default, profile],
+            ..Default::default()
+        }
+        .merge_inline_provider(inline.provide("test/Symbolic.t.sol:Symbolic", "check"))
+        .unwrap();
+
+        assert_eq!(config.fuzz.runs, 2);
+    }
+
+    #[test]
+    fn merge_inline_provider_preserves_root_for_default_profile_fallback() {
+        let mut inline = InlineConfig::new();
+        inline.insert(&natspec("forge-config: default.isolate = false")).unwrap();
+
+        let profile = Profile::new("ci");
+        let root = std::path::PathBuf::from("project-root");
+        let config = Config {
+            profile: profile.clone(),
+            profiles: vec![Profile::Default, profile],
+            root: root.clone(),
+            ..Default::default()
+        }
+        .merge_inline_provider(inline.provide("test/Symbolic.t.sol:Symbolic", "check"))
+        .unwrap();
+
+        assert_eq!(config.root, root);
+        assert!(!config.isolate);
+    }
+
+    #[test]
     fn contract_symbolic_enabled_reads_contract_inline_config() {
         let mut inline = InlineConfig::new();
         inline

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -830,7 +830,7 @@ impl Config {
     /// Applies an inline provider on top of the current config without reloading external
     /// providers such as `foundry.toml`, env vars, or remappings.
     pub fn merge_inline_provider<T: Provider>(&self, provider: T) -> Result<Self, Error> {
-        let provider = Figment::from(provider);
+        let provider = Figment::from(provider).select(self.profile.clone());
         let invariant_corpus_random_sequence_weight_configured =
             self.invariant.corpus_random_sequence_weight_configured
                 || provider.contains("invariant.corpus_random_sequence_weight")
@@ -2692,8 +2692,12 @@ impl Provider for Config {
     #[track_caller]
     fn data(&self) -> Result<Map<Profile, Dict>, figment::Error> {
         let mut data = Serialized::defaults(self).data()?;
+        let root = Value::serialize(self.root.clone())?;
+        if let Some(entry) = data.get_mut(&Self::DEFAULT_PROFILE) {
+            entry.insert("root".to_string(), root.clone());
+        }
         if let Some(entry) = data.get_mut(&self.profile) {
-            entry.insert("root".to_string(), Value::serialize(self.root.clone())?);
+            entry.insert("root".to_string(), root);
         }
         Ok(data)
     }

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -356,6 +356,48 @@ forgetest_init!(is_isolate_mode_uses_effective_isolation, |prj, cmd| {
         .assert_success();
 });
 
+forgetest_init!(
+    inline_isolate_inherits_default_fs_permissions_for_non_default_profile,
+    |prj, cmd| {
+        std::fs::write(
+            prj.root().join("foundry.toml"),
+            r#"
+        [profile.default]
+        src = "src"
+        out = "out"
+        libs = ["lib"]
+        fs_permissions = [{ access = "read-write", path = "./data" }]
+
+        [profile.test]
+        "#,
+        )
+        .unwrap();
+        prj.add_test(
+            "inline_isolate_fs_permissions.sol",
+            r#"
+        import {Test} from "forge-std/Test.sol";
+
+        contract InlineIsolateFsPermissionsTest is Test {
+            function setUp() public {
+                if (!vm.exists("./data")) {
+                    vm.createDir("./data", true);
+                }
+            }
+
+            /// forge-config: default.isolate = true
+            function testInlineIsolateCanCreateFile() public {
+                vm.writeFile("./data/new.txt", "hello");
+                vm.removeFile("./data/new.txt");
+            }
+        }
+    "#,
+        );
+
+        cmd.env("FOUNDRY_PROFILE", "test");
+        cmd.args(["test", "--match-test", "testInlineIsolateCanCreateFile"]).assert_success();
+    }
+);
+
 forgetest_init!(config_inline_evm_version, |prj, cmd| {
     prj.add_test(
         "inline.sol",


### PR DESCRIPTION
Fixes #15512.

Inline config merges first wrapped the inline provider in a Figment selected on the provider's default profile. That could switch extraction away from the active profile, and Config provider data only restored `root` on the selected profile even though the rest of the Config data is emitted under the default profile. With a non-default `FOUNDRY_PROFILE` and a `default.*` inline annotation, the merged config could fall back to default profile data with `root = "."`. New filesystem paths then normalized relative while permissions canonicalized against the project directory, so creating a new file under an inherited `fs_permissions` entry was denied.

This keeps inline provider merges selected on the active profile and restores `root` in default provider data as well, so profile fallback preserves the project root. The regression test covers inline `isolate` with a non-default profile inheriting default `fs_permissions` and creating a new file.

AI assistance was used to investigate the issue and draft this change.
