### PR TITLE
refactor(symbolic): share path pop helper

### DIFF
--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -1112,10 +1112,7 @@ impl SymbolicExecutor {
             parents.push_back(parent);
         }
 
-        let Some(first) = (match self.config.exploration_order {
-            SymbolicExplorationOrder::Bfs => parents.pop_front(),
-            SymbolicExplorationOrder::Dfs => parents.pop_back(),
-        }) else {
+        let Some(first) = self.pop_next_path(&mut parents) else {
             return Ok(StepOutcome::AssumeRejected);
         };
         *state = first;
@@ -1478,10 +1475,7 @@ impl SymbolicExecutor {
             }
         }
 
-        let Some(first) = (match self.config.exploration_order {
-            SymbolicExplorationOrder::Bfs => parents.pop_front(),
-            SymbolicExplorationOrder::Dfs => parents.pop_back(),
-        }) else {
+        let Some(first) = self.pop_next_path(&mut parents) else {
             return Ok(StepOutcome::AssumeRejected);
         };
         *state = first;

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -304,10 +304,7 @@ impl SymbolicExecutor {
             parents.push_back(parent);
         }
 
-        let Some(first) = (match self.config.exploration_order {
-            SymbolicExplorationOrder::Bfs => parents.pop_front(),
-            SymbolicExplorationOrder::Dfs => parents.pop_back(),
-        }) else {
+        let Some(first) = self.pop_next_path(&mut parents) else {
             return Ok(StepOutcome::AssumeRejected);
         };
         *state = first;
@@ -416,10 +413,7 @@ impl SymbolicExecutor {
             branches.push_back(branch);
         }
 
-        let Some(first_branch) = (match self.config.exploration_order {
-            SymbolicExplorationOrder::Bfs => branches.pop_front(),
-            SymbolicExplorationOrder::Dfs => branches.pop_back(),
-        }) else {
+        let Some(first_branch) = self.pop_next_path(&mut branches) else {
             return Ok(Some(StepOutcome::AssumeRejected));
         };
         *state = first_branch;

--- a/crates/evm/symbolic/src/executor/create.rs
+++ b/crates/evm/symbolic/src/executor/create.rs
@@ -209,10 +209,7 @@ impl SymbolicExecutor {
             parents.push_back(parent);
         }
 
-        let Some(first) = (match self.config.exploration_order {
-            SymbolicExplorationOrder::Bfs => parents.pop_front(),
-            SymbolicExplorationOrder::Dfs => parents.pop_back(),
-        }) else {
+        let Some(first) = self.pop_next_path(&mut parents) else {
             return Ok(StepOutcome::AssumeRejected);
         };
         *state = first;

--- a/crates/evm/symbolic/src/executor/mod.rs
+++ b/crates/evm/symbolic/src/executor/mod.rs
@@ -7,3 +7,12 @@ mod create;
 mod invariant;
 mod opcodes;
 mod run;
+
+impl SymbolicExecutor {
+    pub(super) fn pop_next_path(&self, paths: &mut VecDeque<PathState>) -> Option<PathState> {
+        match self.config.exploration_order {
+            SymbolicExplorationOrder::Bfs => paths.pop_front(),
+            SymbolicExplorationOrder::Dfs => paths.pop_back(),
+        }
+    }
+}


### PR DESCRIPTION
This follows up on #15487 by extracting the exploration-order-aware `VecDeque<PathState>` pop into a shared symbolic executor helper. The call, create, and cheatcode paths now use the same helper when selecting the next branch while leaving the remaining branch queue behavior unchanged.

Prepared with AI assistance.
