### PR TITLE
feat(bench): add PR bench helpers for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,38 @@ with", or command lists unless explicitly requested. Do not use templates,
 bullet lists, or long essays. When writing PR bodies from scripts, use a file or
 heredoc with real newlines; never pass escaped `\n` sequences.
 
+### Performance PRs
+
+When drafting or updating a PR body for a performance-related change, benchmark
+the feature branch against `master` or the user-specified base before writing the
+performance claims.
+
+- Use the local benchmark runners under `benches/` unless the user explicitly
+  asks for GitHub Actions or the Derek/decofe automation.
+- Use `foundry-bench` when the claim is about elapsed time for a Foundry command
+  on an existing Solidity project: `forge build`, cached rebuilds, `forge test`,
+  fuzz-test replay, isolated tests, coverage, or focused symbolic tests.
+- For invariant or campaign-style benchmarking, use `foundry-scfuzzbench`; this
+  is the local equivalent of the `derek bench invariant`/`decofe bench
+  invariant` PR flow, which publishes a `scfuzzbench` event.
+- The local runners do not compare two local refs in one invocation. Run the
+  baseline and candidate separately, with identical benchmark inputs, timeout,
+  worker count, environment, target repository, and output schema.
+- For branch-vs-base PR comparisons, use the profiling profile
+  (`FOUNDRY_BENCH_LOCAL_BUILD_PROFILE=profiling`) rather than an ad hoc debug or
+  release build. Keep ordinary `foundry-bench --versions local` comparisons on
+  the default release distribution profile.
+- Include only benchmarks that exercise the changed path. Do not pad the PR body
+  with unrelated benchmark suites.
+- Report both wall-time results and domain counters when available, for example
+  solver queries, reported solver time, throughput, coverage relscore/relcov,
+  or invariant findings.
+- If results are neutral, noisy, or regress a secondary metric, state that
+  directly. Do not convert noise into a performance claim.
+- Keep the PR body short: one paragraph explaining the optimization and why it
+  is correct, followed by a `### Results` table.
+- Exact benchmark commands and result-table mechanics in `benches/README.md`.
+
 ## Notes
 
 - Use `RUST_LOG=<filter>` for debugging CLI internals, for example

--- a/benches/README.md
+++ b/benches/README.md
@@ -86,6 +86,95 @@ foundry-bench --verbose
 foundry-bench --output-dir ./results --output-file LATEST_RESULTS.md
 ```
 
+## Branch vs master PR-body workflow
+
+Use this workflow when preparing performance numbers for a PR body. It keeps the
+baseline and candidate builds isolated and makes the final table easy to audit.
+
+### Command timing with foundry-bench
+
+Use `foundry-bench` when the performance claim is about elapsed time for a
+Foundry command on an existing Solidity repository. It answers questions like:
+
+- Did this branch make `forge build` faster or slower?
+- Did cached rebuilds change?
+- Did `forge test` or `forge test --isolate` change?
+- Did fuzz-test execution time change?
+- Did `forge coverage --ir-minimum` change?
+- Did focused symbolic test wall time or solver counters change?
+
+Do not use `foundry-bench` for long-running invariant campaign quality,
+throughput, corpus, showmap, or differential-coverage comparisons. Use
+`foundry-scfuzzbench` for those.
+
+Pick `BENCHMARKS` from the changed path:
+
+| Changed path | Suggested `BENCHMARKS` |
+| --- | --- |
+| Compiler, artifact caching, project graph, dependency resolution | `forge_build_no_cache,forge_build_with_cache` |
+| Test runner, EVM execution, cheatcodes, traces used by tests | `forge_test` |
+| Isolation semantics or per-test state reset | `forge_isolate_test` |
+| Fuzz runner execution overhead, fuzz fixtures, corpus replay behavior | `forge_fuzz_test` |
+| Coverage instrumentation or report generation | `forge_coverage` |
+| Symbolic executor or SMT solving | `forge_symbolic_test` |
+
+Pick `REPOS` so the external project actually exercises the changed path. Use a
+single focused repo first, then add more only if the result would otherwise be
+unconvincing. The workflow accepts the same repo syntax as normal
+`foundry-bench`: `org/repo[:rev][ <extra forge args>]`.
+
+Examples:
+
+```bash
+# Test-runner or EVM execution change.
+BENCHMARKS=forge_test
+REPOS="ithacaxyz/account:v0.5.7"
+
+# Build/cache change.
+BENCHMARKS=forge_build_no_cache,forge_build_with_cache
+REPOS="vectorized/solady:v0.1.26"
+
+# Coverage change.
+BENCHMARKS=forge_coverage
+REPOS="uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75"
+
+# Symbolic change with focused counters.
+BENCHMARKS=forge_symbolic_test
+REPOS="Vectorized/solady:v0.1.26"
+```
+
+Run the matched branch-vs-base timing comparison:
+
+```bash
+BASE_REF=origin/master \
+BENCHMARKS=forge_test \
+REPOS="ithacaxyz/account:v0.5.7,vectorized/solady:v0.1.26" \
+benches/scripts/pr-bench.sh
+```
+
+The script builds the `foundry-bench` harness from the current checkout once,
+then points it at each checked-out workspace with
+`FOUNDRY_BENCH_WORKSPACE_ROOT`. The `local` version builds and activates that
+workspace with `FOUNDRY_BENCH_LOCAL_BUILD_PROFILE=profiling` before each run.
+Keep `REPOS`, `BENCHMARKS`, and any per-repo extra arguments identical for
+`master` and `candidate`. Override `CANDIDATE_REF`, `RUN_ID`, or `BENCH_ROOT`
+when needed.
+
+For PR bodies, reduce the two JSON/Markdown outputs into a concise table:
+
+```md
+### Results
+
+| Benchmark | master | this PR | delta |
+| --- | ---: | ---: | ---: |
+| `forge_test/ithacaxyz-account` wall time | ... | ... | ... |
+```
+
+Include domain counters next to wall time when the benchmark produces them, for
+example symbolic solver queries, reported solver time, invariant throughput, or
+coverage relscore/relcov. If the delta is within noise, describe it as neutral
+or inconclusive.
+
 ## Running scfuzzbench Campaigns
 
 `foundry-scfuzzbench` runs a local scfuzzbench Foundry campaign, invokes the scfuzzbench
@@ -102,6 +191,28 @@ cargo run -p foundry-bench --bin foundry-scfuzzbench -- \
   --output-dir /tmp/foundry-scfuzzbench-aave \
   --foundry-bin "$(command -v forge)"
 ```
+
+To compare a feature branch against `master` locally, run two matched campaigns:
+one with a `forge` binary built from `master`, and one with a `forge` binary
+built from the candidate branch. The runner intentionally records each campaign
+separately; compare the resulting artifact bundles when drafting the PR body.
+
+```bash
+TARGET_REPO=https://github.com/Recon-Fuzz/aave-v4-scfuzzbench.git \
+TARGET_REF=v0.5.6-recon \
+BENCHMARK_TYPE=property \
+TIMEOUT_SECONDS=3600 \
+WORKERS=1 \
+benches/scripts/pr-scfuzzbench.sh
+```
+
+Use the same `TARGET_REPO`, `TARGET_REF`, `BENCHMARK_TYPE`,
+`TIMEOUT_SECONDS`, `WORKERS`, and `FOUNDRY_TEST_ARGS` for both runs. For
+optimization campaigns, pass the same `PROPERTIES_PATH` to both runs. Summarize
+the PR body from `llm_summary.md`, `REPORT.md`, `summary.csv`,
+`cumulative.csv`, and the differential coverage artifacts in each output
+directory. Override `BASE_REF`, `CANDIDATE_REF`, `RUN_ID`, or `BENCH_ROOT` when
+needed.
 
 By default the runner pins `https://github.com/tempoxyz/scfuzzbench.git@main`. Override that with
 `--scfuzzbench-repo` and `--scfuzzbench-ref` while the scfuzzbench changes are being upstreamed.

--- a/benches/scripts/pr-bench.sh
+++ b/benches/scripts/pr-bench.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/master}"
+CANDIDATE_REF="${CANDIDATE_REF:-HEAD}"
+BENCHMARKS="${BENCHMARKS:-forge_test}"
+REPOS="${REPOS:-ithacaxyz/account:v0.5.7}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%d%H%M%S)}"
+BENCH_ROOT="${BENCH_ROOT:-/tmp/foundry-pr-bench-${RUN_ID}}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+git fetch origin master
+
+mkdir -p "${BENCH_ROOT}/results"
+git worktree add --detach "${BENCH_ROOT}/master" "${BASE_REF}"
+git worktree add --detach "${BENCH_ROOT}/candidate" "${CANDIDATE_REF}"
+
+cargo build --locked --release --bin foundry-bench
+
+for label in master candidate; do
+  (
+    foundry_dir="${BENCH_ROOT}/${label}/.foundry"
+    FOUNDRY_BENCH_WORKSPACE_ROOT="${BENCH_ROOT}/${label}" \
+      FOUNDRY_BENCH_LOCAL_BUILD_PROFILE=profiling \
+      FOUNDRY_DIR="${foundry_dir}" \
+      PATH="${foundry_dir}/bin:${PATH}" \
+      "${REPO_ROOT}/target/release/foundry-bench" \
+        --versions local \
+        --repos "${REPOS}" \
+        --benchmarks "${BENCHMARKS}" \
+        --output-dir "${BENCH_ROOT}/results" \
+        --output-file "${label}.md" \
+        --json-output "${label}.json" \
+        --verbose
+  )
+done
+
+printf 'Benchmark results written to %s/results\n' "${BENCH_ROOT}"

--- a/benches/scripts/pr-bench.sh
+++ b/benches/scripts/pr-bench.sh
@@ -7,13 +7,17 @@ BENCHMARKS="${BENCHMARKS:-forge_test}"
 REPOS="${REPOS:-ithacaxyz/account:v0.5.7}"
 RUN_ID="${RUN_ID:-$(date -u +%Y%m%d%H%M%S)}"
 BENCH_ROOT="${BENCH_ROOT:-/tmp/foundry-pr-bench-${RUN_ID}}"
-RUNNER_TARGET_DIR="${BENCH_ROOT}/runner-target"
-RUNNER_BIN="${RUNNER_TARGET_DIR}/release/foundry-bench"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 cd "${REPO_ROOT}"
+
+if [[ "${BENCH_ROOT}" != /* ]]; then
+  BENCH_ROOT="${REPO_ROOT}/${BENCH_ROOT}"
+fi
+RUNNER_TARGET_DIR="${BENCH_ROOT}/runner-target"
+RUNNER_BIN="${RUNNER_TARGET_DIR}/release/foundry-bench"
 
 if [[ -n "$(git status --porcelain)" ]]; then
   printf 'error: working directory is dirty; commit or stash changes before benchmarking\n' >&2

--- a/benches/scripts/pr-bench.sh
+++ b/benches/scripts/pr-bench.sh
@@ -7,6 +7,8 @@ BENCHMARKS="${BENCHMARKS:-forge_test}"
 REPOS="${REPOS:-ithacaxyz/account:v0.5.7}"
 RUN_ID="${RUN_ID:-$(date -u +%Y%m%d%H%M%S)}"
 BENCH_ROOT="${BENCH_ROOT:-/tmp/foundry-pr-bench-${RUN_ID}}"
+RUNNER_TARGET_DIR="${BENCH_ROOT}/runner-target"
+RUNNER_BIN="${RUNNER_TARGET_DIR}/release/foundry-bench"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -24,16 +26,17 @@ mkdir -p "${BENCH_ROOT}/results"
 git worktree add --detach "${BENCH_ROOT}/master" "${BASE_REF}"
 git worktree add --detach "${BENCH_ROOT}/candidate" "${CANDIDATE_REF}"
 
-cargo build --locked --release --bin foundry-bench
+CARGO_TARGET_DIR="${RUNNER_TARGET_DIR}" cargo build --locked --release --bin foundry-bench
 
 for label in master candidate; do
   (
+    unset CARGO_TARGET_DIR
     foundry_dir="${BENCH_ROOT}/${label}/.foundry"
     FOUNDRY_BENCH_WORKSPACE_ROOT="${BENCH_ROOT}/${label}" \
       FOUNDRY_BENCH_LOCAL_BUILD_PROFILE=profiling \
       FOUNDRY_DIR="${foundry_dir}" \
       PATH="${foundry_dir}/bin:${PATH}" \
-      "${REPO_ROOT}/target/release/foundry-bench" \
+      "${RUNNER_BIN}" \
         --versions local \
         --repos "${REPOS}" \
         --benchmarks "${BENCHMARKS}" \

--- a/benches/scripts/pr-bench.sh
+++ b/benches/scripts/pr-bench.sh
@@ -13,6 +13,11 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 cd "${REPO_ROOT}"
 
+if [[ -n "$(git status --porcelain)" ]]; then
+  printf 'error: working directory is dirty; commit or stash changes before benchmarking\n' >&2
+  exit 1
+fi
+
 git fetch origin master
 
 mkdir -p "${BENCH_ROOT}/results"

--- a/benches/scripts/pr-scfuzzbench.sh
+++ b/benches/scripts/pr-scfuzzbench.sh
@@ -12,13 +12,17 @@ FOUNDRY_TEST_ARGS="${FOUNDRY_TEST_ARGS:-}"
 PROPERTIES_PATH="${PROPERTIES_PATH:-}"
 RUN_ID="${RUN_ID:-$(date -u +%Y%m%d%H%M%S)}"
 BENCH_ROOT="${BENCH_ROOT:-/tmp/foundry-scfuzzbench-${RUN_ID}}"
-RUNNER_TARGET_DIR="${BENCH_ROOT}/runner-target"
-RUNNER_BIN="${RUNNER_TARGET_DIR}/release/foundry-scfuzzbench"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 cd "${REPO_ROOT}"
+
+if [[ "${BENCH_ROOT}" != /* ]]; then
+  BENCH_ROOT="${REPO_ROOT}/${BENCH_ROOT}"
+fi
+RUNNER_TARGET_DIR="${BENCH_ROOT}/runner-target"
+RUNNER_BIN="${RUNNER_TARGET_DIR}/release/foundry-scfuzzbench"
 
 if [[ -n "$(git status --porcelain)" ]]; then
   printf 'error: working directory is dirty; commit or stash changes before benchmarking\n' >&2

--- a/benches/scripts/pr-scfuzzbench.sh
+++ b/benches/scripts/pr-scfuzzbench.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/master}"
+CANDIDATE_REF="${CANDIDATE_REF:-HEAD}"
+TARGET_REPO="${TARGET_REPO:-https://github.com/Recon-Fuzz/aave-v4-scfuzzbench.git}"
+TARGET_REF="${TARGET_REF:-v0.5.6-recon}"
+BENCHMARK_TYPE="${BENCHMARK_TYPE:-property}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-3600}"
+WORKERS="${WORKERS:-1}"
+FOUNDRY_TEST_ARGS="${FOUNDRY_TEST_ARGS:-}"
+PROPERTIES_PATH="${PROPERTIES_PATH:-}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%d%H%M%S)}"
+BENCH_ROOT="${BENCH_ROOT:-/tmp/foundry-scfuzzbench-${RUN_ID}}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "${REPO_ROOT}"
+
+git fetch origin master
+
+mkdir -p "${BENCH_ROOT}"
+git worktree add --detach "${BENCH_ROOT}/master" "${BASE_REF}"
+git worktree add --detach "${BENCH_ROOT}/candidate" "${CANDIDATE_REF}"
+
+(
+  cd "${REPO_ROOT}"
+  cargo build --locked --release --bin foundry-scfuzzbench
+)
+
+for label in master candidate; do
+  (
+    cd "${BENCH_ROOT}/${label}"
+    cargo build --locked --profile profiling --bin forge
+  )
+
+  args=(
+    --target-repo "${TARGET_REPO}"
+    --target-ref "${TARGET_REF}"
+    --benchmark-type "${BENCHMARK_TYPE}"
+    --timeout-seconds "${TIMEOUT_SECONDS}"
+    --workers "${WORKERS}"
+    --output-dir "${BENCH_ROOT}/${label}-artifacts"
+    --foundry-bin "${BENCH_ROOT}/${label}/target/profiling/forge"
+  )
+
+  if [[ -n "${FOUNDRY_TEST_ARGS}" ]]; then
+    args+=(--foundry-test-args "${FOUNDRY_TEST_ARGS}")
+  fi
+
+  if [[ -n "${PROPERTIES_PATH}" ]]; then
+    args+=(--properties-path "${PROPERTIES_PATH}")
+  fi
+
+  "${REPO_ROOT}/target/release/foundry-scfuzzbench" "${args[@]}"
+done
+
+printf 'scfuzzbench artifacts written under %s\n' "${BENCH_ROOT}"

--- a/benches/scripts/pr-scfuzzbench.sh
+++ b/benches/scripts/pr-scfuzzbench.sh
@@ -12,6 +12,8 @@ FOUNDRY_TEST_ARGS="${FOUNDRY_TEST_ARGS:-}"
 PROPERTIES_PATH="${PROPERTIES_PATH:-}"
 RUN_ID="${RUN_ID:-$(date -u +%Y%m%d%H%M%S)}"
 BENCH_ROOT="${BENCH_ROOT:-/tmp/foundry-scfuzzbench-${RUN_ID}}"
+RUNNER_TARGET_DIR="${BENCH_ROOT}/runner-target"
+RUNNER_BIN="${RUNNER_TARGET_DIR}/release/foundry-scfuzzbench"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -31,13 +33,15 @@ git worktree add --detach "${BENCH_ROOT}/candidate" "${CANDIDATE_REF}"
 
 (
   cd "${REPO_ROOT}"
-  cargo build --locked --release --bin foundry-scfuzzbench
+  CARGO_TARGET_DIR="${RUNNER_TARGET_DIR}" cargo build --locked --release --bin foundry-scfuzzbench
 )
 
 for label in master candidate; do
+  foundry_target_dir="${BENCH_ROOT}/${label}-target"
+
   (
     cd "${BENCH_ROOT}/${label}"
-    cargo build --locked --profile profiling --bin forge
+    CARGO_TARGET_DIR="${foundry_target_dir}" cargo build --locked --profile profiling --bin forge
   )
 
   args=(
@@ -47,7 +51,7 @@ for label in master candidate; do
     --timeout-seconds "${TIMEOUT_SECONDS}"
     --workers "${WORKERS}"
     --output-dir "${BENCH_ROOT}/${label}-artifacts"
-    --foundry-bin "${BENCH_ROOT}/${label}/target/profiling/forge"
+    --foundry-bin "${foundry_target_dir}/profiling/forge"
   )
 
   if [[ -n "${FOUNDRY_TEST_ARGS}" ]]; then
@@ -58,7 +62,7 @@ for label in master candidate; do
     args+=(--properties-path "${PROPERTIES_PATH}")
   fi
 
-  "${REPO_ROOT}/target/release/foundry-scfuzzbench" "${args[@]}"
+  "${RUNNER_BIN}" "${args[@]}"
 done
 
 printf 'scfuzzbench artifacts written under %s\n' "${BENCH_ROOT}"

--- a/benches/scripts/pr-scfuzzbench.sh
+++ b/benches/scripts/pr-scfuzzbench.sh
@@ -18,6 +18,11 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 cd "${REPO_ROOT}"
 
+if [[ -n "$(git status --porcelain)" ]]; then
+  printf 'error: working directory is dirty; commit or stash changes before benchmarking\n' >&2
+  exit 1
+fi
+
 git fetch origin master
 
 mkdir -p "${BENCH_ROOT}"

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -770,7 +770,9 @@ fn stddev(values: &[f64]) -> Option<f64> {
 /// The workspace root, embedded at compile time.
 /// `benches/` is one level below the workspace root.
 const WORKSPACE_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
-const LOCAL_BUILD_PROFILE: &str = "dist";
+const WORKSPACE_ROOT_ENV: &str = "FOUNDRY_BENCH_WORKSPACE_ROOT";
+const LOCAL_BUILD_PROFILE_ENV: &str = "FOUNDRY_BENCH_LOCAL_BUILD_PROFILE";
+const DEFAULT_LOCAL_BUILD_PROFILE: &str = "dist";
 const FOUNDRY_BINS: [&str; 4] = ["forge", "cast", "anvil", "chisel"];
 
 /// Switch to a specific foundry version.
@@ -804,20 +806,20 @@ pub fn switch_foundry_version(version: &str) -> Result<()> {
     Ok(())
 }
 
-/// Build and activate the local workspace using the release distribution profile.
-/// Builds only the shipped Foundry binaries to match the profile of the
-/// downloaded release artifacts without linking unused workspace binaries.
+/// Build and activate the local workspace.
+/// Builds only the shipped Foundry binaries without linking unused workspace binaries.
 #[allow(unused_must_use)]
 pub fn install_local_version() -> Result<()> {
-    let workspace =
-        std::fs::canonicalize(WORKSPACE_ROOT).wrap_err("Failed to resolve workspace root")?;
+    let workspace = workspace_root()?;
+    let profile = local_build_profile();
     sh_println!(
-        "  Building local workspace at {} with {LOCAL_BUILD_PROFILE} profile",
-        workspace.display()
+        "  Building local workspace at {} with {} profile",
+        workspace.display(),
+        profile.to_string_lossy()
     );
 
     let mut cmd = Command::new("cargo");
-    cmd.current_dir(&workspace).args(["build", "--locked", "--profile", LOCAL_BUILD_PROFILE]);
+    cmd.current_dir(&workspace).args(["build", "--locked", "--profile"]).arg(&profile);
     for bin in FOUNDRY_BINS {
         cmd.args(["--bin", bin]);
     }
@@ -828,18 +830,32 @@ pub fn install_local_version() -> Result<()> {
         eyre::bail!("local Foundry build failed");
     }
 
-    activate_local_binaries(&workspace)?;
-    sh_println!("  Successfully activated local {LOCAL_BUILD_PROFILE} build");
+    activate_local_binaries(&workspace, &profile)?;
+    sh_println!("  Successfully activated local {} build", profile.to_string_lossy());
     Ok(())
 }
 
-fn activate_local_binaries(workspace: &Path) -> Result<()> {
+fn workspace_root() -> Result<PathBuf> {
+    let workspace = env::var_os(WORKSPACE_ROOT_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(WORKSPACE_ROOT));
+    std::fs::canonicalize(&workspace)
+        .wrap_err_with(|| format!("Failed to resolve workspace root {}", workspace.display()))
+}
+
+fn local_build_profile() -> std::ffi::OsString {
+    env::var_os(LOCAL_BUILD_PROFILE_ENV)
+        .filter(|profile| !profile.is_empty())
+        .unwrap_or_else(|| DEFAULT_LOCAL_BUILD_PROFILE.into())
+}
+
+fn activate_local_binaries(workspace: &Path, profile: &std::ffi::OsStr) -> Result<()> {
     let bin_dir = foundry_bin_dir()?;
     fs::create_dir_all(&bin_dir).wrap_err_with(|| {
         format!("Failed to create Foundry bin directory at {}", bin_dir.display())
     })?;
 
-    let local_bin_dir = workspace.join("target").join(LOCAL_BUILD_PROFILE);
+    let local_bin_dir = workspace.join("target").join(profile);
     for bin in FOUNDRY_BINS {
         let bin_name = format!("{bin}{}", env::consts::EXE_SUFFIX);
         let source = local_bin_dir.join(&bin_name);


### PR DESCRIPTION
This adds local helpers for generating PR performance numbers from matched branch-vs-master benchmark runs. The timing helper builds one foundry-bench harness from the current checkout, points it at isolated base and candidate worktrees, and activates each checked-out Foundry build through an isolated `FOUNDRY_DIR/PATH` so the measured forge matches the intended ref.

The docs keep AGENTS.md at the policy level while keeping the operational command sequences into benches/scripts. The default `foundry-bench` local profile remains release-like for `stable/nightly` comparisons, while the PR helper opts into the `profiling` profile explicitly for branch-vs-master runs.

Authored with AI assistance.
