### PR TITLE
feat(anvil): add TIP-20 deal RPC

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -575,6 +575,10 @@ pub enum EthRequest {
     )]
     DealERC20(Address, Address, #[serde(deserialize_with = "deserialize_number")] U256),
 
+    /// Modifies the TIP-20 balance of an account.
+    #[serde(rename = "anvil_dealTIP20")]
+    DealTIP20(Address, Address, #[serde(deserialize_with = "deserialize_number")] U256),
+
     /// Sets the ERC20 allowance for a spender
     #[serde(rename = "anvil_setERC20Allowance")]
     SetERC20Allowance(

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1984,6 +1984,9 @@ impl EthApi<FoundryNetwork> {
             EthRequest::DealERC20(addr, token_addr, val) => {
                 self.anvil_deal_erc20(addr, token_addr, val).await.to_rpc_result()
             }
+            EthRequest::DealTIP20(addr, token_addr, val) => {
+                self.anvil_deal_tip20(addr, token_addr, val).await.to_rpc_result()
+            }
             EthRequest::SetERC20Allowance(owner, spender, token_addr, val) => self
                 .anvil_set_erc20_allowance(owner, spender, token_addr, val)
                 .await
@@ -3537,6 +3540,12 @@ impl EthApi<FoundryNetwork> {
     ) -> Result<()> {
         node_info!("anvil_dealERC20");
 
+        if self.backend.is_tempo()
+            && self.backend.try_set_tip20_balance(address, token_address, balance).await?
+        {
+            return Ok(());
+        }
+
         sol! {
             #[sol(rpc)]
             contract IERC20 {
@@ -3560,6 +3569,21 @@ impl EthApi<FoundryNetwork> {
         )
         .await?;
 
+        Ok(())
+    }
+
+    /// Deals TIP-20 tokens to an address.
+    ///
+    /// Handler for RPC call: `anvil_dealTIP20`.
+    pub async fn anvil_deal_tip20(
+        &self,
+        address: Address,
+        token_address: Address,
+        balance: U256,
+    ) -> Result<()> {
+        node_info!("anvil_dealTIP20");
+        self.ensure_tempo_mode()?;
+        self.backend.set_tip20_balance(address, token_address, balance).await?;
         Ok(())
     }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -194,9 +194,10 @@ use tempo_evm::evm::TempoEvmFactory;
 use tempo_hardfork::TempoHardfork;
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS, extend_tempo_precompiles,
-    storage::{StorageActions, StorageCtx},
+    storage::{Handler, StorageActions, StorageCtx},
     tip_fee_manager::{IFeeManager, TipFeeManager},
     tip20::{ISSUER_ROLE, ITIP20, TIP20Token},
+    tip20_factory::TIP20Factory,
 };
 use tempo_primitives::TEMPO_TX_TYPE_ID;
 use tempo_revm::{
@@ -5133,6 +5134,39 @@ impl Backend<FoundryNetwork> {
                 .mint(admin, user_token, validator_token, amount, admin)
                 .map_err(tempo_db_err)?;
             Ok(())
+        })
+        .await
+    }
+
+    /// Sets an account's balance for a deployed TIP-20 token (Tempo-only).
+    pub async fn set_tip20_balance(
+        &self,
+        address: Address,
+        token_address: Address,
+        balance: U256,
+    ) -> DatabaseResult<()> {
+        if self.try_set_tip20_balance(address, token_address, balance).await? {
+            return Ok(());
+        }
+
+        Err(tempo_db_err(format!("address {token_address} is not a deployed TIP-20 token")))
+    }
+
+    /// Sets an account's balance if the address is a deployed TIP-20 token (Tempo-only).
+    pub async fn try_set_tip20_balance(
+        &self,
+        address: Address,
+        token_address: Address,
+        balance: U256,
+    ) -> DatabaseResult<bool> {
+        self.with_tempo_storage(|| {
+            if !TIP20Factory::new().is_tip20(token_address).map_err(tempo_db_err)? {
+                return Ok(false);
+            }
+
+            let mut token = TIP20Token::from_address(token_address).map_err(tempo_db_err)?;
+            token.balances[address].write(balance).map_err(tempo_db_err)?;
+            Ok(true)
         })
         .await
     }

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1388,33 +1388,6 @@ async fn can_get_node_info_tempo_t1() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn can_deal_erc20_tempo() {
-    use foundry_evm::core::tempo::{ALPHA_USD_ADDRESS, PATH_USD_ADDRESS};
-
-    let (api, _handle) = spawn(NodeConfig::test_tempo()).await;
-
-    let target = Address::random();
-
-    // TIP20 tokens are precompile-backed — anvil_dealERC20 uses access-list slot probing
-    // which doesn't discover precompile storage slots. Verify this fails gracefully.
-    for token_addr in [PATH_USD_ADDRESS, ALPHA_USD_ADDRESS] {
-        let amount = U256::from(5_000_000); // 5 tokens (6 decimals)
-
-        let result = api.anvil_deal_erc20(target, token_addr, amount).await;
-        assert!(
-            result.is_err(),
-            "anvil_dealERC20 should fail for precompile-based TIP20 {token_addr}"
-        );
-
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("no slot found"),
-            "Error should mention slot discovery failure, got: {err}"
-        );
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn can_get_default_base_fee_tempo() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
     let provider = handle.http_provider();

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -416,6 +416,76 @@ async fn test_tempo_precompiles_have_code() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_deal_tip20() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo().with_no_mining(true)).await;
+    let provider = handle.http_provider();
+    let recipient = Address::random();
+    let token = IERC20::new(ALPHA_USD, &provider);
+    let supply_before = token.totalSupply().call().await.unwrap();
+
+    provider
+        .raw_request::<_, ()>("anvil_dealTIP20".into(), (recipient, ALPHA_USD, U256::from(100)))
+        .await
+        .unwrap();
+    assert_eq!(token.balanceOf(recipient).call().await.unwrap(), U256::from(100));
+    assert_eq!(token.totalSupply().call().await.unwrap(), supply_before);
+
+    provider
+        .raw_request::<_, ()>("anvil_dealTIP20".into(), (recipient, ALPHA_USD, U256::from(40)))
+        .await
+        .unwrap();
+    assert_eq!(token.balanceOf(recipient).call().await.unwrap(), U256::from(40));
+    assert_eq!(token.totalSupply().call().await.unwrap(), supply_before);
+    assert_eq!(provider.txpool_status().await.unwrap().pending, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_deal_erc20_supports_tip20() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo().with_no_mining(true)).await;
+    let provider = handle.http_provider();
+    let recipient = Address::random();
+    let token = IERC20::new(ALPHA_USD, &provider);
+    let supply_before = token.totalSupply().call().await.unwrap();
+
+    provider
+        .raw_request::<_, ()>("anvil_dealERC20".into(), (recipient, ALPHA_USD, U256::from(100)))
+        .await
+        .unwrap();
+    assert_eq!(token.balanceOf(recipient).call().await.unwrap(), U256::from(100));
+    assert_eq!(token.totalSupply().call().await.unwrap(), supply_before);
+
+    provider
+        .raw_request::<_, ()>("anvil_dealERC20".into(), (recipient, ALPHA_USD, U256::from(40)))
+        .await
+        .unwrap();
+    assert_eq!(token.balanceOf(recipient).call().await.unwrap(), U256::from(40));
+    assert_eq!(token.totalSupply().call().await.unwrap(), supply_before);
+    assert_eq!(provider.txpool_status().await.unwrap().pending, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_deal_tip20_rejects_invalid_token() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+    let result: std::result::Result<(), _> = provider
+        .raw_request("anvil_dealTIP20".into(), (Address::random(), Address::random(), U256::ONE))
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_deal_tip20_rejects_non_tempo_node() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let result: std::result::Result<(), _> = provider
+        .raw_request("anvil_dealTIP20".into(), (Address::random(), ALPHA_USD, U256::ONE))
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_pre_t5_channel_reserve_has_no_sentinel_code() {
     let (api, _handle) =
         spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T4.into()))).await;


### PR DESCRIPTION
## Motivation

Adds `anvil_dealTIP20` for directly setting the balance of a deployed TIP-20 token. The endpoint validates tokens through the TIP-20 factory and preserves deal
semantics by updating only the balance slot without changing total supply or protocol roles.

On Tempo nodes, `anvil_dealERC20` now detects TIP-20 addresses and uses the same native path, allowing existing ERC-20 tooling to work with TIP-20 tokens.
