### PR TITLE
refactor: centralize abi-only compilation

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -23,12 +23,10 @@ use foundry_compilers::{
     solc::SolcSettings,
 };
 use num_format::{Locale, ToFormattedString};
-use solar::interface::source_map::FileName;
 use std::{
     collections::BTreeMap,
     fmt::Display,
     io::IsTerminal,
-    ops::ControlFlow,
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
@@ -608,52 +606,15 @@ pub fn compile_target_abi(
     target_name: &str,
 ) -> Result<JsonAbi> {
     let target_path = dunce::canonicalize(target_path)?;
-    let mut output = compile_abi_project(
+    let output = compile_abi_project(
         project,
         ProjectCompiler::new().quiet(true).files([target_path.clone()]),
     )?;
-
-    if is_solidity_file(&target_path) {
-        return target_abi_from_solar(&mut output, &target_path, target_name);
-    }
 
     let artifact = output
         .find(&target_path, target_name)
         .ok_or_eyre("failed to find target artifact when compiling for abi")?;
     artifact.abi.clone().ok_or_eyre("target artifact does not have an ABI")
-}
-
-fn target_abi_from_solar(
-    output: &mut ProjectCompileOutput<MultiCompiler>,
-    target_path: &Path,
-    target_name: &str,
-) -> Result<JsonAbi> {
-    let compiler = output.parser_mut().solc_mut().compiler_mut();
-    compiler.enter_mut(|compiler| -> Result<JsonAbi> {
-        let Ok(ControlFlow::Continue(())) = compiler.lower_asts() else {
-            eyre::bail!("failed to lower Solar ASTs when compiling target ABI");
-        };
-
-        let gcx = compiler.gcx();
-        let contract_id = gcx
-            .hir
-            .contract_ids()
-            .find(|&id| {
-                let contract = gcx.hir.contract(id);
-                contract.name.as_str() == target_name
-                    && match &gcx.hir.source(contract.source).file.name {
-                        FileName::Real(path) => path == target_path,
-                        _ => false,
-                    }
-            })
-            .ok_or_eyre("failed to find target contract in Solar HIR when compiling for abi")?;
-
-        Ok(gcx.contract_abi(contract_id).into_iter().collect())
-    })
-}
-
-fn is_solidity_file(path: &Path) -> bool {
-    path.extension().and_then(|ext| ext.to_str()).is_some_and(|ext| ext == "sol")
 }
 
 /// Creates a [Project] from an Etherscan source.

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -8,7 +8,7 @@ use comfy_table::{Cell, Color, Table, modifiers::UTF8_ROUND_CORNERS, presets::AS
 use eyre::{OptionExt, Result};
 use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{
-    Artifact, Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, SolcConfig,
+    Artifact, Graph, Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, SolcConfig,
     artifacts::{
         BytecodeObject, Contract, Source, output_selection::OutputSelection, remappings::Remapping,
     },
@@ -17,7 +17,7 @@ use foundry_compilers::{
         solc::{Solc, SolcCompiler},
     },
     info::ContractInfo as CompilerContractInfo,
-    multi::{MultiCompiler, MultiCompilerSettings},
+    multi::{MultiCompiler, MultiCompilerParser, MultiCompilerSettings},
     project::Preprocessor,
     report::{BasicStdoutReporter, NoReporter, Report},
     solc::SolcSettings,
@@ -603,20 +603,20 @@ where
 
 /// Compiles the target contract requesting only ABI output and returns its ABI.
 pub fn compile_target_abi(
-    project: &mut Project<MultiCompiler>,
+    project: &Project<MultiCompiler>,
     target_path: &Path,
     target_name: &str,
 ) -> Result<JsonAbi> {
     let target_path = dunce::canonicalize(target_path)?;
-    let mut output = compile_abi_project(
-        project,
-        ProjectCompiler::new().quiet(true).files([target_path.clone()]),
-    )?;
-
     if is_solidity_file(&target_path) {
-        return target_abi_from_solar(&mut output, &target_path, target_name);
+        return target_abi_from_solar(project, &target_path, target_name);
     }
 
+    let mut project = project.clone();
+    let output = compile_abi_project(
+        &mut project,
+        ProjectCompiler::new().quiet(true).files([target_path.clone()]),
+    )?;
     let artifact = output
         .find(&target_path, target_name)
         .ok_or_eyre("failed to find target artifact when compiling for abi")?;
@@ -624,11 +624,14 @@ pub fn compile_target_abi(
 }
 
 fn target_abi_from_solar(
-    output: &mut ProjectCompileOutput<MultiCompiler>,
+    project: &Project<MultiCompiler>,
     target_path: &Path,
     target_name: &str,
 ) -> Result<JsonAbi> {
-    let compiler = output.parser_mut().solc_mut().compiler_mut();
+    let sources = [(target_path.to_path_buf(), Source::read(target_path)?)].into_iter().collect();
+    let (_sources, mut edges) =
+        Graph::<MultiCompilerParser>::resolve_sources(&project.paths, sources)?.into_sources();
+    let compiler = edges.parser_mut().solc_mut().compiler_mut();
     compiler.enter_mut(|compiler| -> Result<JsonAbi> {
         let Ok(ControlFlow::Continue(())) = compiler.lower_asts() else {
             eyre::bail!("failed to lower Solar ASTs when compiling target ABI");

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -8,7 +8,7 @@ use comfy_table::{Cell, Color, Table, modifiers::UTF8_ROUND_CORNERS, presets::AS
 use eyre::{OptionExt, Result};
 use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{
-    Artifact, Graph, Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, SolcConfig,
+    Artifact, Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, SolcConfig,
     artifacts::{
         BytecodeObject, Contract, Source, output_selection::OutputSelection, remappings::Remapping,
     },
@@ -17,7 +17,7 @@ use foundry_compilers::{
         solc::{Solc, SolcCompiler},
     },
     info::ContractInfo as CompilerContractInfo,
-    multi::{MultiCompiler, MultiCompilerParser, MultiCompilerSettings},
+    multi::{MultiCompiler, MultiCompilerSettings},
     project::Preprocessor,
     report::{BasicStdoutReporter, NoReporter, Report},
     solc::SolcSettings,
@@ -603,20 +603,20 @@ where
 
 /// Compiles the target contract requesting only ABI output and returns its ABI.
 pub fn compile_target_abi(
-    project: &Project<MultiCompiler>,
+    project: &mut Project<MultiCompiler>,
     target_path: &Path,
     target_name: &str,
 ) -> Result<JsonAbi> {
     let target_path = dunce::canonicalize(target_path)?;
-    if is_solidity_file(&target_path) {
-        return target_abi_from_solar(project, &target_path, target_name);
-    }
-
-    let mut project = project.clone();
-    let output = compile_abi_project(
-        &mut project,
+    let mut output = compile_abi_project(
+        project,
         ProjectCompiler::new().quiet(true).files([target_path.clone()]),
     )?;
+
+    if is_solidity_file(&target_path) {
+        return target_abi_from_solar(&mut output, &target_path, target_name);
+    }
+
     let artifact = output
         .find(&target_path, target_name)
         .ok_or_eyre("failed to find target artifact when compiling for abi")?;
@@ -624,14 +624,11 @@ pub fn compile_target_abi(
 }
 
 fn target_abi_from_solar(
-    project: &Project<MultiCompiler>,
+    output: &mut ProjectCompileOutput<MultiCompiler>,
     target_path: &Path,
     target_name: &str,
 ) -> Result<JsonAbi> {
-    let sources = [(target_path.to_path_buf(), Source::read(target_path)?)].into_iter().collect();
-    let (_sources, mut edges) =
-        Graph::<MultiCompilerParser>::resolve_sources(&project.paths, sources)?.into_sources();
-    let compiler = edges.parser_mut().solc_mut().compiler_mut();
+    let compiler = output.parser_mut().solc_mut().compiler_mut();
     compiler.enter_mut(|compiler| -> Result<JsonAbi> {
         let Ok(ControlFlow::Continue(())) = compiler.lower_asts() else {
             eyre::bail!("failed to lower Solar ASTs when compiling target ABI");

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -3,12 +3,15 @@
 use crate::{
     TestFunctionExt, preprocessor::DynamicTestLinkingPreprocessor, shell, term::SpinnerReporter,
 };
+use alloy_json_abi::JsonAbi;
 use comfy_table::{Cell, Color, Table, modifiers::UTF8_ROUND_CORNERS, presets::ASCII_MARKDOWN};
-use eyre::Result;
+use eyre::{OptionExt, Result};
 use foundry_block_explorers::contract::Metadata;
 use foundry_compilers::{
     Artifact, Project, ProjectBuilder, ProjectCompileOutput, ProjectPathsConfig, SolcConfig,
-    artifacts::{BytecodeObject, Contract, Source, remappings::Remapping},
+    artifacts::{
+        BytecodeObject, Contract, Source, output_selection::OutputSelection, remappings::Remapping,
+    },
     compilers::{
         Compiler,
         solc::{Solc, SolcCompiler},
@@ -20,10 +23,12 @@ use foundry_compilers::{
     solc::SolcSettings,
 };
 use num_format::{Locale, ToFormattedString};
+use solar::interface::source_map::FileName;
 use std::{
     collections::BTreeMap,
     fmt::Display,
     io::IsTerminal,
+    ops::ControlFlow,
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
@@ -579,6 +584,76 @@ where
     DynamicTestLinkingPreprocessor: Preprocessor<C>,
 {
     ProjectCompiler::new().quiet(quiet).files([target_path.into()]).compile(project)
+}
+
+/// Compiles the project requesting only ABI output.
+pub fn compile_abi_project<C: Compiler<CompilerContract = Contract>>(
+    project: &mut Project<C>,
+    compiler: ProjectCompiler,
+) -> Result<ProjectCompileOutput<C>>
+where
+    DynamicTestLinkingPreprocessor: Preprocessor<C>,
+{
+    project.update_output_selection(|selection| {
+        // Request ABI so compilers populate `contracts` without producing bytecode outputs.
+        *selection = OutputSelection::common_output_selection(["abi".to_string()]);
+    });
+    compiler.compile(project)
+}
+
+/// Compiles the target contract requesting only ABI output and returns its ABI.
+pub fn compile_target_abi(
+    project: &mut Project<MultiCompiler>,
+    target_path: &Path,
+    target_name: &str,
+) -> Result<JsonAbi> {
+    let target_path = dunce::canonicalize(target_path)?;
+    let mut output = compile_abi_project(
+        project,
+        ProjectCompiler::new().quiet(true).files([target_path.clone()]),
+    )?;
+
+    if is_solidity_file(&target_path) {
+        return target_abi_from_solar(&mut output, &target_path, target_name);
+    }
+
+    let artifact = output
+        .find(&target_path, target_name)
+        .ok_or_eyre("failed to find target artifact when compiling for abi")?;
+    artifact.abi.clone().ok_or_eyre("target artifact does not have an ABI")
+}
+
+fn target_abi_from_solar(
+    output: &mut ProjectCompileOutput<MultiCompiler>,
+    target_path: &Path,
+    target_name: &str,
+) -> Result<JsonAbi> {
+    let compiler = output.parser_mut().solc_mut().compiler_mut();
+    compiler.enter_mut(|compiler| -> Result<JsonAbi> {
+        let Ok(ControlFlow::Continue(())) = compiler.lower_asts() else {
+            eyre::bail!("failed to lower Solar ASTs when compiling target ABI");
+        };
+
+        let gcx = compiler.gcx();
+        let contract_id = gcx
+            .hir
+            .contract_ids()
+            .find(|&id| {
+                let contract = gcx.hir.contract(id);
+                contract.name.as_str() == target_name
+                    && match &gcx.hir.source(contract.source).file.name {
+                        FileName::Real(path) => path == target_path,
+                        _ => false,
+                    }
+            })
+            .ok_or_eyre("failed to find target contract in Solar HIR when compiling for abi")?;
+
+        Ok(gcx.contract_abi(contract_id).into_iter().collect())
+    })
+}
+
+fn is_solidity_file(path: &Path) -> bool {
+    path.extension().and_then(|ext| ext.to_str()).is_some_and(|ext| ext == "sol")
 }
 
 /// Creates a [Project] from an Etherscan source.

--- a/crates/forge/src/cmd/selectors.rs
+++ b/crates/forge/src/cmd/selectors.rs
@@ -4,16 +4,14 @@ use comfy_table::{Table, modifiers::UTF8_ROUND_CORNERS, presets::ASCII_MARKDOWN}
 use eyre::Result;
 use foundry_cli::{
     opts::{BuildOpts, ProjectPathOpts},
-    utils::{FoundryPathExt, cache_local_signatures, cache_signatures_from_abis},
+    utils::{FoundryPathExt, LoadConfig, cache_local_signatures, cache_signatures_from_abis},
 };
 use foundry_common::{
-    compile::{PathOrContractInfo, ProjectCompiler, compile_target},
+    compile::{PathOrContractInfo, ProjectCompiler, compile_abi_project},
     selectors::{SelectorImportData, import_selectors},
     shell,
 };
-use foundry_compilers::{
-    Project, artifacts::output_selection::OutputSelection, info::ContractInfo, multi::MultiCompiler,
-};
+use foundry_compilers::{Project, info::ContractInfo, multi::MultiCompiler};
 use std::{collections::BTreeMap, fs::canonicalize};
 
 /// CLI arguments for `forge selectors`.
@@ -95,12 +93,13 @@ impl SelectorsSubcommands {
                 }
 
                 sh_status!("Caching selectors for contracts in the project...")?;
-                let project = abi_only_project(project_paths)?;
-                let outcome = ProjectCompiler::new().quiet(true).compile(&project)?;
+                let mut project = project_from_paths(project_paths)?;
+                let outcome =
+                    compile_abi_project(&mut project, ProjectCompiler::new().quiet(true))?;
                 cache_local_signatures(&outcome)?;
             }
             Self::Upload { contract, all, project_paths } => {
-                let project = abi_only_project(project_paths)?;
+                let mut project = project_from_paths(project_paths)?;
                 let output = if let Some(contract_info) = &contract {
                     let Some(contract_name) = contract_info.name() else {
                         eyre::bail!("No contract name provided.")
@@ -110,9 +109,9 @@ impl SelectorsSubcommands {
                         .path()
                         .map(Ok)
                         .unwrap_or_else(|| project.find_contract_path(contract_name))?;
-                    compile_target(&target_path, &project, false)?
+                    compile_abi_project(&mut project, ProjectCompiler::new().files([target_path]))?
                 } else {
-                    ProjectCompiler::new().compile(&project)?
+                    compile_abi_project(&mut project, ProjectCompiler::new())?
                 };
                 let artifacts = if all {
                     output
@@ -225,8 +224,9 @@ impl SelectorsSubcommands {
             }
             Self::List { contract, project_paths, no_group } => {
                 sh_status!("Listing selectors for contracts in the project...")?;
-                let project = abi_only_project(project_paths)?;
-                let outcome = ProjectCompiler::new().quiet(true).compile(&project)?;
+                let mut project = project_from_paths(project_paths)?;
+                let outcome =
+                    compile_abi_project(&mut project, ProjectCompiler::new().quiet(true))?;
                 let artifacts = if let Some(contract) = contract {
                     let found_artifact = outcome.find_first(&contract);
                     let artifact = found_artifact
@@ -360,8 +360,9 @@ impl SelectorsSubcommands {
             Self::Find { selector, project_paths } => {
                 sh_status!("Searching for selector {selector:?} in the project...")?;
 
-                let project = abi_only_project(project_paths)?;
-                let outcome = ProjectCompiler::new().quiet(true).compile(&project)?;
+                let mut project = project_from_paths(project_paths)?;
+                let outcome =
+                    compile_abi_project(&mut project, ProjectCompiler::new().quiet(true))?;
                 let artifacts = outcome
                     .into_artifacts_with_files()
                     .filter(|(file, _, _)| {
@@ -432,10 +433,7 @@ impl SelectorsSubcommands {
     }
 }
 
-fn abi_only_project(project_paths: ProjectPathOpts) -> Result<Project<MultiCompiler>> {
-    let mut project = BuildOpts { project_paths, ..Default::default() }.project()?;
-    project.update_output_selection(|selection| {
-        *selection = OutputSelection::common_output_selection(["abi".to_string()]);
-    });
-    Ok(project)
+fn project_from_paths(project_paths: ProjectPathOpts) -> Result<Project<MultiCompiler>> {
+    let config = BuildOpts { project_paths, ..Default::default() }.load_config()?;
+    Ok(config.project()?)
 }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -34,12 +34,13 @@ use foundry_cli::{
     utils::{self, LoadConfig},
 };
 use foundry_common::{
-    EmptyTestFilter, TestFilter, TestFunctionExt, TestFunctionKind, compile::ProjectCompiler, fs,
-    shell,
+    EmptyTestFilter, TestFilter, TestFunctionExt, TestFunctionKind,
+    compile::{ProjectCompiler, compile_abi_project},
+    fs, shell,
 };
 use foundry_compilers::{
     ProjectCompileOutput,
-    artifacts::{Libraries, output_selection::OutputSelection},
+    artifacts::Libraries,
     compilers::{
         Language,
         multi::{MultiCompiler, MultiCompilerLanguage},
@@ -1124,10 +1125,7 @@ impl TestArgs {
         }
 
         let mut project = config.create_project(true, true)?;
-        project.update_output_selection(|selection| {
-            *selection = OutputSelection::common_output_selection(["abi".to_string()]);
-        });
-        let output = project.compile()?;
+        let output = compile_abi_project(&mut project, ProjectCompiler::new().quiet(true))?;
         if output.has_compiler_errors() {
             sh_println!("{output}")?;
             eyre::bail!("Compilation failed");
@@ -1236,13 +1234,10 @@ impl TestArgs {
         let quiet = shell::is_json() || self.junit;
 
         if self.list {
-            project.update_output_selection(|selection| {
-                *selection = OutputSelection::common_output_selection(["abi".to_string()]);
-            });
-            let output = ProjectCompiler::new()
-                .dynamic_test_linking(dynamic_test_linking)
-                .quiet(quiet)
-                .compile(&project)?;
+            let output = compile_abi_project(
+                &mut project,
+                ProjectCompiler::new().dynamic_test_linking(dynamic_test_linking).quiet(quiet),
+            )?;
             let inline_config = Arc::new(InlineConfig::new_parsed(&output, &config)?);
             return Ok((
                 project_root,

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -5,13 +5,11 @@ use crate::{
 };
 use alloy_json_abi::JsonAbi;
 use async_trait::async_trait;
-use eyre::{Context, OptionExt, Result};
-use foundry_common::compile::ProjectCompiler;
+use eyre::{Context, Result};
+use foundry_common::compile::compile_target_abi;
 use foundry_compilers::{
     Project,
-    artifacts::{
-        Source, StandardJsonCompilerInput, output_selection::OutputSelection, vyper::VyperInput,
-    },
+    artifacts::{Source, StandardJsonCompilerInput, vyper::VyperInput},
     compilers::solc::SolcCompiler,
     multi::MultiCompilerSettings,
     solc::{Solc, SolcLanguage},
@@ -87,20 +85,7 @@ impl VerificationContext {
     /// Compiles target contract requesting only ABI and returns it.
     pub fn get_target_abi(&self) -> Result<JsonAbi> {
         let mut project = self.project.clone();
-        project.update_output_selection(|selection| {
-            *selection = OutputSelection::common_output_selection(["abi".to_string()]);
-        });
-
-        let output = ProjectCompiler::new()
-            .quiet(true)
-            .files([self.target_path.clone()])
-            .compile(&project)?;
-
-        let artifact = output
-            .find(&self.target_path, &self.target_name)
-            .ok_or_eyre("failed to find target artifact when compiling for abi")?;
-
-        artifact.abi.clone().ok_or_eyre("target artifact does not have an ABI")
+        compile_target_abi(&mut project, &self.target_path, &self.target_name)
     }
 }
 

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -84,7 +84,8 @@ impl VerificationContext {
 
     /// Compiles target contract requesting only ABI and returns it.
     pub fn get_target_abi(&self) -> Result<JsonAbi> {
-        compile_target_abi(&self.project, &self.target_path, &self.target_name)
+        let mut project = self.project.clone();
+        compile_target_abi(&mut project, &self.target_path, &self.target_name)
     }
 }
 

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -84,8 +84,7 @@ impl VerificationContext {
 
     /// Compiles target contract requesting only ABI and returns it.
     pub fn get_target_abi(&self) -> Result<JsonAbi> {
-        let mut project = self.project.clone();
-        compile_target_abi(&mut project, &self.target_path, &self.target_name)
+        compile_target_abi(&self.project, &self.target_path, &self.target_name)
     }
 }
 


### PR DESCRIPTION
Centralizes ABI-only compilation in foundry_common so selectors, test discovery, and verification all share the same narrow helper path instead of constructing ABI-only projects inline. The target ABI helper keeps the current compiler-backed behavior while removing the duplicated setup around output selection, quiet compilation, and ABI extraction.

AI assistance was used to draft this change.
