### PR TITLE
perf(symbolic): simplify storage key constraints

### DIFF
--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -194,7 +194,9 @@ impl SymExpr {
         }
         match (self.storage_layout_key(cx), write_key.storage_layout_key(cx)) {
             (Some((read_base, read_offset)), Some((write_base, write_offset))) => {
-                let read_base = SymBoolExpr::eq(cx, read_base, write_base);
+                let read_base = read_base
+                    .storage_base_eq(cx, &write_base)
+                    .unwrap_or_else(|| SymBoolExpr::eq(cx, read_base, write_base));
                 let read_offset = SymBoolExpr::eq(cx, read_offset, write_offset);
                 SymBoolExpr::and(cx, vec![read_base, read_offset])
             }
@@ -202,6 +204,28 @@ impl SymExpr {
             (None, Some(_)) if self.as_const().is_some() => SymBoolExpr::constant(cx, false),
             _ => SymBoolExpr::eq(cx, self.clone(), write_key.clone()),
         }
+    }
+
+    fn storage_base_eq(&self, cx: &mut SymCx, other: &Self) -> Option<SymBoolExpr> {
+        let (read_key, read_slot) = self.storage_mapping_key(cx)?;
+        let (write_key, write_slot) = other.storage_mapping_key(cx)?;
+
+        let key_eq = SymBoolExpr::eq(cx, read_key, write_key);
+        let slot_eq = read_slot
+            .storage_base_eq(cx, &write_slot)
+            .unwrap_or_else(|| SymBoolExpr::eq(cx, read_slot, write_slot));
+        Some(SymBoolExpr::and(cx, vec![key_eq, slot_eq]))
+    }
+
+    fn storage_mapping_key(&self, cx: &mut SymCx) -> Option<(Self, Self)> {
+        let SymExprKind::Keccak { len, bytes, .. } = self.kind() else { return None };
+        if len.as_const() != Some(U256::from(64)) || bytes.len() < 64 {
+            return None;
+        }
+
+        let key = Self::from_bytes(cx, bytes[..32].iter().cloned());
+        let slot = Self::from_bytes(cx, bytes[32..64].iter().cloned());
+        Some((key, slot))
     }
 
     fn storage_mapping_root_slot(&self, cx: &mut SymCx) -> Option<U256> {

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -633,6 +633,16 @@ impl ConstraintContext {
 
     fn normalize_bool(&self, cx: &mut SymCx, expr: SymBoolExpr) -> SymBoolExpr {
         match expr.kind() {
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
+                if self.masked_word_eq_self(left, right) =>
+            {
+                // `x & mask == x => true` when the current context proves `x <= mask`.
+                SymBoolExpr::constant(cx, true)
+            }
+            SymBoolExprKind::Not(value) if self.masked_eq_self_condition(value) => {
+                // `x & mask != x => false` when the current context proves `x <= mask`.
+                SymBoolExpr::constant(cx, false)
+            }
             _ if expr
                 .zero_check_operand()
                 .is_some_and(|left| self.word_bool_always_true(cx, left)) =>
@@ -650,6 +660,32 @@ impl ConstraintContext {
             }
             _ => expr,
         }
+    }
+
+    fn masked_eq_self_condition(&self, expr: &SymBoolExpr) -> bool {
+        match expr.kind() {
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => {
+                self.masked_word_eq_self(left, right)
+            }
+            _ => false,
+        }
+    }
+
+    fn masked_word_eq_self(&self, left: &SymExpr, right: &SymExpr) -> bool {
+        self.masked_word_side_eq_self(left, right) || self.masked_word_side_eq_self(right, left)
+    }
+
+    fn masked_word_side_eq_self(&self, masked: &SymExpr, value: &SymExpr) -> bool {
+        let SymExprKind::BinOp(SymBinOp::And, left, right) = masked.kind() else { return false };
+        let Some((source, mask)) = right
+            .as_const()
+            .map(|mask| (left, mask))
+            .or_else(|| left.as_const().map(|mask| (right, mask)))
+        else {
+            return false;
+        };
+        let Some(bits) = mask_low_bits(mask) else { return false };
+        source == value && self.unsigned_bits(value) <= bits
     }
 
     fn record_upper_bound_constraint(&mut self, constraint: &SymBoolExpr) {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2163,6 +2163,27 @@ fn symbolic_storage_key_equality_expands_distinct_keccak_bases() {
 }
 
 #[test]
+fn symbolic_storage_key_equality_compares_mapping_key_words() {
+    let mut cx = SymCx::new();
+    let left_owner = SymExpr::var(&mut cx, "left_owner");
+    let right_owner = SymExpr::var(&mut cx, "right_owner");
+    let slot = SymExpr::constant(&mut cx, U256::from(3));
+
+    let mut left_key_bytes = left_owner.clone().into_byte_exprs(&mut cx);
+    left_key_bytes.extend(slot.clone().into_byte_exprs(&mut cx));
+    let left = keccak_word(&mut cx, left_key_bytes);
+
+    let mut right_key_bytes = right_owner.clone().into_byte_exprs(&mut cx);
+    right_key_bytes.extend(slot.into_byte_exprs(&mut cx));
+    let right = keccak_word(&mut cx, right_key_bytes);
+
+    let condition = left.storage_key_eq(&mut cx, &right);
+    let expected = SymBoolExpr::eq(&mut cx, left_owner, right_owner);
+
+    assert_eq!(condition, expected);
+}
+
+#[test]
 fn symbolic_storage_key_equality_rejects_concrete_plain_slot_alias() {
     let mut cx = SymCx::new();
     let owner = SymExpr::var(&mut cx, "owner");
@@ -3036,6 +3057,40 @@ fn solver_normalizes_checked_mul_guard_with_context_bound() {
 
     assert_eq!(
         normalize_constraints_for_solver(&mut cx, &constraints),
+        vec![SymBoolExpr::constant(&mut cx, false)]
+    );
+}
+
+#[test]
+fn solver_normalizes_mask_equality_with_context_bound() {
+    let mut cx = SymCx::new();
+    let a = SymExpr::var(&mut cx, "a");
+    let mask = (U256::from(1) << 160) - U256::from(1);
+    let mask_expr = SymExpr::constant(&mut cx, mask);
+    let masked = SymExpr::binop(&mut cx, SymBinOp::And, a.clone(), mask_expr);
+    let same_value = SymBoolExpr::eq(&mut cx, masked, a.clone());
+    let upper = SymExpr::constant(&mut cx, U256::from(1) << 160);
+    let bounded = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, a, upper);
+
+    assert_eq!(
+        normalize_constraints_for_solver(&mut cx, &[bounded.clone(), same_value]),
+        vec![bounded]
+    );
+}
+
+#[test]
+fn solver_normalizes_negated_mask_equality_with_context_bound() {
+    let mut cx = SymCx::new();
+    let a = SymExpr::var(&mut cx, "a");
+    let mask = (U256::from(1) << 160) - U256::from(1);
+    let mask_expr = SymExpr::constant(&mut cx, mask);
+    let masked = SymExpr::binop(&mut cx, SymBinOp::And, a.clone(), mask_expr);
+    let different_value = SymBoolExpr::eq(&mut cx, masked, a.clone()).not(&mut cx);
+    let upper = SymExpr::constant(&mut cx, U256::from(1) << 160);
+    let bounded = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, a, upper);
+
+    assert_eq!(
+        normalize_constraints_for_solver(&mut cx, &[bounded, different_value]),
         vec![SymBoolExpr::constant(&mut cx, false)]
     );
 }


### PR DESCRIPTION
Simplifies symbolic storage-key constraints in two places:

- compares 64-byte mapping keccak bases as reconstructed key/slot words, preserving nested mapping recursion.
- folds `(x & mask) == x` when current path constraints already prove `x` fits the mask.

### Results

| Check | master | this PR | delta |
| --- | ---: | ---: | ---: |
| symbolic bug suite hyperfine | 465.6ms +/- 6.1ms | 448.6ms +/- 8.2ms | 1.04x faster |
| bug suite SMT queries | 106 | 100 | -5.7% |
| bug suite solver queries | 287 | 283 | -1.4% |
| bug suite SMT input bytes | 84,800 | 59,375 | -30.0% |
| foundry-bench solady wall | 0.357s | 0.357s | neutral |
| foundry-bench solady SMT queries | 70 | 63 | -10.0% |
| foundry-bench farcaster wall | 0.290s | 0.244s | -15.9% |
| foundry-bench farcaster SMT queries | 27 | 9 | -66.7% |

Angstrom was unchanged on SMT counters and within noise on wall time: 0.472s -> 0.477s.