### PR TITLE
fix: support ArbSys block number on Arbitrum forks

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -117,7 +117,7 @@ use foundry_evm::{
         get_blob_base_fee_update_fraction_by_spec_id, get_blob_params_by_spec_id,
     },
 };
-use foundry_evm_networks::NetworkConfigs;
+use foundry_evm_networks::{NetworkConfigs, arbitrum};
 #[cfg(feature = "optimism")]
 use foundry_primitives::get_deposit_tx_parts;
 use foundry_primitives::{
@@ -1209,6 +1209,13 @@ impl<N: Network> Backend<N> {
         }
     }
 
+    fn inject_arbitrum_precompile(&self, precompiles: &mut PrecompilesMap, evm_env: &EvmEnv) {
+        let Some(block_number) = self.arbitrum_block_number(evm_env) else { return };
+        precompiles.apply_precompile(&arbitrum::ARB_SYS_ADDRESS, move |_| {
+            Some(arbitrum::arb_sys_precompile(block_number))
+        });
+    }
+
     fn inject_tempo_precompiles<DB, I>(&self, evm: &mut tempo_evm::evm::TempoEvm<DB, I>)
     where
         DB: Database,
@@ -1277,6 +1284,7 @@ impl<N: Network> Backend<N> {
             inspector,
         );
         self.inject_precompiles(evm.precompiles_mut());
+        self.inject_arbitrum_precompile(evm.precompiles_mut(), evm_env);
         Ok(evm.transact(tx_env)?)
     }
 
@@ -1386,6 +1394,7 @@ impl<N: Network> Backend<N> {
         macro_rules! run {
             ($evm:expr) => {{
                 self.inject_precompiles($evm.precompiles_mut());
+                self.inject_arbitrum_precompile($evm.precompiles_mut(), evm_env);
                 let mut executor = AnvilBlockExecutor::new($evm, parent_hash, spec_id);
                 executor.apply_pre_execution_changes().expect("pre-execution changes failed");
                 let pool_result = execute_pool_transactions(
@@ -1642,6 +1651,15 @@ impl<N: Network> Backend<N> {
         let (exit_reason, gas_used, out, _logs) = unpack_execution_result(result);
         let access_list = inspector.access_list();
         Ok((exit_reason, out, gas_used, access_list))
+    }
+
+    fn arbitrum_block_number(&self, evm_env: &EvmEnv) -> Option<u64> {
+        if !arbitrum::is_arbitrum_chain(evm_env.cfg_env.chain_id) {
+            return None;
+        }
+
+        let env_block = evm_env.block_env.number.saturating_to();
+        Some(self.get_fork().map_or(env_block, |fork| fork.block_number().max(env_block)))
     }
 
     pub fn get_code_with_state(

--- a/crates/evm/core/src/backend/cow.rs
+++ b/crates/evm/core/src/backend/cow.rs
@@ -242,6 +242,10 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for CowBackend<'_, FEN
         self.backend.active_fork_url()
     }
 
+    fn active_fork_block_number(&self) -> Option<u64> {
+        self.backend.active_fork_block_number()
+    }
+
     fn ensure_fork(&self, id: Option<LocalForkId>) -> eyre::Result<LocalForkId> {
         self.backend.ensure_fork(id)
     }

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -238,6 +238,11 @@ pub trait DatabaseExt<F: FoundryEvmFactory>:
     /// Returns the Fork url that's currently used in the database, if fork mode is on
     fn active_fork_url(&self) -> Option<String>;
 
+    /// Returns the active fork's current fork block number, if any.
+    fn active_fork_block_number(&self) -> Option<u64> {
+        None
+    }
+
     /// Whether the database is currently in forked mode.
     fn is_forked_mode(&self) -> bool {
         self.active_fork_id().is_some()
@@ -1427,6 +1432,27 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         self.forks.get_fork_url(fork.clone()).ok()?
     }
 
+    fn active_fork_block_number(&self) -> Option<u64> {
+        let fork = self.inner.issued_local_fork_ids.get(&self.active_fork_id()?)?;
+        let fork_block = fork_block_number(fork);
+        let env_block = self
+            .forks
+            .get_evm_env(fork.clone())
+            .ok()
+            .flatten()
+            .map(|env| env.block_env.number().saturating_to::<u64>());
+
+        // On Arbitrum, `fork_block` is the L2 fork pin while `env_block` can be remapped to the
+        // lower L1 block number. For tx-level forks, the fork pin is the parent state block while
+        // the env is updated to the transaction's block. The larger value is the current L2 block.
+        match (fork_block, env_block) {
+            (Some(fork_block), Some(env_block)) => Some(fork_block.max(env_block)),
+            (Some(fork_block), None) => Some(fork_block),
+            (None, Some(env_block)) => Some(env_block),
+            (None, None) => None,
+        }
+    }
+
     fn ensure_fork(&self, id: Option<LocalForkId>) -> eyre::Result<LocalForkId> {
         if let Some(id) = id {
             if self.inner.issued_local_fork_ids.contains_key(&id) {
@@ -2198,9 +2224,16 @@ fn apply_state_changeset<N: Network, B: ForkBlockEnv>(
     fork.refresh_journaled_states(journaled_state, persistent_accounts)
 }
 
+fn fork_block_number(fork: &ForkId) -> Option<u64> {
+    let (_, block) = fork.as_str().rsplit_once('@')?;
+    let block = block.split_once('-').map_or(block, |(block, _)| block);
+    let block = block.strip_prefix("0x")?;
+    u64::from_str_radix(block, 16).ok()
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{backend::Backend, evm::EthEvmNetwork, opts::EvmOpts};
+    use crate::{backend::Backend, evm::EthEvmNetwork, fork::ForkId, opts::EvmOpts};
     use alloy_primitives::{U256, address};
     use alloy_provider::Provider;
     use foundry_common::provider::get_http_provider;
@@ -2253,5 +2286,16 @@ mod tests {
         assert!(db.accounts().read().contains_key(&address));
         assert!(db.storage().read().contains_key(&address));
         assert_eq!(db.storage().read().get(&address).unwrap().len(), num_slots as usize);
+    }
+
+    #[test]
+    fn parses_fork_block_number_from_fork_id() {
+        let fork = ForkId::new("https://example.com/@rpc", Some(75_219_831));
+        assert_eq!(super::fork_block_number(&fork), Some(75_219_831));
+        assert_eq!(
+            super::fork_block_number(&format!("{}-1", fork.as_str()).into()),
+            Some(75_219_831)
+        );
+        assert_eq!(super::fork_block_number(&ForkId::new("https://example.com", None)), None);
     }
 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -22,7 +22,7 @@ use foundry_evm_core::{
     },
 };
 use foundry_evm_coverage::HitMaps;
-use foundry_evm_networks::NetworkConfigs;
+use foundry_evm_networks::{NetworkConfigs, arbitrum};
 use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     Inspector,
@@ -1366,6 +1366,10 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             }
         }
 
+        if let Some(outcome) = handle_arbitrum_system_call::<FEN>(ecx, call) {
+            return Some(outcome);
+        }
+
         if self.enable_isolation && !self.in_inner_context && ecx.journal().depth() == 1 {
             match call.scheme {
                 // Isolate CALLs
@@ -1528,6 +1532,44 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                 inspector, contract, target, value,
             )
         });
+    }
+}
+
+fn handle_arbitrum_system_call<FEN: FoundryEvmNetwork>(
+    ecx: &mut FoundryContextFor<'_, FEN>,
+    call: &CallInputs,
+) -> Option<CallOutcome> {
+    if call.target_address != arbitrum::ARB_SYS_ADDRESS
+        || call.bytecode_address != arbitrum::ARB_SYS_ADDRESS
+        || !arbitrum::is_arbitrum_chain(ecx.cfg().chain_id)
+    {
+        return None;
+    }
+
+    let input = call.input.bytes(ecx);
+    if input.get(..4) != Some(&arbitrum::ARB_BLOCK_NUMBER_SELECTOR) {
+        return None;
+    }
+
+    let block_number = ecx.db().active_fork_block_number()?;
+    Some(arbitrum_call_outcome(
+        call,
+        InstructionResult::Return,
+        arbitrum::arb_block_number_output(block_number),
+    ))
+}
+
+fn arbitrum_call_outcome(
+    call: &CallInputs,
+    result: InstructionResult,
+    output: Bytes,
+) -> CallOutcome {
+    CallOutcome {
+        result: InterpreterResult { result, output, gas: Gas::new(call.gas_limit) },
+        memory_offset: call.return_memory_offset.clone(),
+        was_precompile_called: true,
+        precompile_call_logs: vec![],
+        charged_new_account_state_gas: call.charged_new_account_state_gas,
     }
 }
 

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1552,20 +1552,34 @@ fn handle_arbitrum_system_call<FEN: FoundryEvmNetwork>(
     }
 
     let block_number = ecx.db().active_fork_block_number()?;
-    Some(arbitrum_call_outcome(
-        call,
-        InstructionResult::Return,
-        arbitrum::arb_block_number_output(block_number),
-    ))
+    let Some((gas_cost, output)) = arbitrum::arb_block_number_call(call.gas_limit, block_number)
+    else {
+        return Some(arbitrum_call_outcome(
+            call,
+            InstructionResult::PrecompileOOG,
+            0,
+            Bytes::new(),
+        ));
+    };
+
+    Some(arbitrum_call_outcome(call, InstructionResult::Return, gas_cost, output))
 }
 
 fn arbitrum_call_outcome(
     call: &CallInputs,
     result: InstructionResult,
+    gas_used: u64,
     output: Bytes,
 ) -> CallOutcome {
+    let mut gas = Gas::new(call.gas_limit);
+    if !result.is_ok() {
+        gas.spend_all();
+    } else {
+        let _ = gas.record_regular_cost(gas_used);
+    }
+
     CallOutcome {
-        result: InterpreterResult { result, output, gas: Gas::new(call.gas_limit) },
+        result: InterpreterResult { result, output, gas },
         memory_offset: call.return_memory_offset.clone(),
         was_precompile_called: true,
         precompile_call_logs: vec![],

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1572,10 +1572,10 @@ fn arbitrum_call_outcome(
     output: Bytes,
 ) -> CallOutcome {
     let mut gas = Gas::new(call.gas_limit);
-    if !result.is_ok() {
-        gas.spend_all();
-    } else {
+    if result.is_ok() {
         let _ = gas.record_regular_cost(gas_used);
+    } else {
+        gas.spend_all();
     }
 
     CallOutcome {

--- a/crates/evm/networks/src/arbitrum.rs
+++ b/crates/evm/networks/src/arbitrum.rs
@@ -1,0 +1,45 @@
+//! Minimal Arbitrum system contract compatibility helpers.
+
+use std::borrow::Cow;
+
+use alloy_chains::Chain;
+use alloy_evm::precompiles::{DynPrecompile, PrecompileInput};
+use alloy_primitives::{Address, Bytes, U256, address, hex};
+use revm::precompile::{PrecompileHalt, PrecompileId, PrecompileOutput, PrecompileResult};
+
+/// ArbSys system contract address.
+pub const ARB_SYS_ADDRESS: Address = address!("0000000000000000000000000000000000000064");
+
+/// `ArbSys.arbBlockNumber()` selector.
+pub const ARB_BLOCK_NUMBER_SELECTOR: [u8; 4] = hex!("a3b1b31d");
+
+/// ID for the ArbSys precompile.
+pub static PRECOMPILE_ID_ARB_SYS: PrecompileId = PrecompileId::Custom(Cow::Borrowed("ArbSys"));
+
+/// Returns whether `chain_id` is an Arbitrum chain.
+pub fn is_arbitrum_chain(chain_id: u64) -> bool {
+    Chain::from_id(chain_id).is_arbitrum()
+}
+
+/// Returns the ABI-encoded result for `ArbSys.arbBlockNumber()`.
+pub fn arb_block_number_output(block_number: u64) -> Bytes {
+    Bytes::copy_from_slice(&U256::from(block_number).to_be_bytes::<32>())
+}
+
+/// Returns an ArbSys precompile for the provided L2 block number.
+pub fn arb_sys_precompile(block_number: u64) -> DynPrecompile {
+    DynPrecompile::new_stateful(PRECOMPILE_ID_ARB_SYS.clone(), move |input| {
+        arb_sys_precompile_call(input, block_number)
+    })
+}
+
+fn arb_sys_precompile_call(input: PrecompileInput<'_>, block_number: u64) -> PrecompileResult {
+    if input.data.get(..4) != Some(&ARB_BLOCK_NUMBER_SELECTOR) {
+        return Ok(PrecompileOutput::halt(
+            PrecompileHalt::Other("unsupported ArbSys selector".into()),
+            input.reservoir,
+        ));
+    }
+
+    Ok(PrecompileOutput::new(0, arb_block_number_output(block_number), input.reservoir))
+}

--- a/crates/evm/networks/src/arbitrum.rs
+++ b/crates/evm/networks/src/arbitrum.rs
@@ -13,6 +13,9 @@ pub const ARB_SYS_ADDRESS: Address = address!("000000000000000000000000000000000
 /// `ArbSys.arbBlockNumber()` selector.
 pub const ARB_BLOCK_NUMBER_SELECTOR: [u8; 4] = hex!("a3b1b31d");
 
+/// Gas charged by Nitro for returning the 32-byte `arbBlockNumber()` result.
+pub const ARB_BLOCK_NUMBER_GAS_COST: u64 = 3;
+
 /// ID for the ArbSys precompile.
 pub static PRECOMPILE_ID_ARB_SYS: PrecompileId = PrecompileId::Custom(Cow::Borrowed("ArbSys"));
 
@@ -24,6 +27,12 @@ pub fn is_arbitrum_chain(chain_id: u64) -> bool {
 /// Returns the ABI-encoded result for `ArbSys.arbBlockNumber()`.
 pub fn arb_block_number_output(block_number: u64) -> Bytes {
     Bytes::copy_from_slice(&U256::from(block_number).to_be_bytes::<32>())
+}
+
+/// Returns the gas cost and ABI-encoded result for `ArbSys.arbBlockNumber()`.
+pub fn arb_block_number_call(gas_limit: u64, block_number: u64) -> Option<(u64, Bytes)> {
+    (gas_limit >= ARB_BLOCK_NUMBER_GAS_COST)
+        .then(|| (ARB_BLOCK_NUMBER_GAS_COST, arb_block_number_output(block_number)))
 }
 
 /// Returns an ArbSys precompile for the provided L2 block number.
@@ -41,5 +50,9 @@ fn arb_sys_precompile_call(input: PrecompileInput<'_>, block_number: u64) -> Pre
         ));
     }
 
-    Ok(PrecompileOutput::new(0, arb_block_number_output(block_number), input.reservoir))
+    let Some((gas_cost, output)) = arb_block_number_call(input.gas, block_number) else {
+        return Ok(PrecompileOutput::halt(PrecompileHalt::OutOfGas, input.reservoir));
+    };
+
+    Ok(PrecompileOutput::new(gas_cost, output, input.reservoir))
 }

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -24,6 +24,7 @@ use tempo_contracts::precompiles::{
     VALIDATOR_CONFIG_V2_ADDRESS,
 };
 
+pub mod arbitrum;
 pub mod celo;
 
 #[cfg(feature = "optimism")]

--- a/crates/forge/tests/cli/precompiles.rs
+++ b/crates/forge/tests/cli/precompiles.rs
@@ -481,3 +481,34 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 
 "#]]);
 });
+
+forgetest_init!(
+    #[ignore]
+    arbitrum_fork_arbsys_arb_block_number,
+    |prj, cmd| {
+        prj.add_test(
+            "ArbitrumArbSys.t.sol",
+            r#"
+import "forge-std/Test.sol";
+
+interface ArbSys {
+    function arbBlockNumber() external view returns (uint256);
+}
+
+contract ArbitrumArbSysTest is Test {
+    function test_arbitrum_fork_arbsys_arb_block_number() public {
+        vm.createSelectFork("https://arbitrum-one.public.blastapi.io", 75219831);
+
+        assertEq(ArbSys(address(0x64)).arbBlockNumber(), 75219831);
+        assertLt(block.number, 75219831);
+
+        vm.rollFork(75219832);
+        assertEq(ArbSys(address(0x64)).arbBlockNumber(), 75219832);
+    }
+}
+   "#,
+        );
+
+        cmd.args(["test", "--mt", "test_arbitrum_fork_arbsys_arb_block_number"]).assert_success();
+    }
+);

--- a/crates/forge/tests/cli/precompiles.rs
+++ b/crates/forge/tests/cli/precompiles.rs
@@ -502,6 +502,11 @@ contract ArbitrumArbSysTest is Test {
         assertEq(ArbSys(address(0x64)).arbBlockNumber(), 75219831);
         assertLt(block.number, 75219831);
 
+        (bool success,) = address(0x64).staticcall{gas: 2}(
+            abi.encodeWithSelector(ArbSys.arbBlockNumber.selector)
+        );
+        assertFalse(success);
+
         vm.rollFork(75219832);
         assertEq(ArbSys(address(0x64)).arbBlockNumber(), 75219832);
     }


### PR DESCRIPTION
Adds narrow Arbitrum fork compatibility for `ArbSys.arbBlockNumber()` at address `0x64`.

This keeps `eth_getCode` behavior unchanged while making local Forge and Anvil fork execution return the current Arbitrum L2 block number, matching live RPC behavior.

Fixes #5085 