### PR TITLE
fix: add Plume chains to different gas calc

### DIFF
--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -138,6 +138,8 @@ pub fn has_different_gas_calc(chain_id: u64) -> bool {
                     | NamedChain::Moonbeam
                     | NamedChain::MoonbeamDev
                     | NamedChain::Moonriver
+                    | NamedChain::Plume
+                    | NamedChain::PlumeTestnet
                     | NamedChain::Polkadot
                     | NamedChain::PolkadotTestnet
             );


### PR DESCRIPTION
Plume is an Arbitrum Orbit chain and shares Arbitrum's gas accounting, so deploying through forge fails with "intrinsic gas too low" unless gas estimation gets the same special-casing that Arbitrum chains receive in `has_different_gas_calc`. This adds `Plume` and `PlumeTestnet` to the list, following the precedent of #13999 which did the same for MegaEth. The original report was against a Plume devnet chain id that no longer exists in `NamedChain`; this covers the current mainnet (98866) and testnet (98867) ids.

Closes #9619

AI assistance was used to prepare this change.
