### PR TITLE
fix ci path normalization tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5206,6 +5206,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solar-compiler",
+ "tempfile",
  "tempo-contracts",
  "tempo-hardfork",
  "tempo-precompiles",

--- a/crates/cheatcodes/Cargo.toml
+++ b/crates/cheatcodes/Cargo.toml
@@ -75,6 +75,7 @@ tempo-precompiles.workspace = true
 tempo-primitives.workspace = true
 
 [dev-dependencies]
+tempfile.workspace = true
 tempo-precompiles = { workspace = true, features = ["test-utils"] }
 
 [features]

--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -272,8 +272,9 @@ fn canonicalize_existing_ancestor(path: &Path) -> PathBuf {
 mod tests {
     use super::*;
     use foundry_config::fs_permissions::PathPermission;
+    use tempfile::TempDir;
 
-    fn config(root: &str, fs_permissions: FsPermissions) -> CheatsConfig {
+    fn config(root: &Path, fs_permissions: FsPermissions) -> CheatsConfig {
         CheatsConfig::new(
             &Config { root: root.into(), fs_permissions, ..Default::default() },
             Default::default(),
@@ -286,8 +287,10 @@ mod tests {
 
     #[test]
     fn test_allowed_paths() {
-        let root = "/my/project/root/";
-        let config = config(root, FsPermissions::new(vec![PathPermission::read_write("./")]));
+        let temp = TempDir::new().unwrap();
+        let root = temp.path().join("my/project/root");
+        std::fs::create_dir_all(&root).unwrap();
+        let config = config(&root, FsPermissions::new(vec![PathPermission::read_write("./")]));
 
         assert!(config.ensure_path_allowed("./t.txt", FsAccessKind::Read).is_ok());
         assert!(config.ensure_path_allowed("./t.txt", FsAccessKind::Write).is_ok());
@@ -310,16 +313,16 @@ mod tests {
 
     #[test]
     fn test_is_foundry_toml() {
-        let root = "/my/project/root/";
+        let root = Path::new("/my/project/root/");
         let config = config(root, FsPermissions::new(vec![PathPermission::read_write("./")]));
 
-        let f = format!("{root}foundry.toml");
+        let f = root.join("foundry.toml");
         assert!(config.is_foundry_toml(f));
 
-        let f = format!("{root}Foundry.toml");
+        let f = root.join("Foundry.toml");
         assert!(config.is_foundry_toml(f));
 
-        let f = format!("{root}lib/other/foundry.toml");
+        let f = root.join("lib/other/foundry.toml");
         assert!(!config.is_foundry_toml(f));
     }
 }

--- a/crates/forge/src/workspace.rs
+++ b/crates/forge/src/workspace.rs
@@ -703,8 +703,14 @@ mod tests {
         assert_eq!(remappings[0].path, format!("{}/", workspace.join("src").display()));
         assert_eq!(remappings[1].path, format!("{}/", external.join("src").display()));
 
-        assert_eq!(temp_config.fs_permissions.permissions[0].path, workspace.join("fixtures"));
-        assert_eq!(temp_config.fs_permissions.permissions[1].path, external.join("fixtures"));
+        assert_eq!(
+            temp_config.fs_permissions.permissions[0].path,
+            normalize_existing_ancestor(&workspace.join("fixtures"))
+        );
+        assert_eq!(
+            temp_config.fs_permissions.permissions[1].path,
+            normalize_existing_ancestor(&external.join("fixtures"))
+        );
 
         let contracts = temp_config.model_checker.unwrap().contracts;
         assert!(contracts.contains_key(&workspace.join("src/Target.sol").display().to_string()));


### PR DESCRIPTION
Fixes CI failures introduced after #13342 by making the affected path tests platform-aware.

The failing jobs were:
- https://github.com/foundry-rs/foundry/actions/runs/28854296237/job/85576939107
- https://github.com/foundry-rs/foundry/actions/runs/28854296237/job/85576939112

Root cause:
- `test_rebase_config_paths_rebases_materialized_project_paths` expected raw joined paths, while `rebase_config_paths` stores normalized existing-ancestor paths. macOS may spell temp paths as `/private/var/...` while the unnormalized expectation uses `/var/...`; Windows can similarly differ between long and short path spellings.
- `test_allowed_paths` used a fake Unix absolute root, which is not portable after the path normalization changes.

Changes:
- Compare rebased fs permission paths against `normalize_existing_ancestor`, matching production behavior.
- Use a real temporary root for `test_allowed_paths` and add the existing workspace `tempfile` dev-dependency to `foundry-cheatcodes`.

Validation:
- `cargo test -p forge workspace::tests::test_rebase_config_paths_rebases_materialized_project_paths`
- `cargo test -p foundry-cheatcodes config::tests::test_allowed_paths`

Prompted by: @grandizzy