### PR TITLE
perf(forge): speed up selector analysis

### DIFF
--- a/crates/forge/src/cmd/selectors.rs
+++ b/crates/forge/src/cmd/selectors.rs
@@ -11,7 +11,12 @@ use foundry_common::{
     selectors::{SelectorImportData, import_selectors},
     shell,
 };
-use foundry_compilers::{Project, info::ContractInfo, multi::MultiCompiler};
+use foundry_compilers::{
+    Project,
+    artifacts::output_selection::{ContractOutputSelection, EvmOutputSelection, OutputSelection},
+    info::ContractInfo,
+    multi::MultiCompiler,
+};
 use std::{collections::BTreeMap, fs::canonicalize};
 
 /// CLI arguments for `forge selectors`.
@@ -163,7 +168,18 @@ impl SelectorsSubcommands {
             }
             Self::Collision { mut first_contract, mut second_contract, build } => {
                 // Compile the project with the two contracts included
-                let project = build.project()?;
+                let user_extra_output = !build.compiler.extra_output.is_empty()
+                    || !build.compiler.extra_output_files.is_empty();
+                let mut project = build.project()?;
+                if !user_extra_output && !project.build_info {
+                    project.no_artifacts = true;
+                    project.update_output_selection(|selection| {
+                        *selection = OutputSelection::common_output_selection([
+                            ContractOutputSelection::Evm(EvmOutputSelection::MethodIdentifiers)
+                                .to_string(),
+                        ]);
+                    });
+                }
                 let mut compiler = ProjectCompiler::new().quiet(true);
 
                 if let Some(contract_path) = &mut first_contract.path {
@@ -435,5 +451,9 @@ impl SelectorsSubcommands {
 
 fn project_from_paths(project_paths: ProjectPathOpts) -> Result<Project<MultiCompiler>> {
     let config = BuildOpts { project_paths, ..Default::default() }.load_config()?;
-    Ok(config.project()?)
+    let mut project = config.project()?;
+    if !project.build_info {
+        project.no_artifacts = true;
+    }
+    Ok(project)
 }

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -4441,6 +4441,65 @@ Uploading selectors for Counter...
 "#]]);
 });
 
+forgetest_init!(selectors_collision_does_not_write_artifacts, |prj, cmd| {
+    prj.add_source(
+        "First.sol",
+        r"
+contract First {
+    function burn(uint256 value) public pure {
+        value;
+    }
+}
+   ",
+    );
+    prj.add_source(
+        "Second.sol",
+        r"
+contract Second {
+    function collate_propagate_storage(bytes16 value) public pure {
+        value;
+    }
+}
+   ",
+    );
+
+    let first_artifact = prj.paths().artifacts.join("First.sol/First.json");
+    let second_artifact = prj.paths().artifacts.join("Second.sol/Second.json");
+
+    let output = cmd.args(["selectors", "collision", "First", "Second"]).assert_success();
+    let stdout = output.get_output().stdout_lossy();
+
+    assert!(stdout.contains("1 collisions found:"), "unexpected stdout:\n{stdout}");
+    assert!(stdout.contains("42966c68"), "unexpected stdout:\n{stdout}");
+    assert!(stdout.contains("burn(uint256)"), "unexpected stdout:\n{stdout}");
+    assert!(stdout.contains("collate_propagate_storage(bytes16)"), "unexpected stdout:\n{stdout}");
+    assert!(!first_artifact.exists());
+    assert!(!second_artifact.exists());
+});
+
+forgetest_init!(selectors_list_does_not_write_artifacts, |prj, cmd| {
+    prj.add_source(
+        "Counter.sol",
+        r"
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+}
+   ",
+    );
+
+    let artifact = prj.paths().artifacts.join("Counter.sol/Counter.json");
+    let output = cmd.args(["selectors", "list", "Counter"]).assert_success();
+    let stdout = output.get_output().stdout_lossy();
+
+    assert!(stdout.contains("Counter"), "unexpected stdout:\n{stdout}");
+    assert!(stdout.contains("setNumber(uint256)"), "unexpected stdout:\n{stdout}");
+    assert!(!artifact.exists());
+});
+
 forgetest_init!(selectors_list_cmd, |prj, cmd| {
     prj.add_source(
         "Counter.sol",


### PR DESCRIPTION
## Summary
- request only method identifiers for `forge selectors collision` and skip artifact writes when build-info is not requested
- skip artifact persistence for ABI-only selector commands loaded through `ProjectPathOpts`
- add regressions for collision/list selector commands not creating artifacts

## Benchmarks
Generated selector collision fixture with 4,000 methods:
- master: 1.499 s ± 0.017 s
- candidate: 301.6 ms ± 10.0 ms
- 4.97x faster

Generated `selectors find` fixture with 20,000 functions:
- master: 609.4 ms ± 78.3 ms, writes 2.8 MB under `out/`
- candidate: 527.0 ms ± 9.9 ms, writes no artifacts
- 1.16x faster
