### PR TITLE
fix(anvil): use TransactionConditional

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -6,6 +6,7 @@ use alloy_primitives::{
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag as BlockNumber, BlockOverrides, Bundle, Filter, Index, StateContext,
     anvil::{Forking, MineOptions},
+    erc4337::TransactionConditional,
     pubsub::{Params as SubscriptionParams, SubscriptionKind},
     request::TransactionRequest,
     simulate::SimulatePayload,
@@ -205,7 +206,7 @@ pub enum EthRequest {
     EthSendRawTransactionSync(Bytes, #[serde(default)] Option<u64>),
 
     #[serde(rename = "eth_sendRawTransactionConditional")]
-    EthSendRawTransactionConditional(Bytes, serde_json::Value),
+    EthSendRawTransactionConditional(Bytes, TransactionConditional),
 
     #[serde(rename = "anvil_classifyTransaction", with = "sequence")]
     AnvilClassifyTransaction(Bytes),

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -53,6 +53,7 @@ use alloy_rpc_types::{
     anvil::{
         ForkedNetwork, Forking, Metadata, MineOptions, NodeEnvironment, NodeForkConfig, NodeInfo,
     },
+    erc4337::TransactionConditional,
     pubsub::TransactionReceiptsParams,
     request::TransactionRequest,
     simulate::{SimulatePayload, SimulatedBlock},
@@ -2715,21 +2716,15 @@ impl EthApi<FoundryNetwork> {
         Ok(*tx.hash())
     }
 
-    /// Sends a signed transaction with an empty transaction condition.
+    /// Sends a signed transaction with an ignored transaction condition.
     ///
     /// Handler for ETH RPC call: `eth_sendRawTransactionConditional`
     pub async fn send_raw_transaction_conditional(
         &self,
         tx: Bytes,
-        condition: serde_json::Value,
+        _condition: TransactionConditional,
     ) -> Result<TxHash> {
         node_info!("eth_sendRawTransactionConditional");
-        if !is_empty_transaction_condition(&condition) {
-            return Err(BlockchainError::RpcError(RpcError::invalid_params(
-                "transaction conditions are not supported",
-            )));
-        }
-
         self.send_raw_transaction(tx).await
     }
 
@@ -3427,18 +3422,6 @@ impl EthApi<FoundryNetwork> {
 
         self.backend.trace_call_many(calls, Some(block_request)).await
     }
-}
-
-fn is_empty_transaction_condition(condition: &serde_json::Value) -> bool {
-    let Some(condition) = condition.as_object() else {
-        return false;
-    };
-
-    condition.iter().all(|(key, value)| match key.as_str() {
-        "knownAccounts" => value.as_object().is_some_and(|accounts| accounts.is_empty()),
-        "blockNumberMin" | "blockNumberMax" | "timestampMin" | "timestampMax" => value.is_null(),
-        _ => false,
-    })
 }
 
 // == impl EthApi anvil endpoints ==

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -18,8 +18,8 @@ use alloy_primitives::{
 };
 use alloy_provider::{PendingTransactionConfig, Provider};
 use alloy_rpc_types::{
-    BlockId, BlockNumberOrTag, BlockTransactions, request::TransactionRequest,
-    state::AccountOverride,
+    BlockId, BlockNumberOrTag, BlockTransactions, erc4337::TransactionConditional,
+    request::TransactionRequest, state::AccountOverride,
 };
 use alloy_rpc_types_eth::{Bundle, EthCallResponse};
 use alloy_serde::WithOtherFields;
@@ -683,7 +683,10 @@ async fn can_send_raw_transaction_conditional() {
     let tx_hash = provider
         .raw_request(
             "eth_sendRawTransactionConditional".into(),
-            (alloy_primitives::Bytes::from(encoded), serde_json::json!({"knownAccounts": {}})),
+            (
+                alloy_primitives::Bytes::from(encoded),
+                TransactionConditional { block_number_min: Some(u64::MAX), ..Default::default() },
+            ),
         )
         .await
         .unwrap();
@@ -701,19 +704,22 @@ async fn can_send_raw_transaction_conditional() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn rejects_raw_transaction_conditional_prestate() {
+async fn ignores_raw_transaction_conditional_prestate() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let provider = handle.http_provider();
 
     let result: std::result::Result<serde_json::Value, _> = provider
         .raw_request(
             "eth_sendRawTransactionConditional".into(),
-            (alloy_primitives::Bytes::default(), serde_json::json!({"blockNumberMin": "0x2"})),
+            (
+                alloy_primitives::Bytes::default(),
+                TransactionConditional { block_number_min: Some(u64::MAX), ..Default::default() },
+            ),
         )
         .await;
 
     let err = result.unwrap_err().to_string();
-    assert!(err.contains("transaction conditions are not supported"), "{err}");
+    assert!(err.contains("Empty transaction data"), "{err}");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Anvil's `eth_sendRawTransactionConditional` request parser was storing the conditional payload as `serde_json::Value` and then manually checking for a narrow empty shape. This switches the RPC request to Alloy's `TransactionConditional` type so request parsing follows the existing Alloy schema.

Anvil still does not enforce transaction conditionals. Instead of rejecting non-empty conditionals, the endpoint now accepts the typed condition and ignores it before sending the raw transaction, which keeps the endpoint usable for clients that always include condition metadata.

Authored with AI assistance.
