### PR TITLE
fix(anvil): preserve active block task

### DIFF
--- a/crates/anvil/src/tasks/block_listener.rs
+++ b/crates/anvil/src/tasks/block_listener.rs
@@ -7,11 +7,15 @@ use std::{
     task::{Context, Poll},
 };
 
-/// A Future that will execute a given `task` for each new block that arrives on the stream.
+/// A future that executes a given `task` for the latest block available on the stream.
+///
+/// Available blocks are coalesced and the latest block is processed after the active task
+/// completes.
 pub struct BlockListener<St, F, Fut> {
     stream: St,
     task_factory: F,
     task: Option<Pin<Box<Fut>>>,
+    stream_done: bool,
     on_shutdown: Shutdown,
 }
 
@@ -21,7 +25,7 @@ where
     F: Fn(<St as Stream>::Item) -> Fut,
 {
     pub const fn new(on_shutdown: Shutdown, block_stream: St, task_factory: F) -> Self {
-        Self { stream: block_stream, task_factory, task: None, on_shutdown }
+        Self { stream: block_stream, task_factory, task: None, stream_done: false, on_shutdown }
     }
 }
 
@@ -40,14 +44,28 @@ where
             return Poll::Ready(());
         }
 
+        if let Some(mut task) = pin.task.take()
+            && task.poll_unpin(cx).is_pending()
+        {
+            pin.task = Some(task);
+            return Poll::Pending;
+        }
+
+        if pin.stream_done {
+            return Poll::Ready(());
+        }
+
         let mut block = None;
         // drain the stream
-        while let Poll::Ready(maybe_block) = pin.stream.poll_next_unpin(cx) {
-            if maybe_block.is_none() {
-                // stream complete
-                return Poll::Ready(());
+        loop {
+            match pin.stream.poll_next_unpin(cx) {
+                Poll::Ready(Some(next_block)) => block = Some(next_block),
+                Poll::Ready(None) => {
+                    pin.stream_done = true;
+                    break;
+                }
+                Poll::Pending => break,
             }
-            block = maybe_block;
         }
 
         if let Some(block) = block {
@@ -59,6 +77,56 @@ where
         {
             pin.task = Some(task);
         }
-        Poll::Pending
+
+        if pin.stream_done && pin.task.is_none() { Poll::Ready(()) } else { Poll::Pending }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shutdown;
+    use futures::{
+        channel::{mpsc, oneshot},
+        task::noop_waker,
+    };
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+
+    #[test]
+    fn waits_for_active_task_before_processing_latest_block() {
+        let (_signal, shutdown) = shutdown::signal();
+        let (tx, rx) = mpsc::unbounded();
+        let (release_tx, release_rx) = oneshot::channel();
+        let release_rx = Arc::new(Mutex::new(Some(release_rx)));
+        let processed = Arc::new(Mutex::new(Vec::new()));
+        let task_release_rx = release_rx;
+        let task_processed = processed.clone();
+        let mut listener = Box::pin(BlockListener::new(shutdown, rx, move |block| {
+            let release_rx = task_release_rx.clone();
+            let processed = task_processed.clone();
+            async move {
+                let release_rx = (block == 1).then(|| release_rx.lock().take().unwrap());
+                if let Some(release_rx) = release_rx {
+                    let _ = release_rx.await;
+                }
+                processed.lock().push(block);
+            }
+        }));
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        tx.unbounded_send(1).unwrap();
+        assert!(listener.as_mut().poll(&mut cx).is_pending());
+
+        tx.unbounded_send(2).unwrap();
+        tx.unbounded_send(3).unwrap();
+        assert!(listener.as_mut().poll(&mut cx).is_pending());
+        assert!(processed.lock().is_empty());
+
+        drop(tx);
+        release_tx.send(()).unwrap();
+        assert!(listener.as_mut().poll(&mut cx).is_ready());
+        assert_eq!(*processed.lock(), [1, 3]);
     }
 }

--- a/crates/anvil/src/tasks/mod.rs
+++ b/crates/anvil/src/tasks/mod.rs
@@ -53,8 +53,8 @@ impl TaskManager {
         })
     }
 
-    /// Spawns a new task that listens for new blocks and resets the forked provider for every new
-    /// block
+    /// Spawns a new task that listens for new blocks and resets the forked provider to the latest
+    /// available block.
     ///
     /// ```
     /// use alloy_network::Ethereum;
@@ -92,8 +92,8 @@ impl TaskManager {
     }
 
     /// Spawns a new [`BlockListener`] task that listens for new blocks (poll-based) See also
-    /// [`Provider::watch_blocks`] and executes the future the `task_factory` returns for the new
-    /// block hash
+    /// [`Provider::watch_blocks`] and executes the future the `task_factory` returns for the latest
+    /// available block hash.
     pub fn spawn_block_poll_listener<N, P, F, Fut>(&self, provider: P, task_factory: F)
     where
         N: Network,
@@ -113,8 +113,8 @@ impl TaskManager {
         });
     }
 
-    /// Spawns a new task that listens for new blocks and resets the forked provider for every new
-    /// block
+    /// Spawns a new task that listens for new blocks and resets the forked provider to the latest
+    /// available block.
     ///
     /// ```
     /// use alloy_network::Ethereum;
@@ -150,7 +150,7 @@ impl TaskManager {
 
     /// Spawns a new [`BlockListener`] task that listens for new blocks (via subscription) See also
     /// [`Provider::subscribe_blocks()`] and executes the future the `task_factory` returns for the
-    /// new block hash
+    /// latest available block.
     pub fn spawn_block_subscription<N, P, F, Fut>(&self, provider: P, task_factory: F)
     where
         N: Network,


### PR DESCRIPTION
`BlockListener` previously replaced its in-flight task whenever another block became available, cancelling the active task. For fork-following listeners, this could interrupt `anvil_reset` after it had begun updating the fork state.

This waits for the active task to finish before coalescing queued notifications and processing the latest block. It also waits for the final task when the stream closes and adds regression coverage for the cancellation and coalescing behavior.
