### PR TITLE
fix(doc): resolve same-contract references to anchor links

### DIFF
--- a/crates/doc/src/hir_ext.rs
+++ b/crates/doc/src/hir_ext.rs
@@ -673,6 +673,13 @@ impl LocalMembers {
     fn member_anchor(&self, member: &str) -> Option<String> {
         self.members.contains(member).then(|| slug_anchor_segment(member))
     }
+
+    /// Anchor for a qualified `{Contract-member[-params...]}` reference, if `member` is
+    /// documented on this page.
+    fn xref_member_anchor(&self, part: &str) -> Option<String> {
+        let member = part.split('-').find(|piece| !piece.is_empty())?;
+        self.members.contains(member).then(|| xref_part_anchor(part))
+    }
 }
 
 /// Escape a string for use as a markdown link label.
@@ -720,7 +727,9 @@ pub fn replace_inline_links(
                 if let Some(local) = local {
                     let anchor = match part {
                         None => local.member_anchor(lookup_name),
-                        Some(member) if lookup_name == local.name => Some(xref_part_anchor(member)),
+                        Some(member) if lookup_name == local.name => {
+                            local.xref_member_anchor(member)
+                        }
                         Some(_) => None,
                     };
                     if let Some(anchor) = anchor
@@ -953,6 +962,15 @@ mod tests {
             Some(&local),
         );
         assert_eq!(out, "See `unknownMember`.");
+
+        // Unknown qualified self-reference should not create a broken same-page anchor.
+        let out = replace_inline_links(
+            "See {ECDSA-doesNotExist}.",
+            &name_to_page,
+            Path::new("src/library.ECDSA.mdx"),
+            Some(&local),
+        );
+        assert_eq!(out, "See `ECDSA`.");
     }
 
     #[test]

--- a/crates/doc/src/hir_ext.rs
+++ b/crates/doc/src/hir_ext.rs
@@ -642,6 +642,39 @@ pub(crate) fn clean_block_doc_content(raw: &str) -> String {
 
 // ── inline link replacement ───────────────────────────────────────────────────
 
+/// Members of the contract page currently being rendered.
+///
+/// Used to resolve `{member}` and `{Contract-member}` references lexically:
+/// a name that belongs to the current contract links to its heading anchor on
+/// the same page instead of going through the global name index (which only
+/// contains top-level items and could otherwise resolve to an unrelated page).
+#[derive(Debug)]
+pub struct LocalMembers {
+    /// The current contract's name.
+    name: String,
+    /// Member names with a heading (and thus an anchor) on the current page.
+    members: HashSet<String>,
+}
+
+impl LocalMembers {
+    /// Create an empty member set for the contract `name`.
+    pub fn new(name: &str) -> Self {
+        Self { name: name.to_string(), members: HashSet::new() }
+    }
+
+    /// Record a member that is rendered as a `### member` heading on the page.
+    pub fn insert(&mut self, member: &str) {
+        self.members.insert(member.to_string());
+    }
+
+    /// Anchor for a bare `{member}` reference, if `member` is documented on this page.
+    ///
+    /// Overloads share the base heading slug; the first heading owns it.
+    fn member_anchor(&self, member: &str) -> Option<String> {
+        self.members.contains(member).then(|| slug_anchor_segment(member))
+    }
+}
+
 /// Escape a string for use as a markdown link label.
 ///
 /// Prevents MDX from treating user-controlled NatSpec label text as JSX or
@@ -654,7 +687,17 @@ fn escape_link_label(s: &str) -> String {
 ///
 /// Matches the legacy pattern: `{[xref-]Ident[-part]}[label]` where `label` defaults
 /// to `Ident`.
-pub fn replace_inline_links(text: &str, name_to_page: &NameToPage, current_page: &Path) -> String {
+///
+/// Resolution prefers lexical proximity: a reference naming a member of the current
+/// contract (`{member}`, or `{Contract-member}` where `Contract` is the current
+/// contract) becomes an anchor-only link within the page; everything else goes
+/// through the global `name_to_page` index.
+pub fn replace_inline_links(
+    text: &str,
+    name_to_page: &NameToPage,
+    current_page: &Path,
+    local: Option<&LocalMembers>,
+) -> String {
     let mut out = String::with_capacity(text.len());
     let bytes = text.as_bytes();
     let mut i = 0;
@@ -670,6 +713,29 @@ pub fn replace_inline_links(text: &str, name_to_page: &NameToPage, current_page:
                 } else {
                     lookup_name
                 };
+
+                // Same-contract references resolve to anchor-only links: a bare
+                // `{member}` documented on this page, or `{Contract-member}` where
+                // `Contract` is the contract being rendered.
+                if let Some(local) = local {
+                    let anchor = match part {
+                        None => local.member_anchor(lookup_name),
+                        Some(member) if lookup_name == local.name => Some(xref_part_anchor(member)),
+                        Some(_) => None,
+                    };
+                    if let Some(anchor) = anchor
+                        && !anchor.is_empty()
+                    {
+                        let default_display = match part {
+                            Some(member) => format!("{lookup_name}.{member}"),
+                            None => lookup_name.to_string(),
+                        };
+                        let display = escape_link_label(label.unwrap_or(&default_display));
+                        out.push_str(&format!("[{display}](#{anchor})"));
+                        i += end;
+                        continue;
+                    }
+                }
 
                 if let Some(candidates) = name_to_page.get(lookup_name) {
                     let page = resolve_page(candidates, current_page);
@@ -845,11 +911,76 @@ mod tests {
             "See {xref-ERC721-_safeMint-address-uint256-}.",
             &name_to_page,
             Path::new("src/contract.Child.mdx"),
+            None,
         );
 
         assert_eq!(
             out,
             "See [ERC721._safeMint-address-uint256-](/src/contract.ERC721#_safemint-address-uint256)."
         );
+    }
+
+    #[test]
+    fn same_contract_member_links_anchor_only() {
+        let name_to_page = NameToPage::new();
+        let mut local = LocalMembers::new("ECDSA");
+        local.insert("toEthSignedMessageHash");
+        local.insert("tryRecover");
+
+        // Bare member reference -> anchor-only link.
+        let out = replace_inline_links(
+            "then calling {toEthSignedMessageHash} on it.",
+            &name_to_page,
+            Path::new("src/library.ECDSA.mdx"),
+            Some(&local),
+        );
+        assert_eq!(out, "then calling [toEthSignedMessageHash](#toethsignedmessagehash) on it.");
+
+        // `{Contract-member}` self-reference -> anchor-only link.
+        let out = replace_inline_links(
+            "Overload of {ECDSA-tryRecover} that ...",
+            &name_to_page,
+            Path::new("src/library.ECDSA.mdx"),
+            Some(&local),
+        );
+        assert_eq!(out, "Overload of [ECDSA.tryRecover](#tryrecover) that ...");
+
+        // Unknown member still falls back to inline code.
+        let out = replace_inline_links(
+            "See {unknownMember}.",
+            &name_to_page,
+            Path::new("src/library.ECDSA.mdx"),
+            Some(&local),
+        );
+        assert_eq!(out, "See `unknownMember`.");
+    }
+
+    #[test]
+    fn local_member_wins_over_global_name() {
+        // A top-level item elsewhere shares the member's name; lexical
+        // proximity resolves to the same-page anchor, not the other page.
+        let mut name_to_page = NameToPage::new();
+        name_to_page
+            .by_name
+            .insert("transfer".to_string(), vec![PathBuf::from("src/other/contract.transfer.mdx")]);
+        let mut local = LocalMembers::new("Token");
+        local.insert("transfer");
+
+        let out = replace_inline_links(
+            "Calls {transfer}.",
+            &name_to_page,
+            Path::new("src/contract.Token.mdx"),
+            Some(&local),
+        );
+        assert_eq!(out, "Calls [transfer](#transfer).");
+
+        // Without local context the global index still resolves.
+        let out = replace_inline_links(
+            "Calls {transfer}.",
+            &name_to_page,
+            Path::new("src/contract.Token.mdx"),
+            None,
+        );
+        assert_eq!(out, "Calls [transfer](/src/other/contract.transfer).");
     }
 }

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -196,7 +196,29 @@ fn render_contract<'ast, 'gcx>(
     deployments: &[Deployment],
 ) -> String {
     let name = c.name.as_str();
-    let comments = collect_comments(docs, name_to_page, page_path);
+
+    // Index the members rendered as headings on this page so `{member}` and
+    // `{Contract-member}` self-references resolve to anchor-only links.
+    let mut local = hir_ext::LocalMembers::new(name);
+    for member in c.body.iter() {
+        match &member.kind {
+            ItemKind::Variable(v) => {
+                if let Some(n) = v.name {
+                    local.insert(n.as_str());
+                }
+            }
+            ItemKind::Function(f) => local.insert(&function_heading(f)),
+            ItemKind::Event(e) => local.insert(e.name.as_str()),
+            ItemKind::Error(e) => local.insert(e.name.as_str()),
+            ItemKind::Struct(s) => local.insert(s.name.as_str()),
+            ItemKind::Enum(e) => local.insert(e.name.as_str()),
+            ItemKind::Udvt(u) => local.insert(u.name.as_str()),
+            _ => {}
+        }
+    }
+    let local = Some(&local);
+
+    let comments = collect_comments(docs, name_to_page, page_path, local);
     let mut out = String::new();
     write_frontmatter(&mut out, name, first_notice(&comments).as_deref());
     writeln!(out, "# {name}").unwrap();
@@ -251,14 +273,14 @@ fn render_contract<'ast, 'gcx>(
                 let vname = v.name.map(|n| n.as_str().to_string()).unwrap_or_default();
                 writeln!(out, "### {vname}").unwrap();
                 writeln!(out).unwrap();
-                let mut c = collect_comments(docs, name_to_page, page_path);
+                let mut c = collect_comments(docs, name_to_page, page_path, local);
                 // Attempt @inheritdoc resolution for public state variables.
                 let inherited = inheritdoc_base(docs).and_then(|base| {
                     hir_id.and_then(|cid| hir_ext::resolve_inheritdoc_var(gcx, cid, &vname, &base))
                 });
                 if let Some(ref base_doc) = inherited {
                     let sanitize =
-                        |s: &str| hir_ext::replace_inline_links(s, name_to_page, page_path);
+                        |s: &str| hir_ext::replace_inline_links(s, name_to_page, page_path, local);
                     if c.notices.is_empty() {
                         let inherited_notices: Vec<String> =
                             base_doc.notices.iter().map(|s| sanitize(s)).collect();
@@ -357,6 +379,7 @@ fn render_contract<'ast, 'gcx>(
                 ctx,
                 name_to_page,
                 page_path,
+                local,
                 inherited.as_ref(),
             );
         }
@@ -368,7 +391,7 @@ fn render_contract<'ast, 'gcx>(
         for (span, e, docs) in &events {
             writeln!(out, "### {}", e.name.as_str()).unwrap();
             writeln!(out).unwrap();
-            let c = collect_comments(docs, name_to_page, page_path);
+            let c = collect_comments(docs, name_to_page, page_path, local);
             write_comment_block(&mut out, &c);
             write_code_block(&mut out, &ctx.dedented_snippet(*span));
             write_param_table(&mut out, "Parameters", &e.parameters, &c, ctx);
@@ -381,7 +404,7 @@ fn render_contract<'ast, 'gcx>(
         for (span, e, docs) in &errors {
             writeln!(out, "### {}", e.name.as_str()).unwrap();
             writeln!(out).unwrap();
-            let c = collect_comments(docs, name_to_page, page_path);
+            let c = collect_comments(docs, name_to_page, page_path, local);
             write_comment_block(&mut out, &c);
             write_code_block(&mut out, &ctx.dedented_snippet(*span));
             write_param_table(&mut out, "Parameters", &e.parameters, &c, ctx);
@@ -394,7 +417,7 @@ fn render_contract<'ast, 'gcx>(
         for (span, s, docs) in &structs {
             writeln!(out, "### {}", s.name.as_str()).unwrap();
             writeln!(out).unwrap();
-            let c = collect_comments(docs, name_to_page, page_path);
+            let c = collect_comments(docs, name_to_page, page_path, local);
             write_comment_block(&mut out, &c);
             write_code_block(&mut out, &ctx.dedented_snippet(*span));
             write_struct_properties_table(&mut out, s.fields, &c, ctx);
@@ -407,7 +430,7 @@ fn render_contract<'ast, 'gcx>(
         for (span, e, docs) in &enums {
             writeln!(out, "### {}", e.name.as_str()).unwrap();
             writeln!(out).unwrap();
-            let c = collect_comments(docs, name_to_page, page_path);
+            let c = collect_comments(docs, name_to_page, page_path, local);
             write_comment_block(&mut out, &c);
             write_code_block(&mut out, &ctx.dedented_snippet(*span));
             write_enum_variants_table(&mut out, e.variants, &c);
@@ -420,7 +443,7 @@ fn render_contract<'ast, 'gcx>(
         for (span, u, docs) in &udvts {
             writeln!(out, "### {}", u.name.as_str()).unwrap();
             writeln!(out).unwrap();
-            let c = collect_comments(docs, name_to_page, page_path);
+            let c = collect_comments(docs, name_to_page, page_path, local);
             write_comment_block(&mut out, &c);
             write_code_block(&mut out, &format!("{};", ctx.dedented_snippet(*span)));
         }
@@ -440,14 +463,14 @@ fn render_free_functions(
     git_url: Option<&str>,
 ) -> String {
     let title = if name.is_empty() { "function" } else { name };
-    let first_comments = collect_comments(overloads[0].2, name_to_page, page_path);
+    let first_comments = collect_comments(overloads[0].2, name_to_page, page_path, None);
     let mut out = String::new();
     write_frontmatter(&mut out, title, first_notice(&first_comments).as_deref());
     writeln!(out, "# {title}").unwrap();
     writeln!(out).unwrap();
     write_git_source(&mut out, git_url);
     for (span, f, docs) in overloads {
-        render_function_section(&mut out, *span, f, docs, ctx, name_to_page, page_path, None);
+        render_function_section(&mut out, *span, f, docs, ctx, name_to_page, page_path, None, None);
     }
     out
 }
@@ -472,7 +495,7 @@ fn render_constants(
         let name = v.name.map(|n| n.as_str().to_string()).unwrap_or_else(|| "_".to_string());
         writeln!(out, "## {name}").unwrap();
         writeln!(out).unwrap();
-        let c = collect_comments(docs, name_to_page, page_path);
+        let c = collect_comments(docs, name_to_page, page_path, None);
         write_comment_block(&mut out, &c);
         write_code_block(&mut out, &ctx.dedented_snippet(*span));
     }
@@ -491,7 +514,7 @@ fn render_struct<'ast>(
     git_url: Option<&str>,
 ) -> String {
     let name = s.name.as_str();
-    let c = collect_comments(docs, name_to_page, page_path);
+    let c = collect_comments(docs, name_to_page, page_path, None);
     let mut out = String::new();
     write_frontmatter(&mut out, name, first_notice(&c).as_deref());
     writeln!(out, "# {name}").unwrap();
@@ -513,7 +536,7 @@ fn render_enum<'ast>(
     git_url: Option<&str>,
 ) -> String {
     let name = e.name.as_str();
-    let c = collect_comments(docs, name_to_page, page_path);
+    let c = collect_comments(docs, name_to_page, page_path, None);
     let mut out = String::new();
     write_frontmatter(&mut out, name, first_notice(&c).as_deref());
     writeln!(out, "# {name}").unwrap();
@@ -535,7 +558,7 @@ fn render_udvt<'ast>(
     git_url: Option<&str>,
 ) -> String {
     let name = u.name.as_str();
-    let c = collect_comments(docs, name_to_page, page_path);
+    let c = collect_comments(docs, name_to_page, page_path, None);
     let mut out = String::new();
     write_frontmatter(&mut out, name, first_notice(&c).as_deref());
     writeln!(out, "# {name}").unwrap();
@@ -556,7 +579,7 @@ fn render_error<'ast>(
     git_url: Option<&str>,
 ) -> String {
     let name = e.name.as_str();
-    let c = collect_comments(docs, name_to_page, page_path);
+    let c = collect_comments(docs, name_to_page, page_path, None);
     let mut out = String::new();
     write_frontmatter(&mut out, name, first_notice(&c).as_deref());
     writeln!(out, "# {name}").unwrap();
@@ -578,7 +601,7 @@ fn render_event<'ast>(
     git_url: Option<&str>,
 ) -> String {
     let name = e.name.as_str();
-    let c = collect_comments(docs, name_to_page, page_path);
+    let c = collect_comments(docs, name_to_page, page_path, None);
     let mut out = String::new();
     write_frontmatter(&mut out, name, first_notice(&c).as_deref());
     writeln!(out, "# {name}").unwrap();
@@ -600,6 +623,7 @@ fn render_function_section(
     ctx: &Ctx<'_>,
     name_to_page: &NameToPage,
     page_path: &Path,
+    local: Option<&hir_ext::LocalMembers>,
     inherited: Option<&hir_ext::InheritedDoc>,
 ) {
     let heading = function_heading(f);
@@ -609,10 +633,10 @@ fn render_function_section(
     }
     writeln!(out, "### {heading}").unwrap();
     writeln!(out).unwrap();
-    let mut c = collect_comments(docs, name_to_page, page_path);
+    let mut c = collect_comments(docs, name_to_page, page_path, local);
     // Merge inherited natspec for missing tags.
     if let Some(inherited) = inherited {
-        let sanitize = |s: &str| hir_ext::replace_inline_links(s, name_to_page, page_path);
+        let sanitize = |s: &str| hir_ext::replace_inline_links(s, name_to_page, page_path, local);
         let inherited_notices: Vec<String> =
             inherited.notices.iter().map(|s| sanitize(s)).collect();
         let inherited_devs: Vec<String> = inherited.devs.iter().map(|s| sanitize(s)).collect();
@@ -724,6 +748,7 @@ fn collect_comments(
     docs: &DocComments<'_>,
     name_to_page: &NameToPage,
     page_path: &Path,
+    local: Option<&hir_ext::LocalMembers>,
 ) -> CommentData {
     let mut data = CommentData {
         titles: Vec::new(),
@@ -779,7 +804,7 @@ fn collect_comments(
             }
 
             // Apply inline {Ident} -> markdown link replacement.
-            let content = hir_ext::replace_inline_links(trimmed, name_to_page, page_path);
+            let content = hir_ext::replace_inline_links(trimmed, name_to_page, page_path, local);
 
             if is_continuation && !prev_doc_was_blank {
                 let appended = match last_section {

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -1059,7 +1059,7 @@ Recover the signer address from `v`, `r`, `s` components.
 
 <i>
 
-Overload of [ECDSA.tryRecover](/src/library.ECDSA#tryrecover-bytes32-bytes) that receives the `v`,
+Overload of [ECDSA.tryRecover](#tryrecover-bytes32-bytes) that receives the `v`,
 `r` and `s` signature fields separately.
 
 Documentation for signature generation:
@@ -1154,6 +1154,181 @@ uint256 public totalSupply;
 // when another contract with the same name lives in a directory closer to the
 // consumer. Without exact-id resolution, the proximity heuristic in
 // `resolve_page` would (wrongly) link to the same-directory namesake.
+// Test that references naming a member of the current contract resolve to anchor-only
+// links on the same page ({member} and {Contract-member} self-references), and that
+// same-file inheritance links to the same-file base instead of a same-named decoy.
+// fixes <https://github.com/foundry-rs/foundry/issues/11677>
+forgetest_init!(same_contract_references_resolve_to_anchors, |prj, cmd| {
+    // Decoys: same-named library and interface in a sibling directory that sorts
+    // first; references in `external/OlympusERC20.sol` must not resolve to them.
+    prj.add_source(
+        "decoys/Decoys.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library ECDSA {
+    function tryRecover(bytes32 hash) internal pure returns (address) {}
+}
+
+interface IERC20 {
+    function balanceOf(address owner) external view returns (uint256);
+}
+"#,
+    );
+
+    prj.add_source(
+        "external/OlympusERC20.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library ECDSA {
+    /// @dev A safe way to ensure this is by receiving a hash of the original
+    /// message and then calling {toEthSignedMessageHash} on it.
+    function recover(bytes32 hash) internal pure returns (address) {}
+
+    /// @dev Overload of {ECDSA-tryRecover} that receives the fields separately.
+    function tryRecover(bytes32 hash, bytes32 r) internal pure returns (address) {}
+
+    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {}
+}
+
+interface IERC20 {
+    function totalSupply() external view returns (uint256);
+}
+
+interface IOHM is IERC20 {
+    function mint(address account_) external;
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+
+    // Same-contract member references become anchor-only links.
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/external/library.ECDSA.mdx"), None),
+        str![[r#"
+---
+title: "ECDSA"
+---
+
+# ECDSA
+
+## Functions
+
+<a id="recover-bytes32"></a>
+
+### recover
+
+<i>
+
+A safe way to ensure this is by receiving a hash of the original
+message and then calling [toEthSignedMessageHash](#toethsignedmessagehash) on it.
+
+</i>
+
+```solidity
+function recover(bytes32 hash) internal pure returns (address);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| hash | `bytes32` |  |
+
+**Returns**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| &lt;none&gt; | `address` |  |
+
+<a id="tryrecover-bytes32-bytes32"></a>
+
+### tryRecover
+
+<i>
+
+Overload of [ECDSA.tryRecover](#tryrecover) that receives the fields separately.
+
+</i>
+
+```solidity
+function tryRecover(bytes32 hash, bytes32 r) internal pure returns (address);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| hash | `bytes32` |  |
+| r | `bytes32` |  |
+
+**Returns**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| &lt;none&gt; | `address` |  |
+
+<a id="toethsignedmessagehash-bytes32"></a>
+
+### toEthSignedMessageHash
+
+```solidity
+function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32);
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| hash | `bytes32` |  |
+
+**Returns**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| &lt;none&gt; | `bytes32` |  |
+
+
+"#]],
+    );
+
+    // Same-file inheritance links to the same-file interface, not the decoy.
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/external/interface.IOHM.mdx"), None),
+        str![[r#"
+---
+title: "IOHM"
+---
+
+# IOHM
+
+**Inherits:** [IERC20](/src/external/interface.IERC20)
+
+## Functions
+
+<a id="mint-address"></a>
+
+### mint
+
+```solidity
+function mint(address account_) external;
+```
+
+**Parameters**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| account_ | `address` |  |
+
+
+"#]],
+    );
+});
+
 forgetest_init!(inheritance_links_use_exact_base_id, |prj, cmd| {
     // Two unrelated `Token` contracts in sibling directories.
     prj.add_source(


### PR DESCRIPTION
#11677 reported four broken link patterns in `forge doc` output against the old mdbook-based pipeline. Rechecking them on current master after the solar/vocs rewrite (#14568), three no longer reproduce: `{Contract-member}` references such as `{ECDSA-tryRecover}` resolve to the same-file contract page instead of an unrelated dependency copy, since cross-reference candidates are restricted to documented sources and disambiguated by path proximity; same-file inheritance like `interface IOHM is IERC20` links to the same-file base through its exact HIR contract id; and inheritance links use the same root-relative vocs URLs as the generated sidebar, so the reported inconsistency with the summary tree no longer exists.

The remaining gap was the first reported case: a reference naming a member of the contract being rendered, like `{toEthSignedMessageHash}` inside `library ECDSA`, produced no link at all and degraded to inline code, because the global name index only contains top-level items. `{Contract-member}` self-references also went through the ambiguous name index even though the target page is by definition the one being rendered. Reference resolution now prefers lexical proximity: the members of the current contract are indexed while rendering its page, and both `{member}` and `{Contract-member}` self-references resolve to anchor-only links (`[toEthSignedMessageHash](#toethsignedmessagehash)`, `[ECDSA.tryRecover](#tryrecover)`) before any global name lookup, so a same-named contract elsewhere in the project can never win over the local definition. Unresolvable references keep rendering as inline code rather than guessing a link.

Closes #11677

This change was developed with AI assistance.
