### PR TITLE
perf(symbolic): shrink SMT CSE planning

### DIFF
--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -68,77 +68,73 @@ impl SymBoolExpr {
         Self::cmp(cx, SymCmpOp::Eq, left, right)
     }
 
-    fn eq_cmp(cx: &mut SymCx, left: SymExpr, right: SymExpr) -> Self {
-        match (left.kind(), right.kind()) {
-            // `a == a => true`.
-            _ if left == right => Self::constant(cx, true),
-            (SymExprKind::Const(left), SymExprKind::Const(right)) => {
-                // `const == const => const`.
-                Self::constant(cx, left == right)
-            }
-            (_, SymExprKind::Const(right_value)) => {
-                if let Some(condition) = Self::bool_word_eq_const(cx, &left, *right_value) {
-                    return condition;
+    pub(crate) fn cmp(cx: &mut SymCx, op: SymCmpOp, left: SymExpr, right: SymExpr) -> Self {
+        match op {
+            SymCmpOp::Eq => match (left.kind(), right.kind()) {
+                // `a == a => true`.
+                _ if left == right => Self::constant(cx, true),
+                (SymExprKind::Const(left), SymExprKind::Const(right)) => {
+                    // `const == const => const`.
+                    Self::constant(cx, left == right)
                 }
-                if let Some(left_value) = left.known_word() {
-                    // `known(a) == const => const`.
-                    return Self::constant(cx, left_value == *right_value);
+                (_, SymExprKind::Const(right_value)) => {
+                    if let Some(condition) = Self::bool_word_eq_const(cx, &left, *right_value) {
+                        return condition;
+                    }
+                    if let Some(left_value) = left.known_word() {
+                        // `known(a) == const => const`.
+                        return Self::constant(cx, left_value == *right_value);
+                    }
+                    // `a == b => ordered(a, b)`.
+                    let (left, right) = SymExpr::ordered_commutative_operands(left, right);
+                    Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
                 }
-                // `a == b => ordered(a, b)`.
-                let (left, right) = SymExpr::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
-            }
-            (SymExprKind::Const(left_value), _) => {
-                if let Some(condition) = Self::bool_word_eq_const(cx, &right, *left_value) {
-                    return condition;
+                (SymExprKind::Const(left_value), _) => {
+                    if let Some(condition) = Self::bool_word_eq_const(cx, &right, *left_value) {
+                        return condition;
+                    }
+                    if let Some(right_value) = right.known_word() {
+                        // `const == known(a) => const`.
+                        return Self::constant(cx, *left_value == right_value);
+                    }
+                    // `a == b => ordered(a, b)`.
+                    let (left, right) = SymExpr::ordered_commutative_operands(left, right);
+                    Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
                 }
-                if let Some(right_value) = right.known_word() {
-                    // `const == known(a) => const`.
-                    return Self::constant(cx, *left_value == right_value);
+                (
+                    SymExprKind::Keccak { len: left_len, bytes: left_bytes, .. },
+                    SymExprKind::Keccak { len: right_len, bytes: right_bytes, .. },
+                ) if left_bytes.len() == right_bytes.len() => {
+                    // `keccak(a) == keccak(b) => len(a) == len(b) && bytes(a) == bytes(b)`.
+                    let mut conditions = vec![Self::eq(cx, left_len.clone(), right_len.clone())];
+                    conditions.extend(
+                        left_bytes
+                            .iter()
+                            .cloned()
+                            .zip(right_bytes.iter().cloned())
+                            .map(|(left, right)| Self::eq(cx, left, right)),
+                    );
+                    Self::and(cx, conditions)
                 }
-                // `a == b => ordered(a, b)`.
-                let (left, right) = SymExpr::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
-            }
-            (
-                SymExprKind::Keccak { len: left_len, bytes: left_bytes, .. },
-                SymExprKind::Keccak { len: right_len, bytes: right_bytes, .. },
-            ) if left_bytes.len() == right_bytes.len() => {
-                // `keccak(a) == keccak(b) => len(a) == len(b) && bytes(a) == bytes(b)`.
-                let mut conditions = vec![Self::eq(cx, left_len.clone(), right_len.clone())];
-                conditions.extend(
-                    left_bytes
+                (
+                    SymExprKind::Hash { algorithm: left_algorithm, bytes: left_bytes, .. },
+                    SymExprKind::Hash { algorithm: right_algorithm, bytes: right_bytes, .. },
+                ) if left_algorithm == right_algorithm && left_bytes.len() == right_bytes.len() => {
+                    // `hash(a) == hash(b) => bytes(a) == bytes(b)`.
+                    let conditions = left_bytes
                         .iter()
                         .cloned()
                         .zip(right_bytes.iter().cloned())
-                        .map(|(left, right)| Self::eq(cx, left, right)),
-                );
-                Self::and(cx, conditions)
-            }
-            (
-                SymExprKind::Hash { algorithm: left_algorithm, bytes: left_bytes, .. },
-                SymExprKind::Hash { algorithm: right_algorithm, bytes: right_bytes, .. },
-            ) if left_algorithm == right_algorithm && left_bytes.len() == right_bytes.len() => {
-                // `hash(a) == hash(b) => bytes(a) == bytes(b)`.
-                let conditions = left_bytes
-                    .iter()
-                    .cloned()
-                    .zip(right_bytes.iter().cloned())
-                    .map(|(left, right)| Self::eq(cx, left, right))
-                    .collect();
-                Self::and(cx, conditions)
-            }
-            _ => {
-                // `a == b => ordered(a, b)`.
-                let (left, right) = SymExpr::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
-            }
-        }
-    }
-
-    pub(crate) fn cmp(cx: &mut SymCx, op: SymCmpOp, left: SymExpr, right: SymExpr) -> Self {
-        match op {
-            SymCmpOp::Eq => Self::eq_cmp(cx, left, right),
+                        .map(|(left, right)| Self::eq(cx, left, right))
+                        .collect();
+                    Self::and(cx, conditions)
+                }
+                _ => {
+                    // `a == b => ordered(a, b)`.
+                    let (left, right) = SymExpr::ordered_commutative_operands(left, right);
+                    Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
+                }
+            },
             SymCmpOp::Ult => match (left.kind(), right.kind()) {
                 // `a < a => false`.
                 _ if left == right => Self::constant(cx, false),

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -752,10 +752,16 @@ impl SymExpr {
         }
 
         if let SymExprKind::BinOp(SymBinOp::Or, left, right) = expr.kind() {
-            // `(a | b) >> n => (a >> n) | (b >> n)`.
+            // Distribute only when it collapses part of the OR; expanding broad
+            // bit-smearing chains eagerly makes SMT CSE much larger.
             let left = Self::shr_const(cx, left.clone(), U256::from(shift));
             let right = Self::shr_const(cx, right.clone(), U256::from(shift));
-            return Self::binop(cx, SymBinOp::Or, left, right);
+            if left.as_const().is_some_and(|value| value.is_zero()) {
+                return right;
+            }
+            if right.as_const().is_some_and(|value| value.is_zero()) {
+                return left;
+            }
         }
 
         let shift = Self::constant(cx, U256::from(shift));

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -250,6 +250,7 @@ pub(super) fn write_smt_assertions(out: &mut String, constraints: &[SymBoolExpr]
 struct SmtCseVisit {
     count: usize,
     binding: Option<usize>,
+    collected: bool,
 }
 
 struct SmtCsePlan {
@@ -275,7 +276,11 @@ impl SmtCsePlan {
     }
 
     fn count_expr(&mut self, expr: &SymExpr) {
-        self.expr_visits.entry(expr.clone()).or_default().count += 1;
+        let visit = self.expr_visits.entry(expr.clone()).or_default();
+        visit.count += 1;
+        if visit.count != 1 {
+            return;
+        }
         match expr.kind() {
             SymExprKind::Const(_)
             | SymExprKind::Var(_)
@@ -302,7 +307,11 @@ impl SmtCsePlan {
     }
 
     fn count_bool(&mut self, expr: &SymBoolExpr) {
-        self.bool_visits.entry(expr.clone()).or_default().count += 1;
+        let visit = self.bool_visits.entry(expr.clone()).or_default();
+        visit.count += 1;
+        if visit.count != 1 {
+            return;
+        }
         match expr.kind() {
             SymBoolExprKind::Const(_) => {}
             SymBoolExprKind::Not(value) => self.count_bool(value),
@@ -319,6 +328,13 @@ impl SmtCsePlan {
     }
 
     fn collect_expr_binding(&mut self, expr: &SymExpr) {
+        {
+            let Some(visit) = self.expr_visits.get_mut(expr) else { return };
+            if visit.collected {
+                return;
+            }
+            visit.collected = true;
+        }
         match expr.kind() {
             SymExprKind::Const(_)
             | SymExprKind::Var(_)
@@ -345,6 +361,13 @@ impl SmtCsePlan {
     }
 
     fn collect_bool_binding(&mut self, expr: &SymBoolExpr) {
+        {
+            let Some(visit) = self.bool_visits.get_mut(expr) else { return };
+            if visit.collected {
+                return;
+            }
+            visit.collected = true;
+        }
         match expr.kind() {
             SymBoolExprKind::Const(_) => {}
             SymBoolExprKind::Not(value) => self.collect_bool_binding(value),


### PR DESCRIPTION
This is stacked on `dani/symbolic-normalization-refactor` and keeps SMT CSE planning linear in the hashconsed expression DAG. It preserves reference counts for binding decisions but avoids walking the same shared node repeatedly, and it avoids eagerly distributing shifts over OR expressions when both sides remain live, which keeps bit-smearing patterns compact.

On Solady `check_HasDuplicateHashmapCapacityTrickEquivalence` with symbolic SMT dumping enabled, this reduced SMT input from 21,908 to 4,961 bytes and max query size from 10,968 to 2,685 bytes. The focused run stayed passing, with wall time moving from 2.40s to 2.38s.

AI assistance was used while preparing this change.
