### PR TITLE
feat(symbolic): emit solidity regression tests

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -2213,7 +2213,12 @@ impl TestArgs {
             if let Some(regression) = &symbolic_regression {
                 for suite_result in results.values_mut() {
                     let artifacts = collect_symbolic_artifacts(suite_result);
-                    let regressions = emit_symbolic_regressions(&config, regression, &artifacts)?;
+                    let regressions = emit_symbolic_regressions(
+                        &config,
+                        regression,
+                        &runner.known_contracts,
+                        &artifacts,
+                    )?;
                     attach_symbolic_regressions(suite_result, &regressions);
                 }
             }
@@ -2227,7 +2232,12 @@ impl TestArgs {
             if let Some(regression) = &symbolic_regression {
                 for suite_result in results.values_mut() {
                     let artifacts = collect_symbolic_artifacts(suite_result);
-                    let regressions = emit_symbolic_regressions(&config, regression, &artifacts)?;
+                    let regressions = emit_symbolic_regressions(
+                        &config,
+                        regression,
+                        &runner.known_contracts,
+                        &artifacts,
+                    )?;
                     attach_symbolic_regressions(suite_result, &regressions);
                 }
             }
@@ -2588,7 +2598,8 @@ impl TestArgs {
 
             if let Some(regression) = &symbolic_regression {
                 let artifacts = collect_symbolic_artifacts(&suite_result);
-                let regressions = emit_symbolic_regressions(&config, regression, &artifacts)?;
+                let regressions =
+                    emit_symbolic_regressions(&config, regression, &known_contracts, &artifacts)?;
                 attach_symbolic_regressions(&mut suite_result, &regressions);
                 if !silent {
                     for regression in regressions {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -12,6 +12,10 @@ use crate::{
         SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA, SuiteResult, SymbolicCounterexampleArtifact,
         SymbolicReplayStatus, TestKindReport, TestOutcome, TestResult, TestStatus,
     },
+    symbolic_regression::{
+        SymbolicRegressionConfig, attach_symbolic_regressions, collect_symbolic_artifacts,
+        emit_symbolic_regressions,
+    },
     traces::{
         CallTraceDecoderBuilder, InternalTraceMode, TraceKind,
         debug::{ContractSources, DebugTraceIdentifier},
@@ -669,6 +673,24 @@ pub struct TestArgs {
         ],
     )]
     pub replay_symbolic_artifact: Option<PathBuf>,
+
+    /// Emit Solidity regression tests for confirmed symbolic counterexamples.
+    #[arg(long, env = "FOUNDRY_SYMBOLIC_EMIT_REGRESSION")]
+    pub emit_regression: bool,
+
+    /// File or directory for generated symbolic regression tests.
+    #[arg(
+        long,
+        env = "FOUNDRY_SYMBOLIC_REGRESSION_OUT",
+        value_name = "PATH",
+        value_hint = ValueHint::AnyPath,
+        requires = "emit_regression"
+    )]
+    pub regression_out: Option<PathBuf>,
+
+    /// Overwrite existing generated symbolic regression tests.
+    #[arg(long, env = "FOUNDRY_SYMBOLIC_REGRESSION_OVERWRITE", requires = "emit_regression")]
+    pub regression_overwrite: bool,
 
     /// Run fuzz tests symbolically and persist non-failing concrete inputs to the fuzz corpus.
     #[arg(long, env = "FOUNDRY_SYMBOLIC_SEED_CORPUS")]
@@ -2076,6 +2098,16 @@ impl TestArgs {
         }
     }
 
+    fn symbolic_regression_config(&self, config: &Config) -> Option<SymbolicRegressionConfig> {
+        self.emit_regression.then(|| SymbolicRegressionConfig {
+            out: self
+                .regression_out
+                .clone()
+                .map(|path| if path.is_relative() { config.root.join(path) } else { path }),
+            overwrite: self.regression_overwrite,
+        })
+    }
+
     /// Run all tests that matches the filter predicate from a test runner
     async fn run_tests_inner<FEN: FoundryEvmNetwork>(
         &self,
@@ -2089,6 +2121,7 @@ impl TestArgs {
         if self.list {
             return list(runner, filter);
         }
+        let symbolic_regression = self.symbolic_regression_config(&config);
 
         trace!(target: "forge::test", "running all tests");
 
@@ -2177,13 +2210,27 @@ impl TestArgs {
                     }
                 }
             }
+            if let Some(regression) = &symbolic_regression {
+                for suite_result in results.values_mut() {
+                    let artifacts = collect_symbolic_artifacts(suite_result);
+                    let regressions = emit_symbolic_regressions(&config, regression, &artifacts)?;
+                    attach_symbolic_regressions(suite_result, &regressions);
+                }
+            }
             sh_println!("{}", serde_json::to_string(&results)?)?;
             let kc = runner.known_contracts.clone();
             return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
         }
 
         if self.junit {
-            let results = runner.test_collect(filter)?;
+            let mut results = runner.test_collect(filter)?;
+            if let Some(regression) = &symbolic_regression {
+                for suite_result in results.values_mut() {
+                    let artifacts = collect_symbolic_artifacts(suite_result);
+                    let regressions = emit_symbolic_regressions(&config, regression, &artifacts)?;
+                    attach_symbolic_regressions(suite_result, &regressions);
+                }
+            }
             sh_println!("{}", junit_xml_report(&results, verbosity).to_string()?)?;
             let kc = runner.known_contracts.clone();
             return Ok(TestOutcome::new(Some(kc), results, self.allow_failure, fuzz_seed));
@@ -2537,6 +2584,21 @@ impl TestArgs {
             // Print suite summary.
             if !silent && has_tests {
                 sh_println!("{}", suite_result.summary())?;
+            }
+
+            if let Some(regression) = &symbolic_regression {
+                let artifacts = collect_symbolic_artifacts(&suite_result);
+                let regressions = emit_symbolic_regressions(&config, regression, &artifacts)?;
+                attach_symbolic_regressions(&mut suite_result, &regressions);
+                if !silent {
+                    for regression in regressions {
+                        sh_warn!(
+                            "Regression test: {} (from {})",
+                            regression.path.display(),
+                            regression.artifact.display()
+                        )?;
+                    }
+                }
             }
 
             // Add the suite result to the outcome.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -13,8 +13,8 @@ use crate::{
         SymbolicReplayStatus, TestKindReport, TestOutcome, TestResult, TestStatus,
     },
     symbolic_regression::{
-        SymbolicRegressionConfig, attach_symbolic_regressions, collect_symbolic_artifacts,
-        emit_symbolic_regressions,
+        SymbolicRegressionConfig, attach_symbolic_regressions_to_suites,
+        collect_symbolic_artifacts_from_suites, emit_symbolic_regressions,
     },
     traces::{
         CallTraceDecoderBuilder, InternalTraceMode, TraceKind,
@@ -2211,16 +2211,14 @@ impl TestArgs {
                 }
             }
             if let Some(regression) = &symbolic_regression {
-                for suite_result in results.values_mut() {
-                    let artifacts = collect_symbolic_artifacts(suite_result);
-                    let regressions = emit_symbolic_regressions(
-                        &config,
-                        regression,
-                        &runner.known_contracts,
-                        &artifacts,
-                    )?;
-                    attach_symbolic_regressions(suite_result, &regressions);
-                }
+                let artifacts = collect_symbolic_artifacts_from_suites(results.values());
+                let regressions = emit_symbolic_regressions(
+                    &config,
+                    regression,
+                    &runner.known_contracts,
+                    &artifacts,
+                )?;
+                attach_symbolic_regressions_to_suites(results.values_mut(), &regressions);
             }
             sh_println!("{}", serde_json::to_string(&results)?)?;
             let kc = runner.known_contracts.clone();
@@ -2230,16 +2228,14 @@ impl TestArgs {
         if self.junit {
             let mut results = runner.test_collect(filter)?;
             if let Some(regression) = &symbolic_regression {
-                for suite_result in results.values_mut() {
-                    let artifacts = collect_symbolic_artifacts(suite_result);
-                    let regressions = emit_symbolic_regressions(
-                        &config,
-                        regression,
-                        &runner.known_contracts,
-                        &artifacts,
-                    )?;
-                    attach_symbolic_regressions(suite_result, &regressions);
-                }
+                let artifacts = collect_symbolic_artifacts_from_suites(results.values());
+                let regressions = emit_symbolic_regressions(
+                    &config,
+                    regression,
+                    &runner.known_contracts,
+                    &artifacts,
+                )?;
+                attach_symbolic_regressions_to_suites(results.values_mut(), &regressions);
             }
             sh_println!("{}", junit_xml_report(&results, verbosity).to_string()?)?;
             let kc = runner.known_contracts.clone();
@@ -2596,28 +2592,27 @@ impl TestArgs {
                 sh_println!("{}", suite_result.summary())?;
             }
 
-            if let Some(regression) = &symbolic_regression {
-                let artifacts = collect_symbolic_artifacts(&suite_result);
-                let regressions =
-                    emit_symbolic_regressions(&config, regression, &known_contracts, &artifacts)?;
-                attach_symbolic_regressions(&mut suite_result, &regressions);
-                if !silent {
-                    for regression in regressions {
-                        sh_warn!(
-                            "Regression test: {} (from {})",
-                            regression.path.display(),
-                            regression.artifact.display()
-                        )?;
-                    }
-                }
-            }
-
             // Add the suite result to the outcome.
             outcome.results.insert(contract_name, suite_result);
 
             // Stop processing the remaining suites if any test failed and `fail_fast` is set.
             if self.fail_fast && any_test_failed {
                 break;
+            }
+        }
+        if let Some(regression) = &symbolic_regression {
+            let artifacts = collect_symbolic_artifacts_from_suites(outcome.results.values());
+            let regressions =
+                emit_symbolic_regressions(&config, regression, &known_contracts, &artifacts)?;
+            attach_symbolic_regressions_to_suites(outcome.results.values_mut(), &regressions);
+            if !silent {
+                for regression in regressions {
+                    sh_warn!(
+                        "Regression test: {} (from {})",
+                        regression.path.display(),
+                        regression.artifact.display()
+                    )?;
+                }
             }
         }
         outcome.last_run_decoder = Some(decoder);

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -34,6 +34,7 @@ pub use runner::ContractRunner;
 mod progress;
 pub mod result;
 mod symbolic_minimizer;
+mod symbolic_regression;
 
 // TODO: remove
 pub use foundry_common::traits::TestFilter;

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -8,6 +8,7 @@ use crate::{
         ContractRunnerContext, InvariantCampaignScope, LIBRARY_DEPLOYER,
         count_runnable_invariant_campaign_anchors,
     },
+    symbolic_regression::SYMBOLIC_REGRESSION_MARKER,
 };
 use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{Address, Bytes, U256};
@@ -128,9 +129,15 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
         let matcher = self.test_function_matcher();
         self.matching_contracts(filter).flat_map(move |(id, c)| {
             let identifier = id.identifier();
-            c.abi
-                .functions()
-                .filter(move |func| matcher.matches_test_function(filter, &identifier, func))
+            let generated_symbolic_regression = is_generated_symbolic_regression_contract(&c.abi);
+            c.abi.functions().filter(move |func| {
+                matcher.matches_test_function(
+                    filter,
+                    &identifier,
+                    func,
+                    generated_symbolic_regression,
+                )
+            })
         })
     }
 
@@ -145,9 +152,13 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
             .filter(|(id, _)| filter.matches_path(&id.source) && filter.matches_contract(&id.name))
             .flat_map(move |(id, c)| {
                 let identifier = id.identifier();
-                c.abi
-                    .functions()
-                    .filter(move |func| matcher.test_function_kind(&identifier, func).is_any_test())
+                let generated_symbolic_regression =
+                    is_generated_symbolic_regression_contract(&c.abi);
+                c.abi.functions().filter(move |func| {
+                    matcher
+                        .test_function_kind(&identifier, func, generated_symbolic_regression)
+                        .is_any_test()
+                })
             })
     }
 
@@ -159,11 +170,17 @@ impl<FEN: FoundryEvmNetwork> MultiContractRunner<FEN> {
                 let source = id.source.as_path().display().to_string();
                 let name = id.name.clone();
                 let identifier = id.identifier();
+                let generated_symbolic_regression =
+                    is_generated_symbolic_regression_contract(&c.abi);
                 let tests = c
                     .abi
                     .functions()
                     .filter(|func| {
-                        let kind = matcher.test_function_kind(&identifier, func);
+                        let kind = matcher.test_function_kind(
+                            &identifier,
+                            func,
+                            generated_symbolic_regression,
+                        );
                         (!self.tcfg.fuzz_only
                             || matches!(
                                 kind,
@@ -886,10 +903,9 @@ impl<'a> TestFunctionMatcher<'a> {
         &self,
         contract_id: &str,
         func: &Function,
+        generated_symbolic_regression: bool,
     ) -> TestFunctionKind {
-        if is_symbolic_regression_contract(contract_id)
-            && !func.name.starts_with("test_regression_")
-        {
+        if generated_symbolic_regression && !func.name.starts_with("test_regression_") {
             return TestFunctionKind::Unknown;
         }
 
@@ -905,11 +921,12 @@ impl<'a> TestFunctionMatcher<'a> {
         filter: &dyn TestFilter,
         contract_id: &str,
         func: &Function,
+        generated_symbolic_regression: bool,
     ) -> bool {
         filter.matches_test_function_kind_in_contract(
             contract_id,
             func,
-            self.test_function_kind(contract_id, func),
+            self.test_function_kind(contract_id, func, generated_symbolic_regression),
         )
     }
 
@@ -920,17 +937,15 @@ impl<'a> TestFunctionMatcher<'a> {
         abi: &JsonAbi,
     ) -> bool {
         let identifier = id.identifier();
+        let generated_symbolic_regression = is_generated_symbolic_regression_contract(abi);
         matches_contract(filter, &id.source, &id.name, &identifier, abi.functions(), |func| {
-            self.test_function_kind(&identifier, func)
+            self.test_function_kind(&identifier, func, generated_symbolic_regression)
         })
     }
 }
 
-fn is_symbolic_regression_contract(contract_id: &str) -> bool {
-    contract_id
-        .rsplit_once(':')
-        .map_or(contract_id, |(_, contract)| contract)
-        .ends_with("_SymbolicRegression")
+pub(crate) fn is_generated_symbolic_regression_contract(abi: &JsonAbi) -> bool {
+    abi.functions().any(|func| func.name == SYMBOLIC_REGRESSION_MARKER && func.inputs.is_empty())
 }
 
 pub(crate) fn matches_contract(
@@ -957,6 +972,15 @@ mod tests {
     use super::*;
     use foundry_common::TestFunctionExt;
 
+    fn abi_with_functions(functions: &[&str]) -> JsonAbi {
+        let mut abi = JsonAbi::new();
+        for function in functions {
+            let function = Function::parse(function).unwrap();
+            abi.functions.entry(function.name.clone()).or_default().push(function);
+        }
+        abi
+    }
+
     #[test]
     fn matches_contract_uses_provided_function_kind() {
         let filter = EmptyTestFilter::default();
@@ -969,5 +993,15 @@ mod tests {
         assert!(!matches_contract(&filter, path, "Symbolic", "Symbolic", [func], |func| {
             func.test_function_kind()
         }));
+    }
+
+    #[test]
+    fn generated_symbolic_regression_detection_uses_marker() {
+        let user_suffix_abi = abi_with_functions(&["test_fails()"]);
+        assert!(!is_generated_symbolic_regression_contract(&user_suffix_abi));
+
+        let generated_abi =
+            abi_with_functions(&[&format!("{SYMBOLIC_REGRESSION_MARKER}()"), "test_fails()"]);
+        assert!(is_generated_symbolic_regression_contract(&generated_abi));
     }
 }

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -887,6 +887,12 @@ impl<'a> TestFunctionMatcher<'a> {
         contract_id: &str,
         func: &Function,
     ) -> TestFunctionKind {
+        if is_symbolic_regression_contract(contract_id)
+            && !func.name.starts_with("test_regression_")
+        {
+            return TestFunctionKind::Unknown;
+        }
+
         TestFunctionKind::classify(
             func.name.as_str(),
             !func.inputs.is_empty(),
@@ -918,6 +924,13 @@ impl<'a> TestFunctionMatcher<'a> {
             self.test_function_kind(&identifier, func)
         })
     }
+}
+
+fn is_symbolic_regression_contract(contract_id: &str) -> bool {
+    contract_id
+        .rsplit_once(':')
+        .map_or(contract_id, |(_, contract)| contract)
+        .ends_with("_SymbolicRegression")
 }
 
 pub(crate) fn matches_contract(

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -1100,6 +1100,15 @@ impl SymbolicArtifactRef {
     }
 }
 
+/// Reference to a generated Solidity regression test for a symbolic counterexample.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SymbolicRegressionRef {
+    /// Source counterexample artifact path.
+    pub artifact: std::path::PathBuf,
+    /// Generated Solidity regression test path.
+    pub path: std::path::PathBuf,
+}
+
 /// Before/after artifact references and counters for concrete symbolic counterexample minimization.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1690,6 +1699,10 @@ pub struct TestResult {
     /// All durable replay artifacts produced for this test result, normalized for JSON consumers.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub counterexample_artifacts: Vec<SymbolicArtifactRef>,
+
+    /// Generated Solidity regression tests for this symbolic counterexample.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub symbolic_regressions: Vec<SymbolicRegressionRef>,
 
     /// Any captured & parsed as strings logs along the test's execution which should
     /// be printed to the user.

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1210,6 +1210,27 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         kind: SymbolicCounterexampleArtifactKind,
         calls: Vec<SymbolicCounterexampleCall>,
     ) -> Option<SymbolicArtifactRef> {
+        self.persist_symbolic_counterexample_artifact_with_replay_semantics(
+            test_name,
+            artifact_file_name,
+            symbolic,
+            SymbolicCounterexampleReplaySemantics {
+                fail_on_revert: self.config.invariant.fail_on_revert,
+            },
+            kind,
+            calls,
+        )
+    }
+
+    fn persist_symbolic_counterexample_artifact_with_replay_semantics(
+        &self,
+        test_name: &str,
+        artifact_file_name: &str,
+        symbolic: &SymbolicResult,
+        replay_semantics: SymbolicCounterexampleReplaySemantics,
+        kind: SymbolicCounterexampleArtifactKind,
+        calls: Vec<SymbolicCounterexampleCall>,
+    ) -> Option<SymbolicArtifactRef> {
         let dir = self
             .config
             .cache_path
@@ -1224,9 +1245,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 test: test_name.to_string(),
             },
             symbolic,
-            SymbolicCounterexampleReplaySemantics {
-                fail_on_revert: self.config.invariant.fail_on_revert,
-            },
+            replay_semantics,
             calls,
         );
 
@@ -1248,6 +1267,23 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         artifact_file_name: &str,
         call_sequence: &[BaseCounterExample],
     ) -> Option<SymbolicArtifactRef> {
+        self.persist_invariant_sequence_counterexample_artifact_with_replay_semantics(
+            test_name,
+            artifact_file_name,
+            call_sequence,
+            SymbolicCounterexampleReplaySemantics {
+                fail_on_revert: self.config.invariant.fail_on_revert,
+            },
+        )
+    }
+
+    fn persist_invariant_sequence_counterexample_artifact_with_replay_semantics(
+        &self,
+        test_name: &str,
+        artifact_file_name: &str,
+        call_sequence: &[BaseCounterExample],
+        replay_semantics: SymbolicCounterexampleReplaySemantics,
+    ) -> Option<SymbolicArtifactRef> {
         if call_sequence.is_empty() {
             return None;
         }
@@ -1266,6 +1302,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             test_name,
             artifact_file_name,
             calls,
+            replay_semantics,
         )
     }
 
@@ -1274,6 +1311,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         test_name: &str,
         artifact_file_name: &str,
         calls: Vec<SymbolicCounterexampleCall>,
+        replay_semantics: SymbolicCounterexampleReplaySemantics,
     ) -> Option<SymbolicArtifactRef> {
         if calls.is_empty() {
             return None;
@@ -1292,10 +1330,11 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             None,
         );
 
-        self.persist_symbolic_counterexample_artifact(
+        self.persist_symbolic_counterexample_artifact_with_replay_semantics(
             test_name,
             artifact_file_name,
             &symbolic_result,
+            replay_semantics,
             SymbolicCounterexampleArtifactKind::Sequence,
             calls,
         )
@@ -1458,6 +1497,9 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             test_name,
             &format!("original__{artifact_file_name}"),
             minimization.original_calls.clone(),
+            SymbolicCounterexampleReplaySemantics {
+                fail_on_revert: self.config.invariant.fail_on_revert,
+            },
         );
         let minimized_artifact = self.persist_invariant_sequence_counterexample_artifact(
             test_name,
@@ -3752,11 +3794,13 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         &current_settings,
                     );
                 }
-                let artifact = self.persist_invariant_sequence_counterexample_artifact(
-                    &invariant_contract.anchor().signature(),
-                    &format!("handler-{reverter}-{selector}"),
-                    &counterexample_calls,
-                );
+                let artifact = self
+                    .persist_invariant_sequence_counterexample_artifact_with_replay_semantics(
+                        &invariant_contract.anchor().signature(),
+                        &format!("handler-{reverter}-{selector}"),
+                        &counterexample_calls,
+                        SymbolicCounterexampleReplaySemantics { fail_on_revert: true },
+                    );
 
                 let counterexample = if counterexample_calls.is_empty() {
                     None

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -4,7 +4,10 @@ use crate::{
     MultiContractRunner, TestFilter,
     coverage::HitMaps,
     fuzz::{BaseCounterExample, FuzzTestResult},
-    multi_runner::{FuzzMinimizeObservation, TestContract, TestFunctionMatcher, TestRunnerConfig},
+    multi_runner::{
+        FuzzMinimizeObservation, TestContract, TestFunctionMatcher, TestRunnerConfig,
+        is_generated_symbolic_regression_contract,
+    },
     progress::{TestsProgress, start_fuzz_progress},
     result::{
         InvariantFailure, InvariantPredicateResult, SuiteResult, SymbolicArtifactRef,
@@ -751,6 +754,8 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 &self.mcr.inline_config,
                 self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
             );
+            let generated_symbolic_regression =
+                is_generated_symbolic_regression_contract(&self.contract.abi);
             !self
                 .contract
                 .abi
@@ -759,13 +764,21 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                     filter.matches_test_function_kind_in_contract(
                         self.name,
                         func,
-                        test_matcher.test_function_kind(self.name, func),
+                        test_matcher.test_function_kind(
+                            self.name,
+                            func,
+                            generated_symbolic_regression,
+                        ),
                     )
                 })
                 .filter(|func| self.function_matches_network_pass(func))
                 .any(|func| {
                     matches!(
-                        test_matcher.test_function_kind(self.name, func),
+                        test_matcher.test_function_kind(
+                            self.name,
+                            func,
+                            generated_symbolic_regression,
+                        ),
                         TestFunctionKind::FuzzTest { .. } | TestFunctionKind::InvariantTest
                     )
                 })
@@ -837,10 +850,16 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 &self.mcr.inline_config,
                 self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
             );
+            let generated_symbolic_regression =
+                is_generated_symbolic_regression_contract(&self.contract.abi);
             self.contract
                 .abi
                 .functions()
-                .filter(|func| test_matcher.test_function_kind(self.name, func).is_invariant_test())
+                .filter(|func| {
+                    test_matcher
+                        .test_function_kind(self.name, func, generated_symbolic_regression)
+                        .is_invariant_test()
+                })
                 .collect()
         };
 
@@ -917,6 +936,8 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 &self.mcr.inline_config,
                 self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
             );
+            let generated_symbolic_regression =
+                is_generated_symbolic_regression_contract(&self.contract.abi);
             self.contract
                 .abi
                 .functions()
@@ -924,7 +945,11 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                     filter.matches_test_function_kind_in_contract(
                         self.name,
                         func,
-                        test_matcher.test_function_kind(self.name, func),
+                        test_matcher.test_function_kind(
+                            self.name,
+                            func,
+                            generated_symbolic_regression,
+                        ),
                     )
                 })
                 .filter(|func| self.function_matches_network_pass(func))
@@ -1052,6 +1077,8 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             &self.mcr.inline_config,
             self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
         );
+        let generated_symbolic_regression =
+            is_generated_symbolic_regression_contract(&self.contract.abi);
 
         if self.progress.is_some() {
             let interrupt = early_exit.clone();
@@ -1116,7 +1143,8 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 }
 
                 let sig = func.signature();
-                let kind = test_matcher.test_function_kind(self.name, func);
+                let kind =
+                    test_matcher.test_function_kind(self.name, func, generated_symbolic_regression);
 
                 let _guard = debug_span!(
                     "test",

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -742,19 +742,37 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
     pub fn run_tests(mut self, filter: &dyn TestFilter) -> SuiteResult {
         let start = Instant::now();
         let mut warnings = Vec::new();
-
         // In fuzz-only mode, drop suites with no runnable fuzz or invariant tests before
         // executing `setUp`. The full function list is built after setup so contract-level
         // inline config can still affect symbolic entrypoint discovery.
-        if self.mcr.tcfg.fuzz_only
-            && !self
+        let skip_fuzz_only_suite = if self.mcr.tcfg.fuzz_only {
+            let test_matcher = TestFunctionMatcher::new(
+                &self.config,
+                &self.mcr.inline_config,
+                self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
+            );
+            !self
                 .contract
                 .abi
                 .functions()
-                .filter(|func| filter.matches_test_function_in_contract(self.name, func))
+                .filter(|func| {
+                    filter.matches_test_function_kind_in_contract(
+                        self.name,
+                        func,
+                        test_matcher.test_function_kind(self.name, func),
+                    )
+                })
                 .filter(|func| self.function_matches_network_pass(func))
-                .any(|func| func.is_fuzz_test() || func.is_invariant_test())
-        {
+                .any(|func| {
+                    matches!(
+                        test_matcher.test_function_kind(self.name, func),
+                        TestFunctionKind::FuzzTest { .. } | TestFunctionKind::InvariantTest
+                    )
+                })
+        } else {
+            false
+        };
+        if skip_fuzz_only_suite {
             return SuiteResult::new(start.elapsed(), BTreeMap::new(), warnings);
         }
 
@@ -813,8 +831,18 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             match_sig
         });
 
-        let invariant_fns: Vec<_> =
-            self.contract.abi.functions().filter(|func| func.is_invariant_test()).collect();
+        let invariant_fns: Vec<_> = {
+            let test_matcher = TestFunctionMatcher::new(
+                &self.config,
+                &self.mcr.inline_config,
+                self.mcr.tcfg.symbolic_artifact_replay.as_ref(),
+            );
+            self.contract
+                .abi
+                .functions()
+                .filter(|func| test_matcher.test_function_kind(self.name, func).is_invariant_test())
+                .collect()
+        };
 
         // Validate signatures up front: invariant functions must take no parameters. Without
         // this, parameterized `invariant_*` functions would slip into contract-level campaigns

--- a/crates/forge/src/symbolic_regression.rs
+++ b/crates/forge/src/symbolic_regression.rs
@@ -5,7 +5,7 @@ use crate::result::{
 };
 use alloy_primitives::{U256, hex};
 use eyre::{Result, bail};
-use foundry_common::fs;
+use foundry_common::{TestFunctionExt, contracts::ContractsByArtifact, fs};
 use foundry_config::Config;
 use std::{
     collections::HashSet,
@@ -30,6 +30,7 @@ pub(crate) struct SymbolicRegression {
 pub(crate) fn emit_symbolic_regressions(
     config: &Config,
     regression: &SymbolicRegressionConfig,
+    known_contracts: &ContractsByArtifact,
     results: &[SymbolicArtifactRef],
 ) -> Result<Vec<SymbolicRegression>> {
     let mut emitted = Vec::new();
@@ -60,6 +61,7 @@ pub(crate) fn emit_symbolic_regressions(
             regression,
             &artifact_ref.path,
             &artifact,
+            known_contracts,
             suffix.as_deref(),
         )?);
     }
@@ -167,6 +169,7 @@ fn emit_symbolic_regression(
     regression: &SymbolicRegressionConfig,
     artifact_path: &Path,
     artifact: &SymbolicCounterexampleArtifact,
+    known_contracts: &ContractsByArtifact,
     suffix: Option<&str>,
 ) -> Result<SymbolicRegression> {
     let (source, contract) = artifact_source_and_contract(artifact_path, artifact)?;
@@ -223,6 +226,7 @@ fn emit_symbolic_regression(
             write_call(&mut out, call, "address(this)", true)?;
         }
         SymbolicCounterexampleArtifactKind::Sequence => {
+            let call_after_invariant = call_after_invariant(known_contracts, artifact)?;
             for call in &artifact.calls {
                 write_call(
                     &mut out,
@@ -236,6 +240,13 @@ fn emit_symbolic_regression(
                 "        __foundrySymbolicRegressionCall(address(this), hex\"{}\", 0, true);",
                 hex::encode(selector_from_signature(&artifact.test.test))
             )?;
+            if call_after_invariant {
+                writeln!(
+                    out,
+                    "        __foundrySymbolicRegressionCall(address(this), hex\"{}\", 0, true);",
+                    hex::encode(selector_from_signature("afterInvariant()"))
+                )?;
+            }
         }
     }
     writeln!(out, "    }}")?;
@@ -340,6 +351,23 @@ fn sanitize_identifier(value: &str) -> String {
 fn handler_regression_suffix(path: &Path) -> Option<String> {
     let stem = path.file_stem()?.to_string_lossy();
     stem.starts_with("handler-").then(|| sanitize_identifier(&stem))
+}
+
+fn call_after_invariant(
+    known_contracts: &ContractsByArtifact,
+    artifact: &SymbolicCounterexampleArtifact,
+) -> Result<bool> {
+    let Some((_, contract)) =
+        known_contracts.find_by_name_or_identifier(&artifact.test.contract)?
+    else {
+        return Ok(false);
+    };
+    let mut after_invariant_fns =
+        contract.abi.functions().filter(|func| func.name.is_after_invariant());
+    let Some(after_invariant) = after_invariant_fns.next() else {
+        return Ok(false);
+    };
+    Ok(after_invariant.name == "afterInvariant" && after_invariant_fns.next().is_none())
 }
 
 fn relative_solidity_import(from_dir: &Path, to_file: &Path) -> String {

--- a/crates/forge/src/symbolic_regression.rs
+++ b/crates/forge/src/symbolic_regression.rs
@@ -244,16 +244,17 @@ fn plan_symbolic_regression(
     match artifact.kind {
         SymbolicCounterexampleArtifactKind::SingleCall => {
             let call = artifact.calls.first().expect("single-call artifact has at least one call");
-            write_call(&mut contents, call, "address(this)", true)?;
+            write_call(&mut contents, call, "address(this)", true, None)?;
         }
         SymbolicCounterexampleArtifactKind::Sequence => {
             let call_after_invariant = call_after_invariant(known_contracts, artifact)?;
-            for call in &artifact.calls {
+            for (index, call) in artifact.calls.iter().enumerate() {
                 write_call(
                     &mut contents,
                     call,
                     &format!("address({})", call.target),
                     artifact.replay_semantics.fail_on_revert,
+                    Some(index),
                 )?;
             }
             writeln!(
@@ -274,7 +275,7 @@ fn plan_symbolic_regression(
     writeln!(contents)?;
     writeln!(
         contents,
-        "    function __foundrySymbolicRegressionCall(address target, bytes memory data, uint256 value, bool bubbleFailure) internal {{"
+        "    function __foundrySymbolicRegressionCall(address target, bytes memory data, uint256 value, bool bubbleFailure) internal returns (bool) {{"
     )?;
     writeln!(contents, "        if (target != address(this)) {{")?;
     writeln!(contents, "            uint256 codeSize;")?;
@@ -290,6 +291,7 @@ fn plan_symbolic_regression(
     writeln!(contents, "                revert(add(ret, 0x20), mload(ret))")?;
     writeln!(contents, "            }}")?;
     writeln!(contents, "        }}")?;
+    writeln!(contents, "        return ok;")?;
     writeln!(contents, "    }}")?;
     writeln!(contents, "}}")?;
 
@@ -341,6 +343,7 @@ fn write_call(
     call: &crate::result::SymbolicCounterexampleCall,
     target: &str,
     bubble_failure: bool,
+    sequence_call_index: Option<usize>,
 ) -> Result<()> {
     if let Some(warp) = call.warp {
         writeln!(
@@ -355,22 +358,87 @@ fn write_call(
     if let Some(value) = call.value
         && !value.is_zero()
     {
-        writeln!(out, "        __foundrySymbolicVm.deal(address(this), {});", u256_literal(value))?;
-        writeln!(
-            out,
-            "        __foundrySymbolicVm.deal({}, {});",
-            call.sender,
-            u256_literal(value)
-        )?;
+        if let Some(index) = sequence_call_index {
+            writeln!(
+                out,
+                "        uint256 __foundrySymbolicValue{index} = {} <= address({}).balance ? {} : address({}).balance;",
+                u256_literal(value),
+                call.sender,
+                u256_literal(value),
+                call.sender
+            )?;
+            writeln!(
+                out,
+                "        if (__foundrySymbolicValue{index} != 0 && {} != address(this)) {{",
+                call.sender
+            )?;
+            writeln!(
+                out,
+                "            __foundrySymbolicVm.deal(address(this), address(this).balance + __foundrySymbolicValue{index});"
+            )?;
+            writeln!(
+                out,
+                "            __foundrySymbolicVm.deal({}, address({}).balance - __foundrySymbolicValue{index});",
+                call.sender, call.sender
+            )?;
+            writeln!(out, "        }}")?;
+        } else {
+            writeln!(
+                out,
+                "        __foundrySymbolicVm.deal(address(this), {});",
+                u256_literal(value)
+            )?;
+            writeln!(
+                out,
+                "        __foundrySymbolicVm.deal({}, {});",
+                call.sender,
+                u256_literal(value)
+            )?;
+        }
     }
     writeln!(out, "        __foundrySymbolicVm.prank({});", call.sender)?;
-    writeln!(
-        out,
-        "        __foundrySymbolicRegressionCall({target}, hex\"{}\", {}, {});",
-        hex::encode(call.calldata.as_ref()),
-        call.value.map_or_else(|| "0".to_string(), u256_literal),
-        if bubble_failure { "true" } else { "false" }
-    )?;
+    let value = sequence_call_index
+        .filter(|_| call.value.is_some_and(|value| !value.is_zero()))
+        .map_or_else(
+            || call.value.map_or_else(|| "0".to_string(), u256_literal),
+            |index| format!("__foundrySymbolicValue{index}"),
+        );
+    if let Some(index) = sequence_call_index {
+        writeln!(
+            out,
+            "        bool __foundrySymbolicOk{index} = __foundrySymbolicRegressionCall({target}, hex\"{}\", {}, {});",
+            hex::encode(call.calldata.as_ref()),
+            value,
+            if bubble_failure { "true" } else { "false" }
+        )?;
+        if call.value.is_some_and(|value| !value.is_zero()) {
+            writeln!(
+                out,
+                "        if (__foundrySymbolicValue{index} != 0 && {} != address(this)) {{",
+                call.sender
+            )?;
+            writeln!(out, "            if (!__foundrySymbolicOk{index}) {{")?;
+            writeln!(
+                out,
+                "                __foundrySymbolicVm.deal({}, address({}).balance + __foundrySymbolicValue{index});",
+                call.sender, call.sender
+            )?;
+            writeln!(
+                out,
+                "                __foundrySymbolicVm.deal(address(this), address(this).balance - __foundrySymbolicValue{index});"
+            )?;
+            writeln!(out, "            }}")?;
+            writeln!(out, "        }}")?;
+        }
+    } else {
+        writeln!(
+            out,
+            "        __foundrySymbolicRegressionCall({target}, hex\"{}\", {}, {});",
+            hex::encode(call.calldata.as_ref()),
+            value,
+            if bubble_failure { "true" } else { "false" }
+        )?;
+    }
     Ok(())
 }
 
@@ -453,6 +521,152 @@ fn normalized_components(path: &Path) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::result::{
+        SymbolicCallTrace, SymbolicCounterexample, SymbolicCounterexampleReplaySemantics,
+        SymbolicCounterexampleTestIdentity, SymbolicReplayMetadata, SymbolicResult,
+    };
+    use alloy_primitives::{Address, Bytes};
+    use foundry_config::SymbolicConfig;
+    use foundry_evm_symbolic::SymbolicStats;
+
+    fn config(root: &Path) -> Config {
+        Config { root: root.to_path_buf(), test: root.join("test"), ..Default::default() }
+    }
+
+    fn artifact(
+        kind: SymbolicCounterexampleArtifactKind,
+        calls: Vec<crate::result::SymbolicCounterexampleCall>,
+    ) -> SymbolicCounterexampleArtifact {
+        let call = calls.first().expect("artifact has at least one call");
+        let symbolic = SymbolicResult::fail_counterexample(
+            &SymbolicConfig::default(),
+            SymbolicStats::default(),
+            SymbolicCallTrace::none(),
+            SymbolicCounterexample {
+                calldata: call.calldata.clone(),
+                args: None,
+                raw_args: None,
+                value: call.value,
+            },
+        );
+        let mut artifact = SymbolicCounterexampleArtifact::new(
+            kind,
+            SymbolicCounterexampleTestIdentity {
+                contract: "test/Regression.t.sol:Regression".to_string(),
+                test: "invariant_value()".to_string(),
+            },
+            &symbolic,
+            SymbolicCounterexampleReplaySemantics { fail_on_revert: false },
+            calls,
+        );
+        artifact.replay = SymbolicReplayMetadata::confirmed();
+        artifact
+    }
+
+    fn value_call(target: Address) -> crate::result::SymbolicCounterexampleCall {
+        crate::result::SymbolicCounterexampleCall {
+            warp: None,
+            roll: None,
+            sender: Address::repeat_byte(0xb0),
+            target,
+            calldata: Bytes::from_static(&[0x12, 0x34, 0x56, 0x78]),
+            value: Some(U256::from(10)),
+            contract_name: None,
+            function_name: None,
+            signature: None,
+            args: None,
+            raw_args: None,
+        }
+    }
+
+    fn plan(
+        kind: SymbolicCounterexampleArtifactKind,
+        calls: Vec<crate::result::SymbolicCounterexampleCall>,
+    ) -> String {
+        let temp = tempfile::tempdir().unwrap();
+        let source = temp.path().join("test/Regression.t.sol");
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        std::fs::write(&source, "contract Regression {}").unwrap();
+
+        let artifact_path = temp.path().join("cache/artifact.json");
+        let artifact = artifact(kind, calls);
+        plan_symbolic_regression(
+            &config(temp.path()),
+            &SymbolicRegressionConfig { out: None, overwrite: false },
+            &artifact_path,
+            &artifact,
+            &ContractsByArtifact::default(),
+            None,
+        )
+        .unwrap()
+        .contents
+    }
+
+    #[test]
+    fn sequence_regression_clamps_and_debits_sender_balance() {
+        let contents = plan(
+            SymbolicCounterexampleArtifactKind::Sequence,
+            vec![value_call(Address::repeat_byte(0x7f)), value_call(Address::repeat_byte(0x8f))],
+        );
+        let lowercase = contents.to_lowercase();
+
+        assert!(lowercase.contains(
+            "uint256 __foundrysymbolicvalue0 = 10 <= address(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0).balance ? 10 : address(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0).balance;"
+        ));
+        assert!(lowercase.contains(
+            "uint256 __foundrysymbolicvalue1 = 10 <= address(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0).balance ? 10 : address(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0).balance;"
+        ));
+        assert!(contents.contains("if (__foundrySymbolicValue0 != 0"));
+        assert!(contents.contains("if (__foundrySymbolicValue1 != 0"));
+        assert!(contents.contains(
+            "__foundrySymbolicVm.deal(address(this), address(this).balance + __foundrySymbolicValue0);"
+        ));
+        assert!(contents.contains("bool __foundrySymbolicOk0 = __foundrySymbolicRegressionCall"));
+        assert!(contents.contains("if (!__foundrySymbolicOk0) {"));
+        assert!(lowercase.contains(
+            "__foundrysymbolicvm.deal(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0, address(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0).balance - __foundrysymbolicvalue0);"
+        ));
+        assert!(lowercase.contains(
+            "__foundrysymbolicvm.deal(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0, address(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0).balance - __foundrysymbolicvalue1);"
+        ));
+        assert!(lowercase.contains(
+            "__foundrysymbolicvm.deal(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0, address(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0).balance + __foundrysymbolicvalue0);"
+        ));
+        assert!(contents.contains(
+            "__foundrySymbolicVm.deal(address(this), address(this).balance - __foundrySymbolicValue0);"
+        ));
+        assert!(lowercase.contains(
+            "__foundrysymbolicregressioncall(address(0x7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f), hex\"12345678\", __foundrysymbolicvalue0, false);"
+        ));
+        assert!(lowercase.contains(
+            "__foundrysymbolicregressioncall(address(0x8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f8f), hex\"12345678\", __foundrysymbolicvalue1, false);"
+        ));
+        assert!(
+            !lowercase.contains(
+                "__foundrysymbolicvm.deal(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0, 10);"
+            )
+        );
+    }
+
+    #[test]
+    fn single_call_regression_preserves_exact_value_funding() {
+        let contents = plan(
+            SymbolicCounterexampleArtifactKind::SingleCall,
+            vec![value_call(Address::repeat_byte(0x7f))],
+        );
+        let lowercase = contents.to_lowercase();
+
+        assert!(contents.contains("__foundrySymbolicVm.deal(address(this), 10);"));
+        assert!(
+            lowercase.contains(
+                "__foundrysymbolicvm.deal(0xb0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0, 10);"
+            )
+        );
+        assert!(contents.contains(
+            "__foundrySymbolicRegressionCall(address(this), hex\"12345678\", 10, true);"
+        ));
+        assert!(!contents.contains("bool __foundrySymbolicOk0 ="));
+    }
 
     #[test]
     fn relative_solidity_import_canonicalizes_symlinked_absolute_paths() {

--- a/crates/forge/src/symbolic_regression.rs
+++ b/crates/forge/src/symbolic_regression.rs
@@ -1,0 +1,382 @@
+use crate::result::{
+    SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA, SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA_VERSION,
+    SuiteResult, SymbolicArtifactRef, SymbolicCounterexampleArtifact,
+    SymbolicCounterexampleArtifactKind, SymbolicRegressionRef, SymbolicReplayStatus,
+};
+use alloy_primitives::{U256, hex};
+use eyre::{Result, bail};
+use foundry_common::fs;
+use foundry_config::Config;
+use std::{
+    collections::HashSet,
+    fmt::Write,
+    path::{Component, Path, PathBuf},
+};
+
+/// Configuration for emitting Solidity regression tests from symbolic counterexamples.
+#[derive(Clone, Debug)]
+pub(crate) struct SymbolicRegressionConfig {
+    pub out: Option<PathBuf>,
+    pub overwrite: bool,
+}
+
+/// Solidity regression file emitted from a symbolic counterexample artifact.
+#[derive(Clone, Debug)]
+pub(crate) struct SymbolicRegression {
+    pub artifact: PathBuf,
+    pub path: PathBuf,
+}
+
+pub(crate) fn emit_symbolic_regressions(
+    config: &Config,
+    regression: &SymbolicRegressionConfig,
+    results: &[SymbolicArtifactRef],
+) -> Result<Vec<SymbolicRegression>> {
+    let mut emitted = Vec::new();
+    let mut seen_tests = HashSet::new();
+    for artifact_ref in results {
+        let artifact = load_artifact(&artifact_ref.path)?;
+        let (_, contract) = artifact_source_and_contract(&artifact_ref.path, &artifact)?;
+        if contract.ends_with("_SymbolicRegression") {
+            continue;
+        }
+        let key = (
+            artifact.test.contract.clone(),
+            artifact.test.test.clone(),
+            match artifact.kind {
+                SymbolicCounterexampleArtifactKind::SingleCall => "single_call",
+                SymbolicCounterexampleArtifactKind::Sequence => "sequence",
+            },
+        );
+        if !seen_tests.insert(key) {
+            continue;
+        }
+        emitted.push(emit_symbolic_regression(config, regression, &artifact_ref.path, &artifact)?);
+    }
+    Ok(emitted)
+}
+
+fn artifact_source_and_contract<'a>(
+    artifact_path: &Path,
+    artifact: &'a SymbolicCounterexampleArtifact,
+) -> Result<(&'a str, &'a str)> {
+    let Some((source, contract)) = artifact.test.contract.rsplit_once(':') else {
+        bail!(
+            "symbolic counterexample artifact {} test.contract must be `path:Contract`, got `{}`",
+            artifact_path.display(),
+            artifact.test.contract
+        );
+    };
+    if source.is_empty() || contract.is_empty() {
+        bail!(
+            "symbolic counterexample artifact {} test.contract must be `path:Contract`, got `{}`",
+            artifact_path.display(),
+            artifact.test.contract
+        );
+    }
+    Ok((source, contract))
+}
+
+pub(crate) fn collect_symbolic_artifacts(suite: &SuiteResult) -> Vec<SymbolicArtifactRef> {
+    let mut artifacts = Vec::new();
+    for result in suite.test_results.values() {
+        for artifact in &result.counterexample_artifacts {
+            if !artifacts.contains(artifact) {
+                artifacts.push(artifact.clone());
+            }
+        }
+    }
+    artifacts
+}
+
+pub(crate) fn attach_symbolic_regressions(
+    suite: &mut SuiteResult,
+    regressions: &[SymbolicRegression],
+) {
+    for result in suite.test_results.values_mut() {
+        for artifact in &result.counterexample_artifacts {
+            for regression in regressions {
+                if artifact.path == regression.artifact
+                    && !result
+                        .symbolic_regressions
+                        .iter()
+                        .any(|existing| existing.path == regression.path)
+                {
+                    result.symbolic_regressions.push(SymbolicRegressionRef {
+                        artifact: regression.artifact.clone(),
+                        path: regression.path.clone(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn load_artifact(path: &Path) -> Result<SymbolicCounterexampleArtifact> {
+    let value = fs::read_json_file::<serde_json::Value>(path)?;
+    let schema_version =
+        value.get("schema_version").and_then(serde_json::Value::as_u64).ok_or_else(|| {
+            eyre::eyre!(
+                "symbolic counterexample artifact {} is missing numeric schema_version",
+                path.display()
+            )
+        })?;
+    if schema_version != u64::from(SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA_VERSION) {
+        bail!(
+            "unsupported symbolic counterexample artifact schema version {} in {}",
+            schema_version,
+            path.display()
+        );
+    }
+    let schema = value.get("schema").and_then(serde_json::Value::as_str).ok_or_else(|| {
+        eyre::eyre!("symbolic counterexample artifact {} is missing string schema", path.display())
+    })?;
+    if schema != SYMBOLIC_COUNTEREXAMPLE_ARTIFACT_SCHEMA {
+        bail!(
+            "unsupported symbolic counterexample artifact schema `{}` in {}",
+            schema,
+            path.display()
+        );
+    }
+    let artifact = serde_json::from_value::<SymbolicCounterexampleArtifact>(value)?;
+    if artifact.replay.status != SymbolicReplayStatus::Confirmed {
+        bail!(
+            "symbolic counterexample artifact {} replay status must be confirmed, got {:?}",
+            path.display(),
+            artifact.replay.status
+        );
+    }
+    if artifact.calls.is_empty() {
+        bail!("symbolic counterexample artifact {} has no calls", path.display());
+    }
+    Ok(artifact)
+}
+
+fn emit_symbolic_regression(
+    config: &Config,
+    regression: &SymbolicRegressionConfig,
+    artifact_path: &Path,
+    artifact: &SymbolicCounterexampleArtifact,
+) -> Result<SymbolicRegression> {
+    let (source, contract) = artifact_source_and_contract(artifact_path, artifact)?;
+
+    let test_name =
+        artifact.test.test.split_once('(').map_or(artifact.test.test.as_str(), |(name, _)| name);
+    let contract_ident = sanitize_identifier(contract);
+    let test_ident = sanitize_identifier(test_name);
+    let generated_contract = format!("{contract_ident}_{test_ident}_SymbolicRegression");
+    let vm_interface = format!("{generated_contract}_Vm");
+    let generated_test = format!("test_regression_{test_ident}_symbolic");
+    let default_path = config.test.join("regressions").join(format!("{generated_contract}.t.sol"));
+    let path = regression.out.as_ref().map_or(default_path, |out| {
+        let out_is_file = if out.exists() {
+            !out.is_dir()
+        } else {
+            out.extension().is_some_and(|ext| ext == std::ffi::OsStr::new("sol"))
+        };
+        if out_is_file { out.clone() } else { out.join(format!("{generated_contract}.t.sol")) }
+    });
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let import_path =
+        relative_solidity_import(path.parent().unwrap_or(&config.root), &config.root.join(source));
+    let mut out = String::new();
+    writeln!(out, "// SPDX-License-Identifier: UNLICENSED")?;
+    writeln!(out, "pragma solidity >=0.8.0;")?;
+    writeln!(out)?;
+    writeln!(out, "import \"{import_path}\";")?;
+    writeln!(out)?;
+    writeln!(out, "interface {vm_interface} {{")?;
+    writeln!(out, "    function deal(address who, uint256 newBalance) external;")?;
+    writeln!(out, "    function prank(address msgSender) external;")?;
+    writeln!(out, "    function roll(uint256 newHeight) external;")?;
+    writeln!(out, "    function warp(uint256 newTimestamp) external;")?;
+    writeln!(out, "}}")?;
+    writeln!(out)?;
+    writeln!(out, "contract {generated_contract} is {contract} {{")?;
+    writeln!(
+        out,
+        "    {vm_interface} private constant __foundrySymbolicVm = {vm_interface}(address(uint160(uint256(keccak256(\"hevm cheat code\")))));"
+    )?;
+    writeln!(out)?;
+    writeln!(out, "    function {generated_test}() public payable {{")?;
+    match artifact.kind {
+        SymbolicCounterexampleArtifactKind::SingleCall => {
+            let call = artifact.calls.first().expect("single-call artifact has at least one call");
+            write_call(&mut out, call, "address(this)", true)?;
+        }
+        SymbolicCounterexampleArtifactKind::Sequence => {
+            for call in &artifact.calls {
+                write_call(
+                    &mut out,
+                    call,
+                    &format!("address({})", call.target),
+                    artifact.replay_semantics.fail_on_revert,
+                )?;
+            }
+            writeln!(
+                out,
+                "        __foundrySymbolicRegressionCall(address(this), hex\"{}\", 0, true);",
+                hex::encode(selector_from_signature(&artifact.test.test))
+            )?;
+        }
+    }
+    writeln!(out, "    }}")?;
+    writeln!(out)?;
+    writeln!(
+        out,
+        "    function __foundrySymbolicRegressionCall(address target, bytes memory data, uint256 value, bool bubbleFailure) internal {{"
+    )?;
+    writeln!(out, "        if (target != address(this)) {{")?;
+    writeln!(out, "            uint256 codeSize;")?;
+    writeln!(out, "            assembly {{ codeSize := extcodesize(target) }}")?;
+    writeln!(
+        out,
+        "            require(codeSize != 0, \"symbolic regression target has no code\");"
+    )?;
+    writeln!(out, "        }}")?;
+    writeln!(out, "        (bool ok, bytes memory ret) = target.call{{value: value}}(data);")?;
+    writeln!(out, "        if (!ok && bubbleFailure) {{")?;
+    writeln!(out, "            assembly {{")?;
+    writeln!(out, "                revert(add(ret, 0x20), mload(ret))")?;
+    writeln!(out, "            }}")?;
+    writeln!(out, "        }}")?;
+    writeln!(out, "    }}")?;
+    writeln!(out, "}}")?;
+
+    if path.exists() && !regression.overwrite {
+        if std::fs::read_to_string(&path).is_ok_and(|existing| existing == out) {
+            return Ok(SymbolicRegression { artifact: artifact_path.to_path_buf(), path });
+        }
+        bail!(
+            "regression test {} already exists; pass --regression-overwrite to replace it",
+            path.display()
+        );
+    }
+
+    std::fs::write(&path, out)?;
+    Ok(SymbolicRegression { artifact: artifact_path.to_path_buf(), path })
+}
+
+fn write_call(
+    out: &mut String,
+    call: &crate::result::SymbolicCounterexampleCall,
+    target: &str,
+    bubble_failure: bool,
+) -> Result<()> {
+    if let Some(warp) = call.warp {
+        writeln!(
+            out,
+            "        __foundrySymbolicVm.warp(block.timestamp + {});",
+            u256_literal(warp)
+        )?;
+    }
+    if let Some(roll) = call.roll {
+        writeln!(out, "        __foundrySymbolicVm.roll(block.number + {});", u256_literal(roll))?;
+    }
+    if let Some(value) = call.value
+        && !value.is_zero()
+    {
+        writeln!(out, "        __foundrySymbolicVm.deal(address(this), {});", u256_literal(value))?;
+        writeln!(
+            out,
+            "        __foundrySymbolicVm.deal({}, {});",
+            call.sender,
+            u256_literal(value)
+        )?;
+    }
+    writeln!(out, "        __foundrySymbolicVm.prank({});", call.sender)?;
+    writeln!(
+        out,
+        "        __foundrySymbolicRegressionCall({target}, hex\"{}\", {}, {});",
+        hex::encode(call.calldata.as_ref()),
+        call.value.map_or_else(|| "0".to_string(), u256_literal),
+        if bubble_failure { "true" } else { "false" }
+    )?;
+    Ok(())
+}
+
+fn selector_from_signature(signature: &str) -> [u8; 4] {
+    let hash = alloy_primitives::keccak256(signature.as_bytes());
+    [hash[0], hash[1], hash[2], hash[3]]
+}
+
+fn u256_literal(value: U256) -> String {
+    if value <= U256::from(u128::MAX) { value.to_string() } else { format!("0x{value:x}") }
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let mut ident = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            ident.push(ch);
+        } else {
+            ident.push('_');
+        }
+    }
+    if ident.is_empty() || ident.as_bytes()[0].is_ascii_digit() {
+        ident.insert(0, '_');
+    }
+    ident
+}
+
+fn relative_solidity_import(from_dir: &Path, to_file: &Path) -> String {
+    let from = std::fs::canonicalize(from_dir).unwrap_or_else(|_| from_dir.to_path_buf());
+    let to = std::fs::canonicalize(to_file).unwrap_or_else(|_| to_file.to_path_buf());
+    let from = normalized_components(&from);
+    let to = normalized_components(&to);
+    let shared = from.iter().zip(&to).take_while(|(left, right)| left == right).count();
+    let mut parts = Vec::new();
+    parts.extend(std::iter::repeat_n("..".to_string(), from.len().saturating_sub(shared)));
+    parts.extend(to[shared..].iter().cloned());
+    if parts.is_empty() {
+        ".".to_string()
+    } else {
+        let path = parts.join("/");
+        if path.starts_with('.') { path } else { format!("./{path}") }
+    }
+}
+
+fn normalized_components(path: &Path) -> Vec<String> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value.to_string_lossy().to_string()),
+            Component::ParentDir => Some("..".to_string()),
+            Component::CurDir => None,
+            Component::RootDir | Component::Prefix(_) => {
+                Some(component.as_os_str().to_string_lossy().to_string())
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relative_solidity_import_canonicalizes_symlinked_absolute_paths() {
+        let tmp = Path::new("/tmp");
+        let Ok(canonical_tmp) = std::fs::canonicalize(tmp) else { return };
+        if canonical_tmp == tmp {
+            return;
+        }
+
+        let root =
+            tmp.join(format!("foundry-symbolic-regression-import-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let from_dir = root.join("test");
+        std::fs::create_dir_all(&from_dir).unwrap();
+        let to_file = from_dir.join("Original.t.sol");
+        std::fs::write(&to_file, "contract Original {}").unwrap();
+        let canonical_to_file = std::fs::canonicalize(&to_file).unwrap();
+
+        let import = relative_solidity_import(&from_dir, &canonical_to_file);
+
+        let _ = std::fs::remove_dir_all(&root);
+        assert_eq!(import, "./Original.t.sol");
+    }
+}

--- a/crates/forge/src/symbolic_regression.rs
+++ b/crates/forge/src/symbolic_regression.rs
@@ -13,6 +13,8 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
+pub(crate) const SYMBOLIC_REGRESSION_MARKER: &str = "__foundry_symbolic_regression_marker";
+
 /// Configuration for emitting Solidity regression tests from symbolic counterexamples.
 #[derive(Clone, Debug)]
 pub(crate) struct SymbolicRegressionConfig {
@@ -239,6 +241,13 @@ fn plan_symbolic_regression(
         contents,
         "    {vm_interface} private constant __foundrySymbolicVm = {vm_interface}(address(uint160(uint256(keccak256(\"hevm cheat code\")))));"
     )?;
+    writeln!(contents)?;
+    writeln!(
+        contents,
+        "    function {SYMBOLIC_REGRESSION_MARKER}() external pure returns (bytes32) {{"
+    )?;
+    writeln!(contents, "        return keccak256(\"foundry.symbolic.regression\");")?;
+    writeln!(contents, "    }}")?;
     writeln!(contents)?;
     writeln!(contents, "    function {generated_test}() public payable {{")?;
     match artifact.kind {

--- a/crates/forge/src/symbolic_regression.rs
+++ b/crates/forge/src/symbolic_regression.rs
@@ -5,10 +5,10 @@ use crate::result::{
 };
 use alloy_primitives::{U256, hex};
 use eyre::{Result, bail};
-use foundry_common::{TestFunctionExt, contracts::ContractsByArtifact, fs};
+use foundry_common::{TestFunctionExt, contracts::ContractsByArtifact, fs, sh_warn};
 use foundry_config::Config;
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt::Write,
     path::{Component, Path, PathBuf},
 };
@@ -27,13 +27,19 @@ pub(crate) struct SymbolicRegression {
     pub path: PathBuf,
 }
 
+struct PlannedSymbolicRegression {
+    regression: SymbolicRegression,
+    contents: String,
+    test: String,
+}
+
 pub(crate) fn emit_symbolic_regressions(
     config: &Config,
     regression: &SymbolicRegressionConfig,
     known_contracts: &ContractsByArtifact,
     results: &[SymbolicArtifactRef],
 ) -> Result<Vec<SymbolicRegression>> {
-    let mut emitted = Vec::new();
+    let mut planned = Vec::new();
     let mut seen_tests = HashSet::new();
     for artifact_ref in results {
         let artifact = load_artifact(&artifact_ref.path)?;
@@ -56,7 +62,7 @@ pub(crate) fn emit_symbolic_regressions(
         } else {
             continue;
         };
-        emitted.push(emit_symbolic_regression(
+        planned.push(plan_symbolic_regression(
             config,
             regression,
             &artifact_ref.path,
@@ -64,6 +70,15 @@ pub(crate) fn emit_symbolic_regressions(
             known_contracts,
             suffix.as_deref(),
         )?);
+    }
+
+    ensure_unique_regression_paths(&planned)?;
+
+    let mut emitted = Vec::new();
+    for plan in planned {
+        if let Some(regression) = write_symbolic_regression(regression, plan)? {
+            emitted.push(regression);
+        }
     }
     Ok(emitted)
 }
@@ -89,35 +104,41 @@ fn artifact_source_and_contract<'a>(
     Ok((source, contract))
 }
 
-pub(crate) fn collect_symbolic_artifacts(suite: &SuiteResult) -> Vec<SymbolicArtifactRef> {
+pub(crate) fn collect_symbolic_artifacts_from_suites<'a>(
+    suites: impl IntoIterator<Item = &'a SuiteResult>,
+) -> Vec<SymbolicArtifactRef> {
     let mut artifacts = Vec::new();
-    for result in suite.test_results.values() {
-        for artifact in &result.counterexample_artifacts {
-            if !artifacts.contains(artifact) {
-                artifacts.push(artifact.clone());
+    for suite in suites {
+        for result in suite.test_results.values() {
+            for artifact in &result.counterexample_artifacts {
+                if !artifacts.contains(artifact) {
+                    artifacts.push(artifact.clone());
+                }
             }
         }
     }
     artifacts
 }
 
-pub(crate) fn attach_symbolic_regressions(
-    suite: &mut SuiteResult,
+pub(crate) fn attach_symbolic_regressions_to_suites<'a>(
+    suites: impl IntoIterator<Item = &'a mut SuiteResult>,
     regressions: &[SymbolicRegression],
 ) {
-    for result in suite.test_results.values_mut() {
-        for artifact in &result.counterexample_artifacts {
-            for regression in regressions {
-                if artifact.path == regression.artifact
-                    && !result
-                        .symbolic_regressions
-                        .iter()
-                        .any(|existing| existing.path == regression.path)
-                {
-                    result.symbolic_regressions.push(SymbolicRegressionRef {
-                        artifact: regression.artifact.clone(),
-                        path: regression.path.clone(),
-                    });
+    for suite in suites {
+        for result in suite.test_results.values_mut() {
+            for artifact in &result.counterexample_artifacts {
+                for regression in regressions {
+                    if artifact.path == regression.artifact
+                        && !result
+                            .symbolic_regressions
+                            .iter()
+                            .any(|existing| existing.path == regression.path)
+                    {
+                        result.symbolic_regressions.push(SymbolicRegressionRef {
+                            artifact: regression.artifact.clone(),
+                            path: regression.path.clone(),
+                        });
+                    }
                 }
             }
         }
@@ -164,14 +185,14 @@ fn load_artifact(path: &Path) -> Result<SymbolicCounterexampleArtifact> {
     Ok(artifact)
 }
 
-fn emit_symbolic_regression(
+fn plan_symbolic_regression(
     config: &Config,
     regression: &SymbolicRegressionConfig,
     artifact_path: &Path,
     artifact: &SymbolicCounterexampleArtifact,
     known_contracts: &ContractsByArtifact,
     suffix: Option<&str>,
-) -> Result<SymbolicRegression> {
+) -> Result<PlannedSymbolicRegression> {
     let (source, contract) = artifact_source_and_contract(artifact_path, artifact)?;
 
     let test_name =
@@ -200,90 +221,119 @@ fn emit_symbolic_regression(
 
     let import_path =
         relative_solidity_import(path.parent().unwrap_or(&config.root), &config.root.join(source));
-    let mut out = String::new();
-    writeln!(out, "// SPDX-License-Identifier: UNLICENSED")?;
-    writeln!(out, "pragma solidity >=0.8.0;")?;
-    writeln!(out)?;
-    writeln!(out, "import \"{import_path}\";")?;
-    writeln!(out)?;
-    writeln!(out, "interface {vm_interface} {{")?;
-    writeln!(out, "    function deal(address who, uint256 newBalance) external;")?;
-    writeln!(out, "    function prank(address msgSender) external;")?;
-    writeln!(out, "    function roll(uint256 newHeight) external;")?;
-    writeln!(out, "    function warp(uint256 newTimestamp) external;")?;
-    writeln!(out, "}}")?;
-    writeln!(out)?;
-    writeln!(out, "contract {generated_contract} is {contract} {{")?;
+    let mut contents = String::new();
+    writeln!(contents, "// SPDX-License-Identifier: UNLICENSED")?;
+    writeln!(contents, "pragma solidity >=0.8.0;")?;
+    writeln!(contents)?;
+    writeln!(contents, "import \"{import_path}\";")?;
+    writeln!(contents)?;
+    writeln!(contents, "interface {vm_interface} {{")?;
+    writeln!(contents, "    function deal(address who, uint256 newBalance) external;")?;
+    writeln!(contents, "    function prank(address msgSender) external;")?;
+    writeln!(contents, "    function roll(uint256 newHeight) external;")?;
+    writeln!(contents, "    function warp(uint256 newTimestamp) external;")?;
+    writeln!(contents, "}}")?;
+    writeln!(contents)?;
+    writeln!(contents, "contract {generated_contract} is {contract} {{")?;
     writeln!(
-        out,
+        contents,
         "    {vm_interface} private constant __foundrySymbolicVm = {vm_interface}(address(uint160(uint256(keccak256(\"hevm cheat code\")))));"
     )?;
-    writeln!(out)?;
-    writeln!(out, "    function {generated_test}() public payable {{")?;
+    writeln!(contents)?;
+    writeln!(contents, "    function {generated_test}() public payable {{")?;
     match artifact.kind {
         SymbolicCounterexampleArtifactKind::SingleCall => {
             let call = artifact.calls.first().expect("single-call artifact has at least one call");
-            write_call(&mut out, call, "address(this)", true)?;
+            write_call(&mut contents, call, "address(this)", true)?;
         }
         SymbolicCounterexampleArtifactKind::Sequence => {
             let call_after_invariant = call_after_invariant(known_contracts, artifact)?;
             for call in &artifact.calls {
                 write_call(
-                    &mut out,
+                    &mut contents,
                     call,
                     &format!("address({})", call.target),
                     artifact.replay_semantics.fail_on_revert,
                 )?;
             }
             writeln!(
-                out,
+                contents,
                 "        __foundrySymbolicRegressionCall(address(this), hex\"{}\", 0, true);",
                 hex::encode(selector_from_signature(&artifact.test.test))
             )?;
             if call_after_invariant {
                 writeln!(
-                    out,
+                    contents,
                     "        __foundrySymbolicRegressionCall(address(this), hex\"{}\", 0, true);",
                     hex::encode(selector_from_signature("afterInvariant()"))
                 )?;
             }
         }
     }
-    writeln!(out, "    }}")?;
-    writeln!(out)?;
+    writeln!(contents, "    }}")?;
+    writeln!(contents)?;
     writeln!(
-        out,
+        contents,
         "    function __foundrySymbolicRegressionCall(address target, bytes memory data, uint256 value, bool bubbleFailure) internal {{"
     )?;
-    writeln!(out, "        if (target != address(this)) {{")?;
-    writeln!(out, "            uint256 codeSize;")?;
-    writeln!(out, "            assembly {{ codeSize := extcodesize(target) }}")?;
+    writeln!(contents, "        if (target != address(this)) {{")?;
+    writeln!(contents, "            uint256 codeSize;")?;
+    writeln!(contents, "            assembly {{ codeSize := extcodesize(target) }}")?;
     writeln!(
-        out,
+        contents,
         "            require(codeSize != 0, \"symbolic regression target has no code\");"
     )?;
-    writeln!(out, "        }}")?;
-    writeln!(out, "        (bool ok, bytes memory ret) = target.call{{value: value}}(data);")?;
-    writeln!(out, "        if (!ok && bubbleFailure) {{")?;
-    writeln!(out, "            assembly {{")?;
-    writeln!(out, "                revert(add(ret, 0x20), mload(ret))")?;
-    writeln!(out, "            }}")?;
-    writeln!(out, "        }}")?;
-    writeln!(out, "    }}")?;
-    writeln!(out, "}}")?;
+    writeln!(contents, "        }}")?;
+    writeln!(contents, "        (bool ok, bytes memory ret) = target.call{{value: value}}(data);")?;
+    writeln!(contents, "        if (!ok && bubbleFailure) {{")?;
+    writeln!(contents, "            assembly {{")?;
+    writeln!(contents, "                revert(add(ret, 0x20), mload(ret))")?;
+    writeln!(contents, "            }}")?;
+    writeln!(contents, "        }}")?;
+    writeln!(contents, "    }}")?;
+    writeln!(contents, "}}")?;
 
-    if path.exists() && !regression.overwrite {
-        if std::fs::read_to_string(&path).is_ok_and(|existing| existing == out) {
-            return Ok(SymbolicRegression { artifact: artifact_path.to_path_buf(), path });
+    Ok(PlannedSymbolicRegression {
+        regression: SymbolicRegression { artifact: artifact_path.to_path_buf(), path },
+        contents,
+        test: format!("{}::{}", artifact.test.contract, artifact.test.test),
+    })
+}
+
+fn ensure_unique_regression_paths(planned: &[PlannedSymbolicRegression]) -> Result<()> {
+    let mut seen = HashMap::<&Path, &PlannedSymbolicRegression>::new();
+    for plan in planned {
+        if let Some(previous) = seen.insert(&plan.regression.path, plan) {
+            bail!(
+                "multiple symbolic regressions resolve to {}; {} and {} cannot share one output file",
+                plan.regression.path.display(),
+                previous.test,
+                plan.test
+            );
         }
-        bail!(
-            "regression test {} already exists; pass --regression-overwrite to replace it",
-            path.display()
-        );
+    }
+    Ok(())
+}
+
+fn write_symbolic_regression(
+    regression: &SymbolicRegressionConfig,
+    plan: PlannedSymbolicRegression,
+) -> Result<Option<SymbolicRegression>> {
+    let SymbolicRegression { artifact, path } = &plan.regression;
+    if path.exists() && !regression.overwrite {
+        if std::fs::read_to_string(path).is_ok_and(|existing| existing == plan.contents) {
+            return Ok(Some(plan.regression));
+        }
+        sh_warn!(
+            "Regression test {} already exists; skipping {} (pass --regression-overwrite to replace it)",
+            path.display(),
+            artifact.display()
+        )?;
+        return Ok(None);
     }
 
-    std::fs::write(&path, out)?;
-    Ok(SymbolicRegression { artifact: artifact_path.to_path_buf(), path })
+    std::fs::write(path, plan.contents)?;
+    Ok(Some(plan.regression))
 }
 
 fn write_call(

--- a/crates/forge/src/symbolic_regression.rs
+++ b/crates/forge/src/symbolic_regression.rs
@@ -48,10 +48,20 @@ pub(crate) fn emit_symbolic_regressions(
                 SymbolicCounterexampleArtifactKind::Sequence => "sequence",
             },
         );
-        if !seen_tests.insert(key) {
+        let suffix = if seen_tests.insert(key) {
+            None
+        } else if let Some(suffix) = handler_regression_suffix(&artifact_ref.path) {
+            Some(suffix)
+        } else {
             continue;
-        }
-        emitted.push(emit_symbolic_regression(config, regression, &artifact_ref.path, &artifact)?);
+        };
+        emitted.push(emit_symbolic_regression(
+            config,
+            regression,
+            &artifact_ref.path,
+            &artifact,
+            suffix.as_deref(),
+        )?);
     }
     Ok(emitted)
 }
@@ -157,6 +167,7 @@ fn emit_symbolic_regression(
     regression: &SymbolicRegressionConfig,
     artifact_path: &Path,
     artifact: &SymbolicCounterexampleArtifact,
+    suffix: Option<&str>,
 ) -> Result<SymbolicRegression> {
     let (source, contract) = artifact_source_and_contract(artifact_path, artifact)?;
 
@@ -164,7 +175,10 @@ fn emit_symbolic_regression(
         artifact.test.test.split_once('(').map_or(artifact.test.test.as_str(), |(name, _)| name);
     let contract_ident = sanitize_identifier(contract);
     let test_ident = sanitize_identifier(test_name);
-    let generated_contract = format!("{contract_ident}_{test_ident}_SymbolicRegression");
+    let generated_contract = suffix.map_or_else(
+        || format!("{contract_ident}_{test_ident}_SymbolicRegression"),
+        |suffix| format!("{contract_ident}_{test_ident}_{suffix}_SymbolicRegression"),
+    );
     let vm_interface = format!("{generated_contract}_Vm");
     let generated_test = format!("test_regression_{test_ident}_symbolic");
     let default_path = config.test.join("regressions").join(format!("{generated_contract}.t.sol"));
@@ -321,6 +335,11 @@ fn sanitize_identifier(value: &str) -> String {
         ident.insert(0, '_');
     }
     ident
+}
+
+fn handler_regression_suffix(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_string_lossy();
+    stem.starts_with("handler-").then(|| sanitize_identifier(&stem))
 }
 
 fn relative_solidity_import(from_dir: &Path, to_file: &Path) -> String {

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1,6 +1,9 @@
 use alloy_primitives::{U256, hex, keccak256};
 use foundry_common::sh_eprintln;
-use foundry_test_utils::{forgetest_init, str, util::OutputExt};
+use foundry_test_utils::{
+    forgetest_init, str,
+    util::{OutputExt, SOLC_VERSION},
+};
 use serde_json::Value;
 use std::{
     path::{Path, PathBuf},
@@ -280,6 +283,226 @@ contract SymbolicSingleCallArtifactEnv is Test {
         .stdout_lossy();
 
     assert!(stdout.contains("artifact env replayed"), "{stdout}");
+});
+
+forgetest_init!(symbolic_emits_stateless_solidity_regression, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emits_stateless_solidity_regression because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicRegressionSingle.t.sol",
+        r#"
+contract SymbolicRegressionSingle {
+    function checkBoom(uint256 x) public pure {
+        assert(x != 42);
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--emit-regression", "--match-test", "checkBoom"])
+        .assert_failure()
+        .get_output()
+        .clone();
+    let stderr = output.stderr_lossy();
+    assert!(stderr.contains("Regression test:"), "{stderr}");
+
+    let regression = prj
+        .root()
+        .join("test/regressions/SymbolicRegressionSingle_checkBoom_SymbolicRegression.t.sol");
+    assert!(regression.exists(), "missing regression {}", regression.display());
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--match-test", "test_regression_checkBoom_symbolic"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("test_regression_checkBoom_symbolic()"), "{stdout}");
+    assert!(stdout.contains("assertion failed"), "{stdout}");
+});
+
+forgetest_init!(symbolic_emits_regression_for_contract_with_receive, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emits_regression_for_contract_with_receive because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicRegressionReceive.t.sol",
+        r#"
+contract SymbolicRegressionReceive {
+    receive() external payable {}
+
+    function checkReceiveRegression(uint256 x) public pure {
+        assert(x != 42);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--symbolic", "--emit-regression", "--match-test", "checkReceiveRegression"])
+        .assert_failure();
+
+    let regression = prj.root().join(
+        "test/regressions/SymbolicRegressionReceive_checkReceiveRegression_SymbolicRegression.t.sol",
+    );
+    let generated = std::fs::read_to_string(&regression)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", regression.display()));
+    assert!(generated.contains("pragma solidity >=0.8.0;"), "{generated}");
+    assert!(!generated.contains("receive() external payable"), "{generated}");
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--match-test", "test_regression_checkReceiveRegression_symbolic"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("test_regression_checkReceiveRegression_symbolic()"), "{stdout}");
+    assert!(stdout.contains("assertion failed"), "{stdout}");
+});
+
+forgetest_init!(symbolic_emit_regression_rerun_reuses_existing_file, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emit_regression_rerun_reuses_existing_file because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicRegressionRerun.t.sol",
+        r#"
+contract SymbolicRegressionRerun {
+    function checkRerun(uint256 x) public pure {
+        assert(x != 42);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--symbolic", "--emit-regression", "--match-test", "checkRerun"])
+        .assert_failure();
+
+    let regression = prj
+        .root()
+        .join("test/regressions/SymbolicRegressionRerun_checkRerun_SymbolicRegression.t.sol");
+    let generated = std::fs::read_to_string(&regression)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", regression.display()));
+
+    let output = cmd
+        .forge_fuse()
+        .args(["test", "--symbolic", "--emit-regression", "--match-test", "checkRerun"])
+        .assert_failure()
+        .get_output()
+        .clone();
+    let stderr = output.stderr_lossy();
+    assert!(!stderr.contains("already exists"), "{stderr}");
+    assert_eq!(
+        std::fs::read_to_string(&regression)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", regression.display())),
+        generated
+    );
+
+    let nested = prj.root().join(
+        "test/regressions/SymbolicRegressionRerun_checkRerun_SymbolicRegression_checkRerun_SymbolicRegression.t.sol",
+    );
+    assert!(!nested.exists(), "unexpected nested regression {}", nested.display());
+});
+
+forgetest_init!(symbolic_emits_regression_under_custom_test_dir, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emits_regression_under_custom_test_dir because z3 is not available"
+        );
+        return;
+    }
+
+    prj.update_config(|config| config.test = "tests".into());
+    let tests_dir = prj.root().join("tests");
+    std::fs::create_dir_all(&tests_dir).unwrap();
+    std::fs::write(
+        tests_dir.join("SymbolicRegressionCustomDir.t.sol"),
+        format!(
+            r#"// SPDX-License-Identifier: UNLICENSED
+pragma solidity ={SOLC_VERSION};
+
+contract SymbolicRegressionCustomDir {{
+    function checkCustomDir(uint256 x) public pure {{
+        assert(x != 42);
+    }}
+}}
+"#
+        ),
+    )
+    .unwrap();
+
+    cmd.args(["test", "--symbolic", "--emit-regression", "--match-test", "checkCustomDir"])
+        .assert_failure();
+
+    let regression = prj.root().join(
+        "tests/regressions/SymbolicRegressionCustomDir_checkCustomDir_SymbolicRegression.t.sol",
+    );
+    assert!(regression.exists(), "missing regression {}", regression.display());
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--match-test", "test_regression_checkCustomDir_symbolic"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("test_regression_checkCustomDir_symbolic()"), "{stdout}");
+    assert!(stdout.contains("assertion failed"), "{stdout}");
+});
+
+forgetest_init!(symbolic_json_reports_solidity_regression, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_json_reports_solidity_regression because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicRegressionJson.t.sol",
+        r#"
+contract SymbolicRegressionJson {
+    function checkJsonRegression(uint256 x) public pure {
+        assert(x != 42);
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--emit-regression",
+            "--json",
+            "--match-test",
+            "checkJsonRegression",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout
+        .clone();
+    let result = json_test_result(&output, "checkJsonRegression(uint256)");
+    let regressions = result["symbolic_regressions"].as_array().expect("symbolic regressions");
+    assert_eq!(regressions.len(), 1);
+    assert!(regressions[0]["artifact"].is_string());
+    let path = regressions[0]["path"].as_str().expect("regression path");
+    assert!(path.ends_with(
+        "test/regressions/SymbolicRegressionJson_checkJsonRegression_SymbolicRegression.t.sol"
+    ));
+    assert!(std::path::Path::new(path).exists());
 });
 
 forgetest_init!(symbolic_passes_scalar_test, |prj, cmd| {
@@ -1518,6 +1741,149 @@ invariant_counterNeverEleven()
 args=[7]
 "#]],
     );
+});
+
+forgetest_init!(symbolic_emits_stateful_solidity_regression, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emits_stateful_solidity_regression because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicRegressionSequence.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicRegressionSequenceTarget {
+    uint256 public value;
+
+    function set(uint256 x) external {
+        if (x == 7) {
+            value = 11;
+        }
+    }
+}
+
+contract SymbolicRegressionSequence is Test {
+    SymbolicRegressionSequenceTarget target;
+
+    function setUp() public {
+        target = new SymbolicRegressionSequenceTarget();
+        targetContract(address(target));
+    }
+
+    function invariant_counterNeverEleven() public view {
+        assert(target.value() != 11);
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--emit-regression",
+            "--match-test",
+            "invariant_counterNeverEleven",
+        ])
+        .assert_failure()
+        .get_output()
+        .clone();
+    let stderr = output.stderr_lossy();
+    assert!(stderr.contains("Regression test:"), "{stderr}");
+
+    let regression = prj.root().join(
+        "test/regressions/SymbolicRegressionSequence_invariant_counterNeverEleven_SymbolicRegression.t.sol",
+    );
+    assert!(regression.exists(), "missing regression {}", regression.display());
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--match-test", "test_regression_invariant_counterNeverEleven_symbolic"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("test_regression_invariant_counterNeverEleven_symbolic()"), "{stdout}");
+    assert!(stdout.contains("assertion failed"), "{stdout}");
+});
+
+forgetest_init!(symbolic_emits_handler_assertion_regression, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emits_handler_assertion_regression because z3 is not available"
+        );
+        return;
+    }
+
+    prj.update_config(|config| {
+        config.invariant.fail_on_revert = false;
+    });
+    prj.add_test(
+        "SymbolicRegressionHandler.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicRegressionHandlerTarget {
+    uint256 sink;
+
+    function boom(uint256 x) external {
+        sink = x;
+        if (x == 7) {
+            assert(false);
+        }
+    }
+}
+
+contract SymbolicRegressionHandler is Test {
+    SymbolicRegressionHandlerTarget target;
+
+    function setUp() public {
+        target = new SymbolicRegressionHandlerTarget();
+        targetContract(address(target));
+    }
+
+    function invariant_ok() public pure {}
+}
+"#,
+    );
+
+    let output = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--emit-regression",
+            "--match-test",
+            "invariant_ok",
+            "--symbolic-invariant-depth",
+            "1",
+        ])
+        .assert_failure()
+        .get_output()
+        .clone();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+    assert!(stdout.contains("Assertion Tests: 1 assertion bug(s) found"), "{stdout}");
+    assert!(stderr.contains("Regression test:"), "{stderr}");
+
+    let regression = prj
+        .root()
+        .join("test/regressions/SymbolicRegressionHandler_invariant_ok_SymbolicRegression.t.sol");
+    assert!(regression.exists(), "missing regression {}", regression.display());
+    let generated = std::fs::read_to_string(&regression)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", regression.display()));
+    assert!(generated.contains("true);"), "{generated}");
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--match-test", "test_regression_invariant_ok_symbolic"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("test_regression_invariant_ok_symbolic()"), "{stdout}");
+    assert!(stdout.contains("assertion failed"), "{stdout}");
 });
 
 forgetest_init!(symbolic_json_reports_minimized_sequence_counterexample, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1810,6 +1810,80 @@ contract SymbolicRegressionSequence is Test {
     assert!(stdout.contains("assertion failed"), "{stdout}");
 });
 
+forgetest_init!(symbolic_emits_stateful_regression_with_after_invariant, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emits_stateful_regression_with_after_invariant because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicRegressionAfterInvariant.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicRegressionAfterInvariantTarget {
+    uint256 public value;
+
+    function set(uint256 x) external {
+        if (x == 7) {
+            value = 1;
+        }
+    }
+}
+
+contract SymbolicRegressionAfterInvariant is Test {
+    SymbolicRegressionAfterInvariantTarget target;
+
+    function setUp() public {
+        target = new SymbolicRegressionAfterInvariantTarget();
+        targetContract(address(target));
+    }
+
+    function invariant_ok() public pure {}
+
+    function afterInvariant() public view {
+        require(target.value() != 1, "afterInvariant failure");
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--emit-regression",
+            "--match-test",
+            "invariant_ok",
+            "--symbolic-invariant-depth",
+            "1",
+        ])
+        .assert_failure()
+        .get_output()
+        .clone();
+    let stderr = output.stderr_lossy();
+    assert!(stderr.contains("Regression test:"), "{stderr}");
+
+    let regression = prj.root().join(
+        "test/regressions/SymbolicRegressionAfterInvariant_invariant_ok_SymbolicRegression.t.sol",
+    );
+    assert!(regression.exists(), "missing regression {}", regression.display());
+    let generated = std::fs::read_to_string(&regression)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", regression.display()));
+    assert!(generated.contains(r#"hex"93969ddf""#), "{generated}");
+
+    let stdout = cmd
+        .forge_fuse()
+        .args(["test", "--match-test", "test_regression_invariant_ok_symbolic"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("test_regression_invariant_ok_symbolic()"), "{stdout}");
+    assert!(stdout.contains("afterInvariant failure"), "{stdout}");
+});
+
 forgetest_init!(symbolic_emits_handler_assertion_regression, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -1886,6 +1886,95 @@ contract SymbolicRegressionHandler is Test {
     assert!(stdout.contains("assertion failed"), "{stdout}");
 });
 
+forgetest_init!(symbolic_emits_multiple_handler_assertion_regressions, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emits_multiple_handler_assertion_regressions because z3 is not available"
+        );
+        return;
+    }
+
+    prj.update_config(|config| {
+        config.invariant.fail_on_revert = false;
+    });
+    prj.add_test(
+        "SymbolicRegressionMultipleHandlers.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicRegressionMultipleHandlersFirst {
+    uint256 sink;
+
+    function boomFirst(uint256 x) external {
+        sink = x;
+        if (x == 7) {
+            assert(false);
+        }
+    }
+}
+
+contract SymbolicRegressionMultipleHandlersSecond {
+    uint256 sink;
+
+    function boomSecond(uint256 x) external {
+        sink = x;
+        if (x == 11) {
+            assert(false);
+        }
+    }
+}
+
+contract SymbolicRegressionMultipleHandlers is Test {
+    SymbolicRegressionMultipleHandlersFirst first;
+    SymbolicRegressionMultipleHandlersSecond second;
+
+    function setUp() public {
+        first = new SymbolicRegressionMultipleHandlersFirst();
+        second = new SymbolicRegressionMultipleHandlersSecond();
+        targetContract(address(first));
+        targetContract(address(second));
+    }
+
+    function invariant_ok() public pure {}
+}
+"#,
+    );
+
+    let output = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--emit-regression",
+            "--match-test",
+            "invariant_ok",
+            "--symbolic-invariant-depth",
+            "1",
+        ])
+        .assert_failure()
+        .get_output()
+        .clone();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+    assert!(stdout.contains("Assertion Tests: 2 assertion bug(s) found"), "{stdout}");
+    assert_eq!(stderr.matches("Regression test:").count(), 2, "{stderr}");
+
+    let regressions_dir = prj.root().join("test/regressions");
+    let regressions = std::fs::read_dir(&regressions_dir)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", regressions_dir.display()))
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "sol"))
+        .collect::<Vec<_>>();
+    assert_eq!(regressions.len(), 2, "{regressions:?}");
+    assert!(
+        regressions.iter().any(|path| path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .contains("_handler_")),
+        "{regressions:?}"
+    );
+});
+
 forgetest_init!(symbolic_json_reports_minimized_sequence_counterexample, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -2049,6 +2049,215 @@ contract SymbolicRegressionMultipleHandlers is Test {
     );
 });
 
+forgetest_init!(symbolic_emit_regression_stale_file_preserves_json_output, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emit_regression_stale_file_preserves_json_output because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicRegressionStaleJson.t.sol",
+        r#"
+contract SymbolicRegressionStaleJson {
+    function checkStaleJson(uint256 x) public pure {
+        assert(x != 42);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--symbolic", "--emit-regression", "--match-test", "checkStaleJson"])
+        .assert_failure();
+
+    let regression = prj.root().join(
+        "test/regressions/SymbolicRegressionStaleJson_checkStaleJson_SymbolicRegression.t.sol",
+    );
+    let mut generated = std::fs::read_to_string(&regression)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", regression.display()));
+    generated = generated.replacen("UNLICENSED", "MIT", 1);
+    std::fs::write(&regression, generated)
+        .unwrap_or_else(|err| panic!("failed to write {}: {err}", regression.display()));
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--symbolic",
+            "--emit-regression",
+            "--json",
+            "--match-test",
+            "checkStaleJson",
+        ])
+        .assert_failure()
+        .get_output()
+        .clone();
+    let stdout = output.stdout.clone();
+    let stderr = output.stderr_lossy();
+    assert!(stderr.contains("already exists; skipping"), "{stderr}");
+
+    let result = json_test_result(&stdout, "checkStaleJson(uint256)");
+    assert!(result.get("symbolic_regressions").is_none(), "{result}");
+});
+
+forgetest_init!(symbolic_regression_contract_runs_only_generated_tests, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_regression_contract_runs_only_generated_tests because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicRegressionCollection.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract SymbolicRegressionCollectionTarget {
+    uint256 public value;
+
+    function set(uint256 x) external {
+        if (x == 7) {
+            value = 11;
+        }
+    }
+}
+
+contract SymbolicRegressionCollection is Test {
+    SymbolicRegressionCollectionTarget target;
+
+    function setUp() public {
+        target = new SymbolicRegressionCollectionTarget();
+        targetContract(address(target));
+    }
+
+    function invariant_counterNeverEleven() public view {
+        assert(target.value() != 11);
+    }
+}
+"#,
+    );
+
+    cmd.args([
+        "test",
+        "--symbolic",
+        "--emit-regression",
+        "--match-test",
+        "invariant_counterNeverEleven",
+        "--symbolic-invariant-depth",
+        "1",
+    ])
+    .assert_failure();
+
+    let stdout = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--match-contract",
+            "SymbolicRegressionCollection_invariant_counterNeverEleven_SymbolicRegression",
+        ])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("Ran 1 test"), "{stdout}");
+    assert!(stdout.contains("test_regression_invariant_counterNeverEleven_symbolic()"), "{stdout}");
+    assert!(!stdout.contains(" invariant_counterNeverEleven()"), "{stdout}");
+});
+
+forgetest_init!(symbolic_emit_regression_rejects_explicit_output_collision, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emit_regression_rejects_explicit_output_collision because z3 is not available"
+        );
+        return;
+    }
+
+    prj.add_test(
+        "SymbolicRegressionCollisionFile.t.sol",
+        r#"
+contract SymbolicRegressionCollisionFileFirst {
+    function checkFirst(uint256 x) public pure {
+        assert(x != 42);
+    }
+}
+
+contract SymbolicRegressionCollisionFileSecond {
+    function checkSecond(uint256 x) public pure {
+        assert(x != 11);
+    }
+}
+"#,
+    );
+
+    let collision_path = prj.root().join("test/onlyone.sol");
+    let stderr = cmd
+        .args([
+            "test",
+            "--symbolic",
+            "--emit-regression",
+            "--regression-out",
+            "test/onlyone.sol",
+            "--regression-overwrite",
+            "--match-test",
+            "check(First|Second)",
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+    assert!(stderr.contains("multiple symbolic regressions resolve to"), "{stderr}");
+    assert!(stderr.contains("checkFirst(uint256)"), "{stderr}");
+    assert!(stderr.contains("checkSecond(uint256)"), "{stderr}");
+    assert!(!collision_path.exists(), "unexpected collision file {}", collision_path.display());
+});
+
+forgetest_init!(symbolic_emit_regression_rejects_default_path_collision, |prj, cmd| {
+    if !z3_available() {
+        let _ = sh_eprintln!(
+            "skipping symbolic_emit_regression_rejects_default_path_collision because z3 is not available"
+        );
+        return;
+    }
+
+    let test_dir = prj.root().join("test");
+    std::fs::create_dir_all(test_dir.join("a")).unwrap();
+    std::fs::create_dir_all(test_dir.join("b")).unwrap();
+    std::fs::write(
+        test_dir.join("a/SameName.t.sol"),
+        r#"
+contract SameName {
+    function checkSame(uint256 x) public pure {
+        assert(x != 42);
+    }
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        test_dir.join("b/SameName.t.sol"),
+        r#"
+contract SameName {
+    function checkSame(uint256 x) public pure {
+        assert(x != 11);
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let collision_path =
+        prj.root().join("test/regressions/SameName_checkSame_SymbolicRegression.t.sol");
+    let stderr = cmd
+        .args(["test", "--symbolic", "--emit-regression", "--match-test", "checkSame"])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+    assert!(stderr.contains("multiple symbolic regressions resolve to"), "{stderr}");
+    assert!(stderr.contains("test/a/SameName.t.sol:SameName::checkSame(uint256)"), "{stderr}");
+    assert!(stderr.contains("test/b/SameName.t.sol:SameName::checkSame(uint256)"), "{stderr}");
+    assert!(!collision_path.exists(), "unexpected collision file {}", collision_path.display());
+});
+
 forgetest_init!(symbolic_json_reports_minimized_sequence_counterexample, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -2165,6 +2165,29 @@ contract SymbolicRegressionCollection is Test {
     assert!(!stdout.contains(" invariant_counterNeverEleven()"), "{stdout}");
 });
 
+forgetest_init!(symbolic_regression_suffix_user_contract_runs_tests, |prj, cmd| {
+    prj.add_test(
+        "RealSymbolicRegression.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract Real_SymbolicRegression is Test {
+    function test_fails() public pure {
+        assert(false);
+    }
+}
+"#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--match-contract", "Real_SymbolicRegression"])
+        .assert_failure()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("test_fails()"), "{stdout}");
+    assert!(stdout.contains("assertion failed"), "{stdout}");
+});
+
 forgetest_init!(symbolic_emit_regression_rejects_explicit_output_collision, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(


### PR DESCRIPTION
## Description

Closes OSS-352 by adding `--emit-regression` support for symbolic test runs. Confirmed symbolic counterexample artifacts can now be converted into ordinary Solidity regression tests, with configurable output paths and overwrite behavior.

The generated tests import the original contract, replay stateless or stateful counterexample calls through Forge, and are reported back in JSON results via `symbolic_regressions`. This makes minimized symbolic failures reproducible as normal `forge test` cases.


### Usage 
```sh
forge test --symbolic --minimize --emit-regression
forge test --match-path 'test/regressions/*.sol'
```

With a custom output directory:

```sh
forge test --symbolic --emit-regression --regression-out test/custom_regressions
```