### PR TITLE
ci: add github actions scan

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,8 +3,10 @@ self-hosted-runner:
     - depot-ubuntu-22.04-16
     - depot-ubuntu-22.04-arm-16
     - depot-ubuntu-24.04-32
+    - depot-ubuntu-latest-arm-16
     - depot-ubuntu-latest
     - depot-ubuntu-latest-16
+    - depot-macos-latest
     - depot-windows-latest-16
 
 config-variables: null

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+self-hosted-runner:
+  labels:
+    - depot-ubuntu-22.04-16
+    - depot-ubuntu-22.04-arm-16
+    - depot-ubuntu-24.04-32
+    - depot-ubuntu-latest
+    - depot-ubuntu-latest-16
+    - depot-windows-latest-16
+
+config-variables: null

--- a/.github/scripts/matrices.py
+++ b/.github/scripts/matrices.py
@@ -45,7 +45,8 @@ class Expanded:
     runner_label: str
     target: str
     svm_target_platform: str
-    flags: str
+    filter: str
+    partition_arg: str
     partition: int
 
     def __init__(
@@ -54,14 +55,16 @@ class Expanded:
         runner_label: str,
         target: str,
         svm_target_platform: str,
-        flags: str,
+        filter: str,
+        partition_arg: str,
         partition: int,
     ):
         self.name = name
         self.runner_label = runner_label
         self.target = target
         self.svm_target_platform = svm_target_platform
-        self.flags = flags
+        self.filter = filter
+        self.partition_arg = partition_arg
         self.partition = partition
 
 
@@ -108,22 +111,21 @@ def main():
                     os_str = f" ({target.target})"
 
                 name = case.name
-                flags = f"-E '{case.filter}'"
+                partition_arg = ""
                 if case.n_partitions > 1:
                     s = f"{partition}/{case.n_partitions}"
                     name += f" ({s})"
-                    flags += f" --partition count:{s}"
+                    partition_arg = f"count:{s}"
 
                 name += os_str
-
-                flags += " --no-fail-fast"
 
                 obj = Expanded(
                     name=name,
                     runner_label=target.runner_label,
                     target=target.target,
                     svm_target_platform=target.svm_target_platform,
-                    flags=flags,
+                    filter=case.filter,
+                    partition_arg=partition_arg,
                     partition=partition,
                 )
                 expanded.append(vars(obj))

--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -35,7 +35,7 @@ jobs:
           sudo apt-get install -y build-essential pkg-config z3
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
 

--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -204,8 +204,8 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           shopt -s nullglob
 
-          stable_parts=( benches/stable-${DATE}-*.json )
-          nightly_parts=( benches/nightly-${DATE}-*.json )
+          stable_parts=( "benches/stable-${DATE}-"*.json )
+          nightly_parts=( "benches/nightly-${DATE}-"*.json )
 
           if [[ ${#stable_parts[@]} -eq 0 && ${#nightly_parts[@]} -eq 0 ]]; then
             echo "No benchmark results produced — all steps failed."

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -193,7 +193,8 @@ jobs:
     steps:
       - name: Checkout repository # zizmor: ignore[artipacked] persists credentials to push benchmark data
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        # persist-credentials defaults to true so we can push.
+        with:
+          persist-credentials: true
 
       - name: Download benchmark results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -70,7 +70,7 @@ jobs:
           sudo apt-get install -y build-essential pkg-config z3
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
 
@@ -191,7 +191,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository # zizmor: ignore[artipacked] persists credentials to push benchmark data
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         # persist-credentials defaults to true so we can push.
 

--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -28,10 +28,10 @@ jobs:
       contents: read
     steps:
       # Checkout the repository
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
 

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -49,15 +49,15 @@ jobs:
       contents: read
     steps:
       # Checkout the repository
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
 
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       # Build and install binaries
       - name: Build and install Foundry binaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: nightly
           components: clippy
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: nightly
           components: rustfmt
@@ -139,7 +139,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
@@ -182,6 +182,12 @@ jobs:
         with:
           category: "/language:${{matrix.language}}"
 
+  scan-github-actions:
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648 # main
+    permissions:
+      actions: read
+      contents: read
+
   ci-success:
     runs-on: ubuntu-latest
     if: always()
@@ -197,6 +203,7 @@ jobs:
       - forge-fmt
       - deny
       - codeql
+      - scan-github-actions
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/crate-checks.yml
+++ b/.github/workflows/crate-checks.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -66,11 +66,11 @@ jobs:
       # - anything else: tagged as-is
       - name: Finalize Docker Metadata
         id: docker_tagging
+        env:
+          TAG: ${{ inputs.tag_name }}
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE: ${{ env.IMAGE_NAME }}
         run: |
-          TAG="${{ inputs.tag_name }}"
-          REGISTRY="${{ env.REGISTRY }}"
-          IMAGE="${{ env.IMAGE_NAME }}"
-
           if [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
             MAJOR="v${BASH_REMATCH[1]}"
             MINOR="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
@@ -86,9 +86,12 @@ jobs:
 
       # Log docker metadata to explicitly know what is being pushed
       - name: Inspect Docker Metadata
+        env:
+          DOCKER_TAGS: ${{ steps.docker_tagging.outputs.docker_tags }}
+          DOCKER_LABELS: ${{ steps.meta.outputs.labels }}
         run: |
-          printf "TAGS -> %s\n" "${{ steps.docker_tagging.outputs.docker_tags }}"
-          printf "LABELS -> %s\n" "${{ steps.meta.outputs.labels }}"
+          printf "TAGS -> %s\n" "$DOCKER_TAGS"
+          printf "LABELS -> %s\n" "$DOCKER_LABELS"
 
       - name: Set up Depot CLI
         uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: nightly-2026-07-01
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,7 +242,7 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail
-          flags=(--locked --target $TARGET --profile $RUST_PROFILE --bins
+          flags=(--locked --target "$TARGET" --profile "$RUST_PROFILE" --bins
             --no-default-features --features "$RUST_FEATURES")
 
           # `jemalloc` is not fully supported on MSVC or aarch64 Linux.
@@ -280,22 +280,25 @@ jobs:
         run: |
           if [[ "$PLATFORM_NAME" == "linux" || "$PLATFORM_NAME" == "alpine" ]]; then
             tar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C "$OUT_DIR" forge cast anvil chisel
-            printf "file_name=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> "$GITHUB_OUTPUT"
+            file_name="foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           elif [ "$PLATFORM_NAME" == "darwin" ]; then
             # We need to use gtar here otherwise the archive is corrupt.
             # See: https://github.com/actions/virtual-environments/issues/2619
             gtar -czvf "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" -C "$OUT_DIR" forge cast anvil chisel
-            printf "file_name=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz" >> "$GITHUB_OUTPUT"
+            file_name="foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.tar.gz"
           else
             cd "$OUT_DIR"
             7z a -tzip "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" forge.exe cast.exe anvil.exe chisel.exe
             mv "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" ../../../
-            printf "file_name=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip" >> "$GITHUB_OUTPUT"
+            file_name="foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.zip"
           fi
-          printf "foundry_attestation=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.attestation.txt" >> "$GITHUB_OUTPUT"
-          printf "foundry_sbom=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.spdx.json" >> "$GITHUB_OUTPUT"
-          printf "foundry_checksum=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.sha256" >> "$GITHUB_OUTPUT"
-          printf "foundry_signature=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.sigstore.json" >> "$GITHUB_OUTPUT"
+          {
+            printf "file_name=%s\n" "$file_name"
+            printf "foundry_attestation=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.attestation.txt"
+            printf "foundry_sbom=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.spdx.json"
+            printf "foundry_checksum=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.sha256"
+            printf "foundry_signature=%s\n" "foundry_${VERSION_NAME}_${PLATFORM_NAME}_${ARCH}.sigstore.json"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate archive checksum
         env:
@@ -342,10 +345,10 @@ jobs:
         shell: bash
         run: |
           sudo apt-get -y install help2man
-          help2man -N $OUT_DIR/forge > forge.1
-          help2man -N $OUT_DIR/cast > cast.1
-          help2man -N $OUT_DIR/anvil > anvil.1
-          help2man -N $OUT_DIR/chisel > chisel.1
+          help2man -N "$OUT_DIR/forge" > forge.1
+          help2man -N "$OUT_DIR/cast" > cast.1
+          help2man -N "$OUT_DIR/anvil" > anvil.1
+          help2man -N "$OUT_DIR/chisel" > chisel.1
           gzip forge.1
           gzip cast.1
           gzip anvil.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           targets: ${{ matrix.target }}

--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           target: ${{ matrix.target }}
@@ -121,4 +121,5 @@ jobs:
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
           ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
           ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
-        run: cargo nextest run --locked ${{ matrix.flags }}
+          NEXTEST_FLAGS: ${{ matrix.flags }}
+        run: cargo nextest run --locked $NEXTEST_FLAGS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,5 +121,11 @@ jobs:
           ETHERSCAN_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
           ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
           ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
-          NEXTEST_FLAGS: ${{ matrix.flags }}
-        run: cargo nextest run --locked $NEXTEST_FLAGS
+          NEXTEST_FILTER: ${{ matrix.filter }}
+          NEXTEST_PARTITION: ${{ matrix.partition_arg }}
+        run: |
+          args=(-E "$NEXTEST_FILTER" --no-fail-fast)
+          if [[ -n "$NEXTEST_PARTITION" ]]; then
+            args+=(--partition "$NEXTEST_PARTITION")
+          fi
+          cargo nextest run --locked "${args[@]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,8 +124,9 @@ jobs:
           NEXTEST_FILTER: ${{ matrix.filter }}
           NEXTEST_PARTITION: ${{ matrix.partition_arg }}
         run: |
-          args=(-E "$NEXTEST_FILTER" --no-fail-fast)
+          args=(-E "$NEXTEST_FILTER")
           if [[ -n "$NEXTEST_PARTITION" ]]; then
             args+=(--partition "$NEXTEST_PARTITION")
           fi
+          args+=(--no-fail-fast)
           cargo nextest run --locked "${args[@]}"


### PR DESCRIPTION
Adds the Tempo GitHub Actions scan reusable workflow to CI and includes it in the `ci-success` aggregate check so workflow security and linting are required alongside the existing jobs.

This also fixes the findings that would fail the new scan: pins the remaining checkout tag refs, moves dynamic shell expressions through environment variables, updates stale version comments on pinned actions, and configures actionlint for the repo's Depot runner labels.

Prompted by: @grandizzy
