### PR TITLE
feat(lint): add modifier-used-only-once detector

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -69,6 +69,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `low-level-calls`: Direct use of low-level calls should be avoided.
   - `event-fields`: `address` event parameters should be `indexed` for efficient log filtering.
   - `unused-error`: Custom error declarations that are never referenced should be removed.
+  - `modifier-used-only-once`: Modifiers invoked by exactly one function can usually be inlined as checks in that function.
 - **Gas Optimizations:**
   - `asm-keccak256`: Recommends using inline assembly for `keccak256` for potential gas savings.
   - `cache-array-length`: Recommends caching storage dynamic array lengths used in `for` loop conditions.

--- a/crates/lint/docs/modifier-used-only-once.md
+++ b/crates/lint/docs/modifier-used-only-once.md
@@ -1,0 +1,40 @@
+# Modifier used only once
+
+**Severity**: `Info`
+**ID**: `modifier-used-only-once`
+
+Flags modifiers invoked by exactly one function in the whole compilation unit.
+
+## What it does
+
+Reports a modifier that exactly one function invokes, constructors included. Invocations are taken from the resolved modifier lists, so base-constructor calls sitting in the same syntactic position are never confused with modifier calls, and each invocation is attributed to the declaration the compiler selected. Invocations are counted across dependencies too, while only modifiers declared in the project's own sources report. Aderyn's detector of the same name counts invocations the same way and does not exempt virtual modifiers or overrides.
+
+Out of scope: `virtual` modifiers and overrides (they exist for dynamic dispatch, so inlining them is not an option), and modifiers never invoked, which are dead code rather than an inlining candidate.
+
+## Why is this bad?
+
+A modifier with a single user adds indirection without factoring anything: the reader jumps to the declaration to understand one function. Writing the checks at the top of that function reads straighter; if a second function needs them later, extracting the modifier back is mechanical.
+
+## Example
+
+### Bad
+
+```solidity
+modifier onlyOwner() {
+    require(msg.sender == owner, "not owner");
+    _;
+}
+
+function withdraw() external onlyOwner {
+    ...
+}
+```
+
+### Good
+
+```solidity
+function withdraw() external {
+    require(msg.sender == owner, "not owner");
+    ...
+}
+```

--- a/crates/lint/src/sol/info/mod.rs
+++ b/crates/lint/src/sol/info/mod.rs
@@ -54,6 +54,9 @@ use event_fields::EVENT_FIELDS;
 mod unused_error;
 use unused_error::UNUSED_ERROR;
 
+mod modifier_used_only_once;
+use modifier_used_only_once::MODIFIER_USED_ONLY_ONCE;
+
 register_lints!(
     (BooleanCst, early, (BOOLEAN_CST)),
     (BooleanEqual, early, (BOOLEAN_EQUAL)),
@@ -74,4 +77,5 @@ register_lints!(
     (MissingInheritance, project, (MISSING_INHERITANCE)),
     (EventFields, early, (EVENT_FIELDS)),
     (UnusedError, project, (UNUSED_ERROR)),
+    (ModifierUsedOnlyOnce, project, (MODIFIER_USED_ONLY_ONCE)),
 );

--- a/crates/lint/src/sol/info/modifier_used_only_once.rs
+++ b/crates/lint/src/sol/info/modifier_used_only_once.rs
@@ -1,0 +1,80 @@
+use super::ModifierUsedOnlyOnce;
+use crate::{
+    linter::{Lint, ProjectLintEmitter, ProjectLintPass, ProjectSource},
+    sol::{Severity, SolLint},
+};
+use solar::{ast::FunctionKind, interface::source_map::FileName, sema::hir};
+use std::collections::HashMap;
+
+declare_forge_lint!(
+    MODIFIER_USED_ONLY_ONCE,
+    Severity::Info,
+    "modifier-used-only-once",
+    "this modifier is used only once; consider inlining its checks into the function"
+);
+
+impl<'ast> ProjectLintPass<'ast> for ModifierUsedOnlyOnce {
+    fn check_project(&mut self, ctx: &ProjectLintEmitter<'_, '_>, sources: &[ProjectSource<'ast>]) {
+        if !ctx.is_lint_enabled(MODIFIER_USED_ONLY_ONCE.id()) {
+            return;
+        }
+        let gcx = ctx.gcx();
+        let hir = &gcx.hir;
+
+        // Map every input source's HIR `SourceId` to the corresponding `ProjectSource` index:
+        // only modifiers declared in user-provided files are reported, while invocations are
+        // counted across the whole unit, dependencies included.
+        let input_source_idx: HashMap<hir::SourceId, usize> = hir
+            .sources_enumerated()
+            .filter_map(|(sid, src)| {
+                let path = match &src.file.name {
+                    FileName::Real(p) => p,
+                    _ => return None,
+                };
+                let idx = sources.iter().position(|s| &s.path == path)?;
+                Some((sid, idx))
+            })
+            .collect();
+
+        if input_source_idx.is_empty() {
+            return;
+        }
+
+        let counts = count_modifier_invocations(hir);
+
+        for function_id in hir.function_ids() {
+            let function = hir.function(function_id);
+            let Some(&src_idx) = input_source_idx.get(&function.source) else { continue };
+            // Only modifier declarations with a body qualify. `virtual` modifiers and
+            // overrides exist for dynamic dispatch, so inlining them is not an option and
+            // their invocation count does not tell the story.
+            if function.kind != FunctionKind::Modifier
+                || function.body.is_none()
+                || function.virtual_
+                || function.override_
+            {
+                continue;
+            }
+            // Exactly one invocation: zero invocations is dead code, a different concern.
+            if counts.get(&function_id).copied().unwrap_or(0) == 1 {
+                ctx.emit(&sources[src_idx], &MODIFIER_USED_ONLY_ONCE, function.keyword_span());
+            }
+        }
+    }
+}
+
+/// Counts, for every modifier of the unit, the functions that invoke it. Invocations live in
+/// each function's resolved modifier list, where base-constructor calls carry a contract id
+/// and stay out of the count.
+fn count_modifier_invocations(hir: &hir::Hir<'_>) -> HashMap<hir::FunctionId, usize> {
+    let mut counts = HashMap::new();
+    // Every function of the unit, constructors included, can invoke modifiers.
+    for function_id in hir.function_ids() {
+        for invocation in hir.function(function_id).modifiers {
+            if let hir::ItemId::Function(modifier_id) = invocation.id {
+                *counts.entry(modifier_id).or_insert(0) += 1;
+            }
+        }
+    }
+    counts
+}

--- a/crates/lint/testdata/ModifierUsedOnlyOnce.sol
+++ b/crates/lint/testdata/ModifierUsedOnlyOnce.sol
@@ -1,0 +1,91 @@
+//@compile-flags: --only-lint modifier-used-only-once
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+// Tests for `modifier-used-only-once`: a modifier invoked by exactly one function can usually
+// be inlined as checks at the top of that function. Invocations are taken from the resolved
+// modifier lists, so base-constructor calls are not confused with modifier calls. Out of
+// scope: `virtual` modifiers and overrides (they exist for dynamic dispatch), modifiers never
+// invoked (dead code is another concern) or invoked more than once.
+
+contract Guarded {
+    address internal owner;
+    uint256 internal count;
+
+    modifier onlyOnce() { //~NOTE: this modifier is used only once
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    modifier usedTwice() {
+        require(count < 100, "full");
+        _;
+    }
+
+    modifier neverUsed() {
+        require(owner != address(0), "unset");
+        _;
+    }
+
+    function first() external onlyOnce usedTwice {
+        count++;
+    }
+
+    function second() external usedTwice {
+        count++;
+    }
+}
+
+// A modifier invoked from a constructor counts like any other invocation.
+contract Eager {
+    bool internal ready;
+
+    modifier once() { //~NOTE: this modifier is used only once
+        require(!ready, "done");
+        _;
+    }
+
+    constructor() once() {
+        ready = true;
+    }
+}
+
+// A `virtual` modifier and its override exist for dynamic dispatch: out of scope even when
+// each is invoked once.
+contract ModBase {
+    modifier guard() virtual {
+        _;
+    }
+
+    function useBase() external guard {}
+}
+
+contract ModChild is ModBase {
+    modifier guard() override {
+        require(msg.sender != address(0), "zero");
+        _;
+    }
+
+    function useChild() external guard {}
+}
+
+// A base-constructor call sits in the same resolved list as modifier invocations: it must
+// not be counted as one.
+contract WithArgs {
+    uint256 internal seed;
+
+    constructor(uint256 s) {
+        seed = s;
+    }
+}
+
+contract ChildWithArgs is WithArgs {
+    modifier seeded() { //~NOTE: this modifier is used only once
+        require(seed != 0, "no seed");
+        _;
+    }
+
+    constructor() WithArgs(42) {}
+
+    function go() external seeded {}
+}

--- a/crates/lint/testdata/ModifierUsedOnlyOnce.stderr
+++ b/crates/lint/testdata/ModifierUsedOnlyOnce.stderr
@@ -1,0 +1,24 @@
+note[modifier-used-only-once]: this modifier is used only once; consider inlining its checks into the function
+   ╭▸ ROOT/testdata/ModifierUsedOnlyOnce.sol:LL:CC
+   │
+LL │     modifier onlyOnce() {
+   │     ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/modifier-used-only-once
+
+note[modifier-used-only-once]: this modifier is used only once; consider inlining its checks into the function
+   ╭▸ ROOT/testdata/ModifierUsedOnlyOnce.sol:LL:CC
+   │
+LL │     modifier once() {
+   │     ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/modifier-used-only-once
+
+note[modifier-used-only-once]: this modifier is used only once; consider inlining its checks into the function
+   ╭▸ ROOT/testdata/ModifierUsedOnlyOnce.sol:LL:CC
+   │
+LL │     modifier seeded() {
+   │     ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/modifier-used-only-once
+


### PR DESCRIPTION
Adds the `modifier-used-only-once` lint from #14381 (Info).

Reports a modifier that exactly one function invokes, constructors included. Invocations are taken from the resolved modifier lists, so base-constructor calls sitting in the same syntactic position are never confused with modifier calls; they are counted across the whole unit, dependencies included, while only modifiers declared in the project's own sources report, mirroring the unused-error pass.

Exemptions on top of Aderyn's counting: `virtual` modifiers and overrides, which exist for dynamic dispatch and cannot be inlined, and zero-invocation modifiers, dead code being a different concern. The fixture pins the constructor invocation, the base-constructor coexistence and each exemption.
