### PR TITLE
refactor(symbolic): intern symbol names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,11 @@ the fixed cheatcode address and are dispatched through the cheatcode inspector.
 Custom network behavior for `anvil`, `forge`, and `cast` is implemented through
 the EVM networks crate.
 
+For symbolic execution work under `crates/evm/symbolic`, read
+`crates/evm/symbolic/AGENTS.md` before editing. It documents the crate's
+internal executor/runtime/expression structure, symbolic result semantics, and
+focused verification commands.
+
 ## Testing
 
 - Add tests for code changes that fix behavior or add functionality.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,9 +50,7 @@ Custom network behavior for `anvil`, `forge`, and `cast` is implemented through
 the EVM networks crate.
 
 For symbolic execution work under `crates/evm/symbolic`, read
-`crates/evm/symbolic/AGENTS.md` before editing. It documents the crate's
-internal executor/runtime/expression structure, symbolic result semantics, and
-focused verification commands.
+`crates/evm/symbolic/AGENTS.md` before editing.
 
 ## Testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5747,6 +5747,7 @@ dependencies = [
  "foundry-config",
  "foundry-evm",
  "hashbrown 0.16.1",
+ "inturn 0.2.0",
  "serde",
  "serde_json",
  "shlex 1.3.0",
@@ -6898,6 +6899,19 @@ dependencies = [
  "dashmap",
  "hashbrown 0.14.5",
  "stumpalo",
+ "thread_local",
+]
+
+[[package]]
+name = "inturn"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630b41dcc27d131bc9b501515a2cb3dfde2b0de4d8b53bd9c97180fb87696aa2"
+dependencies = [
+ "boxcar",
+ "bumpalo",
+ "dashmap",
+ "hashbrown 0.14.5",
  "thread_local",
 ]
 
@@ -11301,7 +11315,7 @@ dependencies = [
  "anstyle",
  "derive_more",
  "dunce",
- "inturn",
+ "inturn 0.1.3",
  "itertools 0.10.5",
  "itoa",
  "normalize-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -455,7 +455,7 @@ futures = { version = "0.3", default-features = false }
 hashbrown = "0.16.1"
 hyper = "1.8"
 indicatif = "0.18"
-inturn = "0.1.2"
+inturn = "0.2.0"
 itertools = "0.15"
 jsonpath_lib = "0.3"
 k256 = "0.13"

--- a/crates/evm/symbolic/AGENTS.md
+++ b/crates/evm/symbolic/AGENTS.md
@@ -47,9 +47,10 @@ scoped to the modeled EVM surface and configured bounds.
   Use `SymExpr::get_var(cx, symbol)` when you already have a `Symbol`.
 - `HashConsed` equality is pointer equality. Structural equality is enforced by
   `HashCons::make`; do not add ad hoc deep equality on handles.
-- `HashCons` is generic over its hasher and defaults to Alloy/foldhash
-  `FixedState` for stable expression hashes. Do not expose raw cached hash
-  accessors just to order expressions.
+- `HashCons` owns an Alloy/foldhash `FixedState` and stores the cached
+  structural hash in each handle. Use hashcons-local helpers for stable
+  expression ordering; do not expose raw cached hash accessors just to order
+  expressions.
 - `SymExpr::binop` must accept both EVM operand orders because simplification
   happens before commutative canonicalization.
 - Normalized commutative word ops put simpler operands on the RHS; constants end

--- a/crates/evm/symbolic/AGENTS.md
+++ b/crates/evm/symbolic/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in `crates/evm/symbolic`.
+
+## First Read
+
+Read `crates/evm/symbolic/README.md` before changing user-facing symbolic
+execution behavior. It defines the external semantics: symbolic tests are
+`check*`, `prove*`, `invariant*`, and `statefulFuzz*` entrypoints; results are
+`Safe`, replay-confirmed `Counterexample`, or `Incomplete`; and `PASS` is only
+scoped to the modeled EVM surface and configured bounds.
+
+## Internal Structure
+
+- `src/lib.rs`: crate boundary, public symbolic run inputs/results, solver
+  availability helpers, SVM compatibility selector mapping, and shared imports.
+- `src/abi.rs`: ABI-to-symbolic calldata/value construction, dynamic length
+  expansion, model concretization, and replay value extraction.
+- `src/executor/`: bytecode execution driver. `run.rs` coordinates paths,
+  `opcodes.rs` implements opcode semantics, `calls.rs` and `create.rs` handle
+  call/create flows, `cheatcodes.rs` handles Foundry and SVM helpers,
+  `constraints.rs` manages branch constraints, and `invariant.rs` builds
+  bounded symbolic invariant sequences.
+- `src/runtime.rs`: module hub for runtime data structures.
+- `src/runtime/state.rs`: `PathState`, call frames, symbolic world overlay,
+  storage, balances, logs, returndata, snapshots, and path-local execution
+  state.
+- `src/runtime/memory.rs`, `bytes.rs`, and `calldata.rs`: byte-precise symbolic
+  memory, byte vectors, calldata, returndata, and copy/load/store helpers.
+- `src/runtime/solver.rs` and `src/runtime/solver/`: SMT-LIB solver backend,
+  solver portfolio scheduling, normalization, cache keys, model parsing,
+  hard-arithmetic fallback, and monotonic-product reasoning.
+- `src/runtime/expr/`: symbolic word and bool expression representation,
+  hash-consing, symbol interning, simplification, canonicalization, SMT
+  emission, traversal, and folding.
+- `src/tests.rs`: crate-level symbolic behavior tests. Put private expression
+  representation tests in the relevant module-local `#[cfg(test)]` module.
+
+## Expression Invariants
+
+- `SymCx` owns all expression storage: word expressions, bool expressions, byte
+  expressions, and the symbol interner.
+- `Symbol` is an id-only nonzero `u32` wrapper. Do not store variable names in
+  symbols or expression leaves. Names live in the `inturn` interner as
+  `Box<str>`.
+- Use `SymExpr::var(cx, name)` when creating a named variable from a string.
+  Use `SymExpr::get_var(cx, symbol)` when you already have a `Symbol`.
+- `HashConsed` equality is pointer equality. Structural equality is enforced by
+  `HashCons::make`; do not add ad hoc deep equality on handles.
+- `HashCons` is generic over its hasher and defaults to Alloy/foldhash
+  `FixedState` for stable expression hashes. Do not expose raw cached hash
+  accessors just to order expressions.
+- `SymExpr::binop` must accept both EVM operand orders because simplification
+  happens before commutative canonicalization.
+- Normalized commutative word ops put simpler operands on the RHS; constants end
+  up on the RHS. For same-complexity operands, keep a stable tie-breaker so
+  `x + y` and `y + x` hash-cons to the same expression.
+- Once matching an already-normalized commutative expression, do not duplicate
+  impossible constant-left cases such as `<constant>, X` and `X, <constant>`.
+  Keep both directions only at construction boundaries or for non-commutative
+  operations.
+- `Eq` comparisons are commutative and ordered through the same expression
+  ordering helper. Unsigned/signed order comparisons are not commutative; do not
+  remove left-constant comparison cases unless the code has already normalized
+  that exact operator.
+
+## Solver And Normalization Notes
+
+- `normalize_constraints_for_solver` and `normalize_bool_for_solver` are the
+  canonical path before SMT and sat-cache keys. Preserve cache-key stability when
+  changing expression ordering.
+- `runtime/solver/opt.rs` contains local rewrites and constraint-context facts.
+  Keep rewrites semantics-preserving under EVM bit-vector behavior.
+- `runtime/solver/hard_arith_fallback.rs` is a bounded model search used before
+  or alongside SMT for hard arithmetic. Validate candidates against the original
+  constraints.
+- Solver models are not trusted until checked against symbolic expressions and,
+  for user-visible failures, replayed through the concrete Foundry executor.
+
+## Testing
+
+Use the existing test infrastructure; do not create standalone test harnesses.
+For focused symbolic changes, run:
+
+```bash
+cargo fmt --all
+cargo check --locked -p foundry-evm-symbolic
+cargo cl --locked -p foundry-evm-symbolic
+cargo nextest run --locked -p foundry-evm-symbolic
+git diff --check
+```
+
+For Forge integration behavior, prefer focused CLI tests such as:
+
+```bash
+cargo nextest run --locked -p forge --test cli test_cmd::symbolic
+SYMBOLIC_CONFORMANCE=1 cargo nextest run --locked -p forge --test cli symbolic_conformance
+SYMBOLIC_LIMITS=1 cargo nextest run --locked -p forge --test cli symbolic_limits
+```
+
+The conformance and limits suites require a local solver and are intentionally
+broader/slower.

--- a/crates/evm/symbolic/AGENTS.md
+++ b/crates/evm/symbolic/AGENTS.md
@@ -85,18 +85,17 @@ For focused symbolic changes, run:
 
 ```bash
 cargo fmt --all
-cargo check --locked -p foundry-evm-symbolic
-cargo cl --locked -p foundry-evm-symbolic
-cargo nextest run --locked -p foundry-evm-symbolic
+cargo check -p foundry-evm-symbolic
+cargo nextest run -p foundry-evm-symbolic
 git diff --check
 ```
 
 For Forge integration behavior, prefer focused CLI tests such as:
 
 ```bash
-cargo nextest run --locked -p forge --test cli test_cmd::symbolic
-SYMBOLIC_CONFORMANCE=1 cargo nextest run --locked -p forge --test cli symbolic_conformance
-SYMBOLIC_LIMITS=1 cargo nextest run --locked -p forge --test cli symbolic_limits
+cargo nextest run -p forge --test cli test_cmd::symbolic
+SYMBOLIC_CONFORMANCE=1 cargo nextest run -p forge --test cli symbolic_conformance
+SYMBOLIC_LIMITS=1 cargo nextest run -p forge --test cli symbolic_limits
 ```
 
 The conformance and limits suites require a local solver and are intentionally

--- a/crates/evm/symbolic/AGENTS.md
+++ b/crates/evm/symbolic/AGENTS.md
@@ -13,49 +13,33 @@ scoped to the modeled EVM surface and configured bounds.
 ## Internal Structure
 
 - `src/lib.rs`: crate boundary, public symbolic run inputs/results, solver
-  availability helpers, SVM compatibility selector mapping, and shared imports.
-- `src/abi.rs`: ABI-to-symbolic calldata/value construction, dynamic length
-  expansion, model concretization, and replay value extraction.
-- `src/executor/`: bytecode execution driver. `run.rs` coordinates paths,
-  `opcodes.rs` implements opcode semantics, `calls.rs` and `create.rs` handle
-  call/create flows, `cheatcodes.rs` handles Foundry and SVM helpers,
-  `constraints.rs` manages branch constraints, and `invariant.rs` builds
-  bounded symbolic invariant sequences.
-- `src/runtime.rs`: module hub for runtime data structures.
-- `src/runtime/state.rs`: `PathState`, call frames, symbolic world overlay,
-  storage, balances, logs, returndata, snapshots, and path-local execution
-  state.
-- `src/runtime/memory.rs`, `bytes.rs`, and `calldata.rs`: byte-precise symbolic
-  memory, byte vectors, calldata, returndata, and copy/load/store helpers.
-- `src/runtime/solver.rs` and `src/runtime/solver/`: SMT-LIB solver backend,
-  solver portfolio scheduling, normalization, cache keys, model parsing,
-  hard-arithmetic fallback, and monotonic-product reasoning.
-- `src/runtime/expr/`: symbolic word and bool expression representation,
-  hash-consing, symbol interning, simplification, canonicalization, SMT
-  emission, traversal, and folding.
+  availability helpers, and compatibility helper mapping.
+- `src/abi.rs`: ABI-to-symbolic calldata/value construction and replay value
+  extraction.
+- `src/executor/`: bytecode execution, calls/creates, cheatcodes, branch
+  constraints, and bounded invariant sequences.
+- `src/runtime/`: symbolic runtime data structures: path state, world overlay,
+  memory, bytes, calldata, expressions, solver integration, precompiles, and
+  EVM helpers.
+- `src/runtime/expr/`: symbolic word/bool expressions, hash-consing, symbol
+  interning, simplification, canonicalization, SMT emission, traversal, and
+  folding.
 - `src/tests.rs`: crate-level symbolic behavior tests. Put private expression
   representation tests in the relevant module-local `#[cfg(test)]` module.
 
 ## Expression Invariants
 
-- `SymCx` owns all expression storage: word expressions, bool expressions, byte
-  expressions, and the symbol interner.
-- `Symbol` is an id-only nonzero `u32` wrapper. Do not store variable names in
-  symbols or expression leaves. Names live in the `inturn` interner as
-  `Box<str>`.
+- `SymCx` owns expression storage and symbol interning.
+- `Symbol` is an id-only handle. Do not store variable names in symbols or
+  expression leaves; keep names in the interner.
 - Use `SymExpr::var(cx, name)` when creating a named variable from a string.
   Use `SymExpr::get_var(cx, symbol)` when you already have a `Symbol`.
-- `HashConsed` equality is pointer equality. Structural equality is enforced by
-  `HashCons::make`; do not add ad hoc deep equality on handles.
-- `HashCons` owns an Alloy/foldhash `FixedState` and stores the cached
-  structural hash in each handle. Use hashcons-local helpers for stable
-  expression ordering; do not expose raw cached hash accessors just to order
-  expressions.
+- `HashConsed` equality is pointer equality. Structural equality is enforced
+  when values are hash-consed.
 - `SymExpr::binop` must accept both EVM operand orders because simplification
   happens before commutative canonicalization.
 - Normalized commutative word ops put simpler operands on the RHS; constants end
-  up on the RHS. For same-complexity operands, keep a stable tie-breaker so
-  `x + y` and `y + x` hash-cons to the same expression.
+  up on the RHS.
 - Once matching an already-normalized commutative expression, do not duplicate
   impossible constant-left cases such as `<constant>, X` and `X, <constant>`.
   Keep both directions only at construction boundaries or for non-commutative
@@ -67,16 +51,11 @@ scoped to the modeled EVM surface and configured bounds.
 
 ## Solver And Normalization Notes
 
-- `normalize_constraints_for_solver` and `normalize_bool_for_solver` are the
-  canonical path before SMT and sat-cache keys. Preserve cache-key stability when
-  changing expression ordering.
-- `runtime/solver/opt.rs` contains local rewrites and constraint-context facts.
-  Keep rewrites semantics-preserving under EVM bit-vector behavior.
-- `runtime/solver/hard_arith_fallback.rs` is a bounded model search used before
-  or alongside SMT for hard arithmetic. Validate candidates against the original
-  constraints.
-- Solver models are not trusted until checked against symbolic expressions and,
-  for user-visible failures, replayed through the concrete Foundry executor.
+- Keep solver rewrites semantics-preserving under EVM bit-vector behavior.
+- Preserve normalization/cache behavior when changing expression ordering or
+  boolean simplification.
+- Solver models are not user-visible counterexamples until replay confirms
+  them.
 
 ## Testing
 

--- a/crates/evm/symbolic/Cargo.toml
+++ b/crates/evm/symbolic/Cargo.toml
@@ -29,6 +29,7 @@ alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 
 base64.workspace = true
 hashbrown.workspace = true
+inturn.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 shlex.workspace = true

--- a/crates/evm/symbolic/src/abi.rs
+++ b/crates/evm/symbolic/src/abi.rs
@@ -444,7 +444,7 @@ impl<'a, 'cx> SymbolicAbiBuilder<'a, 'cx> {
     }
 
     pub(super) fn fresh_word(&mut self, name: &str) -> SymExpr {
-        SymExpr::named_var(self.cx, name)
+        SymExpr::var(self.cx, name)
     }
 
     pub(super) fn fresh_byte(

--- a/crates/evm/symbolic/src/abi.rs
+++ b/crates/evm/symbolic/src/abi.rs
@@ -444,7 +444,7 @@ impl<'a, 'cx> SymbolicAbiBuilder<'a, 'cx> {
     }
 
     pub(super) fn fresh_word(&mut self, name: &str) -> SymExpr {
-        SymExpr::var(self.cx, name)
+        SymExpr::named_var(self.cx, name)
     }
 
     pub(super) fn fresh_byte(

--- a/crates/evm/symbolic/src/runtime/address.rs
+++ b/crates/evm/symbolic/src/runtime/address.rs
@@ -139,7 +139,7 @@ impl SymExpr {
     }
 }
 
-pub(crate) fn stable_symbol(prefix: &'static str, input: &[u8]) -> Symbol {
+pub(crate) fn stable_symbol(cx: &mut SymCx, prefix: &'static str, input: &[u8]) -> Symbol {
     let digest = keccak256(input);
     let mut symbol = String::with_capacity(prefix.len() + 17);
     symbol.push_str(prefix);
@@ -147,5 +147,5 @@ pub(crate) fn stable_symbol(prefix: &'static str, input: &[u8]) -> Symbol {
     for byte in &digest[..8] {
         let _ = write!(symbol, "{byte:02x}");
     }
-    Symbol::intern(&symbol)
+    cx.intern(&symbol)
 }

--- a/crates/evm/symbolic/src/runtime/address.rs
+++ b/crates/evm/symbolic/src/runtime/address.rs
@@ -82,9 +82,8 @@ impl SymExpr {
         }
 
         match this.kind() {
-            SymExprKind::BinOp(SymBinOp::And, left, right) => {
-                (right.is_address_mask() && left.address_expr_equivalent(alias))
-                    || (left.is_address_mask() && right.address_expr_equivalent(alias))
+            SymExprKind::BinOp(SymBinOp::And, left, right) if right.is_address_mask() => {
+                left.address_expr_equivalent(alias)
             }
             SymExprKind::BinOp(SymBinOp::Shr, value, shift) if shift.is_shift_96() => {
                 match value.kind() {
@@ -104,9 +103,6 @@ impl SymExpr {
         match self.kind() {
             SymExprKind::BinOp(SymBinOp::And, left, right) if right.is_address_mask() => {
                 left.symbolic_address_canonical()
-            }
-            SymExprKind::BinOp(SymBinOp::And, left, right) if left.is_address_mask() => {
-                right.symbolic_address_canonical()
             }
             SymExprKind::BinOp(SymBinOp::Shr, value, shift) if shift.is_shift_96() => {
                 match value.kind() {

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -304,11 +304,6 @@ impl SymBoolExpr {
             {
                 Some(left)
             }
-            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
-                if left.as_const().is_some_and(|value| value.is_zero()) =>
-            {
-                Some(right)
-            }
             _ => None,
         }
     }
@@ -331,25 +326,17 @@ impl SymBoolExpr {
         context: &[Self],
     ) -> Option<U256> {
         match self.kind() {
-            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => match (left.kind(), right.kind()) {
-                (_, SymExprKind::Const(value)) => left.equality_forces_const(*value, expr, context),
-                (SymExprKind::Const(value), _) => {
-                    right.equality_forces_const(*value, expr, context)
-                }
+            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => match right.kind() {
+                SymExprKind::Const(value) => left.equality_forces_const(*value, expr, context),
                 _ => None,
             },
             SymBoolExprKind::Not(value) => match value.kind() {
-                SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => {
-                    match (left.kind(), right.kind()) {
-                        (_, SymExprKind::Const(value)) if value.is_zero() => {
-                            left.nonzero_forces_const(expr, context)
-                        }
-                        (SymExprKind::Const(value), _) if value.is_zero() => {
-                            right.nonzero_forces_const(expr, context)
-                        }
-                        _ => None,
+                SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => match right.kind() {
+                    SymExprKind::Const(value) if value.is_zero() => {
+                        left.nonzero_forces_const(expr, context)
                     }
-                }
+                    _ => None,
+                },
                 SymBoolExprKind::Not(value) => value.forces_expr_const_with_context(expr, context),
                 _ => None,
             },

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -539,7 +539,7 @@ impl SymBoolExpr {
 
     pub(crate) fn collect_vars(&self, vars: &mut SymbolicVars) {
         let _ = self.visit_exprs(&mut |expr| {
-            if let Some(var) = expr.kind().var() {
+            if let Some(var) = expr.kind().get_var() {
                 vars.insert(var);
             }
             ControlFlow::<()>::Continue(())
@@ -548,7 +548,7 @@ impl SymBoolExpr {
 
     pub(crate) fn collect_eval_vars(&self, vars: &mut SymbolicVars) {
         let _ = self.visit_exprs(&mut |expr| {
-            if let Some(var) = expr.kind().eval_var() {
+            if let Some(var) = expr.kind().get_eval_var() {
                 vars.insert(var);
             }
             ControlFlow::<()>::Continue(())

--- a/crates/evm/symbolic/src/runtime/expr/bool.rs
+++ b/crates/evm/symbolic/src/runtime/expr/bool.rs
@@ -24,11 +24,6 @@ impl SymBoolExpr {
         self.kind.value()
     }
 
-    #[cfg(test)]
-    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
-        self.kind.ptr_eq(&other.kind)
-    }
-
     pub(in crate::runtime) fn into_kind(self) -> SymBoolExprKind {
         self.kind.into_value()
     }
@@ -437,7 +432,7 @@ impl SymBoolExpr {
     ) -> Result<Option<bool>, SymbolicError> {
         let mut vars = SymbolicVars::default();
         self.collect_eval_vars(&mut vars);
-        if vars.iter().cloned().all(|var| model.contains_name(var)) {
+        if vars.iter().copied().all(|var| model.contains_name(var)) {
             self.eval_model(model).map(Some)
         } else {
             Ok(None)
@@ -544,16 +539,8 @@ impl SymBoolExpr {
 
     pub(crate) fn collect_vars(&self, vars: &mut SymbolicVars) {
         let _ = self.visit_exprs(&mut |expr| {
-            match expr.kind() {
-                SymExprKind::Var(var)
-                | SymExprKind::Keccak { name: var, .. }
-                | SymExprKind::Hash { name: var, .. } => {
-                    vars.insert(var.clone());
-                }
-                SymExprKind::GasLeft(id) => {
-                    vars.insert(SymExpr::gas_left_symbol(*id));
-                }
-                _ => {}
+            if let Some(var) = expr.kind().var() {
+                vars.insert(var);
             }
             ControlFlow::<()>::Continue(())
         });
@@ -561,46 +548,40 @@ impl SymBoolExpr {
 
     pub(crate) fn collect_eval_vars(&self, vars: &mut SymbolicVars) {
         let _ = self.visit_exprs(&mut |expr| {
-            match expr.kind() {
-                SymExprKind::Var(var) | SymExprKind::Hash { name: var, .. } => {
-                    vars.insert(var.clone());
-                }
-                SymExprKind::GasLeft(id) => {
-                    vars.insert(SymExpr::gas_left_symbol(*id));
-                }
-                _ => {}
+            if let Some(var) = expr.kind().eval_var() {
+                vars.insert(var);
             }
             ControlFlow::<()>::Continue(())
         });
     }
 
-    pub(crate) fn smt(&self) -> String {
+    pub(crate) fn smt(&self, cx: &SymCx) -> String {
         let mut smt = String::new();
-        self.write_smt(&mut smt);
+        self.write_smt(cx, &mut smt);
         smt
     }
 
-    pub(in crate::runtime::expr) fn write_smt(&self, out: &mut String) {
+    pub(in crate::runtime::expr) fn write_smt(&self, cx: &SymCx, out: &mut String) {
         match self.kind() {
             SymBoolExprKind::Const(value) => out.push_str(if *value { "true" } else { "false" }),
             SymBoolExprKind::Not(value) => {
                 out.push_str("(not ");
-                value.write_smt(out);
+                value.write_smt(cx, out);
                 out.push(')');
             }
             SymBoolExprKind::And(values) => {
                 out.push_str("(and");
                 for value in values.iter() {
                     out.push(' ');
-                    value.write_smt(out);
+                    value.write_smt(cx, out);
                 }
                 out.push(')');
             }
             SymBoolExprKind::Cmp(op, left, right) => {
                 let _ = write!(out, "({} ", op.smt());
-                left.write_smt(out);
+                left.write_smt(cx, out);
                 out.push(' ');
-                right.write_smt(out);
+                right.write_smt(cx, out);
                 out.push(')');
             }
         }

--- a/crates/evm/symbolic/src/runtime/expr/cx.rs
+++ b/crates/evm/symbolic/src/runtime/expr/cx.rs
@@ -119,6 +119,24 @@ mod tests {
     }
 
     #[test]
+    fn commutative_ops_place_constants_on_rhs() {
+        let mut cx = SymCx::new();
+        let constant_value = U256::from(7);
+
+        for op in [SymBinOp::Add, SymBinOp::Mul, SymBinOp::And, SymBinOp::Or, SymBinOp::Xor] {
+            let x = SymExpr::var(&mut cx, "x");
+            let constant = SymExpr::constant(&mut cx, constant_value);
+            let expr = SymExpr::binop(&mut cx, op, constant, x.clone());
+            let SymExprKind::BinOp(actual_op, left, right) = expr.kind() else {
+                panic!("expected binary expression");
+            };
+            assert_eq!(*actual_op, op);
+            assert_eq!(left, &x);
+            assert_eq!(right.as_const(), Some(constant_value));
+        }
+    }
+
+    #[test]
     fn hashconses_bool_expressions() {
         let mut cx = SymCx::new();
         let x = SymExpr::var(&mut cx, "x");

--- a/crates/evm/symbolic/src/runtime/expr/cx.rs
+++ b/crates/evm/symbolic/src/runtime/expr/cx.rs
@@ -1,10 +1,14 @@
 use super::{hashcons::HashCons, *};
+use inturn::unsync::Interner;
+use std::collections::hash_map::RandomState;
+
+type SymbolInterner = Interner<Symbol, RandomState>;
 
 pub(crate) struct SymCx {
     words: HashCons<SymExprKind>,
     bools: HashCons<SymBoolExprKind>,
     bytes: HashCons<SymBytesKind>,
-    symbols: HashMap<Arc<str>, Symbol>,
+    symbols: SymbolInterner,
     cache: SymCxCache,
 }
 
@@ -33,7 +37,7 @@ impl SymCx {
             words,
             bools,
             bytes,
-            symbols: HashMap::default(),
+            symbols: SymbolInterner::with_hasher(RandomState::default()),
             cache: SymCxCache { zero, one, bool_true, bool_false, bytes_empty },
         }
     }
@@ -66,13 +70,16 @@ impl SymCx {
     }
 
     pub(crate) fn intern(&mut self, name: &str) -> Symbol {
-        if let Some(symbol) = self.symbols.get(name) {
-            return symbol.clone();
-        }
-        let name = Arc::<str>::from(name);
-        let symbol = Symbol::new(name.clone());
-        self.symbols.insert(name, symbol.clone());
-        symbol
+        self.symbols.intern_mut(name)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn symbol(&self, name: &str) -> Symbol {
+        self.symbols.intern(name)
+    }
+
+    pub(crate) fn symbol_name(&self, symbol: Symbol) -> &str {
+        self.symbols.resolve(symbol)
     }
 }
 
@@ -98,37 +105,37 @@ mod tests {
         let first = SymExpr::constant(&mut cx, U256::from(42));
         let second = SymExpr::constant(&mut cx, U256::from(42));
 
-        assert!(first.ptr_eq(&second));
+        assert_eq!(first, second);
     }
 
     #[test]
     fn hashconses_word_expressions() {
         let mut cx = SymCx::new();
-        let x = SymExpr::var(&mut cx, "x");
-        let y = SymExpr::var(&mut cx, "y");
+        let x = SymExpr::named_var(&mut cx, "x");
+        let y = SymExpr::named_var(&mut cx, "y");
 
         let first = SymExpr::binop(&mut cx, SymBinOp::Add, x.clone(), y.clone());
         let second = SymExpr::binop(&mut cx, SymBinOp::Add, x, y);
 
-        assert!(first.ptr_eq(&second));
+        assert_eq!(first, second);
     }
 
     #[test]
     fn hashconses_bool_expressions() {
         let mut cx = SymCx::new();
-        let x = SymExpr::var(&mut cx, "x");
+        let x = SymExpr::named_var(&mut cx, "x");
 
         let upper = SymExpr::constant(&mut cx, U256::from(7));
         let first = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), upper.clone());
         let second = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, upper);
 
-        assert!(first.ptr_eq(&second));
+        assert_eq!(first, second);
     }
 
     #[test]
     fn simplifies_shift_right_over_or_at_construction() {
         let mut cx = SymCx::new();
-        let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
+        let x = SymExpr::named_var(&mut cx, "x").low_byte(&mut cx);
         let low = SymExpr::constant(&mut cx, U256::from(0xff));
         let shift = SymExpr::constant(&mut cx, U256::from(8));
         let high = SymExpr::binop(&mut cx, SymBinOp::Shl, x.clone(), shift.clone());
@@ -141,8 +148,8 @@ mod tests {
     #[test]
     fn simplifies_masked_or_at_construction() {
         let mut cx = SymCx::new();
-        let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
-        let y = SymExpr::var(&mut cx, "y").low_byte(&mut cx);
+        let x = SymExpr::named_var(&mut cx, "x").low_byte(&mut cx);
+        let y = SymExpr::named_var(&mut cx, "y").low_byte(&mut cx);
         let shift = SymExpr::constant(&mut cx, U256::from(8));
         let high = SymExpr::binop(&mut cx, SymBinOp::Shl, x, shift);
         let word = SymExpr::binop(&mut cx, SymBinOp::Or, high, y.clone());

--- a/crates/evm/symbolic/src/runtime/expr/cx.rs
+++ b/crates/evm/symbolic/src/runtime/expr/cx.rs
@@ -1,14 +1,12 @@
 use super::{hashcons::HashCons, *};
+use alloy_primitives::map::DefaultHashBuilder;
 use inturn::unsync::Interner;
-use std::collections::hash_map::RandomState;
-
-type SymbolInterner = Interner<Symbol, RandomState>;
 
 pub(crate) struct SymCx {
     words: HashCons<SymExprKind>,
     bools: HashCons<SymBoolExprKind>,
     bytes: HashCons<SymBytesKind>,
-    symbols: SymbolInterner,
+    symbols: Interner<Symbol, DefaultHashBuilder>,
     cache: SymCxCache,
 }
 
@@ -37,7 +35,7 @@ impl SymCx {
             words,
             bools,
             bytes,
-            symbols: SymbolInterner::with_hasher(RandomState::default()),
+            symbols: Interner::with_hasher(DefaultHashBuilder::default()),
             cache: SymCxCache { zero, one, bool_true, bool_false, bytes_empty },
         }
     }
@@ -111,8 +109,8 @@ mod tests {
     #[test]
     fn hashconses_word_expressions() {
         let mut cx = SymCx::new();
-        let x = SymExpr::named_var(&mut cx, "x");
-        let y = SymExpr::named_var(&mut cx, "y");
+        let x = SymExpr::var(&mut cx, "x");
+        let y = SymExpr::var(&mut cx, "y");
 
         let first = SymExpr::binop(&mut cx, SymBinOp::Add, x.clone(), y.clone());
         let second = SymExpr::binop(&mut cx, SymBinOp::Add, x, y);
@@ -123,7 +121,7 @@ mod tests {
     #[test]
     fn hashconses_bool_expressions() {
         let mut cx = SymCx::new();
-        let x = SymExpr::named_var(&mut cx, "x");
+        let x = SymExpr::var(&mut cx, "x");
 
         let upper = SymExpr::constant(&mut cx, U256::from(7));
         let first = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), upper.clone());
@@ -135,7 +133,7 @@ mod tests {
     #[test]
     fn simplifies_shift_right_over_or_at_construction() {
         let mut cx = SymCx::new();
-        let x = SymExpr::named_var(&mut cx, "x").low_byte(&mut cx);
+        let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
         let low = SymExpr::constant(&mut cx, U256::from(0xff));
         let shift = SymExpr::constant(&mut cx, U256::from(8));
         let high = SymExpr::binop(&mut cx, SymBinOp::Shl, x.clone(), shift.clone());
@@ -148,8 +146,8 @@ mod tests {
     #[test]
     fn simplifies_masked_or_at_construction() {
         let mut cx = SymCx::new();
-        let x = SymExpr::named_var(&mut cx, "x").low_byte(&mut cx);
-        let y = SymExpr::named_var(&mut cx, "y").low_byte(&mut cx);
+        let x = SymExpr::var(&mut cx, "x").low_byte(&mut cx);
+        let y = SymExpr::var(&mut cx, "y").low_byte(&mut cx);
         let shift = SymExpr::constant(&mut cx, U256::from(8));
         let high = SymExpr::binop(&mut cx, SymBinOp::Shl, x, shift);
         let word = SymExpr::binop(&mut cx, SymBinOp::Or, high, y.clone());

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -16,7 +16,7 @@ pub(crate) fn keccak_word_with_len(cx: &mut SymCx, bytes: Vec<SymExpr>, len: Sym
     }
 
     let exprs = bytes;
-    let name = stable_symbol("keccak", format!("{len:?}:{exprs:?}").as_bytes());
+    let name = stable_symbol(cx, "keccak", format!("{len:?}:{exprs:?}").as_bytes());
     SymExpr::keccak_symbol(cx, name, len, exprs)
 }
 
@@ -27,7 +27,7 @@ pub(crate) fn symbolic_hash_word_with_len(
     len: SymExpr,
 ) -> SymExpr {
     let exprs = bytes;
-    let name = stable_symbol(algorithm, format!("{len:?}:{exprs:?}").as_bytes());
+    let name = stable_symbol(cx, algorithm, format!("{len:?}:{exprs:?}").as_bytes());
     let mut identity = Vec::with_capacity(exprs.len() + 1);
     identity.push(len);
     identity.extend(exprs);
@@ -134,14 +134,10 @@ pub(crate) fn symbolic_create_address_word(
     creator_identity: String,
     nonce: SymExpr,
 ) -> SymExpr {
-    let name = stable_symbol("create_address", format!("{creator_identity}:{nonce:?}").as_bytes());
-    let word = SymExpr::var_symbol(cx, name);
-    state.constraints.push(SymBoolExpr::cmp_word_const(
-        cx,
-        SymCmpOp::Ult,
-        &word,
-        U256::from(1) << 160,
-    ));
+    let name =
+        stable_symbol(cx, "create_address", format!("{creator_identity}:{nonce:?}").as_bytes());
+    let word = SymExpr::var(cx, name);
+    state.constraints.push(SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &word, U256::ONE << 160));
     word
 }
 
@@ -153,16 +149,12 @@ pub(crate) fn symbolic_create2_address_word(
     initcode_identity: String,
 ) -> SymExpr {
     let name = stable_symbol(
+        cx,
         "create2_address",
         format!("{creator_identity}:{salt:?}:{initcode_identity}").as_bytes(),
     );
-    let word = SymExpr::var_symbol(cx, name);
-    state.constraints.push(SymBoolExpr::cmp_word_const(
-        cx,
-        SymCmpOp::Ult,
-        &word,
-        U256::from(1) << 160,
-    ));
+    let word = SymExpr::var(cx, name);
+    state.constraints.push(SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &word, U256::ONE << 160));
     word
 }
 
@@ -279,7 +271,7 @@ pub(crate) fn mask_low_bits(mask: U256) -> Option<usize> {
 }
 
 fn power_of_two_shift(value: U256) -> Option<usize> {
-    if value <= U256::from(1) || !value.is_power_of_two() {
+    if value <= U256::ONE || !value.is_power_of_two() {
         return None;
     }
     Some(value.bit_len() - 1)
@@ -351,7 +343,7 @@ impl fmt::Debug for SymExpr {
 pub(in crate::runtime) enum SymExprKind {
     Const(U256),
     Var(Symbol),
-    GasLeft(usize),
+    GasLeft(Symbol),
     Keccak { name: Symbol, len: SymExpr, bytes: Arc<[SymExpr]> },
     Hash { name: Symbol, algorithm: &'static str, bytes: Arc<[SymExpr]> },
     Not(SymExpr),
@@ -360,22 +352,35 @@ pub(in crate::runtime) enum SymExprKind {
     Ite(SymBoolExpr, SymExpr, SymExpr),
 }
 
+impl SymExprKind {
+    pub(in crate::runtime) const fn var(&self) -> Option<Symbol> {
+        match self {
+            Self::Var(symbol)
+            | Self::GasLeft(symbol)
+            | Self::Keccak { name: symbol, .. }
+            | Self::Hash { name: symbol, .. } => Some(*symbol),
+            _ => None,
+        }
+    }
+
+    pub(in crate::runtime) const fn eval_var(&self) -> Option<Symbol> {
+        match self {
+            Self::Var(symbol) | Self::GasLeft(symbol) | Self::Hash { name: symbol, .. } => {
+                Some(*symbol)
+            }
+            _ => None,
+        }
+    }
+}
+
 impl SymExpr {
     pub(in crate::runtime) fn kind(&self) -> &SymExprKind {
         self.kind.value()
     }
 
     #[cfg(test)]
-    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
-        self.kind.ptr_eq(&other.kind)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn var_name(&self) -> Option<&str> {
-        match self.kind() {
-            SymExprKind::Var(name) => Some(name.as_str()),
-            _ => None,
-        }
+    pub(crate) fn var_name<'a>(&self, cx: &'a SymCx) -> Option<&'a str> {
+        self.kind().var().map(|symbol| cx.symbol_name(symbol))
     }
 
     #[cfg(test)]
@@ -412,34 +417,31 @@ impl SymExpr {
     }
 
     pub(crate) fn one(cx: &mut SymCx) -> Self {
-        Self::constant(cx, U256::from(1))
+        Self::constant(cx, U256::ONE)
     }
 
     pub(crate) fn constant(cx: &mut SymCx, value: U256) -> Self {
         if value.is_zero() {
             return cx.cached_zero();
         }
-        if value == U256::from(1) {
+        if value == U256::ONE {
             return cx.cached_one();
         }
         Self::from_kind(cx, SymExprKind::Const(value))
     }
 
-    pub(crate) fn var(cx: &mut SymCx, name: &str) -> Self {
+    pub(crate) fn named_var(cx: &mut SymCx, name: &str) -> Self {
         let symbol = cx.intern(name);
-        Self::var_symbol(cx, symbol)
+        Self::var(cx, symbol)
     }
 
-    pub(crate) fn var_symbol(cx: &mut SymCx, name: Symbol) -> Self {
-        Self::from_kind(cx, SymExprKind::Var(name))
+    pub(crate) fn var(cx: &mut SymCx, symbol: Symbol) -> Self {
+        Self::from_kind(cx, SymExprKind::Var(symbol))
     }
 
     pub(crate) fn gas_left(cx: &mut SymCx, id: usize) -> Self {
-        Self::from_kind(cx, SymExprKind::GasLeft(id))
-    }
-
-    pub(in crate::runtime) fn gas_left_symbol(id: usize) -> Symbol {
-        Symbol::intern(&format!("gasleft_{id}"))
+        let symbol = cx.intern(&format!("gasleft_{id}"));
+        Self::from_kind(cx, SymExprKind::GasLeft(symbol))
     }
 
     pub(crate) fn not(cx: &mut SymCx, value: Self) -> Self {
@@ -486,9 +488,9 @@ impl SymExpr {
                     Self::zero(cx)
                 }
                 // `1 * a => a`.
-                (SymExprKind::Const(value), _) if *value == U256::from(1) => right,
+                (SymExprKind::Const(value), _) if *value == U256::ONE => right,
                 // `a * 1 => a`.
-                (_, SymExprKind::Const(value)) if *value == U256::from(1) => left,
+                (_, SymExprKind::Const(value)) if *value == U256::ONE => left,
                 // `2**n * a => a << n`.
                 (SymExprKind::Const(value), _) if let Some(shift) = power_of_two_shift(*value) => {
                     let shift = Self::constant(cx, U256::from(shift));
@@ -509,7 +511,7 @@ impl SymExpr {
                 // `a / 0 => 0`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => Self::zero(cx),
                 // `a / 1 => a`.
-                (_, SymExprKind::Const(value)) if *value == U256::from(1) => left,
+                (_, SymExprKind::Const(value)) if *value == U256::ONE => left,
                 // `(a - (a & (2**n - 1))) u/ 2**n => a >> n`.
                 (
                     SymExprKind::BinOp(SymBinOp::Sub, value, low_bits),
@@ -539,7 +541,7 @@ impl SymExpr {
                 // `a % 0 => 0`.
                 (_, SymExprKind::Const(value)) if value.is_zero() => Self::zero(cx),
                 // `a % 1 => 0`.
-                (_, SymExprKind::Const(value)) if *value == U256::from(1) => Self::zero(cx),
+                (_, SymExprKind::Const(value)) if *value == U256::ONE => Self::zero(cx),
                 // `a u% 2**n => a & (2**n - 1)`.
                 (_, SymExprKind::Const(divisor))
                     if binop == SymBinOp::URem
@@ -641,9 +643,7 @@ impl SymExpr {
         modulus: Self,
     ) -> Self {
         match (left.kind(), right.kind(), modulus.kind()) {
-            (_, _, SymExprKind::Const(modulus))
-                if modulus.is_zero() || *modulus == U256::from(1) =>
-            {
+            (_, _, SymExprKind::Const(modulus)) if modulus.is_zero() || *modulus == U256::ONE => {
                 // `addmod/mulmod(a, b, 0) => 0`.
                 Self::zero(cx)
             }
@@ -691,7 +691,7 @@ impl SymExpr {
                 Self::bool_word(cx, condition)
             }
             // `ite(c, 1, bool_word(c)) => bool_word(c)`.
-            None if then_expr.as_const() == Some(U256::from(1))
+            None if then_expr.as_const() == Some(U256::ONE)
                 && else_expr.bool_word_condition().as_ref() == Some(&condition) =>
             {
                 else_expr
@@ -1046,10 +1046,15 @@ impl SymExpr {
         &self,
         model: &M,
     ) -> Result<U256, SymbolicError> {
-        Ok(match self.kind() {
+        let kind = self.kind();
+        if let Some(var) = kind.eval_var() {
+            return Ok(model.value(var).unwrap_or_default());
+        }
+        Ok(match kind {
             SymExprKind::Const(value) => *value,
-            SymExprKind::Var(var) => model.value(var.clone()).unwrap_or_default(),
-            SymExprKind::GasLeft(id) => model.value(Self::gas_left_symbol(*id)).unwrap_or_default(),
+            SymExprKind::Var(_) | SymExprKind::GasLeft(_) | SymExprKind::Hash { .. } => {
+                unreachable!("symbolic eval leaf handled above")
+            }
             SymExprKind::Keccak { len, bytes, .. } => {
                 let len = len.eval_model(model)?;
                 let Ok(len) = usize::try_from(len) else {
@@ -1070,7 +1075,6 @@ impl SymExpr {
 
                 U256::from_be_bytes(keccak256(input).0)
             }
-            SymExprKind::Hash { name, .. } => model.value(name.clone()).unwrap_or_default(),
             SymExprKind::Not(value) => !value.eval_model(model)?,
             SymExprKind::BinOp(op, left, right) => {
                 op.eval(left.eval_model(model)?, right.eval_model(model)?)
@@ -1096,7 +1100,7 @@ impl SymExpr {
     ) -> Result<Option<U256>, SymbolicError> {
         let mut vars = SymbolicVars::default();
         self.collect_eval_vars(&mut vars);
-        if vars.iter().cloned().all(|var| model.contains_name(var)) {
+        if vars.iter().copied().all(|var| model.contains_name(var)) {
             self.eval_model(model).map(Some)
         } else {
             Ok(None)
@@ -1110,16 +1114,15 @@ impl SymExpr {
                 if let Some(existing) = model.get(var) {
                     *existing == value
                 } else {
-                    model.insert(var.clone(), value);
+                    model.insert(*var, value);
                     true
                 }
             }
-            SymExprKind::GasLeft(id) => {
-                let var = Self::gas_left_symbol(*id);
-                if let Some(existing) = model.get(&var) {
+            SymExprKind::GasLeft(symbol) => {
+                if let Some(existing) = model.get(symbol) {
                     *existing == value
                 } else {
-                    model.insert(var, value);
+                    model.insert(*symbol, value);
                     true
                 }
             }
@@ -1141,12 +1144,12 @@ impl SymExpr {
     ) -> Option<SymBoolExpr> {
         match (then_expr.as_const(), else_expr.as_const()) {
             (Some(then_value), Some(else_value))
-                if then_value == U256::from(1) && else_value.is_zero() =>
+                if then_value == U256::ONE && else_value.is_zero() =>
             {
                 Some(condition.clone())
             }
             (Some(then_value), Some(else_value))
-                if then_value.is_zero() && else_value == U256::from(1) =>
+                if then_value.is_zero() && else_value == U256::ONE =>
             {
                 None
             }
@@ -1218,14 +1221,8 @@ impl SymExpr {
 
     pub(crate) fn collect_eval_vars(&self, vars: &mut SymbolicVars) {
         let _ = self.visit(&mut |expr| {
-            match expr.kind() {
-                SymExprKind::Var(var) | SymExprKind::Hash { name: var, .. } => {
-                    vars.insert(var.clone());
-                }
-                SymExprKind::GasLeft(id) => {
-                    vars.insert(Self::gas_left_symbol(*id));
-                }
-                _ => {}
+            if let Some(var) = expr.kind().eval_var() {
+                vars.insert(var);
             }
             ControlFlow::<()>::Continue(())
         });
@@ -1677,45 +1674,48 @@ impl SymExpr {
     }
 
     #[cfg(test)]
-    pub(crate) fn smt(&self) -> String {
+    pub(crate) fn smt(&self, cx: &SymCx) -> String {
         let mut smt = String::new();
-        self.write_smt(&mut smt);
+        self.write_smt(cx, &mut smt);
         smt
     }
 
-    pub(in crate::runtime::expr) fn write_smt(&self, out: &mut String) {
-        match self.kind() {
+    pub(in crate::runtime::expr) fn write_smt(&self, cx: &SymCx, out: &mut String) {
+        let kind = self.kind();
+        if let Some(var) = kind.var() {
+            out.push_str(cx.symbol_name(var));
+            return;
+        }
+        match kind {
             SymExprKind::Const(value) => {
                 let _ = write!(out, "(_ bv{value} 256)");
             }
-            SymExprKind::Var(var) => out.push_str(var.as_str()),
-            SymExprKind::GasLeft(id) => {
-                let _ = write!(out, "gasleft_{id}");
-            }
-            SymExprKind::Keccak { name, .. } => out.push_str(name.as_str()),
-            SymExprKind::Hash { name, .. } => out.push_str(name.as_str()),
+            SymExprKind::Var(_)
+            | SymExprKind::GasLeft(_)
+            | SymExprKind::Keccak { .. }
+            | SymExprKind::Hash { .. } => unreachable!("symbolic leaf handled above"),
             SymExprKind::Not(value) => {
                 out.push_str("(bvnot ");
-                value.write_smt(out);
+                value.write_smt(cx, out);
                 out.push(')');
             }
             SymExprKind::BinOp(op, left, right) => {
                 let _ = write!(out, "({} ", op.smt());
-                left.write_smt(out);
+                left.write_smt(cx, out);
                 out.push(' ');
-                right.write_smt(out);
+                right.write_smt(cx, out);
                 out.push(')');
             }
             SymExprKind::TernOp(op, left, right, modulus) => {
-                write_smt_wide_modular_arithmetic(out, op.smt(), left, right, modulus);
+                write_smt_wide_modular_arithmetic(cx, out, op.smt(), left, right, modulus);
             }
             SymExprKind::Ite(cond, left, right) => {
                 out.push_str("(ite ");
-                cond.write_smt(out);
+                cond.write_smt(cx, out);
                 out.push(' ');
-                left.write_smt(out);
+                left.write_smt(cx, out);
                 out.push(' ');
-                right.write_smt(out);
+                right.write_smt(cx, out);
                 out.push(')');
             }
         }
@@ -1723,6 +1723,7 @@ impl SymExpr {
 }
 
 fn write_smt_wide_modular_arithmetic(
+    cx: &SymCx,
     out: &mut String,
     op: &'static str,
     left: &SymExpr,
@@ -1734,15 +1735,15 @@ fn write_smt_wide_modular_arithmetic(
     // else:
     //   low_256((zext(left) op zext(right)) urem zext(modulus))
     out.push_str("(ite (= ");
-    modulus.write_smt(out);
+    modulus.write_smt(cx, out);
     out.push_str(" (_ bv0 256)) (_ bv0 256) ((_ extract 255 0) (bvurem (");
     out.push_str(op);
     out.push_str(" ((_ zero_extend 256) ");
-    left.write_smt(out);
+    left.write_smt(cx, out);
     out.push_str(") ((_ zero_extend 256) ");
-    right.write_smt(out);
+    right.write_smt(cx, out);
     out.push_str(")) ((_ zero_extend 256) ");
-    modulus.write_smt(out);
+    modulus.write_smt(cx, out);
     out.push_str("))))");
 }
 

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -1,4 +1,8 @@
-use super::{hashcons::HashConsed, *};
+use super::{
+    hashcons::{HashConsHasher, HashConsed},
+    *,
+};
+use std::hash::BuildHasher;
 
 pub(crate) fn keccak_word(cx: &mut SymCx, bytes: Vec<SymExpr>) -> SymExpr {
     let len = bytes.len();
@@ -749,11 +753,28 @@ impl SymExpr {
         left: Self,
         right: Self,
     ) -> (Self, Self) {
-        if right.kind.cached_hash() < left.kind.cached_hash() {
-            (right, left)
-        } else {
-            (left, right)
+        match left.complexity().cmp(&right.complexity()) {
+            // Put less complex operands, like constants, on the RHS.
+            std::cmp::Ordering::Less => (right, left),
+            std::cmp::Ordering::Greater => (left, right),
+            std::cmp::Ordering::Equal if right.order_hash() < left.order_hash() => (right, left),
+            std::cmp::Ordering::Equal => (left, right),
         }
+    }
+
+    fn complexity(&self) -> usize {
+        match self.kind() {
+            SymExprKind::Const(_) => 0,
+            SymExprKind::Not(_) => 1,
+            SymExprKind::BinOp(..) => 2,
+            SymExprKind::TernOp(..) => 3,
+            _ => 4,
+        }
+    }
+
+    fn order_hash(&self) -> u64 {
+        const HASHER: HashConsHasher = HashConsHasher::with_seed(0);
+        HASHER.hash_one(&self.kind)
     }
 
     fn and_const(cx: &mut SymCx, expr: Self, mask: U256) -> Self {
@@ -786,22 +807,18 @@ impl SymExpr {
                 // `(a << n) & low_mask(n) => 0`.
                 Self::zero(cx)
             }
-            SymExprKind::BinOp(SymBinOp::And, left, right) => match (left.kind(), right.kind()) {
-                (SymExprKind::Const(value), _) if *value == mask => {
-                    // `(mask & a) & mask => a & mask`.
-                    Self::and_const(cx, right.clone(), mask)
-                }
-                (_, SymExprKind::Const(value)) if *value == mask => {
+            SymExprKind::BinOp(SymBinOp::And, left, right) => {
+                if right.as_const() == Some(mask) {
                     // `(a & mask) & mask => a & mask`.
                     Self::and_const(cx, left.clone(), mask)
-                }
-                // `(a & a) & mask => a & mask`.
-                _ if left == right => Self::and_const(cx, left.clone(), mask),
-                _ => {
+                } else if left == right {
+                    // `(a & a) & mask => a & mask`.
+                    Self::and_const(cx, left.clone(), mask)
+                } else {
                     let mask = Self::constant(cx, mask);
                     Self::from_kind(cx, SymExprKind::BinOp(SymBinOp::And, expr, mask))
                 }
-            },
+            }
             _ => {
                 let mask = Self::constant(cx, mask);
                 Self::from_kind(cx, SymExprKind::BinOp(SymBinOp::And, expr, mask))
@@ -945,11 +962,8 @@ impl SymExpr {
 
     fn low_word_fragment(&self) -> Option<(Self, usize)> {
         let SymExprKind::BinOp(SymBinOp::And, left, right) = self.kind() else { return None };
-        if let Some(mask) = right.as_const() {
-            return mask_low_bits(mask).map(|bits| (left.clone(), bits));
-        }
-        let mask = left.as_const()?;
-        mask_low_bits(mask).map(|bits| (right.clone(), bits))
+        let mask = right.as_const()?;
+        mask_low_bits(mask).map(|bits| (left.clone(), bits))
     }
 
     fn shifted_high_word_fragment(&self) -> Option<(Self, usize)> {
@@ -965,11 +979,8 @@ impl SymExpr {
 
     fn shifted_low_fragment_source(&self) -> Option<(Self, usize, usize)> {
         let SymExprKind::BinOp(SymBinOp::And, left, right) = self.kind() else { return None };
-        if let Some(mask) = right.as_const() {
-            return Self::shifted_low_fragment_source_with_mask(left, mask);
-        }
-        let mask = left.as_const()?;
-        Self::shifted_low_fragment_source_with_mask(right, mask)
+        let mask = right.as_const()?;
+        Self::shifted_low_fragment_source_with_mask(left, mask)
     }
 
     fn shifted_low_fragment_source_with_mask(
@@ -1301,8 +1312,6 @@ impl SymExpr {
             SymExprKind::BinOp(SymBinOp::And, left, right) => {
                 if let Some(mask) = right.as_const() {
                     left.unsigned_bits().min(mask.bit_len())
-                } else if let Some(mask) = left.as_const() {
-                    right.unsigned_bits().min(mask.bit_len())
                 } else {
                     256
                 }
@@ -1360,11 +1369,6 @@ impl SymExpr {
                 if right.as_const() == Some(U256::from(0xff)) =>
             {
                 left.strip_low_byte_mask()
-            }
-            SymExprKind::BinOp(SymBinOp::And, left, right)
-                if left.as_const() == Some(U256::from(0xff)) =>
-            {
-                right.strip_low_byte_mask()
             }
             _ => self,
         }

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -1681,19 +1681,14 @@ impl SymExpr {
     }
 
     pub(in crate::runtime::expr) fn write_smt(&self, cx: &SymCx, out: &mut String) {
-        let kind = self.kind();
-        if let Some(var) = kind.get_var() {
-            out.push_str(cx.symbol_name(var));
-            return;
-        }
-        match kind {
+        match self.kind() {
             SymExprKind::Const(value) => {
                 let _ = write!(out, "(_ bv{value} 256)");
             }
-            SymExprKind::Var(_)
-            | SymExprKind::GasLeft(_)
-            | SymExprKind::Keccak { .. }
-            | SymExprKind::Hash { .. } => unreachable!("symbolic leaf handled above"),
+            SymExprKind::Var(symbol)
+            | SymExprKind::GasLeft(symbol)
+            | SymExprKind::Keccak { name: symbol, .. }
+            | SymExprKind::Hash { name: symbol, .. } => out.push_str(cx.symbol_name(*symbol)),
             SymExprKind::Not(value) => {
                 out.push_str("(bvnot ");
                 value.write_smt(cx, out);

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -1,8 +1,4 @@
-use super::{
-    hashcons::{HashConsHasher, HashConsed},
-    *,
-};
-use std::hash::BuildHasher;
+use super::{hashcons::HashConsed, *};
 
 pub(crate) fn keccak_word(cx: &mut SymCx, bytes: Vec<SymExpr>) -> SymExpr {
     let len = bytes.len();
@@ -757,7 +753,9 @@ impl SymExpr {
             // Put less complex operands, like constants, on the RHS.
             std::cmp::Ordering::Less => (right, left),
             std::cmp::Ordering::Greater => (left, right),
-            std::cmp::Ordering::Equal if right.order_hash() < left.order_hash() => (right, left),
+            std::cmp::Ordering::Equal if right.kind.stable_hash_cmp(&left.kind).is_lt() => {
+                (right, left)
+            }
             std::cmp::Ordering::Equal => (left, right),
         }
     }
@@ -770,11 +768,6 @@ impl SymExpr {
             SymExprKind::TernOp(..) => 3,
             _ => 4,
         }
-    }
-
-    fn order_hash(&self) -> u64 {
-        const HASHER: HashConsHasher = HashConsHasher::with_seed(0);
-        HASHER.hash_one(&self.kind)
     }
 
     fn and_const(cx: &mut SymCx, expr: Self, mask: U256) -> Self {

--- a/crates/evm/symbolic/src/runtime/expr/expr.rs
+++ b/crates/evm/symbolic/src/runtime/expr/expr.rs
@@ -136,7 +136,7 @@ pub(crate) fn symbolic_create_address_word(
 ) -> SymExpr {
     let name =
         stable_symbol(cx, "create_address", format!("{creator_identity}:{nonce:?}").as_bytes());
-    let word = SymExpr::var(cx, name);
+    let word = SymExpr::get_var(cx, name);
     state.constraints.push(SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &word, U256::ONE << 160));
     word
 }
@@ -153,7 +153,7 @@ pub(crate) fn symbolic_create2_address_word(
         "create2_address",
         format!("{creator_identity}:{salt:?}:{initcode_identity}").as_bytes(),
     );
-    let word = SymExpr::var(cx, name);
+    let word = SymExpr::get_var(cx, name);
     state.constraints.push(SymBoolExpr::cmp_word_const(cx, SymCmpOp::Ult, &word, U256::ONE << 160));
     word
 }
@@ -353,7 +353,7 @@ pub(in crate::runtime) enum SymExprKind {
 }
 
 impl SymExprKind {
-    pub(in crate::runtime) const fn var(&self) -> Option<Symbol> {
+    pub(in crate::runtime) const fn get_var(&self) -> Option<Symbol> {
         match self {
             Self::Var(symbol)
             | Self::GasLeft(symbol)
@@ -363,7 +363,7 @@ impl SymExprKind {
         }
     }
 
-    pub(in crate::runtime) const fn eval_var(&self) -> Option<Symbol> {
+    pub(in crate::runtime) const fn get_eval_var(&self) -> Option<Symbol> {
         match self {
             Self::Var(symbol) | Self::GasLeft(symbol) | Self::Hash { name: symbol, .. } => {
                 Some(*symbol)
@@ -379,8 +379,8 @@ impl SymExpr {
     }
 
     #[cfg(test)]
-    pub(crate) fn var_name<'a>(&self, cx: &'a SymCx) -> Option<&'a str> {
-        self.kind().var().map(|symbol| cx.symbol_name(symbol))
+    pub(crate) fn get_var_name<'a>(&self, cx: &'a SymCx) -> Option<&'a str> {
+        self.kind().get_var().map(|symbol| cx.symbol_name(symbol))
     }
 
     #[cfg(test)]
@@ -430,12 +430,12 @@ impl SymExpr {
         Self::from_kind(cx, SymExprKind::Const(value))
     }
 
-    pub(crate) fn named_var(cx: &mut SymCx, name: &str) -> Self {
+    pub(crate) fn var(cx: &mut SymCx, name: &str) -> Self {
         let symbol = cx.intern(name);
-        Self::var(cx, symbol)
+        Self::get_var(cx, symbol)
     }
 
-    pub(crate) fn var(cx: &mut SymCx, symbol: Symbol) -> Self {
+    pub(crate) fn get_var(cx: &mut SymCx, symbol: Symbol) -> Self {
         Self::from_kind(cx, SymExprKind::Var(symbol))
     }
 
@@ -1047,7 +1047,7 @@ impl SymExpr {
         model: &M,
     ) -> Result<U256, SymbolicError> {
         let kind = self.kind();
-        if let Some(var) = kind.eval_var() {
+        if let Some(var) = kind.get_eval_var() {
             return Ok(model.value(var).unwrap_or_default());
         }
         Ok(match kind {
@@ -1221,7 +1221,7 @@ impl SymExpr {
 
     pub(crate) fn collect_eval_vars(&self, vars: &mut SymbolicVars) {
         let _ = self.visit(&mut |expr| {
-            if let Some(var) = expr.kind().eval_var() {
+            if let Some(var) = expr.kind().get_eval_var() {
                 vars.insert(var);
             }
             ControlFlow::<()>::Continue(())
@@ -1682,7 +1682,7 @@ impl SymExpr {
 
     pub(in crate::runtime::expr) fn write_smt(&self, cx: &SymCx, out: &mut String) {
         let kind = self.kind();
-        if let Some(var) = kind.var() {
+        if let Some(var) = kind.get_var() {
             out.push_str(cx.symbol_name(var));
             return;
         }

--- a/crates/evm/symbolic/src/runtime/expr/hashcons.rs
+++ b/crates/evm/symbolic/src/runtime/expr/hashcons.rs
@@ -1,6 +1,7 @@
 use alloy_primitives::map::foldhash::fast::FixedState;
 use hashbrown::{HashTable, hash_table::Entry};
 use std::{
+    cmp::Ordering,
     fmt,
     hash::{BuildHasher, Hash, Hasher},
     sync::{Arc, Weak},
@@ -20,6 +21,11 @@ struct HashConsedInner<T> {
 }
 
 impl<T> HashConsed<T> {
+    #[inline]
+    pub(in crate::runtime::expr) fn stable_hash_cmp(&self, other: &Self) -> Ordering {
+        self.inner.hash.cmp(&other.inner.hash)
+    }
+
     #[inline]
     pub(in crate::runtime) fn value(&self) -> &T {
         &self.inner.value
@@ -80,16 +86,16 @@ impl<T: fmt::Debug> fmt::Debug for HashConsed<T> {
     }
 }
 
-pub(in crate::runtime::expr) type HashConsHasher = FixedState;
+type HashConsHasher = FixedState;
 
 /// Hash-consing table for sharing structurally equal immutable values.
 ///
 /// The table stores weak references so interned values disappear when the rest of
 /// the symbolic state stops using them. `make` only looks up and inserts; dead
 /// weak entries are ignored and left in the table until the context is dropped.
-pub(in crate::runtime) struct HashCons<T, S = HashConsHasher> {
+pub(in crate::runtime) struct HashCons<T> {
     table: HashTable<HashConsEntry<T>>,
-    hash_builder: S,
+    hash_builder: HashConsHasher,
 }
 
 struct HashConsEntry<T> {
@@ -105,23 +111,15 @@ impl<T> HashConsEntry<T> {
 
 impl<T> HashCons<T> {
     pub(in crate::runtime) fn new() -> Self {
-        Self::with_hasher(HashConsHasher::default())
+        Self { table: HashTable::new(), hash_builder: HashConsHasher::default() }
     }
-}
 
-impl<T, S> HashCons<T, S> {
-    pub(in crate::runtime) const fn with_hasher(hash_builder: S) -> Self {
-        Self { table: HashTable::new(), hash_builder }
-    }
-}
-
-impl<T, S: BuildHasher> HashCons<T, S> {
     fn hash<Q: Hash + ?Sized>(&self, value: &Q) -> u64 {
         self.hash_builder.hash_one(value)
     }
 }
 
-impl<T: Eq + Hash, S: BuildHasher> HashCons<T, S> {
+impl<T: Eq + Hash> HashCons<T> {
     pub(in crate::runtime) fn make(&mut self, value: T) -> HashConsed<T> {
         let hash = self.hash(&value);
         let mut found = None;

--- a/crates/evm/symbolic/src/runtime/expr/hashcons.rs
+++ b/crates/evm/symbolic/src/runtime/expr/hashcons.rs
@@ -1,13 +1,11 @@
+use alloy_primitives::map::DefaultHashBuilder;
 use hashbrown::{HashTable, hash_table::Entry};
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt,
-    hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
+    hash::{BuildHasher, Hash, Hasher},
     ptr,
     sync::{Arc, Weak},
 };
-
-type HashBuilder = BuildHasherDefault<DefaultHasher>;
 
 /// Shared handle for a hash-consed value.
 ///
@@ -73,9 +71,9 @@ impl<T: fmt::Debug> fmt::Debug for HashConsed<T> {
 /// The table stores weak references so interned values disappear when the rest of
 /// the symbolic state stops using them. `make` only looks up and inserts; dead
 /// weak entries are ignored and left in the table until the context is dropped.
-pub(in crate::runtime) struct HashCons<T> {
+pub(in crate::runtime) struct HashCons<T, S = DefaultHashBuilder> {
     table: HashTable<HashConsEntry<T>>,
-    hash_builder: HashBuilder,
+    hash_builder: S,
 }
 
 struct HashConsEntry<T> {
@@ -91,15 +89,23 @@ impl<T> HashConsEntry<T> {
 
 impl<T> HashCons<T> {
     pub(in crate::runtime) fn new() -> Self {
-        Self { table: HashTable::new(), hash_builder: HashBuilder::default() }
+        Self::with_hasher(DefaultHashBuilder::default())
     }
+}
 
+impl<T, S> HashCons<T, S> {
+    pub(in crate::runtime) const fn with_hasher(hash_builder: S) -> Self {
+        Self { table: HashTable::new(), hash_builder }
+    }
+}
+
+impl<T, S: BuildHasher> HashCons<T, S> {
     fn hash<Q: Hash + ?Sized>(&self, value: &Q) -> u64 {
         self.hash_builder.hash_one(value)
     }
 }
 
-impl<T: Eq + Hash> HashCons<T> {
+impl<T: Eq + Hash, S: BuildHasher> HashCons<T, S> {
     pub(in crate::runtime) fn make(&mut self, value: T) -> HashConsed<T> {
         let hash = self.hash(&value);
         let mut found = None;
@@ -179,6 +185,5 @@ mod tests {
 
         assert_ne!(first, second);
         assert_eq!(first.value(), second.value());
-        assert_eq!(first.cached_hash(), second.cached_hash());
     }
 }

--- a/crates/evm/symbolic/src/runtime/expr/hashcons.rs
+++ b/crates/evm/symbolic/src/runtime/expr/hashcons.rs
@@ -50,7 +50,7 @@ impl<T> Clone for HashConsed<T> {
 
 impl<T> PartialEq for HashConsed<T> {
     fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.inner, &other.inner)
+        ptr::addr_eq(Arc::as_ptr(&self.inner), Arc::as_ptr(&other.inner))
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/expr/hashcons.rs
+++ b/crates/evm/symbolic/src/runtime/expr/hashcons.rs
@@ -3,6 +3,7 @@ use std::{
     collections::hash_map::DefaultHasher,
     fmt,
     hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
+    ptr,
     sync::{Arc, Weak},
 };
 
@@ -24,10 +25,6 @@ struct HashConsedInner<T> {
 impl<T> HashConsed<T> {
     pub(in crate::runtime) fn cached_hash(&self) -> u64 {
         self.inner.hash
-    }
-
-    pub(in crate::runtime) fn ptr_eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.inner, &other.inner)
     }
 
     pub(in crate::runtime) fn value(&self) -> &T {
@@ -53,7 +50,7 @@ impl<T> Clone for HashConsed<T> {
 
 impl<T> PartialEq for HashConsed<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.ptr_eq(other)
+        Arc::ptr_eq(&self.inner, &other.inner)
     }
 }
 
@@ -143,7 +140,7 @@ mod tests {
         let first = table.make("same".to_string());
         let second = table.make("same".to_string());
 
-        assert!(first.ptr_eq(&second));
+        assert_eq!(first, second);
         assert_eq!(first.cached_hash(), second.cached_hash());
     }
 
@@ -154,7 +151,6 @@ mod tests {
         let first = table.make("first".to_string());
         let second = table.make("second".to_string());
 
-        assert!(!first.ptr_eq(&second));
         assert_ne!(first, second);
     }
 

--- a/crates/evm/symbolic/src/runtime/expr/hashcons.rs
+++ b/crates/evm/symbolic/src/runtime/expr/hashcons.rs
@@ -1,9 +1,8 @@
-use alloy_primitives::map::DefaultHashBuilder;
+use alloy_primitives::map::foldhash::fast::FixedState;
 use hashbrown::{HashTable, hash_table::Entry};
 use std::{
     fmt,
     hash::{BuildHasher, Hash, Hasher},
-    ptr,
     sync::{Arc, Weak},
 };
 
@@ -21,14 +20,12 @@ struct HashConsedInner<T> {
 }
 
 impl<T> HashConsed<T> {
-    pub(in crate::runtime) fn cached_hash(&self) -> u64 {
-        self.inner.hash
-    }
-
+    #[inline]
     pub(in crate::runtime) fn value(&self) -> &T {
         &self.inner.value
     }
 
+    #[inline]
     pub(in crate::runtime) fn into_value(self) -> T
     where
         T: Clone,
@@ -41,22 +38,39 @@ impl<T> HashConsed<T> {
 }
 
 impl<T> Clone for HashConsed<T> {
+    #[inline]
     fn clone(&self) -> Self {
         Self { inner: self.inner.clone() }
     }
 }
 
 impl<T> PartialEq for HashConsed<T> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
-        ptr::addr_eq(Arc::as_ptr(&self.inner), Arc::as_ptr(&other.inner))
+        Arc::ptr_eq(&self.inner, &other.inner)
     }
 }
 
 impl<T> Eq for HashConsed<T> {}
 
 impl<T> Hash for HashConsed<T> {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.cached_hash().hash(state);
+        self.inner.hash.hash(state);
+    }
+}
+
+impl<T: PartialOrd> PartialOrd for HashConsed<T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.value().partial_cmp(other.value())
+    }
+}
+
+impl<T: Ord> Ord for HashConsed<T> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.value().cmp(other.value())
     }
 }
 
@@ -66,12 +80,14 @@ impl<T: fmt::Debug> fmt::Debug for HashConsed<T> {
     }
 }
 
+pub(in crate::runtime::expr) type HashConsHasher = FixedState;
+
 /// Hash-consing table for sharing structurally equal immutable values.
 ///
 /// The table stores weak references so interned values disappear when the rest of
 /// the symbolic state stops using them. `make` only looks up and inserts; dead
 /// weak entries are ignored and left in the table until the context is dropped.
-pub(in crate::runtime) struct HashCons<T, S = DefaultHashBuilder> {
+pub(in crate::runtime) struct HashCons<T, S = HashConsHasher> {
     table: HashTable<HashConsEntry<T>>,
     hash_builder: S,
 }
@@ -89,7 +105,7 @@ impl<T> HashConsEntry<T> {
 
 impl<T> HashCons<T> {
     pub(in crate::runtime) fn new() -> Self {
-        Self::with_hasher(DefaultHashBuilder::default())
+        Self::with_hasher(HashConsHasher::default())
     }
 }
 
@@ -147,7 +163,7 @@ mod tests {
         let second = table.make("same".to_string());
 
         assert_eq!(first, second);
-        assert_eq!(first.cached_hash(), second.cached_hash());
+        assert_eq!(first.inner.hash, second.inner.hash);
     }
 
     #[test]

--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -387,8 +387,9 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             self.cache_model_result(cache_key, model.clone());
             return Ok(model);
         }
-        if constraints_prefer_hard_arith_fallback_first(&smt_constraints)
-            && let Some(model) = validated_hard_arith_fallback_model(&smt_constraints, constraints)
+        if constraints_prefer_hard_arith_fallback_first(cx, &smt_constraints)
+            && let Some(model) =
+                validated_hard_arith_fallback_model(cx, &smt_constraints, constraints)
         {
             self.heuristic_witnesses += 1;
             trace!("model: validated hard arithmetic fallback model before solver");
@@ -396,11 +397,11 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             self.cache_model_result(cache_key, model.clone());
             return Ok(model);
         }
-        let output = match self.query_normalized(&smt_constraints, true, constraints) {
+        let output = match self.query_normalized(cx, &smt_constraints, true, constraints) {
             Ok(output) => output,
             Err(SymbolicError::SolverUnknown) => {
                 if let Some(model) =
-                    validated_hard_arith_fallback_model(&smt_constraints, constraints)
+                    validated_hard_arith_fallback_model(cx, &smt_constraints, constraints)
                 {
                     self.heuristic_witnesses += 1;
                     trace!("model: validated hard arithmetic fallback model after solver unknown");
@@ -415,7 +416,7 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
         let mut lines = output.lines();
         match lines.next().unwrap_or_default().trim() {
             "sat" => {
-                let model = parse_and_validate_model(&output, constraints)?;
+                let model = parse_and_validate_model(cx, &output, constraints)?;
                 self.cache_sat_result(cache_key.clone(), true);
                 self.cache_model_result(cache_key, model.clone());
                 Ok(model)
@@ -427,7 +428,7 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             }
             "unknown" => {
                 if let Some(model) =
-                    validated_hard_arith_fallback_model(&smt_constraints, constraints)
+                    validated_hard_arith_fallback_model(cx, &smt_constraints, constraints)
                 {
                     self.heuristic_witnesses += 1;
                     self.cache_sat_result(cache_key.clone(), true);
@@ -509,8 +510,8 @@ impl SmtLibSubprocessSolver {
             self.cache_sat_result(cache_key, true);
             return Ok(true);
         }
-        if constraints_prefer_hard_arith_fallback_first(&smt_constraints) {
-            if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
+        if constraints_prefer_hard_arith_fallback_first(cx, &smt_constraints) {
+            if validated_hard_arith_fallback_model(cx, &smt_constraints, constraints).is_some() {
                 self.heuristic_witnesses += 1;
                 trace!("is_sat: validated hard arithmetic fallback model before solver");
                 self.cache_sat_result(cache_key, true);
@@ -521,10 +522,11 @@ impl SmtLibSubprocessSolver {
                 return Err(SymbolicError::SolverUnknown);
             }
         }
-        let output = match self.query_normalized(&smt_constraints, false, constraints) {
+        let output = match self.query_normalized(cx, &smt_constraints, false, constraints) {
             Ok(output) => output,
             Err(SymbolicError::SolverUnknown) => {
-                if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
+                if validated_hard_arith_fallback_model(cx, &smt_constraints, constraints).is_some()
+                {
                     self.heuristic_witnesses += 1;
                     trace!("is_sat: validated hard arithmetic fallback model after solver unknown");
                     self.cache_sat_result(cache_key, true);
@@ -544,7 +546,8 @@ impl SmtLibSubprocessSolver {
                 Ok(false)
             }
             "unknown" => {
-                if validated_hard_arith_fallback_model(&smt_constraints, constraints).is_some() {
+                if validated_hard_arith_fallback_model(cx, &smt_constraints, constraints).is_some()
+                {
                     self.heuristic_witnesses += 1;
                     self.cache_sat_result(cache_key, true);
                     Ok(true)
@@ -626,6 +629,7 @@ impl SmtLibSubprocessSolver {
     /// Sends already-normalized constraints to the configured solver portfolio.
     pub(crate) fn query_normalized(
         &mut self,
+        cx: &SymCx,
         smt_constraints: &[SymBoolExpr],
         model: bool,
         model_constraints: &[SymBoolExpr],
@@ -650,9 +654,10 @@ impl SmtLibSubprocessSolver {
             let _ = writeln!(smt, "(set-option :timeout {})", timeout.saturating_mul(1000));
         }
         for var in vars {
-            let _ = writeln!(smt, "(declare-fun {var} () (_ BitVec 256))");
+            let name = cx.symbol_name(var);
+            let _ = writeln!(smt, "(declare-fun {name} () (_ BitVec 256))");
         }
-        write_smt_assertions(&mut smt, smt_constraints)?;
+        write_smt_assertions(cx, &mut smt, smt_constraints)?;
         smt.push_str("(check-sat)\n");
         if model {
             smt.push_str("(get-model)\n");
@@ -667,8 +672,13 @@ impl SmtLibSubprocessSolver {
         }
 
         let started = Instant::now();
-        let result =
-            run_solver_commands(&commands, &smt, self.timeout, model.then_some(model_constraints));
+        let result = run_solver_commands(
+            cx,
+            &commands,
+            &smt,
+            self.timeout,
+            model.then_some(model_constraints),
+        );
         let query_time = started.elapsed();
         self.solver_time += query_time;
         self.smt_max_query_time = self.smt_max_query_time.max(query_time);
@@ -688,10 +698,11 @@ impl SmtLibSubprocessSolver {
 
 /// Returns a hard-arithmetic fallback model only after validating it against original constraints.
 fn validated_hard_arith_fallback_model(
+    cx: &SymCx,
     normalized_constraints: &[SymBoolExpr],
     original_constraints: &[SymBoolExpr],
 ) -> Option<SymbolicModel> {
-    let model = hard_arith_fallback_model(normalized_constraints)?;
+    let model = hard_arith_fallback_model(cx, normalized_constraints)?;
     model_satisfies_constraints(&model, original_constraints).then_some(model)
 }
 
@@ -1141,6 +1152,7 @@ fn merge_counts<K: Eq + std::hash::Hash + Clone>(
 
 /// Runs one or more solver commands and returns the first decisive SMT-LIB response.
 fn run_solver_commands(
+    cx: &SymCx,
     commands: &[SolverCommand],
     smt: &str,
     timeout: Option<u32>,
@@ -1244,7 +1256,7 @@ fn run_solver_commands(
             match outcome {
                 SolverProcessOutcome::Output(output) if solver_output_is_sat(&output) => {
                     if let Some(constraints) = model_constraints
-                        && let Err(err) = validate_solver_model_output(&output, constraints)
+                        && let Err(err) = validate_solver_model_output(cx, &output, constraints)
                     {
                         summaries.push(
                             SolverRunSummary::new(
@@ -1588,10 +1600,12 @@ fn first_solver_line(output: &str) -> &str {
 }
 
 pub(crate) fn parse_and_validate_model(
+    cx: &SymCx,
     output: &str,
     constraints: &[SymBoolExpr],
 ) -> Result<SymbolicModel, SymbolicError> {
-    let model = parse_model(output)?;
+    let symbols = model_symbols_for_constraints(cx, constraints);
+    let model = parse_model_with_symbols(output, &symbols)?;
     if constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap_or(false)) {
         Ok(model)
     } else {
@@ -1609,14 +1623,46 @@ pub(crate) fn parse_and_validate_model(
 }
 
 pub(crate) fn validate_solver_model_output(
+    cx: &SymCx,
     output: &str,
     constraints: &[SymBoolExpr],
 ) -> Result<(), SymbolicError> {
-    parse_and_validate_model(output, constraints).map(|_| ())
+    parse_and_validate_model(cx, output, constraints).map(|_| ())
 }
 
-pub(crate) fn parse_model(output: &str) -> Result<SymbolicModel, SymbolicError> {
+#[cfg(test)]
+pub(crate) fn parse_model(output: &str) -> Result<BTreeMap<String, U256>, SymbolicError> {
+    let mut values = BTreeMap::new();
+    parse_model_values(output, |name, value| {
+        values.insert(name.to_owned(), value);
+    })?;
+    Ok(values)
+}
+
+fn parse_model_with_symbols(
+    output: &str,
+    symbols: &HashMap<String, Symbol>,
+) -> Result<SymbolicModel, SymbolicError> {
+    parse_model_with_symbol(output, |name| symbols.get(name).copied())
+}
+
+fn parse_model_with_symbol(
+    output: &str,
+    mut symbol_for: impl FnMut(&str) -> Option<Symbol>,
+) -> Result<SymbolicModel, SymbolicError> {
     let mut values = SymbolicModel::default();
+    parse_model_values(output, |name, value| {
+        if let Some(symbol) = symbol_for(name) {
+            values.insert(symbol, value);
+        }
+    })?;
+    Ok(values)
+}
+
+fn parse_model_values(
+    output: &str,
+    mut insert_value: impl FnMut(&str, U256),
+) -> Result<(), SymbolicError> {
     let mut tokens = output
         .split(|c: char| c.is_whitespace() || matches!(c, '(' | ')'))
         .filter(|token| !token.is_empty());
@@ -1636,7 +1682,7 @@ pub(crate) fn parse_model(output: &str) -> Result<SymbolicModel, SymbolicError> 
                     })?;
                     let start = 32usize.saturating_sub(decoded.len());
                     bytes[start..start + decoded.len()].copy_from_slice(&decoded);
-                    values.insert(Symbol::intern(name), U256::from_be_bytes(bytes));
+                    insert_value(name, U256::from_be_bytes(bytes));
                     break;
                 }
                 if let Some(binary) = value.strip_prefix("#b") {
@@ -1648,7 +1694,7 @@ pub(crate) fn parse_model(output: &str) -> Result<SymbolicModel, SymbolicError> 
                     let parsed = U256::from_str_radix(binary, 2).map_err(|err| {
                         SymbolicError::Solver(format!("invalid solver binary model value: {err}"))
                     })?;
-                    values.insert(Symbol::intern(name), parsed);
+                    insert_value(name, parsed);
                     break;
                 }
                 if value == "_"
@@ -1657,11 +1703,22 @@ pub(crate) fn parse_model(output: &str) -> Result<SymbolicModel, SymbolicError> 
                     let parsed = U256::from_str_radix(bv, 10).map_err(|err| {
                         SymbolicError::Solver(format!("invalid solver decimal model value: {err}"))
                     })?;
-                    values.insert(Symbol::intern(name), parsed);
+                    insert_value(name, parsed);
                     break;
                 }
             }
         }
     }
-    Ok(values)
+    Ok(())
+}
+
+fn model_symbols_for_constraints(
+    cx: &SymCx,
+    constraints: &[SymBoolExpr],
+) -> HashMap<String, Symbol> {
+    let mut vars = SymbolicVars::default();
+    for constraint in constraints {
+        constraint.collect_vars(&mut vars);
+    }
+    vars.into_iter().map(|symbol| (cx.symbol_name(symbol).to_owned(), symbol)).collect()
 }

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -44,7 +44,10 @@ fn is_hard_arith_node(expr: &SymExpr) -> bool {
 }
 
 /// Returns whether local hard-arithmetic search should run before asking the solver.
-pub(crate) fn constraints_prefer_hard_arith_fallback_first(constraints: &[SymBoolExpr]) -> bool {
+pub(crate) fn constraints_prefer_hard_arith_fallback_first(
+    cx: &SymCx,
+    constraints: &[SymBoolExpr],
+) -> bool {
     if !constraints.iter().any(SymBoolExpr::contains_hard_arith)
         || constraints.iter().any(SymBoolExpr::contains_symbolic_hash)
     {
@@ -55,11 +58,14 @@ pub(crate) fn constraints_prefer_hard_arith_fallback_first(constraints: &[SymBoo
     for constraint in constraints {
         collect_bool_fallback_vars(constraint, &mut vars);
     }
-    let vars = fallback_search_vars(vars);
+    let vars = fallback_search_vars(cx, vars);
     !vars.is_empty() && vars.len() <= HARD_ARITH_FALLBACK_MAX_VARS
 }
 
-pub(crate) fn hard_arith_fallback_model(constraints: &[SymBoolExpr]) -> Option<SymbolicModel> {
+pub(crate) fn hard_arith_fallback_model(
+    cx: &SymCx,
+    constraints: &[SymBoolExpr],
+) -> Option<SymbolicModel> {
     if !constraints.iter().any(SymBoolExpr::contains_hard_arith)
         || constraints.iter().any(SymBoolExpr::contains_symbolic_hash)
     {
@@ -74,16 +80,16 @@ pub(crate) fn hard_arith_fallback_model(constraints: &[SymBoolExpr]) -> Option<S
     }
     let mut constants = constants.into_iter().collect::<Vec<_>>();
     constants.sort_unstable();
-    let vars = fallback_search_vars(vars);
+    let vars = fallback_search_vars(cx, vars);
     if vars.is_empty() || vars.len() > HARD_ARITH_FALLBACK_MAX_VARS {
         return None;
     }
 
     let candidates = vars
         .iter()
-        .map(|var| fallback_candidates_for_var(var.as_str(), constraints, &constants))
+        .map(|var| fallback_candidates_for_var(var, constraints, &constants))
         .collect::<Option<Vec<_>>>()?;
-    let searched_vars = vars.iter().cloned().collect::<SymbolicVars>();
+    let searched_vars = vars.iter().copied().collect::<SymbolicVars>();
     let constraint_vars = constraints
         .iter()
         .map(|constraint| {
@@ -104,14 +110,14 @@ pub(crate) fn hard_arith_fallback_model(constraints: &[SymBoolExpr]) -> Option<S
     search.model(0, &mut model, &mut assignments)
 }
 
-fn fallback_search_vars(vars: SymbolicVars) -> Vec<Symbol> {
+fn fallback_search_vars(cx: &SymCx, vars: SymbolicVars) -> Vec<Symbol> {
     if vars.len() <= HARD_ARITH_FALLBACK_MAX_VARS {
         return vars.into_iter().collect();
     }
 
     vars.into_iter()
         .filter(|var| {
-            let var = var.as_str();
+            let var = cx.symbol_name(*var);
             var.starts_with("calldata")
                 || var.starts_with("sequence")
                 || var.starts_with("create_address")
@@ -122,7 +128,7 @@ fn fallback_search_vars(vars: SymbolicVars) -> Vec<Symbol> {
 }
 
 fn fallback_candidates_for_var(
-    var: &str,
+    var: &Symbol,
     constraints: &[SymBoolExpr],
     constants: &[U256],
 ) -> Option<Vec<U256>> {
@@ -192,7 +198,7 @@ impl FallbackSearch<'_> {
         }
 
         for candidate in &self.candidates[index] {
-            model.insert(self.vars[index].clone(), *candidate);
+            model.insert(self.vars[index], *candidate);
             if fallback_partial_model_satisfies_known_constraints(
                 self.constraints,
                 self.constraint_vars,
@@ -226,21 +232,15 @@ fn fallback_partial_model_satisfies_known_constraints(
 ) -> bool {
     constraints.iter().zip(constraint_vars).all(|(constraint, vars)| {
         !vars.is_subset(searched_vars)
-            || !vars.iter().all(|var| model.contains_name(var.clone()))
+            || !vars.iter().all(|var| model.contains_name(*var))
             || constraint.eval_model(model).unwrap_or(false)
     })
 }
 
 fn collect_bool_fallback_vars(expr: &SymBoolExpr, vars: &mut SymbolicVars) {
     let _ = expr.visit_exprs(&mut |expr| {
-        match expr.kind() {
-            SymExprKind::Var(var) => {
-                vars.insert(var.clone());
-            }
-            SymExprKind::GasLeft(id) => {
-                vars.insert(SymExpr::gas_left_symbol(*id));
-            }
-            _ => {}
+        if let Some(var) = expr.kind().eval_var() {
+            vars.insert(var);
         }
         ControlFlow::<()>::Continue(())
     });
@@ -256,8 +256,8 @@ pub(crate) fn fallback_single_var_model(constraints: &[SymBoolExpr]) -> Option<S
     let mut constants = constants.into_iter().collect::<Vec<_>>();
     constants.sort_unstable();
 
-    let var = if vars.len() == 1 { vars.iter().next()?.clone() } else { return None };
-    let hints = MaskHints::for_var(var.as_str(), constraints);
+    let var = if vars.len() == 1 { *vars.iter().next()? } else { return None };
+    let hints = MaskHints::for_var(&var, constraints);
     if (hints.one & hints.zero) != U256::ZERO {
         return None;
     }
@@ -293,7 +293,7 @@ pub(crate) fn fallback_single_var_model(constraints: &[SymBoolExpr]) -> Option<S
     candidates.sort_unstable();
     for candidate in candidates {
         let mut model = SymbolicModel::default();
-        model.insert(var.clone(), candidate);
+        model.insert(var, candidate);
         if constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap_or(false)) {
             return Some(model);
         }
@@ -322,7 +322,7 @@ struct MaskHints {
 }
 
 impl MaskHints {
-    fn for_var(var: &str, constraints: &[SymBoolExpr]) -> Self {
+    fn for_var(var: &Symbol, constraints: &[SymBoolExpr]) -> Self {
         let mut hints = Self::default();
         for constraint in constraints {
             hints.apply_bool(var, constraint, false);
@@ -330,7 +330,7 @@ impl MaskHints {
         hints
     }
 
-    fn apply_bool(&mut self, var: &str, expr: &SymBoolExpr, inverted: bool) {
+    fn apply_bool(&mut self, var: &Symbol, expr: &SymBoolExpr, inverted: bool) {
         match expr.kind() {
             SymBoolExprKind::Const(_) => {}
             SymBoolExprKind::Not(value) => self.apply_bool(var, value, !inverted),
@@ -346,7 +346,7 @@ impl MaskHints {
         }
     }
 
-    fn apply_equality(&mut self, var: &str, left: &SymExpr, right: &SymExpr, inverted: bool) {
+    fn apply_equality(&mut self, var: &Symbol, left: &SymExpr, right: &SymExpr, inverted: bool) {
         if let Some(mask) =
             zero_mask_equality(var, left, right).or_else(|| zero_mask_equality(var, right, left))
         {
@@ -359,15 +359,17 @@ impl MaskHints {
     }
 }
 
-fn zero_mask_equality(var: &str, masked: &SymExpr, zero: &SymExpr) -> Option<U256> {
+fn zero_mask_equality(var: &Symbol, masked: &SymExpr, zero: &SymExpr) -> Option<U256> {
     if !zero.as_const().is_some_and(|value| value.is_zero()) {
         return None;
     }
     match masked.kind() {
         SymExprKind::BinOp(SymBinOp::And, left, right) => match (left.kind(), right.kind()) {
-            (SymExprKind::Var(name), SymExprKind::Const(mask))
-            | (SymExprKind::Const(mask), SymExprKind::Var(name))
-                if name.as_str() == var =>
+            (_, SymExprKind::Const(mask)) if left.kind().var().is_some_and(|name| &name == var) => {
+                Some(*mask)
+            }
+            (SymExprKind::Const(mask), _)
+                if right.kind().var().is_some_and(|name| &name == var) =>
             {
                 Some(*mask)
             }

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -239,7 +239,7 @@ fn fallback_partial_model_satisfies_known_constraints(
 
 fn collect_bool_fallback_vars(expr: &SymBoolExpr, vars: &mut SymbolicVars) {
     let _ = expr.visit_exprs(&mut |expr| {
-        if let Some(var) = expr.kind().eval_var() {
+        if let Some(var) = expr.kind().get_eval_var() {
             vars.insert(var);
         }
         ControlFlow::<()>::Continue(())
@@ -365,11 +365,13 @@ fn zero_mask_equality(var: &Symbol, masked: &SymExpr, zero: &SymExpr) -> Option<
     }
     match masked.kind() {
         SymExprKind::BinOp(SymBinOp::And, left, right) => match (left.kind(), right.kind()) {
-            (_, SymExprKind::Const(mask)) if left.kind().var().is_some_and(|name| &name == var) => {
+            (_, SymExprKind::Const(mask))
+                if left.kind().get_var().is_some_and(|name| &name == var) =>
+            {
                 Some(*mask)
             }
             (SymExprKind::Const(mask), _)
-                if right.kind().var().is_some_and(|name| &name == var) =>
+                if right.kind().get_var().is_some_and(|name| &name == var) =>
             {
                 Some(*mask)
             }

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -364,19 +364,11 @@ fn zero_mask_equality(var: &Symbol, masked: &SymExpr, zero: &SymExpr) -> Option<
         return None;
     }
     match masked.kind() {
-        SymExprKind::BinOp(SymBinOp::And, left, right) => match (left.kind(), right.kind()) {
-            (_, SymExprKind::Const(mask))
-                if left.kind().get_var().is_some_and(|name| &name == var) =>
-            {
-                Some(*mask)
-            }
-            (SymExprKind::Const(mask), _)
-                if right.kind().get_var().is_some_and(|name| &name == var) =>
-            {
-                Some(*mask)
-            }
-            _ => None,
-        },
+        SymExprKind::BinOp(SymBinOp::And, left, right)
+            if left.kind().get_var().is_some_and(|name| &name == var) =>
+        {
+            right.as_const()
+        }
         _ => None,
     }
 }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -484,20 +484,14 @@ impl SmtCseWriter<'_> {
             return;
         }
 
-        let kind = expr.kind();
-        if let Some(var) = kind.get_var() {
-            out.push_str(self.cx.symbol_name(var));
-            return;
-        }
-
-        match kind {
+        match expr.kind() {
             SymExprKind::Const(value) => {
                 let _ = write!(out, "(_ bv{value} 256)");
             }
-            SymExprKind::Var(_)
-            | SymExprKind::GasLeft(_)
-            | SymExprKind::Keccak { .. }
-            | SymExprKind::Hash { .. } => unreachable!("symbolic leaf handled above"),
+            SymExprKind::Var(symbol)
+            | SymExprKind::GasLeft(symbol)
+            | SymExprKind::Keccak { name: symbol, .. }
+            | SymExprKind::Hash { name: symbol, .. } => out.push_str(self.cx.symbol_name(*symbol)),
             SymExprKind::Not(value) => {
                 out.push_str("(bvnot ");
                 self.write_expr(out, value, skip_expr, skip_bool);

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -485,7 +485,7 @@ impl SmtCseWriter<'_> {
         }
 
         let kind = expr.kind();
-        if let Some(var) = kind.var() {
+        if let Some(var) = kind.get_var() {
             out.push_str(self.cx.symbol_name(var));
             return;
         }

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -78,18 +78,18 @@ fn write_expr_structural_key(out: &mut String, expr: &SymExpr) {
             let _ = write!(out, "0:{value:064x}");
         }
         SymExprKind::Var(name) => {
-            let _ = write!(out, "1:{}", name.as_str());
+            let _ = write!(out, "1:{}", name.id());
         }
-        SymExprKind::GasLeft(id) => {
-            let _ = write!(out, "2:{id:020}");
+        SymExprKind::GasLeft(symbol) => {
+            let _ = write!(out, "2:{}", symbol.id());
         }
         SymExprKind::Keccak { name, len, bytes } => {
-            let _ = write!(out, "3:{}:", name.as_str());
+            let _ = write!(out, "3:{}:", name.id());
             write_expr_structural_key(out, len);
             write_exprs_structural_key(out, bytes);
         }
         SymExprKind::Hash { name, algorithm, bytes } => {
-            let _ = write!(out, "4:{}:{algorithm}:", name.as_str());
+            let _ = write!(out, "4:{}:{algorithm}:", name.id());
             write_exprs_structural_key(out, bytes);
         }
         SymExprKind::Not(value) => {
@@ -211,6 +211,7 @@ impl SymBoolExpr {
 }
 
 pub(super) fn write_smt_assertions(
+    cx: &SymCx,
     out: &mut String,
     constraints: &[SymBoolExpr],
 ) -> Result<(), SymbolicError> {
@@ -224,12 +225,12 @@ pub(super) fn write_smt_assertions(
     let plan = SmtCsePlan::new(constraints);
     if plan.bindings.is_empty() {
         for constraint in constraints {
-            let _ = writeln!(out, "(assert {})", constraint.smt());
+            let _ = writeln!(out, "(assert {})", constraint.smt(cx));
         }
         return Ok(());
     }
 
-    let writer = SmtCseWriter { plan: &plan };
+    let writer = SmtCseWriter { cx, plan: &plan };
     // define binding_0 = term_0
     // ...
     // define binding_n = term_n
@@ -464,6 +465,7 @@ impl SmtBinding {
 }
 
 struct SmtCseWriter<'a> {
+    cx: &'a SymCx,
     plan: &'a SmtCsePlan,
 }
 
@@ -482,16 +484,20 @@ impl SmtCseWriter<'_> {
             return;
         }
 
-        match expr.kind() {
+        let kind = expr.kind();
+        if let Some(var) = kind.var() {
+            out.push_str(self.cx.symbol_name(var));
+            return;
+        }
+
+        match kind {
             SymExprKind::Const(value) => {
                 let _ = write!(out, "(_ bv{value} 256)");
             }
-            SymExprKind::Var(var) => out.push_str(var.as_str()),
-            SymExprKind::GasLeft(id) => {
-                let _ = write!(out, "gasleft_{id}");
-            }
-            SymExprKind::Keccak { name, .. } => out.push_str(name.as_str()),
-            SymExprKind::Hash { name, .. } => out.push_str(name.as_str()),
+            SymExprKind::Var(_)
+            | SymExprKind::GasLeft(_)
+            | SymExprKind::Keccak { .. }
+            | SymExprKind::Hash { .. } => unreachable!("symbolic leaf handled above"),
             SymExprKind::Not(value) => {
                 out.push_str("(bvnot ");
                 self.write_expr(out, value, skip_expr, skip_bool);

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -678,11 +678,7 @@ impl ConstraintContext {
     ) -> Option<(&'a SymExpr, U256)> {
         match constraint.kind() {
             SymBoolExprKind::Cmp(op, left, right) => match *op {
-                SymCmpOp::Eq => match (left.as_const(), right.as_const()) {
-                    (_, Some(value)) => Some((left, value)),
-                    (Some(value), _) => Some((right, value)),
-                    _ => None,
-                },
+                SymCmpOp::Eq => right.as_const().map(|value| (left, value)),
                 SymCmpOp::Ult => match (left.as_const(), right.as_const()) {
                     (_, Some(bound)) => (!bound.is_zero()).then(|| (left, bound - U256::from(1))),
                     _ => None,
@@ -806,29 +802,10 @@ impl SymBoolExpr {
                 })
             }
             SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
-                if left.as_const().is_some_and(|value| value.is_zero()) =>
-            {
-                right.normalized_bool_word_condition(cx).map(|value| value.not(cx)).or_else(|| {
-                    if right.word_bool_always_true(cx) {
-                        // `0 == always_true_word => false`.
-                        Some(Self::constant(cx, false))
-                    } else {
-                        let zero = SymExpr::zero(cx);
-                        Self::normalize_udiv_eq_zero(cx, &zero, right)
-                    }
-                })
-            }
-            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
                 if right.as_const() == Some(U256::from(1)) =>
             {
                 // `bool_word(c) == 1 => c`.
                 left.normalized_bool_word_condition(cx)
-            }
-            SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
-                if left.as_const() == Some(U256::from(1)) =>
-            {
-                // `1 == bool_word(c) => c`.
-                right.normalized_bool_word_condition(cx)
             }
             SymBoolExprKind::Not(value) => match value.kind() {
                 SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
@@ -840,17 +817,6 @@ impl SymBoolExpr {
                     } else {
                         let zero = SymExpr::zero(cx);
                         Self::normalize_udiv_eq_zero(cx, left, &zero).map(|value| value.not(cx))
-                    }
-                }
-                SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right)
-                    if left.as_const().is_some_and(|value| value.is_zero()) =>
-                {
-                    if right.word_bool_always_true(cx) {
-                        // `0 != always_true_word => true`.
-                        Some(Self::constant(cx, true))
-                    } else {
-                        let zero = SymExpr::zero(cx);
-                        Self::normalize_udiv_eq_zero(cx, &zero, right).map(|value| value.not(cx))
                     }
                 }
                 SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) => {
@@ -897,12 +863,6 @@ impl SymBoolExpr {
             && let Some(condition) = left.normalize_eq_zero_for_solver(cx)
         {
             // `word_bool(c) == 0 => !c`.
-            return Some(condition);
-        }
-        if left.as_const().is_some_and(|value| value.is_zero())
-            && let Some(condition) = right.normalize_eq_zero_for_solver(cx)
-        {
-            // `0 == word_bool(c) => !c`.
             return Some(condition);
         }
         None
@@ -1149,8 +1109,6 @@ impl ConstraintContext {
             SymExprKind::BinOp(SymBinOp::And, left, right) => {
                 if let Some(mask) = right.as_const() {
                     self.unsigned_bits(left).min(mask.bit_len())
-                } else if let Some(mask) = left.as_const() {
-                    self.unsigned_bits(right).min(mask.bit_len())
                 } else {
                     256
                 }

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -278,7 +278,7 @@ impl PathState {
         expr.collect_eval_vars(&mut vars);
         let mut model = SymbolicModel::default();
         for var in vars {
-            let var_expr = SymExpr::var_symbol(cx, var.clone());
+            let var_expr = SymExpr::var(cx, var);
             let value = self.constraints.iter().find_map(|constraint| {
                 constraint.forces_expr_const_with_context(&var_expr, &self.constraints)
             })?;
@@ -626,7 +626,7 @@ impl PathState {
     pub(crate) fn fresh_word(&mut self, cx: &mut SymCx, prefix: &'static str) -> SymExpr {
         let id = self.next_symbol;
         self.next_symbol += 1;
-        SymExpr::var(cx, &format!("{prefix}_{id}"))
+        SymExpr::named_var(cx, &format!("{prefix}_{id}"))
     }
 
     pub(crate) fn fresh_gasleft(&mut self, cx: &mut SymCx) -> SymExpr {
@@ -1657,8 +1657,8 @@ impl SymbolicWorld {
         concrete_key: Option<U256>,
     ) -> Result<SymExpr, SymbolicError> {
         if self.arbitrary_storage_all || self.arbitrary_storage_accounts.contains(&address) {
-            let name = stable_symbol("storage", format!("{address:?}:{key:?}").as_bytes());
-            return Ok(SymExpr::var_symbol(cx, name));
+            let name = stable_symbol(cx, "storage", format!("{address:?}:{key:?}").as_bytes());
+            return Ok(SymExpr::var(cx, name));
         }
         if let Some(key) = concrete_key {
             return executor
@@ -1676,8 +1676,8 @@ impl SymbolicWorld {
         } else if self.zero_init_symbolic_storage {
             Ok(SymExpr::zero(cx))
         } else {
-            let name = stable_symbol("storage", format!("{address:?}:{key:?}").as_bytes());
-            Ok(SymExpr::var_symbol(cx, name))
+            let name = stable_symbol(cx, "storage", format!("{address:?}:{key:?}").as_bytes());
+            Ok(SymExpr::var(cx, name))
         }
     }
 

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -278,7 +278,7 @@ impl PathState {
         expr.collect_eval_vars(&mut vars);
         let mut model = SymbolicModel::default();
         for var in vars {
-            let var_expr = SymExpr::var(cx, var);
+            let var_expr = SymExpr::get_var(cx, var);
             let value = self.constraints.iter().find_map(|constraint| {
                 constraint.forces_expr_const_with_context(&var_expr, &self.constraints)
             })?;
@@ -626,7 +626,7 @@ impl PathState {
     pub(crate) fn fresh_word(&mut self, cx: &mut SymCx, prefix: &'static str) -> SymExpr {
         let id = self.next_symbol;
         self.next_symbol += 1;
-        SymExpr::named_var(cx, &format!("{prefix}_{id}"))
+        SymExpr::var(cx, &format!("{prefix}_{id}"))
     }
 
     pub(crate) fn fresh_gasleft(&mut self, cx: &mut SymCx) -> SymExpr {
@@ -1658,7 +1658,7 @@ impl SymbolicWorld {
     ) -> Result<SymExpr, SymbolicError> {
         if self.arbitrary_storage_all || self.arbitrary_storage_accounts.contains(&address) {
             let name = stable_symbol(cx, "storage", format!("{address:?}:{key:?}").as_bytes());
-            return Ok(SymExpr::var(cx, name));
+            return Ok(SymExpr::get_var(cx, name));
         }
         if let Some(key) = concrete_key {
             return executor
@@ -1677,7 +1677,7 @@ impl SymbolicWorld {
             Ok(SymExpr::zero(cx))
         } else {
             let name = stable_symbol(cx, "storage", format!("{address:?}:{key:?}").as_bytes());
-            Ok(SymExpr::var(cx, name))
+            Ok(SymExpr::get_var(cx, name))
         }
     }
 

--- a/crates/evm/symbolic/src/runtime/symbols.rs
+++ b/crates/evm/symbolic/src/runtime/symbols.rs
@@ -1,4 +1,6 @@
 use super::*;
+use inturn::InternerSymbol;
+use std::num::NonZeroU32;
 
 pub(crate) type SymbolicVars = IndexSet<Symbol>;
 
@@ -18,38 +20,33 @@ impl SymbolicModelLookup for SymbolicModel {
     }
 }
 
-#[cfg(test)]
-impl SymbolicModelLookup for BTreeMap<String, U256> {
-    fn value(&self, name: Symbol) -> Option<U256> {
-        self.get(name.as_str()).copied()
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct Symbol(NonZeroU32);
+
+impl Symbol {
+    pub(crate) const fn id(&self) -> NonZeroU32 {
+        self.0
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub(crate) struct Symbol(Arc<str>);
-
-impl Symbol {
-    pub(crate) const fn new(name: Arc<str>) -> Self {
-        Self(name)
+impl InternerSymbol for Symbol {
+    fn try_from_usize(id: usize) -> Option<Self> {
+        id.checked_add(1).and_then(|id| u32::try_from(id).ok()).and_then(NonZeroU32::new).map(Self)
     }
 
-    pub(crate) fn intern(name: &str) -> Self {
-        Self(Arc::from(name))
-    }
-
-    pub(crate) fn as_str(&self) -> &str {
-        &self.0
+    fn to_usize(self) -> usize {
+        usize::try_from(self.0.get() - 1).expect("symbol id fits usize")
     }
 }
 
 impl fmt::Debug for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self.as_str(), f)
+        fmt::Display::fmt(self, f)
     }
 }
 
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+        write!(f, "sym{}", self.id())
     }
 }

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -107,7 +107,7 @@ fn exp_helper_expands_symbolic_base_for_bounded_concrete_exponent() {
     let mut cx = SymCx::new();
     let mut state = empty_state(&mut cx);
     state.stack.push(SymExpr::constant(&mut cx, U256::from(16))).unwrap();
-    state.stack.push(SymExpr::named_var(&mut cx, "base")).unwrap();
+    state.stack.push(SymExpr::var(&mut cx, "base")).unwrap();
 
     state.exp_word(&mut cx).unwrap();
 
@@ -122,7 +122,7 @@ fn exp_helper_expands_symbolic_base_for_bounded_concrete_exponent() {
 fn exp_helper_expands_bounded_symbolic_exponent() {
     let mut cx = SymCx::new();
     let mut state = empty_state(&mut cx);
-    let exponent = SymExpr::named_var(&mut cx, "exponent");
+    let exponent = SymExpr::var(&mut cx, "exponent");
     let five = SymExpr::constant(&mut cx, U256::from(5));
     let bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, exponent.clone(), five);
     state.constraints.push(bound);
@@ -145,7 +145,7 @@ fn shift_helpers_accept_symbolic_amounts() {
     let mut cx = SymCx::new();
     let mut shl = empty_state(&mut cx);
     shl.stack.push(SymExpr::constant(&mut cx, U256::from(1))).unwrap();
-    shl.stack.push(SymExpr::named_var(&mut cx, "shift")).unwrap();
+    shl.stack.push(SymExpr::var(&mut cx, "shift")).unwrap();
     shl.shift_word(&mut cx, ShiftKind::Shl).unwrap();
     let shifted = shl.stack.pop().unwrap();
 
@@ -164,7 +164,7 @@ fn shift_helpers_accept_symbolic_amounts() {
 
     let mut shr = empty_state(&mut cx);
     shr.stack.push(SymExpr::constant(&mut cx, U256::from(1) << 255)).unwrap();
-    shr.stack.push(SymExpr::named_var(&mut cx, "shift")).unwrap();
+    shr.stack.push(SymExpr::var(&mut cx, "shift")).unwrap();
     shr.shift_word(&mut cx, ShiftKind::Shr).unwrap();
     let shifted = shr.stack.pop().unwrap();
 
@@ -183,7 +183,7 @@ fn shift_helpers_accept_symbolic_amounts() {
 
     let mut sar = empty_state(&mut cx);
     sar.stack.push(SymExpr::constant(&mut cx, U256::MAX)).unwrap();
-    sar.stack.push(SymExpr::named_var(&mut cx, "shift")).unwrap();
+    sar.stack.push(SymExpr::var(&mut cx, "shift")).unwrap();
     sar.shift_word(&mut cx, ShiftKind::Sar).unwrap();
     let shifted = sar.stack.pop().unwrap();
 
@@ -199,15 +199,15 @@ fn shift_helpers_accept_symbolic_amounts() {
 fn symbolic_division_guards_zero_divisor() {
     let mut cx = SymCx::new();
     let mut state = empty_state(&mut cx);
-    state.stack.push(SymExpr::named_var(&mut cx, "den")).unwrap();
-    state.stack.push(SymExpr::named_var(&mut cx, "num")).unwrap();
+    state.stack.push(SymExpr::var(&mut cx, "den")).unwrap();
+    state.stack.push(SymExpr::var(&mut cx, "num")).unwrap();
 
     state.bin_word_div_zero_guard(&mut cx, SymBinOp::UDiv).unwrap();
 
-    let den = SymExpr::named_var(&mut cx, "den");
+    let den = SymExpr::var(&mut cx, "den");
     let zero = SymExpr::zero(&mut cx);
     let den_is_zero = SymBoolExpr::eq(&mut cx, den.clone(), zero.clone());
-    let num = SymExpr::named_var(&mut cx, "num");
+    let num = SymExpr::var(&mut cx, "num");
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, num, den);
     let expected = SymExpr::ite(&mut cx, den_is_zero, zero, quotient);
     assert_eq!(state.stack.pop().unwrap(), expected);
@@ -216,7 +216,7 @@ fn symbolic_division_guards_zero_divisor() {
 #[test]
 fn symbolic_byte_extracts_with_concrete_index() {
     let mut cx = SymCx::new();
-    let word = SymExpr::named_var(&mut cx, "word");
+    let word = SymExpr::var(&mut cx, "word");
     let actual = byte_word(&mut cx, U256::from(0), word.clone());
     let shift = SymExpr::constant(&mut cx, U256::from(248));
     let shifted = SymExpr::binop(&mut cx, SymBinOp::Shr, word, shift);
@@ -229,7 +229,7 @@ fn symbolic_byte_extracts_with_concrete_index() {
 fn symbolic_byte_extracts_with_symbolic_index() {
     let mut cx = SymCx::new();
     let word = U256::from_be_bytes(core::array::from_fn::<_, 32, _>(|idx| idx as u8));
-    let index = SymExpr::named_var(&mut cx, "index");
+    let index = SymExpr::var(&mut cx, "index");
     let word = SymExpr::constant(&mut cx, word);
     let byte = byte_word_dynamic(&mut cx, index, word);
 
@@ -244,7 +244,7 @@ fn symbolic_byte_extracts_with_symbolic_index() {
 fn symbolic_signextend_accepts_symbolic_index() {
     let mut cx = SymCx::new();
     let value = SymExpr::constant(&mut cx, U256::from(0x80));
-    let index = SymExpr::named_var(&mut cx, "index");
+    let index = SymExpr::var(&mut cx, "index");
     let extended = signextend_word_dynamic(&mut cx, index, value);
 
     let zero_index = symbolic_model(&mut cx, [("index".to_string(), U256::ZERO)]);
@@ -261,7 +261,7 @@ fn symbolic_byte_preserves_concrete_packed_selector_bytes() {
     let selector = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
     let selector = SymExpr::binop(&mut cx, SymBinOp::Shl, selector, shift_224);
-    let arg = SymExpr::named_var(&mut cx, "arg");
+    let arg = SymExpr::var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
     let shifted_arg = SymExpr::binop(&mut cx, SymBinOp::Shr, arg, shift_32);
     let packed = SymExpr::binop(&mut cx, SymBinOp::Or, selector, shifted_arg);
@@ -287,7 +287,7 @@ fn symbolic_byte_preserves_concrete_packed_selector_bytes() {
 #[test]
 fn word_reassembly_preserves_split_symbolic_word() {
     let mut cx = SymCx::new();
-    let value = SymExpr::named_var(&mut cx, "value");
+    let value = SymExpr::var(&mut cx, "value");
     let one = SymExpr::one(&mut cx);
     let original = SymExpr::binop(&mut cx, SymBinOp::Add, value, one);
     let bytes = original.clone().into_byte_exprs(&mut cx);
@@ -298,7 +298,7 @@ fn word_reassembly_preserves_split_symbolic_word() {
 #[test]
 fn symbolic_address_aliases_match_abi_encoded_address_words() {
     let mut cx = SymCx::new();
-    let source = SymExpr::named_var(&mut cx, "beneficiary");
+    let source = SymExpr::var(&mut cx, "beneficiary");
     let address_mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
     let masked = SymExpr::binop(&mut cx, SymBinOp::And, source.clone(), address_mask);
     let mut encoded = vec![SymExpr::zero(&mut cx); 12];
@@ -316,7 +316,7 @@ fn selector_shift_simplifies_to_concrete_word() {
     let selector_word = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
     let shifted_selector = SymExpr::binop(&mut cx, SymBinOp::Shl, selector_word, shift_224.clone());
-    let arg = SymExpr::named_var(&mut cx, "arg");
+    let arg = SymExpr::var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
     let shifted_arg = SymExpr::binop(&mut cx, SymBinOp::Shr, arg, shift_32);
     let call_word = SymExpr::binop(&mut cx, SymBinOp::Or, shifted_selector, shifted_arg);
@@ -333,7 +333,7 @@ fn selector_equality_folds_known_word_expressions() {
     let selector_word = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
     let shifted_selector = SymExpr::binop(&mut cx, SymBinOp::Shl, selector_word, shift_224.clone());
-    let arg = SymExpr::named_var(&mut cx, "arg");
+    let arg = SymExpr::var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
     let shifted_arg = SymExpr::binop(&mut cx, SymBinOp::Shr, arg, shift_32);
     let call_word = SymExpr::binop(&mut cx, SymBinOp::Or, shifted_selector, shifted_arg);
@@ -462,9 +462,9 @@ fn calldata_word_loads_preserve_structural_words() {
         .remove(0);
     let call_data = calldata.call_data(&mut cx);
 
-    assert_eq!(call_data.load(&mut cx, 4).unwrap(), SymExpr::named_var(&mut cx, "calldata_0"));
-    assert_eq!(call_data.load(&mut cx, 36).unwrap(), SymExpr::named_var(&mut cx, "calldata_1"));
-    assert_eq!(call_data.load(&mut cx, 68).unwrap(), SymExpr::named_var(&mut cx, "calldata_2"));
+    assert_eq!(call_data.load(&mut cx, 4).unwrap(), SymExpr::var(&mut cx, "calldata_0"));
+    assert_eq!(call_data.load(&mut cx, 36).unwrap(), SymExpr::var(&mut cx, "calldata_1"));
+    assert_eq!(call_data.load(&mut cx, 68).unwrap(), SymExpr::var(&mut cx, "calldata_2"));
 }
 
 #[test]
@@ -481,15 +481,15 @@ fn calldata_copy_to_memory_preserves_structural_words() {
 
     memory.copy_calldata_to_offset(&mut cx, dest, offset, 64, &call_data).unwrap();
 
-    assert_eq!(memory.load_word(&mut cx, 0x80).unwrap(), SymExpr::named_var(&mut cx, "calldata_0"));
-    assert_eq!(memory.load_word(&mut cx, 0xa0).unwrap(), SymExpr::named_var(&mut cx, "calldata_1"));
+    assert_eq!(memory.load_word(&mut cx, 0x80).unwrap(), SymExpr::var(&mut cx, "calldata_0"));
+    assert_eq!(memory.load_word(&mut cx, 0xa0).unwrap(), SymExpr::var(&mut cx, "calldata_1"));
 }
 
 #[test]
 fn byte_concat_word_load_assembles_word_fragments() {
     let mut cx = SymCx::new();
     let selector = [0xde, 0xad, 0xbe, 0xef];
-    let word = SymExpr::named_var(&mut cx, "calldata_0");
+    let word = SymExpr::var(&mut cx, "calldata_0");
     let selector_bytes = SymBytes::concrete(&mut cx, selector.to_vec());
     let word_bytes = word.clone().into_bytes(&mut cx);
     let bytes = SymBytes::concat(&mut cx, [selector_bytes, word_bytes]);
@@ -519,7 +519,7 @@ fn byte_concat_word_load_assembles_word_fragments() {
 #[test]
 fn byte_concat_right_aligned_word_assembles_push_fragments() {
     let mut cx = SymCx::new();
-    let immediate = SymExpr::named_var(&mut cx, "push_data");
+    let immediate = SymExpr::var(&mut cx, "push_data");
     let opcode = SymBytes::concrete(&mut cx, vec![opcode::PUSH32]);
     let immediate_bytes = immediate.clone().into_bytes(&mut cx);
     let bytes = SymBytes::concat(&mut cx, [opcode, immediate_bytes]);
@@ -554,7 +554,7 @@ fn calldata_load_accepts_symbolic_offsets() {
         (0u8..40).map(|idx| SymExpr::constant(&mut cx, U256::from(idx + 1))).collect();
     let calldata_bytes = SymBytes::exprs(&mut cx, calldata_bytes);
     let calldata = SymCalldata::from_bytes(&mut cx, calldata_bytes);
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     let loaded = calldata.load_word(&mut cx, offset).unwrap();
     let expected =
         sym_from_bytes!(cx, (1u8..33).map(|idx| SymExpr::constant(&mut cx, U256::from(idx + 1))));
@@ -598,7 +598,7 @@ fn calldata_preserves_symbolic_size_for_call_frames() {
     ];
     let bytes = SymBytes::exprs(&mut cx, bytes);
     memory.store_bytes(&mut cx, 0, bytes);
-    let size = SymExpr::named_var(&mut cx, "size");
+    let size = SymExpr::var(&mut cx, "size");
     let bounded_size = BoundedCopySize::Symbolic { size, max_size: 4 };
     let offset = SymExpr::zero(&mut cx);
     let input = bounded_size.read_from_memory(&mut cx, &memory, offset);
@@ -651,7 +651,7 @@ fn memory_copies_symbolic_calldata_offset() {
     let mut memory = SymMemory::default();
 
     let dest = SymExpr::zero(&mut cx);
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     memory.copy_calldata_to_offset(&mut cx, dest, offset, 2, &calldata).unwrap();
     let word = memory.load_word(&mut cx, 0).unwrap();
 
@@ -681,7 +681,7 @@ fn memory_copies_symbolic_calldata_size_with_guarded_tail() {
     memory.store_bytes(&mut cx, 0, tail);
     let dest = SymExpr::zero(&mut cx);
     let offset = SymExpr::zero(&mut cx);
-    let size = SymExpr::named_var(&mut cx, "size");
+    let size = SymExpr::var(&mut cx, "size");
 
     memory.copy_calldata_symbolic_size(&mut cx, dest, offset, size, 4, &calldata).unwrap();
 
@@ -706,7 +706,7 @@ fn memory_copies_symbolic_bytecode_size_with_guarded_tail() {
     let tail = SymBytes::exprs(&mut cx, vec![tail; 4]);
     memory.store_bytes(&mut cx, 0, tail);
     let dest = SymExpr::zero(&mut cx);
-    let size = SymExpr::named_var(&mut cx, "size");
+    let size = SymExpr::var(&mut cx, "size");
     let bytes = (0u8..4).map(|idx| SymExpr::constant(&mut cx, U256::from(idx + 1))).collect();
     let bytes = SymBytes::exprs(&mut cx, bytes);
     memory.copy_bytes_size_offset(&mut cx, dest, size, bytes).unwrap();
@@ -769,7 +769,7 @@ fn memory_reads_symbolic_size_with_zero_guarded_tail() {
     memory.store_bytes(&mut cx, 32, source);
 
     let offset = SymExpr::constant(&mut cx, U256::from(32));
-    let size = SymExpr::named_var(&mut cx, "size");
+    let size = SymExpr::var(&mut cx, "size");
     let bytes = memory.read_bytes_symbolic_size(&mut cx, offset, size, 4);
 
     let size_two = symbolic_model(&mut cx, [("size".to_string(), U256::from(2))]);
@@ -807,7 +807,7 @@ fn memory_copies_symbolic_memory_size_with_guarded_tail() {
     memory.store_bytes(&mut cx, 32, source_bytes);
     let dest = SymExpr::zero(&mut cx);
     let source = SymExpr::constant(&mut cx, U256::from(32));
-    let size = SymExpr::named_var(&mut cx, "size");
+    let size = SymExpr::var(&mut cx, "size");
 
     memory.copy_memory_symbolic_size(&mut cx, dest, source, size, 4).unwrap();
 
@@ -835,9 +835,9 @@ fn memory_copies_symbolic_size_to_symbolic_dest() {
         (0u8..4).map(|idx| SymExpr::constant(&mut cx, U256::from(idx + 1))).collect();
     let source_bytes = SymBytes::exprs(&mut cx, source_bytes);
     memory.store_bytes(&mut cx, 0x20, source_bytes);
-    let dest = SymExpr::named_var(&mut cx, "dest");
+    let dest = SymExpr::var(&mut cx, "dest");
     let source = SymExpr::constant(&mut cx, U256::from(0x20));
-    let size = SymExpr::named_var(&mut cx, "size");
+    let size = SymExpr::var(&mut cx, "size");
 
     memory.copy_memory_symbolic_size(&mut cx, dest, source, size, 4).unwrap();
 
@@ -861,7 +861,7 @@ fn memory_copies_symbolic_returndata_size_with_guarded_tail() {
     memory.store_bytes(&mut cx, 0, tail);
     let dest = SymExpr::zero(&mut cx);
     let offset = SymExpr::zero(&mut cx);
-    let size = SymExpr::named_var(&mut cx, "size");
+    let size = SymExpr::var(&mut cx, "size");
 
     memory.copy_return_data_symbolic_size(&mut cx, dest, offset, size, 4, &return_data).unwrap();
 
@@ -882,7 +882,7 @@ fn memory_copies_symbolic_returndata_size_with_guarded_tail() {
 fn returndata_reads_symbolic_offset() {
     let mut cx = SymCx::new();
     let return_data = SymReturnData::from_concrete_bytes(&mut cx, vec![1, 2, 3, 4]);
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     let bytes = return_data.read_bytes_offset(&mut cx, offset, 2);
 
     let offset_one = symbolic_model(&mut cx, [("offset".to_string(), U256::from(1))]);
@@ -903,7 +903,7 @@ fn memory_return_data_accepts_symbolic_size() {
     let bytes = SymBytes::exprs(&mut cx, bytes);
     memory.store_bytes(&mut cx, 0, bytes);
     let offset = SymExpr::zero(&mut cx);
-    let len = SymExpr::named_var(&mut cx, "len");
+    let len = SymExpr::var(&mut cx, "len");
 
     let return_data = memory.return_data_symbolic_size(&mut cx, offset, len, 4).unwrap();
 
@@ -921,7 +921,7 @@ fn call_output_preserves_memory_beyond_symbolic_returndata_size() {
         .map(|byte| SymExpr::constant(&mut cx, U256::from(byte)))
         .collect();
     let bytes = SymBytes::exprs(&mut cx, bytes);
-    let len = SymExpr::named_var(&mut cx, "len");
+    let len = SymExpr::var(&mut cx, "len");
     let return_data = SymReturnData::from_bytes_with_len(bytes, len);
     let mut memory = SymMemory::default();
     let tail = SymExpr::constant(&mut cx, U256::from(0xaa));
@@ -965,7 +965,7 @@ fn nested_dynamic_calldata_uses_preorder_lengths() {
 fn memory_round_trips_symbolic_words_as_bytes() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::named_var(&mut cx, "word");
+    let value = SymExpr::var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value.clone());
 
@@ -980,10 +980,10 @@ fn memory_round_trips_symbolic_words_as_bytes() {
 fn memory_load_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::named_var(&mut cx, "word");
+    let value = SymExpr::var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     let loaded = memory.load_word_offset(&mut cx, offset).unwrap();
 
     let model = symbolic_model(
@@ -1003,9 +1003,9 @@ fn memory_load_accepts_symbolic_offsets() {
 fn memory_store_word_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::named_var(&mut cx, "word");
+    let value = SymExpr::var(&mut cx, "word");
 
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     memory.store_word_offset(&mut cx, offset, value);
     let loaded = memory.load_word(&mut cx, 7).unwrap();
 
@@ -1031,8 +1031,8 @@ fn memory_size_tracks_concrete_and_symbolic_extents() {
     memory.store_word(&mut cx, 7, concrete);
     assert_eq!(memory.size_word(&mut cx), SymExpr::constant(&mut cx, U256::from(64)));
 
-    let offset = SymExpr::named_var(&mut cx, "offset");
-    let word = SymExpr::named_var(&mut cx, "word");
+    let offset = SymExpr::var(&mut cx, "offset");
+    let word = SymExpr::var(&mut cx, "word");
     memory.store_word_offset(&mut cx, offset, word);
     let size = memory.size_word(&mut cx);
 
@@ -1054,8 +1054,8 @@ fn memory_concrete_write_overrides_older_symbolic_write() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
 
-    let offset = SymExpr::named_var(&mut cx, "offset");
-    let word = SymExpr::named_var(&mut cx, "word");
+    let offset = SymExpr::var(&mut cx, "offset");
+    let word = SymExpr::var(&mut cx, "word");
     memory.store_word_offset(&mut cx, offset, word);
     let concrete = SymExpr::constant(&mut cx, U256::from(0x55));
     memory.store_word(&mut cx, 7, concrete);
@@ -1073,12 +1073,12 @@ fn memory_dynamic_read_respects_concrete_overwrite_epoch() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
 
-    let write_offset = SymExpr::named_var(&mut cx, "write_offset");
-    let byte = SymExpr::named_var(&mut cx, "byte");
+    let write_offset = SymExpr::var(&mut cx, "write_offset");
+    let byte = SymExpr::var(&mut cx, "byte");
     memory.store_byte_offset(&mut cx, write_offset, byte);
     let concrete = SymExpr::constant(&mut cx, U256::from(0x55));
     memory.store_byte(&mut cx, 5, concrete);
-    let read_offset = SymExpr::named_var(&mut cx, "read_offset");
+    let read_offset = SymExpr::var(&mut cx, "read_offset");
     let loaded = memory.byte_dynamic_with_delta(&mut cx, &read_offset, 0);
 
     let model = symbolic_model(
@@ -1097,13 +1097,13 @@ fn memory_symbolic_write_after_concrete_overwrite_still_applies() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
 
-    let older_offset = SymExpr::named_var(&mut cx, "older_offset");
-    let older_byte = SymExpr::named_var(&mut cx, "older_byte");
+    let older_offset = SymExpr::var(&mut cx, "older_offset");
+    let older_byte = SymExpr::var(&mut cx, "older_byte");
     memory.store_byte_offset(&mut cx, older_offset, older_byte);
     let concrete = SymExpr::constant(&mut cx, U256::from(0x55));
     memory.store_byte(&mut cx, 5, concrete);
-    let later_offset = SymExpr::named_var(&mut cx, "later_offset");
-    let later_byte = SymExpr::named_var(&mut cx, "later_byte");
+    let later_offset = SymExpr::var(&mut cx, "later_offset");
+    let later_byte = SymExpr::var(&mut cx, "later_byte");
     memory.store_byte_offset(&mut cx, later_offset, later_byte);
     let loaded = memory.byte(&mut cx, 5);
 
@@ -1135,8 +1135,8 @@ fn memory_store_byte_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
 
-    let offset = SymExpr::named_var(&mut cx, "offset");
-    let byte = SymExpr::named_var(&mut cx, "byte");
+    let offset = SymExpr::var(&mut cx, "offset");
+    let byte = SymExpr::var(&mut cx, "byte");
     memory.store_byte_offset(&mut cx, offset, byte);
     let loaded = memory.byte(&mut cx, 0x80);
 
@@ -1157,10 +1157,10 @@ fn memory_store_byte_accepts_symbolic_offsets() {
 fn memory_read_bytes_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::named_var(&mut cx, "word");
+    let value = SymExpr::var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     let bytes = memory.read_bytes_offset(&mut cx, offset, 32).materialize(&mut cx);
     let loaded = SymExpr::from_bytes(&mut cx, bytes);
 
@@ -1181,10 +1181,10 @@ fn memory_read_bytes_accepts_symbolic_offsets() {
 fn memory_return_data_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::named_var(&mut cx, "word");
+    let value = SymExpr::var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     let return_data = memory.return_data(&mut cx, offset, 32).unwrap();
     let loaded = return_data.load_word(&mut cx, 0).unwrap();
 
@@ -1199,11 +1199,11 @@ fn memory_return_data_accepts_symbolic_offsets() {
 fn memory_copy_accepts_symbolic_source_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::named_var(&mut cx, "word");
+    let value = SymExpr::var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
     let dest = SymExpr::constant(&mut cx, U256::from(64));
-    let src = SymExpr::named_var(&mut cx, "src");
+    let src = SymExpr::var(&mut cx, "src");
     memory.copy_memory_to_offset(&mut cx, dest, src, 32).unwrap();
     let loaded = memory.load_word(&mut cx, 64).unwrap();
 
@@ -1218,10 +1218,10 @@ fn memory_copy_accepts_symbolic_source_offsets() {
 fn memory_copy_accepts_symbolic_destination_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::named_var(&mut cx, "word");
+    let value = SymExpr::var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
-    let dest = SymExpr::named_var(&mut cx, "dest");
+    let dest = SymExpr::var(&mut cx, "dest");
     let src = SymExpr::constant(&mut cx, U256::from(7));
     memory.copy_memory_to_offset(&mut cx, dest, src, 32).unwrap();
     let loaded = memory.load_word(&mut cx, 64).unwrap();
@@ -1243,10 +1243,10 @@ fn memory_copy_accepts_symbolic_destination_offsets() {
 fn memory_call_output_accepts_symbolic_destination_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let word = SymExpr::named_var(&mut cx, "word");
+    let word = SymExpr::var(&mut cx, "word");
     let bytes = word.into_bytes(&mut cx);
     let return_data = SymReturnData::from_bytes(&mut cx, bytes);
-    let dest = SymExpr::named_var(&mut cx, "dest");
+    let dest = SymExpr::var(&mut cx, "dest");
 
     memory
         .copy_call_output_offset(&mut cx, dest, &BoundedCopySize::Concrete(32), &return_data)
@@ -1269,7 +1269,7 @@ fn memory_call_output_accepts_symbolic_size_with_guarded_tail() {
     let tail = SymBytes::exprs(&mut cx, vec![tail; 4]);
     memory.store_bytes(&mut cx, 0, tail);
     let dest = SymExpr::zero(&mut cx);
-    let size = SymExpr::named_var(&mut cx, "size");
+    let size = SymExpr::var(&mut cx, "size");
     let copy_size = BoundedCopySize::Symbolic { size, max_size: 4 };
 
     memory.copy_call_output_offset(&mut cx, dest, &copy_size, &return_data).unwrap();
@@ -1295,8 +1295,8 @@ fn memory_call_output_accepts_symbolic_destination_and_size() {
     let tail = SymExpr::constant(&mut cx, U256::from(0xaa));
     let tail = SymBytes::exprs(&mut cx, vec![tail; 4]);
     memory.store_bytes(&mut cx, 0x80, tail);
-    let dest = SymExpr::named_var(&mut cx, "dest");
-    let size = SymExpr::named_var(&mut cx, "size");
+    let dest = SymExpr::var(&mut cx, "dest");
+    let size = SymExpr::var(&mut cx, "size");
     let copy_size = BoundedCopySize::Symbolic { size, max_size: 4 };
 
     memory.copy_call_output_offset(&mut cx, dest, &copy_size, &return_data).unwrap();
@@ -1319,13 +1319,13 @@ fn memory_call_output_accepts_symbolic_destination_and_return_len() {
         .map(|byte| SymExpr::constant(&mut cx, U256::from(byte)))
         .collect();
     let bytes = SymBytes::exprs(&mut cx, bytes);
-    let len = SymExpr::named_var(&mut cx, "len");
+    let len = SymExpr::var(&mut cx, "len");
     let return_data = SymReturnData::from_bytes_with_len(bytes, len);
     let mut memory = SymMemory::default();
     let tail = SymExpr::constant(&mut cx, U256::from(0xaa));
     let tail = SymBytes::exprs(&mut cx, vec![tail; 4]);
     memory.store_bytes(&mut cx, 0x80, tail);
-    let dest = SymExpr::named_var(&mut cx, "dest");
+    let dest = SymExpr::var(&mut cx, "dest");
 
     memory
         .copy_call_output_offset(&mut cx, dest, &BoundedCopySize::Concrete(4), &return_data)
@@ -1359,7 +1359,7 @@ fn compute_create2_cheatcode_helper_matches_create2_terms() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let salt = SymExpr::named_var(&mut cx, "salt");
+    let salt = SymExpr::var(&mut cx, "salt");
     let initcode = vec![opcode::STOP];
     let initcode_hash = SymExpr::constant(&mut cx, U256::from_be_bytes(keccak256(&initcode).0));
     let creator_word = SymExpr::constant(&mut cx, address_word(creator));
@@ -1384,8 +1384,8 @@ fn compute_create2_cheatcode_helper_accepts_symbolic_init_code_hash() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let salt = SymExpr::named_var(&mut cx, "salt");
-    let initcode_hash = SymExpr::named_var(&mut cx, "initcode_hash");
+    let salt = SymExpr::var(&mut cx, "salt");
+    let initcode_hash = SymExpr::var(&mut cx, "initcode_hash");
     let creator_word = SymExpr::constant(&mut cx, address_word(creator));
 
     let first = compute_create2_address_word(
@@ -1401,7 +1401,7 @@ fn compute_create2_cheatcode_helper_accepts_symbolic_init_code_hash() {
             .unwrap();
 
     assert_eq!(first, second);
-    assert!(first.var_name(&cx).is_some_and(|name| name.starts_with("create2_address_")));
+    assert!(first.get_var_name(&cx).is_some_and(|name| name.starts_with("create2_address_")));
 }
 
 #[test]
@@ -1409,7 +1409,7 @@ fn compute_create_cheatcode_helper_accepts_symbolic_nonce() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let nonce = SymExpr::named_var(&mut cx, "nonce");
+    let nonce = SymExpr::var(&mut cx, "nonce");
     let creator_word = SymExpr::constant(&mut cx, address_word(creator));
 
     let first =
@@ -1418,7 +1418,7 @@ fn compute_create_cheatcode_helper_accepts_symbolic_nonce() {
     let second = compute_create_address_word(&mut cx, &mut state, creator_word, nonce).unwrap();
 
     assert_eq!(first, second);
-    assert!(first.var_name(&cx).is_some_and(|name| name.starts_with("create_address_")));
+    assert!(first.get_var_name(&cx).is_some_and(|name| name.starts_with("create_address_")));
 }
 
 #[test]
@@ -1426,8 +1426,8 @@ fn compute_create_cheatcode_helper_accepts_symbolic_deployer() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let deployer = SymExpr::named_var(&mut cx, "deployer");
-    let nonce = SymExpr::named_var(&mut cx, "nonce");
+    let deployer = SymExpr::var(&mut cx, "deployer");
+    let nonce = SymExpr::var(&mut cx, "nonce");
 
     let first = compute_create_address_word(&mut cx, &mut state, deployer.clone(), nonce.clone())
         .expect("symbolic deployer is supported");
@@ -1435,7 +1435,7 @@ fn compute_create_cheatcode_helper_accepts_symbolic_deployer() {
         .expect("symbolic deployer is supported");
 
     assert_eq!(first, second);
-    assert!(first.var_name(&cx).is_some_and(|name| name.starts_with("create_address_")));
+    assert!(first.get_var_name(&cx).is_some_and(|name| name.starts_with("create_address_")));
 }
 
 #[test]
@@ -1443,9 +1443,9 @@ fn compute_create2_cheatcode_helper_accepts_symbolic_deployer() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let deployer = SymExpr::named_var(&mut cx, "deployer");
-    let salt = SymExpr::named_var(&mut cx, "salt");
-    let initcode_hash = SymExpr::named_var(&mut cx, "initcode_hash");
+    let deployer = SymExpr::var(&mut cx, "deployer");
+    let salt = SymExpr::var(&mut cx, "salt");
+    let initcode_hash = SymExpr::var(&mut cx, "initcode_hash");
 
     let first = compute_create2_address_word(
         &mut cx,
@@ -1459,7 +1459,7 @@ fn compute_create2_cheatcode_helper_accepts_symbolic_deployer() {
         .expect("symbolic deployer is supported");
 
     assert_eq!(first, second);
-    assert!(first.var_name(&cx).is_some_and(|name| name.starts_with("create2_address_")));
+    assert!(first.get_var_name(&cx).is_some_and(|name| name.starts_with("create2_address_")));
 }
 
 #[test]
@@ -1496,11 +1496,10 @@ fn recorded_logs_return_data_matches_abi_encoding() {
 fn recorded_logs_json_return_data_accepts_symbolic_topics_and_data() {
     let mut cx = SymCx::new();
     let emitter = Address::from([0x33; 20]);
-    let data =
-        vec![SymExpr::constant(&mut cx, U256::from(0x12)), SymExpr::named_var(&mut cx, "byte")];
+    let data = vec![SymExpr::constant(&mut cx, U256::from(0x12)), SymExpr::var(&mut cx, "byte")];
     let data = SymBytes::exprs(&mut cx, data);
     let log = SymbolicLog::new(
-        vec![SymExpr::named_var(&mut cx, "topic")],
+        vec![SymExpr::var(&mut cx, "topic")],
         SymExpr::constant(&mut cx, U256::from(2)),
         data,
         emitter,
@@ -1531,7 +1530,7 @@ fn abi_bytes_encoding_accepts_symbolic_length() {
         SymExpr::constant(&mut cx, U256::from(0x44)),
     ];
     let bytes = SymBytes::exprs(&mut cx, bytes);
-    let len = SymExpr::named_var(&mut cx, "len");
+    let len = SymExpr::var(&mut cx, "len");
     let encoded = encode_packed_bytes_with_len(&mut cx, len, &bytes);
 
     assert_eq!(
@@ -1547,7 +1546,7 @@ fn abi_bytes_encoding_accepts_symbolic_length() {
 fn symbolic_world_resolves_symbolic_create2_address_aliases() {
     let mut cx = SymCx::new();
     let mut world = SymbolicWorld::default();
-    let word = SymExpr::named_var(&mut cx, "create2_address");
+    let word = SymExpr::var(&mut cx, "create2_address");
     let address = world.symbolic_address_slot(word.clone());
     let address_mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
     let masked = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), address_mask);
@@ -1563,7 +1562,7 @@ fn symbolic_create2_accepts_symbolic_salt() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let salt = SymExpr::named_var(&mut cx, "salt");
+    let salt = SymExpr::var(&mut cx, "salt");
     let initcode = SymCode::concrete(&mut cx, vec![opcode::STOP]);
 
     let (word, address) =
@@ -1580,8 +1579,8 @@ fn symbolic_create2_initcode_identity_uses_byte_semantics() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let salt = SymExpr::named_var(&mut cx, "salt");
-    let init_word = SymExpr::named_var(&mut cx, "init_word");
+    let salt = SymExpr::var(&mut cx, "salt");
+    let init_word = SymExpr::var(&mut cx, "init_word");
     let structural_bytes = init_word.clone().into_bytes(&mut cx);
     let structural = SymCode::from_bytes(&mut cx, structural_bytes);
     let init_bytes = init_word.into_byte_exprs(&mut cx);
@@ -1599,7 +1598,7 @@ fn symbolic_create2_initcode_identity_uses_byte_semantics() {
 #[test]
 fn symbolic_return_data_can_be_installed_as_runtime_code() {
     let mut cx = SymCx::new();
-    let runtime_byte = SymExpr::named_var(&mut cx, "runtime_byte");
+    let runtime_byte = SymExpr::var(&mut cx, "runtime_byte");
     let bytes = SymBytes::exprs(&mut cx, vec![runtime_byte.clone()]);
     let data = SymReturnData::from_bytes(&mut cx, bytes);
 
@@ -1613,7 +1612,7 @@ fn symbolic_runtime_size_is_not_installed_as_concrete_code() {
     let mut cx = SymCx::new();
     let stop = SymExpr::constant(&mut cx, U256::from(opcode::STOP));
     let bytes = SymBytes::exprs(&mut cx, vec![stop]);
-    let len = SymExpr::named_var(&mut cx, "runtime_len");
+    let len = SymExpr::var(&mut cx, "runtime_len");
     let data = SymReturnData::from_bytes_with_len(bytes, len);
 
     assert!(matches!(
@@ -1641,7 +1640,7 @@ fn symbolic_codecopy_preserves_symbolic_constructor_bytes() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
     let stop = SymExpr::constant(&mut cx, U256::from(opcode::STOP));
-    let constructor_arg = SymExpr::named_var(&mut cx, "constructor_arg_byte");
+    let constructor_arg = SymExpr::var(&mut cx, "constructor_arg_byte");
     let bytes = SymBytes::exprs(&mut cx, vec![stop, constructor_arg]);
     let initcode = SymCode::from_bytes(&mut cx, bytes);
 
@@ -1649,7 +1648,7 @@ fn symbolic_codecopy_preserves_symbolic_constructor_bytes() {
     memory.store_bytes(&mut cx, 0, init_bytes);
 
     assert_eq!(memory.byte(&mut cx, 0), SymExpr::constant(&mut cx, U256::from(opcode::STOP)));
-    assert_eq!(memory.byte(&mut cx, 1), SymExpr::named_var(&mut cx, "constructor_arg_byte"));
+    assert_eq!(memory.byte(&mut cx, 1), SymExpr::var(&mut cx, "constructor_arg_byte"));
 }
 
 #[test]
@@ -1660,7 +1659,7 @@ fn symbolic_codecopy_accepts_symbolic_offsets() {
     let code = SymCode::from_bytes(&mut cx, code_bytes);
     let mut memory = SymMemory::default();
 
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     let code_bytes = code.read_bytes_offset(&mut cx, offset, 2);
     memory.store_bytes(&mut cx, 0, code_bytes);
     let word = memory.load_word(&mut cx, 0).unwrap();
@@ -1684,10 +1683,10 @@ fn symbolic_initcode_accepts_symbolic_memory_offsets() {
     let mut memory = SymMemory::default();
 
     let stop = SymExpr::constant(&mut cx, U256::from(opcode::STOP));
-    let arg = SymExpr::named_var(&mut cx, "arg");
+    let arg = SymExpr::var(&mut cx, "arg");
     let bytes = SymBytes::exprs(&mut cx, vec![stop, arg]);
     memory.store_bytes(&mut cx, 7, bytes);
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     let initcode = SymCode::from_memory_offset(&mut cx, &memory, offset, 2);
     let mut bytes = initcode.read_bytes(&mut cx, 0, 2).materialize(&mut cx);
     bytes.extend((0..30).map(|_| SymExpr::zero(&mut cx)));
@@ -1707,7 +1706,7 @@ fn symbolic_initcode_accepts_symbolic_memory_offsets() {
 fn path_state_extracts_constrained_symbolic_usize() {
     let mut cx = SymCx::new();
     let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
 
     let seven = SymExpr::constant(&mut cx, U256::from(7));
     let constraint = SymBoolExpr::eq(&mut cx, offset.clone(), seven);
@@ -1720,7 +1719,7 @@ fn path_state_extracts_constrained_symbolic_usize() {
 fn path_state_extracts_symbolic_usize_upper_bound() {
     let mut cx = SymCx::new();
     let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
-    let size = SymExpr::named_var(&mut cx, "size");
+    let size = SymExpr::var(&mut cx, "size");
 
     let five = SymExpr::constant(&mut cx, U256::from(5));
     let constraint = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, size.clone(), five);
@@ -1740,7 +1739,7 @@ fn path_state_child_replaces_frame_and_resets_local_loop_state() {
     let parent_stack = SymExpr::constant(&mut cx, U256::from(0xab));
     state.stack.push(parent_stack).unwrap();
 
-    let constrained = SymExpr::named_var(&mut cx, "constrained");
+    let constrained = SymExpr::var(&mut cx, "constrained");
     let seven = SymExpr::constant(&mut cx, U256::from(7));
     let constraint = SymBoolExpr::eq(&mut cx, constrained, seven);
     state.constraints.push(constraint.clone());
@@ -1779,7 +1778,7 @@ fn path_state_child_replaces_frame_and_resets_local_loop_state() {
 fn path_state_extracts_constrained_symbolic_usize_from_encoded_bool_word() {
     let mut cx = SymCx::new();
     let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
-    let offset = SymExpr::named_var(&mut cx, "offset");
+    let offset = SymExpr::var(&mut cx, "offset");
     let offset_expr = offset.clone();
     let mask = SymExpr::constant(&mut cx, U256::from(0xffff));
 
@@ -1806,7 +1805,7 @@ fn path_state_extracts_constrained_symbolic_usize_from_encoded_bool_word() {
 fn path_state_evaluates_compound_constrained_symbolic_word() {
     let mut cx = SymCx::new();
     let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
-    let value = SymExpr::named_var(&mut cx, "value");
+    let value = SymExpr::var(&mut cx, "value");
     let beef = SymExpr::constant(&mut cx, U256::from(0xbeef));
     let value_constraint = SymBoolExpr::eq(&mut cx, value.clone(), beef);
     state.constraints.push(value_constraint);
@@ -1823,8 +1822,8 @@ fn path_state_evaluates_compound_constrained_symbolic_word() {
 fn symbolic_push_data_reconstructs_symbolic_word() {
     let mut cx = SymCx::new();
     let push2 = SymExpr::constant(&mut cx, U256::from(opcode::PUSH2));
-    let hi = SymExpr::named_var(&mut cx, "immutable_hi");
-    let lo = SymExpr::named_var(&mut cx, "immutable_lo");
+    let hi = SymExpr::var(&mut cx, "immutable_hi");
+    let lo = SymExpr::var(&mut cx, "immutable_lo");
     let bytes = SymBytes::exprs(&mut cx, vec![push2, hi, lo]);
     let code = SymCode::from_bytes(&mut cx, bytes);
 
@@ -1836,7 +1835,7 @@ fn symbolic_push_data_reconstructs_symbolic_word() {
 #[test]
 fn symbolic_push32_preserves_structural_word() {
     let mut cx = SymCx::new();
-    let immediate = SymExpr::named_var(&mut cx, "immutable");
+    let immediate = SymExpr::var(&mut cx, "immutable");
     let opcode = SymBytes::concrete(&mut cx, vec![opcode::PUSH32]);
     let immediate_bytes = immediate.clone().into_bytes(&mut cx);
     let bytes = SymBytes::concat(&mut cx, [opcode, immediate_bytes]);
@@ -1848,7 +1847,7 @@ fn symbolic_push32_preserves_structural_word() {
 #[test]
 fn abi_bytes_return_encodes_symbolic_bytes() {
     let mut cx = SymCx::new();
-    let byte_0 = SymExpr::named_var(&mut cx, "calldata_byte_0");
+    let byte_0 = SymExpr::var(&mut cx, "calldata_byte_0");
     let byte_1 = SymExpr::constant(&mut cx, U256::from(0x42));
     let ret = abi_bytes_return(&mut cx, vec![byte_0.clone(), byte_1.clone()]);
     let offset_bytes = (0..32).map(|idx| ret.byte(&mut cx, idx)).collect::<Vec<_>>();
@@ -1867,9 +1866,9 @@ fn abi_bytes_return_encodes_symbolic_bytes() {
 #[test]
 fn abi_bytes_return_can_encode_symbolic_length() {
     let mut cx = SymCx::new();
-    let len = SymExpr::named_var(&mut cx, "len");
-    let byte_0 = SymExpr::named_var(&mut cx, "byte_0");
-    let byte_1 = SymExpr::named_var(&mut cx, "byte_1");
+    let len = SymExpr::var(&mut cx, "len");
+    let byte_0 = SymExpr::var(&mut cx, "byte_0");
+    let byte_1 = SymExpr::var(&mut cx, "byte_1");
     let ret = abi_bytes_return_with_len(&mut cx, len.clone(), vec![byte_0.clone(), byte_1.clone()]);
     let offset_bytes = (0..32).map(|idx| ret.byte(&mut cx, idx)).collect::<Vec<_>>();
     let offset_word = SymExpr::from_bytes(&mut cx, offset_bytes);
@@ -1886,7 +1885,7 @@ fn abi_bytes_return_can_encode_symbolic_length() {
 #[test]
 fn symbolic_keccak_is_deterministic_for_same_symbolic_bytes() {
     let mut cx = SymCx::new();
-    let bytes = SymExpr::named_var(&mut cx, "slot_key").into_byte_exprs(&mut cx);
+    let bytes = SymExpr::var(&mut cx, "slot_key").into_byte_exprs(&mut cx);
 
     let first = keccak_word(&mut cx, bytes.clone());
     let second = keccak_word(&mut cx, bytes);
@@ -1899,17 +1898,17 @@ fn symbolic_keccak_is_deterministic_for_same_symbolic_bytes() {
 fn symbolic_keccak_tracks_symbolic_length() {
     let mut cx = SymCx::new();
     let bytes = vec![
-        SymExpr::named_var(&mut cx, "byte_0"),
-        SymExpr::named_var(&mut cx, "byte_1"),
+        SymExpr::var(&mut cx, "byte_0"),
+        SymExpr::var(&mut cx, "byte_1"),
         SymExpr::zero(&mut cx),
     ];
-    let len = SymExpr::named_var(&mut cx, "len");
+    let len = SymExpr::var(&mut cx, "len");
 
     let word = keccak_word_with_len(&mut cx, bytes, len);
 
     let (hash_len, hash_bytes_len) =
         word.keccak_len_and_byte_count().expect("expected symbolic keccak term");
-    assert_eq!(hash_len, &SymExpr::named_var(&mut cx, "len"));
+    assert_eq!(hash_len, &SymExpr::var(&mut cx, "len"));
     assert_eq!(hash_bytes_len, 3);
 }
 
@@ -1918,7 +1917,7 @@ fn sym_expr_eval_computes_symbolic_keccak_from_model() {
     let mut cx = SymCx::new();
     let owner = Address::from([0x11; 20]);
     let slot = U256::from(1);
-    let mut bytes = SymExpr::named_var(&mut cx, "owner").into_byte_exprs(&mut cx);
+    let mut bytes = SymExpr::var(&mut cx, "owner").into_byte_exprs(&mut cx);
     bytes.extend(SymExpr::constant(&mut cx, slot).into_byte_exprs(&mut cx));
     let word = keccak_word(&mut cx, bytes);
 
@@ -1934,8 +1933,7 @@ fn sym_expr_eval_computes_symbolic_keccak_from_model() {
 #[test]
 fn symbolic_hash_precompiles_are_deterministic_for_same_symbolic_input() {
     let mut cx = SymCx::new();
-    let input =
-        vec![SymExpr::named_var(&mut cx, "input_0"), SymExpr::named_var(&mut cx, "input_1")];
+    let input = vec![SymExpr::var(&mut cx, "input_0"), SymExpr::var(&mut cx, "input_1")];
 
     let input_len = SymExpr::constant(&mut cx, U256::from(input.len()));
     let input_bytes = SymBytes::exprs(&mut cx, input.clone());
@@ -2035,7 +2033,7 @@ fn identity_precompile_preserves_symbolic_input_len() {
         SymExpr::constant(&mut cx, U256::from(3)),
         SymExpr::constant(&mut cx, U256::from(4)),
     ];
-    let input_len = SymExpr::named_var(&mut cx, "size");
+    let input_len = SymExpr::var(&mut cx, "size");
     let input = SymBytes::exprs(&mut cx, input);
     let return_data = execute_symbolic_precompile(
         &mut cx,
@@ -2060,7 +2058,7 @@ fn advanced_precompiles_accept_symbolic_payloads() {
     modexp_input[31] = SymExpr::constant(&mut cx, U256::from(1));
     modexp_input[63] = SymExpr::constant(&mut cx, U256::from(1));
     modexp_input[95] = SymExpr::constant(&mut cx, U256::from(1));
-    modexp_input[96] = SymExpr::named_var(&mut cx, "base");
+    modexp_input[96] = SymExpr::var(&mut cx, "base");
     modexp_input[97] = SymExpr::constant(&mut cx, U256::from(5));
     modexp_input[98] = SymExpr::constant(&mut cx, U256::from(13));
 
@@ -2089,7 +2087,7 @@ fn advanced_precompiles_accept_symbolic_payloads() {
     assert_eq!(modexp.len(), 1);
     assert_eq!(modexp.byte(&mut cx, 0), modexp_again.byte(&mut cx, 0));
 
-    let mut blake_input = vec![SymExpr::named_var(&mut cx, "blake_input"); 213];
+    let mut blake_input = vec![SymExpr::var(&mut cx, "blake_input"); 213];
     blake_input[212] = SymExpr::zero(&mut cx);
     let blake_len = SymExpr::constant(&mut cx, U256::from(213));
     let blake_input = SymBytes::exprs(&mut cx, blake_input);
@@ -2108,7 +2106,7 @@ fn advanced_precompiles_accept_symbolic_payloads() {
 #[test]
 fn validity_sensitive_symbolic_precompiles_report_incomplete() {
     let mut cx = SymCx::new();
-    let bn_input = vec![SymExpr::named_var(&mut cx, "point"); 128];
+    let bn_input = vec![SymExpr::var(&mut cx, "point"); 128];
     let bn_len = SymExpr::constant(&mut cx, U256::from(128));
     let bn_input = SymBytes::exprs(&mut cx, bn_input);
     let err = execute_symbolic_precompile(
@@ -2124,7 +2122,7 @@ fn validity_sensitive_symbolic_precompiles_report_incomplete() {
         SymbolicError::Unsupported("symbolic bn254 precompile validity not modeled")
     ));
 
-    let blake_input = vec![SymExpr::named_var(&mut cx, "blake_input"); 213];
+    let blake_input = vec![SymExpr::var(&mut cx, "blake_input"); 213];
     let blake_len = SymExpr::constant(&mut cx, U256::from(213));
     let blake_input = SymBytes::exprs(&mut cx, blake_input);
     let err = execute_symbolic_precompile(
@@ -2145,8 +2143,8 @@ fn validity_sensitive_symbolic_precompiles_report_incomplete() {
 fn symbolic_storage_read_after_write_accepts_symbolic_keys() {
     let mut cx = SymCx::new();
     let address = Address::from([0x11; 20]);
-    let key = SymExpr::named_var(&mut cx, "slot");
-    let value = SymExpr::named_var(&mut cx, "value");
+    let key = SymExpr::var(&mut cx, "slot");
+    let value = SymExpr::var(&mut cx, "value");
     let writes = vec![StorageWrite::new(address, key.clone(), value.clone())];
     let base = SymExpr::zero(&mut cx);
 
@@ -2157,9 +2155,9 @@ fn symbolic_storage_read_after_write_accepts_symbolic_keys() {
 fn symbolic_storage_uses_conditional_value_for_maybe_equal_key() {
     let mut cx = SymCx::new();
     let address = Address::from([0x11; 20]);
-    let write_key = SymExpr::named_var(&mut cx, "write_slot");
-    let read_key = SymExpr::named_var(&mut cx, "read_slot");
-    let value = SymExpr::named_var(&mut cx, "value");
+    let write_key = SymExpr::var(&mut cx, "write_slot");
+    let read_key = SymExpr::var(&mut cx, "read_slot");
+    let value = SymExpr::var(&mut cx, "value");
     let writes = vec![StorageWrite::new(address, write_key.clone(), value.clone())];
     let base = SymExpr::zero(&mut cx);
     let selected = StorageWrite::select_from(&mut cx, &writes, address, read_key.clone(), base);
@@ -2173,17 +2171,17 @@ fn symbolic_storage_uses_conditional_value_for_maybe_equal_key() {
 #[test]
 fn symbolic_storage_key_equality_decomposes_keccak_offsets() {
     let mut cx = SymCx::new();
-    let owner = SymExpr::named_var(&mut cx, "owner");
+    let owner = SymExpr::var(&mut cx, "owner");
     let owner_bytes = owner.into_byte_exprs(&mut cx);
     let base = keccak_word(&mut cx, owner_bytes);
-    let left_index = SymExpr::named_var(&mut cx, "left_index");
-    let right_index = SymExpr::named_var(&mut cx, "right_index");
+    let left_index = SymExpr::var(&mut cx, "left_index");
+    let right_index = SymExpr::var(&mut cx, "right_index");
     let left = add_words(&mut cx, base.clone(), left_index);
     let right = add_words(&mut cx, base, right_index);
 
     let actual = left.storage_key_eq(&mut cx, &right);
-    let left_index = SymExpr::named_var(&mut cx, "left_index");
-    let right_index = SymExpr::named_var(&mut cx, "right_index");
+    let left_index = SymExpr::var(&mut cx, "left_index");
+    let right_index = SymExpr::var(&mut cx, "right_index");
     let expected = SymBoolExpr::eq(&mut cx, left_index, right_index);
     assert_eq!(actual, expected);
 }
@@ -2191,18 +2189,18 @@ fn symbolic_storage_key_equality_decomposes_keccak_offsets() {
 #[test]
 fn symbolic_storage_key_equality_expands_distinct_keccak_bases() {
     let mut cx = SymCx::new();
-    let left_owner = SymExpr::named_var(&mut cx, "left_owner");
+    let left_owner = SymExpr::var(&mut cx, "left_owner");
     let left_base = keccak_word(&mut cx, vec![left_owner]);
-    let right_owner = SymExpr::named_var(&mut cx, "right_owner");
+    let right_owner = SymExpr::var(&mut cx, "right_owner");
     let right_base = keccak_word(&mut cx, vec![right_owner]);
-    let index = SymExpr::named_var(&mut cx, "index");
+    let index = SymExpr::var(&mut cx, "index");
 
     let left = add_words(&mut cx, left_base, index.clone());
     let right = add_words(&mut cx, right_base, index);
     let condition = left.storage_key_eq(&mut cx, &right);
 
-    let left_owner = SymExpr::named_var(&mut cx, "left_owner");
-    let right_owner = SymExpr::named_var(&mut cx, "right_owner");
+    let left_owner = SymExpr::var(&mut cx, "left_owner");
+    let right_owner = SymExpr::var(&mut cx, "right_owner");
     let expected = SymBoolExpr::eq(&mut cx, left_owner, right_owner);
     assert_eq!(condition, expected);
 }
@@ -2210,7 +2208,7 @@ fn symbolic_storage_key_equality_expands_distinct_keccak_bases() {
 #[test]
 fn symbolic_storage_key_equality_rejects_concrete_plain_slot_alias() {
     let mut cx = SymCx::new();
-    let owner = SymExpr::named_var(&mut cx, "owner");
+    let owner = SymExpr::var(&mut cx, "owner");
     let owner = owner.into_byte_exprs(&mut cx);
     let owner = keccak_word(&mut cx, owner);
     let zero = SymExpr::zero(&mut cx);
@@ -2225,9 +2223,9 @@ fn symbolic_storage_key_equality_rejects_concrete_plain_slot_alias() {
 #[test]
 fn nested_mapping_key_does_not_alias_plain_mapping_key_under_model() {
     let mut cx = SymCx::new();
-    let owner = SymExpr::named_var(&mut cx, "owner");
-    let spender = SymExpr::named_var(&mut cx, "spender");
-    let recipient = SymExpr::named_var(&mut cx, "recipient");
+    let owner = SymExpr::var(&mut cx, "owner");
+    let spender = SymExpr::var(&mut cx, "spender");
+    let recipient = SymExpr::var(&mut cx, "recipient");
 
     let mut balance_key_bytes = recipient.into_byte_exprs(&mut cx);
     balance_key_bytes.extend(SymExpr::constant(&mut cx, U256::ZERO).into_byte_exprs(&mut cx));
@@ -2373,7 +2371,7 @@ fn calldata_variant_expansion_respects_path_width() {
 #[test]
 fn symbolic_signextend_uses_sign_bit_ite() {
     let mut cx = SymCx::new();
-    let word = SymExpr::named_var(&mut cx, "word");
+    let word = SymExpr::var(&mut cx, "word");
     let actual = signextend_word(&mut cx, U256::ZERO, word.clone());
     let sign_mask = SymExpr::constant(&mut cx, U256::from(0x80));
     let sign_bit = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), sign_mask);
@@ -2437,7 +2435,7 @@ sat
     #x00)
 )
 ";
-    let calldata = SymExpr::named_var(&mut cx, "calldata_0");
+    let calldata = SymExpr::var(&mut cx, "calldata_0");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraints = vec![SymBoolExpr::eq(&mut cx, calldata, one)];
 
@@ -2449,7 +2447,7 @@ sat
 #[test]
 fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
     let mut cx = SymCx::new();
-    let var = SymExpr::named_var(&mut cx, "calldata_0");
+    let var = SymExpr::var(&mut cx, "calldata_0");
     let msg_sender = U256::from_str_radix("1804c8ab1f12e6bbf3894d4083f33e07309d1f38", 16).unwrap();
     let product = SymExpr::binop(&mut cx, SymBinOp::Mul, var.clone(), var.clone());
     let sender_word = SymExpr::constant(&mut cx, msg_sender);
@@ -2473,7 +2471,7 @@ fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
 #[test]
 fn expression_op_simplifies_exact_arithmetic_identities() {
     let mut cx = SymCx::new();
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
 
     let zero = SymExpr::zero(&mut cx);
     let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, x.clone(), zero.clone());
@@ -2481,35 +2479,35 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
     let one = SymExpr::one(&mut cx);
     let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, one, x.clone());
     assert_eq!(actual, x);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let one = SymExpr::one(&mut cx);
     let actual = SymExpr::binop(&mut cx, SymBinOp::UDiv, x.clone(), one);
     assert_eq!(actual, x);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let one = SymExpr::one(&mut cx);
     let actual = SymExpr::binop(&mut cx, SymBinOp::URem, x, one);
     let zero = SymExpr::zero(&mut cx);
     assert_eq!(actual, zero);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let x_again = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
+    let x_again = SymExpr::var(&mut cx, "x");
     let actual = SymExpr::binop(&mut cx, SymBinOp::Sub, x, x_again);
     let zero = SymExpr::zero(&mut cx);
     assert_eq!(actual, zero);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let actual = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), max);
     assert_eq!(actual, x);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let actual = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), x.clone());
     assert_eq!(actual, x);
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let masked = SymExpr::binop(&mut cx, SymBinOp::And, x, mask.clone());
     let actual = SymExpr::binop(&mut cx, SymBinOp::And, masked.clone(), mask);
     assert_eq!(actual, masked);
     let mask_value = (U256::from(1) << 128) - U256::from(1);
     let mask = SymExpr::constant(&mut cx, mask_value);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let left_masked = SymExpr::binop(&mut cx, SymBinOp::And, mask.clone(), x.clone());
     let right_masked = SymExpr::binop(&mut cx, SymBinOp::And, x, mask);
     assert_eq!(left_masked, right_masked);
@@ -2518,19 +2516,19 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
     let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, six, seven);
     let forty_two = SymExpr::constant(&mut cx, U256::from(42));
     assert_eq!(actual, forty_two);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let scale = SymExpr::constant(&mut cx, U256::from(1) << 128);
     let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, x.clone(), scale);
     let shift = SymExpr::constant(&mut cx, U256::from(128));
     let expected = SymExpr::binop(&mut cx, SymBinOp::Shl, x, shift);
     assert_eq!(actual, expected);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let divisor = SymExpr::constant(&mut cx, U256::from(1) << 128);
     let actual = SymExpr::binop(&mut cx, SymBinOp::UDiv, x.clone(), divisor);
     let shift = SymExpr::constant(&mut cx, U256::from(128));
     let expected = SymExpr::binop(&mut cx, SymBinOp::Shr, x, shift);
     assert_eq!(actual, expected);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let divisor = SymExpr::constant(&mut cx, U256::from(1) << 128);
     let actual = SymExpr::binop(&mut cx, SymBinOp::URem, x.clone(), divisor);
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 128) - U256::from(1));
@@ -2541,8 +2539,8 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
 #[test]
 fn bool_word_equality_simplifies_to_condition() {
     let mut cx = SymCx::new();
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, y);
     let word = SymExpr::bool_word(&mut cx, condition.clone());
 
@@ -2562,8 +2560,8 @@ fn bool_word_equality_simplifies_to_condition() {
 #[test]
 fn inverted_bool_word_equality_simplifies_to_condition() {
     let mut cx = SymCx::new();
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, y);
     let zero = SymExpr::zero(&mut cx);
     let one = SymExpr::one(&mut cx);
@@ -2581,7 +2579,7 @@ fn inverted_bool_word_equality_simplifies_to_condition() {
 fn bool_comparison_folds_reflexive_operands() {
     let mut cx = SymCx::new();
 
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), x.clone());
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
@@ -2607,41 +2605,41 @@ fn bool_comparison_folds_unsigned_boundaries() {
     let mut cx = SymCx::new();
 
     let zero = SymExpr::zero(&mut cx);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, zero, x);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
     let zero = SymExpr::zero(&mut cx);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, zero, x);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let zero = SymExpr::zero(&mut cx);
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, zero);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let zero = SymExpr::zero(&mut cx);
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, x, zero);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, max, x);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, max, x);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x, max);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, x, max);
     let expected = SymBoolExpr::constant(&mut cx, true);
@@ -2658,13 +2656,13 @@ fn exact_modular_arithmetic_handles_zero_modulus_and_wide_intermediates() {
     assert_eq!(U256::MAX.mul_mod(U256::MAX, U256::MAX), U256::ZERO);
 
     let model = symbolic_model(&mut cx, [("a".to_string(), U256::MAX)]);
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, max);
     assert_eq!(addmod.eval_model(&model).unwrap(), U256::from(2));
-    let a = SymExpr::named_var(&mut cx, "a");
-    let a_again = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
+    let a_again = SymExpr::var(&mut cx, "a");
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let mulmod = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a, a_again, max);
     assert_eq!(mulmod.eval_model(&model).unwrap(), U256::ZERO);
@@ -2673,13 +2671,13 @@ fn exact_modular_arithmetic_handles_zero_modulus_and_wide_intermediates() {
 #[test]
 fn exact_modular_arithmetic_smt_widens_before_modulo() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
-    let m = SymExpr::named_var(&mut cx, "m");
+    let m = SymExpr::var(&mut cx, "m");
     let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, m).smt(&cx);
-    let a = SymExpr::named_var(&mut cx, "a");
-    let b = SymExpr::named_var(&mut cx, "b");
-    let m = SymExpr::named_var(&mut cx, "m");
+    let a = SymExpr::var(&mut cx, "a");
+    let b = SymExpr::var(&mut cx, "b");
+    let m = SymExpr::var(&mut cx, "m");
     let mulmod = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a, b, m).smt(&cx);
 
     assert!(addmod.contains("((_ zero_extend 256) a)"));
@@ -2693,8 +2691,8 @@ fn exact_modular_arithmetic_smt_widens_before_modulo() {
 #[test]
 fn power_of_two_modular_arithmetic_uses_low_mask() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
-    let b = SymExpr::named_var(&mut cx, "b");
+    let a = SymExpr::var(&mut cx, "a");
+    let b = SymExpr::var(&mut cx, "b");
     let modulus = SymExpr::constant(&mut cx, U256::from(1) << 128);
     let mulmod = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a, b, modulus);
 
@@ -2714,7 +2712,7 @@ fn power_of_two_modular_arithmetic_uses_low_mask() {
 #[test]
 fn low_masked_power_of_two_division_simplifies_to_shift() {
     let mut cx = SymCx::new();
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 128) - U256::from(1));
     let low = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), mask);
     let numerator = SymExpr::binop(&mut cx, SymBinOp::Sub, x.clone(), low);
@@ -2729,7 +2727,7 @@ fn low_masked_power_of_two_division_simplifies_to_shift() {
 #[test]
 fn low_masked_words_preserve_unsigned_ordering() {
     let mut cx = SymCx::new();
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 128) - U256::from(1));
     let low = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), mask);
 
@@ -2751,7 +2749,7 @@ fn low_masked_words_preserve_unsigned_ordering() {
 #[test]
 fn exact_addmod_model_validation_rejects_wrapping_false_pass() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, max);
@@ -2767,8 +2765,8 @@ fn exact_addmod_model_validation_rejects_wrapping_false_pass() {
 #[test]
 fn solver_normalizes_udiv_zero_predicates_without_bvudiv() {
     let mut cx = SymCx::new();
-    let numerator = SymExpr::named_var(&mut cx, "numerator");
-    let denominator = SymExpr::named_var(&mut cx, "denominator");
+    let numerator = SymExpr::var(&mut cx, "numerator");
+    let denominator = SymExpr::var(&mut cx, "denominator");
     let div = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::eq(&mut cx, div, zero);
@@ -2799,8 +2797,8 @@ fn solver_normalizes_udiv_zero_predicates_without_bvudiv() {
 #[test]
 fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
     let mut cx = SymCx::new();
-    let numerator = SymExpr::named_var(&mut cx, "numerator");
-    let denominator = SymExpr::named_var(&mut cx, "denominator");
+    let numerator = SymExpr::var(&mut cx, "numerator");
+    let denominator = SymExpr::var(&mut cx, "denominator");
     let div = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, div, zero);
@@ -2831,8 +2829,8 @@ fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
 #[test]
 fn solver_normalizes_constraint_batches_by_flattening_and_deduping() {
     let mut cx = SymCx::new();
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let ten = SymExpr::constant(&mut cx, U256::from(10));
     let a = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), ten);
     let three = SymExpr::constant(&mut cx, U256::from(3));
@@ -2860,9 +2858,9 @@ fn solver_normalizes_constraint_batches_by_flattening_and_deduping() {
 #[test]
 fn solver_normalizes_erc4626_style_share_zero_predicate() {
     let mut cx = SymCx::new();
-    let assets = SymExpr::named_var(&mut cx, "assets");
-    let supply = SymExpr::named_var(&mut cx, "supply");
-    let total_assets = SymExpr::named_var(&mut cx, "total_assets");
+    let assets = SymExpr::var(&mut cx, "assets");
+    let supply = SymExpr::var(&mut cx, "supply");
+    let total_assets = SymExpr::var(&mut cx, "total_assets");
     let numerator = SymExpr::binop(&mut cx, SymBinOp::Mul, assets, supply);
     let shares = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, total_assets);
     let zero = SymExpr::zero(&mut cx);
@@ -2877,7 +2875,7 @@ fn solver_normalizes_erc4626_style_share_zero_predicate() {
 #[test]
 fn expression_rebuilds_word_from_extracted_byte_terms() {
     let mut cx = SymCx::new();
-    let word = SymExpr::named_var(&mut cx, "word");
+    let word = SymExpr::var(&mut cx, "word");
     let mask = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let masked = SymExpr::binop(&mut cx, SymBinOp::And, word, mask);
     let bytes = masked.clone().into_byte_exprs(&mut cx);
@@ -2889,7 +2887,7 @@ fn expression_rebuilds_word_from_extracted_byte_terms() {
 #[test]
 fn expression_rebuilds_word_from_shifted_fragments() {
     let mut cx = SymCx::new();
-    let word = SymExpr::named_var(&mut cx, "word");
+    let word = SymExpr::var(&mut cx, "word");
     let low_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
     let low_bits = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), low_mask);
     let shift = SymExpr::constant(&mut cx, U256::from(32));
@@ -2905,8 +2903,8 @@ fn expression_rebuilds_word_from_shifted_fragments() {
 #[test]
 fn expression_simplifies_selector_prefixed_word_fragment() {
     let mut cx = SymCx::new();
-    let x = SymExpr::named_var(&mut cx, "calldata_0");
-    let y = SymExpr::named_var(&mut cx, "calldata_1");
+    let x = SymExpr::var(&mut cx, "calldata_0");
+    let y = SymExpr::var(&mut cx, "calldata_1");
     let low_32 = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
     let low_224 = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 224));
     let selector = SymExpr::constant(&mut cx, U256::from(0x771602f7u64) << 224);
@@ -2956,10 +2954,10 @@ fn checked_mul_guard_word(cx: &mut SymCx, zero_operand: &SymExpr, expected: &Sym
 #[test]
 fn solver_normalizes_checked_mul_guard_for_bounded_operands() {
     let mut cx = SymCx::new();
-    let a_word = SymExpr::named_var(&mut cx, "a");
+    let a_word = SymExpr::var(&mut cx, "a");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let a = SymExpr::binop(&mut cx, SymBinOp::And, a_word, u64_max);
-    let b_word = SymExpr::named_var(&mut cx, "b");
+    let b_word = SymExpr::var(&mut cx, "b");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let b = SymExpr::binop(&mut cx, SymBinOp::And, b_word, u64_max);
     let guard = checked_mul_guard_word(&mut cx, &a, &b);
@@ -2975,7 +2973,7 @@ fn solver_normalizes_checked_mul_guard_for_bounded_operands() {
 #[test]
 fn solver_normalizes_checked_mul_guard_from_path_upper_bound() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let factor = SymExpr::constant(&mut cx, U256::from(1_000_000_000_000_000_000u128));
     let guard = checked_mul_guard_word(&mut cx, &a, &factor);
     let zero = SymExpr::zero(&mut cx);
@@ -2996,7 +2994,7 @@ fn solver_normalizes_checked_mul_guard_from_path_upper_bound() {
 #[test]
 fn solver_normalizes_guarded_self_division_guard() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
@@ -3020,7 +3018,7 @@ fn solver_normalizes_guarded_self_division_guard() {
 #[test]
 fn expression_normalizes_guarded_self_division_word() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
@@ -3043,7 +3041,7 @@ fn expression_normalizes_guarded_self_division_word() {
 #[test]
 fn solver_does_not_invert_guarded_zero_self_division() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
@@ -3059,7 +3057,7 @@ fn solver_does_not_invert_guarded_zero_self_division() {
 #[test]
 fn solver_normalizes_guarded_self_division_add_overflow_guard() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
@@ -3077,7 +3075,7 @@ fn solver_normalizes_guarded_self_division_add_overflow_guard() {
 #[test]
 fn solver_normalizes_checked_mul_guard_with_context_bound() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let scale = SymExpr::constant(&mut cx, U256::from(1_000_000_000_000_000_000u128));
     let guard = checked_mul_guard_word(&mut cx, &a, &scale);
     let zero = SymExpr::zero(&mut cx);
@@ -3096,7 +3094,7 @@ fn solver_normalizes_checked_mul_guard_with_context_bound() {
 #[test]
 fn solver_does_not_context_normalize_checked_mul_guard_without_tight_bound() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let scale = SymExpr::constant(&mut cx, U256::from(1_000_000_000_000_000_000u128));
     let guard = checked_mul_guard_word(&mut cx, &a, &scale);
     let zero = SymExpr::zero(&mut cx);
@@ -3120,8 +3118,8 @@ fn solver_does_not_context_normalize_checked_mul_guard_without_tight_bound() {
 #[test]
 fn solver_does_not_normalize_unbounded_checked_mul_guard_to_tautology() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
-    let b = SymExpr::named_var(&mut cx, "b");
+    let a = SymExpr::var(&mut cx, "a");
+    let b = SymExpr::var(&mut cx, "b");
     let guard = checked_mul_guard_word(&mut cx, &a, &b);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::eq(&mut cx, guard, zero);
@@ -3138,7 +3136,7 @@ fn solver_does_not_normalize_unbounded_checked_mul_guard_to_tautology() {
 #[test]
 fn solver_does_not_normalize_checked_mul_guard_when_path_bound_can_overflow() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let factor = SymExpr::constant(&mut cx, U256::from(2));
     let guard = checked_mul_guard_word(&mut cx, &a, &factor);
     let zero = SymExpr::zero(&mut cx);
@@ -3157,14 +3155,14 @@ fn solver_does_not_normalize_checked_mul_guard_when_path_bound_can_overflow() {
 #[test]
 fn solver_normalizes_checked_add_overflow_guard_for_bounded_operands() {
     let mut cx = SymCx::new();
-    let a_raw = SymExpr::named_var(&mut cx, "a");
+    let a_raw = SymExpr::var(&mut cx, "a");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let a = SymExpr::binop(&mut cx, SymBinOp::And, a_raw, u64_max);
-    let b_raw = SymExpr::named_var(&mut cx, "b");
+    let b_raw = SymExpr::var(&mut cx, "b");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let b_masked = SymExpr::binop(&mut cx, SymBinOp::And, b_raw, u64_max);
     let numerator = SymExpr::binop(&mut cx, SymBinOp::Mul, b_masked, a.clone());
-    let denominator_raw = SymExpr::named_var(&mut cx, "denominator");
+    let denominator_raw = SymExpr::var(&mut cx, "denominator");
     let high_mask = SymExpr::constant(&mut cx, U256::MAX >> 64);
     let denominator = SymExpr::binop(&mut cx, SymBinOp::And, denominator_raw, high_mask);
     let b = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
@@ -3180,8 +3178,8 @@ fn solver_normalizes_checked_add_overflow_guard_for_bounded_operands() {
 #[test]
 fn solver_does_not_normalize_unbounded_checked_add_overflow_guard() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
-    let b = SymExpr::named_var(&mut cx, "b");
+    let a = SymExpr::var(&mut cx, "a");
+    let b = SymExpr::var(&mut cx, "b");
     let sum = SymExpr::binop(&mut cx, SymBinOp::Add, a.clone(), b);
     let original = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a, sum);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
@@ -3197,16 +3195,16 @@ fn solver_does_not_normalize_unbounded_checked_add_overflow_guard() {
 #[test]
 fn solver_detects_monotonic_product_contradiction() {
     let mut cx = SymCx::new();
-    let ink_word = SymExpr::named_var(&mut cx, "ink");
+    let ink_word = SymExpr::var(&mut cx, "ink");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let ink = SymExpr::binop(&mut cx, SymBinOp::And, ink_word, u64_max);
-    let art_word = SymExpr::named_var(&mut cx, "art");
+    let art_word = SymExpr::var(&mut cx, "art");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let art = SymExpr::binop(&mut cx, SymBinOp::And, art_word, u64_max);
-    let spot_word = SymExpr::named_var(&mut cx, "spot");
+    let spot_word = SymExpr::var(&mut cx, "spot");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let spot = SymExpr::binop(&mut cx, SymBinOp::And, spot_word, u64_max);
-    let rate_word = SymExpr::named_var(&mut cx, "rate");
+    let rate_word = SymExpr::var(&mut cx, "rate");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let rate = SymExpr::binop(&mut cx, SymBinOp::And, rate_word, u64_max);
     let zero = SymExpr::zero(&mut cx);
@@ -3226,10 +3224,10 @@ fn solver_detects_monotonic_product_contradiction() {
 #[test]
 fn solver_does_not_prune_wrapping_product_inequality() {
     let mut cx = SymCx::new();
-    let ink = SymExpr::named_var(&mut cx, "ink");
-    let art = SymExpr::named_var(&mut cx, "art");
-    let spot = SymExpr::named_var(&mut cx, "spot");
-    let rate = SymExpr::named_var(&mut cx, "rate");
+    let ink = SymExpr::var(&mut cx, "ink");
+    let art = SymExpr::var(&mut cx, "art");
+    let spot = SymExpr::var(&mut cx, "spot");
+    let rate = SymExpr::var(&mut cx, "rate");
     let zero = SymExpr::zero(&mut cx);
     let ink_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, ink.clone(), zero.clone());
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
@@ -3258,8 +3256,8 @@ fn solver_does_not_prune_wrapping_product_inequality() {
 #[test]
 fn hard_arithmetic_detection_flags_symbolic_mul_div_and_mod() {
     let mut cx = SymCx::new();
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
 
     assert!(SymExpr::binop(&mut cx, SymBinOp::Mul, x.clone(), y.clone()).contains_hard_arith());
     assert!(SymExpr::binop(&mut cx, SymBinOp::UDiv, x.clone(), y.clone()).contains_hard_arith());
@@ -3272,9 +3270,9 @@ fn hard_arithmetic_detection_flags_symbolic_mul_div_and_mod() {
 #[test]
 fn hard_arithmetic_fallback_finds_multi_variable_candidate() {
     let mut cx = SymCx::new();
-    let first = SymExpr::named_var(&mut cx, "first");
-    let donation = SymExpr::named_var(&mut cx, "donation");
-    let second = SymExpr::named_var(&mut cx, "second");
+    let first = SymExpr::var(&mut cx, "first");
+    let donation = SymExpr::var(&mut cx, "donation");
+    let second = SymExpr::var(&mut cx, "second");
     let denominator = SymExpr::binop(&mut cx, SymBinOp::Add, first.clone(), donation.clone());
     let numerator = SymExpr::binop(&mut cx, SymBinOp::Mul, second.clone(), first.clone());
     let shares = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
@@ -3293,10 +3291,10 @@ fn hard_arithmetic_fallback_finds_multi_variable_candidate() {
 #[test]
 fn hard_arithmetic_fallback_finds_wrapping_product_inequality_candidate() {
     let mut cx = SymCx::new();
-    let ink = SymExpr::named_var(&mut cx, "ink");
-    let art = SymExpr::named_var(&mut cx, "art");
-    let spot = SymExpr::named_var(&mut cx, "spot");
-    let rate = SymExpr::named_var(&mut cx, "rate");
+    let ink = SymExpr::var(&mut cx, "ink");
+    let art = SymExpr::var(&mut cx, "art");
+    let spot = SymExpr::var(&mut cx, "spot");
+    let rate = SymExpr::var(&mut cx, "rate");
     let zero = SymExpr::zero(&mut cx);
     let ink_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, ink.clone(), zero.clone());
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
@@ -3316,7 +3314,7 @@ fn hard_arithmetic_fallback_finds_wrapping_product_inequality_candidate() {
 #[test]
 fn hard_arithmetic_fallback_finds_exact_mulmod_wide_intermediate_candidate() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
+    let a = SymExpr::var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a.clone(), zero.clone());
     let max = SymExpr::constant(&mut cx, U256::MAX);
@@ -3333,12 +3331,12 @@ fn hard_arithmetic_fallback_finds_exact_mulmod_wide_intermediate_candidate() {
 #[test]
 fn hard_arithmetic_fallback_rejects_unvalidated_partial_model() {
     let mut cx = SymCx::new();
-    let a = SymExpr::named_var(&mut cx, "a");
-    let b = SymExpr::named_var(&mut cx, "b");
-    let c = SymExpr::named_var(&mut cx, "c");
-    let d = SymExpr::named_var(&mut cx, "d");
-    let e = SymExpr::named_var(&mut cx, "e");
-    let f = SymExpr::named_var(&mut cx, "f");
+    let a = SymExpr::var(&mut cx, "a");
+    let b = SymExpr::var(&mut cx, "b");
+    let c = SymExpr::var(&mut cx, "c");
+    let d = SymExpr::var(&mut cx, "d");
+    let e = SymExpr::var(&mut cx, "e");
+    let f = SymExpr::var(&mut cx, "f");
     let product = SymExpr::binop(&mut cx, SymBinOp::Mul, a, b);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let product_eq_one = SymBoolExpr::eq(&mut cx, product, one);
@@ -3360,7 +3358,7 @@ fn hard_arithmetic_fallback_rejects_unvalidated_partial_model() {
 #[test]
 fn hard_arithmetic_fallback_skips_symbolic_hashes() {
     let mut cx = SymCx::new();
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let hash_symbol = cx.intern("hash");
     let hash = SymExpr::hash_symbol(&mut cx, hash_symbol, "sha256", vec![x.clone()]);
     let product = SymExpr::binop(&mut cx, SymBinOp::Mul, x, hash);
@@ -3608,7 +3606,7 @@ fn is_sat_uses_single_var_witness_before_solver() {
     let marker = portfolio_test_marker("single-var-is-sat");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let value = SymExpr::named_var(&mut cx, "calldata_0");
+    let value = SymExpr::var(&mut cx, "calldata_0");
     let limit = SymExpr::constant(&mut cx, U256::from(10));
     let constraints = vec![SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, value, limit)];
 
@@ -3649,7 +3647,7 @@ fn gasleft_fails_at_smt_emission() {
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
     let gas = SymExpr::gas_left(&mut cx, 0);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let constraints = vec![SymBoolExpr::eq(&mut cx, gas, x)];
 
     let err = solver.is_sat(&mut cx, &constraints).unwrap_err();
@@ -3669,7 +3667,7 @@ fn model_uses_single_var_witness_before_solver() {
     let marker = portfolio_test_marker("single-var-model");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let value = SymExpr::named_var(&mut cx, "calldata_0");
+    let value = SymExpr::var(&mut cx, "calldata_0");
     let zero = SymExpr::zero(&mut cx);
     let not_zero = SymBoolExpr::eq(&mut cx, value.clone(), zero).not(&mut cx);
     let limit = SymExpr::constant(&mut cx, U256::from(10));
@@ -3694,8 +3692,8 @@ fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
     let marker = portfolio_test_marker("hard-arith-is-sat");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
     let x_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), zero.clone());
     let y_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, y.clone(), zero);
@@ -3727,8 +3725,8 @@ fn model_uses_validated_hard_arithmetic_fallback_cache() {
     let marker = portfolio_test_marker("hard-arith-model-cache");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
     let x_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), zero.clone());
     let y_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, y.clone(), zero);
@@ -3761,8 +3759,8 @@ fn is_sat_hard_arithmetic_without_witness_still_honors_solver_unsat() {
     let marker = portfolio_test_marker("hard-arith-is-sat-unsat");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
     let x_is_zero = SymBoolExpr::eq(&mut cx, x.clone(), zero);
     let product = SymExpr::binop(&mut cx, SymBinOp::Mul, x, y);
@@ -3790,8 +3788,8 @@ fn sat_cache_reuses_normalized_is_sat_results() {
     let marker = portfolio_test_marker("sat-cache");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let constraints = vec![
@@ -3822,8 +3820,8 @@ fn sat_cache_reuses_nested_commutative_results() {
     let marker = portfolio_test_marker("sat-cache-canonical");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let three = SymExpr::constant(&mut cx, U256::from(3));
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let sum = SymExpr::binop(&mut cx, SymBinOp::Add, x.clone(), y.clone());
@@ -3831,7 +3829,7 @@ fn sat_cache_reuses_nested_commutative_results() {
     let x_eq_one = SymBoolExpr::eq(&mut cx, x.clone(), one.clone());
     let constraints = vec![SymBoolExpr::and(&mut cx, vec![sum_eq_three, x_eq_one])];
     let one_eq_x = SymBoolExpr::eq(&mut cx, one, x);
-    let x_again = SymExpr::named_var(&mut cx, "x");
+    let x_again = SymExpr::var(&mut cx, "x");
     let reordered_sum = SymExpr::binop(&mut cx, SymBinOp::Add, y, x_again);
     let three_eq_sum = SymBoolExpr::eq(&mut cx, three, reordered_sum);
     let reordered_constraints = vec![SymBoolExpr::and(&mut cx, vec![one_eq_x, three_eq_sum])];
@@ -3854,8 +3852,8 @@ fn sat_cache_deduplicates_repeated_constraints() {
     let marker = portfolio_test_marker("sat-cache-dedup");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -3881,8 +3879,8 @@ fn sat_cache_deduplicates_nested_repeated_constraints() {
     let marker = portfolio_test_marker("sat-cache-nested-dedup");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -3911,9 +3909,9 @@ fn sat_cache_flattens_grouped_conjunction_keys() {
     let marker = portfolio_test_marker("sat-cache-and-flatten");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
-    let z = SymExpr::named_var(&mut cx, "z");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
+    let z = SymExpr::var(&mut cx, "z");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let a = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -3942,8 +3940,8 @@ fn sat_cache_reuses_reversed_comparisons() {
     let marker = portfolio_test_marker("sat-cache-reversed-cmp");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 3, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
 
     let ugt = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), y.clone());
     assert!(solver.is_sat(&mut cx, &[ugt]).unwrap());
@@ -3973,8 +3971,8 @@ fn sat_cache_reuses_unsat_branch_complement() {
     let marker = portfolio_test_marker("sat-cache-branch-complement");
     let commands = vec![counted_solver_command_sequence(&marker, &["sat", "unsat"])];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let ten = SymExpr::constant(&mut cx, U256::from(10));
     let x_lt_ten = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), ten);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -4007,7 +4005,7 @@ fn sat_cache_does_not_reuse_unsat_branch_complement_with_unsat_base() {
     let marker = portfolio_test_marker("sat-cache-unsat-base-branch-complement");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let lower = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, x.clone(), two);
@@ -4034,8 +4032,8 @@ fn sat_cache_does_not_cache_unknown_results() {
     let marker = portfolio_test_marker("sat-cache-unknown");
     let commands = vec![counted_solver_command(&marker, "unknown")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 4, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -4065,8 +4063,8 @@ fn model_cache_reuses_normalized_model_results() {
         #x0000000000000000000000000000000000000000000000000000000000000002))";
     let commands = vec![counted_solver_command(&marker, model_output)];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let constraints = vec![
@@ -4104,8 +4102,8 @@ fn model_query_populates_sat_cache() {
         #x0000000000000000000000000000000000000000000000000000000000000002))";
     let commands = vec![counted_solver_command(&marker, model_output)];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -4130,7 +4128,7 @@ fn model_query_populates_sat_cache() {
 fn direct_contradiction_is_sat_short_circuits_locally() {
     let mut cx = SymCx::new();
     let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraint = SymBoolExpr::eq(&mut cx, x, one);
     let constraints = vec![constraint.clone(), constraint.not(&mut cx)];
@@ -4150,13 +4148,13 @@ fn is_sat_reuses_cached_unsat_subset() {
     let marker = portfolio_test_marker("unsat-subset-cache");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
-    let y = SymExpr::named_var(&mut cx, "y");
+    let y = SymExpr::var(&mut cx, "y");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
-    let z = SymExpr::named_var(&mut cx, "z");
+    let z = SymExpr::var(&mut cx, "z");
     let three = SymExpr::constant(&mut cx, U256::from(3));
     let z_eq_three = SymBoolExpr::eq(&mut cx, z, three);
     let unsat_subset = vec![x_eq_one.clone(), y_eq_two.clone()];
@@ -4182,13 +4180,13 @@ fn is_sat_does_not_reuse_cached_sat_subset() {
     let marker = portfolio_test_marker("sat-subset-cache");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
+    let x = SymExpr::var(&mut cx, "x");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
-    let y = SymExpr::named_var(&mut cx, "y");
+    let y = SymExpr::var(&mut cx, "y");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
-    let z = SymExpr::named_var(&mut cx, "z");
+    let z = SymExpr::var(&mut cx, "z");
     let three = SymExpr::constant(&mut cx, U256::from(3));
     let z_eq_three = SymBoolExpr::eq(&mut cx, z, three);
     let sat_subset = vec![x_eq_one.clone(), y_eq_two.clone()];
@@ -4215,8 +4213,8 @@ fn model_short_circuits_when_sat_cache_proved_unsat() {
     let marker = portfolio_test_marker("model-cache-unsat");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -4319,8 +4317,8 @@ fn portfolio_scheduler_promotes_recent_sat_winner() {
     ];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 2, false);
 
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let zero = SymExpr::zero(&mut cx);
     let first = vec![
@@ -4366,8 +4364,8 @@ fn portfolio_scheduler_promotes_recent_unsat_winner() {
 
     solver.capture_diagnostics();
 
-    let x = SymExpr::named_var(&mut cx, "x");
-    let y = SymExpr::named_var(&mut cx, "y");
+    let x = SymExpr::var(&mut cx, "x");
+    let y = SymExpr::var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let zero = SymExpr::zero(&mut cx);
     let first = vec![
@@ -4420,10 +4418,10 @@ fn portfolio_scheduler_penalizes_invalid_models() {
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 16, false);
 
     for query in 0..=PORTFOLIO_SCHEDULER_HISTORY {
-        let calldata = SymExpr::named_var(&mut cx, "calldata_0");
+        let calldata = SymExpr::var(&mut cx, "calldata_0");
         let one = SymExpr::constant(&mut cx, U256::from(1));
         let calldata_constraint = SymBoolExpr::eq(&mut cx, calldata, one);
-        let portfolio_query = SymExpr::named_var(&mut cx, &format!("portfolio_query_{query}"));
+        let portfolio_query = SymExpr::var(&mut cx, &format!("portfolio_query_{query}"));
         let zero = SymExpr::zero(&mut cx);
         let query_constraint = SymBoolExpr::eq(&mut cx, portfolio_query, zero);
         let constraints = vec![calldata_constraint, query_constraint];
@@ -4557,7 +4555,7 @@ fn solver_smt_dump_shares_repeated_subterms() {
         .unwrap(),
     ];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 1, true);
-    let calldata = SymExpr::named_var(&mut cx, "calldata_0");
+    let calldata = SymExpr::var(&mut cx, "calldata_0");
     let byte = calldata.extracted_byte(&mut cx, 0);
     let shift = SymExpr::constant(&mut cx, U256::from(248));
     let shifted = SymExpr::binop(&mut cx, SymBinOp::Shl, byte, shift);

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -31,6 +31,17 @@ fn precompile_address(index: u8) -> Address {
     Address::from(bytes)
 }
 
+fn symbolic_model<S: AsRef<str>>(
+    cx: &mut SymCx,
+    values: impl IntoIterator<Item = (S, U256)>,
+) -> SymbolicModel {
+    values.into_iter().map(|(name, value)| (cx.intern(name.as_ref()), value)).collect()
+}
+
+fn model_value(cx: &SymCx, model: &SymbolicModel, name: &str) -> Option<U256> {
+    model.get(&cx.symbol(name)).copied()
+}
+
 #[test]
 fn precompile_number_respects_active_spec() {
     for number in 1..=4 {
@@ -96,13 +107,13 @@ fn exp_helper_expands_symbolic_base_for_bounded_concrete_exponent() {
     let mut cx = SymCx::new();
     let mut state = empty_state(&mut cx);
     state.stack.push(SymExpr::constant(&mut cx, U256::from(16))).unwrap();
-    state.stack.push(SymExpr::var(&mut cx, "base")).unwrap();
+    state.stack.push(SymExpr::named_var(&mut cx, "base")).unwrap();
 
     state.exp_word(&mut cx).unwrap();
 
     let result = state.stack.pop().unwrap();
     assert_eq!(
-        result.eval_model(&BTreeMap::from([("base".to_string(), U256::from(2))])).unwrap(),
+        result.eval_model(&symbolic_model(&mut cx, [("base".to_string(), U256::from(2))])).unwrap(),
         U256::from(65536)
     );
 }
@@ -111,7 +122,7 @@ fn exp_helper_expands_symbolic_base_for_bounded_concrete_exponent() {
 fn exp_helper_expands_bounded_symbolic_exponent() {
     let mut cx = SymCx::new();
     let mut state = empty_state(&mut cx);
-    let exponent = SymExpr::var(&mut cx, "exponent");
+    let exponent = SymExpr::named_var(&mut cx, "exponent");
     let five = SymExpr::constant(&mut cx, U256::from(5));
     let bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, exponent.clone(), five);
     state.constraints.push(bound);
@@ -122,7 +133,9 @@ fn exp_helper_expands_bounded_symbolic_exponent() {
 
     let result = state.stack.pop().unwrap();
     assert_eq!(
-        result.eval_model(&BTreeMap::from([("exponent".to_string(), U256::from(5))])).unwrap(),
+        result
+            .eval_model(&symbolic_model(&mut cx, [("exponent".to_string(), U256::from(5))]))
+            .unwrap(),
         U256::from(243)
     );
 }
@@ -132,42 +145,52 @@ fn shift_helpers_accept_symbolic_amounts() {
     let mut cx = SymCx::new();
     let mut shl = empty_state(&mut cx);
     shl.stack.push(SymExpr::constant(&mut cx, U256::from(1))).unwrap();
-    shl.stack.push(SymExpr::var(&mut cx, "shift")).unwrap();
+    shl.stack.push(SymExpr::named_var(&mut cx, "shift")).unwrap();
     shl.shift_word(&mut cx, ShiftKind::Shl).unwrap();
     let shifted = shl.stack.pop().unwrap();
 
     assert_eq!(
-        shifted.eval_model(&BTreeMap::from([("shift".to_string(), U256::from(5))])).unwrap(),
+        shifted
+            .eval_model(&symbolic_model(&mut cx, [("shift".to_string(), U256::from(5))]))
+            .unwrap(),
         U256::from(32)
     );
     assert_eq!(
-        shifted.eval_model(&BTreeMap::from([("shift".to_string(), U256::from(256))])).unwrap(),
+        shifted
+            .eval_model(&symbolic_model(&mut cx, [("shift".to_string(), U256::from(256))]))
+            .unwrap(),
         U256::ZERO
     );
 
     let mut shr = empty_state(&mut cx);
     shr.stack.push(SymExpr::constant(&mut cx, U256::from(1) << 255)).unwrap();
-    shr.stack.push(SymExpr::var(&mut cx, "shift")).unwrap();
+    shr.stack.push(SymExpr::named_var(&mut cx, "shift")).unwrap();
     shr.shift_word(&mut cx, ShiftKind::Shr).unwrap();
     let shifted = shr.stack.pop().unwrap();
 
     assert_eq!(
-        shifted.eval_model(&BTreeMap::from([("shift".to_string(), U256::from(255))])).unwrap(),
+        shifted
+            .eval_model(&symbolic_model(&mut cx, [("shift".to_string(), U256::from(255))]))
+            .unwrap(),
         U256::from(1)
     );
     assert_eq!(
-        shifted.eval_model(&BTreeMap::from([("shift".to_string(), U256::from(256))])).unwrap(),
+        shifted
+            .eval_model(&symbolic_model(&mut cx, [("shift".to_string(), U256::from(256))]))
+            .unwrap(),
         U256::ZERO
     );
 
     let mut sar = empty_state(&mut cx);
     sar.stack.push(SymExpr::constant(&mut cx, U256::MAX)).unwrap();
-    sar.stack.push(SymExpr::var(&mut cx, "shift")).unwrap();
+    sar.stack.push(SymExpr::named_var(&mut cx, "shift")).unwrap();
     sar.shift_word(&mut cx, ShiftKind::Sar).unwrap();
     let shifted = sar.stack.pop().unwrap();
 
     assert_eq!(
-        shifted.eval_model(&BTreeMap::from([("shift".to_string(), U256::from(300))])).unwrap(),
+        shifted
+            .eval_model(&symbolic_model(&mut cx, [("shift".to_string(), U256::from(300))]))
+            .unwrap(),
         U256::MAX
     );
 }
@@ -176,15 +199,15 @@ fn shift_helpers_accept_symbolic_amounts() {
 fn symbolic_division_guards_zero_divisor() {
     let mut cx = SymCx::new();
     let mut state = empty_state(&mut cx);
-    state.stack.push(SymExpr::var(&mut cx, "den")).unwrap();
-    state.stack.push(SymExpr::var(&mut cx, "num")).unwrap();
+    state.stack.push(SymExpr::named_var(&mut cx, "den")).unwrap();
+    state.stack.push(SymExpr::named_var(&mut cx, "num")).unwrap();
 
     state.bin_word_div_zero_guard(&mut cx, SymBinOp::UDiv).unwrap();
 
-    let den = SymExpr::var(&mut cx, "den");
+    let den = SymExpr::named_var(&mut cx, "den");
     let zero = SymExpr::zero(&mut cx);
     let den_is_zero = SymBoolExpr::eq(&mut cx, den.clone(), zero.clone());
-    let num = SymExpr::var(&mut cx, "num");
+    let num = SymExpr::named_var(&mut cx, "num");
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, num, den);
     let expected = SymExpr::ite(&mut cx, den_is_zero, zero, quotient);
     assert_eq!(state.stack.pop().unwrap(), expected);
@@ -193,7 +216,7 @@ fn symbolic_division_guards_zero_divisor() {
 #[test]
 fn symbolic_byte_extracts_with_concrete_index() {
     let mut cx = SymCx::new();
-    let word = SymExpr::var(&mut cx, "word");
+    let word = SymExpr::named_var(&mut cx, "word");
     let actual = byte_word(&mut cx, U256::from(0), word.clone());
     let shift = SymExpr::constant(&mut cx, U256::from(248));
     let shifted = SymExpr::binop(&mut cx, SymBinOp::Shr, word, shift);
@@ -206,14 +229,14 @@ fn symbolic_byte_extracts_with_concrete_index() {
 fn symbolic_byte_extracts_with_symbolic_index() {
     let mut cx = SymCx::new();
     let word = U256::from_be_bytes(core::array::from_fn::<_, 32, _>(|idx| idx as u8));
-    let index = SymExpr::var(&mut cx, "index");
+    let index = SymExpr::named_var(&mut cx, "index");
     let word = SymExpr::constant(&mut cx, word);
     let byte = byte_word_dynamic(&mut cx, index, word);
 
-    let in_range = BTreeMap::from([("index".to_string(), U256::from(9))]);
+    let in_range = symbolic_model(&mut cx, [("index".to_string(), U256::from(9))]);
     assert_eq!(byte.eval_model(&in_range).unwrap(), U256::from(9));
 
-    let out_of_range = BTreeMap::from([("index".to_string(), U256::from(32))]);
+    let out_of_range = symbolic_model(&mut cx, [("index".to_string(), U256::from(32))]);
     assert_eq!(byte.eval_model(&out_of_range).unwrap(), U256::ZERO);
 }
 
@@ -221,13 +244,13 @@ fn symbolic_byte_extracts_with_symbolic_index() {
 fn symbolic_signextend_accepts_symbolic_index() {
     let mut cx = SymCx::new();
     let value = SymExpr::constant(&mut cx, U256::from(0x80));
-    let index = SymExpr::var(&mut cx, "index");
+    let index = SymExpr::named_var(&mut cx, "index");
     let extended = signextend_word_dynamic(&mut cx, index, value);
 
-    let zero_index = BTreeMap::from([("index".to_string(), U256::ZERO)]);
+    let zero_index = symbolic_model(&mut cx, [("index".to_string(), U256::ZERO)]);
     assert_eq!(extended.eval_model(&zero_index).unwrap(), U256::MAX - U256::from(0x7f));
 
-    let one_index = BTreeMap::from([("index".to_string(), U256::from(1))]);
+    let one_index = symbolic_model(&mut cx, [("index".to_string(), U256::from(1))]);
     assert_eq!(extended.eval_model(&one_index).unwrap(), U256::from(0x80));
 }
 
@@ -238,7 +261,7 @@ fn symbolic_byte_preserves_concrete_packed_selector_bytes() {
     let selector = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
     let selector = SymExpr::binop(&mut cx, SymBinOp::Shl, selector, shift_224);
-    let arg = SymExpr::var(&mut cx, "arg");
+    let arg = SymExpr::named_var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
     let shifted_arg = SymExpr::binop(&mut cx, SymBinOp::Shr, arg, shift_32);
     let packed = SymExpr::binop(&mut cx, SymBinOp::Or, selector, shifted_arg);
@@ -264,7 +287,7 @@ fn symbolic_byte_preserves_concrete_packed_selector_bytes() {
 #[test]
 fn word_reassembly_preserves_split_symbolic_word() {
     let mut cx = SymCx::new();
-    let value = SymExpr::var(&mut cx, "value");
+    let value = SymExpr::named_var(&mut cx, "value");
     let one = SymExpr::one(&mut cx);
     let original = SymExpr::binop(&mut cx, SymBinOp::Add, value, one);
     let bytes = original.clone().into_byte_exprs(&mut cx);
@@ -275,7 +298,7 @@ fn word_reassembly_preserves_split_symbolic_word() {
 #[test]
 fn symbolic_address_aliases_match_abi_encoded_address_words() {
     let mut cx = SymCx::new();
-    let source = SymExpr::var(&mut cx, "beneficiary");
+    let source = SymExpr::named_var(&mut cx, "beneficiary");
     let address_mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
     let masked = SymExpr::binop(&mut cx, SymBinOp::And, source.clone(), address_mask);
     let mut encoded = vec![SymExpr::zero(&mut cx); 12];
@@ -293,7 +316,7 @@ fn selector_shift_simplifies_to_concrete_word() {
     let selector_word = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
     let shifted_selector = SymExpr::binop(&mut cx, SymBinOp::Shl, selector_word, shift_224.clone());
-    let arg = SymExpr::var(&mut cx, "arg");
+    let arg = SymExpr::named_var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
     let shifted_arg = SymExpr::binop(&mut cx, SymBinOp::Shr, arg, shift_32);
     let call_word = SymExpr::binop(&mut cx, SymBinOp::Or, shifted_selector, shifted_arg);
@@ -310,7 +333,7 @@ fn selector_equality_folds_known_word_expressions() {
     let selector_word = SymExpr::constant(&mut cx, selector);
     let shift_224 = SymExpr::constant(&mut cx, U256::from(224));
     let shifted_selector = SymExpr::binop(&mut cx, SymBinOp::Shl, selector_word, shift_224.clone());
-    let arg = SymExpr::var(&mut cx, "arg");
+    let arg = SymExpr::named_var(&mut cx, "arg");
     let shift_32 = SymExpr::constant(&mut cx, U256::from(32));
     let shifted_arg = SymExpr::binop(&mut cx, SymBinOp::Shr, arg, shift_32);
     let call_word = SymExpr::binop(&mut cx, SymBinOp::Or, shifted_selector, shifted_arg);
@@ -378,11 +401,14 @@ fn dynamic_calldata_encodes_bounded_bytes() {
     let bytes = call_data.read_bytes_offset(&mut cx, offset, 1);
     assert_eq!(bytes.byte(&mut cx, 0), SymExpr::zero(&mut cx));
 
-    let model = BTreeMap::from([
-        ("calldata_0_0".to_string(), U256::from(1)),
-        ("calldata_0_1".to_string(), U256::from(2)),
-        ("calldata_0_2".to_string(), U256::from(3)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [
+            ("calldata_0_0".to_string(), U256::from(1)),
+            ("calldata_0_1".to_string(), U256::from(2)),
+            ("calldata_0_2".to_string(), U256::from(3)),
+        ],
+    );
     assert_eq!(
         calldata.model_to_args(&mut cx, &model).unwrap(),
         vec![DynSolValue::Bytes(vec![1, 2, 3])]
@@ -436,9 +462,9 @@ fn calldata_word_loads_preserve_structural_words() {
         .remove(0);
     let call_data = calldata.call_data(&mut cx);
 
-    assert_eq!(call_data.load(&mut cx, 4).unwrap(), SymExpr::var(&mut cx, "calldata_0"));
-    assert_eq!(call_data.load(&mut cx, 36).unwrap(), SymExpr::var(&mut cx, "calldata_1"));
-    assert_eq!(call_data.load(&mut cx, 68).unwrap(), SymExpr::var(&mut cx, "calldata_2"));
+    assert_eq!(call_data.load(&mut cx, 4).unwrap(), SymExpr::named_var(&mut cx, "calldata_0"));
+    assert_eq!(call_data.load(&mut cx, 36).unwrap(), SymExpr::named_var(&mut cx, "calldata_1"));
+    assert_eq!(call_data.load(&mut cx, 68).unwrap(), SymExpr::named_var(&mut cx, "calldata_2"));
 }
 
 #[test]
@@ -455,15 +481,15 @@ fn calldata_copy_to_memory_preserves_structural_words() {
 
     memory.copy_calldata_to_offset(&mut cx, dest, offset, 64, &call_data).unwrap();
 
-    assert_eq!(memory.load_word(&mut cx, 0x80).unwrap(), SymExpr::var(&mut cx, "calldata_0"));
-    assert_eq!(memory.load_word(&mut cx, 0xa0).unwrap(), SymExpr::var(&mut cx, "calldata_1"));
+    assert_eq!(memory.load_word(&mut cx, 0x80).unwrap(), SymExpr::named_var(&mut cx, "calldata_0"));
+    assert_eq!(memory.load_word(&mut cx, 0xa0).unwrap(), SymExpr::named_var(&mut cx, "calldata_1"));
 }
 
 #[test]
 fn byte_concat_word_load_assembles_word_fragments() {
     let mut cx = SymCx::new();
     let selector = [0xde, 0xad, 0xbe, 0xef];
-    let word = SymExpr::var(&mut cx, "calldata_0");
+    let word = SymExpr::named_var(&mut cx, "calldata_0");
     let selector_bytes = SymBytes::concrete(&mut cx, selector.to_vec());
     let word_bytes = word.clone().into_bytes(&mut cx);
     let bytes = SymBytes::concat(&mut cx, [selector_bytes, word_bytes]);
@@ -481,10 +507,10 @@ fn byte_concat_word_load_assembles_word_fragments() {
     assert_eq!(
         bytes
             .word_at(&mut cx, 0)
-            .eval_model(&BTreeMap::from([(
-                "calldata_0".to_string(),
-                U256::from_be_bytes(word_value)
-            )]))
+            .eval_model(&symbolic_model(
+                &mut cx,
+                [("calldata_0".to_string(), U256::from_be_bytes(word_value))]
+            ))
             .unwrap(),
         U256::from_be_bytes(expected)
     );
@@ -493,7 +519,7 @@ fn byte_concat_word_load_assembles_word_fragments() {
 #[test]
 fn byte_concat_right_aligned_word_assembles_push_fragments() {
     let mut cx = SymCx::new();
-    let immediate = SymExpr::var(&mut cx, "push_data");
+    let immediate = SymExpr::named_var(&mut cx, "push_data");
     let opcode = SymBytes::concrete(&mut cx, vec![opcode::PUSH32]);
     let immediate_bytes = immediate.clone().into_bytes(&mut cx);
     let bytes = SymBytes::concat(&mut cx, [opcode, immediate_bytes]);
@@ -502,7 +528,10 @@ fn byte_concat_right_aligned_word_assembles_push_fragments() {
     assert_eq!(
         bytes
             .right_aligned_word(&mut cx, 29, 4)
-            .eval_model(&BTreeMap::from([("push_data".to_string(), U256::from(0x12345678))]))
+            .eval_model(&symbolic_model(
+                &mut cx,
+                [("push_data".to_string(), U256::from(0x12345678))]
+            ))
             .unwrap(),
         U256::from(0x12345678)
     );
@@ -525,17 +554,21 @@ fn calldata_load_accepts_symbolic_offsets() {
         (0u8..40).map(|idx| SymExpr::constant(&mut cx, U256::from(idx + 1))).collect();
     let calldata_bytes = SymBytes::exprs(&mut cx, calldata_bytes);
     let calldata = SymCalldata::from_bytes(&mut cx, calldata_bytes);
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     let loaded = calldata.load_word(&mut cx, offset).unwrap();
     let expected =
         sym_from_bytes!(cx, (1u8..33).map(|idx| SymExpr::constant(&mut cx, U256::from(idx + 1))));
 
     assert_eq!(
-        loaded.eval_model(&BTreeMap::from([("offset".to_string(), U256::from(1))])).unwrap(),
-        expected.eval_model(&BTreeMap::new()).unwrap()
+        loaded
+            .eval_model(&symbolic_model(&mut cx, [("offset".to_string(), U256::from(1))]))
+            .unwrap(),
+        expected.eval_model(&SymbolicModel::default()).unwrap()
     );
     assert_eq!(
-        loaded.eval_model(&BTreeMap::from([("offset".to_string(), U256::from(40))])).unwrap(),
+        loaded
+            .eval_model(&symbolic_model(&mut cx, [("offset".to_string(), U256::from(40))]))
+            .unwrap(),
         U256::ZERO
     );
 }
@@ -565,12 +598,12 @@ fn calldata_preserves_symbolic_size_for_call_frames() {
     ];
     let bytes = SymBytes::exprs(&mut cx, bytes);
     memory.store_bytes(&mut cx, 0, bytes);
-    let size = SymExpr::var(&mut cx, "size");
+    let size = SymExpr::named_var(&mut cx, "size");
     let bounded_size = BoundedCopySize::Symbolic { size, max_size: 4 };
     let offset = SymExpr::zero(&mut cx);
     let input = bounded_size.read_from_memory(&mut cx, &memory, offset);
     let calldata = bounded_size.calldata(&mut cx, input);
-    let model = BTreeMap::from([("size".to_string(), U256::from(2))]);
+    let model = symbolic_model(&mut cx, [("size".to_string(), U256::from(2))]);
 
     assert_eq!(calldata.size_word().eval_model(&model).unwrap(), U256::from(2));
     let offset = SymExpr::zero(&mut cx);
@@ -595,11 +628,14 @@ fn memory_copies_unaligned_symbolic_calldata_bytes() {
     memory.copy_calldata_to_offset(&mut cx, dest, offset, 3, &call_data).unwrap();
     let word = memory.load_word(&mut cx, 0).unwrap();
 
-    let model = BTreeMap::from([
-        ("calldata_0_0".to_string(), U256::from(1)),
-        ("calldata_0_1".to_string(), U256::from(2)),
-        ("calldata_0_2".to_string(), U256::from(3)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [
+            ("calldata_0_0".to_string(), U256::from(1)),
+            ("calldata_0_1".to_string(), U256::from(2)),
+            ("calldata_0_2".to_string(), U256::from(3)),
+        ],
+    );
     let mut expected = [0u8; 32];
     expected[1..4].copy_from_slice(&[1, 2, 3]);
     assert_eq!(word.eval_model(&model).unwrap(), U256::from_be_bytes(expected));
@@ -615,18 +651,19 @@ fn memory_copies_symbolic_calldata_offset() {
     let mut memory = SymMemory::default();
 
     let dest = SymExpr::zero(&mut cx);
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     memory.copy_calldata_to_offset(&mut cx, dest, offset, 2, &calldata).unwrap();
     let word = memory.load_word(&mut cx, 0).unwrap();
 
     let mut expected = [0u8; 32];
     expected[..2].copy_from_slice(&[4, 5]);
     assert_eq!(
-        word.eval_model(&BTreeMap::from([("offset".to_string(), U256::from(3))])).unwrap(),
+        word.eval_model(&symbolic_model(&mut cx, [("offset".to_string(), U256::from(3))])).unwrap(),
         U256::from_be_bytes(expected)
     );
     assert_eq!(
-        word.eval_model(&BTreeMap::from([("offset".to_string(), U256::from(40))])).unwrap(),
+        word.eval_model(&symbolic_model(&mut cx, [("offset".to_string(), U256::from(40))]))
+            .unwrap(),
         U256::ZERO
     );
 }
@@ -644,17 +681,17 @@ fn memory_copies_symbolic_calldata_size_with_guarded_tail() {
     memory.store_bytes(&mut cx, 0, tail);
     let dest = SymExpr::zero(&mut cx);
     let offset = SymExpr::zero(&mut cx);
-    let size = SymExpr::var(&mut cx, "size");
+    let size = SymExpr::named_var(&mut cx, "size");
 
     memory.copy_calldata_symbolic_size(&mut cx, dest, offset, size, 4, &calldata).unwrap();
 
-    let size_two = BTreeMap::from([("size".to_string(), U256::from(2))]);
+    let size_two = symbolic_model(&mut cx, [("size".to_string(), U256::from(2))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_two).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
     );
 
-    let size_four = BTreeMap::from([("size".to_string(), U256::from(4))]);
+    let size_four = symbolic_model(&mut cx, [("size".to_string(), U256::from(4))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_four).unwrap(),
         vec![1, 2, 3, 4]
@@ -669,18 +706,18 @@ fn memory_copies_symbolic_bytecode_size_with_guarded_tail() {
     let tail = SymBytes::exprs(&mut cx, vec![tail; 4]);
     memory.store_bytes(&mut cx, 0, tail);
     let dest = SymExpr::zero(&mut cx);
-    let size = SymExpr::var(&mut cx, "size");
+    let size = SymExpr::named_var(&mut cx, "size");
     let bytes = (0u8..4).map(|idx| SymExpr::constant(&mut cx, U256::from(idx + 1))).collect();
     let bytes = SymBytes::exprs(&mut cx, bytes);
     memory.copy_bytes_size_offset(&mut cx, dest, size, bytes).unwrap();
 
-    let size_two = BTreeMap::from([("size".to_string(), U256::from(2))]);
+    let size_two = symbolic_model(&mut cx, [("size".to_string(), U256::from(2))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_two).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
     );
 
-    let size_four = BTreeMap::from([("size".to_string(), U256::from(4))]);
+    let size_four = symbolic_model(&mut cx, [("size".to_string(), U256::from(4))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_four).unwrap(),
         vec![1, 2, 3, 4]
@@ -701,7 +738,7 @@ fn memory_copies_folded_symbolic_size_prefix_only() {
     memory.copy_bytes_size_offset(&mut cx, dest, size, bytes).unwrap();
 
     assert_eq!(
-        memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &BTreeMap::new()).unwrap(),
+        memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &SymbolicModel::default()).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
     );
 }
@@ -718,7 +755,7 @@ fn memory_skips_folded_zero_symbolic_size_copy() {
 
     assert_eq!(memory.size_word(&mut cx), SymExpr::zero(&mut cx));
     assert_eq!(
-        memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &BTreeMap::new()).unwrap(),
+        memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &SymbolicModel::default()).unwrap(),
         vec![0, 0, 0, 0]
     );
 }
@@ -732,13 +769,13 @@ fn memory_reads_symbolic_size_with_zero_guarded_tail() {
     memory.store_bytes(&mut cx, 32, source);
 
     let offset = SymExpr::constant(&mut cx, U256::from(32));
-    let size = SymExpr::var(&mut cx, "size");
+    let size = SymExpr::named_var(&mut cx, "size");
     let bytes = memory.read_bytes_symbolic_size(&mut cx, offset, size, 4);
 
-    let size_two = BTreeMap::from([("size".to_string(), U256::from(2))]);
+    let size_two = symbolic_model(&mut cx, [("size".to_string(), U256::from(2))]);
     assert_eq!(bytes.eval_model(&mut cx, &size_two).unwrap(), vec![1, 2, 0, 0]);
 
-    let size_four = BTreeMap::from([("size".to_string(), U256::from(4))]);
+    let size_four = symbolic_model(&mut cx, [("size".to_string(), U256::from(4))]);
     assert_eq!(bytes.eval_model(&mut cx, &size_four).unwrap(), vec![1, 2, 3, 4]);
 }
 
@@ -754,7 +791,7 @@ fn memory_reads_folded_symbolic_size_prefix_only() {
     let size = SymExpr::constant(&mut cx, U256::from(2));
     let bytes = memory.read_bytes_symbolic_size(&mut cx, offset, size, 4);
 
-    assert_eq!(bytes.eval_model(&mut cx, &BTreeMap::new()).unwrap(), vec![1, 2, 0, 0]);
+    assert_eq!(bytes.eval_model(&mut cx, &SymbolicModel::default()).unwrap(), vec![1, 2, 0, 0]);
 }
 
 #[test]
@@ -770,17 +807,17 @@ fn memory_copies_symbolic_memory_size_with_guarded_tail() {
     memory.store_bytes(&mut cx, 32, source_bytes);
     let dest = SymExpr::zero(&mut cx);
     let source = SymExpr::constant(&mut cx, U256::from(32));
-    let size = SymExpr::var(&mut cx, "size");
+    let size = SymExpr::named_var(&mut cx, "size");
 
     memory.copy_memory_symbolic_size(&mut cx, dest, source, size, 4).unwrap();
 
-    let size_two = BTreeMap::from([("size".to_string(), U256::from(2))]);
+    let size_two = symbolic_model(&mut cx, [("size".to_string(), U256::from(2))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_two).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
     );
 
-    let size_four = BTreeMap::from([("size".to_string(), U256::from(4))]);
+    let size_four = symbolic_model(&mut cx, [("size".to_string(), U256::from(4))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_four).unwrap(),
         vec![1, 2, 3, 4]
@@ -798,16 +835,16 @@ fn memory_copies_symbolic_size_to_symbolic_dest() {
         (0u8..4).map(|idx| SymExpr::constant(&mut cx, U256::from(idx + 1))).collect();
     let source_bytes = SymBytes::exprs(&mut cx, source_bytes);
     memory.store_bytes(&mut cx, 0x20, source_bytes);
-    let dest = SymExpr::var(&mut cx, "dest");
+    let dest = SymExpr::named_var(&mut cx, "dest");
     let source = SymExpr::constant(&mut cx, U256::from(0x20));
-    let size = SymExpr::var(&mut cx, "size");
+    let size = SymExpr::named_var(&mut cx, "size");
 
     memory.copy_memory_symbolic_size(&mut cx, dest, source, size, 4).unwrap();
 
-    let model = BTreeMap::from([
-        ("dest".to_string(), U256::from(0x80)),
-        ("size".to_string(), U256::from(2)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("dest".to_string(), U256::from(0x80)), ("size".to_string(), U256::from(2))],
+    );
     assert_eq!(
         memory.read_bytes(&mut cx, 0x80, 4).eval_model(&mut cx, &model).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
@@ -824,17 +861,17 @@ fn memory_copies_symbolic_returndata_size_with_guarded_tail() {
     memory.store_bytes(&mut cx, 0, tail);
     let dest = SymExpr::zero(&mut cx);
     let offset = SymExpr::zero(&mut cx);
-    let size = SymExpr::var(&mut cx, "size");
+    let size = SymExpr::named_var(&mut cx, "size");
 
     memory.copy_return_data_symbolic_size(&mut cx, dest, offset, size, 4, &return_data).unwrap();
 
-    let size_two = BTreeMap::from([("size".to_string(), U256::from(2))]);
+    let size_two = symbolic_model(&mut cx, [("size".to_string(), U256::from(2))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_two).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
     );
 
-    let size_four = BTreeMap::from([("size".to_string(), U256::from(4))]);
+    let size_four = symbolic_model(&mut cx, [("size".to_string(), U256::from(4))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_four).unwrap(),
         vec![1, 2, 3, 4]
@@ -845,13 +882,13 @@ fn memory_copies_symbolic_returndata_size_with_guarded_tail() {
 fn returndata_reads_symbolic_offset() {
     let mut cx = SymCx::new();
     let return_data = SymReturnData::from_concrete_bytes(&mut cx, vec![1, 2, 3, 4]);
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     let bytes = return_data.read_bytes_offset(&mut cx, offset, 2);
 
-    let offset_one = BTreeMap::from([("offset".to_string(), U256::from(1))]);
+    let offset_one = symbolic_model(&mut cx, [("offset".to_string(), U256::from(1))]);
     assert_eq!(bytes.eval_model(&mut cx, &offset_one).unwrap(), vec![2, 3]);
 
-    let offset_four = BTreeMap::from([("offset".to_string(), U256::from(4))]);
+    let offset_four = symbolic_model(&mut cx, [("offset".to_string(), U256::from(4))]);
     assert_eq!(bytes.eval_model(&mut cx, &offset_four).unwrap(), vec![0, 0]);
 }
 
@@ -866,11 +903,11 @@ fn memory_return_data_accepts_symbolic_size() {
     let bytes = SymBytes::exprs(&mut cx, bytes);
     memory.store_bytes(&mut cx, 0, bytes);
     let offset = SymExpr::zero(&mut cx);
-    let len = SymExpr::var(&mut cx, "len");
+    let len = SymExpr::named_var(&mut cx, "len");
 
     let return_data = memory.return_data_symbolic_size(&mut cx, offset, len, 4).unwrap();
 
-    let len_two = BTreeMap::from([("len".to_string(), U256::from(2))]);
+    let len_two = symbolic_model(&mut cx, [("len".to_string(), U256::from(2))]);
     assert_eq!(return_data.len_word().eval_model(&len_two).unwrap(), U256::from(2));
     assert_eq!(return_data.byte(&mut cx, 0).eval_model(&len_two).unwrap(), U256::from(1));
     assert_eq!(return_data.byte(&mut cx, 2).eval_model(&len_two).unwrap(), U256::ZERO);
@@ -884,7 +921,7 @@ fn call_output_preserves_memory_beyond_symbolic_returndata_size() {
         .map(|byte| SymExpr::constant(&mut cx, U256::from(byte)))
         .collect();
     let bytes = SymBytes::exprs(&mut cx, bytes);
-    let len = SymExpr::var(&mut cx, "len");
+    let len = SymExpr::named_var(&mut cx, "len");
     let return_data = SymReturnData::from_bytes_with_len(bytes, len);
     let mut memory = SymMemory::default();
     let tail = SymExpr::constant(&mut cx, U256::from(0xaa));
@@ -896,13 +933,13 @@ fn call_output_preserves_memory_beyond_symbolic_returndata_size() {
         .copy_call_output_offset(&mut cx, dest, &BoundedCopySize::Concrete(4), &return_data)
         .unwrap();
 
-    let len_two = BTreeMap::from([("len".to_string(), U256::from(2))]);
+    let len_two = symbolic_model(&mut cx, [("len".to_string(), U256::from(2))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &len_two).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
     );
 
-    let len_four = BTreeMap::from([("len".to_string(), U256::from(4))]);
+    let len_four = symbolic_model(&mut cx, [("len".to_string(), U256::from(4))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &len_four).unwrap(),
         vec![1, 2, 3, 4]
@@ -928,11 +965,11 @@ fn nested_dynamic_calldata_uses_preorder_lengths() {
 fn memory_round_trips_symbolic_words_as_bytes() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::var(&mut cx, "word");
+    let value = SymExpr::named_var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value.clone());
 
-    let model = BTreeMap::from([("word".to_string(), U256::from(0x1234))]);
+    let model = symbolic_model(&mut cx, [("word".to_string(), U256::from(0x1234))]);
     assert_eq!(
         memory.load_word(&mut cx, 7).unwrap().eval_model(&model).unwrap(),
         value.eval_model(&model).unwrap()
@@ -943,22 +980,22 @@ fn memory_round_trips_symbolic_words_as_bytes() {
 fn memory_load_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::var(&mut cx, "word");
+    let value = SymExpr::named_var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     let loaded = memory.load_word_offset(&mut cx, offset).unwrap();
 
-    let model = BTreeMap::from([
-        ("offset".to_string(), U256::from(7)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(7)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&model).unwrap(), U256::from(0x1234));
 
-    let out_of_range = BTreeMap::from([
-        ("offset".to_string(), U256::from(39)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let out_of_range = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(39)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&out_of_range).unwrap(), U256::ZERO);
 }
 
@@ -966,22 +1003,22 @@ fn memory_load_accepts_symbolic_offsets() {
 fn memory_store_word_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::var(&mut cx, "word");
+    let value = SymExpr::named_var(&mut cx, "word");
 
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     memory.store_word_offset(&mut cx, offset, value);
     let loaded = memory.load_word(&mut cx, 7).unwrap();
 
-    let matching = BTreeMap::from([
-        ("offset".to_string(), U256::from(7)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let matching = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(7)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&matching).unwrap(), U256::from(0x1234));
 
-    let non_matching = BTreeMap::from([
-        ("offset".to_string(), U256::from(100)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let non_matching = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(100)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&non_matching).unwrap(), U256::ZERO);
 }
 
@@ -994,21 +1031,21 @@ fn memory_size_tracks_concrete_and_symbolic_extents() {
     memory.store_word(&mut cx, 7, concrete);
     assert_eq!(memory.size_word(&mut cx), SymExpr::constant(&mut cx, U256::from(64)));
 
-    let offset = SymExpr::var(&mut cx, "offset");
-    let word = SymExpr::var(&mut cx, "word");
+    let offset = SymExpr::named_var(&mut cx, "offset");
+    let word = SymExpr::named_var(&mut cx, "word");
     memory.store_word_offset(&mut cx, offset, word);
     let size = memory.size_word(&mut cx);
 
-    let below_concrete = BTreeMap::from([
-        ("offset".to_string(), U256::from(9)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let below_concrete = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(9)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(size.eval_model(&below_concrete).unwrap(), U256::from(64));
 
-    let above_concrete = BTreeMap::from([
-        ("offset".to_string(), U256::from(70)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let above_concrete = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(70)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(size.eval_model(&above_concrete).unwrap(), U256::from(128));
 }
 
@@ -1017,17 +1054,17 @@ fn memory_concrete_write_overrides_older_symbolic_write() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
 
-    let offset = SymExpr::var(&mut cx, "offset");
-    let word = SymExpr::var(&mut cx, "word");
+    let offset = SymExpr::named_var(&mut cx, "offset");
+    let word = SymExpr::named_var(&mut cx, "word");
     memory.store_word_offset(&mut cx, offset, word);
     let concrete = SymExpr::constant(&mut cx, U256::from(0x55));
     memory.store_word(&mut cx, 7, concrete);
     let loaded = memory.load_word(&mut cx, 7).unwrap();
 
-    let model = BTreeMap::from([
-        ("offset".to_string(), U256::from(7)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(7)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&model).unwrap(), U256::from(0x55));
 }
 
@@ -1036,19 +1073,22 @@ fn memory_dynamic_read_respects_concrete_overwrite_epoch() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
 
-    let write_offset = SymExpr::var(&mut cx, "write_offset");
-    let byte = SymExpr::var(&mut cx, "byte");
+    let write_offset = SymExpr::named_var(&mut cx, "write_offset");
+    let byte = SymExpr::named_var(&mut cx, "byte");
     memory.store_byte_offset(&mut cx, write_offset, byte);
     let concrete = SymExpr::constant(&mut cx, U256::from(0x55));
     memory.store_byte(&mut cx, 5, concrete);
-    let read_offset = SymExpr::var(&mut cx, "read_offset");
+    let read_offset = SymExpr::named_var(&mut cx, "read_offset");
     let loaded = memory.byte_dynamic_with_delta(&mut cx, &read_offset, 0);
 
-    let model = BTreeMap::from([
-        ("write_offset".to_string(), U256::from(5)),
-        ("read_offset".to_string(), U256::from(5)),
-        ("byte".to_string(), U256::from(0xab)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [
+            ("write_offset".to_string(), U256::from(5)),
+            ("read_offset".to_string(), U256::from(5)),
+            ("byte".to_string(), U256::from(0xab)),
+        ],
+    );
     assert_eq!(loaded.eval_model(&model).unwrap(), U256::from(0x55));
 }
 
@@ -1057,30 +1097,36 @@ fn memory_symbolic_write_after_concrete_overwrite_still_applies() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
 
-    let older_offset = SymExpr::var(&mut cx, "older_offset");
-    let older_byte = SymExpr::var(&mut cx, "older_byte");
+    let older_offset = SymExpr::named_var(&mut cx, "older_offset");
+    let older_byte = SymExpr::named_var(&mut cx, "older_byte");
     memory.store_byte_offset(&mut cx, older_offset, older_byte);
     let concrete = SymExpr::constant(&mut cx, U256::from(0x55));
     memory.store_byte(&mut cx, 5, concrete);
-    let later_offset = SymExpr::var(&mut cx, "later_offset");
-    let later_byte = SymExpr::var(&mut cx, "later_byte");
+    let later_offset = SymExpr::named_var(&mut cx, "later_offset");
+    let later_byte = SymExpr::named_var(&mut cx, "later_byte");
     memory.store_byte_offset(&mut cx, later_offset, later_byte);
     let loaded = memory.byte(&mut cx, 5);
 
-    let concrete_wins = BTreeMap::from([
-        ("older_offset".to_string(), U256::from(5)),
-        ("older_byte".to_string(), U256::from(0xaa)),
-        ("later_offset".to_string(), U256::from(6)),
-        ("later_byte".to_string(), U256::from(0xbb)),
-    ]);
+    let concrete_wins = symbolic_model(
+        &mut cx,
+        [
+            ("older_offset".to_string(), U256::from(5)),
+            ("older_byte".to_string(), U256::from(0xaa)),
+            ("later_offset".to_string(), U256::from(6)),
+            ("later_byte".to_string(), U256::from(0xbb)),
+        ],
+    );
     assert_eq!(loaded.eval_model(&concrete_wins).unwrap(), U256::from(0x55));
 
-    let later_symbolic_wins = BTreeMap::from([
-        ("older_offset".to_string(), U256::from(5)),
-        ("older_byte".to_string(), U256::from(0xaa)),
-        ("later_offset".to_string(), U256::from(5)),
-        ("later_byte".to_string(), U256::from(0xbb)),
-    ]);
+    let later_symbolic_wins = symbolic_model(
+        &mut cx,
+        [
+            ("older_offset".to_string(), U256::from(5)),
+            ("older_byte".to_string(), U256::from(0xaa)),
+            ("later_offset".to_string(), U256::from(5)),
+            ("later_byte".to_string(), U256::from(0xbb)),
+        ],
+    );
     assert_eq!(loaded.eval_model(&later_symbolic_wins).unwrap(), U256::from(0xbb));
 }
 
@@ -1089,21 +1135,21 @@ fn memory_store_byte_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
 
-    let offset = SymExpr::var(&mut cx, "offset");
-    let byte = SymExpr::var(&mut cx, "byte");
+    let offset = SymExpr::named_var(&mut cx, "offset");
+    let byte = SymExpr::named_var(&mut cx, "byte");
     memory.store_byte_offset(&mut cx, offset, byte);
     let loaded = memory.byte(&mut cx, 0x80);
 
-    let matching = BTreeMap::from([
-        ("offset".to_string(), U256::from(0x80)),
-        ("byte".to_string(), U256::from(0xab)),
-    ]);
+    let matching = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(0x80)), ("byte".to_string(), U256::from(0xab))],
+    );
     assert_eq!(loaded.eval_model(&matching).unwrap(), U256::from(0xab));
 
-    let non_matching = BTreeMap::from([
-        ("offset".to_string(), U256::from(0x81)),
-        ("byte".to_string(), U256::from(0xab)),
-    ]);
+    let non_matching = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(0x81)), ("byte".to_string(), U256::from(0xab))],
+    );
     assert_eq!(loaded.eval_model(&non_matching).unwrap(), U256::ZERO);
 }
 
@@ -1111,23 +1157,23 @@ fn memory_store_byte_accepts_symbolic_offsets() {
 fn memory_read_bytes_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::var(&mut cx, "word");
+    let value = SymExpr::named_var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     let bytes = memory.read_bytes_offset(&mut cx, offset, 32).materialize(&mut cx);
     let loaded = SymExpr::from_bytes(&mut cx, bytes);
 
-    let model = BTreeMap::from([
-        ("offset".to_string(), U256::from(7)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(7)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&model).unwrap(), U256::from(0x1234));
 
-    let out_of_range = BTreeMap::from([
-        ("offset".to_string(), U256::from(39)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let out_of_range = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(39)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&out_of_range).unwrap(), U256::ZERO);
 }
 
@@ -1135,17 +1181,17 @@ fn memory_read_bytes_accepts_symbolic_offsets() {
 fn memory_return_data_accepts_symbolic_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::var(&mut cx, "word");
+    let value = SymExpr::named_var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     let return_data = memory.return_data(&mut cx, offset, 32).unwrap();
     let loaded = return_data.load_word(&mut cx, 0).unwrap();
 
-    let model = BTreeMap::from([
-        ("offset".to_string(), U256::from(7)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(7)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&model).unwrap(), U256::from(0x1234));
 }
 
@@ -1153,18 +1199,18 @@ fn memory_return_data_accepts_symbolic_offsets() {
 fn memory_copy_accepts_symbolic_source_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::var(&mut cx, "word");
+    let value = SymExpr::named_var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
     let dest = SymExpr::constant(&mut cx, U256::from(64));
-    let src = SymExpr::var(&mut cx, "src");
+    let src = SymExpr::named_var(&mut cx, "src");
     memory.copy_memory_to_offset(&mut cx, dest, src, 32).unwrap();
     let loaded = memory.load_word(&mut cx, 64).unwrap();
 
-    let model = BTreeMap::from([
-        ("src".to_string(), U256::from(7)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("src".to_string(), U256::from(7)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&model).unwrap(), U256::from(0x1234));
 }
 
@@ -1172,24 +1218,24 @@ fn memory_copy_accepts_symbolic_source_offsets() {
 fn memory_copy_accepts_symbolic_destination_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let value = SymExpr::var(&mut cx, "word");
+    let value = SymExpr::named_var(&mut cx, "word");
 
     memory.store_word(&mut cx, 7, value);
-    let dest = SymExpr::var(&mut cx, "dest");
+    let dest = SymExpr::named_var(&mut cx, "dest");
     let src = SymExpr::constant(&mut cx, U256::from(7));
     memory.copy_memory_to_offset(&mut cx, dest, src, 32).unwrap();
     let loaded = memory.load_word(&mut cx, 64).unwrap();
 
-    let matching = BTreeMap::from([
-        ("dest".to_string(), U256::from(64)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let matching = symbolic_model(
+        &mut cx,
+        [("dest".to_string(), U256::from(64)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&matching).unwrap(), U256::from(0x1234));
 
-    let non_matching = BTreeMap::from([
-        ("dest".to_string(), U256::from(96)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let non_matching = symbolic_model(
+        &mut cx,
+        [("dest".to_string(), U256::from(96)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&non_matching).unwrap(), U256::ZERO);
 }
 
@@ -1197,20 +1243,20 @@ fn memory_copy_accepts_symbolic_destination_offsets() {
 fn memory_call_output_accepts_symbolic_destination_offsets() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
-    let word = SymExpr::var(&mut cx, "word");
+    let word = SymExpr::named_var(&mut cx, "word");
     let bytes = word.into_bytes(&mut cx);
     let return_data = SymReturnData::from_bytes(&mut cx, bytes);
-    let dest = SymExpr::var(&mut cx, "dest");
+    let dest = SymExpr::named_var(&mut cx, "dest");
 
     memory
         .copy_call_output_offset(&mut cx, dest, &BoundedCopySize::Concrete(32), &return_data)
         .unwrap();
     let loaded = memory.load_word(&mut cx, 64).unwrap();
 
-    let model = BTreeMap::from([
-        ("dest".to_string(), U256::from(64)),
-        ("word".to_string(), U256::from(0x1234)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("dest".to_string(), U256::from(64)), ("word".to_string(), U256::from(0x1234))],
+    );
     assert_eq!(loaded.eval_model(&model).unwrap(), U256::from(0x1234));
 }
 
@@ -1223,18 +1269,18 @@ fn memory_call_output_accepts_symbolic_size_with_guarded_tail() {
     let tail = SymBytes::exprs(&mut cx, vec![tail; 4]);
     memory.store_bytes(&mut cx, 0, tail);
     let dest = SymExpr::zero(&mut cx);
-    let size = SymExpr::var(&mut cx, "size");
+    let size = SymExpr::named_var(&mut cx, "size");
     let copy_size = BoundedCopySize::Symbolic { size, max_size: 4 };
 
     memory.copy_call_output_offset(&mut cx, dest, &copy_size, &return_data).unwrap();
 
-    let size_two = BTreeMap::from([("size".to_string(), U256::from(2))]);
+    let size_two = symbolic_model(&mut cx, [("size".to_string(), U256::from(2))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_two).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
     );
 
-    let size_four = BTreeMap::from([("size".to_string(), U256::from(4))]);
+    let size_four = symbolic_model(&mut cx, [("size".to_string(), U256::from(4))]);
     assert_eq!(
         memory.read_bytes(&mut cx, 0, 4).eval_model(&mut cx, &size_four).unwrap(),
         vec![1, 2, 3, 4]
@@ -1249,16 +1295,16 @@ fn memory_call_output_accepts_symbolic_destination_and_size() {
     let tail = SymExpr::constant(&mut cx, U256::from(0xaa));
     let tail = SymBytes::exprs(&mut cx, vec![tail; 4]);
     memory.store_bytes(&mut cx, 0x80, tail);
-    let dest = SymExpr::var(&mut cx, "dest");
-    let size = SymExpr::var(&mut cx, "size");
+    let dest = SymExpr::named_var(&mut cx, "dest");
+    let size = SymExpr::named_var(&mut cx, "size");
     let copy_size = BoundedCopySize::Symbolic { size, max_size: 4 };
 
     memory.copy_call_output_offset(&mut cx, dest, &copy_size, &return_data).unwrap();
 
-    let model = BTreeMap::from([
-        ("dest".to_string(), U256::from(0x80)),
-        ("size".to_string(), U256::from(2)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("dest".to_string(), U256::from(0x80)), ("size".to_string(), U256::from(2))],
+    );
     assert_eq!(
         memory.read_bytes(&mut cx, 0x80, 4).eval_model(&mut cx, &model).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
@@ -1273,22 +1319,22 @@ fn memory_call_output_accepts_symbolic_destination_and_return_len() {
         .map(|byte| SymExpr::constant(&mut cx, U256::from(byte)))
         .collect();
     let bytes = SymBytes::exprs(&mut cx, bytes);
-    let len = SymExpr::var(&mut cx, "len");
+    let len = SymExpr::named_var(&mut cx, "len");
     let return_data = SymReturnData::from_bytes_with_len(bytes, len);
     let mut memory = SymMemory::default();
     let tail = SymExpr::constant(&mut cx, U256::from(0xaa));
     let tail = SymBytes::exprs(&mut cx, vec![tail; 4]);
     memory.store_bytes(&mut cx, 0x80, tail);
-    let dest = SymExpr::var(&mut cx, "dest");
+    let dest = SymExpr::named_var(&mut cx, "dest");
 
     memory
         .copy_call_output_offset(&mut cx, dest, &BoundedCopySize::Concrete(4), &return_data)
         .unwrap();
 
-    let model = BTreeMap::from([
-        ("dest".to_string(), U256::from(0x80)),
-        ("len".to_string(), U256::from(2)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("dest".to_string(), U256::from(0x80)), ("len".to_string(), U256::from(2))],
+    );
     assert_eq!(
         memory.read_bytes(&mut cx, 0x80, 4).eval_model(&mut cx, &model).unwrap(),
         vec![1, 2, 0xaa, 0xaa]
@@ -1313,7 +1359,7 @@ fn compute_create2_cheatcode_helper_matches_create2_terms() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let salt = SymExpr::var(&mut cx, "salt");
+    let salt = SymExpr::named_var(&mut cx, "salt");
     let initcode = vec![opcode::STOP];
     let initcode_hash = SymExpr::constant(&mut cx, U256::from_be_bytes(keccak256(&initcode).0));
     let creator_word = SymExpr::constant(&mut cx, address_word(creator));
@@ -1338,8 +1384,8 @@ fn compute_create2_cheatcode_helper_accepts_symbolic_init_code_hash() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let salt = SymExpr::var(&mut cx, "salt");
-    let initcode_hash = SymExpr::var(&mut cx, "initcode_hash");
+    let salt = SymExpr::named_var(&mut cx, "salt");
+    let initcode_hash = SymExpr::named_var(&mut cx, "initcode_hash");
     let creator_word = SymExpr::constant(&mut cx, address_word(creator));
 
     let first = compute_create2_address_word(
@@ -1355,7 +1401,7 @@ fn compute_create2_cheatcode_helper_accepts_symbolic_init_code_hash() {
             .unwrap();
 
     assert_eq!(first, second);
-    assert!(first.var_name().is_some_and(|name| name.starts_with("create2_address_")));
+    assert!(first.var_name(&cx).is_some_and(|name| name.starts_with("create2_address_")));
 }
 
 #[test]
@@ -1363,7 +1409,7 @@ fn compute_create_cheatcode_helper_accepts_symbolic_nonce() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let nonce = SymExpr::var(&mut cx, "nonce");
+    let nonce = SymExpr::named_var(&mut cx, "nonce");
     let creator_word = SymExpr::constant(&mut cx, address_word(creator));
 
     let first =
@@ -1372,7 +1418,7 @@ fn compute_create_cheatcode_helper_accepts_symbolic_nonce() {
     let second = compute_create_address_word(&mut cx, &mut state, creator_word, nonce).unwrap();
 
     assert_eq!(first, second);
-    assert!(first.var_name().is_some_and(|name| name.starts_with("create_address_")));
+    assert!(first.var_name(&cx).is_some_and(|name| name.starts_with("create_address_")));
 }
 
 #[test]
@@ -1380,8 +1426,8 @@ fn compute_create_cheatcode_helper_accepts_symbolic_deployer() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let deployer = SymExpr::var(&mut cx, "deployer");
-    let nonce = SymExpr::var(&mut cx, "nonce");
+    let deployer = SymExpr::named_var(&mut cx, "deployer");
+    let nonce = SymExpr::named_var(&mut cx, "nonce");
 
     let first = compute_create_address_word(&mut cx, &mut state, deployer.clone(), nonce.clone())
         .expect("symbolic deployer is supported");
@@ -1389,7 +1435,7 @@ fn compute_create_cheatcode_helper_accepts_symbolic_deployer() {
         .expect("symbolic deployer is supported");
 
     assert_eq!(first, second);
-    assert!(first.var_name().is_some_and(|name| name.starts_with("create_address_")));
+    assert!(first.var_name(&cx).is_some_and(|name| name.starts_with("create_address_")));
 }
 
 #[test]
@@ -1397,9 +1443,9 @@ fn compute_create2_cheatcode_helper_accepts_symbolic_deployer() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let deployer = SymExpr::var(&mut cx, "deployer");
-    let salt = SymExpr::var(&mut cx, "salt");
-    let initcode_hash = SymExpr::var(&mut cx, "initcode_hash");
+    let deployer = SymExpr::named_var(&mut cx, "deployer");
+    let salt = SymExpr::named_var(&mut cx, "salt");
+    let initcode_hash = SymExpr::named_var(&mut cx, "initcode_hash");
 
     let first = compute_create2_address_word(
         &mut cx,
@@ -1413,7 +1459,7 @@ fn compute_create2_cheatcode_helper_accepts_symbolic_deployer() {
         .expect("symbolic deployer is supported");
 
     assert_eq!(first, second);
-    assert!(first.var_name().is_some_and(|name| name.starts_with("create2_address_")));
+    assert!(first.var_name(&cx).is_some_and(|name| name.starts_with("create2_address_")));
 }
 
 #[test]
@@ -1450,10 +1496,11 @@ fn recorded_logs_return_data_matches_abi_encoding() {
 fn recorded_logs_json_return_data_accepts_symbolic_topics_and_data() {
     let mut cx = SymCx::new();
     let emitter = Address::from([0x33; 20]);
-    let data = vec![SymExpr::constant(&mut cx, U256::from(0x12)), SymExpr::var(&mut cx, "byte")];
+    let data =
+        vec![SymExpr::constant(&mut cx, U256::from(0x12)), SymExpr::named_var(&mut cx, "byte")];
     let data = SymBytes::exprs(&mut cx, data);
     let log = SymbolicLog::new(
-        vec![SymExpr::var(&mut cx, "topic")],
+        vec![SymExpr::named_var(&mut cx, "topic")],
         SymExpr::constant(&mut cx, U256::from(2)),
         data,
         emitter,
@@ -1461,15 +1508,11 @@ fn recorded_logs_json_return_data_accepts_symbolic_topics_and_data() {
 
     let return_data = recorded_logs_json_return_data(&mut cx, vec![log]).unwrap();
     let encoded = (0..return_data.len()).map(|idx| return_data.byte(&mut cx, idx)).collect();
-    let encoded = SymBytes::exprs(&mut cx, encoded)
-        .eval_model(
-            &mut cx,
-            &BTreeMap::from([
-                ("topic".to_string(), U256::from(0xabcd)),
-                ("byte".to_string(), U256::from(0xef)),
-            ]),
-        )
-        .unwrap();
+    let model = symbolic_model(
+        &mut cx,
+        [("topic".to_string(), U256::from(0xabcd)), ("byte".to_string(), U256::from(0xef))],
+    );
+    let encoded = SymBytes::exprs(&mut cx, encoded).eval_model(&mut cx, &model).unwrap();
     let decoded = DynSolType::String.abi_decode(&encoded).unwrap();
     let DynSolValue::String(json) = decoded else { panic!("expected string return") };
 
@@ -1488,13 +1531,13 @@ fn abi_bytes_encoding_accepts_symbolic_length() {
         SymExpr::constant(&mut cx, U256::from(0x44)),
     ];
     let bytes = SymBytes::exprs(&mut cx, bytes);
-    let len = SymExpr::var(&mut cx, "len");
+    let len = SymExpr::named_var(&mut cx, "len");
     let encoded = encode_packed_bytes_with_len(&mut cx, len, &bytes);
 
     assert_eq!(
         encoded
             .word_at(&mut cx, 0)
-            .eval_model(&BTreeMap::from([("len".to_string(), U256::from(2))]))
+            .eval_model(&symbolic_model(&mut cx, [("len".to_string(), U256::from(2))]))
             .unwrap(),
         U256::from(2)
     );
@@ -1504,7 +1547,7 @@ fn abi_bytes_encoding_accepts_symbolic_length() {
 fn symbolic_world_resolves_symbolic_create2_address_aliases() {
     let mut cx = SymCx::new();
     let mut world = SymbolicWorld::default();
-    let word = SymExpr::var(&mut cx, "create2_address");
+    let word = SymExpr::named_var(&mut cx, "create2_address");
     let address = world.symbolic_address_slot(word.clone());
     let address_mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
     let masked = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), address_mask);
@@ -1520,7 +1563,7 @@ fn symbolic_create2_accepts_symbolic_salt() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let salt = SymExpr::var(&mut cx, "salt");
+    let salt = SymExpr::named_var(&mut cx, "salt");
     let initcode = SymCode::concrete(&mut cx, vec![opcode::STOP]);
 
     let (word, address) =
@@ -1537,8 +1580,8 @@ fn symbolic_create2_initcode_identity_uses_byte_semantics() {
     let mut cx = SymCx::new();
     let creator = Address::from([0x11; 20]);
     let mut state = PathState::empty(&mut cx, creator, Address::from([0xaa; 20]), false);
-    let salt = SymExpr::var(&mut cx, "salt");
-    let init_word = SymExpr::var(&mut cx, "init_word");
+    let salt = SymExpr::named_var(&mut cx, "salt");
+    let init_word = SymExpr::named_var(&mut cx, "init_word");
     let structural_bytes = init_word.clone().into_bytes(&mut cx);
     let structural = SymCode::from_bytes(&mut cx, structural_bytes);
     let init_bytes = init_word.into_byte_exprs(&mut cx);
@@ -1556,7 +1599,7 @@ fn symbolic_create2_initcode_identity_uses_byte_semantics() {
 #[test]
 fn symbolic_return_data_can_be_installed_as_runtime_code() {
     let mut cx = SymCx::new();
-    let runtime_byte = SymExpr::var(&mut cx, "runtime_byte");
+    let runtime_byte = SymExpr::named_var(&mut cx, "runtime_byte");
     let bytes = SymBytes::exprs(&mut cx, vec![runtime_byte.clone()]);
     let data = SymReturnData::from_bytes(&mut cx, bytes);
 
@@ -1570,7 +1613,7 @@ fn symbolic_runtime_size_is_not_installed_as_concrete_code() {
     let mut cx = SymCx::new();
     let stop = SymExpr::constant(&mut cx, U256::from(opcode::STOP));
     let bytes = SymBytes::exprs(&mut cx, vec![stop]);
-    let len = SymExpr::var(&mut cx, "runtime_len");
+    let len = SymExpr::named_var(&mut cx, "runtime_len");
     let data = SymReturnData::from_bytes_with_len(bytes, len);
 
     assert!(matches!(
@@ -1598,7 +1641,7 @@ fn symbolic_codecopy_preserves_symbolic_constructor_bytes() {
     let mut cx = SymCx::new();
     let mut memory = SymMemory::default();
     let stop = SymExpr::constant(&mut cx, U256::from(opcode::STOP));
-    let constructor_arg = SymExpr::var(&mut cx, "constructor_arg_byte");
+    let constructor_arg = SymExpr::named_var(&mut cx, "constructor_arg_byte");
     let bytes = SymBytes::exprs(&mut cx, vec![stop, constructor_arg]);
     let initcode = SymCode::from_bytes(&mut cx, bytes);
 
@@ -1606,7 +1649,7 @@ fn symbolic_codecopy_preserves_symbolic_constructor_bytes() {
     memory.store_bytes(&mut cx, 0, init_bytes);
 
     assert_eq!(memory.byte(&mut cx, 0), SymExpr::constant(&mut cx, U256::from(opcode::STOP)));
-    assert_eq!(memory.byte(&mut cx, 1), SymExpr::var(&mut cx, "constructor_arg_byte"));
+    assert_eq!(memory.byte(&mut cx, 1), SymExpr::named_var(&mut cx, "constructor_arg_byte"));
 }
 
 #[test]
@@ -1617,7 +1660,7 @@ fn symbolic_codecopy_accepts_symbolic_offsets() {
     let code = SymCode::from_bytes(&mut cx, code_bytes);
     let mut memory = SymMemory::default();
 
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     let code_bytes = code.read_bytes_offset(&mut cx, offset, 2);
     memory.store_bytes(&mut cx, 0, code_bytes);
     let word = memory.load_word(&mut cx, 0).unwrap();
@@ -1625,11 +1668,12 @@ fn symbolic_codecopy_accepts_symbolic_offsets() {
     let mut expected = [0u8; 32];
     expected[..2].copy_from_slice(&[4, 5]);
     assert_eq!(
-        word.eval_model(&BTreeMap::from([("offset".to_string(), U256::from(3))])).unwrap(),
+        word.eval_model(&symbolic_model(&mut cx, [("offset".to_string(), U256::from(3))])).unwrap(),
         U256::from_be_bytes(expected)
     );
     assert_eq!(
-        word.eval_model(&BTreeMap::from([("offset".to_string(), U256::from(40))])).unwrap(),
+        word.eval_model(&symbolic_model(&mut cx, [("offset".to_string(), U256::from(40))]))
+            .unwrap(),
         U256::ZERO
     );
 }
@@ -1640,10 +1684,10 @@ fn symbolic_initcode_accepts_symbolic_memory_offsets() {
     let mut memory = SymMemory::default();
 
     let stop = SymExpr::constant(&mut cx, U256::from(opcode::STOP));
-    let arg = SymExpr::var(&mut cx, "arg");
+    let arg = SymExpr::named_var(&mut cx, "arg");
     let bytes = SymBytes::exprs(&mut cx, vec![stop, arg]);
     memory.store_bytes(&mut cx, 7, bytes);
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     let initcode = SymCode::from_memory_offset(&mut cx, &memory, offset, 2);
     let mut bytes = initcode.read_bytes(&mut cx, 0, 2).materialize(&mut cx);
     bytes.extend((0..30).map(|_| SymExpr::zero(&mut cx)));
@@ -1652,10 +1696,10 @@ fn symbolic_initcode_accepts_symbolic_memory_offsets() {
     let mut expected = [0u8; 32];
     expected[0] = opcode::STOP;
     expected[1] = 0x2a;
-    let model = BTreeMap::from([
-        ("offset".to_string(), U256::from(7)),
-        ("arg".to_string(), U256::from(0x2a)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [("offset".to_string(), U256::from(7)), ("arg".to_string(), U256::from(0x2a))],
+    );
     assert_eq!(word.eval_model(&model).unwrap(), U256::from_be_bytes(expected));
 }
 
@@ -1663,7 +1707,7 @@ fn symbolic_initcode_accepts_symbolic_memory_offsets() {
 fn path_state_extracts_constrained_symbolic_usize() {
     let mut cx = SymCx::new();
     let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
 
     let seven = SymExpr::constant(&mut cx, U256::from(7));
     let constraint = SymBoolExpr::eq(&mut cx, offset.clone(), seven);
@@ -1676,7 +1720,7 @@ fn path_state_extracts_constrained_symbolic_usize() {
 fn path_state_extracts_symbolic_usize_upper_bound() {
     let mut cx = SymCx::new();
     let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
-    let size = SymExpr::var(&mut cx, "size");
+    let size = SymExpr::named_var(&mut cx, "size");
 
     let five = SymExpr::constant(&mut cx, U256::from(5));
     let constraint = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, size.clone(), five);
@@ -1696,7 +1740,7 @@ fn path_state_child_replaces_frame_and_resets_local_loop_state() {
     let parent_stack = SymExpr::constant(&mut cx, U256::from(0xab));
     state.stack.push(parent_stack).unwrap();
 
-    let constrained = SymExpr::var(&mut cx, "constrained");
+    let constrained = SymExpr::named_var(&mut cx, "constrained");
     let seven = SymExpr::constant(&mut cx, U256::from(7));
     let constraint = SymBoolExpr::eq(&mut cx, constrained, seven);
     state.constraints.push(constraint.clone());
@@ -1735,7 +1779,7 @@ fn path_state_child_replaces_frame_and_resets_local_loop_state() {
 fn path_state_extracts_constrained_symbolic_usize_from_encoded_bool_word() {
     let mut cx = SymCx::new();
     let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
-    let offset = SymExpr::var(&mut cx, "offset");
+    let offset = SymExpr::named_var(&mut cx, "offset");
     let offset_expr = offset.clone();
     let mask = SymExpr::constant(&mut cx, U256::from(0xffff));
 
@@ -1762,7 +1806,7 @@ fn path_state_extracts_constrained_symbolic_usize_from_encoded_bool_word() {
 fn path_state_evaluates_compound_constrained_symbolic_word() {
     let mut cx = SymCx::new();
     let mut state = PathState::empty(&mut cx, Address::ZERO, Address::ZERO, false);
-    let value = SymExpr::var(&mut cx, "value");
+    let value = SymExpr::named_var(&mut cx, "value");
     let beef = SymExpr::constant(&mut cx, U256::from(0xbeef));
     let value_constraint = SymBoolExpr::eq(&mut cx, value.clone(), beef);
     state.constraints.push(value_constraint);
@@ -1779,8 +1823,8 @@ fn path_state_evaluates_compound_constrained_symbolic_word() {
 fn symbolic_push_data_reconstructs_symbolic_word() {
     let mut cx = SymCx::new();
     let push2 = SymExpr::constant(&mut cx, U256::from(opcode::PUSH2));
-    let hi = SymExpr::var(&mut cx, "immutable_hi");
-    let lo = SymExpr::var(&mut cx, "immutable_lo");
+    let hi = SymExpr::named_var(&mut cx, "immutable_hi");
+    let lo = SymExpr::named_var(&mut cx, "immutable_lo");
     let bytes = SymBytes::exprs(&mut cx, vec![push2, hi, lo]);
     let code = SymCode::from_bytes(&mut cx, bytes);
 
@@ -1792,7 +1836,7 @@ fn symbolic_push_data_reconstructs_symbolic_word() {
 #[test]
 fn symbolic_push32_preserves_structural_word() {
     let mut cx = SymCx::new();
-    let immediate = SymExpr::var(&mut cx, "immutable");
+    let immediate = SymExpr::named_var(&mut cx, "immutable");
     let opcode = SymBytes::concrete(&mut cx, vec![opcode::PUSH32]);
     let immediate_bytes = immediate.clone().into_bytes(&mut cx);
     let bytes = SymBytes::concat(&mut cx, [opcode, immediate_bytes]);
@@ -1804,7 +1848,7 @@ fn symbolic_push32_preserves_structural_word() {
 #[test]
 fn abi_bytes_return_encodes_symbolic_bytes() {
     let mut cx = SymCx::new();
-    let byte_0 = SymExpr::var(&mut cx, "calldata_byte_0");
+    let byte_0 = SymExpr::named_var(&mut cx, "calldata_byte_0");
     let byte_1 = SymExpr::constant(&mut cx, U256::from(0x42));
     let ret = abi_bytes_return(&mut cx, vec![byte_0.clone(), byte_1.clone()]);
     let offset_bytes = (0..32).map(|idx| ret.byte(&mut cx, idx)).collect::<Vec<_>>();
@@ -1823,9 +1867,9 @@ fn abi_bytes_return_encodes_symbolic_bytes() {
 #[test]
 fn abi_bytes_return_can_encode_symbolic_length() {
     let mut cx = SymCx::new();
-    let len = SymExpr::var(&mut cx, "len");
-    let byte_0 = SymExpr::var(&mut cx, "byte_0");
-    let byte_1 = SymExpr::var(&mut cx, "byte_1");
+    let len = SymExpr::named_var(&mut cx, "len");
+    let byte_0 = SymExpr::named_var(&mut cx, "byte_0");
+    let byte_1 = SymExpr::named_var(&mut cx, "byte_1");
     let ret = abi_bytes_return_with_len(&mut cx, len.clone(), vec![byte_0.clone(), byte_1.clone()]);
     let offset_bytes = (0..32).map(|idx| ret.byte(&mut cx, idx)).collect::<Vec<_>>();
     let offset_word = SymExpr::from_bytes(&mut cx, offset_bytes);
@@ -1842,7 +1886,7 @@ fn abi_bytes_return_can_encode_symbolic_length() {
 #[test]
 fn symbolic_keccak_is_deterministic_for_same_symbolic_bytes() {
     let mut cx = SymCx::new();
-    let bytes = SymExpr::var(&mut cx, "slot_key").into_byte_exprs(&mut cx);
+    let bytes = SymExpr::named_var(&mut cx, "slot_key").into_byte_exprs(&mut cx);
 
     let first = keccak_word(&mut cx, bytes.clone());
     let second = keccak_word(&mut cx, bytes);
@@ -1855,17 +1899,17 @@ fn symbolic_keccak_is_deterministic_for_same_symbolic_bytes() {
 fn symbolic_keccak_tracks_symbolic_length() {
     let mut cx = SymCx::new();
     let bytes = vec![
-        SymExpr::var(&mut cx, "byte_0"),
-        SymExpr::var(&mut cx, "byte_1"),
+        SymExpr::named_var(&mut cx, "byte_0"),
+        SymExpr::named_var(&mut cx, "byte_1"),
         SymExpr::zero(&mut cx),
     ];
-    let len = SymExpr::var(&mut cx, "len");
+    let len = SymExpr::named_var(&mut cx, "len");
 
     let word = keccak_word_with_len(&mut cx, bytes, len);
 
     let (hash_len, hash_bytes_len) =
         word.keccak_len_and_byte_count().expect("expected symbolic keccak term");
-    assert_eq!(hash_len, &SymExpr::var(&mut cx, "len"));
+    assert_eq!(hash_len, &SymExpr::named_var(&mut cx, "len"));
     assert_eq!(hash_bytes_len, 3);
 }
 
@@ -1874,7 +1918,7 @@ fn sym_expr_eval_computes_symbolic_keccak_from_model() {
     let mut cx = SymCx::new();
     let owner = Address::from([0x11; 20]);
     let slot = U256::from(1);
-    let mut bytes = SymExpr::var(&mut cx, "owner").into_byte_exprs(&mut cx);
+    let mut bytes = SymExpr::named_var(&mut cx, "owner").into_byte_exprs(&mut cx);
     bytes.extend(SymExpr::constant(&mut cx, slot).into_byte_exprs(&mut cx));
     let word = keccak_word(&mut cx, bytes);
 
@@ -1882,7 +1926,7 @@ fn sym_expr_eval_computes_symbolic_keccak_from_model() {
     input.extend(address_word(owner).to_be_bytes::<32>());
     input.extend(slot.to_be_bytes::<32>());
     let expected = U256::from_be_bytes(keccak256(input).0);
-    let model = BTreeMap::from([("owner".to_string(), address_word(owner))]);
+    let model = symbolic_model(&mut cx, [("owner".to_string(), address_word(owner))]);
 
     assert_eq!(word.eval_model(&model).unwrap(), expected);
 }
@@ -1890,7 +1934,8 @@ fn sym_expr_eval_computes_symbolic_keccak_from_model() {
 #[test]
 fn symbolic_hash_precompiles_are_deterministic_for_same_symbolic_input() {
     let mut cx = SymCx::new();
-    let input = vec![SymExpr::var(&mut cx, "input_0"), SymExpr::var(&mut cx, "input_1")];
+    let input =
+        vec![SymExpr::named_var(&mut cx, "input_0"), SymExpr::named_var(&mut cx, "input_1")];
 
     let input_len = SymExpr::constant(&mut cx, U256::from(input.len()));
     let input_bytes = SymBytes::exprs(&mut cx, input.clone());
@@ -1990,7 +2035,7 @@ fn identity_precompile_preserves_symbolic_input_len() {
         SymExpr::constant(&mut cx, U256::from(3)),
         SymExpr::constant(&mut cx, U256::from(4)),
     ];
-    let input_len = SymExpr::var(&mut cx, "size");
+    let input_len = SymExpr::named_var(&mut cx, "size");
     let input = SymBytes::exprs(&mut cx, input);
     let return_data = execute_symbolic_precompile(
         &mut cx,
@@ -2015,7 +2060,7 @@ fn advanced_precompiles_accept_symbolic_payloads() {
     modexp_input[31] = SymExpr::constant(&mut cx, U256::from(1));
     modexp_input[63] = SymExpr::constant(&mut cx, U256::from(1));
     modexp_input[95] = SymExpr::constant(&mut cx, U256::from(1));
-    modexp_input[96] = SymExpr::var(&mut cx, "base");
+    modexp_input[96] = SymExpr::named_var(&mut cx, "base");
     modexp_input[97] = SymExpr::constant(&mut cx, U256::from(5));
     modexp_input[98] = SymExpr::constant(&mut cx, U256::from(13));
 
@@ -2044,7 +2089,7 @@ fn advanced_precompiles_accept_symbolic_payloads() {
     assert_eq!(modexp.len(), 1);
     assert_eq!(modexp.byte(&mut cx, 0), modexp_again.byte(&mut cx, 0));
 
-    let mut blake_input = vec![SymExpr::var(&mut cx, "blake_input"); 213];
+    let mut blake_input = vec![SymExpr::named_var(&mut cx, "blake_input"); 213];
     blake_input[212] = SymExpr::zero(&mut cx);
     let blake_len = SymExpr::constant(&mut cx, U256::from(213));
     let blake_input = SymBytes::exprs(&mut cx, blake_input);
@@ -2063,7 +2108,7 @@ fn advanced_precompiles_accept_symbolic_payloads() {
 #[test]
 fn validity_sensitive_symbolic_precompiles_report_incomplete() {
     let mut cx = SymCx::new();
-    let bn_input = vec![SymExpr::var(&mut cx, "point"); 128];
+    let bn_input = vec![SymExpr::named_var(&mut cx, "point"); 128];
     let bn_len = SymExpr::constant(&mut cx, U256::from(128));
     let bn_input = SymBytes::exprs(&mut cx, bn_input);
     let err = execute_symbolic_precompile(
@@ -2079,7 +2124,7 @@ fn validity_sensitive_symbolic_precompiles_report_incomplete() {
         SymbolicError::Unsupported("symbolic bn254 precompile validity not modeled")
     ));
 
-    let blake_input = vec![SymExpr::var(&mut cx, "blake_input"); 213];
+    let blake_input = vec![SymExpr::named_var(&mut cx, "blake_input"); 213];
     let blake_len = SymExpr::constant(&mut cx, U256::from(213));
     let blake_input = SymBytes::exprs(&mut cx, blake_input);
     let err = execute_symbolic_precompile(
@@ -2100,8 +2145,8 @@ fn validity_sensitive_symbolic_precompiles_report_incomplete() {
 fn symbolic_storage_read_after_write_accepts_symbolic_keys() {
     let mut cx = SymCx::new();
     let address = Address::from([0x11; 20]);
-    let key = SymExpr::var(&mut cx, "slot");
-    let value = SymExpr::var(&mut cx, "value");
+    let key = SymExpr::named_var(&mut cx, "slot");
+    let value = SymExpr::named_var(&mut cx, "value");
     let writes = vec![StorageWrite::new(address, key.clone(), value.clone())];
     let base = SymExpr::zero(&mut cx);
 
@@ -2112,9 +2157,9 @@ fn symbolic_storage_read_after_write_accepts_symbolic_keys() {
 fn symbolic_storage_uses_conditional_value_for_maybe_equal_key() {
     let mut cx = SymCx::new();
     let address = Address::from([0x11; 20]);
-    let write_key = SymExpr::var(&mut cx, "write_slot");
-    let read_key = SymExpr::var(&mut cx, "read_slot");
-    let value = SymExpr::var(&mut cx, "value");
+    let write_key = SymExpr::named_var(&mut cx, "write_slot");
+    let read_key = SymExpr::named_var(&mut cx, "read_slot");
+    let value = SymExpr::named_var(&mut cx, "value");
     let writes = vec![StorageWrite::new(address, write_key.clone(), value.clone())];
     let base = SymExpr::zero(&mut cx);
     let selected = StorageWrite::select_from(&mut cx, &writes, address, read_key.clone(), base);
@@ -2128,17 +2173,17 @@ fn symbolic_storage_uses_conditional_value_for_maybe_equal_key() {
 #[test]
 fn symbolic_storage_key_equality_decomposes_keccak_offsets() {
     let mut cx = SymCx::new();
-    let owner = SymExpr::var(&mut cx, "owner");
+    let owner = SymExpr::named_var(&mut cx, "owner");
     let owner_bytes = owner.into_byte_exprs(&mut cx);
     let base = keccak_word(&mut cx, owner_bytes);
-    let left_index = SymExpr::var(&mut cx, "left_index");
-    let right_index = SymExpr::var(&mut cx, "right_index");
+    let left_index = SymExpr::named_var(&mut cx, "left_index");
+    let right_index = SymExpr::named_var(&mut cx, "right_index");
     let left = add_words(&mut cx, base.clone(), left_index);
     let right = add_words(&mut cx, base, right_index);
 
     let actual = left.storage_key_eq(&mut cx, &right);
-    let left_index = SymExpr::var(&mut cx, "left_index");
-    let right_index = SymExpr::var(&mut cx, "right_index");
+    let left_index = SymExpr::named_var(&mut cx, "left_index");
+    let right_index = SymExpr::named_var(&mut cx, "right_index");
     let expected = SymBoolExpr::eq(&mut cx, left_index, right_index);
     assert_eq!(actual, expected);
 }
@@ -2146,18 +2191,18 @@ fn symbolic_storage_key_equality_decomposes_keccak_offsets() {
 #[test]
 fn symbolic_storage_key_equality_expands_distinct_keccak_bases() {
     let mut cx = SymCx::new();
-    let left_owner = SymExpr::var(&mut cx, "left_owner");
+    let left_owner = SymExpr::named_var(&mut cx, "left_owner");
     let left_base = keccak_word(&mut cx, vec![left_owner]);
-    let right_owner = SymExpr::var(&mut cx, "right_owner");
+    let right_owner = SymExpr::named_var(&mut cx, "right_owner");
     let right_base = keccak_word(&mut cx, vec![right_owner]);
-    let index = SymExpr::var(&mut cx, "index");
+    let index = SymExpr::named_var(&mut cx, "index");
 
     let left = add_words(&mut cx, left_base, index.clone());
     let right = add_words(&mut cx, right_base, index);
     let condition = left.storage_key_eq(&mut cx, &right);
 
-    let left_owner = SymExpr::var(&mut cx, "left_owner");
-    let right_owner = SymExpr::var(&mut cx, "right_owner");
+    let left_owner = SymExpr::named_var(&mut cx, "left_owner");
+    let right_owner = SymExpr::named_var(&mut cx, "right_owner");
     let expected = SymBoolExpr::eq(&mut cx, left_owner, right_owner);
     assert_eq!(condition, expected);
 }
@@ -2165,7 +2210,7 @@ fn symbolic_storage_key_equality_expands_distinct_keccak_bases() {
 #[test]
 fn symbolic_storage_key_equality_rejects_concrete_plain_slot_alias() {
     let mut cx = SymCx::new();
-    let owner = SymExpr::var(&mut cx, "owner");
+    let owner = SymExpr::named_var(&mut cx, "owner");
     let owner = owner.into_byte_exprs(&mut cx);
     let owner = keccak_word(&mut cx, owner);
     let zero = SymExpr::zero(&mut cx);
@@ -2180,9 +2225,9 @@ fn symbolic_storage_key_equality_rejects_concrete_plain_slot_alias() {
 #[test]
 fn nested_mapping_key_does_not_alias_plain_mapping_key_under_model() {
     let mut cx = SymCx::new();
-    let owner = SymExpr::var(&mut cx, "owner");
-    let spender = SymExpr::var(&mut cx, "spender");
-    let recipient = SymExpr::var(&mut cx, "recipient");
+    let owner = SymExpr::named_var(&mut cx, "owner");
+    let spender = SymExpr::named_var(&mut cx, "spender");
+    let recipient = SymExpr::named_var(&mut cx, "recipient");
 
     let mut balance_key_bytes = recipient.into_byte_exprs(&mut cx);
     balance_key_bytes.extend(SymExpr::constant(&mut cx, U256::ZERO).into_byte_exprs(&mut cx));
@@ -2197,11 +2242,14 @@ fn nested_mapping_key_does_not_alias_plain_mapping_key_under_model() {
     let allowance_key = keccak_word(&mut cx, allowance_key_bytes);
 
     let same_address = precompile_address(0x60);
-    let model = BTreeMap::from([
-        ("owner".to_string(), address_word(Address::from([0x11; 20]))),
-        ("spender".to_string(), address_word(same_address)),
-        ("recipient".to_string(), address_word(same_address)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [
+            ("owner".to_string(), address_word(Address::from([0x11; 20]))),
+            ("spender".to_string(), address_word(same_address)),
+            ("recipient".to_string(), address_word(same_address)),
+        ],
+    );
     let condition = balance_key.storage_key_eq(&mut cx, &allowance_key);
 
     assert_eq!(condition, SymBoolExpr::constant(&mut cx, false));
@@ -2325,7 +2373,7 @@ fn calldata_variant_expansion_respects_path_width() {
 #[test]
 fn symbolic_signextend_uses_sign_bit_ite() {
     let mut cx = SymCx::new();
-    let word = SymExpr::var(&mut cx, "word");
+    let word = SymExpr::named_var(&mut cx, "word");
     let actual = signextend_word(&mut cx, U256::ZERO, word.clone());
     let sign_mask = SymExpr::constant(&mut cx, U256::from(0x80));
     let sign_bit = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), sign_mask);
@@ -2351,7 +2399,7 @@ sat
 
     let model = parse_model(output).unwrap();
 
-    assert_eq!(model.get(&Symbol::intern("calldata_0")), Some(&U256::from(42)));
+    assert_eq!(model.get("calldata_0"), Some(&U256::from(42)));
 }
 
 #[test]
@@ -2366,7 +2414,7 @@ sat
 
     let model = parse_model(output).unwrap();
 
-    assert_eq!(model.get(&Symbol::intern("calldata_0")), Some(&U256::from(42)));
+    assert_eq!(model.get("calldata_0"), Some(&U256::from(42)));
 }
 
 #[test]
@@ -2389,11 +2437,11 @@ sat
     #x00)
 )
 ";
-    let calldata = SymExpr::var(&mut cx, "calldata_0");
+    let calldata = SymExpr::named_var(&mut cx, "calldata_0");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraints = vec![SymBoolExpr::eq(&mut cx, calldata, one)];
 
-    let err = validate_solver_model_output(output, &constraints).unwrap_err();
+    let err = validate_solver_model_output(&cx, output, &constraints).unwrap_err();
 
     assert!(err.to_string().contains("does not satisfy path constraints"));
 }
@@ -2401,7 +2449,7 @@ sat
 #[test]
 fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
     let mut cx = SymCx::new();
-    let var = SymExpr::var(&mut cx, "calldata_0");
+    let var = SymExpr::named_var(&mut cx, "calldata_0");
     let msg_sender = U256::from_str_radix("1804c8ab1f12e6bbf3894d4083f33e07309d1f38", 16).unwrap();
     let product = SymExpr::binop(&mut cx, SymBinOp::Mul, var.clone(), var.clone());
     let sender_word = SymExpr::constant(&mut cx, msg_sender);
@@ -2425,7 +2473,7 @@ fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
 #[test]
 fn expression_op_simplifies_exact_arithmetic_identities() {
     let mut cx = SymCx::new();
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
 
     let zero = SymExpr::zero(&mut cx);
     let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, x.clone(), zero.clone());
@@ -2433,35 +2481,35 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
     let one = SymExpr::one(&mut cx);
     let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, one, x.clone());
     assert_eq!(actual, x);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let one = SymExpr::one(&mut cx);
     let actual = SymExpr::binop(&mut cx, SymBinOp::UDiv, x.clone(), one);
     assert_eq!(actual, x);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let one = SymExpr::one(&mut cx);
     let actual = SymExpr::binop(&mut cx, SymBinOp::URem, x, one);
     let zero = SymExpr::zero(&mut cx);
     assert_eq!(actual, zero);
-    let x = SymExpr::var(&mut cx, "x");
-    let x_again = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let x_again = SymExpr::named_var(&mut cx, "x");
     let actual = SymExpr::binop(&mut cx, SymBinOp::Sub, x, x_again);
     let zero = SymExpr::zero(&mut cx);
     assert_eq!(actual, zero);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let actual = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), max);
     assert_eq!(actual, x);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let actual = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), x.clone());
     assert_eq!(actual, x);
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 160) - U256::from(1));
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let masked = SymExpr::binop(&mut cx, SymBinOp::And, x, mask.clone());
     let actual = SymExpr::binop(&mut cx, SymBinOp::And, masked.clone(), mask);
     assert_eq!(actual, masked);
     let mask_value = (U256::from(1) << 128) - U256::from(1);
     let mask = SymExpr::constant(&mut cx, mask_value);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let left_masked = SymExpr::binop(&mut cx, SymBinOp::And, mask.clone(), x.clone());
     let right_masked = SymExpr::binop(&mut cx, SymBinOp::And, x, mask);
     assert_eq!(left_masked, right_masked);
@@ -2470,19 +2518,19 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
     let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, six, seven);
     let forty_two = SymExpr::constant(&mut cx, U256::from(42));
     assert_eq!(actual, forty_two);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let scale = SymExpr::constant(&mut cx, U256::from(1) << 128);
     let actual = SymExpr::binop(&mut cx, SymBinOp::Mul, x.clone(), scale);
     let shift = SymExpr::constant(&mut cx, U256::from(128));
     let expected = SymExpr::binop(&mut cx, SymBinOp::Shl, x, shift);
     assert_eq!(actual, expected);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let divisor = SymExpr::constant(&mut cx, U256::from(1) << 128);
     let actual = SymExpr::binop(&mut cx, SymBinOp::UDiv, x.clone(), divisor);
     let shift = SymExpr::constant(&mut cx, U256::from(128));
     let expected = SymExpr::binop(&mut cx, SymBinOp::Shr, x, shift);
     assert_eq!(actual, expected);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let divisor = SymExpr::constant(&mut cx, U256::from(1) << 128);
     let actual = SymExpr::binop(&mut cx, SymBinOp::URem, x.clone(), divisor);
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 128) - U256::from(1));
@@ -2493,8 +2541,8 @@ fn expression_op_simplifies_exact_arithmetic_identities() {
 #[test]
 fn bool_word_equality_simplifies_to_condition() {
     let mut cx = SymCx::new();
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, y);
     let word = SymExpr::bool_word(&mut cx, condition.clone());
 
@@ -2514,8 +2562,8 @@ fn bool_word_equality_simplifies_to_condition() {
 #[test]
 fn inverted_bool_word_equality_simplifies_to_condition() {
     let mut cx = SymCx::new();
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let condition = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, y);
     let zero = SymExpr::zero(&mut cx);
     let one = SymExpr::one(&mut cx);
@@ -2533,7 +2581,7 @@ fn inverted_bool_word_equality_simplifies_to_condition() {
 fn bool_comparison_folds_reflexive_operands() {
     let mut cx = SymCx::new();
 
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), x.clone());
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
@@ -2559,41 +2607,41 @@ fn bool_comparison_folds_unsigned_boundaries() {
     let mut cx = SymCx::new();
 
     let zero = SymExpr::zero(&mut cx);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, zero, x);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
     let zero = SymExpr::zero(&mut cx);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, zero, x);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let zero = SymExpr::zero(&mut cx);
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, zero);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let zero = SymExpr::zero(&mut cx);
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, x, zero);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, max, x);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
     let max = SymExpr::constant(&mut cx, U256::MAX);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, max, x);
     let expected = SymBoolExpr::constant(&mut cx, true);
     assert_eq!(actual, expected);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x, max);
     let expected = SymBoolExpr::constant(&mut cx, false);
     assert_eq!(actual, expected);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let actual = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, x, max);
     let expected = SymBoolExpr::constant(&mut cx, true);
@@ -2609,14 +2657,14 @@ fn exact_modular_arithmetic_handles_zero_modulus_and_wide_intermediates() {
     assert_eq!(U256::MAX.add_mod(U256::from(2), U256::MAX), U256::from(2));
     assert_eq!(U256::MAX.mul_mod(U256::MAX, U256::MAX), U256::ZERO);
 
-    let model = BTreeMap::from([("a".to_string(), U256::MAX)]);
-    let a = SymExpr::var(&mut cx, "a");
+    let model = symbolic_model(&mut cx, [("a".to_string(), U256::MAX)]);
+    let a = SymExpr::named_var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, max);
     assert_eq!(addmod.eval_model(&model).unwrap(), U256::from(2));
-    let a = SymExpr::var(&mut cx, "a");
-    let a_again = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
+    let a_again = SymExpr::named_var(&mut cx, "a");
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let mulmod = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a, a_again, max);
     assert_eq!(mulmod.eval_model(&model).unwrap(), U256::ZERO);
@@ -2625,14 +2673,14 @@ fn exact_modular_arithmetic_handles_zero_modulus_and_wide_intermediates() {
 #[test]
 fn exact_modular_arithmetic_smt_widens_before_modulo() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
-    let m = SymExpr::var(&mut cx, "m");
-    let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, m).smt();
-    let a = SymExpr::var(&mut cx, "a");
-    let b = SymExpr::var(&mut cx, "b");
-    let m = SymExpr::var(&mut cx, "m");
-    let mulmod = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a, b, m).smt();
+    let m = SymExpr::named_var(&mut cx, "m");
+    let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, m).smt(&cx);
+    let a = SymExpr::named_var(&mut cx, "a");
+    let b = SymExpr::named_var(&mut cx, "b");
+    let m = SymExpr::named_var(&mut cx, "m");
+    let mulmod = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a, b, m).smt(&cx);
 
     assert!(addmod.contains("((_ zero_extend 256) a)"));
     assert!(addmod.contains("bvadd"));
@@ -2645,17 +2693,18 @@ fn exact_modular_arithmetic_smt_widens_before_modulo() {
 #[test]
 fn power_of_two_modular_arithmetic_uses_low_mask() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
-    let b = SymExpr::var(&mut cx, "b");
+    let a = SymExpr::named_var(&mut cx, "a");
+    let b = SymExpr::named_var(&mut cx, "b");
     let modulus = SymExpr::constant(&mut cx, U256::from(1) << 128);
     let mulmod = SymExpr::ternop(&mut cx, SymTernOp::MulMod, a, b, modulus);
 
-    let smt = mulmod.smt();
+    let smt = mulmod.smt(&cx);
     assert!(smt.contains("bvand"));
     assert!(smt.contains("bvmul"));
     assert!(!smt.contains("bvurem"));
 
-    let model = BTreeMap::from([("a".to_string(), U256::MAX), ("b".to_string(), U256::from(3))]);
+    let model =
+        symbolic_model(&mut cx, [("a".to_string(), U256::MAX), ("b".to_string(), U256::from(3))]);
     assert_eq!(
         mulmod.eval_model(&model).unwrap(),
         U256::MAX.mul_mod(U256::from(3), U256::from(1) << 128)
@@ -2665,7 +2714,7 @@ fn power_of_two_modular_arithmetic_uses_low_mask() {
 #[test]
 fn low_masked_power_of_two_division_simplifies_to_shift() {
     let mut cx = SymCx::new();
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 128) - U256::from(1));
     let low = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), mask);
     let numerator = SymExpr::binop(&mut cx, SymBinOp::Sub, x.clone(), low);
@@ -2680,7 +2729,7 @@ fn low_masked_power_of_two_division_simplifies_to_shift() {
 #[test]
 fn low_masked_words_preserve_unsigned_ordering() {
     let mut cx = SymCx::new();
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let mask = SymExpr::constant(&mut cx, (U256::from(1) << 128) - U256::from(1));
     let low = SymExpr::binop(&mut cx, SymBinOp::And, x.clone(), mask);
 
@@ -2702,7 +2751,7 @@ fn low_masked_words_preserve_unsigned_ordering() {
 #[test]
 fn exact_addmod_model_validation_rejects_wrapping_false_pass() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let max = SymExpr::constant(&mut cx, U256::MAX);
     let addmod = SymExpr::ternop(&mut cx, SymTernOp::AddMod, a, two, max);
@@ -2710,7 +2759,7 @@ fn exact_addmod_model_validation_rejects_wrapping_false_pass() {
     let constraints = vec![SymBoolExpr::eq(&mut cx, addmod, one)];
     let output = format!("sat\n((define-fun a () (_ BitVec 256) #x{}))\n", "f".repeat(64));
 
-    let err = validate_solver_model_output(&output, &constraints).unwrap_err();
+    let err = validate_solver_model_output(&cx, &output, &constraints).unwrap_err();
 
     assert!(err.to_string().contains("does not satisfy path constraints"));
 }
@@ -2718,14 +2767,14 @@ fn exact_addmod_model_validation_rejects_wrapping_false_pass() {
 #[test]
 fn solver_normalizes_udiv_zero_predicates_without_bvudiv() {
     let mut cx = SymCx::new();
-    let numerator = SymExpr::var(&mut cx, "numerator");
-    let denominator = SymExpr::var(&mut cx, "denominator");
+    let numerator = SymExpr::named_var(&mut cx, "numerator");
+    let denominator = SymExpr::named_var(&mut cx, "denominator");
     let div = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::eq(&mut cx, div, zero);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
 
-    assert!(!normalized.smt().contains("bvudiv"));
+    assert!(!normalized.smt(&cx).contains("bvudiv"));
 
     for (num, den) in [
         (U256::ZERO, U256::ZERO),
@@ -2735,8 +2784,10 @@ fn solver_normalizes_udiv_zero_predicates_without_bvudiv() {
         (U256::from(3), U256::from(2)),
         (U256::MAX, U256::MAX),
     ] {
-        let model =
-            BTreeMap::from([("numerator".to_string(), num), ("denominator".to_string(), den)]);
+        let model = symbolic_model(
+            &mut cx,
+            [("numerator".to_string(), num), ("denominator".to_string(), den)],
+        );
         assert_eq!(
             original.eval_model(&model).unwrap(),
             normalized.eval_model(&model).unwrap(),
@@ -2748,14 +2799,14 @@ fn solver_normalizes_udiv_zero_predicates_without_bvudiv() {
 #[test]
 fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
     let mut cx = SymCx::new();
-    let numerator = SymExpr::var(&mut cx, "numerator");
-    let denominator = SymExpr::var(&mut cx, "denominator");
+    let numerator = SymExpr::named_var(&mut cx, "numerator");
+    let denominator = SymExpr::named_var(&mut cx, "denominator");
     let div = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, div, zero);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
 
-    assert!(!normalized.smt().contains("bvudiv"));
+    assert!(!normalized.smt(&cx).contains("bvudiv"));
 
     for (num, den) in [
         (U256::ZERO, U256::ZERO),
@@ -2765,8 +2816,10 @@ fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
         (U256::from(3), U256::from(2)),
         (U256::MAX, U256::MAX),
     ] {
-        let model =
-            BTreeMap::from([("numerator".to_string(), num), ("denominator".to_string(), den)]);
+        let model = symbolic_model(
+            &mut cx,
+            [("numerator".to_string(), num), ("denominator".to_string(), den)],
+        );
         assert_eq!(
             original.eval_model(&model).unwrap(),
             normalized.eval_model(&model).unwrap(),
@@ -2778,8 +2831,8 @@ fn solver_normalizes_udiv_nonzero_predicates_without_bvudiv() {
 #[test]
 fn solver_normalizes_constraint_batches_by_flattening_and_deduping() {
     let mut cx = SymCx::new();
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let ten = SymExpr::constant(&mut cx, U256::from(10));
     let a = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), ten);
     let three = SymExpr::constant(&mut cx, U256::from(3));
@@ -2807,9 +2860,9 @@ fn solver_normalizes_constraint_batches_by_flattening_and_deduping() {
 #[test]
 fn solver_normalizes_erc4626_style_share_zero_predicate() {
     let mut cx = SymCx::new();
-    let assets = SymExpr::var(&mut cx, "assets");
-    let supply = SymExpr::var(&mut cx, "supply");
-    let total_assets = SymExpr::var(&mut cx, "total_assets");
+    let assets = SymExpr::named_var(&mut cx, "assets");
+    let supply = SymExpr::named_var(&mut cx, "supply");
+    let total_assets = SymExpr::named_var(&mut cx, "total_assets");
     let numerator = SymExpr::binop(&mut cx, SymBinOp::Mul, assets, supply);
     let shares = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, total_assets);
     let zero = SymExpr::zero(&mut cx);
@@ -2817,14 +2870,14 @@ fn solver_normalizes_erc4626_style_share_zero_predicate() {
     let normalized = normalize_constraints_for_solver(&mut cx, &constraints);
 
     assert_eq!(normalized.len(), 1);
-    assert!(!normalized[0].smt().contains("bvudiv"));
-    assert!(normalized[0].smt().contains("bvmul"));
+    assert!(!normalized[0].smt(&cx).contains("bvudiv"));
+    assert!(normalized[0].smt(&cx).contains("bvmul"));
 }
 
 #[test]
 fn expression_rebuilds_word_from_extracted_byte_terms() {
     let mut cx = SymCx::new();
-    let word = SymExpr::var(&mut cx, "word");
+    let word = SymExpr::named_var(&mut cx, "word");
     let mask = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let masked = SymExpr::binop(&mut cx, SymBinOp::And, word, mask);
     let bytes = masked.clone().into_byte_exprs(&mut cx);
@@ -2836,7 +2889,7 @@ fn expression_rebuilds_word_from_extracted_byte_terms() {
 #[test]
 fn expression_rebuilds_word_from_shifted_fragments() {
     let mut cx = SymCx::new();
-    let word = SymExpr::var(&mut cx, "word");
+    let word = SymExpr::named_var(&mut cx, "word");
     let low_mask = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
     let low_bits = SymExpr::binop(&mut cx, SymBinOp::And, word.clone(), low_mask);
     let shift = SymExpr::constant(&mut cx, U256::from(32));
@@ -2852,8 +2905,8 @@ fn expression_rebuilds_word_from_shifted_fragments() {
 #[test]
 fn expression_simplifies_selector_prefixed_word_fragment() {
     let mut cx = SymCx::new();
-    let x = SymExpr::var(&mut cx, "calldata_0");
-    let y = SymExpr::var(&mut cx, "calldata_1");
+    let x = SymExpr::named_var(&mut cx, "calldata_0");
+    let y = SymExpr::named_var(&mut cx, "calldata_1");
     let low_32 = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 32));
     let low_224 = SymExpr::constant(&mut cx, mask_bits(U256::MAX, 224));
     let selector = SymExpr::constant(&mut cx, U256::from(0x771602f7u64) << 224);
@@ -2903,10 +2956,10 @@ fn checked_mul_guard_word(cx: &mut SymCx, zero_operand: &SymExpr, expected: &Sym
 #[test]
 fn solver_normalizes_checked_mul_guard_for_bounded_operands() {
     let mut cx = SymCx::new();
-    let a_word = SymExpr::var(&mut cx, "a");
+    let a_word = SymExpr::named_var(&mut cx, "a");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let a = SymExpr::binop(&mut cx, SymBinOp::And, a_word, u64_max);
-    let b_word = SymExpr::var(&mut cx, "b");
+    let b_word = SymExpr::named_var(&mut cx, "b");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let b = SymExpr::binop(&mut cx, SymBinOp::And, b_word, u64_max);
     let guard = checked_mul_guard_word(&mut cx, &a, &b);
@@ -2922,7 +2975,7 @@ fn solver_normalizes_checked_mul_guard_for_bounded_operands() {
 #[test]
 fn solver_normalizes_checked_mul_guard_from_path_upper_bound() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let factor = SymExpr::constant(&mut cx, U256::from(1_000_000_000_000_000_000u128));
     let guard = checked_mul_guard_word(&mut cx, &a, &factor);
     let zero = SymExpr::zero(&mut cx);
@@ -2935,7 +2988,7 @@ fn solver_normalizes_checked_mul_guard_from_path_upper_bound() {
     assert_eq!(normalized, vec![SymBoolExpr::constant(&mut cx, false)]);
 
     for value in [U256::ZERO, U256::from(1), U256::from(1000)] {
-        let model = BTreeMap::from([("a".to_string(), value)]);
+        let model = symbolic_model(&mut cx, [("a".to_string(), value)]);
         assert!(!guard_is_false.eval_model(&model).unwrap());
     }
 }
@@ -2943,7 +2996,7 @@ fn solver_normalizes_checked_mul_guard_from_path_upper_bound() {
 #[test]
 fn solver_normalizes_guarded_self_division_guard() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
@@ -2959,7 +3012,7 @@ fn solver_normalizes_guarded_self_division_guard() {
     assert_eq!(normalized, SymBoolExpr::constant(&mut cx, false));
 
     for value in [U256::ZERO, U256::from(1), U256::from(2), U256::MAX] {
-        let model = BTreeMap::from([("a".to_string(), value)]);
+        let model = symbolic_model(&mut cx, [("a".to_string(), value)]);
         assert!(!original.eval_model(&model).unwrap());
     }
 }
@@ -2967,7 +3020,7 @@ fn solver_normalizes_guarded_self_division_guard() {
 #[test]
 fn expression_normalizes_guarded_self_division_word() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
@@ -2979,7 +3032,7 @@ fn expression_normalizes_guarded_self_division_word() {
     assert_eq!(checked_quotient, expected);
 
     for value in [U256::ZERO, U256::from(1), U256::from(2), U256::MAX] {
-        let model = BTreeMap::from([("a".to_string(), value)]);
+        let model = symbolic_model(&mut cx, [("a".to_string(), value)]);
         assert_eq!(
             checked_quotient.eval_model(&model).unwrap(),
             expected.eval_model(&model).unwrap()
@@ -2990,7 +3043,7 @@ fn expression_normalizes_guarded_self_division_word() {
 #[test]
 fn solver_does_not_invert_guarded_zero_self_division() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
@@ -2998,7 +3051,7 @@ fn solver_does_not_invert_guarded_zero_self_division() {
     let normalized = normalize_expr_for_solver(&mut cx, mirrored.clone());
 
     for value in [U256::ZERO, U256::from(1), U256::from(2), U256::MAX] {
-        let model = BTreeMap::from([("a".to_string(), value)]);
+        let model = symbolic_model(&mut cx, [("a".to_string(), value)]);
         assert_eq!(mirrored.eval_model(&model).unwrap(), normalized.eval_model(&model).unwrap());
     }
 }
@@ -3006,7 +3059,7 @@ fn solver_does_not_invert_guarded_zero_self_division() {
 #[test]
 fn solver_normalizes_guarded_self_division_add_overflow_guard() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let a_is_zero = SymBoolExpr::eq(&mut cx, a.clone(), zero.clone());
     let quotient = SymExpr::binop(&mut cx, SymBinOp::UDiv, a.clone(), a);
@@ -3024,7 +3077,7 @@ fn solver_normalizes_guarded_self_division_add_overflow_guard() {
 #[test]
 fn solver_normalizes_checked_mul_guard_with_context_bound() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let scale = SymExpr::constant(&mut cx, U256::from(1_000_000_000_000_000_000u128));
     let guard = checked_mul_guard_word(&mut cx, &a, &scale);
     let zero = SymExpr::zero(&mut cx);
@@ -3043,7 +3096,7 @@ fn solver_normalizes_checked_mul_guard_with_context_bound() {
 #[test]
 fn solver_does_not_context_normalize_checked_mul_guard_without_tight_bound() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let scale = SymExpr::constant(&mut cx, U256::from(1_000_000_000_000_000_000u128));
     let guard = checked_mul_guard_word(&mut cx, &a, &scale);
     let zero = SymExpr::zero(&mut cx);
@@ -3060,15 +3113,15 @@ fn solver_does_not_context_normalize_checked_mul_guard_without_tight_bound() {
         vec![SymBoolExpr::constant(&mut cx, false)]
     );
 
-    let model = BTreeMap::from([("a".to_string(), U256::MAX)]);
+    let model = symbolic_model(&mut cx, [("a".to_string(), U256::MAX)]);
     assert!(guard_is_zero.eval_model(&model).unwrap());
 }
 
 #[test]
 fn solver_does_not_normalize_unbounded_checked_mul_guard_to_tautology() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
-    let b = SymExpr::var(&mut cx, "b");
+    let a = SymExpr::named_var(&mut cx, "a");
+    let b = SymExpr::named_var(&mut cx, "b");
     let guard = checked_mul_guard_word(&mut cx, &a, &b);
     let zero = SymExpr::zero(&mut cx);
     let original = SymBoolExpr::eq(&mut cx, guard, zero);
@@ -3076,7 +3129,8 @@ fn solver_does_not_normalize_unbounded_checked_mul_guard_to_tautology() {
 
     assert_ne!(normalized, SymBoolExpr::constant(&mut cx, false));
 
-    let model = BTreeMap::from([("a".to_string(), U256::MAX), ("b".to_string(), U256::from(2))]);
+    let model =
+        symbolic_model(&mut cx, [("a".to_string(), U256::MAX), ("b".to_string(), U256::from(2))]);
     assert!(original.eval_model(&model).unwrap());
     assert_eq!(original.eval_model(&model).unwrap(), normalized.eval_model(&model).unwrap());
 }
@@ -3084,7 +3138,7 @@ fn solver_does_not_normalize_unbounded_checked_mul_guard_to_tautology() {
 #[test]
 fn solver_does_not_normalize_checked_mul_guard_when_path_bound_can_overflow() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let factor = SymExpr::constant(&mut cx, U256::from(2));
     let guard = checked_mul_guard_word(&mut cx, &a, &factor);
     let zero = SymExpr::zero(&mut cx);
@@ -3095,7 +3149,7 @@ fn solver_does_not_normalize_checked_mul_guard_when_path_bound_can_overflow() {
 
     assert!(!matches!(normalized.as_slice(), [expr] if expr.as_const() == Some(false)));
 
-    let model = BTreeMap::from([("a".to_string(), U256::MAX)]);
+    let model = symbolic_model(&mut cx, [("a".to_string(), U256::MAX)]);
     assert!(original.eval_model(&model).unwrap());
     assert!(normalized.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
 }
@@ -3103,14 +3157,14 @@ fn solver_does_not_normalize_checked_mul_guard_when_path_bound_can_overflow() {
 #[test]
 fn solver_normalizes_checked_add_overflow_guard_for_bounded_operands() {
     let mut cx = SymCx::new();
-    let a_raw = SymExpr::var(&mut cx, "a");
+    let a_raw = SymExpr::named_var(&mut cx, "a");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let a = SymExpr::binop(&mut cx, SymBinOp::And, a_raw, u64_max);
-    let b_raw = SymExpr::var(&mut cx, "b");
+    let b_raw = SymExpr::named_var(&mut cx, "b");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let b_masked = SymExpr::binop(&mut cx, SymBinOp::And, b_raw, u64_max);
     let numerator = SymExpr::binop(&mut cx, SymBinOp::Mul, b_masked, a.clone());
-    let denominator_raw = SymExpr::var(&mut cx, "denominator");
+    let denominator_raw = SymExpr::named_var(&mut cx, "denominator");
     let high_mask = SymExpr::constant(&mut cx, U256::MAX >> 64);
     let denominator = SymExpr::binop(&mut cx, SymBinOp::And, denominator_raw, high_mask);
     let b = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
@@ -3126,15 +3180,16 @@ fn solver_normalizes_checked_add_overflow_guard_for_bounded_operands() {
 #[test]
 fn solver_does_not_normalize_unbounded_checked_add_overflow_guard() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
-    let b = SymExpr::var(&mut cx, "b");
+    let a = SymExpr::named_var(&mut cx, "a");
+    let b = SymExpr::named_var(&mut cx, "b");
     let sum = SymExpr::binop(&mut cx, SymBinOp::Add, a.clone(), b);
     let original = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a, sum);
     let normalized = normalize_bool_for_solver(&mut cx, original.clone());
 
     assert_ne!(normalized, SymBoolExpr::constant(&mut cx, false));
 
-    let model = BTreeMap::from([("a".to_string(), U256::MAX), ("b".to_string(), U256::from(1))]);
+    let model =
+        symbolic_model(&mut cx, [("a".to_string(), U256::MAX), ("b".to_string(), U256::from(1))]);
     assert!(original.eval_model(&model).unwrap());
     assert_eq!(original.eval_model(&model).unwrap(), normalized.eval_model(&model).unwrap());
 }
@@ -3142,16 +3197,16 @@ fn solver_does_not_normalize_unbounded_checked_add_overflow_guard() {
 #[test]
 fn solver_detects_monotonic_product_contradiction() {
     let mut cx = SymCx::new();
-    let ink_word = SymExpr::var(&mut cx, "ink");
+    let ink_word = SymExpr::named_var(&mut cx, "ink");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let ink = SymExpr::binop(&mut cx, SymBinOp::And, ink_word, u64_max);
-    let art_word = SymExpr::var(&mut cx, "art");
+    let art_word = SymExpr::named_var(&mut cx, "art");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let art = SymExpr::binop(&mut cx, SymBinOp::And, art_word, u64_max);
-    let spot_word = SymExpr::var(&mut cx, "spot");
+    let spot_word = SymExpr::named_var(&mut cx, "spot");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let spot = SymExpr::binop(&mut cx, SymBinOp::And, spot_word, u64_max);
-    let rate_word = SymExpr::var(&mut cx, "rate");
+    let rate_word = SymExpr::named_var(&mut cx, "rate");
     let u64_max = SymExpr::constant(&mut cx, U256::from(u64::MAX));
     let rate = SymExpr::binop(&mut cx, SymBinOp::And, rate_word, u64_max);
     let zero = SymExpr::zero(&mut cx);
@@ -3171,10 +3226,10 @@ fn solver_detects_monotonic_product_contradiction() {
 #[test]
 fn solver_does_not_prune_wrapping_product_inequality() {
     let mut cx = SymCx::new();
-    let ink = SymExpr::var(&mut cx, "ink");
-    let art = SymExpr::var(&mut cx, "art");
-    let spot = SymExpr::var(&mut cx, "spot");
-    let rate = SymExpr::var(&mut cx, "rate");
+    let ink = SymExpr::named_var(&mut cx, "ink");
+    let art = SymExpr::named_var(&mut cx, "art");
+    let spot = SymExpr::named_var(&mut cx, "spot");
+    let rate = SymExpr::named_var(&mut cx, "rate");
     let zero = SymExpr::zero(&mut cx);
     let ink_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, ink.clone(), zero.clone());
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
@@ -3188,20 +3243,23 @@ fn solver_does_not_prune_wrapping_product_inequality() {
 
     assert!(!product_monotonic_unsat(&mut cx, &constraints));
 
-    let model = BTreeMap::from([
-        ("ink".to_string(), U256::MAX - U256::from(2)),
-        ("spot".to_string(), U256::MAX - U256::from(2)),
-        ("art".to_string(), U256::MAX - U256::from(1)),
-        ("rate".to_string(), U256::MAX - U256::from(1)),
-    ]);
+    let model = symbolic_model(
+        &mut cx,
+        [
+            ("ink".to_string(), U256::MAX - U256::from(2)),
+            ("spot".to_string(), U256::MAX - U256::from(2)),
+            ("art".to_string(), U256::MAX - U256::from(1)),
+            ("rate".to_string(), U256::MAX - U256::from(1)),
+        ],
+    );
     assert!(constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
 }
 
 #[test]
 fn hard_arithmetic_detection_flags_symbolic_mul_div_and_mod() {
     let mut cx = SymCx::new();
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
 
     assert!(SymExpr::binop(&mut cx, SymBinOp::Mul, x.clone(), y.clone()).contains_hard_arith());
     assert!(SymExpr::binop(&mut cx, SymBinOp::UDiv, x.clone(), y.clone()).contains_hard_arith());
@@ -3214,9 +3272,9 @@ fn hard_arithmetic_detection_flags_symbolic_mul_div_and_mod() {
 #[test]
 fn hard_arithmetic_fallback_finds_multi_variable_candidate() {
     let mut cx = SymCx::new();
-    let first = SymExpr::var(&mut cx, "first");
-    let donation = SymExpr::var(&mut cx, "donation");
-    let second = SymExpr::var(&mut cx, "second");
+    let first = SymExpr::named_var(&mut cx, "first");
+    let donation = SymExpr::named_var(&mut cx, "donation");
+    let second = SymExpr::named_var(&mut cx, "second");
     let denominator = SymExpr::binop(&mut cx, SymBinOp::Add, first.clone(), donation.clone());
     let numerator = SymExpr::binop(&mut cx, SymBinOp::Mul, second.clone(), first.clone());
     let shares = SymExpr::binop(&mut cx, SymBinOp::UDiv, numerator, denominator);
@@ -3227,7 +3285,7 @@ fn hard_arithmetic_fallback_finds_multi_variable_candidate() {
     let shares_zero = SymBoolExpr::eq(&mut cx, shares, zero);
     let constraints = vec![first_nonzero, donation_nonzero, second_nonzero, shares_zero];
 
-    let model = hard_arith_fallback_model(&constraints).unwrap();
+    let model = hard_arith_fallback_model(&cx, &constraints).unwrap();
 
     assert!(constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
 }
@@ -3235,10 +3293,10 @@ fn hard_arithmetic_fallback_finds_multi_variable_candidate() {
 #[test]
 fn hard_arithmetic_fallback_finds_wrapping_product_inequality_candidate() {
     let mut cx = SymCx::new();
-    let ink = SymExpr::var(&mut cx, "ink");
-    let art = SymExpr::var(&mut cx, "art");
-    let spot = SymExpr::var(&mut cx, "spot");
-    let rate = SymExpr::var(&mut cx, "rate");
+    let ink = SymExpr::named_var(&mut cx, "ink");
+    let art = SymExpr::named_var(&mut cx, "art");
+    let spot = SymExpr::named_var(&mut cx, "spot");
+    let rate = SymExpr::named_var(&mut cx, "rate");
     let zero = SymExpr::zero(&mut cx);
     let ink_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, ink.clone(), zero.clone());
     let art_above_ink = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, art.clone(), ink.clone());
@@ -3250,7 +3308,7 @@ fn hard_arithmetic_fallback_finds_wrapping_product_inequality_candidate() {
         SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, left_product, right_product).not(&mut cx);
     let constraints = vec![ink_positive, art_above_ink, spot_positive, rate_above_spot, wrapping];
 
-    let model = hard_arith_fallback_model(&constraints).unwrap();
+    let model = hard_arith_fallback_model(&cx, &constraints).unwrap();
 
     assert!(constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
 }
@@ -3258,7 +3316,7 @@ fn hard_arithmetic_fallback_finds_wrapping_product_inequality_candidate() {
 #[test]
 fn hard_arithmetic_fallback_finds_exact_mulmod_wide_intermediate_candidate() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
+    let a = SymExpr::named_var(&mut cx, "a");
     let zero = SymExpr::zero(&mut cx);
     let positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, a.clone(), zero.clone());
     let max = SymExpr::constant(&mut cx, U256::MAX);
@@ -3266,21 +3324,21 @@ fn hard_arithmetic_fallback_finds_exact_mulmod_wide_intermediate_candidate() {
     let exact = SymBoolExpr::eq(&mut cx, product, zero);
     let constraints = vec![positive, exact];
 
-    let model = hard_arith_fallback_model(&constraints).unwrap();
+    let model = hard_arith_fallback_model(&cx, &constraints).unwrap();
 
     assert!(constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
-    assert_eq!(model.get(&Symbol::intern("a")), Some(&U256::MAX));
+    assert_eq!(model_value(&cx, &model, "a"), Some(U256::MAX));
 }
 
 #[test]
 fn hard_arithmetic_fallback_rejects_unvalidated_partial_model() {
     let mut cx = SymCx::new();
-    let a = SymExpr::var(&mut cx, "a");
-    let b = SymExpr::var(&mut cx, "b");
-    let c = SymExpr::var(&mut cx, "c");
-    let d = SymExpr::var(&mut cx, "d");
-    let e = SymExpr::var(&mut cx, "e");
-    let f = SymExpr::var(&mut cx, "f");
+    let a = SymExpr::named_var(&mut cx, "a");
+    let b = SymExpr::named_var(&mut cx, "b");
+    let c = SymExpr::named_var(&mut cx, "c");
+    let d = SymExpr::named_var(&mut cx, "d");
+    let e = SymExpr::named_var(&mut cx, "e");
+    let f = SymExpr::named_var(&mut cx, "f");
     let product = SymExpr::binop(&mut cx, SymBinOp::Mul, a, b);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let product_eq_one = SymBoolExpr::eq(&mut cx, product, one);
@@ -3294,7 +3352,7 @@ fn hard_arithmetic_fallback_rejects_unvalidated_partial_model() {
     let f_eq_six = SymBoolExpr::eq(&mut cx, f, six);
     let constraints = vec![product_eq_one, c_eq_three, d_eq_four, e_eq_five, f_eq_six];
 
-    let Some(model) = hard_arith_fallback_model(&constraints) else { return };
+    let Some(model) = hard_arith_fallback_model(&cx, &constraints) else { return };
 
     assert!(constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
 }
@@ -3302,13 +3360,14 @@ fn hard_arithmetic_fallback_rejects_unvalidated_partial_model() {
 #[test]
 fn hard_arithmetic_fallback_skips_symbolic_hashes() {
     let mut cx = SymCx::new();
-    let x = SymExpr::var(&mut cx, "x");
-    let hash = SymExpr::hash_symbol(&mut cx, Symbol::intern("hash"), "sha256", vec![x.clone()]);
+    let x = SymExpr::named_var(&mut cx, "x");
+    let hash_symbol = cx.intern("hash");
+    let hash = SymExpr::hash_symbol(&mut cx, hash_symbol, "sha256", vec![x.clone()]);
     let product = SymExpr::binop(&mut cx, SymBinOp::Mul, x, hash);
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraints = vec![SymBoolExpr::eq(&mut cx, product, one)];
 
-    assert!(hard_arith_fallback_model(&constraints).is_none());
+    assert!(hard_arith_fallback_model(&cx, &constraints).is_none());
 }
 
 #[test]
@@ -3549,7 +3608,7 @@ fn is_sat_uses_single_var_witness_before_solver() {
     let marker = portfolio_test_marker("single-var-is-sat");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let value = SymExpr::var(&mut cx, "calldata_0");
+    let value = SymExpr::named_var(&mut cx, "calldata_0");
     let limit = SymExpr::constant(&mut cx, U256::from(10));
     let constraints = vec![SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, value, limit)];
 
@@ -3590,7 +3649,7 @@ fn gasleft_fails_at_smt_emission() {
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
     let gas = SymExpr::gas_left(&mut cx, 0);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let constraints = vec![SymBoolExpr::eq(&mut cx, gas, x)];
 
     let err = solver.is_sat(&mut cx, &constraints).unwrap_err();
@@ -3610,7 +3669,7 @@ fn model_uses_single_var_witness_before_solver() {
     let marker = portfolio_test_marker("single-var-model");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let value = SymExpr::var(&mut cx, "calldata_0");
+    let value = SymExpr::named_var(&mut cx, "calldata_0");
     let zero = SymExpr::zero(&mut cx);
     let not_zero = SymBoolExpr::eq(&mut cx, value.clone(), zero).not(&mut cx);
     let limit = SymExpr::constant(&mut cx, U256::from(10));
@@ -3635,8 +3694,8 @@ fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
     let marker = portfolio_test_marker("hard-arith-is-sat");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
     let x_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), zero.clone());
     let y_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, y.clone(), zero);
@@ -3645,7 +3704,7 @@ fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
     let product_eq_four = SymBoolExpr::eq(&mut cx, product, four);
     let constraints = vec![x_positive, y_positive, product_eq_four];
     let normalized = normalize_constraints_for_solver(&mut cx, &constraints);
-    let model = hard_arith_fallback_model(&normalized).unwrap();
+    let model = hard_arith_fallback_model(&cx, &normalized).unwrap();
 
     assert!(normalized.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
     assert!(solver.is_sat(&mut cx, &constraints).unwrap());
@@ -3668,8 +3727,8 @@ fn model_uses_validated_hard_arithmetic_fallback_cache() {
     let marker = portfolio_test_marker("hard-arith-model-cache");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
     let x_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), zero.clone());
     let y_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, y.clone(), zero);
@@ -3702,8 +3761,8 @@ fn is_sat_hard_arithmetic_without_witness_still_honors_solver_unsat() {
     let marker = portfolio_test_marker("hard-arith-is-sat-unsat");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let zero = SymExpr::zero(&mut cx);
     let x_is_zero = SymBoolExpr::eq(&mut cx, x.clone(), zero);
     let product = SymExpr::binop(&mut cx, SymBinOp::Mul, x, y);
@@ -3712,7 +3771,7 @@ fn is_sat_hard_arithmetic_without_witness_still_honors_solver_unsat() {
     let constraints = vec![x_is_zero, product_eq_one];
     let normalized = normalize_constraints_for_solver(&mut cx, &constraints);
 
-    assert!(hard_arith_fallback_model(&normalized).is_none());
+    assert!(hard_arith_fallback_model(&cx, &normalized).is_none());
     assert!(!solver.is_sat(&mut cx, &constraints).unwrap());
 
     let stats = solver.stats();
@@ -3731,8 +3790,8 @@ fn sat_cache_reuses_normalized_is_sat_results() {
     let marker = portfolio_test_marker("sat-cache");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let constraints = vec![
@@ -3763,8 +3822,8 @@ fn sat_cache_reuses_nested_commutative_results() {
     let marker = portfolio_test_marker("sat-cache-canonical");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let three = SymExpr::constant(&mut cx, U256::from(3));
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let sum = SymExpr::binop(&mut cx, SymBinOp::Add, x.clone(), y.clone());
@@ -3772,7 +3831,7 @@ fn sat_cache_reuses_nested_commutative_results() {
     let x_eq_one = SymBoolExpr::eq(&mut cx, x.clone(), one.clone());
     let constraints = vec![SymBoolExpr::and(&mut cx, vec![sum_eq_three, x_eq_one])];
     let one_eq_x = SymBoolExpr::eq(&mut cx, one, x);
-    let x_again = SymExpr::var(&mut cx, "x");
+    let x_again = SymExpr::named_var(&mut cx, "x");
     let reordered_sum = SymExpr::binop(&mut cx, SymBinOp::Add, y, x_again);
     let three_eq_sum = SymBoolExpr::eq(&mut cx, three, reordered_sum);
     let reordered_constraints = vec![SymBoolExpr::and(&mut cx, vec![one_eq_x, three_eq_sum])];
@@ -3795,8 +3854,8 @@ fn sat_cache_deduplicates_repeated_constraints() {
     let marker = portfolio_test_marker("sat-cache-dedup");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -3822,8 +3881,8 @@ fn sat_cache_deduplicates_nested_repeated_constraints() {
     let marker = portfolio_test_marker("sat-cache-nested-dedup");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -3852,9 +3911,9 @@ fn sat_cache_flattens_grouped_conjunction_keys() {
     let marker = portfolio_test_marker("sat-cache-and-flatten");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
-    let z = SymExpr::var(&mut cx, "z");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
+    let z = SymExpr::named_var(&mut cx, "z");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let a = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -3883,8 +3942,8 @@ fn sat_cache_reuses_reversed_comparisons() {
     let marker = portfolio_test_marker("sat-cache-reversed-cmp");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 3, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
 
     let ugt = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), y.clone());
     assert!(solver.is_sat(&mut cx, &[ugt]).unwrap());
@@ -3914,8 +3973,8 @@ fn sat_cache_reuses_unsat_branch_complement() {
     let marker = portfolio_test_marker("sat-cache-branch-complement");
     let commands = vec![counted_solver_command_sequence(&marker, &["sat", "unsat"])];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let ten = SymExpr::constant(&mut cx, U256::from(10));
     let x_lt_ten = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), ten);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -3948,7 +4007,7 @@ fn sat_cache_does_not_reuse_unsat_branch_complement_with_unsat_base() {
     let marker = portfolio_test_marker("sat-cache-unsat-base-branch-complement");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let lower = SymBoolExpr::cmp(&mut cx, SymCmpOp::Uge, x.clone(), two);
@@ -3975,8 +4034,8 @@ fn sat_cache_does_not_cache_unknown_results() {
     let marker = portfolio_test_marker("sat-cache-unknown");
     let commands = vec![counted_solver_command(&marker, "unknown")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 4, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -4006,8 +4065,8 @@ fn model_cache_reuses_normalized_model_results() {
         #x0000000000000000000000000000000000000000000000000000000000000002))";
     let commands = vec![counted_solver_command(&marker, model_output)];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let constraints = vec![
@@ -4019,14 +4078,10 @@ fn model_cache_reuses_normalized_model_results() {
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let reordered_constraints = vec![y_eq_two, x_eq_one];
 
-    assert_eq!(
-        solver.model(&mut cx, &constraints).unwrap().get(&Symbol::intern("x")),
-        Some(&U256::from(1))
-    );
-    assert_eq!(
-        solver.model(&mut cx, &reordered_constraints).unwrap().get(&Symbol::intern("y")),
-        Some(&U256::from(2))
-    );
+    let model = solver.model(&mut cx, &constraints).unwrap();
+    assert_eq!(model_value(&cx, &model, "x"), Some(U256::from(1)));
+    let model = solver.model(&mut cx, &reordered_constraints).unwrap();
+    assert_eq!(model_value(&cx, &model, "y"), Some(U256::from(2)));
 
     let stats = solver.stats();
     assert_eq!(stats.solver_queries, 1);
@@ -4049,18 +4104,16 @@ fn model_query_populates_sat_cache() {
         #x0000000000000000000000000000000000000000000000000000000000000002))";
     let commands = vec![counted_solver_command(&marker, model_output)];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
     let constraints = vec![x_eq_one, y_eq_two];
 
-    assert_eq!(
-        solver.model(&mut cx, &constraints).unwrap().get(&Symbol::intern("x")),
-        Some(&U256::from(1))
-    );
+    let model = solver.model(&mut cx, &constraints).unwrap();
+    assert_eq!(model_value(&cx, &model, "x"), Some(U256::from(1)));
     assert!(solver.is_sat(&mut cx, &constraints).unwrap());
 
     let stats = solver.stats();
@@ -4077,7 +4130,7 @@ fn model_query_populates_sat_cache() {
 fn direct_contradiction_is_sat_short_circuits_locally() {
     let mut cx = SymCx::new();
     let mut solver = SmtLibSubprocessSolver::new(Ok(Vec::new()), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let constraint = SymBoolExpr::eq(&mut cx, x, one);
     let constraints = vec![constraint.clone(), constraint.not(&mut cx)];
@@ -4097,13 +4150,13 @@ fn is_sat_reuses_cached_unsat_subset() {
     let marker = portfolio_test_marker("unsat-subset-cache");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
-    let y = SymExpr::var(&mut cx, "y");
+    let y = SymExpr::named_var(&mut cx, "y");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
-    let z = SymExpr::var(&mut cx, "z");
+    let z = SymExpr::named_var(&mut cx, "z");
     let three = SymExpr::constant(&mut cx, U256::from(3));
     let z_eq_three = SymBoolExpr::eq(&mut cx, z, three);
     let unsat_subset = vec![x_eq_one.clone(), y_eq_two.clone()];
@@ -4129,13 +4182,13 @@ fn is_sat_does_not_reuse_cached_sat_subset() {
     let marker = portfolio_test_marker("sat-subset-cache");
     let commands = vec![counted_solver_command(&marker, "sat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
+    let x = SymExpr::named_var(&mut cx, "x");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
-    let y = SymExpr::var(&mut cx, "y");
+    let y = SymExpr::named_var(&mut cx, "y");
     let two = SymExpr::constant(&mut cx, U256::from(2));
     let y_eq_two = SymBoolExpr::eq(&mut cx, y, two);
-    let z = SymExpr::var(&mut cx, "z");
+    let z = SymExpr::named_var(&mut cx, "z");
     let three = SymExpr::constant(&mut cx, U256::from(3));
     let z_eq_three = SymBoolExpr::eq(&mut cx, z, three);
     let sat_subset = vec![x_eq_one.clone(), y_eq_two.clone()];
@@ -4162,8 +4215,8 @@ fn model_short_circuits_when_sat_cache_proved_unsat() {
     let marker = portfolio_test_marker("model-cache-unsat");
     let commands = vec![counted_solver_command(&marker, "unsat")];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let x_eq_one = SymBoolExpr::eq(&mut cx, x, one);
     let two = SymExpr::constant(&mut cx, U256::from(2));
@@ -4266,8 +4319,8 @@ fn portfolio_scheduler_promotes_recent_sat_winner() {
     ];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 2, false);
 
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let zero = SymExpr::zero(&mut cx);
     let first = vec![
@@ -4313,8 +4366,8 @@ fn portfolio_scheduler_promotes_recent_unsat_winner() {
 
     solver.capture_diagnostics();
 
-    let x = SymExpr::var(&mut cx, "x");
-    let y = SymExpr::var(&mut cx, "y");
+    let x = SymExpr::named_var(&mut cx, "x");
+    let y = SymExpr::named_var(&mut cx, "y");
     let one = SymExpr::constant(&mut cx, U256::from(1));
     let zero = SymExpr::zero(&mut cx);
     let first = vec![
@@ -4367,17 +4420,15 @@ fn portfolio_scheduler_penalizes_invalid_models() {
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 16, false);
 
     for query in 0..=PORTFOLIO_SCHEDULER_HISTORY {
-        let calldata = SymExpr::var(&mut cx, "calldata_0");
+        let calldata = SymExpr::named_var(&mut cx, "calldata_0");
         let one = SymExpr::constant(&mut cx, U256::from(1));
         let calldata_constraint = SymBoolExpr::eq(&mut cx, calldata, one);
-        let portfolio_query = SymExpr::var(&mut cx, &format!("portfolio_query_{query}"));
+        let portfolio_query = SymExpr::named_var(&mut cx, &format!("portfolio_query_{query}"));
         let zero = SymExpr::zero(&mut cx);
         let query_constraint = SymBoolExpr::eq(&mut cx, portfolio_query, zero);
         let constraints = vec![calldata_constraint, query_constraint];
-        assert_eq!(
-            solver.model(&mut cx, &constraints).unwrap().get(&Symbol::intern("calldata_0")),
-            Some(&U256::from(1))
-        );
+        let model = solver.model(&mut cx, &constraints).unwrap();
+        assert_eq!(model_value(&cx, &model, "calldata_0"), Some(U256::from(1)));
         if query == 0 {
             assert!(marker.exists());
             let _ = std::fs::remove_file(&marker);
@@ -4506,7 +4557,7 @@ fn solver_smt_dump_shares_repeated_subterms() {
         .unwrap(),
     ];
     let mut solver = SmtLibSubprocessSolver::new(Ok(commands), Some(5), 1, true);
-    let calldata = SymExpr::var(&mut cx, "calldata_0");
+    let calldata = SymExpr::named_var(&mut cx, "calldata_0");
     let byte = calldata.extracted_byte(&mut cx, 0);
     let shift = SymExpr::constant(&mut cx, U256::from(248));
     let shifted = SymExpr::binop(&mut cx, SymBinOp::Shl, byte, shift);


### PR DESCRIPTION
This changes symbolic expressions to store variables and generated symbolic terms as compact symbol ids while keeping display names in the SymCx interner. It also centralizes symbol-bearing expression handling through helper methods and removes the crate-local ptr_eq helpers.