### PR TITLE
fix(forge): list only runnable fuzz tests

### DIFF
--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -159,13 +159,24 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
                 let tests = c
                     .abi
                     .functions()
-                    // TODO(@mablr): in fuzz-only mode, make `--list` mirror execution
-                    // by hiding unit/table/symbolic tests that `forge fuzz run/replay` skips.
-                    .filter(|func| matcher.matches_test_function(filter, &identifier, func))
+                    .filter(|func| {
+                        let kind = matcher.test_function_kind(&identifier, func);
+                        (!self.tcfg.fuzz_only
+                            || matches!(
+                                kind,
+                                TestFunctionKind::FuzzTest { .. } | TestFunctionKind::InvariantTest
+                            ))
+                            && filter.matches_test_function_kind_in_contract(
+                                &identifier,
+                                func,
+                                kind,
+                            )
+                    })
                     .map(|func| func.name.clone())
                     .collect::<Vec<_>>();
                 (source, name, tests)
             })
+            .filter(|(_, _, tests)| !tests.is_empty())
             .fold(BTreeMap::new(), |mut acc, (source, name, tests)| {
                 acc.entry(source).or_default().insert(name, tests);
                 acc

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -460,6 +460,35 @@ forgetest_init!(forge_fuzz_rejects_watch, |prj, cmd| {
     assert!(stderr.contains("`--watch` is not supported for `forge fuzz replay`"), "{stderr}");
 });
 
+forgetest_init!(forge_fuzz_list_only_shows_runnable_tests, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzList.t.sol",
+        r#"
+contract ForgeFuzzListTest {
+    function test_unit() public {}
+    function testFuzz_value(uint256 value) public pure {
+        value;
+    }
+    function invariant_ok() public pure {}
+    function table_row() public pure {}
+}
+   "#,
+    );
+
+    cmd.args(["fuzz", "run", "--list", "--mc", "ForgeFuzzListTest"]).assert_success().stdout_eq(
+        str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+test/ForgeFuzzList.t.sol
+  ForgeFuzzListTest
+    invariant_ok
+    testFuzz_value
+
+
+"#]],
+    );
+});
+
 forgetest_init!(forge_showmap_skips_symbolic_tests, |prj, cmd| {
     prj.add_test(
         "ForgeShowmapSymbolic.t.sol",


### PR DESCRIPTION
## Description

Follow-up to #15227 as part of OSS-297.

Fix forge fuzz run --list so it only reports tests that fuzz mode can actually execute.

Previously, list output was built from the broader test discovery result, so unit-style and table tests could appear even though forge fuzz skips them at runtime. The list path now applies the same runnable-test classification used by fuzz execution and omits contracts that have no remaining fuzz or invariant tests after filtering.

The CLI coverage adds a mixed contract with unit, fuzz, invariant, and table tests to assert that fuzz list output includes only runnable entries.