### PR TITLE
feat(fuzz): report symbolic frontier failures

### DIFF
--- a/crates/evm/symbolic/README.md
+++ b/crates/evm/symbolic/README.md
@@ -157,7 +157,9 @@ forge test --match-test test_hard_branch \
 Forge imports up to `symbolic.frontier_limit` records (default 256), replays the
 recorded one-call seed as a path-priority hint, constrains symbolic execution to
 flip the captured comparison result, and persists only candidates that replay
-with the expected concrete outcome.
+with the expected concrete outcome. If the candidate replays as a fuzz failure,
+Forge reports it immediately as the fuzz counterexample and also persists the
+seed for later corpus replay.
 
 To focus solver time on specific captured sites, pass frontier artifact IDs,
 comparison PCs, or calldata selectors:

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -41,6 +41,10 @@ pub struct FuzzArgs {
 }
 
 impl FuzzArgs {
+    #[allow(
+        clippy::large_stack_frames,
+        reason = "FuzzSubcommands carries TestArgs; boxing the parser shape is outside this PR."
+    )]
     pub async fn run(self) -> Result<TestOutcome> {
         match self.command {
             FuzzSubcommands::Run(mut args) => {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -2703,16 +2703,20 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         self.result
     }
 
-    fn try_seed_fuzz_corpus_from_frontiers(&self, func: &Function, fuzz_config: &FuzzConfig) {
+    fn try_seed_fuzz_corpus_from_frontiers(
+        &self,
+        func: &Function,
+        fuzz_config: &FuzzConfig,
+    ) -> Option<FuzzTestResult> {
         if !should_symbolically_use_fuzz_frontiers(&self.config, func) {
-            return;
+            return None;
         }
         if fuzz_config.corpus.corpus_dir.is_none() {
             let _ = sh_warn!(
                 "`--symbolic-use-fuzz-frontiers` requires `--fuzz-corpus-dir` or \
                  `fuzz.corpus_dir`; skipping targeted frontier seeding"
             );
-            return;
+            return None;
         }
 
         for frontier in self.import_symbolic_fuzz_frontiers(func, fuzz_config) {
@@ -2755,6 +2759,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                 }
             };
 
+            let calldata = input.calldata.clone();
+            let args = input.args.clone();
             let replay = self.symbolic_fuzz_seed_replay(sender, &input, fuzz_config);
             let replay_matches = matches!(
                 (expect_failure, replay),
@@ -2799,7 +2805,21 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     );
                 }
             }
+
+            if expect_failure {
+                return Some(FuzzTestResult {
+                    reason: Some(format!(
+                        "targeted symbolic frontier {id} produced a replay-confirmed counterexample"
+                    )),
+                    counterexample: Some(CounterExample::Single(
+                        BaseCounterExample::from_fuzz_call(calldata, args, None),
+                    )),
+                    ..Default::default()
+                });
+            }
         }
+
+        None
     }
 
     fn try_seed_fuzz_corpus_symbolically(&self, func: &Function, fuzz_config: &FuzzConfig) {
@@ -4052,7 +4072,23 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             fuzz_config.corpus.corpus_dir = None;
         }
 
-        self.try_seed_fuzz_corpus_from_frontiers(func, &fuzz_config);
+        let record_counterexample = |result: &FuzzTestResult| {
+            if let Some(CounterExample::Single(counterexample)) = &result.counterexample {
+                if let Err(err) = foundry_common::fs::create_dir_all(&failure_dir) {
+                    error!(%err, "Failed to create fuzz failure dir");
+                } else if let Err(err) =
+                    foundry_common::fs::write_json_file(failure_file.as_path(), counterexample)
+                {
+                    error!(%err, "Failed to record call sequence");
+                }
+            }
+        };
+
+        if let Some(result) = self.try_seed_fuzz_corpus_from_frontiers(func, &fuzz_config) {
+            record_counterexample(&result);
+            self.result.fuzz_result(result);
+            return self.result;
+        }
         self.try_seed_fuzz_corpus_symbolically(func, &fuzz_config);
 
         let progress = start_fuzz_progress(
@@ -4109,15 +4145,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         };
 
         // Record counterexample.
-        if let Some(CounterExample::Single(counterexample)) = &result.counterexample {
-            if let Err(err) = foundry_common::fs::create_dir_all(failure_dir) {
-                error!(%err, "Failed to create fuzz failure dir");
-            } else if let Err(err) =
-                foundry_common::fs::write_json_file(failure_file.as_path(), counterexample)
-            {
-                error!(%err, "Failed to record call sequence");
-            }
-        }
+        record_counterexample(&result);
 
         self.result.fuzz_result(result);
         self.result

--- a/crates/forge/tests/cli/test_cmd/symbolic.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic.rs
@@ -2671,12 +2671,13 @@ contract SymbolicFuzzFrontierSeed {
             "--symbolic-frontier-selectors",
             &target_frontier_selector,
         ])
-        .assert_success()
+        .assert_failure()
         .get_output()
         .clone();
     let stdout = output.stdout_lossy();
     let stderr = output.stderr_lossy();
     assert!(stdout.contains("testFuzz_frontier(uint64,uint256)"), "{stdout}");
+    assert!(stdout.contains("targeted symbolic frontier"), "{stdout}");
     assert!(
         stderr.contains("Symbolic frontier selection for testFuzz_frontier(uint64,uint256)"),
         "{stderr}"


### PR DESCRIPTION
## What

This makes targeted symbolic frontier solving surface replay-confirmed fuzz failures immediately.

Before this change, `--symbolic-use-fuzz-frontiers` could solve a branch frontier, replay the candidate concretely, persist the resulting input into `--fuzz-corpus-dir`, and then still let the current `forge test` invocation pass. Users had to discover the failure through a later `forge fuzz replay` run.

After this change, if the symbolic frontier candidate replays as a fuzz failure, Forge reports it as the fuzz counterexample for the current run and still persists the seed for later corpus replay.

## Why

This is the smallest useful closed-loop behavior for the merged branch-frontier pipeline:

1. fuzzing captures a frontier comparison;
2. symbolic execution flips that comparison;
3. concrete replay confirms the input fails;
4. the fuzz command reports that failure immediately.

That makes the hybrid flow useful without requiring a separate manual replay step.

## Benchmark

I used a small hard-interval fuzz target where baseline fuzz misses the bug with a fixed seed, while frontier-guided symbolic execution flips the recorded comparison.

```solidity
function testFuzz_magic(uint256 x) public pure {
    uint256 target = uint256(keccak256(abi.encodePacked("hybrid-magic-frontier")));
    if (x > target) {
        if (x < target + 100) {
            assert(false);
        }
    }
}
```

Commands were run with compilation already warm and runtime caches cleared per sample.

| mode | command shape | result | mean |
| --- | --- | --- | ---: |
| baseline fuzz | `--fuzz-runs 10000 --fuzz-seed 0x1234 --threads 1` | passes, misses bug | `343.8 ms ± 2.9 ms` |
| hybrid frontier | `64` fuzz runs to capture frontier, then one targeted symbolic frontier solve | fails with replay-confirmed counterexample | `144.3 ms ± 0.6 ms` |

`hyperfine` reports the hybrid flow as `2.38x ± 0.02x` faster for this repro.

## Notes

This is deliberately much smaller than #15591. It builds on the already-merged stateless frontier capture/consume path and does not depend on the broader stateful invariant symbolic PR.

My read after this benchmark is that #15591 should be kept only if we want the separate stateful-invariant symbolic engine work on its own merits. It should not be the main vehicle for proving the hybrid fuzzer loop: this PR demonstrates the stateless frontier loop with a 3-file behavior change and a focused benchmark, while #15591 remains a broader 22-file symbolic/invariant change.

The second commit is a local clippy hygiene fix for an existing `forge fuzz` parser stack-frame warning that reproduces on clean `origin/master` with current local nightly. It is kept separate from the behavior change.

## Validation

- `cargo +1.96.0 build -p forge`
- `cargo +1.96.0 check -p forge`
- `cargo +1.96.0 test -p forge --test cli test_cmd::symbolic::symbolic_fuzz_frontier_seeding_persists_branch_flipping_input -- --exact --nocapture`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo +nightly clippy -p forge --test cli -- -D warnings`

Authored with AI assistance.

