### PR TITLE
feat(anvil): apply Tempo base fee rules

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1197,6 +1197,10 @@ impl NodeConfig {
         let base_fee_params: BaseFeeParams =
             self.networks.base_fee_params(self.get_genesis_timestamp());
 
+        // On Tempo, the base fee follows the chain's hardfork rules instead of EIP-1559.
+        let tempo_hardfork =
+            self.networks.is_tempo().then(|| TempoHardfork::from(self.get_hardfork()));
+
         let fees = FeeManager::new(
             spec_id,
             self.get_base_fee(),
@@ -1205,6 +1209,7 @@ impl NodeConfig {
             self.get_blob_excess_gas_and_price(),
             self.get_blob_params(),
             base_fee_params,
+            tempo_hardfork,
         );
 
         let (db, fork): (Arc<TokioRwLock<Box<dyn Db>>>, Option<ClientFork>) =
@@ -1423,6 +1428,12 @@ latest block number: {latest_block}"
             self.hardfork = Some(hardfork);
         }
 
+        // The fee manager was built before the fork hardfork was known, so refresh the Tempo
+        // hardfork it uses for base fee calculations.
+        if self.networks.is_tempo() {
+            fees.set_tempo_hardfork(Some(TempoHardfork::from(self.get_hardfork())));
+        }
+
         // if not set explicitly we use the base fee of the latest block
         if self.base_fee.is_none()
             && let Some(base_fee) = block.header.base_fee_per_gas()
@@ -1574,7 +1585,7 @@ latest block number: {latest_block}"
     }
 }
 
-const fn tempo_default_base_fee(hardfork: TempoHardfork) -> u64 {
+pub(crate) const fn tempo_default_base_fee(hardfork: TempoHardfork) -> u64 {
     if hardfork.is_t1() { TEMPO_T1_BASE_FEE } else { TEMPO_T0_BASE_FEE }
 }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2218,6 +2218,20 @@ impl<N: Network> Backend<N> {
         // Fork mode syncs in setup_fork_db_config() instead.
         if fork.read().is_none() {
             env.write().block_env.number = U256::from(genesis.number);
+
+            // The genesis block keeps its base fee, but the next block must already follow Tempo's
+            // rules (e.g. T7 clamps the seed down to the cap). Fork mode seeds this from the fork
+            // block instead.
+            if fees.tempo_hardfork().is_some() {
+                let env = env.read();
+                let next_base_fee = fees.get_next_block_base_fee_per_gas(
+                    0,
+                    env.block_env.gas_limit,
+                    env.block_env.basefee,
+                );
+                drop(env);
+                fees.set_base_fee(next_base_fee);
+            }
         }
 
         let start_timestamp = if let Some(fork) = fork.read().as_ref() {
@@ -2490,18 +2504,24 @@ impl<N: Network> Backend<N> {
         let genesis_timestamp = self.genesis.timestamp;
         let genesis_number = self.genesis.number;
 
+        // Tempo chains seed the hardfork's own fixed base fee on reset; other chains keep the
+        // pre-reset base fee for the genesis block, as before. Computed up front so the env,
+        // storage, and fee manager all agree.
+        let reset_base_fee = self.fees.tempo_hardfork().map(crate::config::tempo_default_base_fee);
+        let genesis_base_fee = reset_base_fee.unwrap_or_else(|| self.fees.base_fee());
+
         // Reset environment to genesis state
         {
             let mut env = self.evm_env.write();
             env.block_env.number = U256::from(genesis_number);
             env.block_env.timestamp = U256::from(genesis_timestamp);
             // Reset other block env fields to their defaults
-            env.block_env.basefee = self.fees.base_fee();
+            env.block_env.basefee = genesis_base_fee;
             env.block_env.prevrandao = Some(B256::ZERO);
         }
 
         // Clear all storage and reinitialize with genesis
-        let base_fee = self.fees.is_eip1559().then(|| self.fees.base_fee());
+        let base_fee = self.fees.is_eip1559().then_some(genesis_base_fee);
         *self.blockchain.storage.write() = BlockchainStorage::new(
             &self.evm_env.read(),
             base_fee,
@@ -2516,9 +2536,21 @@ impl<N: Network> Backend<N> {
         // Reset time manager
         self.time.reset(genesis_timestamp);
 
-        // Reset fees to initial state
+        // Seed the next block's base fee. On Tempo the genesis keeps its fixed default while the
+        // next block already follows the hardfork's rule (e.g. T7 clamps to the cap); other chains
+        // use Anvil's Ethereum default.
         if self.fees.is_eip1559() {
-            self.fees.set_base_fee(crate::eth::fees::INITIAL_BASE_FEE);
+            let next_base_fee = match reset_base_fee {
+                Some(genesis_base_fee) => {
+                    // Seed the fixed genesis fee first so the next-block computation is not
+                    // affected by any manually zeroed base fee, then advance one block per Tempo.
+                    self.fees.set_base_fee(genesis_base_fee);
+                    let gas_limit = self.evm_env.read().block_env.gas_limit;
+                    self.fees.get_next_block_base_fee_per_gas(0, gas_limit, genesis_base_fee)
+                }
+                None => crate::eth::fees::INITIAL_BASE_FEE,
+            };
+            self.fees.set_base_fee(next_base_fee);
         }
 
         self.fees.set_gas_price(crate::eth::fees::INITIAL_GAS_PRICE);
@@ -4920,11 +4952,13 @@ impl Backend<FoundryNetwork> {
                 // update block env
                 block_env.number += U256::from(1);
                 block_env.timestamp += U256::from(12);
-                block_env.basefee = simulated_block
-                    .inner
-                    .header
-                    .next_block_base_fee(self.fees.base_fee_params())
-                    .unwrap_or_default();
+                // Route through the fee manager so Tempo chains use their own base fee rules.
+                let header = &simulated_block.inner.header;
+                block_env.basefee = self.fees.get_next_block_base_fee_per_gas(
+                    header.gas_used(),
+                    header.gas_limit(),
+                    header.base_fee_per_gas().unwrap_or_default(),
+                );
 
                 block_res.push(simulated_block);
             }

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -13,6 +13,7 @@ use alloy_primitives::B256;
 use futures::StreamExt;
 use parking_lot::{Mutex, RwLock};
 use revm::{context_interface::block::BlobExcessGasAndPrice, primitives::hardfork::SpecId};
+use tempo_hardfork::{TempoHardfork, constants::gas::tempo_t7_next_block_base_fee};
 
 use crate::eth::{
     backend::{info::StorageInfo, notifications::NewBlockNotifications},
@@ -58,9 +59,15 @@ pub struct FeeManager {
     elasticity: Arc<RwLock<f64>>,
     /// Network-specific base fee params for EIP-1559 calculations
     base_fee_params: BaseFeeParams,
+    /// The active Tempo hardfork, set only when running a Tempo chain.
+    ///
+    /// Tempo replaces EIP-1559: pre-T7 the base fee is fixed, and T7+ uses the TIP-1067 dynamic
+    /// controller. It is updated once after a fork's hardfork is auto-detected.
+    tempo_hardfork: Arc<RwLock<Option<TempoHardfork>>>,
 }
 
 impl FeeManager {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         spec_id: SpecId,
         base_fee: u64,
@@ -69,6 +76,7 @@ impl FeeManager {
         blob_excess_gas_and_price: BlobExcessGasAndPrice,
         blob_params: BlobParams,
         base_fee_params: BaseFeeParams,
+        tempo_hardfork: Option<TempoHardfork>,
     ) -> Self {
         let elasticity = 1f64 / base_fee_params.elasticity_multiplier as f64;
         Self {
@@ -80,12 +88,18 @@ impl FeeManager {
             blob_excess_gas_and_price: Arc::new(RwLock::new(blob_excess_gas_and_price)),
             elasticity: Arc::new(RwLock::new(elasticity)),
             base_fee_params,
+            tempo_hardfork: Arc::new(RwLock::new(tempo_hardfork)),
         }
     }
 
-    /// Returns the base fee params used for EIP-1559 calculations
-    pub const fn base_fee_params(&self) -> BaseFeeParams {
-        self.base_fee_params
+    /// Returns the active Tempo hardfork, if running a Tempo chain.
+    pub fn tempo_hardfork(&self) -> Option<TempoHardfork> {
+        *self.tempo_hardfork.read()
+    }
+
+    /// Sets the active Tempo hardfork, used after a fork's hardfork is auto-detected.
+    pub fn set_tempo_hardfork(&self, hardfork: Option<TempoHardfork>) {
+        *self.tempo_hardfork.write() = hardfork;
     }
 
     pub fn elasticity(&self) -> f64 {
@@ -160,6 +174,10 @@ impl FeeManager {
         if self.base_fee() == 0 {
             return 0;
         }
+        // Tempo replaces EIP-1559 with its own hardfork-specific base fee rules.
+        if let Some(hardfork) = self.tempo_hardfork() {
+            return tempo_next_block_base_fee(hardfork, gas_used, last_fee_per_gas);
+        }
         calc_next_block_base_fee(gas_used, gas_limit, last_fee_per_gas, self.base_fee_params)
     }
 
@@ -187,6 +205,18 @@ impl FeeManager {
     pub fn blob_params(&self) -> BlobParams {
         *self.blob_params.read()
     }
+}
+
+/// Computes the next block's base fee for a Tempo chain.
+///
+/// - T7+: the TIP-1067 dynamic controller, an EIP-1559 update against a fixed 10M gas target
+///   clamped to `[floor, cap]`.
+/// - Pre-T7: the fixed hardfork base fee (10 gwei pre-T1, 20 gwei T1+).
+fn tempo_next_block_base_fee(hardfork: TempoHardfork, gas_used: u64, parent_base_fee: u64) -> u64 {
+    if hardfork.is_t7() {
+        return tempo_t7_next_block_base_fee(parent_base_fee, gas_used);
+    }
+    crate::config::tempo_default_base_fee(hardfork)
 }
 
 /// An async service that takes care of the `FeeHistory` cache

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -35,7 +35,10 @@ use foundry_evm::core::tempo::{
     active_tempo_precompile_addresses,
 };
 use tempo_alloy::primitives::TempoTxEnvelope;
-use tempo_hardfork::TempoHardfork;
+use tempo_hardfork::{
+    TempoHardfork,
+    constants::gas::{TEMPO_T1_BASE_FEE, TEMPO_T7_BASE_FEE_CAP, TEMPO_T7_BASE_FEE_FLOOR},
+};
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, DEFAULT_FEE_TOKEN,
     RECEIVE_POLICY_GUARD_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
@@ -4089,4 +4092,83 @@ async fn test_anvil_set_fee_amm_liquidity_non_tempo_fails() {
     let result =
         api.anvil_set_fee_amm_liquidity(PATH_USD, ALPHA_USD, U256::from(1_000_000u64)).await;
     assert!(result.is_err(), "anvil_setFeeAmmLiquidity should fail outside of Tempo mode");
+}
+
+/// Pre-T7 Tempo uses a fixed base fee, so mining empty blocks must not drift it (EIP-1559 would).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_pre_t7_base_fee_stays_fixed() {
+    let (api, handle) =
+        spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T1.into()))).await;
+    let provider = handle.http_provider();
+
+    for _ in 0..5 {
+        api.mine_one().await;
+    }
+
+    let latest = provider.get_block(BlockId::latest()).await.unwrap().unwrap().header.number;
+    for n in 0..=latest {
+        let block = provider.get_block(BlockId::number(n)).await.unwrap().unwrap();
+        assert_eq!(
+            block.header.base_fee_per_gas,
+            Some(TEMPO_T1_BASE_FEE),
+            "pre-T7 block {n} base fee should stay fixed"
+        );
+    }
+}
+
+/// `anvil_reset` must restore the Tempo base fee, not fall back to Anvil's Ethereum default.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_base_fee_survives_reset() {
+    let (api, handle) =
+        spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T1.into()))).await;
+    let provider = handle.http_provider();
+
+    for _ in 0..3 {
+        api.mine_one().await;
+    }
+
+    api.anvil_reset(None).await.unwrap();
+    api.mine_one().await;
+
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(
+        block.header.base_fee_per_gas,
+        Some(TEMPO_T1_BASE_FEE),
+        "base fee after reset should be the fixed Tempo value, not the Ethereum default"
+    );
+}
+
+/// T7 Tempo uses the TIP-1067 dynamic controller: empty blocks lower the base fee within the clamp.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_t7_base_fee_is_dynamic() {
+    let (api, handle) =
+        spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T7.into()))).await;
+    let provider = handle.http_provider();
+
+    for _ in 0..8 {
+        api.mine_one().await;
+    }
+
+    // The genesis block keeps the 20B seed (matching Tempo's T7 genesis).
+    let genesis = provider.get_block(BlockId::number(0)).await.unwrap().unwrap();
+    assert_eq!(genesis.header.base_fee_per_gas, Some(TEMPO_T1_BASE_FEE));
+
+    let latest = provider.get_block(BlockId::latest()).await.unwrap().unwrap().header.number;
+    let mut fees = Vec::new();
+    for n in 1..=latest {
+        let block = provider.get_block(BlockId::number(n)).await.unwrap().unwrap();
+        fees.push(block.header.base_fee_per_gas.unwrap());
+    }
+
+    // Block 1 already clamps the 20B seed down to the TIP-1067 cap; generic EIP-1559 would give
+    // ~17.5B instead, so this pins the T7 path. Later empty blocks decay below the cap.
+    assert_eq!(fees[0], TEMPO_T7_BASE_FEE_CAP, "block 1 clamps to the T7 cap: {fees:?}");
+    assert!(fees[1] < TEMPO_T7_BASE_FEE_CAP, "empty blocks decay below the cap: {fees:?}");
+    // Empty blocks never raise the base fee, and it stays within the TIP-1067 clamp.
+    assert!(fees.windows(2).all(|w| w[1] <= w[0]), "base fee should not rise: {fees:?}");
+    let last = *fees.last().unwrap();
+    assert!(
+        (TEMPO_T7_BASE_FEE_FLOOR..=TEMPO_T7_BASE_FEE_CAP).contains(&last),
+        "base fee should be clamped to the TIP-1067 range: {fees:?}"
+    );
 }


### PR DESCRIPTION
Anvil computed every chain's next-block base fee with generic EIP-1559, so a Tempo node never reproduced Tempo's own rules: a fixed base fee pre-T7 and the TIP-1067 dynamic controller at T7+.

The fee manager now mirrors Tempo's chainspec — fixed pre-T7, and `tempo_t7_next_block_base_fee` (clamped to `[floor, cap]`) at T7+ — including on forks, `anvil_reset`, and `eth_simulateV1`. On a T7 chain, genesis keeps the 20B seed and block 1 already clamps to the cap, matching a real Tempo node. Non-Tempo chains are unchanged.