### PR TITLE
feat(fuzz): reuse coverage-winning whole calls

### DIFF
--- a/.changelog/forge-whole-call-donors.md
+++ b/.changelog/forge-whole-call-donors.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added bounded reuse of coverage-winning top-level ABI calls during coverage-guided invariant fuzzing.

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -66,7 +66,11 @@ impl FuzzConfig {
 /// Contains for fuzz testing
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FuzzDictionaryConfig {
-    /// The weight of the dictionary
+    /// Percentage of generated values to draw from the fuzz dictionary.
+    ///
+    /// For invariant campaigns with a corpus, this also controls how often compatible whole calls
+    /// whose concrete execution won an edge or hit-count coverage feature are used instead of
+    /// fully synthesized calldata.
     #[serde(deserialize_with = "crate::deserialize_stringified_percent")]
     pub dictionary_weight: u32,
     /// The flag indicating whether to include values from storage
@@ -116,8 +120,12 @@ impl Default for FuzzDictionaryConfig {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FuzzCorpusConfig {
-    // Path to corpus directory, enabled coverage guided fuzzing mode.
-    // If not set then sequences producing new coverage are not persisted and mutated.
+    /// Path used to persist coverage-winning fuzz and invariant sequences.
+    ///
+    /// When set, coverage-guided corpus mutation is enabled. In invariant campaigns,
+    /// argument-bearing top-level calls whose concrete execution wins an edge or hit-count
+    /// coverage feature also populate a bounded, worker-local ABI donor dictionary for later call
+    /// generation.
     pub corpus_dir: Option<PathBuf>,
     // Path to fuzz branch frontier artifacts for symbolic follow-up.
     pub frontier_dir: Option<PathBuf>,
@@ -263,6 +271,9 @@ pub struct FuzzCorpusMutationWeights {
     /// Weight for replacing a corpus sequence suffix with generated calls.
     pub mutation_weight_suffix: u32,
     /// Weight for ABI-aware argument mutation.
+    ///
+    /// An effective value of zero also disables collection and reuse of coverage-winning
+    /// whole-call donors.
     pub mutation_weight_abi: u32,
     /// Weight for comparison-operand guided argument mutation.
     pub mutation_weight_cmp: u32,

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -41,16 +41,14 @@ use crate::{
 };
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
-use alloy_primitives::{Address, Bytes, I256, U256};
+use alloy_primitives::{Address, B256, Bytes, I256};
 use eyre::{Result, eyre};
-use foundry_common::{ContractsByAddress, ContractsByArtifact, TestFunctionExt, sh_warn};
+use foundry_common::{ContractsByAddress, ContractsByArtifact, sh_warn};
 use foundry_config::{FuzzCorpusConfig, FuzzCorpusMutationWeights};
-use foundry_evm_core::{constants::CALLER, evm::FoundryEvmNetwork, utils::StateChangeset};
+use foundry_evm_core::{constants::MAGIC_ASSUME, evm::FoundryEvmNetwork, utils::StateChangeset};
 use foundry_evm_fuzz::{
-    BasicTxDetails, CallDetails, ObservedCall,
-    invariant::{
-        ArtifactFilters, FuzzRunIdentifiedContracts, InvariantContract, TargetedContracts,
-    },
+    BasicTxDetails,
+    invariant::{ArtifactFilters, FuzzRunIdentifiedContracts, TargetedContracts},
     strategies::{
         EvmFuzzState, FuzzStateReader, InvariantFuzzState, generate_msg_value, mutate_param_value,
     },
@@ -84,9 +82,136 @@ const CACHED_DISK_CORPUS_MAX_LEN: usize = 128;
 // Prefer decoded donors while periodically refreshing the bounded cache from disk.
 const DISK_CORPUS_REFRESH_DENOMINATOR: u32 = 16;
 
+/// Keep whole-call donors worker-local and small enough to scan during deduplication.
+const WHOLE_CALL_DICTIONARY_MAX_LEN: usize = 1024;
+/// Bound retained calldata independently from the number of whole-call donors.
+const WHOLE_CALL_DICTIONARY_MAX_BYTES: usize = 4 * 1024 * 1024;
 /// Threshold for compressing corpus entries.
 /// 4KiB is usually the minimum file size on popular file systems.
 const GZIP_THRESHOLD: usize = 4 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct WholeCallSignature(B256);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WholeCall {
+    /// The unique target that produced this call, or `None` if multiple targets produced it.
+    source_target: Option<Address>,
+    calldata: Bytes,
+}
+
+/// Worker-local ABI donors learned from argument-bearing top-level calls whose complete concrete
+/// execution wins an edge or hit-count coverage feature.
+///
+/// Donors are mutation inputs, not corpus entries. Reusing one never bypasses normal concrete
+/// execution or the existing sequence-level corpus admission rules.
+#[derive(Clone, Default)]
+struct WholeCallDictionary {
+    by_signature: HashMap<WholeCallSignature, VecDeque<WholeCall>>,
+    insertion_order: VecDeque<(WholeCallSignature, Bytes)>,
+    len: usize,
+    calldata_bytes: usize,
+}
+
+impl WholeCallDictionary {
+    fn insert(
+        &mut self,
+        signature: WholeCallSignature,
+        source_target: Address,
+        calldata: Bytes,
+    ) -> bool {
+        let calldata_len = calldata.len();
+        if calldata_len > WHOLE_CALL_DICTIONARY_MAX_BYTES {
+            return false;
+        }
+        if let Some(existing) = self
+            .by_signature
+            .get_mut(&signature)
+            .and_then(|calls| calls.iter_mut().find(|call| call.calldata == calldata))
+        {
+            if existing.source_target != Some(source_target) {
+                existing.source_target = None;
+            }
+            return false;
+        }
+
+        while self.len >= WHOLE_CALL_DICTIONARY_MAX_LEN
+            || self.calldata_bytes + calldata_len > WHOLE_CALL_DICTIONARY_MAX_BYTES
+        {
+            self.evict_oldest();
+        }
+
+        self.by_signature.entry(signature).or_default().push_back(WholeCall {
+            source_target: Some(source_target),
+            calldata: calldata.clone(),
+        });
+        self.insertion_order.push_back((signature, calldata));
+        self.len += 1;
+        self.calldata_bytes += calldata_len;
+        true
+    }
+
+    fn evict_oldest(&mut self) {
+        let Some((signature, calldata)) = self.insertion_order.pop_front() else {
+            return;
+        };
+        let remove_bucket = if let Some(calls) = self.by_signature.get_mut(&signature) {
+            if let Some(index) = calls.iter().position(|call| call.calldata == calldata) {
+                let call = calls.remove(index).expect("whole-call donor index exists");
+                self.len -= 1;
+                self.calldata_bytes = self.calldata_bytes.saturating_sub(call.calldata.len());
+            }
+            calls.is_empty()
+        } else {
+            false
+        };
+        if remove_bucket {
+            self.by_signature.remove(&signature);
+        }
+    }
+
+    fn sample(&self, signature: WholeCallSignature, rng: &mut impl Rng) -> Option<WholeCall> {
+        let calls = self.by_signature.get(&signature)?;
+        calls.get(rng.random_range(0..calls.len())).cloned()
+    }
+
+    const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    fn insert_tx(&mut self, tx: &BasicTxDetails, targets: &TargetedContracts) -> bool {
+        let Some((function, signature)) = fuzzed_function_for_tx(tx, targets) else {
+            return false;
+        };
+        if function.inputs.is_empty()
+            || function.abi_decode_input(&tx.call_details.calldata[4..]).is_err()
+        {
+            return false;
+        }
+        self.insert(signature, tx.call_details.target, tx.call_details.calldata.clone())
+    }
+}
+
+fn fuzzed_function_for_tx<'a>(
+    tx: &BasicTxDetails,
+    targets: &'a TargetedContracts,
+) -> Option<(&'a Function, WholeCallSignature)> {
+    let selector = tx
+        .call_details
+        .calldata
+        .get(..4)
+        .and_then(|selector| <[u8; 4]>::try_from(selector).ok())?;
+    let selector = selector.into();
+    let contract = targets.get(&tx.call_details.target)?;
+    Some((
+        contract.fuzzed_function_by_selector(selector)?,
+        WholeCallSignature(contract.fuzzed_signature_by_selector(selector)?),
+    ))
+}
+
+pub(crate) const fn is_whole_call_coverage_winner(new_coverage: bool, discarded: bool) -> bool {
+    new_coverage && !discarded
+}
 
 fn weighted_arg_mutation(
     rng: &mut impl Rng,
@@ -503,7 +628,6 @@ fn rewrite_campaign_corpus(config: &FuzzCorpusConfig, gzip: bool) -> Result<()> 
 pub(crate) enum CorpusInsertionMode {
     Live,
     Deferred,
-    MemoryOnly,
     WorkerSync,
 }
 
@@ -546,6 +670,7 @@ struct ReplayCoverage<'a> {
     edge_indices: &'a mut EdgeIndexMap,
     sancov_history_map: &'a mut Vec<u8>,
     metrics: Option<&'a mut CorpusMetrics>,
+    whole_calls: Option<&'a mut WholeCallDictionary>,
 }
 
 /// Campaign-level corpus state produced by replaying persisted corpus entries once.
@@ -562,6 +687,7 @@ pub(crate) struct WorkerCorpusSeed {
     sancov_history_map: Vec<u8>,
     top_rated: HashMap<usize, (Uuid, usize)>,
     metrics: CorpusMetrics,
+    whole_calls: WholeCallDictionary,
     failed_replays: usize,
     optimization_best_value: Option<I256>,
     optimization_best_sequence: Vec<BasicTxDetails>,
@@ -640,6 +766,7 @@ impl WorkerCorpusSeed {
             sancov_history_map: self.sancov_history_map.clone(),
             top_rated: HashMap::new(),
             metrics,
+            whole_calls: self.whole_calls.clone(),
             failed_replays: self.failed_replays,
             optimization_best_value: self.optimization_best_value,
             optimization_best_sequence: self.optimization_best_sequence.clone(),
@@ -693,6 +820,7 @@ impl WorkerCorpusSeed {
         let Some(executor) = executor else {
             return Ok(seed);
         };
+        let collect_whole_calls = config.mutation_weights.effective().mutation_weight_abi > 0;
         let mut seen_entries =
             seed.in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
         for entry in unique_corpus_entries(&canonical_replay_dirs(corpus_dir), &mut seen_entries) {
@@ -716,6 +844,7 @@ impl WorkerCorpusSeed {
                 edge_indices: &mut seed.edge_indices,
                 sancov_history_map: &mut seed.sancov_history_map,
                 metrics: Some(&mut seed.metrics),
+                whole_calls: collect_whole_calls.then_some(&mut seed.whole_calls),
             };
             let ReplayOutcome {
                 keep_entry, new_edge, edges_covered, cmp_seq, failed_replays, ..
@@ -777,6 +906,7 @@ impl WorkerCorpusSeed {
                     edge_indices: &mut edge_indices,
                     sancov_history_map: &mut sancov_history_map,
                     metrics: None,
+                    whole_calls: None,
                 };
                 let ReplayOutcome { keep_entry, new_coverage, .. } =
                     replay_corpus_sequence(&entry.tx_seq, executor, target, coverage)?;
@@ -822,8 +952,13 @@ impl GlobalCorpusMetrics {
             cumulative_features_seen: self.cumulative_features_seen.load(Ordering::Relaxed),
             corpus_count: self.corpus_count.load(Ordering::Relaxed),
             favored_items: self.favored_items.load(Ordering::Relaxed),
+            ..Default::default()
         }
     }
+}
+
+const fn usize_is_zero(value: &usize) -> bool {
+    *value == 0
 }
 
 #[derive(Serialize, Default, Clone)]
@@ -836,6 +971,21 @@ pub(crate) struct CorpusMetrics {
     corpus_count: usize,
     // Number of corpus entries that are favored.
     favored_items: usize,
+    // Worker-local number of compatible whole-call donors selected during fresh generation.
+    #[serde(skip_serializing_if = "usize_is_zero")]
+    whole_call_attempts: usize,
+    // Worker-local number of selected donors that produced changed calldata.
+    #[serde(skip_serializing_if = "usize_is_zero")]
+    whole_call_mutations: usize,
+    // Worker-local subset of mutations whose donor came from a different target.
+    #[serde(skip_serializing_if = "usize_is_zero")]
+    whole_call_cross_target_mutations: usize,
+    // Worker-local number of emitted donor mutations that themselves won coverage.
+    #[serde(skip_serializing_if = "usize_is_zero")]
+    whole_call_coverage_wins: usize,
+    // Current number of retained worker-local donors.
+    #[serde(skip_serializing_if = "usize_is_zero")]
+    whole_call_dictionary_entries: usize,
 }
 
 impl fmt::Display for CorpusMetrics {
@@ -846,6 +996,28 @@ impl fmt::Display for CorpusMetrics {
         writeln!(f, "        - cumulative features seen: {}", self.cumulative_features_seen)?;
         writeln!(f, "        - corpus count: {}", self.corpus_count)?;
         write!(f, "        - favored items: {}", self.favored_items)?;
+        if self.whole_call_attempts == 0
+            && self.whole_call_mutations == 0
+            && self.whole_call_cross_target_mutations == 0
+            && self.whole_call_coverage_wins == 0
+            && self.whole_call_dictionary_entries == 0
+        {
+            return Ok(());
+        }
+        writeln!(f)?;
+        writeln!(f, "        - whole-call donor attempts: {}", self.whole_call_attempts)?;
+        writeln!(f, "        - whole-call donor mutations: {}", self.whole_call_mutations)?;
+        writeln!(
+            f,
+            "        - cross-target whole-call mutations: {}",
+            self.whole_call_cross_target_mutations
+        )?;
+        writeln!(f, "        - whole-call coverage wins: {}", self.whole_call_coverage_wins)?;
+        write!(
+            f,
+            "        - whole-call dictionary entries: {}",
+            self.whole_call_dictionary_entries
+        )?;
         Ok(())
     }
 }
@@ -884,6 +1056,12 @@ pub struct WorkerCorpus {
     pub(crate) metrics: CorpusMetrics,
     /// Fuzzed calls generator.
     tx_generator: BoxedStrategy<BasicTxDetails>,
+    /// Coverage-winning top-level calls, kept separate from the replay corpus.
+    whole_calls: WholeCallDictionary,
+    /// Whole-call provenance parallel to the current run's initial sequence.
+    whole_call_plan: Vec<bool>,
+    /// Whether the next transaction to execute came from a whole-call donor.
+    next_whole_call_is_donor: bool,
     /// Call sequence mutation weights used by stateful fuzzing.
     mutation_weights: FuzzCorpusMutationWeights,
     /// Weighted stateful sequence mutation distribution.
@@ -1013,6 +1191,7 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
         if WorkerCorpus::can_replay_tx(tx, target.stateless, target.fuzzed_contracts) {
             let mut call_result = execute_tx(executor, tx)?;
             cmp_seq.push(call_result.evm_cmp_values.take().unwrap_or_default());
+            let discarded = call_result.result.as_ref() == MAGIC_ASSUME;
             let (new_coverage, is_edge) = call_result.merge_all_coverage_with_edges_into(
                 coverage.history_map,
                 coverage.edge_indices,
@@ -1026,6 +1205,30 @@ fn replay_corpus_sequence_with_executor<FEN: FoundryEvmNetwork>(
                 if let Some(metrics) = coverage.metrics.as_deref_mut() {
                     metrics.update_seen(is_edge);
                 }
+                if is_whole_call_coverage_winner(new_coverage, discarded)
+                    && let (Some(whole_calls), Some(fuzzed_contracts)) =
+                        (coverage.whole_calls.as_deref_mut(), target.fuzzed_contracts)
+                    && whole_calls.insert_tx(tx, &fuzzed_contracts.targets())
+                    && let Some(metrics) = coverage.metrics.as_deref_mut()
+                {
+                    metrics.whole_call_dictionary_entries = whole_calls.len;
+                }
+            }
+
+            // Live invariant execution merges coverage before discarding an assumed call, but it
+            // neither commits state nor learns a whole-call donor. Preserve that ordering while
+            // rebuilding coverage from disk and worker sync.
+            if discarded {
+                failed_replays += 1;
+                if trace_sync {
+                    trace!(
+                        target: "corpus",
+                        %new_coverage,
+                        ?tx,
+                        "discarded MAGIC_ASSUME corpus replay",
+                    );
+                }
+                continue;
             }
 
             register_replay_created(
@@ -1143,6 +1346,14 @@ impl WorkerCorpus {
             worker_dir
         });
 
+        let whole_calls = if mutation_weights.mutation_weight_abi > 0 {
+            seed.whole_calls
+        } else {
+            WholeCallDictionary::default()
+        };
+        let mut metrics = seed.metrics;
+        metrics.whole_call_dictionary_entries = whole_calls.len;
+
         let mut corpus = Self {
             id,
             in_memory_corpus: seed.in_memory_corpus,
@@ -1152,8 +1363,11 @@ impl WorkerCorpus {
             sancov_history_map: seed.sancov_history_map,
             top_rated: seed.top_rated,
             failed_replays: seed.failed_replays,
-            metrics: seed.metrics,
+            metrics,
             tx_generator,
+            whole_calls,
+            whole_call_plan: Default::default(),
+            next_whole_call_is_donor: false,
             mutation_weights,
             mutation_distribution,
             arg_mutation_distribution,
@@ -1495,6 +1709,130 @@ impl WorkerCorpus {
         self.last_new_edge_at.map(|at| at.elapsed())
     }
 
+    /// Learns an argument-bearing top-level call only when its complete concrete execution wins an
+    /// edge or hit-count coverage feature.
+    ///
+    /// The call remains a mutation donor, not a corpus entry. A later generated call still
+    /// executes normally, and only sequence-level inputs are eligible for corpus admission.
+    pub(crate) fn admit_whole_call(
+        &mut self,
+        tx: &BasicTxDetails,
+        new_coverage: bool,
+        targeted_contracts: &FuzzRunIdentifiedContracts,
+    ) -> bool {
+        if self.mutation_weights.mutation_weight_abi == 0
+            || !new_coverage
+            || !self.config.is_coverage_guided()
+        {
+            return false;
+        }
+
+        let inserted = self.whole_calls.insert_tx(tx, &targeted_contracts.targets());
+        if inserted {
+            self.metrics.whole_call_dictionary_entries = self.whole_calls.len;
+        }
+        inserted
+    }
+
+    /// Attributes an emitted whole-call mutation to its concrete execution.
+    pub(crate) fn record_whole_call_result(&mut self, new_coverage: bool) {
+        if std::mem::take(&mut self.next_whole_call_is_donor) && new_coverage {
+            self.metrics.whole_call_coverage_wins += 1;
+        }
+    }
+
+    /// Generates a destination normally, then optionally supplies arguments from a
+    /// feature-winning call with the same canonical ABI signature hash.
+    fn new_invariant_tx(
+        &mut self,
+        test_runner: &mut TestRunner,
+        fuzz_state: &InvariantFuzzState,
+        targeted_contracts: &FuzzRunIdentifiedContracts,
+        dictionary_weight: u32,
+    ) -> Result<(BasicTxDetails, bool)> {
+        let mut tx = self.new_tx(test_runner)?;
+        let dictionary_weight = dictionary_weight.min(100);
+        if self.whole_calls.is_empty()
+            || self.mutation_weights.mutation_weight_abi == 0
+            || dictionary_weight == 0
+            || !test_runner.rng().random_ratio(dictionary_weight, 100)
+        {
+            return Ok((tx, false));
+        }
+
+        let targets = targeted_contracts.targets();
+        let Some((function, signature)) = fuzzed_function_for_tx(&tx, &targets) else {
+            return Ok((tx, false));
+        };
+        if function.inputs.is_empty() {
+            return Ok((tx, false));
+        }
+        let Some(donor) = self.whole_calls.sample(signature, test_runner.rng()) else {
+            return Ok((tx, false));
+        };
+        self.metrics.whole_call_attempts += 1;
+
+        let original_calldata = std::mem::replace(&mut tx.call_details.calldata, donor.calldata);
+        let Ok(mutated) = Self::mutate_one_call_argument(
+            function,
+            signature,
+            &tx.call_details.calldata,
+            test_runner,
+            fuzz_state,
+        ) else {
+            tx.call_details.calldata = original_calldata;
+            return Ok((tx, false));
+        };
+        tx.call_details.calldata = mutated;
+        self.metrics.whole_call_mutations += 1;
+        if donor.source_target.is_some_and(|source_target| source_target != tx.call_details.target)
+        {
+            self.metrics.whole_call_cross_target_mutations += 1;
+        }
+
+        Ok((tx, true))
+    }
+
+    /// Mutates exactly one ABI argument while preserving the donor's selector.
+    fn mutate_one_call_argument(
+        function: &Function,
+        signature: WholeCallSignature,
+        calldata: &Bytes,
+        test_runner: &mut TestRunner,
+        fuzz_state: &InvariantFuzzState,
+    ) -> Result<Bytes> {
+        let Some(selector) = calldata.get(..4) else {
+            return Err(eyre!("whole-call donor is shorter than a function selector"));
+        };
+        if selector != &signature.0[..4] {
+            return Err(eyre!("whole-call donor selector does not match generated function"));
+        }
+        if function.inputs.is_empty() {
+            return Err(eyre!("generated function has no arguments to mutate"));
+        }
+
+        let mut values = function
+            .abi_decode_input(&calldata[4..])
+            .map_err(|err| eyre!("failed to decode whole-call donor: {err}"))?;
+        let index = test_runner.rng().random_range(0..values.len());
+        let input_type = function.inputs[index].selector_type().parse()?;
+        values[index] =
+            mutate_param_value(&input_type, values[index].clone(), test_runner, fuzz_state);
+
+        let mutated = function
+            .abi_encode_input(&values)
+            .map_err(|err| eyre!("failed to encode whole-call mutation: {err}"))?;
+        if mutated.as_slice() == calldata.as_ref() {
+            return Err(eyre!("whole-call mutation did not change calldata"));
+        }
+        Ok(mutated.into())
+    }
+
+    fn remember_whole_call_plan(&mut self, plan: Vec<bool>) {
+        self.next_whole_call_is_donor = plan.first().copied().unwrap_or(false);
+        self.whole_call_plan = plan;
+    }
+
     /// Generates new call sequence from in memory corpus. Evicts oldest corpus mutated more than
     /// configured max mutations value. Used by invariant test campaigns.
     #[instrument(skip_all)]
@@ -1503,13 +1841,18 @@ impl WorkerCorpus {
         test_runner: &mut TestRunner,
         fuzz_state: &InvariantFuzzState,
         targeted_contracts: &FuzzRunIdentifiedContracts,
+        dictionary_weight: u32,
     ) -> Result<Vec<BasicTxDetails>> {
         let mut new_seq = vec![];
+        let mut whole_call_positions = Vec::new();
+        self.whole_call_plan.clear();
+        self.next_whole_call_is_donor = false;
 
         // Early return with first_input only if corpus dir / coverage guided fuzzing not
         // configured.
         if !self.config.is_coverage_guided() {
             new_seq.push(self.new_tx(test_runner)?);
+            self.remember_whole_call_plan(vec![false]);
             return Ok(new_seq);
         };
 
@@ -1518,10 +1861,24 @@ impl WorkerCorpus {
                 weighted_mutation_type(test_runner.rng(), &self.mutation_distribution);
 
             let Some(primary) = self.random_mutation_corpus(test_runner.rng())? else {
-                return Ok(vec![self.new_tx(test_runner)?]);
+                let (tx, used_whole_call) = self.new_invariant_tx(
+                    test_runner,
+                    fuzz_state,
+                    targeted_contracts,
+                    dictionary_weight,
+                )?;
+                self.remember_whole_call_plan(vec![used_whole_call]);
+                return Ok(vec![tx]);
             };
             let Some(secondary) = self.random_mutation_corpus(test_runner.rng())? else {
-                return Ok(vec![self.new_tx(test_runner)?]);
+                let (tx, used_whole_call) = self.new_invariant_tx(
+                    test_runner,
+                    fuzz_state,
+                    targeted_contracts,
+                    dictionary_weight,
+                )?;
+                self.remember_whole_call_plan(vec![used_whole_call]);
+                return Ok(vec![tx]);
             };
             let primary = primary.get(&self.in_memory_corpus);
             let secondary = secondary.get(&self.in_memory_corpus);
@@ -1577,11 +1934,22 @@ impl WorkerCorpus {
                     trace!(target: "corpus", "overwrite prefix of {}", corpus.uuid);
 
                     let prefix_len = test_runner.rng().random_range(0..=corpus.tx_seq.len());
-                    new_seq.reserve(corpus.tx_seq.len());
+                    let corpus_len = corpus.tx_seq.len();
+                    let retained = corpus.tx_seq[prefix_len..].to_vec();
+                    new_seq.reserve(corpus_len);
                     for _ in 0..prefix_len {
-                        new_seq.push(self.new_tx(test_runner)?);
+                        let (tx, used_whole_call) = self.new_invariant_tx(
+                            test_runner,
+                            fuzz_state,
+                            targeted_contracts,
+                            dictionary_weight,
+                        )?;
+                        if used_whole_call {
+                            whole_call_positions.push(new_seq.len());
+                        }
+                        new_seq.push(tx);
                     }
-                    new_seq.extend_from_slice(&corpus.tx_seq[prefix_len..]);
+                    new_seq.extend(retained);
                 }
                 MutationType::Suffix => {
                     let corpus =
@@ -1590,10 +1958,20 @@ impl WorkerCorpus {
 
                     let suffix_len = test_runner.rng().random_range(0..corpus.tx_seq.len());
                     let retained_len = corpus.tx_seq.len() - suffix_len;
-                    new_seq.reserve(corpus.tx_seq.len());
-                    new_seq.extend_from_slice(&corpus.tx_seq[..retained_len]);
-                    for _ in retained_len..corpus.tx_seq.len() {
-                        new_seq.push(self.new_tx(test_runner)?);
+                    let corpus_len = corpus.tx_seq.len();
+                    new_seq = corpus.tx_seq[..retained_len].to_vec();
+                    new_seq.reserve(suffix_len);
+                    for _ in retained_len..corpus_len {
+                        let (tx, used_whole_call) = self.new_invariant_tx(
+                            test_runner,
+                            fuzz_state,
+                            targeted_contracts,
+                            dictionary_weight,
+                        )?;
+                        if used_whole_call {
+                            whole_call_positions.push(new_seq.len());
+                        }
+                        new_seq.push(tx);
                     }
                 }
                 MutationType::Abi => {
@@ -1689,7 +2067,16 @@ impl WorkerCorpus {
 
                     new_seq = corpus.tx_seq.clone();
                     let idx = test_runner.rng().random_range(0..=new_seq.len());
-                    new_seq.insert(idx, self.new_tx(test_runner)?);
+                    let (tx, used_whole_call) = self.new_invariant_tx(
+                        test_runner,
+                        fuzz_state,
+                        targeted_contracts,
+                        dictionary_weight,
+                    )?;
+                    new_seq.insert(idx, tx);
+                    if used_whole_call {
+                        whole_call_positions.push(idx);
+                    }
                 }
                 MutationType::Delete => {
                     let corpus =
@@ -1722,8 +2109,22 @@ impl WorkerCorpus {
 
         // Make sure the new sequence contains at least one tx to start fuzzing from.
         if new_seq.is_empty() {
-            new_seq.push(self.new_tx(test_runner)?);
+            let (tx, used_whole_call) = self.new_invariant_tx(
+                test_runner,
+                fuzz_state,
+                targeted_contracts,
+                dictionary_weight,
+            )?;
+            if used_whole_call {
+                whole_call_positions.push(0);
+            }
+            new_seq.push(tx);
         }
+        let mut whole_call_plan = vec![false; new_seq.len()];
+        for position in whole_call_positions {
+            whole_call_plan[position] = true;
+        }
+        self.remember_whole_call_plan(whole_call_plan);
         trace!(target: "corpus", "new sequence of {} calls generated", new_seq.len());
 
         Ok(new_seq)
@@ -1826,127 +2227,19 @@ impl WorkerCorpus {
         tx_seq.into_iter().nth(tx_idx)
     }
 
-    /// Converts replayable observed sub-calls into one normal multi-transaction corpus entry.
-    ///
-    /// This captures calls shaped by a handler or another target call and lets the existing corpus
-    /// machinery mutate, evict, sync, and persist them like any other interesting sequence.
-    pub fn hoist_observed_calls(
-        &mut self,
-        observed: &[ObservedCall],
-        parent_tx: &BasicTxDetails,
-        targeted_contracts: &FuzzRunIdentifiedContracts,
-        insertion_mode: CorpusInsertionMode,
-    ) -> Option<CampaignCorpusEntry> {
-        if !self.config.is_coverage_guided() || observed.is_empty() {
-            return None;
-        }
-
-        let tx_seq = {
-            let targets = targeted_contracts.targets();
-            sequence_from_observed(
-                observed,
-                &targets,
-                ObservedCallDepth::All,
-                Some((parent_tx.warp, parent_tx.roll)),
-            )
-        };
-
-        self.push_observed_sequence(tx_seq, insertion_mode)
-    }
-
-    /// Seeds the corpus from sibling zero-input unit tests by replaying them on a clone of the
-    /// post-setUp executor and keeping the direct replayable calls made by each test.
-    ///
-    /// Returns the number of test-derived corpus entries added.
-    pub fn seed_from_test_traces<FEN: FoundryEvmNetwork>(
-        &mut self,
-        invariant_contract: &InvariantContract<'_>,
-        targeted_contracts: &FuzzRunIdentifiedContracts,
-        executor: &Executor<FEN>,
-    ) -> Result<usize> {
-        if !self.config.is_coverage_guided() {
-            return Ok(0);
-        }
-
-        let mut added = 0;
-
-        for func in invariant_contract.abi.functions() {
-            if !func.is_unit_test() {
-                continue;
-            }
-            if invariant_contract
-                .invariant_fns
-                .iter()
-                .any(|(invariant_fn, _)| func.selector() == invariant_fn.selector())
-            {
-                continue;
-            }
-
-            let calldata = match func.abi_encode_input(&[]) {
-                Ok(calldata) => Bytes::from(calldata),
-                Err(_) => continue,
-            };
-
-            let exec = executor.clone();
-
-            let raw = match exec.call_raw(CALLER, invariant_contract.address, calldata, U256::ZERO)
-            {
-                Ok(raw) => raw,
-                Err(_) => continue,
-            };
-            if raw.reverted {
-                continue;
-            }
-
-            let observed = raw.observed_calls;
-            if observed.is_empty() {
-                continue;
-            }
-
-            let seq = {
-                let targets = targeted_contracts.targets();
-                sequence_from_observed(&observed, &targets, ObservedCallDepth::DirectOnly, None)
-            };
-
-            let insertion_mode = if self.id == 0 {
-                CorpusInsertionMode::Live
-            } else {
-                CorpusInsertionMode::MemoryOnly
-            };
-            let len_before = self.in_memory_corpus.len();
-            let _ = self.push_observed_sequence(seq, insertion_mode);
-            if self.in_memory_corpus.len() > len_before {
-                debug!(target: "corpus", test = %func.name, "seeded corpus sequence from test trace");
-                added += 1;
-            }
-        }
-
-        Ok(added)
-    }
-
-    fn push_observed_sequence(
-        &mut self,
-        tx_seq: Vec<BasicTxDetails>,
-        insertion_mode: CorpusInsertionMode,
-    ) -> Option<CampaignCorpusEntry> {
-        if !self.config.is_coverage_guided() || tx_seq.is_empty() {
-            return None;
-        }
-
-        let corpus = CorpusEntry::new(tx_seq);
-
-        self.insert_corpus_entry(corpus, insertion_mode, false)
-    }
-
     /// Returns the next call to be used in call sequence.
     /// If coverage guided fuzzing is not configured or if previous input was discarded then this is
     /// a new tx from strategy.
     /// If running with coverage guided fuzzing it returns a new call only when sequence
     /// does not have enough entries, or randomly. Otherwise, returns the next call from initial
     /// sequence.
+    #[allow(clippy::too_many_arguments)]
     pub fn generate_next_input(
         &mut self,
         test_runner: &mut TestRunner,
+        fuzz_state: &InvariantFuzzState,
+        targeted_contracts: &FuzzRunIdentifiedContracts,
+        dictionary_weight: u32,
         sequence: &[BasicTxDetails],
         discarded: bool,
         depth: usize,
@@ -1954,7 +2247,14 @@ impl WorkerCorpus {
         // Early return with new input if corpus dir / coverage guided fuzzing not configured or if
         // call was discarded.
         if self.config.corpus_dir.is_none() || discarded {
-            return self.new_tx(test_runner);
+            let (tx, used_whole_call) = self.new_invariant_tx(
+                test_runner,
+                fuzz_state,
+                targeted_contracts,
+                dictionary_weight,
+            )?;
+            self.next_whole_call_is_donor = used_whole_call;
+            return Ok(tx);
         }
 
         // When running with coverage guided fuzzing enabled then generate new sequence if initial
@@ -1962,10 +2262,18 @@ impl WorkerCorpus {
         let fresh_weight = self.config.corpus_random_sequence_weight.min(100);
         let generate_fresh = fresh_weight > 0 && test_runner.rng().random_ratio(fresh_weight, 100);
         if depth >= sequence.len() || generate_fresh {
-            return self.new_tx(test_runner);
+            let (tx, used_whole_call) = self.new_invariant_tx(
+                test_runner,
+                fuzz_state,
+                targeted_contracts,
+                dictionary_weight,
+            )?;
+            self.next_whole_call_is_donor = used_whole_call;
+            return Ok(tx);
         }
 
         // Continue with the next call initial sequence.
+        self.next_whole_call_is_donor = self.whole_call_plan.get(depth).copied().unwrap_or(false);
         Ok(sequence[depth].clone())
     }
 
@@ -2230,6 +2538,8 @@ impl WorkerCorpus {
                 edge_indices: &mut self.edge_indices,
                 sancov_history_map: &mut self.sancov_history_map,
                 metrics: Some(&mut self.metrics),
+                // Invariant donors are worker-local; this synchronization path is stateless.
+                whole_calls: None,
             };
             let ReplayOutcome {
                 keep_entry, new_coverage, new_edge, edges_covered, cmp_seq, ..
@@ -2494,43 +2804,6 @@ impl WorkerCorpus {
     }
 }
 
-#[derive(Clone, Copy)]
-enum ObservedCallDepth {
-    DirectOnly,
-    All,
-}
-
-fn sequence_from_observed(
-    observed: &[ObservedCall],
-    targets: &TargetedContracts,
-    depth: ObservedCallDepth,
-    first_delay: Option<(Option<U256>, Option<U256>)>,
-) -> Vec<BasicTxDetails> {
-    let mut first_delay = first_delay;
-    observed
-        .iter()
-        .filter(|call| matches!(depth, ObservedCallDepth::All) || call.depth == 1)
-        .filter_map(|call| {
-            let mut tx = BasicTxDetails {
-                warp: None,
-                roll: None,
-                sender: call.caller,
-                call_details: CallDetails {
-                    target: call.target,
-                    calldata: call.calldata.clone(),
-                    value: call.value,
-                },
-            };
-            targets.can_replay(&tx).then(|| {
-                let (warp, roll) = first_delay.take().unwrap_or((None, None));
-                tx.warp = warp;
-                tx.roll = roll;
-                tx
-            })
-        })
-        .collect()
-}
-
 fn prepare_campaign_output_dir(config: &FuzzCorpusConfig) {
     let Some(root) = &config.corpus_dir else {
         return;
@@ -2599,13 +2872,27 @@ fn unique_corpus_entries<'a>(
     replay_dirs: &'a [PathBuf],
     seen_entries: &'a mut HashSet<Uuid>,
 ) -> impl Iterator<Item = CorpusDirEntry> + 'a {
-    replay_dirs.iter().flat_map(|replay_dir| read_corpus_dir(replay_dir)).filter(|entry| {
-        let is_new = seen_entries.insert(entry.uuid);
-        if !is_new {
-            trace!(target: "corpus", "skipping duplicate corpus entry {}", entry.uuid);
-        }
-        is_new
-    })
+    replay_dirs
+        .iter()
+        .flat_map(|replay_dir| {
+            let mut entries = read_corpus_dir(replay_dir).collect::<Vec<_>>();
+            // Filesystem iteration order is unspecified. Stable startup replay keeps coverage
+            // attribution, corpus sharding, and whole-call donor insertion reproducible.
+            entries.sort_unstable_by(|left, right| {
+                left.timestamp
+                    .cmp(&right.timestamp)
+                    .then_with(|| left.uuid.cmp(&right.uuid))
+                    .then_with(|| left.path.cmp(&right.path))
+            });
+            entries
+        })
+        .filter(|entry| {
+            let is_new = seen_entries.insert(entry.uuid);
+            if !is_new {
+                trace!(target: "corpus", "skipping duplicate corpus entry {}", entry.uuid);
+            }
+            is_new
+        })
 }
 
 #[cfg(test)]
@@ -2613,6 +2900,7 @@ mod tests {
     use super::*;
     use crate::inspectors::{EdgeCovHit, EdgeCoverage, EdgeKey};
     use alloy_dyn_abi::DynSolValue;
+    use alloy_primitives::{U256, keccak256};
     use foundry_config::FuzzDictionaryConfig;
     use proptest::prelude::Just;
     use revm::database::{CacheDB, EmptyDB};
@@ -2805,8 +3093,12 @@ mod tests {
         let mut manager =
             worker_corpus_with_config(0, config, generated.clone(), WorkerCorpusSeed::default());
         let mut runner = TestRunner::default();
+        let fuzz_state = empty_fuzz_state().into_invariant();
+        let targeted_contracts = empty_targeted_contracts();
 
-        let input = manager.generate_next_input(&mut runner, &[], false, 0).unwrap();
+        let input = manager
+            .generate_next_input(&mut runner, &fuzz_state, &targeted_contracts, 0, &[], false, 0)
+            .unwrap();
 
         assert_eq!(input.call_details.calldata, generated.call_details.calldata);
     }
@@ -2874,7 +3166,8 @@ mod tests {
             [function.selector()],
         );
 
-        let sequence = manager.new_inputs(&mut runner, &fuzz_state, &targeted_contracts).unwrap();
+        let sequence =
+            manager.new_inputs(&mut runner, &fuzz_state, &targeted_contracts, 0).unwrap();
 
         assert_eq!(sequence.len(), 1);
         assert_eq!(sequence[0].call_details.calldata, original.call_details.calldata);
@@ -2898,6 +3191,24 @@ mod tests {
 
         let mut targets = TargetedContracts::new();
         targets.inner.insert(target, contract);
+        FuzzRunIdentifiedContracts::new(targets, false)
+    }
+
+    fn targeted_contracts_with_same_functions(
+        addresses: &[Address],
+        functions: &[Function],
+    ) -> FuzzRunIdentifiedContracts {
+        use alloy_json_abi::JsonAbi;
+        use foundry_evm_fuzz::invariant::TargetedContract;
+
+        let mut targets = TargetedContracts::new();
+        for &address in addresses {
+            let mut abi = JsonAbi::new();
+            for function in functions {
+                abi.functions.entry(function.name.clone()).or_default().push(function.clone());
+            }
+            targets.inner.insert(address, TargetedContract::new("Target".to_string(), abi));
+        }
         FuzzRunIdentifiedContracts::new(targets, false)
     }
 
@@ -2972,6 +3283,7 @@ mod tests {
                 &mut runner,
                 &empty_fuzz_state().into_invariant(),
                 &empty_targeted_contracts(),
+                0,
             )
             .unwrap();
 
@@ -3014,6 +3326,7 @@ mod tests {
                 &mut runner,
                 &empty_fuzz_state().into_invariant(),
                 &empty_targeted_contracts(),
+                0,
             )
             .unwrap();
 
@@ -3053,6 +3366,7 @@ mod tests {
                 &mut runner,
                 &empty_fuzz_state().into_invariant(),
                 &empty_targeted_contracts(),
+                0,
             )
             .unwrap();
 
@@ -3095,6 +3409,7 @@ mod tests {
                 &mut runner,
                 &empty_fuzz_state().into_invariant(),
                 &empty_targeted_contracts(),
+                0,
             )
             .unwrap();
 
@@ -3137,6 +3452,7 @@ mod tests {
                 &mut runner,
                 &empty_fuzz_state().into_invariant(),
                 &empty_targeted_contracts(),
+                0,
             )
             .unwrap();
 
@@ -3284,6 +3600,35 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].uuid, corpus.uuid);
+        assert!(entries[0].path.starts_with(worker0_corpus));
+    }
+
+    #[test]
+    fn persisted_corpus_replay_order_is_deterministic() {
+        let corpus_dir = temp_corpus_dir();
+        let mut later = CorpusEntry::new(vec![basic_tx()]);
+        later.uuid = Uuid::from_u128(1);
+        later.timestamp = 20;
+        let mut early_high_uuid = CorpusEntry::new(vec![basic_tx()]);
+        early_high_uuid.uuid = Uuid::from_u128(3);
+        early_high_uuid.timestamp = 10;
+        let mut early_low_uuid = CorpusEntry::new(vec![basic_tx()]);
+        early_low_uuid.uuid = Uuid::from_u128(2);
+        early_low_uuid.timestamp = 10;
+
+        later.write_to_disk_in(&corpus_dir, false).unwrap();
+        early_high_uuid.write_to_disk_in(&corpus_dir, false).unwrap();
+        early_low_uuid.write_to_disk_in(&corpus_dir, false).unwrap();
+
+        let mut seen = HashSet::new();
+        let replay_order = unique_corpus_entries(std::slice::from_ref(&corpus_dir), &mut seen)
+            .map(|entry| (entry.timestamp, entry.uuid))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            replay_order,
+            vec![(10, early_low_uuid.uuid), (10, early_high_uuid.uuid), (20, later.uuid),]
+        );
     }
 
     #[test]
@@ -3408,11 +3753,13 @@ mod tests {
                 cumulative_features_seen: 11,
                 corpus_count: 1,
                 favored_items: 0,
+                ..Default::default()
             },
             failed_replays: 13,
             optimization_best_value: Some(I256::try_from(17).unwrap()),
             optimization_best_sequence: tx_seq,
             last_new_edge_at: None,
+            ..Default::default()
         };
 
         let manager =
@@ -3446,6 +3793,14 @@ mod tests {
         let entry_ids = entries.iter().map(|entry| entry.uuid).collect::<Vec<_>>();
         let top_rated =
             HashMap::from([(0, (entry_ids[0], 1)), (1, (entry_ids[1], 1)), (2, (entry_ids[2], 1))]);
+        let whole_call_signature = WholeCallSignature(B256::ZERO);
+        let whole_call_calldata = Bytes::from(vec![1, 2, 3, 4]);
+        let mut whole_calls = WholeCallDictionary::default();
+        assert!(whole_calls.insert(
+            whole_call_signature,
+            Address::from([0x42; 20]),
+            whole_call_calldata.clone(),
+        ));
         let seed = WorkerCorpusSeed {
             in_memory_corpus: entries,
             disk_corpus: CachedDiskCorpus::default(),
@@ -3458,7 +3813,9 @@ mod tests {
                 cumulative_features_seen: 11,
                 corpus_count: 10,
                 favored_items: 3,
+                ..Default::default()
             },
+            whole_calls,
             failed_replays: 13,
             optimization_best_value: Some(I256::try_from(17).unwrap()),
             optimization_best_sequence: vec![basic_tx()],
@@ -3509,6 +3866,11 @@ mod tests {
         assert!(shards.iter().all(|shard| shard.sancov_history_map == seed.sancov_history_map));
         assert!(shards.iter().all(|shard| shard.metrics.cumulative_edges_seen == 7));
         assert!(shards.iter().all(|shard| shard.metrics.cumulative_features_seen == 11));
+        assert!(shards.iter().all(|shard| {
+            shard.whole_calls.by_signature.get(&whole_call_signature).is_some_and(|calls| {
+                calls.len() == 1 && calls[0].calldata.as_ref() == whole_call_calldata.as_ref()
+            })
+        }));
     }
 
     #[test]
@@ -3608,262 +3970,314 @@ mod tests {
     }
 
     #[test]
-    fn hoist_observed_calls_bundles_replayable_subcalls_into_one_corpus_entry() {
+    fn whole_call_admission_requires_coverage_and_stays_out_of_corpus() {
         let target = Address::from([0x42; 20]);
-        let other = Address::from([0x43; 20]);
-        let sender = Address::from([0xaa; 20]);
-        let observed_caller = Address::from([0xbb; 20]);
         let foo = Function::parse("foo(uint256)").unwrap();
-        let bar = Function::parse("bar()").unwrap();
-        let foo_selector = foo.selector();
-        let bar_selector = bar.selector();
-        let targeted_contracts = targeted_contracts_with_selective_functions(
-            target,
-            vec![foo, bar],
-            [foo_selector, bar_selector],
-        );
-
-        let mut foo_calldata = vec![0u8; 36];
-        foo_calldata[..4].copy_from_slice(&foo_selector[..]);
-        let bar_calldata = bar_selector.to_vec();
-        let mut unknown_selector = vec![0u8; 36];
-        unknown_selector[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
-        let value = U256::from(1);
-
-        let observed = vec![
-            ObservedCall {
-                depth: 1,
-                caller: observed_caller,
-                target: other,
-                calldata: Bytes::from(foo_calldata.clone()),
-                value: Some(value),
-            },
-            ObservedCall {
-                depth: 1,
-                caller: observed_caller,
-                target,
-                calldata: Bytes::from(foo_calldata),
-                value: None,
-            },
-            ObservedCall {
-                depth: 2,
-                caller: observed_caller,
-                target,
-                calldata: Bytes::from(bar_calldata),
-                value: None,
-            },
-            ObservedCall {
-                depth: 1,
-                caller: observed_caller,
-                target,
-                calldata: Bytes::from(unknown_selector),
-                value: None,
-            },
-            ObservedCall {
-                depth: 1,
-                caller: observed_caller,
-                target,
-                calldata: Bytes::from(vec![0u8; 3]),
-                value: None,
-            },
-        ];
-        let parent_tx = BasicTxDetails {
-            warp: Some(U256::from(123)),
-            roll: Some(U256::from(456)),
-            sender,
-            call_details: CallDetails {
-                target: Address::from([0x99; 20]),
-                calldata: Bytes::new(),
-                value: None,
-            },
-        };
-        let mut manager = empty_worker_corpus(0, temp_corpus_dir());
-
-        let campaign_entry = manager.hoist_observed_calls(
-            &observed,
-            &parent_tx,
-            &targeted_contracts,
-            CorpusInsertionMode::Live,
-        );
-
-        assert!(campaign_entry.is_none());
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(manager.metrics.corpus_count, 1);
-
-        let entry = manager.in_memory_corpus.last().unwrap();
-        assert_eq!(entry.tx_seq.len(), 2);
-        let tx = &entry.tx_seq[0];
-        assert_eq!(tx.warp, parent_tx.warp);
-        assert_eq!(tx.roll, parent_tx.roll);
-        assert_eq!(tx.sender, observed_caller);
-        assert_eq!(tx.call_details.target, target);
-        assert_eq!(&tx.call_details.calldata[..4], &foo_selector[..]);
-        assert_eq!(tx.call_details.value, None);
-
-        let tx = &entry.tx_seq[1];
-        assert_eq!(tx.warp, None);
-        assert_eq!(tx.roll, None);
-        assert_eq!(tx.sender, observed_caller);
-        assert_eq!(tx.call_details.target, target);
-        assert_eq!(&tx.call_details.calldata[..4], &bar_selector[..]);
-        assert_eq!(tx.call_details.value, None);
-    }
-
-    #[test]
-    fn hoist_observed_calls_persists_campaign_entry_immediately() {
-        let target = Address::from([0x42; 20]);
-        let foo = Function::parse("foo()").unwrap();
-        let selector = foo.selector();
-        let targeted_contracts = targeted_contracts_with_selective_functions(target, vec![foo], []);
-        let observed = vec![ObservedCall {
-            depth: 1,
-            caller: Address::from([0xaa; 20]),
-            target,
-            calldata: Bytes::from(selector.to_vec()),
-            value: None,
-        }];
+        let zero_arg = Function::parse("zeroArg()").unwrap();
+        let other = Function::parse("other(uint256)").unwrap();
+        let tx = tx_for_function(target, &foo, &[DynSolValue::Uint(U256::from(7), 256)]);
+        let mut malformed = tx.clone();
+        malformed.call_details.calldata = foo.selector().to_vec().into();
+        let mut off_target = tx.clone();
+        off_target.call_details.target = Address::from([0x43; 20]);
+        let zero_arg_tx = tx_for_function(target, &zero_arg, &[]);
+        let targeted_contracts =
+            targeted_contracts_with_selective_functions(target, vec![foo.clone(), zero_arg], []);
+        let other_selector = other.selector();
+        let filtered_contracts =
+            targeted_contracts_with_selective_functions(target, vec![foo, other], [other_selector]);
         let corpus_root = temp_corpus_dir();
         let worker_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        let campaign_entry = manager.hoist_observed_calls(
-            &observed,
-            &basic_tx(),
-            &targeted_contracts,
-            CorpusInsertionMode::Deferred,
-        );
-
-        assert!(campaign_entry.is_none());
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker_corpus_dir).count(), 1);
-    }
-
-    #[test]
-    fn hoist_observed_calls_skips_empty_or_non_coverage_guided_inputs() {
-        let target = Address::from([0x42; 20]);
-        let foo = Function::parse("foo()").unwrap();
-        let selector = foo.selector();
-        let targeted_contracts = targeted_contracts_with_selective_functions(target, vec![foo], []);
-        let observed = vec![ObservedCall {
-            depth: 1,
-            caller: Address::from([0xaa; 20]),
-            target,
-            calldata: Bytes::from(selector.to_vec()),
-            value: None,
-        }];
-
         let mut no_corpus_config = corpus_config(temp_corpus_dir());
         no_corpus_config.corpus_dir = None;
-        let mut manager = WorkerCorpus::from_seed(
-            0,
-            no_corpus_config,
-            Just(basic_tx()).boxed(),
-            WorkerCorpusSeed::default(),
-        )
-        .unwrap();
-        assert!(
-            manager
-                .hoist_observed_calls(
-                    &observed,
-                    &basic_tx(),
-                    &targeted_contracts,
-                    CorpusInsertionMode::Live
-                )
-                .is_none()
-        );
-        assert!(manager.in_memory_corpus.is_empty());
+        let mut no_corpus =
+            worker_corpus_with_config(0, no_corpus_config, tx.clone(), WorkerCorpusSeed::default());
 
-        let mut manager = empty_worker_corpus(0, temp_corpus_dir());
-        assert!(
-            manager
-                .hoist_observed_calls(
-                    &[],
-                    &basic_tx(),
-                    &targeted_contracts,
-                    CorpusInsertionMode::Live
-                )
-                .is_none()
+        assert!(!no_corpus.admit_whole_call(&tx, true, &targeted_contracts));
+        assert!(!manager.admit_whole_call(&tx, false, &targeted_contracts));
+        assert!(!manager.admit_whole_call(&tx, true, &filtered_contracts));
+        assert!(!manager.admit_whole_call(&malformed, true, &targeted_contracts));
+        assert!(!manager.admit_whole_call(&off_target, true, &targeted_contracts));
+        assert!(!manager.admit_whole_call(&zero_arg_tx, true, &targeted_contracts));
+        assert_eq!(manager.whole_calls.len, 0);
+        assert!(manager.admit_whole_call(&tx, true, &targeted_contracts));
+        assert!(!manager.admit_whole_call(&tx, true, &targeted_contracts));
+        assert_eq!(manager.whole_calls.len, 1);
+        assert_eq!(manager.metrics.whole_call_dictionary_entries, 1);
+        assert!(manager.in_memory_corpus.is_empty());
+        assert_eq!(manager.metrics.corpus_count, 0);
+        assert_eq!(read_corpus_dir(&worker_corpus_dir).count(), 0);
+    }
+
+    #[test]
+    fn discarded_magic_assume_coverage_is_not_a_whole_call_winner() {
+        assert!(is_whole_call_coverage_winner(true, false));
+        assert!(!is_whole_call_coverage_winner(true, true));
+        assert!(!is_whole_call_coverage_winner(false, false));
+    }
+
+    #[test]
+    fn whole_call_dictionary_is_bounded_by_entries_and_bytes() {
+        let mut dictionary = WholeCallDictionary::default();
+        let first_signature = WholeCallSignature(B256::ZERO);
+
+        for index in 0..=WHOLE_CALL_DICTIONARY_MAX_LEN {
+            let signature = WholeCallSignature(U256::from(index).into());
+            assert!(dictionary.insert(
+                signature,
+                Address::from([index as u8; 20]),
+                Bytes::from(index.to_be_bytes().to_vec()),
+            ));
+        }
+        assert_eq!(dictionary.len, WHOLE_CALL_DICTIONARY_MAX_LEN);
+        assert_eq!(
+            dictionary.calldata_bytes,
+            dictionary.insertion_order.iter().map(|(_, calldata)| calldata.len()).sum::<usize>()
         );
+        assert!(!dictionary.by_signature.contains_key(&first_signature));
+
+        let oversized = Bytes::from(vec![0; WHOLE_CALL_DICTIONARY_MAX_BYTES + 1]);
+        assert!(!dictionary.insert(WholeCallSignature(B256::ZERO), Address::ZERO, oversized));
+
+        let mut dictionary = WholeCallDictionary::default();
+        let chunk_len = WHOLE_CALL_DICTIONARY_MAX_BYTES / 2 + 1;
+        let second_signature = WholeCallSignature(U256::from(1).into());
+        assert!(
+            dictionary.insert(first_signature, Address::ZERO, Bytes::from(vec![1; chunk_len]),)
+        );
+        assert!(dictionary.insert(
+            second_signature,
+            Address::ZERO,
+            Bytes::from(vec![2; chunk_len]),
+        ));
+        assert_eq!(dictionary.len, 1);
+        assert_eq!(dictionary.calldata_bytes, chunk_len);
+        assert!(!dictionary.by_signature.contains_key(&first_signature));
+        assert!(dictionary.by_signature.contains_key(&second_signature));
+    }
+
+    #[test]
+    fn whole_call_dictionary_separates_selector_collisions() {
+        let mut dictionary = WholeCallDictionary::default();
+        let first_function = Function::parse("burn(uint256)").unwrap();
+        let second_function = Function::parse("collate_propagate_storage(bytes16)").unwrap();
+        assert_eq!(first_function.selector(), second_function.selector());
+        let first = WholeCallSignature(keccak256(first_function.signature()));
+        let second = WholeCallSignature(keccak256(second_function.signature()));
+        assert_ne!(first, second);
+        assert!(dictionary.insert(first, Address::ZERO, Bytes::from(vec![1])));
+        assert!(dictionary.insert(second, Address::ZERO, Bytes::from(vec![2])));
+        let mut runner = TestRunner::default();
+
+        assert_eq!(dictionary.sample(first, runner.rng()).unwrap().calldata, Bytes::from(vec![1]));
+        assert_eq!(dictionary.sample(second, runner.rng()).unwrap().calldata, Bytes::from(vec![2]));
+    }
+
+    #[test]
+    fn cached_whole_call_signatures_separate_cross_target_selector_collisions() {
+        use alloy_json_abi::JsonAbi;
+        use foundry_evm_fuzz::invariant::TargetedContract;
+
+        let first_target = Address::from([0x41; 20]);
+        let second_target = Address::from([0x42; 20]);
+        let first_function = Function::parse("burn(uint256)").unwrap();
+        let second_function = Function::parse("collate_propagate_storage(bytes16)").unwrap();
+        assert_eq!(first_function.selector(), second_function.selector());
+
+        let mut targets = TargetedContracts::new();
+        for (target, function) in
+            [(first_target, first_function.clone()), (second_target, second_function.clone())]
+        {
+            let mut abi = JsonAbi::new();
+            abi.functions.entry(function.name.clone()).or_default().push(function);
+            targets.insert(target, TargetedContract::new("Target".to_string(), abi));
+        }
+        let first_tx = tx_for_function(
+            first_target,
+            &first_function,
+            &[DynSolValue::Uint(U256::from(1), 256)],
+        );
+        let second_tx = tx_for_function(
+            second_target,
+            &second_function,
+            &[DynSolValue::FixedBytes(B256::ZERO, 16)],
+        );
+
+        let (_, first_signature) = fuzzed_function_for_tx(&first_tx, &targets).unwrap();
+        let (_, second_signature) = fuzzed_function_for_tx(&second_tx, &targets).unwrap();
+
+        assert_ne!(first_signature, second_signature);
+    }
+
+    #[test]
+    fn whole_call_dictionary_deduplicates_identical_calls_across_targets() {
+        let mut dictionary = WholeCallDictionary::default();
+        let signature = WholeCallSignature(B256::ZERO);
+        let calldata = Bytes::from(vec![1, 2, 3, 4]);
+        let first_target = Address::from([0x41; 20]);
+        let second_target = Address::from([0x42; 20]);
+
+        assert!(dictionary.insert(signature, first_target, calldata.clone()));
+        assert!(!dictionary.insert(signature, second_target, calldata.clone()));
+        assert_eq!(dictionary.len, 1);
+
+        let mut runner = TestRunner::default();
+        let retained = dictionary.sample(signature, runner.rng()).unwrap();
+        assert_eq!(retained.source_target, None);
+        assert_eq!(retained.calldata, calldata);
+    }
+
+    #[test]
+    fn fresh_generation_retargets_whole_call_and_attributes_coverage() {
+        let source_target = Address::from([0x41; 20]);
+        let destination_target = Address::from([0x42; 20]);
+        let function = Function::parse("target(bool,bool)").unwrap();
+        let source = tx_for_function(
+            source_target,
+            &function,
+            &[DynSolValue::Bool(true), DynSolValue::Bool(true)],
+        );
+        let mut destination = tx_for_function(
+            destination_target,
+            &function,
+            &[DynSolValue::Bool(false), DynSolValue::Bool(false)],
+        );
+        destination.warp = Some(U256::from(11));
+        destination.roll = Some(U256::from(12));
+        destination.sender = Address::from([0xaa; 20]);
+        destination.call_details.value = Some(U256::from(13));
+        let targeted_contracts = targeted_contracts_with_same_functions(
+            &[source_target, destination_target],
+            std::slice::from_ref(&function),
+        );
+        let mut config = corpus_config(temp_corpus_dir());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_abi: 1,
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
+            mutation_weight_insert: 0,
+            mutation_weight_delete: 0,
+            mutation_weight_swap: 0,
+        };
+        let mut manager =
+            worker_corpus_with_config(0, config, destination, WorkerCorpusSeed::default());
+        assert!(manager.admit_whole_call(&source, true, &targeted_contracts));
+
+        let fuzz_state = empty_fuzz_state().into_invariant();
+        let mut runner = TestRunner::default();
+        let emitted = (0..64)
+            .find_map(|_| {
+                let sequence =
+                    manager.new_inputs(&mut runner, &fuzz_state, &targeted_contracts, 100).unwrap();
+                (manager.metrics.whole_call_mutations > 0)
+                    .then(|| sequence.into_iter().next().unwrap())
+            })
+            .expect("whole-call donor should be selected");
+        let decoded = function.abi_decode_input(&emitted.call_details.calldata[4..]).unwrap();
+
+        assert_eq!(decoded.iter().filter(|value| value.as_bool() == Some(true)).count(), 1);
+        assert_eq!(emitted.warp, Some(U256::from(11)));
+        assert_eq!(emitted.roll, Some(U256::from(12)));
+        assert_eq!(emitted.sender, Address::from([0xaa; 20]));
+        assert_eq!(emitted.call_details.target, destination_target);
+        assert_eq!(emitted.call_details.value, Some(U256::from(13)));
+        assert_eq!(manager.metrics.whole_call_attempts, 1);
+        assert_eq!(manager.metrics.whole_call_mutations, 1);
+        assert_eq!(manager.metrics.whole_call_cross_target_mutations, 1);
+        assert_eq!(manager.metrics.whole_call_coverage_wins, 0);
+
+        manager.record_whole_call_result(true);
+        assert_eq!(manager.metrics.whole_call_coverage_wins, 1);
+        assert!(manager.admit_whole_call(&emitted, true, &targeted_contracts));
+        assert_eq!(manager.whole_calls.len, 2);
         assert!(manager.in_memory_corpus.is_empty());
     }
 
     #[test]
-    fn sequence_from_observed_keeps_only_direct_replayable_calls() {
+    fn whole_call_generation_honors_dictionary_weight_and_tracks_sequence_position() {
         let target = Address::from([0x42; 20]);
-        let other = Address::from([0x43; 20]);
-        let sender = Address::from([0xaa; 20]);
-        let nested_caller = Address::from([0xbb; 20]);
-        let foo = Function::parse("foo(uint256)").unwrap();
-        let bar = Function::parse("bar()").unwrap();
-        let foo_selector = foo.selector();
-        let bar_selector = bar.selector();
-        let targeted_contracts =
-            targeted_contracts_with_selective_functions(target, vec![foo, bar], [foo_selector]);
-        let targets = targeted_contracts.targets();
+        let function = Function::parse("target(bool,bool)").unwrap();
+        let donor =
+            tx_for_function(target, &function, &[DynSolValue::Bool(true), DynSolValue::Bool(true)]);
+        let generated = tx_for_function(
+            target,
+            &function,
+            &[DynSolValue::Bool(false), DynSolValue::Bool(false)],
+        );
+        let targeted_contracts = targeted_contracts_with_same_functions(
+            std::slice::from_ref(&target),
+            std::slice::from_ref(&function),
+        );
+        let mut config = corpus_config(temp_corpus_dir());
+        config.corpus_random_sequence_weight = 0;
+        let mut manager =
+            worker_corpus_with_config(0, config, generated.clone(), WorkerCorpusSeed::default());
+        assert!(manager.admit_whole_call(&donor, true, &targeted_contracts));
 
-        let mut foo_calldata = vec![0u8; 36];
-        foo_calldata[..4].copy_from_slice(&foo_selector[..]);
-        let bar_calldata = bar_selector.to_vec();
-        let observed = vec![
-            ObservedCall {
-                depth: 1,
-                caller: sender,
-                target,
-                calldata: Bytes::from(foo_calldata.clone()),
-                value: None,
-            },
-            ObservedCall {
-                depth: 2,
-                caller: nested_caller,
-                target,
-                calldata: Bytes::from(foo_calldata),
-                value: None,
-            },
-            ObservedCall {
-                depth: 1,
-                caller: sender,
-                target,
-                calldata: Bytes::from(bar_calldata),
-                value: None,
-            },
-            ObservedCall {
-                depth: 1,
-                caller: sender,
-                target: other,
-                calldata: Bytes::from(foo_selector.to_vec()),
-                value: None,
-            },
-        ];
+        let fuzz_state = empty_fuzz_state().into_invariant();
+        let mut runner = TestRunner::default();
+        for _ in 0..32 {
+            let _ = manager.new_inputs(&mut runner, &fuzz_state, &targeted_contracts, 0).unwrap();
+        }
+        assert_eq!(manager.metrics.whole_call_attempts, 0);
+        assert_eq!(manager.metrics.whole_call_mutations, 0);
 
-        let seq = sequence_from_observed(&observed, &targets, ObservedCallDepth::DirectOnly, None);
-
-        assert_eq!(seq.len(), 1);
-        assert_eq!(seq[0].sender, sender);
-        assert_eq!(seq[0].call_details.target, target);
-        assert_eq!(&seq[0].call_details.calldata[..4], &foo_selector[..]);
+        // Provenance is positional, so an identical ordinary call before a donor call cannot
+        // consume the donor's coverage attribution.
+        manager.remember_whole_call_plan(vec![false, true]);
+        manager.record_whole_call_result(true);
+        assert_eq!(manager.metrics.whole_call_coverage_wins, 0);
+        let sequence = vec![generated.clone(), generated];
+        let _ = manager
+            .generate_next_input(
+                &mut runner,
+                &fuzz_state,
+                &targeted_contracts,
+                100,
+                &sequence,
+                false,
+                1,
+            )
+            .unwrap();
+        manager.record_whole_call_result(true);
+        assert_eq!(manager.metrics.whole_call_coverage_wins, 1);
     }
 
     #[test]
-    fn push_observed_sequence_live_persists_and_memory_only_does_not() {
-        let corpus_root = temp_corpus_dir();
-        let worker0_corpus_dir = corpus_root.join("worker0").join(CORPUS_DIR);
-        let mut manager = empty_worker_corpus(0, corpus_root.clone());
+    fn whole_call_admission_is_disabled_without_abi_mutation() {
+        let target = Address::from([0x42; 20]);
+        let function = Function::parse("target(uint256)").unwrap();
+        let tx = tx_for_function(target, &function, &[DynSolValue::Uint(U256::from(42), 256)]);
+        let targeted_contracts =
+            targeted_contracts_with_selective_functions(target, vec![function], []);
+        let mut config = corpus_config(temp_corpus_dir());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_repeat: 1,
+            mutation_weight_splice: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
+            mutation_weight_insert: 0,
+            mutation_weight_delete: 0,
+            mutation_weight_swap: 0,
+        };
+        let mut manager =
+            worker_corpus_with_config(0, config, tx.clone(), WorkerCorpusSeed::default());
 
-        assert!(
-            manager.push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::Live).is_none()
-        );
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker0_corpus_dir).count(), 1);
-
-        let mut manager = empty_worker_corpus(1, corpus_root.clone());
-        let worker1_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
-        assert!(
-            manager
-                .push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::MemoryOnly)
-                .is_none()
-        );
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker1_corpus_dir).count(), 0);
+        assert!(!manager.admit_whole_call(&tx, true, &targeted_contracts));
+        assert!(manager.whole_calls.is_empty());
     }
 
     #[test]
@@ -3953,7 +4367,6 @@ mod tests {
     fn invariant_insertions_do_not_disable_culling() {
         let mut deferred = empty_worker_corpus(1, temp_corpus_dir());
         let mut live = empty_worker_corpus(0, temp_corpus_dir());
-        let mut memory_only = empty_worker_corpus(1, temp_corpus_dir());
 
         for idx in 0..32 {
             let tx = basic_tx_with_calldata(vec![idx]);
@@ -3965,10 +4378,9 @@ mod tests {
                 None,
             );
             live.process_inputs(std::slice::from_ref(&tx), &[], true, vec![1], None);
-            let _ = memory_only.push_observed_sequence(vec![tx], CorpusInsertionMode::MemoryOnly);
         }
 
-        for manager in [&deferred, &live, &memory_only] {
+        for manager in [&deferred, &live] {
             assert_eq!(manager.in_memory_corpus.len(), 1);
             assert_eq!(manager.metrics.corpus_count, manager.in_memory_corpus.len());
             assert!(manager.pending_sync_uuids.is_empty());

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -2,8 +2,9 @@ use crate::{
     executors::{
         DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, RawCallResult,
         corpus::{
-            CorpusInsertionMode, DynamicTargetCtx, ReplayTarget, WorkerCorpus, WorkerCorpusSeed,
-            finalize_corpus_after_campaign, prepare_corpus_for_campaign,
+            DynamicTargetCtx, ReplayTarget, WorkerCorpus, WorkerCorpusSeed,
+            finalize_corpus_after_campaign, is_whole_call_coverage_winner,
+            prepare_corpus_for_campaign,
         },
     },
     inspectors::Fuzzer,
@@ -30,7 +31,7 @@ use foundry_evm_core::{
     precompiles::PRECOMPILES,
 };
 use foundry_evm_fuzz::{
-    BasicTxDetails, FuzzCase, FuzzFixtures, ObservedCall,
+    BasicTxDetails, FuzzCase, FuzzFixtures,
     invariant::{
         ArtifactFilters, FuzzRunIdentifiedContracts, InvariantContract, InvariantSettings,
         RandomCallGenerator, SenderFilters, TargetedContract, TargetedContracts,
@@ -376,6 +377,7 @@ fn focused_targeted_contracts(
     let (address, function) = candidates[candidate_index].clone();
     let mut contract = targeted_contracts.get(&address)?.clone();
     contract.targeted_functions = vec![function];
+    contract.rebuild_function_lookups();
 
     let mut focused = TargetedContracts::new();
     focused.insert(address, contract);
@@ -1164,12 +1166,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             let failures_revision = failures_checkpoint.revision();
             let mut stop_after_run = false;
             let mut run_cancelled = false;
-            let mut observed_call_entries = Vec::<(Vec<ObservedCall>, BasicTxDetails)>::new();
 
             let initial_seq = corpus_manager.new_inputs(
                 &mut invariant_test.test_data.branch_runner,
                 &invariant_test.fuzz_state,
                 &invariant_test.targeted_contracts,
+                config.dictionary.dictionary_weight,
             )?;
 
             let run_depth =
@@ -1265,13 +1267,14 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 if new_call_coverage {
                     current_run.new_coverage = true;
                 }
-                let observed_calls = std::mem::take(&mut call_result.observed_calls);
-                if new_call_coverage && !observed_calls.is_empty() {
-                    observed_call_entries.push((
-                        observed_calls,
-                        current_run.inputs.last().expect("checked above").clone(),
-                    ));
-                }
+                let current_input = current_run.inputs.last().expect("checked above");
+                let coverage_winning = is_whole_call_coverage_winner(new_call_coverage, discarded);
+                corpus_manager.record_whole_call_result(coverage_winning);
+                corpus_manager.admit_whole_call(
+                    current_input,
+                    coverage_winning,
+                    &invariant_test.targeted_contracts,
+                );
 
                 if discarded {
                     current_run.inputs.pop();
@@ -1464,6 +1467,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
                 current_run.inputs.push(corpus_manager.generate_next_input(
                     &mut invariant_test.test_data.branch_runner,
+                    &invariant_test.fuzz_state,
+                    &invariant_test.targeted_contracts,
+                    config.dictionary.dictionary_weight,
                     &initial_seq,
                     discarded,
                     current_run.depth as usize,
@@ -1525,22 +1531,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 > failures_checkpoint.handler_count()
             {
                 campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
-            }
-
-            let insertion_mode = if corpus_persistence.is_deferred() {
-                CorpusInsertionMode::Deferred
-            } else {
-                CorpusInsertionMode::Live
-            };
-            for (observed_calls, parent_tx) in observed_call_entries {
-                if let Some(entry) = corpus_manager.hoist_observed_calls(
-                    &observed_calls,
-                    &parent_tx,
-                    &invariant_test.targeted_contracts,
-                    insertion_mode,
-                ) {
-                    corpus_entries.push(entry);
-                }
             }
 
             // Extend corpus only after the run and its optional hook have completed.
@@ -1826,10 +1816,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // Set up fuzzer WITHOUT call_generator initially.
         // We defer call_override until after the initial invariant check to avoid
         // injecting random calls during setup which would break the invariant assertion.
-        executor.inspector_mut().set_fuzzer(
-            Fuzzer::new(config.dictionary.max_fuzz_dictionary_values, mapping_slots)
-                .with_call_recording(config.corpus.is_coverage_guided()),
-        );
+        executor
+            .inspector_mut()
+            .set_fuzzer(Fuzzer::new(config.dictionary.max_fuzz_dictionary_values, mapping_slots));
 
         // Let's make sure the invariant is sound before actually starting the run:
         // We'll assert the invariant in its initial state, and if it fails, we'll
@@ -1850,24 +1839,17 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         )?;
         if let Some(fuzzer) = executor.inspector_mut().fuzzer.as_mut() {
             fuzz_state.collect_fuzzer_values(fuzzer);
-            let _ = fuzzer.take_observed_calls();
         }
-        let mut worker = WorkerCorpus::from_seed(
+        let worker = WorkerCorpus::from_seed(
             plan.worker_id as usize,
             config.corpus.clone(),
             strategy.boxed(),
             corpus_seed,
         )?;
 
-        if let Err(err) =
-            worker.seed_from_test_traces(invariant_contract, &targeted_contracts, executor)
-        {
-            debug!(target: "corpus", %err, "failed to seed corpus from test traces");
-        }
-
-        // NOW enable call_override after the initial invariant check and corpus trace seeding have
-        // passed. This allows `override_call_strat` to inject calls during actual fuzz runs for
-        // reentrancy vulnerability detection.
+        // NOW enable call_override after the initial invariant check has passed. This allows
+        // `override_call_strat` to inject calls during actual fuzz runs for reentrancy
+        // vulnerability detection.
         if config.call_override {
             let target_contract_ref = Arc::new(RwLock::new(Address::ZERO));
 
@@ -2947,6 +2929,7 @@ mod tests {
         let target = Address::from([0x11; 20]);
         let first = function("first(uint256)");
         let second = function("second(uint256)");
+        let first_selector = first.selector();
         let second_selector = second.selector();
         let mut contract = targeted_contract("Target", vec![first.clone(), second.clone()]);
         contract.targeted_functions = vec![first, second];
@@ -2960,6 +2943,8 @@ mod tests {
         assert_eq!(focused.len(), 1);
         assert_eq!(focused_functions.len(), 1);
         assert_eq!(focused_functions[0].selector(), second_selector);
+        assert!(focused[&target].fuzzed_function_by_selector(first_selector).is_none());
+        assert!(focused[&target].fuzzed_function_by_selector(second_selector).is_some());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -41,7 +41,6 @@ use foundry_evm_core::{
     utils::StateChangeset,
 };
 use foundry_evm_coverage::HitMaps;
-use foundry_evm_fuzz::ObservedCall;
 use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     bytecode::Bytecode,
@@ -1094,8 +1093,6 @@ pub struct RawCallResult<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     pub edge_coverage: Option<EdgeCoverage>,
     /// EVM comparison operands collected during the call.
     pub evm_cmp_values: Option<Vec<CmpOperands>>,
-    /// Observed sub-calls collected during the call.
-    pub observed_calls: Vec<ObservedCall>,
     /// Sancov edge coverage from instrumented native Rust crates (e.g. precompiles).
     /// Tracked separately from EVM edge coverage to avoid ID-space collisions.
     pub sancov_coverage: Option<Vec<u8>>,
@@ -1136,7 +1133,6 @@ impl<FEN: FoundryEvmNetwork> Default for RawCallResult<FEN> {
             line_coverage: None,
             edge_coverage: None,
             evm_cmp_values: None,
-            observed_calls: Vec::new(),
             sancov_coverage: None,
             sancov_cmp_values: None,
             transactions: None,
@@ -1455,7 +1451,7 @@ impl<T, FEN: FoundryEvmNetwork> std::ops::DerefMut for CallResult<T, FEN> {
 fn convert_executed_result<FEN: FoundryEvmNetwork>(
     evm_env: EvmEnvFor<FEN>,
     tx_env: TxEnvFor<FEN>,
-    mut inspector: InspectorStack<FEN>,
+    inspector: InspectorStack<FEN>,
     ResultAndState { result, state: state_changeset }: ResultAndState<HaltReasonFor<FEN>>,
     db: &dyn DatabaseRef<Error = DatabaseError>,
     has_state_snapshot_failure: bool,
@@ -1481,12 +1477,6 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
         Some(Output::Call(data)) => data.clone(),
         _ => Bytes::new(),
     };
-    let observed_calls = inspector
-        .inner
-        .fuzzer
-        .as_mut()
-        .map(|fuzzer| fuzzer.take_observed_calls())
-        .unwrap_or_default();
 
     let InspectorData {
         mut logs,
@@ -1526,7 +1516,6 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
         line_coverage,
         edge_coverage,
         evm_cmp_values,
-        observed_calls,
         sancov_coverage: None,
         sancov_cmp_values: None,
         transactions,

--- a/crates/evm/fuzz/src/inspector.rs
+++ b/crates/evm/fuzz/src/inspector.rs
@@ -1,5 +1,5 @@
 use crate::invariant::RandomCallGenerator;
-use alloy_primitives::{Address, B256, Bytes, U256, map::AddressMap};
+use alloy_primitives::{B256, map::AddressMap};
 use foundry_common::mapping_slots::{MappingSlots, step as mapping_step};
 use foundry_evm_core::constants::CHEATCODE_ADDRESS;
 use revm::{
@@ -7,20 +7,6 @@ use revm::{
     context::{ContextTr, JournalTr, Transaction},
     interpreter::{CallInput, CallInputs, CallOutcome, CallScheme, CallValue, Interpreter},
 };
-
-/// A sub-call observed by the [`Fuzzer`] inspector.
-///
-/// `depth` is 1-indexed relative to the top-level call: depth 1 is a direct call
-/// from the top-level callee, depth 2 is a sub-call of that call, and so on. The
-/// top-level call itself is never recorded.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ObservedCall {
-    pub depth: u32,
-    pub caller: Address,
-    pub target: Address,
-    pub calldata: Bytes,
-    pub value: Option<U256>,
-}
 
 /// An inspector that can fuzz and collect data for that effect.
 #[derive(Clone, Debug)]
@@ -35,12 +21,6 @@ pub struct Fuzzer {
     pub max_collected_values: usize,
     /// Mapping accesses observed during execution, used for storage slot sampling.
     pub mapping_slots: Option<AddressMap<MappingSlots>>,
-    /// Whether sub-calls should be buffered for later corpus seeding.
-    record_calls: bool,
-    /// Sub-calls observed since the last drain.
-    observed_calls: Vec<ObservedCall>,
-    /// Current EVM call depth. 0 means no active call, 1 means top-level call.
-    call_depth: u32,
 }
 
 impl<CTX: ContextTr> Inspector<CTX> for Fuzzer {
@@ -61,17 +41,6 @@ impl<CTX: ContextTr> Inspector<CTX> for Fuzzer {
             self.override_call(ecx, inputs);
         }
 
-        self.call_depth = self.call_depth.saturating_add(1);
-        if self.should_record_observed_call(inputs.scheme) {
-            self.observed_calls.push(ObservedCall {
-                depth: self.call_depth - 1,
-                caller: inputs.caller,
-                target: inputs.target_address,
-                calldata: inputs.input.bytes(ecx),
-                value: inputs.transfer_value().filter(|value| !value.is_zero()),
-            });
-        }
-
         // We only collect `stack` and `memory` data before and after calls.
         // this will be turned off on the next `step`
         self.collect = true;
@@ -90,8 +59,6 @@ impl<CTX: ContextTr> Inspector<CTX> for Fuzzer {
         // We only collect `stack` and `memory` data before and after calls.
         // this will be turned off on the next `step`
         self.collect = true;
-
-        self.call_depth = self.call_depth.saturating_sub(1);
     }
 }
 
@@ -107,51 +74,7 @@ impl Fuzzer {
             collected_values: Vec::new(),
             max_collected_values,
             mapping_slots,
-            record_calls: false,
-            observed_calls: Vec::new(),
-            call_depth: 0,
         }
-    }
-
-    /// Enables or disables sub-call buffering.
-    pub const fn with_call_recording(mut self, record_calls: bool) -> Self {
-        self.record_calls = record_calls;
-        self
-    }
-
-    /// Enables or disables sub-call buffering on an existing inspector.
-    pub const fn set_call_recording(&mut self, record_calls: bool) {
-        self.record_calls = record_calls;
-    }
-
-    /// Returns the buffered sub-calls observed since the last drain.
-    pub fn take_observed_calls(&mut self) -> Vec<ObservedCall> {
-        std::mem::take(&mut self.observed_calls)
-    }
-
-    #[cfg(test)]
-    fn record_observed_call(
-        &mut self,
-        caller: Address,
-        target: Address,
-        calldata: Bytes,
-        value: Option<U256>,
-        scheme: CallScheme,
-    ) {
-        if self.should_record_observed_call(scheme) {
-            self.observed_calls.push(ObservedCall {
-                depth: self.call_depth - 1,
-                caller,
-                target,
-                calldata,
-                value,
-            });
-        }
-    }
-
-    #[inline]
-    const fn should_record_observed_call(&self, scheme: CallScheme) -> bool {
-        self.record_calls && self.call_depth > 1 && matches!(scheme, CallScheme::Call)
     }
 
     /// Collects `stack` and `memory` values into the fuzz dictionary.
@@ -246,95 +169,5 @@ impl Fuzzer {
 
         // Track that we're inside an overridden call to avoid recursive overrides
         call_generator.override_depth = 1;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn fuzzer(record_calls: bool) -> Fuzzer {
-        Fuzzer::new(16, None).with_call_recording(record_calls)
-    }
-
-    #[test]
-    fn observed_calls_are_disabled_by_default() {
-        let mut fuzzer = Fuzzer::new(16, None);
-        fuzzer.call_depth = 2;
-
-        fuzzer.record_observed_call(
-            Address::from([0xaa; 20]),
-            Address::from([0x11; 20]),
-            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
-            Some(U256::from(1)),
-            CallScheme::Call,
-        );
-
-        assert!(fuzzer.take_observed_calls().is_empty());
-    }
-
-    #[test]
-    fn observed_calls_skip_top_level_call() {
-        let mut fuzzer = fuzzer(true);
-        fuzzer.call_depth = 1;
-
-        fuzzer.record_observed_call(
-            Address::from([0xaa; 20]),
-            Address::from([0x11; 20]),
-            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
-            None,
-            CallScheme::Call,
-        );
-
-        assert!(fuzzer.take_observed_calls().is_empty());
-    }
-
-    #[test]
-    fn observed_calls_record_subcall_depth_target_calldata_and_value() {
-        let mut fuzzer = fuzzer(true);
-        let caller = Address::from([0x11; 20]);
-        let target = Address::from([0x22; 20]);
-        let calldata = Bytes::from_static(&[0xca, 0xfe, 0xba, 0xbe]);
-        let value = Some(U256::from(7));
-        fuzzer.call_depth = 3;
-
-        fuzzer.record_observed_call(caller, target, calldata.clone(), value, CallScheme::Call);
-
-        assert_eq!(
-            fuzzer.take_observed_calls(),
-            vec![ObservedCall { depth: 2, caller, target, calldata, value }]
-        );
-    }
-
-    #[test]
-    fn observed_calls_skip_non_call_schemes() {
-        let mut fuzzer = fuzzer(true);
-        fuzzer.call_depth = 2;
-
-        fuzzer.record_observed_call(
-            Address::from([0x11; 20]),
-            Address::from([0x22; 20]),
-            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
-            None,
-            CallScheme::DelegateCall,
-        );
-
-        assert!(fuzzer.take_observed_calls().is_empty());
-    }
-
-    #[test]
-    fn take_observed_calls_drains_buffer() {
-        let mut fuzzer = fuzzer(true);
-        fuzzer.call_depth = 2;
-        fuzzer.record_observed_call(
-            Address::from([0xaa; 20]),
-            Address::from([0x33; 20]),
-            Bytes::from_static(&[0x12, 0x34, 0x56, 0x78]),
-            None,
-            CallScheme::Call,
-        );
-
-        assert_eq!(fuzzer.take_observed_calls().len(), 1);
-        assert!(fuzzer.take_observed_calls().is_empty());
     }
 }

--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -1,5 +1,5 @@
 use alloy_json_abi::{Event, Function, JsonAbi};
-use alloy_primitives::{Address, B256, Selector, map::HashMap};
+use alloy_primitives::{Address, B256, Selector, keccak256, map::HashMap};
 use foundry_compilers::artifacts::StorageLayout;
 use itertools::Either;
 use serde::{Deserialize, Serialize};
@@ -25,6 +25,13 @@ type DynamicTargetArtifactMatchCache =
     Rc<RefCell<HashMap<DynamicTargetCacheKey, Option<CachedTargetContract>>>>;
 type FuzzedFunction = (Address, Function);
 type FunctionLookup = HashMap<Selector, Function>;
+type FuzzedFunctionLookup = HashMap<Selector, CachedFuzzedFunction>;
+
+#[derive(Clone, Debug)]
+struct CachedFuzzedFunction {
+    function: Function,
+    signature: B256,
+}
 
 /// Returns true if the function returns `int256`, indicating optimization mode.
 /// In optimization mode, the fuzzer maximizes the return value instead of checking invariants.
@@ -325,7 +332,7 @@ pub struct TargetedContract {
     /// Contract events indexed by topic0 and indexed-topic count for log dictionary decoding.
     pub event_lookup: Arc<TargetedContractEvents>,
     functions_by_selector: FunctionLookup,
-    fuzzed_functions_by_selector: FunctionLookup,
+    fuzzed_functions_by_selector: FuzzedFunctionLookup,
 }
 
 impl TargetedContract {
@@ -351,7 +358,7 @@ impl TargetedContract {
             storage_layout,
             event_lookup,
             functions_by_selector: FunctionLookup::default(),
-            fuzzed_functions_by_selector: FunctionLookup::default(),
+            fuzzed_functions_by_selector: FuzzedFunctionLookup::default(),
         };
         contract.rebuild_function_lookups();
         contract
@@ -397,9 +404,14 @@ impl TargetedContract {
                 functions
             });
         let fuzzed_functions_by_selector = self.abi_fuzzed_functions().fold(
-            FunctionLookup::default(),
+            FuzzedFunctionLookup::default(),
             |mut functions, function| {
-                functions.entry(function.selector()).or_insert_with(|| function.clone());
+                let signature = keccak256(function.signature());
+                let selector = Selector::from_slice(&signature[..4]);
+                functions.entry(selector).or_insert_with(|| CachedFuzzedFunction {
+                    function: function.clone(),
+                    signature,
+                });
                 functions
             },
         );
@@ -414,7 +426,12 @@ impl TargetedContract {
 
     /// Returns a fuzzable function for the given selector.
     pub fn fuzzed_function_by_selector(&self, selector: Selector) -> Option<&Function> {
-        self.fuzzed_functions_by_selector.get(&selector)
+        self.fuzzed_functions_by_selector.get(&selector).map(|cached| &cached.function)
+    }
+
+    /// Returns the cached canonical signature hash for a fuzzable function.
+    pub fn fuzzed_signature_by_selector(&self, selector: Selector) -> Option<B256> {
+        self.fuzzed_functions_by_selector.get(&selector).map(|cached| cached.signature)
     }
 
     /// Returns the function for the given selector.
@@ -761,6 +778,20 @@ mod tests {
     }
 
     #[test]
+    fn targeted_contract_caches_canonical_fuzzed_signature_hashes() {
+        let function = Function::parse("target(uint256,address)").unwrap();
+        let contract = TargetedContract::new(
+            "Target".to_string(),
+            abi_with_functions(&["target(uint256,address)"]),
+        );
+
+        assert_eq!(
+            contract.fuzzed_signature_by_selector(function.selector()),
+            Some(keccak256(function.signature()))
+        );
+    }
+
+    #[test]
     fn abi_fuzzed_functions_filters_excluded_targeted_functions() {
         let allowed = Function::parse("allowed()").unwrap();
         let excluded = Function::parse("excluded()").unwrap();
@@ -783,6 +814,14 @@ mod tests {
         excluded.inner.get_mut(&target).unwrap().add_selectors([foo.selector()], true).unwrap();
         assert!(!excluded.can_replay(&tx(target, foo.selector().to_vec())));
         assert!(excluded.can_replay(&tx(target, bar.selector().to_vec())));
+        assert!(
+            excluded
+                .inner
+                .get(&target)
+                .unwrap()
+                .fuzzed_signature_by_selector(foo.selector())
+                .is_none()
+        );
         assert_eq!(
             excluded.fuzzed_artifacts(&tx(target, foo.selector().to_vec())).1.unwrap().name,
             "foo"
@@ -792,6 +831,14 @@ mod tests {
         targeted.inner.get_mut(&target).unwrap().add_selectors([foo.selector()], false).unwrap();
         assert!(targeted.can_replay(&tx(target, foo.selector().to_vec())));
         assert!(!targeted.can_replay(&tx(target, bar.selector().to_vec())));
+        assert!(
+            targeted
+                .inner
+                .get(&target)
+                .unwrap()
+                .fuzzed_signature_by_selector(bar.selector())
+                .is_none()
+        );
         assert_eq!(
             targeted.fuzzed_metric_key_for_selector(target, bar.selector()).unwrap(),
             "Target.bar"

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -31,7 +31,7 @@ pub mod strategies;
 pub use strategies::LiteralMaps;
 
 mod inspector;
-pub use inspector::{Fuzzer, ObservedCall};
+pub use inspector::Fuzzer;
 
 /// Metadata needed to reproduce a fuzz run.
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]

--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -10,6 +10,22 @@ Most users should interact with this crate through Forge. The Rust crate is the
 engine that Forge calls after it has compiled contracts, run `setUp`, selected
 tests, and prepared the concrete executor backend.
 
+## Choosing a workflow
+
+- Use `forge fuzz run` for an automatic fuzz or invariant campaign. With
+  symbolic features disabled, it persists and reuses coverage-winning sequences
+  without starting a solver. The whole-call donor mechanism is concrete and
+  does not itself enable symbolic execution.
+- Use `forge test --symbolic` when you intentionally want bounded symbolic
+  exploration of `check*`, `prove*`, `invariant*`, or `statefulFuzz*`
+  properties.
+- Use `--symbolic-seed-corpus` or `--symbolic-use-fuzz-frontiers` only when you
+  intentionally want a solver prelude before an ordinary concrete fuzz
+  campaign in the same invocation. Use `--symbolic-use-fuzz-corpus` for
+  symbolic-only exploration prioritized by an existing concrete corpus. None of
+  these options is required before ordinary fuzz runs or enables an automatic
+  hybrid engine.
+
 ## Quick Start
 
 Symbolic tests are Solidity functions named `check*` or `prove*`.
@@ -100,8 +116,18 @@ non-failing fuzz-test inputs into the configured `fuzz.corpus_dir`:
 forge test --symbolic-seed-corpus --fuzz-corpus-dir fuzz_corpus
 ```
 
-Forge symbolically executes matching fuzz tests, reuses their normal corpus
-layout, and writes a successful concrete input as a seed for later fuzz runs.
+Forge first symbolically executes matching fuzz tests, reuses their normal
+corpus layout, and writes a successful concrete input. The same invocation then
+loads that seed and runs the ordinary concrete fuzz campaign. Continue the
+explicit corpus in a later campaign, then inspect it with:
+
+```sh
+forge fuzz run --corpus-dir fuzz_corpus --match-test test_hard_branch
+forge fuzz show fuzz_corpus
+```
+
+The [showmap corpus guide](../../../docs/dev/showmap.md) covers minimization,
+replay, and differential-coverage export.
 
 Symbolic execution can import the same Foundry fuzz corpus as path-priority
 hints for fuzz tests:

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -48,7 +48,7 @@ impl FuzzArgs {
         match self.command {
             FuzzSubcommands::Run(args) => {
                 let mut test = TestArgs::from_fuzz_run(args);
-                test.enable_fuzz_only_with_auto_fuzz_corpus();
+                test.enable_fuzz_only_with_auto_corpora();
                 Box::pin(test.run())
             }
             FuzzSubcommands::Replay(args) => Box::pin(args.run()),
@@ -79,7 +79,7 @@ impl FuzzArgs {
 #[derive(Clone, Debug, Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum FuzzSubcommands {
-    /// Run only fuzz and invariant tests.
+    /// Run fuzz and invariant tests with cache-backed corpus reuse.
     Run(FuzzRunArgs),
     /// Replay persisted fuzz failures, or corpus entries with `--corpus-dir`.
     Replay(FuzzReplayArgs),
@@ -91,7 +91,7 @@ pub enum FuzzSubcommands {
     Tmin(FuzzTminArgs),
 }
 
-/// Run only fuzz and invariant tests.
+/// Run only fuzz and invariant tests with cache-backed corpus reuse.
 #[derive(Clone, Debug, Parser)]
 pub struct FuzzRunArgs {
     #[command(flatten)]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -103,6 +103,7 @@ use summary::{TestSummaryReport, format_invariant_metrics_table};
 
 const DEBUGGER_MATCHING_TESTS_DISPLAY_LIMIT: usize = 12;
 const AUTO_FUZZ_FAILURE_DIR: &str = "fuzz";
+const AUTO_INVARIANT_FAILURE_DIR: &str = "invariant";
 const AUTO_CORPUS_DIR: &str = "corpus";
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -110,7 +111,7 @@ enum FuzzOnlyMode {
     #[default]
     Disabled,
     Enabled,
-    WithAutoFuzzCorpus,
+    WithAutoCorpora,
 }
 
 impl FuzzOnlyMode {
@@ -118,8 +119,8 @@ impl FuzzOnlyMode {
         !matches!(self, Self::Disabled)
     }
 
-    const fn uses_auto_fuzz_corpus(self) -> bool {
-        matches!(self, Self::WithAutoFuzzCorpus)
+    const fn uses_auto_corpora(self) -> bool {
+        matches!(self, Self::WithAutoCorpora)
     }
 }
 
@@ -458,7 +459,8 @@ pub struct CampaignArgs {
     #[arg(long, value_name = "PATH", value_hint = ValueHint::DirPath)]
     pub corpus_dir: Option<PathBuf>,
 
-    /// Percent of calldata generated from the dictionary.
+    /// Percent of calldata generated from dictionaries, including compatible invariant whole-call
+    /// donors.
     #[arg(long, value_name = "PERCENT")]
     pub dictionary_weight: Option<u32>,
 
@@ -904,7 +906,7 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_SYMBOLIC_REGRESSION_OVERWRITE", requires = "emit_regression")]
     pub regression_overwrite: bool,
 
-    /// Run fuzz tests symbolically and persist non-failing concrete inputs to the fuzz corpus.
+    /// Pre-seed the fuzz corpus symbolically, then run the ordinary concrete fuzz campaign.
     #[arg(long, env = "FOUNDRY_SYMBOLIC_SEED_CORPUS")]
     pub symbolic_seed_corpus: bool,
 
@@ -916,7 +918,7 @@ pub struct TestArgs {
     #[arg(long, env = "FOUNDRY_SYMBOLIC_CORPUS_SEED_LIMIT", value_name = "COUNT")]
     pub symbolic_corpus_seed_limit: Option<usize>,
 
-    /// Run targeted symbolic solving from existing fuzz branch frontier artifacts.
+    /// Pre-seed the fuzz corpus from branch frontiers symbolically, then run concrete fuzzing.
     #[arg(long, env = "FOUNDRY_SYMBOLIC_USE_FUZZ_FRONTIERS")]
     pub symbolic_use_fuzz_frontiers: bool,
 
@@ -1310,14 +1312,14 @@ impl TestArgs {
         self.fuzz_only = FuzzOnlyMode::Enabled;
     }
 
-    /// Restricts this test invocation to fuzz and invariant tests and enables a default fuzz corpus
-    /// dir after user config is loaded.
-    pub(crate) const fn enable_fuzz_only_with_auto_fuzz_corpus(&mut self) {
-        self.fuzz_only = FuzzOnlyMode::WithAutoFuzzCorpus;
+    /// Restricts this invocation to fuzz and invariant tests and enables default corpus
+    /// directories after user config is loaded.
+    pub(crate) const fn enable_fuzz_only_with_auto_corpora(&mut self) {
+        self.fuzz_only = FuzzOnlyMode::WithAutoCorpora;
     }
 
-    fn apply_auto_fuzz_corpus_dir(&self, config: &mut Config) {
-        if !self.fuzz_only.uses_auto_fuzz_corpus() {
+    fn apply_auto_corpus_dirs(&self, config: &mut Config) {
+        if !self.fuzz_only.uses_auto_corpora() {
             return;
         }
 
@@ -1326,6 +1328,15 @@ impl TestArgs {
                 Some(root) => root.join(AUTO_CORPUS_DIR),
                 None => config.cache_path.join(AUTO_FUZZ_FAILURE_DIR).join(AUTO_CORPUS_DIR),
             });
+        }
+        if config.invariant.corpus.corpus_dir.is_none() {
+            config.invariant.corpus.corpus_dir =
+                Some(match &config.invariant.failure_persist_dir {
+                    Some(root) => root.join(AUTO_CORPUS_DIR),
+                    None => {
+                        config.cache_path.join(AUTO_INVARIANT_FAILURE_DIR).join(AUTO_CORPUS_DIR)
+                    }
+                });
         }
     }
 
@@ -1689,7 +1700,7 @@ impl TestArgs {
         let test_failures_file = config.test_failures_file.clone();
         let mut config = workspace::rebase_config_paths(&config, temp_path).sanitized();
         config.test_failures_file = test_failures_file;
-        self.apply_auto_fuzz_corpus_dir(&mut config);
+        self.apply_auto_corpus_dirs(&mut config);
         let project = config.project()?;
         let project_root = project.paths.root.clone();
         let replay_symbolic_artifact = self.load_symbolic_artifact_replay()?;
@@ -1740,7 +1751,7 @@ impl TestArgs {
             apply_mutation_compiler_overrides(&mut config);
         }
 
-        self.apply_auto_fuzz_corpus_dir(&mut config);
+        self.apply_auto_corpus_dirs(&mut config);
 
         // Set up the project.
         let mut project = config.project()?;
@@ -4401,45 +4412,52 @@ mod tests {
     }
 
     #[test]
-    fn auto_fuzz_corpus_defaults_to_cache_failure_layout() {
+    fn auto_corpora_default_to_cache_failure_layouts() {
         let mut args = TestArgs::parse_from(["foundry-cli"]);
-        args.enable_fuzz_only_with_auto_fuzz_corpus();
+        args.enable_fuzz_only_with_auto_corpora();
         let mut config = Config::default();
 
-        args.apply_auto_fuzz_corpus_dir(&mut config);
+        args.apply_auto_corpus_dirs(&mut config);
 
         assert_eq!(
             config.fuzz.corpus.corpus_dir,
             Some(config.cache_path.join(AUTO_FUZZ_FAILURE_DIR).join(AUTO_CORPUS_DIR))
         );
-        assert_eq!(config.invariant.corpus.corpus_dir, None);
+        assert_eq!(
+            config.invariant.corpus.corpus_dir,
+            Some(config.cache_path.join(AUTO_INVARIANT_FAILURE_DIR).join(AUTO_CORPUS_DIR))
+        );
     }
 
     #[test]
-    fn auto_fuzz_corpus_uses_configured_failure_persist_dirs() {
+    fn auto_corpora_use_configured_failure_persist_dirs() {
         let mut args = TestArgs::parse_from(["foundry-cli"]);
-        args.enable_fuzz_only_with_auto_fuzz_corpus();
+        args.enable_fuzz_only_with_auto_corpora();
         let mut config = Config::default();
         config.fuzz.failure_persist_dir = Some(PathBuf::from("custom_fuzz_failures"));
+        config.invariant.failure_persist_dir = Some(PathBuf::from("custom_invariant_failures"));
 
-        args.apply_auto_fuzz_corpus_dir(&mut config);
+        args.apply_auto_corpus_dirs(&mut config);
 
         assert_eq!(
             config.fuzz.corpus.corpus_dir,
             Some(PathBuf::from("custom_fuzz_failures").join(AUTO_CORPUS_DIR))
         );
-        assert_eq!(config.invariant.corpus.corpus_dir, None);
+        assert_eq!(
+            config.invariant.corpus.corpus_dir,
+            Some(PathBuf::from("custom_invariant_failures").join(AUTO_CORPUS_DIR))
+        );
     }
 
     #[test]
-    fn auto_fuzz_corpus_preserves_configured_corpus_dirs() {
+    fn auto_corpora_preserve_configured_corpus_dirs() {
         let mut args = TestArgs::parse_from(["foundry-cli"]);
-        args.enable_fuzz_only_with_auto_fuzz_corpus();
+        args.enable_fuzz_only_with_auto_corpora();
         let mut config = Config::default();
         config.fuzz.corpus.corpus_dir = Some(PathBuf::from("configured_fuzz_corpus"));
         config.invariant.corpus.corpus_dir = Some(PathBuf::from("configured_invariant_corpus"));
 
-        args.apply_auto_fuzz_corpus_dir(&mut config);
+        args.apply_auto_corpus_dirs(&mut config);
 
         assert_eq!(config.fuzz.corpus.corpus_dir, Some(PathBuf::from("configured_fuzz_corpus")));
         assert_eq!(
@@ -4454,7 +4472,7 @@ mod tests {
         args.enable_fuzz_only();
         let mut config = Config::default();
 
-        args.apply_auto_fuzz_corpus_dir(&mut config);
+        args.apply_auto_corpus_dirs(&mut config);
 
         assert_eq!(config.fuzz.corpus.corpus_dir, None);
         assert_eq!(config.invariant.corpus.corpus_dir, None);

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1,7 +1,7 @@
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::JsonAbi;
 use alloy_primitives::{U256, hex};
-use foundry_config::fs_permissions::PathPermission;
+use foundry_config::{FuzzCorpusMutationWeights, fs_permissions::PathPermission};
 use foundry_evm::fuzz::BaseCounterExample;
 use foundry_test_utils::{TestCommand, forgetest_init, str};
 use regex::Regex;
@@ -3197,8 +3197,196 @@ contract ForgeFuzzAutoCorpusSeedTest is Test {
         .join("ForgeFuzzAutoCorpusSeedTest")
         .join("worker0")
         .join("corpus");
-    assert!(!has_regular_file(&corpus_root));
+    assert!(has_regular_file(&corpus_root), "forge fuzz run did not populate its invariant corpus");
     assert!(!marker.exists());
+});
+
+forgetest_init!(forge_fuzz_run_reuses_whole_calls_for_new_coverage, |prj, cmd| {
+    let discovered_marker = prj.root().join("whole-call-discovered.txt");
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 1;
+        config.invariant.check_interval = 0;
+        config.invariant.dictionary.dictionary_weight = 100;
+        config.invariant.corpus.corpus_dir = Some("invariant_corpus".into());
+        config.invariant.corpus.corpus_gzip = false;
+        config.invariant.corpus.corpus_random_sequence_weight = 0;
+        config.invariant.corpus.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            // Replace the single persisted call with a newly generated call.
+            mutation_weight_prefix: 1_000_000,
+            mutation_weight_suffix: 0,
+            // Enables automatic whole-call donor collection and reuse.
+            mutation_weight_abi: 1,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
+            mutation_weight_insert: 0,
+            mutation_weight_delete: 0,
+            mutation_weight_swap: 0,
+        };
+        config.fs_permissions.add(PathPermission::read_write(prj.root()));
+    });
+    prj.add_test(
+        "ForgeFuzzWholeCallReuse.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+
+contract ForgeFuzzWholeCallTarget {
+    Vm private constant vm =
+        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    bytes32[4] private hashes;
+    bool private immutable replay;
+    bool public discovered;
+
+    constructor(bool replay_, bytes32[4] memory hashes_) {
+        replay = replay_;
+        hashes = hashes_;
+    }
+
+    function target(uint256 a, uint256 b, uint256 c, uint256 d) external {
+        if (!replay) {
+            string memory objectKey = "whole-call-hashes";
+            string memory json =
+                vm.serializeBytes32(objectKey, "a", keccak256(abi.encode(a)));
+            vm.serializeBytes32(objectKey, "b", keccak256(abi.encode(b)));
+            vm.serializeBytes32(objectKey, "c", keccak256(abi.encode(c)));
+            json = vm.serializeBytes32(objectKey, "d", keccak256(abi.encode(d)));
+            vm.writeJson(
+                json,
+                string.concat(vm.projectRoot(), "/whole-call-hashes.json")
+            );
+            return;
+        }
+
+        uint256 count;
+        if (keccak256(abi.encode(a)) == hashes[0]) count++;
+        if (keccak256(abi.encode(b)) == hashes[1]) count++;
+        if (keccak256(abi.encode(c)) == hashes[2]) count++;
+        if (keccak256(abi.encode(d)) == hashes[3]) count++;
+        if (count == 3) {
+            discovered = true;
+        }
+    }
+}
+
+contract ForgeFuzzWholeCallReuseTest is Test {
+    ForgeFuzzWholeCallTarget private target;
+
+    function setUp() public {
+        bool replay = vm.envOr("FOUNDRY_TEST_WHOLE_CALL_REPLAY", false);
+        bytes32[4] memory hashes;
+        if (replay) {
+            string memory json = vm.readFile(
+                string.concat(vm.projectRoot(), "/whole-call-hashes.json")
+            );
+            hashes[0] = vm.parseJsonBytes32(json, ".a");
+            hashes[1] = vm.parseJsonBytes32(json, ".b");
+            hashes[2] = vm.parseJsonBytes32(json, ".c");
+            hashes[3] = vm.parseJsonBytes32(json, ".d");
+        }
+        target = new ForgeFuzzWholeCallTarget(replay, hashes);
+        targetContract(address(target));
+    }
+
+    function invariant_ok() public {
+        if (target.discovered()) {
+            vm.writeFile(
+                string.concat(vm.projectRoot(), "/whole-call-discovered.txt"),
+                "discovered"
+            );
+        }
+    }
+}
+   "#,
+    );
+
+    cmd.args([
+        "fuzz",
+        "run",
+        "--mc",
+        "ForgeFuzzWholeCallReuseTest",
+        "--mt",
+        "invariant_ok",
+        "--threads",
+        "1",
+        "--workers",
+        "1",
+        "--depth",
+        "1",
+        "--runs",
+        "1",
+        // The first process only creates the restart corpus and hashed oracle.
+        "--dictionary-weight",
+        "0",
+        "--seed",
+        "0x1234",
+        "-q",
+    ])
+    .assert_success();
+
+    let corpus_root = prj
+        .root()
+        .join("invariant_corpus")
+        .join("ForgeFuzzWholeCallReuseTest")
+        .join("worker0")
+        .join("corpus");
+    assert!(has_regular_file(&corpus_root), "first run did not persist a donor corpus");
+    assert!(
+        prj.root().join("whole-call-hashes.json").is_file(),
+        "first run did not persist the hashed replay oracle"
+    );
+    assert!(
+        !discovered_marker.exists(),
+        "the recording campaign unexpectedly reached the replay branch"
+    );
+
+    cmd.forge_fuse().env("FOUNDRY_TEST_WHOLE_CALL_REPLAY", "true");
+    let resumed = cmd
+        .args([
+            "fuzz",
+            "run",
+            "--mc",
+            "ForgeFuzzWholeCallReuseTest",
+            "--mt",
+            "invariant_ok",
+            "--threads",
+            "1",
+            "--workers",
+            "1",
+            "--depth",
+            "1",
+            "--runs",
+            "100000000",
+            "--timeout",
+            "10",
+            "--seed",
+            "0x1234",
+            "-vv",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(resumed.get_output().stdout.clone()).unwrap();
+    let pulse_metrics = stdout.lines().filter_map(|line| {
+        let payload: Value = serde_json::from_str(line).ok()?;
+        (payload["event"] == "pulse").then(|| payload["metrics"].clone())
+    });
+    let useful_pulse = pulse_metrics.into_iter().find(|metrics| {
+        metrics["whole_call_dictionary_entries"].as_u64().is_some_and(|value| value > 0)
+            && metrics["whole_call_mutations"].as_u64().is_some_and(|value| value > 0)
+            && metrics["whole_call_coverage_wins"].as_u64().is_some_and(|value| value > 0)
+    });
+    assert!(
+        useful_pulse.is_some(),
+        "expected a reloaded whole-call donor to win concrete coverage:\n{stdout}"
+    );
+    assert!(
+        discovered_marker.exists(),
+        "whole-call reuse did not reach the destination's three-matching-arguments branch"
+    );
 });
 
 forgetest_init!(fuzz_branch_frontiers_capture_comparison_for_symbolic_followup, |prj, cmd| {

--- a/docs/dev/showmap.md
+++ b/docs/dev/showmap.md
@@ -5,26 +5,92 @@ emits AFL-`afl-showmap`-style coverage files. Output is consumable by tools like
 [`riesentoaster/differential-coverage`](https://github.com/riesentoaster/differential-coverage)
 for cross-fuzzer / cross-approach coverage comparisons.
 
-## Usage
+## Automatic corpus reuse
+
+An ordinary `forge fuzz run` automatically assigns separate fuzz and invariant
+corpus directories and uses coverage-guided corpus mutation. By default the
+roots are `cache/fuzz/corpus` and `cache/invariant/corpus`; a customized
+`failure_persist_dir` instead produces `<failure_persist_dir>/corpus`. Explicit
+`corpus_dir` configuration or `--corpus-dir` overrides that location.
+`forge test` only enables this behavior when a corpus directory is configured.
+
+In invariant campaigns, Foundry also retains a worker-local dictionary of
+argument-bearing top-level calls whose complete concrete execution won an edge
+or hit-count coverage feature. It is bounded to 1,024 entries and 4 MiB of
+calldata per worker. The retained startup replay seed has the same bound, so a
+conservative campaign-level calldata bound is `(workers + 1) × 4 MiB`.
+
+Each donor is keyed by the full hash of the canonical ABI function signature,
+rather than only the four-byte selector. For each freshly generated invariant
+call, Foundry first selects the destination and function normally. It may then
+reuse calldata from a compatible donor, retarget it to that already-selected
+destination, and mutate exactly one ABI argument. The generated call still
+executes normally. Reusing a donor does not bypass the existing sequence-level
+corpus admission rules: only sequence-level inputs that improve coverage or the
+optimization objective are persisted.
+
+Nested calls are not collected: their calldata alone does not reproduce the
+caller, value, preceding state, or reentrancy context that made the original
+execution interesting.
+
+Whole-call donors are in-memory generation inputs, not additional corpus
+entries. Corpus replay at startup reconstructs the donor dictionary from
+coverage-winning calls in persisted sequences, then each invariant worker
+learns locally. The existing
+`dictionary_weight` controls how often a compatible donor is selected; zero
+disables donor reuse. An effective `mutation_weight_abi = 0` disables both donor
+collection and reuse.
+
+This concrete mutation is most relevant to invariant campaigns where correlated
+ABI arguments matter, including handlers that share a canonical signature. It
+does not derive unknown cryptographic preimages or generally solve nonlinear
+constraints, and does not claim a general hard-branch improvement. There is no
+separate `forge fuzz seed` subcommand: `forge fuzz run` learns and reuses these
+donors automatically, while the explicit CLI entry point for solver-assisted
+pre-seeding is `forge test --symbolic-seed-corpus`.
+
+## Campaign and inspection workflow
 
 ```bash
-# 1. Run a normal campaign with `corpus_dir` configured to populate the corpus.
-forge test
+# 1. Populate or continue an explicitly located corpus with a normal campaign.
+# Omitting --corpus-dir uses forge fuzz run's cache-backed default.
+forge fuzz run --corpus-dir corpus --mc MyInvariantTest --mt invariant_
 
-# 2. Replay it.
-forge test \
+# 2. Decode and inspect the persisted sequences.
+forge fuzz show corpus
+
+# 3. Keep only entries that add coverage. The output path must not exist.
+forge fuzz cmin corpus --corpus-out corpus-min \
+  --mc MyInvariantTest --mt invariant_
+
+# 4. Confirm that the minimized entries still replay for the selected test.
+forge fuzz replay --corpus-dir corpus-min \
+  --mc MyInvariantTest --mt invariant_
+
+# 5. Export coverage for comparison.
+forge fuzz run \
   --showmap-out coverage_data \
+  --showmap-corpus-dir corpus-min \
   --showmap-approach foundry \
-  --showmap-domain evm
+  --showmap-domain evm \
+  --mc MyInvariantTest \
+  --mt invariant_
 ```
+
+Use the same test filters and replay-critical EVM/build options for the
+campaign, minimization, replay, and showmap steps. `corpus_dir` may instead be
+configured under the applicable `[profile.<name>.fuzz]` or
+`[profile.<name>.invariant]` section in `foundry.toml`.
 
 This skips the regular fuzz/invariant campaign and unit/table tests, then for
 every selected fuzz/invariant test:
 
 1. Resolves the per-test corpus dir (or `--showmap-corpus-dir <PATH>` override).
-2. Walks `worker0/corpus/*.json[.gz]`.
+2. Walks every `worker*/corpus/*.json[.gz]` and deduplicates synchronized
+   copies by corpus identity (UUID and timestamp).
 3. Replays each entry through a fresh executor.
-4. Aggregates per-call EVM (and/or sancov) edge bitmaps with saturating add.
+4. Aggregates per-call EVM instruction/PC hit maps and/or sancov edge bitmaps
+   with saturating add.
 5. Writes one or more files under `<showmap-out>/<approach>__<suite>__<test>/`.
 
 ## Flags

--- a/docs/dev/showmap.md
+++ b/docs/dev/showmap.md
@@ -29,9 +29,12 @@ executes normally. Reusing a donor does not bypass the existing sequence-level
 corpus admission rules: only sequence-level inputs that improve coverage or the
 optimization objective are persisted.
 
-Nested calls are not collected: their calldata alone does not reproduce the
-caller, value, preceding state, or reentrancy context that made the original
-execution interesting.
+Nested calls are not collected. Even if a recorder retains their caller and
+value, replaying a nested frame as a top-level transaction cannot reproduce the
+surrounding call frame, reentrancy context, or preceding sequence state. The
+whole-call dictionary intentionally preserves ABI-argument correlation rather
+than full call reproducibility; sender, value, warp, and roll are generated
+normally.
 
 Whole-call donors are in-memory generation inputs, not additional corpus
 entries. Corpus replay at startup reconstructs the donor dictionary from
@@ -46,8 +49,9 @@ ABI arguments matter, including handlers that share a canonical signature. It
 does not derive unknown cryptographic preimages or generally solve nonlinear
 constraints, and does not claim a general hard-branch improvement. There is no
 separate `forge fuzz seed` subcommand: `forge fuzz run` learns and reuses these
-donors automatically, while the explicit CLI entry point for solver-assisted
-pre-seeding is `forge test --symbolic-seed-corpus`.
+donors automatically. Solver-assisted pre-seeding remains explicit through
+`forge test --symbolic-seed-corpus` or the two-step
+`--fuzz-frontier-dir`/`--symbolic-use-fuzz-frontiers` workflow.
 
 ## Campaign and inspection workflow
 
@@ -87,7 +91,7 @@ every selected fuzz/invariant test:
 
 1. Resolves the per-test corpus dir (or `--showmap-corpus-dir <PATH>` override).
 2. Walks every `worker*/corpus/*.json[.gz]` and deduplicates synchronized
-   copies by corpus identity (UUID and timestamp).
+   copies by corpus UUID.
 3. Replays each entry through a fresh executor.
 4. Aggregates per-call EVM instruction/PC hit maps and/or sancov edge bitmaps
    with saturating add.


### PR DESCRIPTION
This retargets #15631 away from automatic symbolic assistance. The solver
prototype did generate cold-start seeds on selected linear fixtures, but its
automatic A/B campaigns did not retain a final coverage advantage: Nerite and
Aave controls caught up within 15 minutes, and Liquity ended a one-hour run with
the same 2,755 PC offsets despite one useful seed. The later long-plateau policy
ran seven assists after roughly 7.6 million concrete runs across Tomb, Spark
PSM, and Aave KeyValueList but produced no candidate, useful corpus entry, or
counterexample: four attempts ended with no input, two reverted on every input,
and one timed out. That evidence, along with the solver lifecycle and resource
cost, did not justify making it part of ordinary fuzz campaigns.

Stacked on #15816, this instead follows Echidna's direct generation primitive: a [concretely executed top-level call is retained only when its execution grows coverage](https://github.com/crytic/echidna/blob/58d7fc5860de5a7a6e5a3f46384f3e9d9a486596/lib/Echidna/Campaign.hs#L569-L584), in a [signature-keyed whole-call dictionary](https://github.com/crytic/echidna/blob/58d7fc5860de5a7a6e5a3f46384f3e9d9a486596/lib/Echidna/ABI.hs#L109-L137), and a reused call has [one ABI argument mutated](https://github.com/crytic/echidna/blob/58d7fc5860de5a7a6e5a3f46384f3e9d9a486596/lib/Echidna/ABI.hs#L349-L356). The #15816 stack inherits #15220, which hoists recorded nested calls into the invariant corpus and seeds it from sibling zero-input test traces; #15817 moves coverage-winning observed calls to a separate generation pool. This PR intentionally removes both seed paths, the nested-call recorder and depth bookkeeping, and the public `ObservedCall`/`RawCallResult.observed_calls` surface.

Although the inherited recorder retains caller and value, replaying a nested frame as a top-level transaction cannot reproduce the surrounding call frame, reentrancy context, or preceding sequence state. This design instead preserves only ABI-argument correlation from calls with unambiguous top-level coverage attribution. Sender, value, warp, and roll are generated normally, and a donor can still depend on earlier state in its original invariant sequence; reuse is a heuristic, not full-call reproduction.

This PR instead retains argument-bearing top-level ABI calldata whose complete concrete execution first raises the worker's edge or hit-count map. Donors are indexed by the full canonical-signature hash. For each freshly generated invariant call, Foundry still selects the destination, function, sender, and value normally; it may then retarget compatible donor calldata to that destination and mutate exactly one ABI argument. The call executes normally, and only sequence-level inputs satisfying the existing coverage or optimization admission rules are persisted.

Absent explicit corpus paths, an ordinary `forge fuzz run` creates and reuses separate `cache/fuzz/corpus` and `cache/invariant/corpus` roots automatically; a configured `failure_persist_dir` derives `<dir>/corpus`. Ordinary `forge test` remains opt-in through configured corpus paths. There is no `forge fuzz seed` subcommand. This donor mechanism adds no solver, hybrid engine, extra worker, or new mode flag; solver pre-seeding remains explicit through `forge test --symbolic-seed-corpus` or the two-step `--fuzz-frontier-dir`/`--symbolic-use-fuzz-frontiers` workflow.

Startup replay reconstructs donors from top-level calls that win coverage during replay. Parallel workers clone that seed and then learn locally. Each worker and the retained startup seed are separately bounded to 1,024 donors and 4 MiB of calldata, so the conservative campaign-level calldata bound is `(workers + 1) × 4 MiB` plus container overhead. `dictionary_weight = 0` disables donor selection; an effective `mutation_weight_abi = 0` disables collection and reuse. The dictionary weight is shared with Foundry's existing value dictionary rather than introducing another knob. Keeping dictionaries worker-local avoids shared hot-path synchronization, but discoveries are not live-shared between parallel workers; that is an explicit parallel-efficiency limitation.

### Results

The Sky rows used the earlier donor-only build `def3ea2f4dc2` against #15816 so
both arms still had the inherited nested-call recorder; they isolate the donor
mechanism but are not a benchmark of the final composite diff. The deterministic
fixture and Superform campaign use benchmarked implementation commit
`1303932c9b4c`; the later `a377bf2c8fc9` commit changes documentation only.
The cold real-world A/B arms use baseline #15816 commit
`926d4e36fd160aaaf5f34b2e085a992e3e933c9a`, pinned targets, seed
`0x5f3759df`, depth 100, the default dictionary/ABI weights (40/4), separate
initially empty corpora, and replay-only showmaps. The primary metric is the
exact set of emitted `(8-byte deployed bytecode-hash prefix, PC)` IDs; corpus
size, collision-free branch-edge and hit-count telemetry, throughput, and RSS
are diagnostics.

The Superform candidate completed in 3,600 seconds wall time. The host
suspended repeatedly during the baseline: Forge still accumulated 3,569
seconds of user CPU and 14.50 million calls before its one-hour active timeout,
but `/usr/bin/time` recorded 10,493 seconds wall time. The coverage comparison
is retained; arm-order and wall-throughput differences are not treated as
causal.

| Campaign | Baseline | Candidate | Interpretation |
| --- | --- | --- | --- |
| Deterministic two-process corpus-reconstruction fixture | No whole-call reconstruction | Reconstructs exact persisted ABI calldata against a hash-only oracle in a second process; one-argument donor mutation reaches a new branch requiring exactly three of four correlated preimages | Establishes cross-process corpus reconstruction and causally attributes the branch to a replayed whole-call donor |
| [Sky `dss-conduits` `invariant_A_B_C_D`](https://github.com/sky-ecosystem/dss-conduits/blob/a09e16356374b3ec4f25292d3ae5b4682790263f/test/arranger-conduit/invariants/BoundedInvariants.t.sol), 1 hour, 2 workers | #15816: 20,096,800 calls; 43 corpus files; 11,540 bytecode/PC IDs | Donor-only `def3ea2f4dc2`: 19,366,600 calls; 51 corpus files; the same 11,540 IDs; summed worker high-water marks of 3,333,985 donor mutations, 654,028 cross-target mutations, 61 hit-count/edge feature wins, and 96 entries | Heavy activation, but no failure and zero new retained bytecode/PC locations. LCOV reported four getter-only lines and zero branches; both arms warned that `--ir-minimum` source mappings can be inaccurate, so this is not usefulness evidence. The baseline-first throughput comparison is not causal because unrelated host contention occurred during the candidate arm. |
| Sky warm-corpus continuation, another hour, 2 workers | — | Donor-only `def3ea2f4dc2`: 18,040,300 additional calls; 51 to 54 corpus files; summed worker high-water mark of 9,333,467 donor mutations; one hit-count win and no new edge; the same 11,540 bytecode/PC IDs | The three files arrived in the first 64 seconds, then the campaign plateaued for the rest of the hour. This raises that exploratory candidate build to 37,406,900 calls without expanding retained PC coverage or finding a failure. |
| [Superform v2 `ERC7540OracleInvariantTest.invariant_INV2_noOverAttribution`](https://github.com/superform-xyz/v2-core/blob/9920d580d636d8d89a2954c9909989df477b3ade/test/invariant/ERC7540OracleInvariant.t.sol#L425-L519), 1 active hour, 1 worker | 14,497,500 calls; 29 corpus files; 40 new-edge and 21 hit-count feature events; 11,194 emitted PC IDs; cmin kept 11/29 entries spanning 1,368 collision-free EVM edges; 129.5 MiB max RSS | 14,207,100 calls; 33 corpus files; 42 new-edge and 26 hit-count feature events; 1,373,633 donor mutations, including 804,289 cross-target and 14 feature-winning mutations; the same 11,194 PC IDs; cmin kept 13/33 entries spanning the same 1,368 edges; 135.0 MiB max RSS | No failure and zero candidate-only PC or collision-free edge identities. The exact sorted edge-key sets have the same SHA-256 (`82f767da…`) and no set difference. The extra live events and two extra minimized entries are consistent with corpus-composition, hit-count, and discovery-order effects, not expanded control-flow reach. |

The Superform repository was pinned at `9920d580d636d8d89a2954c9909989df477b3ade`
and remained clean. Because unrelated suites in that checkout did not compile,
the harness imported the exact upstream invariant and its dependency closure
through a minimal Foundry root; it did not edit the benchmark source. INV2
asserts the vanilla and Centrifuge handlers, while the targeted degraded handler
still contributes cross-target generation traffic but is not checked by that
property.

The deterministic fixture establishes that the mechanism works, but neither
real-world campaign expanded retained PC or collision-free edge coverage or
found a failure. Heavy donor activity and live feature counters are not enough
to justify merging this as default behavior. This therefore remains a draft
and should be treated as experimental until a pinned real target shows a
repeatable candidate-only edge or failure across multiple seeds. It is a
bounded alternative to #15817, not a broad DeFi or time-to-bug claim and not a
claim that nested observed calls belong in the corpus.

Developed with extensive Codex assistance across architecture analysis, implementation, tests, documentation, benchmark harnesses, result analysis, and this PR description.
