### PR TITLE
perf(symbolic): use two-var solver witnesses

### DIFF
--- a/crates/evm/symbolic/src/runtime/solver.rs
+++ b/crates/evm/symbolic/src/runtime/solver.rs
@@ -7,7 +7,9 @@ mod monotonic_product;
 mod opt;
 
 use hard_arith_fallback::constraints_prefer_hard_arith_fallback_first;
-pub(crate) use hard_arith_fallback::{fallback_single_var_model, hard_arith_fallback_model};
+pub(crate) use hard_arith_fallback::{
+    fallback_single_var_model, fallback_two_var_model, hard_arith_fallback_model,
+};
 #[cfg(test)]
 pub(crate) use monotonic_product::product_monotonic_unsat;
 use monotonic_product::product_monotonic_unsat_normalized;
@@ -387,6 +389,13 @@ impl SymbolicSolver for SmtLibSubprocessSolver {
             self.cache_model_result(cache_key, model.clone());
             return Ok(model);
         }
+        if let Some(model) = fallback_two_var_model(&smt_constraints)
+            && model_satisfies_constraints(&model, constraints)
+        {
+            self.cache_sat_result(cache_key.clone(), true);
+            self.cache_model_result(cache_key, model.clone());
+            return Ok(model);
+        }
         if constraints_prefer_hard_arith_fallback_first(cx, &smt_constraints)
             && let Some(model) =
                 validated_hard_arith_fallback_model(cx, &smt_constraints, constraints)
@@ -505,6 +514,12 @@ impl SmtLibSubprocessSolver {
             return Ok(false);
         }
         if let Some(model) = fallback_single_var_model(&smt_constraints)
+            && model_satisfies_constraints(&model, constraints)
+        {
+            self.cache_sat_result(cache_key, true);
+            return Ok(true);
+        }
+        if let Some(model) = fallback_two_var_model(&smt_constraints)
             && model_satisfies_constraints(&model, constraints)
         {
             self.cache_sat_result(cache_key, true);

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -303,20 +303,23 @@ pub(crate) fn fallback_single_var_model(constraints: &[SymBoolExpr]) -> Option<S
 }
 
 pub(crate) fn fallback_two_var_model(constraints: &[SymBoolExpr]) -> Option<SymbolicModel> {
-    if constraints.iter().any(SymBoolExpr::contains_hard_arith)
-        || constraints.iter().any(SymBoolExpr::contains_symbolic_hash)
-        || constraints.iter().any(SymBoolExpr::contains_gasleft)
-    {
+    if constraints.iter().any(SymBoolExpr::contains_hard_arith) {
         return None;
     }
 
     let mut vars = SymbolicVars::default();
-    let mut constants = HashSet::<U256>::default();
     for constraint in constraints {
         collect_bool_fallback_vars(constraint, &mut vars);
-        collect_bool_constants(constraint, &mut constants);
+        if vars.len() > 2 {
+            return None;
+        }
     }
     if vars.len() != 2 {
+        return None;
+    }
+    if constraints.iter().any(SymBoolExpr::contains_symbolic_hash)
+        || constraints.iter().any(SymBoolExpr::contains_gasleft)
+    {
         return None;
     }
     if !constraints_have_two_var_relation(constraints, &vars)
@@ -325,6 +328,10 @@ pub(crate) fn fallback_two_var_model(constraints: &[SymBoolExpr]) -> Option<Symb
         return None;
     }
 
+    let mut constants = HashSet::<U256>::default();
+    for constraint in constraints {
+        collect_bool_constants(constraint, &mut constants);
+    }
     let mut constants = constants.into_iter().collect::<Vec<_>>();
     constants.sort_unstable();
     let vars = vars.into_iter().collect::<Vec<_>>();
@@ -357,16 +364,25 @@ fn constraints_have_two_var_relation(
     constraints: &[SymBoolExpr],
     searched_vars: &SymbolicVars,
 ) -> bool {
-    constraints.iter().any(|constraint| bool_expr_has_two_var_relation(constraint, searched_vars))
+    constraints
+        .iter()
+        .any(|constraint| bool_expr_has_two_var_relation(constraint, searched_vars, false))
 }
 
-fn bool_expr_has_two_var_relation(expr: &SymBoolExpr, searched_vars: &SymbolicVars) -> bool {
+fn bool_expr_has_two_var_relation(
+    expr: &SymBoolExpr,
+    searched_vars: &SymbolicVars,
+    inverted: bool,
+) -> bool {
     match expr.kind() {
         SymBoolExprKind::Const(_) => false,
-        SymBoolExprKind::Not(expr) => bool_expr_has_two_var_relation(expr, searched_vars),
-        SymBoolExprKind::And(exprs) => {
-            exprs.iter().any(|expr| bool_expr_has_two_var_relation(expr, searched_vars))
+        SymBoolExprKind::Not(expr) => {
+            bool_expr_has_two_var_relation(expr, searched_vars, !inverted)
         }
+        SymBoolExprKind::And(exprs) if !inverted => {
+            exprs.iter().any(|expr| bool_expr_has_two_var_relation(expr, searched_vars, false))
+        }
+        SymBoolExprKind::And(_) => false,
         SymBoolExprKind::Cmp(_, left, right) => {
             let mut vars = SymbolicVars::default();
             collect_expr_fallback_vars(left, &mut vars);
@@ -381,17 +397,18 @@ fn constraints_bind_each_search_var(
     searched_vars: &SymbolicVars,
 ) -> bool {
     searched_vars.iter().all(|var| {
-        constraints.iter().any(|constraint| bool_expr_binds_single_var(constraint, *var))
+        constraints.iter().any(|constraint| bool_expr_binds_single_var(constraint, *var, false))
     })
 }
 
-fn bool_expr_binds_single_var(expr: &SymBoolExpr, bound_var: Symbol) -> bool {
+fn bool_expr_binds_single_var(expr: &SymBoolExpr, bound_var: Symbol, inverted: bool) -> bool {
     match expr.kind() {
         SymBoolExprKind::Const(_) => false,
-        SymBoolExprKind::Not(expr) => bool_expr_binds_single_var(expr, bound_var),
-        SymBoolExprKind::And(exprs) => {
-            exprs.iter().any(|expr| bool_expr_binds_single_var(expr, bound_var))
+        SymBoolExprKind::Not(expr) => bool_expr_binds_single_var(expr, bound_var, !inverted),
+        SymBoolExprKind::And(exprs) if !inverted => {
+            exprs.iter().any(|expr| bool_expr_binds_single_var(expr, bound_var, false))
         }
+        SymBoolExprKind::And(_) => false,
         SymBoolExprKind::Cmp(_, left, right) => {
             let mut vars = SymbolicVars::default();
             collect_expr_fallback_vars(left, &mut vars);

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -302,6 +302,51 @@ pub(crate) fn fallback_single_var_model(constraints: &[SymBoolExpr]) -> Option<S
     None
 }
 
+pub(crate) fn fallback_two_var_model(constraints: &[SymBoolExpr]) -> Option<SymbolicModel> {
+    if constraints.iter().any(SymBoolExpr::contains_hard_arith)
+        || constraints.iter().any(SymBoolExpr::contains_symbolic_hash)
+    {
+        return None;
+    }
+
+    let mut vars = SymbolicVars::default();
+    let mut constants = HashSet::<U256>::default();
+    for constraint in constraints {
+        collect_bool_fallback_vars(constraint, &mut vars);
+        collect_bool_constants(constraint, &mut constants);
+    }
+    if vars.len() != 2 {
+        return None;
+    }
+
+    let mut constants = constants.into_iter().collect::<Vec<_>>();
+    constants.sort_unstable();
+    let vars = vars.into_iter().collect::<Vec<_>>();
+    let candidates = vars
+        .iter()
+        .map(|var| fallback_candidates_for_var(var, constraints, &constants))
+        .collect::<Option<Vec<_>>>()?;
+    let searched_vars = vars.iter().copied().collect::<SymbolicVars>();
+    let constraint_vars = constraints
+        .iter()
+        .map(|constraint| {
+            let mut vars = SymbolicVars::default();
+            constraint.collect_vars(&mut vars);
+            vars
+        })
+        .collect::<Vec<_>>();
+    let search = FallbackSearch {
+        constraints,
+        constraint_vars: &constraint_vars,
+        searched_vars: &searched_vars,
+        vars: &vars,
+        candidates: &candidates,
+    };
+    let mut model = SymbolicModel::default();
+    let mut assignments = 0usize;
+    search.model(0, &mut model, &mut assignments)
+}
+
 fn push_fallback_candidate(candidates: &mut HashSet<U256>, candidate: U256, hints: MaskHints) {
     candidates.insert((candidate | hints.one) & !hints.zero);
 }

--- a/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
+++ b/crates/evm/symbolic/src/runtime/solver/hard_arith_fallback.rs
@@ -305,6 +305,7 @@ pub(crate) fn fallback_single_var_model(constraints: &[SymBoolExpr]) -> Option<S
 pub(crate) fn fallback_two_var_model(constraints: &[SymBoolExpr]) -> Option<SymbolicModel> {
     if constraints.iter().any(SymBoolExpr::contains_hard_arith)
         || constraints.iter().any(SymBoolExpr::contains_symbolic_hash)
+        || constraints.iter().any(SymBoolExpr::contains_gasleft)
     {
         return None;
     }
@@ -316,6 +317,11 @@ pub(crate) fn fallback_two_var_model(constraints: &[SymBoolExpr]) -> Option<Symb
         collect_bool_constants(constraint, &mut constants);
     }
     if vars.len() != 2 {
+        return None;
+    }
+    if !constraints_have_two_var_relation(constraints, &vars)
+        || !constraints_bind_each_search_var(constraints, &vars)
+    {
         return None;
     }
 
@@ -345,6 +351,69 @@ pub(crate) fn fallback_two_var_model(constraints: &[SymBoolExpr]) -> Option<Symb
     let mut model = SymbolicModel::default();
     let mut assignments = 0usize;
     search.model(0, &mut model, &mut assignments)
+}
+
+fn constraints_have_two_var_relation(
+    constraints: &[SymBoolExpr],
+    searched_vars: &SymbolicVars,
+) -> bool {
+    constraints.iter().any(|constraint| bool_expr_has_two_var_relation(constraint, searched_vars))
+}
+
+fn bool_expr_has_two_var_relation(expr: &SymBoolExpr, searched_vars: &SymbolicVars) -> bool {
+    match expr.kind() {
+        SymBoolExprKind::Const(_) => false,
+        SymBoolExprKind::Not(expr) => bool_expr_has_two_var_relation(expr, searched_vars),
+        SymBoolExprKind::And(exprs) => {
+            exprs.iter().any(|expr| bool_expr_has_two_var_relation(expr, searched_vars))
+        }
+        SymBoolExprKind::Cmp(_, left, right) => {
+            let mut vars = SymbolicVars::default();
+            collect_expr_fallback_vars(left, &mut vars);
+            collect_expr_fallback_vars(right, &mut vars);
+            vars.len() == 2 && vars.is_subset(searched_vars)
+        }
+    }
+}
+
+fn constraints_bind_each_search_var(
+    constraints: &[SymBoolExpr],
+    searched_vars: &SymbolicVars,
+) -> bool {
+    searched_vars.iter().all(|var| {
+        constraints.iter().any(|constraint| bool_expr_binds_single_var(constraint, *var))
+    })
+}
+
+fn bool_expr_binds_single_var(expr: &SymBoolExpr, bound_var: Symbol) -> bool {
+    match expr.kind() {
+        SymBoolExprKind::Const(_) => false,
+        SymBoolExprKind::Not(expr) => bool_expr_binds_single_var(expr, bound_var),
+        SymBoolExprKind::And(exprs) => {
+            exprs.iter().any(|expr| bool_expr_binds_single_var(expr, bound_var))
+        }
+        SymBoolExprKind::Cmp(_, left, right) => {
+            let mut vars = SymbolicVars::default();
+            collect_expr_fallback_vars(left, &mut vars);
+            collect_expr_fallback_vars(right, &mut vars);
+            vars.len() == 1
+                && vars.contains(&bound_var)
+                && (expr_contains_const(left) || expr_contains_const(right))
+        }
+    }
+}
+
+fn collect_expr_fallback_vars(expr: &SymExpr, vars: &mut SymbolicVars) {
+    let _ = expr.visit(&mut |expr| {
+        if let Some(var) = expr.kind().get_eval_var() {
+            vars.insert(var);
+        }
+        ControlFlow::<()>::Continue(())
+    });
+}
+
+fn expr_contains_const(expr: &SymExpr) -> bool {
+    expr.visit_bool(|expr| matches!(expr.kind(), SymExprKind::Const(_)))
 }
 
 fn push_fallback_candidate(candidates: &mut HashSet<U256>, candidate: U256, hints: MaskHints) {

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3863,6 +3863,66 @@ fn model_uses_two_var_witness_before_solver() {
 
 #[cfg(unix)]
 #[test]
+fn is_sat_falls_through_when_two_var_witness_misses() {
+    let mut cx = SymCx::new();
+    let marker = portfolio_test_marker("two-var-fallthrough");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x = SymExpr::var(&mut cx, "calldata_0");
+    let y = SymExpr::var(&mut cx, "calldata_1");
+    let ten = SymExpr::constant(&mut cx, U256::from(10));
+    let twenty = SymExpr::constant(&mut cx, U256::from(20));
+    let thirty = SymExpr::constant(&mut cx, U256::from(30));
+    let thirty_eight = SymExpr::constant(&mut cx, U256::from(38));
+    let sum = SymExpr::binop(&mut cx, SymBinOp::Add, x.clone(), y.clone());
+    let constraints = vec![
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, x.clone(), ten),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, twenty.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ugt, y.clone(), twenty),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, y, thirty),
+        SymBoolExpr::eq(&mut cx, sum, thirty_eight),
+    ];
+
+    assert!(solver.is_sat(&mut cx, &constraints).unwrap());
+    assert!(solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.sat_queries, 2);
+    assert_eq!(stats.sat_cache_hits, 1);
+    assert_eq!(stats.smt_queries, 1);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+fn is_sat_ignores_disjunctive_two_var_bounds() {
+    let mut cx = SymCx::new();
+    let marker = portfolio_test_marker("two-var-disjunctive-bounds");
+    let commands = vec![counted_solver_command(&marker, "sat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 1, false);
+    let x = SymExpr::var(&mut cx, "calldata_0");
+    let y = SymExpr::var(&mut cx, "calldata_1");
+    let ten = SymExpr::constant(&mut cx, U256::from(10));
+    let x_below_ten = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x.clone(), ten.clone());
+    let y_below_ten = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, y.clone(), ten);
+    let constraints = vec![
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, y),
+        SymBoolExpr::or(&mut cx, vec![x_below_ten, y_below_ten]),
+    ];
+
+    assert!(solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 1);
+    assert_eq!(counted_solver_invocations(&marker), 1);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
 fn is_sat_uses_validated_hard_arithmetic_fallback_before_solver() {
     let mut cx = SymCx::new();
     let marker = portfolio_test_marker("hard-arith-is-sat");

--- a/crates/evm/symbolic/src/tests.rs
+++ b/crates/evm/symbolic/src/tests.rs
@@ -3740,6 +3740,33 @@ fn is_sat_uses_single_var_witness_before_solver() {
 
 #[cfg(unix)]
 #[test]
+fn is_sat_uses_two_var_witness_before_solver() {
+    let mut cx = SymCx::new();
+    let marker = portfolio_test_marker("two-var-is-sat");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
+    let x = SymExpr::var(&mut cx, "calldata_0");
+    let y = SymExpr::var(&mut cx, "calldata_1");
+    let zero = SymExpr::zero(&mut cx);
+    let ten = SymExpr::constant(&mut cx, U256::from(10));
+    let constraints = vec![
+        SymBoolExpr::eq(&mut cx, x.clone(), zero.clone()).not(&mut cx),
+        SymBoolExpr::eq(&mut cx, y.clone(), zero).not(&mut cx),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, x, y.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, y, ten),
+    ];
+
+    assert!(solver.is_sat(&mut cx, &constraints).unwrap());
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(counted_solver_invocations(&marker), 0);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
 fn gasleft_can_use_single_var_witness_before_solver() {
     let mut cx = SymCx::new();
     let marker = portfolio_test_marker("gasleft-single-var");
@@ -3792,6 +3819,36 @@ fn model_uses_single_var_witness_before_solver() {
     let limit = SymExpr::constant(&mut cx, U256::from(10));
     let below_limit = SymBoolExpr::cmp(&mut cx, SymCmpOp::Ult, value, limit);
     let constraints = vec![not_zero, below_limit];
+
+    let model = solver.model(&mut cx, &constraints).unwrap();
+    assert!(constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap()));
+
+    let stats = solver.stats();
+    assert_eq!(stats.solver_queries, 1);
+    assert_eq!(stats.smt_queries, 0);
+    assert_eq!(stats.model_queries, 1);
+    assert_eq!(counted_solver_invocations(&marker), 0);
+    let _ = std::fs::remove_file(&marker);
+}
+
+#[cfg(unix)]
+#[test]
+fn model_uses_two_var_witness_before_solver() {
+    let mut cx = SymCx::new();
+    let marker = portfolio_test_marker("two-var-model");
+    let commands = vec![counted_solver_command(&marker, "unsat")];
+    let mut solver = SmtLibSubprocessSolver::new(Ok(commands), None, 2, false);
+    let x = SymExpr::var(&mut cx, "calldata_0");
+    let y = SymExpr::var(&mut cx, "calldata_1");
+    let zero = SymExpr::zero(&mut cx);
+    let cap = SymExpr::constant(&mut cx, U256::from(1_000_000));
+    let constraints = vec![
+        SymBoolExpr::eq(&mut cx, x.clone(), zero.clone()).not(&mut cx),
+        SymBoolExpr::eq(&mut cx, y.clone(), zero).not(&mut cx),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, y.clone(), x.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, x, cap.clone()),
+        SymBoolExpr::cmp(&mut cx, SymCmpOp::Ule, y, cap),
+    ];
 
     let model = solver.model(&mut cx, &constraints).unwrap();
     assert!(constraints.iter().all(|constraint| constraint.eval_model(&model).unwrap()));


### PR DESCRIPTION
Extends the local symbolic solver witness path from one eval var to bounded two-var constraints. Candidate models are still validated against the original path constraints before caching.

This is intentionally narrow: it requires an atomic two-var relation plus concrete one-var bounds for each searched var, and skips hard arithmetic, symbolic hashes, and `gasleft`-shaped constraints so solver/cache/portfolio behavior still exercises SMT where expected.

| Benchmark | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `grandizzy/symbolic-bug-suite` expected failures | 23/23 | 23/23 | unchanged |
| `grandizzy/symbolic-bug-suite` SMT queries | 81 | 63 | -22.2% |
| `grandizzy/symbolic-bug-suite` solver time | 980ms | 659ms | -32.8% |
| `grandizzy/symbolic-bug-suite` SMT input bytes | 48,307 | 39,483 | -18.3% |
