### PR TITLE
fix(forge): filter internal libraries from --sizes

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -289,28 +289,39 @@ impl ProjectCompiler {
             }
 
             // Internal libraries are inlined into consumers and never deployed; skip them.
+            // Only artifacts whose ABI has no functions can be internal libraries, so restrict the
+            // solar parse to those sources to avoid a second full parse pass.
             let abs_source = |path: &Path| -> PathBuf {
                 if path.is_absolute() { path.to_path_buf() } else { self.project_root.join(path) }
             };
             let source_paths = artifacts
                 .values()
                 .flatten()
+                .filter(|(_, artifact)| {
+                    artifact.abi.as_ref().is_some_and(|abi| abi.functions().next().is_none())
+                })
                 .map(|(path, _)| abs_source(path))
                 .collect::<BTreeSet<_>>();
             let libraries = collect_libraries(&source_paths);
 
             for (name, artifact_list) in artifacts {
-                for (path, artifact) in &artifact_list {
-                    // A library with no functions in its ABI is internal-only; fail open if the
-                    // ABI is missing.
-                    let is_library =
-                        libraries.get(&abs_source(path)).is_some_and(|libs| libs.contains(&name));
-                    let has_no_abi_functions =
-                        artifact.abi.as_ref().is_some_and(|abi| abi.functions().next().is_none());
-                    if is_library && has_no_abi_functions {
-                        continue;
-                    }
+                // A library with no functions in its ABI is internal-only; fail open if the ABI is
+                // missing. Filter first so the duplicate-name suffix below reflects kept contracts.
+                let kept = artifact_list
+                    .iter()
+                    .filter(|(path, artifact)| {
+                        let is_library = libraries
+                            .get(&abs_source(path))
+                            .is_some_and(|libs| libs.contains(&name));
+                        let has_no_abi_functions = artifact
+                            .abi
+                            .as_ref()
+                            .is_some_and(|abi| abi.functions().next().is_none());
+                        !(is_library && has_no_abi_functions)
+                    })
+                    .collect::<Vec<_>>();
 
+                for (path, artifact) in &kept {
                     let runtime_size = contract_size(*artifact, false).unwrap_or_default();
                     let init_size = contract_size(*artifact, true).unwrap_or_default();
 
@@ -325,7 +336,7 @@ impl ProjectCompiler {
                         })
                         .unwrap_or(false);
 
-                    let unique_name = if artifact_list.len() > 1 {
+                    let unique_name = if kept.len() > 1 {
                         format!(
                             "{} ({})",
                             name,

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -23,8 +23,13 @@ use foundry_compilers::{
     solc::SolcSettings,
 };
 use num_format::{Locale, ToFormattedString};
+use solar::{
+    ast::{Arena, ContractKind, ItemKind},
+    interface::{Session, source_map::FileName},
+    parse::Parser,
+};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::Display,
     io::IsTerminal,
     path::{Path, PathBuf},
@@ -283,8 +288,29 @@ impl ProjectCompiler {
                 artifacts.entry(id.name.clone()).or_default().push((id.source.clone(), artifact));
             }
 
+            // Internal libraries are inlined into consumers and never deployed; skip them.
+            let abs_source = |path: &Path| -> PathBuf {
+                if path.is_absolute() { path.to_path_buf() } else { self.project_root.join(path) }
+            };
+            let source_paths = artifacts
+                .values()
+                .flatten()
+                .map(|(path, _)| abs_source(path))
+                .collect::<BTreeSet<_>>();
+            let libraries = collect_libraries(&source_paths);
+
             for (name, artifact_list) in artifacts {
                 for (path, artifact) in &artifact_list {
+                    // A library with no functions in its ABI is internal-only; fail open if the
+                    // ABI is missing.
+                    let is_library =
+                        libraries.get(&abs_source(path)).is_some_and(|libs| libs.contains(&name));
+                    let has_no_abi_functions =
+                        artifact.abi.as_ref().is_some_and(|abi| abi.functions().next().is_none());
+                    if is_library && has_no_abi_functions {
+                        continue;
+                    }
+
                     let runtime_size = contract_size(*artifact, false).unwrap_or_default();
                     let init_size = contract_size(*artifact, true).unwrap_or_default();
 
@@ -529,6 +555,44 @@ impl SizeReport {
 
         table
     }
+}
+
+/// Parses each source file with solar and returns the library names declared in it.
+///
+/// Files that fail to parse are skipped, so a missing entry means "unknown", not "no libraries".
+fn collect_libraries(sources: &BTreeSet<PathBuf>) -> HashMap<PathBuf, HashSet<String>> {
+    let mut result: HashMap<PathBuf, HashSet<String>> = HashMap::new();
+    let sess = Session::builder().with_silent_emitter(None).build();
+    let _ = sess.enter(|| -> solar::interface::Result<()> {
+        for path in sources {
+            let arena = Arena::new();
+            let mut parser = match Parser::from_lazy_source_code(
+                &sess,
+                &arena,
+                FileName::from(path.clone()),
+                || std::fs::read_to_string(path),
+            ) {
+                Ok(parser) => parser,
+                Err(_) => continue,
+            };
+            let Ok(ast) = parser.parse_file() else { continue };
+            let libs = ast
+                .items
+                .iter()
+                .filter_map(|item| match &item.kind {
+                    ItemKind::Contract(c) if c.kind == ContractKind::Library => {
+                        Some(c.name.as_str().to_string())
+                    }
+                    _ => None,
+                })
+                .collect::<HashSet<_>>();
+            if !libs.is_empty() {
+                result.insert(path.clone(), libs);
+            }
+        }
+        Ok(())
+    });
+    result
 }
 
 /// Returns the deployed or init size of the contract.

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -444,6 +444,44 @@ contract Consumer {
     );
 });
 
+// tests that when a filtered internal library shares a name with a kept contract, the survivor is
+// unique and prints without the `(path)` disambiguation suffix.
+// <https://github.com/foundry-rs/foundry/issues/1356>
+forgetest!(build_sizes_filtered_internal_library_frees_unique_name, |prj, cmd| {
+    prj.add_source(
+        "a/Foo",
+        r"
+library Foo {
+    function add(uint256 a) internal pure returns (uint256) {
+        return a + 1;
+    }
+}
+",
+    );
+    prj.add_source(
+        "b/Foo",
+        r"
+contract Foo {
+    function f() external pure returns (uint256) {
+        return 1;
+    }
+}
+",
+    );
+
+    cmd.args(["build", "--sizes"]).assert_success().stdout_eq(str![[r#"
+...
+
+╭----------+------------------+-------------------+--------------------+---------------------╮
+| Contract | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
++============================================================================================+
+| Foo      | 175              | 201               | 24,401             | 48,951              |
+╰----------+------------------+-------------------+--------------------+---------------------╯
+
+
+"#]]);
+});
+
 // tests that skip key in config can be used to skip non-compilable contract
 forgetest_init!(test_can_skip_contract, |prj, cmd| {
     prj.add_source(

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -369,6 +369,81 @@ contract Counter {
     );
 });
 
+// tests that `--sizes` filters out internal libraries (libraries without any external/public
+// functions), which are never deployed on their own.
+// <https://github.com/foundry-rs/foundry/issues/1356>
+forgetest!(build_sizes_filters_internal_libraries, |prj, cmd| {
+    prj.add_source(
+        "Libraries",
+        r"
+// Internal library: all functions internal, never deployed on its own.
+library InternalLib {
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a + b;
+    }
+}
+
+// Internal library that declares an event and error but no external functions.
+library EventLib {
+    event Ping(uint256 x);
+    error Boom();
+    function ping(uint256 a) internal pure returns (uint256) {
+        return a;
+    }
+}
+
+// Public library: deployed and linked.
+library PublicLib {
+    function sub(uint256 a, uint256 b) public pure returns (uint256) {
+        return a - b;
+    }
+}
+
+contract Consumer {
+    using InternalLib for uint256;
+    function run(uint256 x) external pure returns (uint256) {
+        return x.add(1);
+    }
+}
+",
+    );
+
+    // `InternalLib` and `EventLib` must not appear; `PublicLib` and `Consumer` must.
+    cmd.args(["build", "--sizes"]).assert_success().stdout_eq(str![[r#"
+...
+
+╭-----------+------------------+-------------------+--------------------+---------------------╮
+| Contract  | Runtime Size (B) | Initcode Size (B) | Runtime Margin (B) | Initcode Margin (B) |
++=============================================================================================+
+| Consumer  | 430              | 458               | 24,146             | 48,694              |
+|-----------+------------------+-------------------+--------------------+---------------------|
+| PublicLib | 432              | 509               | 24,144             | 48,643              |
+╰-----------+------------------+-------------------+--------------------+---------------------╯
+
+
+"#]]);
+
+    cmd.forge_fuse().args(["build", "--sizes", "--json"]).assert_success().stdout_eq(
+        str![[r#"
+{
+  "Consumer": {
+    "runtime_size": 430,
+    "init_size": 458,
+    "runtime_margin": 24146,
+    "init_margin": 48694
+  },
+  "PublicLib": {
+    "runtime_size": 432,
+    "init_size": 509,
+    "runtime_margin": 24144,
+    "init_margin": 48643
+  }
+}
+"#]]
+        .is_json(),
+    );
+});
+
 // tests that skip key in config can be used to skip non-compilable contract
 forgetest_init!(test_can_skip_contract, |prj, cmd| {
     prj.add_source(


### PR DESCRIPTION
`forge build --sizes` listed internal libraries (no external/public functions) with a misleading size, even though they're inlined into consumers and never deployed. Now with Solar, it parses sources to detect libraries and skips those with no functions in their ABI. 

Closes #1356.