### PR TITLE
refactor(cast): decode-transaction via FoundryTxEnvelope

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -32,7 +32,7 @@ use foundry_common::{
     shell, stdin,
 };
 use foundry_evm_networks::NetworkVariant;
-use foundry_primitives::{FoundryTxEnvelope, PaymentLaneClassification};
+use foundry_primitives::{FoundryNetwork, FoundryTxEnvelope, PaymentLaneClassification};
 #[cfg(feature = "optimism")]
 use op_alloy_network::Optimism;
 use std::time::Instant;
@@ -938,13 +938,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
         CastSubcommand::Logs(cmd) => cmd.run().await?,
         CastSubcommand::DecodeTransaction { tx, network } => {
             let tx = stdin::unwrap_line(tx)?;
-            let tx_bytes = hex::decode(&tx)?;
-            let ty = tx_bytes.first().copied();
-            // Auto-detect the network from the transaction type byte unless an explicit
-            // `--network` override was provided, so e.g. a Tempo tx (type `0x76`) decodes
-            // without `--network tempo`.
-            let variant = network.or_else(|| ty.and_then(NetworkVariant::from_tx_type));
-            let decoded_tx = match variant {
+            let decoded_tx = match network {
                 #[cfg(feature = "optimism")]
                 Some(NetworkVariant::Optimism) => {
                     SimpleCast::decode_raw_transaction::<Optimism>(&tx)?
@@ -952,7 +946,13 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                 Some(NetworkVariant::Tempo) => {
                     SimpleCast::decode_raw_transaction::<TempoNetwork>(&tx)?
                 }
-                _ => SimpleCast::decode_raw_transaction::<Ethereum>(&tx)?,
+                Some(NetworkVariant::Ethereum) => {
+                    SimpleCast::decode_raw_transaction::<Ethereum>(&tx)?
+                }
+                // Without an explicit `--network` override, decode with the Foundry envelope,
+                // which dispatches on the EIP-2718 type byte for the transaction types compiled
+                // into `FoundryNetwork`, including Tempo txs (`0x76`).
+                None => SimpleCast::decode_raw_transaction::<FoundryNetwork>(&tx)?,
             };
             print_json_object(decoded_tx)?;
         }

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -1214,7 +1214,10 @@ pub enum CastSubcommand {
         /// Encoded transaction
         tx: Option<String>,
 
-        /// Specify the Network for correct encoding.
+        /// Override the network used to decode the transaction.
+        ///
+        /// By default, cast decodes with Foundry's transaction envelope, which recognizes
+        /// standard Ethereum txs and Foundry-supported network-specific tx types such as Tempo.
         #[arg(long, short, num_args = 1, value_name = "NETWORK")]
         network: Option<NetworkVariant>,
     },

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -6330,6 +6330,14 @@ casttest!(cast_decode_tx_tempo_autodetect, |_prj, cmd| {
     assert_eq!(decoded["type"], "0x76");
 });
 
+// Test that `--network ethereum` forces Ethereum decoding and rejects a Tempo tx (type `0x76`),
+// so the flag remains a meaningful override rather than falling back to auto-detection.
+casttest!(cast_decode_tx_network_ethereum_rejects_tempo, |_prj, cmd| {
+    let tx = "0x76f8cf82a5bf1485059682f018830494e5f85ef85c9420c0000000000000000000007d9cc57068833ea780b84440c10f190000000000000000000000008a871f4189067637cfc4cc1500abd6244bf1df740000000000000000000000000000000000000000000000000000000005f5e100c08082057e80809420c000000000000000000000000000000000000080c0b841eb100c4cbd96903bf9e97968c0982670bb90fc191ee4544c7ff32d44e901dbea3f6fbdd58255051135c2fe1aa81583a270d96009cbe375f4605ef15971273a4f1b";
+
+    cmd.args(["decode-tx", "--network", "ethereum", tx]).assert_failure();
+});
+
 // Test that `--network tempo` and `-n tempo` (short form) produce identical output for decode-tx.
 // Uses a known Tempo mainnet transaction.
 casttest!(cast_decode_tx_network_flag_short_and_long_equivalent, |_prj, cmd| {

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -132,19 +132,6 @@ impl NetworkVariant {
             Self::Tempo => "tempo",
         }
     }
-
-    /// Resolves the network that owns a network-specific EIP-2718 transaction type byte.
-    ///
-    /// Standard Ethereum types (legacy and `0x00`..=`0x04`) are shared by every network and
-    /// return [`None`], since they can be decoded with the default [`Self::Ethereum`] variant.
-    /// Only network-specific type bytes map to a concrete variant.
-    pub const fn from_tx_type(ty: u8) -> Option<Self> {
-        match ty {
-            // Tempo AA transaction.
-            0x76 => Some(Self::Tempo),
-            _ => None,
-        }
-    }
 }
 
 impl std::fmt::Display for NetworkVariant {


### PR DESCRIPTION
Routes the no-flag `cast decode-transaction` path through `FoundryNetwork`/`FoundryTxEnvelope`, which already dispatches on the EIP-2718 type byte. Removes the duplicate `NetworkVariant::from_tx_type` table added in #15607. Same behavior; `--network` still works as an explicit override.