### PR TITLE
refactor(anvil): deduplicate Tempo boilerplate

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2539,13 +2539,7 @@ impl EthApi<FoundryNetwork> {
         // pre-validate
         self.backend.validate_pool_transaction(&pending_transaction).await?;
 
-        let (requires, provides) = if let Some((requires, provides)) =
-            tempo_parallel_nonce_markers(&pending_transaction)
-        {
-            (requires, provides)
-        } else {
-            (required_marker(nonce, on_chain_nonce, from), vec![to_marker(nonce, from)])
-        };
+        let (requires, provides) = nonce_markers(&pending_transaction, nonce, on_chain_nonce, from);
 
         self.add_pending_transaction(pending_transaction, requires, provides)
     }
@@ -2598,13 +2592,7 @@ impl EthApi<FoundryNetwork> {
         self.backend.validate_pool_transaction(&pending_transaction).await?;
 
         let on_chain_nonce = self.backend.current_nonce(from).await?;
-        let (requires, provides) = if let Some((requires, provides)) =
-            tempo_parallel_nonce_markers(&pending_transaction)
-        {
-            (requires, provides)
-        } else {
-            (required_marker(nonce, on_chain_nonce, from), vec![to_marker(nonce, from)])
-        };
+        let (requires, provides) = nonce_markers(&pending_transaction, nonce, on_chain_nonce, from);
 
         self.add_pending_transaction(pending_transaction, requires, provides)
     }
@@ -3799,13 +3787,7 @@ impl EthApi<FoundryNetwork> {
         // pre-validate
         self.backend.validate_pool_transaction(&pending_transaction).await?;
 
-        let (requires, provides) = if let Some((requires, provides)) =
-            tempo_parallel_nonce_markers(&pending_transaction)
-        {
-            (requires, provides)
-        } else {
-            (required_marker(nonce, on_chain_nonce, from), vec![to_marker(nonce, from)])
-        };
+        let (requires, provides) = nonce_markers(&pending_transaction, nonce, on_chain_nonce, from);
 
         self.add_pending_transaction(pending_transaction, requires, provides)
     }
@@ -4322,9 +4304,7 @@ impl EthApi<FoundryNetwork> {
     /// Only supported when running in Tempo mode (`--tempo`).
     pub async fn anvil_set_fee_token(&self, user: Address, token: Address) -> Result<()> {
         node_info!("anvil_setFeeToken");
-        if !self.backend.is_tempo() {
-            return Err(BlockchainError::RpcUnimplemented);
-        }
+        self.ensure_tempo_mode()?;
         self.backend.set_fee_token(user, token).await?;
         Ok(())
     }
@@ -4340,9 +4320,7 @@ impl EthApi<FoundryNetwork> {
         token: Address,
     ) -> Result<()> {
         node_info!("anvil_setValidatorFeeToken");
-        if !self.backend.is_tempo() {
-            return Err(BlockchainError::RpcUnimplemented);
-        }
+        self.ensure_tempo_mode()?;
         self.backend.set_validator_fee_token(validator, token).await?;
         Ok(())
     }
@@ -4359,11 +4337,14 @@ impl EthApi<FoundryNetwork> {
         amount: U256,
     ) -> Result<()> {
         node_info!("anvil_setFeeAmmLiquidity");
-        if !self.backend.is_tempo() {
-            return Err(BlockchainError::RpcUnimplemented);
-        }
+        self.ensure_tempo_mode()?;
         self.backend.set_fee_amm_liquidity(user_token, validator_token, amount).await?;
         Ok(())
+    }
+
+    /// Ensures anvil runs in Tempo mode (`--tempo`), the RPC method is unavailable otherwise.
+    fn ensure_tempo_mode(&self) -> Result<()> {
+        if self.backend.is_tempo() { Ok(()) } else { Err(BlockchainError::RpcUnimplemented) }
     }
 }
 
@@ -4394,6 +4375,19 @@ fn tempo_parallel_nonce_markers(
         .as_ref()
         .has_nonzero_tempo_nonce_key()
         .then(|| (vec![], vec![pending_transaction.hash().to_vec()]))
+}
+
+/// Returns the pool `(requires, provides)` markers for a transaction, accounting for
+/// Tempo's 2D nonce system (see [`tempo_parallel_nonce_markers`]).
+fn nonce_markers(
+    pending_transaction: &PendingTransaction<FoundryTxEnvelope>,
+    nonce: u64,
+    on_chain_nonce: u64,
+    from: Address,
+) -> (Vec<TxMarker>, Vec<TxMarker>) {
+    tempo_parallel_nonce_markers(pending_transaction).unwrap_or_else(|| {
+        (required_marker(nonce, on_chain_nonce, from), vec![to_marker(nonce, from)])
+    })
 }
 
 fn txpool_transaction_key(pending_transaction: &PendingTransaction<FoundryTxEnvelope>) -> String {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -101,7 +101,10 @@ use flate2::{Compression, read::GzDecoder, write::GzEncoder};
 use foundry_evm::{
     backend::{DatabaseError, DatabaseResult, RevertStateSnapshotAction},
     constants::DEFAULT_CREATE2_DEPLOYER_RUNTIME_CODE,
-    core::precompiles::EC_RECOVER,
+    core::{
+        evm::{EvmEnvFor, TempoEvmNetwork},
+        precompiles::EC_RECOVER,
+    },
     decode::RevertDecoder,
     hardfork::FoundryHardfork,
     inspectors::AccessListInspector,
@@ -1306,6 +1309,20 @@ impl<N: Network> Backend<N> {
         Ok((result, base))
     }
 
+    /// Builds the Tempo [`EvmEnv`] (spec, gas params, [`TempoBlockEnv`]) from a base
+    /// env.
+    fn build_tempo_evm_env(&self, evm_env: &EvmEnv) -> EvmEnvFor<TempoEvmNetwork> {
+        let hardfork = self.tempo_hardfork();
+        EvmEnv::new(
+            evm_env.cfg_env.clone().with_spec_and_gas_params(hardfork, tempo_gas_params(hardfork)),
+            TempoBlockEnv {
+                inner: evm_env.block_env.clone(),
+                timestamp_millis_part: 0,
+                ..Default::default()
+            },
+        )
+    }
+
     /// Creates a Tempo EVM, injects precompiles, and transacts with a native [`TempoTxEnv`].
     fn transact_tempo_with_inspector_ref<'db, I, DB>(
         &self,
@@ -1319,15 +1336,7 @@ impl<N: Network> Backend<N> {
         I: Inspector<TempoContext<WrapDatabaseRef<&'db DB>>>,
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
-        let hardfork = self.tempo_hardfork();
-        let tempo_env = EvmEnv::new(
-            evm_env.cfg_env.clone().with_spec_and_gas_params(hardfork, tempo_gas_params(hardfork)),
-            TempoBlockEnv {
-                inner: evm_env.block_env.clone(),
-                timestamp_millis_part: 0,
-                ..Default::default()
-            },
-        );
+        let tempo_env = self.build_tempo_evm_env(evm_env);
         let mut evm = TempoEvmFactory::default().create_evm_with_inspector(
             WrapDatabaseRef(db),
             tempo_env,
@@ -1397,18 +1406,7 @@ impl<N: Network> Backend<N> {
         }
 
         if self.is_tempo() {
-            let hardfork = self.tempo_hardfork();
-            let tempo_env = EvmEnv::new(
-                evm_env
-                    .cfg_env
-                    .clone()
-                    .with_spec_and_gas_params(hardfork, tempo_gas_params(hardfork)),
-                TempoBlockEnv {
-                    inner: evm_env.block_env.clone(),
-                    timestamp_millis_part: 0,
-                    ..Default::default()
-                },
-            );
+            let tempo_env = self.build_tempo_evm_env(evm_env);
             let mut evm =
                 TempoEvmFactory::default().create_evm_with_inspector(db, tempo_env, inspector);
             run!(evm)
@@ -4982,24 +4980,13 @@ impl Backend<FoundryNetwork> {
 
     /// Sets the fee token for a user address (Tempo-only).
     pub async fn set_fee_token(&self, user: Address, token: Address) -> DatabaseResult<()> {
-        let hardfork = self.hardfork();
-        let chain_id = self.evm_env.read().cfg_env.chain_id;
-        let timestamp = U256::from(self.evm_env.read().block_env.timestamp);
-        let block_number: u64 = self.evm_env.read().block_env.number.to();
-        let mut db = self.db.write().await;
-        let mut storage = AnvilStorageProvider::new(
-            &mut **db,
-            chain_id,
-            timestamp,
-            block_number,
-            hardfork.into(),
-        );
-        StorageCtx::enter(&mut storage, || {
+        self.with_tempo_storage(|| {
             let mut fee_manager = TipFeeManager::new();
             fee_manager
                 .set_user_token(user, IFeeManager::setUserTokenCall { token })
-                .map_err(|e| DatabaseError::AnyRequest(Arc::new(eyre::eyre!("{e}"))))
+                .map_err(tempo_db_err)
         })
+        .await
     }
 
     /// Sets the fee token for a validator address (Tempo-only).
@@ -5008,19 +4995,7 @@ impl Backend<FoundryNetwork> {
         validator: Address,
         token: Address,
     ) -> DatabaseResult<()> {
-        let hardfork = self.hardfork();
-        let chain_id = self.evm_env.read().cfg_env.chain_id;
-        let timestamp = U256::from(self.evm_env.read().block_env.timestamp);
-        let block_number: u64 = self.evm_env.read().block_env.number.to();
-        let mut db = self.db.write().await;
-        let mut storage = AnvilStorageProvider::new(
-            &mut **db,
-            chain_id,
-            timestamp,
-            block_number,
-            hardfork.into(),
-        );
-        StorageCtx::enter(&mut storage, || {
+        self.with_tempo_storage(|| {
             let mut fee_manager = TipFeeManager::new();
             // Use Address::ZERO as beneficiary so the check `sender != beneficiary` passes
             fee_manager
@@ -5029,8 +5004,9 @@ impl Backend<FoundryNetwork> {
                     IFeeManager::setValidatorTokenCall { token },
                     Address::ZERO,
                 )
-                .map_err(|e| DatabaseError::AnyRequest(Arc::new(eyre::eyre!("{e}"))))
+                .map_err(tempo_db_err)
         })
+        .await
     }
 
     /// Mints FeeAMM liquidity for a token pair (Tempo-only).
@@ -5040,11 +5016,37 @@ impl Backend<FoundryNetwork> {
         validator_token: Address,
         amount: U256,
     ) -> DatabaseResult<()> {
-        let hardfork = self.hardfork();
-        let chain_id = self.evm_env.read().cfg_env.chain_id;
-        let timestamp = U256::from(self.evm_env.read().block_env.timestamp);
-        let block_number: u64 = self.evm_env.read().block_env.number.to();
         let admin = Address::ZERO;
+        self.with_tempo_storage(|| {
+            // Mint the required tokens to admin so it can provide liquidity.
+            // grant_role_internal bypasses the caller check, matching genesis seeding.
+            for &token_address in &[user_token, validator_token] {
+                let mut token = TIP20Token::from_address(token_address).map_err(tempo_db_err)?;
+                token.grant_role_internal(admin, *ISSUER_ROLE).map_err(tempo_db_err)?;
+                token.mint(admin, ITIP20::mintCall { to: admin, amount }).map_err(tempo_db_err)?;
+            }
+            let mut fee_manager = TipFeeManager::new();
+            fee_manager
+                .mint(admin, user_token, validator_token, amount, admin)
+                .map_err(tempo_db_err)?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Runs `f` inside a Tempo storage context initialized from the current state
+    /// (Tempo-only).
+    async fn with_tempo_storage<R>(&self, f: impl FnOnce() -> R) -> R {
+        let hardfork = self.hardfork();
+        // One consistent snapshot of the current env to build the storage context.
+        let (chain_id, timestamp, block_number) = {
+            let env = self.evm_env.read();
+            (
+                env.cfg_env.chain_id,
+                U256::from(env.block_env.timestamp),
+                env.block_env.number.to::<u64>(),
+            )
+        };
         let mut db = self.db.write().await;
         let mut storage = AnvilStorageProvider::new(
             &mut **db,
@@ -5053,26 +5055,13 @@ impl Backend<FoundryNetwork> {
             block_number,
             hardfork.into(),
         );
-        StorageCtx::enter(&mut storage, || {
-            // Mint the required tokens to admin so it can provide liquidity.
-            // grant_role_internal bypasses the caller check, matching genesis seeding.
-            for &token_address in &[user_token, validator_token] {
-                let mut token = TIP20Token::from_address(token_address)
-                    .map_err(|e| DatabaseError::AnyRequest(Arc::new(eyre::eyre!("{e}"))))?;
-                token
-                    .grant_role_internal(admin, *ISSUER_ROLE)
-                    .map_err(|e| DatabaseError::AnyRequest(Arc::new(eyre::eyre!("{e}"))))?;
-                token
-                    .mint(admin, ITIP20::mintCall { to: admin, amount })
-                    .map_err(|e| DatabaseError::AnyRequest(Arc::new(eyre::eyre!("{e}"))))?;
-            }
-            let mut fee_manager = TipFeeManager::new();
-            fee_manager
-                .mint(admin, user_token, validator_token, amount, admin)
-                .map_err(|e| DatabaseError::AnyRequest(Arc::new(eyre::eyre!("{e}"))))?;
-            Ok(())
-        })
+        StorageCtx::enter(&mut storage, f)
     }
+}
+
+/// Converts a Tempo error into an anvil [`DatabaseError`].
+fn tempo_db_err<E: std::fmt::Display>(e: E) -> DatabaseError {
+    DatabaseError::AnyRequest(Arc::new(eyre::eyre!("{e}")))
 }
 
 /// Get max nonce from transaction pool by address.


### PR DESCRIPTION
## Motivation

The Tempo integration in anvil repeats a few blocks of boilerplate that have to be edited in several places whenever a signature or an error mapping changes.

## Solution

Four mechanical extractions, no behavior change:

- `Backend::with_tempo_storage` owns the storage-context preamble (hardfork, chain id, timestamp, block number, db write lock) that the three fee setters repeated (the snapshot is now taken under a single `evm_env` read instead of three), and `tempo_db_err` owns the eyre-to-`DatabaseError` mapping they each spelled out on every fallible call.
- `Backend::build_tempo_evm_env` builds the Tempo `EvmEnv` (spec plus gas params plus `TempoBlockEnv`) that the transact path and the block-executor path both assembled inline.
- `nonce_markers` folds the 2D-nonce fallback around the existing `tempo_parallel_nonce_markers` at the three call sites that repeated it verbatim. The fourth site (`send_raw_transaction`) computes its on-chain nonce lazily inside the fallback and intentionally stays as is, folding it would add an await on the Tempo path.
- `EthApi::ensure_tempo_mode` replaces the `is_tempo` guard the three Tempo-only RPC setters repeated.

`cargo test -p anvil` passes (449 tests; the only failure, `fork::flaky_test_arb_fork_mining`, fails identically on a pristine master checkout from this environment, so it is unrelated), and `cargo clippy -p anvil` is clean.
