### PR TITLE
chore(forge): remove stale fuzz bare-name filter todo

### DIFF
--- a/crates/forge/src/cmd/test/filter.rs
+++ b/crates/forge/src/cmd/test/filter.rs
@@ -266,9 +266,6 @@ impl TestFilter for ProjectPathsAwareFilter {
                     && (failure.test == signature || failure.test == name)
             })
         } else {
-            // TODO(@mablr): let exact bare-name fuzz filters such as `^testFoo$`
-            // match `testFoo(uint256)` when running `forge fuzz`, while preserving signature
-            // matching for overloaded tests.
             kind.is_any_test() && self.args_filter.matches_test(&func.signature())
         }
     }


### PR DESCRIPTION
## Motivation

This removes a stale TODO about making exact bare-name fuzz filters such as `^testFoo$` match parameterized fuzz test signatures like `testFoo(uint256)`.

`--match-test` currently applies to ABI test signatures, not bare function names. That behavior is consistent across forge test, forge coverage, and forge fuzz run: users can match a test by using an unanchored name regex such as `testFoo`, or by anchoring the full signature shape such as `^testFoo\\(uint256\\)$`. Special-casing forge fuzz run would make fuzz filtering semantics diverge from the rest of Forge and would require overload-specific selection logic for a narrow UX edge case.
