### PR TITLE
feat(lint): add unused-error detector

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -66,6 +66,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `missing-inheritance`: Flags contracts that implement every external function of an interface without explicitly inheriting from it.
   - `low-level-calls`: Direct use of low-level calls should be avoided.
   - `event-fields`: `address` event parameters should be `indexed` for efficient log filtering.
+  - `unused-error`: Custom error declarations that are never referenced should be removed.
 - **Gas Optimizations:**
   - `asm-keccak256`: Recommends using inline assembly for `keccak256` for potential gas savings.
   - `cache-array-length`: Recommends caching storage dynamic array lengths used in `for` loop conditions.

--- a/crates/lint/docs/unused-error.md
+++ b/crates/lint/docs/unused-error.md
@@ -1,0 +1,44 @@
+# Unused error
+
+**Severity**: `Info`
+**ID**: `unused-error`
+
+Flags a custom error declaration that is never referenced anywhere in the compiled sources.
+
+## What it does
+
+Reports each `error` declaration whose symbol is never referenced. Any resolved reference counts
+as a use: a `revert Err(...)` statement (including the qualified `revert Lib.Err(...)`),
+`require(cond, Err(...))` (Solidity 0.8.26+), and `Err.selector` (including through
+`abi.encodeWithSelector`). Uses are collected across the whole compilation unit,
+so an error declared in a shared file and reverted elsewhere in the project is not reported.
+
+Errors declared in interfaces and abstract contracts are not reported: they are ABI surface
+meant for implementers and off-chain consumers, which may live outside the compiled sources.
+
+## Why is this bad?
+
+An unused error is dead code. It suggests a missing revert path or a leftover from a refactor.
+
+## Example
+
+### Bad
+
+```solidity
+error Unauthorized(); // declared but never referenced
+```
+
+### Good
+
+```solidity
+error Unauthorized();
+
+function withdraw() external {
+    if (msg.sender != owner) revert Unauthorized();
+}
+```
+
+## Limitations
+
+A selector hardcoded in inline assembly or built with `abi.encodeWithSignature("Err(...)")` does
+not reference the declaration and is not seen as a use.

--- a/crates/lint/src/sol/info/mod.rs
+++ b/crates/lint/src/sol/info/mod.rs
@@ -51,6 +51,9 @@ use missing_inheritance::MISSING_INHERITANCE;
 mod event_fields;
 use event_fields::EVENT_FIELDS;
 
+mod unused_error;
+use unused_error::UNUSED_ERROR;
+
 register_lints!(
     (BooleanCst, early, (BOOLEAN_CST)),
     (BooleanEqual, early, (BOOLEAN_EQUAL)),
@@ -70,4 +73,5 @@ register_lints!(
     (RedundantBaseConstructorCall, late, (REDUNDANT_BASE_CONSTRUCTOR_CALL)),
     (MissingInheritance, project, (MISSING_INHERITANCE)),
     (EventFields, early, (EVENT_FIELDS)),
+    (UnusedError, project, (UNUSED_ERROR)),
 );

--- a/crates/lint/src/sol/info/unused_error.rs
+++ b/crates/lint/src/sol/info/unused_error.rs
@@ -1,0 +1,188 @@
+use crate::{
+    linter::{Lint, ProjectLintEmitter, ProjectLintPass, ProjectSource},
+    sol::{Severity, SolLint, info::UnusedError},
+};
+use solar::{
+    ast::ContractKind,
+    interface::{data_structures::Never, source_map::FileName},
+    sema::hir::{self, Visit as _},
+};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::ControlFlow,
+};
+
+declare_forge_lint!(UNUSED_ERROR, Severity::Info, "unused-error", "custom error is never used");
+
+impl<'ast> ProjectLintPass<'ast> for UnusedError {
+    fn check_project(&mut self, ctx: &ProjectLintEmitter<'_, '_>, sources: &[ProjectSource<'ast>]) {
+        if !ctx.is_lint_enabled(UNUSED_ERROR.id()) {
+            return;
+        }
+
+        let gcx = ctx.gcx();
+        let hir = &gcx.hir;
+
+        // Map every input source's HIR `SourceId` to the corresponding `ProjectSource` index, so
+        // only errors declared in user-provided files are reported. Uses are still collected
+        // across the whole unit, so an error declared here and reverted in a dependency (or the
+        // other way around) is attributed correctly.
+        let input_source_idx: HashMap<hir::SourceId, usize> = hir
+            .sources_enumerated()
+            .filter_map(|(sid, src)| {
+                let path = match &src.file.name {
+                    FileName::Real(p) => p,
+                    _ => return None,
+                };
+                let idx = sources.iter().position(|s| &s.path == path)?;
+                Some((sid, idx))
+            })
+            .collect();
+
+        if input_source_idx.is_empty() {
+            return;
+        }
+
+        let used = collect_used_errors(hir);
+
+        // Report input-file error declarations that no expression in the unit references.
+        for error_id in hir.error_ids() {
+            let error = hir.error(error_id);
+            let Some(&src_idx) = input_source_idx.get(&error.source) else { continue };
+            // Errors declared in interfaces and abstract contracts are ABI surface meant for
+            // implementers and off-chain consumers, which may live outside the compiled sources.
+            if let Some(contract_id) = error.contract
+                && matches!(
+                    hir.contract(contract_id).kind,
+                    ContractKind::Interface | ContractKind::AbstractContract
+                )
+            {
+                continue;
+            }
+            if !used.contains(&error_id) {
+                ctx.emit(&sources[src_idx], &UNUSED_ERROR, error.span);
+            }
+        }
+    }
+}
+
+/// Collects every [`hir::ErrorId`] referenced by an expression anywhere in the unit.
+///
+/// Resolved identifiers cover almost every use: the lowering resolves the full path of
+/// `revert Lib.Err(...)` into a single `Ident`, and `require(cond, Err(...))` or `Err.selector`
+/// reference the error through a resolved `Ident` as well. The one exception is a qualified
+/// member access such as `Lib.Err.selector`: the inner `Err` segment carries no resolution in
+/// the HIR, so it is resolved by name against the items of the base contract or namespace.
+fn collect_used_errors<'hir>(hir: &'hir hir::Hir<'hir>) -> HashSet<hir::ErrorId> {
+    let mut collector = UsedErrorCollector { hir, used: HashSet::new() };
+    // Walk every source of the unit: functions, modifiers, and variable initializers.
+    for source_id in hir.source_ids() {
+        let _ = collector.visit_nested_source(source_id);
+    }
+    collector.used
+}
+
+struct UsedErrorCollector<'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    used: HashSet<hir::ErrorId>,
+}
+
+impl<'hir> hir::Visit<'hir> for UsedErrorCollector<'hir> {
+    type BreakValue = Never;
+
+    fn hir(&self) -> &'hir hir::Hir<'hir> {
+        self.hir
+    }
+
+    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        match &expr.kind {
+            // Direct resolved reference: `revert Err()`, `revert Lib.Err()` (fully resolved by
+            // the lowering), `require(cond, Err())`, `Err.selector`, ...
+            hir::ExprKind::Ident(resolutions) => {
+                // Symbols can be overloaded: consider every resolution.
+                for res in *resolutions {
+                    if let hir::Res::Item(hir::ItemId::Error(error_id)) = res {
+                        self.used.insert(*error_id);
+                    }
+                }
+            }
+            // `Lib.Err.selector`: the `Err` member carries no resolution, so look the name up in
+            // the items of the scopes its base can designate.
+            hir::ExprKind::Member(base, member) => {
+                for items in self.scope_items(base) {
+                    self.mark_named_error(items, member);
+                }
+            }
+            _ => {}
+        }
+        self.walk_expr(expr)
+    }
+}
+
+impl<'hir> UsedErrorCollector<'hir> {
+    /// Marks as used the errors of `items` whose name matches `member`.
+    fn mark_named_error(&mut self, items: &[hir::ItemId], member: &solar::ast::Ident) {
+        // Scopes cannot hold two same-name errors, but scan every item to stay conservative.
+        for item_id in items {
+            if let hir::ItemId::Error(error_id) = item_id
+                && self.hir.error(*error_id).name.name == member.name
+            {
+                self.used.insert(*error_id);
+            }
+        }
+    }
+
+    /// Returns the items of the named scopes `expr` can designate: a contract or library through
+    /// a resolved identifier, a module alias, or a member chain leading to one (`NS.Lib`).
+    fn scope_items(&self, expr: &hir::Expr<'_>) -> Vec<&'hir [hir::ItemId]> {
+        let mut scopes = Vec::new();
+        match &expr.kind {
+            hir::ExprKind::Ident(resolutions) => {
+                for res in *resolutions {
+                    match res {
+                        hir::Res::Item(hir::ItemId::Contract(contract_id)) => {
+                            scopes.push(self.hir.contract(*contract_id).items);
+                        }
+                        // A module alias exposes the file's global symbols, including the ones it
+                        // re-exports through its own imports: take the transitive closure.
+                        hir::Res::Namespace(source_id) => {
+                            for sid in self.reachable_sources(*source_id) {
+                                scopes.push(self.hir.source(sid).items);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            // A chained scope access (`NS.Lib`): look the name up in the scopes of the base.
+            hir::ExprKind::Member(inner_base, name) => {
+                for items in self.scope_items(inner_base) {
+                    for item_id in items {
+                        if let hir::ItemId::Contract(contract_id) = item_id
+                            && self.hir.contract(*contract_id).name.name == name.name
+                        {
+                            scopes.push(self.hir.contract(*contract_id).items);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        scopes
+    }
+
+    /// Returns `root` and every source transitively reachable through its imports.
+    fn reachable_sources(&self, root: hir::SourceId) -> Vec<hir::SourceId> {
+        let mut seen: HashSet<hir::SourceId> = HashSet::new();
+        let mut stack = vec![root];
+        // Imports can form cycles (a file may even import itself): track visited sources.
+        while let Some(source_id) = stack.pop() {
+            if seen.insert(source_id) {
+                for (_, imported) in self.hir.source(source_id).imports {
+                    stack.push(*imported);
+                }
+            }
+        }
+        seen.into_iter().collect()
+    }
+}

--- a/crates/lint/src/sol/info/unused_error.rs
+++ b/crates/lint/src/sol/info/unused_error.rs
@@ -4,8 +4,12 @@ use crate::{
 };
 use solar::{
     ast::ContractKind,
-    interface::{data_structures::Never, source_map::FileName},
-    sema::hir::{self, Visit as _},
+    interface::{Symbol, data_structures::Never, source_map::FileName},
+    sema::{
+        Gcx,
+        hir::{self, Visit as _},
+        ty::{Ty, TyKind},
+    },
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -43,7 +47,7 @@ impl<'ast> ProjectLintPass<'ast> for UnusedError {
             return;
         }
 
-        let used = collect_used_errors(hir);
+        let used = collect_used_errors(gcx);
 
         // Report input-file error declarations that no expression in the unit references.
         for error_id in hir.error_ids() {
@@ -72,29 +76,46 @@ impl<'ast> ProjectLintPass<'ast> for UnusedError {
 /// `revert Lib.Err(...)` into a single `Ident`, and `require(cond, Err(...))` or `Err.selector`
 /// reference the error through a resolved `Ident` as well. The one exception is a qualified
 /// member access such as `Lib.Err.selector`: the inner `Err` segment carries no resolution in
-/// the HIR, so it is resolved by name against the items of the base contract or namespace.
-fn collect_used_errors<'hir>(hir: &'hir hir::Hir<'hir>) -> HashSet<hir::ErrorId> {
-    let mut collector = UsedErrorCollector { hir, used: HashSet::new() };
+/// the HIR, so it is resolved against the scope its base designates: the items of a contract,
+/// or, for a module alias, Solar's resolved source scope, which binds exactly the names the
+/// file declares and imports (aliases included) rather than the raw items of the transitively
+/// imported files.
+fn collect_used_errors(gcx: Gcx<'_>) -> HashSet<hir::ErrorId> {
+    let hir = &gcx.hir;
+    let mut used = HashSet::new();
     // Walk every source of the unit: functions, modifiers, and variable initializers.
     for source_id in hir.source_ids() {
+        let mut collector = UsedErrorCollector { gcx, hir, current_source: source_id, used };
         let _ = collector.visit_nested_source(source_id);
+        used = collector.used;
     }
-    collector.used
+    used
 }
 
-struct UsedErrorCollector<'hir> {
-    hir: &'hir hir::Hir<'hir>,
+/// A named scope a qualified member can resolve against.
+enum MemberScope {
+    /// A contract or library: its declared items.
+    Contract(hir::ContractId),
+    /// A module alias: Solar's resolved scope for that source.
+    Module(hir::SourceId),
+}
+
+struct UsedErrorCollector<'gcx> {
+    gcx: Gcx<'gcx>,
+    hir: &'gcx hir::Hir<'gcx>,
+    /// The source being walked: module member lookups are made from its viewpoint.
+    current_source: hir::SourceId,
     used: HashSet<hir::ErrorId>,
 }
 
-impl<'hir> hir::Visit<'hir> for UsedErrorCollector<'hir> {
+impl<'gcx> hir::Visit<'gcx> for UsedErrorCollector<'gcx> {
     type BreakValue = Never;
 
-    fn hir(&self) -> &'hir hir::Hir<'hir> {
+    fn hir(&self) -> &'gcx hir::Hir<'gcx> {
         self.hir
     }
 
-    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+    fn visit_expr(&mut self, expr: &'gcx hir::Expr<'gcx>) -> ControlFlow<Self::BreakValue> {
         match &expr.kind {
             // Direct resolved reference: `revert Err()`, `revert Lib.Err()` (fully resolved by
             // the lowering), `require(cond, Err())`, `Err.selector`, ...
@@ -106,11 +127,24 @@ impl<'hir> hir::Visit<'hir> for UsedErrorCollector<'hir> {
                     }
                 }
             }
-            // `Lib.Err.selector`: the `Err` member carries no resolution, so look the name up in
-            // the items of the scopes its base can designate.
+            // `Lib.Err.selector`: the `Err` member carries no resolution, so resolve it against
+            // the scope its base designates.
             hir::ExprKind::Member(base, member) => {
-                for items in self.scope_items(base) {
-                    self.mark_named_error(items, member);
+                for scope in self.base_scopes(base) {
+                    match scope {
+                        MemberScope::Contract(contract_id) => {
+                            self.mark_named_error(contract_id, member.name);
+                        }
+                        // In the resolved scope an import alias binds under its local name to
+                        // the exact declaration: mark that error, not a same-name lookalike.
+                        MemberScope::Module(source_id) => {
+                            for member_ty in self.module_members_named(source_id, member.name) {
+                                if let TyKind::Error(_, error_id) = member_ty.kind {
+                                    self.used.insert(error_id);
+                                }
+                            }
+                        }
+                    }
                 }
             }
             _ => {}
@@ -119,49 +153,73 @@ impl<'hir> hir::Visit<'hir> for UsedErrorCollector<'hir> {
     }
 }
 
-impl<'hir> UsedErrorCollector<'hir> {
-    /// Marks as used the errors of `items` whose name matches `member`.
-    fn mark_named_error(&mut self, items: &[hir::ItemId], member: &solar::ast::Ident) {
+impl<'gcx> UsedErrorCollector<'gcx> {
+    /// Marks as used the errors of the contract whose name matches `name`.
+    fn mark_named_error(&mut self, contract_id: hir::ContractId, name: Symbol) {
         // Scopes cannot hold two same-name errors, but scan every item to stay conservative.
-        for item_id in items {
+        for item_id in self.hir.contract(contract_id).items {
             if let hir::ItemId::Error(error_id) = item_id
-                && self.hir.error(*error_id).name.name == member.name
+                && self.hir.error(*error_id).name.name == name
             {
                 self.used.insert(*error_id);
             }
         }
     }
 
-    /// Returns the items of the named scopes `expr` can designate: a contract or library through
-    /// a resolved identifier, a module alias, or a member chain leading to one (`NS.Lib`).
-    fn scope_items(&self, expr: &hir::Expr<'_>) -> Vec<&'hir [hir::ItemId]> {
+    /// Returns the types of the members named `name` in the resolved scope of module
+    /// `source_id`.
+    ///
+    /// `members_of` on a module type iterates Solar's resolved source scope: the file's own
+    /// declarations plus the names its imports actually bind, under their local (alias) names.
+    fn module_members_named(&self, source_id: hir::SourceId, name: Symbol) -> Vec<Ty<'gcx>> {
+        let module_ty = self.gcx.type_of_res(hir::Res::Namespace(source_id));
+        self.gcx
+            .members_of(module_ty, self.current_source, None)
+            .filter(|member| member.name == name)
+            .map(|member| member.ty)
+            .collect()
+    }
+
+    /// Returns the named scopes `expr` can designate: a contract or library through a resolved
+    /// identifier, a module alias, or a member chain leading to one (`NS.Lib`, `NS.Inner`).
+    fn base_scopes(&self, expr: &hir::Expr<'_>) -> Vec<MemberScope> {
         let mut scopes = Vec::new();
         match &expr.kind {
             hir::ExprKind::Ident(resolutions) => {
                 for res in *resolutions {
                     match res {
                         hir::Res::Item(hir::ItemId::Contract(contract_id)) => {
-                            scopes.push(self.hir.contract(*contract_id).items);
+                            scopes.push(MemberScope::Contract(*contract_id));
                         }
-                        // A module alias exposes the file's global symbols, including the ones it
-                        // re-exports through its own imports: take the transitive closure.
                         hir::Res::Namespace(source_id) => {
-                            for sid in self.reachable_sources(*source_id) {
-                                scopes.push(self.hir.source(sid).items);
-                            }
+                            scopes.push(MemberScope::Module(*source_id));
                         }
                         _ => {}
                     }
                 }
             }
-            // A chained scope access (`NS.Lib`): look the name up in the scopes of the base.
+            // A chained scope access (`NS.Lib`, `NS.Inner`): resolve the name in the scopes of
+            // the base. Contracts do not nest named scopes, so only module bases descend.
             hir::ExprKind::Member(inner_base, name) => {
-                for items in self.scope_items(inner_base) {
-                    for item_id in items {
-                        if let hir::ItemId::Contract(contract_id) = item_id
-                            && self.hir.contract(*contract_id).name.name == name.name
-                        {
-                            scopes.push(self.hir.contract(*contract_id).items);
+                for scope in self.base_scopes(inner_base) {
+                    if let MemberScope::Module(source_id) = scope {
+                        for member_ty in self.module_members_named(source_id, name.name) {
+                            // A contract or library is a type-namespace item, so its member
+                            // type comes wrapped as `Type(Contract(..))`; a nested module
+                            // alias comes as a bare `Module(..)`.
+                            let member_ty = match member_ty.kind {
+                                TyKind::Type(inner) => inner,
+                                _ => member_ty,
+                            };
+                            match member_ty.kind {
+                                TyKind::Contract(contract_id) => {
+                                    scopes.push(MemberScope::Contract(contract_id));
+                                }
+                                TyKind::Module(inner_source) => {
+                                    scopes.push(MemberScope::Module(inner_source));
+                                }
+                                _ => {}
+                            }
                         }
                     }
                 }
@@ -169,20 +227,5 @@ impl<'hir> UsedErrorCollector<'hir> {
             _ => {}
         }
         scopes
-    }
-
-    /// Returns `root` and every source transitively reachable through its imports.
-    fn reachable_sources(&self, root: hir::SourceId) -> Vec<hir::SourceId> {
-        let mut seen: HashSet<hir::SourceId> = HashSet::new();
-        let mut stack = vec![root];
-        // Imports can form cycles (a file may even import itself): track visited sources.
-        while let Some(source_id) = stack.pop() {
-            if seen.insert(source_id) {
-                for (_, imported) in self.hir.source(source_id).imports {
-                    stack.push(*imported);
-                }
-            }
-        }
-        seen.into_iter().collect()
     }
 }

--- a/crates/lint/testdata/UnusedError.sol
+++ b/crates/lint/testdata/UnusedError.sol
@@ -1,0 +1,66 @@
+//@compile-flags: --only-lint unused-error
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+// Tests for `unused-error`: a custom error declaration that is never referenced anywhere in the
+// compiled sources. Any resolved reference counts as a use: `revert Err()`, the qualified
+// `revert Lib.Err()`, `require(cond, Err())` (0.8.26+), and `Err.selector`, including through
+// `abi.encodeWithSelector`. Errors declared in interfaces and abstract contracts are exempt:
+// they are ABI surface for implementers and off-chain consumers.
+
+import "./UnusedError.sol" as Self;
+
+error UnusedFileLevel(); //~NOTE: custom error is never used
+
+error UsedFileLevel(uint256 value);
+
+library Errors {
+    error UnusedInLibrary(); //~NOTE: custom error is never used
+
+    error UsedViaQualifiedRevert();
+    error UsedViaQualifiedSelector();
+    error UsedViaChainedSelector();
+}
+
+interface IVault {
+    // interface errors are ABI surface for implementers and clients: exempt
+    error InterfaceOnly();
+}
+
+abstract contract BaseVault {
+    // abstract contract errors are part of the inheritance API: exempt
+    error AbstractOnly();
+
+    // declared in the base, reverted only by the concrete child: used
+    error RaisedByChild();
+}
+
+contract Vault is BaseVault {
+    error UnusedInContract(); //~NOTE: custom error is never used
+    error AlsoUnused(uint256 balance); //~NOTE: custom error is never used
+
+    error UsedInRevert();
+    error UsedInRequire();
+    error UsedViaSelector();
+    error UsedViaEncodeWithSelector(uint256 amount);
+
+    function f(uint256 x) external pure returns (bytes memory data) {
+        // plain revert statement
+        if (x == 1) revert UsedInRevert();
+        // qualified revert through the library
+        if (x == 2) revert Errors.UsedViaQualifiedRevert();
+        // require with a custom error (0.8.26+)
+        require(x != 3, UsedInRequire());
+        // revert with a file-level error
+        if (x == 4) revert UsedFileLevel(x);
+        // reverting the error declared in the abstract base
+        if (x == 5) revert RaisedByChild();
+        // selector-only uses
+        bytes4 s = UsedViaSelector.selector;
+        bytes4 q = Errors.UsedViaQualifiedSelector.selector;
+        // member chain through a module alias
+        bytes4 c = Self.Errors.UsedViaChainedSelector.selector;
+        data = abi.encodeWithSelector(UsedViaEncodeWithSelector.selector, x);
+        data = bytes.concat(data, s, q, c);
+    }
+}

--- a/crates/lint/testdata/UnusedError.sol
+++ b/crates/lint/testdata/UnusedError.sol
@@ -9,10 +9,19 @@ pragma solidity ^0.8.27;
 // they are ABI surface for implementers and off-chain consumers.
 
 import "./UnusedError.sol" as Self;
+import "./auxiliary/UnusedErrorReexport.sol" as R;
+import "./auxiliary/UnusedErrorHidden.sol" as H;
 
 error UnusedFileLevel(); //~NOTE: custom error is never used
 
 error UsedFileLevel(uint256 value);
+
+// used only through the alias re-export chain `R.Written.selector`
+error UsedViaAliasReexport();
+
+// shares its name with the library in the hidden-import fixture: the raw transitive walk
+// used to mark it used through `H.Hidden.id()`, the resolved scope must not mark it used
+error Hidden(); //~NOTE: custom error is never used
 
 library Errors {
     error UnusedInLibrary(); //~NOTE: custom error is never used
@@ -60,7 +69,11 @@ contract Vault is BaseVault {
         bytes4 q = Errors.UsedViaQualifiedSelector.selector;
         // member chain through a module alias
         bytes4 c = Self.Errors.UsedViaChainedSelector.selector;
+        // alias re-export chain through a module namespace
+        bytes4 a = R.Written.selector;
+        // `H.Hidden` is the library bound in that namespace, not the file-level error
+        uint256 one = H.Hidden.id();
         data = abi.encodeWithSelector(UsedViaEncodeWithSelector.selector, x);
-        data = bytes.concat(data, s, q, c);
+        data = bytes.concat(data, s, q, c, a, bytes32(one));
     }
 }

--- a/crates/lint/testdata/UnusedError.stderr
+++ b/crates/lint/testdata/UnusedError.stderr
@@ -9,6 +9,14 @@ LL │ error UnusedFileLevel();
 note[unused-error]: custom error is never used
    ╭▸ ROOT/testdata/UnusedError.sol:LL:CC
    │
+LL │ error Hidden();
+   │ ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-error
+
+note[unused-error]: custom error is never used
+   ╭▸ ROOT/testdata/UnusedError.sol:LL:CC
+   │
 LL │     error UnusedInLibrary();
    │     ━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/UnusedError.stderr
+++ b/crates/lint/testdata/UnusedError.stderr
@@ -1,0 +1,32 @@
+note[unused-error]: custom error is never used
+   ╭▸ ROOT/testdata/UnusedError.sol:LL:CC
+   │
+LL │ error UnusedFileLevel();
+   │ ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-error
+
+note[unused-error]: custom error is never used
+   ╭▸ ROOT/testdata/UnusedError.sol:LL:CC
+   │
+LL │     error UnusedInLibrary();
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-error
+
+note[unused-error]: custom error is never used
+   ╭▸ ROOT/testdata/UnusedError.sol:LL:CC
+   │
+LL │     error UnusedInContract();
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-error
+
+note[unused-error]: custom error is never used
+   ╭▸ ROOT/testdata/UnusedError.sol:LL:CC
+   │
+LL │     error AlsoUnused(uint256 balance);
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unused-error
+

--- a/crates/lint/testdata/auxiliary/UnusedErrorHidden.sol
+++ b/crates/lint/testdata/auxiliary/UnusedErrorHidden.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+// The import edge back to the fixture is what used to leak its raw items into this file's
+// namespace: only `Errors` is actually bound here, so the fixture's `error Hidden()` must
+// not be reachable through `H.`.
+import {Errors} from "../UnusedError.sol";
+
+library Hidden {
+    function id() internal pure returns (uint256) {
+        return 1;
+    }
+}

--- a/crates/lint/testdata/auxiliary/UnusedErrorReexport.sol
+++ b/crates/lint/testdata/auxiliary/UnusedErrorReexport.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+// Re-exports the fixture's error under a new name: a use of `R.Written` in the fixture
+// must count as a use of `UsedViaAliasReexport`.
+import {UsedViaAliasReexport as Written} from "../UnusedError.sol";


### PR DESCRIPTION
Adds the `unused-error` detector to `forge lint`, one of the open items in #14381 (Slither/Aderyn parity; Aderyn ships it as `unused-error`).

## What it does

Flags a custom error declaration that no expression in the compiled sources references.

Any resolved reference counts as a use: `revert Err(...)` (including the qualified `revert Lib.Err(...)`, which the lowering resolves into a single identifier), `require(cond, Err(...))` (Solidity 0.8.26+), and `Err.selector` (including through `abi.encodeWithSelector`). A qualified member access such as `Lib.Err.selector` carries no resolution on the `Err` segment in the HIR, so the name is looked up in the scopes its base can designate: a contract or library, a module alias (including the symbols it re-exports through its own imports), or a member chain leading to one (`NS.Lib.Err.selector`).

It is a project pass: uses are collected across the whole compilation unit while only errors declared in input files are reported, so a shared errors file that is reverted from elsewhere in the project is attributed correctly. Errors declared in interfaces and abstract contracts are not reported: they are ABI surface for implementers and off-chain consumers, which may live outside the compiled sources.

## Severity

Info.

## Tests

`crates/lint/testdata/UnusedError.sol` covers flagged declarations at contract, library, and file level, and the non-flagged uses: plain and qualified reverts, `require` with a custom error, selector accesses (direct, qualified, and chained through a module alias), `abi.encodeWithSelector`, an error declared in an abstract base and reverted by the child, and the interface / abstract contract exemptions.

## Limitations

A selector hardcoded in inline assembly or built with `abi.encodeWithSignature("Err(...)")` does not reference the declaration and is not seen as a use.

Part of #14381.
