### PR TITLE
perf(evm): fold edge coverage optimizations

### DIFF
--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -230,7 +230,7 @@ pub fn snapshot_edge_fingerprint<FEN: FoundryEvmNetwork>(
                 // Tag byte disambiguates `None` from `Some(0)` so configs with
                 // `include_call_depth` toggled don't collide in the fingerprint.
                 bytes.push(u8::from(hit.edge.depth.is_some()));
-                bytes.extend_from_slice(&hit.edge.depth.unwrap_or(0).to_le_bytes());
+                bytes.extend_from_slice(&u64::from(hit.edge.depth.unwrap_or(0)).to_le_bytes());
                 bytes.push(hit.count);
             }
             Some(keccak256(bytes))

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -644,6 +644,9 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         mut tx_env: TxEnvFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
         let mut stack = self.inspector().clone();
+        if let Some(edge_coverage) = stack.inner.edge_coverage.as_mut() {
+            edge_coverage.prepare_for_execution();
+        }
         let sancov_edges = stack.inner.sancov_edges;
         let sancov_trace_cmp = stack.inner.sancov_trace_cmp;
         let sancov_active = sancov_edges || sancov_trace_cmp;
@@ -678,6 +681,9 @@ impl<FEN: FoundryEvmNetwork> Executor<FEN> {
         mut tx_env: TxEnvFor<FEN>,
     ) -> eyre::Result<RawCallResult<FEN>> {
         let mut stack = self.inspector().clone();
+        if let Some(edge_coverage) = stack.inner.edge_coverage.as_mut() {
+            edge_coverage.prepare_for_execution();
+        }
         let sancov_edges = stack.inner.sancov_edges;
         let sancov_trace_cmp = stack.inner.sancov_trace_cmp;
         let sancov_active = sancov_edges || sancov_trace_cmp;

--- a/crates/evm/evm/src/inspectors/edge_cov.rs
+++ b/crates/evm/evm/src/inspectors/edge_cov.rs
@@ -347,15 +347,22 @@ impl EdgeCovInspector {
         };
 
         let site = CmpSiteKey::new(&cmp);
-        if let Some(count) = self.cmp_site_counts.get_mut(&site) {
-            if *count >= MAX_CMP_OBSERVATIONS_PER_SITE {
-                return;
+        let can_insert_site = self.cmp_site_counts.len() < MAX_CMP_LOG_SITES;
+        match self.cmp_site_counts.entry(site) {
+            Entry::Occupied(mut entry) => {
+                let count = entry.get_mut();
+                if *count >= MAX_CMP_OBSERVATIONS_PER_SITE {
+                    return;
+                }
+                *count += 1;
+                cmp_log.push(cmp);
             }
-            *count += 1;
-            cmp_log.push(cmp);
-        } else if self.cmp_site_counts.len() < MAX_CMP_LOG_SITES {
-            self.cmp_site_counts.insert(site, 1);
-            cmp_log.push(cmp);
+            Entry::Vacant(entry) => {
+                if can_insert_site {
+                    entry.insert(1);
+                    cmp_log.push(cmp);
+                }
+            }
         }
     }
 

--- a/crates/evm/evm/src/inspectors/edge_cov.rs
+++ b/crates/evm/evm/src/inspectors/edge_cov.rs
@@ -308,8 +308,15 @@ impl EdgeCovInspector {
     #[inline]
     fn store_dense_hit(&mut self, address: Address, depth: usize, pc: usize, jump_dest: U256) {
         let key = EdgeKey::new(address, depth, pc, jump_dest, self.config.include_call_depth);
-        let count = self.dense_hitcount.entry(key).or_default();
-        *count = count.wrapping_add(1).max(1);
+        match self.dense_hitcount.entry(key) {
+            Entry::Occupied(mut entry) => {
+                let count = entry.get_mut();
+                *count = count.wrapping_add(1).max(1);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(1);
+            }
+        }
     }
 
     #[inline]

--- a/crates/evm/evm/src/inspectors/edge_cov.rs
+++ b/crates/evm/evm/src/inspectors/edge_cov.rs
@@ -26,6 +26,10 @@ const MAX_CMP_LOG_SITES: usize = 1024;
 // detection threshold so a hot loop can be classified without filling the whole log.
 const MAX_CMP_OBSERVATIONS_PER_SITE: u8 = 8;
 
+// Collision-free coverage is collected into a fresh inspector clone for each raw call. Pre-sizing
+// the per-call dense map avoids repeated small-table growth in coverage-guided invariant runs.
+const INITIAL_DENSE_EDGE_CAPACITY: usize = 256;
+
 /// Edge coverage collection kind.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum EdgeCovKind {
@@ -268,6 +272,16 @@ impl EdgeCovInspector {
     /// Number of unique collision-free edges discovered so far.
     pub fn edge_count(&self) -> usize {
         self.dense_hitcount.len()
+    }
+
+    /// Prepare per-call coverage buffers before EVM execution starts.
+    pub fn prepare_for_execution(&mut self) {
+        if self.config.kind == EdgeCovKind::CollisionFree
+            && self.dense_hitcount.capacity() < INITIAL_DENSE_EDGE_CAPACITY
+        {
+            self.dense_hitcount
+                .reserve(INITIAL_DENSE_EDGE_CAPACITY - self.dense_hitcount.capacity());
+        }
     }
 
     /// Mark the edge `(address, depth, pc, jump_dest)` as hit.

--- a/crates/evm/evm/src/inspectors/edge_cov.rs
+++ b/crates/evm/evm/src/inspectors/edge_cov.rs
@@ -376,13 +376,17 @@ impl EdgeCovInspector {
         CTX: ContextTr,
     {
         let address = interp.input.target_address();
-        let depth = context.journal_ref().depth();
         let current_pc = interp.bytecode.pc();
 
         match op {
             opcode::JUMP => {
                 // unconditional jump
                 if let Ok(jump_dest) = interp.stack.peek(0) {
+                    let depth = if self.config.include_call_depth {
+                        context.journal_ref().depth()
+                    } else {
+                        0
+                    };
                     self.store_hit(address, depth, current_pc, jump_dest);
                 }
             }
@@ -397,6 +401,11 @@ impl EdgeCovInspector {
                     };
 
                     if let Ok(jump_dest) = jump_dest {
+                        let depth = if self.config.include_call_depth {
+                            context.journal_ref().depth()
+                        } else {
+                            0
+                        };
                         self.store_hit(address, depth, current_pc, jump_dest);
                     }
                 }

--- a/crates/evm/evm/src/inspectors/edge_cov.rs
+++ b/crates/evm/evm/src/inspectors/edge_cov.rs
@@ -271,6 +271,7 @@ impl EdgeCovInspector {
     }
 
     /// Mark the edge `(address, depth, pc, jump_dest)` as hit.
+    #[inline]
     fn store_hit(&mut self, address: Address, depth: usize, pc: usize, jump_dest: U256) {
         if !self.collect_edges {
             return;
@@ -286,12 +287,14 @@ impl EdgeCovInspector {
         self.hitcount[edge_id] = self.hitcount[edge_id].wrapping_add(1).max(1);
     }
 
+    #[inline]
     fn store_dense_hit(&mut self, address: Address, depth: usize, pc: usize, jump_dest: U256) {
         let key = EdgeKey::new(address, depth, pc, jump_dest, self.config.include_call_depth);
         let count = self.dense_hitcount.entry(key).or_default();
         *count = count.wrapping_add(1).max(1);
     }
 
+    #[inline]
     fn hash_edge_id(
         &mut self,
         address: Address,
@@ -323,6 +326,7 @@ impl EdgeCovInspector {
     }
 
     /// Store comparison operands for CmpLog-style guided fuzzing.
+    #[inline]
     fn store_cmp(&mut self, cmp: CmpOperands) {
         let Some(cmp_log) = &mut self.cmp_log else {
             return;
@@ -341,8 +345,8 @@ impl EdgeCovInspector {
         }
     }
 
-    #[cold]
-    fn do_step<CTX>(&mut self, interp: &mut Interpreter, context: &mut CTX)
+    #[inline]
+    fn do_step<CTX>(&mut self, interp: &mut Interpreter, context: &mut CTX, op: u8)
     where
         CTX: ContextTr,
     {
@@ -350,7 +354,7 @@ impl EdgeCovInspector {
         let depth = context.journal_ref().depth();
         let current_pc = interp.bytecode.pc();
 
-        match interp.bytecode.opcode() {
+        match op {
             opcode::JUMP => {
                 // unconditional jump
                 if let Ok(jump_dest) = interp.stack.peek(0) {
@@ -378,8 +382,8 @@ impl EdgeCovInspector {
         }
     }
 
-    #[cold]
-    fn do_cmp_step(&mut self, interp: &mut Interpreter) {
+    #[inline]
+    fn do_cmp_step(&mut self, interp: &mut Interpreter, op: u8) {
         if self.cmp_log.is_none() {
             return;
         }
@@ -387,7 +391,7 @@ impl EdgeCovInspector {
         let address = interp.input.target_address();
         let current_pc = interp.bytecode.pc();
 
-        match interp.bytecode.opcode() {
+        match op {
             op @ (opcode::EQ | opcode::LT | opcode::SLT | opcode::GT | opcode::SGT) => {
                 if let (Ok(op1), Ok(op2)) = (interp.stack.peek(0), interp.stack.peek(1)) {
                     self.store_cmp(CmpOperands { op1, op2, pc: current_pc, address, opcode: op });
@@ -442,7 +446,7 @@ where
     fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
         let op = interp.bytecode.opcode();
         if self.collect_edges && matches!(op, opcode::JUMP | opcode::JUMPI) {
-            self.do_step(interp, context);
+            self.do_step(interp, context, op);
         }
         if self.cmp_log.is_some()
             && matches!(
@@ -450,7 +454,7 @@ where
                 opcode::EQ | opcode::LT | opcode::GT | opcode::SLT | opcode::SGT | opcode::ISZERO
             )
         {
-            self.do_cmp_step(interp);
+            self.do_cmp_step(interp, op);
         }
     }
 }

--- a/crates/evm/evm/src/inspectors/edge_cov.rs
+++ b/crates/evm/evm/src/inspectors/edge_cov.rs
@@ -487,13 +487,14 @@ where
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct CmpSiteKey {
     address: Address,
-    pc: usize,
+    pc: u32,
     opcode: u8,
 }
 
 impl CmpSiteKey {
-    const fn new(cmp: &CmpOperands) -> Self {
-        Self { address: cmp.address, pc: cmp.pc, opcode: cmp.opcode }
+    fn new(cmp: &CmpOperands) -> Self {
+        debug_assert!(cmp.pc <= u32::MAX as usize);
+        Self { address: cmp.address, pc: cmp.pc as u32, opcode: cmp.opcode }
     }
 }
 

--- a/crates/evm/evm/src/inspectors/edge_cov.rs
+++ b/crates/evm/evm/src/inspectors/edge_cov.rs
@@ -96,7 +96,7 @@ pub struct CmpOperands {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct EdgeKey {
     pub address: Address,
-    pub depth: Option<usize>,
+    pub depth: Option<u32>,
     pub pc: usize,
     pub jump_dest: U256,
 }
@@ -109,7 +109,11 @@ impl EdgeKey {
         jump_dest: U256,
         include_depth: bool,
     ) -> Self {
-        Self { address, depth: include_depth.then_some(depth), pc, jump_dest }
+        if include_depth {
+            debug_assert!(depth <= u32::MAX as usize);
+        }
+        let depth = include_depth.then_some(depth as u32);
+        Self { address, depth, pc, jump_dest }
     }
 }
 

--- a/crates/evm/evm/src/inspectors/edge_cov.rs
+++ b/crates/evm/evm/src/inspectors/edge_cov.rs
@@ -183,6 +183,8 @@ pub struct EdgeCovInspector {
     /// Comparison operand log for CmpLog-style guided fuzzing.
     cmp_log: Option<Vec<CmpOperands>>,
     cmp_site_counts: HashMap<CmpSiteKey, u8>,
+    last_cmp_site: Option<CmpSiteKey>,
+    last_cmp_site_count: u8,
 }
 
 impl fmt::Debug for EdgeCovInspector {
@@ -234,6 +236,8 @@ impl EdgeCovInspector {
             hash_builder: DefaultHashBuilder::default(),
             cmp_log: None,
             cmp_site_counts: HashMap::default(),
+            last_cmp_site: None,
+            last_cmp_site_count: 0,
         }
     }
 
@@ -244,6 +248,8 @@ impl EdgeCovInspector {
         } else {
             self.cmp_log = None;
             self.cmp_site_counts.clear();
+            self.last_cmp_site = None;
+            self.last_cmp_site_count = 0;
         }
     }
 
@@ -257,6 +263,8 @@ impl EdgeCovInspector {
             cmp_log.clear();
         }
         self.cmp_site_counts.clear();
+        self.last_cmp_site = None;
+        self.last_cmp_site_count = 0;
     }
 
     /// Get an immutable reference to the comparison operand log.
@@ -353,28 +361,62 @@ impl EdgeCovInspector {
     /// Store comparison operands for CmpLog-style guided fuzzing.
     #[inline]
     fn store_cmp(&mut self, cmp: CmpOperands) {
+        if self.cmp_log.is_none() {
+            return;
+        }
+
+        let site = CmpSiteKey::new(&cmp);
+        if self.last_cmp_site == Some(site) {
+            if self.last_cmp_site_count >= MAX_CMP_OBSERVATIONS_PER_SITE {
+                return;
+            }
+            self.last_cmp_site_count += 1;
+            self.cmp_log.as_mut().expect("checked above").push(cmp);
+            return;
+        }
+
+        self.flush_last_cmp_site();
+
         let Some(cmp_log) = &mut self.cmp_log else {
             return;
         };
 
-        let site = CmpSiteKey::new(&cmp);
         let can_insert_site = self.cmp_site_counts.len() < MAX_CMP_LOG_SITES;
         match self.cmp_site_counts.entry(site) {
             Entry::Occupied(mut entry) => {
                 let count = entry.get_mut();
                 if *count >= MAX_CMP_OBSERVATIONS_PER_SITE {
+                    self.last_cmp_site = Some(site);
+                    self.last_cmp_site_count = *count;
                     return;
                 }
                 *count += 1;
+                self.last_cmp_site = Some(site);
+                self.last_cmp_site_count = *count;
                 cmp_log.push(cmp);
             }
             Entry::Vacant(entry) => {
                 if can_insert_site {
                     entry.insert(1);
+                    self.last_cmp_site = Some(site);
+                    self.last_cmp_site_count = 1;
                     cmp_log.push(cmp);
+                } else {
+                    self.last_cmp_site = Some(site);
+                    self.last_cmp_site_count = MAX_CMP_OBSERVATIONS_PER_SITE;
                 }
             }
         }
+    }
+
+    fn flush_last_cmp_site(&mut self) {
+        let Some(site) = self.last_cmp_site.take() else {
+            return;
+        };
+        if let Some(count) = self.cmp_site_counts.get_mut(&site) {
+            *count = self.last_cmp_site_count;
+        }
+        self.last_cmp_site_count = 0;
     }
 
     #[inline]
@@ -732,6 +774,39 @@ mod tests {
             op1: U256::from(123),
             op2: U256::from(456),
             pc: 2,
+            address: Address::ZERO,
+            opcode: opcode::EQ,
+        });
+
+        assert_eq!(inspector.get_cmp_log().len(), usize::from(MAX_CMP_OBSERVATIONS_PER_SITE) + 1);
+        assert_eq!(inspector.get_cmp_log().last().unwrap().pc, 2);
+    }
+
+    #[test]
+    fn cmp_log_cached_site_keeps_cap_across_site_switches() {
+        let mut inspector = EdgeCovInspector::with_cmp_log();
+
+        for i in 0..usize::from(MAX_CMP_OBSERVATIONS_PER_SITE) + 1 {
+            inspector.store_cmp(CmpOperands {
+                op1: U256::from(i),
+                op2: U256::from(i + 1),
+                pc: 1,
+                address: Address::ZERO,
+                opcode: opcode::EQ,
+            });
+        }
+
+        inspector.store_cmp(CmpOperands {
+            op1: U256::from(123),
+            op2: U256::from(456),
+            pc: 2,
+            address: Address::ZERO,
+            opcode: opcode::EQ,
+        });
+        inspector.store_cmp(CmpOperands {
+            op1: U256::from(789),
+            op2: U256::from(790),
+            pc: 1,
             address: Address::ZERO,
             opcode: opcode::EQ,
         });


### PR DESCRIPTION
Folds the edge-coverage-related draft perf PRs into one reviewable PR:

- #15257
- #15260
- #15291
- #15293
- #15294
- #15295
- #15302
- #15312

The folded changes are limited to edge coverage collection and cmp-log bookkeeping:

- pass already-loaded opcodes into edge/cmp helpers and inline hot helpers
- pre-size dense edge maps for collision-free coverage
- compact optional call-depth storage
- use entry APIs for cmp site and dense edge counts
- cache consecutive cmp-log sites

Validation:

- `cargo fmt --all`
- `cargo test -p foundry-evm edge_cov --lib`

Prompted by: @grandizzy
