### PR TITLE
feat(tracing): add `--compact-labels` flag to hide addresses when label is available

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -126,6 +126,11 @@ pub struct CallArgs {
     #[arg(long, default_value_t = false, requires = "trace")]
     disable_labels: bool,
 
+    /// Hides addresses in trace parameters when a label is available.
+    /// Can only be set with `--trace`.
+    #[arg(long, default_value_t = false, requires = "trace")]
+    compact_labels: bool,
+
     /// Opens an interactive debugger.
     /// Can only be used with `--trace`.
     #[arg(long, requires = "trace")]
@@ -295,6 +300,7 @@ impl CallArgs {
             data,
             with_local_artifacts,
             disable_labels,
+            compact_labels,
             wallet,
             ..
         } = self;
@@ -444,6 +450,7 @@ impl CallArgs {
                 false,
                 false,
                 disable_labels,
+                compact_labels,
                 None,
                 None,
             )
@@ -563,6 +570,7 @@ impl CallArgs {
                 debug,
                 decode_internal,
                 disable_labels,
+                compact_labels,
                 None,
                 None,
             )

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -91,6 +91,10 @@ pub struct RunArgs {
     #[arg(long, default_value_t = false)]
     prestate_tracer: bool,
 
+    /// Hides addresses in trace parameters when a label is available.
+    #[arg(long, default_value_t = false)]
+    compact_labels: bool,
+
     /// Label addresses in the trace.
     ///
     /// Example: 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth
@@ -157,6 +161,7 @@ impl RunArgs {
         let debug = self.debug;
         let decode_internal = self.decode_internal;
         let disable_labels = self.disable_labels;
+        let compact_labels = self.compact_labels;
         let compute_units_per_second = if self.rpc.common.no_rpc_rate_limit {
             Some(u64::MAX)
         } else {
@@ -401,6 +406,7 @@ impl RunArgs {
             debug,
             decode_internal,
             disable_labels,
+            compact_labels,
             self.trace_depth,
             resolved_tempo_hardfork,
         )

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -27,6 +27,7 @@ pub(crate) async fn handle_traces(
     debug: bool,
     decode_internal: bool,
     disable_label: bool,
+    compact_labels: bool,
     trace_depth: Option<usize>,
     tempo_hardfork: Option<TempoHardfork>,
 ) -> eyre::Result<()> {
@@ -66,7 +67,8 @@ pub(crate) async fn handle_traces(
         .with_tempo_hardfork(
             tempo_hardfork
                 .or_else(|| chain.is_tempo().then(|| config.evm_spec_id::<TempoHardfork>())),
-        );
+        )
+        .with_compact_labels(compact_labels);
     let mut identifier = TraceIdentifiers::new().with_external(config, Some(chain))?;
     if let Some(contracts) = &known_contracts {
         builder = builder.with_known_contracts(contracts);

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -134,6 +134,13 @@ impl CallTraceDecoderBuilder {
         self
     }
 
+    /// Hides addresses in trace parameters when a label is available.
+    #[inline]
+    pub const fn with_compact_labels(mut self, compact: bool) -> Self {
+        self.decoder.compact_labels = compact;
+        self
+    }
+
     /// Sets the debug identifier for the decoder.
     #[inline]
     pub fn with_debug_identifier(mut self, identifier: DebugTraceIdentifier) -> Self {
@@ -199,6 +206,9 @@ pub struct CallTraceDecoder {
 
     /// The Tempo hardfork, used to determine hardfork-specific precompiles.
     pub tempo_hardfork: Option<TempoHardfork>,
+
+    /// Hide addresses when a label is available, showing only the label.
+    pub compact_labels: bool,
 }
 
 impl CallTraceDecoder {
@@ -329,6 +339,8 @@ impl CallTraceDecoder {
             chain_id: None,
 
             tempo_hardfork: None,
+
+            compact_labels: false,
         }
     }
 
@@ -1015,6 +1027,9 @@ impl CallTraceDecoder {
         if let DynSolValue::Address(addr) = value
             && let Some(label) = self.labels.get(addr)
         {
+            if self.compact_labels {
+                return label.clone();
+            }
             return format!("{label}: [{addr}]");
         }
         format_token(value)

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1006,6 +1006,10 @@ pub struct TestArgs {
     )]
     pub showmap_corpus_dir: Option<PathBuf>,
 
+    /// Hides addresses in trace parameters when a label is available.
+    #[arg(long, help_heading = "Display options")]
+    pub compact_labels: bool,
+
     #[command(flatten)]
     filter: FilterArgs,
 
@@ -2662,6 +2666,7 @@ impl TestArgs {
         let mut builder = CallTraceDecoderBuilder::new()
             .with_known_contracts(&known_contracts)
             .with_label_disabled(self.disable_labels)
+            .with_compact_labels(self.compact_labels)
             .with_verbosity(verbosity)
             .with_chain_id(remote_chain.map(|c| c.id()))
             .with_tempo_hardfork(

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -358,6 +358,7 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
             .with_tempo_hardfork(
                 is_tempo.then(|| self.script_config.config.evm_spec_id::<TempoHardfork>()),
             )
+            .with_compact_labels(self.args.compact_labels)
             .build();
 
         let use_debug_bytecodes =

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -224,6 +224,10 @@ pub struct ScriptArgs {
     #[arg(long)]
     pub disable_labels: bool,
 
+    /// Hides addresses in trace parameters when a label is available.
+    #[arg(long)]
+    pub compact_labels: bool,
+
     /// The Etherscan (or equivalent) API key
     #[arg(long, env = "ETHERSCAN_API_KEY", value_name = "KEY")]
     pub etherscan_api_key: Option<String>,


### PR DESCRIPTION
When an address appears as a parameter in a decoded trace and has a label, it currently renders as `LabelName: [0xAddr]`. The `--compact-labels` flag shows only the label name, which makes traces easier to read once the addresses are already identified. The flag is available in `cast run`, `cast call`, `forge test`, and `forge script`.

This replaces #13899, which was opened in March, stayed green without review, and was closed by the stale bot in June. The branch has been rebased onto current `master` and the trace decoder now threads the flag alongside the `chain_id` and `tempo_hardfork` options that landed in the meantime.

Closes #3381

AI assistance was used for this change, per CONTRIBUTING.md.
