### PR TITLE
ci: run nextest step with bash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
           ETH_SEPOLIA_RPC: ${{ secrets.ETH_SEPOLIA_RPC }}
           NEXTEST_FILTER: ${{ matrix.filter }}
           NEXTEST_PARTITION: ${{ matrix.partition_arg }}
+        shell: bash
         run: |
           args=(-E "$NEXTEST_FILTER")
           if [[ -n "$NEXTEST_PARTITION" ]]; then


### PR DESCRIPTION
Fixes the post-merge Windows CI failure from the GitHub Actions scan follow-up. The nextest step now builds its arguments with a Bash array, but the default shell on Windows runners is PowerShell, which fails to parse the Bash syntax before tests run. Set the step shell to Bash so the same command works across the push matrix.

Prompted by: @grandizzy
