### PR TITLE
fix(lint): emit safe suggestions in unwrapped-modifier-logic

### DIFF
--- a/crates/lint/src/sol/codesize/unwrapped_modifier_logic.rs
+++ b/crates/lint/src/sol/codesize/unwrapped_modifier_logic.rs
@@ -5,8 +5,9 @@ use crate::{
 };
 use solar::{
     ast,
-    sema::hir::{self, Res},
+    sema::hir::{self, Res, Visit as _},
 };
+use std::ops::ControlFlow;
 
 declare_forge_lint!(
     UNWRAPPED_MODIFIER_LOGIC,
@@ -113,18 +114,25 @@ impl UnwrappedModifierLogic {
         res
     }
 
-    fn get_snippet<'a>(
+    fn get_snippet<'hir>(
         &self,
         ctx: &LintContext,
-        hir: &hir::Hir<'_>,
+        hir: &'hir hir::Hir<'hir>,
         func: &hir::Function<'_>,
-        before: &'a [hir::Stmt<'a>],
-        after: &'a [hir::Stmt<'a>],
+        before: &'hir [hir::Stmt<'hir>],
+        after: &'hir [hir::Stmt<'hir>],
     ) -> Option<Suggestion> {
         let wrap_before = !before.is_empty() && self.stmts_require_wrapping(hir, before);
         let wrap_after = !after.is_empty() && self.stmts_require_wrapping(hir, after);
 
         if !(wrap_before || wrap_after) {
+            return None;
+        }
+
+        // A local variable declared before the placeholder and referenced after it makes any
+        // rewrite unsafe: extracted helpers only receive the modifier's parameters, so moving
+        // either side out of the modifier separates the declaration from its use.
+        if has_shared_locals(hir, before, after) {
             return None;
         }
 
@@ -152,18 +160,27 @@ impl UnwrappedModifierLogic {
         let body_indent = " ".repeat(ctx.get_span_indentation(
             before.first().or(after.first()).map(|stmt| stmt.span).unwrap_or(func.span),
         ));
-        let body = match (wrap_before, wrap_after) {
-            (true, true) => format!(
-                "{body_indent}_{modifier_name}Before({param_list});\n{body_indent}_;\n{body_indent}_{modifier_name}After({param_list});"
-            ),
-            (true, false) => {
-                format!("{body_indent}_{modifier_name}({param_list});\n{body_indent}_;")
+        // Statements on a side that doesn't require wrapping are preserved verbatim in the new
+        // modifier body, so the rewrite never drops them.
+        let mut body_lines = Vec::new();
+        if wrap_before {
+            let suffix = if wrap_after { "Before" } else { "" };
+            body_lines.push(format!("{body_indent}_{modifier_name}{suffix}({param_list});"));
+        } else {
+            for stmt in before {
+                body_lines.push(format!("{body_indent}{}", ctx.span_to_snippet(stmt.span)?));
             }
-            (false, true) => {
-                format!("{body_indent}_;\n{body_indent}_{modifier_name}({param_list});")
+        }
+        body_lines.push(format!("{body_indent}_;"));
+        if wrap_after {
+            let suffix = if wrap_before { "After" } else { "" };
+            body_lines.push(format!("{body_indent}_{modifier_name}{suffix}({param_list});"));
+        } else {
+            for stmt in after {
+                body_lines.push(format!("{body_indent}{}", ctx.span_to_snippet(stmt.span)?));
             }
-            _ => unreachable!(),
-        };
+        }
+        let body = body_lines.join("\n");
 
         let mod_indent = " ".repeat(ctx.get_span_indentation(func.span));
         let mut replacement =
@@ -172,19 +189,18 @@ impl UnwrappedModifierLogic {
         let build_func = |stmts: &[hir::Stmt<'_>], suffix: &str| {
             let body_stmts = stmts
                 .iter()
-                .filter_map(|s| ctx.span_to_snippet(s.span))
-                .map(|code| format!("\n{body_indent}{code}"))
-                .collect::<String>();
-            format!(
+                .map(|s| ctx.span_to_snippet(s.span).map(|code| format!("\n{body_indent}{code}")))
+                .collect::<Option<String>>()?;
+            Some(format!(
                 "\n\n{mod_indent}function _{modifier_name}{suffix}({param_decls}) internal {{{body_stmts}\n{mod_indent}}}"
-            )
+            ))
         };
 
         if wrap_before {
-            replacement.push_str(&build_func(before, if wrap_after { "Before" } else { "" }));
+            replacement.push_str(&build_func(before, if wrap_after { "Before" } else { "" })?);
         }
         if wrap_after {
-            replacement.push_str(&build_func(after, if wrap_before { "After" } else { "" }));
+            replacement.push_str(&build_func(after, if wrap_before { "After" } else { "" })?);
         }
 
         Some(
@@ -195,6 +211,57 @@ impl UnwrappedModifierLogic {
             .with_desc("wrap modifier logic to reduce code size"),
         )
     }
+}
+
+/// Visitor that breaks on the first reference to any of the tracked local variables.
+struct SharedLocalFinder<'a, 'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    locals: &'a [hir::VariableId],
+}
+
+impl<'hir> hir::Visit<'hir> for SharedLocalFinder<'_, 'hir> {
+    type BreakValue = ();
+
+    fn hir(&self) -> &'hir hir::Hir<'hir> {
+        self.hir
+    }
+
+    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let hir::ExprKind::Ident(resolutions) = &expr.kind
+            && resolutions.iter().any(
+                |r| matches!(r, Res::Item(hir::ItemId::Variable(id)) if self.locals.contains(id)),
+            )
+        {
+            return ControlFlow::Break(());
+        }
+        self.walk_expr(expr)
+    }
+}
+
+/// Returns `true` if a local variable declared in the `before` segment is referenced in the
+/// `after` segment.
+///
+/// Only top-level declarations need to be tracked: declarations nested inside blocks, loops, or
+/// `try` clauses are scoped to them and cannot be referenced after the placeholder.
+fn has_shared_locals<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    before: &'hir [hir::Stmt<'hir>],
+    after: &'hir [hir::Stmt<'hir>],
+) -> bool {
+    let mut declared = Vec::new();
+    for stmt in before {
+        match &stmt.kind {
+            hir::StmtKind::DeclSingle(id) => declared.push(*id),
+            hir::StmtKind::DeclMulti(ids, _) => declared.extend(ids.iter().copied().flatten()),
+            _ => {}
+        }
+    }
+    if declared.is_empty() {
+        return false;
+    }
+
+    let mut finder = SharedLocalFinder { hir, locals: &declared };
+    after.iter().any(|stmt| finder.visit_stmt(stmt).is_break())
 }
 
 /// Recursively counts placeholder (`_`) statements within a list of statements, descending into

--- a/crates/lint/src/sol/codesize/unwrapped_modifier_logic.rs
+++ b/crates/lint/src/sol/codesize/unwrapped_modifier_logic.rs
@@ -118,7 +118,7 @@ impl UnwrappedModifierLogic {
         &self,
         ctx: &LintContext,
         hir: &'hir hir::Hir<'hir>,
-        func: &hir::Function<'_>,
+        func: &'hir hir::Function<'hir>,
         before: &'hir [hir::Stmt<'hir>],
         after: &'hir [hir::Stmt<'hir>],
     ) -> Option<Suggestion> {
@@ -132,7 +132,9 @@ impl UnwrappedModifierLogic {
         // A local variable declared before the placeholder and referenced after it makes any
         // rewrite unsafe: extracted helpers only receive the modifier's parameters, so moving
         // either side out of the modifier separates the declaration from its use.
-        if has_shared_locals(hir, before, after) {
+        if has_shared_locals(hir, before, after)
+            || (wrap_before && has_written_params_used_after(hir, func.parameters, before, after))
+        {
             return None;
         }
 
@@ -262,6 +264,94 @@ fn has_shared_locals<'hir>(
 
     let mut finder = SharedLocalFinder { hir, locals: &declared };
     after.iter().any(|stmt| finder.visit_stmt(stmt).is_break())
+}
+
+/// Returns `true` if a modifier parameter is written in the `before` segment and referenced in
+/// the `after` segment.
+fn has_written_params_used_after<'hir>(
+    hir: &'hir hir::Hir<'hir>,
+    params: &'hir [hir::VariableId],
+    before: &'hir [hir::Stmt<'hir>],
+    after: &'hir [hir::Stmt<'hir>],
+) -> bool {
+    let mut written = Vec::new();
+    let mut finder = ParamWriteFinder { hir, params, written: &mut written };
+    for stmt in before {
+        let _ = finder.visit_stmt(stmt);
+    }
+
+    if written.is_empty() {
+        return false;
+    }
+
+    let mut finder = SharedLocalFinder { hir, locals: &written };
+    after.iter().any(|stmt| finder.visit_stmt(stmt).is_break())
+}
+
+/// Visitor that collects modifier parameters written by an expression.
+struct ParamWriteFinder<'a, 'hir> {
+    hir: &'hir hir::Hir<'hir>,
+    params: &'a [hir::VariableId],
+    written: &'a mut Vec<hir::VariableId>,
+}
+
+impl<'hir> hir::Visit<'hir> for ParamWriteFinder<'_, 'hir> {
+    type BreakValue = ();
+
+    fn hir(&self) -> &'hir hir::Hir<'hir> {
+        self.hir
+    }
+
+    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        match &expr.kind {
+            hir::ExprKind::Assign(lhs, _, _) | hir::ExprKind::Delete(lhs) => {
+                collect_written_params(lhs, self.params, self.written);
+            }
+            hir::ExprKind::Unary(op, inner)
+                if matches!(
+                    op.kind,
+                    ast::UnOpKind::PreInc
+                        | ast::UnOpKind::PreDec
+                        | ast::UnOpKind::PostInc
+                        | ast::UnOpKind::PostDec
+                ) =>
+            {
+                collect_written_params(inner, self.params, self.written);
+            }
+            _ => {}
+        }
+
+        self.walk_expr(expr)
+    }
+}
+
+fn collect_written_params(
+    expr: &hir::Expr<'_>,
+    params: &[hir::VariableId],
+    written: &mut Vec<hir::VariableId>,
+) {
+    match &expr.kind {
+        hir::ExprKind::Ident(resolutions) => {
+            for resolution in *resolutions {
+                if let Res::Item(hir::ItemId::Variable(id)) = resolution
+                    && params.contains(id)
+                    && !written.contains(id)
+                {
+                    written.push(*id);
+                }
+            }
+        }
+        hir::ExprKind::Tuple(items) => {
+            for item in items.iter().flatten() {
+                collect_written_params(item, params, written);
+            }
+        }
+        hir::ExprKind::Index(base, _)
+        | hir::ExprKind::Slice(base, _, _)
+        | hir::ExprKind::Member(base, _)
+        | hir::ExprKind::YulMember(base, _) => collect_written_params(base, params, written),
+        _ => {}
+    }
 }
 
 /// Recursively counts placeholder (`_`) statements within a list of statements, descending into

--- a/crates/lint/testdata/UnwrappedModifierLogic.sol
+++ b/crates/lint/testdata/UnwrappedModifierLogic.sol
@@ -252,4 +252,13 @@ contract UnwrappedModifierLogicTest {
             mstore(0x40, m)
         }
     }
+
+    // No lint: `amount` is mutated before the placeholder and read after it.
+    // Extracting the pre-placeholder side into a helper would mutate only the helper's
+    // by-value parameter copy, while the post-placeholder code would see the original value.
+    modifier mutatedParamUsedAfter(uint256 amount) {
+        amount += 1;
+        _;
+        _payMeSubsidizedGasAfter(amount, amount);
+    }
 }

--- a/crates/lint/testdata/UnwrappedModifierLogic.sol
+++ b/crates/lint/testdata/UnwrappedModifierLogic.sol
@@ -112,6 +112,35 @@ contract UnwrappedModifierLogicTest {
         checkPublic(sender);
     }
 
+    // Bad because there are multiple valid function calls before the placeholder.
+    // The single call after the placeholder must be preserved in the rewrite.
+    modifier beforeWrappedAfterKept(address sender) { //~NOTE: wrap modifier logic to reduce code size
+        checkPublic(sender); // These should become _beforeWrappedAfterKept(sender)
+        checkPrivate(sender);
+        _;
+        checkInternal(sender); // This should stay in the modifier
+    }
+
+    // Bad because there are multiple valid function calls after the placeholder.
+    // The single call before the placeholder must be preserved in the rewrite.
+    modifier afterWrappedBeforeKept(address sender) { //~NOTE: wrap modifier logic to reduce code size
+        checkPublic(sender); // This should stay in the modifier
+        _;
+        checkPrivate(sender); // These should become _afterWrappedBeforeKept(sender)
+        checkInternal(sender);
+    }
+
+    // Bad because there are multiple valid function calls after the placeholder.
+    // The assembly block before the placeholder must be preserved in the rewrite.
+    modifier keepAssemblyBefore() { //~NOTE: wrap modifier logic to reduce code size
+        assembly ("memory-safe") {
+            mstore(0x00, 0)
+        }
+        _;
+        checkPublic(msg.sender); // These should become _keepAssemblyBefore()
+        checkPrivate(msg.sender);
+    }
+
     /// -----------------------------------------------------------------------
     /// Bad patterns (uses built-in control flow)
     /// -----------------------------------------------------------------------
@@ -173,5 +202,54 @@ contract UnwrappedModifierLogicTest {
     modifier onlyOwnerContract(address sender) { //~NOTE: wrap modifier logic to reduce code size
         c.onlyOwner(sender);
         _;
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Exceptions (locals declared before the placeholder and used after it)
+    /// -----------------------------------------------------------------------
+
+    function gasLeft() internal view returns (uint256) {
+        return gasleft();
+    }
+
+    function _payMeSubsidizedGasAfter(uint256 pre, uint256 amount) internal {}
+
+    // No lint: `pre` cannot be forwarded to the extracted helper.
+    modifier payMeSubsidizedGas(uint256 amount) {
+        uint256 pre = gasLeft();
+        _;
+        _payMeSubsidizedGasAfter(pre, amount);
+    }
+
+    // No lint: `pre` is shared across the placeholder, even though both sides would
+    // otherwise be wrapped.
+    modifier payMeSubsidizedGasAndLog(uint256 amount) {
+        uint256 pre = gasLeft();
+        checkPublic(msg.sender);
+        _;
+        checkPrivate(msg.sender);
+        _payMeSubsidizedGasAfter(pre, amount);
+    }
+
+    // No lint: `pre` is used after the placeholder, and the assembly block prevents
+    // wrapping the declaring side.
+    modifier trackFreeMemory() {
+        uint256 pre;
+        assembly ("memory-safe") {
+            pre := mload(0x40)
+        }
+        _;
+        checkPublic(msg.sender);
+        require(pre != 0, "no free memory");
+    }
+
+    // No lint: `m` is used inside the assembly block after the placeholder.
+    modifier restoreFreeMemory() {
+        uint256 m = gasLeft();
+        checkPublic(msg.sender);
+        _;
+        assembly ("memory-safe") {
+            mstore(0x40, m)
+        }
     }
 }

--- a/crates/lint/testdata/UnwrappedModifierLogic.stderr
+++ b/crates/lint/testdata/UnwrappedModifierLogic.stderr
@@ -85,6 +85,86 @@ LL +     }
 note[unwrapped-modifier-logic]: wrap modifier logic to reduce code size
    ╭▸ ROOT/testdata/UnwrappedModifierLogic.sol:LL:CC
    │
+LL │ ┏     modifier beforeWrappedAfterKept(address sender) {
+LL │ ┃         checkPublic(sender); // These should become _beforeWrappedAfterKept(sender)
+LL │ ┃         checkPrivate(sender);
+LL │ ┃         _;
+LL │ ┃         checkInternal(sender); // This should stay in the modifier
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unwrapped-modifier-logic
+help: wrap modifier logic to reduce code size
+   ╭╴
+LL ±     modifier beforeWrappedAfterKept(address sender) {
+LL +         _beforeWrappedAfterKept(sender);
+LL +         _;
+LL +         checkInternal(sender);
+LL +     }
+LL + 
+LL +     function _beforeWrappedAfterKept(address sender) internal {
+LL +         checkPublic(sender);
+LL +         checkPrivate(sender);
+LL +     }
+   ╰╴
+
+note[unwrapped-modifier-logic]: wrap modifier logic to reduce code size
+   ╭▸ ROOT/testdata/UnwrappedModifierLogic.sol:LL:CC
+   │
+LL │ ┏     modifier afterWrappedBeforeKept(address sender) {
+LL │ ┃         checkPublic(sender); // This should stay in the modifier
+LL │ ┃         _;
+LL │ ┃         checkPrivate(sender); // These should become _afterWrappedBeforeKept(sender)
+LL │ ┃         checkInternal(sender);
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unwrapped-modifier-logic
+help: wrap modifier logic to reduce code size
+   ╭╴
+LL ±     modifier afterWrappedBeforeKept(address sender) {
+LL +         checkPublic(sender);
+LL +         _;
+LL +         _afterWrappedBeforeKept(sender);
+LL +     }
+LL + 
+LL +     function _afterWrappedBeforeKept(address sender) internal {
+LL +         checkPrivate(sender);
+LL +         checkInternal(sender);
+LL +     }
+   ╰╴
+
+note[unwrapped-modifier-logic]: wrap modifier logic to reduce code size
+   ╭▸ ROOT/testdata/UnwrappedModifierLogic.sol:LL:CC
+   │
+LL │ ┏     modifier keepAssemblyBefore() {
+LL │ ┃         assembly ("memory-safe") {
+LL │ ┃             mstore(0x00, 0)
+   ‡ ┃
+LL │ ┃         checkPrivate(msg.sender);
+LL │ ┃     }
+   │ ┗━━━━━┛
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/unwrapped-modifier-logic
+help: wrap modifier logic to reduce code size
+   ╭╴
+LL ±     modifier keepAssemblyBefore() {
+LL +         assembly ("memory-safe") {
+LL +             mstore(0x00, 0)
+LL +         }
+LL +         _;
+LL +         _keepAssemblyBefore();
+LL +     }
+LL + 
+LL +     function _keepAssemblyBefore() internal {
+LL +         checkPublic(msg.sender);
+LL +         checkPrivate(msg.sender);
+LL +     }
+   ╰╴
+
+note[unwrapped-modifier-logic]: wrap modifier logic to reduce code size
+   ╭▸ ROOT/testdata/UnwrappedModifierLogic.sol:LL:CC
+   │
 LL │ ┏     modifier onlyOwner() {
 LL │ ┃         require(isOwner[msg.sender], "Not owner"); // _onlyOwner();
 LL │ ┃         _;


### PR DESCRIPTION
The machine-applicable suggestion emitted by `unwrapped-modifier-logic` could corrupt user code in three ways. First, when only one side of the placeholder required wrapping, the rewritten modifier body consisted solely of the helper call and `_;`, silently dropping the other side's statements from the modifier. Second, a local variable declared before `_;` was hoisted into the extracted helper along with the rest of the segment, so any reference to it after the placeholder no longer resolved, since helpers only receive the modifier's parameters. Third, extracting a write to a modifier parameter into the pre-placeholder helper could change later reads because value-type parameters are passed to the helper by value.

The rewrite now preserves the non-wrapped side's statements verbatim in the new modifier body and bails out entirely when a local declared before the placeholder is referenced after it. It also suppresses the suggestion when extracting the pre-placeholder segment would separate a modifier parameter write from a later reference. The detection walks the relevant HIR, including assembly blocks, and recognizes assignments, deletion, increment and decrement operations, tuple targets, and indexed or member targets. Snippet extraction failures now also abort the suggestion instead of producing partial code.

Closes #12724

This change was developed with AI assistance.
