### PR TITLE
fix(forge): keep mutation config after reload

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1277,18 +1277,16 @@ impl TestArgs {
         // Merge all configs.
         let (mut config, evm_opts) = self.load_config_and_evm_opts()?;
 
-        let should_mutate = self.mutate.is_some();
-
-        // Force dyn test linking for mutation testing
-        if should_mutate {
-            config.dynamic_test_linking = true;
-            config.cache = true;
-        }
-
         if install::install_missing_dependencies(&mut config).await && config.auto_detect_remappings
         {
             // need to re-configure here to also catch additional remappings
             config = self.load_config()?;
+        }
+
+        if self.mutate.is_some() {
+            // Force dyn test linking and cache usage for mutation testing after any config reload.
+            config.dynamic_test_linking = true;
+            config.cache = true;
         }
 
         // Set up the project.


### PR DESCRIPTION
Mutation mode requires dynamic test linking and cache usage before the test project is built. If missing dependency installation triggers a config reload for auto-detected remappings, applying those settings before the reload can lose them.

This applies the mutation-required config overrides after the dependency-install reload path has completed, keeping fresh dependency installs consistent with normal mutation setup without duplicating the override logic.
