### PR TITLE
feat(cheatcodes): allow mockCall without code injection

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -7370,6 +7370,26 @@
     },
     {
       "func": {
+        "id": "mockCall_4",
+        "description": "Mocks a call to an address, returning specified data.\nCalldata can either be strict or a partial match, e.g. if you only\npass a Solidity selector to the expected calldata, then the entire Solidity\nfunction will be mocked.\nOverload to control whether code is injected into `callee`. The other overloads etch a\nsingle byte into an empty account to circumvent Solidity's `extcodesize` check, with the\nside effect that unmocked calls to it no longer revert; `injectCode = false` leaves the\naccount codeless, so unmocked calls to it revert in the caller. Mocked calls that return\ndata still succeed, as Solidity checks `returndatasize()` instead of `extcodesize()` when\nreturn data is expected, but mocked calls to functions without return values may still\nrevert in the caller due to the `extcodesize` check.",
+        "declaration": "function mockCall(address callee, bytes calldata data, bytes calldata returnData, bool injectCode) external;",
+        "visibility": "external",
+        "mutability": "",
+        "signature": "mockCall(address,bytes,bytes,bool)",
+        "selector": "0xb4bc5617",
+        "selectorBytes": [
+          180,
+          188,
+          86,
+          23
+        ]
+      },
+      "group": "evm",
+      "status": "stable",
+      "safety": "unsafe"
+    },
+    {
+      "func": {
         "id": "mockCalls_0",
         "description": "Mocks multiple calls to an address, returning specified data for each call.",
         "declaration": "function mockCalls(address callee, bytes calldata data, bytes[] calldata returnData) external;",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -688,6 +688,21 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Unsafe)]
     function mockCall(address callee, uint256 msgValue, bytes4 data, bytes calldata returnData) external;
 
+    /// Mocks a call to an address, returning specified data.
+    /// Calldata can either be strict or a partial match, e.g. if you only
+    /// pass a Solidity selector to the expected calldata, then the entire Solidity
+    /// function will be mocked.
+    ///
+    /// Overload to control whether code is injected into `callee`. The other overloads etch a
+    /// single byte into an empty account to circumvent Solidity's `extcodesize` check, with the
+    /// side effect that unmocked calls to it no longer revert; `injectCode = false` leaves the
+    /// account codeless, so unmocked calls to it revert in the caller. Mocked calls that return
+    /// data still succeed, as Solidity checks `returndatasize()` instead of `extcodesize()` when
+    /// return data is expected, but mocked calls to functions without return values may still
+    /// revert in the caller due to the `extcodesize` check.
+    #[cheatcode(group = Evm, safety = Unsafe)]
+    function mockCall(address callee, bytes calldata data, bytes calldata returnData, bool injectCode) external;
+
     /// Mocks multiple calls to an address, returning specified data for each call.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function mockCalls(address callee, bytes calldata data, bytes[] calldata returnData) external;

--- a/crates/cheatcodes/src/evm/mock.rs
+++ b/crates/cheatcodes/src/evm/mock.rs
@@ -105,6 +105,18 @@ impl Cheatcode for mockCall_3Call {
     }
 }
 
+impl Cheatcode for mockCall_4Call {
+    fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
+        let Self { callee, data, returnData, injectCode } = self;
+        if *injectCode {
+            let _ = make_acc_non_empty(callee, ccx)?;
+        }
+
+        mock_call(ccx.state, callee, data, None, returnData, InstructionResult::Return);
+        Ok(Default::default())
+    }
+}
+
 impl Cheatcode for mockCalls_0Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { callee, data, returnData } = self;

--- a/testdata/default/cheats/MockCall.t.sol
+++ b/testdata/default/cheats/MockCall.t.sol
@@ -207,6 +207,53 @@ contract MockCallTest is Test {
         assertEq(mock.add(1, 2), 10);
         mock.noReturnValue();
     }
+
+    // Ref: https://github.com/foundry-rs/foundry/issues/10703
+    function testMockCallEmptyAccountNoCodeInjection() public {
+        Mock mock = Mock(address(100));
+
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.add.selector), abi.encode(10), false);
+
+        // Mocked calls that return data succeed while the account remains codeless.
+        assertEq(mock.add(1, 2), 10);
+        assertEq(address(mock).code.length, 0);
+
+        // Unmocked calls to the empty account revert in the caller.
+        vm.expectRevert();
+        this.exposedCallNumberA(mock);
+    }
+
+    function testMockCallNoCodeInjectionNoReturnValue() public {
+        Mock mock = Mock(address(100));
+
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.noReturnValue.selector), abi.encode(), false);
+
+        // Mocked calls to functions without return values still revert in the caller due to the
+        // `extcodesize` check on the codeless account.
+        vm.expectRevert();
+        this.exposedCallNoReturnValue(mock);
+    }
+
+    function testMockCallEmptyAccountInjectCode() public {
+        Mock mock = Mock(address(100));
+
+        // `injectCode = true` behaves like the other overloads: code is injected into the empty
+        // account so that mocked calls to functions without return values succeed as well.
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.add.selector), abi.encode(10), true);
+        vm.mockCall(address(mock), abi.encodeWithSelector(mock.noReturnValue.selector), abi.encode(), true);
+
+        assertEq(mock.add(1, 2), 10);
+        mock.noReturnValue();
+        assertEq(address(mock).code.length, 1);
+    }
+
+    function exposedCallNumberA(Mock mock) external view returns (uint256) {
+        return mock.numberA();
+    }
+
+    function exposedCallNoReturnValue(Mock mock) external {
+        mock.noReturnValue();
+    }
 }
 
 contract MockCallRevertTest is Test {

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -361,6 +361,7 @@ interface Vm {
     function mockCall(address callee, uint256 msgValue, bytes calldata data, bytes calldata returnData) external;
     function mockCall(address callee, bytes4 data, bytes calldata returnData) external;
     function mockCall(address callee, uint256 msgValue, bytes4 data, bytes calldata returnData) external;
+    function mockCall(address callee, bytes calldata data, bytes calldata returnData, bool injectCode) external;
     function mockCalls(address callee, bytes calldata data, bytes[] calldata returnData) external;
     function mockCalls(address callee, uint256 msgValue, bytes calldata data, bytes[] calldata returnData) external;
     function mockFunction(address callee, address target, bytes calldata data) external;


### PR DESCRIPTION
`vm.mockCall` etches a single byte onto an empty target account so that Solidity's `extcodesize` check passes. As reported in #10703, this has the side effect that once any mock is registered for an empty address, every unmocked call to that address silently succeeds instead of reverting, which can hide bugs in tests. Following the approach agreed on in the issue, this adds a `mockCall(address callee, bytes calldata data, bytes calldata returnData, bool injectCode)` overload that lets users opt out of the code injection with `injectCode = false`, leaving the account codeless so unmocked calls to it revert in the caller as they would for any address without code.

One nuance, documented on the cheatcode: without the injected code, mocked calls that return data still succeed because solc checks `returndatasize()` instead of `extcodesize()` when return data is expected, but mocked calls to functions without return values may still revert in the caller due to the `extcodesize` check, so the opt-out is primarily useful when the mocked functions return data. The new overload is placed after the existing `mockCall` overloads so the generated call struct names remain stable.

Closes #10703

AI assistance was used to implement this change.
