### PR TITLE
ci: pin docs nightly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
-          toolchain: nightly
+          toolchain: nightly-2026-07-01
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items --locked


### PR DESCRIPTION
Pins the docs workflow to `nightly-2026-07-01`, the last known passing nightly for docs, while the current nightly is hitting a rustdoc ICE in `attrs_for_def` when documenting `foundry_cheatcodes::spec`.

This is intended as a temporary CI unblock until the upstream rust-lang regression is fixed.

Prompted by: @grandizzy
