### PR TITLE
fix(fuzz): omit frontier new_coverage when not collected

### DIFF
--- a/crates/evm/evm/src/executors/fuzz/frontier.rs
+++ b/crates/evm/evm/src/executors/fuzz/frontier.rs
@@ -70,8 +70,10 @@ pub(super) struct FuzzBranchFrontier {
     /// Fuzz worker that produced the record, if known.
     #[serde(skip_serializing_if = "Option::is_none")]
     worker: Option<u32>,
-    /// Whether this call also expanded coverage from the worker's current map.
-    new_coverage: bool,
+    /// Whether this call also expanded coverage from the worker's current map. Only present when
+    /// edge coverage is collected (corpus, edge-coverage metrics, or sancov); omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    new_coverage: Option<bool>,
     /// Index of the call in the recorded sequence. Stateless fuzzing records one call.
     call_index: usize,
     /// Concrete call sequence that reached the frontier.
@@ -134,7 +136,7 @@ impl FuzzFrontierRecorder {
         target: Address,
         calldata: &Bytes,
         cmp_values: &[CmpOperands],
-        new_coverage: bool,
+        new_coverage: Option<bool>,
     ) {
         if self.limit == 0 || cmp_values.is_empty() {
             return;
@@ -206,7 +208,7 @@ impl FuzzBranchFrontier {
         cmp: CmpOperands,
         result: bool,
         operand_delta: U256,
-        new_coverage: bool,
+        new_coverage: Option<bool>,
         call_index: usize,
     ) -> Self {
         Self {
@@ -382,7 +384,7 @@ mod tests {
             cmp,
             result,
             U256::from(operand_delta),
-            false,
+            None,
             0,
         )
     }

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -382,13 +382,17 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             .map_err(|e| TestCaseError::fail(e.to_string()))?;
         let cmp_values = call.evm_cmp_values.take().unwrap_or_default();
         let new_coverage = coverage_metrics.merge_edge_coverage(&mut call);
+        // `new_coverage` is only meaningful when edge coverage is collected; otherwise
+        // `merge_edge_coverage` always returns `false`, so record it as unknown for frontiers.
+        let frontier_new_coverage =
+            self.config.corpus.collect_edge_coverage().then_some(new_coverage);
         frontier_recorder.capture_stateless_call(
             fuzz_run,
             self.sender,
             address,
             &calldata,
             &cmp_values,
-            new_coverage,
+            frontier_new_coverage,
         );
         coverage_metrics.process_inputs(
             &[BasicTxDetails {

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -137,7 +137,9 @@ configured record limit, and a `frontiers` array. Each frontier contains:
 - the EVM comparison site (`address`, `pc`, `opcode`, `opcode_name`)
 - concrete operands (`lhs`, `rhs`), the comparison result, and an
   `operand_delta` priority score interpreted according to opcode signedness
-- whether the call also expanded the worker's coverage map
+- whether the call also expanded the worker's coverage map (`new_coverage`),
+  present only when edge coverage is collected via a corpus directory, edge
+  coverage metrics, or sancov, and omitted otherwise
 
 Frontier capture is opt-in and bounded by `fuzz.frontier_limit` (default 256).
 It reuses the fuzzer's comparison-operand inspector and does not store traces.

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1085,7 +1085,7 @@ contract ForgeFuzzFrontierTest {
         ])
         .assert_success();
 
-    let assert_frontier_artifact = |frontier_dir: &str| {
+    let assert_frontier_artifact = |frontier_dir: &str, expect_new_coverage: bool| {
         let frontier_path = prj
             .root()
             .join(frontier_dir)
@@ -1119,6 +1119,14 @@ contract ForgeFuzzFrontierTest {
         assert_eq!(frontier["operands"]["operand_delta"], "0x0");
         assert_eq!(frontier["operands"]["result"], false);
 
+        // `new_coverage` is only recorded when edge coverage is collected; frontier-only capture
+        // omits it rather than reporting an always-false value.
+        if expect_new_coverage {
+            assert!(frontier["new_coverage"].is_boolean(), "{frontier:#}");
+        } else {
+            assert!(frontier.get("new_coverage").is_none(), "{frontier:#}");
+        }
+
         let sequence = frontier["sequence"].as_array().unwrap();
         assert_eq!(sequence.len(), 1);
         assert!(
@@ -1131,7 +1139,7 @@ contract ForgeFuzzFrontierTest {
         assert!(calldata.starts_with(&format!("0x{expected_selector}")), "{calldata}");
         assert!(calldata.ends_with(&format!("{:064x}{:064x}", 100u64, 100u64)), "{calldata}");
     };
-    assert_frontier_artifact("fuzz_frontiers");
+    assert_frontier_artifact("fuzz_frontiers", false);
 
     prj.update_config(|config| {
         config.fuzz.corpus.sancov_edges = true;
@@ -1151,7 +1159,7 @@ contract ForgeFuzzFrontierTest {
             "sancov_fuzz_frontiers",
         ])
         .assert_success();
-    assert_frontier_artifact("sancov_fuzz_frontiers");
+    assert_frontier_artifact("sancov_fuzz_frontiers", true);
 });
 
 forgetest_init!(forge_fuzz_replay_scopes_generated_corpus_root_to_target, |prj, cmd| {


### PR DESCRIPTION
The branch-frontier artifact always wrote `new_coverage=false` in the documented frontier-only workflow, since edge coverage isn't collected there. Make it `Option<bool>` and omit it unless edge coverage is collected (corpus, edge-coverage metrics, or sancov).