### PR TITLE
perf(symbolic): skip local unsat facts

### DIFF
--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -499,7 +499,7 @@ impl SmtLibSubprocessSolver {
         )
         .entered();
         trace!(query_id = self.queries, constraint_count = constraints.len(), "solver is_sat");
-        if constraints_are_directly_unsat(cx, &smt_constraints) {
+        if constraints_are_directly_unsat(&smt_constraints) {
             trace!("is_sat: direct contradiction");
             self.cache_sat_result(cache_key, false);
             return Ok(false);

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -167,14 +167,18 @@ const fn expr_ternop_key(op: SymTernOp) -> u8 {
 }
 
 /// Returns whether normalized conjunctive constraints contain a direct contradiction.
-pub(super) fn constraints_are_directly_unsat(cx: &mut SymCx, constraints: &[SymBoolExpr]) -> bool {
-    if constraints.iter().any(|constraint| match constraint.kind() {
-        SymBoolExprKind::Const(false) => true,
-        SymBoolExprKind::Not(inner) => constraints.contains(inner),
-        _ => {
-            let negated = constraint.clone().not(cx);
-            constraints.contains(&negated)
-        }
+pub(super) fn constraints_are_directly_unsat(constraints: &[SymBoolExpr]) -> bool {
+    if constraints
+        .iter()
+        .any(|constraint| matches!(constraint.kind(), SymBoolExprKind::Const(false)))
+    {
+        return true;
+    }
+
+    let constraint_set: HashSet<_> = constraints.iter().collect();
+    if constraints.iter().any(|constraint| {
+        let SymBoolExprKind::Not(inner) = constraint.kind() else { return false };
+        constraint_set.contains(inner)
     }) {
         return true;
     }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -168,14 +168,332 @@ const fn expr_ternop_key(op: SymTernOp) -> u8 {
 
 /// Returns whether normalized conjunctive constraints contain a direct contradiction.
 pub(super) fn constraints_are_directly_unsat(cx: &mut SymCx, constraints: &[SymBoolExpr]) -> bool {
-    constraints.iter().any(|constraint| match constraint.kind() {
+    if constraints.iter().any(|constraint| match constraint.kind() {
         SymBoolExprKind::Const(false) => true,
         SymBoolExprKind::Not(inner) => constraints.contains(inner),
         _ => {
             let negated = constraint.clone().not(cx);
             constraints.contains(&negated)
         }
-    })
+    }) {
+        return true;
+    }
+
+    DirectUnsatFacts::new(constraints).is_unsat()
+}
+
+#[derive(Default)]
+struct DirectUnsatFacts<'a> {
+    impossible: bool,
+    ranges: HashMap<&'a SymExpr, UnsignedRange>,
+    non_zero: HashSet<&'a SymExpr>,
+    masked_inequalities: Vec<(&'a SymExpr, U256)>,
+    bool_word_inequalities: Vec<&'a SymExpr>,
+    add_wrap_inequalities: Vec<(&'a SymExpr, U256)>,
+    sub_wrap_inequalities: Vec<(&'a SymExpr, U256)>,
+    product_upper_inequalities: Vec<(&'a SymExpr, U256, U256)>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct UnsignedRange {
+    lower: Option<U256>,
+    upper: Option<U256>,
+}
+
+impl UnsignedRange {
+    fn is_empty(&self) -> bool {
+        matches!((self.lower, self.upper), (Some(lower), Some(upper)) if lower > upper)
+    }
+}
+
+impl<'a> DirectUnsatFacts<'a> {
+    fn new(constraints: &'a [SymBoolExpr]) -> Self {
+        let mut facts = Self::default();
+        for constraint in constraints {
+            facts.collect_bool(constraint);
+        }
+        facts
+    }
+
+    fn collect_bool(&mut self, expr: &'a SymBoolExpr) {
+        match expr.kind() {
+            SymBoolExprKind::And(values) => {
+                for value in values.iter() {
+                    self.collect_bool(value);
+                }
+            }
+            SymBoolExprKind::Not(value) => {
+                self.collect_unsigned_range(value, false);
+                if let Some(expr) = zero_equality_expr(value) {
+                    self.non_zero.insert(expr);
+                }
+                if let Some(masked) = masked_equality_expr(value) {
+                    self.masked_inequalities.push(masked);
+                }
+                if let Some(expr) = bool_word_equality_expr(value) {
+                    self.bool_word_inequalities.push(expr);
+                }
+            }
+            _ => {
+                self.collect_unsigned_range(expr, true);
+                if let Some(inequality) = add_wrap_inequality(expr) {
+                    self.add_wrap_inequalities.push(inequality);
+                }
+                if let Some(inequality) = sub_wrap_inequality(expr) {
+                    self.sub_wrap_inequalities.push(inequality);
+                }
+                if let Some(inequality) = product_upper_inequality(expr) {
+                    self.product_upper_inequalities.push(inequality);
+                }
+            }
+        }
+    }
+
+    fn collect_unsigned_range(&mut self, expr: &'a SymBoolExpr, asserted: bool) {
+        let SymBoolExprKind::Cmp(op, left, right) = expr.kind() else { return };
+        match *op {
+            SymCmpOp::Eq if asserted => {
+                if let Some(value) = right.as_const() {
+                    self.record_exact(left, value);
+                }
+                if let Some(value) = left.as_const() {
+                    self.record_exact(right, value);
+                }
+            }
+            SymCmpOp::Ult => self.collect_unsigned_less_than(left, right, asserted),
+            SymCmpOp::Ugt => self.collect_unsigned_less_than(right, left, asserted),
+            SymCmpOp::Ule => self.collect_unsigned_less_or_equal(left, right, asserted),
+            SymCmpOp::Uge => self.collect_unsigned_less_or_equal(right, left, asserted),
+            SymCmpOp::Eq | SymCmpOp::Slt | SymCmpOp::Sgt => {}
+        }
+    }
+
+    fn collect_unsigned_less_than(
+        &mut self,
+        left: &'a SymExpr,
+        right: &'a SymExpr,
+        asserted: bool,
+    ) {
+        match (asserted, left.as_const(), right.as_const()) {
+            (true, _, Some(bound)) => {
+                if bound.is_zero() {
+                    self.impossible = true;
+                } else {
+                    self.record_upper(left, bound - U256::from(1));
+                }
+            }
+            (true, Some(bound), _) => {
+                if bound == U256::MAX {
+                    self.impossible = true;
+                } else {
+                    self.record_lower(right, bound + U256::from(1));
+                }
+            }
+            (false, _, Some(bound)) => self.record_lower(left, bound),
+            (false, Some(bound), _) => self.record_upper(right, bound),
+            _ => {}
+        }
+    }
+
+    fn collect_unsigned_less_or_equal(
+        &mut self,
+        left: &'a SymExpr,
+        right: &'a SymExpr,
+        asserted: bool,
+    ) {
+        match (asserted, left.as_const(), right.as_const()) {
+            (true, _, Some(bound)) => self.record_upper(left, bound),
+            (true, Some(bound), _) => self.record_lower(right, bound),
+            (false, _, Some(bound)) => {
+                if bound == U256::MAX {
+                    self.impossible = true;
+                } else {
+                    self.record_lower(left, bound + U256::from(1));
+                }
+            }
+            (false, Some(bound), _) => {
+                if bound.is_zero() {
+                    self.impossible = true;
+                } else {
+                    self.record_upper(right, bound - U256::from(1));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn record_exact(&mut self, expr: &'a SymExpr, value: U256) {
+        self.record_lower(expr, value);
+        self.record_upper(expr, value);
+    }
+
+    fn record_lower(&mut self, expr: &'a SymExpr, lower: U256) {
+        if let Some(value) = expr.as_const() {
+            self.impossible |= value < lower;
+            return;
+        }
+        let range = self.ranges.entry(expr).or_default();
+        range.lower = Some(range.lower.map_or(lower, |current| current.max(lower)));
+        self.impossible |= range.is_empty();
+    }
+
+    fn record_upper(&mut self, expr: &'a SymExpr, upper: U256) {
+        if let Some(value) = expr.as_const() {
+            self.impossible |= value > upper;
+            return;
+        }
+        let range = self.ranges.entry(expr).or_default();
+        range.upper = Some(range.upper.map_or(upper, |current| current.min(upper)));
+        self.impossible |= range.is_empty();
+    }
+
+    fn upper_bound(&self, expr: &SymExpr) -> Option<U256> {
+        expr.as_const().or_else(|| self.ranges.get(expr).and_then(|range| range.upper))
+    }
+
+    fn is_unsat(&self) -> bool {
+        self.impossible
+            || self.ranges.values().any(UnsignedRange::is_empty)
+            || self
+                .non_zero
+                .iter()
+                .any(|expr| self.upper_bound(expr).is_some_and(|upper| upper.is_zero()))
+            || self.masked_inequalities.iter().any(|(expr, mask)| {
+                self.upper_bound(expr).is_some_and(|upper| mask_covers_upper_bound(*mask, upper))
+            })
+            || self
+                .bool_word_inequalities
+                .iter()
+                .any(|expr| self.upper_bound(expr).is_some_and(|upper| upper <= U256::from(1)))
+            || self
+                .add_wrap_inequalities
+                .iter()
+                .any(|(expr, constant)| add_wrap_is_unsat(self.upper_bound(expr), *constant))
+            || self.sub_wrap_inequalities.iter().any(|(expr, constant)| {
+                self.upper_bound(expr).is_some_and(|upper| upper <= *constant)
+            })
+            || self.product_upper_inequalities.iter().any(|(expr, factor, limit)| {
+                product_upper_is_unsat(self.upper_bound(expr), *factor, *limit)
+            })
+    }
+}
+
+fn zero_equality_expr(expr: &SymBoolExpr) -> Option<&SymExpr> {
+    let SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) = expr.kind() else { return None };
+    zero_pair_expr(left, right).or_else(|| zero_pair_expr(right, left))
+}
+
+fn zero_pair_expr<'a>(zero: &SymExpr, expr: &'a SymExpr) -> Option<&'a SymExpr> {
+    zero.as_const().is_some_and(|value| value.is_zero()).then_some(expr)
+}
+
+fn masked_equality_expr(expr: &SymBoolExpr) -> Option<(&SymExpr, U256)> {
+    let SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) = expr.kind() else { return None };
+    masked_pair_expr(left, right).or_else(|| masked_pair_expr(right, left))
+}
+
+fn masked_pair_expr<'a>(expr: &'a SymExpr, masked: &'a SymExpr) -> Option<(&'a SymExpr, U256)> {
+    let SymExprKind::BinOp(SymBinOp::And, left, right) = masked.kind() else { return None };
+    match (left.kind(), right.kind()) {
+        (SymExprKind::Const(mask), _) if right == expr => Some((expr, *mask)),
+        (_, SymExprKind::Const(mask)) if left == expr => Some((expr, *mask)),
+        _ => None,
+    }
+}
+
+fn bool_word_equality_expr(expr: &SymBoolExpr) -> Option<&SymExpr> {
+    let SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) = expr.kind() else { return None };
+    bool_word_pair(left, right).or_else(|| bool_word_pair(right, left))
+}
+
+fn bool_word_pair<'a>(expr: &'a SymExpr, bool_word: &'a SymExpr) -> Option<&'a SymExpr> {
+    let condition_expr = bool_word_of_nonzero_expr(bool_word)?;
+    (condition_expr == expr).then_some(expr)
+}
+
+fn bool_word_of_nonzero_expr(expr: &SymExpr) -> Option<&SymExpr> {
+    let SymExprKind::Ite(condition, then_expr, else_expr) = expr.kind() else { return None };
+    if then_expr.as_const() != Some(U256::from(1))
+        || !else_expr.as_const().is_some_and(|value| value.is_zero())
+    {
+        return None;
+    }
+    let SymBoolExprKind::Not(condition) = condition.kind() else { return None };
+    zero_equality_expr(condition)
+}
+
+fn add_wrap_inequality(expr: &SymBoolExpr) -> Option<(&SymExpr, U256)> {
+    match expr.kind() {
+        SymBoolExprKind::Cmp(SymCmpOp::Ult, left, right) => add_wrap_pair(left, right),
+        SymBoolExprKind::Cmp(SymCmpOp::Ugt, left, right) => add_wrap_pair(right, left),
+        _ => None,
+    }
+}
+
+fn add_wrap_pair<'a>(sum: &'a SymExpr, limit: &SymExpr) -> Option<(&'a SymExpr, U256)> {
+    let limit = limit.as_const()?;
+    let SymExprKind::BinOp(SymBinOp::Add, left, right) = sum.kind() else { return None };
+    match (left.as_const(), right.as_const()) {
+        (Some(constant), _) if constant == limit => Some((right, constant)),
+        (_, Some(constant)) if constant == limit => Some((left, constant)),
+        _ => None,
+    }
+}
+
+fn add_wrap_is_unsat(upper: Option<U256>, constant: U256) -> bool {
+    constant.is_zero() || upper.is_some_and(|upper| upper <= U256::MAX - constant)
+}
+
+fn sub_wrap_inequality(expr: &SymBoolExpr) -> Option<(&SymExpr, U256)> {
+    match expr.kind() {
+        SymBoolExprKind::Cmp(SymCmpOp::Ult, left, right) => sub_wrap_pair(left, right),
+        SymBoolExprKind::Cmp(SymCmpOp::Ugt, left, right) => sub_wrap_pair(right, left),
+        _ => None,
+    }
+}
+
+fn sub_wrap_pair<'a>(limit: &SymExpr, difference: &'a SymExpr) -> Option<(&'a SymExpr, U256)> {
+    let limit = limit.as_const()?;
+    let SymExprKind::BinOp(SymBinOp::Sub, left, right) = difference.kind() else { return None };
+    (left.as_const() == Some(limit)).then_some((right, limit))
+}
+
+fn product_upper_inequality(expr: &SymBoolExpr) -> Option<(&SymExpr, U256, U256)> {
+    match expr.kind() {
+        SymBoolExprKind::Cmp(SymCmpOp::Ult, left, right) => product_upper_pair(left, right),
+        SymBoolExprKind::Cmp(SymCmpOp::Ugt, left, right) => product_upper_pair(right, left),
+        _ => None,
+    }
+}
+
+fn product_upper_pair<'a>(
+    limit: &SymExpr,
+    product: &'a SymExpr,
+) -> Option<(&'a SymExpr, U256, U256)> {
+    let limit = limit.as_const()?;
+    let (expr, factor) = mul_const_operand(product)?;
+    Some((expr, factor, limit))
+}
+
+fn mul_const_operand(expr: &SymExpr) -> Option<(&SymExpr, U256)> {
+    let SymExprKind::BinOp(SymBinOp::Mul, left, right) = expr.kind() else { return None };
+    match (left.as_const(), right.as_const()) {
+        (Some(factor), _) => Some((right, factor)),
+        (_, Some(factor)) => Some((left, factor)),
+        _ => None,
+    }
+}
+
+fn product_upper_is_unsat(upper: Option<U256>, factor: U256, limit: U256) -> bool {
+    factor.is_zero() || upper.is_some_and(|upper| upper <= limit / factor)
+}
+
+fn mask_covers_upper_bound(mask: U256, upper_bound: U256) -> bool {
+    if mask == U256::MAX {
+        return true;
+    }
+    let limit = mask.wrapping_add(U256::from(1));
+    !limit.is_zero() && (limit & (limit - U256::from(1))).is_zero() && upper_bound <= mask
 }
 
 /// Returns whether every expression in `subset` appears in `superset`.

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3827,11 +3827,9 @@ fn sat_cache_does_not_reuse_unsat_branch_complement_with_unsat_base() {
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
     let x = SymExpr::var(&mut cx, "x");
-    let two = SymExpr::constant(&mut cx, U256::from(2));
     let one = SymExpr::constant(&mut cx, U256::from(1));
-    let lower = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, x.clone(), two);
-    let upper = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, x.clone(), one.clone());
-    let base = SymBoolExpr::and(&mut cx, vec![lower, upper]);
+    let incremented = SymExpr::binop(&mut cx, SymBinOp::Add, x.clone(), one.clone());
+    let base = SymBoolExpr::eq(&mut cx, incremented, x.clone());
     let condition = SymBoolExpr::eq(&mut cx, x, one);
 
     assert!(!solver.is_sat_branch(&mut cx, &[base.clone(), condition.clone()]).unwrap());
@@ -3959,6 +3957,147 @@ fn direct_contradiction_is_sat_short_circuits_locally() {
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraint = SymBoolExpr::eq(&mut cx, x, one);
     let constraints = vec![constraint.clone(), constraint.not(&mut cx)];
+
+    assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.sat_queries, 1);
+}
+
+#[test]
+fn unsigned_zero_contradiction_is_sat_short_circuits_locally() {
+    let mut cx = SymCx::new();
+    let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
+    let x = SymExpr::var(&mut cx, "x");
+    let zero = SymExpr::zero(&mut cx);
+    let positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, zero.clone(), x.clone());
+    let non_zero = SymBoolExpr::eq(&mut cx, x, zero).not(&mut cx);
+    let constraints = vec![positive.not(&mut cx), non_zero];
+
+    assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.sat_queries, 1);
+}
+
+#[test]
+fn masked_upper_bound_contradiction_is_sat_short_circuits_locally() {
+    let mut cx = SymCx::new();
+    let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
+    let x = SymExpr::var(&mut cx, "x");
+    let mask = SymExpr::constant(&mut cx, U256::from(0xffff));
+    let masked = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), mask);
+    let mask_changes_x = SymBoolExpr::eq(&mut cx, x.clone(), masked).not(&mut cx);
+    let limit = SymExpr::constant(&mut cx, U256::from(0x1_0000));
+    let below_limit = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, limit);
+    let constraints = vec![mask_changes_x, below_limit];
+
+    assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.sat_queries, 1);
+}
+
+#[test]
+fn unsigned_range_contradiction_is_sat_short_circuits_locally() {
+    let mut cx = SymCx::new();
+    let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
+    let x = SymExpr::var(&mut cx, "x");
+    let limit = SymExpr::constant(&mut cx, U256::from(100));
+    let at_most_limit =
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, limit.clone(), x.clone()).not(&mut cx);
+    let above_limit = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, x, limit).not(&mut cx);
+    let constraints = vec![at_most_limit, above_limit];
+
+    assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.sat_queries, 1);
+}
+
+#[test]
+fn bool_word_range_contradiction_is_sat_short_circuits_locally() {
+    let mut cx = SymCx::new();
+    let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
+    let x = SymExpr::var(&mut cx, "x");
+    let zero = SymExpr::zero(&mut cx);
+    let one = SymExpr::one(&mut cx);
+    let is_nonzero = SymBoolExpr::eq(&mut cx, x.clone(), zero).not(&mut cx);
+    let zero = SymExpr::zero(&mut cx);
+    let bool_word = SymExpr::ite(&mut cx, is_nonzero, one, zero);
+    let not_bool_word = SymBoolExpr::eq(&mut cx, x.clone(), bool_word).not(&mut cx);
+    let two = SymExpr::constant(&mut cx, U256::from(2));
+    let below_two = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, two);
+    let constraints = vec![not_bool_word, below_two];
+
+    assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.sat_queries, 1);
+}
+
+#[test]
+fn bounded_add_wrap_contradiction_is_sat_short_circuits_locally() {
+    let mut cx = SymCx::new();
+    let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
+    let x = SymExpr::var(&mut cx, "x");
+    let bound = SymExpr::constant(&mut cx, U256::from(1000));
+    let at_most_bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, bound, x.clone()).not(&mut cx);
+    let base = SymExpr::constant(&mut cx, U256::from(1_000_000));
+    let sum = SymExpr::binop(&mut cx, SymBinOp::Add, base.clone(), x);
+    let wrapped = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, sum, base);
+    let constraints = vec![at_most_bound, wrapped];
+
+    assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.sat_queries, 1);
+}
+
+#[test]
+fn bounded_sub_wrap_contradiction_is_sat_short_circuits_locally() {
+    let mut cx = SymCx::new();
+    let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
+    let x = SymExpr::var(&mut cx, "x");
+    let limit = SymExpr::constant(&mut cx, U256::from(200));
+    let at_most_limit =
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, limit.clone(), x.clone()).not(&mut cx);
+    let difference = SymExpr::binop(&mut cx, SymBinOp::Sub, limit.clone(), x);
+    let underflowed = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, limit, difference);
+    let constraints = vec![at_most_limit, underflowed];
+
+    assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.sat_queries, 1);
+}
+
+#[test]
+fn bounded_product_contradiction_is_sat_short_circuits_locally() {
+    let mut cx = SymCx::new();
+    let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
+    let x = SymExpr::var(&mut cx, "x");
+    let bound = SymExpr::constant(&mut cx, U256::from(800));
+    let at_most_bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, bound, x.clone()).not(&mut cx);
+    let factor = SymExpr::constant(&mut cx, U256::from(100));
+    let product = SymExpr::binop(&mut cx, SymBinOp::Mul, factor, x);
+    let product_limit = SymExpr::constant(&mut cx, U256::from(80_000));
+    let above_product_limit = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, product_limit, product);
+    let constraints = vec![at_most_bound, above_product_limit];
 
     assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
 
@@ -4390,8 +4529,11 @@ fn solver_smt_dump_shares_repeated_subterms() {
     let shifted = SymExpr::binop(&mut cx, SymBinOp::Shl, byte, shift);
     let zero = SymExpr::zero(&mut cx);
     let shifted_zero = SymBoolExpr::eq(&mut cx, shifted.clone(), zero.clone());
-    let shifted_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, shifted, zero);
-    let constraints = vec![shifted_zero, shifted_positive];
+    let one = SymExpr::one(&mut cx);
+    let shifted_at_most_one = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, shifted, one);
+    let other = SymExpr::var(&mut cx, "calldata_1");
+    let other_zero = SymBoolExpr::eq(&mut cx, other, zero);
+    let constraints = vec![shifted_zero, shifted_at_most_one, other_zero];
 
     solver.capture_diagnostics();
 


### PR DESCRIPTION
Extends the symbolic solver's direct contradiction pass with local unsigned range facts and bounded wrap/product checks so common unsat branches can return before emitting SMT.

Bug suite (`grandizzy/symbolic-bug-suite`, 22/22 expected failures):
- SMT queries: 95 -> 70
- paired solver time avg: 1345.5ms -> 1126.4ms
- hyperfine: 452.0ms +/- 9.1ms -> 438.6ms +/- 8.2ms

`foundry-bench --benchmarks forge_symbolic_test`:
- Solady SMT: 70 -> 60, solver 409ms -> 352ms
- Angstrom unchanged SMT: 2 -> 2
- Farcaster SMT: 35 -> 25, solver 183ms -> 138ms