### PR TITLE
test(forge): `fuzz tmin` semantics coverage

### DIFF
--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -19,6 +19,8 @@ use foundry_common::{
     shell::{OutputMode, Shell},
 };
 use foundry_config::Config;
+#[cfg(test)]
+use foundry_evm::executors::ReplayFailure;
 use foundry_evm::{
     executors::{CorpusDirEntry, ReplayObservation, ShowmapDomain, read_corpus_tree},
     fuzz::BasicTxDetails,
@@ -1285,6 +1287,40 @@ mod tests {
         let observations = BTreeMap::from([
             ("A".to_string(), ReplayObservation { evm_edges: vec![1], ..Default::default() }),
             ("B".to_string(), ReplayObservation { evm_edges: vec![1], ..Default::default() }),
+        ]);
+
+        assert!(has_new_active_targets(&observations, &baseline));
+    }
+
+    #[test]
+    fn has_new_active_targets_rejects_candidate_only_failures() {
+        let baseline = BTreeMap::from([(
+            "A".to_string(),
+            ReplayObservation { evm_edges: vec![1], ..Default::default() },
+        )]);
+        let observations = BTreeMap::from([
+            ("A".to_string(), ReplayObservation { evm_edges: vec![1], ..Default::default() }),
+            (
+                "B".to_string(),
+                ReplayObservation {
+                    failure: Some(ReplayFailure::AfterInvariant),
+                    ..Default::default()
+                },
+            ),
+        ]);
+
+        assert!(has_new_active_targets(&observations, &baseline));
+    }
+
+    #[test]
+    fn has_new_active_targets_rejects_candidate_only_replayed_transactions() {
+        let baseline = BTreeMap::from([(
+            "A".to_string(),
+            ReplayObservation { evm_edges: vec![1], ..Default::default() },
+        )]);
+        let observations = BTreeMap::from([
+            ("A".to_string(), ReplayObservation { evm_edges: vec![1], ..Default::default() }),
+            ("B".to_string(), ReplayObservation { replayed: 1, ..Default::default() }),
         ]);
 
         assert!(has_new_active_targets(&observations, &baseline));

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -19,8 +19,6 @@ use foundry_common::{
     shell::{OutputMode, Shell},
 };
 use foundry_config::Config;
-#[cfg(test)]
-use foundry_evm::executors::ReplayFailure;
 use foundry_evm::{
     executors::{CorpusDirEntry, ReplayObservation, ShowmapDomain, read_corpus_tree},
     fuzz::BasicTxDetails,
@@ -1233,6 +1231,7 @@ fn merge_new_edge_vec(cumulative: &mut Vec<u8>, candidate: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use foundry_evm::executors::ReplayFailure;
 
     fn decoder_with_functions(functions: Vec<Function>) -> CorpusDecoder {
         let mut decoder = CorpusDecoder::default();

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1609,6 +1609,63 @@ contract ForgeFuzzTminFailureTargetTest {
     );
 });
 
+forgetest_init!(forge_fuzz_tmin_rejects_assume_and_skip_candidates, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzTminRejectedCandidateTarget.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzTminRejectedCandidateTargetTest is Test {
+    uint256 value;
+
+    function testFuzz_rejectedCandidates(uint256 input) public {
+        if (input == 0) {
+            vm.assume(false);
+        }
+        if (input == 1) {
+            vm.skip(true, "skip one");
+        }
+        if (input == 2) {
+            value = 1;
+        }
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzTminRejectedCandidateTarget.t.sol/ForgeFuzzTminRejectedCandidateTargetTest.json",
+    );
+    let calldata = calldata_for(&abi, "testFuzz_rejectedCandidates", 2);
+    let corpus = prj.root().join("tmin-rejected-candidates-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &calldata);
+
+    cmd.forge_fuse()
+        .args([
+            "fuzz",
+            "tmin",
+            "--mc",
+            "ForgeFuzzTminRejectedCandidateTargetTest",
+            "--mt",
+            "testFuzz_rejectedCandidates",
+            "tmin-rejected-candidates-corpus/00000000-0000-0000-0000-000000000001-1.json",
+            "--corpus-out",
+            "tmin-rejected-candidates-output.json",
+        ])
+        .assert_success();
+
+    let args = output_calldata_args(
+        prj.root(),
+        "tmin-rejected-candidates-output.json",
+        &abi,
+        "testFuzz_rejectedCandidates",
+    );
+    assert_eq!(args, vec![DynSolValue::Uint(U256::from(2), 256)]);
+});
+
 forgetest_init!(forge_fuzz_tmin_rejects_existing_output, |prj, cmd| {
     prj.add_test(
         "ForgeFuzzTminExistingOutput.t.sol",


### PR DESCRIPTION
Adds guardrail coverage for `forge fuzz tmin` replay semantics.

The tests lock down that candidate-only active targets are rejected when they produce failures or replayed transactions, and that calldata shrink candidates are not accepted when they turn a successful replay into `vm.assume` or `vm.skip`.

Follow-up to #15227 #15549.
