### PR TITLE
feat(fuzz): add `cmin` corpus minimization subcommand

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -290,8 +290,25 @@ struct ReplayOutcome {
 }
 
 #[derive(Clone, Copy)]
+pub struct StatelessReplayTarget<'a> {
+    pub function: &'a Function,
+    pub address: Address,
+}
+
+impl StatelessReplayTarget<'_> {
+    fn can_replay(self, tx: &BasicTxDetails) -> bool {
+        tx.call_details.target == self.address
+            && tx
+                .call_details
+                .calldata
+                .get(..4)
+                .is_some_and(|selector| self.function.selector() == selector)
+    }
+}
+
+#[derive(Clone, Copy)]
 pub(crate) struct ReplayTarget<'a> {
-    pub(crate) fuzzed_function: Option<&'a Function>,
+    pub(crate) stateless: Option<StatelessReplayTarget<'a>>,
     pub(crate) fuzzed_contracts: Option<&'a FuzzRunIdentifiedContracts>,
     pub(crate) dynamic: Option<&'a DynamicTargetCtx<'a>>,
 }
@@ -401,9 +418,7 @@ impl WorkerCorpusSeed {
     pub(crate) fn load_from_disk<FEN: FoundryEvmNetwork>(
         config: &FuzzCorpusConfig,
         executor: Option<&Executor<FEN>>,
-        fuzzed_function: Option<&Function>,
-        fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
-        dynamic: Option<DynamicTargetCtx<'_>>,
+        target: ReplayTarget<'_>,
     ) -> Result<Self> {
         let mut seed = Self::empty(config).with_optimization_state(config);
         let Some(corpus_dir) = &config.corpus_dir else {
@@ -417,7 +432,7 @@ impl WorkerCorpusSeed {
             seed.metrics.corpus_count += 1;
         }
 
-        if fuzzed_contracts.is_some() && has_legacy_invariant_corpus_dirs(corpus_dir) {
+        if target.fuzzed_contracts.is_some() && has_legacy_invariant_corpus_dirs(corpus_dir) {
             let _ = sh_warn!(
                 "Ignoring legacy invariant corpus directories under {}; new corpus entries are persisted under the contract-level corpus directory.",
                 corpus_dir.display(),
@@ -429,7 +444,6 @@ impl WorkerCorpusSeed {
         };
         let mut seen_entries =
             seed.in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
-        let target = ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic: dynamic.as_ref() };
         for entry in unique_corpus_entries(&canonical_replay_dirs(corpus_dir), &mut seen_entries) {
             // A corrupt or truncated corpus file (e.g. a process killed mid-write, since entries
             // are persisted non-atomically) must not abort the whole campaign startup: skip it
@@ -739,7 +753,7 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
     let mut created: Vec<Address> = Vec::new();
 
     for tx in tx_seq {
-        if WorkerCorpus::can_replay_tx(tx, target.fuzzed_function, target.fuzzed_contracts) {
+        if WorkerCorpus::can_replay_tx(tx, target.stateless, target.fuzzed_contracts) {
             let mut call_result = execute_tx(executor, tx)?;
             cmp_seq.push(call_result.evm_cmp_values.take().unwrap_or_default());
             let (new_coverage, is_edge) = call_result.merge_all_coverage(
@@ -779,7 +793,7 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
             cmp_seq.push(Vec::new());
             failed_replays += 1;
 
-            if reject_unmatched_function && target.fuzzed_function.is_some() {
+            if reject_unmatched_function && target.stateless.is_some() {
                 rollback_replay_created(target.fuzzed_contracts, created);
                 return Ok(ReplayOutcome {
                     keep_entry: false,
@@ -809,18 +823,10 @@ impl WorkerCorpus {
         tx_generator: BoxedStrategy<BasicTxDetails>,
         // Only required by master worker (id = 0) to replay existing corpus.
         executor: Option<&Executor<FEN>>,
-        fuzzed_function: Option<&Function>,
-        fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
-        dynamic: Option<DynamicTargetCtx<'_>>,
+        target: ReplayTarget<'_>,
     ) -> Result<Self> {
         let seed = if id == 0 {
-            WorkerCorpusSeed::load_from_disk(
-                &config,
-                executor,
-                fuzzed_function,
-                fuzzed_contracts,
-                dynamic,
-            )?
+            WorkerCorpusSeed::load_from_disk(&config, executor, target)?
         } else {
             WorkerCorpusSeed::empty(&config).with_optimization_state(&config)
         };
@@ -1730,9 +1736,7 @@ impl WorkerCorpus {
     fn calibrate<FEN: FoundryEvmNetwork>(
         &mut self,
         executor: &Executor<FEN>,
-        fuzzed_function: Option<&Function>,
-        fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
-        dynamic: Option<&DynamicTargetCtx<'_>>,
+        target: ReplayTarget<'_>,
     ) -> Result<()> {
         let Some(worker_dir) = &self.worker_dir else {
             return Ok(());
@@ -1741,7 +1745,6 @@ impl WorkerCorpus {
 
         let mut executor = executor.clone();
         for (entry, tx_seq) in self.load_sync_corpus()? {
-            let target = ReplayTarget { fuzzed_function, fuzzed_contracts, dynamic };
             let coverage = ReplayCoverage {
                 history_map: &mut self.history_map,
                 edge_indices: &mut self.edge_indices,
@@ -1937,16 +1940,14 @@ impl WorkerCorpus {
         &mut self,
         num_workers: usize,
         executor: &Executor<FEN>,
-        fuzzed_function: Option<&Function>,
-        fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
-        dynamic: Option<&DynamicTargetCtx<'_>>,
+        target: ReplayTarget<'_>,
         global_corpus_metrics: &GlobalCorpusMetrics,
     ) -> Result<()> {
         trace!(target: "corpus", "syncing");
 
         self.sync_metrics(global_corpus_metrics);
 
-        self.calibrate(executor, fuzzed_function, fuzzed_contracts, dynamic)?;
+        self.calibrate(executor, target)?;
         if self.id == 0 {
             self.export_to_workers(num_workers)?;
         } else {
@@ -1966,16 +1967,11 @@ impl WorkerCorpus {
     /// Helper to check if a tx can be replayed.
     pub(crate) fn can_replay_tx(
         tx: &BasicTxDetails,
-        fuzzed_function: Option<&Function>,
+        stateless: Option<StatelessReplayTarget<'_>>,
         fuzzed_contracts: Option<&FuzzRunIdentifiedContracts>,
     ) -> bool {
         fuzzed_contracts.is_some_and(|contracts| contracts.targets().can_replay(tx))
-            || fuzzed_function.is_some_and(|function| {
-                tx.call_details
-                    .calldata
-                    .get(..4)
-                    .is_some_and(|selector| function.selector() == selector)
-            })
+            || stateless.is_some_and(|target| target.can_replay(tx))
     }
 }
 
@@ -2598,9 +2594,7 @@ mod tests {
             corpus_config(corpus_root),
             Just(basic_tx()).boxed(),
             None,
-            None,
-            None,
-            None,
+            ReplayTarget { stateless: None, fuzzed_contracts: None, dynamic: None },
         )
         .unwrap();
 

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -1,6 +1,6 @@
 use crate::executors::{
     DURATION_BETWEEN_METRICS_REPORT, EarlyExit, Executor, FuzzTestTimer, RawCallResult,
-    corpus::{GlobalCorpusMetrics, WorkerCorpus},
+    corpus::{GlobalCorpusMetrics, ReplayTarget, StatelessReplayTarget, WorkerCorpus},
 };
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
@@ -568,15 +568,18 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                 call_details: CallDetails { target: Default::default(), calldata, value },
             });
 
+        let replay_target = ReplayTarget {
+            stateless: Some(StatelessReplayTarget { function: func, address }),
+            fuzzed_contracts: None,
+            dynamic: None,
+        };
         let mut corpus = WorkerCorpus::new(
             worker_id,
             self.config.corpus.clone(),
             strategy.boxed(),
             // Master worker replays the persisted corpus using the executor
             (worker_id == 0).then_some(&self.executor_f),
-            Some(func),
-            None, // fuzzed_contracts for invariant tests
-            None, // dynamic target ctx (invariant-only)
+            replay_target,
         )?;
         let mut executor = self.executor_f.clone();
 
@@ -655,9 +658,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                     corpus.sync(
                         self.num_workers,
                         &executor,
-                        Some(func),
-                        None,
-                        None,
+                        replay_target,
                         &shared_state.global_corpus_metrics,
                     )?;
                     trace!("finished corpus sync in {:?}", timer.elapsed());

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -899,12 +899,15 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         corpus_replay_executor.inspector_mut().collect_evm_cmp_log(
             invariant_worker_collects_evm_cmp_log(&self.config, 0, actual_worker_count),
         );
+        let dynamic = self.dynamic_target_ctx();
         let corpus_seed = WorkerCorpusSeed::load_from_disk(
             &self.config.corpus,
             Some(&corpus_replay_executor),
-            None,
-            Some(&replay_targets),
-            Some(self.dynamic_target_ctx()),
+            ReplayTarget {
+                stateless: None,
+                fuzzed_contracts: Some(&replay_targets),
+                dynamic: Some(&dynamic),
+            },
         )?;
         let corpus_persistence = if actual_worker_count > 1 {
             InvariantCorpusPersistence::Deferred
@@ -1031,7 +1034,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 corpus_entries,
                 &self.executor,
                 ReplayTarget {
-                    fuzzed_function: None,
+                    stateless: None,
                     fuzzed_contracts: Some(&replay_targets),
                     dynamic: Some(&dynamic_target_ctx),
                 },

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -79,13 +79,14 @@ mod sancov;
 mod showmap;
 mod trace;
 
-pub use corpus::{DynamicTargetCtx, persist_corpus_seed};
+pub use corpus::{DynamicTargetCtx, StatelessReplayTarget, persist_corpus_seed};
 pub use corpus_io::{
     CorpusDirEntry, canonical_replay_dirs, parse_corpus_filename, read_corpus_dir, read_corpus_tree,
 };
 pub use showmap::{
-    InvariantReplayOptions, ReplayFailure, ShowmapDomain, ShowmapOpts, ShowmapReplayTarget,
-    ShowmapStats, replay_corpus_to_showmap,
+    InvariantReplayOptions, MinimizationReplayInput, ReplayFailure, ReplayObservation,
+    ShowmapDomain, ShowmapOpts, ShowmapReplayTarget, ShowmapStats, replay_corpus_to_showmap,
+    replay_sequence_for_minimization,
 };
 pub use trace::TracingExecutor;
 

--- a/crates/evm/evm/src/executors/showmap.rs
+++ b/crates/evm/evm/src/executors/showmap.rs
@@ -12,26 +12,33 @@
 //!
 //! Output is consumable by tools like `riesentoaster/differential-coverage`.
 
-use crate::executors::{
-    Executor,
-    corpus::{DynamicTargetCtx, WorkerCorpus, register_replay_created, rollback_replay_created},
-    corpus_io::read_corpus_tree,
-    invariant::{
-        call_after_invariant_function, call_invariant_function, did_fail_on_assert, execute_tx,
-        snapshot_edge_fingerprint,
+use crate::{
+    executors::{
+        Executor,
+        corpus::{
+            DynamicTargetCtx, StatelessReplayTarget, WorkerCorpus, register_replay_created,
+            rollback_replay_created,
+        },
+        corpus_io::read_corpus_tree,
+        invariant::{
+            call_after_invariant_function, call_invariant_function, did_fail_on_assert, execute_tx,
+            snapshot_edge_fingerprint,
+        },
     },
+    inspectors::EdgeIndexMap,
 };
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
 use alloy_primitives::{Address, B256, Selector, hex};
 use eyre::Result;
+use foundry_config::FuzzCorpusConfig;
 use foundry_evm_core::{
     constants::{CHEATCODE_ADDRESS, MAGIC_ASSUME},
     decode::SkipReason,
     evm::FoundryEvmNetwork,
 };
 use foundry_evm_coverage::HitMaps;
-use foundry_evm_fuzz::invariant::FuzzRunIdentifiedContracts;
+use foundry_evm_fuzz::{BasicTxDetails, invariant::FuzzRunIdentifiedContracts};
 use std::{
     collections::HashMap,
     fmt,
@@ -110,7 +117,7 @@ pub struct ShowmapStats {
 
 /// Test target metadata needed to replay corpus entries.
 pub struct ShowmapReplayTarget<'a> {
-    pub fuzzed_function: Option<&'a Function>,
+    pub stateless: Option<StatelessReplayTarget<'a>>,
     pub fuzz_fail_on_revert: bool,
     pub fuzzed_contracts: Option<&'a FuzzRunIdentifiedContracts>,
     pub invariant_address: Option<Address>,
@@ -170,10 +177,49 @@ impl fmt::Display for ReplayFailure {
     }
 }
 
+impl ReplayFailure {
+    /// Whether this failure terminates the run, mirroring the campaign.
+    const fn is_terminal(&self) -> bool {
+        !matches!(self, Self::Handler { terminal: false, .. })
+    }
+
+    /// Whether this failure is a broken invariant predicate.
+    const fn is_predicate(&self) -> bool {
+        matches!(self, Self::Invariant { .. } | Self::AfterInvariant)
+    }
+}
+
+/// Records `failure` as the representative failure for an observation, preferring
+/// terminal failures over non-terminal handler bugs and keeping the first of each class.
+fn record_replay_failure(slot: &mut Option<ReplayFailure>, failure: ReplayFailure) {
+    match slot {
+        None => *slot = Some(failure),
+        Some(existing) if !existing.is_terminal() && failure.is_terminal() => *slot = Some(failure),
+        Some(_) => {}
+    }
+}
+
+/// Facts observed while replaying one candidate for corpus minimization.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ReplayObservation {
+    /// AFL-bucketed EVM edge coverage for the candidate.
+    pub evm_edges: Vec<u8>,
+    /// AFL-bucketed native sancov edge coverage for the candidate.
+    pub sancov_edges: Vec<u8>,
+    /// Comparable failure identity, if replaying this candidate fails.
+    pub failure: Option<ReplayFailure>,
+    /// Number of replayable transactions executed.
+    pub replayed: usize,
+    /// Number of transactions that do not target this fuzz/invariant context.
+    pub unmatched: usize,
+    /// Number of transactions rejected via `vm.assume`/`vm.skip`.
+    pub skipped: usize,
+}
+
 /// Replay every corpus entry under `corpus_dir` and emit showmap files.
 ///
-/// `fuzzed_function` is set for stateless fuzz tests; `fuzzed_contracts` is set
-/// for invariant tests (txs are committed between calls in that case).
+/// `stateless` is set for stateless fuzz tests; `fuzzed_contracts` is set for
+/// invariant tests (txs are committed between calls in that case).
 /// `dynamic` lets invariant replay register contracts deployed mid-sequence so
 /// follow-up calls into them aren't dropped.
 pub fn replay_corpus_to_showmap<FEN: FoundryEvmNetwork>(
@@ -222,7 +268,7 @@ pub fn replay_corpus_to_showmap<FEN: FoundryEvmNetwork>(
         let mut last_accepted_checked_invariant = false;
         let mut entry_failure: Option<ReplayFailure> = None;
         for tx in &tx_seq {
-            if !WorkerCorpus::can_replay_tx(tx, target.fuzzed_function, target.fuzzed_contracts) {
+            if !WorkerCorpus::can_replay_tx(tx, target.stateless, target.fuzzed_contracts) {
                 continue;
             }
 
@@ -383,6 +429,133 @@ pub fn replay_corpus_to_showmap<FEN: FoundryEvmNetwork>(
     }
 
     Ok(stats)
+}
+
+pub struct MinimizationReplayInput<'a> {
+    pub sequence: &'a [BasicTxDetails],
+    pub evm_edge_indices: &'a mut EdgeIndexMap,
+    pub corpus: &'a FuzzCorpusConfig,
+}
+
+/// Replays one candidate input and returns coverage/failure facts for minimizers.
+pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
+    executor: &Executor<FEN>,
+    input: MinimizationReplayInput<'_>,
+    target: ShowmapReplayTarget<'_>,
+) -> Result<ReplayObservation> {
+    let mut observation = ReplayObservation::default();
+    let mut executor = executor.clone();
+    executor.inspector_mut().collect_edge_coverage_with_config(input.corpus);
+    executor.inspector_mut().collect_sancov_edges(input.corpus.collect_sancov_edges());
+    executor.inspector_mut().collect_sancov_trace_cmp(input.corpus.collect_sancov_trace_cmp());
+
+    let mut created = Vec::new();
+    let mut accepted = 0usize;
+    let mut last_accepted_checked_invariant = false;
+    for tx in input.sequence {
+        if !WorkerCorpus::can_replay_tx(tx, target.stateless, target.fuzzed_contracts) {
+            observation.unmatched += 1;
+            continue;
+        }
+
+        let mut call_result = execute_tx(&mut executor, tx)?;
+        let target_addr = tx.call_details.target;
+        let selector =
+            tx.call_details.calldata.get(..4).map(Selector::from_slice).unwrap_or_default();
+        let fingerprint = snapshot_edge_fingerprint(&call_result);
+
+        if call_result.result.as_ref() == MAGIC_ASSUME
+            || (call_result.reverter == Some(CHEATCODE_ADDRESS)
+                && SkipReason::decode(&call_result.result).is_some())
+        {
+            observation.skipped += 1;
+            continue;
+        }
+
+        call_result.merge_all_coverage(
+            &mut observation.evm_edges,
+            input.evm_edge_indices,
+            &mut observation.sancov_edges,
+        );
+        observation.replayed += 1;
+
+        register_replay_created(
+            &call_result.state_changeset,
+            target.dynamic,
+            target.fuzzed_contracts,
+            &mut created,
+        );
+
+        if target.fuzzed_contracts.is_some() {
+            accepted += 1;
+            last_accepted_checked_invariant = false;
+            if let Some(failure) = invariant_handler_failure(
+                target_addr,
+                selector,
+                did_fail_on_assert(&call_result, &call_result.state_changeset),
+                target.invariant_fns,
+                &call_result,
+                fingerprint,
+            ) {
+                let terminal = failure.is_terminal();
+                record_replay_failure(&mut observation.failure, failure);
+                if terminal {
+                    break;
+                }
+            }
+            executor.commit(&mut call_result);
+            if should_check_invariant(
+                accepted,
+                target.invariant_replay.check_interval,
+                target.invariant_replay.is_optimization,
+            ) {
+                last_accepted_checked_invariant = true;
+                if !target.invariant_replay.is_optimization
+                    && !observation.failure.as_ref().is_some_and(ReplayFailure::is_predicate)
+                    && let Some(address) = target.invariant_address
+                    && let Some(failure) =
+                        broken_invariant(&executor, address, target.invariant_fns)?
+                {
+                    record_replay_failure(&mut observation.failure, failure);
+                }
+            }
+        } else if !fuzz_replay_call_succeeded(
+            &executor,
+            target_addr,
+            &mut call_result,
+            target.fuzz_fail_on_revert,
+        ) {
+            record_replay_failure(
+                &mut observation.failure,
+                ReplayFailure::Fuzz { selector, fingerprint },
+            );
+            break;
+        }
+
+        if observation.failure.as_ref().is_some_and(ReplayFailure::is_terminal) {
+            break;
+        }
+    }
+
+    if !observation.failure.as_ref().is_some_and(ReplayFailure::is_terminal)
+        && accepted > 0
+        && target.fuzzed_contracts.is_some()
+        && let Some(address) = target.invariant_address
+    {
+        if !target.invariant_replay.is_optimization
+            && !last_accepted_checked_invariant
+            && let Some(failure) = broken_invariant(&executor, address, target.invariant_fns)?
+        {
+            record_replay_failure(&mut observation.failure, failure);
+        } else if target.invariant_replay.call_after_invariant
+            && let Some(failure) = broken_after_invariant(&executor, address)?
+        {
+            record_replay_failure(&mut observation.failure, failure);
+        }
+    }
+
+    rollback_replay_created(target.fuzzed_contracts, created);
+    Ok(observation)
 }
 
 fn replay_failure_report(replay_failures: &[String], failed_entries: usize) -> String {

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -1,13 +1,22 @@
-use crate::{cmd::test::TestArgs, multi_runner::ShowmapConfig, result::TestOutcome};
+use crate::{
+    cmd::test::{FilterArgs, FuzzMinimizeReplaySession, TestArgs},
+    multi_runner::{FuzzMinimizeEdgeIndices, FuzzMinimizeObservation, ShowmapConfig},
+    result::TestOutcome,
+};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::Selector;
 use clap::{Parser, Subcommand, ValueEnum, ValueHint};
 use eyre::{Context, Result, bail};
-use foundry_common::{fmt::format_tokens_raw, fs, sh_println};
+use foundry_cli::opts::{BuildOpts, EvmArgs, GlobalArgs};
+use foundry_common::{
+    fmt::format_tokens_raw,
+    fs, sh_println, sh_status,
+    shell::{OutputMode, Shell},
+};
 use foundry_config::Config;
 use foundry_evm::{
-    executors::{CorpusDirEntry, ShowmapDomain, read_corpus_tree},
+    executors::{CorpusDirEntry, ReplayObservation, ShowmapDomain, read_corpus_tree},
     fuzz::BasicTxDetails,
 };
 use serde::Serialize;
@@ -16,6 +25,7 @@ use std::{
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
+use tempfile::{Builder as TempDirBuilder, TempDir};
 
 /// Run and manage Forge fuzzing corpora.
 #[derive(Clone, Debug, Parser)]
@@ -36,6 +46,10 @@ impl FuzzArgs {
                 args.run()?;
                 Ok(TestOutcome::empty(None, true))
             }
+            FuzzSubcommands::Cmin(args) => {
+                args.run().await?;
+                Ok(TestOutcome::empty(None, true))
+            }
         }
     }
 
@@ -43,7 +57,7 @@ impl FuzzArgs {
         match &self.command {
             FuzzSubcommands::Run(args) => args.junit,
             FuzzSubcommands::Replay(args) => args.is_junit(),
-            FuzzSubcommands::Show(_) => false,
+            FuzzSubcommands::Show(_) | FuzzSubcommands::Cmin(_) => false,
         }
     }
 
@@ -68,7 +82,9 @@ pub enum FuzzSubcommands {
     Replay(FuzzReplayArgs),
     /// Print persisted corpus entries.
     Show(FuzzShowArgs),
-    // TODO(@mablr): add corpus minimization subcommands `cmin`/`tmin`.
+    /// Minimize a corpus by keeping entries that contribute new coverage.
+    Cmin(FuzzCminArgs),
+    // TODO(@mablr): add corpus test case minimization subcommand `tmin`.
 }
 
 /// Replay persisted fuzz failures, or corpus entries with `--corpus-dir`.
@@ -175,6 +191,214 @@ impl FuzzShowArgs {
         }
         Ok(())
     }
+}
+
+/// Minimize a corpus by keeping entries that contribute new coverage.
+#[derive(Clone, Debug, Parser)]
+pub struct FuzzCminArgs {
+    #[command(flatten)]
+    test: FuzzMinimizeTestArgs,
+    /// Input corpus directory.
+    #[arg(value_name = "CORPUS_DIR", value_hint = ValueHint::DirPath)]
+    corpus_dir: PathBuf,
+    /// Output corpus directory.
+    #[arg(long = "corpus-out", value_name = "DIR", value_hint = ValueHint::DirPath)]
+    out: PathBuf,
+}
+
+impl FuzzCminArgs {
+    async fn run(self) -> Result<()> {
+        if cmin_out_exists(&self.out) {
+            bail!("output corpus directory already exists: {}", self.out.display());
+        }
+
+        let staging_out = temporary_cmin_out(&self.out)?;
+        let summary = self.run_to(staging_out.path()).await?;
+        let staging_path = staging_out.keep();
+
+        if cmin_out_exists(&self.out) {
+            bail!(
+                "output corpus directory already exists: {}; minimized corpus remains staged at {}",
+                self.out.display(),
+                staging_path.display()
+            );
+        }
+
+        std::fs::rename(&staging_path, &self.out).with_context(|| {
+            format!(
+                "failed to rename minimized corpus {} to {}",
+                staging_path.display(),
+                self.out.display()
+            )
+        })?;
+
+        sh_println!(
+            "minimized corpus: kept {}/{} entries in {}",
+            summary.kept,
+            summary.total,
+            self.out.display()
+        )?;
+        if summary.skipped > 0 {
+            sh_status!(
+                "skipped {} entries or txs that could not be read or replayed",
+                summary.skipped
+            )?;
+        }
+        Ok(())
+    }
+
+    async fn run_to(&self, out_dir: &Path) -> Result<CminSummary> {
+        let session = self.test.clone().prepare_session(&self.corpus_dir).await?;
+        let mut kept = 0usize;
+        let mut total = 0usize;
+        let mut skipped_entries = 0usize;
+        let mut unreadable = 0usize;
+        let mut empty = 0usize;
+        let mut unmatched_txs = 0usize;
+        let mut rejected_txs = 0usize;
+        let mut failed_entries = 0usize;
+        let mut successful_replays = 0usize;
+        let mut failed_replays = 0usize;
+        let mut replayed = 0usize;
+        let mut cumulative = BTreeMap::<String, ReplayObservation>::new();
+        let evm_edge_indices = FuzzMinimizeEdgeIndices::default();
+
+        for entry in read_corpus_entries(&self.corpus_dir)? {
+            total += 1;
+            let sequence = entry
+                .read_tx_seq()
+                .with_context(|| format!("failed to read corpus entry {}", entry.path.display()));
+            let Ok(sequence) = sequence else {
+                skipped_entries += 1;
+                unreadable += 1;
+                continue;
+            };
+            if sequence.is_empty() {
+                skipped_entries += 1;
+                empty += 1;
+                continue;
+            }
+            let observations = replay_candidate(&session, evm_edge_indices.clone(), sequence)?;
+            let mut entry_improved = false;
+            let mut entry_failed = false;
+            let mut entry_failed_replays = 0usize;
+            let mut entry_replayed = 0usize;
+            let mut entry_unmatched_txs = 0usize;
+            let mut entry_rejected_txs = 0usize;
+            for FuzzMinimizeObservation { target, observation } in observations {
+                if observation.failure.is_some() {
+                    entry_failed = true;
+                    entry_failed_replays += observation.replayed;
+                    continue;
+                }
+                entry_replayed += observation.replayed;
+                entry_unmatched_txs = entry_unmatched_txs.max(observation.unmatched);
+                entry_rejected_txs = entry_rejected_txs.max(observation.skipped);
+                let cumulative = cumulative.entry(target).or_default();
+                entry_improved |= merge_new_edges(cumulative, &observation);
+            }
+            if entry_replayed > 0 {
+                replayed += entry_replayed;
+                successful_replays += entry_replayed;
+            } else if entry_failed {
+                skipped_entries += 1;
+                failed_entries += 1;
+                failed_replays += entry_failed_replays;
+            } else {
+                unmatched_txs += entry_unmatched_txs;
+                rejected_txs += entry_rejected_txs;
+            }
+            if !entry_improved {
+                continue;
+            }
+
+            let out = if self.corpus_dir.is_file() {
+                out_dir.join(entry.path.file_name().unwrap_or_default())
+            } else {
+                let relative = entry.path.strip_prefix(&self.corpus_dir).with_context(|| {
+                    format!(
+                        "corpus entry {} is not under {}",
+                        entry.path.display(),
+                        self.corpus_dir.display()
+                    )
+                })?;
+                out_dir.join(relative)
+            };
+            if let Some(parent) = out.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            std::fs::copy(&entry.path, &out).with_context(|| {
+                format!("failed to copy {} to {}", entry.path.display(), out.display())
+            })?;
+            kept += 1;
+        }
+
+        if total > 0 && replayed == 0 {
+            let corpus = self.corpus_dir.display();
+            if unreadable == total {
+                bail!(
+                    "replayed 0 transactions from {corpus}; all {unreadable} corpus entries could not be read"
+                );
+            }
+            if failed_entries > 0 {
+                bail!(
+                    "replayed 0 successful transactions from {corpus}; {failed_entries} corpus \
+                     entries failed during replay after {failed_replays} replayed transactions"
+                );
+            }
+            if unmatched_txs > 0 {
+                bail!(
+                    "replayed 0 transactions from {corpus}; {unmatched_txs} transactions did not match \
+                     the test; check that --mc/--mt and replay-critical options match the corpus \
+                     entries"
+                );
+            }
+            if rejected_txs > 0 {
+                bail!(
+                    "replayed 0 transactions from {corpus}; {rejected_txs} transactions were rejected \
+                     by vm.assume or vm.skip"
+                );
+            }
+            if empty == total.saturating_sub(unreadable) {
+                bail!(
+                    "replayed 0 transactions from {corpus}; corpus entries were empty{}",
+                    if unreadable > 0 {
+                        format!(" or unreadable ({unreadable} unreadable)")
+                    } else {
+                        String::new()
+                    }
+                );
+            }
+            bail!(
+                "replayed 0 transactions from {corpus}; {successful_replays} successful replayed \
+                 transactions, {unreadable} unreadable entries, {empty} empty entries, \
+                 {rejected_txs} rejected transactions"
+            );
+        }
+
+        Ok(CminSummary { kept, total, skipped: skipped_entries + unmatched_txs + rejected_txs })
+    }
+}
+
+fn cmin_out_exists(out: &Path) -> bool {
+    std::fs::symlink_metadata(out).is_ok()
+}
+
+struct CminSummary {
+    kept: usize,
+    total: usize,
+    skipped: usize,
+}
+
+fn temporary_cmin_out(out: &Path) -> Result<TempDir> {
+    let parent =
+        out.parent().filter(|parent| !parent.as_os_str().is_empty()).unwrap_or(Path::new("."));
+    let filename =
+        out.file_name().ok_or_else(|| eyre::eyre!("missing output corpus directory name"))?;
+    let prefix = format!(".{}.tmp-", filename.to_string_lossy());
+    TempDirBuilder::new().prefix(&prefix).tempdir_in(parent).with_context(|| {
+        format!("failed to create temporary output directory for {}", out.display())
+    })
 }
 
 #[derive(Serialize)]
@@ -317,4 +541,80 @@ fn read_corpus_entries(path: &Path) -> Result<Vec<CorpusDirEntry>> {
         bail!("no corpus entries found under {}", path.display());
     }
     Ok(entries)
+}
+
+#[derive(Clone, Debug, Parser)]
+struct FuzzMinimizeTestArgs {
+    #[command(flatten)]
+    global: GlobalArgs,
+    #[command(flatten)]
+    filter: FilterArgs,
+    #[command(flatten)]
+    evm: EvmArgs,
+    #[command(flatten)]
+    build: BuildOpts,
+}
+
+impl FuzzMinimizeTestArgs {
+    async fn prepare_session(self, corpus_dir: &Path) -> Result<FuzzMinimizeReplaySession> {
+        let mut test = TestArgs::parse_from(["test", "-q"]);
+        test.set_fuzz_minimize_replay_options(self.global, self.evm, self.build, self.filter);
+        test.enable_fuzz_only();
+        prepare_minimize_session(&mut test, corpus_dir).await
+    }
+}
+
+struct QuietShellGuard {
+    previous: OutputMode,
+}
+
+impl QuietShellGuard {
+    fn new() -> Self {
+        let mut shell = Shell::get();
+        let previous = shell.output_mode();
+        shell.set_output_mode(OutputMode::Quiet);
+        Self { previous }
+    }
+}
+
+impl Drop for QuietShellGuard {
+    fn drop(&mut self) {
+        Shell::get().set_output_mode(self.previous);
+    }
+}
+
+async fn prepare_minimize_session(
+    test: &mut TestArgs,
+    corpus_dir: &Path,
+) -> Result<FuzzMinimizeReplaySession> {
+    let _quiet = QuietShellGuard::new();
+    test.prepare_fuzz_minimize_replay(corpus_dir).await
+}
+
+fn replay_candidate(
+    session: &FuzzMinimizeReplaySession,
+    evm_edge_indices: FuzzMinimizeEdgeIndices,
+    sequence: Vec<BasicTxDetails>,
+) -> Result<Vec<FuzzMinimizeObservation>> {
+    let _quiet = QuietShellGuard::new();
+    session.replay(sequence, evm_edge_indices)
+}
+
+fn merge_new_edges(cumulative: &mut ReplayObservation, observation: &ReplayObservation) -> bool {
+    merge_new_edge_vec(&mut cumulative.evm_edges, &observation.evm_edges)
+        | merge_new_edge_vec(&mut cumulative.sancov_edges, &observation.sancov_edges)
+}
+
+fn merge_new_edge_vec(cumulative: &mut Vec<u8>, candidate: &[u8]) -> bool {
+    if cumulative.len() < candidate.len() {
+        cumulative.resize(candidate.len(), 0);
+    }
+    let mut improved = false;
+    for (cumulative, &candidate) in cumulative.iter_mut().zip(candidate) {
+        if candidate > 0 && *cumulative == 0 {
+            *cumulative = candidate;
+            improved = true;
+        }
+    }
+    improved
 }

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -611,10 +611,24 @@ fn merge_new_edge_vec(cumulative: &mut Vec<u8>, candidate: &[u8]) -> bool {
     }
     let mut improved = false;
     for (cumulative, &candidate) in cumulative.iter_mut().zip(candidate) {
-        if candidate > 0 && *cumulative == 0 {
+        if *cumulative < candidate {
             *cumulative = candidate;
             improved = true;
         }
     }
     improved
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_new_edges_keeps_sancov_hit_count_bucket_increases() {
+        let mut cumulative = ReplayObservation { sancov_edges: vec![0, 1], ..Default::default() };
+        let candidate = ReplayObservation { sancov_edges: vec![0, 8], ..Default::default() };
+
+        assert!(merge_new_edges(&mut cumulative, &candidate));
+        assert_eq!(cumulative.sancov_edges, vec![0, 8]);
+    }
 }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -4,7 +4,8 @@ use crate::{
     decode::decode_console_logs,
     gas_report::GasReport,
     multi_runner::{
-        MultiNetworkConfig, ShowmapConfig, SymbolicArtifactReplayConfig, TestFunctionMatcher,
+        FuzzMinimizeConfig, FuzzMinimizeEdgeIndices, FuzzMinimizeObservation, MultiNetworkConfig,
+        ShowmapConfig, SymbolicArtifactReplayConfig, TestFunctionMatcher,
     },
     mutation::{MutationRunConfig, run_mutation_testing},
     result::{
@@ -55,7 +56,7 @@ use foundry_evm::{
         BlockEnvFor, EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor,
     },
     executors::ShowmapDomain,
-    fuzz::CounterExample,
+    fuzz::{BasicTxDetails, CounterExample},
     hardforks::TempoHardfork,
     opts::EvmOpts,
     traces::{backtrace::BacktraceBuilder, identifier::TraceIdentifiers, prune_trace_depth},
@@ -67,7 +68,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt::Write,
     path::{Path, PathBuf},
-    sync::{Arc, mpsc::channel},
+    sync::{Arc, Mutex, mpsc::channel},
     time::{Duration, Instant},
 };
 use yansi::Paint;
@@ -75,7 +76,11 @@ use yansi::Paint;
 mod evm_profile_server;
 mod filter;
 mod summary;
-use crate::{result::TestKind, traces::render_trace_arena_inner};
+use crate::{
+    result::TestKind,
+    runner::{count_runnable_invariant_campaign_anchors, function_matches_network_pass},
+    traces::render_trace_arena_inner,
+};
 pub use filter::{FilterArgs, ProjectPathsAwareFilter};
 use filter::{RerunFailure, RerunFailures};
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
@@ -104,6 +109,145 @@ fn validate_showmap_name(kind: &str, name: &str) -> Result<()> {
 fn validate_showmap_config(showmap: &ShowmapConfig) -> Result<()> {
     validate_showmap_name("showmap approach", &showmap.approach)?;
     validate_showmap_name("showmap trial", &showmap.trial)
+}
+
+pub(crate) struct FuzzMinimizeReplaySession {
+    filter: ProjectPathsAwareFilter,
+    passes: Vec<FuzzMinimizeReplayPass>,
+}
+
+type FuzzMinimizeReplay = Box<dyn Fn(&ProjectPathsAwareFilter, FuzzMinimizeConfig) -> Result<()>>;
+
+struct FuzzMinimizeReplayPass {
+    target_count: usize,
+    replay: FuzzMinimizeReplay,
+}
+
+impl FuzzMinimizeReplaySession {
+    pub(crate) fn replay(
+        &self,
+        sequence: Vec<BasicTxDetails>,
+        evm_edge_indices: FuzzMinimizeEdgeIndices,
+    ) -> Result<Vec<FuzzMinimizeObservation>> {
+        let observations = Arc::new(Mutex::new(Vec::new()));
+        let fuzz_minimize = FuzzMinimizeConfig {
+            input: sequence.into(),
+            evm_edge_indices,
+            observations: observations.clone(),
+        };
+
+        for pass in &self.passes {
+            if pass.target_count == 0 {
+                continue;
+            }
+            (pass.replay)(&self.filter, fuzz_minimize.clone())?;
+        }
+
+        let observations = observations
+            .lock()
+            .map_err(|_| eyre::eyre!("minimize observations lock poisoned"))?
+            .clone();
+        if observations.is_empty() {
+            bail!("fuzz minimization replay produced no observation for the matched test");
+        }
+        Ok(observations)
+    }
+}
+
+fn replay_with_runner<FEN: FoundryEvmNetwork>(
+    runner: &MultiContractRunner<FEN>,
+    filter: &ProjectPathsAwareFilter,
+    fuzz_minimize: FuzzMinimizeConfig,
+) -> Result<()> {
+    let mut runner = runner.clone();
+    runner.tcfg.fuzz_minimize = Some(fuzz_minimize);
+    let results = runner.test_collect(filter)?;
+    for (suite, suite_result) in results {
+        for (test, test_result) in suite_result.test_results {
+            if test_result.status == TestStatus::Failure {
+                bail!(
+                    "fuzz minimization replay failed for {suite}::{test}: {}",
+                    test_result.reason.as_deref().unwrap_or("unknown error")
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn fuzz_minimize_replay<FEN: FoundryEvmNetwork>(
+    runner: MultiContractRunner<FEN>,
+    filter: &ProjectPathsAwareFilter,
+) -> FuzzMinimizeReplayPass {
+    let target_count = count_fuzz_minimize_targets(&runner, filter);
+    FuzzMinimizeReplayPass {
+        target_count,
+        replay: Box::new(move |filter, fuzz_minimize| {
+            replay_with_runner(&runner, filter, fuzz_minimize)
+        }),
+    }
+}
+
+fn count_fuzz_minimize_targets<FEN: FoundryEvmNetwork>(
+    runner: &MultiContractRunner<FEN>,
+    filter: &dyn TestFilter,
+) -> usize {
+    runner
+        .matching_contracts(filter)
+        .map(|(id, contract)| {
+            let contract_name = id.identifier();
+            let fuzz_targets = contract
+                .abi
+                .functions()
+                .filter(|func| func.is_fuzz_test())
+                .filter(|func| filter.matches_test_function_in_contract(&contract_name, func))
+                .filter(|func| {
+                    function_matches_network_pass(
+                        &runner.tcfg.multi_network.all_override_networks,
+                        runner.tcfg.multi_network.pass_network.as_ref(),
+                        runner.tcfg.inline_config.network_for(
+                            &runner.tcfg.config.profile,
+                            &contract_name,
+                            &func.name,
+                        ),
+                    )
+                })
+                .count();
+            let invariant_targets = count_runnable_invariant_campaign_anchors(
+                &contract.abi,
+                filter,
+                crate::runner::InvariantCampaignScope {
+                    config: &runner.tcfg.config,
+                    inline_config: &runner.tcfg.inline_config,
+                    contract_name: &contract_name,
+                    all_override_networks: &runner.tcfg.multi_network.all_override_networks,
+                    pass_network: runner.tcfg.multi_network.pass_network.as_ref(),
+                },
+            );
+            fuzz_targets + invariant_targets
+        })
+        .sum()
+}
+
+#[derive(Clone, Copy)]
+enum NetworkDispatchKind {
+    Tempo,
+    #[cfg(feature = "optimism")]
+    Optimism,
+    Eth,
+}
+
+const fn network_dispatch_kind(evm_opts: &EvmOpts) -> NetworkDispatchKind {
+    if evm_opts.networks.is_tempo() {
+        return NetworkDispatchKind::Tempo;
+    }
+
+    #[cfg(feature = "optimism")]
+    if evm_opts.networks.is_optimism() {
+        return NetworkDispatchKind::Optimism;
+    }
+
+    NetworkDispatchKind::Eth
 }
 
 /// Output format for EVM execution profiles.
@@ -176,6 +320,12 @@ impl TestExecutionOptions {
     pub(crate) fn coverage(inline_config: Arc<InlineConfig>) -> Self {
         Self { coverage: true, ..Self::default_run(inline_config) }
     }
+}
+
+#[derive(Clone)]
+struct FuzzMinimizeNetworkPassOptions {
+    inline_config: Arc<InlineConfig>,
+    multi_network: MultiNetworkConfig,
 }
 
 fn sources_to_compile_from_artifacts(
@@ -782,6 +932,20 @@ impl TestArgs {
         self.showmap_override = Some(showmap);
     }
 
+    /// Sets replay-critical options for internal fuzz minimizer callers.
+    pub(crate) fn set_fuzz_minimize_replay_options(
+        &mut self,
+        global: GlobalArgs,
+        evm: EvmArgs,
+        build: BuildOpts,
+        filter: FilterArgs,
+    ) {
+        self.global = global;
+        self.evm = evm;
+        self.build = build;
+        self.filter = filter;
+    }
+
     /// Replays persisted fuzz failures without running a new fuzz campaign.
     pub(crate) const fn enable_fuzz_failure_replay(&mut self) {
         self.fuzz_failure_replay = true;
@@ -1038,6 +1202,102 @@ impl TestArgs {
             inline_config,
             replay_symbolic_artifact,
         ))
+    }
+
+    pub(crate) async fn prepare_fuzz_minimize_replay(
+        &mut self,
+        corpus_dir: &Path,
+    ) -> Result<FuzzMinimizeReplaySession> {
+        let (_, mut config, mut evm_opts, output, filter, inline_config, _) =
+            self.compile_project().await?;
+
+        if config.fuzz.run == Some(0) {
+            bail!("`fuzz.run` must be greater than 0");
+        }
+
+        if self.gas_report {
+            evm_opts.isolate = true;
+        } else {
+            config.fuzz.gas_report_samples = 0;
+            config.invariant.gas_report_samples = 0;
+        }
+        if config.fuzz.corpus.corpus_dir.is_none() {
+            config.fuzz.corpus.corpus_dir = Some(corpus_dir.to_path_buf());
+        }
+        if config.invariant.corpus.corpus_dir.is_none() {
+            config.invariant.corpus.corpus_dir = Some(corpus_dir.to_path_buf());
+        }
+
+        config.fuzz.seed = config.fuzz.seed.or(Some(U256::ZERO));
+
+        evm_opts.infer_network_from_fork().await;
+
+        let override_networks = inline_config.referenced_override_networks(&config.profile);
+        let mut passes = Vec::new();
+
+        if override_networks.is_empty() {
+            passes.push(
+                self.dispatch_fuzz_minimize_network(
+                    &evm_opts,
+                    config,
+                    evm_opts.clone(),
+                    &output,
+                    FuzzMinimizeNetworkPassOptions {
+                        inline_config: inline_config.clone(),
+                        multi_network: MultiNetworkConfig::default(),
+                    },
+                    &filter,
+                )
+                .await?,
+            );
+        } else {
+            let all_override_networks = override_networks.clone();
+            passes.push(
+                self.dispatch_fuzz_minimize_network(
+                    &evm_opts,
+                    config.clone(),
+                    evm_opts.clone(),
+                    &output,
+                    FuzzMinimizeNetworkPassOptions {
+                        inline_config: inline_config.clone(),
+                        multi_network: MultiNetworkConfig {
+                            all_override_networks: all_override_networks.clone(),
+                            pass_network: None,
+                        },
+                    },
+                    &filter,
+                )
+                .await?,
+            );
+
+            for &network in &override_networks {
+                let mut pass_evm_opts = evm_opts.clone();
+                pass_evm_opts.networks = network.into();
+                passes.push(
+                    self.dispatch_fuzz_minimize_network(
+                        &pass_evm_opts,
+                        config.clone(),
+                        pass_evm_opts.clone(),
+                        &output,
+                        FuzzMinimizeNetworkPassOptions {
+                            inline_config: inline_config.clone(),
+                            multi_network: MultiNetworkConfig {
+                                all_override_networks: all_override_networks.clone(),
+                                pass_network: Some(network),
+                            },
+                        },
+                        &filter,
+                    )
+                    .await?,
+                );
+            }
+        }
+
+        if passes.iter().all(|pass| pass.target_count == 0) {
+            bail!("fuzz minimization requires at least one matched fuzz or invariant test");
+        }
+
+        Ok(FuzzMinimizeReplaySession { filter, passes })
     }
 
     /// Executes all the tests in the project.
@@ -1701,6 +1961,29 @@ impl TestArgs {
         Ok((libraries, outcome))
     }
 
+    async fn build_fuzz_minimize_runner<FEN: FoundryEvmNetwork>(
+        &self,
+        config: Config,
+        evm_opts: EvmOpts,
+        output: &ProjectCompileOutput,
+        options: FuzzMinimizeNetworkPassOptions,
+    ) -> eyre::Result<MultiContractRunner<FEN>> {
+        let (evm_env, tx_env, fork_block) =
+            evm_opts.env::<SpecFor<FEN>, BlockEnvFor<FEN>, TxEnvFor<FEN>>().await?;
+
+        let config = Arc::new(config);
+        MultiContractRunnerBuilder::new(config.clone(), options.inline_config)
+            .initial_balance(evm_opts.initial_balance)
+            .sender(evm_opts.sender)
+            .with_fork(evm_opts.get_fork(&config, evm_env.cfg_env.chain_id, fork_block))
+            .enable_isolation(evm_opts.isolate)
+            .fail_fast(self.fail_fast)
+            .with_multi_network(options.multi_network)
+            .with_fuzz_only(self.fuzz_only)
+            .with_fuzz_failure_replay(self.fuzz_failure_replay)
+            .build::<FEN, MultiCompiler>(output, evm_env, tx_env, evm_opts)
+    }
+
     /// Dispatches `build_and_run_tests` to the correct network type based on `evm_opts.networks`.
     async fn dispatch_network(
         &self,
@@ -1711,20 +1994,52 @@ impl TestArgs {
         filter: &ProjectPathsAwareFilter,
         execution: TestExecutionOptions,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
-        if dispatch_opts.networks.is_tempo() {
-            self.build_and_run_tests::<TempoEvmNetwork>(config, evm_opts, output, filter, execution)
+        match network_dispatch_kind(dispatch_opts) {
+            NetworkDispatchKind::Tempo => {
+                self.build_and_run_tests::<TempoEvmNetwork>(
+                    config, evm_opts, output, filter, execution,
+                )
                 .await
-        } else {
-            #[cfg(feature = "optimism")]
-            if dispatch_opts.networks.is_optimism() {
-                return self
-                    .build_and_run_tests::<OpEvmNetwork>(
-                        config, evm_opts, output, filter, execution,
-                    )
-                    .await;
             }
-            self.build_and_run_tests::<EthEvmNetwork>(config, evm_opts, output, filter, execution)
+            #[cfg(feature = "optimism")]
+            NetworkDispatchKind::Optimism => {
+                self.build_and_run_tests::<OpEvmNetwork>(
+                    config, evm_opts, output, filter, execution,
+                )
                 .await
+            }
+            NetworkDispatchKind::Eth => {
+                self.build_and_run_tests::<EthEvmNetwork>(
+                    config, evm_opts, output, filter, execution,
+                )
+                .await
+            }
+        }
+    }
+
+    async fn dispatch_fuzz_minimize_network(
+        &self,
+        dispatch_opts: &EvmOpts,
+        config: Config,
+        evm_opts: EvmOpts,
+        output: &ProjectCompileOutput,
+        options: FuzzMinimizeNetworkPassOptions,
+        filter: &ProjectPathsAwareFilter,
+    ) -> eyre::Result<FuzzMinimizeReplayPass> {
+        match network_dispatch_kind(dispatch_opts) {
+            NetworkDispatchKind::Tempo => self
+                .build_fuzz_minimize_runner::<TempoEvmNetwork>(config, evm_opts, output, options)
+                .await
+                .map(|runner| fuzz_minimize_replay(runner, filter)),
+            #[cfg(feature = "optimism")]
+            NetworkDispatchKind::Optimism => self
+                .build_fuzz_minimize_runner::<OpEvmNetwork>(config, evm_opts, output, options)
+                .await
+                .map(|runner| fuzz_minimize_replay(runner, filter)),
+            NetworkDispatchKind::Eth => self
+                .build_fuzz_minimize_runner::<EthEvmNetwork>(config, evm_opts, output, options)
+                .await
+                .map(|runner| fuzz_minimize_replay(runner, filter)),
         }
     }
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -26,10 +26,13 @@ use foundry_evm::{
     backend::Backend,
     core::evm::{EvmEnvFor, FoundryEvmNetwork, SpecFor, TxEnvFor},
     decode::RevertDecoder,
-    executors::{EarlyExit, Executor, ExecutorBuilder, ShowmapDomain},
+    executors::{EarlyExit, Executor, ExecutorBuilder, ReplayObservation, ShowmapDomain},
     fork::CreateFork,
-    fuzz::strategies::{EnumBounds, LiteralsDictionary},
-    inspectors::CheatsConfig,
+    fuzz::{
+        BasicTxDetails,
+        strategies::{EnumBounds, LiteralsDictionary},
+    },
+    inspectors::{CheatsConfig, EdgeIndexMap},
     opts::EvmOpts,
     traces::{InternalTraceMode, TraceRequirements},
 };
@@ -42,7 +45,7 @@ use std::{
     collections::BTreeMap,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
-    sync::{Arc, mpsc},
+    sync::{Arc, Mutex, mpsc},
     time::Instant,
 };
 
@@ -373,6 +376,30 @@ pub struct ShowmapConfig {
     pub emit_files: bool,
 }
 
+pub type FuzzMinimizeEdgeIndices = Arc<Mutex<BTreeMap<String, Arc<Mutex<EdgeIndexMap>>>>>;
+
+/// CLI-only options that switch fuzz/invariant tests into single-entry replay
+/// mode for corpus minimization.
+#[derive(Clone, Debug)]
+pub struct FuzzMinimizeConfig {
+    /// Entry to replay.
+    pub input: Arc<[BasicTxDetails]>,
+    /// Shared edge-index assignments for all candidate replays in this minimization invocation,
+    /// namespaced by matched target.
+    pub evm_edge_indices: FuzzMinimizeEdgeIndices,
+    /// Shared replay observations collected from matched fuzz/invariant tests.
+    pub observations: Arc<Mutex<Vec<FuzzMinimizeObservation>>>,
+}
+
+/// Replay observation for one matched minimization target.
+#[derive(Clone, Debug)]
+pub struct FuzzMinimizeObservation {
+    /// Stable target identity for this minimization run.
+    pub target: String,
+    /// Replay result for this target.
+    pub observation: ReplayObservation,
+}
+
 #[derive(Clone, Debug)]
 pub struct SymbolicArtifactReplayConfig {
     /// Artifact payload to replay.
@@ -421,6 +448,8 @@ pub struct TestRunnerConfig<FEN: FoundryEvmNetwork> {
     /// When set, fuzz/invariant tests run in corpus replay mode and emit
     /// AFL-`afl-showmap`-style files instead of running a campaign.
     pub showmap: Option<ShowmapConfig>,
+    /// When set, fuzz/invariant tests replay one candidate input and record minimization facts.
+    pub fuzz_minimize: Option<FuzzMinimizeConfig>,
     /// Run only fuzz and invariant tests.
     pub fuzz_only: bool,
     /// Replay persisted fuzz failures without running a new fuzz campaign.
@@ -554,6 +583,8 @@ pub struct MultiContractRunnerBuilder {
     pub multi_network: MultiNetworkConfig,
     /// Showmap replay mode (CLI-only, off by default).
     pub showmap: Option<ShowmapConfig>,
+    /// Fuzz minimization replay mode (CLI-only, off by default).
+    pub fuzz_minimize: Option<FuzzMinimizeConfig>,
     /// Run only fuzz and invariant tests.
     pub fuzz_only: bool,
     /// Replay persisted fuzz failures without running a new fuzz campaign.
@@ -578,6 +609,7 @@ impl MultiContractRunnerBuilder {
             fail_fast: false,
             multi_network: Default::default(),
             showmap: None,
+            fuzz_minimize: None,
             fuzz_only: false,
             fuzz_failure_replay: false,
             symbolic_artifact_replay: None,
@@ -586,6 +618,11 @@ impl MultiContractRunnerBuilder {
 
     pub fn with_showmap(mut self, showmap: Option<ShowmapConfig>) -> Self {
         self.showmap = showmap;
+        self
+    }
+
+    pub fn with_fuzz_minimize(mut self, fuzz_minimize: Option<FuzzMinimizeConfig>) -> Self {
+        self.fuzz_minimize = fuzz_minimize;
         self
     }
 
@@ -796,6 +833,7 @@ impl MultiContractRunnerBuilder {
                 early_exit: EarlyExit::new(self.fail_fast),
                 multi_network: self.multi_network,
                 showmap: self.showmap,
+                fuzz_minimize: self.fuzz_minimize,
                 fuzz_only: self.fuzz_only,
                 fuzz_failure_replay: self.fuzz_failure_replay,
                 symbolic_artifact_replay: self.symbolic_artifact_replay,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -4,7 +4,7 @@ use crate::{
     MultiContractRunner, TestFilter,
     coverage::HitMaps,
     fuzz::{BaseCounterExample, FuzzTestResult},
-    multi_runner::{TestContract, TestFunctionMatcher, TestRunnerConfig},
+    multi_runner::{FuzzMinimizeObservation, TestContract, TestFunctionMatcher, TestRunnerConfig},
     progress::{TestsProgress, start_fuzz_progress},
     result::{
         InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicArtifactRef,
@@ -33,8 +33,9 @@ use foundry_evm::{
     core::evm::FoundryEvmNetwork,
     decode::{RevertDecoder, SkipReason},
     executors::{
-        CallResult, EvmError, Executor, ITest, InvariantReplayOptions, RawCallResult, ShowmapOpts,
-        ShowmapReplayTarget, canonical_replay_dirs,
+        CallResult, EvmError, Executor, ITest, InvariantReplayOptions, MinimizationReplayInput,
+        RawCallResult, ShowmapOpts, ShowmapReplayTarget, StatelessReplayTarget,
+        canonical_replay_dirs,
         fuzz::FuzzedExecutor,
         invariant::{
             CheckSequenceFailureSite, CheckSequenceOptions, CheckSequenceOutcome,
@@ -43,6 +44,7 @@ use foundry_evm::{
             replay_handler_failure_sequence, replay_run,
         },
         persist_corpus_seed, read_corpus_dir, replay_corpus_to_showmap,
+        replay_sequence_for_minimization,
     },
     fuzz::{
         BasicTxDetails, CallDetails, CounterExample, FuzzFixtures, fixture_name,
@@ -67,7 +69,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     ops::Deref,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, Mutex},
     time::Instant,
 };
 use tokio::signal;
@@ -1120,6 +1122,19 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
     /// Returns whether verbose symbolic diagnostics should be rendered after progress clears.
     fn should_defer_symbolic_diagnostics(&self) -> bool {
         self.cr.progress.is_some() && self.config.symbolic.dump_smt
+    }
+
+    fn fuzz_minimize_target_id(&self, test_name: &str) -> String {
+        let network = self
+            .cr
+            .mcr
+            .tcfg
+            .multi_network
+            .pass_network
+            .as_ref()
+            .map(|network| format!("{network:?}"))
+            .unwrap_or_else(|| "default".to_string());
+        format!("{network}:{}::{test_name}", self.cr.name)
     }
 
     fn persist_symbolic_counterexample_artifact(
@@ -2654,7 +2669,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 corpus_dir,
                 &showmap,
                 ShowmapReplayTarget {
-                    fuzzed_function: None,
+                    stateless: None,
                     fuzz_fail_on_revert: false,
                     fuzzed_contracts: Some(&targeted),
                     invariant_address: Some(invariant_address),
@@ -2751,6 +2766,68 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         } else {
             Cow::Borrowed(func.name.as_str())
         };
+
+        if let Some(minimize) = self.cr.mcr.tcfg.fuzz_minimize.as_ref() {
+            let target = self.fuzz_minimize_target_id(invariant_display_name.as_ref());
+            if let Err(e) = evm.select_contract_artifacts(self.address) {
+                self.result.invariant_setup_fail(e);
+                return self.result;
+            }
+            let Ok((_, targeted)) = evm.select_contracts_and_senders(self.address).map_err(|e| {
+                self.result.invariant_setup_fail(e);
+            }) else {
+                return self.result;
+            };
+            let dynamic = evm.dynamic_target_ctx();
+            let Ok(mut evm_edge_indices_by_target) = minimize.evm_edge_indices.lock() else {
+                self.result.single_fail(Some("minimize edge index lock poisoned".to_string()));
+                return self.result;
+            };
+            let evm_edge_indices = evm_edge_indices_by_target
+                .entry(target.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(Default::default())))
+                .clone();
+            drop(evm_edge_indices_by_target);
+            let Ok(mut evm_edge_indices) = evm_edge_indices.lock() else {
+                self.result.single_fail(Some("minimize edge index lock poisoned".to_string()));
+                return self.result;
+            };
+            match replay_sequence_for_minimization(
+                &evm.executor,
+                MinimizationReplayInput {
+                    sequence: minimize.input.as_ref(),
+                    evm_edge_indices: &mut evm_edge_indices,
+                    corpus: &invariant_config.corpus,
+                },
+                ShowmapReplayTarget {
+                    stateless: None,
+                    fuzz_fail_on_revert: false,
+                    fuzzed_contracts: Some(&targeted),
+                    invariant_address: Some(invariant_contract.address),
+                    invariant_fns: &invariant_contract.invariant_fns,
+                    invariant_replay: InvariantReplayOptions {
+                        check_interval: invariant_config.check_interval,
+                        call_after_invariant,
+                        is_optimization,
+                    },
+                    dynamic: Some(&dynamic),
+                },
+            ) {
+                Ok(observation) => {
+                    let replayed = observation.replayed;
+                    let skipped = observation.skipped + observation.unmatched;
+                    let Ok(mut observations) = minimize.observations.lock() else {
+                        self.result
+                            .single_fail(Some("minimize observations lock poisoned".to_string()));
+                        return self.result;
+                    };
+                    observations.push(FuzzMinimizeObservation { target, observation });
+                    self.result.replay_result(replayed, 0, skipped, std::time::Duration::ZERO);
+                }
+                Err(e) => self.result.single_fail(Some(e.to_string())),
+            }
+            return self.result;
+        }
 
         let progress = start_fuzz_progress(
             self.cr.progress,
@@ -3381,12 +3458,16 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     narrow_generated_fuzz_corpus_root(corpus_dir, self.cr.name, &func.name)
                 })
                 .or_else(|| fuzz_config.corpus.corpus_dir.clone());
+            let fuzzed_address = self.address;
             return self.run_showmap(
                 func,
                 corpus_dir,
                 &showmap,
                 ShowmapReplayTarget {
-                    fuzzed_function: Some(func),
+                    stateless: Some(StatelessReplayTarget {
+                        function: func,
+                        address: fuzzed_address,
+                    }),
                     fuzz_fail_on_revert: fuzz_config.fail_on_revert,
                     fuzzed_contracts: None,
                     invariant_address: None,
@@ -3395,6 +3476,57 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     dynamic: None,
                 },
             );
+        }
+
+        if let Some(minimize) = self.cr.mcr.tcfg.fuzz_minimize.as_ref() {
+            let target = self.fuzz_minimize_target_id(&func.signature());
+            let Ok(mut evm_edge_indices_by_target) = minimize.evm_edge_indices.lock() else {
+                self.result.single_fail(Some("minimize edge index lock poisoned".to_string()));
+                return self.result;
+            };
+            let evm_edge_indices = evm_edge_indices_by_target
+                .entry(target.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(Default::default())))
+                .clone();
+            drop(evm_edge_indices_by_target);
+            let Ok(mut evm_edge_indices) = evm_edge_indices.lock() else {
+                self.result.single_fail(Some("minimize edge index lock poisoned".to_string()));
+                return self.result;
+            };
+            match replay_sequence_for_minimization(
+                self.executor.as_ref(),
+                MinimizationReplayInput {
+                    sequence: minimize.input.as_ref(),
+                    evm_edge_indices: &mut evm_edge_indices,
+                    corpus: &fuzz_config.corpus,
+                },
+                ShowmapReplayTarget {
+                    stateless: Some(StatelessReplayTarget {
+                        function: func,
+                        address: self.address,
+                    }),
+                    fuzz_fail_on_revert: fuzz_config.fail_on_revert,
+                    fuzzed_contracts: None,
+                    invariant_address: None,
+                    invariant_fns: &[],
+                    invariant_replay: InvariantReplayOptions::default(),
+                    dynamic: None,
+                },
+            ) {
+                Ok(observation) => {
+                    let replayed = observation.replayed;
+                    let skipped = observation.skipped + observation.unmatched;
+                    let Ok(mut observations) = minimize.observations.lock() else {
+                        self.result
+                            .single_fail(Some("minimize observations lock poisoned".to_string()));
+                        return self.result;
+                    };
+                    observations.push(FuzzMinimizeObservation { target, observation });
+                    self.result.replay_result(replayed, 0, skipped, std::time::Duration::ZERO);
+                }
+                Err(e) => self.result.single_fail(Some(e.to_string())),
+            }
+            return self.result;
         }
 
         // Load persisted counterexample, if any.

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -687,6 +687,54 @@ contract ForgeFuzzCminTargetTest {
     );
 });
 
+forgetest_init!(forge_fuzz_cmin_keeps_hit_count_bucket_increases, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminBucketTarget.t.sol",
+        r#"
+contract ForgeFuzzCminBucketTargetTest {
+    uint256 value;
+
+    function testFuzz_reps(uint256 input) public {
+        uint256 n = input % 5;
+        for (uint256 i = 0; i < n; i++) {
+            value = value + i + 1;
+        }
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminBucketTarget.t.sol/ForgeFuzzCminBucketTargetTest.json",
+    );
+    let one = calldata_for(&abi, "testFuzz_reps", 1);
+    let four = calldata_for(&abi, "testFuzz_reps", 4);
+    let corpus = prj.root().join("corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000002-2.json", &four);
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminBucketTargetTest",
+            "--mt",
+            "testFuzz_reps",
+            "corpus",
+            "--corpus-out",
+            "min-corpus",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("minimized corpus: kept 2/2 entries in min-corpus"), "{stdout}");
+    assert_eq!(regular_file_count(&prj.root().join("min-corpus")), 2);
+});
+
 forgetest_init!(forge_fuzz_cmin_handles_multiple_matched_targets, |prj, cmd| {
     prj.add_test(
         "ForgeFuzzCminMultiTarget.t.sol",

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -4,7 +4,7 @@ use foundry_evm::fuzz::BaseCounterExample;
 use foundry_test_utils::{TestCommand, forgetest_init, str};
 use regex::Regex;
 use serde_json::Value;
-use std::path::Path;
+use std::{collections::BTreeSet, path::Path};
 
 const DEFAULT_SENDER: &str = "0x0000000000000000000000000000000000000001";
 const DEFAULT_TEST_TARGET: &str = "0x7FA9385bE102ac3EAc297483Dd6233D62b3e1496";
@@ -56,6 +56,40 @@ fn has_regular_file(root: &Path) -> bool {
             let path = entry.unwrap().path();
             path.is_file() || (path.is_dir() && has_regular_file(&path))
         })
+}
+
+fn regular_file_count(root: &Path) -> usize {
+    if !root.exists() {
+        return 0;
+    }
+    std::fs::read_dir(root)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .map(|path| if path.is_dir() { regular_file_count(&path) } else { 1 })
+        .sum()
+}
+
+fn showmap_edge_ids(root: &Path) -> BTreeSet<String> {
+    fn visit(path: &Path, out: &mut BTreeSet<String>) {
+        if path.is_dir() {
+            for entry in std::fs::read_dir(path).unwrap() {
+                visit(&entry.unwrap().path(), out);
+            }
+            return;
+        }
+        if path.extension().is_none_or(|extension| extension != "txt") {
+            return;
+        }
+        let body = std::fs::read_to_string(path).unwrap();
+        for line in body.lines() {
+            let (id, _) = line.split_once(':').unwrap_or_else(|| panic!("malformed {line}"));
+            out.insert(id.to_string());
+        }
+    }
+
+    let mut edges = BTreeSet::new();
+    visit(root, &mut edges);
+    edges
 }
 
 forgetest_init!(test_can_scrape_bytecode, |prj, cmd| {
@@ -527,6 +561,569 @@ corpus/00000000-0000-0000-0000-000000000002-2.json (1 txs)
         .assert_success();
     let stdout = String::from_utf8(replay.get_output().stdout.clone()).unwrap();
     assert!(stdout.contains("[PASS] testFuzz_setNumber(uint256) (replay: 2 entries"), "{stdout}");
+});
+
+forgetest_init!(forge_fuzz_cmin_keeps_coverage_adding_entries, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminTarget.t.sol",
+        r#"
+contract ForgeFuzzCminTargetTest {
+    uint256 value;
+
+    function testFuzz_branch(uint256 input) public {
+        if (input == 1) {
+            value = 1;
+        }
+        if (input == 2) {
+            value = 2;
+        }
+        if (input == 3) {
+            revert("boom");
+        }
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi =
+        artifact_abi(prj.root(), "out/ForgeFuzzCminTarget.t.sol/ForgeFuzzCminTargetTest.json");
+    let one = calldata_for(&abi, "testFuzz_branch", 1);
+    let two = calldata_for(&abi, "testFuzz_branch", 2);
+    let three = calldata_for(&abi, "testFuzz_branch", 3);
+    let corpus = prj.root().join("corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000002-2.json", &one);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000003-3.json", &two);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000004-4.json", &three);
+    std::fs::write(corpus.join("00000000-0000-0000-0000-000000000005-5.json"), "[]").unwrap();
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminTargetTest",
+            "--mt",
+            "testFuzz_branch",
+            "corpus",
+            "--corpus-out",
+            "min-corpus",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stdout.contains("minimized corpus: kept 2/5 entries in min-corpus"), "{stdout}");
+    assert!(stderr.contains("skipped 2 entries or txs"), "{stderr}");
+    assert_eq!(regular_file_count(&prj.root().join("min-corpus")), 2);
+
+    cmd.forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminTargetTest",
+            "--mt",
+            "testFuzz_branch",
+            "corpus",
+            "--corpus-out",
+            "min-corpus",
+        ])
+        .assert_failure();
+
+    let preserve_corpus = prj.root().join("preserve-corpus");
+    std::fs::create_dir_all(&preserve_corpus).unwrap();
+    write_corpus_entry(&preserve_corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
+    write_corpus_entry(&preserve_corpus, "00000000-0000-0000-0000-000000000002-2.json", &one);
+    write_corpus_entry(&preserve_corpus, "00000000-0000-0000-0000-000000000003-3.json", &two);
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--mc",
+            "ForgeFuzzCminTargetTest",
+            "--mt",
+            "testFuzz_branch",
+            "--showmap-out",
+            "showmap-before-cmin",
+            "--showmap-corpus-dir",
+            "preserve-corpus",
+            "--showmap-trial",
+            "t",
+        ])
+        .assert_success();
+    cmd.forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminTargetTest",
+            "--mt",
+            "testFuzz_branch",
+            "preserve-corpus",
+            "--corpus-out",
+            "min-preserve-corpus",
+        ])
+        .assert_success();
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--mc",
+            "ForgeFuzzCminTargetTest",
+            "--mt",
+            "testFuzz_branch",
+            "--showmap-out",
+            "showmap-after-cmin",
+            "--showmap-corpus-dir",
+            "min-preserve-corpus",
+            "--showmap-trial",
+            "t",
+        ])
+        .assert_success();
+    assert_eq!(
+        showmap_edge_ids(&prj.root().join("showmap-before-cmin")),
+        showmap_edge_ids(&prj.root().join("showmap-after-cmin"))
+    );
+});
+
+forgetest_init!(forge_fuzz_cmin_handles_multiple_matched_targets, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminMultiTarget.t.sol",
+        r#"
+contract ForgeFuzzCminMultiTargetTest {
+    uint256 left;
+    uint256 right;
+
+    function testFuzz_left(uint256 input) public {
+        if (input == 1) {
+            left = 1;
+        }
+    }
+
+    function testFuzz_right(uint256 input) public {
+        if (input == 2) {
+            right = 2;
+        }
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminMultiTarget.t.sol/ForgeFuzzCminMultiTargetTest.json",
+    );
+    let left = calldata_for(&abi, "testFuzz_left", 1);
+    let right = calldata_for(&abi, "testFuzz_right", 2);
+    let corpus = prj.root().join("multi-target-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &left);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000002-2.json", &right);
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminMultiTargetTest",
+            "multi-target-corpus",
+            "--corpus-out",
+            "min-multi-target-corpus",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("minimized corpus: kept 2/2 entries in min-multi-target-corpus"),
+        "{stdout}"
+    );
+    assert_eq!(regular_file_count(&prj.root().join("min-multi-target-corpus")), 2);
+});
+
+forgetest_init!(forge_fuzz_cmin_namespaces_coverage_by_matched_target, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminNamespacedTargets.t.sol",
+        r#"
+contract ForgeFuzzCminNamespacedAlphaTest {
+    uint256 value;
+
+    function testFuzz_shared(uint256 input) public {
+        if (input == 1) {
+            value = 1;
+        }
+    }
+}
+
+contract ForgeFuzzCminNamespacedBetaTest {
+    uint256 value;
+
+    function testFuzz_shared(uint256 input) public {
+        if (input == 2) {
+            value = 2;
+        }
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminNamespacedTargets.t.sol/ForgeFuzzCminNamespacedAlphaTest.json",
+    );
+    let one = calldata_for(&abi, "testFuzz_shared", 1);
+    let two = calldata_for(&abi, "testFuzz_shared", 2);
+    let corpus = prj.root().join("namespaced-target-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000002-2.json", &two);
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminNamespaced(Alpha|Beta)Test",
+            "--mt",
+            "testFuzz_shared",
+            "namespaced-target-corpus",
+            "--corpus-out",
+            "min-namespaced-target-corpus",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("minimized corpus: kept 2/2 entries in min-namespaced-target-corpus"),
+        "{stdout}"
+    );
+    assert_eq!(regular_file_count(&prj.root().join("min-namespaced-target-corpus")), 2);
+});
+
+forgetest_init!(forge_fuzz_cmin_keeps_entry_when_one_target_fails, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminTargetFailure.t.sol",
+        r#"
+contract ForgeFuzzCminTargetFailureAlphaTest {
+    uint256 value;
+
+    function testFuzz_shared(uint256 input) public {
+        if (input == 1) {
+            value = 1;
+        }
+    }
+}
+
+contract ForgeFuzzCminTargetFailureBetaTest {
+    function testFuzz_shared(uint256 input) public pure {
+        if (input == 1) {
+            revert("beta rejects");
+        }
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminTargetFailure.t.sol/ForgeFuzzCminTargetFailureAlphaTest.json",
+    );
+    let one = calldata_for(&abi, "testFuzz_shared", 1);
+    let corpus = prj.root().join("target-failure-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminTargetFailure(Alpha|Beta)Test",
+            "--mt",
+            "testFuzz_shared",
+            "target-failure-corpus",
+            "--corpus-out",
+            "min-target-failure-corpus",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("minimized corpus: kept 1/1 entries in min-target-failure-corpus"),
+        "{stdout}"
+    );
+    assert_eq!(regular_file_count(&prj.root().join("min-target-failure-corpus")), 1);
+});
+
+forgetest_init!(forge_fuzz_cmin_counts_zero_replay_entries_once_per_corpus_entry, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminZeroReplayMultiTarget.t.sol",
+        r#"
+contract ForgeFuzzCminZeroReplayAlphaTest {
+    function testFuzz_shared(uint256 input) public pure {
+        if (input == 1) {
+            revert("alpha rejects");
+        }
+    }
+}
+
+contract ForgeFuzzCminZeroReplayBetaTest {
+    function testFuzz_shared(uint256 input) public pure {
+        if (input == 1) {
+            revert("beta rejects");
+        }
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminZeroReplayMultiTarget.t.sol/ForgeFuzzCminZeroReplayAlphaTest.json",
+    );
+    let one = calldata_for(&abi, "testFuzz_shared", 1);
+    let corpus = prj.root().join("zero-replay-multi-target-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminZeroReplay(Alpha|Beta)Test",
+            "--mt",
+            "testFuzz_shared",
+            "zero-replay-multi-target-corpus",
+            "--corpus-out",
+            "min-zero-replay-multi-target-corpus",
+        ])
+        .assert_failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.contains("1 corpus entries failed during replay"), "{stderr}");
+    assert!(!stderr.contains("2 corpus entries failed during replay"), "{stderr}");
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminZeroReplay(Alpha|Beta)Test",
+            "--mt",
+            "testFuzz_shared",
+            "--sender",
+            "0x000000000000000000000000000000000000dEaD",
+            "zero-replay-multi-target-corpus",
+            "--corpus-out",
+            "min-zero-replay-stale-multi-target-corpus",
+        ])
+        .assert_failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.contains("1 transactions did not match the test"), "{stderr}");
+    assert!(!stderr.contains("2 transactions did not match the test"), "{stderr}");
+});
+
+forgetest_init!(forge_fuzz_cmin_rejects_stale_stateless_target, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminStaleTarget.t.sol",
+        r#"
+contract ForgeFuzzCminStaleTargetTest {
+    uint256 value;
+
+    function testFuzz_branch(uint256 input) public {
+        if (input == 1) {
+            value = 1;
+        }
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminStaleTarget.t.sol/ForgeFuzzCminStaleTargetTest.json",
+    );
+    let one = calldata_for(&abi, "testFuzz_branch", 1);
+    let corpus = prj.root().join("stale-target-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
+
+    cmd.forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminStaleTargetTest",
+            "--mt",
+            "testFuzz_branch",
+            "stale-target-corpus",
+            "--corpus-out",
+            "min-stale-target-corpus",
+        ])
+        .assert_success();
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminStaleTargetTest",
+            "--mt",
+            "testFuzz_branch",
+            "--sender",
+            "0x000000000000000000000000000000000000dEaD",
+            "stale-target-corpus",
+            "--corpus-out",
+            "min-wrong-sender-corpus",
+        ])
+        .assert_failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.contains("replayed 0 transactions from stale-target-corpus"), "{stderr}");
+    assert!(stderr.contains("replay-critical options"), "{stderr}");
+    assert!(!prj.root().join("min-wrong-sender-corpus").exists());
+});
+
+forgetest_init!(forge_fuzz_cmin_reports_zero_replay_reasons, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminZeroReplay.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzCminZeroReplayTest is Test {
+    function testFuzz_assumeAlways(uint256 input) public {
+        input;
+        vm.assume(false);
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminZeroReplay.t.sol/ForgeFuzzCminZeroReplayTest.json",
+    );
+    let assume = calldata_for(&abi, "testFuzz_assumeAlways", 1);
+    let assume_corpus = prj.root().join("assume-corpus");
+    std::fs::create_dir_all(&assume_corpus).unwrap();
+    write_corpus_entry(&assume_corpus, "00000000-0000-0000-0000-000000000001-1.json", &assume);
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminZeroReplayTest",
+            "--mt",
+            "testFuzz_assumeAlways",
+            "assume-corpus",
+            "--corpus-out",
+            "min-assume-corpus",
+        ])
+        .assert_failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.contains("1 transactions were rejected by vm.assume or vm.skip"), "{stderr}");
+    assert!(!stderr.contains("replay-critical options"), "{stderr}");
+    assert!(!prj.root().join("min-assume-corpus").exists());
+
+    let empty_corpus = prj.root().join("empty-corpus");
+    std::fs::create_dir_all(&empty_corpus).unwrap();
+    std::fs::write(empty_corpus.join("00000000-0000-0000-0000-000000000002-2.json"), "[]").unwrap();
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminZeroReplayTest",
+            "--mt",
+            "testFuzz_assumeAlways",
+            "empty-corpus",
+            "--corpus-out",
+            "min-empty-corpus",
+        ])
+        .assert_failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.contains("corpus entries were empty"), "{stderr}");
+    assert!(!stderr.contains("replay-critical options"), "{stderr}");
+    assert!(!prj.root().join("min-empty-corpus").exists());
+});
+
+forgetest_init!(forge_fuzz_cmin_minimizes_invariant_corpus, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminInvariantTarget.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzCminInvariantTargetTest is Test {
+    uint256 value;
+
+    function setUp() public {
+        targetContract(address(this));
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = this.touch.selector;
+        targetSelector(FuzzSelector({addr: address(this), selectors: selectors}));
+    }
+
+    function touch(uint256 input) external {
+        if (input == 1) {
+            value = 1;
+        }
+        if (input == 2) {
+            value = 2;
+        }
+    }
+
+    function invariant_ok() public view {
+        assertTrue(value <= 2);
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminInvariantTarget.t.sol/ForgeFuzzCminInvariantTargetTest.json",
+    );
+    let one = calldata_for(&abi, "touch", 1);
+    let two = calldata_for(&abi, "touch", 2);
+    let corpus = prj.root().join("invariant-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000002-2.json", &one);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000003-3.json", &two);
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminInvariantTargetTest",
+            "--mt",
+            "invariant_ok",
+            "invariant-corpus",
+            "--corpus-out",
+            "min-invariant-corpus",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("minimized corpus: kept 2/3 entries in min-invariant-corpus"),
+        "{stdout}"
+    );
+    assert_eq!(regular_file_count(&prj.root().join("min-invariant-corpus")), 2);
 });
 
 forgetest_init!(forge_fuzz_replay_invariant_fail_on_revert, |prj, cmd| {


### PR DESCRIPTION
## Description

Part of OSS-297

Adds `forge fuzz cmin`, a corpus minimizer that replays persisted fuzz/invariant corpus entries and keeps only replayable inputs that add new coverage. It preserves corpus layout, stages output safely, rejects existing outputs, and reports actionable diagnostics for stale, empty, unreadable, rejected, or failing entries.

Multi-target runs namespace coverage per target, and replayable coverage preservation is tested via showmap edge-set comparison.

Design decisions (can be discussed): Reverting entries are intentionally skipped, and multi-target zero-replay diagnostics de-duplicate counts for readability.