### PR TITLE
fix(forge): preflight mutate mode conflicts

### DIFF
--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -140,6 +140,7 @@ impl CoverageArgs {
         // Merge CLI args with `[profile.<name>.coverage]` config values. CLI
         // flags take precedence; unset CLI flags fall back to the config.
         self.resolve_with(&config.coverage);
+        self.test.ensure_mutation_mode_compatible(true)?;
 
         let (paths, mut output) = {
             let (project, output) = self.build(&config)?;

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1083,6 +1083,53 @@ impl TestArgs {
         self.compile_and_run().await
     }
 
+    pub(crate) fn ensure_mutation_mode_compatible(&self, coverage: bool) -> Result<()> {
+        if self.mutate.is_none() {
+            return Ok(());
+        }
+
+        // Mutation testing has bespoke orchestration that is not compatible with these modes.
+        // Run this before compiling when the caller owns the build step so project errors do not
+        // mask CLI conflicts.
+        let mut conflicts = Vec::new();
+        if self.list {
+            conflicts.push("--list");
+        }
+        if self.debug {
+            conflicts.push("--debug");
+        }
+        if self.flamegraph {
+            conflicts.push("--flamegraph");
+        }
+        if self.flamechart {
+            conflicts.push("--flamechart");
+        }
+        if self.evm_profile.is_some() {
+            conflicts.push("--evm-profile");
+        }
+        if self.junit {
+            conflicts.push("--junit");
+        }
+        if coverage {
+            conflicts.push("coverage");
+        }
+        if self.showmap_out.is_some() {
+            conflicts.push("--showmap-out");
+        }
+        if self.replay_symbolic_artifact.is_some() {
+            conflicts.push("--replay-symbolic-artifact");
+        }
+        if !conflicts.is_empty() {
+            bail!(
+                "`--mutate` cannot be combined with: {}. Re-run without those flags to use \
+                 mutation testing.",
+                conflicts.join(", ")
+            );
+        }
+
+        Ok(())
+    }
+
     /// Builds a `ShowmapConfig` from the showmap CLI flags, if `--showmap-out` is set.
     fn showmap_config(&self) -> Result<Option<ShowmapConfig>> {
         if let Some(showmap) = self.showmap_override.clone() {
@@ -1429,6 +1476,8 @@ impl TestArgs {
             return self.compile_and_run_brutalized().await;
         }
 
+        self.ensure_mutation_mode_compatible(false)?;
+
         let (
             project_root,
             config,
@@ -1734,53 +1783,10 @@ impl TestArgs {
         filter: &ProjectPathsAwareFilter,
         mut execution: TestExecutionOptions,
     ) -> Result<TestOutcome> {
+        self.ensure_mutation_mode_compatible(execution.coverage)?;
+
         if config.fuzz.run == Some(0) {
             bail!("`fuzz.run` must be greater than 0");
-        }
-
-        // Mutation testing has bespoke orchestration (per-mutant temp
-        // workspaces, baseline + N mutants, aggregated mutation report). It is
-        // not compatible with the single-run debug / flame / list / junit
-        // modes — running them together would either mix incompatible output
-        // formats, or run the secondary mode against the baseline tests and
-        // then silently continue into mutation testing. Reject up front with a
-        // clear error rather than do the wrong thing.
-        if self.mutate.is_some() {
-            let mut conflicts = Vec::new();
-            if self.list {
-                conflicts.push("--list");
-            }
-            if self.debug {
-                conflicts.push("--debug");
-            }
-            if self.flamegraph {
-                conflicts.push("--flamegraph");
-            }
-            if self.flamechart {
-                conflicts.push("--flamechart");
-            }
-            if self.evm_profile.is_some() {
-                conflicts.push("--evm-profile");
-            }
-            if self.junit {
-                conflicts.push("--junit");
-            }
-            if execution.coverage {
-                conflicts.push("coverage");
-            }
-            if self.showmap_out.is_some() {
-                conflicts.push("--showmap-out");
-            }
-            if self.replay_symbolic_artifact.is_some() {
-                conflicts.push("--replay-symbolic-artifact");
-            }
-            if !conflicts.is_empty() {
-                bail!(
-                    "`--mutate` cannot be combined with: {}. Re-run without those flags to use \
-                     mutation testing.",
-                    conflicts.join(", ")
-                );
-            }
         }
 
         self.warn_unsupported_engine_flags(

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -2704,3 +2704,31 @@ contract CounterTest is DSTest {
     assert!(lcov_content.contains("FN:"), "Coverage should include function data");
     assert!(lcov_content.contains("DA:"), "Coverage should include line hit data");
 });
+
+forgetest_init!(coverage_rejects_mutation_mode_before_compile, |prj, cmd| {
+    prj.add_source(
+        "Broken.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Broken {
+    function broken() public pure returns (uint256) {
+        return;
+    }
+}
+"#,
+    );
+
+    let output = cmd.args(["coverage", "--mutate", "src/Broken.sol"]).assert_failure();
+    let stderr = output.get_output().stderr_lossy();
+
+    assert!(
+        stderr.contains("`--mutate` cannot be combined with: coverage"),
+        "unexpected stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Compiler run failed"),
+        "mutation/coverage conflict should be reported before compile errors:\n{stderr}"
+    );
+});

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -158,6 +158,34 @@ contract CounterTest {
     );
 });
 
+forgetest_init!(mutation_testing_rejects_list_mode_before_compile, |prj, cmd| {
+    prj.add_source(
+        "Broken.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Broken {
+    function broken() public pure returns (uint256) {
+        return;
+    }
+}
+"#,
+    );
+
+    let output = cmd.args(["test", "--mutate", "src/Broken.sol", "--list"]).assert_failure();
+    let stderr = output.get_output().stderr_lossy();
+
+    assert!(
+        stderr.contains("`--mutate` cannot be combined with: --list"),
+        "unexpected stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Compiler run failed"),
+        "mutation/list conflict should be reported before compile errors:\n{stderr}"
+    );
+});
+
 forgetest_init!(mutation_testing_rejects_all_skipped_baseline, |prj, cmd| {
     prj.add_source(
         "Counter.sol",


### PR DESCRIPTION
## Motivation

This preflights `--mutate` mode conflicts before compilation so invalid project sources no longer mask clearer CLI incompatibility errors. The shared compatibility check is now reused by `forge coverage`, which rejects `forge coverage --mutate` before the coverage-specific build/analysis path, while `run_tests` keeps the same defensive check for nonstandard callers.