### PR TITLE
perf(symbolic): use single-var solver witnesses

### DIFF
--- a/crates/evm/symbolic/src/runtime/bytes.rs
+++ b/crates/evm/symbolic/src/runtime/bytes.rs
@@ -430,7 +430,9 @@ impl SymBytes {
     }
 
     pub(crate) fn materialize(&self, cx: &mut SymCx) -> Vec<SymExpr> {
-        (0..self.len()).map(|idx| self.byte(cx, idx)).collect()
+        let mut out = Vec::with_capacity(self.len());
+        self.append_expr_range(cx, 0, self.len(), &mut out);
+        out
     }
 
     pub(crate) fn same_bytes(&self, cx: &mut SymCx, other: &Self) -> bool {
@@ -571,4 +573,111 @@ impl SymBytes {
             }
         }
     }
+
+    fn append_expr_range(
+        &self,
+        cx: &mut SymCx,
+        mut offset: usize,
+        mut len: usize,
+        out: &mut Vec<SymExpr>,
+    ) {
+        if len == 0 {
+            return;
+        }
+
+        match self.kind() {
+            SymBytesKind::Concrete(bytes) => {
+                if offset >= bytes.len() {
+                    append_zero_exprs(cx, out, len);
+                    return;
+                }
+
+                let take = (bytes.len() - offset).min(len);
+                out.extend(
+                    bytes[offset..offset + take]
+                        .iter()
+                        .copied()
+                        .map(|byte| SymExpr::constant(cx, U256::from(byte))),
+                );
+                if len > take {
+                    append_zero_exprs(cx, out, len - take);
+                }
+            }
+            SymBytesKind::Exprs(bytes) => {
+                if offset >= bytes.len() {
+                    append_zero_exprs(cx, out, len);
+                    return;
+                }
+
+                let take = (bytes.len() - offset).min(len);
+                out.extend(bytes[offset..offset + take].iter().cloned());
+                if len > take {
+                    append_zero_exprs(cx, out, len - take);
+                }
+            }
+            SymBytesKind::Concat(values) => {
+                for bytes in values {
+                    if len == 0 {
+                        break;
+                    }
+
+                    let bytes_len = bytes.len();
+                    if offset >= bytes_len {
+                        offset -= bytes_len;
+                        continue;
+                    }
+
+                    let take = (bytes_len - offset).min(len);
+                    bytes.append_expr_range(cx, offset, take, out);
+                    len -= take;
+                    offset = 0;
+                }
+
+                if len != 0 {
+                    append_zero_exprs(cx, out, len);
+                }
+            }
+            SymBytesKind::Slice { bytes, offset: base_offset, len: slice_len } => {
+                if offset >= *slice_len {
+                    append_zero_exprs(cx, out, len);
+                    return;
+                }
+
+                let take = (*slice_len - offset).min(len);
+                if let Some(base_offset) = base_offset.eval()
+                    && let Ok(base_offset) = usize::try_from(base_offset)
+                    && let Some(offset) = base_offset.checked_add(offset)
+                {
+                    bytes.append_expr_range(cx, offset, take, out);
+                    if len > take {
+                        append_zero_exprs(cx, out, len - take);
+                    }
+                } else {
+                    append_byte_range(cx, self, offset, len, out);
+                }
+            }
+            SymBytesKind::Word(_) | SymBytesKind::Sized { .. } => {
+                append_byte_range(cx, self, offset, len, out);
+            }
+        }
+    }
+}
+
+fn append_zero_exprs(cx: &mut SymCx, out: &mut Vec<SymExpr>, len: usize) {
+    out.extend((0..len).map(|_| SymExpr::zero(cx)));
+}
+
+fn append_byte_range(
+    cx: &mut SymCx,
+    bytes: &SymBytes,
+    offset: usize,
+    len: usize,
+    out: &mut Vec<SymExpr>,
+) {
+    out.extend((0..len).map(|idx| {
+        offset
+            .checked_add(idx)
+            .map(|offset| bytes.byte(cx, offset))
+            .unwrap_or_else(|| SymExpr::zero(cx))
+    }));
 }

--- a/crates/evm/symbolic/src/runtime/bytes.rs
+++ b/crates/evm/symbolic/src/runtime/bytes.rs
@@ -430,9 +430,7 @@ impl SymBytes {
     }
 
     pub(crate) fn materialize(&self, cx: &mut SymCx) -> Vec<SymExpr> {
-        let mut out = Vec::with_capacity(self.len());
-        self.append_expr_range(cx, 0, self.len(), &mut out);
-        out
+        (0..self.len()).map(|idx| self.byte(cx, idx)).collect()
     }
 
     pub(crate) fn same_bytes(&self, cx: &mut SymCx, other: &Self) -> bool {
@@ -573,111 +571,4 @@ impl SymBytes {
             }
         }
     }
-
-    fn append_expr_range(
-        &self,
-        cx: &mut SymCx,
-        mut offset: usize,
-        mut len: usize,
-        out: &mut Vec<SymExpr>,
-    ) {
-        if len == 0 {
-            return;
-        }
-
-        match self.kind() {
-            SymBytesKind::Concrete(bytes) => {
-                if offset >= bytes.len() {
-                    append_zero_exprs(cx, out, len);
-                    return;
-                }
-
-                let take = (bytes.len() - offset).min(len);
-                out.extend(
-                    bytes[offset..offset + take]
-                        .iter()
-                        .copied()
-                        .map(|byte| SymExpr::constant(cx, U256::from(byte))),
-                );
-                if len > take {
-                    append_zero_exprs(cx, out, len - take);
-                }
-            }
-            SymBytesKind::Exprs(bytes) => {
-                if offset >= bytes.len() {
-                    append_zero_exprs(cx, out, len);
-                    return;
-                }
-
-                let take = (bytes.len() - offset).min(len);
-                out.extend(bytes[offset..offset + take].iter().cloned());
-                if len > take {
-                    append_zero_exprs(cx, out, len - take);
-                }
-            }
-            SymBytesKind::Concat(values) => {
-                for bytes in values {
-                    if len == 0 {
-                        break;
-                    }
-
-                    let bytes_len = bytes.len();
-                    if offset >= bytes_len {
-                        offset -= bytes_len;
-                        continue;
-                    }
-
-                    let take = (bytes_len - offset).min(len);
-                    bytes.append_expr_range(cx, offset, take, out);
-                    len -= take;
-                    offset = 0;
-                }
-
-                if len != 0 {
-                    append_zero_exprs(cx, out, len);
-                }
-            }
-            SymBytesKind::Slice { bytes, offset: base_offset, len: slice_len } => {
-                if offset >= *slice_len {
-                    append_zero_exprs(cx, out, len);
-                    return;
-                }
-
-                let take = (*slice_len - offset).min(len);
-                if let Some(base_offset) = base_offset.eval()
-                    && let Ok(base_offset) = usize::try_from(base_offset)
-                    && let Some(offset) = base_offset.checked_add(offset)
-                {
-                    bytes.append_expr_range(cx, offset, take, out);
-                    if len > take {
-                        append_zero_exprs(cx, out, len - take);
-                    }
-                } else {
-                    append_byte_range(cx, self, offset, len, out);
-                }
-            }
-            SymBytesKind::Word(_) | SymBytesKind::Sized { .. } => {
-                append_byte_range(cx, self, offset, len, out);
-            }
-        }
-    }
-}
-
-fn append_zero_exprs(cx: &mut SymCx, out: &mut Vec<SymExpr>, len: usize) {
-    out.extend((0..len).map(|_| SymExpr::zero(cx)));
-}
-
-fn append_byte_range(
-    cx: &mut SymCx,
-    bytes: &SymBytes,
-    offset: usize,
-    len: usize,
-    out: &mut Vec<SymExpr>,
-) {
-    out.extend((0..len).map(|idx| {
-        offset
-            .checked_add(idx)
-            .map(|offset| bytes.byte(cx, offset))
-            .unwrap_or_else(|| SymExpr::zero(cx))
-    }));
 }

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -7,9 +7,7 @@ mod monotonic_product;
 mod opt;
 
 use hard_arith_fallback::constraints_prefer_hard_arith_fallback_first;
-#[cfg(test)]
-pub(crate) use hard_arith_fallback::fallback_single_var_model;
-pub(crate) use hard_arith_fallback::hard_arith_fallback_model;
+pub(crate) use hard_arith_fallback::{fallback_single_var_model, hard_arith_fallback_model};
 #[cfg(test)]
 pub(crate) use monotonic_product::product_monotonic_unsat;
 use monotonic_product::product_monotonic_unsat_normalized;
@@ -385,6 +383,13 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         )
         .entered();
         trace!(query_id = self.queries, constraint_count = constraints.len(), "solver model");
+        if let Some(model) = fallback_single_var_model(&smt_constraints)
+            && model_satisfies_constraints(&model, constraints)
+        {
+            self.cache_sat_result(cache_key.clone(), true);
+            self.cache_model_result(cache_key, model.clone());
+            return Ok(model);
+        }
         if constraints_prefer_hard_arith_fallback_first(&smt_constraints)
             && let Some(model) = validated_hard_arith_fallback_model(&smt_constraints, constraints)
         {
@@ -503,6 +508,12 @@ impl SmtLibSubprocessSolver {
             trace!("is_sat: monotonic product contradiction");
             self.cache_sat_result(cache_key, false);
             return Ok(false);
+        }
+        if let Some(model) = fallback_single_var_model(&smt_constraints)
+            && model_satisfies_constraints(&model, constraints)
+        {
+            self.cache_sat_result(cache_key, true);
+            return Ok(true);
         }
         if constraints_prefer_hard_arith_fallback_first(&smt_constraints) {
             if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -240,7 +240,6 @@ fn collect_bool_fallback_vars(expr: &SymBoolExpr, vars: &mut SymbolicVars) {
     });
 }
 
-#[cfg(test)]
 pub(crate) fn fallback_single_var_model(constraints: &[SymBoolExpr]) -> Option<SymbolicModel> {
     let mut vars = SymbolicVars::default();
     let mut constants = HashSet::<U256>::default();

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -519,6 +519,30 @@ fn byte_concat_concrete_bytes_flattens_slices_with_padding() {
 }
 
 #[test]
+fn byte_concat_materialize_flattens_slices_with_padding() {
+    let mut cx = SymCx::new();
+    let left_a = SymExpr::var(&mut cx, "left_a");
+    let left_b = SymExpr::var(&mut cx, "left_b");
+    let right = SymExpr::var(&mut cx, "right");
+    let left = SymBytes::exprs(&mut cx, vec![left_a, left_b.clone()]);
+    let middle = SymBytes::concrete(&mut cx, vec![3]);
+    let right_bytes = SymBytes::exprs(&mut cx, vec![right.clone()]);
+    let bytes =
+        SymBytes::concat(&mut cx, [left, middle, right_bytes]).slice_concrete(&mut cx, 1, 5);
+
+    assert_eq!(
+        bytes.materialize(&mut cx),
+        vec![
+            left_b,
+            SymExpr::constant(&mut cx, U256::from(3)),
+            right,
+            SymExpr::zero(&mut cx),
+            SymExpr::zero(&mut cx),
+        ]
+    );
+}
+
+#[test]
 fn calldata_load_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let calldata_bytes =

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -519,30 +519,6 @@ fn byte_concat_concrete_bytes_flattens_slices_with_padding() {
 }
 
 #[test]
-fn byte_concat_materialize_flattens_slices_with_padding() {
-    let mut cx = SymCx::new();
-    let left_a = SymExpr::var(&mut cx, "left_a");
-    let left_b = SymExpr::var(&mut cx, "left_b");
-    let right = SymExpr::var(&mut cx, "right");
-    let left = SymBytes::exprs(&mut cx, vec![left_a, left_b.clone()]);
-    let middle = SymBytes::concrete(&mut cx, vec![3]);
-    let right_bytes = SymBytes::exprs(&mut cx, vec![right.clone()]);
-    let bytes =
-        SymBytes::concat(&mut cx, [left, middle, right_bytes]).slice_concrete(&mut cx, 1, 5);
-
-    assert_eq!(
-        bytes.materialize(&mut cx),
-        vec![
-            left_b,
-            SymExpr::constant(&mut cx, U256::from(3)),
-            right,
-            SymExpr::zero(&mut cx),
-            SymExpr::zero(&mut cx),
-        ]
-    );
-}
-
-#[test]
 fn calldata_load_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let calldata_bytes =
@@ -3474,6 +3450,51 @@ fn counted_solver_invocations(marker: &Path) -> usize {
 
 #[cfg(unix)]
 #[test]
+fn is_sat_uses_single_var_witness_before_solver() {
+    let mut cx = SymCx::new();
+    let marker = portfolio_test_marker("single-var-is-sat");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
+    let value = SymExpr::var(&mut cx, "calldata_0");
+    let limit = SymExpr::constant(&mut cx, U256::from(10));
+    let constraints = vec![SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, value, limit)];
+
+    assert!(solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(counted_solver_invocations(&marker), 0);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+fn model_uses_single_var_witness_before_solver() {
+    let mut cx = SymCx::new();
+    let marker = portfolio_test_marker("single-var-model");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
+    let value = SymExpr::var(&mut cx, "calldata_0");
+    let zero = SymExpr::zero(&mut cx);
+    let not_zero = SymBoolExpr::eq(&mut cx, value.clone(), zero).not(&mut cx);
+    let limit = SymExpr::constant(&mut cx, U256::from(10));
+    let below_limit = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, value, limit);
+    let constraints = vec![not_zero, below_limit];
+
+    let model = solver.model(&mut cx, &constraints).unwrap();
+    assert!(constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.model_queries, 1);
+    assert_eq!(counted_solver_invocations(&marker), 0);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
 fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
     let mut cx = SymCx::new();
     let marker = portfolio_test_marker("hard-arith-is-sat");
@@ -3640,10 +3661,13 @@ fn sat_cache_deduplicates_repeated_constraints() {
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
     let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let constraint = SymBoolExpr::eq(&mut cx, x, one);
-    let duplicated = vec![constraint.clone(), constraint.clone()];
-    let deduplicated = vec![constraint];
+    let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
+    let two = SymExpr::constant(&mut cx, U256::from(2));
+    let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
+    let duplicated = vec![x_eq_one.clone(), y_eq_two.clone(), x_eq_one.clone()];
+    let deduplicated = vec![x_eq_one, y_eq_two];
 
     assert!(solver.is_sat(&mut cx, &duplicated).unwrap());
     assert!(solver.is_sat(&mut cx, &deduplicated).unwrap());
@@ -3664,11 +3688,16 @@ fn sat_cache_deduplicates_nested_repeated_constraints() {
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
     let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let constraint = SymBoolExpr::eq(&mut cx, x, one);
-    let duplicated =
-        vec![SymBoolExpr::raw_and(&mut cx, vec![constraint.clone(), constraint.clone()])];
-    let deduplicated = vec![constraint];
+    let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
+    let two = SymExpr::constant(&mut cx, U256::from(2));
+    let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
+    let duplicated = vec![SymBoolExpr::raw_and(
+        &mut cx,
+        vec![x_eq_one.clone(), y_eq_two.clone(), x_eq_one.clone()],
+    )];
+    let deduplicated = vec![x_eq_one, y_eq_two];
 
     assert!(solver.is_sat(&mut cx, &duplicated).unwrap());
     assert!(solver.is_sat(&mut cx, &deduplicated).unwrap());
@@ -3751,15 +3780,23 @@ fn sat_cache_reuses_unsat_branch_complement() {
     let commands = vec![counted_solver_command_sequence(&marker, &["sat", "unsat"])];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
     let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let ten = SymExpr::constant(&mut cx, U256::from(10));
-    let base = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), ten);
+    let x_lt_ten = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), ten);
+    let two = SymExpr::constant(&mut cx, U256::from(2));
+    let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
+    let base = vec![x_lt_ten, y_eq_two];
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let condition = SymBoolExpr::eq(&mut cx, x, one);
     let not_condition = condition.clone().not(&mut cx);
+    let mut condition_path = base.clone();
+    condition_path.push(condition);
+    let mut complement_path = base.clone();
+    complement_path.push(not_condition);
 
-    assert!(solver.is_sat(&mut cx, std::slice::from_ref(&base)).unwrap());
-    assert!(!solver.is_sat_branch(&mut cx, &[base.clone(), condition]).unwrap());
-    assert!(solver.is_sat_branch(&mut cx, &[base, not_condition]).unwrap());
+    assert!(solver.is_sat(&mut cx, &base).unwrap());
+    assert!(!solver.is_sat_branch(&mut cx, &condition_path).unwrap());
+    assert!(solver.is_sat_branch(&mut cx, &complement_path).unwrap());
 
     let stats = solver.stats();
     assert_eq!(stats.solver_queries, 2);
@@ -3804,8 +3841,12 @@ fn sat_cache_does_not_cache_unknown_results() {
     let commands = vec![counted_solver_command(&marker, "unknown")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 4, false);
     let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let constraints = vec![SymBoolExpr::eq(&mut cx, x, one)];
+    let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
+    let two = SymExpr::constant(&mut cx, U256::from(2));
+    let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
+    let constraints = vec![x_eq_one, y_eq_two];
 
     assert!(matches!(solver.is_sat(&mut cx, &constraints), Err(SymbolicError::SolverUnknown)));
     assert!(matches!(solver.is_sat(&mut cx, &constraints), Err(SymbolicError::SolverUnknown)));
@@ -3868,12 +3909,18 @@ fn model_query_populates_sat_cache() {
     let marker = portfolio_test_marker("model-cache-sat");
     let model_output = "sat\n\
         ((define-fun x () (_ BitVec 256) \
-        #x0000000000000000000000000000000000000000000000000000000000000001))";
+        #x0000000000000000000000000000000000000000000000000000000000000001)\n\
+        (define-fun y () (_ BitVec 256) \
+        #x0000000000000000000000000000000000000000000000000000000000000002))";
     let commands = vec![counted_solver_command(&marker, model_output)];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
     let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let constraints = vec![SymBoolExpr::eq(&mut cx, x, one)];
+    let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
+    let two = SymExpr::constant(&mut cx, U256::from(2));
+    let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
+    let constraints = vec![x_eq_one, y_eq_two];
 
     assert_eq!(
         solver.model(&mut cx, &constraints).unwrap().get(&Symbol::intern("x")),
@@ -3921,9 +3968,13 @@ fn is_sat_reuses_cached_unsat_subset() {
     let y = SymExpr::var(&mut cx, "y");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
+    let z = SymExpr::var(&mut cx, "z");
+    let three = SymExpr::constant(&mut cx, U256::from(3));
+    let z_eq_three = SymBoolExpr::eq(&mut cx, z, three);
+    let unsat_subset = vec![x_eq_one.clone(), y_eq_two.clone()];
 
-    assert!(!solver.is_sat(&mut cx, std::slice::from_ref(&x_eq_one)).unwrap());
-    assert!(!solver.is_sat(&mut cx, &[x_eq_one, y_eq_two]).unwrap());
+    assert!(!solver.is_sat(&mut cx, &unsat_subset).unwrap());
+    assert!(!solver.is_sat(&mut cx, &[x_eq_one, y_eq_two, z_eq_three]).unwrap());
 
     let stats = solver.stats();
     assert_eq!(stats.solver_queries, 1);
@@ -3949,10 +4000,14 @@ fn is_sat_does_not_reuse_cached_sat_subset() {
     let y = SymExpr::var(&mut cx, "y");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
+    let z = SymExpr::var(&mut cx, "z");
+    let three = SymExpr::constant(&mut cx, U256::from(3));
+    let z_eq_three = SymBoolExpr::eq(&mut cx, z, three);
+    let sat_subset = vec![x_eq_one.clone(), y_eq_two.clone()];
 
-    assert!(solver.is_sat(&mut cx, std::slice::from_ref(&x_eq_one)).unwrap());
+    assert!(solver.is_sat(&mut cx, &sat_subset).unwrap());
     assert!(matches!(
-        solver.is_sat(&mut cx, &[x_eq_one, y_eq_two]),
+        solver.is_sat(&mut cx, &[x_eq_one, y_eq_two, z_eq_three]),
         Err(SymbolicError::SolverQueryLimit(1))
     ));
 
@@ -3973,8 +4028,12 @@ fn model_short_circuits_when_sat_cache_proved_unsat() {
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
     let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let constraints = vec![SymBoolExpr::eq(&mut cx, x, one)];
+    let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
+    let two = SymExpr::constant(&mut cx, U256::from(2));
+    let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
+    let constraints = vec![x_eq_one, y_eq_two];
 
     assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
     assert!(
@@ -4073,10 +4132,15 @@ fn portfolio_scheduler_promotes_recent_sat_winner() {
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 2, false);
 
     let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let first = vec![SymBoolExpr::eq(&mut cx, x.clone(), one)];
+    let zero = SymExpr::zero(&mut cx);
+    let first = vec![
+        SymBoolExpr::eq(&mut cx, x.clone(), one),
+        SymBoolExpr::eq(&mut cx, y.clone(), zero.clone()),
+    ];
     let two = SymExpr::constant(&mut cx, U256::from(2));
-    let second = vec![SymBoolExpr::eq(&mut cx, x, two)];
+    let second = vec![SymBoolExpr::eq(&mut cx, x, two), SymBoolExpr::eq(&mut cx, y, zero)];
 
     assert!(solver.is_sat(&mut cx, &first).unwrap());
     assert!(marker.exists());
@@ -4115,10 +4179,15 @@ fn portfolio_scheduler_promotes_recent_unsat_winner() {
     solver.capture_diagnostics();
 
     let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let first = vec![SymBoolExpr::eq(&mut cx, x.clone(), one)];
+    let zero = SymExpr::zero(&mut cx);
+    let first = vec![
+        SymBoolExpr::eq(&mut cx, x.clone(), one),
+        SymBoolExpr::eq(&mut cx, y.clone(), zero.clone()),
+    ];
     let two = SymExpr::constant(&mut cx, U256::from(2));
-    let second = vec![SymBoolExpr::eq(&mut cx, x, two)];
+    let second = vec![SymBoolExpr::eq(&mut cx, x, two), SymBoolExpr::eq(&mut cx, y, zero)];
 
     assert!(!solver.is_sat(&mut cx, &first).unwrap());
     assert!(!solver.is_sat(&mut cx, &second).unwrap());


### PR DESCRIPTION
Symbolic solving now reuses the existing validated single-variable witness search before spawning an SMT subprocess for satisfiable `is_sat` and `model` queries. The fast path only returns after evaluating every original constraint against the candidate model, so unresolved cases still fall through to the solver.

### Results

| Benchmark | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `grandizzy/symbolic-bug-suite` wall time | 555.6ms ± 15.6ms | 510.2ms ± 39.6ms | 1.09x ± 0.09 faster |
| bug-suite backend SMT queries | 211 | 95 | -55.0% |
| bug-suite reported solver time | 3131ms | 1501ms | -52.1% |
| built-in symbolic benches wall total | 6.137s | 6.183s | +0.7% |
| built-in symbolic benches solver total | 5845ms | 5649ms | -3.4% |
| built-in symbolic benches SMT queries | 140 | 107 | -23.6% |