### PR TITLE
feat: add symbolic benchmark suite

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -86,6 +86,11 @@ foundry-bench --verbose
 foundry-bench --output-dir ./results --output-file LATEST_RESULTS.md
 ```
 
+`forge_symbolic_test` keeps the existing focused commands for Solady, Angstrom, and Farcaster
+and uses the generic symbolic command for other repositories.
+Use `--symbolic-sidecar-output <FILE>` with exactly one `--versions` value to capture the
+versioned per-run results. Like `--json-output`, the sidecar path is relative to `--output-dir`.
+
 ## Branch vs master PR-body workflow
 
 Use this workflow when preparing performance numbers for a PR body. It keeps the
@@ -255,6 +260,7 @@ The artifact bundle exposes:
 - `--verbose` - Show detailed benchmark output
 - `--output-dir <DIR>` - Directory for output files (default: benches)
 - `--output-file <FILE_NAME.md>` - Name of the output file (default: LATEST.md)
+- `--symbolic-sidecar-output <FILE.json>` - Write the opt-in v1 symbolic samples sidecar (requires exactly one version)
 
 ## Benchmark Structure
 
@@ -264,7 +270,7 @@ The artifact bundle exposes:
 - `forge_fuzz_test` - Benchmarks non-isolated `forge test` with only fuzz tests (tests with parameters)
 - `forge_coverage` - Benchmarks `forge coverage --ir-minimum` command across repos
 - `forge_isolate_test` - Benchmarks isolated `forge test` command across repos
-- `forge_symbolic_test` - Benchmarks focused `forge test --symbolic --json` checks and reports symbolic solver counters
+- `forge_symbolic_test` - Benchmarks `forge test --symbolic` for any repository, with focused recipes for Solady, Angstrom, and Farcaster. Compatibility JSON retains the median-wall-run counter projection; the optional sidecar records all five aligned samples, exact tests/statuses, and solver counters.
 
 ## Configuration
 

--- a/benches/fixtures/symbolic/FarcasterNativeSymbolic.t.sol
+++ b/benches/fixtures/symbolic/FarcasterNativeSymbolic.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {Test} from "forge-std/Test.sol";
+import {Migration} from "../src/abstract/Migration.sol";
+
+contract MigrationHarness is Migration {
+    constructor(uint24 gracePeriod, address migrator, address initialOwner)
+        Migration(gracePeriod, migrator, initialOwner)
+    {}
+}
+
+contract FarcasterNativeSymbolicTest is Test {
+    function check_migrateOnlyMigrator(
+        uint24 gracePeriod,
+        address migrator,
+        address initialOwner,
+        address caller,
+        uint40 timestamp
+    ) public {
+        vm.assume(timestamp != 0);
+
+        MigrationHarness migration = new MigrationHarness(gracePeriod, migrator, initialOwner);
+
+        vm.warp(timestamp);
+        vm.prank(caller);
+        (bool success,) = address(migration).call(abi.encodeCall(Migration.migrate, ()));
+
+        assert(success == (caller == migrator));
+        if (success) {
+            assert(migration.isMigrated());
+            assert(migration.migratedAt() == timestamp);
+        }
+    }
+
+    function check_setMigratorOnlyOwner(
+        uint24 gracePeriod,
+        address migrator,
+        address initialOwner,
+        address caller,
+        address nextMigrator
+    ) public {
+        MigrationHarness migration = new MigrationHarness(gracePeriod, migrator, initialOwner);
+
+        vm.prank(caller);
+        (bool success,) =
+            address(migration).call(abi.encodeCall(Migration.setMigrator, (nextMigrator)));
+
+        assert(success == (caller == initialOwner));
+        if (success) {
+            assert(migration.migrator() == nextMigrator);
+        } else {
+            assert(migration.migrator() == migrator);
+        }
+    }
+}

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,12 +1,14 @@
 //! Foundry benchmark runner.
 
-use crate::results::{HyperfineOutput, HyperfineResult, SymbolicBenchmarkSummary};
+use crate::{
+    results::{HyperfineOutput, HyperfineResult},
+    symbolic::{Fixture, Overlay, Sample, Sidecar},
+};
 use eyre::{Result, WrapErr};
 use foundry_common::{sh_eprintln, sh_println};
 use foundry_compilers::project_util::TempProject;
 use foundry_test_utils::util::clone_remote;
 use once_cell::sync::Lazy;
-use serde_json::Value;
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -16,92 +18,10 @@ use std::{
 };
 
 pub mod results;
+pub mod symbolic;
 
 /// Default number of runs for benchmarks
 pub const RUNS: u32 = 5;
-
-const SOLADY_SYMBOLIC_MATCH_TEST: &str = concat!(
-    "check_(",
-    "SaturatingAddEquivalence|",
-    "SaturatingMulEquivalence|",
-    "HasDuplicateHashmapCapacityTrickEquivalence|",
-    "IsPermit2AndValueIsNotInfinityTrickEquivalence|",
-    "IsNotUint256MaxTrickEquivalence|",
-    "DelayRestriction|",
-    "OperationStateDifferentialTrick|",
-    "CarryBoundsTrick|",
-    "SafeCastInt256ToIntTrickEquivalence|",
-    "P256Normalized|",
-    "AuxPackEquivalence|",
-    "EcrecoverTrickEquivalence|",
-    "EcrecoverLoopTrick",
-    ")"
-);
-const ANGSTROM_SYMBOLIC_MATCH_TEST: &str = "check_matchesSolady_fullMulX128";
-const ANGSTROM_SYMBOLIC_MATCH_PATH: &str = "test/libraries/X128MathLib.t.sol";
-const FARCASTER_SYMBOLIC_MATCH_PATH: &str = "test/FarcasterNativeSymbolic.t.sol";
-const FARCASTER_SYMBOLIC_BENCHMARK_TEST: &str = r#"// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
-
-import {Test} from "forge-std/Test.sol";
-import {Migration} from "../src/abstract/Migration.sol";
-
-contract MigrationHarness is Migration {
-    constructor(uint24 gracePeriod, address migrator, address initialOwner)
-        Migration(gracePeriod, migrator, initialOwner)
-    {}
-}
-
-contract FarcasterNativeSymbolicTest is Test {
-    function check_migrateOnlyMigrator(
-        uint24 gracePeriod,
-        address migrator,
-        address initialOwner,
-        address caller,
-        uint40 timestamp
-    ) public {
-        vm.assume(timestamp != 0);
-
-        MigrationHarness migration = new MigrationHarness(gracePeriod, migrator, initialOwner);
-
-        vm.warp(timestamp);
-        vm.prank(caller);
-        (bool success,) = address(migration).call(abi.encodeCall(Migration.migrate, ()));
-
-        assert(success == (caller == migrator));
-        if (success) {
-            assert(migration.isMigrated());
-            assert(migration.migratedAt() == timestamp);
-        }
-    }
-
-    function check_setMigratorOnlyOwner(
-        uint24 gracePeriod,
-        address migrator,
-        address initialOwner,
-        address caller,
-        address nextMigrator
-    ) public {
-        MigrationHarness migration = new MigrationHarness(gracePeriod, migrator, initialOwner);
-
-        vm.prank(caller);
-        (bool success,) =
-            address(migration).call(abi.encodeCall(Migration.setMigrator, (nextMigrator)));
-
-        assert(success == (caller == initialOwner));
-        if (success) {
-            assert(migration.migrator() == nextMigrator);
-        } else {
-            assert(migration.migrator() == migrator);
-        }
-    }
-}
-"#;
-
-struct SymbolicBenchmarkSpec {
-    build_command: String,
-    test_command: String,
-}
 
 /// Configuration for repositories to benchmark
 #[derive(Debug, Clone)]
@@ -210,6 +130,9 @@ pub struct BenchmarkProject {
     pub root_path: PathBuf,
     /// Optional extra arguments appended to every benchmark command.
     pub extra_args: Option<String>,
+    pub org: String,
+    pub repo: String,
+    pub revision: String,
 }
 
 impl BenchmarkProject {
@@ -251,18 +174,28 @@ impl BenchmarkProject {
             }
         }
 
-        Self::install_symbolic_benchmark_fixtures(&root_path, config)?;
-
         // Git submodules are already cloned via --recursive flag
         // But npm dependencies still need to be installed
         Self::install_npm_dependencies(&root_path)?;
 
         sh_println!("  ✅ Project {} setup complete at {}", config.name, root);
+        let revision = String::from_utf8(
+            Command::new("git")
+                .current_dir(&root_path)
+                .args(["rev-parse", "HEAD"])
+                .output()?
+                .stdout,
+        )?
+        .trim()
+        .to_string();
         Ok(Self {
             name: config.name.clone(),
             root_path,
             temp_project,
             extra_args: config.extra_args.clone(),
+            org: config.org.clone(),
+            repo: config.repo.clone(),
+            revision,
         })
     }
 
@@ -272,68 +205,6 @@ impl BenchmarkProject {
             Some(extra) => format!("{base} {extra}"),
             None => base.to_string(),
         }
-    }
-
-    fn symbolic_benchmark_spec(&self) -> SymbolicBenchmarkSpec {
-        let name = self.name.to_ascii_lowercase();
-        if name == "solady" || name.ends_with("-solady") {
-            return SymbolicBenchmarkSpec {
-                build_command:
-                    "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build"
-                        .to_string(),
-                test_command: format!(
-                    "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge test \
-                     --symbolic --json \
-                     --match-test '{SOLADY_SYMBOLIC_MATCH_TEST}'"
-                ),
-            };
-        }
-        if name == "angstrom" || name.ends_with("-angstrom") {
-            return SymbolicBenchmarkSpec {
-                build_command:
-                    "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build --root contracts"
-                        .to_string(),
-                test_command: format!(
-                    "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge test \
-                     --root contracts --symbolic --json --symbolic-timeout 5 --match-path \
-                     {ANGSTROM_SYMBOLIC_MATCH_PATH} --match-test {ANGSTROM_SYMBOLIC_MATCH_TEST}"
-                ),
-            };
-        }
-        if name == "farcasterxyz-contracts" || name == "farcaster-contracts" {
-            return SymbolicBenchmarkSpec {
-                build_command:
-                    "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build"
-                        .to_string(),
-                test_command: format!(
-                    "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge test \
-                     --symbolic --json \
-                     --symbolic-timeout 5 --match-path '{FARCASTER_SYMBOLIC_MATCH_PATH}' \
-                     --match-test 'check_'"
-                ),
-            };
-        }
-        SymbolicBenchmarkSpec {
-            build_command:
-                "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge build"
-                    .to_string(),
-            test_command:
-                "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false forge test --symbolic --json"
-                    .to_string(),
-        }
-    }
-
-    fn install_symbolic_benchmark_fixtures(root: &Path, config: &RepoConfig) -> Result<()> {
-        if config.org.eq_ignore_ascii_case("farcasterxyz") && config.repo == "contracts" {
-            // Farcaster's checked-in Halmos tests create symbolic values in setUp,
-            // which native forge symbolic does not produce benchmark counters for.
-            std::fs::write(
-                root.join(FARCASTER_SYMBOLIC_MATCH_PATH),
-                FARCASTER_SYMBOLIC_BENCHMARK_TEST,
-            )
-            .wrap_err("Failed to install Farcaster symbolic benchmark test")?;
-        }
-        Ok(())
     }
 
     /// Install npm dependencies if package.json exists
@@ -584,77 +455,105 @@ impl BenchmarkProject {
         runs: u32,
         verbose: bool,
     ) -> Result<HyperfineResult> {
-        let spec = self.symbolic_benchmark_spec();
-        let command = self.cmd(&spec.test_command);
-
-        let status = Command::new("bash")
-            .current_dir(&self.root_path)
-            .args(["-lc", &spec.build_command])
-            .status()
-            .wrap_err("Failed to build project before symbolic benchmark")?;
-        if !status.success() {
-            eyre::bail!(
-                "forge build failed before symbolic benchmark with command: {}",
-                spec.build_command
-            );
-        }
-
-        let mut times = Vec::with_capacity(runs as usize);
-        let mut summaries = Vec::with_capacity(runs as usize);
-        let mut exit_codes = Vec::with_capacity(runs as usize);
-
-        for _ in 0..runs {
-            let started = Instant::now();
-            let output = Command::new("bash")
+        let fixture = Fixture::identify(&self.org, &self.repo);
+        let command = self.cmd(&fixture.test_command());
+        let build_command = fixture.build_command();
+        let overlay = Overlay::install(&self.root_path, fixture)?;
+        let benchmark = (|| -> Result<HyperfineResult> {
+            let status = Command::new("bash")
                 .current_dir(&self.root_path)
-                .args(["-lc", &command])
-                .output()
-                .wrap_err("Failed to run forge symbolic benchmark")?;
-            let elapsed = started.elapsed().as_secs_f64();
-            times.push(elapsed);
-            exit_codes.push(output.status.code().unwrap_or(-1));
-
-            if verbose {
-                let _ = sh_println!("{}", String::from_utf8_lossy(&output.stderr));
+                .args(["-lc", &build_command])
+                .status()
+                .wrap_err("Failed to build project before symbolic benchmark")?;
+            if !status.success() {
+                eyre::bail!(
+                    "forge build failed before symbolic benchmark with command: {}",
+                    build_command
+                );
             }
 
-            let summary = match parse_symbolic_benchmark_summary(&output.stdout) {
-                Ok(summary) => summary,
-                Err(err) => {
-                    if !output.status.success() {
-                        let _ = sh_eprintln!("{}", String::from_utf8_lossy(&output.stderr));
-                        eyre::bail!(
-                            "forge symbolic benchmark failed with command: {command}; {err}"
-                        );
-                    }
-                    return Err(err);
+            let mut times = Vec::with_capacity(runs as usize);
+            let mut samples = Vec::with_capacity(runs as usize);
+            let mut exit_codes = Vec::with_capacity(runs as usize);
+
+            for _ in 0..runs {
+                let started = Instant::now();
+                let output = Command::new("bash")
+                    .current_dir(&self.root_path)
+                    .args(["-lc", &command])
+                    .output()
+                    .wrap_err("Failed to run forge symbolic benchmark")?;
+                let elapsed = started.elapsed().as_secs_f64();
+                let exit_code = output.status.code().unwrap_or(-1);
+                if !matches!(exit_code, 0 | 1) {
+                    let _ = sh_eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+                    eyre::bail!(
+                        "forge symbolic benchmark exited abnormally with code {exit_code}: {command}"
+                    );
                 }
-            };
-            if !output.status.success() && verbose {
-                let _ = sh_eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+                times.push(elapsed);
+                exit_codes.push(exit_code);
+
+                if verbose {
+                    let _ = sh_println!("{}", String::from_utf8_lossy(&output.stderr));
+                }
+
+                let run = match symbolic::parse(&output.stdout) {
+                    Ok(summary) => summary,
+                    Err(err) => {
+                        if !output.status.success() {
+                            let _ = sh_eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+                            eyre::bail!(
+                                "forge symbolic benchmark failed with command: {command}; {err}"
+                            );
+                        }
+                        return Err(err);
+                    }
+                };
+                if !output.status.success() && verbose {
+                    let _ = sh_eprintln!("{}", String::from_utf8_lossy(&output.stderr));
+                }
+                samples.push(Sample { wall_time_seconds: elapsed, exit_code, run });
             }
-            summaries.push(summary);
+
+            let symbolic = samples
+                .get(median_index(&times))
+                .map(|sample| symbolic::compatibility(&sample.run))
+                .ok_or_else(|| eyre::eyre!("symbolic benchmark produced no runs"))?;
+            let sidecar = Sidecar::new(
+                fixture,
+                &format!("{}/{}", self.org, self.repo),
+                &self.revision,
+                &build_command,
+                &command,
+                samples,
+            );
+
+            Ok(HyperfineResult {
+                command,
+                mean: mean(&times),
+                stddev: stddev(&times),
+                median: median(&times),
+                user: 0.0,
+                system: 0.0,
+                min: times.iter().copied().reduce(f64::min).unwrap_or_default(),
+                max: times.iter().copied().reduce(f64::max).unwrap_or_default(),
+                times,
+                exit_codes: Some(exit_codes),
+                parameters: None,
+                symbolic: Some(symbolic),
+                symbolic_sidecar: Some(sidecar),
+            })
+        })();
+        let cleanup = overlay.finish();
+        match (benchmark, cleanup) {
+            (Ok(result), Ok(())) => Ok(result),
+            (Err(err), Ok(())) => Err(err),
+            (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
+            (Err(err), Err(cleanup_err)) => Err(eyre::eyre!(
+                "{err}; additionally, symbolic fixture cleanup failed: {cleanup_err}"
+            )),
         }
-
-        let symbolic = summaries
-            .get(median_index(&times))
-            .cloned()
-            .ok_or_else(|| eyre::eyre!("symbolic benchmark produced no runs"))?;
-
-        Ok(HyperfineResult {
-            command,
-            mean: mean(&times),
-            stddev: stddev(&times),
-            median: median(&times),
-            user: 0.0,
-            system: 0.0,
-            min: times.iter().copied().reduce(f64::min).unwrap_or_default(),
-            max: times.iter().copied().reduce(f64::max).unwrap_or_default(),
-            times,
-            exit_codes: Some(exit_codes),
-            parameters: None,
-            symbolic: Some(symbolic),
-        })
     }
 
     /// Get the root path of the project
@@ -681,61 +580,6 @@ impl BenchmarkProject {
             _ => eyre::bail!("Unknown benchmark: {}", benchmark),
         }
     }
-}
-
-fn parse_symbolic_benchmark_summary(stdout: &[u8]) -> Result<SymbolicBenchmarkSummary> {
-    let json: Value =
-        serde_json::from_slice(stdout).wrap_err("Invalid forge test --json output")?;
-    let suites = json.as_object().ok_or_else(|| eyre::eyre!("Expected JSON object"))?;
-    let mut summary = SymbolicBenchmarkSummary::default();
-
-    for suite in suites.values() {
-        let Some(results) = suite.get("test_results").and_then(Value::as_object) else {
-            continue;
-        };
-        for result in results.values() {
-            let Some(stats) = result
-                .pointer("/symbolic/solver/stats")
-                .or_else(|| result.pointer("/kind/Symbolic"))
-            else {
-                continue;
-            };
-            summary.tests += 1;
-            let status = result.get("status").and_then(Value::as_str).unwrap_or_default();
-            let reason = result.get("reason").and_then(Value::as_str).unwrap_or_default();
-            if status == "Success" {
-                summary.passed += 1;
-            } else if reason.contains("incomplete symbolic execution") {
-                summary.incomplete += 1;
-            } else {
-                summary.failed += 1;
-            }
-            summary.paths += metric(stats, "paths");
-            summary.solver_queries += metric(stats, "solver_queries");
-            summary.smt_queries += metric(stats, "smt_queries");
-            summary.sat_queries += metric(stats, "sat_queries");
-            summary.model_queries += metric(stats, "model_queries");
-            summary.sat_cache_hits += metric(stats, "sat_cache_hits");
-            summary.model_cache_hits += metric(stats, "model_cache_hits");
-            summary.heuristic_witnesses += metric(stats, "heuristic_witnesses");
-            summary.solver_time_ms += metric(stats, "solver_time_ms");
-            summary.smt_input_bytes += metric(stats, "smt_input_bytes");
-            summary.smt_max_query_bytes =
-                summary.smt_max_query_bytes.max(metric(stats, "smt_max_query_bytes"));
-            summary.smt_build_time_ms += metric(stats, "smt_build_time_ms");
-            summary.smt_max_query_time_ms =
-                summary.smt_max_query_time_ms.max(metric(stats, "smt_max_query_time_ms"));
-        }
-    }
-
-    if summary.tests == 0 {
-        eyre::bail!("forge symbolic benchmark produced no symbolic test results");
-    }
-    Ok(summary)
-}
-
-fn metric(stats: &Value, key: &str) -> u64 {
-    stats.get(key).and_then(Value::as_u64).unwrap_or_default()
 }
 
 fn mean(values: &[f64]) -> f64 {
@@ -963,77 +807,5 @@ pub fn get_forge_version_details() -> Result<String> {
     } else {
         // Fallback to just the first line if format is unexpected
         Ok(lines.first().unwrap_or(&"unknown").to_string())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_symbolic_benchmark_summary() {
-        let stdout = br#"{
-            "test/Foo.t.sol:FooTest": {
-                "test_results": {
-                    "check_one(uint256)": {
-                        "kind": {
-                            "Symbolic": {
-                                "paths": 2,
-                                "solver_queries": 3,
-                                "smt_queries": 2,
-                                "sat_queries": 4,
-                                "model_queries": 0,
-                                "sat_cache_hits": 1,
-                                "model_cache_hits": 0,
-                                "heuristic_witnesses": 0,
-                                "solver_time_ms": 12,
-                                "smt_input_bytes": 1024,
-                                "smt_max_query_bytes": 600,
-                                "smt_build_time_ms": 1,
-                                "smt_max_query_time_ms": 9
-                            }
-                        },
-                        "status": "Success"
-                    },
-                    "check_two(uint256)": {
-                        "symbolic": {
-                            "solver": {
-                                "stats": {
-                                    "paths": 0,
-                                    "solver_queries": 1,
-                                    "smt_queries": 1,
-                                    "sat_queries": 1,
-                                    "model_queries": 0,
-                                    "sat_cache_hits": 0,
-                                    "model_cache_hits": 0,
-                                    "heuristic_witnesses": 0,
-                                    "solver_time_ms": 5,
-                                    "smt_input_bytes": 10,
-                                    "smt_max_query_bytes": 10,
-                                    "smt_build_time_ms": 0,
-                                    "smt_max_query_time_ms": 5
-                                }
-                            }
-                        },
-                        "status": "Failure",
-                        "reason": "incomplete symbolic execution (Timeout): solver returned unknown"
-                    }
-                }
-            }
-        }"#;
-
-        let summary = parse_symbolic_benchmark_summary(stdout).unwrap();
-        assert_eq!(summary.tests, 2);
-        assert_eq!(summary.passed, 1);
-        assert_eq!(summary.failed, 0);
-        assert_eq!(summary.incomplete, 1);
-        assert_eq!(summary.paths, 2);
-        assert_eq!(summary.smt_queries, 3);
-        assert_eq!(summary.sat_cache_hits, 1);
-        assert_eq!(summary.solver_time_ms, 17);
-        assert_eq!(summary.smt_input_bytes, 1034);
-        assert_eq!(summary.smt_max_query_bytes, 600);
-        assert_eq!(summary.smt_build_time_ms, 1);
-        assert_eq!(summary.smt_max_query_time_ms, 9);
     }
 }

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -50,6 +50,10 @@ struct Cli {
     #[clap(long)]
     json_output: Option<PathBuf>,
 
+    /// Filename for the opt-in versioned symbolic benchmark sidecar.
+    #[clap(long)]
+    symbolic_sidecar_output: Option<PathBuf>,
+
     /// Run only specific benchmarks (comma-separated:
     /// forge_test,forge_build_no_cache,forge_build_with_cache,forge_fuzz_test,forge_coverage,
     /// forge_symbolic_test)
@@ -110,6 +114,9 @@ fn main() -> Result<()> {
     } else {
         FOUNDRY_VERSIONS.iter().map(|&s| s.to_string()).collect()
     };
+    if cli.symbolic_sidecar_output.is_some() && versions.len() != 1 {
+        eyre::bail!("--symbolic-sidecar-output requires exactly one --versions entry");
+    }
 
     // Get repo configurations
     let repos = if let Some(repo_specs) = cli.repos.clone() {
@@ -276,6 +283,31 @@ fn main() -> Result<()> {
         let json_path = cli.output_dir.join(json_filename);
         fs::write(&json_path, json).wrap_err("Failed to write JSON summary")?;
         sh_println!("✅ JSON summary written to: {}", json_path.display());
+    }
+
+    if let Some(filename) = cli.symbolic_sidecar_output {
+        let mut sidecars = std::collections::BTreeMap::new();
+        for (benchmark, version_data) in &results.data {
+            if benchmark != "forge_symbolic_test" {
+                continue;
+            }
+            for version in &versions {
+                if let Some(repo_data) = version_data.get(version) {
+                    for (repo, result) in repo_data {
+                        if let Some(sidecar) = &result.symbolic_sidecar {
+                            sidecars.insert(format!("forge_symbolic_test/{repo}"), sidecar);
+                        }
+                    }
+                }
+            }
+        }
+        if sidecars.is_empty() {
+            eyre::bail!("symbolic sidecar requested but no symbolic results were produced");
+        }
+        let path = cli.output_dir.join(filename);
+        fs::create_dir_all(path.parent().unwrap_or(&cli.output_dir))?;
+        fs::write(&path, serde_json::to_string_pretty(&sidecars)?)?;
+        sh_println!("✅ Symbolic sidecar written to: {}", path.display());
     }
 
     Ok(())

--- a/benches/src/results.rs
+++ b/benches/src/results.rs
@@ -1,4 +1,4 @@
-use crate::RepoConfig;
+use crate::{RepoConfig, symbolic::Sidecar};
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, process::Command, thread};
@@ -22,6 +22,8 @@ pub struct HyperfineResult {
     pub parameters: Option<HashMap<String, serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub symbolic: Option<SymbolicBenchmarkSummary>,
+    #[serde(skip)]
+    pub symbolic_sidecar: Option<Sidecar>,
 }
 
 /// Aggregated symbolic counters for one benchmark run.
@@ -376,6 +378,7 @@ mod tests {
             exit_codes: None,
             parameters: None,
             symbolic: None,
+            symbolic_sidecar: None,
         }
     }
 

--- a/benches/src/symbolic.rs
+++ b/benches/src/symbolic.rs
@@ -25,7 +25,7 @@ pub enum Fixture {
 }
 
 impl Fixture {
-    pub fn identify(org: &str, repo: &str) -> Self {
+    pub const fn identify(org: &str, repo: &str) -> Self {
         if org.eq_ignore_ascii_case("vectorized") && repo.eq_ignore_ascii_case("solady") {
             Self::Solady
         } else if org.eq_ignore_ascii_case("sorellalabs") && repo.eq_ignore_ascii_case("angstrom") {
@@ -280,7 +280,7 @@ pub fn parse(stdout: &[u8]) -> Result<ParsedRun> {
     if run.outcomes.is_empty() {
         eyre::bail!("forge symbolic benchmark produced no symbolic test results")
     }
-    run.outcomes.sort_by(|a, b| a.identity().cmp(&b.identity()));
+    run.outcomes.sort_by_key(TestOutcome::identity);
     run.passed =
         run.outcomes.iter().filter(|outcome| outcome.status == OutcomeStatus::Passed).count();
     run.failed =
@@ -376,7 +376,7 @@ fn optional_max(
     Ok(())
 }
 
-pub fn compatibility(run: &ParsedRun) -> SymbolicBenchmarkSummary {
+pub const fn compatibility(run: &ParsedRun) -> SymbolicBenchmarkSummary {
     let m = &run.metrics;
     SymbolicBenchmarkSummary {
         tests: run.outcomes.len(),
@@ -462,7 +462,7 @@ mod tests {
         let stats = serde_json::json!({"paths": 1, "solver_queries": 2});
         let stdout = serde_json::to_vec(&serde_json::json!({"test/FarcasterNativeSymbolic.t.sol:FarcasterNativeSymbolicTest":{"test_results":{
             "check_migrateOnlyMigrator(uint24,address,address,address,uint40)":{
-                "kind":{"Symbolic":stats.clone()},"status":"Success"
+                "kind":{"Symbolic":stats},"status":"Success"
             },
             "check_setMigratorOnlyOwner(uint24,address,address,address,address)":{
                 "kind":{"Symbolic":stats},"status":"Failure",

--- a/benches/src/symbolic.rs
+++ b/benches/src/symbolic.rs
@@ -1,0 +1,547 @@
+//! Formal symbolic benchmark suite definitions and result parsing.
+
+use crate::results::SymbolicBenchmarkSummary;
+use eyre::{Result, WrapErr};
+use serde::Serialize;
+use serde_json::Value;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+const FARCASTER_PATH: &str = "test/FarcasterNativeSymbolic.t.sol";
+const FARCASTER_TEST: &str = include_str!("../fixtures/symbolic/FarcasterNativeSymbolic.t.sol");
+const PREFIX: &str =
+    "FOUNDRY_DYNAMIC_TEST_LINKING=false FOUNDRY_LINT_LINT_ON_BUILD=false FOUNDRY_ISOLATE=false";
+const SOLADY_MATCH: &str = "check_(SaturatingAddEquivalence|SaturatingMulEquivalence|HasDuplicateHashmapCapacityTrickEquivalence|IsPermit2AndValueIsNotInfinityTrickEquivalence|IsNotUint256MaxTrickEquivalence|DelayRestriction|OperationStateDifferentialTrick|CarryBoundsTrick|SafeCastInt256ToIntTrickEquivalence|P256Normalized|AuxPackEquivalence|EcrecoverTrickEquivalence|EcrecoverLoopTrick)";
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Fixture {
+    Solady,
+    Angstrom,
+    Farcaster,
+    Generic,
+}
+
+impl Fixture {
+    pub fn identify(org: &str, repo: &str) -> Self {
+        if org.eq_ignore_ascii_case("vectorized") && repo.eq_ignore_ascii_case("solady") {
+            Self::Solady
+        } else if org.eq_ignore_ascii_case("sorellalabs") && repo.eq_ignore_ascii_case("angstrom") {
+            Self::Angstrom
+        } else if org.eq_ignore_ascii_case("farcasterxyz") && repo.eq_ignore_ascii_case("contracts")
+        {
+            Self::Farcaster
+        } else {
+            Self::Generic
+        }
+    }
+
+    pub fn build_command(self) -> String {
+        format!(
+            "{PREFIX} {}",
+            match self {
+                Self::Angstrom => "forge build --root contracts",
+                _ => "forge build",
+            }
+        )
+    }
+
+    pub fn test_command(self) -> String {
+        match self {
+            Self::Solady => {
+                format!("{PREFIX} forge test --symbolic --json --match-test '{SOLADY_MATCH}'")
+            }
+            Self::Angstrom => format!(
+                "{PREFIX} forge test --root contracts --symbolic --json --symbolic-timeout 5 --match-path test/libraries/X128MathLib.t.sol --match-test check_matchesSolady_fullMulX128"
+            ),
+            Self::Farcaster => format!(
+                "{PREFIX} forge test --symbolic --json --symbolic-timeout 5 --match-path '{FARCASTER_PATH}' --match-test 'check_'"
+            ),
+            Self::Generic => format!("{PREFIX} forge test --symbolic --json"),
+        }
+    }
+}
+
+/// Error-safe installation of the Farcaster benchmark overlay.
+pub struct Overlay {
+    path: Option<PathBuf>,
+}
+
+impl Overlay {
+    pub fn install(root: &Path, fixture: Fixture) -> Result<Self> {
+        if !matches!(fixture, Fixture::Farcaster) {
+            return Ok(Self { path: None });
+        }
+        let path = root.join(FARCASTER_PATH);
+        if path.exists() {
+            eyre::bail!("refusing to overwrite existing {}", path.display())
+        }
+        if let Err(write_err) = fs::write(&path, FARCASTER_TEST) {
+            if let Err(cleanup_err) = fs::remove_file(&path)
+                && cleanup_err.kind() != std::io::ErrorKind::NotFound
+            {
+                eyre::bail!(
+                    "failed to install Farcaster symbolic fixture: {write_err}; failed to remove partially written {}: {cleanup_err}",
+                    path.display()
+                )
+            }
+            return Err(write_err).wrap_err("failed to install Farcaster symbolic fixture");
+        }
+        Ok(Self { path: Some(path) })
+    }
+
+    pub fn finish(mut self) -> Result<()> {
+        self.cleanup()
+    }
+
+    fn cleanup(&mut self) -> Result<()> {
+        if let Some(path) = &self.path {
+            fs::remove_file(path).wrap_err_with(|| {
+                format!("failed to remove symbolic fixture {}", path.display())
+            })?;
+            self.path = None;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Overlay {
+    fn drop(&mut self) {
+        let _ = self.cleanup();
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct Metrics {
+    pub paths: u64,
+    pub solver_queries: u64,
+    pub smt_queries: u64,
+    pub sat_queries: u64,
+    pub model_queries: u64,
+    pub sat_cache_hits: u64,
+    pub model_cache_hits: u64,
+    pub heuristic_witnesses: u64,
+    pub solver_time_ms: u64,
+    pub smt_input_bytes: Option<u64>,
+    pub smt_max_query_bytes: Option<u64>,
+    pub smt_build_time_ms: Option<u64>,
+    pub smt_max_query_time_ms: Option<u64>,
+    #[serde(skip)]
+    smt_input_bytes_compat: u64,
+    #[serde(skip)]
+    smt_max_query_bytes_compat: u64,
+    #[serde(skip)]
+    smt_build_time_ms_compat: u64,
+    #[serde(skip)]
+    smt_max_query_time_ms_compat: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutcomeStatus {
+    Passed,
+    Failed,
+    Incomplete,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct TestOutcome {
+    pub suite: String,
+    pub signature: String,
+    pub status: OutcomeStatus,
+}
+
+impl TestOutcome {
+    fn identity(&self) -> String {
+        format!("{}::{}", self.suite, self.signature)
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ParsedRun {
+    pub outcomes: Vec<TestOutcome>,
+    pub passed: usize,
+    pub failed: usize,
+    pub incomplete: usize,
+    pub metrics: Metrics,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Sample {
+    pub wall_time_seconds: f64,
+    pub exit_code: i32,
+    #[serde(flatten)]
+    pub run: ParsedRun,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct Sidecar {
+    pub schema: &'static str,
+    pub schema_version: u32,
+    pub fixture: FixtureMetadata,
+    pub samples: Vec<Sample>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct FixtureMetadata {
+    pub name: Fixture,
+    pub repository: String,
+    pub revision: String,
+    pub build_command: String,
+    pub test_command: String,
+}
+
+impl Sidecar {
+    pub fn new(
+        fixture: Fixture,
+        repository: &str,
+        revision: &str,
+        build_command: &str,
+        test_command: &str,
+        samples: Vec<Sample>,
+    ) -> Self {
+        Self {
+            schema: "foundry:symbolic-benchmark@v1",
+            schema_version: 1,
+            fixture: FixtureMetadata {
+                name: fixture,
+                repository: repository.to_string(),
+                revision: revision.to_string(),
+                build_command: build_command.to_string(),
+                test_command: test_command.to_string(),
+            },
+            samples,
+        }
+    }
+}
+
+pub fn parse(stdout: &[u8]) -> Result<ParsedRun> {
+    let json: Value =
+        serde_json::from_slice(stdout).wrap_err("invalid forge test --json output")?;
+    let suites = json.as_object().ok_or_else(|| eyre::eyre!("expected JSON object"))?;
+    let stable = suites
+        .values()
+        .filter_map(|s| s.get("test_results").and_then(Value::as_object))
+        .flat_map(|r| r.values())
+        .any(|r| r.get("symbolic").is_some());
+    let mut run = ParsedRun {
+        outcomes: Vec::new(),
+        passed: 0,
+        failed: 0,
+        incomplete: 0,
+        metrics: Metrics::default(),
+    };
+    for (suite_name, suite) in suites {
+        let Some(results) = suite.get("test_results").and_then(Value::as_object) else { continue };
+        for (identity, result) in results {
+            let (stats, status) = if stable {
+                let Some(symbolic) = result.get("symbolic") else { continue };
+                if symbolic.get("schema_version").and_then(Value::as_u64) != Some(1) {
+                    eyre::bail!("unknown or missing symbolic schema_version")
+                }
+                let status = symbolic
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| eyre::eyre!("missing symbolic.status"))?;
+                let status = match status {
+                    "pass" => OutcomeStatus::Passed,
+                    "fail_counterexample" => OutcomeStatus::Failed,
+                    "incomplete" => OutcomeStatus::Incomplete,
+                    _ => eyre::bail!("unknown symbolic.status {status}"),
+                };
+                let stats = symbolic
+                    .pointer("/solver/stats")
+                    .filter(|stats| stats.is_object())
+                    .ok_or_else(|| eyre::eyre!("missing or invalid symbolic.solver.stats"))?;
+                (stats, status)
+            } else {
+                let Some(stats) = result.pointer("/kind/Symbolic") else { continue };
+                let status = result.get("status").and_then(Value::as_str).unwrap_or_default();
+                let reason = result.get("reason").and_then(Value::as_str).unwrap_or_default();
+                let status = if status == "Success" {
+                    OutcomeStatus::Passed
+                } else if reason.contains("incomplete symbolic execution") {
+                    OutcomeStatus::Incomplete
+                } else {
+                    OutcomeStatus::Failed
+                };
+                (stats, status)
+            };
+            run.outcomes.push(TestOutcome {
+                suite: suite_name.clone(),
+                signature: identity.clone(),
+                status,
+            });
+            add_metrics(&mut run.metrics, stats, stable, run.outcomes.len() == 1)?;
+        }
+    }
+    if run.outcomes.is_empty() {
+        eyre::bail!("forge symbolic benchmark produced no symbolic test results")
+    }
+    run.outcomes.sort_by(|a, b| a.identity().cmp(&b.identity()));
+    run.passed =
+        run.outcomes.iter().filter(|outcome| outcome.status == OutcomeStatus::Passed).count();
+    run.failed =
+        run.outcomes.iter().filter(|outcome| outcome.status == OutcomeStatus::Failed).count();
+    run.incomplete =
+        run.outcomes.iter().filter(|outcome| outcome.status == OutcomeStatus::Incomplete).count();
+    Ok(run)
+}
+
+fn add_metrics(out: &mut Metrics, stats: &Value, stable: bool, first: bool) -> Result<()> {
+    macro_rules! add {
+        ($field:ident) => {
+            out.$field += required(stats, stringify!($field), stable)?;
+        };
+    }
+    add!(paths);
+    add!(solver_queries);
+    add!(smt_queries);
+    add!(sat_queries);
+    add!(model_queries);
+    add!(sat_cache_hits);
+    add!(model_cache_hits);
+    add!(heuristic_witnesses);
+    add!(solver_time_ms);
+    optional_add(
+        &mut out.smt_input_bytes,
+        &mut out.smt_input_bytes_compat,
+        stats,
+        "smt_input_bytes",
+        first,
+    )?;
+    optional_add(
+        &mut out.smt_build_time_ms,
+        &mut out.smt_build_time_ms_compat,
+        stats,
+        "smt_build_time_ms",
+        first,
+    )?;
+    optional_max(
+        &mut out.smt_max_query_bytes,
+        &mut out.smt_max_query_bytes_compat,
+        stats,
+        "smt_max_query_bytes",
+        first,
+    )?;
+    optional_max(
+        &mut out.smt_max_query_time_ms,
+        &mut out.smt_max_query_time_ms_compat,
+        stats,
+        "smt_max_query_time_ms",
+        first,
+    )?;
+    Ok(())
+}
+
+fn required(v: &Value, key: &str, strict: bool) -> Result<u64> {
+    match v.get(key) {
+        Some(v) => v.as_u64().ok_or_else(|| eyre::eyre!("invalid metric {key}")),
+        None if strict => Err(eyre::eyre!("missing metric {key}")),
+        None => Ok(0),
+    }
+}
+
+fn optional_add(
+    out: &mut Option<u64>,
+    compatibility: &mut u64,
+    v: &Value,
+    key: &str,
+    first: bool,
+) -> Result<()> {
+    let value = v
+        .get(key)
+        .map(|n| n.as_u64().ok_or_else(|| eyre::eyre!("invalid metric {key}")))
+        .transpose()?;
+    *compatibility += value.unwrap_or_default();
+    *out = if first { value } else { (*out).zip(value).map(|(old, value)| old + value) };
+    Ok(())
+}
+
+fn optional_max(
+    out: &mut Option<u64>,
+    compatibility: &mut u64,
+    v: &Value,
+    key: &str,
+    first: bool,
+) -> Result<()> {
+    let value = v
+        .get(key)
+        .map(|n| n.as_u64().ok_or_else(|| eyre::eyre!("invalid metric {key}")))
+        .transpose()?;
+    *compatibility = (*compatibility).max(value.unwrap_or_default());
+    *out = if first { value } else { (*out).zip(value).map(|(old, value)| old.max(value)) };
+    Ok(())
+}
+
+pub fn compatibility(run: &ParsedRun) -> SymbolicBenchmarkSummary {
+    let m = &run.metrics;
+    SymbolicBenchmarkSummary {
+        tests: run.outcomes.len(),
+        passed: run.passed,
+        failed: run.failed,
+        incomplete: run.incomplete,
+        paths: m.paths,
+        solver_queries: m.solver_queries,
+        smt_queries: m.smt_queries,
+        sat_queries: m.sat_queries,
+        model_queries: m.model_queries,
+        sat_cache_hits: m.sat_cache_hits,
+        model_cache_hits: m.model_cache_hits,
+        heuristic_witnesses: m.heuristic_witnesses,
+        solver_time_ms: m.solver_time_ms,
+        smt_input_bytes: m.smt_input_bytes_compat,
+        smt_max_query_bytes: m.smt_max_query_bytes_compat,
+        smt_build_time_ms: m.smt_build_time_ms_compat,
+        smt_max_query_time_ms: m.smt_max_query_time_ms_compat,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stable(status: &str, schema: u64) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({"test/FarcasterNativeSymbolic.t.sol:FarcasterNativeSymbolicTest":{"test_results":{
+            "check_migrateOnlyMigrator(uint24,address,address,address,uint40)":{"symbolic":{"schema_version":schema,"status":status,"bounds":{},"solver":{"name":"z3","command":null,"portfolio":[],"stats":{"paths":1,"solver_queries":2,"smt_queries":3,"sat_queries":4,"model_queries":5,"sat_cache_hits":6,"model_cache_hits":7,"heuristic_witnesses":8,"solver_time_ms":9,"smt_input_bytes":10,"smt_max_query_bytes":11,"smt_build_time_ms":12,"smt_max_query_time_ms":13}}}},
+            "check_setMigratorOnlyOwner(uint24,address,address,address,address)":{"symbolic":{"schema_version":schema,"status":"incomplete","bounds":{},"solver":{"name":"z3","command":null,"portfolio":[],"stats":{"paths":10,"solver_queries":20,"smt_queries":30,"sat_queries":40,"model_queries":50,"sat_cache_hits":60,"model_cache_hits":70,"heuristic_witnesses":80,"solver_time_ms":90}}}}
+        }}})).unwrap()
+    }
+
+    #[test]
+    fn stable_parser_validates_statuses_and_missing_optional_metrics() {
+        let run = parse(&stable("pass", 1)).unwrap();
+        assert_eq!((run.passed, run.failed, run.incomplete), (1, 0, 1));
+        assert_eq!(run.metrics.paths, 11);
+        assert_eq!(run.metrics.solver_time_ms, 99);
+        assert_eq!(run.metrics.smt_max_query_bytes, None);
+        assert_eq!(run.metrics.smt_input_bytes, None);
+        assert_eq!(run.metrics.smt_build_time_ms, None);
+        assert_eq!(run.metrics.smt_max_query_time_ms, None);
+        assert_eq!(
+            run.outcomes[0].suite,
+            "test/FarcasterNativeSymbolic.t.sol:FarcasterNativeSymbolicTest"
+        );
+        let compatibility = compatibility(&run);
+        assert_eq!(compatibility.tests, 2);
+        assert_eq!(compatibility.smt_input_bytes, 10);
+    }
+
+    #[test]
+    fn rejects_unknown_stable_schema() {
+        assert!(parse(&stable("pass", 2)).is_err());
+    }
+
+    #[test]
+    fn aggregates_optional_metrics_only_when_every_test_reports_them() {
+        let first = serde_json::json!({
+            "paths": 1, "solver_queries": 1, "smt_queries": 1, "sat_queries": 1,
+            "model_queries": 1, "sat_cache_hits": 1, "model_cache_hits": 1,
+            "heuristic_witnesses": 1, "solver_time_ms": 1, "smt_input_bytes": 10,
+            "smt_max_query_bytes": 8, "smt_build_time_ms": 2, "smt_max_query_time_ms": 4
+        });
+        let second = serde_json::json!({
+            "paths": 1, "solver_queries": 1, "smt_queries": 1, "sat_queries": 1,
+            "model_queries": 1, "sat_cache_hits": 1, "model_cache_hits": 1,
+            "heuristic_witnesses": 1, "solver_time_ms": 1, "smt_input_bytes": 20,
+            "smt_max_query_bytes": 7, "smt_build_time_ms": 3, "smt_max_query_time_ms": 9
+        });
+        let mut metrics = Metrics::default();
+        add_metrics(&mut metrics, &first, true, true).unwrap();
+        add_metrics(&mut metrics, &second, true, false).unwrap();
+        assert_eq!(metrics.smt_input_bytes, Some(30));
+        assert_eq!(metrics.smt_build_time_ms, Some(5));
+        assert_eq!(metrics.smt_max_query_bytes, Some(8));
+        assert_eq!(metrics.smt_max_query_time_ms, Some(9));
+    }
+
+    #[test]
+    fn parses_whole_output_legacy_results() {
+        let stats = serde_json::json!({"paths": 1, "solver_queries": 2});
+        let stdout = serde_json::to_vec(&serde_json::json!({"test/FarcasterNativeSymbolic.t.sol:FarcasterNativeSymbolicTest":{"test_results":{
+            "check_migrateOnlyMigrator(uint24,address,address,address,uint40)":{
+                "kind":{"Symbolic":stats.clone()},"status":"Success"
+            },
+            "check_setMigratorOnlyOwner(uint24,address,address,address,address)":{
+                "kind":{"Symbolic":stats},"status":"Failure",
+                "reason":"incomplete symbolic execution (Timeout)"
+            }
+        }}}))
+        .unwrap();
+        let run = parse(&stdout).unwrap();
+        assert_eq!((run.passed, run.failed, run.incomplete), (1, 0, 1));
+        assert_eq!(run.metrics.paths, 2);
+    }
+
+    #[test]
+    fn unknown_repository_uses_generic_symbolic_command() {
+        let fixture = Fixture::identify("example", "contracts");
+        assert!(matches!(fixture, Fixture::Generic));
+        assert_eq!(fixture.test_command(), format!("{PREFIX} forge test --symbolic --json"));
+    }
+
+    #[test]
+    fn metrics_serialize_the_complete_v1_counter_set() {
+        let value = serde_json::to_value(Metrics::default()).unwrap();
+        let keys = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            keys,
+            std::collections::BTreeSet::from([
+                "heuristic_witnesses",
+                "model_cache_hits",
+                "model_queries",
+                "paths",
+                "sat_cache_hits",
+                "sat_queries",
+                "smt_build_time_ms",
+                "smt_input_bytes",
+                "smt_max_query_bytes",
+                "smt_max_query_time_ms",
+                "smt_queries",
+                "solver_queries",
+                "solver_time_ms",
+            ])
+        );
+    }
+
+    #[test]
+    fn sidecar_retains_samples_and_revision() {
+        let first = parse(&stable("pass", 1)).unwrap();
+        let second = parse(&stable("fail_counterexample", 1)).unwrap();
+        let samples = [first, second]
+            .into_iter()
+            .map(|run| Sample { wall_time_seconds: 1.0, exit_code: 0, run })
+            .collect();
+        let sidecar = Sidecar::new(
+            Fixture::Farcaster,
+            "farcasterxyz/contracts",
+            "test-revision",
+            "forge build",
+            "forge test --symbolic --json",
+            samples,
+        );
+        assert_eq!(sidecar.fixture.revision, "test-revision");
+        assert_eq!(sidecar.samples.len(), 2);
+    }
+
+    #[test]
+    fn overlay_is_explicitly_removed_and_existing_file_is_preserved() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir(dir.path().join("test")).unwrap();
+        let path = dir.path().join(FARCASTER_PATH);
+        let overlay = Overlay::install(dir.path(), Fixture::Farcaster).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), FARCASTER_TEST);
+        overlay.finish().unwrap();
+        assert!(!path.exists());
+        fs::write(&path, "unexpected").unwrap();
+        assert!(Overlay::install(dir.path(), Fixture::Farcaster).is_err());
+        assert_eq!(fs::read_to_string(path).unwrap(), "unexpected");
+    }
+}


### PR DESCRIPTION
Formalizes the existing `forge_symbolic_test` benchmark and adds an optional sidecar containing all five runs, including wall time, solver counters, and pass, fail, or incomplete outcomes. Existing benchmark commands and JSON output remain compatible.

Closes OSS-472