### PR TITLE
perf(forge): speed up bind generation

### DIFF
--- a/crates/forge/src/cmd/bind.rs
+++ b/crates/forge/src/cmd/bind.rs
@@ -3,7 +3,10 @@ use clap::{Parser, ValueHint};
 use eyre::Result;
 use forge_sol_macro_gen::{MultiSolMacroGen, SolMacroGen};
 use foundry_cli::{opts::BuildOpts, utils::LoadConfig};
-use foundry_common::{compile::ProjectCompiler, fs::json_files};
+use foundry_common::{
+    compile::{ProjectCompiler, compile_abi_project},
+    fs::json_files,
+};
 use foundry_config::impl_figment_convert;
 use regex::Regex;
 use std::{
@@ -118,8 +121,8 @@ impl BindArgs {
         }
 
         if !self.skip_build {
-            let project = self.build.project()?;
-            let _ = ProjectCompiler::new().compile(&project)?;
+            let mut project = self.build.project()?;
+            let _ = compile_abi_project(&mut project, ProjectCompiler::new())?;
         }
 
         let config = self.load_config()?;

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -1,3 +1,4 @@
+use foundry_compilers::utils::read_json_file;
 use std::{path::Path, process::Command};
 
 fn assert_bindings_compile(bindings_path: &Path) {
@@ -56,6 +57,29 @@ Generating bindings for [..] contracts
 Bindings have been generated to [..]
 
 "#]]);
+});
+
+forgetest_init!(bind_writes_abi_only_artifacts, |prj, cmd| {
+    prj.add_source(
+        "BindTarget.sol",
+        r#"
+contract BindTarget {
+    function value() public pure returns (uint256) {
+        return 1;
+    }
+}
+"#,
+    );
+    prj.clear();
+
+    cmd.args(["bind", "--select", "^BindTarget$"]).assert_success();
+
+    let artifact_path = prj.paths().artifacts.join("BindTarget.sol/BindTarget.json");
+    let artifact: serde_json::Value = read_json_file(&artifact_path).unwrap();
+    let abi = artifact["abi"].as_array().expect("bind artifact should include ABI");
+    assert!(!abi.is_empty());
+    assert!(artifact["bytecode"]["object"].as_str().is_none());
+    assert!(artifact["deployedBytecode"]["object"].as_str().is_none());
 });
 
 // <https://github.com/foundry-rs/foundry/issues/11177>


### PR DESCRIPTION
## Summary

- Compile `forge bind`'s implicit build with ABI-only output, matching the data the binding generator actually consumes.
- Keep generated ABI artifacts available for `SolMacroGen`, but avoid producing creation/runtime bytecode during binding generation.
- Add a CLI regression test that a clean `forge bind` run writes ABI artifacts without bytecode objects.

## Benchmarks

Synthetic binding-generation project with 24 contracts and heavy function bodies, cleaning `out`, `cache`, and generated bindings before every sample:

```text
hyperfine --warmup 1 --runs 8 --prepare 'rm -rf /tmp/foundry-bind-bench/out /tmp/foundry-bind-bench/cache /tmp/foundry-bind-bench/bindings' \
  '/tmp/forge-bind-master bind --root /tmp/foundry-bind-bench --overwrite --bindings-path /tmp/foundry-bind-bench/bindings --select "^Heavy"' \
  '/tmp/forge-bind-candidate bind --root /tmp/foundry-bind-bench --overwrite --bindings-path /tmp/foundry-bind-bench/bindings --select "^Heavy"'
```

```text
master:    2.374 s +/- 0.015 s
candidate: 959.8 ms +/- 6.8 ms
speedup:   2.47x
```

On the same fixture, generated output dropped from `2.4M out + 6.0M bindings` to `100K out + 3.9M bindings`.
