### PR TITLE
chore: replace isolate bench with no-isolate bench

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -557,8 +557,8 @@ impl BenchmarkProject {
         )
     }
 
-    /// Benchmark forge test with --isolate flag
-    pub fn bench_forge_isolate_test(
+    /// Benchmark forge test with --no-isolate flag
+    pub fn bench_forge_no_isolate_test(
         &self,
         version: &str,
         runs: u32,
@@ -566,13 +566,13 @@ impl BenchmarkProject {
     ) -> Result<HyperfineResult> {
         // Build before running tests
         self.hyperfine(
-            "forge_isolate_test",
+            "forge_no_isolate_test",
             version,
             &self.cmd(
-                "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_ISOLATE=true forge test --isolate",
+                "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_ISOLATE=false forge test --no-isolate",
             ),
             runs,
-            Some("FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_ISOLATE=true forge build"),
+            Some("FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_ISOLATE=false forge build"),
             None,
             None,
             verbose,
@@ -678,7 +678,7 @@ impl BenchmarkProject {
             "forge_build_with_cache" => self.bench_forge_build_with_cache(version, runs, verbose),
             "forge_fuzz_test" => self.bench_forge_fuzz_test(version, runs, verbose),
             "forge_coverage" => self.bench_forge_coverage(version, runs, verbose),
-            "forge_isolate_test" => self.bench_forge_isolate_test(version, runs, verbose),
+            "forge_no_isolate_test" => self.bench_forge_no_isolate_test(version, runs, verbose),
             "forge_symbolic_test" => self.bench_forge_symbolic_test(version, runs, verbose),
             _ => eyre::bail!("Unknown benchmark: {}", benchmark),
         }

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -15,7 +15,7 @@ const ALL_BENCHMARKS: [&str; 7] = [
     "forge_build_with_cache",
     "forge_fuzz_test",
     "forge_coverage",
-    "forge_isolate_test",
+    "forge_no_isolate_test",
     "forge_symbolic_test",
 ];
 

--- a/benches/src/results.rs
+++ b/benches/src/results.rs
@@ -304,7 +304,7 @@ pub fn format_benchmark_name(name: &str) -> String {
         "forge_build_with_cache" => "Forge Build (With Cache)",
         "forge_fuzz_test" => "Forge Fuzz Test",
         "forge_coverage" => "Forge Coverage",
-        "forge_isolate_test" => "Forge Test (Isolated)",
+        "forge_no_isolate_test" => "Forge Test (No Isolate)",
         "forge_symbolic_test" => "Forge Symbolic Test",
         _ => name,
     }


### PR DESCRIPTION
## Summary
- replace the explicit isolate forge benchmark with a no-isolate benchmark
- update the benchmark id, dispatch, display label, and command/setup env

## Tests
- cargo +nightly fmt --check
- git diff --check
- cargo check -p foundry-bench (blocked: Cargo cannot fetch foundry-rs/optimism dependency at a305f5a..., HTTP 401/revision not found)

Prompted by: @grandizzy