### PR TITLE
feat(anvil): add anvil_setNextBlockPrevRandao

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -606,6 +606,10 @@ pub enum EthRequest {
     #[serde(rename = "anvil_setCoinbase", alias = "hardhat_setCoinbase", with = "sequence")]
     SetCoinbase(Address),
 
+    /// Sets the `prevrandao` value of the next block
+    #[serde(rename = "anvil_setNextBlockPrevRandao", with = "sequence")]
+    SetNextBlockPrevRandao(B256),
+
     /// Sets the chain id
     #[serde(rename = "anvil_setChainId", deserialize_with = "deserialize_u64_seq")]
     SetChainId(u64),
@@ -1420,6 +1424,13 @@ mod tests {
     fn test_serde_custom_coinbase() {
         let s = r#"{"method": "anvil_setCoinbase", "params":
 ["0x295a70b2de5e3953354a6a8344e616ed314d7251"]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_serde_custom_set_next_block_prevrandao() {
+        let s = r#"{"method": "anvil_setNextBlockPrevRandao", "params": ["0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -403,6 +403,18 @@ impl<N: Network> EthApi<N> {
         Ok(())
     }
 
+    /// Sets the `prevrandao` value of the next block.
+    ///
+    /// This is a one-shot override: it applies to the next mined block only, after which anvil
+    /// resumes deriving `prevrandao` from the parent hash and block number.
+    ///
+    /// Handler for RPC call: `anvil_setNextBlockPrevRandao`
+    pub async fn anvil_set_next_block_prevrandao(&self, prevrandao: B256) -> Result<()> {
+        node_info!("anvil_setNextBlockPrevRandao");
+        self.backend.set_next_block_prevrandao(prevrandao);
+        Ok(())
+    }
+
     /// Retrieves the Anvil node configuration params.
     ///
     /// Handler for RPC call: `anvil_nodeInfo`
@@ -1985,6 +1997,9 @@ impl EthApi<FoundryNetwork> {
                 self.anvil_set_storage_at(addr, slot, val).await.to_rpc_result()
             }
             EthRequest::SetCoinbase(addr) => self.anvil_set_coinbase(addr).await.to_rpc_result(),
+            EthRequest::SetNextBlockPrevRandao(prevrandao) => {
+                self.anvil_set_next_block_prevrandao(prevrandao).await.to_rpc_result()
+            }
             EthRequest::SetChainId(id) => self.anvil_set_chain_id(id).await.to_rpc_result(),
             EthRequest::SetLogging(log) => self.anvil_set_logging(log).await.to_rpc_result(),
             EthRequest::SetMinGasPrice(gas) => {

--- a/crates/anvil/src/eth/backend/cheats.rs
+++ b/crates/anvil/src/eth/backend/cheats.rs
@@ -2,7 +2,7 @@
 
 use alloy_evm::precompiles::{Precompile, PrecompileInput};
 use alloy_primitives::{
-    Address, Bytes,
+    Address, B256, Bytes,
     map::{AddressHashSet, foldhash::HashMap},
 };
 use parking_lot::RwLock;
@@ -83,6 +83,22 @@ impl CheatsManager {
     pub fn has_recover_overrides(&self) -> bool {
         !self.state.read().signature_overrides.is_empty()
     }
+
+    /// Sets the `prevrandao` value to use for the next mined block.
+    ///
+    /// This is a one-shot override that is consumed by the next block and applies to that block
+    /// only.
+    pub fn set_next_block_prevrandao(&self, prevrandao: B256) {
+        trace!(target: "cheats", %prevrandao, "set next block prevrandao");
+        self.state.write().next_block_prevrandao.replace(prevrandao);
+    }
+
+    /// Takes the manually set `prevrandao` value for the next block, if any.
+    ///
+    /// This consumes the override so it only applies to a single block.
+    pub fn take_next_block_prevrandao(&self) -> Option<B256> {
+        self.state.write().next_block_prevrandao.take()
+    }
 }
 
 /// Container type for all the state variables
@@ -94,6 +110,9 @@ pub struct CheatsState {
     pub auto_impersonate_accounts: bool,
     /// Overrides for ecrecover: Signature => Address
     pub signature_overrides: HashMap<Bytes, Address>,
+    /// The `prevrandao` value to use for the next mined block, if manually set via
+    /// `anvil_setNextBlockPrevRandao`.
+    pub next_block_prevrandao: Option<B256>,
 }
 
 impl CheatEcrecover {

--- a/crates/anvil/src/eth/backend/cheats.rs
+++ b/crates/anvil/src/eth/backend/cheats.rs
@@ -99,6 +99,14 @@ impl CheatsManager {
     pub fn take_next_block_prevrandao(&self) -> Option<B256> {
         self.state.write().next_block_prevrandao.take()
     }
+
+    /// Clears any manually set `prevrandao` value for the next block.
+    ///
+    /// Used on reset/revert so a set-but-unmined override does not leak into a later block,
+    /// mirroring how the next-block timestamp override is cleared by `TimeManager::reset`.
+    pub fn clear_next_block_prevrandao(&self) {
+        self.state.write().next_block_prevrandao.take();
+    }
 }
 
 /// Container type for all the state variables

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2481,6 +2481,8 @@ impl<N: Network> Backend<N> {
 
                 // reset the time to the timestamp of the forked block
                 self.time.reset(fork_block.header.timestamp());
+                // drop any pending next-block prevrandao override so it does not leak into a block
+                self.cheats.clear_next_block_prevrandao();
 
                 // also reset the total difficulty
                 self.blockchain.storage.write().total_difficulty = fork.total_difficulty();
@@ -2543,6 +2545,8 @@ impl<N: Network> Backend<N> {
 
         // Reset time manager
         self.time.reset(genesis_timestamp);
+        // drop any pending next-block prevrandao override so it does not leak into a block
+        self.cheats.clear_next_block_prevrandao();
 
         // Seed the next block's base fee. On Tempo the genesis keeps its fixed default while the
         // next block already follows the hardfork's rule (e.g. T7 clamps to the cap); other chains
@@ -2622,6 +2626,8 @@ impl<N: Network> Backend<N> {
 
             let reset_time = block.header.timestamp();
             self.time.reset(reset_time);
+            // drop any pending next-block prevrandao override so it does not leak into a block
+            self.cheats.clear_next_block_prevrandao();
 
             let mut env = self.evm_env.write();
             env.block_env = BlockEnv {
@@ -4126,6 +4132,8 @@ where
             env.block_env.prevrandao = common_block.header.mix_hash();
 
             self.time.reset(env.block_env.timestamp.saturating_to());
+            // drop any pending next-block prevrandao override so it does not leak into a block
+            self.cheats.clear_next_block_prevrandao();
         }
 
         {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -504,6 +504,14 @@ impl<N: Network> Backend<N> {
         self.evm_env.write().block_env.beneficiary = address;
     }
 
+    /// Sets the `prevrandao` value to use for the next mined block.
+    ///
+    /// This is a one-shot override that is consumed by the next block; afterwards anvil resumes its
+    /// default per-block `prevrandao` derivation.
+    pub fn set_next_block_prevrandao(&self, prevrandao: B256) {
+        self.cheats.set_next_block_prevrandao(prevrandao);
+    }
+
     /// Sets the nonce of the given address
     pub async fn set_nonce(&self, address: Address, nonce: U256) -> DatabaseResult<()> {
         self.db.write().await.set_nonce(address, nonce.try_into().unwrap_or(u64::MAX))
@@ -2892,7 +2900,11 @@ where
             let mut input = Vec::with_capacity(40);
             input.extend_from_slice(best_hash.as_slice());
             input.extend_from_slice(&block_number.to_le_bytes());
-            evm_env.block_env.prevrandao = Some(keccak256(&input));
+            // Use the `prevrandao` value set via `anvil_setNextBlockPrevRandao` for this block if
+            // one was provided, otherwise derive it from the parent hash and block number. The
+            // manual override is consumed here so it only applies to this single block.
+            evm_env.block_env.prevrandao =
+                Some(self.cheats.take_next_block_prevrandao().unwrap_or_else(|| keccak256(&input)));
 
             if self.prune_state_history_config.is_state_history_supported() {
                 let db = self.db.read().await.current_state();

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -647,6 +647,41 @@ async fn test_set_next_block_prevrandao_evm() {
     assert_eq!(block.header.mix_hash, Some(prevrandao));
 }
 
+// Tests that a `prevrandao` override set via `anvil_setNextBlockPrevRandao` but not yet mined is
+// dropped by `anvil_reset`, so the pending value cannot leak into a block mined after the reset.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_next_block_prevrandao_cleared_on_reset() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+
+    let prevrandao = b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+
+    api.anvil_set_next_block_prevrandao(prevrandao).await.unwrap();
+    // resetting must drop the pending override before it is consumed by a block
+    api.anvil_reset(None).await.unwrap();
+    api.mine_one().await;
+
+    let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_ne!(block.header.mix_hash, Some(prevrandao));
+}
+
+// Tests that a `prevrandao` override set via `anvil_setNextBlockPrevRandao` but not yet mined is
+// dropped by `evm_revert`, so the pending value cannot leak into a block mined after the revert.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_next_block_prevrandao_cleared_on_revert() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+
+    let prevrandao = b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+
+    let state_snapshot = api.evm_snapshot().await.unwrap();
+    api.anvil_set_next_block_prevrandao(prevrandao).await.unwrap();
+    // reverting must drop the pending override before it is consumed by a block
+    api.evm_revert(state_snapshot).await.unwrap();
+    api.mine_one().await;
+
+    let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_ne!(block.header.mix_hash, Some(prevrandao));
+}
+
 // test that after a snapshot revert, the env block is reset
 // to its correct value (block number, etc.)
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_consensus::{SignableTransaction, TxEip1559};
 use alloy_network::{EthereumWallet, TransactionBuilder, TxSignerSync};
-use alloy_primitives::{Address, Bytes, TxKind, U256, address, fixed_bytes};
+use alloy_primitives::{Address, Bytes, TxKind, U256, address, b256, fixed_bytes};
 use alloy_provider::{Provider, ext::TxPoolApi};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, TransactionRequest,
@@ -601,6 +601,50 @@ async fn test_fork_revert_next_block_timestamp() {
     api.mine_one().await;
     let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert!(block.header.timestamp >= latest_block.header.timestamp);
+}
+
+// Tests that `anvil_setNextBlockPrevRandao` overrides the `prevrandao` (block header `mixHash`) of
+// the next mined block, and that the override is one-shot: subsequent blocks fall back to anvil's
+// default per-block `prevrandao` derivation.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_next_block_prevrandao() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+
+    let prevrandao = b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+
+    api.anvil_set_next_block_prevrandao(prevrandao).await.unwrap();
+    api.mine_one().await;
+
+    let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(block.header.mix_hash, Some(prevrandao));
+
+    // the override only applies to a single block: the next block uses the default derivation
+    api.mine_one().await;
+    let next = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_ne!(next.header.mix_hash, Some(prevrandao));
+}
+
+// Tests that the `prevrandao` set via `anvil_setNextBlockPrevRandao` is observed by the EVM: the
+// `PREVRANDAO` opcode (exposed through `Multicall::getCurrentBlockDifficulty`) returns the manually
+// set value for the overridden block.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_next_block_prevrandao_evm() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    // deploying the contract auto-mines a block
+    let multicall = Multicall::deploy(&provider).await.unwrap();
+
+    let prevrandao = b256!("0x00000000000000000000000000000000000000000000000000000000deadbeef");
+    api.anvil_set_next_block_prevrandao(prevrandao).await.unwrap();
+    api.mine_one().await;
+
+    // post-merge the `PREVRANDAO` opcode (0x44) returns the current block's `prevrandao`
+    let difficulty = multicall.getCurrentBlockDifficulty().call().await.unwrap();
+    assert_eq!(difficulty, U256::from_be_bytes(prevrandao.0));
+
+    let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(block.header.mix_hash, Some(prevrandao));
 }
 
 // test that after a snapshot revert, the env block is reset


### PR DESCRIPTION
## Motivation

Anvil lets users pin most header fields of the next block — coinbase, timestamp, base fee, and so on — but there was no way to control `prevrandao`, the post-merge replacement for `difficulty` that surfaces in the header as `mixHash` and is exposed to the EVM through the `PREVRANDAO` (`0x44`) opcode. Contracts that read `block.prevrandao` as a randomness source could therefore only be exercised against whatever value anvil derives internally, which makes deterministic tests and the reproduction of a specific on-chain scenario awkward.

## Solution

Add `anvil_setNextBlockPrevRandao`, which sets the `prevrandao` value used for the next mined block. Mirroring the semantics of `evm_setNextBlockTimestamp`, the override is one-shot: it applies to the next block only and is consumed as that block is mined, after which anvil resumes its default per-block derivation from the parent hash and block number. The value is held on the existing cheats state and taken in `do_mine_block`, so it flows into both the block header's `mixHash` and the EVM environment and is observable via the `PREVRANDAO` opcode within the overridden block.

Coverage includes a serde round-trip for the new method plus two integration tests: one asserting the header's `mixHash` is overridden and reverts to the default derivation on the following block, and one asserting the value is visible to the EVM through `Multicall.getCurrentBlockDifficulty`.

*This PR was written primarily by Claude Code.*

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

(similar functions also had no documentation at the moment)