### PR TITLE
fix(forge): print no-tests warning to stderr

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -2256,7 +2256,7 @@ impl TestArgs {
                 runner.matching_test_functions(&EmptyTestFilter::default()).count()
             };
             if total_tests == 0 {
-                sh_println!(
+                sh_warn!(
                     "No tests found in project! Forge looks for functions that start with `test`"
                 )?;
             } else {

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -206,17 +206,15 @@ contract Dummy {}
 ",
     );
 
-    cmd.arg("test").assert_success().stdout_eq(str![[r#"
-...
-No tests found in project! Forge looks for functions that start with `test`
+    cmd.arg("test").assert_success().stderr_eq(str![[r#"
+Warning: No tests found in project! Forge looks for functions that start with `test`
 
 "#]]);
 
     cmd.forge_fuse();
     dummy_test_filter(&mut cmd);
-    cmd.assert_success().stdout_eq(str![[r#"
-...
-No tests found in project! Forge looks for functions that start with `test`
+    cmd.assert_success().stderr_eq(str![[r#"
+Warning: No tests found in project! Forge looks for functions that start with `test`
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -111,14 +111,14 @@ contract SymbolicIgnored {
 "#,
     );
 
-    let stdout = cmd
+    let stderr = cmd
         .args(["test", "--match-test", "checkWouldFail"])
         .assert_success()
         .get_output()
-        .stdout_lossy();
+        .stderr_lossy();
 
     assert_relevant_lines(
-        &stdout,
+        &stderr,
         foundry_test_utils::str![[r#"
 No tests found
 "#]],


### PR DESCRIPTION
The "No tests found in project!" warning was printed to stdout, which corrupts `--json` output. Move it to stderr, matching the sibling "no tests match" branch.