### PR TITLE
perf(symbolic): try simple uint pair shrink

### DIFF
--- a/crates/forge/src/symbolic_minimizer.rs
+++ b/crates/forge/src/symbolic_minimizer.rs
@@ -1259,6 +1259,15 @@ fn minimize_u256_pair_delta_candidates(
     current_right: U256,
     try_candidate: &mut impl FnMut(U256, U256) -> bool,
 ) -> bool {
+    let one = U256::from(1);
+    if (current_left, current_right) != (one, one)
+        && !current_left.is_zero()
+        && !current_right.is_zero()
+        && try_candidate(one, one)
+    {
+        return true;
+    }
+
     match current_left.cmp(&current_right) {
         std::cmp::Ordering::Equal => {
             !current_left.is_zero() && try_candidate(U256::ZERO, U256::ZERO)
@@ -1554,6 +1563,22 @@ mod tests {
         }
 
         assert_eq!(value, DynSolValue::Uint(U256::from(36), 256));
+    }
+
+    #[test]
+    fn uint_pair_delta_minimization_tries_simple_nonzero_pair_first() {
+        let mut candidates = Vec::new();
+
+        assert!(minimize_u256_pair_delta_candidates(
+            U256::from(100),
+            U256::from(50),
+            &mut |left, right| {
+                candidates.push((left, right));
+                (left, right) == (U256::from(1), U256::from(1))
+            },
+        ));
+
+        assert_eq!(candidates, vec![(U256::from(1), U256::from(1))]);
     }
 
     #[test]


### PR DESCRIPTION
Tries `(1, 1)` before the existing delta-only shrink for correlated nonzero uint pairs. This keeps the old zero/delta candidates intact; it only gives replay minimization one cheap chance to collapse both args to the smallest nonzero pair before spending bisection attempts.

### Results

| Benchmark | master | this PR | delta |
| --- | ---: | ---: | ---: |
| symbolic-bug-suite wall time (6 runs) | 1.804s ± 0.008s | 1.818s ± 0.035s | neutral / 0.8% slower |
| failures found | 23/23 | 23/23 | same |
| paths / solver queries / SMT queries | 212 / 283 / 100 | 212 / 283 / 100 | same |
| minimization attempts | 675 | 467 | -30.8% |
| accepted minimizations | 153 | 107 | -30.1% |

Foundry-bench `forge_symbolic_test` still needs a clean post-rebase rerun; the draft is mainly for reviewing whether the replay-count win is worth keeping despite neutral wall time.

AI-assisted.
