### PR TITLE
perf(forge): speed up inspect fields

### DIFF
--- a/crates/forge/src/cmd/inspect.rs
+++ b/crates/forge/src/cmd/inspect.rs
@@ -13,7 +13,7 @@ use foundry_compilers::{
         StorageLayout,
         output_selection::{
             BytecodeOutputSelection, ContractOutputSelection, DeployedBytecodeOutputSelection,
-            EvmOutputSelection, EwasmOutputSelection,
+            EvmOutputSelection, EwasmOutputSelection, OutputSelection,
         },
     },
     solc::SolcLanguage,
@@ -54,6 +54,9 @@ impl InspectArgs {
 
         trace!(target: "forge", ?field, ?contract, "running forge inspect");
 
+        let user_extra_output = !build.compiler.extra_output.is_empty()
+            || !build.compiler.extra_output_files.is_empty();
+
         // Map field to ContractOutputSelection
         let mut cos = build.compiler.extra_output;
         if !field.can_skip_field() && !cos.iter().any(|selected| field == *selected) {
@@ -77,7 +80,15 @@ impl InspectArgs {
         };
 
         // Build the project
-        let project = modified_build_args.project()?;
+        let mut project = modified_build_args.project()?;
+        if !user_extra_output
+            && !project.build_info
+            && let Some(selection) = field.inspect_output_selection()
+        {
+            project.no_artifacts = true;
+            project
+                .update_output_selection(|output_selection| *output_selection = selection.clone());
+        }
         let target_path = find_target_path(&project, &contract)?;
         if field == ContractArtifactField::Linearization && !is_solidity_source(&target_path) {
             eyre::bail!(
@@ -731,6 +742,21 @@ impl ContractArtifactField {
                 | Self::Libraries
                 | Self::Linearization
         )
+    }
+
+    fn inspect_output_selection(&self) -> Option<OutputSelection> {
+        match self {
+            Self::Artifact
+            | Self::Bytecode
+            | Self::DeployedBytecode
+            | Self::StandardJson
+            | Self::Libraries
+            | Self::Linearization => None,
+            _ => {
+                let selection: ContractOutputSelection = (*self).try_into().ok()?;
+                Some(OutputSelection::common_output_selection([selection.to_string()]))
+            }
+        }
     }
 }
 

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3895,6 +3895,29 @@ forgetest!(inspect_custom_counter_abi, |prj, cmd| {
 "#]]);
 });
 
+forgetest!(inspect_abi_does_not_write_artifacts, |prj, cmd| {
+    prj.add_source("Counter.sol", CUSTOM_COUNTER);
+
+    let artifact_path = prj.paths().artifacts.join("Counter.sol/Counter.json");
+
+    cmd.args(["inspect", "Counter", "abi", "--json"]).assert_success();
+    assert!(!artifact_path.exists());
+
+    cmd.forge_fuse().arg("build").assert_success();
+    let built = std::fs::read(&artifact_path).unwrap();
+    let artifact: serde_json::Value =
+        foundry_compilers::utils::read_json_file(&artifact_path).unwrap();
+    let bytecode = artifact["bytecode"]["object"]
+        .as_str()
+        .expect("build artifact should include creation bytecode");
+    assert!(bytecode.starts_with("0x"));
+    assert!(bytecode.len() > 2);
+
+    cmd.forge_fuse().args(["inspect", "Counter", "abi", "--json"]).assert_success();
+    let inspected = std::fs::read(&artifact_path).unwrap();
+    assert_eq!(built, inspected);
+});
+
 forgetest!(inspect_custom_counter_events, |prj, cmd| {
     prj.add_source("Counter.sol", CUSTOM_COUNTER);
 


### PR DESCRIPTION
## Summary
- request only the compiler output needed by default read-only `forge inspect` fields
- avoid artifact writes for narrowed inspect fields such as `abi`, `events`, `errors`, `method-identifiers`, and `storage-layout`
- preserve existing behavior for `artifact`, `bytecode`, `libraries`, `standard-json`, `linearization`, explicit extra outputs, and build-info

## Results
Benchmarked on a generated 9007-line Solidity fixture with 3000 functions, events, and errors.

| Command | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `inspect HugeInspect abi --json` | 2.239s | 919.6ms | 2.43x |
| `inspect HugeInspect method-identifiers --json` | 1.739s | 305.1ms | 5.70x |
| `inspect HugeInspect storage-layout --json` | 1.686s | 276.2ms | 6.10x |

Output matched master byte-for-byte for narrowed fields. Fresh narrowed inspect runs wrote zero artifact files; `bytecode` and `artifact` retained existing artifact writes.
