### PR TITLE
fix(cast): route send fee estimation through shared estimator

### DIFF
--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -577,6 +577,16 @@ impl Erc20Subcommand {
                                 .await?;
                             sponsor.attach_and_print::<N>(&mut tx, from).await?;
                         }
+                    } else {
+                        // Fill only the fees; the provider fills nonce and gas limit.
+                        fill_transaction_gas_fees(
+                            &$provider,
+                            &mut tx,
+                            chain.is_legacy(),
+                            false,
+                            config.eip1559_fee_estimate,
+                        )
+                        .await?;
                     }
                     cast_send(
                         $provider,

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -27,7 +27,7 @@ use foundry_common::{
     tempo::{TEMPO_BROWSER_GAS_BUFFER, maybe_print_fee_token, resolve_and_set_fee_token},
 };
 #[doc(hidden)]
-pub use foundry_config::{Chain, utils::*};
+pub use foundry_config::{Chain, Eip1559FeeEstimatePreset, utils::*};
 use foundry_wallets::{TempoAccessKeyConfig, WalletSigner};
 use tempo_alloy::TempoNetwork;
 
@@ -409,8 +409,14 @@ impl Erc20Subcommand {
                     let mut tx = { $build_tx }.into_transaction_request();
                     let chain = get_chain(config.chain, &$provider).await?;
                     tx_opts.apply::<TempoNetwork>(&mut tx, chain.is_legacy());
-                    tempo::fill_access_key_transaction(&$provider, &mut tx, access_key, chain)
-                        .await?;
+                    tempo::fill_access_key_transaction(
+                        &$provider,
+                        &mut tx,
+                        access_key,
+                        chain,
+                        config.eip1559_fee_estimate,
+                    )
+                    .await?;
                     if needs_sponsor_payload {
                         if print_sponsor_hash {
                             if let Some(fee_payer) = sponsor_fee_payer {
@@ -470,7 +476,15 @@ impl Erc20Subcommand {
                     let mut tx = { $build_tx }.into_transaction_request();
                     let chain = get_chain(config.chain, &$provider).await?;
                     tx_opts.apply::<N>(&mut tx, chain.is_legacy());
-                    fill_tx(&$provider, &mut tx, browser.address(), chain, true).await?;
+                    fill_tx(
+                        &$provider,
+                        &mut tx,
+                        browser.address(),
+                        chain,
+                        true,
+                        config.eip1559_fee_estimate,
+                    )
+                    .await?;
                     if print_sponsor_hash {
                         if let Some(fee_payer) = sponsor_fee_payer {
                             resolve_and_set_fee_token(
@@ -528,7 +542,15 @@ impl Erc20Subcommand {
                     let chain = get_chain(config.chain, &$provider).await?;
                     tx_opts.apply::<N>(&mut tx, chain.is_legacy());
                     if needs_sponsor_payload {
-                        fill_tx(&$provider, &mut tx, from, chain, false).await?;
+                        fill_tx(
+                            &$provider,
+                            &mut tx,
+                            from,
+                            chain,
+                            false,
+                            config.eip1559_fee_estimate,
+                        )
+                        .await?;
                         if print_sponsor_hash {
                             if let Some(fee_payer) = sponsor_fee_payer {
                                 resolve_and_set_fee_token(
@@ -696,6 +718,7 @@ async fn fill_tx<N: Network, P: Provider<N>>(
     from: Address,
     chain: Chain,
     browser: bool,
+    eip1559_fee_estimate: Eip1559FeeEstimatePreset,
 ) -> eyre::Result<()>
 where
     N::TransactionRequest: FoundryTransactionBuilder<N>,
@@ -709,7 +732,7 @@ where
 
     let legacy = chain.is_legacy();
 
-    fill_transaction_gas_fees(provider, tx, legacy, browser).await?;
+    fill_transaction_gas_fees(provider, tx, legacy, browser, eip1559_fee_estimate).await?;
 
     if tx.gas_limit().is_none() {
         let mut estimated = provider.estimate_gas(tx.clone()).await?;

--- a/crates/cast/src/cmd/tip20/mine.rs
+++ b/crates/cast/src/cmd/tip20/mine.rs
@@ -114,7 +114,14 @@ pub(super) async fn register(
     sh_status!("Submitting registerVirtualMaster({salt}) on Tempo...")?;
 
     if let Some(ref access_key) = tempo_access_key {
-        tempo::fill_access_key_transaction(&provider, &mut tx, access_key, chain).await?;
+        tempo::fill_access_key_transaction(
+            &provider,
+            &mut tx,
+            access_key,
+            chain,
+            config.eip1559_fee_estimate,
+        )
+        .await?;
         cast_send_with_access_key(
             &provider,
             tx,

--- a/crates/cast/src/cmd/tip20/mine.rs
+++ b/crates/cast/src/cmd/tip20/mine.rs
@@ -4,7 +4,7 @@ use crate::{
         send::{cast_send, cast_send_with_access_key},
     },
     tempo,
-    tx::{SendTxOpts, TxParams},
+    tx::{SendTxOpts, TxParams, fill_transaction_gas_fees},
 };
 use alloy_primitives::{Address, B256, keccak256};
 use alloy_signer::Signer;
@@ -137,6 +137,15 @@ pub(super) async fn register(
         .await?;
     } else {
         let provider = build_provider_with_signer::<TempoNetwork>(&send_tx, signer)?;
+        // Fill only the fees; the provider fills nonce and gas limit.
+        fill_transaction_gas_fees(
+            &provider,
+            &mut tx,
+            chain.is_legacy(),
+            false,
+            config.eip1559_fee_estimate,
+        )
+        .await?;
         cast_send(
             provider,
             tx,

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -5,7 +5,7 @@ use crate::{
         tip20::mine,
     },
     tempo,
-    tx::{CastTxSender, SendTxOpts, TxParams},
+    tx::{CastTxSender, SendTxOpts, TxParams, fill_transaction_gas_fees},
 };
 use alloy_network::Network;
 use alloy_primitives::{Address, B256};
@@ -240,6 +240,15 @@ async fn register(
         }
     } else {
         let provider = build_provider_with_signer::<TempoNetwork>(&send_tx, signer)?;
+        // Fill only the fees; the provider fills nonce and gas limit.
+        fill_transaction_gas_fees(
+            &provider,
+            &mut tx,
+            chain.is_legacy(),
+            false,
+            config.eip1559_fee_estimate,
+        )
+        .await?;
         if shell::is_json() {
             // JSON mode bypasses `cast_send`, so report the selection here.
             let fee_token = resolve_and_set_fee_token(

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -186,7 +186,14 @@ async fn register(
     sh_status!("Submitting registerVirtualMaster({salt})...")?;
 
     if let Some(ref access_key) = tempo_access_key {
-        tempo::fill_access_key_transaction(&provider, &mut tx, access_key, chain).await?;
+        tempo::fill_access_key_transaction(
+            &provider,
+            &mut tx,
+            access_key,
+            chain,
+            config.eip1559_fee_estimate,
+        )
+        .await?;
         if shell::is_json() {
             // JSON mode bypasses `cast_send_with_access_key`, so report the selection here.
             let fee_token = resolve_and_set_fee_token(

--- a/crates/cast/src/tempo.rs
+++ b/crates/cast/src/tempo.rs
@@ -6,7 +6,7 @@ use alloy_provider::Provider;
 use eyre::Result;
 use foundry_cli::opts::TempoOpts;
 use foundry_common::FoundryTransactionBuilder;
-use foundry_config::Chain;
+use foundry_config::{Chain, Eip1559FeeEstimatePreset};
 use foundry_wallets::{TempoAccessKeyConfig, WalletOpts, WalletSigner};
 use tempo_alloy::TempoNetwork;
 
@@ -49,6 +49,7 @@ pub(crate) async fn fill_access_key_transaction<P>(
     tx: &mut <TempoNetwork as Network>::TransactionRequest,
     access_key: &TempoAccessKeyConfig,
     chain: Chain,
+    eip1559_fee_estimate: Eip1559FeeEstimatePreset,
 ) -> Result<()>
 where
     P: Provider<TempoNetwork>,
@@ -67,7 +68,7 @@ where
     if tx.nonce().is_none() {
         tx.set_nonce(provider.get_transaction_count(access_key.wallet_address).await?);
     }
-    fill_transaction_gas_fees(provider, tx, chain.is_legacy(), false).await?;
+    fill_transaction_gas_fees(provider, tx, chain.is_legacy(), false, eip1559_fee_estimate).await?;
     if tx.gas_limit().is_none() {
         tx.set_gas_limit(provider.estimate_gas(tx.clone()).await?);
     }

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -16,10 +16,13 @@ use foundry_cli::{
     utils::{self, parse_function_args},
 };
 use foundry_common::{
-    FoundryTransactionBuilder, TransactionReceiptWithRevertReason, fmt::*,
-    get_pretty_receipt_w_reason_attr, shell,
+    FoundryTransactionBuilder, TransactionReceiptWithRevertReason,
+    fmt::*,
+    get_pretty_receipt_w_reason_attr,
+    provider::fee::{estimate_eip1559_fees, resolve_broadcast_eip1559_fees},
+    shell,
 };
-use foundry_config::{Chain, Config};
+use foundry_config::{Chain, Config, Eip1559FeeEstimatePreset};
 use foundry_wallets::{BrowserWalletOpts, TempoAccessKeyConfig, WalletOpts, WalletSigner};
 use itertools::Itertools;
 use serde_json::value::RawValue;
@@ -394,6 +397,8 @@ pub struct CastTxBuilder<N: Network, P, S> {
     fill: bool,
     /// Whether the filled transaction will be submitted through a browser wallet.
     browser: bool,
+    /// The preset used when estimating EIP-1559 fees.
+    eip1559_fee_estimate: Eip1559FeeEstimatePreset,
     auth: Vec<CliAuthorizationList>,
     chain: Chain,
     etherscan_api_key: Option<String>,
@@ -442,6 +447,7 @@ where
             eip4844: tx_opts.eip4844,
             fill: true,
             browser: false,
+            eip1559_fee_estimate: config.eip1559_fee_estimate,
             chain,
             etherscan_api_key,
             etherscan_api_url,
@@ -462,6 +468,7 @@ where
             eip4844: self.eip4844,
             fill: self.fill,
             browser: self.browser,
+            eip1559_fee_estimate: self.eip1559_fee_estimate,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
             etherscan_api_url: self.etherscan_api_url,
@@ -526,6 +533,7 @@ where
             eip4844: self.eip4844,
             fill: self.fill,
             browser: self.browser,
+            eip1559_fee_estimate: self.eip1559_fee_estimate,
             chain: self.chain,
             etherscan_api_key: self.etherscan_api_key,
             etherscan_api_url: self.etherscan_api_url,
@@ -706,7 +714,14 @@ where
             self.tx.set_max_fee_per_blob_gas(self.provider.get_blob_base_fee().await?)
         }
 
-        fill_transaction_gas_fees(&self.provider, &mut self.tx, self.legacy, self.browser).await
+        fill_transaction_gas_fees(
+            &self.provider,
+            &mut self.tx,
+            self.legacy,
+            self.browser,
+            self.eip1559_fee_estimate,
+        )
+        .await
     }
 
     /// Fills gas limit from the provider.
@@ -773,6 +788,7 @@ pub(crate) async fn fill_transaction_gas_fees<N: Network, P: Provider<N>>(
     tx: &mut N::TransactionRequest,
     legacy: bool,
     browser: bool,
+    eip1559_fee_estimate: Eip1559FeeEstimatePreset,
 ) -> Result<()>
 where
     N::TransactionRequest: FoundryTransactionBuilder<N>,
@@ -785,15 +801,19 @@ where
     }
 
     if tx.max_fee_per_gas().is_none() || tx.max_priority_fee_per_gas().is_none() {
-        let mut estimate = provider.estimate_eip1559_fees().await?;
-        if browser
-            && tx.max_priority_fee_per_gas().is_none()
-            && let Ok(suggested_tip) = provider.get_max_priority_fee_per_gas().await
-            && suggested_tip > estimate.max_priority_fee_per_gas
-        {
-            estimate.max_fee_per_gas += suggested_tip - estimate.max_priority_fee_per_gas;
-            estimate.max_priority_fee_per_gas = suggested_tip;
-        }
+        let estimate = estimate_eip1559_fees(provider, eip1559_fee_estimate).await?;
+
+        // Only honor the browser-suggested tip when the user has not pinned a
+        // priority fee; `resolve_broadcast_eip1559_fees` ignores a lower tip.
+        let browser_suggested_tip = if browser && tx.max_priority_fee_per_gas().is_none() {
+            provider.get_max_priority_fee_per_gas().await.ok()
+        } else {
+            None
+        };
+
+        // User `--gas-price`/`--priority-gas-price` overrides are already applied
+        // to `tx`; pass `None` so they are not double-applied here.
+        let estimate = resolve_broadcast_eip1559_fees(estimate, None, None, browser_suggested_tip)?;
 
         if tx.max_fee_per_gas().is_none() {
             tx.set_max_fee_per_gas(estimate.max_fee_per_gas);


### PR DESCRIPTION
`cast send` called alloy's unfiltered EIP-1559 estimator, so it disagreed with `forge script`, which was switched to Foundry's estimator in #15559.

It now uses the same `estimate_eip1559_fees` estimator as `forge script`, so both apply the near-empty-block filter and produce identical fees for the same chain state.