### PR TITLE
feat(symbolic): target fuzz branch frontiers

### DIFF
--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -55,6 +55,8 @@ const SYMBOLIC_KEYS: &[&str] = &[
     "use_fuzz_frontiers",
     "frontier_limit",
     "frontier_ids",
+    "frontier_pcs",
+    "frontier_selectors",
     "solver",
     "solver_command",
     "solver_portfolio",

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -54,6 +54,7 @@ const SYMBOLIC_KEYS: &[&str] = &[
     "corpus_seed_limit",
     "use_fuzz_frontiers",
     "frontier_limit",
+    "frontier_ids",
     "solver",
     "solver_command",
     "solver_portfolio",

--- a/crates/config/src/symbolic.rs
+++ b/crates/config/src/symbolic.rs
@@ -45,6 +45,12 @@ pub struct SymbolicConfig {
     /// Fuzz branch frontier artifact IDs to import. Empty imports by artifact order.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub frontier_ids: Vec<u64>,
+    /// Fuzz branch frontier comparison program counters to import. Empty imports any PC.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub frontier_pcs: Vec<usize>,
+    /// Fuzz branch frontier calldata selectors to import. Empty imports any selector.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub frontier_selectors: Vec<String>,
     /// Solver executable to invoke.
     pub solver: String,
     /// Exact solver command to invoke. When set, this overrides `solver`.
@@ -110,6 +116,8 @@ impl Default for SymbolicConfig {
             use_fuzz_frontiers: false,
             frontier_limit: 256,
             frontier_ids: Vec::new(),
+            frontier_pcs: Vec::new(),
+            frontier_selectors: Vec::new(),
             solver: "z3".to_string(),
             solver_command: None,
             solver_portfolio: Vec::new(),
@@ -168,6 +176,8 @@ mod tests {
             "use_fuzz_frontiers": false,
             "frontier_limit": 256,
             "frontier_ids": [],
+            "frontier_pcs": [],
+            "frontier_selectors": [],
             "solver": "z3",
             "timeout": 30,
             "max_depth": 10000,

--- a/crates/config/src/symbolic.rs
+++ b/crates/config/src/symbolic.rs
@@ -42,6 +42,9 @@ pub struct SymbolicConfig {
     pub use_fuzz_frontiers: bool,
     /// Maximum number of fuzz branch frontiers to try for one symbolic run.
     pub frontier_limit: usize,
+    /// Fuzz branch frontier artifact IDs to import. Empty imports by artifact order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub frontier_ids: Vec<u64>,
     /// Solver executable to invoke.
     pub solver: String,
     /// Exact solver command to invoke. When set, this overrides `solver`.
@@ -106,6 +109,7 @@ impl Default for SymbolicConfig {
             corpus_seed_limit: 32,
             use_fuzz_frontiers: false,
             frontier_limit: 256,
+            frontier_ids: Vec::new(),
             solver: "z3".to_string(),
             solver_command: None,
             solver_portfolio: Vec::new(),
@@ -163,6 +167,7 @@ mod tests {
             "corpus_seed_limit": 32,
             "use_fuzz_frontiers": false,
             "frontier_limit": 256,
+            "frontier_ids": [],
             "solver": "z3",
             "timeout": 30,
             "max_depth": 10000,

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -159,6 +159,20 @@ recorded one-call seed as a path-priority hint, constrains symbolic execution to
 flip the captured comparison result, and persists only candidates that replay
 with the expected concrete outcome.
 
+To focus solver time on specific captured sites, pass frontier artifact IDs:
+
+```sh
+forge test --match-test test_hard_branch \
+  --fuzz-frontier-dir fuzz_frontiers \
+  --fuzz-corpus-dir fuzz_corpus \
+  --symbolic-use-fuzz-frontiers \
+  --symbolic-frontier-ids 3,7
+```
+
+`symbolic.frontier_ids` defaults to `[]`, which preserves artifact-order import.
+When set, Forge only imports matching frontier IDs and warns if a requested ID
+cannot be imported.
+
 > **Hash-model caveat:** `PASS` also assumes collision and preimage resistance
 > for symbolic `KECCAK256` and hash-like precompile terms. The executor may use
 > equal symbolic hashes to infer equal symbolic preimages or lengths in modeled
@@ -319,6 +333,7 @@ default_array_lengths = []
 default_bytes_lengths = []
 max_calldata_bytes = 4096
 invariant_depth = 10
+frontier_ids = []
 symbolic_call_targets = false
 dump_smt = false
 storage_layout = "solidity"

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -159,19 +159,27 @@ recorded one-call seed as a path-priority hint, constrains symbolic execution to
 flip the captured comparison result, and persists only candidates that replay
 with the expected concrete outcome.
 
-To focus solver time on specific captured sites, pass frontier artifact IDs:
+To focus solver time on specific captured sites, pass frontier artifact IDs,
+comparison PCs, or calldata selectors:
 
 ```sh
 forge test --match-test test_hard_branch \
   --fuzz-frontier-dir fuzz_frontiers \
   --fuzz-corpus-dir fuzz_corpus \
   --symbolic-use-fuzz-frontiers \
-  --symbolic-frontier-ids 3,7
+  --symbolic-frontier-ids 3,7 \
+  --symbolic-frontier-pcs 128,412 \
+  --symbolic-frontier-selectors 0x12345678
 ```
 
-`symbolic.frontier_ids` defaults to `[]`, which preserves artifact-order import.
-When set, Forge only imports matching frontier IDs and warns if a requested ID
-cannot be imported.
+`symbolic.frontier_ids`, `symbolic.frontier_pcs`, and
+`symbolic.frontier_selectors` default to `[]`, meaning any value for that
+dimension. Non-empty filters compose conjunctively, so the example imports only
+records matching one of the requested IDs, one of the requested PCs, and one of
+the requested selectors. Forge keeps the artifact order as the priority order
+after filtering, imports up to `symbolic.frontier_limit` records, reports how
+many records were imported or skipped by target filters, and warns if a
+requested target cannot be imported.
 
 > **Hash-model caveat:** `PASS` also assumes collision and preimage resistance
 > for symbolic `KECCAK256` and hash-like precompile terms. The executor may use
@@ -334,6 +342,8 @@ default_bytes_lengths = []
 max_calldata_bytes = 4096
 invariant_depth = 10
 frontier_ids = []
+frontier_pcs = []
+frontier_selectors = []
 symbolic_call_targets = false
 dump_smt = false
 storage_layout = "solidity"

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -694,6 +694,19 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_SYMBOLIC_FRONTIER_IDS", value_name = "IDS", value_delimiter = ',')]
     pub symbolic_frontier_ids: Option<Vec<u64>>,
 
+    /// Comma-separated fuzz branch frontier comparison PCs to try.
+    #[arg(long, env = "FOUNDRY_SYMBOLIC_FRONTIER_PCS", value_name = "PCS", value_delimiter = ',')]
+    pub symbolic_frontier_pcs: Option<Vec<usize>>,
+
+    /// Comma-separated fuzz branch frontier calldata selectors to try.
+    #[arg(
+        long,
+        env = "FOUNDRY_SYMBOLIC_FRONTIER_SELECTORS",
+        value_name = "SELECTORS",
+        value_delimiter = ','
+    )]
+    pub symbolic_frontier_selectors: Option<Vec<String>>,
+
     /// Solver executable used for symbolic tests.
     #[arg(long, env = "FOUNDRY_SYMBOLIC_SOLVER", value_name = "PATH_OR_NAME")]
     pub symbolic_solver: Option<String>,
@@ -2811,6 +2824,12 @@ impl Provider for TestArgs {
         if let Some(frontier_ids) = self.symbolic_frontier_ids.clone() {
             symbolic_dict.insert("frontier_ids".to_string(), frontier_ids.into());
         }
+        if let Some(frontier_pcs) = self.symbolic_frontier_pcs.clone() {
+            symbolic_dict.insert("frontier_pcs".to_string(), frontier_pcs.into());
+        }
+        if let Some(frontier_selectors) = self.symbolic_frontier_selectors.clone() {
+            symbolic_dict.insert("frontier_selectors".to_string(), frontier_selectors.into());
+        }
         if let Some(solver) = self.symbolic_solver.clone() {
             symbolic_dict.insert("solver".to_string(), solver.into());
         }
@@ -3491,6 +3510,10 @@ mod tests {
             "3",
             "--symbolic-frontier-ids",
             "4,9",
+            "--symbolic-frontier-pcs",
+            "123,456",
+            "--symbolic-frontier-selectors",
+            "0x12345678,deadbeef",
             "--invariant-depth",
             "300",
             "--invariant-min-depth",
@@ -3548,6 +3571,14 @@ mod tests {
         assert!(figment.extract_inner::<bool>("symbolic.use_fuzz_frontiers").unwrap());
         assert_eq!(figment.extract_inner::<usize>("symbolic.frontier_limit").unwrap(), 3);
         assert_eq!(figment.extract_inner::<Vec<u64>>("symbolic.frontier_ids").unwrap(), vec![4, 9]);
+        assert_eq!(
+            figment.extract_inner::<Vec<usize>>("symbolic.frontier_pcs").unwrap(),
+            vec![123, 456]
+        );
+        assert_eq!(
+            figment.extract_inner::<Vec<String>>("symbolic.frontier_selectors").unwrap(),
+            vec!["0x12345678", "deadbeef"]
+        );
         assert_eq!(figment.extract_inner::<u32>("invariant.depth").unwrap(), 300);
         assert_eq!(figment.extract_inner::<u32>("invariant.min_depth").unwrap(), 20);
         assert_eq!(
@@ -3595,6 +3626,8 @@ mod tests {
         assert!(config.symbolic.use_fuzz_frontiers);
         assert_eq!(config.symbolic.frontier_limit, 3);
         assert_eq!(config.symbolic.frontier_ids, vec![4, 9]);
+        assert_eq!(config.symbolic.frontier_pcs, vec![123, 456]);
+        assert_eq!(config.symbolic.frontier_selectors, vec!["0x12345678", "deadbeef"]);
         assert_eq!(config.invariant.depth, 300);
         assert_eq!(config.invariant.min_depth, 20);
         assert_eq!(config.invariant.depth_mode, InvariantDepthMode::Random);

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -690,6 +690,10 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_SYMBOLIC_FRONTIER_LIMIT", value_name = "COUNT")]
     pub symbolic_frontier_limit: Option<usize>,
 
+    /// Comma-separated fuzz branch frontier artifact IDs to try.
+    #[arg(long, env = "FOUNDRY_SYMBOLIC_FRONTIER_IDS", value_name = "IDS", value_delimiter = ',')]
+    pub symbolic_frontier_ids: Option<Vec<u64>>,
+
     /// Solver executable used for symbolic tests.
     #[arg(long, env = "FOUNDRY_SYMBOLIC_SOLVER", value_name = "PATH_OR_NAME")]
     pub symbolic_solver: Option<String>,
@@ -2804,6 +2808,9 @@ impl Provider for TestArgs {
         if let Some(frontier_limit) = self.symbolic_frontier_limit {
             symbolic_dict.insert("frontier_limit".to_string(), frontier_limit.into());
         }
+        if let Some(frontier_ids) = self.symbolic_frontier_ids.clone() {
+            symbolic_dict.insert("frontier_ids".to_string(), frontier_ids.into());
+        }
         if let Some(solver) = self.symbolic_solver.clone() {
             symbolic_dict.insert("solver".to_string(), solver.into());
         }
@@ -3482,6 +3489,8 @@ mod tests {
             "--symbolic-use-fuzz-frontiers",
             "--symbolic-frontier-limit",
             "3",
+            "--symbolic-frontier-ids",
+            "4,9",
             "--invariant-depth",
             "300",
             "--invariant-min-depth",
@@ -3538,6 +3547,7 @@ mod tests {
         assert_eq!(figment.extract_inner::<u32>("fuzz.mutation_weight_cmp").unwrap(), 5);
         assert!(figment.extract_inner::<bool>("symbolic.use_fuzz_frontiers").unwrap());
         assert_eq!(figment.extract_inner::<usize>("symbolic.frontier_limit").unwrap(), 3);
+        assert_eq!(figment.extract_inner::<Vec<u64>>("symbolic.frontier_ids").unwrap(), vec![4, 9]);
         assert_eq!(figment.extract_inner::<u32>("invariant.depth").unwrap(), 300);
         assert_eq!(figment.extract_inner::<u32>("invariant.min_depth").unwrap(), 20);
         assert_eq!(
@@ -3584,6 +3594,7 @@ mod tests {
         assert_eq!(config.fuzz.corpus.mutation_weights.mutation_weight_cmp, 5);
         assert!(config.symbolic.use_fuzz_frontiers);
         assert_eq!(config.symbolic.frontier_limit, 3);
+        assert_eq!(config.symbolic.frontier_ids, vec![4, 9]);
         assert_eq!(config.invariant.depth, 300);
         assert_eq!(config.invariant.min_depth, 20);
         assert_eq!(config.invariant.depth_mode, InvariantDepthMode::Random);

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1881,17 +1881,40 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         }
 
         let requested_ids = &self.config.symbolic.frontier_ids;
+        let requested_pcs = &self.config.symbolic.frontier_pcs;
+        let requested_selectors = &self.config.symbolic.frontier_selectors;
+        let parsed_selectors = parse_frontier_selectors(requested_selectors, &signature);
         let select_frontier_ids = !requested_ids.is_empty();
+        let select_frontier_pcs = !requested_pcs.is_empty();
+        let select_frontier_selectors = !requested_selectors.is_empty();
+        let selection_active =
+            select_frontier_ids || select_frontier_pcs || select_frontier_selectors;
         let mut skipped_by_selection = 0usize;
         let mut imported_ids = Vec::new();
+        let mut imported_pcs = Vec::new();
+        let mut imported_selectors = Vec::new();
         let mut imported = Vec::with_capacity(limit.min(artifact.frontiers.len()));
         for frontier in artifact.frontiers {
-            if imported.len() == limit {
-                break;
-            }
             if select_frontier_ids && !requested_ids.contains(&frontier.id) {
                 skipped_by_selection += 1;
                 continue;
+            }
+            if select_frontier_pcs && !requested_pcs.contains(&frontier.site.pc) {
+                skipped_by_selection += 1;
+                continue;
+            }
+            if select_frontier_selectors
+                && frontier_selector(&frontier)
+                    .is_none_or(|selector| !parsed_selectors.contains(&selector))
+            {
+                skipped_by_selection += 1;
+                continue;
+            }
+            if imported.len() == limit {
+                if selection_active {
+                    continue;
+                }
+                break;
             }
             if !is_symbolic_frontier_opcode(frontier.site.opcode) {
                 debug!(
@@ -1930,6 +1953,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 input,
             });
             imported_ids.push(frontier.id);
+            imported_pcs.push(frontier.site.pc);
+            if let Some(selector) = frontier_selector(&frontier) {
+                imported_selectors.push(selector);
+            }
         }
 
         if select_frontier_ids {
@@ -1941,8 +1968,59 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         path = %frontier_path.display(),
                         "requested fuzz branch frontier was not imported"
                     );
+                    let _ = sh_warn!(
+                        "requested fuzz branch frontier id {id} was not imported for {signature}"
+                    );
                 }
             }
+        }
+        if select_frontier_pcs {
+            for pc in requested_pcs {
+                if !imported_pcs.contains(pc) {
+                    warn!(
+                        pc,
+                        test = %signature,
+                        path = %frontier_path.display(),
+                        "requested fuzz branch frontier pc was not imported"
+                    );
+                    let _ = sh_warn!(
+                        "requested fuzz branch frontier pc {pc} was not imported for {signature}"
+                    );
+                }
+            }
+        }
+        if select_frontier_selectors {
+            for selector in &parsed_selectors {
+                if !imported_selectors.contains(selector) {
+                    let selector = hex::encode_prefixed(selector);
+                    warn!(
+                        selector = %selector,
+                        test = %signature,
+                        path = %frontier_path.display(),
+                        "requested fuzz branch frontier selector was not imported"
+                    );
+                    let _ = sh_warn!(
+                        "requested fuzz branch frontier selector {selector} was not imported for \
+                         {signature}"
+                    );
+                }
+            }
+        }
+        if selection_active {
+            let id_filter = frontier_filter_display(requested_ids);
+            let pc_filter = frontier_filter_display(requested_pcs);
+            let selector_filter = if requested_selectors.is_empty() {
+                "any".to_string()
+            } else {
+                requested_selectors.iter().format(", ").to_string()
+            };
+            let _ = sh_status!(
+                "Symbolic frontier selection for {signature}: imported {}, skipped {} by target \
+                 filters (ids: {id_filter}; pcs: {pc_filter}; selectors: {selector_filter}; \
+                 limit: {limit})",
+                imported.len(),
+                skipped_by_selection
+            );
         }
 
         debug!(
@@ -1952,6 +2030,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             limit,
             skipped_by_selection,
             requested_ids = ?requested_ids,
+            requested_pcs = ?requested_pcs,
+            requested_selectors = ?requested_selectors,
             "imported fuzz branch frontiers for targeted symbolic seeding"
         );
         imported
@@ -4265,6 +4345,43 @@ fn replay_persisted_call_sequence<FEN: FoundryEvmNetwork>(
 
 const fn is_symbolic_frontier_opcode(op: u8) -> bool {
     matches!(op, opcode::EQ | opcode::LT | opcode::GT | opcode::SLT | opcode::SGT | opcode::ISZERO)
+}
+
+fn frontier_selector(frontier: &FuzzBranchFrontierRecord) -> Option<Selector> {
+    frontier
+        .sequence
+        .get(frontier.call_index)
+        .and_then(|call| call.call_details.calldata.get(..4))
+        .map(Selector::from_slice)
+}
+
+fn parse_frontier_selectors(selectors: &[String], signature: &str) -> Vec<Selector> {
+    selectors
+        .iter()
+        .filter_map(|selector| match parse_frontier_selector(selector) {
+            Some(selector) => Some(selector),
+            None => {
+                let _ = sh_warn!(
+                    "invalid symbolic frontier selector `{selector}` for {signature}; expected \
+                     a 4-byte hex selector like 0x12345678"
+                );
+                None
+            }
+        })
+        .collect()
+}
+
+fn parse_frontier_selector(selector: &str) -> Option<Selector> {
+    let selector = selector.strip_prefix("0x").unwrap_or(selector);
+    if selector.len() != 8 {
+        return None;
+    }
+    let bytes = hex::decode(selector).ok()?;
+    Some(Selector::from_slice(&bytes))
+}
+
+fn frontier_filter_display<T: std::fmt::Display>(values: &[T]) -> String {
+    if values.is_empty() { "any".to_string() } else { values.iter().format(", ").to_string() }
 }
 
 /// Helper function to set test corpus dir and to compose persisted failure paths.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1880,10 +1880,18 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             return Vec::new();
         }
 
+        let requested_ids = &self.config.symbolic.frontier_ids;
+        let select_frontier_ids = !requested_ids.is_empty();
+        let mut skipped_by_selection = 0usize;
+        let mut imported_ids = Vec::new();
         let mut imported = Vec::with_capacity(limit.min(artifact.frontiers.len()));
         for frontier in artifact.frontiers {
             if imported.len() == limit {
                 break;
+            }
+            if select_frontier_ids && !requested_ids.contains(&frontier.id) {
+                skipped_by_selection += 1;
+                continue;
             }
             if !is_symbolic_frontier_opcode(frontier.site.opcode) {
                 debug!(
@@ -1921,6 +1929,20 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 ),
                 input,
             });
+            imported_ids.push(frontier.id);
+        }
+
+        if select_frontier_ids {
+            for id in requested_ids {
+                if !imported_ids.contains(id) {
+                    warn!(
+                        id,
+                        test = %signature,
+                        path = %frontier_path.display(),
+                        "requested fuzz branch frontier was not imported"
+                    );
+                }
+            }
         }
 
         debug!(
@@ -1928,6 +1950,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             path = %frontier_path.display(),
             imported = imported.len(),
             limit,
+            skipped_by_selection,
+            requested_ids = ?requested_ids,
             "imported fuzz branch frontiers for targeted symbolic seeding"
         );
         imported

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -376,6 +376,8 @@ forgetest!(can_extract_config_values, |prj, cmd| {
             use_fuzz_frontiers: true,
             frontier_limit: 11,
             frontier_ids: vec![4, 9],
+            frontier_pcs: vec![123, 456],
+            frontier_selectors: vec!["0x12345678".to_string(), "deadbeef".to_string()],
             solver: "custom-z3".to_string(),
             solver_command: None,
             solver_portfolio: Vec::new(),

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -375,6 +375,7 @@ forgetest!(can_extract_config_values, |prj, cmd| {
             corpus_seed_limit: 17,
             use_fuzz_frontiers: true,
             frontier_limit: 11,
+            frontier_ids: vec![4, 9],
             solver: "custom-z3".to_string(),
             solver_command: None,
             solver_portfolio: Vec::new(),

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -49,6 +49,28 @@ fn keep_only_matching_frontier(
     target_frontier
 }
 
+fn matching_frontier(
+    root: &Path,
+    contract: &str,
+    test: &str,
+    missing: &str,
+    mut matches: impl FnMut(&Value) -> bool,
+) -> Value {
+    let frontier_path = frontier_artifact_path(root, contract, test);
+    let artifact: Value = serde_json::from_slice(
+        &std::fs::read(&frontier_path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", frontier_path.display())),
+    )
+    .unwrap();
+    artifact["frontiers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|frontier| matches(frontier))
+        .cloned()
+        .unwrap_or_else(|| panic!("missing {missing} frontier in {artifact}"))
+}
+
 fn single_uint_corpus_values(
     root: &Path,
     contract: &str,
@@ -1847,6 +1869,18 @@ contract SymbolicFuzzFrontierSeed {
         ])
         .assert_success();
 
+    let target_frontier = matching_frontier(
+        prj.root(),
+        "SymbolicFuzzFrontierSeed",
+        "testFuzz_frontier",
+        "missed fee multiplier",
+        |frontier| {
+            frontier["site"]["opcode_name"] == "LT"
+                && (frontier["operands"]["lhs"] == "0x64" || frontier["operands"]["rhs"] == "0x64")
+        },
+    );
+    let target_frontier_id = target_frontier["id"].as_u64().unwrap().to_string();
+
     let output = cmd
         .forge_fuse()
         .args([
@@ -1865,7 +1899,9 @@ contract SymbolicFuzzFrontierSeed {
             "fuzz_corpus",
             "--symbolic-use-fuzz-frontiers",
             "--symbolic-frontier-limit",
-            "8",
+            "1",
+            "--symbolic-frontier-ids",
+            &target_frontier_id,
         ])
         .assert_success()
         .get_output()

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1880,6 +1880,9 @@ contract SymbolicFuzzFrontierSeed {
         },
     );
     let target_frontier_id = target_frontier["id"].as_u64().unwrap().to_string();
+    let target_frontier_pc = target_frontier["site"]["pc"].as_u64().unwrap().to_string();
+    let target_frontier_selector =
+        target_frontier["sequence"][0]["calldata"].as_str().unwrap()[..10].to_string();
 
     let output = cmd
         .forge_fuse()
@@ -1902,11 +1905,21 @@ contract SymbolicFuzzFrontierSeed {
             "1",
             "--symbolic-frontier-ids",
             &target_frontier_id,
+            "--symbolic-frontier-pcs",
+            &target_frontier_pc,
+            "--symbolic-frontier-selectors",
+            &target_frontier_selector,
         ])
         .assert_success()
         .get_output()
-        .stdout_lossy();
-    assert!(output.contains("testFuzz_frontier(uint64,uint256)"), "{output}");
+        .clone();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+    assert!(stdout.contains("testFuzz_frontier(uint64,uint256)"), "{stdout}");
+    assert!(
+        stderr.contains("Symbolic frontier selection for testFuzz_frontier(uint64,uint256)"),
+        "{stderr}"
+    );
 
     let corpus_dir = prj
         .root()


### PR DESCRIPTION
### Summary

Fuzz frontier artifacts can contain many branch sites, but solver time is limited; these filters let users focus symbolic seeding on specific high-value frontier records by artifact ID, comparison PC, or calldata selector instead of spending the budget strictly by artifact order.

- Add `symbolic.frontier_ids`, `symbolic.frontier_pcs`, and `symbolic.frontier_selectors` plus matching CLI flags for targeted fuzz frontier imports.
- Compose non-empty frontier filters conjunctively, then preserve artifact-order priority under `symbolic.frontier_limit`.
- Emit a frontier selection status line with imported/skipped counts and warn when requested IDs, PCs, or selectors cannot be imported.
- Document how frontier targeting works with the JSON frontier artifact fields.