### PR TITLE
feat(traces): decode T7 storage credits precompile

### DIFF
--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -30,7 +30,8 @@ use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
 use std::{collections::BTreeMap, sync::OnceLock};
 use tempo_contracts::precompiles::{
     IAccountKeychain, IAddressRegistry, IFeeManager, IReceivePolicyGuard, ISignatureVerifier,
-    IStablecoinDEX, ITIP20ChannelReserve, ITIP20Factory, ITIP403Registry, IValidatorConfig,
+    IStablecoinDEX, IStorageCredits, ITIP20ChannelReserve, ITIP20Factory, ITIP403Registry,
+    IValidatorConfig,
 };
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
@@ -221,6 +222,7 @@ impl CallTraceDecoder {
             ITIP403Registry::abi::contract(),
             ITIP20Factory::abi::contract(),
             IStablecoinDEX::abi::contract(),
+            IStorageCredits::abi::contract(),
             INonce::abi::contract(),
             IValidatorConfig::abi::contract(),
             IAccountKeychain::abi::contract(),
@@ -278,6 +280,9 @@ impl CallTraceDecoder {
                 .chain(Vm::abi::functions().into_values())
                 // Tempo
                 .chain(IFeeManager::abi::functions().into_values())
+                // `IStorageCredits` shares the `balanceOf(address)` selector with `ITIP20`, so it
+                // must be chained first to keep `ITIP20`'s `uint256` return as the global fallback.
+                .chain(IStorageCredits::abi::functions().into_values())
                 .chain(ITIP20::abi::functions().into_values())
                 .chain(ITIP403Registry::abi::functions().into_values())
                 .chain(ITIP20Factory::abi::functions().into_values())
@@ -1132,7 +1137,7 @@ fn indexed_inputs(event: &Event) -> usize {
 mod tests {
     use super::*;
     use alloy_primitives::{address, aliases::U96, hex};
-    use alloy_sol_types::{SolCall, SolEvent};
+    use alloy_sol_types::{SolCall, SolError, SolEvent};
 
     #[test]
     fn test_selector_collision_resolution() {
@@ -1834,6 +1839,52 @@ mod tests {
         assert_eq!(params[0].0, "channelId");
         assert_eq!(params[8].0, "deposit");
         assert!(params[8].1.starts_with("1000000"));
+    }
+
+    #[tokio::test]
+    async fn test_t7_storage_credits_call_and_error_decode() {
+        let mut decoder = CallTraceDecoder::new().clone();
+        decoder.chain_id = Some(4217);
+
+        // A write call decodes to its signature and the precompile address is labeled.
+        let set_mode = IStorageCredits::setModeCall { newMode: IStorageCredits::Mode::Direct };
+        let trace = CallTrace {
+            address: STORAGE_CREDITS_ADDRESS,
+            data: set_mode.abi_encode().into(),
+            depth: 0,
+            success: true,
+            ..Default::default()
+        };
+        let decoded = decoder.decode_function(&trace).await;
+        assert_eq!(decoded.label.as_deref(), Some("StorageCredits"));
+        assert_eq!(decoded.call_data.expect("setMode should decode").signature, "setMode(uint8)");
+
+        // A view call unique to this precompile also decodes.
+        let mode_of = IStorageCredits::modeOfCall { account: Address::repeat_byte(0x11) };
+        let trace = CallTrace {
+            address: STORAGE_CREDITS_ADDRESS,
+            data: mode_of.abi_encode().into(),
+            depth: 0,
+            success: true,
+            ..Default::default()
+        };
+        let decoded = decoder.decode_function(&trace).await;
+        assert_eq!(decoded.call_data.expect("modeOf should decode").signature, "modeOf(address)");
+
+        // The precompile's custom errors decode by name in reverts.
+        let revert = decoder
+            .revert_decoder
+            .decode(IStorageCredits::InvalidMode {}.abi_encode().as_slice(), None);
+        assert!(revert.contains("InvalidMode"), "{revert}");
+
+        // `balanceOf(address)` collides with `ITIP20`'s selector; the global map must keep
+        // `ITIP20`'s `uint256` return so ordinary token balances above `u64::MAX` still decode.
+        let selector = IStorageCredits::balanceOfCall::SELECTOR;
+        let funcs = decoder.functions.get(&selector).expect("balanceOf selector is registered");
+        assert!(
+            funcs.iter().any(|f| f.outputs.first().is_some_and(|o| o.ty == "uint256")),
+            "global balanceOf must return uint256"
+        );
     }
 
     // A mock identifier that records which addresses it was asked to identify.


### PR DESCRIPTION
The trace decoder labeled the T7 Storage Credits precompile but never registered its ABI, so its calls and reverts showed as raw selectors. This registers `IStorageCredits` so they decode like every other Tempo precompile.

Chained ahead of `ITIP20` to avoid the shared `balanceOf(address)` selector clobbering TIP20's `uint256` return.