### PR TITLE
perf(symbolic): normalize expression construction

### DIFF
--- a/crates/evm/symbolic/src/abi.rs
+++ b/crates/evm/symbolic/src/abi.rs
@@ -187,7 +187,7 @@ impl<'a, 'cx> SymbolicAbiBuilder<'a, 'cx> {
                 let word = self.fresh_word(&name);
                 state.constraints.push(SymBoolExpr::cmp_word_const(
                     self.cx,
-                    SymBoolExprOp::Ult,
+                    SymCmpOp::Ult,
                     &word,
                     U256::from(2),
                 ));
@@ -456,20 +456,20 @@ impl<'a, 'cx> SymbolicAbiBuilder<'a, 'cx> {
         let word = self.fresh_word(name);
         state.constraints.push(SymBoolExpr::cmp_word_const(
             self.cx,
-            SymBoolExprOp::Ult,
+            SymCmpOp::Ult,
             &word,
             U256::from(256),
         ));
         if printable {
             state.constraints.push(SymBoolExpr::cmp_word_const(
                 self.cx,
-                SymBoolExprOp::Uge,
+                SymCmpOp::Uge,
                 &word,
                 U256::from(0x20),
             ));
             state.constraints.push(SymBoolExpr::cmp_word_const(
                 self.cx,
-                SymBoolExprOp::Ule,
+                SymCmpOp::Ule,
                 &word,
                 U256::from(0x7e),
             ));
@@ -540,7 +540,7 @@ impl<'a, 'cx> SymbolicAbiBuilder<'a, 'cx> {
         if bits < 256 {
             state.constraints.push(SymBoolExpr::cmp_word_const(
                 self.cx,
-                SymBoolExprOp::Ult,
+                SymCmpOp::Ult,
                 word,
                 U256::from(1) << bits,
             ));

--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -1261,7 +1261,7 @@ impl SymbolicExecutor {
         }
 
         let balance = state.world.balance_word_for_address(&mut self.cx, executor, state.address);
-        let can_pay = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Uge, balance, value);
+        let can_pay = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Uge, balance, value);
         match can_pay.as_const() {
             Some(true) => Ok(true),
             Some(false) => {
@@ -1320,7 +1320,7 @@ impl SymbolicExecutor {
         }
 
         let balance = state.world.balance_word_for_address(&mut self.cx, executor, state.address);
-        let can_pay = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Uge, balance, value);
+        let can_pay = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Uge, balance, value);
         match can_pay.as_const() {
             Some(true) => Ok(true),
             Some(false) => {

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -3190,50 +3190,50 @@ impl SymbolicExecutor {
             assertLt_0Call::SELECTOR | assertLt_1Call::SELECTOR => {
                 let left = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 0)?;
                 let right = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 1)?;
-                let condition = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Ult, left, right);
+                let condition = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Ult, left, right);
                 return self.handle_assertion(state, condition);
             }
             assertLe_0Call::SELECTOR | assertLe_1Call::SELECTOR => {
                 let left = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 0)?;
                 let right = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 1)?;
-                let condition = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Ule, left, right);
+                let condition = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Ule, left, right);
                 return self.handle_assertion(state, condition);
             }
             assertGt_0Call::SELECTOR | assertGt_1Call::SELECTOR => {
                 let left = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 0)?;
                 let right = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 1)?;
-                let condition = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Ugt, left, right);
+                let condition = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Ugt, left, right);
                 return self.handle_assertion(state, condition);
             }
             assertGe_0Call::SELECTOR | assertGe_1Call::SELECTOR => {
                 let left = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 0)?;
                 let right = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 1)?;
-                let condition = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Uge, left, right);
+                let condition = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Uge, left, right);
                 return self.handle_assertion(state, condition);
             }
             assertLt_2Call::SELECTOR | assertLt_3Call::SELECTOR => {
                 let left = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 0)?;
                 let right = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 1)?;
-                let condition = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Slt, left, right);
+                let condition = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Slt, left, right);
                 return self.handle_assertion(state, condition);
             }
             assertGt_2Call::SELECTOR | assertGt_3Call::SELECTOR => {
                 let left = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 0)?;
                 let right = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 1)?;
-                let condition = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Sgt, left, right);
+                let condition = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Sgt, left, right);
                 return self.handle_assertion(state, condition);
             }
             assertLe_2Call::SELECTOR | assertLe_3Call::SELECTOR => {
                 let left = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 0)?;
                 let right = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 1)?;
-                let condition = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Sgt, left, right);
+                let condition = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Sgt, left, right);
                 let condition = condition.not(&mut self.cx);
                 return self.handle_assertion(state, condition);
             }
             assertGe_2Call::SELECTOR | assertGe_3Call::SELECTOR => {
                 let left = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 0)?;
                 let right = read_abi_word_arg(&mut self.cx, &state.memory, args_offset, 1)?;
-                let condition = SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Slt, left, right);
+                let condition = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Slt, left, right);
                 let condition = condition.not(&mut self.cx);
                 return self.handle_assertion(state, condition);
             }
@@ -3261,13 +3261,13 @@ impl SymbolicExecutor {
                 let value = state.fresh_word(&mut self.cx, "vmRandomUintRange");
                 state.constraints.push(SymBoolExpr::cmp_word_expr(
                     &mut self.cx,
-                    SymBoolExprOp::Uge,
+                    SymCmpOp::Uge,
                     &value,
                     min,
                 ));
                 state.constraints.push(SymBoolExpr::cmp_word_expr(
                     &mut self.cx,
-                    SymBoolExprOp::Ule,
+                    SymCmpOp::Ule,
                     &value,
                     max,
                 ));

--- a/crates/evm/symbolic/src/executor/constraints.rs
+++ b/crates/evm/symbolic/src/executor/constraints.rs
@@ -56,7 +56,7 @@ impl SymbolicExecutor {
         let mut above_max = state.constraints.clone();
         above_max.push(SymBoolExpr::cmp_word_const(
             &mut self.cx,
-            SymBoolExprOp::Ugt,
+            SymCmpOp::Ugt,
             expr,
             U256::from(max),
         ));
@@ -71,7 +71,7 @@ impl SymbolicExecutor {
             let mut above_mid = state.constraints.clone();
             above_mid.push(SymBoolExpr::cmp_word_const(
                 &mut self.cx,
-                SymBoolExprOp::Ugt,
+                SymCmpOp::Ugt,
                 expr,
                 U256::from(mid),
             ));
@@ -94,7 +94,7 @@ impl SymbolicExecutor {
             return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
         }
         let condition =
-            SymBoolExpr::cmp_word_const(&mut self.cx, SymBoolExprOp::Uge, expr, U256::from(min));
+            SymBoolExpr::cmp_word_const(&mut self.cx, SymCmpOp::Uge, expr, U256::from(min));
         match condition.as_const() {
             Some(value) => Ok(value),
             None => {
@@ -150,9 +150,9 @@ impl SymbolicExecutor {
         let min_value = SymExpr::constant(&mut self.cx, min_word);
         let max_value = SymExpr::constant(&mut self.cx, max_word);
         let min_condition =
-            SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Uge, value_expr.clone(), min_value);
+            SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Uge, value_expr.clone(), min_value);
         let max_condition =
-            SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Ule, value_expr.clone(), max_value);
+            SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Ule, value_expr.clone(), max_value);
         let in_range = SymBoolExpr::and(&mut self.cx, vec![min_condition, max_condition]);
         let (_in_range_constraints, in_range_sat) =
             self.constraints_with_condition(state, in_range.clone())?;
@@ -168,9 +168,9 @@ impl SymbolicExecutor {
 
         let bounded = state.fresh_word(&mut self.cx, "vmBoundUint");
         let min_condition =
-            SymBoolExpr::cmp_word_const(&mut self.cx, SymBoolExprOp::Uge, &bounded, min_word);
+            SymBoolExpr::cmp_word_const(&mut self.cx, SymCmpOp::Uge, &bounded, min_word);
         let max_condition =
-            SymBoolExpr::cmp_word_const(&mut self.cx, SymBoolExprOp::Ule, &bounded, max_word);
+            SymBoolExpr::cmp_word_const(&mut self.cx, SymCmpOp::Ule, &bounded, max_word);
         state.constraints.push(min_condition);
         state.constraints.push(max_condition);
         let same_value = SymBoolExpr::eq(&mut self.cx, bounded.clone(), value_expr);
@@ -210,9 +210,9 @@ impl SymbolicExecutor {
         let min_value = SymExpr::constant(&mut self.cx, min_word);
         let max_value = SymExpr::constant(&mut self.cx, max_word);
         let below_min =
-            SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Slt, value_expr.clone(), min_value);
+            SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Slt, value_expr.clone(), min_value);
         let above_max =
-            SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Sgt, value_expr.clone(), max_value);
+            SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Sgt, value_expr.clone(), max_value);
         let below_min = below_min.not(&mut self.cx);
         let above_max = above_max.not(&mut self.cx);
         let in_range = SymBoolExpr::and(&mut self.cx, vec![below_min, above_max]);
@@ -230,9 +230,9 @@ impl SymbolicExecutor {
 
         let bounded = state.fresh_word(&mut self.cx, "vmBoundInt");
         let below_min =
-            SymBoolExpr::cmp_word_const(&mut self.cx, SymBoolExprOp::Slt, &bounded, min_word);
+            SymBoolExpr::cmp_word_const(&mut self.cx, SymCmpOp::Slt, &bounded, min_word);
         let above_max =
-            SymBoolExpr::cmp_word_const(&mut self.cx, SymBoolExprOp::Sgt, &bounded, max_word);
+            SymBoolExpr::cmp_word_const(&mut self.cx, SymCmpOp::Sgt, &bounded, max_word);
         let below_min = below_min.not(&mut self.cx);
         let above_max = above_max.not(&mut self.cx);
         state.constraints.push(below_min);

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -66,13 +66,13 @@ impl SymbolicExecutor {
                 let a = state.stack.pop()?;
                 let b = state.stack.pop()?;
                 let n = state.stack.pop()?;
-                state.stack.push(SymExpr::addmod(&mut self.cx, a, b, n))?;
+                state.stack.push(SymExpr::ternop(&mut self.cx, SymExprTernOp::AddMod, a, b, n))?;
             }
             opcode::MULMOD => {
                 let a = state.stack.pop()?;
                 let b = state.stack.pop()?;
                 let n = state.stack.pop()?;
-                state.stack.push(SymExpr::mulmod(&mut self.cx, a, b, n))?;
+                state.stack.push(SymExpr::ternop(&mut self.cx, SymExprTernOp::MulMod, a, b, n))?;
             }
             opcode::LT => {
                 state.cmp_word(&mut self.cx, SymBoolExprOp::Ult)?;

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -39,40 +39,40 @@ impl SymbolicExecutor {
             }
             opcode::STOP => return Ok(StepOutcome::Halt),
             opcode::ADD => {
-                state.bin_word(&mut self.cx, SymExprBinOp::Add)?;
+                state.bin_word(&mut self.cx, SymBinOp::Add)?;
             }
             opcode::SUB => {
-                state.bin_word(&mut self.cx, SymExprBinOp::Sub)?;
+                state.bin_word(&mut self.cx, SymBinOp::Sub)?;
             }
             opcode::MUL => {
-                state.bin_word(&mut self.cx, SymExprBinOp::Mul)?;
+                state.bin_word(&mut self.cx, SymBinOp::Mul)?;
             }
             opcode::EXP => {
                 state.exp_word(&mut self.cx)?;
             }
             opcode::DIV => {
-                state.bin_word_div_zero_guard(&mut self.cx, SymExprBinOp::UDiv)?;
+                state.bin_word_div_zero_guard(&mut self.cx, SymBinOp::UDiv)?;
             }
             opcode::SDIV => {
-                state.bin_word_div_zero_guard(&mut self.cx, SymExprBinOp::SDiv)?;
+                state.bin_word_div_zero_guard(&mut self.cx, SymBinOp::SDiv)?;
             }
             opcode::MOD => {
-                state.bin_word_div_zero_guard(&mut self.cx, SymExprBinOp::URem)?;
+                state.bin_word_div_zero_guard(&mut self.cx, SymBinOp::URem)?;
             }
             opcode::SMOD => {
-                state.bin_word_div_zero_guard(&mut self.cx, SymExprBinOp::SRem)?;
+                state.bin_word_div_zero_guard(&mut self.cx, SymBinOp::SRem)?;
             }
             opcode::ADDMOD => {
                 let a = state.stack.pop()?;
                 let b = state.stack.pop()?;
                 let n = state.stack.pop()?;
-                state.stack.push(SymExpr::ternop(&mut self.cx, SymExprTernOp::AddMod, a, b, n))?;
+                state.stack.push(SymExpr::ternop(&mut self.cx, SymTernOp::AddMod, a, b, n))?;
             }
             opcode::MULMOD => {
                 let a = state.stack.pop()?;
                 let b = state.stack.pop()?;
                 let n = state.stack.pop()?;
-                state.stack.push(SymExpr::ternop(&mut self.cx, SymExprTernOp::MulMod, a, b, n))?;
+                state.stack.push(SymExpr::ternop(&mut self.cx, SymTernOp::MulMod, a, b, n))?;
             }
             opcode::LT => {
                 state.cmp_word(&mut self.cx, SymCmpOp::Ult)?;
@@ -99,13 +99,13 @@ impl SymbolicExecutor {
                 state.stack.push(SymExpr::bool_word(&mut self.cx, value))?;
             }
             opcode::AND => {
-                state.bin_word(&mut self.cx, SymExprBinOp::And)?;
+                state.bin_word(&mut self.cx, SymBinOp::And)?;
             }
             opcode::OR => {
-                state.bin_word(&mut self.cx, SymExprBinOp::Or)?;
+                state.bin_word(&mut self.cx, SymBinOp::Or)?;
             }
             opcode::XOR => {
-                state.bin_word(&mut self.cx, SymExprBinOp::Xor)?;
+                state.bin_word(&mut self.cx, SymBinOp::Xor)?;
             }
             opcode::NOT => {
                 let value = state.stack.pop()?;
@@ -779,7 +779,7 @@ impl SymbolicExecutor {
         if offset.contains_gasleft() || size.contains_gasleft() {
             return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
         }
-        let end = SymExpr::binop(&mut self.cx, SymExprBinOp::Add, offset, size);
+        let end = SymExpr::binop(&mut self.cx, SymBinOp::Add, offset, size);
         let in_bounds =
             SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Ule, end, state.return_data.len_expr());
         match in_bounds.as_const() {

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -75,16 +75,16 @@ impl SymbolicExecutor {
                 state.stack.push(SymExpr::ternop(&mut self.cx, SymExprTernOp::MulMod, a, b, n))?;
             }
             opcode::LT => {
-                state.cmp_word(&mut self.cx, SymBoolExprOp::Ult)?;
+                state.cmp_word(&mut self.cx, SymCmpOp::Ult)?;
             }
             opcode::GT => {
-                state.cmp_word(&mut self.cx, SymBoolExprOp::Ugt)?;
+                state.cmp_word(&mut self.cx, SymCmpOp::Ugt)?;
             }
             opcode::SLT => {
-                state.cmp_word(&mut self.cx, SymBoolExprOp::Slt)?;
+                state.cmp_word(&mut self.cx, SymCmpOp::Slt)?;
             }
             opcode::SGT => {
-                state.cmp_word(&mut self.cx, SymBoolExprOp::Sgt)?;
+                state.cmp_word(&mut self.cx, SymCmpOp::Sgt)?;
             }
             opcode::EQ => {
                 let a = state.stack.pop()?;
@@ -781,7 +781,7 @@ impl SymbolicExecutor {
         }
         let end = SymExpr::binop(&mut self.cx, SymExprBinOp::Add, offset, size);
         let in_bounds =
-            SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Ule, end, state.return_data.len_expr());
+            SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Ule, end, state.return_data.len_expr());
         match in_bounds.as_const() {
             Some(value) => Ok(value),
             None => {

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -39,28 +39,28 @@ impl SymbolicExecutor {
             }
             opcode::STOP => return Ok(StepOutcome::Halt),
             opcode::ADD => {
-                state.bin_word(&mut self.cx, SymExprOp::Add)?;
+                state.bin_word(&mut self.cx, SymExprBinOp::Add)?;
             }
             opcode::SUB => {
-                state.bin_word(&mut self.cx, SymExprOp::Sub)?;
+                state.bin_word(&mut self.cx, SymExprBinOp::Sub)?;
             }
             opcode::MUL => {
-                state.bin_word(&mut self.cx, SymExprOp::Mul)?;
+                state.bin_word(&mut self.cx, SymExprBinOp::Mul)?;
             }
             opcode::EXP => {
                 state.exp_word(&mut self.cx)?;
             }
             opcode::DIV => {
-                state.bin_word_div_zero_guard(&mut self.cx, SymExprOp::UDiv)?;
+                state.bin_word_div_zero_guard(&mut self.cx, SymExprBinOp::UDiv)?;
             }
             opcode::SDIV => {
-                state.bin_word_div_zero_guard(&mut self.cx, SymExprOp::SDiv)?;
+                state.bin_word_div_zero_guard(&mut self.cx, SymExprBinOp::SDiv)?;
             }
             opcode::MOD => {
-                state.bin_word_div_zero_guard(&mut self.cx, SymExprOp::URem)?;
+                state.bin_word_div_zero_guard(&mut self.cx, SymExprBinOp::URem)?;
             }
             opcode::SMOD => {
-                state.bin_word_div_zero_guard(&mut self.cx, SymExprOp::SRem)?;
+                state.bin_word_div_zero_guard(&mut self.cx, SymExprBinOp::SRem)?;
             }
             opcode::ADDMOD => {
                 let a = state.stack.pop()?;
@@ -99,13 +99,13 @@ impl SymbolicExecutor {
                 state.stack.push(SymExpr::bool_word(&mut self.cx, value))?;
             }
             opcode::AND => {
-                state.bin_word(&mut self.cx, SymExprOp::And)?;
+                state.bin_word(&mut self.cx, SymExprBinOp::And)?;
             }
             opcode::OR => {
-                state.bin_word(&mut self.cx, SymExprOp::Or)?;
+                state.bin_word(&mut self.cx, SymExprBinOp::Or)?;
             }
             opcode::XOR => {
-                state.bin_word(&mut self.cx, SymExprOp::Xor)?;
+                state.bin_word(&mut self.cx, SymExprBinOp::Xor)?;
             }
             opcode::NOT => {
                 let value = state.stack.pop()?;
@@ -779,7 +779,7 @@ impl SymbolicExecutor {
         if offset.contains_gasleft() || size.contains_gasleft() {
             return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
         }
-        let end = SymExpr::op(&mut self.cx, SymExprOp::Add, offset, size);
+        let end = SymExpr::binop(&mut self.cx, SymExprBinOp::Add, offset, size);
         let in_bounds =
             SymBoolExpr::cmp(&mut self.cx, SymBoolExprOp::Ule, end, state.return_data.len_expr());
         match in_bounds.as_const() {

--- a/crates/evm/symbolic/src/runtime/address.rs
+++ b/crates/evm/symbolic/src/runtime/address.rs
@@ -82,13 +82,13 @@ impl SymExpr {
         }
 
         match this.kind() {
-            SymExprKind::Op(SymExprOp::And, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::And, left, right) => {
                 (right.is_address_mask() && left.address_expr_equivalent(alias))
                     || (left.is_address_mask() && right.address_expr_equivalent(alias))
             }
-            SymExprKind::Op(SymExprOp::Shr, value, shift) if shift.is_shift_96() => {
+            SymExprKind::BinOp(SymExprBinOp::Shr, value, shift) if shift.is_shift_96() => {
                 match value.kind() {
-                    SymExprKind::Op(SymExprOp::Shl, inner, inner_shift)
+                    SymExprKind::BinOp(SymExprBinOp::Shl, inner, inner_shift)
                         if inner_shift.is_shift_96() =>
                     {
                         inner.address_expr_equivalent(alias)
@@ -102,15 +102,15 @@ impl SymExpr {
 
     fn symbolic_address_canonical(&self) -> &Self {
         match self.kind() {
-            SymExprKind::Op(SymExprOp::And, left, right) if right.is_address_mask() => {
+            SymExprKind::BinOp(SymExprBinOp::And, left, right) if right.is_address_mask() => {
                 left.symbolic_address_canonical()
             }
-            SymExprKind::Op(SymExprOp::And, left, right) if left.is_address_mask() => {
+            SymExprKind::BinOp(SymExprBinOp::And, left, right) if left.is_address_mask() => {
                 right.symbolic_address_canonical()
             }
-            SymExprKind::Op(SymExprOp::Shr, value, shift) if shift.is_shift_96() => {
+            SymExprKind::BinOp(SymExprBinOp::Shr, value, shift) if shift.is_shift_96() => {
                 match value.kind() {
-                    SymExprKind::Op(SymExprOp::Shl, inner, inner_shift)
+                    SymExprKind::BinOp(SymExprBinOp::Shl, inner, inner_shift)
                         if inner_shift.is_shift_96() =>
                     {
                         inner.symbolic_address_canonical()

--- a/crates/evm/symbolic/src/runtime/address.rs
+++ b/crates/evm/symbolic/src/runtime/address.rs
@@ -82,13 +82,13 @@ impl SymExpr {
         }
 
         match this.kind() {
-            SymExprKind::BinOp(SymExprBinOp::And, left, right) => {
+            SymExprKind::BinOp(SymBinOp::And, left, right) => {
                 (right.is_address_mask() && left.address_expr_equivalent(alias))
                     || (left.is_address_mask() && right.address_expr_equivalent(alias))
             }
-            SymExprKind::BinOp(SymExprBinOp::Shr, value, shift) if shift.is_shift_96() => {
+            SymExprKind::BinOp(SymBinOp::Shr, value, shift) if shift.is_shift_96() => {
                 match value.kind() {
-                    SymExprKind::BinOp(SymExprBinOp::Shl, inner, inner_shift)
+                    SymExprKind::BinOp(SymBinOp::Shl, inner, inner_shift)
                         if inner_shift.is_shift_96() =>
                     {
                         inner.address_expr_equivalent(alias)
@@ -102,15 +102,15 @@ impl SymExpr {
 
     fn symbolic_address_canonical(&self) -> &Self {
         match self.kind() {
-            SymExprKind::BinOp(SymExprBinOp::And, left, right) if right.is_address_mask() => {
+            SymExprKind::BinOp(SymBinOp::And, left, right) if right.is_address_mask() => {
                 left.symbolic_address_canonical()
             }
-            SymExprKind::BinOp(SymExprBinOp::And, left, right) if left.is_address_mask() => {
+            SymExprKind::BinOp(SymBinOp::And, left, right) if left.is_address_mask() => {
                 right.symbolic_address_canonical()
             }
-            SymExprKind::BinOp(SymExprBinOp::Shr, value, shift) if shift.is_shift_96() => {
+            SymExprKind::BinOp(SymBinOp::Shr, value, shift) if shift.is_shift_96() => {
                 match value.kind() {
-                    SymExprKind::BinOp(SymExprBinOp::Shl, inner, inner_shift)
+                    SymExprKind::BinOp(SymBinOp::Shl, inner, inner_shift)
                         if inner_shift.is_shift_96() =>
                     {
                         inner.symbolic_address_canonical()

--- a/crates/evm/symbolic/src/runtime/bytes.rs
+++ b/crates/evm/symbolic/src/runtime/bytes.rs
@@ -174,7 +174,7 @@ impl SymBytes {
                 }
                 let source = bytes.byte(cx, offset);
                 let offset = SymExpr::constant(cx, U256::from(offset));
-                let condition = SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, offset, size.clone());
+                let condition = SymBoolExpr::cmp(cx, SymCmpOp::Ult, offset, size.clone());
                 let zero = SymExpr::zero(cx);
                 SymExpr::ite(cx, condition, source, zero)
             }

--- a/crates/evm/symbolic/src/runtime/bytes.rs
+++ b/crates/evm/symbolic/src/runtime/bytes.rs
@@ -386,7 +386,7 @@ impl SymBytes {
 
                     let take = (bytes_len - offset).min(remaining);
                     let fragment = bytes.word_fragment_at(cx, offset, take, out_offset)?;
-                    out = SymExpr::binop(cx, SymExprBinOp::Or, out, fragment);
+                    out = SymExpr::binop(cx, SymBinOp::Or, out, fragment);
                     out_offset += take;
                     remaining -= take;
                     offset = 0;
@@ -418,11 +418,11 @@ impl SymBytes {
         let mask = mask_bits(U256::MAX, len * 8);
 
         let src_trailing_bits = SymExpr::constant(cx, U256::from(src_trailing_bits));
-        let expr = SymExpr::binop(cx, SymExprBinOp::Shr, word, src_trailing_bits);
+        let expr = SymExpr::binop(cx, SymBinOp::Shr, word, src_trailing_bits);
         let mask = SymExpr::constant(cx, mask);
-        let expr = SymExpr::binop(cx, SymExprBinOp::And, expr, mask);
+        let expr = SymExpr::binop(cx, SymBinOp::And, expr, mask);
         let dst_trailing_bits = SymExpr::constant(cx, U256::from(dst_trailing_bits));
-        Some(SymExpr::binop(cx, SymExprBinOp::Shl, expr, dst_trailing_bits))
+        Some(SymExpr::binop(cx, SymBinOp::Shl, expr, dst_trailing_bits))
     }
 
     pub(crate) fn materialize(&self, cx: &mut SymCx) -> Vec<SymExpr> {

--- a/crates/evm/symbolic/src/runtime/bytes.rs
+++ b/crates/evm/symbolic/src/runtime/bytes.rs
@@ -386,7 +386,7 @@ impl SymBytes {
 
                     let take = (bytes_len - offset).min(remaining);
                     let fragment = bytes.word_fragment_at(cx, offset, take, out_offset)?;
-                    out = SymExpr::op(cx, SymExprOp::Or, out, fragment);
+                    out = SymExpr::binop(cx, SymExprBinOp::Or, out, fragment);
                     out_offset += take;
                     remaining -= take;
                     offset = 0;
@@ -418,11 +418,11 @@ impl SymBytes {
         let mask = mask_bits(U256::MAX, len * 8);
 
         let src_trailing_bits = SymExpr::constant(cx, U256::from(src_trailing_bits));
-        let expr = SymExpr::op(cx, SymExprOp::Shr, word, src_trailing_bits);
+        let expr = SymExpr::binop(cx, SymExprBinOp::Shr, word, src_trailing_bits);
         let mask = SymExpr::constant(cx, mask);
-        let expr = SymExpr::op(cx, SymExprOp::And, expr, mask);
+        let expr = SymExpr::binop(cx, SymExprBinOp::And, expr, mask);
         let dst_trailing_bits = SymExpr::constant(cx, U256::from(dst_trailing_bits));
-        Some(SymExpr::op(cx, SymExprOp::Shl, expr, dst_trailing_bits))
+        Some(SymExpr::binop(cx, SymExprBinOp::Shl, expr, dst_trailing_bits))
     }
 
     pub(crate) fn materialize(&self, cx: &mut SymCx) -> Vec<SymExpr> {

--- a/crates/evm/symbolic/src/runtime/cheatcodes.rs
+++ b/crates/evm/symbolic/src/runtime/cheatcodes.rs
@@ -434,8 +434,8 @@ pub(crate) fn push_hex_byte(cx: &mut SymCx, out: &mut Vec<SymExpr>, byte: SymExp
         let shift = SymExpr::constant(cx, U256::from(4));
         let mask = SymExpr::constant(cx, U256::from(0x0f));
         (
-            SymExpr::op(cx, SymExprOp::Shr, expr.clone(), shift),
-            SymExpr::op(cx, SymExprOp::And, expr, mask),
+            SymExpr::binop(cx, SymExprBinOp::Shr, expr.clone(), shift),
+            SymExpr::binop(cx, SymExprBinOp::And, expr, mask),
         )
     };
     out.push(hex_nibble_ascii(cx, high));
@@ -452,9 +452,9 @@ pub(crate) fn hex_nibble_ascii(cx: &mut SymCx, nibble: SymExpr) -> SymExpr {
         let ten = SymExpr::constant(cx, U256::from(10));
         let condition = SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, nibble.clone(), ten);
         let zero = SymExpr::constant(cx, U256::from(b'0'));
-        let digit = SymExpr::op(cx, SymExprOp::Add, nibble.clone(), zero);
+        let digit = SymExpr::binop(cx, SymExprBinOp::Add, nibble.clone(), zero);
         let alpha_base = SymExpr::constant(cx, U256::from(b'a' - 10));
-        let alpha = SymExpr::op(cx, SymExprOp::Add, nibble, alpha_base);
+        let alpha = SymExpr::binop(cx, SymExprBinOp::Add, nibble, alpha_base);
         SymExpr::ite(cx, condition, digit, alpha)
     }
 }

--- a/crates/evm/symbolic/src/runtime/cheatcodes.rs
+++ b/crates/evm/symbolic/src/runtime/cheatcodes.rs
@@ -450,7 +450,7 @@ pub(crate) fn hex_nibble_ascii(cx: &mut SymCx, nibble: SymExpr) -> SymExpr {
         SymExpr::constant(cx, U256::from(byte))
     } else {
         let ten = SymExpr::constant(cx, U256::from(10));
-        let condition = SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, nibble.clone(), ten);
+        let condition = SymBoolExpr::cmp(cx, SymCmpOp::Ult, nibble.clone(), ten);
         let zero = SymExpr::constant(cx, U256::from(b'0'));
         let digit = SymExpr::binop(cx, SymExprBinOp::Add, nibble.clone(), zero);
         let alpha_base = SymExpr::constant(cx, U256::from(b'a' - 10));

--- a/crates/evm/symbolic/src/runtime/cheatcodes.rs
+++ b/crates/evm/symbolic/src/runtime/cheatcodes.rs
@@ -434,8 +434,8 @@ pub(crate) fn push_hex_byte(cx: &mut SymCx, out: &mut Vec<SymExpr>, byte: SymExp
         let shift = SymExpr::constant(cx, U256::from(4));
         let mask = SymExpr::constant(cx, U256::from(0x0f));
         (
-            SymExpr::binop(cx, SymExprBinOp::Shr, expr.clone(), shift),
-            SymExpr::binop(cx, SymExprBinOp::And, expr, mask),
+            SymExpr::binop(cx, SymBinOp::Shr, expr.clone(), shift),
+            SymExpr::binop(cx, SymBinOp::And, expr, mask),
         )
     };
     out.push(hex_nibble_ascii(cx, high));
@@ -452,9 +452,9 @@ pub(crate) fn hex_nibble_ascii(cx: &mut SymCx, nibble: SymExpr) -> SymExpr {
         let ten = SymExpr::constant(cx, U256::from(10));
         let condition = SymBoolExpr::cmp(cx, SymCmpOp::Ult, nibble.clone(), ten);
         let zero = SymExpr::constant(cx, U256::from(b'0'));
-        let digit = SymExpr::binop(cx, SymExprBinOp::Add, nibble.clone(), zero);
+        let digit = SymExpr::binop(cx, SymBinOp::Add, nibble.clone(), zero);
         let alpha_base = SymExpr::constant(cx, U256::from(b'a' - 10));
-        let alpha = SymExpr::binop(cx, SymExprBinOp::Add, nibble, alpha_base);
+        let alpha = SymExpr::binop(cx, SymBinOp::Add, nibble, alpha_base);
         SymExpr::ite(cx, condition, digit, alpha)
     }
 }

--- a/crates/evm/symbolic/src/runtime/evm.rs
+++ b/crates/evm/symbolic/src/runtime/evm.rs
@@ -34,7 +34,7 @@ pub(crate) fn exp_expr_for_concrete_exponent(
 
     let mut expr = base.clone();
     for _ in 1..exponent {
-        expr = SymExpr::op(cx, SymExprOp::Mul, expr, base.clone());
+        expr = SymExpr::binop(cx, SymExprBinOp::Mul, expr, base.clone());
     }
     expr
 }
@@ -93,13 +93,13 @@ pub(crate) fn signextend_word(cx: &mut SymCx, byte_index: U256, value: SymExpr) 
     let sign_bit = U256::from(1) << bit_index;
     let mask_value = sign_bit - U256::from(1);
     let sign_bit = SymExpr::constant(cx, sign_bit);
-    let masked_sign = SymExpr::op(cx, SymExprOp::And, value.clone(), sign_bit);
+    let masked_sign = SymExpr::binop(cx, SymExprBinOp::And, value.clone(), sign_bit);
     let zero = SymExpr::zero(cx);
     let condition = SymBoolExpr::eq(cx, masked_sign, zero);
     let inverse_mask = SymExpr::constant(cx, !mask_value);
     let mask = SymExpr::constant(cx, mask_value);
-    let masked = SymExpr::op(cx, SymExprOp::And, value.clone(), mask);
-    let extended = SymExpr::op(cx, SymExprOp::Or, value, inverse_mask);
+    let masked = SymExpr::binop(cx, SymExprBinOp::And, value.clone(), mask);
+    let extended = SymExpr::binop(cx, SymExprBinOp::Or, value, inverse_mask);
     SymExpr::ite(cx, condition, masked, extended)
 }
 
@@ -185,7 +185,7 @@ pub(crate) fn shift_left(cx: &mut SymCx, value: SymExpr, bits: usize) -> SymExpr
         SymExpr::constant(cx, value << bits)
     } else {
         let bits = SymExpr::constant(cx, U256::from(bits));
-        SymExpr::op(cx, SymExprOp::Shl, value, bits)
+        SymExpr::binop(cx, SymExprBinOp::Shl, value, bits)
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/evm.rs
+++ b/crates/evm/symbolic/src/runtime/evm.rs
@@ -34,7 +34,7 @@ pub(crate) fn exp_expr_for_concrete_exponent(
 
     let mut expr = base.clone();
     for _ in 1..exponent {
-        expr = SymExpr::binop(cx, SymExprBinOp::Mul, expr, base.clone());
+        expr = SymExpr::binop(cx, SymBinOp::Mul, expr, base.clone());
     }
     expr
 }
@@ -93,13 +93,13 @@ pub(crate) fn signextend_word(cx: &mut SymCx, byte_index: U256, value: SymExpr) 
     let sign_bit = U256::from(1) << bit_index;
     let mask_value = sign_bit - U256::from(1);
     let sign_bit = SymExpr::constant(cx, sign_bit);
-    let masked_sign = SymExpr::binop(cx, SymExprBinOp::And, value.clone(), sign_bit);
+    let masked_sign = SymExpr::binop(cx, SymBinOp::And, value.clone(), sign_bit);
     let zero = SymExpr::zero(cx);
     let condition = SymBoolExpr::eq(cx, masked_sign, zero);
     let inverse_mask = SymExpr::constant(cx, !mask_value);
     let mask = SymExpr::constant(cx, mask_value);
-    let masked = SymExpr::binop(cx, SymExprBinOp::And, value.clone(), mask);
-    let extended = SymExpr::binop(cx, SymExprBinOp::Or, value, inverse_mask);
+    let masked = SymExpr::binop(cx, SymBinOp::And, value.clone(), mask);
+    let extended = SymExpr::binop(cx, SymBinOp::Or, value, inverse_mask);
     SymExpr::ite(cx, condition, masked, extended)
 }
 
@@ -185,7 +185,7 @@ pub(crate) fn shift_left(cx: &mut SymCx, value: SymExpr, bits: usize) -> SymExpr
         SymExpr::constant(cx, value << bits)
     } else {
         let bits = SymExpr::constant(cx, U256::from(bits));
-        SymExpr::binop(cx, SymExprBinOp::Shl, value, bits)
+        SymExpr::binop(cx, SymBinOp::Shl, value, bits)
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -16,8 +16,7 @@ pub(in crate::runtime) enum SymBoolExprKind {
     Const(bool),
     Not(SymBoolExpr),
     And(Arc<[SymBoolExpr]>),
-    Eq(SymExpr, SymExpr),
-    Cmp(SymBoolExprOp, SymExpr, SymExpr),
+    Cmp(SymCmpOp, SymExpr, SymExpr),
 }
 
 impl SymBoolExpr {
@@ -44,7 +43,7 @@ impl SymBoolExpr {
 
     pub(crate) fn cmp_word_const(
         cx: &mut SymCx,
-        op: SymBoolExprOp,
+        op: SymCmpOp,
         word: &SymExpr,
         value: U256,
     ) -> Self {
@@ -66,6 +65,10 @@ impl SymBoolExpr {
     }
 
     pub(crate) fn eq(cx: &mut SymCx, left: SymExpr, right: SymExpr) -> Self {
+        Self::cmp(cx, SymCmpOp::Eq, left, right)
+    }
+
+    fn eq_cmp(cx: &mut SymCx, left: SymExpr, right: SymExpr) -> Self {
         match (left.kind(), right.kind()) {
             _ if left == right => Self::constant(cx, true),
             (SymExprKind::Const(left), SymExprKind::Const(right)) => {
@@ -79,7 +82,7 @@ impl SymBoolExpr {
                     return Self::constant(cx, left_value == *right_value);
                 }
                 let (left, right) = SymExpr::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymBoolExprKind::Eq(left, right))
+                Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
             }
             (SymExprKind::Const(left_value), _) => {
                 if let Some(condition) = Self::bool_word_eq_const(cx, &right, *left_value) {
@@ -89,7 +92,7 @@ impl SymBoolExpr {
                     return Self::constant(cx, *left_value == right_value);
                 }
                 let (left, right) = SymExpr::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymBoolExprKind::Eq(left, right))
+                Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
             }
             (
                 SymExprKind::Keccak { len: left_len, bytes: left_bytes, .. },
@@ -119,41 +122,44 @@ impl SymBoolExpr {
             }
             _ => {
                 let (left, right) = SymExpr::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymBoolExprKind::Eq(left, right))
+                Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
             }
         }
     }
 
-    pub(crate) fn cmp(cx: &mut SymCx, op: SymBoolExprOp, left: SymExpr, right: SymExpr) -> Self {
+    pub(crate) fn cmp(cx: &mut SymCx, op: SymCmpOp, left: SymExpr, right: SymExpr) -> Self {
+        if op == SymCmpOp::Eq {
+            return Self::eq_cmp(cx, left, right);
+        }
         match (op, left.kind(), right.kind()) {
             (op, _, _) if left == right => {
-                Self::constant(cx, matches!(op, SymBoolExprOp::Ule | SymBoolExprOp::Uge))
+                Self::constant(cx, matches!(op, SymCmpOp::Ule | SymCmpOp::Uge))
             }
             (op, SymExprKind::Const(left), SymExprKind::Const(right)) => {
                 Self::constant(cx, op.eval(*left, *right))
             }
-            (SymBoolExprOp::Ugt, SymExprKind::Const(value), _) if value.is_zero() => {
+            (SymCmpOp::Ugt, SymExprKind::Const(value), _) if value.is_zero() => {
                 Self::constant(cx, false)
             }
-            (SymBoolExprOp::Ule, SymExprKind::Const(value), _) if value.is_zero() => {
+            (SymCmpOp::Ule, SymExprKind::Const(value), _) if value.is_zero() => {
                 Self::constant(cx, true)
             }
-            (SymBoolExprOp::Ult, _, SymExprKind::Const(value)) if value.is_zero() => {
+            (SymCmpOp::Ult, _, SymExprKind::Const(value)) if value.is_zero() => {
                 Self::constant(cx, false)
             }
-            (SymBoolExprOp::Uge, _, SymExprKind::Const(value)) if value.is_zero() => {
+            (SymCmpOp::Uge, _, SymExprKind::Const(value)) if value.is_zero() => {
                 Self::constant(cx, true)
             }
-            (SymBoolExprOp::Ult, SymExprKind::Const(value), _) if *value == U256::MAX => {
+            (SymCmpOp::Ult, SymExprKind::Const(value), _) if *value == U256::MAX => {
                 Self::constant(cx, false)
             }
-            (SymBoolExprOp::Uge, SymExprKind::Const(value), _) if *value == U256::MAX => {
+            (SymCmpOp::Uge, SymExprKind::Const(value), _) if *value == U256::MAX => {
                 Self::constant(cx, true)
             }
-            (SymBoolExprOp::Ugt, _, SymExprKind::Const(value)) if *value == U256::MAX => {
+            (SymCmpOp::Ugt, _, SymExprKind::Const(value)) if *value == U256::MAX => {
                 Self::constant(cx, false)
             }
-            (SymBoolExprOp::Ule, _, SymExprKind::Const(value)) if *value == U256::MAX => {
+            (SymCmpOp::Ule, _, SymExprKind::Const(value)) if *value == U256::MAX => {
                 Self::constant(cx, true)
             }
             _ => Self::from_kind(cx, SymBoolExprKind::Cmp(op, left, right)),
@@ -245,12 +251,12 @@ impl SymBoolExpr {
 
     pub(in crate::runtime) fn zero_check_operand(&self) -> Option<&SymExpr> {
         match self.kind() {
-            SymBoolExprKind::Eq(left, right)
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                 if right.as_const().is_some_and(|value| value.is_zero()) =>
             {
                 Some(left)
             }
-            SymBoolExprKind::Eq(left, right)
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                 if left.as_const().is_some_and(|value| value.is_zero()) =>
             {
                 Some(right)
@@ -277,7 +283,7 @@ impl SymBoolExpr {
         context: &[Self],
     ) -> Option<U256> {
         match self.kind() {
-            SymBoolExprKind::Eq(left, right) => match (left.kind(), right.kind()) {
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => match (left.kind(), right.kind()) {
                 (_, SymExprKind::Const(value)) => left.equality_forces_const(*value, expr, context),
                 (SymExprKind::Const(value), _) => {
                     right.equality_forces_const(*value, expr, context)
@@ -285,15 +291,17 @@ impl SymBoolExpr {
                 _ => None,
             },
             SymBoolExprKind::Not(value) => match value.kind() {
-                SymBoolExprKind::Eq(left, right) => match (left.kind(), right.kind()) {
-                    (_, SymExprKind::Const(value)) if value.is_zero() => {
-                        left.nonzero_forces_const(expr, context)
+                SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => {
+                    match (left.kind(), right.kind()) {
+                        (_, SymExprKind::Const(value)) if value.is_zero() => {
+                            left.nonzero_forces_const(expr, context)
+                        }
+                        (SymExprKind::Const(value), _) if value.is_zero() => {
+                            right.nonzero_forces_const(expr, context)
+                        }
+                        _ => None,
                     }
-                    (SymExprKind::Const(value), _) if value.is_zero() => {
-                        right.nonzero_forces_const(expr, context)
-                    }
-                    _ => None,
-                },
+                }
                 SymBoolExprKind::Not(value) => value.forces_expr_const_with_context(expr, context),
                 _ => None,
             },
@@ -316,32 +324,30 @@ impl SymBoolExpr {
                 }
                 bound
             }
-            SymBoolExprKind::Eq(left, right) => match (left == expr, right == expr) {
-                (true, _) => right.eval().and_then(|value| usize::try_from(value).ok()),
-                (_, true) => left.eval().and_then(|value| usize::try_from(value).ok()),
-                _ => None,
-            },
             SymBoolExprKind::Cmp(op, left, right) => {
+                if *op == SymCmpOp::Eq {
+                    return match (left == expr, right == expr) {
+                        (true, _) => right.eval().and_then(|value| usize::try_from(value).ok()),
+                        (_, true) => left.eval().and_then(|value| usize::try_from(value).ok()),
+                        _ => None,
+                    };
+                }
                 if left == expr {
                     match *op {
-                        SymBoolExprOp::Ult => right
+                        SymCmpOp::Ult => right
                             .eval()
                             .and_then(|bound| (!bound.is_zero()).then(|| bound - U256::from(1)))
                             .and_then(|value| usize::try_from(value).ok()),
-                        SymBoolExprOp::Ule => {
-                            right.eval().and_then(|value| usize::try_from(value).ok())
-                        }
+                        SymCmpOp::Ule => right.eval().and_then(|value| usize::try_from(value).ok()),
                         _ => None,
                     }
                 } else if right == expr {
                     match *op {
-                        SymBoolExprOp::Ugt => left
+                        SymCmpOp::Ugt => left
                             .eval()
                             .and_then(|bound| (!bound.is_zero()).then(|| bound - U256::from(1)))
                             .and_then(|value| usize::try_from(value).ok()),
-                        SymBoolExprOp::Uge => {
-                            left.eval().and_then(|value| usize::try_from(value).ok())
-                        }
+                        SymCmpOp::Uge => left.eval().and_then(|value| usize::try_from(value).ok()),
                         _ => None,
                     }
                 } else {
@@ -365,9 +371,6 @@ impl SymBoolExpr {
                     }
                 }
                 true
-            }
-            SymBoolExprKind::Eq(left, right) => {
-                left.eval_model(model)? == right.eval_model(model)?
             }
             SymBoolExprKind::Cmp(op, left, right) => {
                 op.eval(left.eval_model(model)?, right.eval_model(model)?)
@@ -401,7 +404,7 @@ impl SymBoolExpr {
                     value.visit_exprs(visitor)?;
                 }
             }
-            SymBoolExprKind::Eq(left, right) | SymBoolExprKind::Cmp(_, left, right) => {
+            SymBoolExprKind::Cmp(_, left, right) => {
                 left.visit(visitor)?;
                 right.visit(visitor)?;
             }
@@ -434,7 +437,6 @@ impl SymBoolExpr {
                 let values = values.iter().cloned().map(|value| value.fold(cx, folder)).collect();
                 Self::and(cx, values)
             }
-            SymBoolExprKind::Eq(left, right) => Self::eq(cx, left, right),
             SymBoolExprKind::Cmp(op, left, right) => Self::cmp(cx, op, left, right),
             SymBoolExprKind::Const(_) => unreachable!("leaf boolean returned before folding"),
         };
@@ -460,11 +462,6 @@ impl SymBoolExpr {
                     values.iter().cloned().map(|value| value.fold_exprs(cx, folder)).collect();
                 Self::and(cx, values)
             }
-            SymBoolExprKind::Eq(left, right) => {
-                let left = left.fold(cx, folder);
-                let right = right.fold(cx, folder);
-                Self::eq(cx, left, right)
-            }
             SymBoolExprKind::Cmp(op, left, right) => {
                 let left = left.fold(cx, folder);
                 let right = right.fold(cx, folder);
@@ -481,7 +478,7 @@ impl SymBoolExpr {
 
     pub(crate) fn cmp_word_expr(
         cx: &mut SymCx,
-        op: SymBoolExprOp,
+        op: SymCmpOp,
         word: &SymExpr,
         expr: SymExpr,
     ) -> Self {
@@ -540,13 +537,6 @@ impl SymBoolExpr {
                 }
                 out.push(')');
             }
-            SymBoolExprKind::Eq(left, right) => {
-                out.push_str("(= ");
-                left.write_smt(out);
-                out.push(' ');
-                right.write_smt(out);
-                out.push(')');
-            }
             SymBoolExprKind::Cmp(op, left, right) => {
                 let _ = write!(out, "({} ", op.smt());
                 left.write_smt(out);
@@ -559,7 +549,8 @@ impl SymBoolExpr {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum SymBoolExprOp {
+pub(crate) enum SymCmpOp {
+    Eq,
     Ult,
     Ugt,
     Ule,
@@ -568,9 +559,10 @@ pub(crate) enum SymBoolExprOp {
     Sgt,
 }
 
-impl SymBoolExprOp {
+impl SymCmpOp {
     pub(crate) const fn smt(self) -> &'static str {
         match self {
+            Self::Eq => "=",
             Self::Ult => "bvult",
             Self::Ugt => "bvugt",
             Self::Ule => "bvule",
@@ -582,6 +574,7 @@ impl SymBoolExprOp {
 
     pub(crate) fn eval(self, left: U256, right: U256) -> bool {
         match self {
+            Self::Eq => left == right,
             Self::Ult => left < right,
             Self::Ugt => left > right,
             Self::Ule => left <= right,

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -137,51 +137,69 @@ impl SymBoolExpr {
     }
 
     pub(crate) fn cmp(cx: &mut SymCx, op: SymCmpOp, left: SymExpr, right: SymExpr) -> Self {
-        if op == SymCmpOp::Eq {
-            return Self::eq_cmp(cx, left, right);
-        }
-        match (op, left.kind(), right.kind()) {
-            // `a <= a => true`, `a < a => false`.
-            (op, _, _) if left == right => {
-                Self::constant(cx, matches!(op, SymCmpOp::Ule | SymCmpOp::Uge))
-            }
-            (op, SymExprKind::Const(left), SymExprKind::Const(right)) => {
-                // `const < const => const`.
-                Self::constant(cx, op.eval(*left, *right))
-            }
-            // `0 > a => false`.
-            (SymCmpOp::Ugt, SymExprKind::Const(value), _) if value.is_zero() => {
-                Self::constant(cx, false)
-            }
-            // `0 <= a => true`.
-            (SymCmpOp::Ule, SymExprKind::Const(value), _) if value.is_zero() => {
-                Self::constant(cx, true)
-            }
-            // `a < 0 => false`.
-            (SymCmpOp::Ult, _, SymExprKind::Const(value)) if value.is_zero() => {
-                Self::constant(cx, false)
-            }
-            // `a >= 0 => true`.
-            (SymCmpOp::Uge, _, SymExprKind::Const(value)) if value.is_zero() => {
-                Self::constant(cx, true)
-            }
-            // `MAX < a => false`.
-            (SymCmpOp::Ult, SymExprKind::Const(value), _) if *value == U256::MAX => {
-                Self::constant(cx, false)
-            }
-            // `MAX >= a => true`.
-            (SymCmpOp::Uge, SymExprKind::Const(value), _) if *value == U256::MAX => {
-                Self::constant(cx, true)
-            }
-            // `a > MAX => false`.
-            (SymCmpOp::Ugt, _, SymExprKind::Const(value)) if *value == U256::MAX => {
-                Self::constant(cx, false)
-            }
-            // `a <= MAX => true`.
-            (SymCmpOp::Ule, _, SymExprKind::Const(value)) if *value == U256::MAX => {
-                Self::constant(cx, true)
-            }
-            _ => Self::from_kind(cx, SymBoolExprKind::Cmp(op, left, right)),
+        match op {
+            SymCmpOp::Eq => Self::eq_cmp(cx, left, right),
+            SymCmpOp::Ult => match (left.kind(), right.kind()) {
+                // `a < a => false`.
+                _ if left == right => Self::constant(cx, false),
+                (SymExprKind::Const(left), SymExprKind::Const(right)) => {
+                    // `const < const => const`.
+                    Self::constant(cx, op.eval(*left, *right))
+                }
+                // `a < 0 => false`.
+                (_, SymExprKind::Const(value)) if value.is_zero() => Self::constant(cx, false),
+                // `MAX < a => false`.
+                (SymExprKind::Const(value), _) if *value == U256::MAX => Self::constant(cx, false),
+                _ => Self::from_kind(cx, SymBoolExprKind::Cmp(op, left, right)),
+            },
+            SymCmpOp::Ugt => match (left.kind(), right.kind()) {
+                // `a > a => false`.
+                _ if left == right => Self::constant(cx, false),
+                (SymExprKind::Const(left), SymExprKind::Const(right)) => {
+                    // `const > const => const`.
+                    Self::constant(cx, op.eval(*left, *right))
+                }
+                // `0 > a => false`.
+                (SymExprKind::Const(value), _) if value.is_zero() => Self::constant(cx, false),
+                // `a > MAX => false`.
+                (_, SymExprKind::Const(value)) if *value == U256::MAX => Self::constant(cx, false),
+                _ => Self::from_kind(cx, SymBoolExprKind::Cmp(op, left, right)),
+            },
+            SymCmpOp::Ule => match (left.kind(), right.kind()) {
+                // `a <= a => true`.
+                _ if left == right => Self::constant(cx, true),
+                (SymExprKind::Const(left), SymExprKind::Const(right)) => {
+                    // `const <= const => const`.
+                    Self::constant(cx, op.eval(*left, *right))
+                }
+                // `0 <= a => true`.
+                (SymExprKind::Const(value), _) if value.is_zero() => Self::constant(cx, true),
+                // `a <= MAX => true`.
+                (_, SymExprKind::Const(value)) if *value == U256::MAX => Self::constant(cx, true),
+                _ => Self::from_kind(cx, SymBoolExprKind::Cmp(op, left, right)),
+            },
+            SymCmpOp::Uge => match (left.kind(), right.kind()) {
+                // `a >= a => true`.
+                _ if left == right => Self::constant(cx, true),
+                (SymExprKind::Const(left), SymExprKind::Const(right)) => {
+                    // `const >= const => const`.
+                    Self::constant(cx, op.eval(*left, *right))
+                }
+                // `a >= 0 => true`.
+                (_, SymExprKind::Const(value)) if value.is_zero() => Self::constant(cx, true),
+                // `MAX >= a => true`.
+                (SymExprKind::Const(value), _) if *value == U256::MAX => Self::constant(cx, true),
+                _ => Self::from_kind(cx, SymBoolExprKind::Cmp(op, left, right)),
+            },
+            SymCmpOp::Slt | SymCmpOp::Sgt => match (left.kind(), right.kind()) {
+                // `a <s a => false`, `a >s a => false`.
+                _ if left == right => Self::constant(cx, false),
+                (SymExprKind::Const(left), SymExprKind::Const(right)) => {
+                    // `const <s const => const`.
+                    Self::constant(cx, op.eval(*left, *right))
+                }
+                _ => Self::from_kind(cx, SymBoolExprKind::Cmp(op, left, right)),
+            },
         }
     }
 

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -68,77 +68,73 @@ impl SymBoolExpr {
         Self::cmp(cx, SymCmpOp::Eq, left, right)
     }
 
-    fn eq_cmp(cx: &mut SymCx, left: SymExpr, right: SymExpr) -> Self {
-        match (left.kind(), right.kind()) {
-            // `a == a => true`.
-            _ if left == right => Self::constant(cx, true),
-            (SymExprKind::Const(left), SymExprKind::Const(right)) => {
-                // `const == const => const`.
-                Self::constant(cx, left == right)
-            }
-            (_, SymExprKind::Const(right_value)) => {
-                if let Some(condition) = Self::bool_word_eq_const(cx, &left, *right_value) {
-                    return condition;
+    pub(crate) fn cmp(cx: &mut SymCx, op: SymCmpOp, left: SymExpr, right: SymExpr) -> Self {
+        match op {
+            SymCmpOp::Eq => match (left.kind(), right.kind()) {
+                // `a == a => true`.
+                _ if left == right => Self::constant(cx, true),
+                (SymExprKind::Const(left), SymExprKind::Const(right)) => {
+                    // `const == const => const`.
+                    Self::constant(cx, left == right)
                 }
-                if let Some(left_value) = left.known_word() {
-                    // `known(a) == const => const`.
-                    return Self::constant(cx, left_value == *right_value);
+                (_, SymExprKind::Const(right_value)) => {
+                    if let Some(condition) = Self::bool_word_eq_const(cx, &left, *right_value) {
+                        return condition;
+                    }
+                    if let Some(left_value) = left.known_word() {
+                        // `known(a) == const => const`.
+                        return Self::constant(cx, left_value == *right_value);
+                    }
+                    // `a == b => ordered(a, b)`.
+                    let (left, right) = SymExpr::ordered_commutative_operands(left, right);
+                    Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
                 }
-                // `a == b => ordered(a, b)`.
-                let (left, right) = SymExpr::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
-            }
-            (SymExprKind::Const(left_value), _) => {
-                if let Some(condition) = Self::bool_word_eq_const(cx, &right, *left_value) {
-                    return condition;
+                (SymExprKind::Const(left_value), _) => {
+                    if let Some(condition) = Self::bool_word_eq_const(cx, &right, *left_value) {
+                        return condition;
+                    }
+                    if let Some(right_value) = right.known_word() {
+                        // `const == known(a) => const`.
+                        return Self::constant(cx, *left_value == right_value);
+                    }
+                    // `a == b => ordered(a, b)`.
+                    let (left, right) = SymExpr::ordered_commutative_operands(left, right);
+                    Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
                 }
-                if let Some(right_value) = right.known_word() {
-                    // `const == known(a) => const`.
-                    return Self::constant(cx, *left_value == right_value);
+                (
+                    SymExprKind::Keccak { len: left_len, bytes: left_bytes, .. },
+                    SymExprKind::Keccak { len: right_len, bytes: right_bytes, .. },
+                ) if left_bytes.len() == right_bytes.len() => {
+                    // `keccak(a) == keccak(b) => len(a) == len(b) && bytes(a) == bytes(b)`.
+                    let mut conditions = vec![Self::eq(cx, left_len.clone(), right_len.clone())];
+                    conditions.extend(
+                        left_bytes
+                            .iter()
+                            .cloned()
+                            .zip(right_bytes.iter().cloned())
+                            .map(|(left, right)| Self::eq(cx, left, right)),
+                    );
+                    Self::and(cx, conditions)
                 }
-                // `a == b => ordered(a, b)`.
-                let (left, right) = SymExpr::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
-            }
-            (
-                SymExprKind::Keccak { len: left_len, bytes: left_bytes, .. },
-                SymExprKind::Keccak { len: right_len, bytes: right_bytes, .. },
-            ) if left_bytes.len() == right_bytes.len() => {
-                // `keccak(a) == keccak(b) => len(a) == len(b) && bytes(a) == bytes(b)`.
-                let mut conditions = vec![Self::eq(cx, left_len.clone(), right_len.clone())];
-                conditions.extend(
-                    left_bytes
+                (
+                    SymExprKind::Hash { algorithm: left_algorithm, bytes: left_bytes, .. },
+                    SymExprKind::Hash { algorithm: right_algorithm, bytes: right_bytes, .. },
+                ) if left_algorithm == right_algorithm && left_bytes.len() == right_bytes.len() => {
+                    // `hash(a) == hash(b) => bytes(a) == bytes(b)`.
+                    let conditions = left_bytes
                         .iter()
                         .cloned()
                         .zip(right_bytes.iter().cloned())
-                        .map(|(left, right)| Self::eq(cx, left, right)),
-                );
-                Self::and(cx, conditions)
-            }
-            (
-                SymExprKind::Hash { algorithm: left_algorithm, bytes: left_bytes, .. },
-                SymExprKind::Hash { algorithm: right_algorithm, bytes: right_bytes, .. },
-            ) if left_algorithm == right_algorithm && left_bytes.len() == right_bytes.len() => {
-                // `hash(a) == hash(b) => bytes(a) == bytes(b)`.
-                let conditions = left_bytes
-                    .iter()
-                    .cloned()
-                    .zip(right_bytes.iter().cloned())
-                    .map(|(left, right)| Self::eq(cx, left, right))
-                    .collect();
-                Self::and(cx, conditions)
-            }
-            _ => {
-                // `a == b => ordered(a, b)`.
-                let (left, right) = SymExpr::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
-            }
-        }
-    }
-
-    pub(crate) fn cmp(cx: &mut SymCx, op: SymCmpOp, left: SymExpr, right: SymExpr) -> Self {
-        match op {
-            SymCmpOp::Eq => Self::eq_cmp(cx, left, right),
+                        .map(|(left, right)| Self::eq(cx, left, right))
+                        .collect();
+                    Self::and(cx, conditions)
+                }
+                _ => {
+                    // `a == b => ordered(a, b)`.
+                    let (left, right) = SymExpr::ordered_commutative_operands(left, right);
+                    Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
+                }
+            },
             SymCmpOp::Ult => match (left.kind(), right.kind()) {
                 // `a < a => false`.
                 _ if left == right => Self::constant(cx, false),

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -70,8 +70,10 @@ impl SymBoolExpr {
 
     fn eq_cmp(cx: &mut SymCx, left: SymExpr, right: SymExpr) -> Self {
         match (left.kind(), right.kind()) {
+            // `a == a => true`.
             _ if left == right => Self::constant(cx, true),
             (SymExprKind::Const(left), SymExprKind::Const(right)) => {
+                // `const == const => const`.
                 Self::constant(cx, left == right)
             }
             (_, SymExprKind::Const(right_value)) => {
@@ -79,8 +81,10 @@ impl SymBoolExpr {
                     return condition;
                 }
                 if let Some(left_value) = left.known_word() {
+                    // `known(a) == const => const`.
                     return Self::constant(cx, left_value == *right_value);
                 }
+                // `a == b => ordered(a, b)`.
                 let (left, right) = SymExpr::ordered_commutative_operands(left, right);
                 Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
             }
@@ -89,8 +93,10 @@ impl SymBoolExpr {
                     return condition;
                 }
                 if let Some(right_value) = right.known_word() {
+                    // `const == known(a) => const`.
                     return Self::constant(cx, *left_value == right_value);
                 }
+                // `a == b => ordered(a, b)`.
                 let (left, right) = SymExpr::ordered_commutative_operands(left, right);
                 Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
             }
@@ -98,6 +104,7 @@ impl SymBoolExpr {
                 SymExprKind::Keccak { len: left_len, bytes: left_bytes, .. },
                 SymExprKind::Keccak { len: right_len, bytes: right_bytes, .. },
             ) if left_bytes.len() == right_bytes.len() => {
+                // `keccak(a) == keccak(b) => len(a) == len(b) && bytes(a) == bytes(b)`.
                 let mut conditions = vec![Self::eq(cx, left_len.clone(), right_len.clone())];
                 conditions.extend(
                     left_bytes
@@ -112,6 +119,7 @@ impl SymBoolExpr {
                 SymExprKind::Hash { algorithm: left_algorithm, bytes: left_bytes, .. },
                 SymExprKind::Hash { algorithm: right_algorithm, bytes: right_bytes, .. },
             ) if left_algorithm == right_algorithm && left_bytes.len() == right_bytes.len() => {
+                // `hash(a) == hash(b) => bytes(a) == bytes(b)`.
                 let conditions = left_bytes
                     .iter()
                     .cloned()
@@ -121,6 +129,7 @@ impl SymBoolExpr {
                 Self::and(cx, conditions)
             }
             _ => {
+                // `a == b => ordered(a, b)`.
                 let (left, right) = SymExpr::ordered_commutative_operands(left, right);
                 Self::from_kind(cx, SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right))
             }
@@ -132,33 +141,43 @@ impl SymBoolExpr {
             return Self::eq_cmp(cx, left, right);
         }
         match (op, left.kind(), right.kind()) {
+            // `a <= a => true`, `a < a => false`.
             (op, _, _) if left == right => {
                 Self::constant(cx, matches!(op, SymCmpOp::Ule | SymCmpOp::Uge))
             }
             (op, SymExprKind::Const(left), SymExprKind::Const(right)) => {
+                // `const < const => const`.
                 Self::constant(cx, op.eval(*left, *right))
             }
+            // `0 > a => false`.
             (SymCmpOp::Ugt, SymExprKind::Const(value), _) if value.is_zero() => {
                 Self::constant(cx, false)
             }
+            // `0 <= a => true`.
             (SymCmpOp::Ule, SymExprKind::Const(value), _) if value.is_zero() => {
                 Self::constant(cx, true)
             }
+            // `a < 0 => false`.
             (SymCmpOp::Ult, _, SymExprKind::Const(value)) if value.is_zero() => {
                 Self::constant(cx, false)
             }
+            // `a >= 0 => true`.
             (SymCmpOp::Uge, _, SymExprKind::Const(value)) if value.is_zero() => {
                 Self::constant(cx, true)
             }
+            // `MAX < a => false`.
             (SymCmpOp::Ult, SymExprKind::Const(value), _) if *value == U256::MAX => {
                 Self::constant(cx, false)
             }
+            // `MAX >= a => true`.
             (SymCmpOp::Uge, SymExprKind::Const(value), _) if *value == U256::MAX => {
                 Self::constant(cx, true)
             }
+            // `a > MAX => false`.
             (SymCmpOp::Ugt, _, SymExprKind::Const(value)) if *value == U256::MAX => {
                 Self::constant(cx, false)
             }
+            // `a <= MAX => true`.
             (SymCmpOp::Ule, _, SymExprKind::Const(value)) if *value == U256::MAX => {
                 Self::constant(cx, true)
             }
@@ -170,15 +189,20 @@ impl SymBoolExpr {
         let mut out = Vec::new();
         for value in values {
             match value.kind() {
+                // `true && a => a`.
                 SymBoolExprKind::Const(true) => {}
+                // `false && a => false`.
                 SymBoolExprKind::Const(false) => return Self::constant(cx, false),
+                // `(a && b) && c => a && b && c`.
                 SymBoolExprKind::And(values) => out.extend(values.iter().cloned()),
                 _ => out.push(value),
             }
         }
         if out.is_empty() {
+            // `and() => true`.
             Self::constant(cx, true)
         } else if out.len() == 1 {
+            // `and(a) => a`.
             out.pop().expect("single item exists")
         } else {
             Self::from_kind(cx, SymBoolExprKind::And(out.into()))
@@ -189,16 +213,21 @@ impl SymBoolExpr {
         let mut out = Vec::new();
         for value in values {
             match value.kind() {
+                // `false || a => a`.
                 SymBoolExprKind::Const(false) => {}
+                // `true || a => true`.
                 SymBoolExprKind::Const(true) => return Self::constant(cx, true),
                 _ => out.push(value),
             }
         }
         if out.is_empty() {
+            // `or() => false`.
             Self::constant(cx, false)
         } else if out.len() == 1 {
+            // `or(a) => a`.
             out.pop().expect("single item exists")
         } else {
+            // `a || b => !(!a && !b)`.
             let values = out.into_iter().map(|value| Self::not_bool(cx, value)).collect();
             let and = Self::and(cx, values);
             Self::not_bool(cx, and)
@@ -207,7 +236,9 @@ impl SymBoolExpr {
 
     pub(crate) fn not_bool(cx: &mut SymCx, value: Self) -> Self {
         match value.kind() {
+            // `!const => const`.
             SymBoolExprKind::Const(value) => Self::constant(cx, !*value),
+            // `!!a => a`.
             SymBoolExprKind::Not(value) => value.clone(),
             _ => Self::from_kind(cx, SymBoolExprKind::Not(value)),
         }

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -78,6 +78,7 @@ impl SymBoolExpr {
                 if let Some(left_value) = left.known_word() {
                     return Self::constant(cx, left_value == *right_value);
                 }
+                let (left, right) = SymExpr::ordered_commutative_operands(left, right);
                 Self::from_kind(cx, SymBoolExprKind::Eq(left, right))
             }
             (SymExprKind::Const(left_value), _) => {
@@ -87,6 +88,7 @@ impl SymBoolExpr {
                 if let Some(right_value) = right.known_word() {
                     return Self::constant(cx, *left_value == right_value);
                 }
+                let (left, right) = SymExpr::ordered_commutative_operands(left, right);
                 Self::from_kind(cx, SymBoolExprKind::Eq(left, right))
             }
             (
@@ -115,7 +117,10 @@ impl SymBoolExpr {
                     .collect();
                 Self::and(cx, conditions)
             }
-            _ => Self::from_kind(cx, SymBoolExprKind::Eq(left, right)),
+            _ => {
+                let (left, right) = SymExpr::ordered_commutative_operands(left, right);
+                Self::from_kind(cx, SymBoolExprKind::Eq(left, right))
+            }
         }
     }
 
@@ -234,6 +239,22 @@ impl SymBoolExpr {
     pub(crate) fn as_const(&self) -> Option<bool> {
         match self.kind() {
             SymBoolExprKind::Const(value) => Some(*value),
+            _ => None,
+        }
+    }
+
+    pub(in crate::runtime) fn zero_check_operand(&self) -> Option<&SymExpr> {
+        match self.kind() {
+            SymBoolExprKind::Eq(left, right)
+                if right.as_const().is_some_and(|value| value.is_zero()) =>
+            {
+                Some(left)
+            }
+            SymBoolExprKind::Eq(left, right)
+                if left.as_const().is_some_and(|value| value.is_zero()) =>
+            {
+                Some(right)
+            }
             _ => None,
         }
     }

--- a/crates/evm/symbolic/src/runtime/expr/cx.rs
+++ b/crates/evm/symbolic/src/runtime/expr/cx.rs
@@ -124,4 +124,31 @@ mod tests {
 
         assert!(first.ptr_eq(&second));
     }
+
+    #[test]
+    fn simplifies_shift_right_over_or_at_construction() {
+        let mut cx = SymCx::new();
+        let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
+        let low = SymExpr::constant(&mut cx, U256::from(0xff));
+        let shift = SymExpr::constant(&mut cx, U256::from(8));
+        let high = SymExpr::op(&mut cx, SymExprOp::Shl, x.clone(), shift.clone());
+        let word = SymExpr::op(&mut cx, SymExprOp::Or, high, low);
+        let shifted = SymExpr::op(&mut cx, SymExprOp::Shr, word, shift);
+
+        assert_eq!(shifted, x);
+    }
+
+    #[test]
+    fn simplifies_masked_or_at_construction() {
+        let mut cx = SymCx::new();
+        let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
+        let y = SymExpr::var(&mut cx, "y").low_byte(&mut cx);
+        let shift = SymExpr::constant(&mut cx, U256::from(8));
+        let high = SymExpr::op(&mut cx, SymExprOp::Shl, x, shift);
+        let word = SymExpr::op(&mut cx, SymExprOp::Or, high, y.clone());
+        let mask = SymExpr::constant(&mut cx, U256::from(0xff));
+        let masked = SymExpr::op(&mut cx, SymExprOp::And, word, mask);
+
+        assert_eq!(masked, y);
+    }
 }

--- a/crates/evm/symbolic/src/runtime/expr/cx.rs
+++ b/crates/evm/symbolic/src/runtime/expr/cx.rs
@@ -107,8 +107,8 @@ mod tests {
         let x = SymExpr::var(&mut cx, "x");
         let y = SymExpr::var(&mut cx, "y");
 
-        let first = SymExpr::binop(&mut cx, SymExprBinOp::Add, x.clone(), y.clone());
-        let second = SymExpr::binop(&mut cx, SymExprBinOp::Add, x, y);
+        let first = SymExpr::binop(&mut cx, SymBinOp::Add, x.clone(), y.clone());
+        let second = SymExpr::binop(&mut cx, SymBinOp::Add, x, y);
 
         assert!(first.ptr_eq(&second));
     }
@@ -131,9 +131,9 @@ mod tests {
         let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
         let low = SymExpr::constant(&mut cx, U256::from(0xff));
         let shift = SymExpr::constant(&mut cx, U256::from(8));
-        let high = SymExpr::binop(&mut cx, SymExprBinOp::Shl, x.clone(), shift.clone());
-        let word = SymExpr::binop(&mut cx, SymExprBinOp::Or, high, low);
-        let shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shr, word, shift);
+        let high = SymExpr::binop(&mut cx, SymBinOp::Shl, x.clone(), shift.clone());
+        let word = SymExpr::binop(&mut cx, SymBinOp::Or, high, low);
+        let shifted = SymExpr::binop(&mut cx, SymBinOp::Shr, word, shift);
 
         assert_eq!(shifted, x);
     }
@@ -144,10 +144,10 @@ mod tests {
         let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
         let y = SymExpr::var(&mut cx, "y").low_byte(&mut cx);
         let shift = SymExpr::constant(&mut cx, U256::from(8));
-        let high = SymExpr::binop(&mut cx, SymExprBinOp::Shl, x, shift);
-        let word = SymExpr::binop(&mut cx, SymExprBinOp::Or, high, y.clone());
+        let high = SymExpr::binop(&mut cx, SymBinOp::Shl, x, shift);
+        let word = SymExpr::binop(&mut cx, SymBinOp::Or, high, y.clone());
         let mask = SymExpr::constant(&mut cx, U256::from(0xff));
-        let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, word, mask);
+        let masked = SymExpr::binop(&mut cx, SymBinOp::And, word, mask);
 
         assert_eq!(masked, y);
     }

--- a/crates/evm/symbolic/src/runtime/expr/cx.rs
+++ b/crates/evm/symbolic/src/runtime/expr/cx.rs
@@ -119,8 +119,8 @@ mod tests {
         let x = SymExpr::var(&mut cx, "x");
 
         let upper = SymExpr::constant(&mut cx, U256::from(7));
-        let first = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, x.clone(), upper.clone());
-        let second = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, x, upper);
+        let first = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), upper.clone());
+        let second = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, upper);
 
         assert!(first.ptr_eq(&second));
     }

--- a/crates/evm/symbolic/src/runtime/expr/cx.rs
+++ b/crates/evm/symbolic/src/runtime/expr/cx.rs
@@ -107,8 +107,8 @@ mod tests {
         let x = SymExpr::var(&mut cx, "x");
         let y = SymExpr::var(&mut cx, "y");
 
-        let first = SymExpr::op(&mut cx, SymExprOp::Add, x.clone(), y.clone());
-        let second = SymExpr::op(&mut cx, SymExprOp::Add, x, y);
+        let first = SymExpr::binop(&mut cx, SymExprBinOp::Add, x.clone(), y.clone());
+        let second = SymExpr::binop(&mut cx, SymExprBinOp::Add, x, y);
 
         assert!(first.ptr_eq(&second));
     }
@@ -131,9 +131,9 @@ mod tests {
         let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
         let low = SymExpr::constant(&mut cx, U256::from(0xff));
         let shift = SymExpr::constant(&mut cx, U256::from(8));
-        let high = SymExpr::op(&mut cx, SymExprOp::Shl, x.clone(), shift.clone());
-        let word = SymExpr::op(&mut cx, SymExprOp::Or, high, low);
-        let shifted = SymExpr::op(&mut cx, SymExprOp::Shr, word, shift);
+        let high = SymExpr::binop(&mut cx, SymExprBinOp::Shl, x.clone(), shift.clone());
+        let word = SymExpr::binop(&mut cx, SymExprBinOp::Or, high, low);
+        let shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shr, word, shift);
 
         assert_eq!(shifted, x);
     }
@@ -144,10 +144,10 @@ mod tests {
         let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
         let y = SymExpr::var(&mut cx, "y").low_byte(&mut cx);
         let shift = SymExpr::constant(&mut cx, U256::from(8));
-        let high = SymExpr::op(&mut cx, SymExprOp::Shl, x, shift);
-        let word = SymExpr::op(&mut cx, SymExprOp::Or, high, y.clone());
+        let high = SymExpr::binop(&mut cx, SymExprBinOp::Shl, x, shift);
+        let word = SymExpr::binop(&mut cx, SymExprBinOp::Or, high, y.clone());
         let mask = SymExpr::constant(&mut cx, U256::from(0xff));
-        let masked = SymExpr::op(&mut cx, SymExprOp::And, word, mask);
+        let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, word, mask);
 
         assert_eq!(masked, y);
     }

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -325,8 +325,7 @@ pub(in crate::runtime) enum SymExprKind {
     Hash { name: Symbol, algorithm: &'static str, bytes: Arc<[SymExpr]> },
     Not(SymExpr),
     BinOp(SymExprBinOp, SymExpr, SymExpr),
-    AddMod { left: SymExpr, right: SymExpr, modulus: SymExpr },
-    MulMod { left: SymExpr, right: SymExpr, modulus: SymExpr },
+    TernOp(SymExprTernOp, SymExpr, SymExpr, SymExpr),
     Ite(SymBoolExpr, SymExpr, SymExpr),
 }
 
@@ -563,36 +562,28 @@ impl SymExpr {
         }
     }
 
-    pub(crate) fn addmod(cx: &mut SymCx, left: Self, right: Self, modulus: Self) -> Self {
+    pub(crate) fn ternop(
+        cx: &mut SymCx,
+        ternop: SymExprTernOp,
+        left: Self,
+        right: Self,
+        modulus: Self,
+    ) -> Self {
         match (left.kind(), right.kind(), modulus.kind()) {
             (_, _, SymExprKind::Const(modulus))
                 if modulus.is_zero() || *modulus == U256::from(1) =>
             {
+                // `addmod/mulmod(a, b, 0) => 0`.
                 Self::zero(cx)
             }
             (SymExprKind::Const(left), SymExprKind::Const(right), SymExprKind::Const(modulus)) => {
-                Self::constant(cx, left.add_mod(*right, *modulus))
+                // `addmod/mulmod(const, const, const) => const`.
+                Self::constant(cx, ternop.eval(*left, *right, *modulus))
             }
             _ => {
+                // `addmod/mulmod(a, b, m) => addmod/mulmod(ordered(a, b), m)`.
                 let (left, right) = Self::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymExprKind::AddMod { left, right, modulus })
-            }
-        }
-    }
-
-    pub(crate) fn mulmod(cx: &mut SymCx, left: Self, right: Self, modulus: Self) -> Self {
-        match (left.kind(), right.kind(), modulus.kind()) {
-            (_, _, SymExprKind::Const(modulus))
-                if modulus.is_zero() || *modulus == U256::from(1) =>
-            {
-                Self::zero(cx)
-            }
-            (SymExprKind::Const(left), SymExprKind::Const(right), SymExprKind::Const(modulus)) => {
-                Self::constant(cx, left.mul_mod(*right, *modulus))
-            }
-            _ => {
-                let (left, right) = Self::ordered_commutative_operands(left, right);
-                Self::from_kind(cx, SymExprKind::MulMod { left, right, modulus })
+                Self::from_kind(cx, SymExprKind::TernOp(ternop, left, right, modulus))
             }
         }
     }
@@ -999,12 +990,11 @@ impl SymExpr {
             SymExprKind::BinOp(op, left, right) => {
                 op.eval(left.eval_model(model)?, right.eval_model(model)?)
             }
-            SymExprKind::AddMod { left, right, modulus } => left
-                .eval_model(model)?
-                .add_mod(right.eval_model(model)?, modulus.eval_model(model)?),
-            SymExprKind::MulMod { left, right, modulus } => left
-                .eval_model(model)?
-                .mul_mod(right.eval_model(model)?, modulus.eval_model(model)?),
+            SymExprKind::TernOp(op, left, right, modulus) => op.eval(
+                left.eval_model(model)?,
+                right.eval_model(model)?,
+                modulus.eval_model(model)?,
+            ),
             SymExprKind::Ite(cond, then_expr, else_expr) => {
                 if cond.eval_model(model)? {
                     then_expr.eval_model(model)?
@@ -1199,7 +1189,7 @@ impl SymExpr {
                 | SymExprBinOp::SRem
                 | SymExprBinOp::Sar => None,
             },
-            SymExprKind::AddMod { .. } | SymExprKind::MulMod { .. } => None,
+            SymExprKind::TernOp(_, _, _, _) => None,
         }
     }
 
@@ -1246,9 +1236,7 @@ impl SymExpr {
                 }
             }
             SymExprKind::BinOp(SymExprBinOp::UDiv, left, _) => left.unsigned_bits(),
-            SymExprKind::AddMod { modulus, .. } | SymExprKind::MulMod { modulus, .. } => {
-                modulus.unsigned_bits()
-            }
+            SymExprKind::TernOp(_, _, _, modulus) => modulus.unsigned_bits(),
             SymExprKind::Ite(_, left, right) => left.unsigned_bits().max(right.unsigned_bits()),
             _ => 256,
         }
@@ -1377,7 +1365,7 @@ impl SymExpr {
                 | SymExprBinOp::SRem
                 | SymExprBinOp::Sar => None,
             },
-            SymExprKind::AddMod { .. } | SymExprKind::MulMod { .. } => None,
+            SymExprKind::TernOp(_, _, _, _) => None,
         }
     }
 
@@ -1474,7 +1462,7 @@ impl SymExpr {
             {
                 value.nonzero_forces_const(target, context)
             }
-            SymExprKind::AddMod { .. } | SymExprKind::MulMod { .. } => None,
+            SymExprKind::TernOp(_, _, _, _) => None,
             SymExprKind::BinOp(_, _, _) => None,
         }
     }
@@ -1520,8 +1508,7 @@ impl SymExpr {
                 left.visit(visitor)?;
                 right.visit(visitor)?;
             }
-            SymExprKind::AddMod { left, right, modulus }
-            | SymExprKind::MulMod { left, right, modulus } => {
+            SymExprKind::TernOp(_, left, right, modulus) => {
                 left.visit(visitor)?;
                 right.visit(visitor)?;
                 modulus.visit(visitor)?;
@@ -1573,17 +1560,11 @@ impl SymExpr {
                 let right = right.fold(cx, folder);
                 Self::binop(cx, op, left, right)
             }
-            SymExprKind::AddMod { left, right, modulus } => {
+            SymExprKind::TernOp(op, left, right, modulus) => {
                 let left = left.fold(cx, folder);
                 let right = right.fold(cx, folder);
                 let modulus = modulus.fold(cx, folder);
-                Self::addmod(cx, left, right, modulus)
-            }
-            SymExprKind::MulMod { left, right, modulus } => {
-                let left = left.fold(cx, folder);
-                let right = right.fold(cx, folder);
-                let modulus = modulus.fold(cx, folder);
-                Self::mulmod(cx, left, right, modulus)
+                Self::ternop(cx, op, left, right, modulus)
             }
             SymExprKind::Ite(condition, then_expr, else_expr) => {
                 let condition = condition.fold_exprs(cx, folder);
@@ -1628,11 +1609,8 @@ impl SymExpr {
                 right.write_smt(out);
                 out.push(')');
             }
-            SymExprKind::AddMod { left, right, modulus } => {
-                write_smt_wide_modular_arithmetic(out, "bvadd", left, right, modulus);
-            }
-            SymExprKind::MulMod { left, right, modulus } => {
-                write_smt_wide_modular_arithmetic(out, "bvmul", left, right, modulus);
+            SymExprKind::TernOp(op, left, right, modulus) => {
+                write_smt_wide_modular_arithmetic(out, op.smt(), left, right, modulus);
             }
             SymExprKind::Ite(cond, left, right) => {
                 out.push_str("(ite ");
@@ -1669,6 +1647,31 @@ fn write_smt_wide_modular_arithmetic(
     out.push_str(")) ((_ zero_extend 256) ");
     modulus.write_smt(out);
     out.push_str("))))");
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum SymExprTernOp {
+    AddMod,
+    MulMod,
+}
+
+impl SymExprTernOp {
+    pub(crate) const fn smt(self) -> &'static str {
+        match self {
+            Self::AddMod => "bvadd",
+            Self::MulMod => "bvmul",
+        }
+    }
+
+    pub(crate) fn eval(self, left: U256, right: U256, modulus: U256) -> U256 {
+        if modulus.is_zero() {
+            return U256::ZERO;
+        }
+        match self {
+            Self::AddMod => left.add_mod(right, modulus),
+            Self::MulMod => left.mul_mod(right, modulus),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -221,17 +221,17 @@ impl SymExpr {
     fn storage_layout_key(&self, cx: &mut SymCx) -> Option<(Self, Self)> {
         match self.kind() {
             SymExprKind::Keccak { .. } => Some((self.clone(), Self::zero(cx))),
-            SymExprKind::BinOp(SymExprBinOp::Add, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Add, left, right) => {
                 if let Some((base, offset)) = left.storage_layout_key(cx)
                     && !right.contains_keccak()
                 {
-                    let offset = Self::binop(cx, SymExprBinOp::Add, offset, right.clone());
+                    let offset = Self::binop(cx, SymBinOp::Add, offset, right.clone());
                     return Some((base, offset));
                 }
                 if let Some((base, offset)) = right.storage_layout_key(cx)
                     && !left.contains_keccak()
                 {
-                    let offset = Self::binop(cx, SymExprBinOp::Add, offset, left.clone());
+                    let offset = Self::binop(cx, SymBinOp::Add, offset, left.clone());
                     return Some((base, offset));
                 }
                 None
@@ -243,8 +243,8 @@ impl SymExpr {
 
 fn masked_expr_matches(candidate: &SymExprKind, target: &SymExpr) -> Option<U256> {
     match candidate {
-        SymExprKind::BinOp(SymExprBinOp::And, left, right) if left == target => right.eval(),
-        SymExprKind::BinOp(SymExprBinOp::And, left, right) if right == target => left.eval(),
+        SymExprKind::BinOp(SymBinOp::And, left, right) if left == target => right.eval(),
+        SymExprKind::BinOp(SymBinOp::And, left, right) if right == target => left.eval(),
         _ => None,
     }
 }
@@ -324,8 +324,8 @@ pub(in crate::runtime) enum SymExprKind {
     Keccak { name: Symbol, len: SymExpr, bytes: Arc<[SymExpr]> },
     Hash { name: Symbol, algorithm: &'static str, bytes: Arc<[SymExpr]> },
     Not(SymExpr),
-    BinOp(SymExprBinOp, SymExpr, SymExpr),
-    TernOp(SymExprTernOp, SymExpr, SymExpr, SymExpr),
+    BinOp(SymBinOp, SymExpr, SymExpr),
+    TernOp(SymTernOp, SymExpr, SymExpr, SymExpr),
     Ite(SymBoolExpr, SymExpr, SymExpr),
 }
 
@@ -415,9 +415,9 @@ impl SymExpr {
         }
     }
 
-    pub(crate) fn binop(cx: &mut SymCx, binop: SymExprBinOp, left: Self, right: Self) -> Self {
+    pub(crate) fn binop(cx: &mut SymCx, binop: SymBinOp, left: Self, right: Self) -> Self {
         match binop {
-            SymExprBinOp::Add => match (left.kind(), right.kind()) {
+            SymBinOp::Add => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const + const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -428,7 +428,7 @@ impl SymExpr {
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
                 _ => Self::commutative_binop(cx, binop, left, right),
             },
-            SymExprBinOp::Sub => match (left.kind(), right.kind()) {
+            SymBinOp::Sub => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const - const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -439,7 +439,7 @@ impl SymExpr {
                 _ if left == right => Self::zero(cx),
                 _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprBinOp::Mul => match (left.kind(), right.kind()) {
+            SymBinOp::Mul => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const * const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -456,7 +456,7 @@ impl SymExpr {
                 (_, SymExprKind::Const(value)) if *value == U256::from(1) => left,
                 _ => Self::commutative_binop(cx, binop, left, right),
             },
-            SymExprBinOp::UDiv | SymExprBinOp::SDiv => match (left.kind(), right.kind()) {
+            SymBinOp::UDiv | SymBinOp::SDiv => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const / const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -467,7 +467,7 @@ impl SymExpr {
                 (_, SymExprKind::Const(value)) if *value == U256::from(1) => left,
                 _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprBinOp::URem | SymExprBinOp::SRem => match (left.kind(), right.kind()) {
+            SymBinOp::URem | SymBinOp::SRem => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const % const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -478,7 +478,7 @@ impl SymExpr {
                 (_, SymExprKind::Const(value)) if *value == U256::from(1) => Self::zero(cx),
                 _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprBinOp::And => match (left.kind(), right.kind()) {
+            SymBinOp::And => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const & const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -499,7 +499,7 @@ impl SymExpr {
                 (_, SymExprKind::Const(mask)) => Self::and_const(cx, left, *mask),
                 _ => Self::commutative_binop(cx, binop, left, right),
             },
-            SymExprBinOp::Or => match (left.kind(), right.kind()) {
+            SymBinOp::Or => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const | const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -512,7 +512,7 @@ impl SymExpr {
                 _ if left == right => left,
                 _ => Self::or(cx, left, right),
             },
-            SymExprBinOp::Xor => match (left.kind(), right.kind()) {
+            SymBinOp::Xor => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const ^ const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -525,7 +525,7 @@ impl SymExpr {
                 _ if left == right => Self::zero(cx),
                 _ => Self::commutative_binop(cx, binop, left, right),
             },
-            SymExprBinOp::Shl => match (left.kind(), right.kind()) {
+            SymBinOp::Shl => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const << const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -538,7 +538,7 @@ impl SymExpr {
                 (_, SymExprKind::Const(value)) if *value >= U256::from(256) => Self::zero(cx),
                 _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprBinOp::Shr => match (left.kind(), right.kind()) {
+            SymBinOp::Shr => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const >> const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -550,7 +550,7 @@ impl SymExpr {
                 (_, SymExprKind::Const(value)) => Self::shr_const(cx, left, *value),
                 _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprBinOp::Sar => match (left.kind(), right.kind()) {
+            SymBinOp::Sar => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     // `const >>s const => const`.
                     Self::constant(cx, binop.eval(*left_value, *right_value))
@@ -564,7 +564,7 @@ impl SymExpr {
 
     pub(crate) fn ternop(
         cx: &mut SymCx,
-        ternop: SymExprTernOp,
+        ternop: SymTernOp,
         left: Self,
         right: Self,
         modulus: Self,
@@ -654,10 +654,10 @@ impl SymExpr {
             // `byte_parts(a) | byte_parts(a) => a`.
             return rebuilt;
         }
-        Self::commutative_binop(cx, SymExprBinOp::Or, left, right)
+        Self::commutative_binop(cx, SymBinOp::Or, left, right)
     }
 
-    fn commutative_binop(cx: &mut SymCx, op: SymExprBinOp, left: Self, right: Self) -> Self {
+    fn commutative_binop(cx: &mut SymCx, op: SymBinOp, left: Self, right: Self) -> Self {
         // `a + b => b + a`.
         let (left, right) = Self::ordered_commutative_operands(left, right);
         Self::from_kind(cx, SymExprKind::BinOp(op, left, right))
@@ -687,13 +687,13 @@ impl SymExpr {
         match expr.kind() {
             // `const & mask => const`.
             SymExprKind::Const(value) => Self::constant(cx, *value & mask),
-            SymExprKind::BinOp(SymExprBinOp::Or, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Or, left, right) => {
                 // `(a | b) & mask => (a & mask) | (b & mask)`.
                 let left = Self::and_const(cx, left.clone(), mask);
                 let right = Self::and_const(cx, right.clone(), mask);
-                Self::binop(cx, SymExprBinOp::Or, left, right)
+                Self::binop(cx, SymBinOp::Or, left, right)
             }
-            SymExprKind::BinOp(SymExprBinOp::Shl, _, shift)
+            SymExprKind::BinOp(SymBinOp::Shl, _, shift)
                 if mask_low_bits(mask).is_some_and(|bits| {
                     shift
                         .as_const()
@@ -704,8 +704,7 @@ impl SymExpr {
                 // `(a << n) & low_mask(n) => 0`.
                 Self::zero(cx)
             }
-            SymExprKind::BinOp(SymExprBinOp::And, left, right) => match (left.kind(), right.kind())
-            {
+            SymExprKind::BinOp(SymBinOp::And, left, right) => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(value), _) if *value == mask => {
                     // `(mask & a) & mask => a & mask`.
                     Self::and_const(cx, right.clone(), mask)
@@ -718,12 +717,12 @@ impl SymExpr {
                 _ if left == right => Self::and_const(cx, left.clone(), mask),
                 _ => {
                     let mask = Self::constant(cx, mask);
-                    Self::from_kind(cx, SymExprKind::BinOp(SymExprBinOp::And, expr, mask))
+                    Self::from_kind(cx, SymExprKind::BinOp(SymBinOp::And, expr, mask))
                 }
             },
             _ => {
                 let mask = Self::constant(cx, mask);
-                Self::from_kind(cx, SymExprKind::BinOp(SymExprBinOp::And, expr, mask))
+                Self::from_kind(cx, SymExprKind::BinOp(SymBinOp::And, expr, mask))
             }
         }
     }
@@ -744,7 +743,7 @@ impl SymExpr {
             return Self::zero(cx);
         }
 
-        if let SymExprKind::BinOp(SymExprBinOp::Shl, inner, left_shift) = expr.kind()
+        if let SymExprKind::BinOp(SymBinOp::Shl, inner, left_shift) = expr.kind()
             && left_shift.as_const() == Some(U256::from(shift))
             && inner.unsigned_bits() <= 256 - shift
         {
@@ -752,15 +751,15 @@ impl SymExpr {
             return inner.clone();
         }
 
-        if let SymExprKind::BinOp(SymExprBinOp::Or, left, right) = expr.kind() {
+        if let SymExprKind::BinOp(SymBinOp::Or, left, right) = expr.kind() {
             // `(a | b) >> n => (a >> n) | (b >> n)`.
             let left = Self::shr_const(cx, left.clone(), U256::from(shift));
             let right = Self::shr_const(cx, right.clone(), U256::from(shift));
-            return Self::binop(cx, SymExprBinOp::Or, left, right);
+            return Self::binop(cx, SymBinOp::Or, left, right);
         }
 
         let shift = Self::constant(cx, U256::from(shift));
-        Self::from_kind(cx, SymExprKind::BinOp(SymExprBinOp::Shr, expr, shift))
+        Self::from_kind(cx, SymExprKind::BinOp(SymBinOp::Shr, expr, shift))
     }
 
     fn rebuild_from_or_terms(left: &Self, right: &Self) -> Option<Self> {
@@ -773,7 +772,7 @@ impl SymExpr {
 
     pub(in crate::runtime) fn push_or_terms<'a>(&'a self, terms: &mut Vec<&'a Self>) {
         match self.kind() {
-            SymExprKind::BinOp(SymExprBinOp::Or, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Or, left, right) => {
                 left.push_or_terms(terms);
                 right.push_or_terms(terms);
             }
@@ -812,7 +811,7 @@ impl SymExpr {
 
     fn extracted_shifted_byte_term(&self) -> Option<(Self, usize)> {
         match self.kind() {
-            SymExprKind::BinOp(SymExprBinOp::Shl, byte, shift) => {
+            SymExprKind::BinOp(SymBinOp::Shl, byte, shift) => {
                 let shift = shift.as_const()?;
                 let Ok(shift) = usize::try_from(shift) else { return None };
                 if shift % 8 != 0 || shift > 248 {
@@ -831,7 +830,7 @@ impl SymExpr {
         if index == 31 {
             return Some(expr.clone());
         }
-        let SymExprKind::BinOp(SymExprBinOp::Shr, source, shift) = expr.kind() else { return None };
+        let SymExprKind::BinOp(SymBinOp::Shr, source, shift) = expr.kind() else { return None };
         let shift = shift.as_const()?;
         (shift == U256::from((31 - index) * 8)).then(|| source.clone())
     }
@@ -857,7 +856,7 @@ impl SymExpr {
     }
 
     fn low_word_fragment(&self) -> Option<(Self, usize)> {
-        let SymExprKind::BinOp(SymExprBinOp::And, left, right) = self.kind() else { return None };
+        let SymExprKind::BinOp(SymBinOp::And, left, right) = self.kind() else { return None };
         if let Some(mask) = right.as_const() {
             return mask_low_bits(mask).map(|bits| (left.clone(), bits));
         }
@@ -866,7 +865,7 @@ impl SymExpr {
     }
 
     fn shifted_high_word_fragment(&self) -> Option<(Self, usize)> {
-        let SymExprKind::BinOp(SymExprBinOp::Shl, value, shift) = self.kind() else { return None };
+        let SymExprKind::BinOp(SymBinOp::Shl, value, shift) = self.kind() else { return None };
         let bits = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
         if bits == 0 || bits >= 256 {
             return None;
@@ -877,7 +876,7 @@ impl SymExpr {
     }
 
     fn shifted_low_fragment_source(&self) -> Option<(Self, usize, usize)> {
-        let SymExprKind::BinOp(SymExprBinOp::And, left, right) = self.kind() else { return None };
+        let SymExprKind::BinOp(SymBinOp::And, left, right) = self.kind() else { return None };
         if let Some(mask) = right.as_const() {
             return Self::shifted_low_fragment_source_with_mask(left, mask);
         }
@@ -891,7 +890,7 @@ impl SymExpr {
     ) -> Option<(Self, usize, usize)> {
         let width = mask_low_bits(mask)?;
         match value.kind() {
-            SymExprKind::BinOp(SymExprBinOp::Shr, source, shift) => {
+            SymExprKind::BinOp(SymBinOp::Shr, source, shift) => {
                 let shift = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
                 Some((source.clone(), shift, width))
             }
@@ -904,7 +903,7 @@ impl SymExpr {
             return Self::constant(cx, U256::from(word.to::<u8>()));
         }
         let mask = Self::constant(cx, U256::from(0xff));
-        Self::binop(cx, SymExprBinOp::And, self, mask)
+        Self::binop(cx, SymBinOp::And, self, mask)
     }
 
     pub(crate) fn into_byte_exprs(self, cx: &mut SymCx) -> Vec<Self> {
@@ -937,9 +936,9 @@ impl SymExpr {
                 byte
             } else {
                 let shift = Self::constant(cx, U256::from(shift));
-                Self::binop(cx, SymExprBinOp::Shl, byte, shift)
+                Self::binop(cx, SymBinOp::Shl, byte, shift)
             };
-            expr = Self::binop(cx, SymExprBinOp::Or, expr, byte);
+            expr = Self::binop(cx, SymBinOp::Or, expr, byte);
         }
         expr
     }
@@ -1106,7 +1105,7 @@ impl SymExpr {
     }
 
     pub(crate) fn contains_udiv(&self) -> bool {
-        self.visit_bool(|expr| matches!(expr.kind(), SymExprKind::BinOp(SymExprBinOp::UDiv, _, _)))
+        self.visit_bool(|expr| matches!(expr.kind(), SymExprKind::BinOp(SymBinOp::UDiv, _, _)))
     }
 
     pub(crate) fn contains_ite(&self) -> bool {
@@ -1115,7 +1114,7 @@ impl SymExpr {
 
     pub(in crate::runtime) fn udiv_operands(&self) -> Option<(&Self, &Self)> {
         match self.kind() {
-            SymExprKind::BinOp(SymExprBinOp::UDiv, numerator, denominator) => {
+            SymExprKind::BinOp(SymBinOp::UDiv, numerator, denominator) => {
                 Some((numerator, denominator))
             }
             _ => None,
@@ -1149,14 +1148,14 @@ impl SymExpr {
                 (then_byte == else_byte).then_some(then_byte)
             }
             SymExprKind::BinOp(op, left, right) => match op {
-                SymExprBinOp::And => match (left.known_byte(index), right.known_byte(index)) {
+                SymBinOp::And => match (left.known_byte(index), right.known_byte(index)) {
                     (Some(left), Some(right)) => Some(left & right),
                     (Some(0), _) | (_, Some(0)) => Some(0),
                     _ => None,
                 },
-                SymExprBinOp::Or => Some(left.known_byte(index)? | right.known_byte(index)?),
-                SymExprBinOp::Xor => Some(left.known_byte(index)? ^ right.known_byte(index)?),
-                SymExprBinOp::Shl => {
+                SymBinOp::Or => Some(left.known_byte(index)? | right.known_byte(index)?),
+                SymBinOp::Xor => Some(left.known_byte(index)? ^ right.known_byte(index)?),
+                SymBinOp::Shl => {
                     let shift = right.as_const()?;
                     if shift >= U256::from(256) {
                         return Some(0);
@@ -1168,7 +1167,7 @@ impl SymExpr {
                     let source_index = index + shift / 8;
                     if source_index >= 32 { Some(0) } else { left.known_byte(source_index) }
                 }
-                SymExprBinOp::Shr => {
+                SymBinOp::Shr => {
                     let shift = right.as_const()?;
                     if shift >= U256::from(256) {
                         return Some(0);
@@ -1180,14 +1179,14 @@ impl SymExpr {
                     let byte_shift = shift / 8;
                     if index < byte_shift { Some(0) } else { left.known_byte(index - byte_shift) }
                 }
-                SymExprBinOp::Add
-                | SymExprBinOp::Sub
-                | SymExprBinOp::Mul
-                | SymExprBinOp::UDiv
-                | SymExprBinOp::URem
-                | SymExprBinOp::SDiv
-                | SymExprBinOp::SRem
-                | SymExprBinOp::Sar => None,
+                SymBinOp::Add
+                | SymBinOp::Sub
+                | SymBinOp::Mul
+                | SymBinOp::UDiv
+                | SymBinOp::URem
+                | SymBinOp::SDiv
+                | SymBinOp::SRem
+                | SymBinOp::Sar => None,
             },
             SymExprKind::TernOp(_, _, _, _) => None,
         }
@@ -1204,7 +1203,7 @@ impl SymExpr {
     pub(crate) fn unsigned_bits(&self) -> usize {
         match self.kind() {
             SymExprKind::Const(value) => value.bit_len().max(1),
-            SymExprKind::BinOp(SymExprBinOp::And, left, right) => {
+            SymExprKind::BinOp(SymBinOp::And, left, right) => {
                 if let Some(mask) = right.as_const() {
                     left.unsigned_bits().min(mask.bit_len())
                 } else if let Some(mask) = left.as_const() {
@@ -1213,13 +1212,13 @@ impl SymExpr {
                     256
                 }
             }
-            SymExprKind::BinOp(SymExprBinOp::Add, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Add, left, right) => {
                 left.unsigned_bits().max(right.unsigned_bits()).saturating_add(1).min(256)
             }
-            SymExprKind::BinOp(SymExprBinOp::Mul, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Mul, left, right) => {
                 left.unsigned_bits().saturating_add(right.unsigned_bits()).min(256)
             }
-            SymExprKind::BinOp(SymExprBinOp::Shl, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Shl, left, right) => {
                 if let Some(shift) = right.as_const().and_then(|shift| usize::try_from(shift).ok())
                 {
                     left.unsigned_bits().saturating_add(shift).min(256)
@@ -1227,7 +1226,7 @@ impl SymExpr {
                     256
                 }
             }
-            SymExprKind::BinOp(SymExprBinOp::Shr, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Shr, left, right) => {
                 if let Some(shift) = right.as_const().and_then(|shift| usize::try_from(shift).ok())
                 {
                     left.unsigned_bits().saturating_sub(shift).max(1)
@@ -1235,7 +1234,7 @@ impl SymExpr {
                     256
                 }
             }
-            SymExprKind::BinOp(SymExprBinOp::UDiv, left, _) => left.unsigned_bits(),
+            SymExprKind::BinOp(SymBinOp::UDiv, left, _) => left.unsigned_bits(),
             SymExprKind::TernOp(_, _, _, modulus) => modulus.unsigned_bits(),
             SymExprKind::Ite(_, left, right) => left.unsigned_bits().max(right.unsigned_bits()),
             _ => 256,
@@ -1245,9 +1244,9 @@ impl SymExpr {
     pub(crate) fn extracted_byte(&self, cx: &mut SymCx, index: usize) -> Self {
         debug_assert!(index < 32);
         let shift = Self::constant(cx, U256::from((31 - index) * 8));
-        let shifted = Self::binop(cx, SymExprBinOp::Shr, self.clone(), shift);
+        let shifted = Self::binop(cx, SymBinOp::Shr, self.clone(), shift);
         let mask = Self::constant(cx, U256::from(0xff));
-        Self::binop(cx, SymExprBinOp::And, shifted, mask)
+        Self::binop(cx, SymBinOp::And, shifted, mask)
     }
 
     pub(crate) fn extracted_byte_source(&self, index: usize) -> Option<Self> {
@@ -1255,19 +1254,19 @@ impl SymExpr {
         if index == 31 {
             return Some(expr.clone());
         }
-        let SymExprKind::BinOp(SymExprBinOp::Shr, source, shift) = expr.kind() else { return None };
+        let SymExprKind::BinOp(SymBinOp::Shr, source, shift) = expr.kind() else { return None };
         let shift = shift.as_const()?;
         (shift == U256::from((31 - index) * 8)).then(|| source.clone())
     }
 
     pub(crate) fn strip_low_byte_mask(&self) -> &Self {
         match self.kind() {
-            SymExprKind::BinOp(SymExprBinOp::And, left, right)
+            SymExprKind::BinOp(SymBinOp::And, left, right)
                 if right.as_const() == Some(U256::from(0xff)) =>
             {
                 left.strip_low_byte_mask()
             }
-            SymExprKind::BinOp(SymExprBinOp::And, left, right)
+            SymExprKind::BinOp(SymBinOp::And, left, right)
                 if left.as_const() == Some(U256::from(0xff)) =>
             {
                 right.strip_low_byte_mask()
@@ -1297,34 +1296,34 @@ impl SymExpr {
                 Some(Self::ite(cx, cond.clone(), then_expr, else_expr))
             }
             SymExprKind::BinOp(op, left, right) => match op {
-                SymExprBinOp::And => Self::binary_byte_term(
+                SymBinOp::And => Self::binary_byte_term(
                     cx,
                     left,
                     right,
                     index,
-                    SymExprBinOp::And,
+                    SymBinOp::And,
                     |byte| byte == 0xff,
                     |byte| byte == 0,
                 ),
-                SymExprBinOp::Or => Self::binary_byte_term(
+                SymBinOp::Or => Self::binary_byte_term(
                     cx,
                     left,
                     right,
                     index,
-                    SymExprBinOp::Or,
+                    SymBinOp::Or,
                     |byte| byte == 0,
                     |_| false,
                 ),
-                SymExprBinOp::Xor => Self::binary_byte_term(
+                SymBinOp::Xor => Self::binary_byte_term(
                     cx,
                     left,
                     right,
                     index,
-                    SymExprBinOp::Xor,
+                    SymBinOp::Xor,
                     |byte| byte == 0,
                     |_| false,
                 ),
-                SymExprBinOp::Shl => {
+                SymBinOp::Shl => {
                     let shift = right.eval()?;
                     if shift >= U256::from(256) {
                         return Some(Self::zero(cx));
@@ -1340,7 +1339,7 @@ impl SymExpr {
                         left.byte_term(cx, source_index)
                     }
                 }
-                SymExprBinOp::Shr => {
+                SymBinOp::Shr => {
                     let shift = right.eval()?;
                     if shift >= U256::from(256) {
                         return Some(Self::zero(cx));
@@ -1356,14 +1355,14 @@ impl SymExpr {
                         left.byte_term(cx, index - byte_shift)
                     }
                 }
-                SymExprBinOp::Add
-                | SymExprBinOp::Sub
-                | SymExprBinOp::Mul
-                | SymExprBinOp::UDiv
-                | SymExprBinOp::URem
-                | SymExprBinOp::SDiv
-                | SymExprBinOp::SRem
-                | SymExprBinOp::Sar => None,
+                SymBinOp::Add
+                | SymBinOp::Sub
+                | SymBinOp::Mul
+                | SymBinOp::UDiv
+                | SymBinOp::URem
+                | SymBinOp::SDiv
+                | SymBinOp::SRem
+                | SymBinOp::Sar => None,
             },
             SymExprKind::TernOp(_, _, _, _) => None,
         }
@@ -1374,7 +1373,7 @@ impl SymExpr {
         left: &Self,
         right: &Self,
         index: usize,
-        op: SymExprBinOp,
+        op: SymBinOp,
         identity: impl Fn(u8) -> bool,
         absorbing: impl Fn(u8) -> bool,
     ) -> Option<Self> {
@@ -1439,7 +1438,7 @@ impl SymExpr {
                     None
                 }
             }
-            SymExprKind::BinOp(SymExprBinOp::Or, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Or, left, right) => {
                 if left.eval().is_some_and(|value| value.is_zero()) {
                     return right.nonzero_forces_const(target, context);
                 }
@@ -1448,7 +1447,7 @@ impl SymExpr {
                 }
                 None
             }
-            SymExprKind::BinOp(SymExprBinOp::And, left, right) => {
+            SymExprKind::BinOp(SymBinOp::And, left, right) => {
                 if left.eval().is_some_and(|value| !value.is_zero()) {
                     return right.nonzero_forces_const(target, context);
                 }
@@ -1457,7 +1456,7 @@ impl SymExpr {
                 }
                 None
             }
-            SymExprKind::BinOp(SymExprBinOp::Shl | SymExprBinOp::Shr, value, shift)
+            SymExprKind::BinOp(SymBinOp::Shl | SymBinOp::Shr, value, shift)
                 if shift.eval().is_some_and(|shift| shift.is_zero()) =>
             {
                 value.nonzero_forces_const(target, context)
@@ -1479,7 +1478,7 @@ impl SymExpr {
             SymExprKind::Const(expr) => Self::constant(cx, expr.wrapping_add(value)),
             _ => {
                 let value = Self::constant(cx, value);
-                Self::binop(cx, SymExprBinOp::Add, expr, value)
+                Self::binop(cx, SymBinOp::Add, expr, value)
             }
         }
     }
@@ -1650,12 +1649,12 @@ fn write_smt_wide_modular_arithmetic(
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum SymExprTernOp {
+pub(crate) enum SymTernOp {
     AddMod,
     MulMod,
 }
 
-impl SymExprTernOp {
+impl SymTernOp {
     pub(crate) const fn smt(self) -> &'static str {
         match self {
             Self::AddMod => "bvadd",
@@ -1675,7 +1674,7 @@ impl SymExprTernOp {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum SymExprBinOp {
+pub(crate) enum SymBinOp {
     Add,
     Sub,
     Mul,
@@ -1691,7 +1690,7 @@ pub(crate) enum SymExprBinOp {
     Sar,
 }
 
-impl SymExprBinOp {
+impl SymBinOp {
     pub(crate) const fn smt(self) -> &'static str {
         match self {
             Self::Add => "bvadd",

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -221,17 +221,17 @@ impl SymExpr {
     fn storage_layout_key(&self, cx: &mut SymCx) -> Option<(Self, Self)> {
         match self.kind() {
             SymExprKind::Keccak { .. } => Some((self.clone(), Self::zero(cx))),
-            SymExprKind::Op(SymExprOp::Add, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Add, left, right) => {
                 if let Some((base, offset)) = left.storage_layout_key(cx)
                     && !right.contains_keccak()
                 {
-                    let offset = Self::op(cx, SymExprOp::Add, offset, right.clone());
+                    let offset = Self::binop(cx, SymExprBinOp::Add, offset, right.clone());
                     return Some((base, offset));
                 }
                 if let Some((base, offset)) = right.storage_layout_key(cx)
                     && !left.contains_keccak()
                 {
-                    let offset = Self::op(cx, SymExprOp::Add, offset, left.clone());
+                    let offset = Self::binop(cx, SymExprBinOp::Add, offset, left.clone());
                     return Some((base, offset));
                 }
                 None
@@ -243,8 +243,8 @@ impl SymExpr {
 
 fn masked_expr_matches(candidate: &SymExprKind, target: &SymExpr) -> Option<U256> {
     match candidate {
-        SymExprKind::Op(SymExprOp::And, left, right) if left == target => right.eval(),
-        SymExprKind::Op(SymExprOp::And, left, right) if right == target => left.eval(),
+        SymExprKind::BinOp(SymExprBinOp::And, left, right) if left == target => right.eval(),
+        SymExprKind::BinOp(SymExprBinOp::And, left, right) if right == target => left.eval(),
         _ => None,
     }
 }
@@ -324,7 +324,7 @@ pub(in crate::runtime) enum SymExprKind {
     Keccak { name: Symbol, len: SymExpr, bytes: Arc<[SymExpr]> },
     Hash { name: Symbol, algorithm: &'static str, bytes: Arc<[SymExpr]> },
     Not(SymExpr),
-    Op(SymExprOp, SymExpr, SymExpr),
+    BinOp(SymExprBinOp, SymExpr, SymExpr),
     AddMod { left: SymExpr, right: SymExpr, modulus: SymExpr },
     MulMod { left: SymExpr, right: SymExpr, modulus: SymExpr },
     Ite(SymBoolExpr, SymExpr, SymExpr),
@@ -416,111 +416,149 @@ impl SymExpr {
         }
     }
 
-    pub(crate) fn op(cx: &mut SymCx, op: SymExprOp, left: Self, right: Self) -> Self {
-        match op {
-            SymExprOp::Add => match (left.kind(), right.kind()) {
+    pub(crate) fn binop(cx: &mut SymCx, binop: SymExprBinOp, left: Self, right: Self) -> Self {
+        match binop {
+            SymExprBinOp::Add => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const + const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `0 + a => a`.
                 (SymExprKind::Const(value), _) if value.is_zero() => right,
+                // `a + 0 => a`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
-                _ => Self::commutative_op(cx, op, left, right),
+                _ => Self::commutative_binop(cx, binop, left, right),
             },
-            SymExprOp::Sub => match (left.kind(), right.kind()) {
+            SymExprBinOp::Sub => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const - const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `a - 0 => a`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
+                // `a - a => 0`.
                 _ if left == right => Self::zero(cx),
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprOp::Mul => match (left.kind(), right.kind()) {
+            SymExprBinOp::Mul => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const * const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `0 * a => 0`.
                 (SymExprKind::Const(value), _) | (_, SymExprKind::Const(value))
                     if value.is_zero() =>
                 {
                     Self::zero(cx)
                 }
+                // `1 * a => a`.
                 (SymExprKind::Const(value), _) if *value == U256::from(1) => right,
+                // `a * 1 => a`.
                 (_, SymExprKind::Const(value)) if *value == U256::from(1) => left,
-                _ => Self::commutative_op(cx, op, left, right),
+                _ => Self::commutative_binop(cx, binop, left, right),
             },
-            SymExprOp::UDiv | SymExprOp::SDiv => match (left.kind(), right.kind()) {
+            SymExprBinOp::UDiv | SymExprBinOp::SDiv => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const / const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `a / 0 => 0`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => Self::zero(cx),
+                // `a / 1 => a`.
                 (_, SymExprKind::Const(value)) if *value == U256::from(1) => left,
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprOp::URem | SymExprOp::SRem => match (left.kind(), right.kind()) {
+            SymExprBinOp::URem | SymExprBinOp::SRem => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const % const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `a % 0 => 0`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => Self::zero(cx),
+                // `a % 1 => 0`.
                 (_, SymExprKind::Const(value)) if *value == U256::from(1) => Self::zero(cx),
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprOp::And => match (left.kind(), right.kind()) {
+            SymExprBinOp::And => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const & const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `0 & a => 0`.
                 (SymExprKind::Const(value), _) | (_, SymExprKind::Const(value))
                     if value.is_zero() =>
                 {
                     Self::zero(cx)
                 }
+                // `MAX & a => a`.
                 (SymExprKind::Const(value), _) if *value == U256::MAX => right,
+                // `a & MAX => a`.
                 (_, SymExprKind::Const(value)) if *value == U256::MAX => left,
+                // `a & a => a`.
                 _ if left == right => left,
                 (SymExprKind::Const(mask), _) => Self::and_const(cx, right, *mask),
                 (_, SymExprKind::Const(mask)) => Self::and_const(cx, left, *mask),
-                _ => Self::commutative_op(cx, op, left, right),
+                _ => Self::commutative_binop(cx, binop, left, right),
             },
-            SymExprOp::Or => match (left.kind(), right.kind()) {
+            SymExprBinOp::Or => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const | const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `0 | a => a`.
                 (SymExprKind::Const(value), _) if value.is_zero() => right,
+                // `a | 0 => a`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
+                // `a | a => a`.
                 _ if left == right => left,
                 _ => Self::or(cx, left, right),
             },
-            SymExprOp::Xor => match (left.kind(), right.kind()) {
+            SymExprBinOp::Xor => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const ^ const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `0 ^ a => a`.
                 (SymExprKind::Const(value), _) if value.is_zero() => right,
+                // `a ^ 0 => a`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
+                // `a ^ a => 0`.
                 _ if left == right => Self::zero(cx),
-                _ => Self::commutative_op(cx, op, left, right),
+                _ => Self::commutative_binop(cx, binop, left, right),
             },
-            SymExprOp::Shl => match (left.kind(), right.kind()) {
+            SymExprBinOp::Shl => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const << const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `a << 0 => a`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
+                // `0 << a => 0`.
                 (SymExprKind::Const(value), _) if value.is_zero() => Self::zero(cx),
+                // `a << 256 => 0`.
                 (_, SymExprKind::Const(value)) if *value >= U256::from(256) => Self::zero(cx),
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprOp::Shr => match (left.kind(), right.kind()) {
+            SymExprBinOp::Shr => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const >> const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `a >> 0 => a`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
+                // `0 >> a => 0`.
                 (SymExprKind::Const(value), _) if value.is_zero() => Self::zero(cx),
                 (_, SymExprKind::Const(value)) => Self::shr_const(cx, left, *value),
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
-            SymExprOp::Sar => match (left.kind(), right.kind()) {
+            SymExprBinOp::Sar => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
-                    Self::constant(cx, op.eval(*left_value, *right_value))
+                    // `const >>s const => const`.
+                    Self::constant(cx, binop.eval(*left_value, *right_value))
                 }
+                // `a >>s 0 => a`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ => Self::from_kind(cx, SymExprKind::BinOp(binop, left, right)),
             },
         }
     }
@@ -566,20 +604,26 @@ impl SymExpr {
         else_expr: Self,
     ) -> Self {
         match condition.as_const() {
+            // `ite(true, a, b) => a`.
             Some(true) => then_expr,
+            // `ite(false, a, b) => b`.
             Some(false) => else_expr,
+            // `ite(c, a, a) => a`.
             None if then_expr == else_expr => then_expr,
+            // `ite(a == 0, 0, a / a) => a != 0`.
             None if then_expr.as_const().is_some_and(|value| value.is_zero())
                 && Self::self_div_expr_matches_zero_check(&condition, &else_expr) =>
             {
                 let condition = condition.not(cx);
                 Self::bool_word(cx, condition)
             }
+            // `ite(c, 1, bool_word(c)) => bool_word(c)`.
             None if then_expr.as_const() == Some(U256::from(1))
                 && else_expr.bool_word_condition().as_ref() == Some(&condition) =>
             {
                 else_expr
             }
+            // `ite(c, bool_word(c), 0) => bool_word(c)`.
             None if else_expr.as_const().is_some_and(|value| value.is_zero())
                 && then_expr.bool_word_condition().as_ref() == Some(&condition) =>
             {
@@ -616,14 +660,16 @@ impl SymExpr {
 
     fn or(cx: &mut SymCx, left: Self, right: Self) -> Self {
         if let Some(rebuilt) = Self::rebuild_from_or_terms(&left, &right) {
+            // `byte_parts(a) | byte_parts(a) => a`.
             return rebuilt;
         }
-        Self::commutative_op(cx, SymExprOp::Or, left, right)
+        Self::commutative_binop(cx, SymExprBinOp::Or, left, right)
     }
 
-    fn commutative_op(cx: &mut SymCx, op: SymExprOp, left: Self, right: Self) -> Self {
+    fn commutative_binop(cx: &mut SymCx, op: SymExprBinOp, left: Self, right: Self) -> Self {
+        // `a + b => b + a`.
         let (left, right) = Self::ordered_commutative_operands(left, right);
-        Self::from_kind(cx, SymExprKind::Op(op, left, right))
+        Self::from_kind(cx, SymExprKind::BinOp(op, left, right))
     }
 
     pub(in crate::runtime::expr) fn ordered_commutative_operands(
@@ -639,20 +685,24 @@ impl SymExpr {
 
     fn and_const(cx: &mut SymCx, expr: Self, mask: U256) -> Self {
         if mask.is_zero() {
+            // `a & 0 => 0`.
             return Self::zero(cx);
         }
         if mask == U256::MAX {
+            // `a & MAX => a`.
             return expr;
         }
 
         match expr.kind() {
+            // `const & mask => const`.
             SymExprKind::Const(value) => Self::constant(cx, *value & mask),
-            SymExprKind::Op(SymExprOp::Or, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Or, left, right) => {
+                // `(a | b) & mask => (a & mask) | (b & mask)`.
                 let left = Self::and_const(cx, left.clone(), mask);
                 let right = Self::and_const(cx, right.clone(), mask);
-                Self::op(cx, SymExprOp::Or, left, right)
+                Self::binop(cx, SymExprBinOp::Or, left, right)
             }
-            SymExprKind::Op(SymExprOp::Shl, _, shift)
+            SymExprKind::BinOp(SymExprBinOp::Shl, _, shift)
                 if mask_low_bits(mask).is_some_and(|bits| {
                     shift
                         .as_const()
@@ -660,56 +710,66 @@ impl SymExpr {
                         .is_some_and(|shift| bits <= shift)
                 }) =>
             {
+                // `(a << n) & low_mask(n) => 0`.
                 Self::zero(cx)
             }
-            SymExprKind::Op(SymExprOp::And, left, right) => match (left.kind(), right.kind()) {
+            SymExprKind::BinOp(SymExprBinOp::And, left, right) => match (left.kind(), right.kind())
+            {
                 (SymExprKind::Const(value), _) if *value == mask => {
+                    // `(mask & a) & mask => a & mask`.
                     Self::and_const(cx, right.clone(), mask)
                 }
                 (_, SymExprKind::Const(value)) if *value == mask => {
+                    // `(a & mask) & mask => a & mask`.
                     Self::and_const(cx, left.clone(), mask)
                 }
+                // `(a & a) & mask => a & mask`.
                 _ if left == right => Self::and_const(cx, left.clone(), mask),
                 _ => {
                     let mask = Self::constant(cx, mask);
-                    Self::from_kind(cx, SymExprKind::Op(SymExprOp::And, expr, mask))
+                    Self::from_kind(cx, SymExprKind::BinOp(SymExprBinOp::And, expr, mask))
                 }
             },
             _ => {
                 let mask = Self::constant(cx, mask);
-                Self::from_kind(cx, SymExprKind::Op(SymExprOp::And, expr, mask))
+                Self::from_kind(cx, SymExprKind::BinOp(SymExprBinOp::And, expr, mask))
             }
         }
     }
 
     fn shr_const(cx: &mut SymCx, expr: Self, shift: U256) -> Self {
         if shift.is_zero() {
+            // `a >> 0 => a`.
             return expr;
         }
         if shift >= U256::from(256) {
+            // `a >> 256 => 0`.
             return Self::zero(cx);
         }
 
         let shift = usize::try_from(shift).expect("shift is less than 256");
         if expr.unsigned_bits() <= shift {
+            // `small(a) >> bits(a) => 0`.
             return Self::zero(cx);
         }
 
-        if let SymExprKind::Op(SymExprOp::Shl, inner, left_shift) = expr.kind()
+        if let SymExprKind::BinOp(SymExprBinOp::Shl, inner, left_shift) = expr.kind()
             && left_shift.as_const() == Some(U256::from(shift))
             && inner.unsigned_bits() <= 256 - shift
         {
+            // `(a << n) >> n => a`.
             return inner.clone();
         }
 
-        if let SymExprKind::Op(SymExprOp::Or, left, right) = expr.kind() {
+        if let SymExprKind::BinOp(SymExprBinOp::Or, left, right) = expr.kind() {
+            // `(a | b) >> n => (a >> n) | (b >> n)`.
             let left = Self::shr_const(cx, left.clone(), U256::from(shift));
             let right = Self::shr_const(cx, right.clone(), U256::from(shift));
-            return Self::op(cx, SymExprOp::Or, left, right);
+            return Self::binop(cx, SymExprBinOp::Or, left, right);
         }
 
         let shift = Self::constant(cx, U256::from(shift));
-        Self::from_kind(cx, SymExprKind::Op(SymExprOp::Shr, expr, shift))
+        Self::from_kind(cx, SymExprKind::BinOp(SymExprBinOp::Shr, expr, shift))
     }
 
     fn rebuild_from_or_terms(left: &Self, right: &Self) -> Option<Self> {
@@ -722,7 +782,7 @@ impl SymExpr {
 
     pub(in crate::runtime) fn push_or_terms<'a>(&'a self, terms: &mut Vec<&'a Self>) {
         match self.kind() {
-            SymExprKind::Op(SymExprOp::Or, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Or, left, right) => {
                 left.push_or_terms(terms);
                 right.push_or_terms(terms);
             }
@@ -761,7 +821,7 @@ impl SymExpr {
 
     fn extracted_shifted_byte_term(&self) -> Option<(Self, usize)> {
         match self.kind() {
-            SymExprKind::Op(SymExprOp::Shl, byte, shift) => {
+            SymExprKind::BinOp(SymExprBinOp::Shl, byte, shift) => {
                 let shift = shift.as_const()?;
                 let Ok(shift) = usize::try_from(shift) else { return None };
                 if shift % 8 != 0 || shift > 248 {
@@ -780,7 +840,7 @@ impl SymExpr {
         if index == 31 {
             return Some(expr.clone());
         }
-        let SymExprKind::Op(SymExprOp::Shr, source, shift) = expr.kind() else { return None };
+        let SymExprKind::BinOp(SymExprBinOp::Shr, source, shift) = expr.kind() else { return None };
         let shift = shift.as_const()?;
         (shift == U256::from((31 - index) * 8)).then(|| source.clone())
     }
@@ -806,7 +866,7 @@ impl SymExpr {
     }
 
     fn low_word_fragment(&self) -> Option<(Self, usize)> {
-        let SymExprKind::Op(SymExprOp::And, left, right) = self.kind() else { return None };
+        let SymExprKind::BinOp(SymExprBinOp::And, left, right) = self.kind() else { return None };
         if let Some(mask) = right.as_const() {
             return mask_low_bits(mask).map(|bits| (left.clone(), bits));
         }
@@ -815,7 +875,7 @@ impl SymExpr {
     }
 
     fn shifted_high_word_fragment(&self) -> Option<(Self, usize)> {
-        let SymExprKind::Op(SymExprOp::Shl, value, shift) = self.kind() else { return None };
+        let SymExprKind::BinOp(SymExprBinOp::Shl, value, shift) = self.kind() else { return None };
         let bits = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
         if bits == 0 || bits >= 256 {
             return None;
@@ -826,7 +886,7 @@ impl SymExpr {
     }
 
     fn shifted_low_fragment_source(&self) -> Option<(Self, usize, usize)> {
-        let SymExprKind::Op(SymExprOp::And, left, right) = self.kind() else { return None };
+        let SymExprKind::BinOp(SymExprBinOp::And, left, right) = self.kind() else { return None };
         if let Some(mask) = right.as_const() {
             return Self::shifted_low_fragment_source_with_mask(left, mask);
         }
@@ -840,7 +900,7 @@ impl SymExpr {
     ) -> Option<(Self, usize, usize)> {
         let width = mask_low_bits(mask)?;
         match value.kind() {
-            SymExprKind::Op(SymExprOp::Shr, source, shift) => {
+            SymExprKind::BinOp(SymExprBinOp::Shr, source, shift) => {
                 let shift = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
                 Some((source.clone(), shift, width))
             }
@@ -853,7 +913,7 @@ impl SymExpr {
             return Self::constant(cx, U256::from(word.to::<u8>()));
         }
         let mask = Self::constant(cx, U256::from(0xff));
-        Self::op(cx, SymExprOp::And, self, mask)
+        Self::binop(cx, SymExprBinOp::And, self, mask)
     }
 
     pub(crate) fn into_byte_exprs(self, cx: &mut SymCx) -> Vec<Self> {
@@ -886,9 +946,9 @@ impl SymExpr {
                 byte
             } else {
                 let shift = Self::constant(cx, U256::from(shift));
-                Self::op(cx, SymExprOp::Shl, byte, shift)
+                Self::binop(cx, SymExprBinOp::Shl, byte, shift)
             };
-            expr = Self::op(cx, SymExprOp::Or, expr, byte);
+            expr = Self::binop(cx, SymExprBinOp::Or, expr, byte);
         }
         expr
     }
@@ -936,7 +996,7 @@ impl SymExpr {
             }
             SymExprKind::Hash { name, .. } => model.value(name.clone()).unwrap_or_default(),
             SymExprKind::Not(value) => !value.eval_model(model)?,
-            SymExprKind::Op(op, left, right) => {
+            SymExprKind::BinOp(op, left, right) => {
                 op.eval(left.eval_model(model)?, right.eval_model(model)?)
             }
             SymExprKind::AddMod { left, right, modulus } => left
@@ -1056,7 +1116,7 @@ impl SymExpr {
     }
 
     pub(crate) fn contains_udiv(&self) -> bool {
-        self.visit_bool(|expr| matches!(expr.kind(), SymExprKind::Op(SymExprOp::UDiv, _, _)))
+        self.visit_bool(|expr| matches!(expr.kind(), SymExprKind::BinOp(SymExprBinOp::UDiv, _, _)))
     }
 
     pub(crate) fn contains_ite(&self) -> bool {
@@ -1065,7 +1125,7 @@ impl SymExpr {
 
     pub(in crate::runtime) fn udiv_operands(&self) -> Option<(&Self, &Self)> {
         match self.kind() {
-            SymExprKind::Op(SymExprOp::UDiv, numerator, denominator) => {
+            SymExprKind::BinOp(SymExprBinOp::UDiv, numerator, denominator) => {
                 Some((numerator, denominator))
             }
             _ => None,
@@ -1098,15 +1158,15 @@ impl SymExpr {
                 let else_byte = else_expr.known_byte(index)?;
                 (then_byte == else_byte).then_some(then_byte)
             }
-            SymExprKind::Op(op, left, right) => match op {
-                SymExprOp::And => match (left.known_byte(index), right.known_byte(index)) {
+            SymExprKind::BinOp(op, left, right) => match op {
+                SymExprBinOp::And => match (left.known_byte(index), right.known_byte(index)) {
                     (Some(left), Some(right)) => Some(left & right),
                     (Some(0), _) | (_, Some(0)) => Some(0),
                     _ => None,
                 },
-                SymExprOp::Or => Some(left.known_byte(index)? | right.known_byte(index)?),
-                SymExprOp::Xor => Some(left.known_byte(index)? ^ right.known_byte(index)?),
-                SymExprOp::Shl => {
+                SymExprBinOp::Or => Some(left.known_byte(index)? | right.known_byte(index)?),
+                SymExprBinOp::Xor => Some(left.known_byte(index)? ^ right.known_byte(index)?),
+                SymExprBinOp::Shl => {
                     let shift = right.as_const()?;
                     if shift >= U256::from(256) {
                         return Some(0);
@@ -1118,7 +1178,7 @@ impl SymExpr {
                     let source_index = index + shift / 8;
                     if source_index >= 32 { Some(0) } else { left.known_byte(source_index) }
                 }
-                SymExprOp::Shr => {
+                SymExprBinOp::Shr => {
                     let shift = right.as_const()?;
                     if shift >= U256::from(256) {
                         return Some(0);
@@ -1130,14 +1190,14 @@ impl SymExpr {
                     let byte_shift = shift / 8;
                     if index < byte_shift { Some(0) } else { left.known_byte(index - byte_shift) }
                 }
-                SymExprOp::Add
-                | SymExprOp::Sub
-                | SymExprOp::Mul
-                | SymExprOp::UDiv
-                | SymExprOp::URem
-                | SymExprOp::SDiv
-                | SymExprOp::SRem
-                | SymExprOp::Sar => None,
+                SymExprBinOp::Add
+                | SymExprBinOp::Sub
+                | SymExprBinOp::Mul
+                | SymExprBinOp::UDiv
+                | SymExprBinOp::URem
+                | SymExprBinOp::SDiv
+                | SymExprBinOp::SRem
+                | SymExprBinOp::Sar => None,
             },
             SymExprKind::AddMod { .. } | SymExprKind::MulMod { .. } => None,
         }
@@ -1154,7 +1214,7 @@ impl SymExpr {
     pub(crate) fn unsigned_bits(&self) -> usize {
         match self.kind() {
             SymExprKind::Const(value) => value.bit_len().max(1),
-            SymExprKind::Op(SymExprOp::And, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::And, left, right) => {
                 if let Some(mask) = right.as_const() {
                     left.unsigned_bits().min(mask.bit_len())
                 } else if let Some(mask) = left.as_const() {
@@ -1163,13 +1223,13 @@ impl SymExpr {
                     256
                 }
             }
-            SymExprKind::Op(SymExprOp::Add, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Add, left, right) => {
                 left.unsigned_bits().max(right.unsigned_bits()).saturating_add(1).min(256)
             }
-            SymExprKind::Op(SymExprOp::Mul, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Mul, left, right) => {
                 left.unsigned_bits().saturating_add(right.unsigned_bits()).min(256)
             }
-            SymExprKind::Op(SymExprOp::Shl, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Shl, left, right) => {
                 if let Some(shift) = right.as_const().and_then(|shift| usize::try_from(shift).ok())
                 {
                     left.unsigned_bits().saturating_add(shift).min(256)
@@ -1177,7 +1237,7 @@ impl SymExpr {
                     256
                 }
             }
-            SymExprKind::Op(SymExprOp::Shr, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Shr, left, right) => {
                 if let Some(shift) = right.as_const().and_then(|shift| usize::try_from(shift).ok())
                 {
                     left.unsigned_bits().saturating_sub(shift).max(1)
@@ -1185,7 +1245,7 @@ impl SymExpr {
                     256
                 }
             }
-            SymExprKind::Op(SymExprOp::UDiv, left, _) => left.unsigned_bits(),
+            SymExprKind::BinOp(SymExprBinOp::UDiv, left, _) => left.unsigned_bits(),
             SymExprKind::AddMod { modulus, .. } | SymExprKind::MulMod { modulus, .. } => {
                 modulus.unsigned_bits()
             }
@@ -1197,9 +1257,9 @@ impl SymExpr {
     pub(crate) fn extracted_byte(&self, cx: &mut SymCx, index: usize) -> Self {
         debug_assert!(index < 32);
         let shift = Self::constant(cx, U256::from((31 - index) * 8));
-        let shifted = Self::op(cx, SymExprOp::Shr, self.clone(), shift);
+        let shifted = Self::binop(cx, SymExprBinOp::Shr, self.clone(), shift);
         let mask = Self::constant(cx, U256::from(0xff));
-        Self::op(cx, SymExprOp::And, shifted, mask)
+        Self::binop(cx, SymExprBinOp::And, shifted, mask)
     }
 
     pub(crate) fn extracted_byte_source(&self, index: usize) -> Option<Self> {
@@ -1207,19 +1267,19 @@ impl SymExpr {
         if index == 31 {
             return Some(expr.clone());
         }
-        let SymExprKind::Op(SymExprOp::Shr, source, shift) = expr.kind() else { return None };
+        let SymExprKind::BinOp(SymExprBinOp::Shr, source, shift) = expr.kind() else { return None };
         let shift = shift.as_const()?;
         (shift == U256::from((31 - index) * 8)).then(|| source.clone())
     }
 
     pub(crate) fn strip_low_byte_mask(&self) -> &Self {
         match self.kind() {
-            SymExprKind::Op(SymExprOp::And, left, right)
+            SymExprKind::BinOp(SymExprBinOp::And, left, right)
                 if right.as_const() == Some(U256::from(0xff)) =>
             {
                 left.strip_low_byte_mask()
             }
-            SymExprKind::Op(SymExprOp::And, left, right)
+            SymExprKind::BinOp(SymExprBinOp::And, left, right)
                 if left.as_const() == Some(U256::from(0xff)) =>
             {
                 right.strip_low_byte_mask()
@@ -1248,35 +1308,35 @@ impl SymExpr {
                 let else_expr = else_expr.byte_term(cx, index)?;
                 Some(Self::ite(cx, cond.clone(), then_expr, else_expr))
             }
-            SymExprKind::Op(op, left, right) => match op {
-                SymExprOp::And => Self::binary_byte_term(
+            SymExprKind::BinOp(op, left, right) => match op {
+                SymExprBinOp::And => Self::binary_byte_term(
                     cx,
                     left,
                     right,
                     index,
-                    SymExprOp::And,
+                    SymExprBinOp::And,
                     |byte| byte == 0xff,
                     |byte| byte == 0,
                 ),
-                SymExprOp::Or => Self::binary_byte_term(
+                SymExprBinOp::Or => Self::binary_byte_term(
                     cx,
                     left,
                     right,
                     index,
-                    SymExprOp::Or,
+                    SymExprBinOp::Or,
                     |byte| byte == 0,
                     |_| false,
                 ),
-                SymExprOp::Xor => Self::binary_byte_term(
+                SymExprBinOp::Xor => Self::binary_byte_term(
                     cx,
                     left,
                     right,
                     index,
-                    SymExprOp::Xor,
+                    SymExprBinOp::Xor,
                     |byte| byte == 0,
                     |_| false,
                 ),
-                SymExprOp::Shl => {
+                SymExprBinOp::Shl => {
                     let shift = right.eval()?;
                     if shift >= U256::from(256) {
                         return Some(Self::zero(cx));
@@ -1292,7 +1352,7 @@ impl SymExpr {
                         left.byte_term(cx, source_index)
                     }
                 }
-                SymExprOp::Shr => {
+                SymExprBinOp::Shr => {
                     let shift = right.eval()?;
                     if shift >= U256::from(256) {
                         return Some(Self::zero(cx));
@@ -1308,14 +1368,14 @@ impl SymExpr {
                         left.byte_term(cx, index - byte_shift)
                     }
                 }
-                SymExprOp::Add
-                | SymExprOp::Sub
-                | SymExprOp::Mul
-                | SymExprOp::UDiv
-                | SymExprOp::URem
-                | SymExprOp::SDiv
-                | SymExprOp::SRem
-                | SymExprOp::Sar => None,
+                SymExprBinOp::Add
+                | SymExprBinOp::Sub
+                | SymExprBinOp::Mul
+                | SymExprBinOp::UDiv
+                | SymExprBinOp::URem
+                | SymExprBinOp::SDiv
+                | SymExprBinOp::SRem
+                | SymExprBinOp::Sar => None,
             },
             SymExprKind::AddMod { .. } | SymExprKind::MulMod { .. } => None,
         }
@@ -1326,7 +1386,7 @@ impl SymExpr {
         left: &Self,
         right: &Self,
         index: usize,
-        op: SymExprOp,
+        op: SymExprBinOp,
         identity: impl Fn(u8) -> bool,
         absorbing: impl Fn(u8) -> bool,
     ) -> Option<Self> {
@@ -1337,7 +1397,7 @@ impl SymExpr {
             (_, Some(right)) if absorbing(right) => Some(Self::constant(cx, U256::from(right))),
             (Some(left), _) if identity(left) => Some(right),
             (_, Some(right)) if identity(right) => Some(left),
-            _ => Some(Self::op(cx, op, left, right)),
+            _ => Some(Self::binop(cx, op, left, right)),
         }
     }
 
@@ -1391,7 +1451,7 @@ impl SymExpr {
                     None
                 }
             }
-            SymExprKind::Op(SymExprOp::Or, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Or, left, right) => {
                 if left.eval().is_some_and(|value| value.is_zero()) {
                     return right.nonzero_forces_const(target, context);
                 }
@@ -1400,7 +1460,7 @@ impl SymExpr {
                 }
                 None
             }
-            SymExprKind::Op(SymExprOp::And, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::And, left, right) => {
                 if left.eval().is_some_and(|value| !value.is_zero()) {
                     return right.nonzero_forces_const(target, context);
                 }
@@ -1409,13 +1469,13 @@ impl SymExpr {
                 }
                 None
             }
-            SymExprKind::Op(SymExprOp::Shl | SymExprOp::Shr, value, shift)
+            SymExprKind::BinOp(SymExprBinOp::Shl | SymExprBinOp::Shr, value, shift)
                 if shift.eval().is_some_and(|shift| shift.is_zero()) =>
             {
                 value.nonzero_forces_const(target, context)
             }
             SymExprKind::AddMod { .. } | SymExprKind::MulMod { .. } => None,
-            SymExprKind::Op(_, _, _) => None,
+            SymExprKind::BinOp(_, _, _) => None,
         }
     }
 
@@ -1431,7 +1491,7 @@ impl SymExpr {
             SymExprKind::Const(expr) => Self::constant(cx, expr.wrapping_add(value)),
             _ => {
                 let value = Self::constant(cx, value);
-                Self::op(cx, SymExprOp::Add, expr, value)
+                Self::binop(cx, SymExprBinOp::Add, expr, value)
             }
         }
     }
@@ -1456,7 +1516,7 @@ impl SymExpr {
                 }
             }
             SymExprKind::Not(value) => value.visit(visitor)?,
-            SymExprKind::Op(_, left, right) => {
+            SymExprKind::BinOp(_, left, right) => {
                 left.visit(visitor)?;
                 right.visit(visitor)?;
             }
@@ -1508,10 +1568,10 @@ impl SymExpr {
                 let value = value.fold(cx, folder);
                 Self::not(cx, value)
             }
-            SymExprKind::Op(op, left, right) => {
+            SymExprKind::BinOp(op, left, right) => {
                 let left = left.fold(cx, folder);
                 let right = right.fold(cx, folder);
-                Self::op(cx, op, left, right)
+                Self::binop(cx, op, left, right)
             }
             SymExprKind::AddMod { left, right, modulus } => {
                 let left = left.fold(cx, folder);
@@ -1561,7 +1621,7 @@ impl SymExpr {
                 value.write_smt(out);
                 out.push(')');
             }
-            SymExprKind::Op(op, left, right) => {
+            SymExprKind::BinOp(op, left, right) => {
                 let _ = write!(out, "({} ", op.smt());
                 left.write_smt(out);
                 out.push(' ');
@@ -1612,7 +1672,7 @@ fn write_smt_wide_modular_arithmetic(
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum SymExprOp {
+pub(crate) enum SymExprBinOp {
     Add,
     Sub,
     Mul,
@@ -1628,7 +1688,7 @@ pub(crate) enum SymExprOp {
     Sar,
 }
 
-impl SymExprOp {
+impl SymExprBinOp {
     pub(crate) const fn smt(self) -> &'static str {
         match self {
             Self::Add => "bvadd",

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -752,10 +752,16 @@ impl SymExpr {
         }
 
         if let SymExprKind::BinOp(SymBinOp::Or, left, right) = expr.kind() {
-            // `(a | b) >> n => (a >> n) | (b >> n)`.
+            // Distribute only when it collapses part of the OR; expanding broad
+            // bit-smearing chains eagerly makes SMT CSE much larger.
             let left = Self::shr_const(cx, left.clone(), U256::from(shift));
             let right = Self::shr_const(cx, right.clone(), U256::from(shift));
-            return Self::binop(cx, SymBinOp::Or, left, right);
+            if left.as_const().is_some_and(|value| value.is_zero()) {
+                return right;
+            }
+            if right.as_const().is_some_and(|value| value.is_zero()) {
+                return left;
+            }
         }
 
         let shift = Self::constant(cx, U256::from(shift));

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -138,7 +138,7 @@ pub(crate) fn symbolic_create_address_word(
     let word = SymExpr::var_symbol(cx, name);
     state.constraints.push(SymBoolExpr::cmp_word_const(
         cx,
-        SymBoolExprOp::Ult,
+        SymCmpOp::Ult,
         &word,
         U256::from(1) << 160,
     ));
@@ -159,7 +159,7 @@ pub(crate) fn symbolic_create2_address_word(
     let word = SymExpr::var_symbol(cx, name);
     state.constraints.push(SymBoolExpr::cmp_word_const(
         cx,
-        SymBoolExprOp::Ult,
+        SymCmpOp::Ult,
         &word,
         U256::from(1) << 160,
     ));
@@ -251,7 +251,7 @@ fn masked_expr_matches(candidate: &SymExprKind, target: &SymExpr) -> Option<U256
 
 fn context_forces_masked_expr(context: &[SymBoolExpr], target: &SymExpr, mask: U256) -> bool {
     context.iter().any(|condition| match condition.kind() {
-        SymBoolExprKind::Eq(left, right) => {
+        SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => {
             (left == target && masked_expr_matches(right.kind(), target) == Some(mask))
                 || (right == target && masked_expr_matches(left.kind(), target) == Some(mask))
         }

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -273,6 +273,11 @@ pub(crate) fn concrete_expr_bytes(
         .collect()
 }
 
+pub(crate) fn mask_low_bits(mask: U256) -> Option<usize> {
+    let bits = mask.bit_len();
+    (mask == mask_bits(U256::MAX, bits)).then_some(bits)
+}
+
 fn word_from_extracted_bytes(bytes: &[SymExpr]) -> Option<SymExpr> {
     if bytes.len() < 32 {
         return None;
@@ -419,7 +424,7 @@ impl SymExpr {
                 }
                 (SymExprKind::Const(value), _) if value.is_zero() => right,
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ => Self::commutative_op(cx, op, left, right),
             },
             SymExprOp::Sub => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
@@ -440,7 +445,7 @@ impl SymExpr {
                 }
                 (SymExprKind::Const(value), _) if *value == U256::from(1) => right,
                 (_, SymExprKind::Const(value)) if *value == U256::from(1) => left,
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ => Self::commutative_op(cx, op, left, right),
             },
             SymExprOp::UDiv | SymExprOp::SDiv => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
@@ -472,22 +477,42 @@ impl SymExpr {
                 _ if left == right => left,
                 (SymExprKind::Const(mask), _) => Self::and_const(cx, right, *mask),
                 (_, SymExprKind::Const(mask)) => Self::and_const(cx, left, *mask),
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ => Self::commutative_op(cx, op, left, right),
             },
-            SymExprOp::Or | SymExprOp::Xor => match (left.kind(), right.kind()) {
+            SymExprOp::Or => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     Self::constant(cx, op.eval(*left_value, *right_value))
                 }
                 (SymExprKind::Const(value), _) if value.is_zero() => right,
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
-                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+                _ if left == right => left,
+                _ => Self::or(cx, left, right),
             },
-            SymExprOp::Shl | SymExprOp::Shr => match (left.kind(), right.kind()) {
+            SymExprOp::Xor => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Self::constant(cx, op.eval(*left_value, *right_value))
+                }
+                (SymExprKind::Const(value), _) if value.is_zero() => right,
+                (_, SymExprKind::Const(value)) if value.is_zero() => left,
+                _ if left == right => Self::zero(cx),
+                _ => Self::commutative_op(cx, op, left, right),
+            },
+            SymExprOp::Shl => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
                     Self::constant(cx, op.eval(*left_value, *right_value))
                 }
                 (_, SymExprKind::Const(value)) if value.is_zero() => left,
                 (SymExprKind::Const(value), _) if value.is_zero() => Self::zero(cx),
+                (_, SymExprKind::Const(value)) if *value >= U256::from(256) => Self::zero(cx),
+                _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
+            },
+            SymExprOp::Shr => match (left.kind(), right.kind()) {
+                (SymExprKind::Const(left_value), SymExprKind::Const(right_value)) => {
+                    Self::constant(cx, op.eval(*left_value, *right_value))
+                }
+                (_, SymExprKind::Const(value)) if value.is_zero() => left,
+                (SymExprKind::Const(value), _) if value.is_zero() => Self::zero(cx),
+                (_, SymExprKind::Const(value)) => Self::shr_const(cx, left, *value),
                 _ => Self::from_kind(cx, SymExprKind::Op(op, left, right)),
             },
             SymExprOp::Sar => match (left.kind(), right.kind()) {
@@ -510,7 +535,10 @@ impl SymExpr {
             (SymExprKind::Const(left), SymExprKind::Const(right), SymExprKind::Const(modulus)) => {
                 Self::constant(cx, left.add_mod(*right, *modulus))
             }
-            _ => Self::from_kind(cx, SymExprKind::AddMod { left, right, modulus }),
+            _ => {
+                let (left, right) = Self::ordered_commutative_operands(left, right);
+                Self::from_kind(cx, SymExprKind::AddMod { left, right, modulus })
+            }
         }
     }
 
@@ -524,7 +552,10 @@ impl SymExpr {
             (SymExprKind::Const(left), SymExprKind::Const(right), SymExprKind::Const(modulus)) => {
                 Self::constant(cx, left.mul_mod(*right, *modulus))
             }
-            _ => Self::from_kind(cx, SymExprKind::MulMod { left, right, modulus }),
+            _ => {
+                let (left, right) = Self::ordered_commutative_operands(left, right);
+                Self::from_kind(cx, SymExprKind::MulMod { left, right, modulus })
+            }
         }
     }
 
@@ -538,6 +569,22 @@ impl SymExpr {
             Some(true) => then_expr,
             Some(false) => else_expr,
             None if then_expr == else_expr => then_expr,
+            None if then_expr.as_const().is_some_and(|value| value.is_zero())
+                && Self::self_div_expr_matches_zero_check(&condition, &else_expr) =>
+            {
+                let condition = condition.not(cx);
+                Self::bool_word(cx, condition)
+            }
+            None if then_expr.as_const() == Some(U256::from(1))
+                && else_expr.bool_word_condition().as_ref() == Some(&condition) =>
+            {
+                else_expr
+            }
+            None if else_expr.as_const().is_some_and(|value| value.is_zero())
+                && then_expr.bool_word_condition().as_ref() == Some(&condition) =>
+            {
+                then_expr
+            }
             None => Self::from_kind(cx, SymExprKind::Ite(condition, then_expr, else_expr)),
         }
     }
@@ -546,6 +593,12 @@ impl SymExpr {
         let one = Self::one(cx);
         let zero = Self::zero(cx);
         Self::ite(cx, value, one, zero)
+    }
+
+    fn self_div_expr_matches_zero_check(cond: &SymBoolExpr, expr: &Self) -> bool {
+        let Some(zero_operand) = cond.zero_check_operand() else { return false };
+        let Some((numerator, denominator)) = expr.udiv_operands() else { return false };
+        numerator == zero_operand && denominator == zero_operand
     }
 
     pub(crate) fn keccak_symbol(cx: &mut SymCx, name: Symbol, len: Self, bytes: Vec<Self>) -> Self {
@@ -561,6 +614,29 @@ impl SymExpr {
         Self::from_kind(cx, SymExprKind::Hash { name, algorithm, bytes: bytes.into() })
     }
 
+    fn or(cx: &mut SymCx, left: Self, right: Self) -> Self {
+        if let Some(rebuilt) = Self::rebuild_from_or_terms(&left, &right) {
+            return rebuilt;
+        }
+        Self::commutative_op(cx, SymExprOp::Or, left, right)
+    }
+
+    fn commutative_op(cx: &mut SymCx, op: SymExprOp, left: Self, right: Self) -> Self {
+        let (left, right) = Self::ordered_commutative_operands(left, right);
+        Self::from_kind(cx, SymExprKind::Op(op, left, right))
+    }
+
+    pub(in crate::runtime::expr) fn ordered_commutative_operands(
+        left: Self,
+        right: Self,
+    ) -> (Self, Self) {
+        if right.kind.cached_hash() < left.kind.cached_hash() {
+            (right, left)
+        } else {
+            (left, right)
+        }
+    }
+
     fn and_const(cx: &mut SymCx, expr: Self, mask: U256) -> Self {
         if mask.is_zero() {
             return Self::zero(cx);
@@ -570,6 +646,22 @@ impl SymExpr {
         }
 
         match expr.kind() {
+            SymExprKind::Const(value) => Self::constant(cx, *value & mask),
+            SymExprKind::Op(SymExprOp::Or, left, right) => {
+                let left = Self::and_const(cx, left.clone(), mask);
+                let right = Self::and_const(cx, right.clone(), mask);
+                Self::op(cx, SymExprOp::Or, left, right)
+            }
+            SymExprKind::Op(SymExprOp::Shl, _, shift)
+                if mask_low_bits(mask).is_some_and(|bits| {
+                    shift
+                        .as_const()
+                        .and_then(|shift| usize::try_from(shift).ok())
+                        .is_some_and(|shift| bits <= shift)
+                }) =>
+            {
+                Self::zero(cx)
+            }
             SymExprKind::Op(SymExprOp::And, left, right) => match (left.kind(), right.kind()) {
                 (SymExprKind::Const(value), _) if *value == mask => {
                     Self::and_const(cx, right.clone(), mask)
@@ -587,6 +679,172 @@ impl SymExpr {
                 let mask = Self::constant(cx, mask);
                 Self::from_kind(cx, SymExprKind::Op(SymExprOp::And, expr, mask))
             }
+        }
+    }
+
+    fn shr_const(cx: &mut SymCx, expr: Self, shift: U256) -> Self {
+        if shift.is_zero() {
+            return expr;
+        }
+        if shift >= U256::from(256) {
+            return Self::zero(cx);
+        }
+
+        let shift = usize::try_from(shift).expect("shift is less than 256");
+        if expr.unsigned_bits() <= shift {
+            return Self::zero(cx);
+        }
+
+        if let SymExprKind::Op(SymExprOp::Shl, inner, left_shift) = expr.kind()
+            && left_shift.as_const() == Some(U256::from(shift))
+            && inner.unsigned_bits() <= 256 - shift
+        {
+            return inner.clone();
+        }
+
+        if let SymExprKind::Op(SymExprOp::Or, left, right) = expr.kind() {
+            let left = Self::shr_const(cx, left.clone(), U256::from(shift));
+            let right = Self::shr_const(cx, right.clone(), U256::from(shift));
+            return Self::op(cx, SymExprOp::Or, left, right);
+        }
+
+        let shift = Self::constant(cx, U256::from(shift));
+        Self::from_kind(cx, SymExprKind::Op(SymExprOp::Shr, expr, shift))
+    }
+
+    fn rebuild_from_or_terms(left: &Self, right: &Self) -> Option<Self> {
+        let mut terms = Vec::new();
+        left.push_or_terms(&mut terms);
+        right.push_or_terms(&mut terms);
+        Self::rebuild_from_extracted_byte_terms(&terms)
+            .or_else(|| Self::rebuild_from_shifted_word_fragments(&terms))
+    }
+
+    pub(in crate::runtime) fn push_or_terms<'a>(&'a self, terms: &mut Vec<&'a Self>) {
+        match self.kind() {
+            SymExprKind::Op(SymExprOp::Or, left, right) => {
+                left.push_or_terms(terms);
+                right.push_or_terms(terms);
+            }
+            _ => terms.push(self),
+        }
+    }
+
+    fn rebuild_from_extracted_byte_terms(terms: &[&Self]) -> Option<Self> {
+        if terms.len() <= 1 {
+            return None;
+        }
+
+        let mut source = None;
+        let mut seen = [false; 32];
+        for term in terms {
+            if term.as_const().is_some_and(|value| value.is_zero()) {
+                continue;
+            }
+            let (term_source, index) = term.extracted_shifted_byte_term()?;
+            match &source {
+                Some(source) if source != &term_source => return None,
+                Some(_) => {}
+                None => source = Some(term_source),
+            }
+            seen[index] = true;
+        }
+
+        let source = source?;
+        for (index, seen) in seen.into_iter().enumerate() {
+            if !seen && source.known_byte(index) != Some(0) {
+                return None;
+            }
+        }
+        Some(source)
+    }
+
+    fn extracted_shifted_byte_term(&self) -> Option<(Self, usize)> {
+        match self.kind() {
+            SymExprKind::Op(SymExprOp::Shl, byte, shift) => {
+                let shift = shift.as_const()?;
+                let Ok(shift) = usize::try_from(shift) else { return None };
+                if shift % 8 != 0 || shift > 248 {
+                    return None;
+                }
+                let index = 31 - shift / 8;
+                let source = byte.extracted_unshifted_byte_source(index)?;
+                Some((source, index))
+            }
+            _ => self.extracted_unshifted_byte_source(31).map(|source| (source, 31)),
+        }
+    }
+
+    fn extracted_unshifted_byte_source(&self, index: usize) -> Option<Self> {
+        let expr = self.strip_low_byte_mask();
+        if index == 31 {
+            return Some(expr.clone());
+        }
+        let SymExprKind::Op(SymExprOp::Shr, source, shift) = expr.kind() else { return None };
+        let shift = shift.as_const()?;
+        (shift == U256::from((31 - index) * 8)).then(|| source.clone())
+    }
+
+    fn rebuild_from_shifted_word_fragments(terms: &[&Self]) -> Option<Self> {
+        if terms.len() != 2 {
+            return None;
+        }
+
+        let left_low = terms[0].low_word_fragment();
+        let right_low = terms[1].low_word_fragment();
+        let left_high = terms[0].shifted_high_word_fragment();
+        let right_high = terms[1].shifted_high_word_fragment();
+        match (left_low, right_low, left_high, right_high) {
+            (Some((low_source, low_bits)), None, None, Some((high_source, high_bits)))
+            | (None, Some((low_source, low_bits)), Some((high_source, high_bits)), None)
+                if low_source == high_source && low_bits == high_bits =>
+            {
+                Some(low_source)
+            }
+            _ => None,
+        }
+    }
+
+    fn low_word_fragment(&self) -> Option<(Self, usize)> {
+        let SymExprKind::Op(SymExprOp::And, left, right) = self.kind() else { return None };
+        if let Some(mask) = right.as_const() {
+            return mask_low_bits(mask).map(|bits| (left.clone(), bits));
+        }
+        let mask = left.as_const()?;
+        mask_low_bits(mask).map(|bits| (right.clone(), bits))
+    }
+
+    fn shifted_high_word_fragment(&self) -> Option<(Self, usize)> {
+        let SymExprKind::Op(SymExprOp::Shl, value, shift) = self.kind() else { return None };
+        let bits = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
+        if bits == 0 || bits >= 256 {
+            return None;
+        }
+
+        let (source, source_shift, width) = value.shifted_low_fragment_source()?;
+        (source_shift == bits && width == 256 - bits).then_some((source, bits))
+    }
+
+    fn shifted_low_fragment_source(&self) -> Option<(Self, usize, usize)> {
+        let SymExprKind::Op(SymExprOp::And, left, right) = self.kind() else { return None };
+        if let Some(mask) = right.as_const() {
+            return Self::shifted_low_fragment_source_with_mask(left, mask);
+        }
+        let mask = left.as_const()?;
+        Self::shifted_low_fragment_source_with_mask(right, mask)
+    }
+
+    fn shifted_low_fragment_source_with_mask(
+        value: &Self,
+        mask: U256,
+    ) -> Option<(Self, usize, usize)> {
+        let width = mask_low_bits(mask)?;
+        match value.kind() {
+            SymExprKind::Op(SymExprOp::Shr, source, shift) => {
+                let shift = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
+                Some((source.clone(), shift, width))
+            }
+            _ => Some((value.clone(), 0, width)),
         }
     }
 
@@ -801,6 +1059,19 @@ impl SymExpr {
         self.visit_bool(|expr| matches!(expr.kind(), SymExprKind::Op(SymExprOp::UDiv, _, _)))
     }
 
+    pub(crate) fn contains_ite(&self) -> bool {
+        self.visit_bool(|expr| matches!(expr.kind(), SymExprKind::Ite(_, _, _)))
+    }
+
+    pub(in crate::runtime) fn udiv_operands(&self) -> Option<(&Self, &Self)> {
+        match self.kind() {
+            SymExprKind::Op(SymExprOp::UDiv, numerator, denominator) => {
+                Some((numerator, denominator))
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) fn collect_eval_vars(&self, vars: &mut SymbolicVars) {
         let _ = self.visit(&mut |expr| {
             match expr.kind() {
@@ -878,6 +1149,49 @@ impl SymExpr {
             *byte = self.known_byte(idx)?;
         }
         Some(U256::from_be_bytes(word))
+    }
+
+    pub(crate) fn unsigned_bits(&self) -> usize {
+        match self.kind() {
+            SymExprKind::Const(value) => value.bit_len().max(1),
+            SymExprKind::Op(SymExprOp::And, left, right) => {
+                if let Some(mask) = right.as_const() {
+                    left.unsigned_bits().min(mask.bit_len())
+                } else if let Some(mask) = left.as_const() {
+                    right.unsigned_bits().min(mask.bit_len())
+                } else {
+                    256
+                }
+            }
+            SymExprKind::Op(SymExprOp::Add, left, right) => {
+                left.unsigned_bits().max(right.unsigned_bits()).saturating_add(1).min(256)
+            }
+            SymExprKind::Op(SymExprOp::Mul, left, right) => {
+                left.unsigned_bits().saturating_add(right.unsigned_bits()).min(256)
+            }
+            SymExprKind::Op(SymExprOp::Shl, left, right) => {
+                if let Some(shift) = right.as_const().and_then(|shift| usize::try_from(shift).ok())
+                {
+                    left.unsigned_bits().saturating_add(shift).min(256)
+                } else {
+                    256
+                }
+            }
+            SymExprKind::Op(SymExprOp::Shr, left, right) => {
+                if let Some(shift) = right.as_const().and_then(|shift| usize::try_from(shift).ok())
+                {
+                    left.unsigned_bits().saturating_sub(shift).max(1)
+                } else {
+                    256
+                }
+            }
+            SymExprKind::Op(SymExprOp::UDiv, left, _) => left.unsigned_bits(),
+            SymExprKind::AddMod { modulus, .. } | SymExprKind::MulMod { modulus, .. } => {
+                modulus.unsigned_bits()
+            }
+            SymExprKind::Ite(_, left, right) => left.unsigned_bits().max(right.unsigned_bits()),
+            _ => 256,
+        }
     }
 
     pub(crate) fn extracted_byte(&self, cx: &mut SymCx, index: usize) -> Self {

--- a/crates/evm/symbolic/src/runtime/expr/hashcons.rs
+++ b/crates/evm/symbolic/src/runtime/expr/hashcons.rs
@@ -22,7 +22,7 @@ struct HashConsedInner<T> {
 }
 
 impl<T> HashConsed<T> {
-    fn cached_hash(&self) -> u64 {
+    pub(in crate::runtime) fn cached_hash(&self) -> u64 {
         self.inner.hash
     }
 

--- a/crates/evm/symbolic/src/runtime/memory.rs
+++ b/crates/evm/symbolic/src/runtime/memory.rs
@@ -93,7 +93,7 @@ impl SymMemory {
         if left == right {
             left
         } else {
-            let condition = SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, left.clone(), right.clone());
+            let condition = SymBoolExpr::cmp(cx, SymCmpOp::Ult, left.clone(), right.clone());
             SymExpr::ite(cx, condition, right, left)
         }
     }
@@ -517,7 +517,7 @@ impl SymMemory {
         existing: SymExpr,
     ) -> SymExpr {
         let idx = SymExpr::constant(cx, U256::from(idx));
-        let condition = SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, idx, size.clone());
+        let condition = SymBoolExpr::cmp(cx, SymCmpOp::Ult, idx, size.clone());
         SymExpr::ite(cx, condition, source, existing)
     }
 
@@ -621,11 +621,11 @@ impl SymMemory {
         let mut guards = Vec::new();
         if let Some(output_size) = output_size {
             let idx_expr = SymExpr::constant(cx, U256::from(idx));
-            guards.push(SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, idx_expr, output_size.clone()));
+            guards.push(SymBoolExpr::cmp(cx, SymCmpOp::Ult, idx_expr, output_size.clone()));
         }
         if return_data.has_symbolic_len() {
             let idx_expr = SymExpr::constant(cx, U256::from(idx));
-            guards.push(SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, idx_expr, return_data.len_expr()));
+            guards.push(SymBoolExpr::cmp(cx, SymCmpOp::Ult, idx_expr, return_data.len_expr()));
         }
         let guard = SymBoolExpr::and(cx, guards);
         match guard.as_const() {

--- a/crates/evm/symbolic/src/runtime/memory.rs
+++ b/crates/evm/symbolic/src/runtime/memory.rs
@@ -56,11 +56,11 @@ struct SymbolicMemoryWrite {
 impl SymbolicMemoryWrite {
     fn size_after_access(&self, cx: &mut SymCx) -> SymExpr {
         let len = SymExpr::constant(cx, U256::from(self.bytes.len()));
-        let end = SymExpr::binop(cx, SymExprBinOp::Add, self.offset.clone(), len);
+        let end = SymExpr::binop(cx, SymBinOp::Add, self.offset.clone(), len);
         let round = SymExpr::constant(cx, U256::from(31));
-        let rounded = SymExpr::binop(cx, SymExprBinOp::Add, end, round);
+        let rounded = SymExpr::binop(cx, SymBinOp::Add, end, round);
         let mask = SymExpr::constant(cx, !U256::from(31));
-        SymExpr::binop(cx, SymExprBinOp::And, rounded, mask)
+        SymExpr::binop(cx, SymBinOp::And, rounded, mask)
     }
 
     fn concrete_offset(&self) -> Option<usize> {

--- a/crates/evm/symbolic/src/runtime/memory.rs
+++ b/crates/evm/symbolic/src/runtime/memory.rs
@@ -56,11 +56,11 @@ struct SymbolicMemoryWrite {
 impl SymbolicMemoryWrite {
     fn size_after_access(&self, cx: &mut SymCx) -> SymExpr {
         let len = SymExpr::constant(cx, U256::from(self.bytes.len()));
-        let end = SymExpr::op(cx, SymExprOp::Add, self.offset.clone(), len);
+        let end = SymExpr::binop(cx, SymExprBinOp::Add, self.offset.clone(), len);
         let round = SymExpr::constant(cx, U256::from(31));
-        let rounded = SymExpr::op(cx, SymExprOp::Add, end, round);
+        let rounded = SymExpr::binop(cx, SymExprBinOp::Add, end, round);
         let mask = SymExpr::constant(cx, !U256::from(31));
-        SymExpr::op(cx, SymExprOp::And, rounded, mask)
+        SymExpr::binop(cx, SymExprBinOp::And, rounded, mask)
     }
 
     fn concrete_offset(&self) -> Option<usize> {

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -14,10 +14,7 @@ pub(crate) use hard_arith_fallback::hard_arith_fallback_model;
 pub(crate) use monotonic_product::product_monotonic_unsat;
 use monotonic_product::product_monotonic_unsat_normalized;
 pub(crate) use opt::normalize_constraints_for_solver;
-use opt::{
-    constraint_cache_key, constraints_are_directly_unsat, sorted_bool_exprs_are_subset,
-    write_smt_assertions,
-};
+use opt::{constraints_are_directly_unsat, sorted_bool_exprs_are_subset, write_smt_assertions};
 #[cfg(test)]
 pub(crate) use opt::{normalize_bool_for_solver, normalize_expr_for_solver};
 
@@ -350,7 +347,7 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
         }
         let smt_constraints = normalize_constraints_for_solver(cx, constraints);
-        let cache_key = constraint_cache_key(cx, &smt_constraints);
+        let cache_key = smt_constraints.clone();
 
         if self.sat_cache.get(&cache_key) == Some(&false) {
             self.model_cache.remove(&cache_key);
@@ -455,7 +452,7 @@ impl SmtLibSubprocessSolver {
             return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
         }
         let smt_constraints = normalize_constraints_for_solver(cx, constraints);
-        let cache_key = constraint_cache_key(cx, &smt_constraints);
+        let cache_key = smt_constraints.clone();
         if let Some(result) = self.sat_cache.get(&cache_key) {
             self.sat_cache_hits += 1;
             trace!(result, "is_sat: normalized cache hit");
@@ -471,16 +468,14 @@ impl SmtLibSubprocessSolver {
             && let Some((condition, base)) = constraints.split_last()
             && {
                 let normalized_base = normalize_constraints_for_solver(cx, base);
-                let base_key = constraint_cache_key(cx, &normalized_base);
-                self.sat_cache.get(&base_key) == Some(&true)
+                self.sat_cache.get(&normalized_base) == Some(&true)
             }
             && {
                 let mut complement = Vec::with_capacity(constraints.len());
                 complement.extend(base.iter().cloned());
                 complement.push(condition.clone().not(cx));
                 let normalized_complement = normalize_constraints_for_solver(cx, &complement);
-                let complement_key = constraint_cache_key(cx, &normalized_complement);
-                self.has_cached_unsat_subset(&complement_key)
+                self.has_cached_unsat_subset(&normalized_complement)
             }
         {
             self.sat_cache_hits += 1;

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -28,9 +28,11 @@ impl SymExpr {
 
 fn is_hard_arith_node(expr: &SymExpr) -> bool {
     match expr.kind() {
-        SymExprKind::Op(SymExprOp::Mul, left, right) => left.contains_var() && right.contains_var(),
-        SymExprKind::Op(
-            SymExprOp::UDiv | SymExprOp::URem | SymExprOp::SDiv | SymExprOp::SRem,
+        SymExprKind::BinOp(SymExprBinOp::Mul, left, right) => {
+            left.contains_var() && right.contains_var()
+        }
+        SymExprKind::BinOp(
+            SymExprBinOp::UDiv | SymExprBinOp::URem | SymExprBinOp::SDiv | SymExprBinOp::SRem,
             left,
             right,
         ) => left.contains_var() || right.contains_var(),
@@ -356,7 +358,7 @@ fn zero_mask_equality(var: &str, masked: &SymExpr, zero: &SymExpr) -> Option<U25
         return None;
     }
     match masked.kind() {
-        SymExprKind::Op(SymExprOp::And, left, right) => match (left.kind(), right.kind()) {
+        SymExprKind::BinOp(SymExprBinOp::And, left, right) => match (left.kind(), right.kind()) {
             (SymExprKind::Var(name), SymExprKind::Const(mask))
             | (SymExprKind::Const(mask), SymExprKind::Var(name))
                 if name.as_str() == var =>

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -36,8 +36,7 @@ fn is_hard_arith_node(expr: &SymExpr) -> bool {
             left,
             right,
         ) => left.contains_var() || right.contains_var(),
-        SymExprKind::AddMod { left, right, modulus }
-        | SymExprKind::MulMod { left, right, modulus } => {
+        SymExprKind::TernOp(_, left, right, modulus) => {
             left.contains_var() || right.contains_var() || modulus.contains_var()
         }
         _ => false,

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -334,7 +334,9 @@ impl MaskHints {
                     self.apply_bool(var, value, false);
                 }
             }
-            SymBoolExprKind::Eq(left, right) => self.apply_equality(var, left, right, inverted),
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => {
+                self.apply_equality(var, left, right, inverted)
+            }
             SymBoolExprKind::Cmp(_, _, _) | SymBoolExprKind::And(_) => {}
         }
     }

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -28,11 +28,11 @@ impl SymExpr {
 
 fn is_hard_arith_node(expr: &SymExpr) -> bool {
     match expr.kind() {
-        SymExprKind::BinOp(SymExprBinOp::Mul, left, right) => {
+        SymExprKind::BinOp(SymBinOp::Mul, left, right) => {
             left.contains_var() && right.contains_var()
         }
         SymExprKind::BinOp(
-            SymExprBinOp::UDiv | SymExprBinOp::URem | SymExprBinOp::SDiv | SymExprBinOp::SRem,
+            SymBinOp::UDiv | SymBinOp::URem | SymBinOp::SDiv | SymBinOp::SRem,
             left,
             right,
         ) => left.contains_var() || right.contains_var(),
@@ -359,7 +359,7 @@ fn zero_mask_equality(var: &str, masked: &SymExpr, zero: &SymExpr) -> Option<U25
         return None;
     }
     match masked.kind() {
-        SymExprKind::BinOp(SymExprBinOp::And, left, right) => match (left.kind(), right.kind()) {
+        SymExprKind::BinOp(SymBinOp::And, left, right) => match (left.kind(), right.kind()) {
             (SymExprKind::Var(name), SymExprKind::Const(mask))
             | (SymExprKind::Const(mask), SymExprKind::Var(name))
                 if name.as_str() == var =>

--- a/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
+++ b/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
@@ -99,7 +99,7 @@ fn product_less_than_known_ordered<'a>(
 
 fn mul_operands(expr: &SymExpr) -> Option<(&SymExpr, &SymExpr)> {
     match expr.kind() {
-        SymExprKind::Op(SymExprOp::Mul, left, right) => Some((left, right)),
+        SymExprKind::BinOp(SymExprBinOp::Mul, left, right) => Some((left, right)),
         _ => None,
     }
 }

--- a/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
+++ b/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
@@ -36,13 +36,13 @@ fn collect_order_facts<'a>(
                 collect_order_facts(value, less_than, positive);
             }
         }
-        SymBoolExprKind::Cmp(SymBoolExprOp::Ult, left, right) => {
+        SymBoolExprKind::Cmp(SymCmpOp::Ult, left, right) => {
             less_than.insert((left, right));
             if left.as_const().is_some_and(|value| value.is_zero()) {
                 positive.insert(right);
             }
         }
-        SymBoolExprKind::Cmp(SymBoolExprOp::Ugt, left, right) => {
+        SymBoolExprKind::Cmp(SymCmpOp::Ugt, left, right) => {
             less_than.insert((right, left));
             if right.as_const().is_some_and(|value| value.is_zero()) {
                 positive.insert(left);
@@ -50,7 +50,7 @@ fn collect_order_facts<'a>(
         }
         SymBoolExprKind::Const(_)
         | SymBoolExprKind::Not(_)
-        | SymBoolExprKind::Eq(_, _)
+        | SymBoolExprKind::Cmp(SymCmpOp::Eq, _, _)
         | SymBoolExprKind::Cmp(_, _, _) => {}
     }
 }
@@ -59,7 +59,7 @@ fn product_less_than_negation(
     expr: &SymBoolExpr,
 ) -> Option<(&SymExpr, &SymExpr, &SymExpr, &SymExpr)> {
     let SymBoolExprKind::Not(value) = expr.kind() else { return None };
-    let SymBoolExprKind::Cmp(SymBoolExprOp::Ult, left, right) = value.kind() else {
+    let SymBoolExprKind::Cmp(SymCmpOp::Ult, left, right) = value.kind() else {
         return None;
     };
     let (left_a, left_b) = mul_operands(left)?;

--- a/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
+++ b/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
@@ -48,10 +48,7 @@ fn collect_order_facts<'a>(
                 positive.insert(left);
             }
         }
-        SymBoolExprKind::Const(_)
-        | SymBoolExprKind::Not(_)
-        | SymBoolExprKind::Cmp(SymCmpOp::Eq, _, _)
-        | SymBoolExprKind::Cmp(_, _, _) => {}
+        SymBoolExprKind::Const(_) | SymBoolExprKind::Not(_) | SymBoolExprKind::Cmp(_, _, _) => {}
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
+++ b/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
@@ -96,7 +96,7 @@ fn product_less_than_known_ordered<'a>(
 
 fn mul_operands(expr: &SymExpr) -> Option<(&SymExpr, &SymExpr)> {
     match expr.kind() {
-        SymExprKind::BinOp(SymExprBinOp::Mul, left, right) => Some((left, right)),
+        SymExprKind::BinOp(SymBinOp::Mul, left, right) => Some((left, right)),
         _ => None,
     }
 }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -250,6 +250,7 @@ pub(super) fn write_smt_assertions(out: &mut String, constraints: &[SymBoolExpr]
 struct SmtCseVisit {
     count: usize,
     binding: Option<usize>,
+    collected: bool,
 }
 
 struct SmtCsePlan {
@@ -275,7 +276,11 @@ impl SmtCsePlan {
     }
 
     fn count_expr(&mut self, expr: &SymExpr) {
-        self.expr_visits.entry(expr.clone()).or_default().count += 1;
+        let visit = self.expr_visits.entry(expr.clone()).or_default();
+        visit.count += 1;
+        if visit.count != 1 {
+            return;
+        }
         match expr.kind() {
             SymExprKind::Const(_)
             | SymExprKind::Var(_)
@@ -302,7 +307,11 @@ impl SmtCsePlan {
     }
 
     fn count_bool(&mut self, expr: &SymBoolExpr) {
-        self.bool_visits.entry(expr.clone()).or_default().count += 1;
+        let visit = self.bool_visits.entry(expr.clone()).or_default();
+        visit.count += 1;
+        if visit.count != 1 {
+            return;
+        }
         match expr.kind() {
             SymBoolExprKind::Const(_) => {}
             SymBoolExprKind::Not(value) => self.count_bool(value),
@@ -319,6 +328,13 @@ impl SmtCsePlan {
     }
 
     fn collect_expr_binding(&mut self, expr: &SymExpr) {
+        {
+            let Some(visit) = self.expr_visits.get_mut(expr) else { return };
+            if visit.collected {
+                return;
+            }
+            visit.collected = true;
+        }
         match expr.kind() {
             SymExprKind::Const(_)
             | SymExprKind::Var(_)
@@ -345,6 +361,13 @@ impl SmtCsePlan {
     }
 
     fn collect_bool_binding(&mut self, expr: &SymBoolExpr) {
+        {
+            let Some(visit) = self.bool_visits.get_mut(expr) else { return };
+            if visit.collected {
+                return;
+            }
+            visit.collected = true;
+        }
         match expr.kind() {
             SymBoolExprKind::Const(_) => {}
             SymBoolExprKind::Not(value) => self.collect_bool_binding(value),

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -614,6 +614,7 @@ impl ConstraintContext {
                 .zero_check_operand()
                 .is_some_and(|left| self.word_bool_always_true(cx, left)) =>
             {
+                // `always_true_word == 0 => false`.
                 SymBoolExpr::constant(cx, false)
             }
             SymBoolExprKind::Not(value)
@@ -621,6 +622,7 @@ impl ConstraintContext {
                     .zero_check_operand()
                     .is_some_and(|left| self.word_bool_always_true(cx, left)) =>
             {
+                // `always_true_word != 0 => true`.
                 SymBoolExpr::constant(cx, true)
             }
             _ => expr,
@@ -706,16 +708,19 @@ fn normalize_ite_expr_for_solver(
 ) -> SymExpr {
     let cond = normalize_bool_for_solver(cx, cond);
     if left == right {
+        // `ite(c, a, a) => a`.
         return left;
     }
     if left.as_const() == Some(U256::from(1))
         && right.normalized_bool_word_condition(cx).as_ref() == Some(&cond)
     {
+        // `ite(c, 1, bool_word(c)) => bool_word(c)`.
         return right;
     }
     if right.as_const().is_some_and(|value| value.is_zero())
         && left.normalized_bool_word_condition(cx).as_ref() == Some(&cond)
     {
+        // `ite(c, bool_word(c), 0) => bool_word(c)`.
         return left;
     }
     SymExpr::ite(cx, cond, left, right)
@@ -743,6 +748,7 @@ impl SymBoolExpr {
             {
                 left.normalized_bool_word_condition(cx).map(|value| value.not(cx)).or_else(|| {
                     if left.word_bool_always_true(cx) {
+                        // `always_true_word == 0 => false`.
                         Some(Self::constant(cx, false))
                     } else {
                         let zero = SymExpr::zero(cx);
@@ -755,6 +761,7 @@ impl SymBoolExpr {
             {
                 right.normalized_bool_word_condition(cx).map(|value| value.not(cx)).or_else(|| {
                     if right.word_bool_always_true(cx) {
+                        // `0 == always_true_word => false`.
                         Some(Self::constant(cx, false))
                     } else {
                         let zero = SymExpr::zero(cx);
@@ -765,11 +772,13 @@ impl SymBoolExpr {
             SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                 if right.as_const() == Some(U256::from(1)) =>
             {
+                // `bool_word(c) == 1 => c`.
                 left.normalized_bool_word_condition(cx)
             }
             SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                 if left.as_const() == Some(U256::from(1)) =>
             {
+                // `1 == bool_word(c) => c`.
                 right.normalized_bool_word_condition(cx)
             }
             SymBoolExprKind::Not(value) => match value.kind() {
@@ -777,6 +786,7 @@ impl SymBoolExpr {
                     if right.as_const().is_some_and(|value| value.is_zero()) =>
                 {
                     if left.word_bool_always_true(cx) {
+                        // `always_true_word != 0 => true`.
                         Some(Self::constant(cx, true))
                     } else {
                         let zero = SymExpr::zero(cx);
@@ -787,6 +797,7 @@ impl SymBoolExpr {
                     if left.as_const().is_some_and(|value| value.is_zero()) =>
                 {
                     if right.word_bool_always_true(cx) {
+                        // `0 != always_true_word => true`.
                         Some(Self::constant(cx, true))
                     } else {
                         let zero = SymExpr::zero(cx);
@@ -824,7 +835,9 @@ impl SymBoolExpr {
         right: &SymExpr,
     ) -> Option<Self> {
         match op {
+            // `a + b > a => false` when `a + b` cannot overflow.
             SymCmpOp::Ugt if left.add_overflow_check(right) => Some(Self::constant(cx, false)),
+            // `a < a + b => false` when `a + b` cannot overflow.
             SymCmpOp::Ult if right.add_overflow_check(left) => Some(Self::constant(cx, false)),
             _ => None,
         }
@@ -834,11 +847,13 @@ impl SymBoolExpr {
         if right.as_const().is_some_and(|value| value.is_zero())
             && let Some(condition) = left.normalize_eq_zero_for_solver(cx)
         {
+            // `word_bool(c) == 0 => !c`.
             return Some(condition);
         }
         if left.as_const().is_some_and(|value| value.is_zero())
             && let Some(condition) = right.normalize_eq_zero_for_solver(cx)
         {
+            // `0 == word_bool(c) => !c`.
             return Some(condition);
         }
         None
@@ -851,27 +866,35 @@ impl SymBoolExpr {
         right: &SymExpr,
     ) -> Option<Self> {
         match (op, left.as_const(), right.as_const()) {
+            // `a > 0 => a != 0`.
             (SymCmpOp::Ugt, _, Some(value)) if value.is_zero() => {
                 left.normalize_ne_zero_for_solver(cx)
             }
+            // `a >= 1 => a != 0`.
             (SymCmpOp::Uge, _, Some(value)) if value == U256::from(1) => {
                 left.normalize_ne_zero_for_solver(cx)
             }
+            // `a <= 0 => a == 0`.
             (SymCmpOp::Ule, _, Some(value)) if value.is_zero() => {
                 left.normalize_eq_zero_for_solver(cx)
             }
+            // `a < 1 => a == 0`.
             (SymCmpOp::Ult, _, Some(value)) if value == U256::from(1) => {
                 left.normalize_eq_zero_for_solver(cx)
             }
+            // `0 < a => a != 0`.
             (SymCmpOp::Ult, Some(value), _) if value.is_zero() => {
                 right.normalize_ne_zero_for_solver(cx)
             }
+            // `1 <= a => a != 0`.
             (SymCmpOp::Ule, Some(value), _) if value == U256::from(1) => {
                 right.normalize_ne_zero_for_solver(cx)
             }
+            // `0 >= a => a == 0`.
             (SymCmpOp::Uge, Some(value), _) if value.is_zero() => {
                 right.normalize_eq_zero_for_solver(cx)
             }
+            // `1 > a => a == 0`.
             (SymCmpOp::Ugt, Some(value), _) if value == U256::from(1) => {
                 right.normalize_eq_zero_for_solver(cx)
             }
@@ -905,6 +928,7 @@ impl SymExpr {
 
     fn normalize_eq_zero_for_solver(&self, cx: &mut SymCx) -> Option<SymBoolExpr> {
         if let Some((numerator, denominator)) = self.udiv_operands() {
+            // `a / b == 0 => b == 0 || a < b`.
             return Some(Self::udiv_zero_condition(cx, numerator, denominator));
         }
         if let SymExprKind::Ite(condition, then_expr, else_expr) = self.kind() {
@@ -927,6 +951,7 @@ impl SymExpr {
             if then_zero.contains_udiv() || else_zero.contains_udiv() {
                 return None;
             }
+            // `ite(c, a, b) == 0 => (c && a == 0) || (!c && b == 0)`.
             let condition = normalize_bool_for_solver(cx, condition.clone());
             let then_condition = SymBoolExpr::and(cx, vec![condition.clone(), then_zero]);
             let not_condition = condition.not(cx);
@@ -938,6 +963,7 @@ impl SymExpr {
 
     fn normalize_ne_zero_for_solver(&self, cx: &mut SymCx) -> Option<SymBoolExpr> {
         if let Some((numerator, denominator)) = self.udiv_operands() {
+            // `a / b != 0 => b != 0 && a >= b`.
             return Some(Self::udiv_nonzero_condition(cx, numerator, denominator));
         }
         if let SymExprKind::Ite(condition, then_expr, else_expr) = self.kind() {
@@ -960,6 +986,7 @@ impl SymExpr {
             if then_nonzero.contains_udiv() || else_nonzero.contains_udiv() {
                 return None;
             }
+            // `ite(c, a, b) != 0 => (c && a != 0) || (!c && b != 0)`.
             let condition = normalize_bool_for_solver(cx, condition.clone());
             let then_condition = SymBoolExpr::and(cx, vec![condition.clone(), then_nonzero]);
             let not_condition = condition.not(cx);
@@ -1004,12 +1031,14 @@ impl ConstraintContext {
             let negated = term.clone().not(cx);
             bool_terms.contains(&negated)
         }) {
+            // `c || !c => true`.
             return true;
         }
         for zero_term in &bool_terms {
             let Some(zero_operand) = zero_term.zero_check_operand() else { continue };
             if bool_terms.iter().any(|term| self.checked_mul_guard_for_operand(term, zero_operand))
             {
+                // `a == 0 || guarded_mul_div(a) => true`.
                 return true;
             }
         }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -647,35 +647,54 @@ impl ConstraintContext {
         constraint: &'a SymBoolExpr,
     ) -> Option<(&'a SymExpr, U256)> {
         match constraint.kind() {
-            SymBoolExprKind::Cmp(op, left, right) => {
-                match (*op, left.as_const(), right.as_const()) {
-                    (SymCmpOp::Eq, _, Some(value)) => Some((left, value)),
-                    (SymCmpOp::Eq, Some(value), _) => Some((right, value)),
-                    (SymCmpOp::Ult, _, Some(bound)) => {
-                        (!bound.is_zero()).then(|| (left, bound - U256::from(1)))
-                    }
-                    (SymCmpOp::Ule, _, Some(bound)) => Some((left, bound)),
-                    (SymCmpOp::Ugt, Some(bound), _) => {
-                        (!bound.is_zero()).then(|| (right, bound - U256::from(1)))
-                    }
-                    (SymCmpOp::Uge, Some(bound), _) => Some((right, bound)),
+            SymBoolExprKind::Cmp(op, left, right) => match *op {
+                SymCmpOp::Eq => match (left.as_const(), right.as_const()) {
+                    (_, Some(value)) => Some((left, value)),
+                    (Some(value), _) => Some((right, value)),
                     _ => None,
-                }
-            }
+                },
+                SymCmpOp::Ult => match (left.as_const(), right.as_const()) {
+                    (_, Some(bound)) => (!bound.is_zero()).then(|| (left, bound - U256::from(1))),
+                    _ => None,
+                },
+                SymCmpOp::Ule => match (left.as_const(), right.as_const()) {
+                    (_, Some(bound)) => Some((left, bound)),
+                    _ => None,
+                },
+                SymCmpOp::Ugt => match (left.as_const(), right.as_const()) {
+                    (Some(bound), _) => (!bound.is_zero()).then(|| (right, bound - U256::from(1))),
+                    _ => None,
+                },
+                SymCmpOp::Uge => match (left.as_const(), right.as_const()) {
+                    (Some(bound), _) => Some((right, bound)),
+                    _ => None,
+                },
+                SymCmpOp::Slt | SymCmpOp::Sgt => None,
+            },
             SymBoolExprKind::Not(value) => match value.kind() {
-                SymBoolExprKind::Cmp(op, left, right) => {
-                    match (*op, left.as_const(), right.as_const()) {
-                        (SymCmpOp::Ugt, _, Some(bound)) => Some((left, bound)),
-                        (SymCmpOp::Uge, _, Some(bound)) => {
+                SymBoolExprKind::Cmp(op, left, right) => match *op {
+                    SymCmpOp::Ugt => match (left.as_const(), right.as_const()) {
+                        (_, Some(bound)) => Some((left, bound)),
+                        _ => None,
+                    },
+                    SymCmpOp::Uge => match (left.as_const(), right.as_const()) {
+                        (_, Some(bound)) => {
                             (!bound.is_zero()).then(|| (left, bound - U256::from(1)))
                         }
-                        (SymCmpOp::Ult, Some(bound), _) => Some((right, bound)),
-                        (SymCmpOp::Ule, Some(bound), _) => {
+                        _ => None,
+                    },
+                    SymCmpOp::Ult => match (left.as_const(), right.as_const()) {
+                        (Some(bound), _) => Some((right, bound)),
+                        _ => None,
+                    },
+                    SymCmpOp::Ule => match (left.as_const(), right.as_const()) {
+                        (Some(bound), _) => {
                             (!bound.is_zero()).then(|| (right, bound - U256::from(1)))
                         }
                         _ => None,
-                    }
-                }
+                    },
+                    SymCmpOp::Eq | SymCmpOp::Slt | SymCmpOp::Sgt => None,
+                },
                 _ => None,
             },
             SymBoolExprKind::Const(_) | SymBoolExprKind::And(_) => None,
@@ -865,40 +884,40 @@ impl SymBoolExpr {
         left: &SymExpr,
         right: &SymExpr,
     ) -> Option<Self> {
-        match (op, left.as_const(), right.as_const()) {
-            // `a > 0 => a != 0`.
-            (SymCmpOp::Ugt, _, Some(value)) if value.is_zero() => {
-                left.normalize_ne_zero_for_solver(cx)
-            }
-            // `a >= 1 => a != 0`.
-            (SymCmpOp::Uge, _, Some(value)) if value == U256::from(1) => {
-                left.normalize_ne_zero_for_solver(cx)
-            }
-            // `a <= 0 => a == 0`.
-            (SymCmpOp::Ule, _, Some(value)) if value.is_zero() => {
-                left.normalize_eq_zero_for_solver(cx)
-            }
-            // `a < 1 => a == 0`.
-            (SymCmpOp::Ult, _, Some(value)) if value == U256::from(1) => {
-                left.normalize_eq_zero_for_solver(cx)
-            }
-            // `0 < a => a != 0`.
-            (SymCmpOp::Ult, Some(value), _) if value.is_zero() => {
-                right.normalize_ne_zero_for_solver(cx)
-            }
-            // `1 <= a => a != 0`.
-            (SymCmpOp::Ule, Some(value), _) if value == U256::from(1) => {
-                right.normalize_ne_zero_for_solver(cx)
-            }
-            // `0 >= a => a == 0`.
-            (SymCmpOp::Uge, Some(value), _) if value.is_zero() => {
-                right.normalize_eq_zero_for_solver(cx)
-            }
-            // `1 > a => a == 0`.
-            (SymCmpOp::Ugt, Some(value), _) if value == U256::from(1) => {
-                right.normalize_eq_zero_for_solver(cx)
-            }
-            _ => None,
+        match op {
+            SymCmpOp::Ugt => match (left.as_const(), right.as_const()) {
+                // `a > 0 => a != 0`.
+                (_, Some(value)) if value.is_zero() => left.normalize_ne_zero_for_solver(cx),
+                // `1 > a => a == 0`.
+                (Some(value), _) if value == U256::from(1) => {
+                    right.normalize_eq_zero_for_solver(cx)
+                }
+                _ => None,
+            },
+            SymCmpOp::Uge => match (left.as_const(), right.as_const()) {
+                // `a >= 1 => a != 0`.
+                (_, Some(value)) if value == U256::from(1) => left.normalize_ne_zero_for_solver(cx),
+                // `0 >= a => a == 0`.
+                (Some(value), _) if value.is_zero() => right.normalize_eq_zero_for_solver(cx),
+                _ => None,
+            },
+            SymCmpOp::Ule => match (left.as_const(), right.as_const()) {
+                // `a <= 0 => a == 0`.
+                (_, Some(value)) if value.is_zero() => left.normalize_eq_zero_for_solver(cx),
+                // `1 <= a => a != 0`.
+                (Some(value), _) if value == U256::from(1) => {
+                    right.normalize_ne_zero_for_solver(cx)
+                }
+                _ => None,
+            },
+            SymCmpOp::Ult => match (left.as_const(), right.as_const()) {
+                // `a < 1 => a == 0`.
+                (_, Some(value)) if value == U256::from(1) => left.normalize_eq_zero_for_solver(cx),
+                // `0 < a => a != 0`.
+                (Some(value), _) if value.is_zero() => right.normalize_ne_zero_for_solver(cx),
+                _ => None,
+            },
+            SymCmpOp::Eq | SymCmpOp::Slt | SymCmpOp::Sgt => None,
         }
     }
 }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -63,14 +63,8 @@ fn write_bool_structural_key(out: &mut String, expr: &SymBoolExpr) {
                 out.push(';');
             }
         }
-        SymBoolExprKind::Eq(left, right) => {
-            out.push_str("3:");
-            write_expr_structural_key(out, left);
-            out.push(':');
-            write_expr_structural_key(out, right);
-        }
         SymBoolExprKind::Cmp(op, left, right) => {
-            let _ = write!(out, "4:{}:", bool_op_key(*op));
+            let _ = write!(out, "3:{}:", cmp_op_key(*op));
             write_expr_structural_key(out, left);
             out.push(':');
             write_expr_structural_key(out, right);
@@ -135,14 +129,15 @@ fn write_exprs_structural_key(out: &mut String, exprs: &[SymExpr]) {
     }
 }
 
-const fn bool_op_key(op: SymBoolExprOp) -> u8 {
+const fn cmp_op_key(op: SymCmpOp) -> u8 {
     match op {
-        SymBoolExprOp::Ult => 0,
-        SymBoolExprOp::Ugt => 1,
-        SymBoolExprOp::Ule => 2,
-        SymBoolExprOp::Uge => 3,
-        SymBoolExprOp::Slt => 4,
-        SymBoolExprOp::Sgt => 5,
+        SymCmpOp::Eq => 0,
+        SymCmpOp::Ult => 1,
+        SymCmpOp::Ugt => 2,
+        SymCmpOp::Ule => 3,
+        SymCmpOp::Uge => 4,
+        SymCmpOp::Slt => 5,
+        SymCmpOp::Sgt => 6,
     }
 }
 
@@ -316,7 +311,7 @@ impl SmtCsePlan {
                     self.count_bool(value);
                 }
             }
-            SymBoolExprKind::Eq(left, right) | SymBoolExprKind::Cmp(_, left, right) => {
+            SymBoolExprKind::Cmp(_, left, right) => {
                 self.count_expr(left);
                 self.count_expr(right);
             }
@@ -358,7 +353,7 @@ impl SmtCsePlan {
                     self.collect_bool_binding(value);
                 }
             }
-            SymBoolExprKind::Eq(left, right) | SymBoolExprKind::Cmp(_, left, right) => {
+            SymBoolExprKind::Cmp(_, left, right) => {
                 self.collect_expr_binding(left);
                 self.collect_expr_binding(right);
             }
@@ -548,13 +543,6 @@ impl SmtCseWriter<'_> {
                 }
                 out.push(')');
             }
-            SymBoolExprKind::Eq(left, right) => {
-                out.push_str("(= ");
-                self.write_expr(out, left, skip_expr, skip_bool);
-                out.push(' ');
-                self.write_expr(out, right, skip_expr, skip_bool);
-                out.push(')');
-            }
             SymBoolExprKind::Cmp(op, left, right) => {
                 let _ = write!(out, "({} ", op.smt());
                 self.write_expr(out, left, skip_expr, skip_bool);
@@ -572,12 +560,6 @@ fn normalize_bool_node_for_solver(cx: &mut SymCx, expr: SymBoolExpr) -> SymBoolE
     }
 
     match expr.kind() {
-        SymBoolExprKind::Eq(left, right) => {
-            let left = normalize_expr_for_solver(cx, left.clone());
-            let right = normalize_expr_for_solver(cx, right.clone());
-            let normalized = SymBoolExpr::eq(cx, left, right);
-            normalized.normalize_udiv_for_solver(cx).unwrap_or(normalized)
-        }
         SymBoolExprKind::Cmp(op, left, right) => {
             let left = normalize_expr_for_solver(cx, left.clone());
             let right = normalize_expr_for_solver(cx, right.clone());
@@ -590,18 +572,18 @@ fn normalize_bool_node_for_solver(cx: &mut SymCx, expr: SymBoolExpr) -> SymBoolE
 
 fn normalize_cmp_for_solver(
     cx: &mut SymCx,
-    op: SymBoolExprOp,
+    op: SymCmpOp,
     left: SymExpr,
     right: SymExpr,
 ) -> SymBoolExpr {
     match op {
         // `a > b => b < a`.
-        SymBoolExprOp::Ugt => SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, right, left),
+        SymCmpOp::Ugt => SymBoolExpr::cmp(cx, SymCmpOp::Ult, right, left),
         // `a >= b => b <= a`.
-        SymBoolExprOp::Uge => SymBoolExpr::cmp(cx, SymBoolExprOp::Ule, right, left),
+        SymCmpOp::Uge => SymBoolExpr::cmp(cx, SymCmpOp::Ule, right, left),
         // `a >s b => b <s a`.
-        SymBoolExprOp::Sgt => SymBoolExpr::cmp(cx, SymBoolExprOp::Slt, right, left),
-        SymBoolExprOp::Ult | SymBoolExprOp::Ule | SymBoolExprOp::Slt => {
+        SymCmpOp::Sgt => SymBoolExpr::cmp(cx, SymCmpOp::Slt, right, left),
+        SymCmpOp::Eq | SymCmpOp::Ult | SymCmpOp::Ule | SymCmpOp::Slt => {
             SymBoolExpr::cmp(cx, op, left, right)
         }
     }
@@ -663,33 +645,30 @@ impl ConstraintContext {
         constraint: &'a SymBoolExpr,
     ) -> Option<(&'a SymExpr, U256)> {
         match constraint.kind() {
-            SymBoolExprKind::Eq(left, right) => match (left.as_const(), right.as_const()) {
-                (_, Some(value)) => Some((left, value)),
-                (Some(value), _) => Some((right, value)),
-                _ => None,
-            },
             SymBoolExprKind::Cmp(op, left, right) => {
                 match (*op, left.as_const(), right.as_const()) {
-                    (SymBoolExprOp::Ult, _, Some(bound)) => {
+                    (SymCmpOp::Eq, _, Some(value)) => Some((left, value)),
+                    (SymCmpOp::Eq, Some(value), _) => Some((right, value)),
+                    (SymCmpOp::Ult, _, Some(bound)) => {
                         (!bound.is_zero()).then(|| (left, bound - U256::from(1)))
                     }
-                    (SymBoolExprOp::Ule, _, Some(bound)) => Some((left, bound)),
-                    (SymBoolExprOp::Ugt, Some(bound), _) => {
+                    (SymCmpOp::Ule, _, Some(bound)) => Some((left, bound)),
+                    (SymCmpOp::Ugt, Some(bound), _) => {
                         (!bound.is_zero()).then(|| (right, bound - U256::from(1)))
                     }
-                    (SymBoolExprOp::Uge, Some(bound), _) => Some((right, bound)),
+                    (SymCmpOp::Uge, Some(bound), _) => Some((right, bound)),
                     _ => None,
                 }
             }
             SymBoolExprKind::Not(value) => match value.kind() {
                 SymBoolExprKind::Cmp(op, left, right) => {
                     match (*op, left.as_const(), right.as_const()) {
-                        (SymBoolExprOp::Ugt, _, Some(bound)) => Some((left, bound)),
-                        (SymBoolExprOp::Uge, _, Some(bound)) => {
+                        (SymCmpOp::Ugt, _, Some(bound)) => Some((left, bound)),
+                        (SymCmpOp::Uge, _, Some(bound)) => {
                             (!bound.is_zero()).then(|| (left, bound - U256::from(1)))
                         }
-                        (SymBoolExprOp::Ult, Some(bound), _) => Some((right, bound)),
-                        (SymBoolExprOp::Ule, Some(bound), _) => {
+                        (SymCmpOp::Ult, Some(bound), _) => Some((right, bound)),
+                        (SymCmpOp::Ule, Some(bound), _) => {
                             (!bound.is_zero()).then(|| (right, bound - U256::from(1)))
                         }
                         _ => None,
@@ -759,7 +738,7 @@ impl SymExpr {
 impl SymBoolExpr {
     fn normalize_udiv_for_solver(&self, cx: &mut SymCx) -> Option<Self> {
         match self.kind() {
-            SymBoolExprKind::Eq(left, right)
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                 if right.as_const().is_some_and(|value| value.is_zero()) =>
             {
                 left.normalized_bool_word_condition(cx).map(|value| value.not(cx)).or_else(|| {
@@ -771,7 +750,7 @@ impl SymBoolExpr {
                     }
                 })
             }
-            SymBoolExprKind::Eq(left, right)
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                 if left.as_const().is_some_and(|value| value.is_zero()) =>
             {
                 right.normalized_bool_word_condition(cx).map(|value| value.not(cx)).or_else(|| {
@@ -783,22 +762,18 @@ impl SymBoolExpr {
                     }
                 })
             }
-            SymBoolExprKind::Eq(left, right) if right.as_const() == Some(U256::from(1)) => {
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
+                if right.as_const() == Some(U256::from(1)) =>
+            {
                 left.normalized_bool_word_condition(cx)
             }
-            SymBoolExprKind::Eq(left, right) if left.as_const() == Some(U256::from(1)) => {
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
+                if left.as_const() == Some(U256::from(1)) =>
+            {
                 right.normalized_bool_word_condition(cx)
             }
             SymBoolExprKind::Not(value) => match value.kind() {
-                SymBoolExprKind::Cmp(op, left, right) => {
-                    Self::normalize_add_overflow_cmp(cx, *op, left, right)
-                        .map(|value| value.not(cx))
-                        .or_else(|| {
-                            Self::normalize_udiv_cmp(cx, *op, left, right)
-                                .map(|value| value.not(cx))
-                        })
-                }
-                SymBoolExprKind::Eq(left, right)
+                SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                     if right.as_const().is_some_and(|value| value.is_zero()) =>
                 {
                     if left.word_bool_always_true(cx) {
@@ -808,7 +783,7 @@ impl SymBoolExpr {
                         Self::normalize_udiv_eq_zero(cx, left, &zero).map(|value| value.not(cx))
                     }
                 }
-                SymBoolExprKind::Eq(left, right)
+                SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                     if left.as_const().is_some_and(|value| value.is_zero()) =>
                 {
                     if right.word_bool_always_true(cx) {
@@ -818,12 +793,22 @@ impl SymBoolExpr {
                         Self::normalize_udiv_eq_zero(cx, &zero, right).map(|value| value.not(cx))
                     }
                 }
-                SymBoolExprKind::Eq(left, right) => {
+                SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => {
                     Self::normalize_udiv_eq_zero(cx, left, right).map(|value| value.not(cx))
+                }
+                SymBoolExprKind::Cmp(op, left, right) => {
+                    Self::normalize_add_overflow_cmp(cx, *op, left, right)
+                        .map(|value| value.not(cx))
+                        .or_else(|| {
+                            Self::normalize_udiv_cmp(cx, *op, left, right)
+                                .map(|value| value.not(cx))
+                        })
                 }
                 _ => None,
             },
-            SymBoolExprKind::Eq(left, right) => Self::normalize_udiv_eq_zero(cx, left, right),
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => {
+                Self::normalize_udiv_eq_zero(cx, left, right)
+            }
             SymBoolExprKind::Cmp(op, left, right) => {
                 Self::normalize_add_overflow_cmp(cx, *op, left, right)
                     .or_else(|| Self::normalize_udiv_cmp(cx, *op, left, right))
@@ -834,13 +819,13 @@ impl SymBoolExpr {
 
     fn normalize_add_overflow_cmp(
         cx: &mut SymCx,
-        op: SymBoolExprOp,
+        op: SymCmpOp,
         left: &SymExpr,
         right: &SymExpr,
     ) -> Option<Self> {
         match op {
-            SymBoolExprOp::Ugt if left.add_overflow_check(right) => Some(Self::constant(cx, false)),
-            SymBoolExprOp::Ult if right.add_overflow_check(left) => Some(Self::constant(cx, false)),
+            SymCmpOp::Ugt if left.add_overflow_check(right) => Some(Self::constant(cx, false)),
+            SymCmpOp::Ult if right.add_overflow_check(left) => Some(Self::constant(cx, false)),
             _ => None,
         }
     }
@@ -861,33 +846,33 @@ impl SymBoolExpr {
 
     fn normalize_udiv_cmp(
         cx: &mut SymCx,
-        op: SymBoolExprOp,
+        op: SymCmpOp,
         left: &SymExpr,
         right: &SymExpr,
     ) -> Option<Self> {
         match (op, left.as_const(), right.as_const()) {
-            (SymBoolExprOp::Ugt, _, Some(value)) if value.is_zero() => {
+            (SymCmpOp::Ugt, _, Some(value)) if value.is_zero() => {
                 left.normalize_ne_zero_for_solver(cx)
             }
-            (SymBoolExprOp::Uge, _, Some(value)) if value == U256::from(1) => {
+            (SymCmpOp::Uge, _, Some(value)) if value == U256::from(1) => {
                 left.normalize_ne_zero_for_solver(cx)
             }
-            (SymBoolExprOp::Ule, _, Some(value)) if value.is_zero() => {
+            (SymCmpOp::Ule, _, Some(value)) if value.is_zero() => {
                 left.normalize_eq_zero_for_solver(cx)
             }
-            (SymBoolExprOp::Ult, _, Some(value)) if value == U256::from(1) => {
+            (SymCmpOp::Ult, _, Some(value)) if value == U256::from(1) => {
                 left.normalize_eq_zero_for_solver(cx)
             }
-            (SymBoolExprOp::Ult, Some(value), _) if value.is_zero() => {
+            (SymCmpOp::Ult, Some(value), _) if value.is_zero() => {
                 right.normalize_ne_zero_for_solver(cx)
             }
-            (SymBoolExprOp::Ule, Some(value), _) if value == U256::from(1) => {
+            (SymCmpOp::Ule, Some(value), _) if value == U256::from(1) => {
                 right.normalize_ne_zero_for_solver(cx)
             }
-            (SymBoolExprOp::Uge, Some(value), _) if value.is_zero() => {
+            (SymCmpOp::Uge, Some(value), _) if value.is_zero() => {
                 right.normalize_eq_zero_for_solver(cx)
             }
-            (SymBoolExprOp::Ugt, Some(value), _) if value == U256::from(1) => {
+            (SymCmpOp::Ugt, Some(value), _) if value == U256::from(1) => {
                 right.normalize_eq_zero_for_solver(cx)
             }
             _ => None,
@@ -989,7 +974,7 @@ impl SymExpr {
         let denominator = normalize_expr_for_solver(cx, denominator.clone());
         let zero = Self::zero(cx);
         let denominator_zero = SymBoolExpr::eq(cx, denominator.clone(), zero);
-        let below_denominator = SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, numerator, denominator);
+        let below_denominator = SymBoolExpr::cmp(cx, SymCmpOp::Ult, numerator, denominator);
         SymBoolExpr::or(cx, vec![denominator_zero, below_denominator])
     }
 
@@ -998,7 +983,7 @@ impl SymExpr {
         let denominator = normalize_expr_for_solver(cx, denominator.clone());
         let zero = Self::zero(cx);
         let denominator_nonzero = SymBoolExpr::eq(cx, denominator.clone(), zero).not(cx);
-        let at_least_denominator = SymBoolExpr::cmp(cx, SymBoolExprOp::Uge, numerator, denominator);
+        let at_least_denominator = SymBoolExpr::cmp(cx, SymCmpOp::Uge, numerator, denominator);
         SymBoolExpr::and(cx, vec![denominator_nonzero, at_least_denominator])
     }
 }
@@ -1032,7 +1017,9 @@ impl ConstraintContext {
     }
 
     fn checked_mul_guard_for_operand(&self, expr: &SymBoolExpr, zero_operand: &SymExpr) -> bool {
-        let SymBoolExprKind::Eq(left, right) = expr.kind() else { return false };
+        let SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) = expr.kind() else {
+            return false;
+        };
         self.checked_mul_guard_side(left, right, zero_operand)
             || self.checked_mul_guard_side(right, left, zero_operand)
     }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -647,54 +647,35 @@ impl ConstraintContext {
         constraint: &'a SymBoolExpr,
     ) -> Option<(&'a SymExpr, U256)> {
         match constraint.kind() {
-            SymBoolExprKind::Cmp(op, left, right) => match *op {
-                SymCmpOp::Eq => match (left.as_const(), right.as_const()) {
-                    (_, Some(value)) => Some((left, value)),
-                    (Some(value), _) => Some((right, value)),
+            SymBoolExprKind::Cmp(op, left, right) => {
+                match (*op, left.as_const(), right.as_const()) {
+                    (SymCmpOp::Eq, _, Some(value)) => Some((left, value)),
+                    (SymCmpOp::Eq, Some(value), _) => Some((right, value)),
+                    (SymCmpOp::Ult, _, Some(bound)) => {
+                        (!bound.is_zero()).then(|| (left, bound - U256::from(1)))
+                    }
+                    (SymCmpOp::Ule, _, Some(bound)) => Some((left, bound)),
+                    (SymCmpOp::Ugt, Some(bound), _) => {
+                        (!bound.is_zero()).then(|| (right, bound - U256::from(1)))
+                    }
+                    (SymCmpOp::Uge, Some(bound), _) => Some((right, bound)),
                     _ => None,
-                },
-                SymCmpOp::Ult => match (left.as_const(), right.as_const()) {
-                    (_, Some(bound)) => (!bound.is_zero()).then(|| (left, bound - U256::from(1))),
-                    _ => None,
-                },
-                SymCmpOp::Ule => match (left.as_const(), right.as_const()) {
-                    (_, Some(bound)) => Some((left, bound)),
-                    _ => None,
-                },
-                SymCmpOp::Ugt => match (left.as_const(), right.as_const()) {
-                    (Some(bound), _) => (!bound.is_zero()).then(|| (right, bound - U256::from(1))),
-                    _ => None,
-                },
-                SymCmpOp::Uge => match (left.as_const(), right.as_const()) {
-                    (Some(bound), _) => Some((right, bound)),
-                    _ => None,
-                },
-                SymCmpOp::Slt | SymCmpOp::Sgt => None,
-            },
+                }
+            }
             SymBoolExprKind::Not(value) => match value.kind() {
-                SymBoolExprKind::Cmp(op, left, right) => match *op {
-                    SymCmpOp::Ugt => match (left.as_const(), right.as_const()) {
-                        (_, Some(bound)) => Some((left, bound)),
-                        _ => None,
-                    },
-                    SymCmpOp::Uge => match (left.as_const(), right.as_const()) {
-                        (_, Some(bound)) => {
+                SymBoolExprKind::Cmp(op, left, right) => {
+                    match (*op, left.as_const(), right.as_const()) {
+                        (SymCmpOp::Ugt, _, Some(bound)) => Some((left, bound)),
+                        (SymCmpOp::Uge, _, Some(bound)) => {
                             (!bound.is_zero()).then(|| (left, bound - U256::from(1)))
                         }
-                        _ => None,
-                    },
-                    SymCmpOp::Ult => match (left.as_const(), right.as_const()) {
-                        (Some(bound), _) => Some((right, bound)),
-                        _ => None,
-                    },
-                    SymCmpOp::Ule => match (left.as_const(), right.as_const()) {
-                        (Some(bound), _) => {
+                        (SymCmpOp::Ult, Some(bound), _) => Some((right, bound)),
+                        (SymCmpOp::Ule, Some(bound), _) => {
                             (!bound.is_zero()).then(|| (right, bound - U256::from(1)))
                         }
                         _ => None,
-                    },
-                    SymCmpOp::Eq | SymCmpOp::Slt | SymCmpOp::Sgt => None,
-                },
+                    }
+                }
                 _ => None,
             },
             SymBoolExprKind::Const(_) | SymBoolExprKind::And(_) => None,
@@ -884,40 +865,40 @@ impl SymBoolExpr {
         left: &SymExpr,
         right: &SymExpr,
     ) -> Option<Self> {
-        match op {
-            SymCmpOp::Ugt => match (left.as_const(), right.as_const()) {
-                // `a > 0 => a != 0`.
-                (_, Some(value)) if value.is_zero() => left.normalize_ne_zero_for_solver(cx),
-                // `1 > a => a == 0`.
-                (Some(value), _) if value == U256::from(1) => {
-                    right.normalize_eq_zero_for_solver(cx)
-                }
-                _ => None,
-            },
-            SymCmpOp::Uge => match (left.as_const(), right.as_const()) {
-                // `a >= 1 => a != 0`.
-                (_, Some(value)) if value == U256::from(1) => left.normalize_ne_zero_for_solver(cx),
-                // `0 >= a => a == 0`.
-                (Some(value), _) if value.is_zero() => right.normalize_eq_zero_for_solver(cx),
-                _ => None,
-            },
-            SymCmpOp::Ule => match (left.as_const(), right.as_const()) {
-                // `a <= 0 => a == 0`.
-                (_, Some(value)) if value.is_zero() => left.normalize_eq_zero_for_solver(cx),
-                // `1 <= a => a != 0`.
-                (Some(value), _) if value == U256::from(1) => {
-                    right.normalize_ne_zero_for_solver(cx)
-                }
-                _ => None,
-            },
-            SymCmpOp::Ult => match (left.as_const(), right.as_const()) {
-                // `a < 1 => a == 0`.
-                (_, Some(value)) if value == U256::from(1) => left.normalize_eq_zero_for_solver(cx),
-                // `0 < a => a != 0`.
-                (Some(value), _) if value.is_zero() => right.normalize_ne_zero_for_solver(cx),
-                _ => None,
-            },
-            SymCmpOp::Eq | SymCmpOp::Slt | SymCmpOp::Sgt => None,
+        match (op, left.as_const(), right.as_const()) {
+            // `a > 0 => a != 0`.
+            (SymCmpOp::Ugt, _, Some(value)) if value.is_zero() => {
+                left.normalize_ne_zero_for_solver(cx)
+            }
+            // `a >= 1 => a != 0`.
+            (SymCmpOp::Uge, _, Some(value)) if value == U256::from(1) => {
+                left.normalize_ne_zero_for_solver(cx)
+            }
+            // `a <= 0 => a == 0`.
+            (SymCmpOp::Ule, _, Some(value)) if value.is_zero() => {
+                left.normalize_eq_zero_for_solver(cx)
+            }
+            // `a < 1 => a == 0`.
+            (SymCmpOp::Ult, _, Some(value)) if value == U256::from(1) => {
+                left.normalize_eq_zero_for_solver(cx)
+            }
+            // `0 < a => a != 0`.
+            (SymCmpOp::Ult, Some(value), _) if value.is_zero() => {
+                right.normalize_ne_zero_for_solver(cx)
+            }
+            // `1 <= a => a != 0`.
+            (SymCmpOp::Ule, Some(value), _) if value == U256::from(1) => {
+                right.normalize_ne_zero_for_solver(cx)
+            }
+            // `0 >= a => a == 0`.
+            (SymCmpOp::Uge, Some(value), _) if value.is_zero() => {
+                right.normalize_eq_zero_for_solver(cx)
+            }
+            // `1 > a => a == 0`.
+            (SymCmpOp::Ugt, Some(value), _) if value == U256::from(1) => {
+                right.normalize_eq_zero_for_solver(cx)
+            }
+            _ => None,
         }
     }
 }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -47,16 +47,6 @@ fn bool_structural_key(expr: &SymBoolExpr) -> String {
     key
 }
 
-fn expr_structural_key(expr: &SymExpr) -> String {
-    let mut key = String::new();
-    write_expr_structural_key(&mut key, expr);
-    key
-}
-
-fn expr_should_swap(left: &SymExpr, right: &SymExpr) -> bool {
-    expr_structural_key(right) < expr_structural_key(left)
-}
-
 fn write_bool_structural_key(out: &mut String, expr: &SymBoolExpr) {
     match expr.kind() {
         SymBoolExprKind::Const(value) => {
@@ -244,11 +234,7 @@ impl SymBoolExpr {
             SymBoolExprKind::Eq(left, right) => {
                 let left = left.clone().cache_key(cx);
                 let right = right.clone().cache_key(cx);
-                if expr_should_swap(&left, &right) {
-                    Self::eq(cx, right, left)
-                } else {
-                    Self::eq(cx, left, right)
-                }
+                Self::eq(cx, left, right)
             }
             SymBoolExprKind::Cmp(op, left, right) => {
                 let left = left.clone().cache_key(cx);
@@ -302,39 +288,12 @@ impl SymExpr {
 
     fn cache_key_node(cx: &mut SymCx, expr: Self) -> Self {
         match expr.kind() {
-            SymExprKind::Op(op, left, right) if op.is_commutative() => {
-                if expr_should_swap(left, right) {
-                    Self::op(cx, *op, right.clone(), left.clone())
-                } else {
-                    expr
-                }
-            }
-            SymExprKind::AddMod { left, right, modulus } => {
-                if expr_should_swap(left, right) {
-                    Self::addmod(cx, right.clone(), left.clone(), modulus.clone())
-                } else {
-                    expr
-                }
-            }
-            SymExprKind::MulMod { left, right, modulus } => {
-                if expr_should_swap(left, right) {
-                    Self::mulmod(cx, right.clone(), left.clone(), modulus.clone())
-                } else {
-                    expr
-                }
-            }
             SymExprKind::Ite(cond, left, right) => {
                 let cond = cond.clone().cache_key(cx);
                 Self::ite(cx, cond, left.clone(), right.clone())
             }
             _ => expr,
         }
-    }
-}
-
-impl SymExprOp {
-    const fn is_commutative(self) -> bool {
-        matches!(self, Self::Add | Self::Mul | Self::And | Self::Or | Self::Xor)
     }
 }
 
@@ -700,8 +659,6 @@ fn normalize_bool_node_for_solver(cx: &mut SymCx, expr: SymBoolExpr) -> SymBoolE
     }
 
     match expr.kind() {
-        SymBoolExprKind::Not(value) => value.clone().not(cx),
-        SymBoolExprKind::And(values) => SymBoolExpr::and(cx, values.iter().cloned().collect()),
         SymBoolExprKind::Eq(left, right) => {
             let left = normalize_expr_for_solver(cx, left.clone());
             let right = normalize_expr_for_solver(cx, right.clone());
@@ -714,7 +671,7 @@ fn normalize_bool_node_for_solver(cx: &mut SymCx, expr: SymBoolExpr) -> SymBoolE
             let normalized = SymBoolExpr::cmp(cx, *op, left, right);
             normalized.normalize_udiv_for_solver(cx).unwrap_or(normalized)
         }
-        SymBoolExprKind::Const(value) => SymBoolExpr::constant(cx, *value),
+        _ => expr,
     }
 }
 
@@ -815,49 +772,14 @@ impl ConstraintContext {
 
 /// Normalizes one word expression into an equivalent, solver-friendlier form.
 pub(crate) fn normalize_expr_for_solver(cx: &mut SymCx, expr: SymExpr) -> SymExpr {
+    if !expr.contains_ite() {
+        return expr;
+    }
     expr.fold(cx, &mut normalize_expr_node_for_solver)
 }
 
 fn normalize_expr_node_for_solver(cx: &mut SymCx, expr: SymExpr) -> SymExpr {
-    if let Some(rebuilt) = expr.rebuild_from_extracted_byte_terms()
-        && rebuilt != expr
-    {
-        return normalize_expr_for_solver(cx, rebuilt);
-    }
-    if let Some(rebuilt) = expr.rebuild_from_shifted_word_fragments()
-        && rebuilt != expr
-    {
-        return normalize_expr_for_solver(cx, rebuilt);
-    }
-    if let Some(rebuilt) = expr.normalize_masked_shift_for_solver(cx)
-        && rebuilt != expr
-    {
-        return normalize_expr_for_solver(cx, rebuilt);
-    }
-    if let Some(rebuilt) = expr.normalize_masked_or_for_solver(cx)
-        && rebuilt != expr
-    {
-        return normalize_expr_for_solver(cx, rebuilt);
-    }
-    if let Some(rebuilt) = expr.normalize_shift_right_for_solver(cx)
-        && rebuilt != expr
-    {
-        return normalize_expr_for_solver(cx, rebuilt);
-    }
-
     match expr.kind() {
-        SymExprKind::Op(
-            op
-            @ (SymExprOp::Add | SymExprOp::Mul | SymExprOp::And | SymExprOp::Or | SymExprOp::Xor),
-            left,
-            right,
-        ) => {
-            if expr_should_swap(left, right) {
-                SymExpr::op(cx, *op, right.clone(), left.clone())
-            } else {
-                expr
-            }
-        }
         SymExprKind::Ite(cond, left, right) => {
             normalize_ite_expr_for_solver(cx, cond.clone(), left.clone(), right.clone())
         }
@@ -875,9 +797,6 @@ fn normalize_ite_expr_for_solver(
     if left == right {
         return left;
     }
-    if let Some(condition) = guarded_self_div_word_condition(cx, &cond, &left, &right) {
-        return SymExpr::bool_word(cx, condition);
-    }
     if left.as_const() == Some(U256::from(1))
         && right.normalized_bool_word_condition(cx).as_ref() == Some(&cond)
     {
@@ -891,239 +810,7 @@ fn normalize_ite_expr_for_solver(
     SymExpr::ite(cx, cond, left, right)
 }
 
-/// Returns the boolean represented by `a == 0 ? 0 : a / a`.
-fn guarded_self_div_word_condition(
-    cx: &mut SymCx,
-    cond: &SymBoolExpr,
-    left: &SymExpr,
-    right: &SymExpr,
-) -> Option<SymBoolExpr> {
-    if left.as_const().is_some_and(|value| value.is_zero())
-        && self_div_expr_matches_zero_check(cond, right)
-    {
-        return Some(cond.clone().not(cx));
-    }
-    None
-}
-
-/// Returns whether `expr` is `a / a` for the operand guarded by `cond`.
-fn self_div_expr_matches_zero_check(cond: &SymBoolExpr, expr: &SymExpr) -> bool {
-    let Some(zero_operand) = cond.zero_check_operand() else { return false };
-    let Some((numerator, denominator)) = expr.udiv_operands() else { return false };
-    numerator == zero_operand && denominator == zero_operand
-}
-
 impl SymExpr {
-    fn rebuild_from_extracted_byte_terms(&self) -> Option<Self> {
-        let mut terms = Vec::new();
-        self.push_or_terms(&mut terms);
-        if terms.len() <= 1 {
-            return None;
-        }
-
-        let mut source = None;
-        let mut seen = [false; 32];
-        for term in terms {
-            if term.as_const().is_some_and(|value| value.is_zero()) {
-                continue;
-            }
-            let (term_source, index) = term.extracted_shifted_byte_term()?;
-            match &source {
-                Some(source) if source != &term_source => return None,
-                Some(_) => {}
-                None => source = Some(term_source),
-            }
-            seen[index] = true;
-        }
-
-        let source = source?;
-        for (index, seen) in seen.into_iter().enumerate() {
-            if !seen && source.known_byte(index) != Some(0) {
-                return None;
-            }
-        }
-        Some(source)
-    }
-
-    fn push_or_terms<'a>(&'a self, terms: &mut Vec<&'a Self>) {
-        match self.kind() {
-            SymExprKind::Op(SymExprOp::Or, left, right) => {
-                left.push_or_terms(terms);
-                right.push_or_terms(terms);
-            }
-            _ => terms.push(self),
-        }
-    }
-
-    fn extracted_shifted_byte_term(&self) -> Option<(Self, usize)> {
-        match self.kind() {
-            SymExprKind::Op(SymExprOp::Shl, byte, shift) => {
-                let shift = shift.as_const()?;
-                let Ok(shift) = usize::try_from(shift) else { return None };
-                if shift % 8 != 0 || shift > 248 {
-                    return None;
-                }
-                let index = 31 - shift / 8;
-                let source = byte.extracted_unshifted_byte_source(index)?;
-                Some((source, index))
-            }
-            _ => self.extracted_unshifted_byte_source(31).map(|source| (source, 31)),
-        }
-    }
-
-    fn extracted_unshifted_byte_source(&self, index: usize) -> Option<Self> {
-        let expr = self.strip_low_byte_mask();
-        if index == 31 {
-            return Some(expr.clone());
-        }
-        let SymExprKind::Op(SymExprOp::Shr, source, shift) = expr.kind() else { return None };
-        let shift = shift.as_const()?;
-        (shift == U256::from((31 - index) * 8)).then(|| source.clone())
-    }
-
-    fn rebuild_from_shifted_word_fragments(&self) -> Option<Self> {
-        let mut terms = Vec::new();
-        self.push_or_terms(&mut terms);
-        if terms.len() != 2 {
-            return None;
-        }
-
-        let left_low = terms[0].low_word_fragment();
-        let right_low = terms[1].low_word_fragment();
-        let left_high = terms[0].shifted_high_word_fragment();
-        let right_high = terms[1].shifted_high_word_fragment();
-        match (left_low, right_low, left_high, right_high) {
-            (Some((low_source, low_bits)), None, None, Some((high_source, high_bits)))
-            | (None, Some((low_source, low_bits)), Some((high_source, high_bits)), None)
-                if low_source == high_source && low_bits == high_bits =>
-            {
-                Some(low_source)
-            }
-            _ => None,
-        }
-    }
-
-    fn low_word_fragment(&self) -> Option<(Self, usize)> {
-        let SymExprKind::Op(SymExprOp::And, left, right) = self.kind() else { return None };
-        if let Some(mask) = right.as_const() {
-            return mask_low_bits(mask).map(|bits| (left.clone(), bits));
-        }
-        let mask = left.as_const()?;
-        mask_low_bits(mask).map(|bits| (right.clone(), bits))
-    }
-
-    fn shifted_high_word_fragment(&self) -> Option<(Self, usize)> {
-        let SymExprKind::Op(SymExprOp::Shl, value, shift) = self.kind() else { return None };
-        let bits = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
-        if bits == 0 || bits >= 256 {
-            return None;
-        }
-
-        let (source, source_shift, width) = value.shifted_low_fragment_source()?;
-        (source_shift == bits && width == 256 - bits).then_some((source, bits))
-    }
-
-    fn shifted_low_fragment_source(&self) -> Option<(Self, usize, usize)> {
-        let SymExprKind::Op(SymExprOp::And, left, right) = self.kind() else { return None };
-        if let Some(mask) = right.as_const() {
-            return Self::shifted_low_fragment_source_with_mask(left, mask);
-        }
-        let mask = left.as_const()?;
-        Self::shifted_low_fragment_source_with_mask(right, mask)
-    }
-
-    fn shifted_low_fragment_source_with_mask(
-        value: &Self,
-        mask: U256,
-    ) -> Option<(Self, usize, usize)> {
-        let width = mask_low_bits(mask)?;
-        match value.kind() {
-            SymExprKind::Op(SymExprOp::Shr, source, shift) => {
-                let shift = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
-                Some((source.clone(), shift, width))
-            }
-            _ => Some((value.clone(), 0, width)),
-        }
-    }
-
-    fn normalize_masked_shift_for_solver(&self, cx: &mut SymCx) -> Option<Self> {
-        let SymExprKind::Op(SymExprOp::And, left, right) = self.kind() else { return None };
-        let (value, mask) = if let Some(mask) = right.as_const() {
-            (left, mask)
-        } else {
-            (right, left.as_const()?)
-        };
-        let mask_bits = mask_low_bits(mask)?;
-        let SymExprKind::Op(SymExprOp::Shl, _, shift) = value.kind() else { return None };
-        let shift = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
-        (mask_bits <= shift).then(|| Self::zero(cx))
-    }
-
-    fn normalize_masked_or_for_solver(&self, cx: &mut SymCx) -> Option<Self> {
-        let SymExprKind::Op(SymExprOp::And, left, right) = self.kind() else { return None };
-        let (value, mask) = if let Some(mask) = right.as_const() {
-            (left, mask)
-        } else {
-            (right, left.as_const()?)
-        };
-        let SymExprKind::Op(SymExprOp::Or, or_left, or_right) = value.kind() else { return None };
-
-        let mask_expr = Self::constant(cx, mask);
-        let left = Self::op(cx, SymExprOp::And, or_left.clone(), mask_expr);
-        let left = normalize_expr_for_solver(cx, left);
-        if left.as_const().is_some_and(|value| value.is_zero()) {
-            let mask_expr = Self::constant(cx, mask);
-            let right = Self::op(cx, SymExprOp::And, or_right.clone(), mask_expr);
-            return Some(normalize_expr_for_solver(cx, right));
-        }
-
-        let mask_expr = Self::constant(cx, mask);
-        let right = Self::op(cx, SymExprOp::And, or_right.clone(), mask_expr);
-        let right = normalize_expr_for_solver(cx, right);
-        if right.as_const().is_some_and(|value| value.is_zero()) {
-            return Some(left);
-        }
-
-        None
-    }
-
-    fn normalize_shift_right_for_solver(&self, cx: &mut SymCx) -> Option<Self> {
-        let SymExprKind::Op(SymExprOp::Shr, value, shift) = self.kind() else { return None };
-        let shift = shift.as_const().and_then(|shift| usize::try_from(shift).ok())?;
-        if shift == 0 || shift >= 256 {
-            return None;
-        }
-        if value.unsigned_bits() <= shift {
-            return Some(Self::zero(cx));
-        }
-
-        if let SymExprKind::Op(SymExprOp::Shl, inner, left_shift) = value.kind()
-            && left_shift.as_const() == Some(U256::from(shift))
-            && inner.unsigned_bits() <= 256 - shift
-        {
-            return Some(inner.clone());
-        }
-
-        let SymExprKind::Op(SymExprOp::Or, left, right) = value.kind() else { return None };
-        let shift_expr = Self::constant(cx, U256::from(shift));
-        let left = Self::op(cx, SymExprOp::Shr, left.clone(), shift_expr);
-        let left = normalize_expr_for_solver(cx, left);
-        if left.as_const().is_some_and(|value| value.is_zero()) {
-            let shift_expr = Self::constant(cx, U256::from(shift));
-            let right = Self::op(cx, SymExprOp::Shr, right.clone(), shift_expr);
-            return Some(normalize_expr_for_solver(cx, right));
-        }
-
-        let shift_expr = Self::constant(cx, U256::from(shift));
-        let right = Self::op(cx, SymExprOp::Shr, right.clone(), shift_expr);
-        let right = normalize_expr_for_solver(cx, right);
-        if right.as_const().is_some_and(|value| value.is_zero()) {
-            return Some(left);
-        }
-
-        None
-    }
-
     fn add_cannot_overflow_256(&self, right: &Self) -> bool {
         self.unsigned_bits().max(right.unsigned_bits()).saturating_add(1) <= 256
     }
@@ -1135,38 +822,6 @@ impl SymExpr {
     pub(crate) fn mul_cannot_overflow_256(&self, right: &Self) -> bool {
         self.unsigned_bits().saturating_add(right.unsigned_bits()) <= 256
     }
-
-    fn unsigned_bits(&self) -> usize {
-        match self.kind() {
-            SymExprKind::Const(value) => value.bit_len().max(1),
-            SymExprKind::Op(SymExprOp::And, left, right) => {
-                if let Some(mask) = right.as_const() {
-                    left.unsigned_bits().min(mask.bit_len())
-                } else if let Some(mask) = left.as_const() {
-                    right.unsigned_bits().min(mask.bit_len())
-                } else {
-                    256
-                }
-            }
-            SymExprKind::Op(SymExprOp::Add, left, right) => {
-                left.unsigned_bits().max(right.unsigned_bits()).saturating_add(1).min(256)
-            }
-            SymExprKind::Op(SymExprOp::Mul, left, right) => {
-                left.unsigned_bits().saturating_add(right.unsigned_bits()).min(256)
-            }
-            SymExprKind::Op(SymExprOp::UDiv, left, _) => left.unsigned_bits(),
-            SymExprKind::AddMod { modulus, .. } | SymExprKind::MulMod { modulus, .. } => {
-                modulus.unsigned_bits()
-            }
-            SymExprKind::Ite(_, left, right) => left.unsigned_bits().max(right.unsigned_bits()),
-            _ => 256,
-        }
-    }
-}
-
-fn mask_low_bits(mask: U256) -> Option<usize> {
-    let bits = mask.bit_len();
-    (mask == mask_bits(U256::MAX, bits)).then_some(bits)
 }
 
 impl SymBoolExpr {
@@ -1242,22 +897,6 @@ impl SymBoolExpr {
                     .or_else(|| Self::normalize_udiv_cmp(cx, *op, left, right))
             }
             SymBoolExprKind::Const(_) | SymBoolExprKind::And(_) => None,
-        }
-    }
-
-    fn zero_check_operand(&self) -> Option<&SymExpr> {
-        match self.kind() {
-            SymBoolExprKind::Eq(left, right)
-                if right.as_const().is_some_and(|value| value.is_zero()) =>
-            {
-                Some(left)
-            }
-            SymBoolExprKind::Eq(left, right)
-                if left.as_const().is_some_and(|value| value.is_zero()) =>
-            {
-                Some(right)
-            }
-            _ => None,
         }
     }
 
@@ -1411,15 +1050,6 @@ impl SymExpr {
             return Some(SymBoolExpr::or(cx, vec![then_condition, else_condition]));
         }
         None
-    }
-
-    fn udiv_operands(&self) -> Option<(&Self, &Self)> {
-        match self.kind() {
-            SymExprKind::Op(SymExprOp::UDiv, numerator, denominator) => {
-                Some((numerator, denominator))
-            }
-            _ => None,
-        }
     }
 
     fn udiv_zero_condition(cx: &mut SymCx, numerator: &Self, denominator: &Self) -> SymBoolExpr {

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -172,19 +172,6 @@ const fn expr_op_key(op: SymExprOp) -> u8 {
     }
 }
 
-/// Returns a structural key for normalized solver cache lookups.
-pub(super) fn constraint_cache_key(
-    cx: &mut SymCx,
-    constraints: &[SymBoolExpr],
-) -> Vec<SymBoolExpr> {
-    let mut key = Vec::with_capacity(constraints.len());
-    for constraint in constraints.iter().cloned() {
-        constraint.cache_key(cx).push_cache_key_conjuncts(&mut key);
-    }
-    sort_dedup_bool_exprs(&mut key);
-    key
-}
-
 /// Returns whether normalized conjunctive constraints contain a direct contradiction.
 pub(super) fn constraints_are_directly_unsat(cx: &mut SymCx, constraints: &[SymBoolExpr]) -> bool {
     constraints.iter().any(|constraint| match constraint.kind() {
@@ -216,58 +203,6 @@ pub(crate) fn normalize_bool_for_solver(cx: &mut SymCx, expr: SymBoolExpr) -> Sy
 }
 
 impl SymBoolExpr {
-    fn cache_key(self, cx: &mut SymCx) -> Self {
-        self.fold(cx, &mut Self::cache_key_node)
-    }
-
-    fn cache_key_node(cx: &mut SymCx, expr: Self) -> Self {
-        match expr.kind() {
-            SymBoolExprKind::Not(value) => value.clone().not(cx),
-            SymBoolExprKind::And(values) => {
-                let mut conjuncts = Vec::new();
-                for value in values.iter().cloned() {
-                    value.push_cache_key_conjuncts(&mut conjuncts);
-                }
-                sort_dedup_bool_exprs(&mut conjuncts);
-                Self::and(cx, conjuncts)
-            }
-            SymBoolExprKind::Eq(left, right) => {
-                let left = left.clone().cache_key(cx);
-                let right = right.clone().cache_key(cx);
-                Self::eq(cx, left, right)
-            }
-            SymBoolExprKind::Cmp(op, left, right) => {
-                let left = left.clone().cache_key(cx);
-                let right = right.clone().cache_key(cx);
-                Self::cache_key_cmp(cx, *op, left, right)
-            }
-            SymBoolExprKind::Const(value) => Self::constant(cx, *value),
-        }
-    }
-
-    fn push_cache_key_conjuncts(self, out: &mut Vec<Self>) {
-        match self.kind() {
-            SymBoolExprKind::Const(true) => {}
-            SymBoolExprKind::And(values) => {
-                for value in values.iter().cloned() {
-                    value.push_cache_key_conjuncts(out);
-                }
-            }
-            _ => out.push(self),
-        }
-    }
-
-    fn cache_key_cmp(cx: &mut SymCx, op: SymBoolExprOp, left: SymExpr, right: SymExpr) -> Self {
-        match op {
-            SymBoolExprOp::Ugt => Self::cmp(cx, SymBoolExprOp::Ult, right, left),
-            SymBoolExprOp::Uge => Self::cmp(cx, SymBoolExprOp::Ule, right, left),
-            SymBoolExprOp::Sgt => Self::cmp(cx, SymBoolExprOp::Slt, right, left),
-            SymBoolExprOp::Ult | SymBoolExprOp::Ule | SymBoolExprOp::Slt => {
-                Self::cmp(cx, op, left, right)
-            }
-        }
-    }
-
     fn push_normalized_conjuncts(self, out: &mut Vec<Self>) {
         match self.kind() {
             SymBoolExprKind::Const(true) => {}
@@ -277,22 +212,6 @@ impl SymBoolExpr {
                 }
             }
             _ => out.push(self),
-        }
-    }
-}
-
-impl SymExpr {
-    fn cache_key(self, cx: &mut SymCx) -> Self {
-        self.fold(cx, &mut Self::cache_key_node)
-    }
-
-    fn cache_key_node(cx: &mut SymCx, expr: Self) -> Self {
-        match expr.kind() {
-            SymExprKind::Ite(cond, left, right) => {
-                let cond = cond.clone().cache_key(cx);
-                Self::ite(cx, cond, left.clone(), right.clone())
-            }
-            _ => expr,
         }
     }
 }
@@ -668,10 +587,29 @@ fn normalize_bool_node_for_solver(cx: &mut SymCx, expr: SymBoolExpr) -> SymBoolE
         SymBoolExprKind::Cmp(op, left, right) => {
             let left = normalize_expr_for_solver(cx, left.clone());
             let right = normalize_expr_for_solver(cx, right.clone());
-            let normalized = SymBoolExpr::cmp(cx, *op, left, right);
+            let normalized = normalize_cmp_for_solver(cx, *op, left, right);
             normalized.normalize_udiv_for_solver(cx).unwrap_or(normalized)
         }
         _ => expr,
+    }
+}
+
+fn normalize_cmp_for_solver(
+    cx: &mut SymCx,
+    op: SymBoolExprOp,
+    left: SymExpr,
+    right: SymExpr,
+) -> SymBoolExpr {
+    match op {
+        // `a > b => b < a`.
+        SymBoolExprOp::Ugt => SymBoolExpr::cmp(cx, SymBoolExprOp::Ult, right, left),
+        // `a >= b => b <= a`.
+        SymBoolExprOp::Uge => SymBoolExpr::cmp(cx, SymBoolExprOp::Ule, right, left),
+        // `a >s b => b <s a`.
+        SymBoolExprOp::Sgt => SymBoolExpr::cmp(cx, SymBoolExprOp::Slt, right, left),
+        SymBoolExprOp::Ult | SymBoolExprOp::Ule | SymBoolExprOp::Slt => {
+            SymBoolExpr::cmp(cx, op, left, right)
+        }
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -102,8 +102,8 @@ fn write_expr_structural_key(out: &mut String, expr: &SymExpr) {
             out.push_str("5:");
             write_expr_structural_key(out, value);
         }
-        SymExprKind::Op(op, left, right) => {
-            let _ = write!(out, "6:{}:", expr_op_key(*op));
+        SymExprKind::BinOp(op, left, right) => {
+            let _ = write!(out, "6:{}:", expr_binop_key(*op));
             write_expr_structural_key(out, left);
             out.push(':');
             write_expr_structural_key(out, right);
@@ -154,21 +154,21 @@ const fn bool_op_key(op: SymBoolExprOp) -> u8 {
     }
 }
 
-const fn expr_op_key(op: SymExprOp) -> u8 {
+const fn expr_binop_key(op: SymExprBinOp) -> u8 {
     match op {
-        SymExprOp::Add => 0,
-        SymExprOp::Sub => 1,
-        SymExprOp::Mul => 2,
-        SymExprOp::UDiv => 3,
-        SymExprOp::URem => 4,
-        SymExprOp::SDiv => 5,
-        SymExprOp::SRem => 6,
-        SymExprOp::And => 7,
-        SymExprOp::Or => 8,
-        SymExprOp::Xor => 9,
-        SymExprOp::Shl => 10,
-        SymExprOp::Shr => 11,
-        SymExprOp::Sar => 12,
+        SymExprBinOp::Add => 0,
+        SymExprBinOp::Sub => 1,
+        SymExprBinOp::Mul => 2,
+        SymExprBinOp::UDiv => 3,
+        SymExprBinOp::URem => 4,
+        SymExprBinOp::SDiv => 5,
+        SymExprBinOp::SRem => 6,
+        SymExprBinOp::And => 7,
+        SymExprBinOp::Or => 8,
+        SymExprBinOp::Xor => 9,
+        SymExprBinOp::Shl => 10,
+        SymExprBinOp::Shr => 11,
+        SymExprBinOp::Sar => 12,
     }
 }
 
@@ -289,7 +289,7 @@ impl SmtCsePlan {
             | SymExprKind::Keccak { .. }
             | SymExprKind::Hash { .. } => {}
             SymExprKind::Not(value) => self.count_expr(value),
-            SymExprKind::Op(_, left, right) => {
+            SymExprKind::BinOp(_, left, right) => {
                 self.count_expr(left);
                 self.count_expr(right);
             }
@@ -333,7 +333,7 @@ impl SmtCsePlan {
             | SymExprKind::Keccak { .. }
             | SymExprKind::Hash { .. } => {}
             SymExprKind::Not(value) => self.collect_expr_binding(value),
-            SymExprKind::Op(_, left, right) => {
+            SymExprKind::BinOp(_, left, right) => {
                 self.collect_expr_binding(left);
                 self.collect_expr_binding(right);
             }
@@ -475,7 +475,7 @@ impl SmtCseWriter<'_> {
                 self.write_expr(out, value, skip_expr, skip_bool);
                 out.push(')');
             }
-            SymExprKind::Op(op, left, right) => {
+            SymExprKind::BinOp(op, left, right) => {
                 let _ = write!(out, "({} ", op.smt());
                 self.write_expr(out, left, skip_expr, skip_bool);
                 out.push(' ');
@@ -914,7 +914,7 @@ impl SymExpr {
     }
 
     fn add_with_operand<'a>(&'a self, operand: &Self) -> Option<(&'a Self, &'a Self)> {
-        let SymExprKind::Op(SymExprOp::Add, left, right) = self.kind() else { return None };
+        let SymExprKind::BinOp(SymExprBinOp::Add, left, right) = self.kind() else { return None };
         if left == operand {
             Some((left, right))
         } else if right == operand {
@@ -1062,7 +1062,7 @@ impl ConstraintContext {
         if denominator != zero_operand {
             return false;
         }
-        let SymExprKind::Op(SymExprOp::Mul, left, right) = numerator.kind() else {
+        let SymExprKind::BinOp(SymExprBinOp::Mul, left, right) = numerator.kind() else {
             return false;
         };
         let other = if left == zero_operand {
@@ -1087,7 +1087,7 @@ impl ConstraintContext {
             | SymExprKind::Keccak { .. }
             | SymExprKind::Hash { .. }
             | SymExprKind::Not(_) => expr.unsigned_bits(),
-            SymExprKind::Op(SymExprOp::And, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::And, left, right) => {
                 if let Some(mask) = right.as_const() {
                     self.unsigned_bits(left).min(mask.bit_len())
                 } else if let Some(mask) = left.as_const() {
@@ -1096,13 +1096,13 @@ impl ConstraintContext {
                     256
                 }
             }
-            SymExprKind::Op(SymExprOp::Add, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Add, left, right) => {
                 self.unsigned_bits(left).max(self.unsigned_bits(right)).saturating_add(1).min(256)
             }
-            SymExprKind::Op(SymExprOp::Mul, left, right) => {
+            SymExprKind::BinOp(SymExprBinOp::Mul, left, right) => {
                 self.unsigned_bits(left).saturating_add(self.unsigned_bits(right)).min(256)
             }
-            SymExprKind::Op(SymExprOp::UDiv, left, _) => self.unsigned_bits(left),
+            SymExprKind::BinOp(SymExprBinOp::UDiv, left, _) => self.unsigned_bits(left),
             SymExprKind::Ite(_, left, right) => {
                 self.unsigned_bits(left).max(self.unsigned_bits(right))
             }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -108,16 +108,8 @@ fn write_expr_structural_key(out: &mut String, expr: &SymExpr) {
             out.push(':');
             write_expr_structural_key(out, right);
         }
-        SymExprKind::AddMod { left, right, modulus } => {
-            out.push_str("7:");
-            write_expr_structural_key(out, left);
-            out.push(':');
-            write_expr_structural_key(out, right);
-            out.push(':');
-            write_expr_structural_key(out, modulus);
-        }
-        SymExprKind::MulMod { left, right, modulus } => {
-            out.push_str("8:");
+        SymExprKind::TernOp(op, left, right, modulus) => {
+            let _ = write!(out, "7:{}:", expr_ternop_key(*op));
             write_expr_structural_key(out, left);
             out.push(':');
             write_expr_structural_key(out, right);
@@ -169,6 +161,13 @@ const fn expr_binop_key(op: SymExprBinOp) -> u8 {
         SymExprBinOp::Shl => 10,
         SymExprBinOp::Shr => 11,
         SymExprBinOp::Sar => 12,
+    }
+}
+
+const fn expr_ternop_key(op: SymExprTernOp) -> u8 {
+    match op {
+        SymExprTernOp::AddMod => 0,
+        SymExprTernOp::MulMod => 1,
     }
 }
 
@@ -293,8 +292,7 @@ impl SmtCsePlan {
                 self.count_expr(left);
                 self.count_expr(right);
             }
-            SymExprKind::AddMod { left, right, modulus }
-            | SymExprKind::MulMod { left, right, modulus } => {
+            SymExprKind::TernOp(_, left, right, modulus) => {
                 self.count_expr(modulus);
                 self.count_expr(left);
                 self.count_expr(right);
@@ -337,8 +335,7 @@ impl SmtCsePlan {
                 self.collect_expr_binding(left);
                 self.collect_expr_binding(right);
             }
-            SymExprKind::AddMod { left, right, modulus }
-            | SymExprKind::MulMod { left, right, modulus } => {
+            SymExprKind::TernOp(_, left, right, modulus) => {
                 self.collect_expr_binding(modulus);
                 self.collect_expr_binding(left);
                 self.collect_expr_binding(right);
@@ -482,11 +479,8 @@ impl SmtCseWriter<'_> {
                 self.write_expr(out, right, skip_expr, skip_bool);
                 out.push(')');
             }
-            SymExprKind::AddMod { left, right, modulus } => {
-                self.write_wide_modular_arithmetic(out, "bvadd", left, right, modulus);
-            }
-            SymExprKind::MulMod { left, right, modulus } => {
-                self.write_wide_modular_arithmetic(out, "bvmul", left, right, modulus);
+            SymExprKind::TernOp(op, left, right, modulus) => {
+                self.write_wide_modular_arithmetic(out, op.smt(), left, right, modulus);
             }
             SymExprKind::Ite(cond, left, right) => {
                 out.push_str("(ite ");

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -141,28 +141,28 @@ const fn cmp_op_key(op: SymCmpOp) -> u8 {
     }
 }
 
-const fn expr_binop_key(op: SymExprBinOp) -> u8 {
+const fn expr_binop_key(op: SymBinOp) -> u8 {
     match op {
-        SymExprBinOp::Add => 0,
-        SymExprBinOp::Sub => 1,
-        SymExprBinOp::Mul => 2,
-        SymExprBinOp::UDiv => 3,
-        SymExprBinOp::URem => 4,
-        SymExprBinOp::SDiv => 5,
-        SymExprBinOp::SRem => 6,
-        SymExprBinOp::And => 7,
-        SymExprBinOp::Or => 8,
-        SymExprBinOp::Xor => 9,
-        SymExprBinOp::Shl => 10,
-        SymExprBinOp::Shr => 11,
-        SymExprBinOp::Sar => 12,
+        SymBinOp::Add => 0,
+        SymBinOp::Sub => 1,
+        SymBinOp::Mul => 2,
+        SymBinOp::UDiv => 3,
+        SymBinOp::URem => 4,
+        SymBinOp::SDiv => 5,
+        SymBinOp::SRem => 6,
+        SymBinOp::And => 7,
+        SymBinOp::Or => 8,
+        SymBinOp::Xor => 9,
+        SymBinOp::Shl => 10,
+        SymBinOp::Shr => 11,
+        SymBinOp::Sar => 12,
     }
 }
 
-const fn expr_ternop_key(op: SymExprTernOp) -> u8 {
+const fn expr_ternop_key(op: SymTernOp) -> u8 {
     match op {
-        SymExprTernOp::AddMod => 0,
-        SymExprTernOp::MulMod => 1,
+        SymTernOp::AddMod => 0,
+        SymTernOp::MulMod => 1,
     }
 }
 
@@ -916,7 +916,7 @@ impl SymExpr {
     }
 
     fn add_with_operand<'a>(&'a self, operand: &Self) -> Option<(&'a Self, &'a Self)> {
-        let SymExprKind::BinOp(SymExprBinOp::Add, left, right) = self.kind() else { return None };
+        let SymExprKind::BinOp(SymBinOp::Add, left, right) = self.kind() else { return None };
         if left == operand {
             Some((left, right))
         } else if right == operand {
@@ -1072,7 +1072,7 @@ impl ConstraintContext {
         if denominator != zero_operand {
             return false;
         }
-        let SymExprKind::BinOp(SymExprBinOp::Mul, left, right) = numerator.kind() else {
+        let SymExprKind::BinOp(SymBinOp::Mul, left, right) = numerator.kind() else {
             return false;
         };
         let other = if left == zero_operand {
@@ -1097,7 +1097,7 @@ impl ConstraintContext {
             | SymExprKind::Keccak { .. }
             | SymExprKind::Hash { .. }
             | SymExprKind::Not(_) => expr.unsigned_bits(),
-            SymExprKind::BinOp(SymExprBinOp::And, left, right) => {
+            SymExprKind::BinOp(SymBinOp::And, left, right) => {
                 if let Some(mask) = right.as_const() {
                     self.unsigned_bits(left).min(mask.bit_len())
                 } else if let Some(mask) = left.as_const() {
@@ -1106,13 +1106,13 @@ impl ConstraintContext {
                     256
                 }
             }
-            SymExprKind::BinOp(SymExprBinOp::Add, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Add, left, right) => {
                 self.unsigned_bits(left).max(self.unsigned_bits(right)).saturating_add(1).min(256)
             }
-            SymExprKind::BinOp(SymExprBinOp::Mul, left, right) => {
+            SymExprKind::BinOp(SymBinOp::Mul, left, right) => {
                 self.unsigned_bits(left).saturating_add(self.unsigned_bits(right)).min(256)
             }
-            SymExprKind::BinOp(SymExprBinOp::UDiv, left, _) => self.unsigned_bits(left),
+            SymExprKind::BinOp(SymBinOp::UDiv, left, _) => self.unsigned_bits(left),
             SymExprKind::Ite(_, left, right) => {
                 self.unsigned_bits(left).max(self.unsigned_bits(right))
             }

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -413,7 +413,7 @@ impl PathState {
     pub(crate) fn cmp_word(
         &mut self,
         cx: &mut SymCx,
-        op: SymBoolExprOp,
+        op: SymCmpOp,
     ) -> Result<StepOutcome, SymbolicError> {
         let a = self.stack.pop()?;
         let b = self.stack.pop()?;
@@ -579,12 +579,7 @@ impl PathState {
             } else {
                 U256::from(1) << usize::try_from(bits).expect("checked bit width")
             };
-            self.constraints.push(SymBoolExpr::cmp_word_const(
-                cx,
-                SymBoolExprOp::Ult,
-                &value,
-                upper,
-            ));
+            self.constraints.push(SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &value, upper));
         }
         value
     }
@@ -603,13 +598,13 @@ impl PathState {
                 let byte = self.fresh_bounded_uint(cx, U256::from(8));
                 self.constraints.push(SymBoolExpr::cmp_word_const(
                     cx,
-                    SymBoolExprOp::Uge,
+                    SymCmpOp::Uge,
                     &byte,
                     U256::from(0x20),
                 ));
                 self.constraints.push(SymBoolExpr::cmp_word_const(
                     cx,
-                    SymBoolExprOp::Ule,
+                    SymCmpOp::Ule,
                     &byte,
                     U256::from(0x7e),
                 ));
@@ -625,10 +620,10 @@ impl PathState {
         } else if bits < U256::from(256) {
             let magnitude =
                 U256::from(1) << (usize::try_from(bits).expect("checked bit width") - 1);
-            let lt = SymBoolExpr::cmp_word_const(cx, SymBoolExprOp::Ult, &value, magnitude);
+            let lt = SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &value, magnitude);
             let ge = SymBoolExpr::cmp_word_const(
                 cx,
-                SymBoolExprOp::Uge,
+                SymCmpOp::Uge,
                 &value,
                 U256::ZERO.wrapping_sub(magnitude),
             );
@@ -805,7 +800,7 @@ impl ExpectedRevert {
                 let prefix_len = SymExpr::constant(cx, U256::from(prefix.len()));
                 conditions.push(SymBoolExpr::cmp(
                     cx,
-                    SymBoolExprOp::Uge,
+                    SymCmpOp::Uge,
                     return_data.len_expr(),
                     prefix_len,
                 ));

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -299,15 +299,11 @@ impl PathState {
             | SymExprKind::Keccak { .. }
             | SymExprKind::Hash { .. } => None,
             SymExprKind::Not(_) => None,
-            SymExprKind::AddMod { modulus, .. } | SymExprKind::MulMod { modulus, .. } => {
-                match modulus.eval() {
-                    Some(modulus) if modulus.is_zero() => Some(0),
-                    Some(modulus) => usize::try_from(modulus - U256::from(1)).ok(),
-                    None => {
-                        self.expr_upper_bound_usize(modulus).and_then(|bound| bound.checked_sub(1))
-                    }
-                }
-            }
+            SymExprKind::TernOp(_, _, _, modulus) => match modulus.eval() {
+                Some(modulus) if modulus.is_zero() => Some(0),
+                Some(modulus) => usize::try_from(modulus - U256::from(1)).ok(),
+                None => self.expr_upper_bound_usize(modulus).and_then(|bound| bound.checked_sub(1)),
+            },
             SymExprKind::Ite(_, left, right) => {
                 Some(self.expr_upper_bound_usize(left)?.max(self.expr_upper_bound_usize(right)?))
             }

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -311,26 +311,26 @@ impl PathState {
             SymExprKind::Ite(_, left, right) => {
                 Some(self.expr_upper_bound_usize(left)?.max(self.expr_upper_bound_usize(right)?))
             }
-            SymExprKind::Op(op, left, right) => match op {
-                SymExprOp::Add => self
+            SymExprKind::BinOp(op, left, right) => match op {
+                SymExprBinOp::Add => self
                     .expr_upper_bound_usize(left)?
                     .checked_add(self.expr_upper_bound_usize(right)?),
-                SymExprOp::Mul => self
+                SymExprBinOp::Mul => self
                     .expr_upper_bound_usize(left)?
                     .checked_mul(self.expr_upper_bound_usize(right)?),
-                SymExprOp::UDiv => {
+                SymExprBinOp::UDiv => {
                     let left = self.expr_upper_bound_usize(left)?;
                     match right.eval()? {
                         divisor if divisor.is_zero() => Some(0),
                         divisor => Some(left / usize::try_from(divisor).ok()?),
                     }
                 }
-                SymExprOp::URem => match right.eval() {
+                SymExprBinOp::URem => match right.eval() {
                     Some(divisor) if divisor.is_zero() => Some(0),
                     Some(divisor) => usize::try_from(divisor - U256::from(1)).ok(),
                     None => self.expr_upper_bound_usize(left),
                 },
-                SymExprOp::And => right
+                SymExprBinOp::And => right
                     .eval()
                     .and_then(|value| usize::try_from(value).ok())
                     .or_else(|| left.eval().and_then(|value| usize::try_from(value).ok()))
@@ -339,18 +339,18 @@ impl PathState {
                             .or_else(|| self.expr_upper_bound_usize(right))
                             .map_or(mask, |bound| bound.min(mask))
                     }),
-                SymExprOp::Shr => {
+                SymExprBinOp::Shr => {
                     let left = self.expr_upper_bound_usize(left)?;
                     let shift = usize::try_from(right.eval()?).ok()?;
                     Some(if shift >= usize::BITS as usize { 0 } else { left >> shift })
                 }
-                SymExprOp::Sub
-                | SymExprOp::SDiv
-                | SymExprOp::SRem
-                | SymExprOp::Or
-                | SymExprOp::Xor
-                | SymExprOp::Shl
-                | SymExprOp::Sar => None,
+                SymExprBinOp::Sub
+                | SymExprBinOp::SDiv
+                | SymExprBinOp::SRem
+                | SymExprBinOp::Or
+                | SymExprBinOp::Xor
+                | SymExprBinOp::Shl
+                | SymExprBinOp::Sar => None,
             },
         };
 
@@ -392,24 +392,24 @@ impl PathState {
     pub(crate) fn bin_word(
         &mut self,
         cx: &mut SymCx,
-        op: SymExprOp,
+        op: SymExprBinOp,
     ) -> Result<StepOutcome, SymbolicError> {
         let a = self.stack.pop()?;
         let b = self.stack.pop()?;
-        self.stack.push(SymExpr::op(cx, op, a, b))?;
+        self.stack.push(SymExpr::binop(cx, op, a, b))?;
         Ok(StepOutcome::Continue)
     }
 
     pub(crate) fn bin_word_div_zero_guard(
         &mut self,
         cx: &mut SymCx,
-        op: SymExprOp,
+        op: SymExprBinOp,
     ) -> Result<StepOutcome, SymbolicError> {
         let a = self.stack.pop()?;
         let b = self.stack.pop()?;
         let zero = SymExpr::zero(cx);
         let condition = SymBoolExpr::eq(cx, b.clone(), zero.clone());
-        let expr = SymExpr::op(cx, op, a, b);
+        let expr = SymExpr::binop(cx, op, a, b);
         self.stack.push(SymExpr::ite(cx, condition, zero, expr))?;
         Ok(StepOutcome::Continue)
     }
@@ -452,9 +452,9 @@ impl PathState {
             SymExpr::constant(cx, result)
         } else {
             let expr = match kind {
-                ShiftKind::Shl => SymExpr::op(cx, SymExprOp::Shl, value, shift),
-                ShiftKind::Shr => SymExpr::op(cx, SymExprOp::Shr, value, shift),
-                ShiftKind::Sar => SymExpr::op(cx, SymExprOp::Sar, value, shift),
+                ShiftKind::Shl => SymExpr::binop(cx, SymExprBinOp::Shl, value, shift),
+                ShiftKind::Shr => SymExpr::binop(cx, SymExprBinOp::Shr, value, shift),
+                ShiftKind::Sar => SymExpr::binop(cx, SymExprBinOp::Sar, value, shift),
             };
             expr.known_word().map(|word| SymExpr::constant(cx, word)).unwrap_or(expr)
         };
@@ -1701,8 +1701,8 @@ impl SymbolicWorld {
         }
         let from_balance = self.balance_word_for_address(cx, executor, from);
         let to_balance = self.balance_word_for_address(cx, executor, to);
-        let from_balance = SymExpr::op(cx, SymExprOp::Sub, from_balance, value.clone());
-        let to_balance = SymExpr::op(cx, SymExprOp::Add, to_balance, value);
+        let from_balance = SymExpr::binop(cx, SymExprBinOp::Sub, from_balance, value.clone());
+        let to_balance = SymExpr::binop(cx, SymExprBinOp::Add, to_balance, value);
         self.set_balance_word(from, from_balance);
         self.set_balance_word(to, to_balance);
     }
@@ -1772,7 +1772,8 @@ impl SymbolicWorld {
         let balance = self.balance_word_for_address(cx, executor, address);
         if beneficiary != address && !balance.as_const().is_some_and(|value| value.is_zero()) {
             let beneficiary_balance = self.balance_word_for_address(cx, executor, beneficiary);
-            let beneficiary_balance = SymExpr::op(cx, SymExprOp::Add, beneficiary_balance, balance);
+            let beneficiary_balance =
+                SymExpr::binop(cx, SymExprBinOp::Add, beneficiary_balance, balance);
             self.set_balance_word(beneficiary, beneficiary_balance);
         }
         self.balances.insert(address, SymExpr::zero(cx));
@@ -1801,7 +1802,8 @@ impl SymbolicWorld {
             let beneficiary_balance = self.balance_word_for_address(cx, executor, beneficiary);
             // Symbolic balances are treated as possibly non-zero, matching transfer's
             // account-existence approximation.
-            let beneficiary_balance = SymExpr::op(cx, SymExprOp::Add, beneficiary_balance, balance);
+            let beneficiary_balance =
+                SymExpr::binop(cx, SymExprBinOp::Add, beneficiary_balance, balance);
             self.set_balance_word(beneficiary, beneficiary_balance);
             self.balances.insert(address, SymExpr::zero(cx));
         }

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -308,25 +308,25 @@ impl PathState {
                 Some(self.expr_upper_bound_usize(left)?.max(self.expr_upper_bound_usize(right)?))
             }
             SymExprKind::BinOp(op, left, right) => match op {
-                SymExprBinOp::Add => self
+                SymBinOp::Add => self
                     .expr_upper_bound_usize(left)?
                     .checked_add(self.expr_upper_bound_usize(right)?),
-                SymExprBinOp::Mul => self
+                SymBinOp::Mul => self
                     .expr_upper_bound_usize(left)?
                     .checked_mul(self.expr_upper_bound_usize(right)?),
-                SymExprBinOp::UDiv => {
+                SymBinOp::UDiv => {
                     let left = self.expr_upper_bound_usize(left)?;
                     match right.eval()? {
                         divisor if divisor.is_zero() => Some(0),
                         divisor => Some(left / usize::try_from(divisor).ok()?),
                     }
                 }
-                SymExprBinOp::URem => match right.eval() {
+                SymBinOp::URem => match right.eval() {
                     Some(divisor) if divisor.is_zero() => Some(0),
                     Some(divisor) => usize::try_from(divisor - U256::from(1)).ok(),
                     None => self.expr_upper_bound_usize(left),
                 },
-                SymExprBinOp::And => right
+                SymBinOp::And => right
                     .eval()
                     .and_then(|value| usize::try_from(value).ok())
                     .or_else(|| left.eval().and_then(|value| usize::try_from(value).ok()))
@@ -335,18 +335,18 @@ impl PathState {
                             .or_else(|| self.expr_upper_bound_usize(right))
                             .map_or(mask, |bound| bound.min(mask))
                     }),
-                SymExprBinOp::Shr => {
+                SymBinOp::Shr => {
                     let left = self.expr_upper_bound_usize(left)?;
                     let shift = usize::try_from(right.eval()?).ok()?;
                     Some(if shift >= usize::BITS as usize { 0 } else { left >> shift })
                 }
-                SymExprBinOp::Sub
-                | SymExprBinOp::SDiv
-                | SymExprBinOp::SRem
-                | SymExprBinOp::Or
-                | SymExprBinOp::Xor
-                | SymExprBinOp::Shl
-                | SymExprBinOp::Sar => None,
+                SymBinOp::Sub
+                | SymBinOp::SDiv
+                | SymBinOp::SRem
+                | SymBinOp::Or
+                | SymBinOp::Xor
+                | SymBinOp::Shl
+                | SymBinOp::Sar => None,
             },
         };
 
@@ -388,7 +388,7 @@ impl PathState {
     pub(crate) fn bin_word(
         &mut self,
         cx: &mut SymCx,
-        op: SymExprBinOp,
+        op: SymBinOp,
     ) -> Result<StepOutcome, SymbolicError> {
         let a = self.stack.pop()?;
         let b = self.stack.pop()?;
@@ -399,7 +399,7 @@ impl PathState {
     pub(crate) fn bin_word_div_zero_guard(
         &mut self,
         cx: &mut SymCx,
-        op: SymExprBinOp,
+        op: SymBinOp,
     ) -> Result<StepOutcome, SymbolicError> {
         let a = self.stack.pop()?;
         let b = self.stack.pop()?;
@@ -448,9 +448,9 @@ impl PathState {
             SymExpr::constant(cx, result)
         } else {
             let expr = match kind {
-                ShiftKind::Shl => SymExpr::binop(cx, SymExprBinOp::Shl, value, shift),
-                ShiftKind::Shr => SymExpr::binop(cx, SymExprBinOp::Shr, value, shift),
-                ShiftKind::Sar => SymExpr::binop(cx, SymExprBinOp::Sar, value, shift),
+                ShiftKind::Shl => SymExpr::binop(cx, SymBinOp::Shl, value, shift),
+                ShiftKind::Shr => SymExpr::binop(cx, SymBinOp::Shr, value, shift),
+                ShiftKind::Sar => SymExpr::binop(cx, SymBinOp::Sar, value, shift),
             };
             expr.known_word().map(|word| SymExpr::constant(cx, word)).unwrap_or(expr)
         };
@@ -1692,8 +1692,8 @@ impl SymbolicWorld {
         }
         let from_balance = self.balance_word_for_address(cx, executor, from);
         let to_balance = self.balance_word_for_address(cx, executor, to);
-        let from_balance = SymExpr::binop(cx, SymExprBinOp::Sub, from_balance, value.clone());
-        let to_balance = SymExpr::binop(cx, SymExprBinOp::Add, to_balance, value);
+        let from_balance = SymExpr::binop(cx, SymBinOp::Sub, from_balance, value.clone());
+        let to_balance = SymExpr::binop(cx, SymBinOp::Add, to_balance, value);
         self.set_balance_word(from, from_balance);
         self.set_balance_word(to, to_balance);
     }
@@ -1764,7 +1764,7 @@ impl SymbolicWorld {
         if beneficiary != address && !balance.as_const().is_some_and(|value| value.is_zero()) {
             let beneficiary_balance = self.balance_word_for_address(cx, executor, beneficiary);
             let beneficiary_balance =
-                SymExpr::binop(cx, SymExprBinOp::Add, beneficiary_balance, balance);
+                SymExpr::binop(cx, SymBinOp::Add, beneficiary_balance, balance);
             self.set_balance_word(beneficiary, beneficiary_balance);
         }
         self.balances.insert(address, SymExpr::zero(cx));
@@ -1794,7 +1794,7 @@ impl SymbolicWorld {
             // Symbolic balances are treated as possibly non-zero, matching transfer's
             // account-existence approximation.
             let beneficiary_balance =
-                SymExpr::binop(cx, SymExprBinOp::Add, beneficiary_balance, balance);
+                SymExpr::binop(cx, SymBinOp::Add, beneficiary_balance, balance);
             self.set_balance_word(beneficiary, beneficiary_balance);
             self.balances.insert(address, SymExpr::zero(cx));
         }

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -15,7 +15,7 @@ fn symbolic_calldata_variants(
 }
 
 fn add_words(cx: &mut SymCx, left: SymExpr, right: SymExpr) -> SymExpr {
-    SymExpr::op(cx, SymExprOp::Add, left, right)
+    SymExpr::binop(cx, SymExprBinOp::Add, left, right)
 }
 
 macro_rules! sym_from_bytes {
@@ -114,7 +114,7 @@ fn binary_helpers_use_evm_operand_order() {
     state.stack.push(SymExpr::constant(&mut cx, U256::from(2))).unwrap();
     state.stack.push(SymExpr::constant(&mut cx, U256::from(10))).unwrap();
 
-    state.bin_word(&mut cx, SymExprOp::Sub).unwrap();
+    state.bin_word(&mut cx, SymExprBinOp::Sub).unwrap();
 
     assert_eq!(state.stack.pop().unwrap(), SymExpr::constant(&mut cx, U256::from(8)));
 }
@@ -231,13 +231,13 @@ fn symbolic_division_guards_zero_divisor() {
     state.stack.push(SymExpr::var(&mut cx, "den")).unwrap();
     state.stack.push(SymExpr::var(&mut cx, "num")).unwrap();
 
-    state.bin_word_div_zero_guard(&mut cx, SymExprOp::UDiv).unwrap();
+    state.bin_word_div_zero_guard(&mut cx, SymExprBinOp::UDiv).unwrap();
 
     let den = SymExpr::var(&mut cx, "den");
     let zero = SymExpr::zero(&mut cx);
     let den_is_zero = SymBoolExpr::eq(&mut cx, den.clone(), zero.clone());
     let num = SymExpr::var(&mut cx, "num");
-    let quotient = SymExpr::op(&mut cx, SymExprOp::UDiv, num, den);
+    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, num, den);
     let expected = SymExpr::ite(&mut cx, den_is_zero, zero, quotient);
     assert_eq!(state.stack.pop().unwrap(), expected);
 }
@@ -248,9 +248,9 @@ fn symbolic_byte_extracts_with_concrete_index() {
     let word = SymExpr::var(&mut cx, "word");
     let actual = byte_word(&mut cx, U256::from(0), word.clone());
     let shift = SymExpr::constant(&mut cx, U256::from(248));
-    let shifted = SymExpr::op(&mut cx, SymExprOp::Shr, word, shift);
+    let shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shr, word, shift);
     let mask = SymExpr::constant(&mut cx, U256::from(0xff));
-    let expected = SymExpr::op(&mut cx, SymExprOp::And, shifted, mask);
+    let expected = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted, mask);
     assert_eq!(actual, expected);
 }
 
@@ -289,11 +289,11 @@ fn symbolic_byte_preserves_concrete_packed_selector_bytes() {
     let selector = U256::from(0x12345678);
     let selector = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
-    let selector = SymExpr::op(&mut cx, SymExprOp::Shl, selector, shift_224);
+    let selector = SymExpr::binop(&mut cx, SymExprBinOp::Shl, selector, shift_224);
     let arg = SymExpr::var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted_arg = SymExpr::op(&mut cx, SymExprOp::Shr, arg, shift_32);
-    let packed = SymExpr::op(&mut cx, SymExprOp::Or, selector, shifted_arg);
+    let shifted_arg = SymExpr::binop(&mut cx, SymExprBinOp::Shr, arg, shift_32);
+    let packed = SymExpr::binop(&mut cx, SymExprBinOp::Or, selector, shifted_arg);
 
     assert_eq!(
         byte_word(&mut cx, U256::from(0), packed.clone()),
@@ -318,7 +318,7 @@ fn word_reassembly_preserves_split_symbolic_word() {
     let mut cx = SymCx::new();
     let value = SymExpr::var(&mut cx, "value");
     let one = SymExpr::one(&mut cx);
-    let original = SymExpr::op(&mut cx, SymExprOp::Add, value, one);
+    let original = SymExpr::binop(&mut cx, SymExprBinOp::Add, value, one);
     let bytes = original.clone().into_byte_exprs(&mut cx);
 
     assert_eq!(SymExpr::from_bytes(&mut cx, bytes), original);
@@ -329,7 +329,7 @@ fn symbolic_address_aliases_match_abi_encoded_address_words() {
     let mut cx = SymCx::new();
     let source = SymExpr::var(&mut cx, "beneficiary");
     let address_mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
-    let masked = SymExpr::op(&mut cx, SymExprOp::And, source.clone(), address_mask);
+    let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, source.clone(), address_mask);
     let mut encoded = vec![SymExpr::zero(&mut cx); 12];
     encoded.extend((12..32).map(|idx| byte_word(&mut cx, U256::from(idx), masked.clone())));
     let reassembled = SymExpr::from_bytes(&mut cx, encoded);
@@ -344,12 +344,13 @@ fn selector_shift_simplifies_to_concrete_word() {
     let selector = U256::from(0x12345678);
     let selector_word = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
-    let shifted_selector = SymExpr::op(&mut cx, SymExprOp::Shl, selector_word, shift_224.clone());
+    let shifted_selector =
+        SymExpr::binop(&mut cx, SymExprBinOp::Shl, selector_word, shift_224.clone());
     let arg = SymExpr::var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted_arg = SymExpr::op(&mut cx, SymExprOp::Shr, arg, shift_32);
-    let call_word = SymExpr::op(&mut cx, SymExprOp::Or, shifted_selector, shifted_arg);
-    let selector_expr = SymExpr::op(&mut cx, SymExprOp::Shr, call_word, shift_224);
+    let shifted_arg = SymExpr::binop(&mut cx, SymExprBinOp::Shr, arg, shift_32);
+    let call_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, shifted_selector, shifted_arg);
+    let selector_expr = SymExpr::binop(&mut cx, SymExprBinOp::Shr, call_word, shift_224);
 
     assert_eq!(selector_expr.known_word(), Some(selector));
 }
@@ -361,12 +362,13 @@ fn selector_equality_folds_known_word_expressions() {
     let other = U256::from(0x9a8325a0u32);
     let selector_word = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
-    let shifted_selector = SymExpr::op(&mut cx, SymExprOp::Shl, selector_word, shift_224.clone());
+    let shifted_selector =
+        SymExpr::binop(&mut cx, SymExprBinOp::Shl, selector_word, shift_224.clone());
     let arg = SymExpr::var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted_arg = SymExpr::op(&mut cx, SymExprOp::Shr, arg, shift_32);
-    let call_word = SymExpr::op(&mut cx, SymExprOp::Or, shifted_selector, shifted_arg);
-    let selector_expr = SymExpr::op(&mut cx, SymExprOp::Shr, call_word, shift_224);
+    let shifted_arg = SymExpr::binop(&mut cx, SymExprBinOp::Shr, arg, shift_32);
+    let call_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, shifted_selector, shifted_arg);
+    let selector_expr = SymExpr::binop(&mut cx, SymExprBinOp::Shr, call_word, shift_224);
 
     let selector_word = SymExpr::constant(&mut cx, selector);
     let actual = SymBoolExpr::eq(&mut cx, selector_expr.clone(), selector_word);
@@ -390,7 +392,7 @@ fn calldata_selector_load_simplifies_to_concrete_word() {
     let offset = SymExpr::zero(&mut cx);
     let loaded = call_data.load_word(&mut cx, offset).unwrap();
     let shift = SymExpr::constant(&mut cx, U256::from(224));
-    let selector_expr = SymExpr::op(&mut cx, SymExprOp::Shr, loaded, shift);
+    let selector_expr = SymExpr::binop(&mut cx, SymExprBinOp::Shr, loaded, shift);
 
     assert_eq!(selector_expr.known_word(), Some(selector));
     let selector_word = SymExpr::constant(&mut cx, selector);
@@ -1536,7 +1538,7 @@ fn symbolic_world_resolves_symbolic_create2_address_aliases() {
     let word = SymExpr::var(&mut cx, "create2_address");
     let address = world.symbolic_address_slot(word.clone());
     let address_mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
-    let masked = SymExpr::op(&mut cx, SymExprOp::And, word.clone(), address_mask);
+    let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, word.clone(), address_mask);
 
     assert_eq!(world.resolve_address(&word), Some(address));
     assert_eq!(world.resolve_address(&masked), Some(address));
@@ -1722,19 +1724,21 @@ fn path_state_extracts_constrained_symbolic_usize_from_encoded_bool_word() {
     let offset_expr = offset.clone();
     let mask = SymExpr::constant(&mut cx, U256::from(0xffff));
 
-    let masked_offset = SymExpr::op(&mut cx, SymExprOp::And, offset_expr.clone(), mask.clone());
+    let masked_offset =
+        SymExpr::binop(&mut cx, SymExprBinOp::And, offset_expr.clone(), mask.clone());
     let offset_constraint = SymBoolExpr::eq(&mut cx, masked_offset, offset_expr.clone());
     state.constraints.push(offset_constraint);
     let expected_offset = SymExpr::constant(&mut cx, U256::from(0x80));
-    let masked_offset = SymExpr::op(&mut cx, SymExprOp::And, mask, offset_expr);
+    let masked_offset = SymExpr::binop(&mut cx, SymExprBinOp::And, mask, offset_expr);
     let condition = SymBoolExpr::eq(&mut cx, expected_offset, masked_offset);
     let one = SymExpr::one(&mut cx);
     let zero = SymExpr::zero(&mut cx);
     let condition_word = SymExpr::ite(&mut cx, condition, one, zero.clone());
-    let shifted_condition = SymExpr::op(&mut cx, SymExprOp::Shr, condition_word, zero.clone());
+    let shifted_condition =
+        SymExpr::binop(&mut cx, SymExprBinOp::Shr, condition_word, zero.clone());
     let byte_mask = SymExpr::constant(&mut cx, U256::from(0xff));
-    let bool_byte = SymExpr::op(&mut cx, SymExprOp::And, shifted_condition, byte_mask);
-    let bool_word = SymExpr::op(&mut cx, SymExprOp::Or, zero.clone(), bool_byte);
+    let bool_byte = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted_condition, byte_mask);
+    let bool_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, zero.clone(), bool_byte);
     let bool_word_zero = SymBoolExpr::eq(&mut cx, bool_word, zero);
     state.constraints.push(bool_word_zero.not(&mut cx));
 
@@ -1752,8 +1756,8 @@ fn path_state_evaluates_compound_constrained_symbolic_word() {
 
     let zero = SymExpr::zero(&mut cx);
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let masked_value = SymExpr::op(&mut cx, SymExprOp::And, value, u64_max);
-    let encoded_word = SymExpr::op(&mut cx, SymExprOp::Or, zero, masked_value);
+    let masked_value = SymExpr::binop(&mut cx, SymExprBinOp::And, value, u64_max);
+    let encoded_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, zero, masked_value);
 
     assert_eq!(state.constrained_word(&mut cx, &encoded_word), Some(U256::from(0xbeef)));
 }
@@ -2311,13 +2315,13 @@ fn symbolic_signextend_uses_sign_bit_ite() {
     let word = SymExpr::var(&mut cx, "word");
     let actual = signextend_word(&mut cx, U256::ZERO, word.clone());
     let sign_mask = SymExpr::constant(&mut cx, U256::from(0x80));
-    let sign_bit = SymExpr::op(&mut cx, SymExprOp::And, word.clone(), sign_mask);
+    let sign_bit = SymExpr::binop(&mut cx, SymExprBinOp::And, word.clone(), sign_mask);
     let zero = SymExpr::zero(&mut cx);
     let sign_bit_zero = SymBoolExpr::eq(&mut cx, sign_bit, zero);
     let positive_mask = SymExpr::constant(&mut cx, U256::from(0x7f));
-    let positive = SymExpr::op(&mut cx, SymExprOp::And, word.clone(), positive_mask);
+    let positive = SymExpr::binop(&mut cx, SymExprBinOp::And, word.clone(), positive_mask);
     let negative_mask = SymExpr::constant(&mut cx, !U256::from(0x7f));
-    let negative = SymExpr::op(&mut cx, SymExprOp::Or, word, negative_mask);
+    let negative = SymExpr::binop(&mut cx, SymExprBinOp::Or, word, negative_mask);
     let expected = SymExpr::ite(&mut cx, sign_bit_zero, positive, negative);
     assert_eq!(actual, expected);
 }
@@ -2386,17 +2390,17 @@ fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
     let mut cx = SymCx::new();
     let var = SymExpr::var(&mut cx, "calldata_0");
     let msg_sender = U256::from_str_radix("1804c8ab1f12e6bbf3894d4083f33e07309d1f38", 16).unwrap();
-    let product = SymExpr::op(&mut cx, SymExprOp::Mul, var.clone(), var.clone());
+    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, var.clone(), var.clone());
     let sender_word = SymExpr::constant(&mut cx, msg_sender);
     let product_below_sender =
         SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, product, sender_word.clone());
     let above_sender = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, var.clone(), sender_word);
     let mask_800 = SymExpr::constant(&mut cx, U256::from(0x800));
-    let masked_800 = SymExpr::op(&mut cx, SymExprOp::And, var.clone(), mask_800);
+    let masked_800 = SymExpr::binop(&mut cx, SymExprBinOp::And, var.clone(), mask_800);
     let zero = SymExpr::zero(&mut cx);
     let has_800 = SymBoolExpr::eq(&mut cx, masked_800, zero.clone()).not(&mut cx);
     let mask_10000 = SymExpr::constant(&mut cx, U256::from(0x10000));
-    let masked_10000 = SymExpr::op(&mut cx, SymExprOp::And, var, mask_10000);
+    let masked_10000 = SymExpr::binop(&mut cx, SymExprBinOp::And, var, mask_10000);
     let lacks_10000 = SymBoolExpr::eq(&mut cx, masked_10000, zero);
     let constraints = vec![product_below_sender, above_sender, has_800, lacks_10000];
 
@@ -2411,40 +2415,40 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
     let x = SymExpr::var(&mut cx, "x");
 
     let zero = SymExpr::zero(&mut cx);
-    let actual = SymExpr::op(&mut cx, SymExprOp::Mul, x.clone(), zero.clone());
+    let actual = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x.clone(), zero.clone());
     assert_eq!(actual, zero);
     let one = SymExpr::one(&mut cx);
-    let actual = SymExpr::op(&mut cx, SymExprOp::Mul, one, x.clone());
+    let actual = SymExpr::binop(&mut cx, SymExprBinOp::Mul, one, x.clone());
     assert_eq!(actual, x);
     let x = SymExpr::var(&mut cx, "x");
     let one = SymExpr::one(&mut cx);
-    let actual = SymExpr::op(&mut cx, SymExprOp::UDiv, x.clone(), one);
+    let actual = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, x.clone(), one);
     assert_eq!(actual, x);
     let x = SymExpr::var(&mut cx, "x");
     let one = SymExpr::one(&mut cx);
-    let actual = SymExpr::op(&mut cx, SymExprOp::URem, x, one);
+    let actual = SymExpr::binop(&mut cx, SymExprBinOp::URem, x, one);
     let zero = SymExpr::zero(&mut cx);
     assert_eq!(actual, zero);
     let x = SymExpr::var(&mut cx, "x");
     let x_again = SymExpr::var(&mut cx, "x");
-    let actual = SymExpr::op(&mut cx, SymExprOp::Sub, x, x_again);
+    let actual = SymExpr::binop(&mut cx, SymExprBinOp::Sub, x, x_again);
     let zero = SymExpr::zero(&mut cx);
     assert_eq!(actual, zero);
     let x = SymExpr::var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let actual = SymExpr::op(&mut cx, SymExprOp::And, x.clone(), max);
+    let actual = SymExpr::binop(&mut cx, SymExprBinOp::And, x.clone(), max);
     assert_eq!(actual, x);
     let x = SymExpr::var(&mut cx, "x");
-    let actual = SymExpr::op(&mut cx, SymExprOp::And, x.clone(), x.clone());
+    let actual = SymExpr::binop(&mut cx, SymExprBinOp::And, x.clone(), x.clone());
     assert_eq!(actual, x);
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
     let x = SymExpr::var(&mut cx, "x");
-    let masked = SymExpr::op(&mut cx, SymExprOp::And, x, mask.clone());
-    let actual = SymExpr::op(&mut cx, SymExprOp::And, masked.clone(), mask);
+    let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, x, mask.clone());
+    let actual = SymExpr::binop(&mut cx, SymExprBinOp::And, masked.clone(), mask);
     assert_eq!(actual, masked);
     let six = SymExpr::constant(&mut cx, U256::from(6));
     let seven = SymExpr::constant(&mut cx, U256::from(7));
-    let actual = SymExpr::op(&mut cx, SymExprOp::Mul, six, seven);
+    let actual = SymExpr::binop(&mut cx, SymExprBinOp::Mul, six, seven);
     let forty_two = SymExpr::constant(&mut cx, U256::from(42));
     assert_eq!(actual, forty_two);
 }
@@ -2622,7 +2626,7 @@ fn solver_normalizes_udiv_zero_predicates_without_bvudiv() {
     let mut cx = SymCx::new();
     let numerator = SymExpr::var(&mut cx, "numerator");
     let denominator = SymExpr::var(&mut cx, "denominator");
-    let div = SymExpr::op(&mut cx, SymExprOp::UDiv, numerator, denominator);
+    let div = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::eq(&mut cx, div, zero);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
@@ -2652,7 +2656,7 @@ fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
     let mut cx = SymCx::new();
     let numerator = SymExpr::var(&mut cx, "numerator");
     let denominator = SymExpr::var(&mut cx, "denominator");
-    let div = SymExpr::op(&mut cx, SymExprOp::UDiv, numerator, denominator);
+    let div = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, div, zero);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
@@ -2712,8 +2716,8 @@ fn solver_normalizes_erc4626_style_share_zero_predicate() {
     let assets = SymExpr::var(&mut cx, "assets");
     let supply = SymExpr::var(&mut cx, "supply");
     let total_assets = SymExpr::var(&mut cx, "total_assets");
-    let numerator = SymExpr::op(&mut cx, SymExprOp::Mul, assets, supply);
-    let shares = SymExpr::op(&mut cx, SymExprOp::UDiv, numerator, total_assets);
+    let numerator = SymExpr::binop(&mut cx, SymExprBinOp::Mul, assets, supply);
+    let shares = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, total_assets);
     let zero = SymExpr::zero(&mut cx);
     let constraints = vec![SymBoolExpr::eq(&mut cx, shares, zero)];
     let normalized = normalize_constraints_for_solver(&mut cx, &constraints);
@@ -2728,7 +2732,7 @@ fn expression_rebuilds_word_from_extracted_byte_terms() {
     let mut cx = SymCx::new();
     let word = SymExpr::var(&mut cx, "word");
     let mask = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let masked = SymExpr::op(&mut cx, SymExprOp::And, word, mask);
+    let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, word, mask);
     let bytes = masked.clone().into_byte_exprs(&mut cx);
     let rebuilt_word = SymExpr::from_bytes(&mut cx, bytes);
 
@@ -2740,13 +2744,13 @@ fn expression_rebuilds_word_from_shifted_fragments() {
     let mut cx = SymCx::new();
     let word = SymExpr::var(&mut cx, "word");
     let low_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
-    let low_bits = SymExpr::op(&mut cx, SymExprOp::And, word.clone(), low_mask);
+    let low_bits = SymExpr::binop(&mut cx, SymExprBinOp::And, word.clone(), low_mask);
     let shift = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted = SymExpr::op(&mut cx, SymExprOp::Shr, word.clone(), shift.clone());
+    let shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shr, word.clone(), shift.clone());
     let high_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 224));
-    let masked_high = SymExpr::op(&mut cx, SymExprOp::And, shifted, high_mask);
-    let high_bits = SymExpr::op(&mut cx, SymExprOp::Shl, masked_high, shift);
-    let rebuilt_expr = SymExpr::op(&mut cx, SymExprOp::Or, low_bits, high_bits);
+    let masked_high = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted, high_mask);
+    let high_bits = SymExpr::binop(&mut cx, SymExprBinOp::Shl, masked_high, shift);
+    let rebuilt_expr = SymExpr::binop(&mut cx, SymExprBinOp::Or, low_bits, high_bits);
 
     assert_eq!(rebuilt_expr, word);
 }
@@ -2761,29 +2765,31 @@ fn expression_simplifies_selector_prefixed_word_fragment() {
     let selector = SymExpr::constant(&mut cx, U256::from(0x771602f7u64) << 224);
 
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted_x = SymExpr::op(&mut cx, SymExprOp::Shr, x.clone(), shift_32.clone());
-    let x_high = SymExpr::op(&mut cx, SymExprOp::And, shifted_x, low_224.clone());
-    let first_word = SymExpr::op(&mut cx, SymExprOp::Or, selector, x_high);
-    let shifted_y = SymExpr::op(&mut cx, SymExprOp::Shr, y.clone(), shift_32.clone());
-    let y_high = SymExpr::op(&mut cx, SymExprOp::And, shifted_y, low_224.clone());
-    let x_low = SymExpr::op(&mut cx, SymExprOp::And, x.clone(), low_32.clone());
+    let shifted_x = SymExpr::binop(&mut cx, SymExprBinOp::Shr, x.clone(), shift_32.clone());
+    let x_high = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted_x, low_224.clone());
+    let first_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, selector, x_high);
+    let shifted_y = SymExpr::binop(&mut cx, SymExprBinOp::Shr, y.clone(), shift_32.clone());
+    let y_high = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted_y, low_224.clone());
+    let x_low = SymExpr::binop(&mut cx, SymExprBinOp::And, x.clone(), low_32.clone());
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
-    let x_low_shifted = SymExpr::op(&mut cx, SymExprOp::Shl, x_low, shift_224.clone());
-    let second_word = SymExpr::op(&mut cx, SymExprOp::Or, y_high, x_low_shifted);
-    let second_word_shifted = SymExpr::op(&mut cx, SymExprOp::Shr, second_word.clone(), shift_224);
-    let rebuilt_low = SymExpr::op(&mut cx, SymExprOp::And, second_word_shifted, low_32);
-    let first_word_masked = SymExpr::op(&mut cx, SymExprOp::And, first_word, low_224);
-    let rebuilt_high = SymExpr::op(&mut cx, SymExprOp::Shl, first_word_masked, shift_32.clone());
-    let rebuilt = SymExpr::op(&mut cx, SymExprOp::Or, rebuilt_low, rebuilt_high);
+    let x_low_shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shl, x_low, shift_224.clone());
+    let second_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, y_high, x_low_shifted);
+    let second_word_shifted =
+        SymExpr::binop(&mut cx, SymExprBinOp::Shr, second_word.clone(), shift_224);
+    let rebuilt_low = SymExpr::binop(&mut cx, SymExprBinOp::And, second_word_shifted, low_32);
+    let first_word_masked = SymExpr::binop(&mut cx, SymExprBinOp::And, first_word, low_224);
+    let rebuilt_high =
+        SymExpr::binop(&mut cx, SymExprBinOp::Shl, first_word_masked, shift_32.clone());
+    let rebuilt = SymExpr::binop(&mut cx, SymExprBinOp::Or, rebuilt_low, rebuilt_high);
 
     assert_eq!(rebuilt, x);
 
     let next_low_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
-    let next_low = SymExpr::op(&mut cx, SymExprOp::And, y.clone(), next_low_mask);
+    let next_low = SymExpr::binop(&mut cx, SymExprBinOp::And, y.clone(), next_low_mask);
     let next_high_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 224));
-    let next_high = SymExpr::op(&mut cx, SymExprOp::And, second_word, next_high_mask);
-    let next_high_shifted = SymExpr::op(&mut cx, SymExprOp::Shl, next_high, shift_32);
-    let rebuilt_next = SymExpr::op(&mut cx, SymExprOp::Or, next_low, next_high_shifted);
+    let next_high = SymExpr::binop(&mut cx, SymExprBinOp::And, second_word, next_high_mask);
+    let next_high_shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shl, next_high, shift_32);
+    let rebuilt_next = SymExpr::binop(&mut cx, SymExprBinOp::Or, next_low, next_high_shifted);
 
     assert_eq!(rebuilt_next, y);
 }
@@ -2791,14 +2797,14 @@ fn expression_simplifies_selector_prefixed_word_fragment() {
 fn checked_mul_guard_word(cx: &mut SymCx, zero_operand: &SymExpr, expected: &SymExpr) -> SymExpr {
     let zero = SymExpr::zero(cx);
     let operand_is_zero = SymBoolExpr::eq(cx, zero_operand.clone(), zero.clone());
-    let product = SymExpr::op(cx, SymExprOp::Mul, zero_operand.clone(), expected.clone());
-    let quotient = SymExpr::op(cx, SymExprOp::UDiv, product, zero_operand.clone());
+    let product = SymExpr::binop(cx, SymExprBinOp::Mul, zero_operand.clone(), expected.clone());
+    let quotient = SymExpr::binop(cx, SymExprBinOp::UDiv, product, zero_operand.clone());
     let checked_product = SymExpr::ite(cx, operand_is_zero.clone(), zero, quotient);
     let operand_is_zero_word = SymExpr::bool_word(cx, operand_is_zero);
     let product_matches_expected = SymBoolExpr::eq(cx, checked_product, expected.clone());
     let product_matches_expected_word = SymExpr::bool_word(cx, product_matches_expected);
 
-    SymExpr::op(cx, SymExprOp::Or, operand_is_zero_word, product_matches_expected_word)
+    SymExpr::binop(cx, SymExprBinOp::Or, operand_is_zero_word, product_matches_expected_word)
 }
 
 #[test]
@@ -2806,10 +2812,10 @@ fn solver_normalizes_checked_mul_guard_for_bounded_operands() {
     let mut cx = SymCx::new();
     let a_word = SymExpr::var(&mut cx, "a");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let a = SymExpr::op(&mut cx, SymExprOp::And, a_word, u64_max);
+    let a = SymExpr::binop(&mut cx, SymExprBinOp::And, a_word, u64_max);
     let b_word = SymExpr::var(&mut cx, "b");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let b = SymExpr::op(&mut cx, SymExprOp::And, b_word, u64_max);
+    let b = SymExpr::binop(&mut cx, SymExprBinOp::And, b_word, u64_max);
     let guard = checked_mul_guard_word(&mut cx, &a, &b);
     let zero = SymExpr::zero(&mut cx);
     let guard_is_zero = SymBoolExpr::eq(&mut cx, guard, zero);
@@ -2847,13 +2853,13 @@ fn solver_normalizes_guarded_self_division_guard() {
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
-    let quotient = SymExpr::op(&mut cx, SymExprOp::UDiv, a.clone(), a);
+    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, a.clone(), a);
     let checked_quotient = SymExpr::ite(&mut cx, a_is_zero.clone(), zero.clone(), quotient);
     let a_is_zero_word = SymExpr::bool_word(&mut cx, a_is_zero);
     let one = SymExpr::one(&mut cx);
     let quotient_is_one = SymBoolExpr::eq(&mut cx, checked_quotient, one);
     let quotient_is_one_word = SymExpr::bool_word(&mut cx, quotient_is_one);
-    let guard = SymExpr::op(&mut cx, SymExprOp::Or, a_is_zero_word, quotient_is_one_word);
+    let guard = SymExpr::binop(&mut cx, SymExprBinOp::Or, a_is_zero_word, quotient_is_one_word);
     let original = SymBoolExpr::eq(&mut cx, guard, zero);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
 
@@ -2871,7 +2877,7 @@ fn expression_normalizes_guarded_self_division_word() {
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
-    let quotient = SymExpr::op(&mut cx, SymExprOp::UDiv, a.clone(), a);
+    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, a.clone(), a);
     let checked_quotient = SymExpr::ite(&mut cx, a_is_zero.clone(), zero, quotient);
     let a_is_nonzero = a_is_zero.not(&mut cx);
     let one = SymExpr::one(&mut cx);
@@ -2894,7 +2900,7 @@ fn solver_does_not_invert_guarded_zero_self_division() {
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
-    let quotient = SymExpr::op(&mut cx, SymExprOp::UDiv, a.clone(), a);
+    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, a.clone(), a);
     let mirrored = SymExpr::ite(&mut cx, a_is_zero, quotient, zero);
     let normalized = normalize_expr_for_solver(&mut cx, mirrored.clone());
 
@@ -2910,10 +2916,10 @@ fn solver_normalizes_guarded_self_division_add_overflow_guard() {
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
-    let quotient = SymExpr::op(&mut cx, SymExprOp::UDiv, a.clone(), a);
+    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, a.clone(), a);
     let checked_quotient = SymExpr::ite(&mut cx, a_is_zero, zero, quotient);
     let one = SymExpr::one(&mut cx);
-    let sum = SymExpr::op(&mut cx, SymExprOp::Add, one, checked_quotient.clone());
+    let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, one, checked_quotient.clone());
     let condition = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, checked_quotient, sum);
 
     assert_eq!(
@@ -3006,16 +3012,16 @@ fn solver_normalizes_checked_add_overflow_guard_for_bounded_operands() {
     let mut cx = SymCx::new();
     let a_raw = SymExpr::var(&mut cx, "a");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let a = SymExpr::op(&mut cx, SymExprOp::And, a_raw, u64_max);
+    let a = SymExpr::binop(&mut cx, SymExprBinOp::And, a_raw, u64_max);
     let b_raw = SymExpr::var(&mut cx, "b");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let b_masked = SymExpr::op(&mut cx, SymExprOp::And, b_raw, u64_max);
-    let numerator = SymExpr::op(&mut cx, SymExprOp::Mul, b_masked, a.clone());
+    let b_masked = SymExpr::binop(&mut cx, SymExprBinOp::And, b_raw, u64_max);
+    let numerator = SymExpr::binop(&mut cx, SymExprBinOp::Mul, b_masked, a.clone());
     let denominator_raw = SymExpr::var(&mut cx, "denominator");
     let high_mask = SymExpr::constant(&mut cx, U256::MAX >> 64);
-    let denominator = SymExpr::op(&mut cx, SymExprOp::And, denominator_raw, high_mask);
-    let b = SymExpr::op(&mut cx, SymExprOp::UDiv, numerator, denominator);
-    let sum = SymExpr::op(&mut cx, SymExprOp::Add, a.clone(), b);
+    let denominator = SymExpr::binop(&mut cx, SymExprBinOp::And, denominator_raw, high_mask);
+    let b = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
+    let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, a.clone(), b);
     let condition = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, a, sum);
 
     assert_eq!(
@@ -3029,7 +3035,7 @@ fn solver_does_not_normalize_unbounded_checked_add_overflow_guard() {
     let mut cx = SymCx::new();
     let a = SymExpr::var(&mut cx, "a");
     let b = SymExpr::var(&mut cx, "b");
-    let sum = SymExpr::op(&mut cx, SymExprOp::Add, a.clone(), b);
+    let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, a.clone(), b);
     let original = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, a, sum);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
 
@@ -3045,23 +3051,23 @@ fn solver_detects_monotonic_product_contradiction() {
     let mut cx = SymCx::new();
     let ink_word = SymExpr::var(&mut cx, "ink");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let ink = SymExpr::op(&mut cx, SymExprOp::And, ink_word, u64_max);
+    let ink = SymExpr::binop(&mut cx, SymExprBinOp::And, ink_word, u64_max);
     let art_word = SymExpr::var(&mut cx, "art");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let art = SymExpr::op(&mut cx, SymExprOp::And, art_word, u64_max);
+    let art = SymExpr::binop(&mut cx, SymExprBinOp::And, art_word, u64_max);
     let spot_word = SymExpr::var(&mut cx, "spot");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let spot = SymExpr::op(&mut cx, SymExprOp::And, spot_word, u64_max);
+    let spot = SymExpr::binop(&mut cx, SymExprBinOp::And, spot_word, u64_max);
     let rate_word = SymExpr::var(&mut cx, "rate");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let rate = SymExpr::op(&mut cx, SymExprOp::And, rate_word, u64_max);
+    let rate = SymExpr::binop(&mut cx, SymExprBinOp::And, rate_word, u64_max);
     let zero = SymExpr::zero(&mut cx);
     let ink_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, ink.clone(), zero.clone());
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, art.clone(), ink.clone());
     let spot_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, spot.clone(), zero);
     let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, rate.clone(), spot.clone());
-    let left_product = SymExpr::op(&mut cx, SymExprOp::Mul, ink, spot);
-    let right_product = SymExpr::op(&mut cx, SymExprOp::Mul, art, rate);
+    let left_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, ink, spot);
+    let right_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, art, rate);
     let wrapping =
         SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
@@ -3081,8 +3087,8 @@ fn solver_does_not_prune_wrapping_product_inequality() {
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, art.clone(), ink.clone());
     let spot_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, spot.clone(), zero);
     let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, rate.clone(), spot.clone());
-    let left_product = SymExpr::op(&mut cx, SymExprOp::Mul, ink, spot);
-    let right_product = SymExpr::op(&mut cx, SymExprOp::Mul, art, rate);
+    let left_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, ink, spot);
+    let right_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, art, rate);
     let wrapping =
         SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
@@ -3104,11 +3110,13 @@ fn hard_arithmetic_detection_flags_symbolic_mul_div_and_mod() {
     let x = SymExpr::var(&mut cx, "x");
     let y = SymExpr::var(&mut cx, "y");
 
-    assert!(SymExpr::op(&mut cx, SymExprOp::Mul, x.clone(), y.clone()).contains_hard_arith());
-    assert!(SymExpr::op(&mut cx, SymExprOp::UDiv, x.clone(), y.clone()).contains_hard_arith());
-    assert!(SymExpr::op(&mut cx, SymExprOp::URem, x.clone(), y).contains_hard_arith());
+    assert!(SymExpr::binop(&mut cx, SymExprBinOp::Mul, x.clone(), y.clone()).contains_hard_arith());
+    assert!(
+        SymExpr::binop(&mut cx, SymExprBinOp::UDiv, x.clone(), y.clone()).contains_hard_arith()
+    );
+    assert!(SymExpr::binop(&mut cx, SymExprBinOp::URem, x.clone(), y).contains_hard_arith());
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let mul = SymExpr::op(&mut cx, SymExprOp::Mul, x, one);
+    let mul = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, one);
     assert!(!mul.contains_hard_arith());
 }
 
@@ -3118,9 +3126,9 @@ fn hard_arithmetic_fallback_finds_multi_variable_candidate() {
     let first = SymExpr::var(&mut cx, "first");
     let donation = SymExpr::var(&mut cx, "donation");
     let second = SymExpr::var(&mut cx, "second");
-    let denominator = SymExpr::op(&mut cx, SymExprOp::Add, first.clone(), donation.clone());
-    let numerator = SymExpr::op(&mut cx, SymExprOp::Mul, second.clone(), first.clone());
-    let shares = SymExpr::op(&mut cx, SymExprOp::UDiv, numerator, denominator);
+    let denominator = SymExpr::binop(&mut cx, SymExprBinOp::Add, first.clone(), donation.clone());
+    let numerator = SymExpr::binop(&mut cx, SymExprBinOp::Mul, second.clone(), first.clone());
+    let shares = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let first_nonzero = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, first, zero.clone());
     let donation_nonzero = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, donation, zero.clone());
@@ -3145,8 +3153,8 @@ fn hard_arithmetic_fallback_finds_wrapping_product_inequality_candidate() {
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, art.clone(), ink.clone());
     let spot_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, spot.clone(), zero);
     let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, rate.clone(), spot.clone());
-    let left_product = SymExpr::op(&mut cx, SymExprOp::Mul, ink, spot);
-    let right_product = SymExpr::op(&mut cx, SymExprOp::Mul, art, rate);
+    let left_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, ink, spot);
+    let right_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, art, rate);
     let wrapping =
         SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
@@ -3182,7 +3190,7 @@ fn hard_arithmetic_fallback_rejects_unvalidated_partial_model() {
     let d = SymExpr::var(&mut cx, "d");
     let e = SymExpr::var(&mut cx, "e");
     let f = SymExpr::var(&mut cx, "f");
-    let product = SymExpr::op(&mut cx, SymExprOp::Mul, a, b);
+    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, a, b);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let product_eq_one = SymBoolExpr::eq(&mut cx, product, one);
     let three = SymExpr::constant(&mut cx, U256::from(3));
@@ -3205,7 +3213,7 @@ fn hard_arithmetic_fallback_skips_symbolic_hashes() {
     let mut cx = SymCx::new();
     let x = SymExpr::var(&mut cx, "x");
     let hash = SymExpr::hash_symbol(&mut cx, Symbol::intern("hash"), "sha256", vec![x.clone()]);
-    let product = SymExpr::op(&mut cx, SymExprOp::Mul, x, hash);
+    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, hash);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraints = vec![SymBoolExpr::eq(&mut cx, product, one)];
 
@@ -3455,7 +3463,7 @@ fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
     let zero = SymExpr::zero(&mut cx);
     let x_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, x.clone(), zero.clone());
     let y_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, y.clone(), zero);
-    let product = SymExpr::op(&mut cx, SymExprOp::Mul, x, y);
+    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, y);
     let four = SymExpr::constant(&mut cx, U256::from(4));
     let product_eq_four = SymBoolExpr::eq(&mut cx, product, four);
     let constraints = vec![x_positive, y_positive, product_eq_four];
@@ -3488,7 +3496,7 @@ fn model_uses_validated_hard_arithmetic_fallback_cache() {
     let zero = SymExpr::zero(&mut cx);
     let x_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, x.clone(), zero.clone());
     let y_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, y.clone(), zero);
-    let product = SymExpr::op(&mut cx, SymExprOp::Mul, x, y);
+    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, y);
     let four = SymExpr::constant(&mut cx, U256::from(4));
     let product_eq_four = SymBoolExpr::eq(&mut cx, product, four);
     let constraints = vec![x_positive, y_positive, product_eq_four];
@@ -3521,7 +3529,7 @@ fn is_sat_hard_arithmetic_without_witness_still_honors_solver_unsat() {
     let y = SymExpr::var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
     let x_is_zero = SymBoolExpr::eq(&mut cx, x.clone(), zero);
-    let product = SymExpr::op(&mut cx, SymExprOp::Mul, x, y);
+    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, y);
     let one = SymExpr::one(&mut cx);
     let product_eq_one = SymBoolExpr::eq(&mut cx, product, one);
     let constraints = vec![x_is_zero, product_eq_one];
@@ -3582,13 +3590,13 @@ fn sat_cache_reuses_nested_commutative_results() {
     let y = SymExpr::var(&mut cx, "y");
     let three = SymExpr::constant(&mut cx, U256::from(3));
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let sum = SymExpr::op(&mut cx, SymExprOp::Add, x.clone(), y.clone());
+    let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, x.clone(), y.clone());
     let sum_eq_three = SymBoolExpr::eq(&mut cx, sum, three.clone());
     let x_eq_one = SymBoolExpr::eq(&mut cx, x.clone(), one.clone());
     let constraints = vec![SymBoolExpr::and(&mut cx, vec![sum_eq_three, x_eq_one])];
     let one_eq_x = SymBoolExpr::eq(&mut cx, one, x);
     let x_again = SymExpr::var(&mut cx, "x");
-    let reordered_sum = SymExpr::op(&mut cx, SymExprOp::Add, y, x_again);
+    let reordered_sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, y, x_again);
     let three_eq_sum = SymBoolExpr::eq(&mut cx, three, reordered_sum);
     let reordered_constraints = vec![SymBoolExpr::and(&mut cx, vec![one_eq_x, three_eq_sum])];
 
@@ -4276,7 +4284,7 @@ fn solver_smt_dump_shares_repeated_subterms() {
     let calldata = SymExpr::var(&mut cx, "calldata_0");
     let byte = calldata.extracted_byte(&mut cx, 0);
     let shift = SymExpr::constant(&mut cx, U256::from(248));
-    let shifted = SymExpr::op(&mut cx, SymExprOp::Shl, byte, shift);
+    let shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shl, byte, shift);
     let zero = SymExpr::zero(&mut cx);
     let shifted_zero = SymBoolExpr::eq(&mut cx, shifted.clone(), zero.clone());
     let shifted_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, shifted, zero);

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -15,7 +15,7 @@ fn symbolic_calldata_variants(
 }
 
 fn add_words(cx: &mut SymCx, left: SymExpr, right: SymExpr) -> SymExpr {
-    SymExpr::binop(cx, SymExprBinOp::Add, left, right)
+    SymExpr::binop(cx, SymBinOp::Add, left, right)
 }
 
 macro_rules! sym_from_bytes {
@@ -114,7 +114,7 @@ fn binary_helpers_use_evm_operand_order() {
     state.stack.push(SymExpr::constant(&mut cx, U256::from(2))).unwrap();
     state.stack.push(SymExpr::constant(&mut cx, U256::from(10))).unwrap();
 
-    state.bin_word(&mut cx, SymExprBinOp::Sub).unwrap();
+    state.bin_word(&mut cx, SymBinOp::Sub).unwrap();
 
     assert_eq!(state.stack.pop().unwrap(), SymExpr::constant(&mut cx, U256::from(8)));
 }
@@ -231,13 +231,13 @@ fn symbolic_division_guards_zero_divisor() {
     state.stack.push(SymExpr::var(&mut cx, "den")).unwrap();
     state.stack.push(SymExpr::var(&mut cx, "num")).unwrap();
 
-    state.bin_word_div_zero_guard(&mut cx, SymExprBinOp::UDiv).unwrap();
+    state.bin_word_div_zero_guard(&mut cx, SymBinOp::UDiv).unwrap();
 
     let den = SymExpr::var(&mut cx, "den");
     let zero = SymExpr::zero(&mut cx);
     let den_is_zero = SymBoolExpr::eq(&mut cx, den.clone(), zero.clone());
     let num = SymExpr::var(&mut cx, "num");
-    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, num, den);
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, num, den);
     let expected = SymExpr::ite(&mut cx, den_is_zero, zero, quotient);
     assert_eq!(state.stack.pop().unwrap(), expected);
 }
@@ -248,9 +248,9 @@ fn symbolic_byte_extracts_with_concrete_index() {
     let word = SymExpr::var(&mut cx, "word");
     let actual = byte_word(&mut cx, U256::from(0), word.clone());
     let shift = SymExpr::constant(&mut cx, U256::from(248));
-    let shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shr, word, shift);
+    let shifted = SymExpr::binop(&mut cx, SymBinOp::Shr, word, shift);
     let mask = SymExpr::constant(&mut cx, U256::from(0xff));
-    let expected = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted, mask);
+    let expected = SymExpr::binop(&mut cx, SymBinOp::And, shifted, mask);
     assert_eq!(actual, expected);
 }
 
@@ -289,11 +289,11 @@ fn symbolic_byte_preserves_concrete_packed_selector_bytes() {
     let selector = U256::from(0x12345678);
     let selector = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
-    let selector = SymExpr::binop(&mut cx, SymExprBinOp::Shl, selector, shift_224);
+    let selector = SymExpr::binop(&mut cx, SymBinOp::Shl, selector, shift_224);
     let arg = SymExpr::var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted_arg = SymExpr::binop(&mut cx, SymExprBinOp::Shr, arg, shift_32);
-    let packed = SymExpr::binop(&mut cx, SymExprBinOp::Or, selector, shifted_arg);
+    let shifted_arg = SymExpr::binop(&mut cx, SymBinOp::Shr, arg, shift_32);
+    let packed = SymExpr::binop(&mut cx, SymBinOp::Or, selector, shifted_arg);
 
     assert_eq!(
         byte_word(&mut cx, U256::from(0), packed.clone()),
@@ -318,7 +318,7 @@ fn word_reassembly_preserves_split_symbolic_word() {
     let mut cx = SymCx::new();
     let value = SymExpr::var(&mut cx, "value");
     let one = SymExpr::one(&mut cx);
-    let original = SymExpr::binop(&mut cx, SymExprBinOp::Add, value, one);
+    let original = SymExpr::binop(&mut cx, SymBinOp::Add, value, one);
     let bytes = original.clone().into_byte_exprs(&mut cx);
 
     assert_eq!(SymExpr::from_bytes(&mut cx, bytes), original);
@@ -329,7 +329,7 @@ fn symbolic_address_aliases_match_abi_encoded_address_words() {
     let mut cx = SymCx::new();
     let source = SymExpr::var(&mut cx, "beneficiary");
     let address_mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
-    let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, source.clone(), address_mask);
+    let masked = SymExpr::binop(&mut cx, SymBinOp::And, source.clone(), address_mask);
     let mut encoded = vec![SymExpr::zero(&mut cx); 12];
     encoded.extend((12..32).map(|idx| byte_word(&mut cx, U256::from(idx), masked.clone())));
     let reassembled = SymExpr::from_bytes(&mut cx, encoded);
@@ -344,13 +344,12 @@ fn selector_shift_simplifies_to_concrete_word() {
     let selector = U256::from(0x12345678);
     let selector_word = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
-    let shifted_selector =
-        SymExpr::binop(&mut cx, SymExprBinOp::Shl, selector_word, shift_224.clone());
+    let shifted_selector = SymExpr::binop(&mut cx, SymBinOp::Shl, selector_word, shift_224.clone());
     let arg = SymExpr::var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted_arg = SymExpr::binop(&mut cx, SymExprBinOp::Shr, arg, shift_32);
-    let call_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, shifted_selector, shifted_arg);
-    let selector_expr = SymExpr::binop(&mut cx, SymExprBinOp::Shr, call_word, shift_224);
+    let shifted_arg = SymExpr::binop(&mut cx, SymBinOp::Shr, arg, shift_32);
+    let call_word = SymExpr::binop(&mut cx, SymBinOp::Or, shifted_selector, shifted_arg);
+    let selector_expr = SymExpr::binop(&mut cx, SymBinOp::Shr, call_word, shift_224);
 
     assert_eq!(selector_expr.known_word(), Some(selector));
 }
@@ -362,13 +361,12 @@ fn selector_equality_folds_known_word_expressions() {
     let other = U256::from(0x9a8325a0u32);
     let selector_word = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
-    let shifted_selector =
-        SymExpr::binop(&mut cx, SymExprBinOp::Shl, selector_word, shift_224.clone());
+    let shifted_selector = SymExpr::binop(&mut cx, SymBinOp::Shl, selector_word, shift_224.clone());
     let arg = SymExpr::var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted_arg = SymExpr::binop(&mut cx, SymExprBinOp::Shr, arg, shift_32);
-    let call_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, shifted_selector, shifted_arg);
-    let selector_expr = SymExpr::binop(&mut cx, SymExprBinOp::Shr, call_word, shift_224);
+    let shifted_arg = SymExpr::binop(&mut cx, SymBinOp::Shr, arg, shift_32);
+    let call_word = SymExpr::binop(&mut cx, SymBinOp::Or, shifted_selector, shifted_arg);
+    let selector_expr = SymExpr::binop(&mut cx, SymBinOp::Shr, call_word, shift_224);
 
     let selector_word = SymExpr::constant(&mut cx, selector);
     let actual = SymBoolExpr::eq(&mut cx, selector_expr.clone(), selector_word);
@@ -392,7 +390,7 @@ fn calldata_selector_load_simplifies_to_concrete_word() {
     let offset = SymExpr::zero(&mut cx);
     let loaded = call_data.load_word(&mut cx, offset).unwrap();
     let shift = SymExpr::constant(&mut cx, U256::from(224));
-    let selector_expr = SymExpr::binop(&mut cx, SymExprBinOp::Shr, loaded, shift);
+    let selector_expr = SymExpr::binop(&mut cx, SymBinOp::Shr, loaded, shift);
 
     assert_eq!(selector_expr.known_word(), Some(selector));
     let selector_word = SymExpr::constant(&mut cx, selector);
@@ -1538,7 +1536,7 @@ fn symbolic_world_resolves_symbolic_create2_address_aliases() {
     let word = SymExpr::var(&mut cx, "create2_address");
     let address = world.symbolic_address_slot(word.clone());
     let address_mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
-    let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, word.clone(), address_mask);
+    let masked = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), address_mask);
 
     assert_eq!(world.resolve_address(&word), Some(address));
     assert_eq!(world.resolve_address(&masked), Some(address));
@@ -1724,21 +1722,19 @@ fn path_state_extracts_constrained_symbolic_usize_from_encoded_bool_word() {
     let offset_expr = offset.clone();
     let mask = SymExpr::constant(&mut cx, U256::from(0xffff));
 
-    let masked_offset =
-        SymExpr::binop(&mut cx, SymExprBinOp::And, offset_expr.clone(), mask.clone());
+    let masked_offset = SymExpr::binop(&mut cx, SymBinOp::And, offset_expr.clone(), mask.clone());
     let offset_constraint = SymBoolExpr::eq(&mut cx, masked_offset, offset_expr.clone());
     state.constraints.push(offset_constraint);
     let expected_offset = SymExpr::constant(&mut cx, U256::from(0x80));
-    let masked_offset = SymExpr::binop(&mut cx, SymExprBinOp::And, mask, offset_expr);
+    let masked_offset = SymExpr::binop(&mut cx, SymBinOp::And, mask, offset_expr);
     let condition = SymBoolExpr::eq(&mut cx, expected_offset, masked_offset);
     let one = SymExpr::one(&mut cx);
     let zero = SymExpr::zero(&mut cx);
     let condition_word = SymExpr::ite(&mut cx, condition, one, zero.clone());
-    let shifted_condition =
-        SymExpr::binop(&mut cx, SymExprBinOp::Shr, condition_word, zero.clone());
+    let shifted_condition = SymExpr::binop(&mut cx, SymBinOp::Shr, condition_word, zero.clone());
     let byte_mask = SymExpr::constant(&mut cx, U256::from(0xff));
-    let bool_byte = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted_condition, byte_mask);
-    let bool_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, zero.clone(), bool_byte);
+    let bool_byte = SymExpr::binop(&mut cx, SymBinOp::And, shifted_condition, byte_mask);
+    let bool_word = SymExpr::binop(&mut cx, SymBinOp::Or, zero.clone(), bool_byte);
     let bool_word_zero = SymBoolExpr::eq(&mut cx, bool_word, zero);
     state.constraints.push(bool_word_zero.not(&mut cx));
 
@@ -1756,8 +1752,8 @@ fn path_state_evaluates_compound_constrained_symbolic_word() {
 
     let zero = SymExpr::zero(&mut cx);
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let masked_value = SymExpr::binop(&mut cx, SymExprBinOp::And, value, u64_max);
-    let encoded_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, zero, masked_value);
+    let masked_value = SymExpr::binop(&mut cx, SymBinOp::And, value, u64_max);
+    let encoded_word = SymExpr::binop(&mut cx, SymBinOp::Or, zero, masked_value);
 
     assert_eq!(state.constrained_word(&mut cx, &encoded_word), Some(U256::from(0xbeef)));
 }
@@ -2315,13 +2311,13 @@ fn symbolic_signextend_uses_sign_bit_ite() {
     let word = SymExpr::var(&mut cx, "word");
     let actual = signextend_word(&mut cx, U256::ZERO, word.clone());
     let sign_mask = SymExpr::constant(&mut cx, U256::from(0x80));
-    let sign_bit = SymExpr::binop(&mut cx, SymExprBinOp::And, word.clone(), sign_mask);
+    let sign_bit = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), sign_mask);
     let zero = SymExpr::zero(&mut cx);
     let sign_bit_zero = SymBoolExpr::eq(&mut cx, sign_bit, zero);
     let positive_mask = SymExpr::constant(&mut cx, U256::from(0x7f));
-    let positive = SymExpr::binop(&mut cx, SymExprBinOp::And, word.clone(), positive_mask);
+    let positive = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), positive_mask);
     let negative_mask = SymExpr::constant(&mut cx, !U256::from(0x7f));
-    let negative = SymExpr::binop(&mut cx, SymExprBinOp::Or, word, negative_mask);
+    let negative = SymExpr::binop(&mut cx, SymBinOp::Or, word, negative_mask);
     let expected = SymExpr::ite(&mut cx, sign_bit_zero, positive, negative);
     assert_eq!(actual, expected);
 }
@@ -2390,17 +2386,17 @@ fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
     let mut cx = SymCx::new();
     let var = SymExpr::var(&mut cx, "calldata_0");
     let msg_sender = U256::from_str_radix("1804c8ab1f12e6bbf3894d4083f33e07309d1f38", 16).unwrap();
-    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, var.clone(), var.clone());
+    let product = SymExpr::binop(&mut cx, SymBinOp::Mul, var.clone(), var.clone());
     let sender_word = SymExpr::constant(&mut cx, msg_sender);
     let product_below_sender =
         SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, product, sender_word.clone());
     let above_sender = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, var.clone(), sender_word);
     let mask_800 = SymExpr::constant(&mut cx, U256::from(0x800));
-    let masked_800 = SymExpr::binop(&mut cx, SymExprBinOp::And, var.clone(), mask_800);
+    let masked_800 = SymExpr::binop(&mut cx, SymBinOp::And, var.clone(), mask_800);
     let zero = SymExpr::zero(&mut cx);
     let has_800 = SymBoolExpr::eq(&mut cx, masked_800, zero.clone()).not(&mut cx);
     let mask_10000 = SymExpr::constant(&mut cx, U256::from(0x10000));
-    let masked_10000 = SymExpr::binop(&mut cx, SymExprBinOp::And, var, mask_10000);
+    let masked_10000 = SymExpr::binop(&mut cx, SymBinOp::And, var, mask_10000);
     let lacks_10000 = SymBoolExpr::eq(&mut cx, masked_10000, zero);
     let constraints = vec![product_below_sender, above_sender, has_800, lacks_10000];
 
@@ -2415,40 +2411,40 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
     let x = SymExpr::var(&mut cx, "x");
 
     let zero = SymExpr::zero(&mut cx);
-    let actual = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x.clone(), zero.clone());
+    let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, x.clone(), zero.clone());
     assert_eq!(actual, zero);
     let one = SymExpr::one(&mut cx);
-    let actual = SymExpr::binop(&mut cx, SymExprBinOp::Mul, one, x.clone());
+    let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, one, x.clone());
     assert_eq!(actual, x);
     let x = SymExpr::var(&mut cx, "x");
     let one = SymExpr::one(&mut cx);
-    let actual = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, x.clone(), one);
+    let actual = SymExpr::binop(&mut cx, SymBinOp::UDiv, x.clone(), one);
     assert_eq!(actual, x);
     let x = SymExpr::var(&mut cx, "x");
     let one = SymExpr::one(&mut cx);
-    let actual = SymExpr::binop(&mut cx, SymExprBinOp::URem, x, one);
+    let actual = SymExpr::binop(&mut cx, SymBinOp::URem, x, one);
     let zero = SymExpr::zero(&mut cx);
     assert_eq!(actual, zero);
     let x = SymExpr::var(&mut cx, "x");
     let x_again = SymExpr::var(&mut cx, "x");
-    let actual = SymExpr::binop(&mut cx, SymExprBinOp::Sub, x, x_again);
+    let actual = SymExpr::binop(&mut cx, SymBinOp::Sub, x, x_again);
     let zero = SymExpr::zero(&mut cx);
     assert_eq!(actual, zero);
     let x = SymExpr::var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let actual = SymExpr::binop(&mut cx, SymExprBinOp::And, x.clone(), max);
+    let actual = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), max);
     assert_eq!(actual, x);
     let x = SymExpr::var(&mut cx, "x");
-    let actual = SymExpr::binop(&mut cx, SymExprBinOp::And, x.clone(), x.clone());
+    let actual = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), x.clone());
     assert_eq!(actual, x);
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
     let x = SymExpr::var(&mut cx, "x");
-    let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, x, mask.clone());
-    let actual = SymExpr::binop(&mut cx, SymExprBinOp::And, masked.clone(), mask);
+    let masked = SymExpr::binop(&mut cx, SymBinOp::And, x, mask.clone());
+    let actual = SymExpr::binop(&mut cx, SymBinOp::And, masked.clone(), mask);
     assert_eq!(actual, masked);
     let six = SymExpr::constant(&mut cx, U256::from(6));
     let seven = SymExpr::constant(&mut cx, U256::from(7));
-    let actual = SymExpr::binop(&mut cx, SymExprBinOp::Mul, six, seven);
+    let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, six, seven);
     let forty_two = SymExpr::constant(&mut cx, U256::from(42));
     assert_eq!(actual, forty_two);
 }
@@ -2576,12 +2572,12 @@ fn exact_modular_arithmetic_handles_zero_modulus_and_wide_intermediates() {
     let a = SymExpr::var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let addmod = SymExpr::ternop(&mut cx, SymExprTernOp::AddMod, a, two, max);
+    let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, max);
     assert_eq!(addmod.eval_model(&model).unwrap(), U256::from(2));
     let a = SymExpr::var(&mut cx, "a");
     let a_again = SymExpr::var(&mut cx, "a");
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let mulmod = SymExpr::ternop(&mut cx, SymExprTernOp::MulMod, a, a_again, max);
+    let mulmod = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a, a_again, max);
     assert_eq!(mulmod.eval_model(&model).unwrap(), U256::ZERO);
 }
 
@@ -2591,11 +2587,11 @@ fn exact_modular_arithmetic_smt_widens_before_modulo() {
     let a = SymExpr::var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let m = SymExpr::var(&mut cx, "m");
-    let addmod = SymExpr::ternop(&mut cx, SymExprTernOp::AddMod, a, two, m).smt();
+    let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, m).smt();
     let a = SymExpr::var(&mut cx, "a");
     let b = SymExpr::var(&mut cx, "b");
     let m = SymExpr::var(&mut cx, "m");
-    let mulmod = SymExpr::ternop(&mut cx, SymExprTernOp::MulMod, a, b, m).smt();
+    let mulmod = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a, b, m).smt();
 
     assert!(addmod.contains("((_ zero_extend 256) a)"));
     assert!(addmod.contains("bvadd"));
@@ -2611,7 +2607,7 @@ fn exact_addmod_model_validation_rejects_wrapping_false_pass() {
     let a = SymExpr::var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let addmod = SymExpr::ternop(&mut cx, SymExprTernOp::AddMod, a, two, max);
+    let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, max);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraints = vec![SymBoolExpr::eq(&mut cx, addmod, one)];
     let output = format!("sat\n((define-fun a () (_ BitVec 256) #x{}))\n", "f".repeat(64));
@@ -2626,7 +2622,7 @@ fn solver_normalizes_udiv_zero_predicates_without_bvudiv() {
     let mut cx = SymCx::new();
     let numerator = SymExpr::var(&mut cx, "numerator");
     let denominator = SymExpr::var(&mut cx, "denominator");
-    let div = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
+    let div = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::eq(&mut cx, div, zero);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
@@ -2656,7 +2652,7 @@ fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
     let mut cx = SymCx::new();
     let numerator = SymExpr::var(&mut cx, "numerator");
     let denominator = SymExpr::var(&mut cx, "denominator");
-    let div = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
+    let div = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, div, zero);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
@@ -2716,8 +2712,8 @@ fn solver_normalizes_erc4626_style_share_zero_predicate() {
     let assets = SymExpr::var(&mut cx, "assets");
     let supply = SymExpr::var(&mut cx, "supply");
     let total_assets = SymExpr::var(&mut cx, "total_assets");
-    let numerator = SymExpr::binop(&mut cx, SymExprBinOp::Mul, assets, supply);
-    let shares = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, total_assets);
+    let numerator = SymExpr::binop(&mut cx, SymBinOp::Mul, assets, supply);
+    let shares = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, total_assets);
     let zero = SymExpr::zero(&mut cx);
     let constraints = vec![SymBoolExpr::eq(&mut cx, shares, zero)];
     let normalized = normalize_constraints_for_solver(&mut cx, &constraints);
@@ -2732,7 +2728,7 @@ fn expression_rebuilds_word_from_extracted_byte_terms() {
     let mut cx = SymCx::new();
     let word = SymExpr::var(&mut cx, "word");
     let mask = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let masked = SymExpr::binop(&mut cx, SymExprBinOp::And, word, mask);
+    let masked = SymExpr::binop(&mut cx, SymBinOp::And, word, mask);
     let bytes = masked.clone().into_byte_exprs(&mut cx);
     let rebuilt_word = SymExpr::from_bytes(&mut cx, bytes);
 
@@ -2744,13 +2740,13 @@ fn expression_rebuilds_word_from_shifted_fragments() {
     let mut cx = SymCx::new();
     let word = SymExpr::var(&mut cx, "word");
     let low_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
-    let low_bits = SymExpr::binop(&mut cx, SymExprBinOp::And, word.clone(), low_mask);
+    let low_bits = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), low_mask);
     let shift = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shr, word.clone(), shift.clone());
+    let shifted = SymExpr::binop(&mut cx, SymBinOp::Shr, word.clone(), shift.clone());
     let high_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 224));
-    let masked_high = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted, high_mask);
-    let high_bits = SymExpr::binop(&mut cx, SymExprBinOp::Shl, masked_high, shift);
-    let rebuilt_expr = SymExpr::binop(&mut cx, SymExprBinOp::Or, low_bits, high_bits);
+    let masked_high = SymExpr::binop(&mut cx, SymBinOp::And, shifted, high_mask);
+    let high_bits = SymExpr::binop(&mut cx, SymBinOp::Shl, masked_high, shift);
+    let rebuilt_expr = SymExpr::binop(&mut cx, SymBinOp::Or, low_bits, high_bits);
 
     assert_eq!(rebuilt_expr, word);
 }
@@ -2765,31 +2761,30 @@ fn expression_simplifies_selector_prefixed_word_fragment() {
     let selector = SymExpr::constant(&mut cx, U256::from(0x771602f7u64) << 224);
 
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
-    let shifted_x = SymExpr::binop(&mut cx, SymExprBinOp::Shr, x.clone(), shift_32.clone());
-    let x_high = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted_x, low_224.clone());
-    let first_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, selector, x_high);
-    let shifted_y = SymExpr::binop(&mut cx, SymExprBinOp::Shr, y.clone(), shift_32.clone());
-    let y_high = SymExpr::binop(&mut cx, SymExprBinOp::And, shifted_y, low_224.clone());
-    let x_low = SymExpr::binop(&mut cx, SymExprBinOp::And, x.clone(), low_32.clone());
+    let shifted_x = SymExpr::binop(&mut cx, SymBinOp::Shr, x.clone(), shift_32.clone());
+    let x_high = SymExpr::binop(&mut cx, SymBinOp::And, shifted_x, low_224.clone());
+    let first_word = SymExpr::binop(&mut cx, SymBinOp::Or, selector, x_high);
+    let shifted_y = SymExpr::binop(&mut cx, SymBinOp::Shr, y.clone(), shift_32.clone());
+    let y_high = SymExpr::binop(&mut cx, SymBinOp::And, shifted_y, low_224.clone());
+    let x_low = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), low_32.clone());
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
-    let x_low_shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shl, x_low, shift_224.clone());
-    let second_word = SymExpr::binop(&mut cx, SymExprBinOp::Or, y_high, x_low_shifted);
+    let x_low_shifted = SymExpr::binop(&mut cx, SymBinOp::Shl, x_low, shift_224.clone());
+    let second_word = SymExpr::binop(&mut cx, SymBinOp::Or, y_high, x_low_shifted);
     let second_word_shifted =
-        SymExpr::binop(&mut cx, SymExprBinOp::Shr, second_word.clone(), shift_224);
-    let rebuilt_low = SymExpr::binop(&mut cx, SymExprBinOp::And, second_word_shifted, low_32);
-    let first_word_masked = SymExpr::binop(&mut cx, SymExprBinOp::And, first_word, low_224);
-    let rebuilt_high =
-        SymExpr::binop(&mut cx, SymExprBinOp::Shl, first_word_masked, shift_32.clone());
-    let rebuilt = SymExpr::binop(&mut cx, SymExprBinOp::Or, rebuilt_low, rebuilt_high);
+        SymExpr::binop(&mut cx, SymBinOp::Shr, second_word.clone(), shift_224);
+    let rebuilt_low = SymExpr::binop(&mut cx, SymBinOp::And, second_word_shifted, low_32);
+    let first_word_masked = SymExpr::binop(&mut cx, SymBinOp::And, first_word, low_224);
+    let rebuilt_high = SymExpr::binop(&mut cx, SymBinOp::Shl, first_word_masked, shift_32.clone());
+    let rebuilt = SymExpr::binop(&mut cx, SymBinOp::Or, rebuilt_low, rebuilt_high);
 
     assert_eq!(rebuilt, x);
 
     let next_low_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
-    let next_low = SymExpr::binop(&mut cx, SymExprBinOp::And, y.clone(), next_low_mask);
+    let next_low = SymExpr::binop(&mut cx, SymBinOp::And, y.clone(), next_low_mask);
     let next_high_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 224));
-    let next_high = SymExpr::binop(&mut cx, SymExprBinOp::And, second_word, next_high_mask);
-    let next_high_shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shl, next_high, shift_32);
-    let rebuilt_next = SymExpr::binop(&mut cx, SymExprBinOp::Or, next_low, next_high_shifted);
+    let next_high = SymExpr::binop(&mut cx, SymBinOp::And, second_word, next_high_mask);
+    let next_high_shifted = SymExpr::binop(&mut cx, SymBinOp::Shl, next_high, shift_32);
+    let rebuilt_next = SymExpr::binop(&mut cx, SymBinOp::Or, next_low, next_high_shifted);
 
     assert_eq!(rebuilt_next, y);
 }
@@ -2797,14 +2792,14 @@ fn expression_simplifies_selector_prefixed_word_fragment() {
 fn checked_mul_guard_word(cx: &mut SymCx, zero_operand: &SymExpr, expected: &SymExpr) -> SymExpr {
     let zero = SymExpr::zero(cx);
     let operand_is_zero = SymBoolExpr::eq(cx, zero_operand.clone(), zero.clone());
-    let product = SymExpr::binop(cx, SymExprBinOp::Mul, zero_operand.clone(), expected.clone());
-    let quotient = SymExpr::binop(cx, SymExprBinOp::UDiv, product, zero_operand.clone());
+    let product = SymExpr::binop(cx, SymBinOp::Mul, zero_operand.clone(), expected.clone());
+    let quotient = SymExpr::binop(cx, SymBinOp::UDiv, product, zero_operand.clone());
     let checked_product = SymExpr::ite(cx, operand_is_zero.clone(), zero, quotient);
     let operand_is_zero_word = SymExpr::bool_word(cx, operand_is_zero);
     let product_matches_expected = SymBoolExpr::eq(cx, checked_product, expected.clone());
     let product_matches_expected_word = SymExpr::bool_word(cx, product_matches_expected);
 
-    SymExpr::binop(cx, SymExprBinOp::Or, operand_is_zero_word, product_matches_expected_word)
+    SymExpr::binop(cx, SymBinOp::Or, operand_is_zero_word, product_matches_expected_word)
 }
 
 #[test]
@@ -2812,10 +2807,10 @@ fn solver_normalizes_checked_mul_guard_for_bounded_operands() {
     let mut cx = SymCx::new();
     let a_word = SymExpr::var(&mut cx, "a");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let a = SymExpr::binop(&mut cx, SymExprBinOp::And, a_word, u64_max);
+    let a = SymExpr::binop(&mut cx, SymBinOp::And, a_word, u64_max);
     let b_word = SymExpr::var(&mut cx, "b");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let b = SymExpr::binop(&mut cx, SymExprBinOp::And, b_word, u64_max);
+    let b = SymExpr::binop(&mut cx, SymBinOp::And, b_word, u64_max);
     let guard = checked_mul_guard_word(&mut cx, &a, &b);
     let zero = SymExpr::zero(&mut cx);
     let guard_is_zero = SymBoolExpr::eq(&mut cx, guard, zero);
@@ -2853,13 +2848,13 @@ fn solver_normalizes_guarded_self_division_guard() {
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
-    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, a.clone(), a);
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
     let checked_quotient = SymExpr::ite(&mut cx, a_is_zero.clone(), zero.clone(), quotient);
     let a_is_zero_word = SymExpr::bool_word(&mut cx, a_is_zero);
     let one = SymExpr::one(&mut cx);
     let quotient_is_one = SymBoolExpr::eq(&mut cx, checked_quotient, one);
     let quotient_is_one_word = SymExpr::bool_word(&mut cx, quotient_is_one);
-    let guard = SymExpr::binop(&mut cx, SymExprBinOp::Or, a_is_zero_word, quotient_is_one_word);
+    let guard = SymExpr::binop(&mut cx, SymBinOp::Or, a_is_zero_word, quotient_is_one_word);
     let original = SymBoolExpr::eq(&mut cx, guard, zero);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
 
@@ -2877,7 +2872,7 @@ fn expression_normalizes_guarded_self_division_word() {
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
-    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, a.clone(), a);
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
     let checked_quotient = SymExpr::ite(&mut cx, a_is_zero.clone(), zero, quotient);
     let a_is_nonzero = a_is_zero.not(&mut cx);
     let one = SymExpr::one(&mut cx);
@@ -2900,7 +2895,7 @@ fn solver_does_not_invert_guarded_zero_self_division() {
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
-    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, a.clone(), a);
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
     let mirrored = SymExpr::ite(&mut cx, a_is_zero, quotient, zero);
     let normalized = normalize_expr_for_solver(&mut cx, mirrored.clone());
 
@@ -2916,10 +2911,10 @@ fn solver_normalizes_guarded_self_division_add_overflow_guard() {
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
-    let quotient = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, a.clone(), a);
+    let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
     let checked_quotient = SymExpr::ite(&mut cx, a_is_zero, zero, quotient);
     let one = SymExpr::one(&mut cx);
-    let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, one, checked_quotient.clone());
+    let sum = SymExpr::binop(&mut cx, SymBinOp::Add, one, checked_quotient.clone());
     let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, checked_quotient, sum);
 
     assert_eq!(
@@ -3012,16 +3007,16 @@ fn solver_normalizes_checked_add_overflow_guard_for_bounded_operands() {
     let mut cx = SymCx::new();
     let a_raw = SymExpr::var(&mut cx, "a");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let a = SymExpr::binop(&mut cx, SymExprBinOp::And, a_raw, u64_max);
+    let a = SymExpr::binop(&mut cx, SymBinOp::And, a_raw, u64_max);
     let b_raw = SymExpr::var(&mut cx, "b");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let b_masked = SymExpr::binop(&mut cx, SymExprBinOp::And, b_raw, u64_max);
-    let numerator = SymExpr::binop(&mut cx, SymExprBinOp::Mul, b_masked, a.clone());
+    let b_masked = SymExpr::binop(&mut cx, SymBinOp::And, b_raw, u64_max);
+    let numerator = SymExpr::binop(&mut cx, SymBinOp::Mul, b_masked, a.clone());
     let denominator_raw = SymExpr::var(&mut cx, "denominator");
     let high_mask = SymExpr::constant(&mut cx, U256::MAX >> 64);
-    let denominator = SymExpr::binop(&mut cx, SymExprBinOp::And, denominator_raw, high_mask);
-    let b = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
-    let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, a.clone(), b);
+    let denominator = SymExpr::binop(&mut cx, SymBinOp::And, denominator_raw, high_mask);
+    let b = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
+    let sum = SymExpr::binop(&mut cx, SymBinOp::Add, a.clone(), b);
     let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a, sum);
 
     assert_eq!(
@@ -3035,7 +3030,7 @@ fn solver_does_not_normalize_unbounded_checked_add_overflow_guard() {
     let mut cx = SymCx::new();
     let a = SymExpr::var(&mut cx, "a");
     let b = SymExpr::var(&mut cx, "b");
-    let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, a.clone(), b);
+    let sum = SymExpr::binop(&mut cx, SymBinOp::Add, a.clone(), b);
     let original = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a, sum);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
 
@@ -3051,23 +3046,23 @@ fn solver_detects_monotonic_product_contradiction() {
     let mut cx = SymCx::new();
     let ink_word = SymExpr::var(&mut cx, "ink");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let ink = SymExpr::binop(&mut cx, SymExprBinOp::And, ink_word, u64_max);
+    let ink = SymExpr::binop(&mut cx, SymBinOp::And, ink_word, u64_max);
     let art_word = SymExpr::var(&mut cx, "art");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let art = SymExpr::binop(&mut cx, SymExprBinOp::And, art_word, u64_max);
+    let art = SymExpr::binop(&mut cx, SymBinOp::And, art_word, u64_max);
     let spot_word = SymExpr::var(&mut cx, "spot");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let spot = SymExpr::binop(&mut cx, SymExprBinOp::And, spot_word, u64_max);
+    let spot = SymExpr::binop(&mut cx, SymBinOp::And, spot_word, u64_max);
     let rate_word = SymExpr::var(&mut cx, "rate");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
-    let rate = SymExpr::binop(&mut cx, SymExprBinOp::And, rate_word, u64_max);
+    let rate = SymExpr::binop(&mut cx, SymBinOp::And, rate_word, u64_max);
     let zero = SymExpr::zero(&mut cx);
     let ink_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, ink.clone(), zero.clone());
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
     let spot_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, spot.clone(), zero);
     let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, rate.clone(), spot.clone());
-    let left_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, ink, spot);
-    let right_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, art, rate);
+    let left_product = SymExpr::binop(&mut cx, SymBinOp::Mul, ink, spot);
+    let right_product = SymExpr::binop(&mut cx, SymBinOp::Mul, art, rate);
     let wrapping =
         SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
@@ -3087,8 +3082,8 @@ fn solver_does_not_prune_wrapping_product_inequality() {
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
     let spot_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, spot.clone(), zero);
     let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, rate.clone(), spot.clone());
-    let left_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, ink, spot);
-    let right_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, art, rate);
+    let left_product = SymExpr::binop(&mut cx, SymBinOp::Mul, ink, spot);
+    let right_product = SymExpr::binop(&mut cx, SymBinOp::Mul, art, rate);
     let wrapping =
         SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
@@ -3110,13 +3105,11 @@ fn hard_arithmetic_detection_flags_symbolic_mul_div_and_mod() {
     let x = SymExpr::var(&mut cx, "x");
     let y = SymExpr::var(&mut cx, "y");
 
-    assert!(SymExpr::binop(&mut cx, SymExprBinOp::Mul, x.clone(), y.clone()).contains_hard_arith());
-    assert!(
-        SymExpr::binop(&mut cx, SymExprBinOp::UDiv, x.clone(), y.clone()).contains_hard_arith()
-    );
-    assert!(SymExpr::binop(&mut cx, SymExprBinOp::URem, x.clone(), y).contains_hard_arith());
+    assert!(SymExpr::binop(&mut cx, SymBinOp::Mul, x.clone(), y.clone()).contains_hard_arith());
+    assert!(SymExpr::binop(&mut cx, SymBinOp::UDiv, x.clone(), y.clone()).contains_hard_arith());
+    assert!(SymExpr::binop(&mut cx, SymBinOp::URem, x.clone(), y).contains_hard_arith());
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let mul = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, one);
+    let mul = SymExpr::binop(&mut cx, SymBinOp::Mul, x, one);
     assert!(!mul.contains_hard_arith());
 }
 
@@ -3126,9 +3119,9 @@ fn hard_arithmetic_fallback_finds_multi_variable_candidate() {
     let first = SymExpr::var(&mut cx, "first");
     let donation = SymExpr::var(&mut cx, "donation");
     let second = SymExpr::var(&mut cx, "second");
-    let denominator = SymExpr::binop(&mut cx, SymExprBinOp::Add, first.clone(), donation.clone());
-    let numerator = SymExpr::binop(&mut cx, SymExprBinOp::Mul, second.clone(), first.clone());
-    let shares = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
+    let denominator = SymExpr::binop(&mut cx, SymBinOp::Add, first.clone(), donation.clone());
+    let numerator = SymExpr::binop(&mut cx, SymBinOp::Mul, second.clone(), first.clone());
+    let shares = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let first_nonzero = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, first, zero.clone());
     let donation_nonzero = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, donation, zero.clone());
@@ -3153,8 +3146,8 @@ fn hard_arithmetic_fallback_finds_wrapping_product_inequality_candidate() {
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
     let spot_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, spot.clone(), zero);
     let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, rate.clone(), spot.clone());
-    let left_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, ink, spot);
-    let right_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, art, rate);
+    let left_product = SymExpr::binop(&mut cx, SymBinOp::Mul, ink, spot);
+    let right_product = SymExpr::binop(&mut cx, SymBinOp::Mul, art, rate);
     let wrapping =
         SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
@@ -3171,7 +3164,7 @@ fn hard_arithmetic_fallback_finds_exact_mulmod_wide_intermediate_candidate() {
     let zero = SymExpr::zero(&mut cx);
     let positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a.clone(), zero.clone());
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let product = SymExpr::ternop(&mut cx, SymExprTernOp::MulMod, a.clone(), a, max);
+    let product = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a.clone(), a, max);
     let exact = SymBoolExpr::eq(&mut cx, product, zero);
     let constraints = vec![positive, exact];
 
@@ -3190,7 +3183,7 @@ fn hard_arithmetic_fallback_rejects_unvalidated_partial_model() {
     let d = SymExpr::var(&mut cx, "d");
     let e = SymExpr::var(&mut cx, "e");
     let f = SymExpr::var(&mut cx, "f");
-    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, a, b);
+    let product = SymExpr::binop(&mut cx, SymBinOp::Mul, a, b);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let product_eq_one = SymBoolExpr::eq(&mut cx, product, one);
     let three = SymExpr::constant(&mut cx, U256::from(3));
@@ -3213,7 +3206,7 @@ fn hard_arithmetic_fallback_skips_symbolic_hashes() {
     let mut cx = SymCx::new();
     let x = SymExpr::var(&mut cx, "x");
     let hash = SymExpr::hash_symbol(&mut cx, Symbol::intern("hash"), "sha256", vec![x.clone()]);
-    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, hash);
+    let product = SymExpr::binop(&mut cx, SymBinOp::Mul, x, hash);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraints = vec![SymBoolExpr::eq(&mut cx, product, one)];
 
@@ -3463,7 +3456,7 @@ fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
     let zero = SymExpr::zero(&mut cx);
     let x_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), zero.clone());
     let y_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, y.clone(), zero);
-    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, y);
+    let product = SymExpr::binop(&mut cx, SymBinOp::Mul, x, y);
     let four = SymExpr::constant(&mut cx, U256::from(4));
     let product_eq_four = SymBoolExpr::eq(&mut cx, product, four);
     let constraints = vec![x_positive, y_positive, product_eq_four];
@@ -3496,7 +3489,7 @@ fn model_uses_validated_hard_arithmetic_fallback_cache() {
     let zero = SymExpr::zero(&mut cx);
     let x_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), zero.clone());
     let y_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, y.clone(), zero);
-    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, y);
+    let product = SymExpr::binop(&mut cx, SymBinOp::Mul, x, y);
     let four = SymExpr::constant(&mut cx, U256::from(4));
     let product_eq_four = SymBoolExpr::eq(&mut cx, product, four);
     let constraints = vec![x_positive, y_positive, product_eq_four];
@@ -3529,7 +3522,7 @@ fn is_sat_hard_arithmetic_without_witness_still_honors_solver_unsat() {
     let y = SymExpr::var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
     let x_is_zero = SymBoolExpr::eq(&mut cx, x.clone(), zero);
-    let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, y);
+    let product = SymExpr::binop(&mut cx, SymBinOp::Mul, x, y);
     let one = SymExpr::one(&mut cx);
     let product_eq_one = SymBoolExpr::eq(&mut cx, product, one);
     let constraints = vec![x_is_zero, product_eq_one];
@@ -3590,13 +3583,13 @@ fn sat_cache_reuses_nested_commutative_results() {
     let y = SymExpr::var(&mut cx, "y");
     let three = SymExpr::constant(&mut cx, U256::from(3));
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, x.clone(), y.clone());
+    let sum = SymExpr::binop(&mut cx, SymBinOp::Add, x.clone(), y.clone());
     let sum_eq_three = SymBoolExpr::eq(&mut cx, sum, three.clone());
     let x_eq_one = SymBoolExpr::eq(&mut cx, x.clone(), one.clone());
     let constraints = vec![SymBoolExpr::and(&mut cx, vec![sum_eq_three, x_eq_one])];
     let one_eq_x = SymBoolExpr::eq(&mut cx, one, x);
     let x_again = SymExpr::var(&mut cx, "x");
-    let reordered_sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, y, x_again);
+    let reordered_sum = SymExpr::binop(&mut cx, SymBinOp::Add, y, x_again);
     let three_eq_sum = SymBoolExpr::eq(&mut cx, three, reordered_sum);
     let reordered_constraints = vec![SymBoolExpr::and(&mut cx, vec![one_eq_x, three_eq_sum])];
 
@@ -4284,7 +4277,7 @@ fn solver_smt_dump_shares_repeated_subterms() {
     let calldata = SymExpr::var(&mut cx, "calldata_0");
     let byte = calldata.extracted_byte(&mut cx, 0);
     let shift = SymExpr::constant(&mut cx, U256::from(248));
-    let shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shl, byte, shift);
+    let shifted = SymExpr::binop(&mut cx, SymBinOp::Shl, byte, shift);
     let zero = SymExpr::zero(&mut cx);
     let shifted_zero = SymBoolExpr::eq(&mut cx, shifted.clone(), zero.clone());
     let shifted_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, shifted, zero);

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2724,20 +2724,19 @@ fn solver_normalizes_erc4626_style_share_zero_predicate() {
 }
 
 #[test]
-fn solver_rebuilds_word_from_extracted_byte_terms() {
+fn expression_rebuilds_word_from_extracted_byte_terms() {
     let mut cx = SymCx::new();
     let word = SymExpr::var(&mut cx, "word");
     let mask = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let masked = SymExpr::op(&mut cx, SymExprOp::And, word, mask);
     let bytes = masked.clone().into_byte_exprs(&mut cx);
     let rebuilt_word = SymExpr::from_bytes(&mut cx, bytes);
-    let rebuilt = normalize_expr_for_solver(&mut cx, rebuilt_word);
 
-    assert_eq!(rebuilt, normalize_expr_for_solver(&mut cx, masked));
+    assert_eq!(rebuilt_word, masked);
 }
 
 #[test]
-fn solver_rebuilds_word_from_shifted_fragments() {
+fn expression_rebuilds_word_from_shifted_fragments() {
     let mut cx = SymCx::new();
     let word = SymExpr::var(&mut cx, "word");
     let low_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
@@ -2748,13 +2747,12 @@ fn solver_rebuilds_word_from_shifted_fragments() {
     let masked_high = SymExpr::op(&mut cx, SymExprOp::And, shifted, high_mask);
     let high_bits = SymExpr::op(&mut cx, SymExprOp::Shl, masked_high, shift);
     let rebuilt_expr = SymExpr::op(&mut cx, SymExprOp::Or, low_bits, high_bits);
-    let rebuilt = normalize_expr_for_solver(&mut cx, rebuilt_expr);
 
-    assert_eq!(rebuilt, word);
+    assert_eq!(rebuilt_expr, word);
 }
 
 #[test]
-fn solver_simplifies_selector_prefixed_word_fragment() {
+fn expression_simplifies_selector_prefixed_word_fragment() {
     let mut cx = SymCx::new();
     let x = SymExpr::var(&mut cx, "calldata_0");
     let y = SymExpr::var(&mut cx, "calldata_1");
@@ -2778,7 +2776,7 @@ fn solver_simplifies_selector_prefixed_word_fragment() {
     let rebuilt_high = SymExpr::op(&mut cx, SymExprOp::Shl, first_word_masked, shift_32.clone());
     let rebuilt = SymExpr::op(&mut cx, SymExprOp::Or, rebuilt_low, rebuilt_high);
 
-    assert_eq!(normalize_expr_for_solver(&mut cx, rebuilt), x);
+    assert_eq!(rebuilt, x);
 
     let next_low_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
     let next_low = SymExpr::op(&mut cx, SymExprOp::And, y.clone(), next_low_mask);
@@ -2787,7 +2785,7 @@ fn solver_simplifies_selector_prefixed_word_fragment() {
     let next_high_shifted = SymExpr::op(&mut cx, SymExprOp::Shl, next_high, shift_32);
     let rebuilt_next = SymExpr::op(&mut cx, SymExprOp::Or, next_low, next_high_shifted);
 
-    assert_eq!(normalize_expr_for_solver(&mut cx, rebuilt_next), y);
+    assert_eq!(rebuilt_next, y);
 }
 
 fn checked_mul_guard_word(cx: &mut SymCx, zero_operand: &SymExpr, expected: &SymExpr) -> SymExpr {
@@ -2868,27 +2866,24 @@ fn solver_normalizes_guarded_self_division_guard() {
 }
 
 #[test]
-fn solver_normalizes_guarded_self_division_word() {
+fn expression_normalizes_guarded_self_division_word() {
     let mut cx = SymCx::new();
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
     let quotient = SymExpr::op(&mut cx, SymExprOp::UDiv, a.clone(), a);
     let checked_quotient = SymExpr::ite(&mut cx, a_is_zero.clone(), zero, quotient);
-    let normalized = normalize_expr_for_solver(&mut cx, checked_quotient.clone());
-
-    assert!(!normalized.smt().contains("bvudiv"));
     let a_is_nonzero = a_is_zero.not(&mut cx);
     let one = SymExpr::one(&mut cx);
     let zero = SymExpr::zero(&mut cx);
     let expected = SymExpr::ite(&mut cx, a_is_nonzero, one, zero);
-    assert_eq!(normalized, expected);
+    assert_eq!(checked_quotient, expected);
 
     for value in [U256::ZERO, U256::from(1), U256::from(2), U256::MAX] {
         let model = BTreeMap::from([("a".to_string(), value)]);
         assert_eq!(
             checked_quotient.eval_model(&model).unwrap(),
-            normalized.eval_model(&model).unwrap()
+            expected.eval_model(&model).unwrap()
         );
     }
 }
@@ -4293,7 +4288,11 @@ fn solver_smt_dump_shares_repeated_subterms() {
     let diagnostics = solver.take_diagnostics().unwrap();
 
     assert!(diagnostics.contains("(define-fun __sym_expr_"));
-    assert!(diagnostics.contains("(assert (= __sym_expr_"));
+    assert!(
+        diagnostics
+            .lines()
+            .any(|line| line.starts_with("(assert (= ") && line.contains("__sym_expr_"))
+    );
     assert_eq!(diagnostics.matches("(bvlshr calldata_0 (_ bv248 256))").count(), 1);
 }
 

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2576,12 +2576,12 @@ fn exact_modular_arithmetic_handles_zero_modulus_and_wide_intermediates() {
     let a = SymExpr::var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let addmod = SymExpr::addmod(&mut cx, a, two, max);
+    let addmod = SymExpr::ternop(&mut cx, SymExprTernOp::AddMod, a, two, max);
     assert_eq!(addmod.eval_model(&model).unwrap(), U256::from(2));
     let a = SymExpr::var(&mut cx, "a");
     let a_again = SymExpr::var(&mut cx, "a");
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let mulmod = SymExpr::mulmod(&mut cx, a, a_again, max);
+    let mulmod = SymExpr::ternop(&mut cx, SymExprTernOp::MulMod, a, a_again, max);
     assert_eq!(mulmod.eval_model(&model).unwrap(), U256::ZERO);
 }
 
@@ -2591,11 +2591,11 @@ fn exact_modular_arithmetic_smt_widens_before_modulo() {
     let a = SymExpr::var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let m = SymExpr::var(&mut cx, "m");
-    let addmod = SymExpr::addmod(&mut cx, a, two, m).smt();
+    let addmod = SymExpr::ternop(&mut cx, SymExprTernOp::AddMod, a, two, m).smt();
     let a = SymExpr::var(&mut cx, "a");
     let b = SymExpr::var(&mut cx, "b");
     let m = SymExpr::var(&mut cx, "m");
-    let mulmod = SymExpr::mulmod(&mut cx, a, b, m).smt();
+    let mulmod = SymExpr::ternop(&mut cx, SymExprTernOp::MulMod, a, b, m).smt();
 
     assert!(addmod.contains("((_ zero_extend 256) a)"));
     assert!(addmod.contains("bvadd"));
@@ -2611,7 +2611,7 @@ fn exact_addmod_model_validation_rejects_wrapping_false_pass() {
     let a = SymExpr::var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let addmod = SymExpr::addmod(&mut cx, a, two, max);
+    let addmod = SymExpr::ternop(&mut cx, SymExprTernOp::AddMod, a, two, max);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraints = vec![SymBoolExpr::eq(&mut cx, addmod, one)];
     let output = format!("sat\n((define-fun a () (_ BitVec 256) #x{}))\n", "f".repeat(64));
@@ -3171,7 +3171,7 @@ fn hard_arithmetic_fallback_finds_exact_mulmod_wide_intermediate_candidate() {
     let zero = SymExpr::zero(&mut cx);
     let positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, a.clone(), zero.clone());
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let product = SymExpr::mulmod(&mut cx, a.clone(), a, max);
+    let product = SymExpr::ternop(&mut cx, SymExprTernOp::MulMod, a.clone(), a, max);
     let exact = SymBoolExpr::eq(&mut cx, product, zero);
     let constraints = vec![positive, exact];
 

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -126,7 +126,7 @@ fn comparison_helpers_use_evm_operand_order() {
     state.stack.push(SymExpr::constant(&mut cx, U256::from(2))).unwrap();
     state.stack.push(SymExpr::constant(&mut cx, U256::from(10))).unwrap();
 
-    state.cmp_word(&mut cx, SymBoolExprOp::Ult).unwrap();
+    state.cmp_word(&mut cx, SymCmpOp::Ult).unwrap();
 
     assert_eq!(state.stack.pop().unwrap(), SymExpr::constant(&mut cx, U256::ZERO));
 }
@@ -165,7 +165,7 @@ fn exp_helper_expands_bounded_symbolic_exponent() {
     let mut state = empty_state(&mut cx);
     let exponent = SymExpr::var(&mut cx, "exponent");
     let five = SymExpr::constant(&mut cx, U256::from(5));
-    let bound = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ule, exponent.clone(), five);
+    let bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, exponent.clone(), five);
     state.constraints.push(bound);
     state.stack.push(exponent).unwrap();
     state.stack.push(SymExpr::constant(&mut cx, U256::from(3))).unwrap();
@@ -1710,7 +1710,7 @@ fn path_state_extracts_symbolic_usize_upper_bound() {
     let size = SymExpr::var(&mut cx, "size");
 
     let five = SymExpr::constant(&mut cx, U256::from(5));
-    let constraint = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, size.clone(), five);
+    let constraint = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, size.clone(), five);
     state.constraints.push(constraint);
 
     assert_eq!(state.upper_bound_usize(&mut cx, &size), Some(4));
@@ -2393,8 +2393,8 @@ fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
     let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, var.clone(), var.clone());
     let sender_word = SymExpr::constant(&mut cx, msg_sender);
     let product_below_sender =
-        SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, product, sender_word.clone());
-    let above_sender = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, var.clone(), sender_word);
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, product, sender_word.clone());
+    let above_sender = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, var.clone(), sender_word);
     let mask_800 = SymExpr::constant(&mut cx, U256::from(0x800));
     let masked_800 = SymExpr::binop(&mut cx, SymExprBinOp::And, var.clone(), mask_800);
     let zero = SymExpr::zero(&mut cx);
@@ -2458,7 +2458,7 @@ fn bool_word_equality_simplifies_to_condition() {
     let mut cx = SymCx::new();
     let x = SymExpr::var(&mut cx, "x");
     let y = SymExpr::var(&mut cx, "y");
-    let condition = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, x, y);
+    let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, y);
     let word = SymExpr::bool_word(&mut cx, condition.clone());
 
     let one = SymExpr::one(&mut cx);
@@ -2479,7 +2479,7 @@ fn inverted_bool_word_equality_simplifies_to_condition() {
     let mut cx = SymCx::new();
     let x = SymExpr::var(&mut cx, "x");
     let y = SymExpr::var(&mut cx, "y");
-    let condition = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, x, y);
+    let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, y);
     let zero = SymExpr::zero(&mut cx);
     let one = SymExpr::one(&mut cx);
     let word = SymExpr::ite(&mut cx, condition.clone(), zero, one);
@@ -2497,22 +2497,22 @@ fn bool_comparison_folds_reflexive_operands() {
     let mut cx = SymCx::new();
 
     let x = SymExpr::var(&mut cx, "x");
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, x.clone(), x.clone());
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), x.clone());
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, x.clone(), x.clone());
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), x.clone());
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ule, x.clone(), x.clone());
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, x.clone(), x.clone());
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Uge, x.clone(), x.clone());
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, x.clone(), x.clone());
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Slt, x.clone(), x.clone());
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Slt, x.clone(), x.clone());
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Sgt, x.clone(), x);
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Sgt, x.clone(), x);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
 }
@@ -2523,42 +2523,42 @@ fn bool_comparison_folds_unsigned_boundaries() {
 
     let zero = SymExpr::zero(&mut cx);
     let x = SymExpr::var(&mut cx, "x");
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, zero, x);
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, zero, x);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
     let zero = SymExpr::zero(&mut cx);
     let x = SymExpr::var(&mut cx, "x");
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ule, zero, x);
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, zero, x);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
     let x = SymExpr::var(&mut cx, "x");
     let zero = SymExpr::zero(&mut cx);
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, x, zero);
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, zero);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
     let x = SymExpr::var(&mut cx, "x");
     let zero = SymExpr::zero(&mut cx);
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Uge, x, zero);
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, x, zero);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let x = SymExpr::var(&mut cx, "x");
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, max, x);
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, max, x);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let x = SymExpr::var(&mut cx, "x");
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Uge, max, x);
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, max, x);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
     let x = SymExpr::var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, x, max);
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x, max);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
     let x = SymExpr::var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let actual = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ule, x, max);
+    let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, x, max);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
 }
@@ -2658,7 +2658,7 @@ fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
     let denominator = SymExpr::var(&mut cx, "denominator");
     let div = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
-    let original = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, div, zero);
+    let original = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, div, zero);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
 
     assert!(!normalized.smt().contains("bvudiv"));
@@ -2687,7 +2687,7 @@ fn solver_normalizes_constraint_batches_by_flattening_and_deduping() {
     let x = SymExpr::var(&mut cx, "x");
     let y = SymExpr::var(&mut cx, "y");
     let ten = SymExpr::constant(&mut cx, U256::from(10));
-    let a = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, x.clone(), ten);
+    let a = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), ten);
     let three = SymExpr::constant(&mut cx, U256::from(3));
     let b = SymBoolExpr::eq(&mut cx, y.clone(), three);
     let grouped = vec![
@@ -2835,7 +2835,7 @@ fn solver_normalizes_checked_mul_guard_from_path_upper_bound() {
     let zero = SymExpr::zero(&mut cx);
     let guard_is_false = SymBoolExpr::eq(&mut cx, guard, zero);
     let thousand = SymExpr::constant(&mut cx, U256::from(1000));
-    let upper_bound = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ule, a, thousand);
+    let upper_bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, a, thousand);
     let constraints = vec![upper_bound, guard_is_false.clone()];
     let normalized = normalize_constraints_for_solver(&mut cx, &constraints);
 
@@ -2920,7 +2920,7 @@ fn solver_normalizes_guarded_self_division_add_overflow_guard() {
     let checked_quotient = SymExpr::ite(&mut cx, a_is_zero, zero, quotient);
     let one = SymExpr::one(&mut cx);
     let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, one, checked_quotient.clone());
-    let condition = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, checked_quotient, sum);
+    let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, checked_quotient, sum);
 
     assert_eq!(
         normalize_bool_for_solver(&mut cx, condition),
@@ -2935,9 +2935,9 @@ fn solver_normalizes_checked_mul_guard_with_context_bound() {
     let scale = SymExpr::constant(&mut cx, U256::from(1_000_000_000_000_000_000u128));
     let guard = checked_mul_guard_word(&mut cx, &a, &scale);
     let zero = SymExpr::zero(&mut cx);
-    let a_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, a.clone(), zero.clone());
+    let a_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a.clone(), zero.clone());
     let thousand = SymExpr::constant(&mut cx, U256::from(1000));
-    let above_thousand = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, a, thousand).not(&mut cx);
+    let above_thousand = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a, thousand).not(&mut cx);
     let guard_is_zero = SymBoolExpr::eq(&mut cx, guard, zero);
     let constraints = vec![a_positive, above_thousand, guard_is_zero];
 
@@ -2961,7 +2961,7 @@ fn solver_does_not_context_normalize_checked_mul_guard_without_tight_bound() {
         vec![SymBoolExpr::constant(&mut cx, false)]
     );
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let bound = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ule, a, max);
+    let bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, a, max);
     assert_ne!(
         normalize_constraints_for_solver(&mut cx, &[bound, guard_is_zero.clone()]),
         vec![SymBoolExpr::constant(&mut cx, false)]
@@ -2997,7 +2997,7 @@ fn solver_does_not_normalize_checked_mul_guard_when_path_bound_can_overflow() {
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::eq(&mut cx, guard, zero);
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let bound = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ule, a, max);
+    let bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, a, max);
     let normalized = normalize_constraints_for_solver(&mut cx, &[bound, original.clone()]);
 
     assert!(!matches!(normalized.as_slice(), [expr] if expr.as_const() == Some(false)));
@@ -3022,7 +3022,7 @@ fn solver_normalizes_checked_add_overflow_guard_for_bounded_operands() {
     let denominator = SymExpr::binop(&mut cx, SymExprBinOp::And, denominator_raw, high_mask);
     let b = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
     let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, a.clone(), b);
-    let condition = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, a, sum);
+    let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a, sum);
 
     assert_eq!(
         normalize_bool_for_solver(&mut cx, condition),
@@ -3036,7 +3036,7 @@ fn solver_does_not_normalize_unbounded_checked_add_overflow_guard() {
     let a = SymExpr::var(&mut cx, "a");
     let b = SymExpr::var(&mut cx, "b");
     let sum = SymExpr::binop(&mut cx, SymExprBinOp::Add, a.clone(), b);
-    let original = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, a, sum);
+    let original = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a, sum);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
 
     assert_ne!(normalized, SymBoolExpr::constant(&mut cx, false));
@@ -3062,14 +3062,14 @@ fn solver_detects_monotonic_product_contradiction() {
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let rate = SymExpr::binop(&mut cx, SymExprBinOp::And, rate_word, u64_max);
     let zero = SymExpr::zero(&mut cx);
-    let ink_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, ink.clone(), zero.clone());
-    let art_above_ink = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, art.clone(), ink.clone());
-    let spot_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, spot.clone(), zero);
-    let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, rate.clone(), spot.clone());
+    let ink_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, ink.clone(), zero.clone());
+    let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
+    let spot_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, spot.clone(), zero);
+    let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, rate.clone(), spot.clone());
     let left_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, ink, spot);
     let right_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, art, rate);
     let wrapping =
-        SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, left_product, right_product).not(&mut cx);
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
 
     assert!(product_monotonic_unsat(&mut cx, &constraints));
@@ -3083,14 +3083,14 @@ fn solver_does_not_prune_wrapping_product_inequality() {
     let spot = SymExpr::var(&mut cx, "spot");
     let rate = SymExpr::var(&mut cx, "rate");
     let zero = SymExpr::zero(&mut cx);
-    let ink_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, ink.clone(), zero.clone());
-    let art_above_ink = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, art.clone(), ink.clone());
-    let spot_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, spot.clone(), zero);
-    let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, rate.clone(), spot.clone());
+    let ink_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, ink.clone(), zero.clone());
+    let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
+    let spot_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, spot.clone(), zero);
+    let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, rate.clone(), spot.clone());
     let left_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, ink, spot);
     let right_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, art, rate);
     let wrapping =
-        SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, left_product, right_product).not(&mut cx);
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
 
     assert!(!product_monotonic_unsat(&mut cx, &constraints));
@@ -3130,9 +3130,9 @@ fn hard_arithmetic_fallback_finds_multi_variable_candidate() {
     let numerator = SymExpr::binop(&mut cx, SymExprBinOp::Mul, second.clone(), first.clone());
     let shares = SymExpr::binop(&mut cx, SymExprBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
-    let first_nonzero = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, first, zero.clone());
-    let donation_nonzero = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, donation, zero.clone());
-    let second_nonzero = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, second, zero.clone());
+    let first_nonzero = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, first, zero.clone());
+    let donation_nonzero = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, donation, zero.clone());
+    let second_nonzero = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, second, zero.clone());
     let shares_zero = SymBoolExpr::eq(&mut cx, shares, zero);
     let constraints = vec![first_nonzero, donation_nonzero, second_nonzero, shares_zero];
 
@@ -3149,14 +3149,14 @@ fn hard_arithmetic_fallback_finds_wrapping_product_inequality_candidate() {
     let spot = SymExpr::var(&mut cx, "spot");
     let rate = SymExpr::var(&mut cx, "rate");
     let zero = SymExpr::zero(&mut cx);
-    let ink_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, ink.clone(), zero.clone());
-    let art_above_ink = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, art.clone(), ink.clone());
-    let spot_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, spot.clone(), zero);
-    let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, rate.clone(), spot.clone());
+    let ink_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, ink.clone(), zero.clone());
+    let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
+    let spot_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, spot.clone(), zero);
+    let rate_above_spot = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, rate.clone(), spot.clone());
     let left_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, ink, spot);
     let right_product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, art, rate);
     let wrapping =
-        SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, left_product, right_product).not(&mut cx);
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
 
     let model = hard_arith_fallback_model(&constraints).unwrap();
@@ -3169,7 +3169,7 @@ fn hard_arithmetic_fallback_finds_exact_mulmod_wide_intermediate_candidate() {
     let mut cx = SymCx::new();
     let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
-    let positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, a.clone(), zero.clone());
+    let positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a.clone(), zero.clone());
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let product = SymExpr::ternop(&mut cx, SymExprTernOp::MulMod, a.clone(), a, max);
     let exact = SymBoolExpr::eq(&mut cx, product, zero);
@@ -3461,8 +3461,8 @@ fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
     let x = SymExpr::var(&mut cx, "x");
     let y = SymExpr::var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
-    let x_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, x.clone(), zero.clone());
-    let y_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, y.clone(), zero);
+    let x_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), zero.clone());
+    let y_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, y.clone(), zero);
     let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, y);
     let four = SymExpr::constant(&mut cx, U256::from(4));
     let product_eq_four = SymBoolExpr::eq(&mut cx, product, four);
@@ -3494,8 +3494,8 @@ fn model_uses_validated_hard_arithmetic_fallback_cache() {
     let x = SymExpr::var(&mut cx, "x");
     let y = SymExpr::var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
-    let x_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, x.clone(), zero.clone());
-    let y_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, y.clone(), zero);
+    let x_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), zero.clone());
+    let y_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, y.clone(), zero);
     let product = SymExpr::binop(&mut cx, SymExprBinOp::Mul, x, y);
     let four = SymExpr::constant(&mut cx, U256::from(4));
     let product_eq_four = SymBoolExpr::eq(&mut cx, product, four);
@@ -3701,17 +3701,17 @@ fn sat_cache_reuses_reversed_comparisons() {
     let x = SymExpr::var(&mut cx, "x");
     let y = SymExpr::var(&mut cx, "y");
 
-    let ugt = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, x.clone(), y.clone());
+    let ugt = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), y.clone());
     assert!(solver.is_sat(&mut cx, &[ugt]).unwrap());
-    let ult = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, y.clone(), x.clone());
+    let ult = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, y.clone(), x.clone());
     assert!(solver.is_sat(&mut cx, &[ult]).unwrap());
-    let uge = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Uge, x.clone(), y.clone());
+    let uge = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, x.clone(), y.clone());
     assert!(solver.is_sat(&mut cx, &[uge]).unwrap());
-    let ule = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ule, y.clone(), x.clone());
+    let ule = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, y.clone(), x.clone());
     assert!(solver.is_sat(&mut cx, &[ule]).unwrap());
-    let sgt = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Sgt, x.clone(), y.clone());
+    let sgt = SymBoolExpr::cmp(&mut cx, SymCmpOp::Sgt, x.clone(), y.clone());
     assert!(solver.is_sat(&mut cx, &[sgt]).unwrap());
-    let slt = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Slt, y, x);
+    let slt = SymBoolExpr::cmp(&mut cx, SymCmpOp::Slt, y, x);
     assert!(solver.is_sat(&mut cx, &[slt]).unwrap());
 
     let stats = solver.stats();
@@ -3731,7 +3731,7 @@ fn sat_cache_reuses_unsat_branch_complement() {
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
     let x = SymExpr::var(&mut cx, "x");
     let ten = SymExpr::constant(&mut cx, U256::from(10));
-    let base = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ult, x.clone(), ten);
+    let base = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), ten);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let condition = SymBoolExpr::eq(&mut cx, x, one);
     let not_condition = condition.clone().not(&mut cx);
@@ -3758,8 +3758,8 @@ fn sat_cache_does_not_reuse_unsat_branch_complement_with_unsat_base() {
     let x = SymExpr::var(&mut cx, "x");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let lower = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Uge, x.clone(), two);
-    let upper = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ule, x.clone(), one.clone());
+    let lower = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, x.clone(), two);
+    let upper = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, x.clone(), one.clone());
     let base = SymBoolExpr::and(&mut cx, vec![lower, upper]);
     let condition = SymBoolExpr::eq(&mut cx, x, one);
 
@@ -4287,7 +4287,7 @@ fn solver_smt_dump_shares_repeated_subterms() {
     let shifted = SymExpr::binop(&mut cx, SymExprBinOp::Shl, byte, shift);
     let zero = SymExpr::zero(&mut cx);
     let shifted_zero = SymBoolExpr::eq(&mut cx, shifted.clone(), zero.clone());
-    let shifted_positive = SymBoolExpr::cmp(&mut cx, SymBoolExprOp::Ugt, shifted, zero);
+    let shifted_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, shifted, zero);
     let constraints = vec![shifted_zero, shifted_positive];
 
     solver.capture_diagnostics();


### PR DESCRIPTION
This refactors symbolic solver normalization so more simple rewrites happen when expressions are constructed instead of being rebuilt later in the solver path. It also simplifies the solver-side normalization/cache flow, folds comparison equality into the comparison op handling, models addmod/mulmod as ternary word ops, and keeps the SMT CSE planning changes from the stacked PR.

The intent is to reduce repeated symbolic expression rebuilding and make normalized solver queries cheaper and more predictable without changing the external symbolic test surface.
