### PR TITLE
fix(anvil): preserve Tempo header fields

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -920,9 +920,15 @@ impl<N: Network> EthApi<N> {
     /// Returns block header with given hash.
     ///
     /// Handler for ETH RPC call: `eth_getHeaderByHash`
-    pub async fn header_by_hash(&self, hash: B256) -> Result<Option<AnyRpcHeader>> {
+    pub async fn header_by_hash(
+        &self,
+        hash: B256,
+    ) -> Result<Option<WithOtherFields<AnyRpcHeader>>> {
         node_info!("eth_getHeaderByHash");
-        Ok(self.backend.block_by_hash(hash).await?.map(|block| block.header.clone()))
+        Ok(self.backend.block_by_hash(hash).await?.map(|block| {
+            let WithOtherFields { inner: block, other } = block.0;
+            WithOtherFields { inner: block.header, other }
+        }))
     }
 
     /// Returns a _full_ block with given hash.
@@ -2337,13 +2343,20 @@ impl EthApi<FoundryNetwork> {
     /// Returns block header with given number.
     ///
     /// Handler for ETH RPC call: `eth_getHeaderByNumber`
-    pub async fn header_by_number(&self, number: BlockNumber) -> Result<Option<AnyRpcHeader>> {
+    pub async fn header_by_number(
+        &self,
+        number: BlockNumber,
+    ) -> Result<Option<WithOtherFields<AnyRpcHeader>>> {
         node_info!("eth_getHeaderByNumber");
         if number == BlockNumber::Pending {
-            return Ok(Some(self.pending_block().await.header.clone()));
+            let WithOtherFields { inner: block, other } = self.pending_block().await.0;
+            return Ok(Some(WithOtherFields { inner: block.header, other }));
         }
 
-        Ok(self.backend.block_by_number(number).await?.map(|block| block.header.clone()))
+        Ok(self.backend.block_by_number(number).await?.map(|block| {
+            let WithOtherFields { inner: block, other } = block.0;
+            WithOtherFields { inner: block.header, other }
+        }))
     }
 
     /// Returns a _full_ block with given number

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -34,7 +34,7 @@ use foundry_evm::core::tempo::{
     TEMPO_PRECOMPILE_ADDRESSES, TEMPO_TIP20_TOKENS, THETA_USD_ADDRESS,
     active_tempo_precompile_addresses,
 };
-use tempo_alloy::primitives::TempoTxEnvelope;
+use tempo_alloy::{primitives::TempoTxEnvelope, rpc::TempoHeaderResponse};
 use tempo_hardfork::{
     TempoHardfork,
     constants::gas::{TEMPO_T1_BASE_FEE, TEMPO_T7_BASE_FEE_CAP, TEMPO_T7_BASE_FEE_FLOOR},
@@ -47,7 +47,7 @@ use tempo_precompiles::{
     tip403_registry::{ALLOW_ALL_POLICY_ID, ITIP403Registry, REJECT_ALL_POLICY_ID},
 };
 use tempo_primitives::{
-    AASigned, TempoSignature, TempoTransaction,
+    AASigned, TempoHeader, TempoSignature, TempoTransaction,
     transaction::{Call, KeyAuthorization, PrimitiveSignature, SignatureType},
 };
 
@@ -61,6 +61,14 @@ const DEX_MIN_ORDER_AMOUNT: u128 = 100_000_000;
 /// Gas limit for TIP20 transfer calls (precompile interactions need more gas).
 const TIP20_TRANSFER_GAS: u64 = 300_000;
 const T5_PRECOMPILE_GAS: u64 = 10_000_000;
+
+fn assert_tempo_header_fields(header: &TempoHeaderResponse) {
+    let inner: &TempoHeader = header.as_ref();
+    assert_eq!(header.timestamp_millis, inner.timestamp_millis());
+    assert_eq!(inner.general_gas_limit, inner.inner.gas_limit);
+    assert_eq!(inner.shared_gas_limit, 0);
+    assert_eq!(inner.timestamp_millis_part, 0);
+}
 
 #[cfg(feature = "cli")]
 struct ChildGuard(Child);
@@ -85,6 +93,19 @@ fn anvil_binary() -> PathBuf {
         .and_then(|deps| deps.parent())
         .expect("target/debug directory")
         .join("anvil")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_get_tempo_header_by_number() {
+    let (api, handle) = spawn(NodeConfig::test_tempo()).await;
+    api.mine_one().await;
+
+    let provider = handle.http_provider();
+    for number in ["0x1", "pending"] {
+        let header: Option<TempoHeaderResponse> =
+            provider.client().request("eth_getHeaderByNumber", (number,)).await.unwrap();
+        assert_tempo_header_fields(&header.unwrap());
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Anvil injects Tempo timestamp and gas metadata into the RPC block wrapper's extra fields, but `eth_getHeaderByNumber` and `eth_getHeaderByHash` previously cloned only the inner header and discarded that metadata. Tempo clients decoding `TempoHeaderResponse` therefore failed because required fields such as `timestampMillis` were missing.

This preserves the wrapper fields when extracting mined and pending headers and adds integration coverage that decodes Tempo header responses through the HTTP RPC. Standard Ethereum header responses remain unchanged because their extra-field maps are empty.

Authored with AI assistance.
