### PR TITLE
fix(config): warn on deprecated keys in all profiles

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7072,6 +7072,30 @@ mod tests {
     }
 
     #[test]
+    fn warns_on_deprecated_profile_names() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.cancun]
+                "#,
+            )?;
+
+            let cfg = Config::load().unwrap();
+            assert!(
+                cfg.warnings.iter().any(|w| matches!(
+                    w,
+                    crate::Warning::DeprecatedKey { old, new }
+                    if old == "cancun" && new == "evm_version = Cancun"
+                )),
+                "Expected deprecated profile-name warning, got: {:?}",
+                cfg.warnings
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
     fn warns_on_unknown_keys_in_profile() {
         figment::Jail::expect_with(|jail| {
             jail.create_file(

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -7044,6 +7044,34 @@ mod tests {
     }
 
     #[test]
+    fn warns_on_deprecated_keys_in_inactive_profiles() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "foundry.toml",
+                r#"
+                [profile.default]
+                src = "src"
+
+                [profile.ci]
+                deny_warnings = true
+                "#,
+            )?;
+
+            let cfg = Config::load().unwrap();
+            assert!(
+                cfg.warnings.iter().any(|w| matches!(
+                    w,
+                    crate::Warning::DeprecatedKey { old, new }
+                    if old == "deny_warnings" && new == "deny = warnings"
+                )),
+                "Expected deprecated key warning for inactive profile, got: {:?}",
+                cfg.warnings
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
     fn warns_on_unknown_keys_in_profile() {
         figment::Jail::expect_with(|jail| {
             jail.create_file(

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -150,15 +150,13 @@ impl<P: Provider> WarningsProvider<P> {
             .filter(|(profile, _)| **profile == Config::PROFILE_SECTION)
             .map(|(_, dict)| dict);
 
-        out.extend(profiles.clone().flat_map(BTreeMap::keys).filter_map(deprecated_key_warning));
-        out.extend(
-            profiles
-                .clone()
-                .filter_map(|dict| dict.get(self.profile.as_str().as_str()))
-                .filter_map(Value::as_dict)
-                .flat_map(BTreeMap::keys)
-                .filter_map(deprecated_key_warning),
-        );
+        let deprecated_profile_keys = profiles
+            .clone()
+            .flat_map(BTreeMap::values)
+            .filter_map(Value::as_dict)
+            .flat_map(BTreeMap::keys)
+            .collect::<BTreeSet<_>>();
+        out.extend(deprecated_profile_keys.into_iter().filter_map(deprecated_key_warning));
 
         // Add warning for unknown keys within profiles (root keys only here).
         if let Ok(default_map) = figment::providers::Serialized::defaults(&Config::default()).data()

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -152,9 +152,9 @@ impl<P: Provider> WarningsProvider<P> {
 
         let deprecated_profile_keys = profiles
             .clone()
-            .flat_map(BTreeMap::values)
-            .filter_map(Value::as_dict)
-            .flat_map(BTreeMap::keys)
+            .flat_map(|dict| {
+                dict.keys().chain(dict.values().filter_map(Value::as_dict).flat_map(BTreeMap::keys))
+            })
             .collect::<BTreeSet<_>>();
         out.extend(deprecated_profile_keys.into_iter().filter_map(deprecated_key_warning));
 


### PR DESCRIPTION
## Motivation

Deprecated config key warnings were only collected from profile names and then from the currently selected profile. As a result, a deprecated key inside an inactive profile, for example `[profile.ci] deny_warnings = true`, was not reported when loading the default profile.

Refs #15654.

## Solution

Walk the profile tables under `[profile]` and collect their root keys before applying the deprecation map. This keeps the warning path consistent with unknown-key validation, which already checks every profile, while preserving the existing warning shape.

A regression test covers a deprecated key in an inactive profile.

## AI assistance

I used Codex to inspect this code path and run local tests. The final patch is scoped to the config warning traversal and regression test.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Tests

- `cargo test -p foundry-config warns_on_deprecated_keys_in_inactive_profiles --lib`
- `cargo test -p foundry-config --lib`
- `cargo +nightly fmt -- --check`
- `cargo check -p foundry-config`