### PR TITLE
perf(symbolic): reduce branch solver probes

### DIFF
--- a/crates/evm/symbolic/src/executor/create.rs
+++ b/crates/evm/symbolic/src/executor/create.rs
@@ -230,10 +230,7 @@ impl SymbolicExecutor {
         let path_limit = self.config.path_width() as usize;
         let depth_limit = self.config.execution_depth() as usize;
 
-        while let Some(mut state) = match self.config.exploration_order {
-            SymbolicExplorationOrder::Bfs => worklist.pop_front(),
-            SymbolicExplorationOrder::Dfs => worklist.pop_back(),
-        } {
+        while let Some(mut state) = self.pop_next_feasible_path(&mut worklist)? {
             if *completed_paths >= path_limit {
                 return Err(SymbolicError::Unsupported("symbolic path limit exceeded"));
             }

--- a/crates/evm/symbolic/src/executor/invariant.rs
+++ b/crates/evm/symbolic/src/executor/invariant.rs
@@ -136,10 +136,7 @@ impl SymbolicExecutor {
         let path_limit = self.config.path_width() as usize;
         let depth_limit = self.config.execution_depth() as usize;
 
-        while let Some(mut state) = match self.config.exploration_order {
-            SymbolicExplorationOrder::Bfs => worklist.pop_front(),
-            SymbolicExplorationOrder::Dfs => worklist.pop_back(),
-        } {
+        while let Some(mut state) = self.pop_next_feasible_path(&mut worklist)? {
             if *completed_paths >= path_limit {
                 return Err(SymbolicError::Unsupported("symbolic path limit exceeded"));
             }

--- a/crates/evm/symbolic/src/executor/mod.rs
+++ b/crates/evm/symbolic/src/executor/mod.rs
@@ -15,4 +15,19 @@ impl SymbolicExecutor {
             SymbolicExplorationOrder::Dfs => paths.pop_back(),
         }
     }
+
+    pub(super) fn pop_next_feasible_path(
+        &mut self,
+        paths: &mut VecDeque<PathState>,
+    ) -> Result<Option<PathState>, SymbolicError> {
+        while let Some(mut state) = self.pop_next_path(paths) {
+            if state.take_deferred_feasibility_check()
+                && !self.branch_is_sat_or_defer(&state.constraints)?
+            {
+                continue;
+            }
+            return Ok(Some(state));
+        }
+        Ok(None)
+    }
 }

--- a/crates/evm/symbolic/src/executor/opcodes.rs
+++ b/crates/evm/symbolic/src/executor/opcodes.rs
@@ -551,41 +551,33 @@ impl SymbolicExecutor {
                         false_state.set_corpus_seed_models(false_seed_models);
                         false_state.pc = fallthrough;
 
-                        let true_feasible = self.take_loop_jump(&mut true_state, fallthrough, dest)
-                            && self.branch_is_sat_or_defer(&true_state.constraints)?;
-                        let false_feasible =
-                            self.branch_is_sat_or_defer(&false_state.constraints)?;
-                        trace!(true_feasible, false_feasible, "JUMPI symbolic branch");
-                        match (true_feasible, false_feasible) {
-                            (true, true) => {
-                                let true_seed_count = true_state.corpus_seed_model_count();
-                                let false_seed_count = false_state.corpus_seed_model_count();
-                                match (
-                                    false_seed_count.cmp(&true_seed_count),
-                                    self.config.exploration_order,
-                                ) {
-                                    (
-                                        std::cmp::Ordering::Greater,
-                                        SymbolicExplorationOrder::Bfs,
-                                    )
-                                    | (std::cmp::Ordering::Less, SymbolicExplorationOrder::Dfs) => {
-                                        worklist.push_back(false_state);
-                                        worklist.push_back(true_state);
-                                    }
-                                    (
-                                        std::cmp::Ordering::Greater,
-                                        SymbolicExplorationOrder::Dfs,
-                                    )
-                                    | (std::cmp::Ordering::Less, SymbolicExplorationOrder::Bfs)
-                                    | (std::cmp::Ordering::Equal, _) => {
-                                        worklist.push_back(true_state);
-                                        worklist.push_back(false_state);
-                                    }
+                        let true_pending = self.take_loop_jump(&mut true_state, fallthrough, dest);
+                        if true_pending {
+                            true_state.defer_feasibility_check();
+                        }
+                        false_state.defer_feasibility_check();
+                        trace!(true_pending, false_pending = true, "JUMPI symbolic branch");
+                        if true_pending {
+                            let true_seed_count = true_state.corpus_seed_model_count();
+                            let false_seed_count = false_state.corpus_seed_model_count();
+                            match (
+                                false_seed_count.cmp(&true_seed_count),
+                                self.config.exploration_order,
+                            ) {
+                                (std::cmp::Ordering::Greater, SymbolicExplorationOrder::Bfs)
+                                | (std::cmp::Ordering::Less, SymbolicExplorationOrder::Dfs) => {
+                                    worklist.push_back(false_state);
+                                    worklist.push_back(true_state);
+                                }
+                                (std::cmp::Ordering::Greater, SymbolicExplorationOrder::Dfs)
+                                | (std::cmp::Ordering::Less, SymbolicExplorationOrder::Bfs)
+                                | (std::cmp::Ordering::Equal, _) => {
+                                    worklist.push_back(true_state);
+                                    worklist.push_back(false_state);
                                 }
                             }
-                            (true, false) => worklist.push_back(true_state),
-                            (false, true) => worklist.push_back(false_state),
-                            (false, false) => {}
+                        } else {
+                            worklist.push_back(false_state);
                         }
                         return Ok(StepOutcome::Forked);
                     }

--- a/crates/evm/symbolic/src/executor/run.rs
+++ b/crates/evm/symbolic/src/executor/run.rs
@@ -230,10 +230,7 @@ impl SymbolicExecutor {
         let path_limit = self.config.path_width() as usize;
         let depth_limit = self.config.execution_depth() as usize;
 
-        while let Some(mut state) = match self.config.exploration_order {
-            SymbolicExplorationOrder::Bfs => worklist.pop_front(),
-            SymbolicExplorationOrder::Dfs => worklist.pop_back(),
-        } {
+        while let Some(mut state) = self.pop_next_feasible_path(&mut worklist)? {
             if completed_paths >= path_limit {
                 debug!(completed_paths, path_limit, "symbolic path limit reached");
                 return Ok(SymbolicRunResult::Incomplete {

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -351,12 +351,18 @@ impl MaskHints {
             zero_mask_equality(var, left, right).or_else(|| zero_mask_equality(var, right, left))
         {
             if inverted {
-                self.one |= mask;
+                if is_single_bit(mask) {
+                    self.one |= mask;
+                }
             } else {
                 self.zero |= mask;
             }
         }
     }
+}
+
+fn is_single_bit(value: U256) -> bool {
+    !value.is_zero() && (value & (value - U256::from(1))).is_zero()
 }
 
 fn zero_mask_equality(var: &Symbol, masked: &SymExpr, zero: &SymExpr) -> Option<U256> {

--- a/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
+++ b/crates/evm/symbolic/src/runtime/solver/monotonic_product.rs
@@ -48,7 +48,23 @@ fn collect_order_facts<'a>(
                 positive.insert(left);
             }
         }
-        SymBoolExprKind::Const(_) | SymBoolExprKind::Not(_) | SymBoolExprKind::Cmp(_, _, _) => {}
+        SymBoolExprKind::Not(value) => {
+            if let Some(expr) = nonzero_expr(value) {
+                positive.insert(expr);
+            }
+        }
+        SymBoolExprKind::Const(_) | SymBoolExprKind::Cmp(_, _, _) => {}
+    }
+}
+
+fn nonzero_expr(expr: &SymBoolExpr) -> Option<&SymExpr> {
+    let SymBoolExprKind::Cmp(SymCmpOp::Eq, left, right) = expr.kind() else { return None };
+    if left.as_const().is_some_and(|value| value.is_zero()) {
+        Some(right)
+    } else if right.as_const().is_some_and(|value| value.is_zero()) {
+        Some(left)
+    } else {
+        None
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/solver/opt.rs
+++ b/crates/evm/symbolic/src/runtime/solver/opt.rs
@@ -913,38 +913,55 @@ impl SymBoolExpr {
         match op {
             SymCmpOp::Ugt => match (left.as_const(), right.as_const()) {
                 // `a > 0 => a != 0`.
-                (_, Some(value)) if value.is_zero() => left.normalize_ne_zero_for_solver(cx),
+                (_, Some(value)) if value.is_zero() => left
+                    .normalize_ne_zero_for_solver(cx)
+                    .or_else(|| Some(Self::eq_zero(cx, left).not(cx))),
                 // `1 > a => a == 0`.
-                (Some(value), _) if value == U256::from(1) => {
-                    right.normalize_eq_zero_for_solver(cx)
-                }
+                (Some(value), _) if value == U256::from(1) => right
+                    .normalize_eq_zero_for_solver(cx)
+                    .or_else(|| Some(Self::eq_zero(cx, right))),
                 _ => None,
             },
             SymCmpOp::Uge => match (left.as_const(), right.as_const()) {
                 // `a >= 1 => a != 0`.
-                (_, Some(value)) if value == U256::from(1) => left.normalize_ne_zero_for_solver(cx),
+                (_, Some(value)) if value == U256::from(1) => left
+                    .normalize_ne_zero_for_solver(cx)
+                    .or_else(|| Some(Self::eq_zero(cx, left).not(cx))),
                 // `0 >= a => a == 0`.
-                (Some(value), _) if value.is_zero() => right.normalize_eq_zero_for_solver(cx),
+                (Some(value), _) if value.is_zero() => right
+                    .normalize_eq_zero_for_solver(cx)
+                    .or_else(|| Some(Self::eq_zero(cx, right))),
                 _ => None,
             },
             SymCmpOp::Ule => match (left.as_const(), right.as_const()) {
                 // `a <= 0 => a == 0`.
-                (_, Some(value)) if value.is_zero() => left.normalize_eq_zero_for_solver(cx),
-                // `1 <= a => a != 0`.
-                (Some(value), _) if value == U256::from(1) => {
-                    right.normalize_ne_zero_for_solver(cx)
+                (_, Some(value)) if value.is_zero() => {
+                    left.normalize_eq_zero_for_solver(cx).or_else(|| Some(Self::eq_zero(cx, left)))
                 }
+                // `1 <= a => a != 0`.
+                (Some(value), _) if value == U256::from(1) => right
+                    .normalize_ne_zero_for_solver(cx)
+                    .or_else(|| Some(Self::eq_zero(cx, right).not(cx))),
                 _ => None,
             },
             SymCmpOp::Ult => match (left.as_const(), right.as_const()) {
                 // `a < 1 => a == 0`.
-                (_, Some(value)) if value == U256::from(1) => left.normalize_eq_zero_for_solver(cx),
+                (_, Some(value)) if value == U256::from(1) => {
+                    left.normalize_eq_zero_for_solver(cx).or_else(|| Some(Self::eq_zero(cx, left)))
+                }
                 // `0 < a => a != 0`.
-                (Some(value), _) if value.is_zero() => right.normalize_ne_zero_for_solver(cx),
+                (Some(value), _) if value.is_zero() => right
+                    .normalize_ne_zero_for_solver(cx)
+                    .or_else(|| Some(Self::eq_zero(cx, right).not(cx))),
                 _ => None,
             },
             SymCmpOp::Eq | SymCmpOp::Slt | SymCmpOp::Sgt => None,
         }
+    }
+
+    fn eq_zero(cx: &mut SymCx, expr: &SymExpr) -> Self {
+        let zero = SymExpr::zero(cx);
+        Self::eq(cx, expr.clone(), zero)
     }
 }
 

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -20,6 +20,7 @@ pub(crate) struct PathState {
     corpus_seed_models: Vec<Arc<SymbolicModel>>,
     branch_target: Option<SymbolicBranchTarget>,
     branch_target_reached: bool,
+    needs_feasibility_check: bool,
     pub(crate) loop_jumps: HashMap<usize, u32>,
     pub(crate) expected_revert: Option<ExpectedRevert>,
     pub(crate) assume_no_revert_next_call: Option<AssumeNoRevert>,
@@ -69,6 +70,7 @@ impl PathState {
             corpus_seed_models: Vec::new(),
             branch_target: None,
             branch_target_reached: false,
+            needs_feasibility_check: false,
             loop_jumps: HashMap::default(),
             expected_revert: None,
             assume_no_revert_next_call: None,
@@ -116,6 +118,7 @@ impl PathState {
             corpus_seed_models: Vec::new(),
             branch_target: None,
             branch_target_reached: false,
+            needs_feasibility_check: false,
             loop_jumps: HashMap::default(),
             expected_revert: None,
             assume_no_revert_next_call: None,
@@ -165,6 +168,7 @@ impl PathState {
             corpus_seed_models: self.corpus_seed_models.clone(),
             branch_target: self.branch_target,
             branch_target_reached: self.branch_target_reached,
+            needs_feasibility_check: self.needs_feasibility_check,
             loop_jumps: HashMap::default(),
             expected_revert: self.expected_revert.clone(),
             assume_no_revert_next_call: self.assume_no_revert_next_call.clone(),
@@ -336,6 +340,16 @@ impl PathState {
 
     pub(crate) const fn satisfies_branch_target(&self) -> bool {
         self.branch_target.is_none() || self.branch_target_reached
+    }
+
+    pub(crate) const fn defer_feasibility_check(&mut self) {
+        self.needs_feasibility_check = true;
+    }
+
+    pub(crate) const fn take_deferred_feasibility_check(&mut self) -> bool {
+        let needs_check = self.needs_feasibility_check;
+        self.needs_feasibility_check = false;
+        needs_check
     }
 
     pub(crate) fn expr_upper_bound_usize(&self, expr: &SymExpr) -> Option<usize> {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3182,6 +3182,35 @@ fn solver_normalizes_negated_mask_equality_with_context_bound() {
 }
 
 #[test]
+fn solver_normalizes_unsigned_zero_comparisons() {
+    let mut cx = SymCx::new();
+    let x = SymExpr::var(&mut cx, "x");
+    let shift = SymExpr::constant(&mut cx, U256::from(1));
+    let shifted = SymExpr::binop(&mut cx, SymBinOp::Shl, x.clone(), shift);
+    let zero = SymExpr::zero(&mut cx);
+    let positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, zero, shifted.clone());
+    let zero = SymExpr::zero(&mut cx);
+    let shifted_zero = SymBoolExpr::eq(&mut cx, shifted.clone(), zero);
+
+    assert_eq!(normalize_bool_for_solver(&mut cx, positive), shifted_zero.clone().not(&mut cx));
+
+    let zero = SymExpr::zero(&mut cx);
+    let positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, zero, shifted);
+    let not_positive = positive.not(&mut cx);
+    assert_eq!(normalize_bool_for_solver(&mut cx, not_positive), shifted_zero);
+
+    let one = SymExpr::constant(&mut cx, U256::from(1));
+    let below_one = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), one);
+    let zero = SymExpr::zero(&mut cx);
+    let x_zero = SymBoolExpr::eq(&mut cx, x.clone(), zero);
+    assert_eq!(normalize_bool_for_solver(&mut cx, below_one), x_zero);
+
+    let one = SymExpr::constant(&mut cx, U256::from(1));
+    let at_least_one = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, one, x);
+    assert_eq!(normalize_bool_for_solver(&mut cx, at_least_one), x_zero.not(&mut cx));
+}
+
+#[test]
 fn solver_does_not_context_normalize_checked_mul_guard_without_tight_bound() {
     let mut cx = SymCx::new();
     let a = SymExpr::var(&mut cx, "a");
@@ -4650,9 +4679,10 @@ fn solver_smt_dump_shares_repeated_subterms() {
     let shift = SymExpr::constant(&mut cx, U256::from(248));
     let shifted = SymExpr::binop(&mut cx, SymBinOp::Shl, byte, shift);
     let zero = SymExpr::zero(&mut cx);
-    let shifted_zero = SymBoolExpr::eq(&mut cx, shifted.clone(), zero.clone());
-    let shifted_positive = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, shifted, zero);
-    let constraints = vec![shifted_zero, shifted_positive];
+    let shifted_zero = SymBoolExpr::eq(&mut cx, shifted.clone(), zero);
+    let other = SymExpr::var(&mut cx, "other");
+    let shifted_not_other = SymBoolExpr::eq(&mut cx, shifted, other).not(&mut cx);
+    let constraints = vec![shifted_zero, shifted_not_other];
 
     solver.capture_diagnostics();
 

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -2490,6 +2490,41 @@ fn fallback_model_finds_wrapping_arithmetic_riddle_candidate() {
 }
 
 #[test]
+fn fallback_model_keeps_multi_bit_nonzero_masks_weak() {
+    let mut cx = SymCx::new();
+    let calldata = SymExpr::var(&mut cx, "calldata_0");
+    let zero = SymExpr::zero(&mut cx);
+    let mask = SymExpr::constant(&mut cx, U256::from(0xffff));
+    let value = SymExpr::binop(&mut cx, SymBinOp::And, calldata.clone(), mask);
+    let value_nonzero = SymBoolExpr::eq(&mut cx, value.clone(), zero).not(&mut cx);
+    let calldata_limit = SymExpr::constant(&mut cx, U256::from(1) << 16);
+    let calldata_bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, calldata, calldata_limit);
+    let reserve = SymExpr::constant(&mut cx, U256::from(10_000));
+    let value_bound = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, value.clone(), reserve.clone());
+    let remaining = SymExpr::binop(&mut cx, SymBinOp::Sub, reserve.clone(), value);
+    let left_product = SymExpr::binop(&mut cx, SymBinOp::Mul, reserve, remaining);
+    let factor = SymExpr::constant(&mut cx, U256::from(100_009_984));
+    let product = SymExpr::binop(&mut cx, SymBinOp::Mul, left_product, factor);
+    let buggy_threshold = SymExpr::constant(&mut cx, U256::from(100_000_000_000_000u64));
+    let above_buggy_threshold =
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, product.clone(), buggy_threshold).not(&mut cx);
+    let intended_threshold = SymExpr::constant(&mut cx, U256::from(10_000_000_000_000_000u64));
+    let below_intended_threshold =
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, product, intended_threshold);
+    let constraints = vec![
+        value_nonzero,
+        calldata_bound,
+        value_bound,
+        above_buggy_threshold,
+        below_intended_threshold,
+    ];
+
+    let model = fallback_single_var_model(&constraints).unwrap();
+
+    assert!(constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
+}
+
+#[test]
 fn expression_op_simplifies_exact_arithmetic_identities() {
     let mut cx = SymCx::new();
     let x = SymExpr::var(&mut cx, "x");


### PR DESCRIPTION
Reduces solver work in symbolic execution by keeping multi-bit nonzero mask hints weak, deferring symbolic `JUMPI` feasibility checks until a path is actually popped, and normalizing unsigned zero-bound comparisons into equality/nonzero checks. This cuts speculative SMT work without changing the replay-confirmed counterexample boundary.

### Results

`grandizzy/symbolic-bug-suite`, profiling `forge`, `--symbolic --threads 1`, 23/23 failures found on both master and this branch.

| Metric | master | this PR | delta |
| --- | ---: | ---: | ---: |
| wall time | `1.828s ± 0.049s` | `1.529s ± 0.026s` | `1.20x ± 0.04` faster |
| solver queries | `283` | `274` | `-3.2%` |
| SMT queries | `100` | `81` | `-19.0%` |
| sat queries | `332` | `328` | `-1.2%` |
| reported solver time | `954ms` | `639ms` | `-33.0%` |
| SMT input | `59.4 KiB` | `48.3 KiB` | `-18.7%` |

`foundry-bench` on `Vectorized/solady:v0.1.26` (`forge_symbolic_test`, profiling profile) was effectively neutral on wall time but moved in the same solver direction: `0.349s ± 0.010s` -> `0.340s ± 0.008s`, solver `432ms` -> `392ms`, SMT `63` -> `59` queries.

AI assistance was used for code generation, benchmarking, and PR text.
