### PR TITLE
perf(fuzz): fold empty dictionary collection skips

### DIFF
--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -478,7 +478,7 @@ impl FuzzDictionary {
             // Insert push bytes.
             self.insert_push_bytes_values(address, &account.info);
             // Insert storage values.
-            if self.config.include_storage {
+            if self.config.include_storage && !account.storage.is_empty() {
                 let slot_identifier_key = targets.get(address).and_then(|contract| {
                     contract.storage_layout.as_ref().map(|layout| {
                         let key = Arc::as_ptr(layout) as usize;

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -425,7 +425,9 @@ impl FuzzDictionary {
         }
 
         // Insert samples collected from current call in fuzz dictionary.
-        self.insert_sample_values(samples, run_depth);
+        if !samples.is_empty() {
+            self.insert_sample_values(samples, run_depth);
+        }
     }
 
     fn decode_log_events(

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -159,6 +159,10 @@ impl InvariantFuzzState {
         run_depth: u32,
         mapping_slots: Option<&AddressMap<MappingSlots>>,
     ) {
+        if logs.is_empty() && result.is_empty() && state_changeset.is_empty() {
+            return;
+        }
+
         let mut dict = self.inner.borrow_mut();
         let targets = fuzzed_contracts.targets();
         let (target_contract, target_function) = if logs.is_empty() && result.is_empty() {

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -543,9 +543,6 @@ impl FuzzDictionary {
         let Some(code) = &account_info.code else {
             return;
         };
-        if self.addresses.contains(address) {
-            return;
-        }
         self.insert_address(*address);
         if self.values_full() {
             return;

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -140,6 +140,10 @@ impl InvariantFuzzState {
     }
 
     pub fn collect_fuzzer_values(&self, fuzzer: &mut Fuzzer) {
+        if fuzzer.collected_values.is_empty() {
+            return;
+        }
+
         let mut dict = self.inner.borrow_mut();
         for value in fuzzer.collected_values.drain(..) {
             dict.insert_value(value);

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -533,6 +533,9 @@ impl FuzzDictionary {
         let Some(code) = &account_info.code else {
             return;
         };
+        if self.addresses.contains(address) {
+            return;
+        }
         self.insert_address(*address);
         if self.values_full() {
             return;


### PR DESCRIPTION
Folds small fuzz-state dictionary skip guards into one reviewable PR:

- #15314
- #15315
- #15317
- #15318

This intentionally does not fold #15303: applying that address guard breaks `same_address_with_new_bytecode_is_scanned_again`, because the same address can later have different bytecode that still needs scanning.

The folded changes skip work for empty inputs in fuzz dictionary collection paths:

- empty call value collection
- empty fuzzer value drain
- empty decoded log samples
- empty storage changes before storage-layout lookup

Validation:

- `cargo fmt --all`
- `cargo test -p foundry-evm-fuzz strategies::state --lib`

Prompted by: @grandizzy
