### PR TITLE
feat(lint): add dangerous-unary-operator detector

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -22,6 +22,7 @@ It helps enforce best practices and improve code quality within Foundry projects
 - **Medium Severity:**
   - `assert-state-change`: Flags state-modifying expressions inside `assert()` arguments.
   - `boolean-cst`: Flags misuse of boolean constants.
+  - `dangerous-unary-operator`: Flags an assignment whose `=` is fused to a unary operator (`=-`, `=~`), e.g. `x =- 1`, which parses as `x = -1` instead of the intended compound `x -= 1`.
   - `divide-before-multiply`: Warns against performing division before multiplication in the same expression, which can cause precision loss.
   - `incorrect-erc20-interface`: Flags ERC20 interfaces and implementations with non-compliant function signatures.
   - `incorrect-erc721-interface`: Flags ERC721 interfaces and implementations with non-compliant function signatures.

--- a/crates/lint/docs/dangerous-unary-operator.md
+++ b/crates/lint/docs/dangerous-unary-operator.md
@@ -1,0 +1,30 @@
+# Dangerous unary operator
+
+**Severity**: `Med`
+**ID**: `dangerous-unary-operator`
+
+Flags an assignment whose `=` is fused to a unary operator (`=-`, `=~`), which parses as a plain assignment of a unary expression rather than the compound assignment it resembles.
+
+## What it does
+
+Reports `x =- y` and `x =~ y` when the source writes `=` directly against the unary operator, with no space. `x =- 1` lexes as `x` `=` `-` `1` and parses as `x = -1`, identical to the intentional spaced form, but it is a common typo for the compound `x -= 1`. The spaced forms (`x = -1`, `x = ~y`) and the real compound operators (`x -= 1`) are left alone. This mirrors Slither's `dangerous-unary-expression`.
+
+`=+` is not reported: unary `+` was removed in Solidity 0.5.0, so `x =+ 1` is a parse error and never reaches the linter.
+
+## Why is this bad?
+
+`x =- 1` silently assigns `-1` instead of decrementing `x`. Developers reaching for `-=` can transpose the operator into `=-`, and because the code compiles and runs, the wrong value is used with no warning.
+
+## Example
+
+### Bad
+
+```solidity
+x =- 1; // parses as `x = -1`, not `x -= 1`
+```
+
+### Good
+
+```solidity
+x -= 1;
+```

--- a/crates/lint/docs/dangerous-unary-operator.md
+++ b/crates/lint/docs/dangerous-unary-operator.md
@@ -7,7 +7,7 @@ Flags an assignment whose `=` is fused to a unary operator (`=-`, `=~`), which p
 
 ## What it does
 
-Reports `x =- y` and `x =~ y` when the source writes `=` directly against the unary operator, with no space. `x =- 1` lexes as `x` `=` `-` `1` and parses as `x = -1`, identical to the intentional spaced form, but it is a common typo for the compound `x -= 1`. The spaced forms (`x = -1`, `x = ~y`) and the real compound operators (`x -= 1`) are left alone. This mirrors Slither's `dangerous-unary-expression`.
+Reports `x =- y` and `x =~ y` when the source writes `=` directly against the unary operator, with no space. `x =- 1` lexes as `x` `=` `-` `1` and parses as `x = -1`, identical to the intentional spaced form, but it is a common typo for the compound `x -= 1`. The fused unary is also reported when it only leads a larger right-hand side: `x =- a + 1` parses as `x = (-a) + 1`, still a plain assignment rather than the `x -= a + 1` it resembles. The spaced forms (`x = -1`, `x = ~y`) and the real compound operators (`x -= 1`) are left alone. This mirrors Slither's `incorrect-unary` (Dangerous unary expressions).
 
 `=+` is not reported: unary `+` was removed in Solidity 0.5.0, so `x =+ 1` is a parse error and never reaches the linter.
 

--- a/crates/lint/src/sol/med/dangerous_unary_operator.rs
+++ b/crates/lint/src/sol/med/dangerous_unary_operator.rs
@@ -17,18 +17,33 @@ impl<'ast> EarlyLintPass<'ast> for DangerousUnaryOperator {
         // `x =- 1` lexes as `x` `=` `-` `1` and parses as a plain assignment of `-1`, identical to
         // the intentional `x = -1`, yet it reads like the compound `x -= 1` it was probably meant
         // to be. Solidity has no `~=` operator either, so `x =~ y` is the same trap.
-        // Because the parsed node matches the legitimate spaced form, only flag when the
-        // source fuses `=` to the unary operator (`=-` / `=~`), never `= -`. `=+` never
+        // The fused unary can also lead a larger RHS: `x =- a + 1` parses as `x = (-a) + 1`, whose
+        // RHS is a `Binary` (or `Ternary`) with the `-a` unary as its leftmost operand. Follow the
+        // left spine to that leading unary so those forms are caught too, not only `x =- a`.
+        // Because the parsed node matches the legitimate spaced form, only flag when the source
+        // fuses `=` to the leading unary (`=-` / `=~`), never `= -`. The gap between the LHS and
+        // `rhs.span` (which starts at that unary) holds only whitespace, comments and the `=`
+        // token, and no comment can end with `=` (block comments end with `*/`, line comments
+        // with a newline), so the gap ends with `=` exactly when the pair is fused. `=+` never
         // reaches here: unary `+` was removed in Solidity 0.5.0, and solar drops it during
         // parsing without producing a node.
         if let ExprKind::Assign(lhs, None, rhs) = &expr.kind
-            && let ExprKind::Unary(op, _) = &rhs.kind
-            && matches!(op.kind, UnOpKind::Neg | UnOpKind::BitNot)
-            && ctx
-                .span_to_snippet(lhs.span.between(op.span))
-                .is_some_and(|gap| gap.trim_start() == "=")
+            && leads_with_fusable_unary(rhs)
+            && ctx.span_to_snippet(lhs.span.between(rhs.span)).is_some_and(|gap| gap.ends_with('='))
         {
             ctx.emit(&DANGEROUS_UNARY_OPERATOR, expr.span);
         }
+    }
+}
+
+/// Whether the leftmost operand of `expr` is a `-` or `~` unary, following the left spine of
+/// binary and ternary expressions. `rhs.span` begins at that leading unary, so a fused `=-` / `=~`
+/// is caught whether the unary is the whole RHS (`x =- a`) or only leads it (`x =- a + 1`).
+fn leads_with_fusable_unary(expr: &Expr<'_>) -> bool {
+    match &expr.kind {
+        ExprKind::Unary(op, _) => matches!(op.kind, UnOpKind::Neg | UnOpKind::BitNot),
+        ExprKind::Binary(lhs, _, _) => leads_with_fusable_unary(lhs),
+        ExprKind::Ternary(cond, _, _) => leads_with_fusable_unary(cond),
+        _ => false,
     }
 }

--- a/crates/lint/src/sol/med/dangerous_unary_operator.rs
+++ b/crates/lint/src/sol/med/dangerous_unary_operator.rs
@@ -1,0 +1,34 @@
+use super::DangerousUnaryOperator;
+use crate::{
+    linter::{EarlyLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::ast::{Expr, ExprKind, UnOpKind};
+
+declare_forge_lint!(
+    DANGEROUS_UNARY_OPERATOR,
+    Severity::Med,
+    "dangerous-unary-operator",
+    "unary operator fused to `=`: `x =- 1` parses as `x = -1`, not `x -= 1`"
+);
+
+impl<'ast> EarlyLintPass<'ast> for DangerousUnaryOperator {
+    fn check_expr(&mut self, ctx: &LintContext, expr: &'ast Expr<'ast>) {
+        // `x =- 1` lexes as `x` `=` `-` `1` and parses as a plain assignment of `-1`, identical to
+        // the intentional `x = -1`, yet it reads like the compound `x -= 1` it was probably meant
+        // to be. Solidity has no `~=` operator either, so `x =~ y` is the same trap.
+        // Because the parsed node matches the legitimate spaced form, only flag when the
+        // source fuses `=` to the unary operator (`=-` / `=~`), never `= -`. `=+` never
+        // reaches here: unary `+` was removed in Solidity 0.5.0, and solar drops it during
+        // parsing without producing a node.
+        if let ExprKind::Assign(lhs, None, rhs) = &expr.kind
+            && let ExprKind::Unary(op, _) = &rhs.kind
+            && matches!(op.kind, UnOpKind::Neg | UnOpKind::BitNot)
+            && ctx
+                .span_to_snippet(lhs.span.between(op.span))
+                .is_some_and(|gap| gap.trim_start() == "=")
+        {
+            ctx.emit(&DANGEROUS_UNARY_OPERATOR, expr.span);
+        }
+    }
+}

--- a/crates/lint/src/sol/med/mod.rs
+++ b/crates/lint/src/sol/med/mod.rs
@@ -3,6 +3,9 @@ use crate::sol::{EarlyLintPass, LateLintPass, SolLint};
 mod assert_state_change;
 use assert_state_change::ASSERT_STATE_CHANGE;
 
+mod dangerous_unary_operator;
+use dangerous_unary_operator::DANGEROUS_UNARY_OPERATOR;
+
 mod div_mul;
 use div_mul::DIVIDE_BEFORE_MULTIPLY;
 
@@ -50,6 +53,7 @@ use weak_prng::WEAK_PRNG;
 
 register_lints!(
     (AssertStateChange, late, (ASSERT_STATE_CHANGE)),
+    (DangerousUnaryOperator, early, (DANGEROUS_UNARY_OPERATOR)),
     (DivideBeforeMultiply, late, (DIVIDE_BEFORE_MULTIPLY)),
     (IncorrectERC20Interface, late, (INCORRECT_ERC20_INTERFACE)),
     (IncorrectERC721Interface, late, (INCORRECT_ERC721_INTERFACE)),

--- a/crates/lint/testdata/DangerousUnaryOperator.sol
+++ b/crates/lint/testdata/DangerousUnaryOperator.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+// Tests for `dangerous-unary-operator`: an assignment whose `=` is fused to a unary operator
+// (`=-`, `=~`) parses as a plain assignment of a unary expression (`x = -1`), not the compound
+// assignment (`x -= 1`) it resembles. Spaced unary assignments and real compound operators are
+// left alone. `=+` is not testable: unary `+` is a parse error in modern Solidity.
+
+contract DangerousUnaryOperator {
+    function bad(int256 x, uint256 y) external pure returns (int256 a, uint256 b, int256 c) {
+        a =- 1; //~WARN: unary operator fused to
+        b =~ y; //~WARN: unary operator fused to
+        c =-x; //~WARN: unary operator fused to
+    }
+
+    function ok(int256 x, uint256 y)
+        external
+        pure
+        returns (int256 a, uint256 b, int256 c, int256 d)
+    {
+        a = -1; // spaced negation: intentional
+        b = ~y; // spaced bitwise not: intentional
+        c -= 1; // real compound assignment
+        d = x - 1; // subtraction: the RHS does not start with a unary operator
+    }
+}

--- a/crates/lint/testdata/DangerousUnaryOperator.sol
+++ b/crates/lint/testdata/DangerousUnaryOperator.sol
@@ -1,26 +1,37 @@
+//@compile-flags: --only-lint dangerous-unary-operator
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
 // Tests for `dangerous-unary-operator`: an assignment whose `=` is fused to a unary operator
 // (`=-`, `=~`) parses as a plain assignment of a unary expression (`x = -1`), not the compound
-// assignment (`x -= 1`) it resembles. Spaced unary assignments and real compound operators are
-// left alone. `=+` is not testable: unary `+` is a parse error in modern Solidity.
+// assignment (`x -= 1`) it resembles. The fused unary may also lead a larger RHS (`x =- a + 1`
+// parses as `x = (-a) + 1`). Spaced unary assignments and real compound operators are left alone.
+// `=+` is not testable: unary `+` is a parse error in modern Solidity.
 
 contract DangerousUnaryOperator {
-    function bad(int256 x, uint256 y) external pure returns (int256 a, uint256 b, int256 c) {
+    function bad(int256 x, uint256 y)
+        external
+        pure
+        returns (int256 a, uint256 b, int256 c, int256 d, int256 e, int256 f)
+    {
         a =- 1; //~WARN: unary operator fused to
         b =~ y; //~WARN: unary operator fused to
         c =-x; //~WARN: unary operator fused to
+        d =- x + 1; //~WARN: unary operator fused to
+        e =- x * 2; //~WARN: unary operator fused to
+        f /* note */=- 1; //~WARN: unary operator fused to
     }
 
     function ok(int256 x, uint256 y)
         external
         pure
-        returns (int256 a, uint256 b, int256 c, int256 d)
+        returns (int256 a, uint256 b, int256 c, int256 d, int256 e, int256 f)
     {
         a = -1; // spaced negation: intentional
         b = ~y; // spaced bitwise not: intentional
         c -= 1; // real compound assignment
         d = x - 1; // subtraction: the RHS does not start with a unary operator
+        e = -x + 1; // spaced negation leading a binary RHS: intentional, must not flag
+        f =/* note */- 1; // a comment between `=` and the unary breaks the fusion
     }
 }

--- a/crates/lint/testdata/DangerousUnaryOperator.stderr
+++ b/crates/lint/testdata/DangerousUnaryOperator.stderr
@@ -1,0 +1,24 @@
+warning[dangerous-unary-operator]: unary operator fused to `=`: `x =- 1` parses as `x = -1`, not `x -= 1`
+   ╭▸ ROOT/testdata/DangerousUnaryOperator.sol:LL:CC
+   │
+LL │         a =- 1;
+   │         ━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dangerous-unary-operator
+
+warning[dangerous-unary-operator]: unary operator fused to `=`: `x =- 1` parses as `x = -1`, not `x -= 1`
+   ╭▸ ROOT/testdata/DangerousUnaryOperator.sol:LL:CC
+   │
+LL │         b =~ y;
+   │         ━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dangerous-unary-operator
+
+warning[dangerous-unary-operator]: unary operator fused to `=`: `x =- 1` parses as `x = -1`, not `x -= 1`
+   ╭▸ ROOT/testdata/DangerousUnaryOperator.sol:LL:CC
+   │
+LL │         c =-x;
+   │         ━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dangerous-unary-operator
+

--- a/crates/lint/testdata/DangerousUnaryOperator.stderr
+++ b/crates/lint/testdata/DangerousUnaryOperator.stderr
@@ -22,3 +22,27 @@ LL │         c =-x;
    │
    ╰ help: https://getfoundry.sh/forge/linting/dangerous-unary-operator
 
+warning[dangerous-unary-operator]: unary operator fused to `=`: `x =- 1` parses as `x = -1`, not `x -= 1`
+   ╭▸ ROOT/testdata/DangerousUnaryOperator.sol:LL:CC
+   │
+LL │         d =- x + 1;
+   │         ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dangerous-unary-operator
+
+warning[dangerous-unary-operator]: unary operator fused to `=`: `x =- 1` parses as `x = -1`, not `x -= 1`
+   ╭▸ ROOT/testdata/DangerousUnaryOperator.sol:LL:CC
+   │
+LL │         e =- x * 2;
+   │         ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dangerous-unary-operator
+
+warning[dangerous-unary-operator]: unary operator fused to `=`: `x =- 1` parses as `x = -1`, not `x -= 1`
+   ╭▸ ROOT/testdata/DangerousUnaryOperator.sol:LL:CC
+   │
+LL │         f /* note */=- 1;
+   │         ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/dangerous-unary-operator
+


### PR DESCRIPTION
Adds the `dangerous-unary-operator` detector to `forge lint`, one of the open items in #14381 (Slither/Aderyn parity).

## What it does

Flags an assignment whose `=` is fused to a unary operator (`=-`, `=~`), e.g. `x =- 1`, which parses as `x = -1` (a plain assignment of a unary expression) rather than the compound `x -= 1` it resembles. Mirrors Slither's `incorrect-unary` (Dangerous unary expressions).

It is an early AST pass. Because `x =- 1` and the legitimate `x = -1` parse to the same node, it only fires when the source fuses `=` to the leading unary, by checking that the snippet between the LHS and the RHS ends with `=`. The unary may be the whole RHS (`x =- 1`) or lead a larger one (`x =- a + 1`, which parses as `x = (-a) + 1`). Spaced forms (`x = -1`, `x = ~y`), real compound operators (`x -= 1`), plain subtraction (`x = y - 1`), and forms where a comment sits between `=` and the operator are left alone.

`=+` is not reported: unary `+` was removed in Solidity 0.5.0, so `x =+ 1` is a parse error that solar drops without producing a node, and it never reaches the linter.

## Severity

Medium.

## Tests

`crates/lint/testdata/DangerousUnaryOperator.sol` covers the fused forms, including a unary leading a larger RHS and a comment before the `=` (flagged), and the spaced / compound / subtraction / broken-fusion forms (not flagged).

Part of #14381.
