### PR TITLE
feat(debugger): add opcodes pane command

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -89,6 +89,7 @@ pub(crate) struct TUIContext<'a> {
     /// Whether to decode active buffer as utf8 or not.
     pub(crate) buf_utf: bool,
     pub(crate) show_shortcuts: bool,
+    pub(crate) show_opcodes: bool,
     pub(crate) show_source: bool,
     pub(crate) show_variables: bool,
     pub(crate) show_stack: bool,
@@ -116,6 +117,7 @@ impl<'a> TUIContext<'a> {
             stack_labels: false,
             buf_utf: false,
             show_shortcuts: true,
+            show_opcodes: true,
             show_source: true,
             show_variables: true,
             show_stack: true,
@@ -634,6 +636,8 @@ impl TUIContext<'_> {
             self.run_buffer_command(command, BufferKind::Returndata, parts);
         } else if STORAGE_COMMANDS.contains(&command) {
             self.run_storage_command(command, parts);
+        } else if OPCODE_COMMANDS.contains(&command) {
+            self.run_pane_command(command, PaneCommand::Opcodes, parts);
         } else if SOURCE_COMMANDS.contains(&command) {
             self.run_pane_command(command, PaneCommand::Source, parts);
         } else if VARIABLES_COMMANDS.contains(&command) {
@@ -682,6 +686,10 @@ impl TUIContext<'_> {
             return self.set_error(command_usage(command, ""));
         }
         let shown = match pane {
+            PaneCommand::Opcodes => {
+                self.show_opcodes = !self.show_opcodes;
+                self.show_opcodes
+            }
             PaneCommand::Source => {
                 self.show_source = !self.show_source;
                 self.show_source
@@ -899,6 +907,7 @@ const MEMORY_COMMANDS: &[&str] = &["mem", "memory"];
 const CALLDATA_COMMANDS: &[&str] = &["calldata", "cd"];
 const RETURNDATA_COMMANDS: &[&str] = &["returndata", "ret", "rd"];
 const STORAGE_COMMANDS: &[&str] = &["storage", "store", "slot"];
+const OPCODE_COMMANDS: &[&str] = &["opcodes", "opcode", "ops"];
 const SOURCE_COMMANDS: &[&str] = &["source", "src"];
 const VARIABLES_COMMANDS: &[&str] = &["variables", "vars"];
 const STACK_COMMANDS: &[&str] = &["stack"];
@@ -906,6 +915,7 @@ const HELP_COMMANDS: &[&str] = &["help", "h"];
 
 #[derive(Clone, Copy)]
 enum PaneCommand {
+    Opcodes,
     Source,
     Variables,
     Stack,
@@ -914,6 +924,7 @@ enum PaneCommand {
 impl PaneCommand {
     const fn label(self) -> &'static str {
         match self {
+            Self::Opcodes => "Opcodes",
             Self::Source => "Source",
             Self::Variables => "Variables",
             Self::Stack => "Stack",
@@ -927,13 +938,14 @@ fn command_usage(command: &str, arg: &str) -> String {
 
 fn command_help() -> String {
     format!(
-        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>, {}, {}, {}",
+        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>, {}, {}, {}, {}",
         command_aliases(CONTINUE_COMMANDS),
         command_aliases(PC_COMMANDS),
         command_aliases(MEMORY_COMMANDS),
         command_aliases(CALLDATA_COMMANDS),
         command_aliases(RETURNDATA_COMMANDS),
         command_aliases(STORAGE_COMMANDS),
+        command_aliases(OPCODE_COMMANDS),
         command_aliases(SOURCE_COMMANDS),
         command_aliases(VARIABLES_COMMANDS),
         command_aliases(STACK_COMMANDS)
@@ -2113,6 +2125,7 @@ mod tests {
             CALLDATA_COMMANDS,
             RETURNDATA_COMMANDS,
             STORAGE_COMMANDS,
+            OPCODE_COMMANDS,
             SOURCE_COMMANDS,
             VARIABLES_COMMANDS,
             STACK_COMMANDS,
@@ -2137,6 +2150,14 @@ mod tests {
         let mut context = context_with_arena(vec![node(address, CallKind::Call, &[1])]);
         let mut tui = TUIContext::new(&mut context);
         tui.init();
+
+        tui.run_command_from_input("opcodes");
+        assert!(!tui.show_opcodes);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Opcodes pane: hidden");
+
+        tui.run_command_from_input(":ops");
+        assert!(tui.show_opcodes);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Opcodes pane: shown");
 
         tui.run_command_from_input("source");
         assert!(!tui.show_source);

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -110,15 +110,18 @@ impl TUIContext<'_> {
             self.draw_footer(f, footer);
         }
 
+        let opcodes_weight = if self.show_opcodes { 1 } else { 0 };
         let source_weight = if self.show_source { 3 } else { 0 };
         let memory_weight = if self.show_source { 1 } else { 2 };
-        let total_weight = 1
+        let total_weight = opcodes_weight
             + memory_weight
             + source_weight
             + if self.show_variables { 1 } else { 0 }
             + if self.show_stack { 1 } else { 0 };
         let mut constraints = Vec::with_capacity(5);
-        constraints.push(Constraint::Ratio(1, total_weight));
+        if self.show_opcodes {
+            constraints.push(Constraint::Ratio(opcodes_weight, total_weight));
+        }
         if self.show_variables {
             constraints.push(Constraint::Ratio(1, total_weight));
         }
@@ -132,8 +135,9 @@ impl TUIContext<'_> {
 
         let panes = Layout::new(Direction::Vertical, constraints).split(app);
         let mut panes = panes.iter();
-        let op_pane = *panes.next().expect("opcode pane is always visible");
-        self.draw_op_list(f, op_pane);
+        if self.show_opcodes {
+            self.draw_op_list(f, *panes.next().expect("opcodes pane is visible"));
+        }
         if self.show_variables {
             self.draw_variables(f, *panes.next().expect("variables pane is visible"));
         }
@@ -173,35 +177,44 @@ impl TUIContext<'_> {
             unreachable!()
         };
 
-        // Split app in 2 horizontally.
-        let [app_left, app_right] =
-            Layout::new(Direction::Horizontal, [Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)])
-                .split(app)[..]
-        else {
-            unreachable!()
-        };
-
-        let (op_pane, src_pane) = if self.show_source {
-            // Split left pane in 2 vertically to opcode list and source.
-            let [op_pane, src_pane] = Layout::new(
-                Direction::Vertical,
-                [Constraint::Ratio(1, 4), Constraint::Ratio(3, 4)],
+        let has_left_pane = self.show_opcodes || self.show_source;
+        let (app_left, app_right) = if has_left_pane {
+            // Split app in 2 horizontally.
+            let [app_left, app_right] = Layout::new(
+                Direction::Horizontal,
+                [Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)],
             )
-            .split(app_left)[..] else {
+            .split(app)[..] else {
                 unreachable!()
             };
-            (op_pane, Some(src_pane))
+            (Some(app_left), app_right)
         } else {
-            (app_left, None)
+            (None, app)
         };
 
         if footer_height > 0 {
             self.draw_footer(f, footer);
         }
-        if let Some(src_pane) = src_pane {
-            self.draw_src(f, src_pane);
+        if let Some(app_left) = app_left {
+            let total_weight =
+                if self.show_opcodes { 1 } else { 0 } + if self.show_source { 3 } else { 0 };
+            let mut constraints = Vec::with_capacity(2);
+            if self.show_opcodes {
+                constraints.push(Constraint::Ratio(1, total_weight));
+            }
+            if self.show_source {
+                constraints.push(Constraint::Ratio(3, total_weight));
+            }
+
+            let panes = Layout::new(Direction::Vertical, constraints).split(app_left);
+            let mut panes = panes.iter();
+            if self.show_opcodes {
+                self.draw_op_list(f, *panes.next().expect("opcodes pane is visible"));
+            }
+            if self.show_source {
+                self.draw_src(f, *panes.next().expect("source pane is visible"));
+            }
         }
-        self.draw_op_list(f, op_pane);
 
         let total_weight =
             2 + if self.show_variables { 1 } else { 0 } + if self.show_stack { 1 } else { 0 };
@@ -1448,6 +1461,30 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(!screen.contains("Contract call"));
+        assert!(screen.contains("Memory (max expansion: 0 bytes)"));
+    }
+
+    #[test]
+    fn hidden_opcodes_pane_omits_opcode_panel() {
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![trace_step(Vec::new())])]);
+        context.layout = DebuggerLayout::Horizontal;
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.show_opcodes = false;
+        let backend = TestBackend::new(220, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|f| tui.draw_layout(f)).unwrap();
+
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(!screen.contains("address:"));
+        assert!(screen.contains("Contract call"));
         assert!(screen.contains("Memory (max expansion: 0 bytes)"));
     }
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     multi_runner::{
         FuzzMinimizeConfig, FuzzMinimizeEdgeIndices, FuzzMinimizeObservation, MultiNetworkConfig,
         ShowmapConfig, SymbolicArtifactReplayConfig, TestFunctionMatcher,
+        is_generated_symbolic_regression_contract,
     },
     mutation::{MutationRunConfig, run_mutation_testing},
     result::{
@@ -3070,10 +3071,15 @@ fn list_from_output(
             let source = id.source.as_path().display().to_string();
             let identifier = id.identifier();
             let name = id.name;
+            let generated_symbolic_regression = is_generated_symbolic_regression_contract(abi);
             let tests = abi
                 .functions()
                 .filter(|func| {
-                    let kind = matcher.test_function_kind(&identifier, func);
+                    let kind = matcher.test_function_kind(
+                        &identifier,
+                        func,
+                        generated_symbolic_regression,
+                    );
                     (!fuzz_only
                         || matches!(
                             kind,


### PR DESCRIPTION
Adds command-mode visibility controls for the debugger opcode/trace pane: `:opcodes`, `:opcode`, and `:ops`. This continues the pane-command pattern from the previous source/variables/stack work without adding another global shortcut.

When the opcode pane is hidden, the vertical layout omits it and the horizontal layout lets the remaining left/right panes reclaim the space. If both source and opcodes are hidden, the variables/stack/buffer panes use the full width.

This branch also carries a tiny current-master compile unblocker in `forge test --list`: the new list-from-compile-output path now derives `generated_symbolic_regression` from the ABI before calling `test_function_kind`, matching the existing `MultiContractRunner::list` path. Without that, `cargo build -p forge --bin forge` fails on current `master` because `test_function_kind` now requires the third argument.