### PR TITLE
perf(cast): speed up local interface generation

### DIFF
--- a/crates/cast/src/cmd/interface.rs
+++ b/crates/cast/src/cmd/interface.rs
@@ -9,7 +9,7 @@ use foundry_cli::{
 };
 use foundry_common::{
     ContractsByArtifact,
-    compile::{PathOrContractInfo, ProjectCompiler},
+    compile::{PathOrContractInfo, ProjectCompiler, compile_abi_project},
     find_target_path, fs, shell,
 };
 use foundry_config::load_config;
@@ -142,13 +142,14 @@ pub fn load_abi_from_file(path: &str, name: Option<String>) -> Result<Vec<(JsonA
 /// Load the ABI from the artifact of a locally compiled contract.
 fn load_abi_from_artifact(path_or_contract: &str) -> Result<Vec<(JsonAbi, String)>> {
     let config = load_config()?;
-    let project = config.project()?;
+    let mut project = config.project()?;
+    project.no_artifacts = true;
     let compiler = ProjectCompiler::new().quiet(true);
 
     let contract = PathOrContractInfo::from_str(path_or_contract)?;
 
     let target_path = find_target_path(&project, &contract)?;
-    let output = compiler.files([target_path.clone()]).compile(&project)?;
+    let output = compile_abi_project(&mut project, compiler.files([target_path.clone()]))?;
 
     let contracts_by_artifact = ContractsByArtifact::from(output);
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3146,6 +3146,40 @@ interface Interface {
     ]);
 });
 
+casttest!(interface_local_contract_does_not_write_artifacts, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_source(
+        "InterfaceTarget",
+        r#"
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract InterfaceTarget {
+    event ValueSet(uint256 value);
+
+    function setValue(uint256 value) external {
+        emit ValueSet(value);
+    }
+}
+    "#,
+    );
+
+    let source = prj.root().join("src/InterfaceTarget.sol");
+    let artifact = prj.root().join("out/InterfaceTarget.sol/InterfaceTarget.json");
+    let output =
+        cmd.cast_fuse().arg("interface").arg(&source).assert_success().get_output().stdout_lossy();
+    assert!(output.contains("interface InterfaceTarget"), "{output}");
+    assert!(output.contains("event ValueSet(uint256 value);"), "{output}");
+    assert!(!artifact.exists());
+
+    fs::create_dir_all(artifact.parent().unwrap()).unwrap();
+    fs::write(&artifact, b"sentinel").unwrap();
+
+    cmd.cast_fuse().arg("interface").arg(&source).assert_success();
+    let after = fs::read(&artifact).unwrap();
+    assert_eq!(after, b"sentinel");
+});
+
 // tests that fetches WETH interface from etherscan
 // <https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2>
 casttest!(flaky_fetch_weth_interface_from_etherscan, |_prj, cmd| {


### PR DESCRIPTION
## Summary
- compile local `cast interface` targets with ABI-only output
- avoid writing artifacts for this read-only interface generation path
- add CLI coverage that local interface generation leaves artifact paths untouched

## Results
Benchmarked on a 3000-function/event/error Solidity fixture.

| Scenario | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| cold local source | 1.092s | 326.6ms | 3.34x |
| after full build in prepare | 1.072s | 321.1ms | 3.34x |