### PR TITLE
ci: reuse Tempo bump PR branch

### DIFF
--- a/.github/scripts/bump-tempo.sh
+++ b/.github/scripts/bump-tempo.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 #   Sets outputs in $GITHUB_OUTPUT if it exists:
 #     - current_rev: The current tempo revision
 #     - latest_rev: The latest tempo revision on main
+#     - latest_rev_short: The short latest tempo revision
 #     - updated: "true" if dependencies were updated, "false" otherwise
 #     - changelog: Path to changelog file (if updated)
 
@@ -107,6 +108,7 @@ main() {
   LATEST_REV=$(get_latest_rev)
   echo "Latest revision:  $LATEST_REV"
   set_output "latest_rev" "$LATEST_REV"
+  set_output "latest_rev_short" "${LATEST_REV:0:7}"
 
   if [[ "$CURRENT_REV" == "$LATEST_REV" ]]; then
     echo ""

--- a/.github/workflows/bump-tempo.yml
+++ b/.github/workflows/bump-tempo.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Bump tempo dependencies
         id: bump
@@ -25,35 +26,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: ./.github/scripts/bump-tempo.sh
 
-      - name: Create Pull Request
+      - name: Create or update Pull Request
         if: steps.bump.outputs.updated == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          LATEST_REV: ${{ steps.bump.outputs.latest_rev }}
-          CHANGELOG_FILE: ${{ steps.bump.outputs.changelog }}
-        run: |
-          BRANCH_NAME="deps/bump-tempo-${LATEST_REV:0:7}"
-
-          # Skip if a PR already exists for this branch
-          EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --state open --json number --jq '.[0].number')
-          if [[ -n "$EXISTING_PR" ]]; then
-            echo "PR #${EXISTING_PR} already exists for ${BRANCH_NAME}, skipping."
-            exit 0
-          fi
-
-          # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Create and push branch (force-push in case a stale branch exists from a prior failed run)
-          git checkout -b "$BRANCH_NAME"
-          git add Cargo.toml Cargo.lock
-          git commit -m "chore(deps): bump tempo dependencies to ${LATEST_REV:0:7}"
-          git push --force-with-lease origin "$BRANCH_NAME"
-
-          # Create PR
-          gh pr create \
-            --title "chore(deps): bump tempo dependencies to ${LATEST_REV:0:7}" \
-            --body-file "$CHANGELOG_FILE" \
-            --base master \
-            --head "$BRANCH_NAME"
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          add-paths: |
+            Cargo.toml
+            Cargo.lock
+          commit-message: "chore(deps): bump tempo dependencies to ${{ steps.bump.outputs.latest_rev_short }}"
+          title: "chore(deps): bump tempo dependencies to ${{ steps.bump.outputs.latest_rev_short }}"
+          body-path: ${{ steps.bump.outputs.changelog }}
+          branch: deps/bump-tempo


### PR DESCRIPTION
## Summary
- use the existing `peter-evans/create-pull-request` action for Tempo bump PR creation and updates
- reuse the stable `deps/bump-tempo` branch so repeated runs update one PR
- emit `latest_rev_short` from the bump script for PR title and commit messages

Prompted by: @DaniPopes

## Test
- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/bump-tempo.yml')); print('yaml ok')"`
- `bash -n .github/scripts/bump-tempo.sh`
