### PR TITLE
refactor(symbolic): defer gasleft solver errors

### DIFF
--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -638,9 +638,6 @@ impl SymbolicExecutor {
             Some(true) => Ok((state.constraints.clone(), true)),
             Some(false) => Ok((state.constraints.clone(), false)),
             None => {
-                if condition.contains_gasleft() {
-                    return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-                }
                 let mut constraints = state.constraints.clone();
                 constraints.push(condition);
                 let sat = self.solver.is_sat(&mut self.cx, &constraints)?;

--- a/crates/evm/symbolic/src/executor/cheatcodes.rs
+++ b/crates/evm/symbolic/src/executor/cheatcodes.rs
@@ -15,10 +15,6 @@ impl SymbolicExecutor {
             None => {}
         }
 
-        if pass.contains_gasleft() {
-            return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-        }
-
         let mut fail_constraints = state.constraints.clone();
         fail_constraints.push(fail);
         if self.solver.is_sat(&mut self.cx, &fail_constraints)? {

--- a/crates/evm/symbolic/src/executor/constraints.rs
+++ b/crates/evm/symbolic/src/executor/constraints.rs
@@ -30,9 +30,6 @@ impl SymbolicExecutor {
             Some(true) => Ok(CheatcodeOutcome::Continue(Vec::new())),
             Some(false) => Ok(CheatcodeOutcome::AssumeRejected),
             None => {
-                if condition.contains_gasleft() {
-                    return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-                }
                 state.constraints.push(condition);
                 if self.solver.is_sat(&mut self.cx, &state.constraints)? {
                     Ok(CheatcodeOutcome::Continue(Vec::new()))
@@ -50,9 +47,6 @@ impl SymbolicExecutor {
         max: usize,
         reason: &'static str,
     ) -> Result<usize, SymbolicError> {
-        if expr.contains_gasleft() {
-            return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-        }
         let mut above_max = state.constraints.clone();
         above_max.push(SymBoolExpr::cmp_word_const(
             &mut self.cx,
@@ -90,9 +84,6 @@ impl SymbolicExecutor {
         expr: &SymExpr,
         min: usize,
     ) -> Result<bool, SymbolicError> {
-        if expr.contains_gasleft() {
-            return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-        }
         let condition =
             SymBoolExpr::cmp_word_const(&mut self.cx, SymCmpOp::Uge, expr, U256::from(min));
         match condition.as_const() {

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -535,9 +535,6 @@ impl SymbolicExecutor {
                     }
                     Some(false) => {}
                     None => {
-                        if cond.contains_gasleft() {
-                            return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-                        }
                         let op_pc = state.pc.saturating_sub(1);
                         let _branch_span = trace_span!("jumpi_branch", pc = op_pc, dest).entered();
                         let true_cond = cond.nonzero_bool(&mut self.cx);

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -550,6 +550,9 @@ impl SymBoolExpr {
                 | SymExprKind::Hash { name: var, .. } => {
                     vars.insert(var.clone());
                 }
+                SymExprKind::GasLeft(id) => {
+                    vars.insert(SymExpr::gas_left_symbol(*id));
+                }
                 _ => {}
             }
             ControlFlow::<()>::Continue(())
@@ -561,6 +564,9 @@ impl SymBoolExpr {
             match expr.kind() {
                 SymExprKind::Var(var) | SymExprKind::Hash { name: var, .. } => {
                     vars.insert(var.clone());
+                }
+                SymExprKind::GasLeft(id) => {
+                    vars.insert(SymExpr::gas_left_symbol(*id));
                 }
                 _ => {}
             }

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -438,6 +438,10 @@ impl SymExpr {
         Self::from_kind(cx, SymExprKind::GasLeft(id))
     }
 
+    pub(in crate::runtime) fn gas_left_symbol(id: usize) -> Symbol {
+        Symbol::intern(&format!("gasleft_{id}"))
+    }
+
     pub(crate) fn not(cx: &mut SymCx, value: Self) -> Self {
         match value.kind() {
             SymExprKind::Const(value) => Self::constant(cx, !*value),
@@ -1045,9 +1049,7 @@ impl SymExpr {
         Ok(match self.kind() {
             SymExprKind::Const(value) => *value,
             SymExprKind::Var(var) => model.value(var.clone()).unwrap_or_default(),
-            SymExprKind::GasLeft(_) => {
-                return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-            }
+            SymExprKind::GasLeft(id) => model.value(Self::gas_left_symbol(*id)).unwrap_or_default(),
             SymExprKind::Keccak { len, bytes, .. } => {
                 let len = len.eval_model(model)?;
                 let Ok(len) = usize::try_from(len) else {
@@ -1109,6 +1111,15 @@ impl SymExpr {
                     *existing == value
                 } else {
                     model.insert(var.clone(), value);
+                    true
+                }
+            }
+            SymExprKind::GasLeft(id) => {
+                let var = Self::gas_left_symbol(*id);
+                if let Some(existing) = model.get(&var) {
+                    *existing == value
+                } else {
+                    model.insert(var, value);
                     true
                 }
             }
@@ -1210,6 +1221,9 @@ impl SymExpr {
             match expr.kind() {
                 SymExprKind::Var(var) | SymExprKind::Hash { name: var, .. } => {
                     vars.insert(var.clone());
+                }
+                SymExprKind::GasLeft(id) => {
+                    vars.insert(Self::gas_left_symbol(*id));
                 }
                 _ => {}
             }

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -341,9 +341,6 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         constraints: &[SymBoolExpr],
     ) -> Result<SymbolicModel, SymbolicError> {
         self.model_queries += 1;
-        if constraints.iter().any(SymBoolExpr::contains_gasleft) {
-            return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-        }
         let smt_constraints = normalize_constraints_for_solver(cx, constraints);
         let cache_key = smt_constraints.clone();
 
@@ -453,9 +450,6 @@ impl SmtLibSubprocessSolver {
         defer_hard_arith_without_witness: bool,
     ) -> Result<bool, SymbolicError> {
         self.sat_queries += 1;
-        if constraints.iter().any(SymBoolExpr::contains_gasleft) {
-            return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
-        }
         let smt_constraints = normalize_constraints_for_solver(cx, constraints);
         let cache_key = smt_constraints.clone();
         if let Some(result) = self.sat_cache.get(&cache_key) {
@@ -658,7 +652,7 @@ impl SmtLibSubprocessSolver {
         for var in vars {
             let _ = writeln!(smt, "(declare-fun {var} () (_ BitVec 256))");
         }
-        write_smt_assertions(&mut smt, smt_constraints);
+        write_smt_assertions(&mut smt, smt_constraints)?;
         smt.push_str("(check-sat)\n");
         if model {
             smt.push_str("(get-model)\n");

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -233,8 +233,14 @@ fn fallback_partial_model_satisfies_known_constraints(
 
 fn collect_bool_fallback_vars(expr: &SymBoolExpr, vars: &mut SymbolicVars) {
     let _ = expr.visit_exprs(&mut |expr| {
-        if let SymExprKind::Var(var) = expr.kind() {
-            vars.insert(var.clone());
+        match expr.kind() {
+            SymExprKind::Var(var) => {
+                vars.insert(var.clone());
+            }
+            SymExprKind::GasLeft(id) => {
+                vars.insert(SymExpr::gas_left_symbol(*id));
+            }
+            _ => {}
         }
         ControlFlow::<()>::Continue(())
     });

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -210,9 +210,15 @@ impl SymBoolExpr {
     }
 }
 
-pub(super) fn write_smt_assertions(out: &mut String, constraints: &[SymBoolExpr]) {
+pub(super) fn write_smt_assertions(
+    out: &mut String,
+    constraints: &[SymBoolExpr],
+) -> Result<(), SymbolicError> {
     if constraints.is_empty() {
-        return;
+        return Ok(());
+    }
+    if constraints.iter().any(SymBoolExpr::contains_gasleft) {
+        return Err(SymbolicError::Unsupported("GAS/gasleft() not modeled"));
     }
 
     let plan = SmtCsePlan::new(constraints);
@@ -220,7 +226,7 @@ pub(super) fn write_smt_assertions(out: &mut String, constraints: &[SymBoolExpr]
         for constraint in constraints {
             let _ = writeln!(out, "(assert {})", constraint.smt());
         }
-        return;
+        return Ok(());
     }
 
     let writer = SmtCseWriter { plan: &plan };
@@ -244,6 +250,7 @@ pub(super) fn write_smt_assertions(out: &mut String, constraints: &[SymBoolExpr]
         writer.write_bool(out, constraint, None, None);
         out.push_str(")\n");
     }
+    Ok(())
 }
 
 #[derive(Default)]

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3564,6 +3564,47 @@ fn is_sat_uses_single_var_witness_before_solver() {
 
 #[cfg(unix)]
 #[test]
+fn gasleft_can_use_single_var_witness_before_solver() {
+    let mut cx = SymCx::new();
+    let marker = portfolio_test_marker("gasleft-single-var");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
+    let gas = SymExpr::gas_left(&mut cx, 0);
+    let limit = SymExpr::constant(&mut cx, U256::from(10));
+    let constraints = vec![SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, gas, limit)];
+
+    assert!(solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(counted_solver_invocations(&marker), 0);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+fn gasleft_fails_at_smt_emission() {
+    let mut cx = SymCx::new();
+    let marker = portfolio_test_marker("gasleft-smt");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
+    let gas = SymExpr::gas_left(&mut cx, 0);
+    let x = SymExpr::var(&mut cx, "x");
+    let constraints = vec![SymBoolExpr::eq(&mut cx, gas, x)];
+
+    let err = solver.is_sat(&mut cx, &constraints).unwrap_err();
+    assert!(matches!(err, SymbolicError::Unsupported("GAS/gasleft() not modeled")));
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 1);
+    assert_eq!(counted_solver_invocations(&marker), 0);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
 fn model_uses_single_var_witness_before_solver() {
     let mut cx = SymCx::new();
     let marker = portfolio_test_marker("single-var-model");


### PR DESCRIPTION
This lets `gasleft()` participate in local symbolic reasoning as a synthetic variable while keeping the raw `GasLeft` expression kind for call-gas handling. Unresolved gasleft expressions still fail before SMT is sent, at assertion emission, so the solver never accidentally models gas consumption.

The concrete-use guards remain in the opcode, call, and log paths where gasleft would need to become an actual EVM value. AI assistance was used in preparing this change.
