### PR TITLE
fix(anvil): mark logs of reorged blocks as removed

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -9,7 +9,7 @@ use crate::{
             self,
             db::SerializableState,
             mem::{MIN_CREATE_GAS, MIN_TRANSACTION_GAS},
-            notifications::NewBlockNotifications,
+            notifications::ChainNotifications,
             validate::TransactionValidator,
         },
         error::{
@@ -760,8 +760,9 @@ impl<N: Network> EthApi<N> {
         self.backend.impersonate_signature(signature, address).await
     }
 
-    /// Returns a new block event stream that yields Notifications when a new block was added
-    pub fn new_block_notifications(&self) -> NewBlockNotifications {
+    /// Returns a new block event stream that yields Notifications when a new block was added or
+    /// when logs were removed from the canonical chain due to a reorg
+    pub fn new_block_notifications(&self) -> ChainNotifications {
         self.backend.new_block_notifications()
     }
 
@@ -2620,7 +2621,8 @@ impl EthApi<FoundryNetwork> {
             return Ok(receipt);
         }
         while let Some(notification) = stream.next().await {
-            if let Some(block) = self.backend.get_block_by_hash(notification.hash)
+            if let Some(new_block) = notification.as_new_block()
+                && let Some(block) = self.backend.get_block_by_hash(new_block.hash)
                 && block.body.transactions.iter().any(|tx| tx.hash() == hash)
                 && let Some(receipt) = self.backend.transaction_receipt(hash).await?
             {
@@ -4067,7 +4069,7 @@ impl EthApi<FoundryNetwork> {
                 .map(|hashes| hashes.into_iter().collect::<std::collections::HashSet<_>>());
 
             loop {
-                let block = tokio::select! {
+                let notification = tokio::select! {
                     biased;
                     // Exit when the subscriber unsubscribes, even while awaiting the next block.
                     _ = tx.closed() => break,
@@ -4075,6 +4077,10 @@ impl EthApi<FoundryNetwork> {
                         Some(block) => block,
                         None => break,
                     },
+                };
+
+                let Some(block) = notification.as_new_block() else {
+                    continue;
                 };
 
                 let receipts = match this.block_receipts(BlockId::Hash(block.hash.into())).await {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -18,7 +18,7 @@ use crate::{
                 state::{storage_root, trie_accounts},
                 storage::MinedTransactionReceipt,
             },
-            notifications::{NewBlockNotification, NewBlockNotifications},
+            notifications::{ChainNotification, ChainNotifications, NewBlockNotification},
             tempo::AnvilStorageProvider,
             time::{TimeManager, utc_from_secs},
             validate::TransactionValidator,
@@ -308,8 +308,9 @@ pub struct Backend<N: Network> {
     fees: FeeManager,
     /// Initialised genesis.
     genesis: GenesisConfig,
-    /// Listeners for new blocks that get notified when a new block was imported.
-    new_block_listeners: Arc<Mutex<Vec<UnboundedSender<NewBlockNotification>>>>,
+    /// Listeners for new blocks that get notified when a new block was imported or when logs were
+    /// removed from the canonical chain due to a reorg.
+    new_block_listeners: Arc<Mutex<Vec<UnboundedSender<ChainNotification>>>>,
     /// Keeps track of active state snapshots at a specific block.
     active_state_snapshots: Arc<Mutex<HashMap<U256, (u64, B256)>>>,
     enable_steps_tracing: bool,
@@ -827,8 +828,9 @@ impl<N: Network> Backend<N> {
         inspector
     }
 
-    /// Returns a new block event stream that yields Notifications when a new block was added
-    pub fn new_block_notifications(&self) -> NewBlockNotifications {
+    /// Returns a new block event stream that yields Notifications when a new block was added or
+    /// when logs were removed from the canonical chain due to a reorg
+    pub fn new_block_notifications(&self) -> ChainNotifications {
         let (tx, rx) = unbounded();
         self.new_block_listeners.lock().push(tx);
         trace!(target: "backed", "added new block listener");
@@ -847,7 +849,22 @@ impl<N: Network> Backend<N> {
         // sender half for the set
         self.new_block_listeners.lock().retain(|tx| !tx.is_closed());
 
-        let notification = NewBlockNotification { hash, header: Arc::new(header) };
+        let notification =
+            ChainNotification::Block(NewBlockNotification { hash, header: Arc::new(header) });
+
+        self.new_block_listeners
+            .lock()
+            .retain(|tx| tx.unbounded_send(notification.clone()).is_ok());
+    }
+
+    /// Notifies all `new_block_listeners` about the logs that were removed from the canonical
+    /// chain due to a reorg.
+    fn notify_on_removed_logs(&self, logs: Vec<Log>) {
+        // cleanup closed notification streams first, if the channel is closed we can remove the
+        // sender half for the set
+        self.new_block_listeners.lock().retain(|tx| !tx.is_closed());
+
+        let notification = ChainNotification::RemovedLogs(Arc::new(logs));
 
         self.new_block_listeners
             .lock()
@@ -2712,6 +2729,44 @@ where
         all_logs
     }
 
+    /// Returns all logs of the blocks with a number greater than `block_number`, marked as
+    /// removed.
+    ///
+    /// This is used during a reorg to capture the logs of the blocks that are about to be
+    /// unwound before their transactions and receipts are cleared from storage, so they can be
+    /// re-delivered to log subscriptions and filters with `removed: true`.
+    fn removed_logs_since(&self, block_number: u64) -> Vec<Log> {
+        let storage = self.blockchain.storage.read();
+        let mut all_logs = Vec::new();
+
+        for num in (block_number + 1)..=storage.best_number {
+            if let Some(hash) = storage.hashes.get(&num)
+                && let Some(block) = storage.blocks.get(hash)
+            {
+                let mut block_log_index = 0u64;
+                for tx in &block.body.transactions {
+                    if let Some(tx) = storage.transactions.get(&tx.hash()) {
+                        for log in tx.receipt.logs() {
+                            all_logs.push(Log {
+                                inner: log.clone(),
+                                block_hash: Some(*hash),
+                                block_number: Some(num),
+                                block_timestamp: Some(block.header.timestamp()),
+                                transaction_hash: Some(tx.info.transaction_hash),
+                                transaction_index: Some(tx.info.transaction_index),
+                                log_index: Some(block_log_index),
+                                removed: true,
+                            });
+                            block_log_index += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        all_logs
+    }
+
     /// Returns the logs of the block that match the filter
     async fn logs_for_block(
         &self,
@@ -4112,6 +4167,10 @@ where
         };
 
         {
+            // Collect the logs of the blocks that are about to be removed from the canonical
+            // chain, while their transactions and receipts are still in storage
+            let removed_logs = self.removed_logs_since(common_block.header.number());
+
             // Unwind the storage back to the common ancestor first
             let removed_blocks =
                 self.blockchain.storage.write().unwind_to(common_block.header.number(), hash);
@@ -4120,6 +4179,12 @@ where
             let removed_hashes: Vec<_> =
                 removed_blocks.iter().map(|b| b.header.hash_slow()).collect();
             self.states.write().remove_block_states(&removed_hashes);
+
+            // Notify all log subscriptions and filters about the removed logs, so they receive
+            // them again marked as removed, before any new chain notifications are emitted
+            if !removed_logs.is_empty() {
+                self.notify_on_removed_logs(removed_logs);
+            }
 
             // Set environment back to common block
             let mut env = self.evm_env.write();

--- a/crates/anvil/src/eth/backend/notifications.rs
+++ b/crates/anvil/src/eth/backend/notifications.rs
@@ -2,8 +2,31 @@
 
 use alloy_consensus::Header;
 use alloy_primitives::B256;
+use alloy_rpc_types::Log;
 use futures::channel::mpsc::UnboundedReceiver;
 use std::sync::Arc;
+
+/// A notification that's emitted when the canonical chain was updated.
+#[derive(Clone, Debug)]
+pub enum ChainNotification {
+    /// A new block was added to the canonical chain.
+    Block(NewBlockNotification),
+    /// Logs of blocks that were removed from the canonical chain due to a reorg.
+    ///
+    /// The logs are marked as `removed` and retain the metadata of the removed blocks they were
+    /// originally included in.
+    RemovedLogs(Arc<Vec<Log>>),
+}
+
+impl ChainNotification {
+    /// Returns the [`NewBlockNotification`] if this notification is for an imported block.
+    pub const fn as_new_block(&self) -> Option<&NewBlockNotification> {
+        match self {
+            Self::Block(block) => Some(block),
+            Self::RemovedLogs(_) => None,
+        }
+    }
+}
 
 /// A notification that's emitted when a new block was imported
 #[derive(Clone, Debug)]
@@ -14,5 +37,5 @@ pub struct NewBlockNotification {
     pub header: Arc<Header>,
 }
 
-/// Type alias for a receiver that receives [NewBlockNotification]
-pub type NewBlockNotifications = UnboundedReceiver<NewBlockNotification>;
+/// Type alias for a receiver that receives [ChainNotification]
+pub type ChainNotifications = UnboundedReceiver<ChainNotification>;

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -16,7 +16,7 @@ use revm::{context_interface::block::BlobExcessGasAndPrice, primitives::hardfork
 use tempo_hardfork::{TempoHardfork, constants::gas::tempo_t7_next_block_base_fee};
 
 use crate::eth::{
-    backend::{info::StorageInfo, notifications::NewBlockNotifications},
+    backend::{info::StorageInfo, notifications::ChainNotifications},
     error::BlockchainError,
 };
 
@@ -227,7 +227,7 @@ where
     /// blob parameters for the current spec
     blob_params: BlobParams,
     /// incoming notifications about new blocks
-    new_blocks: NewBlockNotifications,
+    new_blocks: ChainNotifications,
     /// contains all fee history related entries
     cache: FeeHistoryCache,
     /// number of items to consider
@@ -242,7 +242,7 @@ where
 {
     pub const fn new(
         blob_params: BlobParams,
-        new_blocks: NewBlockNotifications,
+        new_blocks: ChainNotifications,
         cache: FeeHistoryCache,
         storage_info: StorageInfo<N>,
     ) -> Self {
@@ -391,7 +391,9 @@ where
 
         while let Poll::Ready(Some(notification)) = pin.new_blocks.poll_next_unpin(cx) {
             // add the imported block.
-            pin.insert_cache_entry_for_block(notification.hash, notification.header.as_ref());
+            if let Some(block) = notification.as_new_block() {
+                pin.insert_cache_entry_for_block(block.hash, block.header.as_ref());
+            }
         }
 
         Poll::Pending

--- a/crates/anvil/src/filter.rs
+++ b/crates/anvil/src/filter.rs
@@ -1,8 +1,11 @@
 //! Support for polling based filters
 use crate::{
     StorageInfo,
-    eth::{backend::notifications::NewBlockNotifications, error::ToRpcResponseResult},
-    pubsub::filter_logs,
+    eth::{
+        backend::notifications::{ChainNotification, ChainNotifications},
+        error::ToRpcResponseResult,
+    },
+    pubsub::{filter_logs, filter_removed_logs},
 };
 use alloy_consensus::TxReceipt;
 use alloy_network::{AnyRpcTransaction, Network};
@@ -140,7 +143,7 @@ fn new_id() -> String {
 /// Represents a poll based filter
 pub enum EthFilter<N: Network> {
     Logs(Box<LogsFilter<N>>),
-    Blocks(NewBlockNotifications),
+    Blocks(ChainNotifications),
     PendingTransactions(Receiver<TxHash>),
     FullPendingTransactions(mpsc::Receiver<AnyRpcTransaction>),
 }
@@ -168,8 +171,10 @@ where
             Self::Logs(logs) => Poll::Ready(Some(Ok(logs.poll(cx)).to_rpc_result())),
             Self::Blocks(blocks) => {
                 let mut new_blocks = Vec::new();
-                while let Poll::Ready(Some(block)) = blocks.poll_next_unpin(cx) {
-                    new_blocks.push(block.hash);
+                while let Poll::Ready(Some(notification)) = blocks.poll_next_unpin(cx) {
+                    if let Some(block) = notification.as_new_block() {
+                        new_blocks.push(block.hash);
+                    }
                 }
                 Poll::Ready(Some(Ok(new_blocks).to_rpc_result()))
             }
@@ -194,7 +199,7 @@ where
 /// Listens for new blocks and matching logs emitted in that block
 pub struct LogsFilter<N: Network> {
     /// listener for new blocks
-    pub blocks: NewBlockNotifications,
+    pub blocks: ChainNotifications,
     /// accessor for block storage
     pub storage: StorageInfo<N>,
     /// matcher with all provided filter params
@@ -218,11 +223,18 @@ where
     /// Returns all the logs since the last time this filter was polled
     pub fn poll(&mut self, cx: &mut Context<'_>) -> Vec<Log> {
         let mut logs = self.historic.take().unwrap_or_default();
-        while let Poll::Ready(Some(block)) = self.blocks.poll_next_unpin(cx) {
-            let b = self.storage.block(block.hash);
-            let receipts = self.storage.receipts(block.hash);
-            if let (Some(receipts), Some(block)) = (receipts, b) {
-                logs.extend(filter_logs(block, receipts, &self.filter))
+        while let Poll::Ready(Some(notification)) = self.blocks.poll_next_unpin(cx) {
+            match notification {
+                ChainNotification::Block(block) => {
+                    let b = self.storage.block(block.hash);
+                    let receipts = self.storage.receipts(block.hash);
+                    if let (Some(receipts), Some(block)) = (receipts, b) {
+                        logs.extend(filter_logs(block, receipts, &self.filter))
+                    }
+                }
+                ChainNotification::RemovedLogs(removed) => {
+                    logs.extend(filter_removed_logs(&removed, &self.filter))
+                }
             }
         }
         logs

--- a/crates/anvil/src/pubsub.rs
+++ b/crates/anvil/src/pubsub.rs
@@ -1,6 +1,9 @@
 use crate::{
     StorageInfo,
-    eth::{backend::notifications::NewBlockNotifications, error::to_rpc_result},
+    eth::{
+        backend::notifications::{ChainNotification, ChainNotifications},
+        error::to_rpc_result,
+    },
 };
 use alloy_consensus::{BlockHeader, TxReceipt};
 use alloy_network::{AnyRpcTransaction, Network};
@@ -20,7 +23,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 
 /// Listens for new blocks and matching logs emitted in that block
 pub struct LogsSubscription<N: Network> {
-    pub blocks: NewBlockNotifications,
+    pub blocks: ChainNotifications,
     pub storage: StorageInfo<N>,
     pub filter: FilteredParams,
     pub queued: VecDeque<Log>,
@@ -50,19 +53,28 @@ where
                 return Poll::Ready(Some(EthSubscriptionResponse::new(params)));
             }
 
-            if let Some(block) = ready!(self.blocks.poll_next_unpin(cx)) {
-                let b = self.storage.block(block.hash);
-                let receipts = self.storage.receipts(block.hash);
-                if let (Some(receipts), Some(block)) = (receipts, b) {
-                    let logs = filter_logs(block, receipts, &self.filter);
-                    if logs.is_empty() {
-                        // this ensures we poll the receiver until it is pending, in which case the
-                        // underlying `UnboundedReceiver` will register the new waker, see
-                        // [`futures::channel::mpsc::UnboundedReceiver::poll_next()`]
-                        continue;
+            if let Some(notification) = ready!(self.blocks.poll_next_unpin(cx)) {
+                let logs = match notification {
+                    ChainNotification::Block(block) => {
+                        let b = self.storage.block(block.hash);
+                        let receipts = self.storage.receipts(block.hash);
+                        if let (Some(receipts), Some(block)) = (receipts, b) {
+                            filter_logs(block, receipts, &self.filter)
+                        } else {
+                            continue;
+                        }
                     }
-                    self.queued.extend(logs)
+                    ChainNotification::RemovedLogs(logs) => {
+                        filter_removed_logs(&logs, &self.filter)
+                    }
+                };
+                if logs.is_empty() {
+                    // this ensures we poll the receiver until it is pending, in which case the
+                    // underlying `UnboundedReceiver` will register the new waker, see
+                    // [`futures::channel::mpsc::UnboundedReceiver::poll_next()`]
+                    continue;
                 }
+                self.queued.extend(logs)
             } else {
                 return Poll::Ready(None);
             }
@@ -98,7 +110,7 @@ pub struct EthSubscriptionParams {
 /// Represents an ethereum Websocket subscription
 pub enum EthSubscription<N: Network> {
     Logs(Box<LogsSubscription<N>>),
-    Header(NewBlockNotifications, StorageInfo<N>, SubscriptionId),
+    Header(ChainNotifications, StorageInfo<N>, SubscriptionId),
     PendingTransactions(Receiver<TxHash>, SubscriptionId),
     FullPendingTransactions(UnboundedReceiver<AnyRpcTransaction>, SubscriptionId),
     Syncing(Option<SubscriptionId>),
@@ -130,8 +142,10 @@ where
                 // underlying `UnboundedReceiver` will register the new waker, see
                 // [`futures::channel::mpsc::UnboundedReceiver::poll_next()`]
                 loop {
-                    if let Some(block) = ready!(blocks.poll_next_unpin(cx)) {
-                        if let Some(block) = storage.eth_block(block.hash) {
+                    if let Some(notification) = ready!(blocks.poll_next_unpin(cx)) {
+                        if let Some(block) = notification.as_new_block()
+                            && let Some(block) = storage.eth_block(block.hash)
+                        {
                             let params = EthSubscriptionParams {
                                 subscription: id.clone(),
                                 result: to_rpc_result(block),
@@ -241,4 +255,21 @@ where
         }
     }
     logs
+}
+
+/// Returns all logs of reorged out blocks that match the given filter.
+///
+/// The logs are expected to already be marked as `removed` and carry the metadata of the block
+/// they were originally included in, so the filter is applied against that metadata.
+pub fn filter_removed_logs(logs: &[Log], filter: &FilteredParams) -> Vec<Log> {
+    logs.iter()
+        .filter(|log| {
+            filter.filter.is_none()
+                || (filter.filter_block_range(log.block_number.unwrap_or_default())
+                    && filter.filter_block_hash(log.block_hash.unwrap_or_default())
+                    && filter.filter_address(&log.inner.address)
+                    && filter.filter_topics(log.inner.topics()))
+        })
+        .cloned()
+        .collect()
 }

--- a/crates/anvil/tests/it/logs.rs
+++ b/crates/anvil/tests/it/logs.rs
@@ -7,8 +7,9 @@ use crate::{
 use alloy_network::EthereumWallet;
 use alloy_primitives::{B256, map::B256HashSet};
 use alloy_provider::Provider;
-use alloy_rpc_types::{BlockNumberOrTag, Filter};
+use alloy_rpc_types::{BlockNumberOrTag, Filter, Log};
 use anvil::{NodeConfig, spawn};
+use anvil_core::types::ReorgOptions;
 use futures::StreamExt;
 use std::str::FromStr;
 
@@ -195,6 +196,61 @@ async fn watch_events() {
             .hash;
         assert_eq!(log.1.block_hash.unwrap(), hash);
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_filter_changes_reorg_removed() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+
+    let wallet = handle.dev_wallets().next().unwrap();
+    let account = wallet.address();
+    let signer: EthereumWallet = wallet.into();
+
+    let provider = http_provider_with_signer(&handle.http_endpoint(), signer);
+
+    let contract =
+        SimpleStorage::deploy(provider.clone(), "initial value".to_string()).await.unwrap();
+
+    // install a log filter for the contract
+    let filter = Filter::new().address(*contract.address());
+    let filter_id: String = provider.client().request("eth_newFilter", (filter,)).await.unwrap();
+
+    let _ = contract
+        .setValue("hi".to_string())
+        .from(account)
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    let changes: Vec<Log> =
+        provider.client().request("eth_getFilterChanges", (filter_id.clone(),)).await.unwrap();
+    assert_eq!(changes.len(), 1);
+    let log = changes.into_iter().next().unwrap();
+    assert!(!log.removed);
+
+    // reorg out the block containing the `setValue` transaction
+    api.anvil_reorg(ReorgOptions { depth: 1, tx_block_pairs: vec![] }).await.unwrap();
+
+    // the filter yields the log of the reorged out block again, marked as removed
+    let changes: Vec<Log> =
+        provider.client().request("eth_getFilterChanges", (filter_id,)).await.unwrap();
+    let mut expected = log.clone();
+    expected.removed = true;
+    assert_eq!(changes, vec![expected]);
+
+    // eth_getLogs only returns the log emitted in the constructor, which is still canonical
+    let logs = provider
+        .get_logs(
+            &Filter::new().address(*contract.address()).from_block(BlockNumberOrTag::Earliest),
+        )
+        .await
+        .unwrap();
+    assert_eq!(logs.len(), 1);
+    assert!(!logs[0].removed);
+    assert_ne!(logs[0].transaction_hash, log.transaction_hash);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/pubsub.rs
+++ b/crates/anvil/tests/it/pubsub.rs
@@ -11,6 +11,7 @@ use alloy_rpc_types::{
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::sol;
 use anvil::{NodeConfig, spawn};
+use anvil_core::types::{ReorgOptions, TransactionData};
 use foundry_primitives::FoundryTxReceipt;
 use futures::StreamExt;
 use std::time::Duration;
@@ -157,6 +158,73 @@ async fn test_sub_logs_impersonated() {
     let log = logs_sub.next().await.unwrap();
     // ensure the log in the receipt is the same as received via subscription stream
     assert_eq!(receipt.inner.inner.logs()[0], log);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sub_logs_reorg_removed() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let wallet = handle.dev_wallets().next().unwrap();
+    let provider =
+        connect_pubsub_with_wallet(&handle.ws_endpoint(), EthereumWallet::from(wallet.clone()))
+            .await;
+
+    let contract = EmitLogs::deploy(provider.clone(), "initial".to_string()).await.unwrap();
+
+    // subscribe to events from the contract
+    let filter = Filter::new().address(*contract.address());
+    let logs_sub = provider.subscribe_logs(&filter).await.unwrap();
+    let mut logs_sub = logs_sub.into_stream();
+
+    // emit events in two consecutive blocks
+    contract.setValue("first".to_string()).send().await.unwrap().get_receipt().await.unwrap();
+    contract.setValue("second".to_string()).send().await.unwrap().get_receipt().await.unwrap();
+
+    let first_log = logs_sub.next().await.unwrap();
+    let second_log = logs_sub.next().await.unwrap();
+    assert!(!first_log.removed);
+    assert!(!second_log.removed);
+
+    // reorg out both blocks and replace the first one with a block that emits another event
+    let data = contract.setValue("reorged".to_string()).calldata().clone();
+    let tx = TransactionRequest::default()
+        .from(wallet.address())
+        .to(*contract.address())
+        .with_input(data);
+    api.anvil_reorg(ReorgOptions {
+        depth: 2,
+        tx_block_pairs: vec![(TransactionData::JSON(tx), 0)],
+    })
+    .await
+    .unwrap();
+
+    // the logs of the reorged out blocks are delivered again, marked as removed
+    let mut expected = first_log.clone();
+    expected.removed = true;
+    assert_eq!(logs_sub.next().await.unwrap(), expected);
+
+    let mut expected = second_log.clone();
+    expected.removed = true;
+    assert_eq!(logs_sub.next().await.unwrap(), expected);
+
+    // followed by the logs of the new chain
+    let new_log = logs_sub.next().await.unwrap();
+    assert!(!new_log.removed);
+    assert_eq!(new_log.block_number, first_log.block_number);
+    assert_ne!(new_log.block_hash, first_log.block_hash);
+    let value_changed = new_log.log_decode::<EmitLogs::ValueChanged>().unwrap();
+    assert_eq!(value_changed.inner.newValue, "reorged");
+
+    // eth_getLogs only returns the logs of the new canonical chain
+    let canonical_logs = provider
+        .get_logs(&Filter::new().address(*contract.address()).from_block(0u64))
+        .await
+        .unwrap();
+    assert!(canonical_logs.iter().all(|log| !log.removed));
+    let tx_hashes =
+        canonical_logs.iter().map(|log| log.transaction_hash.unwrap()).collect::<Vec<_>>();
+    assert!(!tx_hashes.contains(&first_log.transaction_hash.unwrap()));
+    assert!(!tx_hashes.contains(&second_log.transaction_hash.unwrap()));
+    assert!(tx_hashes.contains(&new_log.transaction_hash.unwrap()));
 }
 
 // FIXME: Use legacy() in tx when implemented in alloy


### PR DESCRIPTION
Anvil always returned logs with `removed: false`, even for logs from blocks that were reorged out via `anvil_reorg`. This makes it impossible to build reorg handling or reorg testing on top of the `removed` field the way geth and reth support it: when blocks are removed from the canonical chain, active log subscriptions and installed log filters should receive the removed blocks' logs again with `removed: true`, followed by the logs of the replacement blocks.

The rollback path now collects the logs of the blocks that are about to be unwound, while their transactions and receipts are still in storage, and delivers them through the existing new block notification channel as a new `ChainNotification::RemovedLogs` variant. Because removed logs and the subsequent new block notifications flow through the same channel, subscribers are guaranteed to see the removed logs first, then the new chain's logs. Log subscriptions and `eth_getFilterChanges` match the removed logs against their filter params and yield them marked as removed, while consumers that only care about imported blocks (newHeads, block filters, fee history) skip the new variant. `eth_getLogs` is unaffected and only returns canonical logs since the reorged blocks are dropped from storage.

Closes #9933

This change was implemented with AI assistance.
