### PR TITLE
perf(symbolic): try simple uint shrinks first

### DIFF
--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -792,10 +792,6 @@ fn minimize_uint(
         return true;
     }
 
-    if minimize_uint_by_search(value, current, bits, try_value) {
-        return true;
-    }
-
     let bit_limit = bits.min(256);
     for bit in (0..bit_limit).rev() {
         let mask = U256::from(1) << bit;
@@ -808,7 +804,7 @@ fn minimize_uint(
         }
     }
 
-    false
+    minimize_uint_by_search(value, current, bits, try_value)
 }
 
 fn minimize_uint_by_search(
@@ -1535,6 +1531,29 @@ mod tests {
             vec![DynSolValue::Uint(U256::from(43), 8)]
         );
         assert!(minimized.attempts < TEST_MAX_MINIMIZATION_ATTEMPTS);
+    }
+
+    #[test]
+    fn uint_minimization_prefers_bit_clearing_before_binary_search() {
+        let mut value = DynSolValue::Uint(U256::from(100), 256);
+        let accepted = [U256::from(100), U256::from(50), U256::from(36)];
+
+        loop {
+            let (current, bits) = match &value {
+                DynSolValue::Uint(current, bits) => (*current, *bits),
+                _ => unreachable!(),
+            };
+            if !minimize_uint(
+                &mut value,
+                current,
+                bits,
+                &mut |candidate| matches!(candidate, DynSolValue::Uint(candidate, _) if accepted.contains(candidate)),
+            ) {
+                break;
+            }
+        }
+
+        assert_eq!(value, DynSolValue::Uint(U256::from(36), 256));
     }
 
     #[test]

--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -787,6 +787,15 @@ fn minimize_uint(
         return true;
     }
 
+    let one = U256::from(1);
+    if current > one && accept_candidate(value, DynSolValue::Uint(one, bits), try_value) {
+        return true;
+    }
+
+    if minimize_uint_by_search(value, current, bits, try_value) {
+        return true;
+    }
+
     let bit_limit = bits.min(256);
     for bit in (0..bit_limit).rev() {
         let mask = U256::from(1) << bit;
@@ -799,7 +808,7 @@ fn minimize_uint(
         }
     }
 
-    minimize_uint_by_search(value, current, bits, try_value)
+    false
 }
 
 fn minimize_uint_by_search(


### PR DESCRIPTION
Tries `1` and binary lowering before clearing individual set bits when minimizing unsigned symbolic counterexample arguments. The existing bit-clearing fallback stays in place for non-monotonic cases.

Bug suite (`grandizzy/symbolic-bug-suite`, 22/22 expected failures):
- minimization attempts: 817 -> 550
- solver counters unchanged: 212 paths, 283 solver queries, 100 SMT queries
- single-thread full suite: 1.097s +/- 0.003s -> 1.086s +/- 0.002s
- DEI+Rari focused: 654.2ms +/- 5.9ms -> 642.4ms +/- 4.6ms

`foundry-bench` (`forge_symbolic_test`, `pr-bench.sh`, 5 runs):
- solady: 0.359s +/- 0.013s -> 0.358s +/- 0.011s
- SorellaLabs-angstrom: 0.494s +/- 0.009s -> 0.487s +/- 0.004s
- farcasterxyz-contracts: 0.253s +/- 0.005s -> 0.262s +/- 0.006s; targeted rerun 0.252s +/- 0.004s -> 0.254s +/- 0.004s
- symbolic pass/incomplete counts and SMT query counts unchanged
