### PR TITLE
chore: ignore quick-xml advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,13 @@ ignore = [
     "RUSTSEC-2024-0436",
     # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
     "RUSTSEC-2026-0173",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0194 quick-xml duplicate
+    # attribute checking is quadratic.
+    "RUSTSEC-2026-0194",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0195 quick-xml namespace
+    # declaration handling can allocate without a bound. No fixed quick-junit,
+    # inferno, or soldeer release is available for either advisory yet.
+    "RUSTSEC-2026-0195",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Temporarily ignores the two new `quick-xml` RustSec advisories that are failing `cargo deny` across PR CI.

The vulnerable `quick-xml` versions are pulled through `quick-junit`, `inferno`, and `soldeer-commands`. I tried updating to `quick-xml >= 0.41.0`, but the current upstream releases do not permit that version yet, so this keeps CI unblocked until fixed dependency releases are available.
