### PR TITLE
fix: compile MPP websocket shim with alloy backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5353,7 +5353,7 @@ dependencies = [
  "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite 0.28.0",
  "toml 1.1.2+spec-1.1.0",
  "tower",
  "tracing",
@@ -12276,12 +12276,8 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
- "rustls-pki-types",
  "tokio",
- "tokio-rustls",
  "tungstenite 0.29.0",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -12682,8 +12678,6 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "rustls",
- "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
 ]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -84,7 +84,9 @@ tempo-alloy.workspace = true
 tempo-primitives.workspace = true
 mpp.workspace = true
 foundry-wallets = { workspace = true, features = ["browser", "tempo"] }
-tokio-tungstenite.workspace = true
+tokio-tungstenite-028 = { package = "tokio-tungstenite", version = "0.28", features = [
+    "rustls-tls-webpki-roots",
+] }
 futures.workspace = true
 alloy-signer-local = { workspace = true, features = ["mnemonic-all-languages"] }
 base64.workspace = true

--- a/crates/common/src/provider/mpp/ws.rs
+++ b/crates/common/src/provider/mpp/ws.rs
@@ -20,7 +20,7 @@ use mpp::{
 use rustls::crypto::{CryptoProvider, aws_lc_rs};
 use std::{io, time::Duration};
 use tokio::time::timeout;
-use tokio_tungstenite::{
+use tokio_tungstenite_028::{
     MaybeTlsStream, WebSocketStream, connect_async,
     tungstenite::{
         Message,
@@ -293,7 +293,7 @@ mod tests {
         protocol::core::{Base64UrlJson, IntentName, MethodName, parse_authorization},
     };
     use tokio::task::JoinHandle;
-    use tokio_tungstenite::accept_async;
+    use tokio_tungstenite_028::accept_async;
     use tower::Service;
 
     fn test_challenge() -> PaymentChallenge {


### PR DESCRIPTION
## Summary
- add a renamed tokio-tungstenite 0.28 dependency for the MPP websocket shim
- use that alias so the established socket type matches alloy-transport-ws 2.1.0
- remove the now-unused direct foundry-common tokio-tungstenite 0.29 dependency

## Testing
- cargo check -p foundry-common
- cargo fmt --check

Prompted by: @DaniPopes