### PR TITLE
feat(forge): enable default corpus for forge fuzz

### DIFF
--- a/benches/src/scfuzzbench.rs
+++ b/benches/src/scfuzzbench.rs
@@ -147,8 +147,6 @@ struct Dirs {
     scfuzz_root: PathBuf,
     scfuzz_work: PathBuf,
     scfuzz_logs: PathBuf,
-    foundry_fuzz_corpus: PathBuf,
-    foundry_invariant_corpus: PathBuf,
     unzipped: PathBuf,
     analysis_logs: PathBuf,
 }
@@ -168,8 +166,6 @@ impl Dirs {
             scfuzz_root: work.join("scfuzz-root"),
             scfuzz_work: work.join("scfuzz-work"),
             scfuzz_logs: work.join("scfuzz-logs"),
-            foundry_fuzz_corpus: work.join("foundry-fuzz-corpus"),
-            foundry_invariant_corpus: work.join("foundry-invariant-corpus"),
             unzipped: work.join("unzipped"),
             analysis_logs: work.join("analysis-logs"),
             work,
@@ -188,8 +184,6 @@ impl Dirs {
             &self.scfuzz_root,
             &self.scfuzz_work,
             &self.scfuzz_logs,
-            &self.foundry_fuzz_corpus,
-            &self.foundry_invariant_corpus,
             &self.unzipped,
             &self.analysis_logs,
         ] {
@@ -209,12 +203,6 @@ impl RunEnv {
     fn apply(&self, command: &mut Command) {
         command.env("PATH", &self.path).env("HOME", &self.home);
     }
-}
-
-fn apply_foundry_corpus_env(command: &mut Command, dirs: &Dirs) {
-    command
-        .env("FOUNDRY_FUZZ_CORPUS_DIR", &dirs.foundry_fuzz_corpus)
-        .env("FOUNDRY_INVARIANT_CORPUS_DIR", &dirs.foundry_invariant_corpus);
 }
 
 struct FoundrySelection {
@@ -795,7 +783,6 @@ fn run_campaign(
     }
 
     foundry.env.apply(&mut command);
-    apply_foundry_corpus_env(&mut command, dirs);
     command
         .env("SCFUZZBENCH_ROOT", &dirs.scfuzz_root)
         .env("SCFUZZBENCH_WORKDIR", &dirs.scfuzz_work)
@@ -1106,10 +1093,6 @@ fn write_manifest(
             "run_id": metadata.run_id,
             "exit_code": metadata.campaign_exit_code,
             "foundry_test_args": cli.foundry_test_args.as_deref(),
-            "foundry_corpus": {
-                "fuzz": dirs.foundry_fuzz_corpus.display().to_string(),
-                "invariant": dirs.foundry_invariant_corpus.display().to_string(),
-            },
             "properties_path": cli.properties_path.as_ref().map(|path| path.display().to_string()),
         },
         "artifacts": artifacts,
@@ -1144,8 +1127,6 @@ fn write_llm_summary(
             "- workers: `{}`",
             cli.workers.map(|w| w.to_string()).unwrap_or_else(|| "default".to_string())
         ),
-        format!("- fuzz corpus: `{}`", dirs.foundry_fuzz_corpus.display()),
-        format!("- invariant corpus: `{}`", dirs.foundry_invariant_corpus.display()),
         format!("- run id: `{}`", metadata.run_id),
         format!(
             "- campaign exit code: `{}`",
@@ -1514,27 +1495,6 @@ mod tests {
         .expect("failed to write relscores");
         fs::write(dirs.data.join("differential_coverage_relcov.csv"), relcov)
             .expect("failed to write relcov");
-    }
-
-    #[test]
-    fn applies_work_local_foundry_corpus_env() {
-        let (_temp, dirs) = temp_dirs();
-        let mut command = Command::new("true");
-
-        apply_foundry_corpus_env(&mut command, &dirs);
-
-        let envs = command
-            .get_envs()
-            .map(|(key, value)| (key.to_owned(), value.map(|value| value.to_owned())))
-            .collect::<Vec<_>>();
-        assert!(envs.iter().any(|(key, value)| {
-            key == "FOUNDRY_FUZZ_CORPUS_DIR"
-                && value.as_deref() == Some(dirs.foundry_fuzz_corpus.as_os_str())
-        }));
-        assert!(envs.iter().any(|(key, value)| {
-            key == "FOUNDRY_INVARIANT_CORPUS_DIR"
-                && value.as_deref() == Some(dirs.foundry_invariant_corpus.as_os_str())
-        }));
     }
 
     #[test]

--- a/benches/src/scfuzzbench.rs
+++ b/benches/src/scfuzzbench.rs
@@ -147,6 +147,8 @@ struct Dirs {
     scfuzz_root: PathBuf,
     scfuzz_work: PathBuf,
     scfuzz_logs: PathBuf,
+    foundry_fuzz_corpus: PathBuf,
+    foundry_invariant_corpus: PathBuf,
     unzipped: PathBuf,
     analysis_logs: PathBuf,
 }
@@ -166,6 +168,8 @@ impl Dirs {
             scfuzz_root: work.join("scfuzz-root"),
             scfuzz_work: work.join("scfuzz-work"),
             scfuzz_logs: work.join("scfuzz-logs"),
+            foundry_fuzz_corpus: work.join("foundry-fuzz-corpus"),
+            foundry_invariant_corpus: work.join("foundry-invariant-corpus"),
             unzipped: work.join("unzipped"),
             analysis_logs: work.join("analysis-logs"),
             work,
@@ -184,6 +188,8 @@ impl Dirs {
             &self.scfuzz_root,
             &self.scfuzz_work,
             &self.scfuzz_logs,
+            &self.foundry_fuzz_corpus,
+            &self.foundry_invariant_corpus,
             &self.unzipped,
             &self.analysis_logs,
         ] {
@@ -203,6 +209,12 @@ impl RunEnv {
     fn apply(&self, command: &mut Command) {
         command.env("PATH", &self.path).env("HOME", &self.home);
     }
+}
+
+fn apply_foundry_corpus_env(command: &mut Command, dirs: &Dirs) {
+    command
+        .env("FOUNDRY_FUZZ_CORPUS_DIR", &dirs.foundry_fuzz_corpus)
+        .env("FOUNDRY_INVARIANT_CORPUS_DIR", &dirs.foundry_invariant_corpus);
 }
 
 struct FoundrySelection {
@@ -783,6 +795,7 @@ fn run_campaign(
     }
 
     foundry.env.apply(&mut command);
+    apply_foundry_corpus_env(&mut command, dirs);
     command
         .env("SCFUZZBENCH_ROOT", &dirs.scfuzz_root)
         .env("SCFUZZBENCH_WORKDIR", &dirs.scfuzz_work)
@@ -1093,6 +1106,10 @@ fn write_manifest(
             "run_id": metadata.run_id,
             "exit_code": metadata.campaign_exit_code,
             "foundry_test_args": cli.foundry_test_args.as_deref(),
+            "foundry_corpus": {
+                "fuzz": dirs.foundry_fuzz_corpus.display().to_string(),
+                "invariant": dirs.foundry_invariant_corpus.display().to_string(),
+            },
             "properties_path": cli.properties_path.as_ref().map(|path| path.display().to_string()),
         },
         "artifacts": artifacts,
@@ -1127,6 +1144,8 @@ fn write_llm_summary(
             "- workers: `{}`",
             cli.workers.map(|w| w.to_string()).unwrap_or_else(|| "default".to_string())
         ),
+        format!("- fuzz corpus: `{}`", dirs.foundry_fuzz_corpus.display()),
+        format!("- invariant corpus: `{}`", dirs.foundry_invariant_corpus.display()),
         format!("- run id: `{}`", metadata.run_id),
         format!(
             "- campaign exit code: `{}`",
@@ -1495,6 +1514,27 @@ mod tests {
         .expect("failed to write relscores");
         fs::write(dirs.data.join("differential_coverage_relcov.csv"), relcov)
             .expect("failed to write relcov");
+    }
+
+    #[test]
+    fn applies_work_local_foundry_corpus_env() {
+        let (_temp, dirs) = temp_dirs();
+        let mut command = Command::new("true");
+
+        apply_foundry_corpus_env(&mut command, &dirs);
+
+        let envs = command
+            .get_envs()
+            .map(|(key, value)| (key.to_owned(), value.map(|value| value.to_owned())))
+            .collect::<Vec<_>>();
+        assert!(envs.iter().any(|(key, value)| {
+            key == "FOUNDRY_FUZZ_CORPUS_DIR"
+                && value.as_deref() == Some(dirs.foundry_fuzz_corpus.as_os_str())
+        }));
+        assert!(envs.iter().any(|(key, value)| {
+            key == "FOUNDRY_INVARIANT_CORPUS_DIR"
+                && value.as_deref() == Some(dirs.foundry_invariant_corpus.as_os_str())
+        }));
     }
 
     #[test]

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -48,7 +48,7 @@ impl FuzzArgs {
         match self.command {
             FuzzSubcommands::Run(args) => {
                 let mut test = TestArgs::from_fuzz_run(args);
-                test.enable_fuzz_only_with_auto_corpus();
+                test.enable_fuzz_only_with_auto_fuzz_corpus();
                 Box::pin(test.run())
             }
             FuzzSubcommands::Replay(args) => Box::pin(args.run()),

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -29,9 +29,12 @@ use std::{
     fs::OpenOptions,
     io::{BufWriter, Write},
     path::{Path, PathBuf},
+    pin::Pin,
     time::{SystemTime, UNIX_EPOCH},
 };
 use tempfile::{Builder as TempDirBuilder, TempDir};
+
+type FuzzOutcomeFuture = Pin<Box<dyn Future<Output = Result<TestOutcome>>>>;
 
 /// Run and manage Forge fuzzing corpora.
 #[derive(Clone, Debug, Parser)]
@@ -41,25 +44,25 @@ pub struct FuzzArgs {
 }
 
 impl FuzzArgs {
-    pub async fn run(self) -> Result<TestOutcome> {
+    pub fn run(self) -> FuzzOutcomeFuture {
         match self.command {
             FuzzSubcommands::Run(mut args) => {
-                args.enable_fuzz_only();
-                args.run().await
+                args.enable_fuzz_only_with_auto_corpus();
+                Box::pin(args.run())
             }
-            FuzzSubcommands::Replay(args) => args.run().await,
-            FuzzSubcommands::Show(args) => {
+            FuzzSubcommands::Replay(args) => Box::pin(args.run()),
+            FuzzSubcommands::Show(args) => Box::pin(async move {
                 args.run()?;
                 Ok(TestOutcome::empty(None, true))
-            }
-            FuzzSubcommands::Cmin(args) => {
+            }),
+            FuzzSubcommands::Cmin(args) => Box::pin(async move {
                 args.run().await?;
                 Ok(TestOutcome::empty(None, true))
-            }
-            FuzzSubcommands::Tmin(args) => {
+            }),
+            FuzzSubcommands::Tmin(args) => Box::pin(async move {
                 args.run().await?;
                 Ok(TestOutcome::empty(None, true))
-            }
+            }),
         }
     }
 

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -97,6 +97,27 @@ use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestSuite};
 use summary::{TestSummaryReport, format_invariant_metrics_table};
 
 const DEBUGGER_MATCHING_TESTS_DISPLAY_LIMIT: usize = 12;
+const AUTO_FUZZ_FAILURE_DIR: &str = "fuzz";
+const AUTO_INVARIANT_FAILURE_DIR: &str = "invariant";
+const AUTO_CORPUS_DIR: &str = "corpus";
+
+#[derive(Clone, Copy, Debug, Default)]
+enum FuzzOnlyMode {
+    #[default]
+    Disabled,
+    Enabled,
+    WithAutoCorpus,
+}
+
+impl FuzzOnlyMode {
+    const fn is_enabled(self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+
+    const fn uses_auto_corpus(self) -> bool {
+        matches!(self, Self::WithAutoCorpus)
+    }
+}
 
 // Loads project's figment and merges the build cli arguments into it
 foundry_config::merge_impl_figment_convert!(TestArgs, build, evm);
@@ -368,7 +389,7 @@ fn sources_to_compile_from_artifacts(
 pub struct TestArgs {
     /// Internal mode used by `forge fuzz`.
     #[arg(skip)]
-    pub(crate) fuzz_only: bool,
+    fuzz_only: FuzzOnlyMode,
 
     /// Internal showmap/replay override used by `forge fuzz replay`.
     #[arg(skip)]
@@ -1003,7 +1024,35 @@ impl TestArgs {
 
     /// Restricts this test invocation to fuzz and invariant tests.
     pub(crate) const fn enable_fuzz_only(&mut self) {
-        self.fuzz_only = true;
+        self.fuzz_only = FuzzOnlyMode::Enabled;
+    }
+
+    /// Restricts this test invocation to fuzz and invariant tests and enables default corpus dirs
+    /// after user config is loaded.
+    pub(crate) const fn enable_fuzz_only_with_auto_corpus(&mut self) {
+        self.fuzz_only = FuzzOnlyMode::WithAutoCorpus;
+    }
+
+    fn apply_auto_fuzz_corpus_dirs(&self, config: &mut Config) {
+        if !self.fuzz_only.uses_auto_corpus() {
+            return;
+        }
+
+        if config.fuzz.corpus.corpus_dir.is_none() {
+            config.fuzz.corpus.corpus_dir = Some(match &config.fuzz.failure_persist_dir {
+                Some(root) => root.join(AUTO_CORPUS_DIR),
+                None => config.cache_path.join(AUTO_FUZZ_FAILURE_DIR).join(AUTO_CORPUS_DIR),
+            });
+        }
+        if config.invariant.corpus.corpus_dir.is_none() {
+            config.invariant.corpus.corpus_dir =
+                Some(match &config.invariant.failure_persist_dir {
+                    Some(root) => root.join(AUTO_CORPUS_DIR),
+                    None => {
+                        config.cache_path.join(AUTO_INVARIANT_FAILURE_DIR).join(AUTO_CORPUS_DIR)
+                    }
+                });
+        }
     }
 
     /// Overrides showmap config for callers that reuse replay mode without the
@@ -1232,6 +1281,7 @@ impl TestArgs {
         let test_failures_file = config.test_failures_file.clone();
         let mut config = workspace::rebase_config_paths(&config, temp_path).sanitized();
         config.test_failures_file = test_failures_file;
+        self.apply_auto_fuzz_corpus_dirs(&mut config);
         let project = config.project()?;
         let project_root = project.paths.root.clone();
         let replay_symbolic_artifact = self.load_symbolic_artifact_replay()?;
@@ -1288,6 +1338,8 @@ impl TestArgs {
             config.dynamic_test_linking = true;
             config.cache = true;
         }
+
+        self.apply_auto_fuzz_corpus_dirs(&mut config);
 
         // Set up the project.
         let mut project = config.project()?;
@@ -1529,7 +1581,7 @@ impl TestArgs {
                 &config,
                 &execution.inline_config,
                 filter,
-                self.fuzz_only,
+                self.fuzz_only.is_enabled(),
                 execution.replay_symbolic_artifact.as_ref(),
             );
         }
@@ -2123,7 +2175,7 @@ impl TestArgs {
             .set_coverage(execution.coverage)
             .with_multi_network(execution.multi_network)
             .with_showmap(showmap)
-            .with_fuzz_only(self.fuzz_only)
+            .with_fuzz_only(self.fuzz_only.is_enabled())
             .with_fuzz_failure_replay(self.fuzz_failure_replay)
             .with_symbolic_artifact_replay(execution.replay_symbolic_artifact)
             .build::<FEN, MultiCompiler>(output, evm_env, tx_env, evm_opts)?;
@@ -2151,7 +2203,7 @@ impl TestArgs {
             .enable_isolation(evm_opts.isolate)
             .fail_fast(self.fail_fast)
             .with_multi_network(options.multi_network)
-            .with_fuzz_only(self.fuzz_only)
+            .with_fuzz_only(self.fuzz_only.is_enabled())
             .with_fuzz_failure_replay(self.fuzz_failure_replay)
             .build::<FEN, MultiCompiler>(output, evm_env, tx_env, evm_opts)
     }
@@ -3729,6 +3781,73 @@ mod tests {
         let args = args.unwrap();
         assert_eq!(args.fuzz_corpus_dir, Some(PathBuf::from("env_fuzz_corpus")));
         assert_eq!(args.invariant_corpus_dir, Some(PathBuf::from("env_invariant_corpus")));
+    }
+
+    #[test]
+    fn auto_fuzz_corpus_defaults_to_cache_failure_layout() {
+        let mut args = TestArgs::parse_from(["foundry-cli"]);
+        args.enable_fuzz_only_with_auto_corpus();
+        let mut config = Config::default();
+
+        args.apply_auto_fuzz_corpus_dirs(&mut config);
+
+        assert_eq!(
+            config.fuzz.corpus.corpus_dir,
+            Some(config.cache_path.join(AUTO_FUZZ_FAILURE_DIR).join(AUTO_CORPUS_DIR))
+        );
+        assert_eq!(
+            config.invariant.corpus.corpus_dir,
+            Some(config.cache_path.join(AUTO_INVARIANT_FAILURE_DIR).join(AUTO_CORPUS_DIR))
+        );
+    }
+
+    #[test]
+    fn auto_fuzz_corpus_uses_configured_failure_persist_dirs() {
+        let mut args = TestArgs::parse_from(["foundry-cli"]);
+        args.enable_fuzz_only_with_auto_corpus();
+        let mut config = Config::default();
+        config.fuzz.failure_persist_dir = Some(PathBuf::from("custom_fuzz_failures"));
+        config.invariant.failure_persist_dir = Some(PathBuf::from("custom_invariant_failures"));
+
+        args.apply_auto_fuzz_corpus_dirs(&mut config);
+
+        assert_eq!(
+            config.fuzz.corpus.corpus_dir,
+            Some(PathBuf::from("custom_fuzz_failures").join(AUTO_CORPUS_DIR))
+        );
+        assert_eq!(
+            config.invariant.corpus.corpus_dir,
+            Some(PathBuf::from("custom_invariant_failures").join(AUTO_CORPUS_DIR))
+        );
+    }
+
+    #[test]
+    fn auto_fuzz_corpus_preserves_configured_corpus_dirs() {
+        let mut args = TestArgs::parse_from(["foundry-cli"]);
+        args.enable_fuzz_only_with_auto_corpus();
+        let mut config = Config::default();
+        config.fuzz.corpus.corpus_dir = Some(PathBuf::from("configured_fuzz_corpus"));
+        config.invariant.corpus.corpus_dir = Some(PathBuf::from("configured_invariant_corpus"));
+
+        args.apply_auto_fuzz_corpus_dirs(&mut config);
+
+        assert_eq!(config.fuzz.corpus.corpus_dir, Some(PathBuf::from("configured_fuzz_corpus")));
+        assert_eq!(
+            config.invariant.corpus.corpus_dir,
+            Some(PathBuf::from("configured_invariant_corpus"))
+        );
+    }
+
+    #[test]
+    fn fuzz_only_does_not_enable_auto_fuzz_corpus() {
+        let mut args = TestArgs::parse_from(["foundry-cli"]);
+        args.enable_fuzz_only();
+        let mut config = Config::default();
+
+        args.apply_auto_fuzz_corpus_dirs(&mut config);
+
+        assert_eq!(config.fuzz.corpus.corpus_dir, None);
+        assert_eq!(config.invariant.corpus.corpus_dir, None);
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -98,7 +98,6 @@ use summary::{TestSummaryReport, format_invariant_metrics_table};
 
 const DEBUGGER_MATCHING_TESTS_DISPLAY_LIMIT: usize = 12;
 const AUTO_FUZZ_FAILURE_DIR: &str = "fuzz";
-const AUTO_INVARIANT_FAILURE_DIR: &str = "invariant";
 const AUTO_CORPUS_DIR: &str = "corpus";
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -106,7 +105,7 @@ enum FuzzOnlyMode {
     #[default]
     Disabled,
     Enabled,
-    WithAutoCorpus,
+    WithAutoFuzzCorpus,
 }
 
 impl FuzzOnlyMode {
@@ -114,8 +113,8 @@ impl FuzzOnlyMode {
         !matches!(self, Self::Disabled)
     }
 
-    const fn uses_auto_corpus(self) -> bool {
-        matches!(self, Self::WithAutoCorpus)
+    const fn uses_auto_fuzz_corpus(self) -> bool {
+        matches!(self, Self::WithAutoFuzzCorpus)
     }
 }
 
@@ -1139,14 +1138,14 @@ impl TestArgs {
         self.fuzz_only = FuzzOnlyMode::Enabled;
     }
 
-    /// Restricts this test invocation to fuzz and invariant tests and enables default corpus dirs
-    /// after user config is loaded.
-    pub(crate) const fn enable_fuzz_only_with_auto_corpus(&mut self) {
-        self.fuzz_only = FuzzOnlyMode::WithAutoCorpus;
+    /// Restricts this test invocation to fuzz and invariant tests and enables a default fuzz corpus
+    /// dir after user config is loaded.
+    pub(crate) const fn enable_fuzz_only_with_auto_fuzz_corpus(&mut self) {
+        self.fuzz_only = FuzzOnlyMode::WithAutoFuzzCorpus;
     }
 
-    fn apply_auto_fuzz_corpus_dirs(&self, config: &mut Config) {
-        if !self.fuzz_only.uses_auto_corpus() {
+    fn apply_auto_fuzz_corpus_dir(&self, config: &mut Config) {
+        if !self.fuzz_only.uses_auto_fuzz_corpus() {
             return;
         }
 
@@ -1155,15 +1154,6 @@ impl TestArgs {
                 Some(root) => root.join(AUTO_CORPUS_DIR),
                 None => config.cache_path.join(AUTO_FUZZ_FAILURE_DIR).join(AUTO_CORPUS_DIR),
             });
-        }
-        if config.invariant.corpus.corpus_dir.is_none() {
-            config.invariant.corpus.corpus_dir =
-                Some(match &config.invariant.failure_persist_dir {
-                    Some(root) => root.join(AUTO_CORPUS_DIR),
-                    None => {
-                        config.cache_path.join(AUTO_INVARIANT_FAILURE_DIR).join(AUTO_CORPUS_DIR)
-                    }
-                });
         }
     }
 
@@ -1535,7 +1525,7 @@ impl TestArgs {
         let test_failures_file = config.test_failures_file.clone();
         let mut config = workspace::rebase_config_paths(&config, temp_path).sanitized();
         config.test_failures_file = test_failures_file;
-        self.apply_auto_fuzz_corpus_dirs(&mut config);
+        self.apply_auto_fuzz_corpus_dir(&mut config);
         let project = config.project()?;
         let project_root = project.paths.root.clone();
         let replay_symbolic_artifact = self.load_symbolic_artifact_replay()?;
@@ -1599,7 +1589,7 @@ impl TestArgs {
             config.cache = true;
         }
 
-        self.apply_auto_fuzz_corpus_dirs(&mut config);
+        self.apply_auto_fuzz_corpus_dir(&mut config);
 
         // Set up the project.
         let mut project = config.project()?;
@@ -4163,50 +4153,43 @@ mod tests {
     #[test]
     fn auto_fuzz_corpus_defaults_to_cache_failure_layout() {
         let mut args = TestArgs::parse_from(["foundry-cli"]);
-        args.enable_fuzz_only_with_auto_corpus();
+        args.enable_fuzz_only_with_auto_fuzz_corpus();
         let mut config = Config::default();
 
-        args.apply_auto_fuzz_corpus_dirs(&mut config);
+        args.apply_auto_fuzz_corpus_dir(&mut config);
 
         assert_eq!(
             config.fuzz.corpus.corpus_dir,
             Some(config.cache_path.join(AUTO_FUZZ_FAILURE_DIR).join(AUTO_CORPUS_DIR))
         );
-        assert_eq!(
-            config.invariant.corpus.corpus_dir,
-            Some(config.cache_path.join(AUTO_INVARIANT_FAILURE_DIR).join(AUTO_CORPUS_DIR))
-        );
+        assert_eq!(config.invariant.corpus.corpus_dir, None);
     }
 
     #[test]
     fn auto_fuzz_corpus_uses_configured_failure_persist_dirs() {
         let mut args = TestArgs::parse_from(["foundry-cli"]);
-        args.enable_fuzz_only_with_auto_corpus();
+        args.enable_fuzz_only_with_auto_fuzz_corpus();
         let mut config = Config::default();
         config.fuzz.failure_persist_dir = Some(PathBuf::from("custom_fuzz_failures"));
-        config.invariant.failure_persist_dir = Some(PathBuf::from("custom_invariant_failures"));
 
-        args.apply_auto_fuzz_corpus_dirs(&mut config);
+        args.apply_auto_fuzz_corpus_dir(&mut config);
 
         assert_eq!(
             config.fuzz.corpus.corpus_dir,
             Some(PathBuf::from("custom_fuzz_failures").join(AUTO_CORPUS_DIR))
         );
-        assert_eq!(
-            config.invariant.corpus.corpus_dir,
-            Some(PathBuf::from("custom_invariant_failures").join(AUTO_CORPUS_DIR))
-        );
+        assert_eq!(config.invariant.corpus.corpus_dir, None);
     }
 
     #[test]
     fn auto_fuzz_corpus_preserves_configured_corpus_dirs() {
         let mut args = TestArgs::parse_from(["foundry-cli"]);
-        args.enable_fuzz_only_with_auto_corpus();
+        args.enable_fuzz_only_with_auto_fuzz_corpus();
         let mut config = Config::default();
         config.fuzz.corpus.corpus_dir = Some(PathBuf::from("configured_fuzz_corpus"));
         config.invariant.corpus.corpus_dir = Some(PathBuf::from("configured_invariant_corpus"));
 
-        args.apply_auto_fuzz_corpus_dirs(&mut config);
+        args.apply_auto_fuzz_corpus_dir(&mut config);
 
         assert_eq!(config.fuzz.corpus.corpus_dir, Some(PathBuf::from("configured_fuzz_corpus")));
         assert_eq!(
@@ -4221,7 +4204,7 @@ mod tests {
         args.enable_fuzz_only();
         let mut config = Config::default();
 
-        args.apply_auto_fuzz_corpus_dirs(&mut config);
+        args.apply_auto_fuzz_corpus_dir(&mut config);
 
         assert_eq!(config.fuzz.corpus.corpus_dir, None);
         assert_eq!(config.invariant.corpus.corpus_dir, None);

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -2714,11 +2714,13 @@ contract ForgeFuzzGeneratedCorpusTest is Test {
     assert!(invariant_stdout.contains(&invariant_corpus_path), "{invariant_stdout}");
 });
 
-forgetest_init!(forge_fuzz_run_seeds_default_invariant_corpus_from_tests, |prj, cmd| {
+forgetest_init!(forge_fuzz_run_keeps_invariant_trace_seeding_opt_in, |prj, cmd| {
+    let marker = prj.root().join("unit-trace-seed-ran.txt");
     prj.update_config(|config| {
         config.invariant.runs = 1;
         config.invariant.depth = 1;
         config.invariant.corpus.corpus_gzip = false;
+        config.fs_permissions.add(PathPermission::write(prj.root()));
     });
     prj.add_test(
         "ForgeFuzzAutoCorpusSeed.t.sol",
@@ -2742,6 +2744,7 @@ contract ForgeFuzzAutoCorpusSeedTest is Test {
     }
 
     function test_seedCorpusFromUnitTestTrace() public {
+        vm.writeFile(string.concat(vm.projectRoot(), "/unit-trace-seed-ran.txt"), "ran");
         handler.touch(0x1234);
     }
 
@@ -2760,13 +2763,8 @@ contract ForgeFuzzAutoCorpusSeedTest is Test {
         .join("ForgeFuzzAutoCorpusSeedTest")
         .join("worker0")
         .join("corpus");
-    let seed_entry = std::fs::read_to_string(find_first_json(&corpus_root)).unwrap();
-    let abi = artifact_abi(
-        prj.root(),
-        "out/ForgeFuzzAutoCorpusSeed.t.sol/ForgeFuzzAutoCorpusHandler.json",
-    );
-    let touch = calldata_for(&abi, "touch", 0x1234);
-    assert!(seed_entry.contains(&touch), "{seed_entry}");
+    assert!(!has_regular_file(&corpus_root));
+    assert!(!marker.exists());
 });
 
 forgetest_init!(fuzz_branch_frontiers_capture_comparison_for_symbolic_followup, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -2469,6 +2469,61 @@ contract ForgeFuzzGeneratedCorpusTest is Test {
     assert!(invariant_stdout.contains(&invariant_corpus_path), "{invariant_stdout}");
 });
 
+forgetest_init!(forge_fuzz_run_seeds_default_invariant_corpus_from_tests, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 1;
+        config.invariant.depth = 1;
+        config.invariant.corpus.corpus_gzip = false;
+    });
+    prj.add_test(
+        "ForgeFuzzAutoCorpusSeed.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzAutoCorpusHandler {
+    uint256 public touched;
+
+    function touch(uint256 value) external {
+        touched = value;
+    }
+}
+
+contract ForgeFuzzAutoCorpusSeedTest is Test {
+    ForgeFuzzAutoCorpusHandler handler;
+
+    function setUp() public {
+        handler = new ForgeFuzzAutoCorpusHandler();
+        targetContract(address(handler));
+    }
+
+    function test_seedCorpusFromUnitTestTrace() public {
+        handler.touch(0x1234);
+    }
+
+    function invariant_ok() public view {}
+}
+   "#,
+    );
+
+    cmd.args(["fuzz", "run", "--mc", "ForgeFuzzAutoCorpusSeedTest", "-q"]).assert_success();
+
+    let corpus_root = prj
+        .root()
+        .join("cache")
+        .join("invariant")
+        .join("corpus")
+        .join("ForgeFuzzAutoCorpusSeedTest")
+        .join("worker0")
+        .join("corpus");
+    let seed_entry = std::fs::read_to_string(find_first_json(&corpus_root)).unwrap();
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzAutoCorpusSeed.t.sol/ForgeFuzzAutoCorpusHandler.json",
+    );
+    let touch = calldata_for(&abi, "touch", 0x1234);
+    assert!(seed_entry.contains(&touch), "{seed_entry}");
+});
+
 forgetest_init!(fuzz_branch_frontiers_capture_comparison_for_symbolic_followup, |prj, cmd| {
     prj.add_test(
         "ForgeFuzzFrontier.t.sol",


### PR DESCRIPTION
## Summary
Coverage-guided fuzzing already persists and replays generated fuzz corpora when a fuzz corpus dir is configured. This change makes `forge fuzz run` give stateless fuzz tests a default corpus dir so users get corpus persistence and seeding without passing `--fuzz-corpus-dir`.

- Makes `forge fuzz run` default `fuzz.corpus_dir` when the user has not configured it.
- Defaults to the existing fuzz failure-persistence layout: `cache/fuzz/corpus`, or under a custom `fuzz.failure_persist_dir`.
- Preserves explicit config/env/CLI corpus dirs.
- Leaves invariant corpus dirs opt-in because invariant corpus mode can seed from sibling zero-input unit-test traces; users can still opt in via `--corpus-dir`, `--invariant-corpus-dir`, config, or env.
- Leaves `forge fuzz replay`, `cmin`, and `tmin` explicit.
