### PR TITLE
feat(anvil): add TIP-20 funding RPCs

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -575,6 +575,10 @@ pub enum EthRequest {
     )]
     DealERC20(Address, Address, #[serde(deserialize_with = "deserialize_number")] U256),
 
+    /// Mints TIP-20 tokens to an account using Anvil's Tempo faucet issuer.
+    #[serde(rename = "tempo_fundAddress", alias = "anvil_dealTip20")]
+    DealTip20(Address, #[serde(default)] Option<Vec<Address>>),
+
     /// Sets the ERC20 allowance for a spender
     #[serde(rename = "anvil_setERC20Allowance")]
     SetERC20Allowance(
@@ -1085,6 +1089,17 @@ mod tests {
         let s = r#"{"method": "anvil_autoImpersonateAccount",  "params": [true]}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_tempo_fund_address_params() {
+        let s = r#"{"method":"tempo_fundAddress","params":["0x0000000000000000000000000000000000000001"]}"#;
+        let request = serde_json::from_str::<EthRequest>(s).unwrap();
+        assert!(matches!(request, EthRequest::DealTip20(_, None)));
+
+        let s = r#"{"method":"anvil_dealTip20","params":["0x0000000000000000000000000000000000000001",["0x20c0000000000000000000000000000000000000"]]}"#;
+        let request = serde_json::from_str::<EthRequest>(s).unwrap();
+        assert!(matches!(request, EthRequest::DealTip20(_, Some(tokens)) if tokens.len() == 1));
     }
 
     #[test]

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1,5 +1,8 @@
 use super::{
-    backend::mem::{BlockRequest, DatabaseRef, State},
+    backend::{
+        mem::{BlockRequest, DatabaseRef, State},
+        tempo::{ADMIN, DEFAULT_TIP20_FUNDING_AMOUNT, DEFAULT_TIP20_TOKENS},
+    },
     sign::build_impersonated,
 };
 use crate::{
@@ -107,6 +110,8 @@ use revm::{
 };
 use std::{sync::Arc, time::Duration};
 use tempo_hardfork::TempoHardfork;
+use tempo_precompiles::tip20::ITIP20;
+use tempo_primitives::subblock::has_sub_block_nonce_key_prefix;
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver, unbounded_channel},
     try_join,
@@ -114,6 +119,9 @@ use tokio::{
 
 /// The client version: `anvil/v{major}.{minor}.{patch}`
 pub const CLIENT_VERSION: &str = concat!("anvil/v", env!("CARGO_PKG_VERSION"));
+
+/// Gas limit for TIP-20 funding transactions, including random 2D nonce bookkeeping.
+const TIP20_FUNDING_GAS_LIMIT: u64 = 1_000_000;
 
 /// The entry point for executing eth api RPC call - The Eth RPC interface.
 ///
@@ -1984,6 +1992,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::DealERC20(addr, token_addr, val) => {
                 self.anvil_deal_erc20(addr, token_addr, val).await.to_rpc_result()
             }
+            EthRequest::DealTip20(addr, tokens) => {
+                self.anvil_deal_tip20(addr, tokens).await.to_rpc_result()
+            }
             EthRequest::SetERC20Allowance(owner, spender, token_addr, val) => self
                 .anvil_set_erc20_allowance(owner, spender, token_addr, val)
                 .await
@@ -3561,6 +3572,52 @@ impl EthApi<FoundryNetwork> {
         .await?;
 
         Ok(())
+    }
+
+    /// Mints TIP-20 tokens to an address.
+    ///
+    /// Handler for RPC calls: `tempo_fundAddress` and `anvil_dealTip20`.
+    pub async fn anvil_deal_tip20(
+        &self,
+        address: Address,
+        token_addresses: Option<Vec<Address>>,
+    ) -> Result<Vec<TxHash>> {
+        node_info!("anvil_dealTip20");
+        self.ensure_tempo_mode()?;
+
+        let token_addresses = token_addresses.as_deref().unwrap_or(&DEFAULT_TIP20_TOKENS);
+        let mut hashes = Vec::with_capacity(token_addresses.len());
+        let amount = U256::from(DEFAULT_TIP20_FUNDING_AMOUNT);
+        self.backend.prepare_tip20_funding(token_addresses, amount).await?;
+
+        for &token_address in token_addresses {
+            let calldata: Bytes = ITIP20::mintCall { to: address, amount }.abi_encode().into();
+            let nonce_key = loop {
+                let key = U256::random();
+                if !key.is_zero() && key != U256::MAX && !has_sub_block_nonce_key_prefix(&key) {
+                    break key;
+                }
+            };
+            let request = TransactionRequest::default()
+                .from(ADMIN)
+                .to(token_address)
+                .with_input(calldata)
+                .with_nonce(0)
+                .with_gas_limit(TIP20_FUNDING_GAS_LIMIT);
+            let mut request = WithOtherFields::new(request);
+            request
+                .other
+                .insert("feeToken".to_string(), serde_json::json!(DEFAULT_TIP20_TOKENS[0]));
+            request.other.insert("nonceKey".to_string(), serde_json::json!(nonce_key));
+
+            // Submit directly as an impersonated transaction instead of mutating Anvil's global
+            // impersonation set. A random 2D nonce lets concurrent faucet calls execute without
+            // contending on the admin's scalar nonce.
+            let hash = self.eth_send_unsigned_transaction(request).await?;
+            hashes.push(hash);
+        }
+
+        Ok(hashes)
     }
 
     /// Sets the ERC20 allowance for a spender

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -19,7 +19,7 @@ use crate::{
                 storage::MinedTransactionReceipt,
             },
             notifications::{ChainNotification, ChainNotifications, NewBlockNotification},
-            tempo::AnvilStorageProvider,
+            tempo::{ADMIN, AnvilStorageProvider},
             time::{TimeManager, utc_from_secs},
             validate::TransactionValidator,
         },
@@ -104,6 +104,7 @@ use foundry_evm::{
     core::{
         evm::{EvmEnvFor, TempoEvmNetwork},
         precompiles::EC_RECOVER,
+        tempo::PATH_USD_ADDRESS,
     },
     decode::RevertDecoder,
     hardfork::FoundryHardfork,
@@ -197,6 +198,7 @@ use tempo_precompiles::{
     storage::{StorageActions, StorageCtx},
     tip_fee_manager::{IFeeManager, TipFeeManager},
     tip20::{ISSUER_ROLE, ITIP20, TIP20Token},
+    tip20_factory::TIP20Factory,
 };
 use tempo_primitives::TEMPO_TX_TYPE_ID;
 use tempo_revm::{
@@ -5132,6 +5134,58 @@ impl Backend<FoundryNetwork> {
             fee_manager
                 .mint(admin, user_token, validator_token, amount, admin)
                 .map_err(tempo_db_err)?;
+            Ok(())
+        })
+        .await
+    }
+
+    /// Prepares TIP-20 tokens for local faucet transactions.
+    ///
+    /// The role grants are permanent local deal-RPC state mutations. Validate the complete token
+    /// list before applying any changes so invalid input cannot leave partial issuer grants behind.
+    pub async fn prepare_tip20_funding(
+        &self,
+        token_addresses: &[Address],
+        fee_funding_amount: U256,
+    ) -> DatabaseResult<()> {
+        if token_addresses.is_empty() {
+            return Ok(());
+        }
+
+        self.with_tempo_storage(|| {
+            let factory = TIP20Factory::new();
+            for &token_address in token_addresses {
+                if !factory.is_tip20(token_address).map_err(tempo_db_err)? {
+                    return Err(tempo_db_err(format!(
+                        "address {token_address} is not a deployed TIP-20 token"
+                    )));
+                }
+            }
+
+            // Forked Tempo nodes skip local genesis initialization, so ensure the fixed faucet
+            // admin can pay its mint transaction fees before queuing them.
+            let mut fee_token = TIP20Token::from_address(PATH_USD_ADDRESS).map_err(tempo_db_err)?;
+            fee_token.grant_role_internal(ADMIN, *ISSUER_ROLE).map_err(tempo_db_err)?;
+            let fee_token_balance = fee_token
+                .balance_of(ITIP20::balanceOfCall { account: ADMIN })
+                .map_err(tempo_db_err)?;
+            if fee_token_balance < fee_funding_amount {
+                fee_token
+                    .mint(
+                        ADMIN,
+                        ITIP20::mintCall {
+                            to: ADMIN,
+                            amount: fee_funding_amount - fee_token_balance,
+                        },
+                    )
+                    .map_err(tempo_db_err)?;
+            }
+
+            for &token_address in token_addresses {
+                let mut token = TIP20Token::from_address(token_address).map_err(tempo_db_err)?;
+                token.grant_role_internal(ADMIN, *ISSUER_ROLE).map_err(tempo_db_err)?;
+            }
+
             Ok(())
         })
         .await

--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -36,7 +36,12 @@ use super::db::Db;
 /// Sender address used for genesis initialization.
 const SENDER: Address = address!("0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38");
 /// Admin address used for genesis initialization.
-const ADMIN: Address = address!("0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f");
+pub(crate) const ADMIN: Address = address!("0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f");
+/// Amount of each TIP-20 token minted by Anvil's local funding helpers.
+pub(crate) const DEFAULT_TIP20_FUNDING_AMOUNT: u64 = u64::MAX;
+/// TIP-20 tokens initialized and funded for Anvil's test accounts.
+pub(crate) const DEFAULT_TIP20_TOKENS: [Address; 4] =
+    [PATH_USD_ADDRESS, ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, THETA_USD_ADDRESS];
 
 /// Storage provider adapter for Anvil's Db to work with Tempo precompiles.
 pub struct AnvilStorageProvider<'a> {
@@ -234,12 +239,10 @@ pub fn initialize_tempo_precompiles(
 
     // Mint fee tokens to test accounts
     // u64::MAX per account - safe since u128::MAX can hold ~18 quintillion u64::MAX values
-    let mint_amount = U256::from(u64::MAX);
-    let tokens = [PATH_USD_ADDRESS, ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, THETA_USD_ADDRESS];
-
+    let mint_amount = U256::from(DEFAULT_TIP20_FUNDING_AMOUNT);
     StorageCtx::enter(&mut storage, || -> Result<(), TempoPrecompileError> {
         // Mint fee tokens to test accounts
-        for &token_address in &tokens {
+        for &token_address in &DEFAULT_TIP20_TOKENS {
             let mut token = TIP20Token::from_address(token_address)?;
             for &account in test_accounts {
                 token.mint(ADMIN, ITIP20::mintCall { to: account, amount: mint_amount })?;
@@ -286,7 +289,7 @@ pub fn initialize_tempo_precompiles(
         }
 
         // Mint fee tokens to the FeeManager contract for liquidity operations
-        for &token_address in &tokens {
+        for &token_address in &DEFAULT_TIP20_TOKENS {
             let mut token = TIP20Token::from_address(token_address)?;
             token.mint(
                 ADMIN,
@@ -301,8 +304,8 @@ pub fn initialize_tempo_precompiles(
 
         // Create bidirectional liquidity pools between all fee tokens
         // Pools are directional: user_token -> validator_token
-        for &user_token in &tokens {
-            for &validator_token in &tokens {
+        for &user_token in &DEFAULT_TIP20_TOKENS {
+            for &validator_token in &DEFAULT_TIP20_TOKENS {
                 if user_token != validator_token {
                     fee_manager.mint(
                         ADMIN,

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -6,7 +6,7 @@
 //! - Native value transfer rejection
 //! - Basic transaction behavior in Tempo mode
 
-use std::num::NonZeroU64;
+use std::{collections::HashSet, num::NonZeroU64};
 #[cfg(feature = "cli")]
 use std::{
     net::TcpListener,
@@ -22,7 +22,7 @@ use alloy_eips::eip2718::Encodable2718;
 use alloy_genesis::Genesis;
 use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, aliases::U96, keccak256};
-use alloy_provider::{Provider, ext::TxPoolApi};
+use alloy_provider::{PendingTransactionConfig, Provider, ext::TxPoolApi};
 use alloy_rpc_types::{BlockId, BlockNumberOrTag, TransactionRequest, anvil::Forking};
 use alloy_serde::WithOtherFields;
 use alloy_signer::Signer;
@@ -308,6 +308,7 @@ sol! {
         function transfer(address to, uint256 amount) external returns (bool);
         function mint(address to, uint256 amount) external;
         function grantRole(bytes32 role, address account) external;
+        function hasRole(address account, bytes32 role) external view returns (bool);
         function ISSUER_ROLE() external view returns (bytes32);
         function logoURI() external view returns (string memory);
         function setLogoURI(string memory logoURI) external;
@@ -413,6 +414,227 @@ async fn test_tempo_precompiles_have_code() {
         let code = api.get_code(*addr, None).await.unwrap();
         assert!(!code.is_empty(), "Token {addr} should have code deployed");
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_fund_address_defaults_to_anvil_tip20_tokens() {
+    let (api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+    let recipient = Address::random();
+
+    assert!(!api.is_impersonated(TEMPO_ADMIN));
+    assert!(!provider.get_accounts().await.unwrap().contains(&TEMPO_ADMIN));
+
+    let hashes: Vec<B256> =
+        provider.raw_request("tempo_fundAddress".into(), (recipient,)).await.unwrap();
+    assert_eq!(hashes.len(), 4);
+
+    for hash in hashes {
+        let mined_hash = provider
+            .watch_pending_transaction(PendingTransactionConfig::new(hash))
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+        assert_eq!(mined_hash, hash);
+        let receipt = provider.get_transaction_receipt(hash).await.unwrap().unwrap();
+        assert!(receipt.status(), "TIP-20 mint transaction should succeed");
+    }
+
+    for token_address in [PATH_USD, ALPHA_USD, BETA_USD, THETA_USD] {
+        let token = ITIP20T5Rpc::new(token_address, &provider);
+        assert_eq!(token.balanceOf(recipient).call().await.unwrap(), U256::from(u64::MAX));
+    }
+
+    assert!(!api.is_impersonated(TEMPO_ADMIN));
+    assert!(!provider.get_accounts().await.unwrap().contains(&TEMPO_ADMIN));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_deal_tip20_accepts_explicit_tokens() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+    let recipient = Address::random();
+    let token_addresses = vec![ALPHA_USD, THETA_USD];
+
+    let path = ITIP20T5Rpc::new(PATH_USD, &provider);
+    let admin_balance_before = path.balanceOf(TEMPO_ADMIN).call().await.unwrap();
+    let block_before = provider.get_block_number().await.unwrap();
+    let empty: Vec<B256> = provider
+        .raw_request("anvil_dealTip20".into(), (recipient, Vec::<Address>::new()))
+        .await
+        .unwrap();
+    assert!(empty.is_empty());
+    assert_eq!(provider.get_block_number().await.unwrap(), block_before);
+    assert_eq!(path.balanceOf(TEMPO_ADMIN).call().await.unwrap(), admin_balance_before);
+
+    let hashes: Vec<B256> = provider
+        .raw_request("anvil_dealTip20".into(), (recipient, token_addresses.clone()))
+        .await
+        .unwrap();
+    assert_eq!(hashes.len(), token_addresses.len());
+
+    for (hash, token_address) in hashes.into_iter().zip(token_addresses) {
+        provider
+            .watch_pending_transaction(PendingTransactionConfig::new(hash))
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+        let receipt = provider.get_transaction_receipt(hash).await.unwrap().unwrap();
+        assert!(receipt.status(), "TIP-20 mint transaction should succeed");
+        assert_eq!(receipt.to(), Some(token_address));
+    }
+
+    assert_eq!(
+        ITIP20T5Rpc::new(ALPHA_USD, &provider).balanceOf(recipient).call().await.unwrap(),
+        U256::from(u64::MAX)
+    );
+    assert_eq!(
+        ITIP20T5Rpc::new(THETA_USD, &provider).balanceOf(recipient).call().await.unwrap(),
+        U256::from(u64::MAX)
+    );
+    assert_eq!(
+        ITIP20T5Rpc::new(PATH_USD, &provider).balanceOf(recipient).call().await.unwrap(),
+        U256::ZERO
+    );
+    assert_eq!(
+        ITIP20T5Rpc::new(BETA_USD, &provider).balanceOf(recipient).call().await.unwrap(),
+        U256::ZERO
+    );
+    let admin_balance_after = path.balanceOf(TEMPO_ADMIN).call().await.unwrap();
+    assert!(admin_balance_after <= U256::from(u64::MAX));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_deal_tip20_prepares_custom_tokens_and_rejects_invalid_addresses() {
+    let (_api, handle) =
+        spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T5.into()))).await;
+    let provider = handle.http_provider();
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let creator = accounts[0];
+    let token_admin = accounts[1];
+    let recipient = Address::random();
+
+    let factory = ITIP20FactoryT5Rpc::new(TIP20_FACTORY_ADDRESS, &provider);
+    let salt = B256::repeat_byte(0xf1);
+    let custom_token = factory.getTokenAddress(creator, salt).call().await.unwrap();
+    let create = TransactionRequest::default()
+        .from(creator)
+        .to(TIP20_FACTORY_ADDRESS)
+        .with_input(
+            factory
+                .createToken(
+                    "DealUSD".to_string(),
+                    "DealUSD".to_string(),
+                    "USD".to_string(),
+                    PATH_USD,
+                    token_admin,
+                    salt,
+                    "https://example.com/deal-usd.png".to_string(),
+                )
+                .calldata()
+                .clone(),
+        )
+        .with_gas_limit(T5_PRECOMPILE_GAS);
+    let receipt = provider
+        .send_transaction(WithOtherFields::new(create))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(receipt.status(), "custom TIP-20 creation should succeed");
+
+    let token = ITIP20T5Rpc::new(custom_token, &provider);
+    let issuer_role = token.ISSUER_ROLE().call().await.unwrap();
+    assert!(!token.hasRole(TEMPO_ADMIN, issuer_role).call().await.unwrap());
+
+    let invalid_token = address!("0x1000000000000000000000000000000000000001");
+    let invalid: std::result::Result<Vec<B256>, _> = provider
+        .raw_request("anvil_dealTip20".into(), (recipient, vec![custom_token, invalid_token]))
+        .await;
+    assert!(invalid.is_err(), "non-TIP-20 addresses should be rejected");
+    assert!(
+        !token.hasRole(TEMPO_ADMIN, issuer_role).call().await.unwrap(),
+        "invalid input should not leave a partial issuer grant"
+    );
+
+    let hashes: Vec<B256> = provider
+        .raw_request("anvil_dealTip20".into(), (recipient, vec![custom_token]))
+        .await
+        .unwrap();
+    assert_eq!(hashes.len(), 1);
+    provider
+        .watch_pending_transaction(PendingTransactionConfig::new(hashes[0]))
+        .await
+        .unwrap()
+        .await
+        .unwrap();
+    let receipt = provider.get_transaction_receipt(hashes[0]).await.unwrap().unwrap();
+    assert!(receipt.status(), "custom TIP-20 mint should succeed");
+    assert!(token.hasRole(TEMPO_ADMIN, issuer_role).call().await.unwrap());
+    assert_eq!(token.balanceOf(recipient).call().await.unwrap(), U256::from(u64::MAX));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_fund_address_supports_concurrent_calls() {
+    const CALL_COUNT: usize = 8;
+
+    let (api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+    let recipient = Address::random();
+    let path = ITIP20T5Rpc::new(PATH_USD, &provider);
+
+    assert!(!api.is_impersonated(TEMPO_ADMIN));
+    let responses = futures::future::join_all((0..CALL_COUNT).map(|_| {
+        provider
+            .raw_request::<_, Vec<B256>>("tempo_fundAddress".into(), (recipient, vec![ALPHA_USD]))
+    }))
+    .await;
+
+    let hashes = responses
+        .into_iter()
+        .map(|response| {
+            let hashes = response.unwrap();
+            assert_eq!(hashes.len(), 1);
+            hashes[0]
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(hashes.iter().copied().collect::<HashSet<_>>().len(), CALL_COUNT);
+
+    for hash in hashes {
+        provider
+            .watch_pending_transaction(PendingTransactionConfig::new(hash))
+            .await
+            .unwrap()
+            .await
+            .unwrap();
+        let receipt = provider.get_transaction_receipt(hash).await.unwrap().unwrap();
+        assert!(receipt.status(), "concurrent TIP-20 mint transaction should succeed");
+        assert_eq!(receipt.to(), Some(ALPHA_USD));
+    }
+
+    let expected_balance = U256::from(u64::MAX) * U256::from(CALL_COUNT);
+    assert_eq!(
+        ITIP20T5Rpc::new(ALPHA_USD, &provider).balanceOf(recipient).call().await.unwrap(),
+        expected_balance
+    );
+    let admin_balance_after = path.balanceOf(TEMPO_ADMIN).call().await.unwrap();
+    assert!(admin_balance_after <= U256::from(u64::MAX));
+    assert!(!api.is_impersonated(TEMPO_ADMIN));
+    assert!(!provider.get_accounts().await.unwrap().contains(&TEMPO_ADMIN));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_fund_address_rejects_non_tempo_nodes() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    let result: std::result::Result<Vec<B256>, _> =
+        provider.raw_request("tempo_fundAddress".into(), (Address::random(),)).await;
+
+    assert!(result.is_err());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Anvil's Tempo mode pre-funds only its genesis accounts, while `anvil_dealERC20` cannot modify precompile-backed TIP-20 balances. This adds `tempo_fundAddress` compatibility and an `anvil_dealTip20` alias, returning one real transaction hash per requested token. Calls without an explicit token list fund PathUSD, AlphaUSD, BetaUSD, and ThetaUSD; callers can instead select any deployed TIP-20.

The helper validates the full token list before changing state, installs the local faucet admin as an issuer for custom or fork-backed tokens, tops up only missing PathUSD fee funds, and submits scoped unsigned Tempo AA mint transactions on independent random 2D nonce lanes. This avoids global impersonation state, supports concurrent calls, preserves caller token order, and makes an empty token list a true no-op.

This PR was written with Codex, including code generation, tests, and review assistance.
