### PR TITLE
feat: support solc Amsterdam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5258,7 +5258,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=ce11bfee31e04a5d70ec6af900c63043f686bc10#ce11bfee31e04a5d70ec6af900c63043f686bc10"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b2a1440a1bc273d24cae797321d3e6f2298acb01#b2a1440a1bc273d24cae797321d3e6f2298acb01"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5504,7 +5504,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=ce11bfee31e04a5d70ec6af900c63043f686bc10#ce11bfee31e04a5d70ec6af900c63043f686bc10"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b2a1440a1bc273d24cae797321d3e6f2298acb01#b2a1440a1bc273d24cae797321d3e6f2298acb01"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5535,7 +5535,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=ce11bfee31e04a5d70ec6af900c63043f686bc10#ce11bfee31e04a5d70ec6af900c63043f686bc10"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b2a1440a1bc273d24cae797321d3e6f2298acb01#b2a1440a1bc273d24cae797321d3e6f2298acb01"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5544,7 +5544,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=ce11bfee31e04a5d70ec6af900c63043f686bc10#ce11bfee31e04a5d70ec6af900c63043f686bc10"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b2a1440a1bc273d24cae797321d3e6f2298acb01#b2a1440a1bc273d24cae797321d3e6f2298acb01"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5564,7 +5564,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=ce11bfee31e04a5d70ec6af900c63043f686bc10#ce11bfee31e04a5d70ec6af900c63043f686bc10"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b2a1440a1bc273d24cae797321d3e6f2298acb01#b2a1440a1bc273d24cae797321d3e6f2298acb01"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5577,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=ce11bfee31e04a5d70ec6af900c63043f686bc10#ce11bfee31e04a5d70ec6af900c63043f686bc10"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b2a1440a1bc273d24cae797321d3e6f2298acb01#b2a1440a1bc273d24cae797321d3e6f2298acb01"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -5908,7 +5908,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=ce11bfee31e04a5d70ec6af900c63043f686bc10#ce11bfee31e04a5d70ec6af900c63043f686bc10"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b2a1440a1bc273d24cae797321d3e6f2298acb01#b2a1440a1bc273d24cae797321d3e6f2298acb01"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=ce11bfee31e04a5d70ec6af900c63043f686bc10#ce11bfee31e04a5d70ec6af900c63043f686bc10"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b2a1440a1bc273d24cae797321d3e6f2298acb01#b2a1440a1bc273d24cae797321d3e6f2298acb01"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "ce11bfee31e04a5d70ec6af900c63043f686bc10", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "b2a1440a1bc273d24cae797321d3e6f2298acb01", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -540,9 +540,9 @@ idna_adapter = "=1.1.0"
 
 [patch.crates-io]
 ## foundry-core
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "ce11bfee31e04a5d70ec6af900c63043f686bc10" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "ce11bfee31e04a5d70ec6af900c63043f686bc10" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "ce11bfee31e04a5d70ec6af900c63043f686bc10" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b2a1440a1bc273d24cae797321d3e6f2298acb01" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b2a1440a1bc273d24cae797321d3e6f2298acb01" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "b2a1440a1bc273d24cae797321d3e6f2298acb01" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -1315,6 +1315,24 @@ forgetest!(normalize_config_evm_version, |_prj, cmd| {
         .stdout_lossy();
     let config: Config = serde_json::from_str(&output).unwrap();
     assert_eq!(config.evm_version, EvmVersion::Cancun);
+
+    let output = cmd
+        .forge_fuse()
+        .args(["config", "--use", "0.8.35", "--evm-version", "amsterdam", "--json"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let config: Config = serde_json::from_str(&output).unwrap();
+    assert_eq!(config.evm_version, EvmVersion::Osaka);
+
+    let output = cmd
+        .forge_fuse()
+        .args(["config", "--use", "0.8.36", "--evm-version", "amsterdam", "--json"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let config: Config = serde_json::from_str(&output).unwrap();
+    assert_eq!(config.evm_version, EvmVersion::Amsterdam);
 });
 
 // Tests that root paths are properly resolved even if submodule specifies remappings for them.

--- a/crates/forge/tests/cli/svm.rs
+++ b/crates/forge/tests/cli/svm.rs
@@ -81,3 +81,11 @@ Ran 2 test suites [ELAPSED]: 3 tests passed, 0 failed, 0 skipped (3 total tests)
 
 "#]]);
 });
+
+forgetest_init!(can_test_with_solc_0_8_36_amsterdam, |prj, cmd| {
+    prj.initialize_default_contracts();
+
+    // Amsterdam is an experimental EVM version in solc 0.8.36.
+    cmd.args(["test", "--use", "0.8.36", "--evm-version", "amsterdam", "--experimental"])
+        .assert_success();
+});


### PR DESCRIPTION
Adds support for compiling and testing with the Amsterdam EVM target using solc 0.8.36.