### PR TITLE
fix(cast): make source output deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5144,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=643aa536a005708ef088633e8afec4f065f32b91#643aa536a005708ef088633e8afec4f065f32b91"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5390,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=643aa536a005708ef088633e8afec4f065f32b91#643aa536a005708ef088633e8afec4f065f32b91"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5400,7 +5400,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.15.0",
+ "itertools 0.13.0",
  "path-slash",
  "rand 0.10.1",
  "rayon",
@@ -5421,7 +5421,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=643aa536a005708ef088633e8afec4f065f32b91#643aa536a005708ef088633e8afec4f065f32b91"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5430,7 +5430,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=643aa536a005708ef088633e8afec4f065f32b91#643aa536a005708ef088633e8afec4f065f32b91"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5450,7 +5450,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=643aa536a005708ef088633e8afec4f065f32b91#643aa536a005708ef088633e8afec4f065f32b91"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5463,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=643aa536a005708ef088633e8afec4f065f32b91#643aa536a005708ef088633e8afec4f065f32b91"
 dependencies = [
  "alloy-primitives",
  "dunce",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3082,7 +3082,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.18",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3241,7 +3241,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4307,7 +4307,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4568,7 +4568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5144,8 +5144,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5d909c241c48b7b23b4615cab31b9273203bc40ac2dc07b3c5d2e1a2ff353c"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5391,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5401,9 +5400,9 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "path-slash",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rayon",
  "semver 1.0.28",
  "serde",
@@ -5422,7 +5421,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5431,7 +5430,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5451,7 +5450,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5464,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=3e01874cb1e7f43d2554dc05fb1823687bdc3ab8#3e01874cb1e7f43d2554dc05fb1823687bdc3ab8"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=e35c4f8ea6501cd92909e631ee0649489f131978#e35c4f8ea6501cd92909e631ee0649489f131978"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6915,7 +6914,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7728,7 +7727,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8839,7 +8838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -8990,7 +8989,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10445,7 +10444,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10504,7 +10503,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11302,7 +11301,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11314,7 +11313,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11337,7 +11336,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.13.0",
  "bumpalo",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -11663,7 +11662,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
  "zip",
 ]
@@ -11791,7 +11790,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12009,7 +12008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13203,7 +13202,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13341,7 +13340,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -540,8 +540,8 @@ idna_adapter = "=1.1.0"
 ## Temporary pins on foundry-rs/foundry-core until foundry-compilers / foundry-block-explorers are
 ## released. Currently at foundry-rs/foundry-core#109 (deterministic contract sources); both crates
 ## point at the same rev so there's a single foundry-compilers in the graph.
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "e35c4f8ea6501cd92909e631ee0649489f131978" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "e35c4f8ea6501cd92909e631ee0649489f131978" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "643aa536a005708ef088633e8afec4f065f32b91" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "643aa536a005708ef088633e8afec4f065f32b91" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -537,8 +537,11 @@ snapbox = { version = "1.2", features = ["json", "regex", "term-svg"] }
 idna_adapter = "=1.1.0"
 
 [patch.crates-io]
-## Temporary dependency on foundry-rs/foundry-core#104 until foundry-compilers is released.
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "3e01874cb1e7f43d2554dc05fb1823687bdc3ab8" }
+## Temporary pins on foundry-rs/foundry-core until foundry-compilers / foundry-block-explorers are
+## released. Currently at foundry-rs/foundry-core#109 (deterministic contract sources); both crates
+## point at the same rev so there's a single foundry-compilers in the graph.
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "e35c4f8ea6501cd92909e631ee0649489f131978" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "e35c4f8ea6501cd92909e631ee0649489f131978" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -31,10 +31,7 @@ use alloy_transport::TransportErrorKind;
 use base::{Base, NumberWithBase, ToBase};
 use chrono::DateTime;
 use eyre::{Context, ContextCompat, OptionExt, Result};
-use foundry_block_explorers::{
-    Client,
-    contract::{ContractMetadata, SourceCodeEntry},
-};
+use foundry_block_explorers::Client;
 use foundry_common::{
     abi::{coerce_value, encode_function_args, encode_function_args_packed, get_event, get_func},
     compile::etherscan_project,
@@ -53,7 +50,6 @@ use rayon::prelude::*;
 use serde::Serialize;
 use std::{
     borrow::Cow,
-    collections::HashMap,
     fmt::Write,
     io,
     marker::PhantomData,
@@ -2264,7 +2260,7 @@ impl SimpleCast {
     ) -> Result<String> {
         let client = explorer_client(chain, etherscan_api_key, explorer_api_url, explorer_url)?;
         let metadata = client.contract_source_code(contract_address.parse()?).await?;
-        Ok(format_etherscan_source(&metadata))
+        Ok(metadata.source_code())
     }
 
     /// Fetches the source code of verified contracts from etherscan and expands the resulting
@@ -2511,28 +2507,6 @@ fn explorer_client(
     builder.build().map_err(Into::into)
 }
 
-/// Formats a verified contract's source deterministically, joining its items.
-fn format_etherscan_source(metadata: &ContractMetadata) -> String {
-    metadata.items.iter().map(|item| format_sources(item.sources())).collect::<Vec<_>>().join("\n")
-}
-
-/// Sorts sources by path so output is stable across runs, prefixing each with a `// File: <path>`
-/// header when there are multiple. A single source is emitted verbatim.
-fn format_sources(sources: HashMap<String, SourceCodeEntry>) -> String {
-    let mut sources = sources.into_iter().collect::<Vec<_>>();
-    sources.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-    if let [(_, entry)] = sources.as_slice() {
-        return entry.content.clone();
-    }
-
-    sources
-        .into_iter()
-        .map(|(path, entry)| format!("// File: {path}\n{}", entry.content))
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 /// Tests for the `eth_getLogs` chunking/bisection helpers, kept in a separate module so they can
 /// use the provider-based [`Cast`] (the `tests` module aliases `Cast` to `SimpleCast`).
 #[cfg(test)]
@@ -2659,27 +2633,8 @@ mod logs_bisecting {
 
 #[cfg(test)]
 mod tests {
-    use super::{DynSolValue, SimpleCast as Cast, format_sources, serialize_value_as_json};
+    use super::{DynSolValue, SimpleCast as Cast, serialize_value_as_json};
     use alloy_primitives::hex;
-    use std::collections::HashMap;
-
-    #[test]
-    fn format_sources_single_file_verbatim() {
-        let sources = HashMap::from([("Contract".to_string(), "contract A {}".into())]);
-        assert_eq!(format_sources(sources), "contract A {}");
-    }
-
-    #[test]
-    fn format_sources_multi_file_sorted_with_headers() {
-        let sources = HashMap::from([
-            ("src/B.sol".to_string(), "contract B {}".into()),
-            ("src/A.sol".to_string(), "contract A {}".into()),
-        ]);
-        assert_eq!(
-            format_sources(sources),
-            "// File: src/A.sol\ncontract A {}\n// File: src/B.sol\ncontract B {}"
-        );
-    }
 
     #[test]
     fn simple_selector() {

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -31,7 +31,10 @@ use alloy_transport::TransportErrorKind;
 use base::{Base, NumberWithBase, ToBase};
 use chrono::DateTime;
 use eyre::{Context, ContextCompat, OptionExt, Result};
-use foundry_block_explorers::Client;
+use foundry_block_explorers::{
+    Client,
+    contract::{ContractMetadata, SourceCodeEntry},
+};
 use foundry_common::{
     abi::{coerce_value, encode_function_args, encode_function_args_packed, get_event, get_func},
     compile::etherscan_project,
@@ -50,6 +53,7 @@ use rayon::prelude::*;
 use serde::Serialize;
 use std::{
     borrow::Cow,
+    collections::HashMap,
     fmt::Write,
     io,
     marker::PhantomData,
@@ -2260,7 +2264,7 @@ impl SimpleCast {
     ) -> Result<String> {
         let client = explorer_client(chain, etherscan_api_key, explorer_api_url, explorer_url)?;
         let metadata = client.contract_source_code(contract_address.parse()?).await?;
-        Ok(metadata.source_code())
+        Ok(format_etherscan_source(&metadata))
     }
 
     /// Fetches the source code of verified contracts from etherscan and expands the resulting
@@ -2507,6 +2511,28 @@ fn explorer_client(
     builder.build().map_err(Into::into)
 }
 
+/// Formats a verified contract's source deterministically, joining its items.
+fn format_etherscan_source(metadata: &ContractMetadata) -> String {
+    metadata.items.iter().map(|item| format_sources(item.sources())).collect::<Vec<_>>().join("\n")
+}
+
+/// Sorts sources by path so output is stable across runs, prefixing each with a `// File: <path>`
+/// header when there are multiple. A single source is emitted verbatim.
+fn format_sources(sources: HashMap<String, SourceCodeEntry>) -> String {
+    let mut sources = sources.into_iter().collect::<Vec<_>>();
+    sources.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+    if let [(_, entry)] = sources.as_slice() {
+        return entry.content.clone();
+    }
+
+    sources
+        .into_iter()
+        .map(|(path, entry)| format!("// File: {path}\n{}", entry.content))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Tests for the `eth_getLogs` chunking/bisection helpers, kept in a separate module so they can
 /// use the provider-based [`Cast`] (the `tests` module aliases `Cast` to `SimpleCast`).
 #[cfg(test)]
@@ -2633,8 +2659,27 @@ mod logs_bisecting {
 
 #[cfg(test)]
 mod tests {
-    use super::{DynSolValue, SimpleCast as Cast, serialize_value_as_json};
+    use super::{DynSolValue, SimpleCast as Cast, format_sources, serialize_value_as_json};
     use alloy_primitives::hex;
+    use std::collections::HashMap;
+
+    #[test]
+    fn format_sources_single_file_verbatim() {
+        let sources = HashMap::from([("Contract".to_string(), "contract A {}".into())]);
+        assert_eq!(format_sources(sources), "contract A {}");
+    }
+
+    #[test]
+    fn format_sources_multi_file_sorted_with_headers() {
+        let sources = HashMap::from([
+            ("src/B.sol".to_string(), "contract B {}".into()),
+            ("src/A.sol".to_string(), "contract A {}".into()),
+        ]);
+        assert_eq!(
+            format_sources(sources),
+            "// File: src/A.sol\ncontract A {}\n// File: src/B.sol\ncontract B {}"
+        );
+    }
 
     #[test]
     fn simple_selector() {


### PR DESCRIPTION
Closes #13577 

`cast source` produced nondeterministic output for multi-file contracts. The fix lives upstream in foundry-rs/foundry-core#109, so this PR consumes it via a block-explorers bump and relies on `metadata.source_code()` for the sorted output.