### PR TITLE
feat(cast): fetch cast run traces via debug_traceTransaction

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -2,7 +2,7 @@ use super::run::{fetch_contracts_bytecode_from_trace, fetch_contracts_bytecode_v
 use crate::{
     Cast,
     debug::handle_traces,
-    rpc_trace::call_frame_to_arena,
+    rpc_trace::{call_frame_to_arena, is_method_not_found_error, is_missing_state_error},
     traces::TraceKind,
     tx::{CastTxBuilder, SenderKind},
 };
@@ -366,32 +366,14 @@ impl CallArgs {
                 .await
                 .map_err(|err| -> eyre::Report {
                     // Two RPC rejections deserve an actionable hint instead of the raw transport
-                    // error, and they need different fixes:
-                    // - `debug` namespace disabled: rejected with JSON-RPC -32601 (method not found).
-                    // - missing historical state: an archive-depth error, usually with a generic
-                    //   code (-32000) distinguishable only by message, hit whenever `--block`
-                    //   targets a block a full node has pruned.
-                    let is_method_not_found =
-                        err.as_error_resp().is_some_and(|resp| resp.code == -32601);
-                    let message = err
-                        .as_error_resp()
-                        .map(|resp| resp.message.to_ascii_lowercase())
-                        .unwrap_or_else(|| err.to_string().to_ascii_lowercase());
-                    let is_missing_state = [
-                        "missing trie node",
-                        "required historical state",
-                        "historical state",
-                        "header not found",
-                        "missing state",
-                    ]
-                    .iter()
-                    .any(|needle| message.contains(*needle));
-
-                    if is_method_not_found {
+                    // error, and they need different fixes: a disabled `debug` namespace, and
+                    // missing historical state, hit whenever `--block` targets a block a full
+                    // node has pruned.
+                    if is_method_not_found_error(&err) {
                         eyre::eyre!(
                             "the RPC endpoint does not support `debug_traceCall` (method not found); use a node with the `debug` namespace enabled (e.g. a local anvil/reth or an archive endpoint), or drop `--debug-trace-call` to run the call locally with `--trace`"
                         )
-                    } else if is_missing_state {
+                    } else if is_missing_state_error(&err) {
                         eyre::eyre!(
                             "the RPC endpoint does not have the historical state for the requested block; use an archive endpoint, or target a more recent block with `--block`"
                         )

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -1,6 +1,8 @@
 use crate::{
     debug::handle_traces,
-    rpc_trace::{call_frame_to_arena, is_method_not_found_error, is_missing_state_error},
+    rpc_trace::{
+        call_frame_to_arena_with_root_address, is_method_not_found_error, is_missing_state_error,
+    },
     traces::TraceKind,
     utils::{apply_chain_and_block_specific_env_changes, block_env_from_header},
 };
@@ -239,8 +241,11 @@ impl RunArgs {
 
             let success = receipt.status();
             let gas_used = receipt.gas_used();
+            let root_create_address = Transaction::to(&tx).is_none().then(|| {
+                receipt.contract_address().unwrap_or_else(|| tx.from().create(tx.nonce()))
+            });
             let arena = SparsedTraceArena {
-                arena: call_frame_to_arena(&frame),
+                arena: call_frame_to_arena_with_root_address(&frame, root_create_address),
                 ignored: Default::default(),
             };
             let result = TraceResult {
@@ -254,7 +259,13 @@ impl RunArgs {
             // for the addresses in the trace, at the transaction's block. Skip the extra
             // round-trips unless local artifacts were requested.
             let contracts_bytecode = if with_local_artifacts {
-                fetch_contracts_bytecode_via_rpc(&provider, &result, tx_block_number.into()).await?
+                fetch_transaction_contracts_bytecode_via_rpc(
+                    &provider,
+                    &result,
+                    tx_hash,
+                    tx_block_number.into(),
+                )
+                .await?
             } else {
                 Default::default()
             };
@@ -573,6 +584,60 @@ pub async fn fetch_contracts_bytecode_via_rpc<N: Network, P: Provider<N>>(
                 Ok(_) => {}
                 Err(err) => {
                     let _ = sh_warn!("Failed to fetch code for {addr}: {err}");
+                }
+            }
+        }
+    }
+    Ok(contracts_bytecode)
+}
+
+/// Fetches bytecode for a mined transaction at its exact transaction index.
+///
+/// The prestate tracer provides the code that existed immediately before the transaction, which
+/// avoids reading end-of-block state for contracts changed or removed by later transactions. Any
+/// address absent from the prestate (for example, a contract created by this transaction) falls
+/// back to `eth_getCode` at the transaction's block.
+async fn fetch_transaction_contracts_bytecode_via_rpc<N: Network, P: Provider<N>>(
+    provider: &P,
+    result: &TraceResult,
+    tx_hash: B256,
+    block: BlockId,
+) -> Result<AddressHashMap<Bytes>> {
+    let mut contracts_bytecode = AddressHashMap::default();
+    let prestate_config = PreStateConfig { disable_storage: Some(true), ..Default::default() };
+    match provider
+        .debug_trace_transaction(tx_hash, GethDebugTracingOptions::prestate_tracer(prestate_config))
+        .await
+    {
+        Ok(trace) => match trace.try_into_pre_state_frame() {
+            Ok(prestate) => {
+                for (&address, account) in prestate.pre_state() {
+                    if let Some(code) = account.code.clone().filter(|code| !code.is_empty()) {
+                        contracts_bytecode.insert(address, code);
+                    }
+                }
+            }
+            Err(err) => {
+                let _ = sh_warn!("Failed to parse transaction prestate for local artifacts: {err}");
+            }
+        },
+        Err(err) => {
+            let _ = sh_warn!("Failed to fetch transaction prestate for local artifacts: {err}");
+        }
+    }
+
+    if let Some(ref traces) = result.traces {
+        for address in gather_trace_addresses(traces) {
+            if contracts_bytecode.contains_key(&address) {
+                continue;
+            }
+            match provider.get_code_at(address).block_id(block).await {
+                Ok(code) if !code.is_empty() => {
+                    contracts_bytecode.insert(address, code);
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    let _ = sh_warn!("Failed to fetch code for {address}: {err}");
                 }
             }
         }

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -1,5 +1,7 @@
 use crate::{
     debug::handle_traces,
+    rpc_trace::{call_frame_to_arena, is_method_not_found_error, is_missing_state_error},
+    traces::TraceKind,
     utils::{apply_chain_and_block_specific_env_changes, block_env_from_header},
 };
 use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
@@ -13,7 +15,7 @@ use alloy_primitives::{
 use alloy_provider::{Provider, ext::DebugApi};
 use alloy_rpc_types::{
     BlockId, BlockTransactions,
-    trace::geth::{GethDebugTracingOptions, PreStateConfig},
+    trace::geth::{CallConfig, GethDebugTracingOptions, GethTrace, PreStateConfig},
 };
 use clap::Parser;
 use eyre::{Result, WrapErr};
@@ -42,7 +44,7 @@ use foundry_evm::{
     executors::{EvmError, Executor, TracingExecutor},
     hardforks::FoundryHardfork,
     opts::EvmOpts,
-    traces::{InternalTraceMode, TraceRequirements, Traces},
+    traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
 };
 use futures::TryFutureExt;
 use revm::{DatabaseRef, context::Block, primitives::hardfork::SpecId};
@@ -90,6 +92,23 @@ pub struct RunArgs {
     /// or response can't be used, cast silently falls back to replaying the block.
     #[arg(long, default_value_t = false)]
     prestate_tracer: bool,
+
+    /// Fetch the transaction's trace from the node via `debug_traceTransaction` (callTracer) and
+    /// render it, instead of re-executing the transaction locally.
+    ///
+    /// This skips the block replay entirely, so it is fast and reflects exactly what happened
+    /// on-chain, including chain-specific EVM behavior a local replay may not reproduce, but it
+    /// requires the node to expose the `debug_` namespace. The result is a call-tree view:
+    /// nested calls, value, gas, emitted logs and revert data. It does not provide the
+    /// opcode-level detail of a local run, so the local-execution-only flags (`--debug`,
+    /// `--decode-internal`, `--trace-printer`, `--quick`, `--prestate-tracer`, `--evm-version`)
+    /// do not apply.
+    #[arg(
+        long,
+        default_value_t = false,
+        conflicts_with_all = ["debug", "decode_internal", "trace_printer", "quick", "prestate_tracer", "evm_version"]
+    )]
+    debug_trace_transaction: bool,
 
     /// Label addresses in the trace.
     ///
@@ -173,6 +192,86 @@ impl RunArgs {
             .await
             .wrap_err_with(|| format!("tx not found: {tx_hash:?}"))?
             .ok_or_else(|| eyre::eyre!("tx not found: {:?}", tx_hash))?;
+
+        // Fetch the trace from the node via `debug_traceTransaction` (callTracer) instead of
+        // re-executing the transaction locally. The node already holds the transaction's exact
+        // pre-state and EVM rules, so this needs no block replay and no local executor; it also
+        // handles system transactions, so this path comes before the system transaction guard.
+        if self.debug_trace_transaction {
+            let tx_block_number = tx
+                .block_number()
+                .ok_or_else(|| eyre::eyre!("tx may still be pending: {:?}", tx_hash))?;
+
+            let geth_trace = provider
+                .debug_trace_transaction(
+                    tx_hash,
+                    GethDebugTracingOptions::call_tracer(CallConfig::default().with_log()),
+                )
+                .await
+                .map_err(|err| -> eyre::Report {
+                    // Two RPC rejections deserve an actionable hint instead of the raw transport
+                    // error, and they need different fixes: a disabled `debug` namespace, and
+                    // missing historical state, hit whenever the transaction's block has been
+                    // pruned by a full node.
+                    if is_method_not_found_error(&err) {
+                        eyre::eyre!(
+                            "the RPC endpoint does not support `debug_traceTransaction` (method not found); use a node with the `debug` namespace enabled (e.g. a local anvil/reth or an archive endpoint), or drop `--debug-trace-transaction` to re-execute the transaction locally"
+                        )
+                    } else if is_missing_state_error(&err) {
+                        eyre::eyre!(
+                            "the RPC endpoint does not have the historical state for the transaction's block; use an archive endpoint"
+                        )
+                    } else {
+                        err.into()
+                    }
+                })?;
+            let GethTrace::CallTracer(frame) = geth_trace else {
+                eyre::bail!(
+                    "`debug_traceTransaction` did not return a callTracer frame; the RPC endpoint \
+                     may not support the `callTracer`"
+                );
+            };
+
+            let success = frame.error.is_none() && frame.revert_reason.is_none();
+            let gas_used = frame.gas_used.saturating_to();
+            let arena = SparsedTraceArena {
+                arena: call_frame_to_arena(&frame),
+                ignored: Default::default(),
+            };
+            let result = TraceResult {
+                success,
+                traces: Some(vec![(TraceKind::Execution, arena)]),
+                gas_used,
+            };
+
+            // Local-artifact labeling matches deployed runtime bytecode against the project
+            // artifacts. There is no local executor on this path, so fetch the code over RPC
+            // for the addresses in the trace, at the transaction's block. Skip the extra
+            // round-trips unless local artifacts were requested.
+            let contracts_bytecode = if with_local_artifacts {
+                fetch_contracts_bytecode_via_rpc(&provider, &result, tx_block_number.into()).await?
+            } else {
+                Default::default()
+            };
+
+            let chain = alloy_chains::Chain::from_id(provider.get_chain_id().await?);
+            handle_traces(
+                result,
+                &config,
+                chain,
+                &contracts_bytecode,
+                label,
+                with_local_artifacts,
+                false,
+                false,
+                disable_labels,
+                self.trace_depth,
+                None,
+            )
+            .await?;
+
+            return Ok(());
+        }
 
         // check if the tx is a system transaction
         if !self.replay_system_txes
@@ -514,6 +613,46 @@ impl figment::Provider for RunArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn debug_trace_transaction_rejects_local_execution_flags() {
+        for flag in
+            ["--debug", "--decode-internal", "--trace-printer", "--quick", "--prestate-tracer"]
+        {
+            let result = RunArgs::try_parse_from([
+                "foundry-cli",
+                "--debug-trace-transaction",
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+                flag,
+            ]);
+            assert!(result.is_err(), "--debug-trace-transaction must reject {flag}");
+        }
+        // --evm-version takes a value, so it is checked separately from the boolean flags above.
+        let result = RunArgs::try_parse_from([
+            "foundry-cli",
+            "--debug-trace-transaction",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "--evm-version",
+            "shanghai",
+        ]);
+        assert!(result.is_err(), "--debug-trace-transaction must reject --evm-version");
+    }
+
+    #[test]
+    fn debug_trace_transaction_accepts_label_and_render_flags() {
+        let args = RunArgs::try_parse_from([
+            "foundry-cli",
+            "--debug-trace-transaction",
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "--label",
+            "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045:vitalik.eth",
+            "--disable-labels",
+            "--trace-depth",
+            "2",
+            "--with-local-artifacts",
+        ]);
+        assert!(args.is_ok(), "--debug-trace-transaction must accept label/rendering flags");
+    }
 
     #[test]
     fn parent_beacon_block_root_is_required_for_cancun() {

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -7,7 +7,7 @@ use crate::{
 use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
 
 use alloy_evm::FromRecoveredTx;
-use alloy_network::{BlockResponse, Network, TransactionResponse};
+use alloy_network::{BlockResponse, Network, ReceiptResponse, TransactionResponse};
 use alloy_primitives::{
     Address, B256, Bytes, U256,
     map::{AddressHashMap, AddressSet},
@@ -232,8 +232,13 @@ impl RunArgs {
                 );
             };
 
-            let success = frame.error.is_none() && frame.revert_reason.is_none();
-            let gas_used = frame.gas_used.saturating_to();
+            let receipt = provider
+                .get_transaction_receipt(tx_hash)
+                .await?
+                .ok_or_else(|| eyre::eyre!("tx receipt not found: {:?}", tx_hash))?;
+
+            let success = receipt.status();
+            let gas_used = receipt.gas_used();
             let arena = SparsedTraceArena {
                 arena: call_frame_to_arena(&frame),
                 ignored: Default::default(),

--- a/crates/cast/src/rpc_trace.rs
+++ b/crates/cast/src/rpc_trace.rs
@@ -4,9 +4,14 @@
 //! `callTracer`) be decoded and rendered with the same machinery used for locally executed traces.
 //! `callTracer` does not record opcode-level steps, so [`CallTrace::steps`] is left empty;
 //! everything the call-tree view needs (calls, value, gas, logs, revert reasons) is preserved.
+//!
+//! Also hosts the shared classification of the RPC rejections a `debug_trace*` request can hit,
+//! so `cast call --debug-trace-call` and `cast run --debug-trace-transaction` surface the same
+//! actionable hints.
 
 use alloy_primitives::{Bytes, LogData, U256};
 use alloy_rpc_types::trace::geth::{CallFrame, CallLogFrame};
+use alloy_transport::TransportError;
 use foundry_evm::traces::{
     CallKind, CallLog, CallTrace, CallTraceArena, CallTraceNode, TraceMemberOrder,
 };
@@ -19,6 +24,31 @@ pub fn call_frame_to_arena(root: &CallFrame) -> CallTraceArena {
     nodes.clear();
     push_frame(nodes, root, None, 0);
     arena
+}
+
+/// Returns `true` if `err` is a JSON-RPC method-not-found rejection (code -32601), which is how
+/// nodes without the `debug` namespace reject `debug_trace*` requests.
+pub fn is_method_not_found_error(err: &TransportError) -> bool {
+    err.as_error_resp().is_some_and(|resp| resp.code == -32601)
+}
+
+/// Returns `true` if `err` looks like a missing-historical-state rejection: an archive-depth
+/// error, usually with a generic code (-32000) distinguishable only by message, hit whenever a
+/// `debug_trace*` request targets a block whose state a full node has pruned.
+pub fn is_missing_state_error(err: &TransportError) -> bool {
+    let message = err
+        .as_error_resp()
+        .map(|resp| resp.message.to_ascii_lowercase())
+        .unwrap_or_else(|| err.to_string().to_ascii_lowercase());
+    [
+        "missing trie node",
+        "required historical state",
+        "historical state",
+        "header not found",
+        "missing state",
+    ]
+    .iter()
+    .any(|needle| message.contains(*needle))
 }
 
 /// Pushes `frame` and all of its children into `nodes`, returning the index of the pushed node.

--- a/crates/cast/src/rpc_trace.rs
+++ b/crates/cast/src/rpc_trace.rs
@@ -9,7 +9,7 @@
 //! so `cast call --debug-trace-call` and `cast run --debug-trace-transaction` surface the same
 //! actionable hints.
 
-use alloy_primitives::{Bytes, LogData, U256};
+use alloy_primitives::{Address, Bytes, LogData, U256};
 use alloy_rpc_types::trace::geth::{CallFrame, CallLogFrame};
 use alloy_transport::TransportError;
 use foundry_evm::traces::{
@@ -19,10 +19,24 @@ use revm::interpreter::InstructionResult;
 
 /// Builds a [`CallTraceArena`] from a geth `callTracer` [`CallFrame`] tree.
 pub fn call_frame_to_arena(root: &CallFrame) -> CallTraceArena {
+    call_frame_to_arena_with_root_address(root, None)
+}
+
+/// Builds a [`CallTraceArena`] and overrides the root frame's address when the tracer omitted it.
+pub fn call_frame_to_arena_with_root_address(
+    root: &CallFrame,
+    root_address: Option<Address>,
+) -> CallTraceArena {
     let mut arena = CallTraceArena::default();
     let nodes = arena.nodes_mut();
     nodes.clear();
     push_frame(nodes, root, None, 0);
+    if let Some(root_address) = root_address
+        && let Some(root) = nodes.first_mut()
+        && root.trace.address.is_zero()
+    {
+        root.trace.address = root_address;
+    }
     arena
 }
 
@@ -233,6 +247,17 @@ mod tests {
         assert_eq!(trace.selfdestruct_transferred_value, Some(U256::from(9u64)));
         assert_eq!(trace.status, Some(InstructionResult::SelfDestruct));
         assert!(trace.is_selfdestruct());
+    }
+
+    #[test]
+    fn fills_missing_root_create_address() {
+        let created = address!("3333333333333333333333333333333333333333");
+        let frame = CallFrame { typ: "CREATE".to_string(), ..Default::default() };
+
+        let arena = call_frame_to_arena_with_root_address(&frame, Some(created));
+
+        assert_eq!(arena.nodes()[0].trace.address, created);
+        assert_eq!(arena.nodes()[0].trace.kind, CallKind::Create);
     }
 
     /// A nested `callTracer` frame (root CALL -> child STATICCALL) with a log on the root,

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3,7 +3,7 @@
 use alloy_chains::NamedChain;
 use alloy_eips::Decodable2718;
 use alloy_hardforks::EthereumHardfork;
-use alloy_network::{TransactionBuilder, TransactionResponse};
+use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
 use alloy_primitives::{Address, B256, Bytes, U256, address, b256, hex, keccak256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::{
@@ -3976,6 +3976,11 @@ Transaction successfully executed.
             .stderr_lossy()
             .contains("Executing previous transactions from the block."),
         "debug_traceTransaction path should not replay previous block transactions"
+    );
+    let receipt = api.transaction_receipt(tx_hash).await.unwrap().unwrap();
+    assert!(
+        assert.get_output().stdout_lossy().contains(&format!("Gas used: {}", receipt.gas_used())),
+        "debug_traceTransaction summary should report the receipt gas used"
     );
 });
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -3940,6 +3940,159 @@ forgetest_async!(cast_run_prestate_tracer_matches_block_replay, |prj, cmd| {
     assert_eq!(replay, prestate, "prestate tracer traces must match block replay traces");
 });
 
+// https://github.com/foundry-rs/foundry/issues/12336
+// `cast run --debug-trace-transaction` fetches the transaction's trace from the node via
+// `debug_traceTransaction` (callTracer) and renders it with the same decoding/rendering machinery
+// as the local replay, skipping local execution entirely: the block replay message must be absent
+// from stderr.
+forgetest_async!(cast_run_debug_trace_transaction, |prj, cmd| {
+    let (api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let tx_hash = deploy_counter_and_set_number(&prj, &mut cmd, &api, &endpoint).await;
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "run",
+            "--debug-trace-transaction",
+            format!("{tx_hash}").as_str(),
+            "--rpc-url",
+            &endpoint,
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [..] 0x5FbDB2315678afecb367f032d93F642f64180aa3::setNumber(111)
+    └─ ← [Return]
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+    assert!(
+        !assert
+            .get_output()
+            .stderr_lossy()
+            .contains("Executing previous transactions from the block."),
+        "debug_traceTransaction path should not replay previous block transactions"
+    );
+});
+
+// `cast run --debug-trace-transaction` must render a multi-node trace: the parent runtime emits a
+// LOG0 and then CALLs a child whose runtime reverts (the parent ignores the failure), exercising
+// the log/sub-call interleaving, nesting and revert rendering through the real pipeline.
+casttest!(cast_run_debug_trace_transaction_renders_nested_call_and_revert, async |_prj, cmd| {
+    let (api, handle) = anvil::spawn(NodeConfig::test()).await;
+
+    // Parent runtime: LOG0(0,0); CALL(gas, 0x..bb, 0,0,0,0,0); POP; STOP.
+    api.anvil_set_code(
+        address!("0x00000000000000000000000000000000000000aa"),
+        "0x60006000a0600060006000600060007300000000000000000000000000000000000000bb5af15000"
+            .parse()
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+    // Child runtime: PUSH1 0 PUSH1 0 REVERT.
+    api.anvil_set_code(
+        address!("0x00000000000000000000000000000000000000bb"),
+        "0x60006000fd".parse().unwrap(),
+    )
+    .await
+    .unwrap();
+
+    cmd.cast_fuse()
+        .args([
+            "send",
+            "0x00000000000000000000000000000000000000aa",
+            "run()",
+            "--private-key",
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success();
+
+    let tx_hash = api
+        .transaction_by_block_number_and_index(BlockNumberOrTag::Latest, Index::from(0))
+        .await
+        .unwrap()
+        .unwrap()
+        .tx_hash();
+
+    cmd.cast_fuse()
+        .args([
+            "run",
+            "--debug-trace-transaction",
+            format!("{tx_hash}").as_str(),
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [..] 0x00000000000000000000000000000000000000AA::run()
+    ├─           data: 0x
+    ├─ [..] 0x00000000000000000000000000000000000000bb::fallback()
+    │   └─ ← [Revert] execution reverted
+    └─ ← [Return]
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+});
+
+// `cast run --debug-trace-transaction --with-local-artifacts` labels the target contract by its
+// local artifact name (Counter::) instead of the raw address: the RPC path has no local executor,
+// so the bytecode for artifact matching must be fetched over RPC at the transaction's block.
+forgetest_async!(cast_run_debug_trace_transaction_with_local_artifacts, |prj, cmd| {
+    let (api, handle) = anvil::spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let tx_hash = deploy_counter_and_set_number(&prj, &mut cmd, &api, &endpoint).await;
+
+    cmd.cast_fuse();
+    cmd.set_current_dir(prj.root());
+    cmd.args([
+        "run",
+        "--debug-trace-transaction",
+        "--la",
+        format!("{tx_hash}").as_str(),
+        "--rpc-url",
+        &endpoint,
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+...
+Traces:
+  [..] Counter::setNumber(111)
+    └─ ← [Return]
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+});
+
+// `--debug-trace-transaction` fetches the trace from the node, so the local-execution-only flags
+// must be rejected by clap.
+casttest!(cast_run_debug_trace_transaction_conflicts_with_debug, |_prj, cmd| {
+    cmd.args([
+        "run",
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "--debug-trace-transaction",
+        "--debug",
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+error: the argument '--debug-trace-transaction' cannot be used with '--debug'
+...
+"#]]);
+});
+
 // tests cast can decode traces when running with verbosity level > 4
 forgetest_async!(show_state_changes_in_traces, |prj, cmd| {
     let (api, handle) = anvil::spawn(NodeConfig::test()).await;


### PR DESCRIPTION
`cast run` re-executes a transaction locally by replaying every prior transaction in its block, which is slow and cannot account for chain-specific EVM customizations the local executor does not implement. #15052 solved the same problem for `cast call` with `--debug-trace-call`; this adds the symmetric `cast run --debug-trace-transaction`, completing the second half of #12336.

The new flag fetches the transaction's trace from the node via `debug_traceTransaction` with the `callTracer` and renders it through the same arena conversion, decoding and rendering path as `--debug-trace-call`, skipping local execution entirely. Since the node already holds the transaction's exact pre-state and EVM rules, this needs no block replay and also handles system transactions. Label and rendering options (`--label`, `--disable-labels`, `--trace-depth`, `--with-local-artifacts`, `--json`) keep working; for `--with-local-artifacts` the runtime bytecode used for artifact matching is fetched over RPC at the transaction's block, as there is no local executor on this path. The local-execution-only flags (`--debug`, `--decode-internal`, `--trace-printer`, `--quick`, `--prestate-tracer`, `--evm-version`) conflict with the new flag, mirroring the interactions of `--debug-trace-call`. The classification of the two RPC rejections that deserve actionable hints (disabled `debug` namespace, pruned historical state) is now shared between `cast call` and `cast run` so both surface the same messages.

Closes #12336

This PR was implemented with AI assistance (code and tests generated by Claude, reviewed before submission).
