### PR TITLE
perf(forge): skip unused fixture collection

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -607,8 +607,6 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             result.reason = reason;
         }
 
-        result.fuzz_fixtures = self.fuzz_fixtures(address);
-
         Ok(result)
     }
 
@@ -808,7 +806,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         });
 
         let setup_time = Instant::now();
-        let setup = self.setup(call_setup);
+        let mut setup = self.setup(call_setup);
         debug!("finished setting up in {:?}", setup_time.elapsed());
 
         if let Some(prev_tracer) = prev_tracer {
@@ -833,24 +831,25 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         // Filter out functions sequentially since it's very fast and there is no need to do it
         // in parallel.
         let find_timer = Instant::now();
-        let test_matcher = TestFunctionMatcher::new(
-            &self.config,
-            &self.mcr.inline_config,
-            self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
-        );
-        let functions = self
-            .contract
-            .abi
-            .functions()
-            .filter(|func| {
-                filter.matches_test_function_kind_in_contract(
-                    self.name,
-                    func,
-                    test_matcher.test_function_kind(self.name, func),
-                )
-            })
-            .filter(|func| self.function_matches_network_pass(func))
-            .collect::<Vec<_>>();
+        let functions = {
+            let test_matcher = TestFunctionMatcher::new(
+                &self.config,
+                &self.mcr.inline_config,
+                self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
+            );
+            self.contract
+                .abi
+                .functions()
+                .filter(|func| {
+                    filter.matches_test_function_kind_in_contract(
+                        self.name,
+                        func,
+                        test_matcher.test_function_kind(self.name, func),
+                    )
+                })
+                .filter(|func| self.function_matches_network_pass(func))
+                .collect::<Vec<_>>()
+        };
         debug!(
             "Found {} test functions out of {} in {:?}",
             functions.len(),
@@ -956,7 +955,23 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             return SuiteResult::new(start.elapsed(), test_results, warnings);
         }
 
+        if functions.iter().any(|func| {
+            matches!(
+                func.test_function_kind(),
+                TestFunctionKind::FuzzTest { .. }
+                    | TestFunctionKind::TableTest
+                    | TestFunctionKind::InvariantTest
+            )
+        }) {
+            setup.fuzz_fixtures = self.fuzz_fixtures(setup.address);
+        }
+
         let early_exit = &self.tcfg.early_exit;
+        let test_matcher = TestFunctionMatcher::new(
+            &self.config,
+            &self.mcr.inline_config,
+            self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
+        );
 
         if self.progress.is_some() {
             let interrupt = early_exit.clone();

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1,5 +1,6 @@
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::{U256, hex};
+use foundry_config::fs_permissions::PathPermission;
 use foundry_evm::fuzz::BaseCounterExample;
 use foundry_test_utils::{TestCommand, forgetest_init, str};
 use regex::Regex;
@@ -142,6 +143,44 @@ Suite result: ok. 1 passed; 0 failed; 1 skipped; [ELAPSED]
 Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 1 skipped (2 total tests)
 
 "#]]);
+});
+
+forgetest_init!(does_not_evaluate_unused_fuzz_fixtures_for_unit_test_filter, |prj, cmd| {
+    let marker = prj.root().join("fixture-called.txt");
+    prj.update_config(|config| config.fs_permissions.add(PathPermission::write(prj.root())));
+    prj.add_test(
+        "UnusedFuzzFixtures.t.sol",
+        r#"
+interface Vm {
+    function projectRoot() external view returns (string memory path);
+    function writeFile(string calldata path, string calldata data) external;
+}
+
+contract UnusedFuzzFixturesTest {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function fixtureAmount() public returns (uint256[] memory values) {
+        vm.writeFile(string.concat(vm.projectRoot(), "/fixture-called.txt"), "called");
+        values = new uint256[](1);
+        values[0] = 1;
+    }
+
+    function testUnit() public pure {}
+
+    /// forge-config: default.fuzz.runs = 1
+    function testFuzzUsesFixture(uint256 amount) public pure {
+        amount;
+    }
+}
+    "#,
+    );
+
+    cmd.args(["test", "--match-test", "testUnit", "-q"]).assert_success();
+    assert!(!marker.exists(), "unit-only run evaluated fuzz fixture");
+
+    cmd.forge_fuse();
+    cmd.args(["test", "--match-test", "testFuzzUsesFixture", "-q"]).assert_success();
+    assert!(marker.exists(), "fuzz run did not evaluate fuzz fixture");
 });
 
 forgetest_init!(forge_fuzz_skips_unit_only_failing_setup, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/table.rs
+++ b/crates/forge/tests/cli/test_cmd/table.rs
@@ -1,5 +1,6 @@
 //! Table tests.
 
+use foundry_config::fs_permissions::PathPermission;
 use foundry_test_utils::{forgetest_init, str};
 
 forgetest_init!(should_run_table_tests, |prj, cmd| {
@@ -126,6 +127,43 @@ Tip: Run `forge test --rerun` to retry only the 6 failed tests
 Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
+});
+
+forgetest_init!(does_not_evaluate_unused_fixtures_for_unit_test_filter, |prj, cmd| {
+    let marker = prj.root().join("fixture-called.txt");
+    prj.update_config(|config| config.fs_permissions.add(PathPermission::write(prj.root())));
+    prj.add_test(
+        "UnusedFixtures.t.sol",
+        r#"
+interface Vm {
+    function projectRoot() external view returns (string memory path);
+    function writeFile(string calldata path, string calldata data) external;
+}
+
+contract UnusedFixturesTest {
+    Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function fixtureAmount() public returns (uint256[] memory values) {
+        vm.writeFile(string.concat(vm.projectRoot(), "/fixture-called.txt"), "called");
+        values = new uint256[](1);
+        values[0] = 1;
+    }
+
+    function testUnit() public pure {}
+
+    function tableUsesFixture(uint256 amount) public pure {
+        amount;
+    }
+}
+    "#,
+    );
+
+    cmd.args(["test", "--match-test", "testUnit", "-q"]).assert_success();
+    assert!(!marker.exists(), "unit-only run evaluated table fixture");
+
+    cmd.forge_fuse();
+    cmd.args(["test", "--match-test", "tableUsesFixture", "-q"]).assert_success();
+    assert!(marker.exists(), "table run did not evaluate table fixture");
 });
 
 // Table tests should show logs and contribute to coverage.


### PR DESCRIPTION
Avoid collecting fuzz/table fixtures during setup when the selected test functions cannot use them. Forge previously evaluated every `fixture*` function and public fixture array for a matched contract immediately after `setUp`, even when the current filter only selected unit tests.

This keeps fixture collection for selected fuzz, table, and invariant tests, but skips it for unit-only and symbolic-only runs.

Warmed-artifact project with one selected unit test and an unused 5,000-entry fixture array in the same contract, debug Forge build:

- master: `340.5 ms +/- 30.8 ms`
- patched: `141.9 ms +/- 39.6 ms`

Selected fuzz test on the same project is effectively unchanged, as expected:

- master: `335.1 ms +/- 19.8 ms`
- patched: `340.6 ms +/- 16.6 ms`