### PR TITLE
perf(forge): speed up test --list

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -29,7 +29,8 @@ use foundry_cli::{
     utils::{self, LoadConfig},
 };
 use foundry_common::{
-    EmptyTestFilter, TestFilter, TestFunctionExt, compile::ProjectCompiler, fs, shell,
+    EmptyTestFilter, TestFilter, TestFunctionExt, TestFunctionKind, compile::ProjectCompiler, fs,
+    shell,
 };
 use foundry_compilers::{
     ProjectCompileOutput,
@@ -1179,7 +1180,7 @@ impl TestArgs {
         }
 
         // Set up the project.
-        let project = config.project()?;
+        let mut project = config.project()?;
         let project_root = project.paths.root.clone();
 
         let replay_symbolic_artifact = self.load_symbolic_artifact_replay()?;
@@ -1210,6 +1211,27 @@ impl TestArgs {
 
         let dynamic_test_linking = config.dynamic_test_linking;
         let quiet = shell::is_json() || self.junit;
+
+        if self.list {
+            project.update_output_selection(|selection| {
+                *selection = OutputSelection::common_output_selection(["abi".to_string()]);
+            });
+            let output = ProjectCompiler::new()
+                .dynamic_test_linking(dynamic_test_linking)
+                .quiet(quiet)
+                .compile(&project)?;
+            let inline_config = Arc::new(InlineConfig::new_parsed(&output, &config)?);
+            return Ok((
+                project_root,
+                config,
+                evm_opts,
+                output,
+                filter,
+                inline_config,
+                replay_symbolic_artifact,
+            ));
+        }
+
         let compile = |files| {
             ProjectCompiler::new()
                 .dynamic_test_linking(dynamic_test_linking)
@@ -1392,6 +1414,17 @@ impl TestArgs {
                     conflicts.join(", ")
                 );
             }
+        }
+
+        if self.list {
+            return list_from_output(
+                output,
+                &config,
+                &execution.inline_config,
+                filter,
+                self.fuzz_only,
+                execution.replay_symbolic_artifact.as_ref(),
+            );
         }
 
         // Explicitly enable isolation for gas reports for more correct gas accounting.
@@ -2940,11 +2973,62 @@ fn list<FEN: FoundryEvmNetwork>(
     filter: &ProjectPathsAwareFilter,
 ) -> Result<TestOutcome> {
     let results = runner.list(filter);
+    print_list_results(&results)?;
+    Ok(TestOutcome::empty(Some(runner.known_contracts), false))
+}
 
+fn list_from_output(
+    output: &ProjectCompileOutput,
+    config: &Config,
+    inline_config: &InlineConfig,
+    filter: &ProjectPathsAwareFilter,
+    fuzz_only: bool,
+    symbolic_artifact_replay: Option<&SymbolicArtifactReplayConfig>,
+) -> Result<TestOutcome> {
+    let matcher = TestFunctionMatcher::new(config, inline_config, symbolic_artifact_replay);
+    let results = output
+        .artifact_ids()
+        .filter_map(|(id, artifact)| {
+            let abi = artifact.abi.as_ref()?;
+            let id = id.with_stripped_file_prefixes(&config.root);
+            if !matcher.matches_contract(filter, &id, abi) {
+                return None;
+            }
+            let source = id.source.as_path().display().to_string();
+            let identifier = id.identifier();
+            let name = id.name;
+            let tests = abi
+                .functions()
+                .filter(|func| {
+                    let kind = matcher.test_function_kind(&identifier, func);
+                    (!fuzz_only
+                        || matches!(
+                            kind,
+                            TestFunctionKind::FuzzTest { .. } | TestFunctionKind::InvariantTest
+                        ))
+                        && filter.matches_test_function_kind_in_contract(&identifier, func, kind)
+                })
+                .map(|func| func.name.clone())
+                .collect::<Vec<_>>();
+            (!tests.is_empty()).then_some((source, name, tests))
+        })
+        .fold(
+            BTreeMap::<String, BTreeMap<String, Vec<String>>>::new(),
+            |mut acc, (source, name, tests)| {
+                acc.entry(source).or_default().insert(name, tests);
+                acc
+            },
+        );
+
+    print_list_results(&results)?;
+    Ok(TestOutcome::empty(None, false))
+}
+
+fn print_list_results(results: &BTreeMap<String, BTreeMap<String, Vec<String>>>) -> Result<()> {
     if shell::is_json() {
         sh_println!("{}", serde_json::to_string(&results)?)?;
     } else {
-        for (file, contracts) in &results {
+        for (file, contracts) in results {
             sh_println!("{file}")?;
             for (contract, tests) in contracts {
                 sh_println!("  {contract}")?;
@@ -2952,7 +3036,7 @@ fn list<FEN: FoundryEvmNetwork>(
             }
         }
     }
-    Ok(TestOutcome::empty(Some(runner.known_contracts), false))
+    Ok(())
 }
 
 /// Merges `other` into `base` by extending suite results.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -2991,7 +2991,12 @@ fn list_from_output(
         .filter_map(|(id, artifact)| {
             let abi = artifact.abi.as_ref()?;
             let id = id.with_stripped_file_prefixes(&config.root);
-            if !matcher.matches_contract(filter, &id, abi) {
+            let deployable = abi
+                .constructor
+                .as_ref()
+                .map(|constructor| constructor.inputs.is_empty())
+                .unwrap_or(true);
+            if !deployable || !matcher.matches_contract(filter, &id, abi) {
                 return None;
             }
             let source = id.source.as_path().display().to_string();

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -192,6 +192,18 @@ contract ListTests {
 }
 "#,
     );
+    prj.add_test(
+        "ConstructorArgListTests.t.sol",
+        r#"
+contract ConstructorArgListTests {
+    constructor(uint256 value) {
+        value;
+    }
+
+    function test_constructor_arg() public pure {}
+}
+"#,
+    );
 
     cmd.args(["test", "--list", "--match-test", "test_"]).assert_success().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -179,6 +179,38 @@ For more information, try '--help'.
     ]]);
 });
 
+forgetest_init!(test_list_outputs_matching_tests, |prj, cmd| {
+    prj.add_test(
+        "ListTests.t.sol",
+        r#"
+contract ListTests {
+    function test_alpha() public pure {}
+    function test_beta() public pure {}
+    function testFuzz_value(uint256 value) public pure {
+        value;
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--list", "--match-test", "test_"]).assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+test/ListTests.t.sol
+  ListTests
+    test_alpha
+    test_beta
+
+
+"#]]);
+
+    cmd.forge_fuse()
+        .args(["test", "--list", "--match-test", "test_alpha", "--json"])
+        .assert_success()
+        .stdout_eq("{\"test/ListTests.t.sol\":{\"ListTests\":[\"test_alpha\"]}}\n");
+});
+
 forgetest_init!(evm_profile_requires_execution_trace, |prj, cmd| {
     prj.add_test(
         "EvmProfileNoExecutionTrace.t.sol",

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -114,6 +114,50 @@ Survived mutants
 "#]]);
 });
 
+forgetest_init!(mutation_testing_rejects_list_mode, |prj, cmd| {
+    prj.add_source(
+        "Counter.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Counter {
+    uint256 public number;
+
+    function increment() public {
+        number++;
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "Counter.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "../src/Counter.sol";
+
+contract CounterTest {
+    function test_Increment() public {
+        Counter counter = new Counter();
+        counter.increment();
+        assert(counter.number() == 1);
+    }
+}
+"#,
+    );
+
+    let output = cmd.args(["test", "--mutate", "src/Counter.sol", "--list"]).assert_failure();
+    let stderr = output.get_output().stderr_lossy();
+
+    assert!(
+        stderr.contains("`--mutate` cannot be combined with: --list"),
+        "unexpected stderr:\n{stderr}"
+    );
+});
+
 forgetest_init!(mutation_testing_rejects_all_skipped_baseline, |prj, cmd| {
     prj.add_source(
         "Counter.sol",


### PR DESCRIPTION
## Summary
`forge test --list` only needs contract ABIs to identify matching test functions. Requesting full bytecode output and constructing runners adds avoidable work, especially for generated or large projects where users and agents repeatedly ask for narrow test lists.

- Compile ABI-only for `forge test --list`.
- Build the list output directly from compiler artifacts using the existing test matcher/filter logic.
- Preserve the existing `--mutate` incompatibility behavior and add CLI regression coverage.

## Benchmarks

Generated 5k-contract fixture, fresh first-run `forge test --list --match-test testTarget -q` after the review update:

- master: `3.42s`
- this change: `0.49s`

Plain and JSON list output were also diffed against master during local investigation.
