### PR TITLE
fix(cast): decode custom errors via local signatures cache

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4527,6 +4527,71 @@ forgetest_async!(cast_call_debug_trace_call_local_artifacts_json_stdout, |prj, c
     });
 });
 
+// `cast call --trace` decodes custom errors through the local signatures cache that `forge build`
+// populates, without requiring `--with-local-artifacts`.
+// <https://github.com/foundry-rs/foundry/issues/11085>
+forgetest_async!(flaky_cast_call_trace_decodes_error_from_signatures_cache, |prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_source(
+        "CustomErrorContract",
+        r#"
+contract CustomErrorContract {
+    error WTF273987(uint256 a, uint256 b);
+
+    function wtf2890230(uint256 a, uint128 b) external pure {
+        revert WTF273987(a, b);
+    }
+}
+"#,
+    );
+
+    // `forge build` caches the project's signatures, including custom errors.
+    cmd.args(["build"]).assert_success();
+
+    // Deploy the contract.
+    cmd.forge_fuse()
+        .args([
+            "create",
+            "./src/CustomErrorContract.sol:CustomErrorContract",
+            "--broadcast",
+            "--private-key",
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success();
+
+    // The revert reason is decoded from the cached signatures, even offline and without
+    // `--with-local-artifacts`.
+    cmd.cast_fuse().env("FOUNDRY_OFFLINE", "true");
+    cmd.args([
+        "call",
+        "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        "wtf2890230(uint256,uint128)",
+        "42",
+        "69",
+        "--trace",
+        "--rpc-url",
+        &handle.http_endpoint(),
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+Traces:
+  [..] 0x5FbDB2315678afecb367f032d93F642f64180aa3::wtf2890230(42, 69)
+    └─ ← [Revert] WTF273987(42, 69)
+
+
+[GAS]
+
+"#]])
+    .stderr_eq(str![[r#"
+Error: Transaction failed.
+
+"#]]);
+});
+
 forgetest_async!(cast_call_custom_override, |prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4539,9 +4539,14 @@ forgetest_async!(flaky_cast_call_trace_decodes_error_from_signatures_cache, |prj
         r#"
 contract CustomErrorContract {
     error WTF273987(uint256 a, uint256 b);
+    error PrintableError18();
 
     function wtf2890230(uint256 a, uint128 b) external pure {
         revert WTF273987(a, b);
+    }
+
+    function printableError() external pure {
+        revert PrintableError18();
     }
 }
 "#,
@@ -4581,6 +4586,32 @@ contract CustomErrorContract {
 Traces:
   [..] 0x5FbDB2315678afecb367f032d93F642f64180aa3::wtf2890230(42, 69)
     └─ ← [Revert] WTF273987(42, 69)
+
+
+[GAS]
+
+"#]])
+    .stderr_eq(str![[r#"
+Error: Transaction failed.
+
+"#]]);
+
+    // A custom error whose selector is valid ASCII must also be decoded from the cache rather than
+    // rendered as a raw string. `PrintableError18()` has selector `0x2e2c426f` (`.,Bo`).
+    cmd.cast_fuse().env("FOUNDRY_OFFLINE", "true");
+    cmd.args([
+        "call",
+        "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+        "printableError()",
+        "--trace",
+        "--rpc-url",
+        &handle.http_endpoint(),
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+Traces:
+  [..] 0x5FbDB2315678afecb367f032d93F642f64180aa3::printableError()
+    └─ ← [Revert] PrintableError18()
 
 
 [GAS]

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -133,12 +133,14 @@ impl RevertDecoder {
     ///
     /// See [`decode`](Self::decode) for more information.
     pub fn maybe_decode(&self, err: &[u8], status: Option<InstructionResult>) -> Option<String> {
-        self.maybe_decode_known(err).or_else(|| Self::maybe_decode_fallback(err, status))
+        self.maybe_decode_known(err)
+            .or_else(|| decode_as_non_empty_string(err))
+            .or_else(|| Self::maybe_decode_fallback(err, status))
     }
 
     /// Tries to decode the given revert bytes as one of the errors known to this decoder:
-    /// Solidity's `Error(string)` and `Panic(uint256)`, `Vm`'s custom errors, custom errors
-    /// registered with this decoder, or a plain string.
+    /// Solidity's `Error(string)` and `Panic(uint256)`, `Vm`'s custom errors, or custom errors
+    /// registered with this decoder.
     ///
     /// Unlike [`maybe_decode`](Self::maybe_decode), this returns `None` for unrecognized custom
     /// errors instead of falling back to a generic `custom error <selector>` representation.
@@ -169,7 +171,7 @@ impl RevertDecoder {
             }
         }
 
-        decode_as_non_empty_string(err)
+        None
     }
 
     /// Formats revert bytes that could not be decoded as a known error.
@@ -290,5 +292,14 @@ mod tests {
 
         assert_eq!(reason, "FOUNDRY::SKIP");
         assert!(SkipReason::decode_self(&reason).is_none());
+    }
+
+    #[test]
+    fn plain_string_is_not_a_known_error() {
+        let decoder = RevertDecoder::new();
+        let data = b".,Bo";
+
+        assert_eq!(decoder.maybe_decode_known(data), None);
+        assert_eq!(decoder.maybe_decode(data, None).as_deref(), Some(".,Bo"));
     }
 }

--- a/crates/evm/core/src/decode.rs
+++ b/crates/evm/core/src/decode.rs
@@ -133,6 +133,16 @@ impl RevertDecoder {
     ///
     /// See [`decode`](Self::decode) for more information.
     pub fn maybe_decode(&self, err: &[u8], status: Option<InstructionResult>) -> Option<String> {
+        self.maybe_decode_known(err).or_else(|| Self::maybe_decode_fallback(err, status))
+    }
+
+    /// Tries to decode the given revert bytes as one of the errors known to this decoder:
+    /// Solidity's `Error(string)` and `Panic(uint256)`, `Vm`'s custom errors, custom errors
+    /// registered with this decoder, or a plain string.
+    ///
+    /// Unlike [`maybe_decode`](Self::maybe_decode), this returns `None` for unrecognized custom
+    /// errors instead of falling back to a generic `custom error <selector>` representation.
+    pub fn maybe_decode_known(&self, err: &[u8]) -> Option<String> {
         // Solidity's `Error(string)` (handled separately in order to strip revert: prefix)
         if let Some(ContractError(Revert(revert))) = RevertReason::decode(err) {
             return Some(revert.reason);
@@ -143,29 +153,29 @@ impl RevertDecoder {
             return Some(e.to_string());
         }
 
-        let string_decoded = decode_as_non_empty_string(err);
-
-        if let Some((selector, data)) = err.split_first_chunk::<SELECTOR_LEN>() {
-            // Custom errors.
-            if let Some(errors) = self.errors.get(selector) {
-                for error in errors {
-                    // If we don't decode, don't return an error, try to decode as a string
-                    // later.
-                    if let Ok(decoded) = error.abi_decode_input(data) {
-                        return Some(format!(
-                            "{}({})",
-                            error.name,
-                            decoded.iter().map(foundry_common::fmt::format_token).format(", ")
-                        ));
-                    }
+        // Custom errors.
+        if let Some((selector, data)) = err.split_first_chunk::<SELECTOR_LEN>()
+            && let Some(errors) = self.errors.get(selector)
+        {
+            for error in errors {
+                // If we don't decode, don't return an error, try to decode as a string later.
+                if let Ok(decoded) = error.abi_decode_input(data) {
+                    return Some(format!(
+                        "{}({})",
+                        error.name,
+                        decoded.iter().map(foundry_common::fmt::format_token).format(", ")
+                    ));
                 }
             }
+        }
 
-            if string_decoded.is_some() {
-                return string_decoded;
-            }
+        decode_as_non_empty_string(err)
+    }
 
-            // Generic custom error.
+    /// Formats revert bytes that could not be decoded as a known error.
+    fn maybe_decode_fallback(err: &[u8], status: Option<InstructionResult>) -> Option<String> {
+        // Generic custom error.
+        if let Some((selector, data)) = err.split_first_chunk::<SELECTOR_LEN>() {
             return Some({
                 let mut s = format!("custom error {}", hex::encode_prefixed(selector));
                 if !data.is_empty() {
@@ -177,10 +187,6 @@ impl RevertDecoder {
                 }
                 s
             });
-        }
-
-        if string_decoded.is_some() {
-            return string_decoded;
         }
 
         if let Some(status) = status

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -26,7 +26,7 @@ use foundry_evm_core::{
 };
 use foundry_evm_hardforks::TempoHardfork;
 use itertools::Itertools;
-use revm::bytecode::opcode::OpCode;
+use revm::{bytecode::opcode::OpCode, interpreter::InstructionResult};
 use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
 
 use std::{collections::BTreeMap, sync::OnceLock};
@@ -610,7 +610,7 @@ impl CallTraceDecoder {
             return DecodedCallTrace {
                 label,
                 call_data: Some(DecodedCallData { signature: "create2".to_string(), args: vec![] }),
-                return_data: self.default_return_data(trace),
+                return_data: self.default_return_data(trace).await,
             };
         }
 
@@ -638,7 +638,7 @@ impl CallTraceDecoder {
                 let return_data = if trace.success {
                     None
                 } else {
-                    let revert_msg = self.revert_decoder.decode(&trace.output, trace.status);
+                    let revert_msg = self.decode_revert(&trace.output, trace.status).await;
 
                     if trace.output.is_empty() || revert_msg.contains("EvmError: Revert") {
                         Some(format!(
@@ -670,7 +670,7 @@ impl CallTraceDecoder {
                 return DecodedCallTrace {
                     label,
                     call_data: self.fallback_call_data(trace),
-                    return_data: self.default_return_data(trace),
+                    return_data: self.default_return_data(trace).await,
                 };
             };
 
@@ -687,13 +687,13 @@ impl CallTraceDecoder {
             DecodedCallTrace {
                 label,
                 call_data: Some(call_data),
-                return_data: self.decode_function_output(trace, contract_functions),
+                return_data: self.decode_function_output(trace, contract_functions).await,
             }
         } else {
             DecodedCallTrace {
                 label,
                 call_data: self.fallback_call_data(trace),
-                return_data: self.default_return_data(trace),
+                return_data: self.default_return_data(trace).await,
             }
         }
     }
@@ -876,9 +876,13 @@ impl CallTraceDecoder {
     }
 
     /// Decodes a function's output into the given trace.
-    fn decode_function_output(&self, trace: &CallTrace, funcs: &[Function]) -> Option<String> {
+    async fn decode_function_output(
+        &self,
+        trace: &CallTrace,
+        funcs: &[Function],
+    ) -> Option<String> {
         if !trace.success {
-            return self.default_return_data(trace);
+            return self.default_return_data(trace).await;
         }
 
         if trace.address == CHEATCODE_ADDRESS
@@ -934,15 +938,35 @@ impl CallTraceDecoder {
     }
 
     /// The default decoded return data for a trace.
-    fn default_return_data(&self, trace: &CallTrace) -> Option<String> {
+    async fn default_return_data(&self, trace: &CallTrace) -> Option<String> {
         // For calls with status None or successful status, don't decode revert data
         // This is due to trace.status is derived from the revm_interpreter::InstructionResult in
         // revm-inspectors status will `None` post revm 27, as `InstructionResult::Continue` does
         // not exists anymore.
-        if trace.status.is_none_or(|s| s.is_ok()) {
+        if trace.status.is_none_or(|s| s.is_ok()) || trace.success {
             return None;
         }
-        (!trace.success).then(|| self.revert_decoder.decode(&trace.output, trace.status))
+        Some(self.decode_revert(&trace.output, trace.status).await)
+    }
+
+    /// Decodes revert data into a human-readable representation.
+    ///
+    /// If the revert decoder does not know the custom error, tries identifying the error selector
+    /// with the signatures identifier, like unknown function and event signatures. This resolves
+    /// errors from the local signatures cache populated by `forge build`, or from remote signature
+    /// databases.
+    async fn decode_revert(&self, output: &[u8], status: Option<InstructionResult>) -> String {
+        if let Some(reason) = self.revert_decoder.maybe_decode_known(output) {
+            return reason;
+        }
+        if let Some(identifier) = &self.signature_identifier
+            && let Some((selector, data)) = output.split_first_chunk::<SELECTOR_LEN>()
+            && let Some(error) = identifier.identify_error(Selector::from(*selector)).await
+            && let Ok(decoded) = error.abi_decode_input(data)
+        {
+            return format!("{}({})", error.name, decoded.iter().map(format_token).format(", "));
+        }
+        self.revert_decoder.decode(output, status)
     }
 
     /// Decodes an event.
@@ -1048,9 +1072,19 @@ impl CallTraceDecoder {
             })
             .filter_map(|n| n.trace.data.first_chunk().map(Selector::from))
             .filter(|selector| !self.functions.contains_key(selector));
+        let errors = nodes
+            .iter()
+            .filter(|&n| {
+                // Only consider reverted traces whose output the revert decoder cannot decode.
+                n.trace.status.is_some_and(|s| !s.is_ok())
+                    && !n.trace.success
+                    && self.revert_decoder.maybe_decode_known(&n.trace.output).is_none()
+            })
+            .filter_map(|n| n.trace.output.first_chunk().map(Selector::from));
         let selectors = events
             .map(SelectorKind::Event)
             .chain(functions.map(SelectorKind::Function))
+            .chain(errors.map(SelectorKind::Error))
             .unique()
             .collect::<Vec<_>>();
         let _ = identifier.identify(&selectors).await;


### PR DESCRIPTION
`cast call --trace` rendered custom errors as `custom error 0x…` even when `forge build` had already cached the error signature in the local signatures cache, while the very same trace decoded the unknown function and event signatures of that contract through this cache. The reported workaround was `--with-local-artifacts`, which compiles the project and collects its ABI errors into the revert decoder.

The root cause is that `CallTraceDecoder` falls back to the `SignaturesIdentifier` for unknown function selectors and event topics, but never for revert data: reverts were decoded exclusively by the `RevertDecoder`, whose custom error table is only filled from known contract ABIs. `SignaturesIdentifier::identify_error` existed but was only used by `cast decode-error`, which is why that command decoded the same selector fine. #11090 did not help here because it only switched the config figment to include remappings when compiling the project for `--with-local-artifacts`; the path without the flag was untouched.

Revert data now goes through the same fallback as functions and events: `RevertDecoder::maybe_decode` is split so the trace decoder can first try all known decodings (`Error(string)`, `Panic(uint256)`, cheatcode errors, registered ABI errors, plain strings) without the generic `custom error <selector>` fallback, then ask the signatures identifier for the unknown error selector, and only fall back to the generic representation if that fails as well. Error selectors of reverted traces are also included in the signature prefetching batch. With this, `cast call --trace` and `cast run` decode custom errors from the signatures cache populated by `forge build` without requiring `--with-local-artifacts`, and from OpenChain when online, consistent with how unknown functions and events are already handled.

Closes #11085

AI assistance was used to diagnose and implement this change.
