### PR TITLE
feat(debugger): add pane toggle commands

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -370,13 +370,6 @@ impl TUIContext<'_> {
                 self.set_info(format!("Variables pane: {state}"));
             }
 
-            // Toggle stack pane.
-            KeyCode::Char('S') => {
-                self.show_stack = !self.show_stack;
-                let state = if self.show_stack { "shown" } else { "hidden" };
-                self.set_info(format!("Stack pane: {state}"));
-            }
-
             // Go to program counter
             KeyCode::Char('p') => {
                 self.key_buffer.clear();
@@ -655,6 +648,8 @@ impl TUIContext<'_> {
             self.run_buffer_command(command, BufferKind::Returndata, parts);
         } else if STORAGE_COMMANDS.contains(&command) {
             self.run_storage_command(command, parts);
+        } else if STACK_COMMANDS.contains(&command) {
+            self.run_stack_command(command, parts);
         } else if HELP_COMMANDS.contains(&command) {
             self.set_info(command_help());
         } else {
@@ -685,6 +680,15 @@ impl TUIContext<'_> {
             return self.set_error(command_usage(command, "<slot>"));
         }
         self.goto_storage_slot_from_input(slot);
+    }
+
+    fn run_stack_command<'a>(&mut self, command: &str, mut args: impl Iterator<Item = &'a str>) {
+        if args.next().is_some() {
+            return self.set_error(command_usage(command, ""));
+        }
+        self.show_stack = !self.show_stack;
+        let state = if self.show_stack { "shown" } else { "hidden" };
+        self.set_info(format!("Stack pane: {state}"));
     }
 
     fn goto_storage_slot_from_input(&mut self, input: &str) {
@@ -887,21 +891,23 @@ const MEMORY_COMMANDS: &[&str] = &["mem", "memory"];
 const CALLDATA_COMMANDS: &[&str] = &["calldata", "cd"];
 const RETURNDATA_COMMANDS: &[&str] = &["returndata", "ret", "rd"];
 const STORAGE_COMMANDS: &[&str] = &["storage", "store", "slot"];
+const STACK_COMMANDS: &[&str] = &["stack"];
 const HELP_COMMANDS: &[&str] = &["help", "h"];
 
 fn command_usage(command: &str, arg: &str) -> String {
-    format!("Usage: :{command} {arg}")
+    if arg.is_empty() { format!("Usage: :{command}") } else { format!("Usage: :{command} {arg}") }
 }
 
 fn command_help() -> String {
     format!(
-        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>",
+        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>, {}",
         command_aliases(CONTINUE_COMMANDS),
         command_aliases(PC_COMMANDS),
         command_aliases(MEMORY_COMMANDS),
         command_aliases(CALLDATA_COMMANDS),
         command_aliases(RETURNDATA_COMMANDS),
-        command_aliases(STORAGE_COMMANDS)
+        command_aliases(STORAGE_COMMANDS),
+        command_aliases(STACK_COMMANDS)
     )
 }
 
@@ -1488,13 +1494,6 @@ mod tests {
         let _ = tui.handle_key_event(key(KeyCode::Char('V')));
         assert!(tui.show_variables);
         assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: shown");
-
-        let _ = tui.handle_key_event(key(KeyCode::Char('S')));
-        assert!(!tui.show_stack);
-        assert_eq!(tui.status.as_ref().unwrap().text, "Stack pane: hidden");
-        let _ = tui.handle_key_event(key(KeyCode::Char('S')));
-        assert!(tui.show_stack);
-        assert_eq!(tui.status.as_ref().unwrap().text, "Stack pane: shown");
 
         let _ = tui.handle_key_event(key(KeyCode::Char('h')));
         assert!(!tui.show_shortcuts);
@@ -2099,6 +2098,7 @@ mod tests {
             CALLDATA_COMMANDS,
             RETURNDATA_COMMANDS,
             STORAGE_COMMANDS,
+            STACK_COMMANDS,
         ] {
             assert!(help.contains(&command_aliases(commands)));
         }
@@ -2112,6 +2112,27 @@ mod tests {
         let status = tui.status.as_ref().unwrap();
         assert_eq!(status.kind, StatusKind::Error);
         assert_eq!(status.text, "Usage: :store <slot>");
+    }
+
+    #[test]
+    fn command_prompt_toggles_stack_pane() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("stack");
+        assert!(!tui.show_stack);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Stack pane: hidden");
+
+        tui.run_command_from_input(":stack");
+        assert!(tui.show_stack);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Stack pane: shown");
+
+        tui.run_command_from_input("stack extra");
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Error);
+        assert_eq!(status.text, "Usage: :stack");
     }
 
     #[test]

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -356,20 +356,6 @@ impl TUIContext<'_> {
                 self.set_info(format!("UTF-8 decoding: {}", toggle_state(self.buf_utf)));
             }
 
-            // Toggle source pane
-            KeyCode::Char('v') => {
-                self.show_source = !self.show_source;
-                let state = if self.show_source { "shown" } else { "hidden" };
-                self.set_info(format!("Source pane: {state}"));
-            }
-
-            // Toggle variables pane.
-            KeyCode::Char('V') => {
-                self.show_variables = !self.show_variables;
-                let state = if self.show_variables { "shown" } else { "hidden" };
-                self.set_info(format!("Variables pane: {state}"));
-            }
-
             // Go to program counter
             KeyCode::Char('p') => {
                 self.key_buffer.clear();
@@ -648,8 +634,12 @@ impl TUIContext<'_> {
             self.run_buffer_command(command, BufferKind::Returndata, parts);
         } else if STORAGE_COMMANDS.contains(&command) {
             self.run_storage_command(command, parts);
+        } else if SOURCE_COMMANDS.contains(&command) {
+            self.run_pane_command(command, PaneCommand::Source, parts);
+        } else if VARIABLES_COMMANDS.contains(&command) {
+            self.run_pane_command(command, PaneCommand::Variables, parts);
         } else if STACK_COMMANDS.contains(&command) {
-            self.run_stack_command(command, parts);
+            self.run_pane_command(command, PaneCommand::Stack, parts);
         } else if HELP_COMMANDS.contains(&command) {
             self.set_info(command_help());
         } else {
@@ -682,13 +672,31 @@ impl TUIContext<'_> {
         self.goto_storage_slot_from_input(slot);
     }
 
-    fn run_stack_command<'a>(&mut self, command: &str, mut args: impl Iterator<Item = &'a str>) {
+    fn run_pane_command<'a>(
+        &mut self,
+        command: &str,
+        pane: PaneCommand,
+        mut args: impl Iterator<Item = &'a str>,
+    ) {
         if args.next().is_some() {
             return self.set_error(command_usage(command, ""));
         }
-        self.show_stack = !self.show_stack;
-        let state = if self.show_stack { "shown" } else { "hidden" };
-        self.set_info(format!("Stack pane: {state}"));
+        let shown = match pane {
+            PaneCommand::Source => {
+                self.show_source = !self.show_source;
+                self.show_source
+            }
+            PaneCommand::Variables => {
+                self.show_variables = !self.show_variables;
+                self.show_variables
+            }
+            PaneCommand::Stack => {
+                self.show_stack = !self.show_stack;
+                self.show_stack
+            }
+        };
+        let state = if shown { "shown" } else { "hidden" };
+        self.set_info(format!("{} pane: {state}", pane.label()));
     }
 
     fn goto_storage_slot_from_input(&mut self, input: &str) {
@@ -891,8 +899,27 @@ const MEMORY_COMMANDS: &[&str] = &["mem", "memory"];
 const CALLDATA_COMMANDS: &[&str] = &["calldata", "cd"];
 const RETURNDATA_COMMANDS: &[&str] = &["returndata", "ret", "rd"];
 const STORAGE_COMMANDS: &[&str] = &["storage", "store", "slot"];
+const SOURCE_COMMANDS: &[&str] = &["source", "src"];
+const VARIABLES_COMMANDS: &[&str] = &["variables", "vars"];
 const STACK_COMMANDS: &[&str] = &["stack"];
 const HELP_COMMANDS: &[&str] = &["help", "h"];
+
+#[derive(Clone, Copy)]
+enum PaneCommand {
+    Source,
+    Variables,
+    Stack,
+}
+
+impl PaneCommand {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Source => "Source",
+            Self::Variables => "Variables",
+            Self::Stack => "Stack",
+        }
+    }
+}
 
 fn command_usage(command: &str, arg: &str) -> String {
     if arg.is_empty() { format!("Usage: :{command}") } else { format!("Usage: :{command} {arg}") }
@@ -900,13 +927,15 @@ fn command_usage(command: &str, arg: &str) -> String {
 
 fn command_help() -> String {
     format!(
-        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>, {}",
+        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>, {}, {}, {}",
         command_aliases(CONTINUE_COMMANDS),
         command_aliases(PC_COMMANDS),
         command_aliases(MEMORY_COMMANDS),
         command_aliases(CALLDATA_COMMANDS),
         command_aliases(RETURNDATA_COMMANDS),
         command_aliases(STORAGE_COMMANDS),
+        command_aliases(SOURCE_COMMANDS),
+        command_aliases(VARIABLES_COMMANDS),
         command_aliases(STACK_COMMANDS)
     )
 }
@@ -1480,20 +1509,6 @@ mod tests {
         let _ = tui.handle_key_event(key(KeyCode::Char('m')));
         assert!(!tui.buf_utf);
         assert_eq!(tui.status.as_ref().unwrap().text, "UTF-8 decoding: off");
-
-        let _ = tui.handle_key_event(key(KeyCode::Char('v')));
-        assert!(!tui.show_source);
-        assert_eq!(tui.status.as_ref().unwrap().text, "Source pane: hidden");
-        let _ = tui.handle_key_event(key(KeyCode::Char('v')));
-        assert!(tui.show_source);
-        assert_eq!(tui.status.as_ref().unwrap().text, "Source pane: shown");
-
-        let _ = tui.handle_key_event(key(KeyCode::Char('V')));
-        assert!(!tui.show_variables);
-        assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: hidden");
-        let _ = tui.handle_key_event(key(KeyCode::Char('V')));
-        assert!(tui.show_variables);
-        assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: shown");
 
         let _ = tui.handle_key_event(key(KeyCode::Char('h')));
         assert!(!tui.show_shortcuts);
@@ -2098,6 +2113,8 @@ mod tests {
             CALLDATA_COMMANDS,
             RETURNDATA_COMMANDS,
             STORAGE_COMMANDS,
+            SOURCE_COMMANDS,
+            VARIABLES_COMMANDS,
             STACK_COMMANDS,
         ] {
             assert!(help.contains(&command_aliases(commands)));
@@ -2115,11 +2132,27 @@ mod tests {
     }
 
     #[test]
-    fn command_prompt_toggles_stack_pane() {
+    fn command_prompt_toggles_panes() {
         let address = Address::repeat_byte(1);
         let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1])]);
         let mut tui = TUIContext::new(&mut context);
         tui.init();
+
+        tui.run_command_from_input("source");
+        assert!(!tui.show_source);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Source pane: hidden");
+
+        tui.run_command_from_input(":src");
+        assert!(tui.show_source);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Source pane: shown");
+
+        tui.run_command_from_input("variables");
+        assert!(!tui.show_variables);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: hidden");
+
+        tui.run_command_from_input(":vars");
+        assert!(tui.show_variables);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: shown");
 
         tui.run_command_from_input("stack");
         assert!(!tui.show_stack);

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -91,6 +91,7 @@ pub(crate) struct TUIContext<'a> {
     pub(crate) show_shortcuts: bool,
     pub(crate) show_source: bool,
     pub(crate) show_variables: bool,
+    pub(crate) show_stack: bool,
     /// The currently active buffer (memory, calldata, returndata) to be drawn.
     pub(crate) active_buffer: BufferKind,
 }
@@ -117,6 +118,7 @@ impl<'a> TUIContext<'a> {
             show_shortcuts: true,
             show_source: true,
             show_variables: true,
+            show_stack: true,
             active_buffer: BufferKind::Memory,
         }
     }
@@ -366,6 +368,13 @@ impl TUIContext<'_> {
                 self.show_variables = !self.show_variables;
                 let state = if self.show_variables { "shown" } else { "hidden" };
                 self.set_info(format!("Variables pane: {state}"));
+            }
+
+            // Toggle stack pane.
+            KeyCode::Char('S') => {
+                self.show_stack = !self.show_stack;
+                let state = if self.show_stack { "shown" } else { "hidden" };
+                self.set_info(format!("Stack pane: {state}"));
             }
 
             // Go to program counter
@@ -1479,6 +1488,13 @@ mod tests {
         let _ = tui.handle_key_event(key(KeyCode::Char('V')));
         assert!(tui.show_variables);
         assert_eq!(tui.status.as_ref().unwrap().text, "Variables pane: shown");
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('S')));
+        assert!(!tui.show_stack);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Stack pane: hidden");
+        let _ = tui.handle_key_event(key(KeyCode::Char('S')));
+        assert!(tui.show_stack);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Stack pane: shown");
 
         let _ = tui.handle_key_event(key(KeyCode::Char('h')));
         assert!(!tui.show_shortcuts);

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -23,6 +23,8 @@ use ratatui::{
 use revm_inspectors::tracing::types::{CallKind, DecodedInternalCall, DecodedTraceStep};
 use std::{collections::VecDeque, fmt::Write};
 
+const SHORTCUT_LINE_COUNT: u16 = 4;
+
 impl TUIContext<'_> {
     pub(crate) fn draw_layout(&mut self, f: &mut Frame<'_>) {
         // We need 100 columns to display a 32 byte word in the memory and stack panes.
@@ -97,9 +99,6 @@ impl TUIContext<'_> {
         let area = f.area();
         let footer_height = self.footer_height();
 
-        // NOTE: `Layout::split` always returns a slice of the same length as the number of
-        // constraints, so the `else` branch is unreachable.
-
         // Split off footer.
         let [app, footer] = Layout::new(
             Direction::Vertical,
@@ -113,83 +112,41 @@ impl TUIContext<'_> {
             self.draw_footer(f, footer);
         }
 
-        if self.show_source && self.show_variables {
-            // Split the app vertically to construct all the panes.
-            let [op_pane, variables_pane, stack_pane, memory_pane, src_pane] = Layout::new(
-                Direction::Vertical,
-                [
-                    Constraint::Ratio(1, 7),
-                    Constraint::Ratio(1, 7),
-                    Constraint::Ratio(1, 7),
-                    Constraint::Ratio(1, 7),
-                    Constraint::Ratio(3, 7),
-                ],
-            )
-            .split(app)[..] else {
-                unreachable!()
-            };
-
-            self.draw_src(f, src_pane);
-            self.draw_op_list(f, op_pane);
-            self.draw_variables(f, variables_pane);
-            self.draw_stack(f, stack_pane);
-            self.draw_buffer(f, memory_pane);
-            return;
+        let source_weight = if self.show_source { 3 } else { 0 };
+        let memory_weight = if self.show_source { 1 } else { 2 };
+        let total_weight = 1
+            + memory_weight
+            + source_weight
+            + if self.show_variables { 1 } else { 0 }
+            + if self.show_stack { 1 } else { 0 };
+        let mut constraints = Vec::with_capacity(5);
+        constraints.push(Constraint::Ratio(1, total_weight));
+        if self.show_variables {
+            constraints.push(Constraint::Ratio(1, total_weight));
         }
-
+        if self.show_stack {
+            constraints.push(Constraint::Ratio(1, total_weight));
+        }
+        constraints.push(Constraint::Ratio(memory_weight, total_weight));
         if self.show_source {
-            let [op_pane, stack_pane, memory_pane, src_pane] = Layout::new(
-                Direction::Vertical,
-                [
-                    Constraint::Ratio(1, 6),
-                    Constraint::Ratio(1, 6),
-                    Constraint::Ratio(1, 6),
-                    Constraint::Ratio(3, 6),
-                ],
-            )
-            .split(app)[..] else {
-                unreachable!()
-            };
-
-            self.draw_src(f, src_pane);
-            self.draw_op_list(f, op_pane);
-            self.draw_stack(f, stack_pane);
-            self.draw_buffer(f, memory_pane);
-            return;
+            constraints.push(Constraint::Ratio(source_weight, total_weight));
         }
 
-        if !self.show_variables {
-            let [op_pane, stack_pane, memory_pane] = Layout::new(
-                Direction::Vertical,
-                [Constraint::Ratio(1, 4), Constraint::Ratio(1, 4), Constraint::Ratio(2, 4)],
-            )
-            .split(app)[..] else {
-                unreachable!()
-            };
-
-            self.draw_op_list(f, op_pane);
-            self.draw_stack(f, stack_pane);
-            self.draw_buffer(f, memory_pane);
-            return;
-        }
-
-        let [op_pane, variables_pane, stack_pane, memory_pane] = Layout::new(
-            Direction::Vertical,
-            [
-                Constraint::Ratio(1, 5),
-                Constraint::Ratio(1, 5),
-                Constraint::Ratio(1, 5),
-                Constraint::Ratio(2, 5),
-            ],
-        )
-        .split(app)[..] else {
-            unreachable!()
-        };
-
+        let panes = Layout::new(Direction::Vertical, constraints).split(app);
+        let mut panes = panes.iter();
+        let op_pane = *panes.next().expect("opcode pane is always visible");
         self.draw_op_list(f, op_pane);
-        self.draw_variables(f, variables_pane);
-        self.draw_stack(f, stack_pane);
+        if self.show_variables {
+            self.draw_variables(f, *panes.next().expect("variables pane is visible"));
+        }
+        if self.show_stack {
+            self.draw_stack(f, *panes.next().expect("stack pane is visible"));
+        }
+        let memory_pane = *panes.next().expect("memory pane is always visible");
         self.draw_buffer(f, memory_pane);
+        if self.show_source {
+            self.draw_src(f, *panes.next().expect("source pane is visible"));
+        }
     }
 
     /// Draws the layout in horizontal mode.
@@ -248,29 +205,26 @@ impl TUIContext<'_> {
         }
         self.draw_op_list(f, op_pane);
 
+        let total_weight =
+            2 + if self.show_variables { 1 } else { 0 } + if self.show_stack { 1 } else { 0 };
+        let mut constraints = Vec::with_capacity(3);
         if self.show_variables {
-            // Split right pane vertically to construct variables, stack and memory.
-            let [variables_pane, stack_pane, memory_pane] = Layout::new(
-                Direction::Vertical,
-                [Constraint::Ratio(1, 4), Constraint::Ratio(1, 4), Constraint::Ratio(2, 4)],
-            )
-            .split(app_right)[..] else {
-                unreachable!()
-            };
-            self.draw_variables(f, variables_pane);
-            self.draw_stack(f, stack_pane);
-            self.draw_buffer(f, memory_pane);
-        } else {
-            let [stack_pane, memory_pane] = Layout::new(
-                Direction::Vertical,
-                [Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)],
-            )
-            .split(app_right)[..] else {
-                unreachable!()
-            };
-            self.draw_stack(f, stack_pane);
-            self.draw_buffer(f, memory_pane);
+            constraints.push(Constraint::Ratio(1, total_weight));
         }
+        if self.show_stack {
+            constraints.push(Constraint::Ratio(1, total_weight));
+        }
+        constraints.push(Constraint::Ratio(2, total_weight));
+
+        let panes = Layout::new(Direction::Vertical, constraints).split(app_right);
+        let mut panes = panes.iter();
+        if self.show_variables {
+            self.draw_variables(f, *panes.next().expect("variables pane is visible"));
+        }
+        if self.show_stack {
+            self.draw_stack(f, *panes.next().expect("stack pane is visible"));
+        }
+        self.draw_buffer(f, *panes.next().expect("memory pane is always visible"));
     }
 
     fn footer_height(&self) -> u16 {
@@ -284,7 +238,7 @@ impl TUIContext<'_> {
                     || self.status.is_some(),
             )
         };
-        let shortcuts = if self.show_shortcuts { 3 } else { 0 };
+        let shortcuts = if self.show_shortcuts { SHORTCUT_LINE_COUNT } else { 0 };
         status_or_input + shortcuts
     }
 
@@ -353,7 +307,7 @@ impl TUIContext<'_> {
     }
 
     fn draw_command_prompt(&self, f: &mut Frame<'_>, area: Rect, input: &str) {
-        let shortcuts = if self.show_shortcuts { 3 } else { 0 };
+        let shortcuts = if self.show_shortcuts { SHORTCUT_LINE_COUNT } else { 0 };
         let [prompt, shortcuts_area] = Layout::new(
             Direction::Vertical,
             [Constraint::Length(3), Constraint::Length(shortcuts)],
@@ -1062,11 +1016,15 @@ fn shortcut_lines() -> Vec<Line<'static>> {
             dimmed,
         )),
         Line::from(Span::styled(
-            "[/] search | [:] command | [n/N] repeat | [l] layout | [b] buffer | [v] source | [V] variables",
+            "[/] search | [:] command | [n/N] repeat | [l] layout | [b] buffer",
             dimmed,
         )),
         Line::from(Span::styled(
-            "[t] labels | [m] decode | [h] help | [J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint",
+            "[v] source | [V] variables | [S] stack | [t] labels | [m] decode | [h] help",
+            dimmed,
+        )),
+        Line::from(Span::styled(
+            "[J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint",
             dimmed,
         )),
     ]
@@ -1520,6 +1478,30 @@ mod tests {
             .collect::<String>();
         assert!(!screen.contains("Variables"));
         assert!(screen.contains("Stack"));
+        assert!(screen.contains("Memory (max expansion: 0 bytes)"));
+    }
+
+    #[test]
+    fn hidden_stack_pane_omits_stack_panel() {
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![trace_step(Vec::new())])]);
+        context.layout = DebuggerLayout::Horizontal;
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.show_stack = false;
+        let backend = TestBackend::new(220, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|f| tui.draw_layout(f)).unwrap();
+
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(!screen.contains("Stack:"));
+        assert!(screen.contains("Variables"));
         assert!(screen.contains("Memory (max expansion: 0 bytes)"));
     }
 

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -23,8 +23,6 @@ use ratatui::{
 use revm_inspectors::tracing::types::{CallKind, DecodedInternalCall, DecodedTraceStep};
 use std::{collections::VecDeque, fmt::Write};
 
-const SHORTCUT_LINE_COUNT: u16 = 4;
-
 impl TUIContext<'_> {
     pub(crate) fn draw_layout(&mut self, f: &mut Frame<'_>) {
         // We need 100 columns to display a 32 byte word in the memory and stack panes.
@@ -238,7 +236,7 @@ impl TUIContext<'_> {
                     || self.status.is_some(),
             )
         };
-        let shortcuts = if self.show_shortcuts { SHORTCUT_LINE_COUNT } else { 0 };
+        let shortcuts = if self.show_shortcuts { 3 } else { 0 };
         status_or_input + shortcuts
     }
 
@@ -307,7 +305,7 @@ impl TUIContext<'_> {
     }
 
     fn draw_command_prompt(&self, f: &mut Frame<'_>, area: Rect, input: &str) {
-        let shortcuts = if self.show_shortcuts { SHORTCUT_LINE_COUNT } else { 0 };
+        let shortcuts = if self.show_shortcuts { 3 } else { 0 };
         let [prompt, shortcuts_area] = Layout::new(
             Direction::Vertical,
             [Constraint::Length(3), Constraint::Length(shortcuts)],
@@ -1016,15 +1014,11 @@ fn shortcut_lines() -> Vec<Line<'static>> {
             dimmed,
         )),
         Line::from(Span::styled(
-            "[/] search | [:] command | [n/N] repeat | [l] layout | [b] buffer",
+            "[/] search | [:] command | [n/N] repeat | [l] layout | [b] buffer | [v] source | [V] variables",
             dimmed,
         )),
         Line::from(Span::styled(
-            "[v] source | [V] variables | [S] stack | [t] labels | [m] decode | [h] help",
-            dimmed,
-        )),
-        Line::from(Span::styled(
-            "[J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint",
+            "[t] labels | [m] decode | [h] help | [J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint",
             dimmed,
         )),
     ]

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -1014,7 +1014,7 @@ fn shortcut_lines() -> Vec<Line<'static>> {
             dimmed,
         )),
         Line::from(Span::styled(
-            "[/] search | [:] command | [n/N] repeat | [l] layout | [b] buffer | [v] source | [V] variables",
+            "[/] search | [:] command | [n/N] repeat | [l] layout | [b] buffer",
             dimmed,
         )),
         Line::from(Span::styled(


### PR DESCRIPTION
Adds command-mode pane visibility controls for source, variables, and stack: `:source`/`:src`, `:variables`/`:vars`, and `:stack`.

This keeps lower-frequency pane configuration behind the existing `:` command prompt instead of adding more global shortcuts. The previously added source and variables pane shortcuts are removed from the key handler and shortcut footer, while the layout splitting now composes the visible variables and stack panes so hidden panes give their space back to the remaining views.
