### PR TITLE
fix(forge): `fuzz show` with ambiguous contract names

### DIFF
--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -171,8 +171,13 @@ impl FuzzShowArgs {
                     sh_println!("{} ({} txs)", entry.path.display(), entry.sequence.len())?;
                     for (idx, tx) in entry.sequence.iter().enumerate() {
                         if let Some(decoded) = &tx.decoded {
+                            let ambiguity = if decoded.ambiguous_contracts.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" ambiguous=[{}]", decoded.ambiguous_contracts.join(","))
+                            };
                             sh_println!(
-                                "  {idx}: {} sender={} target={} value={}",
+                                "  {idx}: {} sender={} target={} value={}{}",
                                 decoded.call,
                                 tx.raw.sender,
                                 tx.raw.call_details.target,
@@ -180,7 +185,8 @@ impl FuzzShowArgs {
                                     .call_details
                                     .value
                                     .map(|v| v.to_string())
-                                    .unwrap_or_else(|| "0".to_string())
+                                    .unwrap_or_else(|| "0".to_string()),
+                                ambiguity
                             )?;
                         } else {
                             sh_println!(
@@ -817,10 +823,7 @@ fn abi_calldata_candidates(calldata: &[u8], decoder: &CorpusDecoder, limit: usiz
     if limit == 0 {
         return Vec::new();
     }
-    let Some(function) = decoder.unique_decodable_function(calldata) else {
-        return Vec::new();
-    };
-    let Ok(args) = function.abi_decode_input(&calldata[4..]) else {
+    let Some((function, args)) = decoder.unique_decodable_function(calldata) else {
         return Vec::new();
     };
 
@@ -1018,7 +1021,10 @@ struct DisplayTxDetails {
 
 #[derive(Serialize)]
 struct DecodedCall {
-    contract: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    contract: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    ambiguous_contracts: Vec<String>,
     signature: String,
     args: Vec<String>,
     call: String,
@@ -1071,46 +1077,66 @@ impl CorpusDecoder {
 
     fn decode(&self, tx: &BasicTxDetails) -> Option<DecodedCall> {
         let calldata = tx.call_details.calldata.as_ref();
-        let function = self.unique_decodable_function(calldata)?;
-        let decoded_args = function.abi_decode_input(&calldata[4..]).ok()?;
-        let args = format_tokens_raw(&decoded_args).collect::<Vec<_>>();
+        if calldata.len() < 4 {
+            return None;
+        }
 
         let selector = Selector::from_slice(&calldata[..4]);
-        self.functions.get(&selector).and_then(|functions| {
-            let indexed = functions.iter().find(|indexed| &indexed.function == function)?;
-            let signature = indexed.function.signature();
+        let functions = self.functions.get(&selector)?;
+        let (function, decoded_args) = self.unique_decodable_function(calldata)?;
+        let args = format_tokens_raw(&decoded_args).collect::<Vec<_>>();
+        let signature = function.signature();
+
+        let mut contracts = functions
+            .iter()
+            .filter(|indexed| indexed.function.signature() == signature.as_str())
+            .map(|indexed| indexed.contract.clone())
+            .collect::<Vec<_>>();
+        contracts.sort();
+        contracts.dedup();
+
+        let function_call = format!("{}({})", function.name, args.join(", "));
+        if contracts.len() == 1 {
+            let contract = contracts.pop()?;
             Some(DecodedCall {
-                call: format!(
-                    "{}.{}({})",
-                    indexed.contract,
-                    indexed.function.name,
-                    args.join(", ")
-                ),
-                contract: indexed.contract.clone(),
+                call: format!("{contract}.{function_call}"),
+                contract: Some(contract),
+                ambiguous_contracts: Vec::new(),
                 signature,
                 args,
             })
-        })
+        } else {
+            Some(DecodedCall {
+                call: function_call,
+                contract: None,
+                ambiguous_contracts: contracts,
+                signature,
+                args,
+            })
+        }
     }
 
-    fn unique_decodable_function(&self, calldata: &[u8]) -> Option<&Function> {
+    fn unique_decodable_function(&self, calldata: &[u8]) -> Option<(&Function, Vec<DynSolValue>)> {
         if calldata.len() < 4 {
             return None;
         }
 
         let selector = Selector::from_slice(&calldata[..4]);
         let mut unique = None;
-        for function in self.functions.get(&selector)?.iter().filter_map(|indexed| {
-            indexed.function.abi_decode_input(&calldata[4..]).ok()?;
-            Some(&indexed.function)
-        }) {
-            match unique {
-                Some(existing) if existing == function => {}
+        for (function, decoded_args) in
+            self.functions.get(&selector)?.iter().filter_map(|indexed| {
+                let decoded_args = indexed.function.abi_decode_input(&calldata[4..]).ok()?;
+                Some((&indexed.function, decoded_args))
+            })
+        {
+            let signature = function.signature();
+            match &unique {
+                Some((existing, _, _)) if existing == &signature => {}
                 Some(_) => return None,
-                None => unique = Some(function),
+                None => unique = Some((signature, function, decoded_args)),
             }
         }
-        unique
+        unique.map(|(_, function, decoded_args)| (function, decoded_args))
     }
 }
 
@@ -1447,5 +1473,25 @@ mod tests {
             abi_calldata_candidates(&calldata[..calldata.len() - 1], &decoder, usize::MAX)
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn abi_calldata_candidates_accept_same_signature_with_metadata_differences() {
+        let function =
+            Function::parse("function target(uint256 value) external returns (uint256)").unwrap();
+        let same_signature = Function::parse("function target(uint256 value) view").unwrap();
+        let calldata =
+            function.abi_encode_input(&[DynSolValue::Uint(U256::from(42), 256)]).unwrap();
+
+        let mut decoder = CorpusDecoder::default();
+        decoder.functions.entry(function.selector()).or_default().extend([
+            IndexedFunction { contract: "WithReturn".to_string(), function: function.clone() },
+            IndexedFunction { contract: "NoReturn".to_string(), function: same_signature },
+        ]);
+
+        let candidates =
+            candidate_args(&function, abi_calldata_candidates(&calldata, &decoder, usize::MAX));
+
+        assert!(candidates.iter().any(|args| args[0] == DynSolValue::Uint(U256::ZERO, 256)));
     }
 }

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -392,6 +392,51 @@ contract ForgeFuzzReplayFailureTest {
     assert!(stdout.contains("[SKIP: not runnable in replay mode] test_unit()"), "{stdout}");
 });
 
+forgetest_init!(forge_fuzz_show_marks_selector_ambiguous_contracts, |prj, cmd| {
+    prj.add_source(
+        "SelectorTwins.sol",
+        r#"
+contract Alpha {
+    function collide(uint256 value) external pure returns (uint256) {
+        return value;
+    }
+}
+
+contract Beta {
+    uint256 public stored;
+
+    function collide(uint256 value) external view {
+        require(stored != value);
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let alpha_abi = artifact_abi(prj.root(), "out/SelectorTwins.sol/Alpha.json");
+    let calldata = calldata_for(&alpha_abi, "collide", 42);
+    let corpus = prj.root().join("corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-00000000be7a-1.json", &calldata);
+
+    let show = cmd.forge_fuse().args(["fuzz", "show", "corpus"]).assert_success();
+    let stdout = String::from_utf8(show.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("  0: collide(42) "), "{stdout}");
+    assert!(stdout.contains(" ambiguous=[Alpha,Beta]"), "{stdout}");
+    assert!(!stdout.contains("Alpha.collide(42)"), "{stdout}");
+    assert!(!stdout.contains("Beta.collide(42)"), "{stdout}");
+
+    let json =
+        cmd.forge_fuse().args(["fuzz", "show", "corpus", "--format", "json"]).assert_success();
+    let stdout = String::from_utf8(json.get_output().stdout.clone()).unwrap();
+    let entries: Value = serde_json::from_str(&stdout).unwrap();
+    let decoded = &entries[0]["sequence"][0]["decoded"];
+    assert!(decoded.get("contract").is_none(), "{decoded}");
+    assert_eq!(decoded["signature"], "collide(uint256)");
+    assert_eq!(decoded["call"], "collide(42)");
+    assert_eq!(decoded["ambiguous_contracts"], serde_json::json!(["Alpha", "Beta"]));
+});
+
 forgetest_init!(forge_fuzz_replay_does_not_fuzz_after_assume_reject, |prj, cmd| {
     prj.update_config(|config| {
         config.fuzz.runs = 32;


### PR DESCRIPTION
Fixes `forge fuzz show` so it does not invent a contract name when a corpus entry's calldata can decode against the same function signature in multiple artifacts.

Instead of printing a misleading `Contract.function(...)`, ambiguous entries now show the function call without a contract prefix and include the candidate contract names. JSON output mirrors that with `contract: null` and `ambiguous_contracts`.

Follow-up to #15227.
