### PR TITLE
feat(lint): add empty-block detector

### DIFF
--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -1733,7 +1733,11 @@ forgetest!(can_fail_compile_with_warnings, |prj, cmd| {
         r"
 pragma solidity *;
 contract A {
-    function testExample() public {}
+    event Example();
+
+    function testExample() public {
+        emit Example();
+    }
 }
    ",
     );

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -28,7 +28,7 @@ contract ContractWithLints {
     function unoptimizedHashGas(uint256 a, uint256 b) public view {
         keccak256(abi.encodePacked(a, b));
     }
-    function FUNCTION_MIXED_CASE_INFO() public {}
+    function FUNCTION_MIXED_CASE_INFO() public { VARIABLE_MIXED_CASE_INFO = 1; }
 }
 "#;
 
@@ -40,7 +40,7 @@ pragma solidity ^0.8.0;
 import { ContractWithLints } from "./ContractWithLints.sol";
 
 contract OtherContractWithLints {
-    function functionMIXEDCaseInfo() public {}
+    function functionMIXEDCaseInfo() public { uint256 x = 1; }
 }
 "#;
 
@@ -73,7 +73,7 @@ pragma solidity ^0.8.0;
 import { UnusedSymbol } from "./DefaultInfoLintsImport.sol";
 
 contract DefaultInfoLints {
-    function BAD_CASE() public {}
+    function BAD_CASE() public { uint256 x = 1; }
 }
 "#;
 
@@ -248,7 +248,7 @@ forgetest!(can_use_config_ignore, |prj, cmd| {
 note[mixed-case-function]: function names should use mixedCase
   [FILE]:9:14
   │
-9 │     function functionMIXEDCaseInfo() public {}
+9 │     function functionMIXEDCaseInfo() public { uint256 x = 1; }
   │              ━━━━━━━━━━━━━━━━━━━━━ help: consider using: `functionMixedCaseInfo`
   │
   ╰ help: https://getfoundry.sh/forge/linting/mixed-case-function
@@ -280,7 +280,7 @@ forgetest!(default_lint_severity_includes_info, |prj, cmd| {
 note[mixed-case-function]: function names should use mixedCase
   [FILE]:8:14
   │
-8 │     function BAD_CASE() public {}
+8 │     function BAD_CASE() public { uint256 x = 1; }
   │              ━━━━━━━━ help: consider using: `badCase`
   │
   ╰ help: https://getfoundry.sh/forge/linting/mixed-case-function
@@ -656,7 +656,7 @@ forgetest!(can_override_config_severity, |prj, cmd| {
 note[mixed-case-function]: function names should use mixedCase
   [FILE]:9:14
   │
-9 │     function functionMIXEDCaseInfo() public {}
+9 │     function functionMIXEDCaseInfo() public { uint256 x = 1; }
   │              ━━━━━━━━━━━━━━━━━━━━━ help: consider using: `functionMixedCaseInfo`
   │
   ╰ help: https://getfoundry.sh/forge/linting/mixed-case-function

--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -42,6 +42,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `block-timestamp`: Warns when `block.timestamp` is used in a comparison, as it may be manipulated by validators.
   - `calls-loop`: External calls inside loops can cause denial-of-service if a call reverts or exhausts gas.
   - `delegatecall-loop`: Payable functions should not use `delegatecall` inside a loop.
+  - `empty-block`: Flags regular functions with an empty body; constructors, `receive`/`fallback`, `virtual` and `payable` functions are exempt.
   - `incorrect-modifier`: Modifiers should not be able to finish without executing `_` or reverting.
   - `missing-events-access-control`: Access control changes should emit events.
   - `missing-zero-check`: Address parameter is used in a state write or value transfer without a zero-address check.

--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -42,7 +42,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `block-timestamp`: Warns when `block.timestamp` is used in a comparison, as it may be manipulated by validators.
   - `calls-loop`: External calls inside loops can cause denial-of-service if a call reverts or exhausts gas.
   - `delegatecall-loop`: Payable functions should not use `delegatecall` inside a loop.
-  - `empty-block`: Flags regular functions with an empty body; constructors, `receive`/`fallback`, `virtual` and `payable` functions are exempt.
+  - `empty-block`: Flags regular functions with an empty body; constructors, `receive`/`fallback`, `virtual` functions, functions with modifiers and value-less `payable` functions are exempt.
   - `incorrect-modifier`: Modifiers should not be able to finish without executing `_` or reverting.
   - `missing-events-access-control`: Access control changes should emit events.
   - `missing-zero-check`: Address parameter is used in a state write or value transfer without a zero-address check.

--- a/crates/lint/docs/empty-block.md
+++ b/crates/lint/docs/empty-block.md
@@ -1,0 +1,39 @@
+# Empty block
+
+**Severity**: `Low`
+**ID**: `empty-block`
+
+Flags regular functions whose body is empty, which is dead or unfinished code.
+
+## What it does
+
+Reports a function whose body is `{}` (a comment does not make a body non-empty). This mirrors Aderyn's `empty-block` detector, restricted to function bodies.
+
+Bodies whose emptiness is the behavior are exempt:
+
+- constructors: an empty body is how a contract calls base constructors (`constructor() Base(1) {}`) or is simply made deployable;
+- `receive` and `fallback`: the empty body is what accepts plain ether transfers or unknown calls;
+- `virtual` functions: an empty body is the intentional default of an extension hook meant to be overridden;
+- `payable` functions: an empty body is an intentional ether sink (`function deposit() external payable {}`).
+
+Functions without a body (interface members, abstract declarations) never fire, and an empty modifier body is a solc compile error (2883), so it never reaches the linter. Empty blocks nested inside a non-empty body (`if (x) {}`) are out of scope.
+
+## Why is this bad?
+
+An empty body on a regular function does nothing: either the implementation was forgotten, or the function is dead code that bloats the contract surface and misleads readers and integrators. An empty override can also silently disable behavior a parent contract intended to provide.
+
+## Example
+
+### Bad
+
+```solidity
+function withdraw() external {}
+```
+
+### Good
+
+```solidity
+function withdraw() external {
+    payable(msg.sender).transfer(address(this).balance);
+}
+```

--- a/crates/lint/docs/empty-block.md
+++ b/crates/lint/docs/empty-block.md
@@ -14,7 +14,8 @@ Bodies whose emptiness is the behavior are exempt:
 - constructors: an empty body is how a contract calls base constructors (`constructor() Base(1) {}`) or is simply made deployable;
 - `receive` and `fallback`: the empty body is what accepts plain ether transfers or unknown calls;
 - `virtual` functions: an empty body is the intentional default of an extension hook meant to be overridden;
-- `payable` functions: an empty body is an intentional ether sink (`function deposit() external payable {}`).
+- functions with modifiers: the modifier carries the behavior, as in `initialize() external initializer {}` or `_authorizeUpgrade(address) internal override onlyOwner {}`;
+- `payable` functions without return values: an empty body is an intentional ether sink (`function deposit() external payable {}`). With a return value the body silently returns the default, which reads as an unfinished stub and is reported.
 
 Functions without a body (interface members, abstract declarations) never fire, and an empty modifier body is a solc compile error (2883), so it never reaches the linter. Empty blocks nested inside a non-empty body (`if (x) {}`) are out of scope.
 

--- a/crates/lint/src/sol/low/empty_block.rs
+++ b/crates/lint/src/sol/low/empty_block.rs
@@ -11,15 +11,20 @@ impl<'ast> EarlyLintPass<'ast> for EmptyBlock {
     fn check_item_function(&mut self, ctx: &LintContext, func: &'ast ItemFunction<'ast>) {
         // An empty body on a regular function is dead or unfinished code. Bodies whose emptiness
         // is the behavior are exempt: constructors, receive/fallback (the empty body accepts
-        // calls or ether), `virtual` functions (an empty default meant to be overridden) and
-        // `payable` functions (an empty ether sink). Functions without a body (interfaces,
-        // abstract declarations) have nothing to flag, and an empty modifier body is a solc
-        // compile error (2883), so it never reaches the linter.
+        // calls or ether), `virtual` functions (an empty default meant to be overridden),
+        // functions with modifiers (`initialize() external initializer {}`,
+        // `_authorizeUpgrade(address) internal override onlyOwner {}`: the modifier carries the
+        // behavior) and `payable` functions without return values (an empty ether sink; with a
+        // return value the body silently returns the default, an unfinished stub). Functions
+        // without a body (interfaces, abstract declarations) have nothing to flag, and an empty
+        // modifier body is a solc compile error (2883), so it never reaches the linter.
         if let Some(body) = &func.body
             && body.is_empty()
             && matches!(func.kind, FunctionKind::Function)
             && func.header.virtual_.is_none()
-            && func.header.state_mutability() != StateMutability::Payable
+            && func.header.modifiers.is_empty()
+            && (func.header.state_mutability() != StateMutability::Payable
+                || func.header.returns.is_some())
         {
             ctx.emit(&EMPTY_BLOCK, body.span);
         }

--- a/crates/lint/src/sol/low/empty_block.rs
+++ b/crates/lint/src/sol/low/empty_block.rs
@@ -1,0 +1,27 @@
+use super::EmptyBlock;
+use crate::{
+    linter::{EarlyLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::ast::{FunctionKind, ItemFunction, StateMutability};
+
+declare_forge_lint!(EMPTY_BLOCK, Severity::Low, "empty-block", "empty function body");
+
+impl<'ast> EarlyLintPass<'ast> for EmptyBlock {
+    fn check_item_function(&mut self, ctx: &LintContext, func: &'ast ItemFunction<'ast>) {
+        // An empty body on a regular function is dead or unfinished code. Bodies whose emptiness
+        // is the behavior are exempt: constructors, receive/fallback (the empty body accepts
+        // calls or ether), `virtual` functions (an empty default meant to be overridden) and
+        // `payable` functions (an empty ether sink). Functions without a body (interfaces,
+        // abstract declarations) have nothing to flag, and an empty modifier body is a solc
+        // compile error (2883), so it never reaches the linter.
+        if let Some(body) = &func.body
+            && body.is_empty()
+            && matches!(func.kind, FunctionKind::Function)
+            && func.header.virtual_.is_none()
+            && func.header.state_mutability() != StateMutability::Payable
+        {
+            ctx.emit(&EMPTY_BLOCK, body.span);
+        }
+    }
+}

--- a/crates/lint/src/sol/low/mod.rs
+++ b/crates/lint/src/sol/low/mod.rs
@@ -9,6 +9,9 @@ use calls_loop::CALLS_LOOP;
 mod delegatecall_loop;
 use delegatecall_loop::DELEGATECALL_LOOP;
 
+mod empty_block;
+use empty_block::EMPTY_BLOCK;
+
 pub(crate) mod incorrect_modifier;
 use incorrect_modifier::INCORRECT_MODIFIER;
 
@@ -39,6 +42,7 @@ register_lints!(
     (BlockTimestamp, late, (BLOCK_TIMESTAMP)),
     (CallsLoop, late, (CALLS_LOOP)),
     (DelegatecallLoop, late, (DELEGATECALL_LOOP)),
+    (EmptyBlock, early, (EMPTY_BLOCK)),
     (IncorrectModifier, late, (INCORRECT_MODIFIER)),
     (MsgValueLoop, late, (MSG_VALUE_LOOP)),
     (MissingEventsAccessControl, late, (MISSING_EVENTS_ACCESS_CONTROL)),

--- a/crates/lint/testdata/BooleanCst.sol
+++ b/crates/lint/testdata/BooleanCst.sol
@@ -21,5 +21,7 @@ contract BooleanCst {
         return true;
     }
 
-    function takesBool(bool value) internal pure {}
+    function takesBool(bool value) internal pure {
+        value;
+    }
 }

--- a/crates/lint/testdata/EmptyBlock.sol
+++ b/crates/lint/testdata/EmptyBlock.sol
@@ -28,6 +28,8 @@ abstract contract EmptyBlockBase {
 
     // Virtual middle hook stays exempt even when it also overrides.
     function middleHook() internal virtual {}
+
+    function _authorizeUpgrade(address newImplementation) internal virtual {}
 }
 
 contract EmptyBlockWithArg {
@@ -45,6 +47,9 @@ contract EmptyBlock is EmptyBlockBase, EmptyBlockWithArg {
 
     // Payable with an empty body is an intentional ether sink.
     function deposit() external payable {}
+
+    // Payable with a return value silently returns the default: an unfinished stub.
+    function payableReturns() external payable returns (uint256) {} //~WARN: empty function body
 
     function emptyPublic() public {} //~WARN: empty function body
 
@@ -64,11 +69,15 @@ contract EmptyBlock is EmptyBlockBase, EmptyBlockWithArg {
     // Overriding a parent declaration with an empty, non-virtual body is dead code.
     function toImplement() external override {} //~WARN: empty function body
 
-    // The modifier body runs, but the function itself is still empty.
-    function withModifier() public noop {} //~WARN: empty function body
+    // The modifier carries the behavior: `initializer`-style and `onlyOwner`-style guards
+    // commonly wrap an intentionally empty body.
+    function withModifier() public noop {}
 
     // Virtual override: still an extension hook, exempt.
     function middleHook() internal virtual override {}
+
+    // The UUPS pattern: the modifier is the whole point of the function.
+    function _authorizeUpgrade(address newImplementation) internal override noop {}
 
     function nonEmpty() public {
         value = 1;

--- a/crates/lint/testdata/EmptyBlock.sol
+++ b/crates/lint/testdata/EmptyBlock.sol
@@ -1,0 +1,82 @@
+//@compile-flags: --only-lint empty-block
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+// Tests for `empty-block`: an empty body on a regular function is dead or unfinished code.
+// Bodies whose emptiness is the behavior are exempt: constructors, receive/fallback (the empty
+// body accepts calls or ether), `virtual` functions (an empty default meant to be overridden)
+// and `payable` functions (an empty ether sink). Functions without a body (interfaces, abstract
+// declarations) never fire. Nested empty blocks (`if (x) {}`) are out of scope.
+
+// An empty free function is dead code.
+function freeEmpty() pure {} //~WARN: empty function body
+
+library EmptyBlockLib {
+    function libEmpty(uint256 x) internal pure {} //~WARN: empty function body
+}
+
+abstract contract EmptyBlockBase {
+    modifier noop() {
+        _;
+    }
+
+    // Virtual with an empty default body: an intentional extension hook, exempt.
+    function hook() internal virtual {}
+
+    // Virtual without a body: nothing to flag.
+    function toImplement() external virtual;
+
+    // Virtual middle hook stays exempt even when it also overrides.
+    function middleHook() internal virtual {}
+}
+
+contract EmptyBlockWithArg {
+    constructor(uint256 x) {} // constructor: exempt, even with a parameter
+}
+
+contract EmptyBlock is EmptyBlockBase, EmptyBlockWithArg {
+    uint256 internal value;
+
+    constructor() EmptyBlockWithArg(1) {} // constructor with a base call: exempt
+
+    receive() external payable {} // receive: exempt
+
+    fallback() external payable {} // fallback: exempt
+
+    // Payable with an empty body is an intentional ether sink.
+    function deposit() external payable {}
+
+    function emptyPublic() public {} //~WARN: empty function body
+
+    function emptyExternal() external {} //~WARN: empty function body
+
+    function emptyInternal() internal {} //~WARN: empty function body
+
+    function emptyPrivate() private {} //~WARN: empty function body
+
+    function emptyView() external view {} //~WARN: empty function body
+
+    function emptyPure() external pure {} //~WARN: empty function body
+
+    // A comment does not make the body non-empty.
+    function commentOnly() public { /* nothing to do */ } //~WARN: empty function body
+
+    // Overriding a parent declaration with an empty, non-virtual body is dead code.
+    function toImplement() external override {} //~WARN: empty function body
+
+    // The modifier body runs, but the function itself is still empty.
+    function withModifier() public noop {} //~WARN: empty function body
+
+    // Virtual override: still an extension hook, exempt.
+    function middleHook() internal virtual override {}
+
+    function nonEmpty() public {
+        value = 1;
+    }
+
+    // Nested empty blocks are out of scope: the body is not empty.
+    function nestedEmptyIf(uint256 x) public {
+        if (x > 0) {}
+        value = x;
+    }
+}

--- a/crates/lint/testdata/EmptyBlock.stderr
+++ b/crates/lint/testdata/EmptyBlock.stderr
@@ -17,6 +17,14 @@ LL │     function libEmpty(uint256 x) internal pure {}
 warning[empty-block]: empty function body
    ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
    │
+LL │     function payableReturns() external payable returns (uint256) {}
+   │                                                                  ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
 LL │     function emptyPublic() public {}
    │                                   ━━
    │
@@ -75,14 +83,6 @@ warning[empty-block]: empty function body
    │
 LL │     function toImplement() external override {}
    │                                              ━━
-   │
-   ╰ help: https://getfoundry.sh/forge/linting/empty-block
-
-warning[empty-block]: empty function body
-   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
-   │
-LL │     function withModifier() public noop {}
-   │                                         ━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/empty-block
 

--- a/crates/lint/testdata/EmptyBlock.stderr
+++ b/crates/lint/testdata/EmptyBlock.stderr
@@ -1,0 +1,88 @@
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │ function freeEmpty() pure {}
+   │                           ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function libEmpty(uint256 x) internal pure {}
+   │                                                ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function emptyPublic() public {}
+   │                                   ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function emptyExternal() external {}
+   │                                       ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function emptyInternal() internal {}
+   │                                       ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function emptyPrivate() private {}
+   │                                     ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function emptyView() external view {}
+   │                                        ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function emptyPure() external pure {}
+   │                                        ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function commentOnly() public { /* nothing to do */ }
+   │                                   ━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function toImplement() external override {}
+   │                                              ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+
+warning[empty-block]: empty function body
+   ╭▸ ROOT/testdata/EmptyBlock.sol:LL:CC
+   │
+LL │     function withModifier() public noop {}
+   │                                         ━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/empty-block
+


### PR DESCRIPTION
## Motivation

`empty-block` is one of the unchecked items of #14381: an empty body on a regular function is dead or unfinished code. This mirrors Aderyn's `empty-block` detector (`aderyn_core/src/detect/low/empty_block.rs`), restricted to function bodies.

## Solution

New `Low` severity early pass: fires on a regular function whose body is `{}` (a comment does not make a body non-empty).

Exempt, because the empty body is the behavior:

- constructors and `receive`/`fallback` (same as Aderyn): base calls, deployability, accepting ether or unknown calls;
- `virtual` functions: an empty body is the intentional default of an extension hook meant to be overridden (deviation from Aderyn, which has no such exemption);
- `payable` functions: an intentional ether sink, e.g. `function deposit() external payable {}` (deviation from Aderyn).

Functions without a body (interfaces, abstract declarations) never fire, and an empty modifier body is a solc compile error (2883), so it never reaches the linter. Empty blocks nested inside a non-empty body (`if (x) {}`) are out of scope: the checklist item is "Empty function body", while Aderyn also flags any nested empty block.

`BooleanCst.sol` had an intentionally empty test helper (`takesBool`) that the new lint flags; it now has a trivial body so the fixture stays single-lint.

## Test

`testdata/EmptyBlock.sol` covers the firing forms (free function, library function, each visibility and mutability, comment-only body, empty non-virtual override, empty body behind a modifier) and the exempt forms (constructor with a parameter, constructor with a base call, receive/fallback, virtual hook, virtual override middle hook, payable sink, bodiless declaration, nested empty `if`).

Running the detector over the repo's own `testdata/` Solidity fixtures yields 16 findings, all empty test helpers in `.t.sol` files (e.g. `doNotRevert()` in `cheats/ExpectRevert.t.sol`), none in non-test sources.

Part of #14381.