### PR TITLE
feat: make bench local build bins configurable

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -156,6 +156,9 @@ The script builds the `foundry-bench` harness from the current checkout once,
 then points it at each checked-out workspace with
 `FOUNDRY_BENCH_WORKSPACE_ROOT`. The `local` version builds and activates that
 workspace with `FOUNDRY_BENCH_LOCAL_BUILD_PROFILE=profiling` before each run.
+By default, the PR script sets `FOUNDRY_BENCH_LOCAL_BUILD_BINS=forge` so forge
+benchmarks do not build unused targets. Set it to a comma- or whitespace-
+separated list such as `forge,cast,anvil,chisel` when a run needs more binaries.
 Keep `REPOS`, `BENCHMARKS`, and any per-repo extra arguments identical for
 `master` and `candidate`. Override `CANDIDATE_REF`, `RUN_ID`, or `BENCH_ROOT`
 when needed.

--- a/benches/scripts/pr-bench.sh
+++ b/benches/scripts/pr-bench.sh
@@ -7,6 +7,7 @@ BENCHMARKS="${BENCHMARKS:-forge_test}"
 REPOS="${REPOS:-ithacaxyz/account:v0.5.7}"
 RUN_ID="${RUN_ID:-$(date -u +%Y%m%d%H%M%S)}"
 BENCH_ROOT="${BENCH_ROOT:-/tmp/foundry-pr-bench-${RUN_ID}}"
+FOUNDRY_BENCH_LOCAL_BUILD_BINS="${FOUNDRY_BENCH_LOCAL_BUILD_BINS:-forge}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -38,6 +39,7 @@ for label in master candidate; do
     foundry_dir="${BENCH_ROOT}/${label}/.foundry"
     FOUNDRY_BENCH_WORKSPACE_ROOT="${BENCH_ROOT}/${label}" \
       FOUNDRY_BENCH_LOCAL_BUILD_PROFILE=profiling \
+      FOUNDRY_BENCH_LOCAL_BUILD_BINS="${FOUNDRY_BENCH_LOCAL_BUILD_BINS}" \
       FOUNDRY_DIR="${foundry_dir}" \
       PATH="${foundry_dir}/bin:${PATH}" \
       "${RUNNER_BIN}" \

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -772,6 +772,7 @@ fn stddev(values: &[f64]) -> Option<f64> {
 const WORKSPACE_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/..");
 const WORKSPACE_ROOT_ENV: &str = "FOUNDRY_BENCH_WORKSPACE_ROOT";
 const LOCAL_BUILD_PROFILE_ENV: &str = "FOUNDRY_BENCH_LOCAL_BUILD_PROFILE";
+const LOCAL_BUILD_BINS_ENV: &str = "FOUNDRY_BENCH_LOCAL_BUILD_BINS";
 const DEFAULT_LOCAL_BUILD_PROFILE: &str = "dist";
 const FOUNDRY_BINS: [&str; 4] = ["forge", "cast", "anvil", "chisel"];
 
@@ -812,15 +813,17 @@ pub fn switch_foundry_version(version: &str) -> Result<()> {
 pub fn install_local_version() -> Result<()> {
     let workspace = workspace_root()?;
     let profile = local_build_profile();
+    let bins = local_build_bins()?;
     sh_println!(
-        "  Building local workspace at {} with {} profile",
+        "  Building local workspace at {} with {} profile for {}",
         workspace.display(),
-        profile.to_string_lossy()
+        profile.to_string_lossy(),
+        bins.join(", ")
     );
 
     let mut cmd = Command::new("cargo");
     cmd.current_dir(&workspace).args(["build", "--locked", "--profile"]).arg(&profile);
-    for bin in FOUNDRY_BINS {
+    for bin in &bins {
         cmd.args(["--bin", bin]);
     }
 
@@ -830,7 +833,7 @@ pub fn install_local_version() -> Result<()> {
         eyre::bail!("local Foundry build failed");
     }
 
-    activate_local_binaries(&workspace, &profile)?;
+    activate_local_binaries(&workspace, &profile, &bins)?;
     sh_println!("  Successfully activated local {} build", profile.to_string_lossy());
     Ok(())
 }
@@ -849,14 +852,37 @@ fn local_build_profile() -> std::ffi::OsString {
         .unwrap_or_else(|| DEFAULT_LOCAL_BUILD_PROFILE.into())
 }
 
-fn activate_local_binaries(workspace: &Path, profile: &std::ffi::OsStr) -> Result<()> {
+fn local_build_bins() -> Result<Vec<String>> {
+    let Some(raw_bins) = env::var_os(LOCAL_BUILD_BINS_ENV).filter(|bins| !bins.is_empty()) else {
+        return Ok(FOUNDRY_BINS.into_iter().map(String::from).collect());
+    };
+
+    let bins = raw_bins
+        .to_string_lossy()
+        .split(|c: char| c == ',' || c.is_ascii_whitespace())
+        .filter(|bin| !bin.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+
+    if bins.is_empty() {
+        eyre::bail!("{LOCAL_BUILD_BINS_ENV} did not contain any binary names");
+    }
+
+    Ok(bins)
+}
+
+fn activate_local_binaries(
+    workspace: &Path,
+    profile: &std::ffi::OsStr,
+    bins: &[String],
+) -> Result<()> {
     let bin_dir = foundry_bin_dir()?;
     fs::create_dir_all(&bin_dir).wrap_err_with(|| {
         format!("Failed to create Foundry bin directory at {}", bin_dir.display())
     })?;
 
     let local_bin_dir = workspace.join("target").join(profile);
-    for bin in FOUNDRY_BINS {
+    for bin in bins {
         let bin_name = format!("{bin}{}", env::consts::EXE_SUFFIX);
         let source = local_bin_dir.join(&bin_name);
         let destination = bin_dir.join(&bin_name);


### PR DESCRIPTION
## Summary
- add FOUNDRY_BENCH_LOCAL_BUILD_BINS to select which local Foundry binaries the bench harness builds and activates
- default pr-bench.sh to building only forge while allowing callers to override the bin list
- document the new env var and accepted comma/whitespace-separated format

## Testing
- cargo +nightly fmt --check
- cargo +nightly clippy -p foundry-bench --all-targets --locked

Prompted by: @grandizzy