### PR TITLE
feat(cast): auto-detect network in decode-transaction

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -938,7 +938,13 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         CastSubcommand::Logs(cmd) => cmd.run().await?,
         CastSubcommand::DecodeTransaction { tx, network } => {
             let tx = stdin::unwrap_line(tx)?;
-            let decoded_tx = match network {
+            let tx_bytes = hex::decode(&tx)?;
+            let ty = tx_bytes.first().copied();
+            // Auto-detect the network from the transaction type byte unless an explicit
+            // `--network` override was provided, so e.g. a Tempo tx (type `0x76`) decodes
+            // without `--network tempo`.
+            let variant = network.or_else(|| ty.and_then(NetworkVariant::from_tx_type));
+            let decoded_tx = match variant {
                 #[cfg(feature = "optimism")]
                 Some(NetworkVariant::Optimism) => {
                     SimpleCast::decode_raw_transaction::<Optimism>(&tx)?

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -6308,6 +6308,28 @@ casttest!(cast_decode_tx_invalid, |_prj, cmd| {
     cmd.args(["decode-tx", "0xinvalid"]).assert_failure();
 });
 
+// Test decode-tx auto-detects the Tempo network from the `0x76` type byte without `--network`,
+// producing the same output as passing `--network tempo` explicitly.
+casttest!(cast_decode_tx_tempo_autodetect, |_prj, cmd| {
+    let tx = "0x76f8cf82a5bf1485059682f018830494e5f85ef85c9420c0000000000000000000007d9cc57068833ea780b84440c10f190000000000000000000000008a871f4189067637cfc4cc1500abd6244bf1df740000000000000000000000000000000000000000000000000000000005f5e100c08082057e80809420c000000000000000000000000000000000000080c0b841eb100c4cbd96903bf9e97968c0982670bb90fc191ee4544c7ff32d44e901dbea3f6fbdd58255051135c2fe1aa81583a270d96009cbe375f4605ef15971273a4f1b";
+
+    let auto = cmd.args(["decode-tx", tx]).assert_success().get_output().stdout.clone();
+
+    let with_flag = cmd
+        .cast_fuse()
+        .args(["decode-tx", "--network", "tempo", tx])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+
+    assert_eq!(auto, with_flag, "auto-detected and --network tempo output should match");
+
+    let output: String = serde_json::from_slice(&auto).unwrap();
+    let decoded: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(decoded["type"], "0x76");
+});
+
 // Test that `--network tempo` and `-n tempo` (short form) produce identical output for decode-tx.
 // Uses a known Tempo mainnet transaction.
 casttest!(cast_decode_tx_network_flag_short_and_long_equivalent, |_prj, cmd| {

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -132,6 +132,19 @@ impl NetworkVariant {
             Self::Tempo => "tempo",
         }
     }
+
+    /// Resolves the network that owns a network-specific EIP-2718 transaction type byte.
+    ///
+    /// Standard Ethereum types (legacy and `0x00`..=`0x04`) are shared by every network and
+    /// return [`None`], since they can be decoded with the default [`Self::Ethereum`] variant.
+    /// Only network-specific type bytes map to a concrete variant.
+    pub const fn from_tx_type(ty: u8) -> Option<Self> {
+        match ty {
+            // Tempo AA transaction.
+            0x76 => Some(Self::Tempo),
+            _ => None,
+        }
+    }
 }
 
 impl std::fmt::Display for NetworkVariant {


### PR DESCRIPTION
`cast decode-transaction` now infers the network from the transaction type byte, so Tempo transactions (type `0x76`) decode without passing `--network tempo`. The flag still works as an explicit override.