### PR TITLE
perf(forge): speed up selectors

### DIFF
--- a/crates/forge/src/cmd/selectors.rs
+++ b/crates/forge/src/cmd/selectors.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::ASCII_MARKDOWN};
 use eyre::Result;
 use foundry_cli::{
-    opts::{BuildOpts, CompilerOpts, ProjectPathOpts},
+    opts::{BuildOpts, ProjectPathOpts},
     utils::{FoundryPathExt, cache_local_signatures, cache_signatures_from_abis},
 };
 use foundry_common::{
@@ -11,7 +11,9 @@ use foundry_common::{
     selectors::{SelectorImportData, import_selectors},
     shell,
 };
-use foundry_compilers::{artifacts::output_selection::ContractOutputSelection, info::ContractInfo};
+use foundry_compilers::{
+    Project, artifacts::output_selection::OutputSelection, info::ContractInfo, multi::MultiCompiler,
+};
 use std::{collections::BTreeMap, fs::canonicalize};
 
 /// CLI arguments for `forge selectors`.
@@ -93,31 +95,12 @@ impl SelectorsSubcommands {
                 }
 
                 sh_status!("Caching selectors for contracts in the project...")?;
-                let build_args = BuildOpts {
-                    project_paths,
-                    compiler: CompilerOpts {
-                        extra_output: vec![ContractOutputSelection::Abi],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                };
-
-                // compile the project to get the artifacts/abis
-                let project = build_args.project()?;
+                let project = abi_only_project(project_paths)?;
                 let outcome = ProjectCompiler::new().quiet(true).compile(&project)?;
                 cache_local_signatures(&outcome)?;
             }
             Self::Upload { contract, all, project_paths } => {
-                let build_args = BuildOpts {
-                    project_paths: project_paths.clone(),
-                    compiler: CompilerOpts {
-                        extra_output: vec![ContractOutputSelection::Abi],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                };
-
-                let project = build_args.project()?;
+                let project = abi_only_project(project_paths)?;
                 let output = if let Some(contract_info) = &contract {
                     let Some(contract_name) = contract_info.name() else {
                         eyre::bail!("No contract name provided.")
@@ -242,17 +225,7 @@ impl SelectorsSubcommands {
             }
             Self::List { contract, project_paths, no_group } => {
                 sh_status!("Listing selectors for contracts in the project...")?;
-                let build_args = BuildOpts {
-                    project_paths,
-                    compiler: CompilerOpts {
-                        extra_output: vec![ContractOutputSelection::Abi],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                };
-
-                // compile the project to get the artifacts/abis
-                let project = build_args.project()?;
+                let project = abi_only_project(project_paths)?;
                 let outcome = ProjectCompiler::new().quiet(true).compile(&project)?;
                 let artifacts = if let Some(contract) = contract {
                     let found_artifact = outcome.find_first(&contract);
@@ -387,16 +360,7 @@ impl SelectorsSubcommands {
             Self::Find { selector, project_paths } => {
                 sh_status!("Searching for selector {selector:?} in the project...")?;
 
-                let build_args = BuildOpts {
-                    project_paths,
-                    compiler: CompilerOpts {
-                        extra_output: vec![ContractOutputSelection::Abi],
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                };
-
-                let project = build_args.project()?;
+                let project = abi_only_project(project_paths)?;
                 let outcome = ProjectCompiler::new().quiet(true).compile(&project)?;
                 let artifacts = outcome
                     .into_artifacts_with_files()
@@ -466,4 +430,12 @@ impl SelectorsSubcommands {
         }
         Ok(())
     }
+}
+
+fn abi_only_project(project_paths: ProjectPathOpts) -> Result<Project<MultiCompiler>> {
+    let mut project = BuildOpts { project_paths, ..Default::default() }.project()?;
+    project.update_output_selection(|selection| {
+        *selection = OutputSelection::common_output_selection(["abi".to_string()]);
+    });
+    Ok(project)
 }


### PR DESCRIPTION
## Summary

The selector subcommands only inspect ABIs. The previous setup added ABI output on top of the default compiler outputs, so these read-only commands still paid for bytecode-oriented output they do not consume.

- Use ABI-only compilation for `forge selectors list`, `find`, `cache`, and `upload`.
- Replace repeated additive `extra_output = Abi` build setup with a shared ABI-only project helper.

## Benchmarks

Generated 5k-contract source fixture, fresh first-run `forge selectors list C0000`:

- master: `10.05s`
- this change: `2.13s`

Isolated warmed copies of the same fixture:

- master: `493.6ms ± 58.4ms`
- this change: `366.4ms ± 31.8ms`

The selector table output was byte-for-byte identical against master in the local comparison.
