### PR TITLE
feat(cast): auto-switch browser wallet chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=904f2f6f12196831fa62cc49aca27bcc78c48f98#904f2f6f12196831fa62cc49aca27bcc78c48f98"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=7808f461e26b2ec980dbd60804c7def861baca7a#7808f461e26b2ec980dbd60804c7def861baca7a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=7808f461e26b2ec980dbd60804c7def861baca7a#7808f461e26b2ec980dbd60804c7def861baca7a"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8cb3bf1f5452ca872fd765c5f51a3074ee511734#8cb3bf1f5452ca872fd765c5f51a3074ee511734"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=7610c7e6f88429caa400ec35606afd28270ecf9f#7610c7e6f88429caa400ec35606afd28270ecf9f"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=904f2f6f12196831fa62cc49aca27bcc78c48f98#904f2f6f12196831fa62cc49aca27bcc78c48f98"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -5924,7 +5924,9 @@ dependencies = [
  "dirs",
  "eth-keystore",
  "eyre",
+ "hidapi-rusb",
  "rpassword",
+ "rusb",
  "rusqlite",
  "serde",
  "serde_json",
@@ -5934,7 +5936,7 @@ dependencies = [
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tower",
- "tower-http 0.6.11",
+ "tower-http 0.7.0",
  "tracing",
  "uuid 1.23.4",
  "webbrowser",
@@ -6325,11 +6327,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -7259,9 +7261,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.37.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -10374,9 +10376,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.39.0"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "904f2f6f12196831fa62cc49aca27bcc78c48f98", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "7808f461e26b2ec980dbd60804c7def861baca7a", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "7610c7e6f88429caa400ec35606afd28270ecf9f", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "904f2f6f12196831fa62cc49aca27bcc78c48f98", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -328,7 +328,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "7808f461e26b2ec980dbd60804c7def861baca7a", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "8cb3bf1f5452ca872fd765c5f51a3074ee511734", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -390,6 +390,11 @@ impl SendTxArgs {
                     .await?;
             }
 
+            if chain.id() != browser.chain_id() {
+                sh_warn!("Switching browser wallet to chain {}", chain)?;
+                browser.switch_chain(chain.id()).await?;
+            }
+
             let tx_hash = browser.send_transaction_via_browser(tx_request).await?;
 
             let cast = CastTxSender::new(&provider);


### PR DESCRIPTION
Adds chain switching to `cast send --browser` so browser-wallet sends can target a configured chain even when the connected wallet starts on a different network. After transaction construction, sponsorship, and fee-token resolution succeed, Cast asks the browser wallet to switch to the transaction chain before submitting the transaction through the wallet.

This depends on foundry-rs/foundry-core#111 for the `foundry-wallets` chain-switch request/response protocol and foundry-rs/foundry-browser-wallet#90 for the browser-side `wallet_switchEthereumChain` handling. The `foundry-wallets` dependency is pinned to the pushed `foundry-core` commit containing that protocol.

Closes #14641.
