### PR TITLE
refactor(fuzz): introduce `FuzzRunArgs`

### DIFF
--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -161,6 +161,10 @@ pub struct InvariantConfig {
     #[serde(default, skip_serializing)]
     #[doc(hidden)]
     pub corpus_random_sequence_weight_configured: bool,
+    /// Whether `workers` was supplied by a config provider.
+    #[serde(default, skip_serializing)]
+    #[doc(hidden)]
+    pub workers_configured: bool,
     /// Path where invariant failures are recorded and replayed.
     pub failure_persist_dir: Option<PathBuf>,
     /// Whether to collect and display fuzzed selectors metrics.
@@ -199,6 +203,7 @@ impl Default for InvariantConfig {
             gas_report_samples: 256,
             corpus: FuzzCorpusConfig::default(),
             corpus_random_sequence_weight_configured: false,
+            workers_configured: false,
             failure_persist_dir: None,
             show_metrics: true,
             timeout: None,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -841,12 +841,16 @@ impl Config {
                 || provider
                     .extract_inner::<bool>("invariant.corpus_random_sequence_weight_configured")
                     .unwrap_or(false);
+        let invariant_workers_configured = self.invariant.workers_configured
+            || provider.contains("invariant.workers")
+            || provider.extract_inner::<bool>("invariant.workers_configured").unwrap_or(false);
         let figment = self.to_figment(FigmentProviders::None).merge(provider);
         let mut config = figment.extract::<Self>()?;
         config.profile = self.profile.clone();
         config.profiles = self.profiles.clone();
         config.invariant.corpus_random_sequence_weight_configured =
             invariant_corpus_random_sequence_weight_configured;
+        config.invariant.workers_configured = invariant_workers_configured;
         config.normalize_hardfork_settings()?;
 
         Ok(config)

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -843,7 +843,8 @@ impl Config {
                     .unwrap_or(false);
         let invariant_workers_configured = self.invariant.workers_configured
             || provider.contains("invariant.workers")
-            || provider.extract_inner::<bool>("invariant.workers_configured").unwrap_or(false);
+            || provider.extract_inner::<bool>("invariant.workers_configured").unwrap_or(false)
+            || provider.extract_inner::<InvariantWorkers>("invariant.workers").is_ok();
         let figment = self.to_figment(FigmentProviders::None).merge(provider);
         let mut config = figment.extract::<Self>()?;
         config.profile = self.profile.clone();
@@ -3069,8 +3070,9 @@ mod tests {
         config.warnings = vec![];
     }
 
-    fn mark_serialized_invariant_corpus_weight(config: &mut Config) {
+    fn mark_serialized_invariant_provenance(config: &mut Config) {
         config.invariant.corpus_random_sequence_weight_configured = true;
+        config.invariant.workers_configured = true;
     }
 
     #[test]
@@ -4805,7 +4807,7 @@ mod tests {
             let mut other = Config::load().unwrap();
             clear_warning(&mut other);
             let mut serialized_default = default;
-            mark_serialized_invariant_corpus_weight(&mut serialized_default);
+            mark_serialized_invariant_provenance(&mut serialized_default);
             assert_eq!(serialized_default, other);
 
             Ok(())
@@ -4875,7 +4877,7 @@ mod tests {
 
             let s = loaded.to_string_pretty().unwrap();
             jail.create_file("foundry.toml", &s)?;
-            mark_serialized_invariant_corpus_weight(&mut loaded);
+            mark_serialized_invariant_provenance(&mut loaded);
 
             let mut reloaded = Config::load().unwrap();
             clear_warning(&mut reloaded);
@@ -4926,7 +4928,7 @@ mod tests {
 
             let s = loaded.to_string_pretty().unwrap();
             jail.create_file("foundry.toml", &s)?;
-            mark_serialized_invariant_corpus_weight(&mut loaded);
+            mark_serialized_invariant_provenance(&mut loaded);
 
             let mut reloaded = Config::load().unwrap();
             clear_warning(&mut reloaded);
@@ -5124,6 +5126,7 @@ mod tests {
                         ..Default::default()
                     },
                     corpus_random_sequence_weight_configured: true,
+                    workers_configured: true,
                     failure_persist_dir: Some(PathBuf::from("cache/invariant")),
                     ..Default::default()
                 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -877,9 +877,13 @@ impl Config {
             .unwrap_or_else(|_| {
                 figment_value_is_configured(&figment, "invariant.corpus_random_sequence_weight")
             });
+        let invariant_workers_configured = figment
+            .extract_inner::<bool>("invariant.workers_configured")
+            .unwrap_or_else(|_| figment_value_is_configured(&figment, "invariant.workers"));
         let mut config = figment.extract::<Self>().map_err(ExtractConfigError::new)?;
         config.invariant.corpus_random_sequence_weight_configured =
             invariant_corpus_random_sequence_weight_configured;
+        config.invariant.workers_configured = invariant_workers_configured;
         let selected_profile = figment.profile().clone();
 
         // The `"profile"` profile contains all the profiles as keys.
@@ -1024,11 +1028,18 @@ impl Config {
                 .unwrap_or_else(|_| {
                     figment_value_is_configured(&figment, "invariant.corpus_random_sequence_weight")
                 });
+        let invariant_workers_configured = self.invariant.workers_configured
+            || figment.extract_inner::<bool>("invariant.workers_configured").unwrap_or_else(|_| {
+                figment.extract_inner::<InvariantWorkers>("invariant.workers").is_ok()
+            });
 
         // normalize defaults
         figment = self.normalize_defaults(figment);
         if invariant_corpus_random_sequence_weight_configured {
             figment = figment.merge(("invariant.corpus_random_sequence_weight_configured", true));
+        }
+        if invariant_workers_configured {
+            figment = figment.merge(("invariant.workers_configured", true));
         }
 
         Figment::from(self).merge(figment).select(profile)
@@ -5136,12 +5147,14 @@ mod tests {
                 FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
             );
             assert!(!loaded.invariant.corpus_random_sequence_weight_configured);
+            assert!(!loaded.invariant.workers_configured);
 
             jail.create_file(
                 "foundry.toml",
                 r#"
                 [invariant]
                 corpus_random_sequence_weight = 10
+                workers = 4
             "#,
             )?;
 
@@ -5151,6 +5164,11 @@ mod tests {
                 FuzzCorpusConfig::DEFAULT_CORPUS_RANDOM_SEQUENCE_WEIGHT
             );
             assert!(loaded.invariant.corpus_random_sequence_weight_configured);
+            assert_eq!(
+                loaded.invariant.workers,
+                InvariantWorkers::Fixed(NonZeroUsize::new(4).unwrap())
+            );
+            assert!(loaded.invariant.workers_configured);
 
             Ok(())
         });

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -63,7 +63,6 @@ pub fn run_command(args: Forge) -> Result<()> {
             }
         }
         ForgeSubcommand::Fuzz(cmd) => {
-            cmd.reject_unsupported_flags()?;
             let silent = cmd.is_junit() || shell::is_json();
             let outcome = global.block_on(cmd.run())?;
             outcome.ensure_ok(silent)

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cmd::test::{FilterArgs, FuzzMinimizeReplaySession, TestArgs},
+    cmd::test::{CampaignArgs, FilterArgs, FuzzMinimizeReplaySession, ShowmapDomainArg, TestArgs},
     multi_runner::{FuzzMinimizeEdgeIndices, FuzzMinimizeObservation, ShowmapConfig},
     result::TestOutcome,
 };
@@ -18,7 +18,7 @@ use foundry_common::{
     fs, sh_println, sh_status,
     shell::{OutputMode, Shell},
 };
-use foundry_config::Config;
+use foundry_config::{Config, filter::GlobMatcher};
 use foundry_evm::{
     executors::{CorpusDirEntry, ReplayObservation, ShowmapDomain, read_corpus_tree},
     fuzz::BasicTxDetails,
@@ -43,10 +43,7 @@ pub struct FuzzArgs {
 impl FuzzArgs {
     pub async fn run(self) -> Result<TestOutcome> {
         match self.command {
-            FuzzSubcommands::Run(mut args) => {
-                args.enable_fuzz_only();
-                args.run().await
-            }
+            FuzzSubcommands::Run(args) => TestArgs::from_fuzz_run(args).run().await,
             FuzzSubcommands::Replay(args) => args.run().await,
             FuzzSubcommands::Show(args) => {
                 args.run()?;
@@ -70,24 +67,13 @@ impl FuzzArgs {
             FuzzSubcommands::Show(_) | FuzzSubcommands::Cmin(_) | FuzzSubcommands::Tmin(_) => false,
         }
     }
-
-    pub fn reject_unsupported_flags(&self) -> Result<()> {
-        match &self.command {
-            FuzzSubcommands::Run(args) if args.is_watch() => {
-                bail!("`--watch` is not supported for `forge fuzz run`")
-            }
-            FuzzSubcommands::Replay(args) if args.is_watch() => {
-                bail!("`--watch` is not supported for `forge fuzz replay`")
-            }
-            _ => Ok(()),
-        }
-    }
 }
 
 #[derive(Clone, Debug, Subcommand)]
+#[allow(clippy::large_enum_variant)]
 pub enum FuzzSubcommands {
     /// Run only fuzz and invariant tests.
-    Run(TestArgs),
+    Run(FuzzRunArgs),
     /// Replay persisted fuzz failures, or corpus entries with `--corpus-dir`.
     Replay(FuzzReplayArgs),
     /// Print persisted corpus entries.
@@ -96,6 +82,122 @@ pub enum FuzzSubcommands {
     Cmin(FuzzCminArgs),
     /// Minimize one corpus entry while preserving its failure or coverage.
     Tmin(FuzzTminArgs),
+}
+
+/// Run only fuzz and invariant tests.
+#[derive(Clone, Debug, Parser)]
+pub struct FuzzRunArgs {
+    #[command(flatten)]
+    pub(crate) global: GlobalArgs,
+
+    /// The contract file you want to test, it's a shortcut for --match-path.
+    #[arg(value_hint = ValueHint::FilePath)]
+    pub(crate) path: Option<GlobMatcher>,
+
+    #[command(flatten)]
+    pub(crate) filter: FilterArgs,
+
+    #[command(flatten)]
+    pub(crate) campaign: CampaignArgs,
+
+    #[command(flatten)]
+    pub(crate) evm: EvmArgs,
+
+    #[command(flatten)]
+    pub(crate) build: BuildOpts,
+
+    /// Output test results as JUnit XML report.
+    #[arg(long, conflicts_with_all = ["quiet", "json", "gas_report", "list", "show_progress"], help_heading = "Display options")]
+    pub(crate) junit: bool,
+
+    /// Exit with code 0 even if a test fails.
+    #[arg(long, env = "FORGE_ALLOW_FAILURE")]
+    pub(crate) allow_failure: bool,
+
+    /// Stop running tests after the first failure.
+    #[arg(long)]
+    pub(crate) fail_fast: bool,
+
+    /// Re-run recorded test failures from last run.
+    /// If no failure recorded then regular test run is performed.
+    #[arg(long)]
+    pub(crate) rerun: bool,
+
+    /// Show test execution progress.
+    #[arg(long, conflicts_with_all = ["quiet", "json"], help_heading = "Display options")]
+    pub(crate) show_progress: bool,
+
+    /// The Etherscan (or equivalent) API key.
+    #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
+    pub(crate) etherscan_api_key: Option<String>,
+
+    /// List fuzz and invariant tests instead of running them.
+    #[arg(long, short, conflicts_with_all = ["show_progress"], help_heading = "Display options")]
+    pub(crate) list: bool,
+
+    /// Print a gas report.
+    #[arg(long, env = "FORGE_GAS_REPORT")]
+    pub(crate) gas_report: bool,
+
+    /// Replay the persisted corpus and emit AFL-`afl-showmap`-style coverage
+    /// files at the given output directory.
+    #[arg(
+        long,
+        value_name = "DIR",
+        value_hint = ValueHint::DirPath,
+        help_heading = "Showmap replay",
+        conflicts_with_all = ["rerun", "fuzz_input_file", "gas_report"],
+    )]
+    pub(crate) showmap_out: Option<PathBuf>,
+
+    /// Emit one showmap file per corpus entry (default: one aggregated file per test).
+    #[arg(long, help_heading = "Showmap replay", requires = "showmap_out")]
+    pub(crate) showmap_per_input: bool,
+
+    /// Coverage domain(s) to dump.
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = ShowmapDomainArg::Evm,
+        help_heading = "Showmap replay",
+        requires = "showmap_out",
+    )]
+    pub(crate) showmap_domain: ShowmapDomainArg,
+
+    /// Approach name (used as a subdirectory of `--showmap-out`).
+    #[arg(
+        long,
+        default_value = "replay",
+        help_heading = "Showmap replay",
+        requires = "showmap_out"
+    )]
+    pub(crate) showmap_approach: String,
+
+    /// Trial identifier embedded in each showmap filename.
+    #[arg(long, help_heading = "Showmap replay", requires = "showmap_out")]
+    pub(crate) showmap_trial: Option<String>,
+
+    /// Override the corpus directory to replay.
+    #[arg(
+        long,
+        value_name = "PATH",
+        value_hint = ValueHint::DirPath,
+        help_heading = "Showmap replay",
+        requires = "showmap_out",
+    )]
+    pub(crate) showmap_corpus_dir: Option<PathBuf>,
+
+    /// Run only the fuzz case at the given 1-based run index.
+    #[arg(long, env = "FOUNDRY_FUZZ_RUN", value_name = "RUN")]
+    pub(crate) fuzz_run: Option<u32>,
+
+    /// Run the fuzz case from the given worker. Requires `--fuzz-run`.
+    #[arg(long, env = "FOUNDRY_FUZZ_WORKER", value_name = "WORKER", requires = "fuzz_run")]
+    pub(crate) fuzz_worker: Option<u32>,
+
+    /// File to rerun fuzz failures from.
+    #[arg(long)]
+    pub(crate) fuzz_input_file: Option<String>,
 }
 
 /// Replay persisted fuzz failures, or corpus entries with `--corpus-dir`.
@@ -132,10 +234,6 @@ impl FuzzReplayArgs {
 
     const fn is_junit(&self) -> bool {
         self.test.junit
-    }
-
-    const fn is_watch(&self) -> bool {
-        self.test.is_watch()
     }
 }
 
@@ -1254,7 +1352,13 @@ fn merge_new_edge_vec(cumulative: &mut Vec<u8>, candidate: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
     use foundry_evm::executors::ReplayFailure;
+
+    #[test]
+    fn fuzz_args_clap_shape_is_valid() {
+        FuzzArgs::command().debug_assert();
+    }
 
     fn decoder_with_functions(functions: Vec<Function>) -> CorpusDecoder {
         let mut decoder = CorpusDecoder::default();

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -191,10 +191,6 @@ pub struct FuzzRunArgs {
     #[arg(long, env = "FOUNDRY_FUZZ_RUN", value_name = "RUN")]
     pub(crate) fuzz_run: Option<u32>,
 
-    /// Run the fuzz case from the given worker. Requires `--fuzz-run`.
-    #[arg(long, env = "FOUNDRY_FUZZ_WORKER", value_name = "WORKER", requires = "fuzz_run")]
-    pub(crate) fuzz_worker: Option<u32>,
-
     /// File to rerun fuzz failures from.
     #[arg(long)]
     pub(crate) fuzz_input_file: Option<String>,
@@ -1358,6 +1354,11 @@ mod tests {
     #[test]
     fn fuzz_args_clap_shape_is_valid() {
         FuzzArgs::command().debug_assert();
+    }
+
+    #[test]
+    fn fuzz_run_rejects_fuzz_worker() {
+        assert!(FuzzArgs::try_parse_from(["foundry-cli", "run", "--fuzz-worker", "1"]).is_err());
     }
 
     fn decoder_with_functions(functions: Vec<Function>) -> CorpusDecoder {

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -187,10 +187,6 @@ pub struct FuzzRunArgs {
     )]
     pub(crate) showmap_corpus_dir: Option<PathBuf>,
 
-    /// Run only the fuzz case at the given 1-based run index.
-    #[arg(long, env = "FOUNDRY_FUZZ_RUN", value_name = "RUN")]
-    pub(crate) fuzz_run: Option<u32>,
-
     /// File to rerun fuzz failures from.
     #[arg(long)]
     pub(crate) fuzz_input_file: Option<String>,
@@ -1357,6 +1353,11 @@ mod tests {
     #[test]
     fn fuzz_run_rejects_fuzz_worker() {
         assert!(FuzzArgs::try_parse_from(["foundry-cli", "run", "--fuzz-worker", "1"]).is_err());
+    }
+
+    #[test]
+    fn fuzz_run_rejects_fuzz_run() {
+        assert!(FuzzArgs::try_parse_from(["foundry-cli", "run", "--fuzz-run", "1"]).is_err());
     }
 
     fn decoder_with_functions(functions: Vec<Function>) -> CorpusDecoder {

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -200,36 +200,34 @@ pub struct FuzzRunArgs {
 #[derive(Clone, Debug, Parser)]
 pub struct FuzzReplayArgs {
     #[command(flatten)]
-    test: TestArgs,
-    /// Replay corpus entries from this directory instead of persisted fuzz failures.
-    #[arg(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
-    corpus_dir: Option<PathBuf>,
+    run: FuzzRunArgs,
 }
 
 impl FuzzReplayArgs {
-    async fn run(mut self) -> Result<TestOutcome> {
-        self.test.enable_fuzz_only();
-        if self.corpus_dir.is_none() {
-            self.test.enable_fuzz_failure_replay();
-            return self.test.run().await;
+    async fn run(self) -> Result<TestOutcome> {
+        let corpus_dir = self.run.campaign.corpus_dir.clone();
+        let mut test = TestArgs::from_fuzz_run(self.run);
+        if corpus_dir.is_none() {
+            test.enable_fuzz_failure_replay();
+            return test.run().await;
         }
 
         let replay_id =
             SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_nanos()).unwrap_or_default();
-        self.test.set_showmap_override(ShowmapConfig {
+        test.set_showmap_override(ShowmapConfig {
             out_dir: std::env::temp_dir().join(format!("forge-fuzz-replay-{replay_id}")),
             approach: "replay".to_string(),
             trial: "replay".to_string(),
             per_input: false,
             domain: ShowmapDomain::Evm,
-            corpus_dir: self.corpus_dir.clone(),
+            corpus_dir,
             emit_files: false,
         });
-        self.test.run().await
+        test.run().await
     }
 
     const fn is_junit(&self) -> bool {
-        self.test.junit
+        self.run.junit
     }
 }
 

--- a/crates/forge/src/cmd/test/filter.rs
+++ b/crates/forge/src/cmd/test/filter.rs
@@ -25,7 +25,7 @@ pub struct RerunFailures {
 /// The filter to use during testing.
 ///
 /// See also `FileFilter`.
-#[derive(Clone, Parser)]
+#[derive(Clone, Default, Parser)]
 #[command(next_help_heading = "Test filtering")]
 pub struct FilterArgs {
     /// Only run test functions matching the specified regex pattern.

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -475,6 +475,7 @@ pub(crate) struct SuppliedEngineFlags {
     pub(crate) frontier_dir: bool,
     pub(crate) frontier_limit: bool,
     pub(crate) fuzz_run: bool,
+    pub(crate) fuzz_input_file: bool,
     pub(crate) depth: bool,
     pub(crate) min_depth: bool,
     pub(crate) depth_mode: bool,
@@ -487,6 +488,7 @@ impl SuppliedEngineFlags {
             frontier_dir: false,
             frontier_limit: false,
             fuzz_run: false,
+            fuzz_input_file: false,
             depth: false,
             min_depth: false,
             depth_mode: false,
@@ -1193,6 +1195,11 @@ impl TestArgs {
                     "`--fuzz-run` only applies to fuzz tests; no matched fuzz tests were found."
                 )?;
             }
+            if flags.fuzz_input_file {
+                sh_warn!(
+                    "`--fuzz-input-file` only applies to fuzz tests; no matched fuzz tests were found."
+                )?;
+            }
         }
 
         if counts.invariant == 0 && counts.fuzz > 0 {
@@ -1225,6 +1232,7 @@ impl TestArgs {
     pub(crate) fn from_fuzz_run(args: FuzzRunArgs) -> Self {
         let mut supplied = args.campaign.supplied_engine_flags();
         supplied.fuzz_run = args.fuzz_run.is_some();
+        supplied.fuzz_input_file = args.fuzz_input_file.is_some();
 
         Self {
             fuzz_only: true,

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -4153,6 +4153,8 @@ mod tests {
             "20",
             "--invariant-depth-mode",
             "random",
+            "--invariant-workers",
+            "4",
             "--invariant-dictionary-weight",
             "45",
             "--invariant-dictionary-addresses",
@@ -4271,6 +4273,10 @@ mod tests {
         assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 25);
         assert_eq!(config.invariant.corpus.corpus_dir, Some(PathBuf::from("invariant_corpus")));
         assert!(config.invariant.corpus_random_sequence_weight_configured);
+        assert_eq!(
+            config.invariant.workers,
+            InvariantWorkers::Fixed(std::num::NonZeroUsize::new(4).unwrap())
+        );
         assert!(config.invariant.workers_configured);
         assert_eq!(config.invariant.corpus.payable_value_weight, 34);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_splice, 2);

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1,4 +1,4 @@
-use super::{install, watch::WatchArgs};
+use super::{fuzz::FuzzRunArgs, install, watch::WatchArgs};
 use crate::{
     MultiContractRunner, MultiContractRunnerBuilder,
     decode::decode_console_logs,
@@ -35,7 +35,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     EmptyTestFilter, TestFilter, TestFunctionExt, TestFunctionKind, compile::ProjectCompiler, fs,
-    shell,
+    sh_warn, shell,
 };
 use foundry_compilers::{
     ProjectCompileOutput,
@@ -358,8 +358,153 @@ fn sources_to_compile_from_artifacts(
         .collect()
 }
 
-/// CLI arguments for `forge test`.
+/// Shared campaign arguments for `forge fuzz run`.
 #[derive(Clone, Debug, Parser)]
+#[command(next_help_heading = "Campaign options")]
+pub struct CampaignArgs {
+    /// Number of runs to execute for each fuzz or invariant campaign.
+    #[arg(long, value_name = "RUNS")]
+    pub runs: Option<u64>,
+
+    /// Campaign-global timeout in seconds.
+    #[arg(long, value_name = "TIMEOUT")]
+    pub timeout: Option<u32>,
+
+    /// Set seed used to generate randomness during fuzz runs.
+    #[arg(long)]
+    pub seed: Option<U256>,
+
+    /// Number of calls executed to try to break invariants in one run.
+    #[arg(long, value_name = "DEPTH")]
+    pub depth: Option<u32>,
+
+    /// Minimum sampled invariant depth when `--depth-mode random` is active.
+    #[arg(long, value_name = "DEPTH")]
+    pub min_depth: Option<u32>,
+
+    /// How invariant run depth is selected.
+    #[arg(long, value_name = "fixed|random")]
+    pub depth_mode: Option<InvariantDepthMode>,
+
+    /// Number of workers to use for invariant test campaigns, or `auto` to derive from `--jobs`.
+    #[arg(long, value_name = "WORKERS")]
+    pub workers: Option<InvariantWorkers>,
+
+    /// Directory for fuzz and invariant corpus persistence.
+    #[arg(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
+    pub corpus_dir: Option<PathBuf>,
+
+    /// Percent of calldata generated from the dictionary.
+    #[arg(long, value_name = "PERCENT")]
+    pub dictionary_weight: Option<u32>,
+
+    /// Maximum dictionary addresses, or `max`.
+    #[arg(long, value_name = "N|max")]
+    pub dictionary_addresses: Option<String>,
+
+    /// Maximum dictionary values, or `max`.
+    #[arg(long, value_name = "N|max")]
+    pub dictionary_values: Option<String>,
+
+    /// Maximum dictionary literals, or `max`.
+    #[arg(long, value_name = "N|max")]
+    pub dictionary_literals: Option<String>,
+
+    /// Percent chance that coverage-guided fuzzing generates fresh input instead of mutating
+    /// corpus input.
+    #[arg(long, value_name = "PERCENT")]
+    pub corpus_random_sequence_weight: Option<u32>,
+
+    /// Percent chance that fuzzed payable calls carry non-zero msg.value.
+    #[arg(long, value_name = "PERCENT")]
+    pub payable_value_weight: Option<u32>,
+
+    /// Corpus mutation weight for splice.
+    #[arg(long, value_name = "WEIGHT")]
+    pub mutation_weight_splice: Option<u32>,
+
+    /// Corpus mutation weight for repeat.
+    #[arg(long, value_name = "WEIGHT")]
+    pub mutation_weight_repeat: Option<u32>,
+
+    /// Corpus mutation weight for interleave.
+    #[arg(long, value_name = "WEIGHT")]
+    pub mutation_weight_interleave: Option<u32>,
+
+    /// Corpus mutation weight for prefix replacement.
+    #[arg(long, value_name = "WEIGHT")]
+    pub mutation_weight_prefix: Option<u32>,
+
+    /// Corpus mutation weight for suffix replacement.
+    #[arg(long, value_name = "WEIGHT")]
+    pub mutation_weight_suffix: Option<u32>,
+
+    /// Corpus mutation weight for ABI argument mutation.
+    #[arg(long, value_name = "WEIGHT")]
+    pub mutation_weight_abi: Option<u32>,
+
+    /// Corpus mutation weight for comparison-operand mutation.
+    #[arg(long, value_name = "WEIGHT")]
+    pub mutation_weight_cmp: Option<u32>,
+
+    /// Directory for fuzz branch frontier artifacts.
+    #[arg(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
+    pub frontier_dir: Option<PathBuf>,
+
+    /// Maximum number of fuzz branch frontier records to write per test.
+    #[arg(long, value_name = "COUNT")]
+    pub frontier_limit: Option<usize>,
+}
+
+impl CampaignArgs {
+    pub(crate) const fn supplied_engine_flags(&self) -> SuppliedEngineFlags {
+        SuppliedEngineFlags {
+            frontier_dir: self.frontier_dir.is_some(),
+            frontier_limit: self.frontier_limit.is_some(),
+            depth: self.depth.is_some(),
+            min_depth: self.min_depth.is_some(),
+            depth_mode: self.depth_mode.is_some(),
+            workers: self.workers.is_some(),
+            ..SuppliedEngineFlags::empty()
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SuppliedEngineFlags {
+    pub(crate) frontier_dir: bool,
+    pub(crate) frontier_limit: bool,
+    pub(crate) fuzz_run: bool,
+    pub(crate) fuzz_worker: bool,
+    pub(crate) depth: bool,
+    pub(crate) min_depth: bool,
+    pub(crate) depth_mode: bool,
+    pub(crate) workers: bool,
+}
+
+impl SuppliedEngineFlags {
+    pub(crate) const fn empty() -> Self {
+        Self {
+            frontier_dir: false,
+            frontier_limit: false,
+            fuzz_run: false,
+            fuzz_worker: false,
+            depth: false,
+            min_depth: false,
+            depth_mode: false,
+            workers: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct MatchedEngineCounts {
+    fuzz: usize,
+    invariant: usize,
+}
+
+/// CLI arguments for `forge test`.
+#[derive(Clone, Debug, Default, Parser)]
 #[command(next_help_heading = "Test options")]
 pub struct TestArgs {
     /// Internal mode used by `forge fuzz`.
@@ -373,6 +518,18 @@ pub struct TestArgs {
     /// Internal mode used by `forge fuzz replay` to replay persisted fuzz failures.
     #[arg(skip)]
     pub(crate) fuzz_failure_replay: bool,
+
+    /// Internal override used by `forge fuzz run --runs` for invariant campaigns.
+    #[arg(skip)]
+    pub(crate) invariant_runs_override: Option<u64>,
+
+    /// Internal override used by `forge fuzz run --timeout` for invariant campaigns.
+    #[arg(skip)]
+    pub(crate) invariant_timeout_override: Option<u32>,
+
+    /// Internal warning metadata used by `forge fuzz run`.
+    #[arg(skip)]
+    pub(crate) warn_unsupported_engine_flags: Option<SuppliedEngineFlags>,
 
     // Include global options for users of this struct.
     #[command(flatten)]
@@ -1008,6 +1165,143 @@ impl TestArgs {
         self.fuzz_failure_replay = true;
     }
 
+    fn warn_unsupported_engine_flags(
+        &self,
+        output: &ProjectCompileOutput,
+        config: &Config,
+        inline_config: &InlineConfig,
+        filter: &ProjectPathsAwareFilter,
+        multi_network: &MultiNetworkConfig,
+    ) -> Result<()> {
+        let Some(flags) = self.warn_unsupported_engine_flags else { return Ok(()) };
+        let counts = matched_engine_counts(output, config, inline_config, filter, multi_network);
+        if counts.fuzz == 0 && counts.invariant == 0 {
+            return Ok(());
+        }
+
+        if counts.fuzz == 0 && counts.invariant > 0 {
+            if flags.frontier_dir {
+                sh_warn!(
+                    "`--frontier-dir` only applies to fuzz tests; no matched fuzz tests were found."
+                )?;
+            }
+            if flags.frontier_limit {
+                sh_warn!(
+                    "`--frontier-limit` only applies to fuzz tests; no matched fuzz tests were found."
+                )?;
+            }
+            if flags.fuzz_run {
+                sh_warn!(
+                    "`--fuzz-run` only applies to fuzz tests; no matched fuzz tests were found."
+                )?;
+            }
+            if flags.fuzz_worker {
+                sh_warn!(
+                    "`--fuzz-worker` only applies to fuzz tests; no matched fuzz tests were found."
+                )?;
+            }
+        }
+
+        if counts.invariant == 0 && counts.fuzz > 0 {
+            if flags.depth {
+                sh_warn!(
+                    "`--depth` only applies to invariant tests; no matched invariant tests were found."
+                )?;
+            }
+            if flags.min_depth {
+                sh_warn!(
+                    "`--min-depth` only applies to invariant tests; no matched invariant tests were found."
+                )?;
+            }
+            if flags.depth_mode {
+                sh_warn!(
+                    "`--depth-mode` only applies to invariant tests; no matched invariant tests were found."
+                )?;
+            }
+            if flags.workers {
+                sh_warn!(
+                    "`--workers` only applies to invariant tests; no matched invariant tests were found."
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Builds the delegated `forge test` invocation for `forge fuzz run`.
+    pub(crate) fn from_fuzz_run(args: FuzzRunArgs) -> Self {
+        let mut supplied = args.campaign.supplied_engine_flags();
+        supplied.fuzz_run = args.fuzz_run.is_some();
+        supplied.fuzz_worker = args.fuzz_worker.is_some();
+
+        Self {
+            fuzz_only: true,
+            warn_unsupported_engine_flags: Some(supplied),
+            global: args.global,
+            path: args.path,
+            gas_report: args.gas_report,
+            allow_failure: args.allow_failure,
+            junit: args.junit,
+            fail_fast: args.fail_fast,
+            etherscan_api_key: args.etherscan_api_key,
+            list: args.list,
+            fuzz_seed: args.campaign.seed,
+            fuzz_runs: args.campaign.runs,
+            invariant_workers: args.campaign.workers,
+            fuzz_run: args.fuzz_run,
+            fuzz_worker: args.fuzz_worker,
+            fuzz_timeout: args.campaign.timeout.map(u64::from),
+            fuzz_dictionary_weight: args.campaign.dictionary_weight,
+            fuzz_dictionary_addresses: args.campaign.dictionary_addresses.clone(),
+            fuzz_dictionary_values: args.campaign.dictionary_values.clone(),
+            fuzz_dictionary_literals: args.campaign.dictionary_literals.clone(),
+            fuzz_corpus_random_sequence_weight: args.campaign.corpus_random_sequence_weight,
+            fuzz_corpus_dir: args.campaign.corpus_dir.clone(),
+            fuzz_frontier_dir: args.campaign.frontier_dir,
+            fuzz_frontier_limit: args.campaign.frontier_limit,
+            fuzz_payable_value_weight: args.campaign.payable_value_weight,
+            fuzz_mutation_weight_splice: args.campaign.mutation_weight_splice,
+            fuzz_mutation_weight_repeat: args.campaign.mutation_weight_repeat,
+            fuzz_mutation_weight_interleave: args.campaign.mutation_weight_interleave,
+            fuzz_mutation_weight_prefix: args.campaign.mutation_weight_prefix,
+            fuzz_mutation_weight_suffix: args.campaign.mutation_weight_suffix,
+            fuzz_mutation_weight_abi: args.campaign.mutation_weight_abi,
+            fuzz_mutation_weight_cmp: args.campaign.mutation_weight_cmp,
+            fuzz_input_file: args.fuzz_input_file,
+            invariant_depth: args.campaign.depth,
+            invariant_min_depth: args.campaign.min_depth,
+            invariant_depth_mode: args.campaign.depth_mode,
+            invariant_dictionary_weight: args.campaign.dictionary_weight,
+            invariant_dictionary_addresses: args.campaign.dictionary_addresses,
+            invariant_dictionary_values: args.campaign.dictionary_values,
+            invariant_dictionary_literals: args.campaign.dictionary_literals,
+            invariant_corpus_random_sequence_weight: args.campaign.corpus_random_sequence_weight,
+            invariant_corpus_dir: args.campaign.corpus_dir,
+            invariant_payable_value_weight: args.campaign.payable_value_weight,
+            invariant_mutation_weight_splice: args.campaign.mutation_weight_splice,
+            invariant_mutation_weight_repeat: args.campaign.mutation_weight_repeat,
+            invariant_mutation_weight_interleave: args.campaign.mutation_weight_interleave,
+            invariant_mutation_weight_prefix: args.campaign.mutation_weight_prefix,
+            invariant_mutation_weight_suffix: args.campaign.mutation_weight_suffix,
+            invariant_mutation_weight_abi: args.campaign.mutation_weight_abi,
+            invariant_mutation_weight_cmp: args.campaign.mutation_weight_cmp,
+            show_progress: args.show_progress,
+            rerun: args.rerun,
+            showmap_out: args.showmap_out,
+            showmap_per_input: args.showmap_per_input,
+            showmap_domain: args.showmap_domain,
+            showmap_approach: args.showmap_approach,
+            showmap_trial: args.showmap_trial,
+            showmap_corpus_dir: args.showmap_corpus_dir,
+            filter: args.filter,
+            evm: args.evm,
+            build: args.build,
+            invariant_runs_override: args.campaign.runs,
+            invariant_timeout_override: args.campaign.timeout,
+            ..Self::default()
+        }
+    }
+
     fn load_symbolic_artifact_replay(&self) -> Result<Option<SymbolicArtifactReplayConfig>> {
         let Some(path) = &self.replay_symbolic_artifact else {
             return Ok(None);
@@ -1438,6 +1732,14 @@ impl TestArgs {
                 );
             }
         }
+
+        self.warn_unsupported_engine_flags(
+            output,
+            &config,
+            &execution.inline_config,
+            filter,
+            &execution.multi_network,
+        )?;
 
         if self.list {
             return list_from_output(
@@ -2824,6 +3126,9 @@ impl Provider for TestArgs {
         dict.insert("fuzz".to_string(), fuzz_dict.into());
 
         let mut invariant_dict = Dict::default();
+        if let Some(invariant_runs) = self.invariant_runs_override {
+            invariant_dict.insert("runs".to_string(), invariant_runs.into());
+        }
         if let Some(invariant_depth) = self.invariant_depth {
             invariant_dict.insert("depth".to_string(), invariant_depth.into());
         }
@@ -2878,6 +3183,9 @@ impl Provider for TestArgs {
         if let Some(invariant_payable_value_weight) = self.invariant_payable_value_weight {
             invariant_dict
                 .insert("payable_value_weight".to_string(), invariant_payable_value_weight.into());
+        }
+        if let Some(invariant_timeout) = self.invariant_timeout_override {
+            invariant_dict.insert("timeout".to_string(), invariant_timeout.into());
         }
         if let Some(weight) = self.invariant_mutation_weight_splice {
             invariant_dict.insert("mutation_weight_splice".to_string(), weight.into());
@@ -3101,6 +3409,71 @@ fn list_from_output(
 
     print_list_results(&results)?;
     Ok(TestOutcome::empty(None, false))
+}
+
+fn matched_engine_counts(
+    output: &ProjectCompileOutput,
+    config: &Config,
+    inline_config: &InlineConfig,
+    filter: &ProjectPathsAwareFilter,
+    multi_network: &MultiNetworkConfig,
+) -> MatchedEngineCounts {
+    let matcher = TestFunctionMatcher::new(config, inline_config, None);
+    output
+        .artifact_ids()
+        .filter_map(|(id, artifact)| artifact.abi.as_ref().map(|abi| (id, abi)))
+        .filter_map(|(id, abi)| {
+            let id = id.with_stripped_file_prefixes(&config.root);
+            let deployable = abi
+                .constructor
+                .as_ref()
+                .map(|constructor| constructor.inputs.is_empty())
+                .unwrap_or(true);
+            if !deployable || !matcher.matches_contract(filter, &id, abi) {
+                return None;
+            }
+
+            let contract_name = id.identifier();
+            let generated_symbolic_regression = is_generated_symbolic_regression_contract(abi);
+            let fuzz = abi
+                .functions()
+                .filter_map(|func| {
+                    let kind = matcher.test_function_kind(
+                        &contract_name,
+                        func,
+                        generated_symbolic_regression,
+                    );
+                    matches!(kind, TestFunctionKind::FuzzTest { .. }).then_some((func, kind))
+                })
+                .filter(|(func, kind)| {
+                    filter.matches_test_function_kind_in_contract(&contract_name, func, *kind)
+                })
+                .filter(|(func, _)| {
+                    function_matches_network_pass(
+                        &multi_network.all_override_networks,
+                        multi_network.pass_network.as_ref(),
+                        inline_config.network_for(&config.profile, &contract_name, &func.name),
+                    )
+                })
+                .count();
+            let invariant = count_runnable_invariant_campaign_anchors(
+                abi,
+                filter,
+                crate::runner::InvariantCampaignScope {
+                    config,
+                    inline_config,
+                    contract_name: &contract_name,
+                    all_override_networks: &multi_network.all_override_networks,
+                    pass_network: multi_network.pass_network.as_ref(),
+                },
+            );
+            Some(MatchedEngineCounts { fuzz, invariant })
+        })
+        .fold(MatchedEngineCounts::default(), |mut acc, counts| {
+            acc.fuzz += counts.fuzz;
+            acc.invariant += counts.invariant;
+            acc
+        })
 }
 
 fn print_list_results(results: &BTreeMap<String, BTreeMap<String, Vec<String>>>) -> Result<()> {
@@ -3501,6 +3874,36 @@ mod tests {
             TestArgs::parse_from(["foundry-cli", "--fuzz-run", "10", "--fuzz-worker", "2"]);
         assert_eq!(args.fuzz_run, Some(10));
         assert_eq!(args.fuzz_worker, Some(2));
+    }
+
+    #[test]
+    fn fuzz_run_adapter_writes_unified_campaign_dials_sparsely() {
+        let args = FuzzRunArgs::parse_from([
+            "foundry-cli",
+            "--runs",
+            "9",
+            "--timeout",
+            "3",
+            "--seed",
+            "0x10",
+            "--depth",
+            "7",
+            "--workers",
+            "2",
+        ]);
+        let args = TestArgs::from_fuzz_run(args);
+        let figment = figment::Figment::from(&args);
+
+        assert_eq!(figment.extract_inner::<u64>("fuzz.runs").unwrap(), 9);
+        assert_eq!(figment.extract_inner::<u64>("fuzz.timeout").unwrap(), 3);
+        assert_eq!(figment.extract_inner::<String>("fuzz.seed").unwrap(), "16");
+        assert_eq!(figment.extract_inner::<u64>("invariant.runs").unwrap(), 9);
+        assert_eq!(figment.extract_inner::<u32>("invariant.timeout").unwrap(), 3);
+        assert_eq!(figment.extract_inner::<u32>("invariant.depth").unwrap(), 7);
+        assert_eq!(
+            figment.extract_inner::<InvariantWorkers>("invariant.workers").unwrap(),
+            InvariantWorkers::Fixed(std::num::NonZeroUsize::new(2).unwrap())
+        );
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -456,47 +456,6 @@ pub struct CampaignArgs {
     pub frontier_limit: Option<usize>,
 }
 
-impl CampaignArgs {
-    pub(crate) const fn supplied_engine_flags(&self) -> SuppliedEngineFlags {
-        SuppliedEngineFlags {
-            frontier_dir: self.frontier_dir.is_some(),
-            frontier_limit: self.frontier_limit.is_some(),
-            depth: self.depth.is_some(),
-            min_depth: self.min_depth.is_some(),
-            depth_mode: self.depth_mode.is_some(),
-            workers: self.workers.is_some(),
-            ..SuppliedEngineFlags::empty()
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct SuppliedEngineFlags {
-    pub(crate) frontier_dir: bool,
-    pub(crate) frontier_limit: bool,
-    pub(crate) fuzz_run: bool,
-    pub(crate) fuzz_input_file: bool,
-    pub(crate) depth: bool,
-    pub(crate) min_depth: bool,
-    pub(crate) depth_mode: bool,
-    pub(crate) workers: bool,
-}
-
-impl SuppliedEngineFlags {
-    pub(crate) const fn empty() -> Self {
-        Self {
-            frontier_dir: false,
-            frontier_limit: false,
-            fuzz_run: false,
-            fuzz_input_file: false,
-            depth: false,
-            min_depth: false,
-            depth_mode: false,
-            workers: false,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, Default)]
 struct MatchedEngineCounts {
     fuzz: usize,
@@ -526,10 +485,6 @@ pub struct TestArgs {
     /// Internal override used by `forge fuzz run --timeout` for invariant campaigns.
     #[arg(skip)]
     pub(crate) invariant_timeout_override: Option<u32>,
-
-    /// Internal warning metadata used by `forge fuzz run`.
-    #[arg(skip)]
-    pub(crate) warn_unsupported_engine_flags: Option<SuppliedEngineFlags>,
 
     // Include global options for users of this struct.
     #[command(flatten)]
@@ -1173,29 +1128,31 @@ impl TestArgs {
         filter: &ProjectPathsAwareFilter,
         multi_network: &MultiNetworkConfig,
     ) -> Result<()> {
-        let Some(flags) = self.warn_unsupported_engine_flags else { return Ok(()) };
+        if !self.fuzz_only {
+            return Ok(());
+        }
         let counts = matched_engine_counts(output, config, inline_config, filter, multi_network);
         if counts.fuzz == 0 && counts.invariant == 0 {
             return Ok(());
         }
 
         if counts.fuzz == 0 && counts.invariant > 0 {
-            if flags.frontier_dir {
+            if self.fuzz_frontier_dir.is_some() {
                 sh_warn!(
                     "`--frontier-dir` only applies to fuzz tests; no matched fuzz tests were found."
                 )?;
             }
-            if flags.frontier_limit {
+            if self.fuzz_frontier_limit.is_some() {
                 sh_warn!(
                     "`--frontier-limit` only applies to fuzz tests; no matched fuzz tests were found."
                 )?;
             }
-            if flags.fuzz_run {
+            if self.fuzz_run.is_some() {
                 sh_warn!(
                     "`--fuzz-run` only applies to fuzz tests; no matched fuzz tests were found."
                 )?;
             }
-            if flags.fuzz_input_file {
+            if self.fuzz_input_file.is_some() {
                 sh_warn!(
                     "`--fuzz-input-file` only applies to fuzz tests; no matched fuzz tests were found."
                 )?;
@@ -1203,22 +1160,22 @@ impl TestArgs {
         }
 
         if counts.invariant == 0 && counts.fuzz > 0 {
-            if flags.depth {
+            if self.invariant_depth.is_some() {
                 sh_warn!(
                     "`--depth` only applies to invariant tests; no matched invariant tests were found."
                 )?;
             }
-            if flags.min_depth {
+            if self.invariant_min_depth.is_some() {
                 sh_warn!(
                     "`--min-depth` only applies to invariant tests; no matched invariant tests were found."
                 )?;
             }
-            if flags.depth_mode {
+            if self.invariant_depth_mode.is_some() {
                 sh_warn!(
                     "`--depth-mode` only applies to invariant tests; no matched invariant tests were found."
                 )?;
             }
-            if flags.workers {
+            if self.invariant_workers.is_some() {
                 sh_warn!(
                     "`--workers` only applies to invariant tests; no matched invariant tests were found."
                 )?;
@@ -1230,13 +1187,8 @@ impl TestArgs {
 
     /// Builds the delegated `forge test` invocation for `forge fuzz run`.
     pub(crate) fn from_fuzz_run(args: FuzzRunArgs) -> Self {
-        let mut supplied = args.campaign.supplied_engine_flags();
-        supplied.fuzz_run = args.fuzz_run.is_some();
-        supplied.fuzz_input_file = args.fuzz_input_file.is_some();
-
         let mut test = Self {
             fuzz_only: true,
-            warn_unsupported_engine_flags: Some(supplied),
             global: args.global,
             path: args.path,
             gas_report: args.gas_report,
@@ -1488,8 +1440,7 @@ impl TestArgs {
         Arc<InlineConfig>,
         Option<SymbolicArtifactReplayConfig>,
     )> {
-        let should_default_fuzz_run_workers_to_auto =
-            self.warn_unsupported_engine_flags.is_some() && self.invariant_workers.is_none();
+        let should_default_fuzz_run_workers_to_auto = self.fuzz_only && self.invariant_workers.is_none();
 
         // Merge all configs.
         let (mut config, evm_opts) = self.load_config_and_evm_opts()?;

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1239,7 +1239,7 @@ impl TestArgs {
             list: args.list,
             fuzz_seed: args.campaign.seed,
             fuzz_runs: args.campaign.runs,
-            invariant_workers: Some(args.campaign.workers.unwrap_or(InvariantWorkers::Auto)),
+            invariant_workers: args.campaign.workers,
             fuzz_run: args.fuzz_run,
             fuzz_timeout: args.campaign.timeout.map(u64::from),
             fuzz_dictionary_weight: args.campaign.dictionary_weight,
@@ -1470,6 +1470,9 @@ impl TestArgs {
         Arc<InlineConfig>,
         Option<SymbolicArtifactReplayConfig>,
     )> {
+        let should_default_fuzz_run_workers_to_auto =
+            self.warn_unsupported_engine_flags.is_some() && self.invariant_workers.is_none();
+
         // Merge all configs.
         let (mut config, evm_opts) = self.load_config_and_evm_opts()?;
 
@@ -1485,6 +1488,9 @@ impl TestArgs {
         {
             // need to re-configure here to also catch additional remappings
             config = self.load_config()?;
+        }
+        if should_default_fuzz_run_workers_to_auto && !config.invariant.workers_configured {
+            config.invariant.workers = InvariantWorkers::Auto;
         }
 
         // Set up the project.
@@ -3898,14 +3904,12 @@ mod tests {
     }
 
     #[test]
-    fn fuzz_run_adapter_defaults_invariant_workers_to_auto() {
+    fn fuzz_run_adapter_writes_invariant_workers_sparsely() {
         let args = TestArgs::from_fuzz_run(FuzzRunArgs::parse_from(["foundry-cli"]));
         let figment = figment::Figment::from(&args);
 
-        assert_eq!(
-            figment.extract_inner::<InvariantWorkers>("invariant.workers").unwrap(),
-            InvariantWorkers::Auto
-        );
+        assert_eq!(args.invariant_workers, None);
+        assert!(figment.extract_inner::<InvariantWorkers>("invariant.workers").is_err());
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -3875,10 +3875,9 @@ mod tests {
 
     #[test]
     fn fuzz_run() {
-        let args: TestArgs =
-            TestArgs::parse_from(["foundry-cli", "--fuzz-run", "10", "--fuzz-worker", "2"]);
+        let args: TestArgs = TestArgs::parse_from(["foundry-cli", "--fuzz-run", "10"]);
         assert_eq!(args.fuzz_run, Some(10));
-        assert_eq!(args.fuzz_worker, Some(2));
+        assert_eq!(args.fuzz_worker, None);
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -475,7 +475,6 @@ pub(crate) struct SuppliedEngineFlags {
     pub(crate) frontier_dir: bool,
     pub(crate) frontier_limit: bool,
     pub(crate) fuzz_run: bool,
-    pub(crate) fuzz_worker: bool,
     pub(crate) depth: bool,
     pub(crate) min_depth: bool,
     pub(crate) depth_mode: bool,
@@ -488,7 +487,6 @@ impl SuppliedEngineFlags {
             frontier_dir: false,
             frontier_limit: false,
             fuzz_run: false,
-            fuzz_worker: false,
             depth: false,
             min_depth: false,
             depth_mode: false,
@@ -1195,11 +1193,6 @@ impl TestArgs {
                     "`--fuzz-run` only applies to fuzz tests; no matched fuzz tests were found."
                 )?;
             }
-            if flags.fuzz_worker {
-                sh_warn!(
-                    "`--fuzz-worker` only applies to fuzz tests; no matched fuzz tests were found."
-                )?;
-            }
         }
 
         if counts.invariant == 0 && counts.fuzz > 0 {
@@ -1232,7 +1225,6 @@ impl TestArgs {
     pub(crate) fn from_fuzz_run(args: FuzzRunArgs) -> Self {
         let mut supplied = args.campaign.supplied_engine_flags();
         supplied.fuzz_run = args.fuzz_run.is_some();
-        supplied.fuzz_worker = args.fuzz_worker.is_some();
 
         Self {
             fuzz_only: true,
@@ -1247,9 +1239,8 @@ impl TestArgs {
             list: args.list,
             fuzz_seed: args.campaign.seed,
             fuzz_runs: args.campaign.runs,
-            invariant_workers: args.campaign.workers,
+            invariant_workers: Some(args.campaign.workers.unwrap_or(InvariantWorkers::Auto)),
             fuzz_run: args.fuzz_run,
-            fuzz_worker: args.fuzz_worker,
             fuzz_timeout: args.campaign.timeout.map(u64::from),
             fuzz_dictionary_weight: args.campaign.dictionary_weight,
             fuzz_dictionary_addresses: args.campaign.dictionary_addresses.clone(),
@@ -3903,6 +3894,17 @@ mod tests {
         assert_eq!(
             figment.extract_inner::<InvariantWorkers>("invariant.workers").unwrap(),
             InvariantWorkers::Fixed(std::num::NonZeroUsize::new(2).unwrap())
+        );
+    }
+
+    #[test]
+    fn fuzz_run_adapter_defaults_invariant_workers_to_auto() {
+        let args = TestArgs::from_fuzz_run(FuzzRunArgs::parse_from(["foundry-cli"]));
+        let figment = figment::Figment::from(&args);
+
+        assert_eq!(
+            figment.extract_inner::<InvariantWorkers>("invariant.workers").unwrap(),
+            InvariantWorkers::Auto
         );
     }
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1220,7 +1220,6 @@ impl TestArgs {
             fail_fast: args.fail_fast,
             etherscan_api_key: args.etherscan_api_key,
             list: args.list,
-            fuzz_run: args.fuzz_run,
             fuzz_input_file: args.fuzz_input_file,
             show_progress: args.show_progress,
             rerun: args.rerun,
@@ -4272,6 +4271,7 @@ mod tests {
         assert_eq!(config.invariant.corpus.corpus_random_sequence_weight, 25);
         assert_eq!(config.invariant.corpus.corpus_dir, Some(PathBuf::from("invariant_corpus")));
         assert!(config.invariant.corpus_random_sequence_weight_configured);
+        assert!(config.invariant.workers_configured);
         assert_eq!(config.invariant.corpus.payable_value_weight, 34);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_splice, 2);
         assert_eq!(config.invariant.corpus.mutation_weights.mutation_weight_cmp, 7);

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1234,7 +1234,7 @@ impl TestArgs {
         supplied.fuzz_run = args.fuzz_run.is_some();
         supplied.fuzz_input_file = args.fuzz_input_file.is_some();
 
-        Self {
+        let mut test = Self {
             fuzz_only: true,
             warn_unsupported_engine_flags: Some(supplied),
             global: args.global,
@@ -1245,45 +1245,8 @@ impl TestArgs {
             fail_fast: args.fail_fast,
             etherscan_api_key: args.etherscan_api_key,
             list: args.list,
-            fuzz_seed: args.campaign.seed,
-            fuzz_runs: args.campaign.runs,
-            invariant_workers: args.campaign.workers,
             fuzz_run: args.fuzz_run,
-            fuzz_timeout: args.campaign.timeout.map(u64::from),
-            fuzz_dictionary_weight: args.campaign.dictionary_weight,
-            fuzz_dictionary_addresses: args.campaign.dictionary_addresses.clone(),
-            fuzz_dictionary_values: args.campaign.dictionary_values.clone(),
-            fuzz_dictionary_literals: args.campaign.dictionary_literals.clone(),
-            fuzz_corpus_random_sequence_weight: args.campaign.corpus_random_sequence_weight,
-            fuzz_corpus_dir: args.campaign.corpus_dir.clone(),
-            fuzz_frontier_dir: args.campaign.frontier_dir,
-            fuzz_frontier_limit: args.campaign.frontier_limit,
-            fuzz_payable_value_weight: args.campaign.payable_value_weight,
-            fuzz_mutation_weight_splice: args.campaign.mutation_weight_splice,
-            fuzz_mutation_weight_repeat: args.campaign.mutation_weight_repeat,
-            fuzz_mutation_weight_interleave: args.campaign.mutation_weight_interleave,
-            fuzz_mutation_weight_prefix: args.campaign.mutation_weight_prefix,
-            fuzz_mutation_weight_suffix: args.campaign.mutation_weight_suffix,
-            fuzz_mutation_weight_abi: args.campaign.mutation_weight_abi,
-            fuzz_mutation_weight_cmp: args.campaign.mutation_weight_cmp,
             fuzz_input_file: args.fuzz_input_file,
-            invariant_depth: args.campaign.depth,
-            invariant_min_depth: args.campaign.min_depth,
-            invariant_depth_mode: args.campaign.depth_mode,
-            invariant_dictionary_weight: args.campaign.dictionary_weight,
-            invariant_dictionary_addresses: args.campaign.dictionary_addresses,
-            invariant_dictionary_values: args.campaign.dictionary_values,
-            invariant_dictionary_literals: args.campaign.dictionary_literals,
-            invariant_corpus_random_sequence_weight: args.campaign.corpus_random_sequence_weight,
-            invariant_corpus_dir: args.campaign.corpus_dir,
-            invariant_payable_value_weight: args.campaign.payable_value_weight,
-            invariant_mutation_weight_splice: args.campaign.mutation_weight_splice,
-            invariant_mutation_weight_repeat: args.campaign.mutation_weight_repeat,
-            invariant_mutation_weight_interleave: args.campaign.mutation_weight_interleave,
-            invariant_mutation_weight_prefix: args.campaign.mutation_weight_prefix,
-            invariant_mutation_weight_suffix: args.campaign.mutation_weight_suffix,
-            invariant_mutation_weight_abi: args.campaign.mutation_weight_abi,
-            invariant_mutation_weight_cmp: args.campaign.mutation_weight_cmp,
             show_progress: args.show_progress,
             rerun: args.rerun,
             showmap_out: args.showmap_out,
@@ -1295,10 +1258,57 @@ impl TestArgs {
             filter: args.filter,
             evm: args.evm,
             build: args.build,
-            invariant_runs_override: args.campaign.runs,
-            invariant_timeout_override: args.campaign.timeout,
             ..Self::default()
-        }
+        };
+        test.apply_fuzz_run_campaign(args.campaign);
+        test
+    }
+
+    fn apply_fuzz_run_campaign(&mut self, campaign: CampaignArgs) {
+        self.fuzz_seed = campaign.seed;
+        self.fuzz_runs = campaign.runs;
+        self.invariant_runs_override = campaign.runs;
+
+        self.fuzz_timeout = campaign.timeout.map(u64::from);
+        self.invariant_timeout_override = campaign.timeout;
+
+        self.fuzz_dictionary_weight = campaign.dictionary_weight;
+        self.invariant_dictionary_weight = campaign.dictionary_weight;
+        self.fuzz_dictionary_addresses = campaign.dictionary_addresses.clone();
+        self.invariant_dictionary_addresses = campaign.dictionary_addresses;
+        self.fuzz_dictionary_values = campaign.dictionary_values.clone();
+        self.invariant_dictionary_values = campaign.dictionary_values;
+        self.fuzz_dictionary_literals = campaign.dictionary_literals.clone();
+        self.invariant_dictionary_literals = campaign.dictionary_literals;
+
+        self.fuzz_corpus_random_sequence_weight = campaign.corpus_random_sequence_weight;
+        self.invariant_corpus_random_sequence_weight = campaign.corpus_random_sequence_weight;
+        self.fuzz_corpus_dir = campaign.corpus_dir.clone();
+        self.invariant_corpus_dir = campaign.corpus_dir;
+
+        self.fuzz_payable_value_weight = campaign.payable_value_weight;
+        self.invariant_payable_value_weight = campaign.payable_value_weight;
+        self.fuzz_mutation_weight_splice = campaign.mutation_weight_splice;
+        self.invariant_mutation_weight_splice = campaign.mutation_weight_splice;
+        self.fuzz_mutation_weight_repeat = campaign.mutation_weight_repeat;
+        self.invariant_mutation_weight_repeat = campaign.mutation_weight_repeat;
+        self.fuzz_mutation_weight_interleave = campaign.mutation_weight_interleave;
+        self.invariant_mutation_weight_interleave = campaign.mutation_weight_interleave;
+        self.fuzz_mutation_weight_prefix = campaign.mutation_weight_prefix;
+        self.invariant_mutation_weight_prefix = campaign.mutation_weight_prefix;
+        self.fuzz_mutation_weight_suffix = campaign.mutation_weight_suffix;
+        self.invariant_mutation_weight_suffix = campaign.mutation_weight_suffix;
+        self.fuzz_mutation_weight_abi = campaign.mutation_weight_abi;
+        self.invariant_mutation_weight_abi = campaign.mutation_weight_abi;
+        self.fuzz_mutation_weight_cmp = campaign.mutation_weight_cmp;
+        self.invariant_mutation_weight_cmp = campaign.mutation_weight_cmp;
+
+        self.fuzz_frontier_dir = campaign.frontier_dir;
+        self.fuzz_frontier_limit = campaign.frontier_limit;
+        self.invariant_depth = campaign.depth;
+        self.invariant_min_depth = campaign.min_depth;
+        self.invariant_depth_mode = campaign.depth_mode;
+        self.invariant_workers = campaign.workers;
     }
 
     fn load_symbolic_artifact_replay(&self) -> Result<Option<SymbolicArtifactReplayConfig>> {

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -322,6 +322,51 @@ forgetest_init!(forge_fuzz_replay_rejects_watch, |_prj, cmd| {
     assert!(stderr.contains("unexpected argument '--watch'"), "{stderr}");
 });
 
+forgetest_init!(forge_fuzz_run_honors_configured_invariant_workers, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 4;
+        config.invariant.depth = 1;
+        config.invariant.workers =
+            foundry_config::InvariantWorkers::Fixed(std::num::NonZeroUsize::new(4).unwrap());
+        config.fuzz.seed = Some(U256::ZERO);
+    });
+    prj.add_test(
+        "ForgeFuzzRunInvariantWorkers.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzRunInvariantWorkersTarget {
+    uint256 public counter;
+
+    function bump() public {
+        counter++;
+    }
+}
+
+contract ForgeFuzzRunInvariantWorkersTest is Test {
+    ForgeFuzzRunInvariantWorkersTarget target;
+
+    function setUp() public {
+        target = new ForgeFuzzRunInvariantWorkersTarget();
+        targetContract(address(target));
+    }
+
+    function invariant_break() public view {
+        require(target.counter() == 0, "broken");
+    }
+}
+   "#,
+    );
+
+    let output = cmd.args(["fuzz", "run", "--json", "--mt", "invariant_break"]).assert_failure();
+    let json: serde_json::Value = serde_json::from_slice(&output.get_output().stdout).unwrap();
+    let suite = json.as_object().unwrap().values().next().unwrap();
+    let tests = suite["test_results"].as_object().unwrap();
+    let result = tests.values().next().unwrap();
+    let kind = &result["kind"]["Invariant"];
+    assert_eq!(kind["workers"], 4, "{json}");
+});
+
 // `forge fuzz replay` (without `--corpus-dir`) must not start a fresh invariant
 // campaign when there is no persisted failure to replay; it should skip instead.
 forgetest_init!(forge_fuzz_replay_invariant_skips_without_persisted_failure, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -758,12 +758,20 @@ contract ForgeFuzzRunInvariantWarningsTest is Test {
             "1",
             "--frontier-dir",
             "frontier",
+            "--fuzz-input-file",
+            "failure",
         ])
         .assert_success();
     let stderr = String::from_utf8(output.get_output().stderr.clone()).unwrap();
     assert!(
         stderr.contains(
             "`--frontier-dir` only applies to fuzz tests; no matched fuzz tests were found."
+        ),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "`--fuzz-input-file` only applies to fuzz tests; no matched fuzz tests were found."
         ),
         "{stderr}"
     );

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -607,16 +607,6 @@ contract ForgeFuzzJunitFailureTest {
     assert!(!stdout.contains("Failing tests:"), "{stdout}");
 });
 
-forgetest_init!(forge_fuzz_rejects_watch, |prj, cmd| {
-    let run = cmd.forge_fuse().args(["fuzz", "run", "--watch"]).assert_failure();
-    let stderr = String::from_utf8(run.get_output().stderr.clone()).unwrap();
-    assert!(stderr.contains("`--watch` is not supported for `forge fuzz run`"), "{stderr}");
-
-    let replay = cmd.forge_fuse().args(["fuzz", "replay", "--watch"]).assert_failure();
-    let stderr = String::from_utf8(replay.get_output().stderr.clone()).unwrap();
-    assert!(stderr.contains("`--watch` is not supported for `forge fuzz replay`"), "{stderr}");
-});
-
 forgetest_init!(forge_fuzz_list_only_shows_runnable_tests, |prj, cmd| {
     prj.add_test(
         "ForgeFuzzList.t.sol",
@@ -644,6 +634,202 @@ test/ForgeFuzzList.t.sol
 
 "#]],
     );
+});
+
+forgetest_init!(forge_fuzz_run_warns_for_invariant_only_flag_on_fuzz_only_match, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzRunWarnings.t.sol",
+        r#"
+contract ForgeFuzzRunWarningsTest {
+    function testFuzz_value(uint256 value) public pure {
+        value;
+    }
+}
+   "#,
+    );
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "run",
+            "--match-contract",
+            "ForgeFuzzRunWarningsTest",
+            "--match-test",
+            "testFuzz",
+            "--runs",
+            "1",
+            "--depth",
+            "5",
+        ])
+        .assert_success();
+    let stderr = String::from_utf8(output.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains(
+            "`--depth` only applies to invariant tests; no matched invariant tests were found."
+        ),
+        "{stderr}"
+    );
+});
+
+forgetest_init!(forge_fuzz_run_warns_for_fuzz_only_flag_on_invariant_only_match, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzRunInvariantWarnings.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzRunInvariantWarningsTest is Test {
+    function setUp() public {
+        targetContract(address(this));
+    }
+
+    function invariant_ok() public pure {}
+
+    function targetTouch(uint256 value) external pure {
+        value;
+    }
+}
+   "#,
+    );
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "run",
+            "--match-contract",
+            "ForgeFuzzRunInvariantWarningsTest",
+            "--match-test",
+            "invariant",
+            "--runs",
+            "1",
+            "--depth",
+            "1",
+            "--frontier-dir",
+            "frontier",
+        ])
+        .assert_success();
+    let stderr = String::from_utf8(output.get_output().stderr.clone()).unwrap();
+    assert!(
+        stderr.contains(
+            "`--frontier-dir` only applies to fuzz tests; no matched fuzz tests were found."
+        ),
+        "{stderr}"
+    );
+});
+
+forgetest_init!(forge_fuzz_run_runs_sets_invariant_runs, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzRunInvariantRuns.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzRunInvariantRunsTest is Test {
+    function setUp() public {
+        targetContract(address(this));
+    }
+
+    function invariant_ok() public pure {}
+
+    function targetTouch(uint256 value) external pure {
+        value;
+    }
+}
+   "#,
+    );
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "run",
+            "--match-contract",
+            "ForgeFuzzRunInvariantRunsTest",
+            "--match-test",
+            "invariant",
+            "--runs",
+            "2",
+            "--depth",
+            "1",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("[PASS] invariant_ok() (runs: 2"), "{stdout}");
+});
+
+forgetest_init!(forge_fuzz_run_does_not_warn_when_both_engines_match, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzRunBothEngines.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzRunBothEnginesTest is Test {
+    function setUp() public {
+        targetContract(address(this));
+    }
+
+    function testFuzz_value(uint256 value) public pure {
+        value;
+    }
+
+    function invariant_ok() public pure {}
+
+    function targetTouch(uint256 value) external pure {
+        value;
+    }
+}
+   "#,
+    );
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "run",
+            "--match-contract",
+            "ForgeFuzzRunBothEnginesTest",
+            "--runs",
+            "1",
+            "--depth",
+            "1",
+            "--seed",
+            "1",
+        ])
+        .assert_success();
+    let stderr = String::from_utf8(output.get_output().stderr.clone()).unwrap();
+    assert!(!stderr.contains("only applies"), "{stderr}");
+});
+
+forgetest_init!(forge_fuzz_run_positional_path_still_filters, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzRunPath.t.sol",
+        r#"
+contract ForgeFuzzRunPathTest {
+    function testFuzz_value(uint256 value) public pure {
+        value;
+    }
+}
+   "#,
+    );
+    prj.add_test(
+        "ForgeFuzzRunOtherPath.t.sol",
+        r#"
+contract ForgeFuzzRunOtherPathTest {
+    function testFuzz_other(uint256 value) public pure {
+        value;
+    }
+}
+   "#,
+    );
+
+    let output = cmd
+        .forge_fuse()
+        .args(["fuzz", "run", "test/ForgeFuzzRunPath.t.sol", "--list"])
+        .assert_success();
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("test/ForgeFuzzRunPath.t.sol"), "{stdout}");
+    assert!(stdout.contains("testFuzz_value"), "{stdout}");
+    assert!(!stdout.contains("ForgeFuzzRunOtherPath"), "{stdout}");
 });
 
 forgetest_init!(forge_showmap_skips_symbolic_tests, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -316,6 +316,12 @@ Ran 1 test suite [ELAPSED]: 0 tests passed, 0 failed, 2 skipped (2 total tests)
     ]]);
 });
 
+forgetest_init!(forge_fuzz_replay_rejects_watch, |_prj, cmd| {
+    let output = cmd.args(["fuzz", "replay", "--watch"]).assert_failure();
+    let stderr = String::from_utf8(output.get_output().stderr.clone()).unwrap();
+    assert!(stderr.contains("unexpected argument '--watch'"), "{stderr}");
+});
+
 // `forge fuzz replay` (without `--corpus-dir`) must not start a fresh invariant
 // campaign when there is no persisted failure to replay; it should skip instead.
 forgetest_init!(forge_fuzz_replay_invariant_skips_without_persisted_failure, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -3974,7 +3974,6 @@ Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
     assert_eq!(persisted_failure.fuzz.seed, Some(U256::from(1)));
     assert_eq!(persisted_failure.fuzz.worker, Some(0));
     let fuzz_run = persisted_failure.fuzz.run.unwrap().to_string();
-    let fuzz_worker = persisted_failure.fuzz.worker.unwrap().to_string();
 
     cmd.forge_fuse()
         .args([
@@ -3983,8 +3982,6 @@ Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
             "1",
             "--fuzz-run",
             &fuzz_run,
-            "--fuzz-worker",
-            &fuzz_worker,
             "--mt",
             "testFuzz_randomUint_shouldFail",
             "-j1",
@@ -4039,7 +4036,6 @@ Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing te
         serde_json::from_slice(&std::fs::read(&failure_file).unwrap()).unwrap();
     let fuzz_seed = format!("{:#x}", persisted_failure.fuzz.seed.unwrap());
     let fuzz_run = persisted_failure.fuzz.run.unwrap().to_string();
-    let fuzz_worker = persisted_failure.fuzz.worker.unwrap().to_string();
 
     let assert = cmd
         .forge_fuse()
@@ -4049,8 +4045,6 @@ Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing te
             &fuzz_seed,
             "--fuzz-run",
             &fuzz_run,
-            "--fuzz-worker",
-            &fuzz_worker,
             "--mt",
             "testFuzz_randomUint_shouldFail",
             "-j1",


### PR DESCRIPTION
## Description

Closes OSS-492

Refactors `forge fuzz run` to use a dedicated argument surface instead of exposing the full `forge test` CLI. The new surface keeps shared fuzz/invariant campaign dials like `--runs`, `--timeout`, `--depth`, and `--workers`, adapts them into `TestArgs`, and continues delegating through the existing test runner.

This also adds invocation-scope warnings when engine-specific flags cannot apply to any matched campaign, defaults invariant workers to auto for `forge fuzz run`, and keeps worker-specific stateless reproduction details out of the public `fuzz run` surface.

### Examples

```bash
forge fuzz run --list
```

```bash
forge fuzz run test/VaultCampaign.t.sol --runs 256 --depth 64
```

```bash
forge fuzz run --match-test '^invariant_' --runs 1000 --depth 128 --workers 4
```

```bash
forge fuzz run --match-contract VaultCampaignTest --runs 512 --depth 32 --dictionary-weight 70 --corpus-dir corpus/fuzz
```

```bash
forge fuzz run --match-test '^testFuzz' --runs 10000 --seed 0x1234
```

```bash
forge fuzz run --match-test '^invariant_' --timeout 300 --depth 64
```
