### PR TITLE
fix: handle invariant interrupts and assertions

### DIFF
--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -2,7 +2,7 @@ use super::{
     FailureKey, InvariantFailureMetrics, InvariantFailures, InvariantFuzzError,
     InvariantFuzzTestResult, InvariantMetrics,
 };
-use crate::executors::{EarlyExit, corpus::CampaignCorpusEntry};
+use crate::executors::{EarlyExit, EvmExecutionCancellation, corpus::CampaignCorpusEntry};
 use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
 use foundry_evm_coverage::HitMaps;
@@ -10,7 +10,7 @@ use foundry_evm_fuzz::BasicTxDetails;
 use std::{
     collections::{HashMap, HashSet},
     sync::{
-        Mutex,
+        Arc, Mutex,
         atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering},
     },
     time::{Duration, Instant},
@@ -74,12 +74,11 @@ pub struct InvariantWorkerPlan {
 /// Shared state used only to coordinate invariant worker execution.
 pub struct InvariantCampaignState {
     started_at: Instant,
-    timeout: Option<Duration>,
+    timed: bool,
     total_runs: AtomicU32,
     total_txs: AtomicU64,
     total_gas: AtomicU64,
-    terminal_stop: AtomicBool,
-    global_early_exit: EarlyExit,
+    cancellation: EvmExecutionCancellation,
     last_metrics_report: Mutex<Instant>,
     failure_metrics: Mutex<CampaignFailureMetrics>,
 }
@@ -93,14 +92,20 @@ struct CampaignFailureMetrics {
 impl InvariantCampaignState {
     pub fn new(early_exit: EarlyExit, timeout: Option<u32>) -> Self {
         let started_at = Instant::now();
+        let deadline = timeout
+            .map(|timeout| Duration::from_secs(timeout.into()))
+            .and_then(|timeout| started_at.checked_add(timeout));
         Self {
             started_at,
-            timeout: timeout.map(|timeout| Duration::from_secs(timeout.into())),
+            timed: timeout.is_some(),
             total_runs: AtomicU32::new(0),
             total_txs: AtomicU64::new(0),
             total_gas: AtomicU64::new(0),
-            terminal_stop: AtomicBool::new(false),
-            global_early_exit: early_exit,
+            cancellation: EvmExecutionCancellation::campaign(
+                early_exit,
+                Arc::new(AtomicBool::new(false)),
+                deadline,
+            ),
             last_metrics_report: Mutex::new(started_at),
             failure_metrics: Mutex::new(CampaignFailureMetrics::default()),
         }
@@ -129,21 +134,15 @@ impl InvariantCampaignState {
     }
 
     pub const fn is_timed_campaign(&self) -> bool {
-        self.timeout.is_some()
-    }
-
-    pub fn is_timed_out(&self) -> bool {
-        self.timeout.is_some_and(|duration| self.elapsed() > duration)
+        self.timed
     }
 
     pub fn should_stop(&self) -> bool {
-        self.global_early_exit.should_stop()
-            || self.terminal_stop.load(Ordering::Relaxed)
-            || self.is_timed_out()
+        self.cancellation.should_stop(true)
     }
 
     pub fn request_terminal_stop(&self) {
-        self.terminal_stop.store(true, Ordering::Relaxed);
+        self.cancellation.request_stop();
     }
 
     pub fn should_emit_metrics_report(&self, interval: Duration) -> bool {
@@ -191,7 +190,11 @@ impl InvariantCampaignState {
     }
 
     pub const fn early_exit(&self) -> &EarlyExit {
-        &self.global_early_exit
+        self.cancellation.early_exit_ref()
+    }
+
+    pub const fn cancellation(&self) -> &EvmExecutionCancellation {
+        &self.cancellation
     }
 }
 

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -173,11 +173,17 @@ impl InvariantCampaignState {
     pub(super) fn sync_handler_failures(&self, failures: &InvariantFailures) {
         let mut failure_metrics =
             self.failure_metrics.lock().expect("failure metrics lock poisoned");
-        for key in failures.failures.keys() {
+        for (key, error) in &failures.failures {
             let FailureKey::Handler(addr, selector) = key else { continue };
-            failure_metrics.handler_sites.insert((*addr, *selector));
+            if failure_metrics.handler_sites.insert((*addr, *selector)) {
+                let reason = error.revert_reason().unwrap_or_default();
+                failure_metrics.metrics.record_handler_failure(*addr, *selector, &reason);
+            }
         }
-        failure_metrics.metrics.broken_handlers = failure_metrics.handler_sites.len();
+        debug_assert_eq!(
+            failure_metrics.metrics.broken_handlers,
+            failure_metrics.handler_sites.len()
+        );
     }
 
     pub(super) fn failure_metrics(&self) -> InvariantFailureMetrics {
@@ -633,6 +639,30 @@ mod tests {
         assert_eq!(state.throughput_totals(), (2, 50));
         assert_eq!(state.increment_runs(), 1);
         assert_eq!(state.total_runs(), 1);
+    }
+
+    #[test]
+    fn campaign_state_deduplicates_handler_failure_events_across_workers() {
+        let state = InvariantCampaignState::new(EarlyExit::new(false), None);
+        let target = Address::repeat_byte(0x11);
+        let selector = Selector::from([0xde, 0xad, 0xbe, 0xef]);
+        let mut first_worker = InvariantFailures::new();
+        first_worker.seed_handler_failure(
+            target,
+            selector,
+            handler_error(target, selector, 2, "assertion failed"),
+        );
+        let mut second_worker = InvariantFailures::new();
+        second_worker.seed_handler_failure(
+            target,
+            selector,
+            handler_error(target, selector, 1, "assertion failed"),
+        );
+
+        state.sync_handler_failures(&first_worker);
+        state.sync_handler_failures(&second_worker);
+
+        assert_eq!(state.failure_metrics().broken_handlers, 1);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/error.rs
+++ b/crates/evm/evm/src/executors/invariant/error.rs
@@ -263,6 +263,8 @@ pub struct InvariantFailures {
     invariant_count: usize,
     /// Cached `FailureKey::Handler` count, read on progress/metrics ticks.
     handler_count: usize,
+    /// Increments whenever a failure or its reproducer is inserted or replaced.
+    revision: usize,
 }
 
 impl InvariantFailures {
@@ -292,6 +294,7 @@ impl InvariantFailures {
 
     pub fn record_failure(&mut self, invariant: &Function, failure: InvariantFuzzError) {
         let prev = self.failures.insert(FailureKey::Invariant(invariant.name.clone()), failure);
+        self.revision = self.revision.wrapping_add(1);
         if prev.is_none() {
             self.invariant_count += 1;
         }
@@ -325,6 +328,11 @@ impl InvariantFailures {
         self.handler_count
     }
 
+    /// Revision of the failure map, including replacements with shorter reproducers.
+    pub const fn revision(&self) -> usize {
+        self.revision
+    }
+
     pub fn handler_failures_mut(&mut self) -> impl Iterator<Item = &mut InvariantFuzzError> {
         self.failures.iter_mut().filter_map(|(key, error)| match key {
             FailureKey::Handler(_, _) => Some(error),
@@ -341,6 +349,7 @@ impl InvariantFailures {
                 FailureKey::Handler(site.0, site.1),
                 InvariantFuzzError::HandlerAssertion(failure),
             );
+            self.revision = self.revision.wrapping_add(1);
             if prev.is_none() {
                 self.handler_count += 1;
             }
@@ -356,6 +365,7 @@ impl InvariantFailures {
         err: InvariantFuzzError,
     ) {
         let prev = self.failures.insert(FailureKey::Handler(target, selector), err);
+        self.revision = self.revision.wrapping_add(1);
         if prev.is_none() {
             self.handler_count += 1;
         }
@@ -440,4 +450,49 @@ pub struct FailedInvariantCaseData {
     pub fail_on_revert: bool,
     /// Whether this failure originated from a handler assertion.
     pub assertion_failure: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use foundry_evm_fuzz::CallDetails;
+
+    fn handler_failure(sequence_len: usize) -> HandlerAssertionFailure {
+        let tx = BasicTxDetails {
+            warp: None,
+            roll: None,
+            sender: Address::ZERO,
+            call_details: CallDetails {
+                target: Address::ZERO,
+                calldata: Bytes::new(),
+                value: None,
+            },
+        };
+        HandlerAssertionFailure::from_replayed_sequence(
+            vec![tx; sequence_len],
+            Address::ZERO,
+            Selector::ZERO,
+            B256::ZERO,
+            "assertion failed".to_string(),
+        )
+    }
+
+    #[test]
+    fn failure_revision_tracks_shorter_handler_reproducer() {
+        let mut failures = InvariantFailures::new();
+        failures.record_handler_failure(handler_failure(2));
+        let checkpoint = failures.revision();
+
+        failures.record_handler_failure(handler_failure(2));
+        assert_eq!(failures.revision(), checkpoint);
+
+        failures.record_handler_failure(handler_failure(1));
+        assert_ne!(failures.revision(), checkpoint);
+        let failure = failures
+            .failures
+            .get(&FailureKey::Handler(Address::ZERO, Selector::ZERO))
+            .and_then(InvariantFuzzError::as_handler_assertion)
+            .unwrap();
+        assert_eq!(failure.call_sequence.len(), 1);
+    }
 }

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -49,7 +49,7 @@ pub(crate) use result::did_fail_on_assert;
 use result::{assert_after_invariant, can_continue, invariant_preflight_check};
 use revm::{context::Block, state::Account};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{Value, json};
 use std::{
     collections::{HashMap as Map, HashSet, btree_map::Entry},
     sync::Arc,
@@ -478,6 +478,32 @@ impl InvariantFailureMetrics {
         });
         let _ = sh_eprintln!("{}", serde_json::to_string(&event).unwrap_or_default());
     }
+
+    /// Records a handler assertion and emits a structured JSON `"failure"` event.
+    fn record_handler_failure(&mut self, target: Address, selector: Selector, reason: &str) {
+        self.broken_handlers += 1;
+
+        let timestamp =
+            SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0);
+        let event = build_handler_failure_event(timestamp, target, selector, reason);
+        let _ = sh_eprintln!("{}", serde_json::to_string(&event).unwrap_or_default());
+    }
+}
+
+fn build_handler_failure_event(
+    timestamp_secs: u64,
+    target: Address,
+    selector: Selector,
+    reason: &str,
+) -> Value {
+    json!({
+        "timestamp": timestamp_secs,
+        "event": "failure",
+        "failure_type": "handler_assertion",
+        "target": target,
+        "selector": selector,
+        "reason": reason,
+    })
 }
 
 /// Bridges newly-recorded invariant breaks from `failures.errors` into the pulse
@@ -1073,6 +1099,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // suite runner so parameterized `invariant_*` functions are rejected with a per-test
         // failure entry before any campaign runs.
         let config = invariant_worker_config(config, plan.worker_id, worker_count);
+        executor.inspector_mut().set_early_exit(campaign_state.early_exit().clone());
 
         let (mut invariant_test, mut corpus_manager) = Self::prepare_worker(
             &mut executor,
@@ -1154,6 +1181,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &mut current_run.executor,
                     current_run.inputs.last().expect("checked above"),
                 )?;
+                if campaign_state.early_exit().should_stop() {
+                    break 'stop;
+                }
                 if let Some(fuzzer) = current_run.executor.inspector_mut().fuzzer.as_mut() {
                     invariant_test.fuzz_state.collect_fuzzer_values(fuzzer);
                 }
@@ -1285,6 +1315,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         };
 
                     let errors_before_check = invariant_test.test_data.failures.invariant_count();
+                    let handlers_before_check = invariant_test.test_data.failures.handler_count();
                     let (continues, broken) = if should_check_invariant {
                         let outcome = can_continue(
                             &invariant_contract,
@@ -1355,6 +1386,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             (true, None)
                         }
                     };
+
+                    if invariant_test.test_data.failures.handler_count() > handlers_before_check {
+                        campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
+                    }
 
                     // Keep `cmp_seq` parallel to `inputs`: only push when the input survived the
                     // pop branch above.
@@ -2931,6 +2966,24 @@ mod tests {
         assert_eq!(payload["metrics"]["broken_invariants"], json!(2));
         assert_eq!(payload["metrics"]["broken_assertions"], json!(7));
         assert!(payload["metrics"].get("broken_handlers").is_none());
+    }
+
+    #[test]
+    fn handler_assertion_failure_event_includes_site_and_reason() {
+        let target = Address::repeat_byte(0x11);
+        let selector = Selector::from([0xde, 0xad, 0xbe, 0xef]);
+
+        assert_eq!(
+            build_handler_failure_event(123, target, selector, "assertion failed"),
+            json!({
+                "timestamp": 123,
+                "event": "failure",
+                "failure_type": "handler_assertion",
+                "target": target,
+                "selector": "0xdeadbeef",
+                "reason": "assertion failed",
+            })
+        );
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -609,13 +609,6 @@ struct InvariantTestData {
     optimization_best_sequence: Vec<BasicTxDetails>,
 }
 
-struct InvariantCallMetric {
-    target: Address,
-    selector: Selector,
-    reverted: bool,
-    discarded: bool,
-}
-
 /// Contains invariant test data.
 struct InvariantTest {
     // Fuzz state of invariant test.
@@ -673,28 +666,17 @@ impl InvariantTest {
     /// Update metrics for a fuzzed selector, extracted from tx details.
     /// Always increments number of calls; discarded runs (through assume cheatcodes) are tracked
     /// separated from reverts.
-    fn call_metric(
-        tx_details: &BasicTxDetails,
-        reverted: bool,
-        discarded: bool,
-    ) -> Option<InvariantCallMetric> {
-        let selector = tx_details
+    fn record_metrics(&mut self, tx_details: &BasicTxDetails, reverted: bool, discarded: bool) {
+        let Some(selector) = tx_details
             .call_details
             .calldata
             .get(..4)
             .and_then(|selector| <[u8; 4]>::try_from(selector).ok())
-            .map(Selector::from)?;
-        Some(InvariantCallMetric {
-            target: tx_details.call_details.target,
-            selector,
-            reverted,
-            discarded,
-        })
-    }
-
-    fn record_metric(&mut self, metric: InvariantCallMetric) {
-        let InvariantCallMetric { target, selector, reverted, discarded } = metric;
-        let cache_key = (target, selector);
+            .map(Selector::from)
+        else {
+            return;
+        };
+        let cache_key = (tx_details.call_details.target, selector);
 
         if let Some(metric_key) = self.test_data.metric_key_cache.get(&cache_key) {
             if let Some(invariant_metrics) = self.test_data.metrics.get_mut(metric_key) {
@@ -711,8 +693,10 @@ impl InvariantTest {
 
         // Not cached: resolve from the current target set. Unresolved keys aren't cached so a tx
         // whose target isn't known yet is re-resolved once that target is added.
-        let Some(metric_key) =
-            self.targeted_contracts.targets().fuzzed_metric_key_for_selector(target, selector)
+        let Some(metric_key) = self
+            .targeted_contracts
+            .targets()
+            .fuzzed_metric_key_for_selector(tx_details.call_details.target, selector)
         else {
             return;
         };
@@ -778,8 +762,6 @@ struct InvariantTestRun<FEN: FoundryEvmNetwork> {
     rejects: u32,
     // Whether new coverage was discovered during this run.
     new_coverage: bool,
-    // Selector metrics staged until the run is accepted.
-    metrics: Vec<InvariantCallMetric>,
     // Line coverage staged until the run is accepted.
     line_coverage: Option<HitMaps>,
     // Whether this run's inputs should become the reported last run.
@@ -815,7 +797,6 @@ impl<FEN: FoundryEvmNetwork> InvariantTestRun<FEN> {
             depth: 0,
             rejects: 0,
             new_coverage: false,
-            metrics: Vec::with_capacity(depth),
             line_coverage: None,
             save_last_run_inputs: false,
             optimization_value: None,
@@ -1150,7 +1131,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             // Per-run failure count snapshot used to gate `afterInvariant` below.
             let failures_before_run = invariant_test.test_data.failures.invariant_count();
             let failures_checkpoint = invariant_test.test_data.failures.clone();
+            let failures_revision = failures_checkpoint.revision();
             let mut stop_after_run = false;
+            let mut run_cancelled = false;
             let mut observed_call_entries = Vec::<(Vec<ObservedCall>, BasicTxDetails)>::new();
 
             let initial_seq = corpus_manager.new_inputs(
@@ -1179,12 +1162,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             while current_run.depth < run_depth {
                 // Check if the timeout has been reached.
                 if campaign_state.should_stop() {
-                    invariant_test.test_data.failures.clone_from(&failures_checkpoint);
                     // Since we never record a revert here the test is still considered
                     // successful even though it timed out. We *want*
                     // this behavior for now, so that's ok, but
                     // future developers should be aware of this.
-                    break 'stop;
+                    run_cancelled = true;
+                    break;
                 }
 
                 // Snapshot `(target, selector)` so `can_continue` can borrow `&mut current_run`
@@ -1210,8 +1193,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run.inputs.last().expect("checked above"),
                 )?;
                 if call_result.execution_cancelled {
-                    invariant_test.test_data.failures.clone_from(&failures_checkpoint);
-                    break 'stop;
+                    run_cancelled = true;
+                    break;
                 }
                 if let Some(fuzzer) = current_run.executor.inspector_mut().fuzzer.as_mut() {
                     invariant_test.fuzz_state.collect_fuzzer_values(fuzzer);
@@ -1221,14 +1204,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 // assumes / pops below) get zero-length entries that the corpus side filters out.
                 let call_cmp_values = call_result.evm_cmp_values.take().unwrap_or_default();
                 let discarded = call_result.result.as_ref() == MAGIC_ASSUME;
-                if config.show_metrics
-                    && let Some(metric) = InvariantTest::call_metric(
+                if config.show_metrics {
+                    invariant_test.record_metrics(
                         current_run.inputs.last().expect("checked above"),
                         call_result.reverted,
                         discarded,
-                    )
-                {
-                    current_run.metrics.push(metric);
+                    );
                 }
 
                 // Collect line coverage from last fuzzed call.
@@ -1267,8 +1248,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             InvariantFuzzError::MaxAssumeRejects(config.max_assume_rejects),
                         );
                         campaign_state.request_terminal_stop();
-                        stop_after_run = true;
-                        break;
+                        break 'stop;
                     }
                 } else {
                     // Commit executed call result.
@@ -1339,8 +1319,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                                 || is_last_call
                         };
 
-                    let mut predicate_cancelled = false;
-                    let mut completed_predicate_finding = false;
                     let (continues, _) = if should_check_invariant {
                         let outcome = can_continue(
                             &invariant_contract,
@@ -1355,8 +1333,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             pre_merge_edges_hash,
                         )
                         .map_err(|e| eyre!(e.to_string()))?;
-                        predicate_cancelled = outcome.cancelled;
-                        completed_predicate_finding = outcome.completed_finding;
+                        run_cancelled = outcome.cancelled;
                         (outcome.continues, None)
                     } else {
                         // Skip invariant check but still track reverts
@@ -1416,14 +1393,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
                     // A predicate or optimization call can be interrupted after the handler
                     // completed. Do not accept the partial run as a successful one.
-                    if predicate_cancelled {
-                        if completed_predicate_finding {
-                            current_run.save_last_run_inputs = true;
-                            stop_after_run = true;
-                            break;
-                        }
-                        invariant_test.test_data.failures.clone_from(&failures_checkpoint);
-                        break 'stop;
+                    if run_cancelled {
+                        break;
                     }
 
                     // Keep `cmp_seq` parallel to `inputs`: only push when the input survived the
@@ -1457,7 +1428,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             // Call `afterInvariant` only if declared and the current run produced no new
             // failure. Multi-predicate campaigns keep running after earlier failures, but the
             // hook must still execute on subsequent runs.
-            if invariant_contract.call_after_invariant
+            if !run_cancelled
+                && invariant_contract.call_after_invariant
                 && invariant_test.test_data.failures.invariant_count() == failures_before_run
             {
                 let (broken, hook_cancelled) = assert_after_invariant(
@@ -1467,15 +1439,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &config,
                 )
                 .map_err(|_| eyre!("Failed to call afterInvariant"))?;
-                if hook_cancelled
-                    && invariant_test.test_data.failures.invariant_count() == failures_before_run
-                    && invariant_test.test_data.failures.handler_count()
-                        == failures_checkpoint.handler_count()
-                {
-                    invariant_test.test_data.failures.clone_from(&failures_checkpoint);
-                    break 'stop;
-                } else if hook_cancelled {
-                    stop_after_run = true;
+                if hook_cancelled {
+                    run_cancelled = true;
                 } else if broken.is_some() {
                     current_run.save_last_run_inputs = true;
                 }
@@ -1485,16 +1450,23 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             // complete failing run. All other campaign stops discard the partial run before any
             // corpus persistence or accounting.
             if campaign_state.should_stop() && !stop_after_run {
-                let completed_finding = invariant_test.test_data.failures.invariant_count()
-                    > failures_before_run
-                    || invariant_test.test_data.failures.handler_count()
-                        > failures_checkpoint.handler_count();
+                run_cancelled = true;
+            }
+
+            if run_cancelled {
+                let completed_finding =
+                    invariant_test.test_data.failures.revision() != failures_revision;
                 if completed_finding {
-                    stop_after_run = true;
+                    record_new_invariant_failures(
+                        campaign_state,
+                        &invariant_contract,
+                        &invariant_test.test_data.failures,
+                    );
+                    campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
                 } else {
                     invariant_test.test_data.failures.clone_from(&failures_checkpoint);
-                    break 'stop;
                 }
+                break 'stop;
             }
 
             if invariant_test.test_data.failures.invariant_count() > failures_before_run {
@@ -1558,9 +1530,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     value,
                     &current_run.inputs[..current_run.optimization_prefix_len],
                 );
-            }
-            for metric in current_run.metrics.drain(..) {
-                invariant_test.record_metric(metric);
             }
             invariant_test.merge_line_coverage(current_run.line_coverage.take());
             for fuzz_run in &current_run.fuzz_runs {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1209,7 +1209,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &mut current_run.executor,
                     current_run.inputs.last().expect("checked above"),
                 )?;
-                if campaign_state.should_stop() {
+                if call_result.execution_cancelled {
                     invariant_test.test_data.failures.clone_from(&failures_checkpoint);
                     break 'stop;
                 }
@@ -1338,6 +1338,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                                 || is_last_call
                         };
 
+                    let mut predicate_cancelled = false;
+                    let mut completed_predicate_finding = false;
                     let (continues, _) = if should_check_invariant {
                         let outcome = can_continue(
                             &invariant_contract,
@@ -1352,7 +1354,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             pre_merge_edges_hash,
                         )
                         .map_err(|e| eyre!(e.to_string()))?;
-                        (outcome.continues, outcome.broken)
+                        predicate_cancelled = outcome.cancelled;
+                        completed_predicate_finding = outcome.completed_finding;
+                        (outcome.continues, None)
                     } else {
                         // Skip invariant check but still track reverts
                         if call_result.reverted {
@@ -1411,7 +1415,12 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
 
                     // A predicate or optimization call can be interrupted after the handler
                     // completed. Do not accept the partial run as a successful one.
-                    if campaign_state.should_stop() {
+                    if predicate_cancelled {
+                        if completed_predicate_finding {
+                            current_run.save_last_run_inputs = true;
+                            stop_after_run = true;
+                            break;
+                        }
                         invariant_test.test_data.failures.clone_from(&failures_checkpoint);
                         break 'stop;
                     }
@@ -1450,14 +1459,23 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             if invariant_contract.call_after_invariant
                 && invariant_test.test_data.failures.invariant_count() == failures_before_run
             {
-                let broken = assert_after_invariant(
+                let (broken, hook_cancelled) = assert_after_invariant(
                     &invariant_contract,
                     &mut invariant_test,
                     &current_run,
                     &config,
                 )
                 .map_err(|_| eyre!("Failed to call afterInvariant"))?;
-                if broken.is_some() {
+                if hook_cancelled
+                    && invariant_test.test_data.failures.invariant_count() == failures_before_run
+                    && invariant_test.test_data.failures.handler_count()
+                        == failures_checkpoint.handler_count()
+                {
+                    invariant_test.test_data.failures.clone_from(&failures_checkpoint);
+                    break 'stop;
+                } else if hook_cancelled {
+                    stop_after_run = true;
+                } else if broken.is_some() {
                     current_run.save_last_run_inputs = true;
                 }
             }
@@ -1466,8 +1484,16 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             // complete failing run. All other campaign stops discard the partial run before any
             // corpus persistence or accounting.
             if campaign_state.should_stop() && !stop_after_run {
-                invariant_test.test_data.failures.clone_from(&failures_checkpoint);
-                break 'stop;
+                let completed_finding = invariant_test.test_data.failures.invariant_count()
+                    > failures_before_run
+                    || invariant_test.test_data.failures.handler_count()
+                        > failures_checkpoint.handler_count();
+                if completed_finding {
+                    stop_after_run = true;
+                } else {
+                    invariant_test.test_data.failures.clone_from(&failures_checkpoint);
+                    break 'stop;
+                }
             }
 
             if invariant_test.test_data.failures.invariant_count() > failures_before_run {

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -2314,8 +2314,19 @@ pub fn execute_tx_and_register_created<FEN: FoundryEvmNetwork>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::executors::ExecutorBuilder;
+    use foundry_config::FuzzDictionaryConfig;
+    use foundry_evm_core::{
+        backend::Backend,
+        evm::{EthEvmNetwork, EvmEnvFor, TxEnvFor},
+    };
     use proptest::{prelude::any, strategy::ValueTree, test_runner::Config};
+    use revm::{
+        bytecode::Bytecode,
+        database::{CacheDB, EmptyDB},
+    };
     use serde_json::json;
+    use std::{sync::mpsc, thread};
 
     fn first_generated_u64(runner: &mut TestRunner) -> u64 {
         any::<u64>().new_tree(runner).unwrap().current()
@@ -2652,6 +2663,114 @@ mod tests {
             abi.functions.entry(function.name.clone()).or_default().push(function);
         }
         TargetedContract::new(identifier.to_string(), abi)
+    }
+
+    #[test]
+    fn campaign_early_exit_interrupts_active_handler_execution() {
+        const GAS_LIMIT: u64 = 1 << 24;
+        let invariant_address = Address::repeat_byte(0x11);
+        let handler_address = Address::repeat_byte(0x22);
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(GAS_LIMIT).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+        );
+        // Return ABI-encoded `true` for the invariant predicate.
+        executor
+            .set_code(
+                invariant_address,
+                Bytecode::new_raw(Bytes::from_static(&[
+                    0x60, 0x01, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3,
+                ])),
+            )
+            .unwrap();
+        // JUMPDEST; PUSH1 0; JUMP loops until the campaign interrupt reaches the inspector.
+        executor
+            .set_code(
+                handler_address,
+                Bytecode::new_raw(Bytes::from_static(&[0x5b, 0x60, 0x00, 0x56])),
+            )
+            .unwrap();
+
+        let (handler_entered_tx, handler_entered_rx) = mpsc::channel();
+        let (handler_release_tx, handler_release_rx) = mpsc::channel();
+        executor.inspector_mut().set_early_exit_test_gate(handler_entered_tx, handler_release_rx);
+
+        let invariant = function("invariant_ok() view returns (bool)");
+        let mut invariant_abi = alloy_json_abi::JsonAbi::new();
+        invariant_abi.functions.entry(invariant.name.clone()).or_default().push(invariant.clone());
+        let invariant_contract = InvariantContract::new(
+            invariant_address,
+            "InvariantTest",
+            vec![(&invariant, false)],
+            0,
+            false,
+            &invariant_abi,
+        );
+
+        let handler = function("loopForever()");
+        let mut handler_contract = targeted_contract("Handler", vec![handler.clone()]);
+        handler_contract.targeted_functions = vec![handler];
+        let mut targeted_contracts = TargetedContracts::new();
+        targeted_contracts.insert(handler_address, handler_contract);
+        let campaign_seed = InvariantCampaignSeed {
+            artifact_filters: ArtifactFilters::default(),
+            sender_filters: SenderFilters::new(vec![CALLER], Vec::new()),
+            targeted_contracts,
+            targets_are_updatable: false,
+            initial_handler_failures: Map::default(),
+        };
+
+        let config =
+            InvariantConfig { runs: 1, depth: 1, show_metrics: false, ..Default::default() };
+        let early_exit = EarlyExit::new(false);
+        let campaign_state = InvariantCampaignState::new(early_exit.clone(), None);
+        let fuzz_state = EvmFuzzState::new(
+            &[],
+            &CacheDB::<EmptyDB>::default(),
+            FuzzDictionaryConfig::default(),
+            None,
+        );
+        let setup_contracts = ContractsByAddress::default();
+        let project_contracts = ContractsByArtifact::default();
+        let (result_tx, result_rx) = mpsc::channel();
+
+        let (handler_entered, result) = thread::scope(|scope| {
+            let handle = scope.spawn(|| {
+                let result = InvariantExecutor::<EthEvmNetwork>::run_invariant_worker(
+                    executor,
+                    test_runner(),
+                    config,
+                    &setup_contracts,
+                    &project_contracts,
+                    InvariantWorkerPlan { worker_id: 0, first_global_run: 0, runs: 1 },
+                    invariant_contract,
+                    &FuzzFixtures::default(),
+                    fuzz_state,
+                    None,
+                    &campaign_state,
+                    campaign_seed,
+                    WorkerCorpusSeed::default(),
+                    InvariantCorpusPersistence::Live,
+                    1,
+                    1,
+                );
+                let _ = result_tx.send(result);
+            });
+
+            let handler_entered = handler_entered_rx.recv_timeout(Duration::from_secs(1)).is_ok();
+            early_exit.record_ctrl_c();
+            let _ = handler_release_tx.send(());
+
+            let result = result_rx.recv_timeout(Duration::from_secs(1));
+            handle.join().unwrap();
+            (handler_entered, result)
+        });
+        assert!(handler_entered, "invariant handler did not begin EVM execution");
+        let output = result.expect("invariant campaign did not observe early exit").unwrap();
+        assert_eq!(output.result.runs, 0);
+        assert_eq!(output.result.calls, 0);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -29,7 +29,7 @@ use foundry_evm_core::{
     precompiles::PRECOMPILES,
 };
 use foundry_evm_fuzz::{
-    BasicTxDetails, FuzzCase, FuzzFixtures,
+    BasicTxDetails, FuzzCase, FuzzFixtures, ObservedCall,
     invariant::{
         ArtifactFilters, FuzzRunIdentifiedContracts, InvariantContract, InvariantSettings,
         RandomCallGenerator, SenderFilters, TargetedContract, TargetedContracts,
@@ -609,6 +609,13 @@ struct InvariantTestData {
     optimization_best_sequence: Vec<BasicTxDetails>,
 }
 
+struct InvariantCallMetric {
+    target: Address,
+    selector: Selector,
+    reverted: bool,
+    discarded: bool,
+}
+
 /// Contains invariant test data.
 struct InvariantTest {
     // Fuzz state of invariant test.
@@ -666,17 +673,28 @@ impl InvariantTest {
     /// Update metrics for a fuzzed selector, extracted from tx details.
     /// Always increments number of calls; discarded runs (through assume cheatcodes) are tracked
     /// separated from reverts.
-    fn record_metrics(&mut self, tx_details: &BasicTxDetails, reverted: bool, discarded: bool) {
-        let Some(selector) = tx_details
+    fn call_metric(
+        tx_details: &BasicTxDetails,
+        reverted: bool,
+        discarded: bool,
+    ) -> Option<InvariantCallMetric> {
+        let selector = tx_details
             .call_details
             .calldata
             .get(..4)
             .and_then(|selector| <[u8; 4]>::try_from(selector).ok())
-            .map(Selector::from)
-        else {
-            return;
-        };
-        let cache_key = (tx_details.call_details.target, selector);
+            .map(Selector::from)?;
+        Some(InvariantCallMetric {
+            target: tx_details.call_details.target,
+            selector,
+            reverted,
+            discarded,
+        })
+    }
+
+    fn record_metric(&mut self, metric: InvariantCallMetric) {
+        let InvariantCallMetric { target, selector, reverted, discarded } = metric;
+        let cache_key = (target, selector);
 
         if let Some(metric_key) = self.test_data.metric_key_cache.get(&cache_key) {
             if let Some(invariant_metrics) = self.test_data.metrics.get_mut(metric_key) {
@@ -693,10 +711,8 @@ impl InvariantTest {
 
         // Not cached: resolve from the current target set. Unresolved keys aren't cached so a tx
         // whose target isn't known yet is re-resolved once that target is added.
-        let Some(metric_key) = self
-            .targeted_contracts
-            .targets()
-            .fuzzed_metric_key_for_selector(tx_details.call_details.target, selector)
+        let Some(metric_key) =
+            self.targeted_contracts.targets().fuzzed_metric_key_for_selector(target, selector)
         else {
             return;
         };
@@ -762,6 +778,12 @@ struct InvariantTestRun<FEN: FoundryEvmNetwork> {
     rejects: u32,
     // Whether new coverage was discovered during this run.
     new_coverage: bool,
+    // Selector metrics staged until the run is accepted.
+    metrics: Vec<InvariantCallMetric>,
+    // Line coverage staged until the run is accepted.
+    line_coverage: Option<HitMaps>,
+    // Whether this run's inputs should become the reported last run.
+    save_last_run_inputs: bool,
     // For optimization mode: the best value found during this run (if any).
     optimization_value: Option<I256>,
     // For optimization mode: the length of the input prefix that produced the best value.
@@ -793,6 +815,9 @@ impl<FEN: FoundryEvmNetwork> InvariantTestRun<FEN> {
             depth: 0,
             rejects: 0,
             new_coverage: false,
+            metrics: Vec::with_capacity(depth),
+            line_coverage: None,
+            save_last_run_inputs: false,
             optimization_value: None,
             optimization_prefix_len: 0,
         }
@@ -1099,7 +1124,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         // suite runner so parameterized `invariant_*` functions are rejected with a per-test
         // failure entry before any campaign runs.
         let config = invariant_worker_config(config, plan.worker_id, worker_count);
-        executor.inspector_mut().set_early_exit(campaign_state.early_exit().clone());
+        executor.inspector_mut().set_execution_cancellation(campaign_state.cancellation().clone());
 
         let (mut invariant_test, mut corpus_manager) = Self::prepare_worker(
             &mut executor,
@@ -1124,7 +1149,9 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         'stop: while should_continue_invariant_worker(campaign_state, runs, plan) {
             // Per-run failure count snapshot used to gate `afterInvariant` below.
             let failures_before_run = invariant_test.test_data.failures.invariant_count();
+            let failures_checkpoint = invariant_test.test_data.failures.clone();
             let mut stop_after_run = false;
+            let mut observed_call_entries = Vec::<(Vec<ObservedCall>, BasicTxDetails)>::new();
 
             let initial_seq = corpus_manager.new_inputs(
                 &mut invariant_test.test_data.branch_runner,
@@ -1152,6 +1179,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             while current_run.depth < run_depth {
                 // Check if the timeout has been reached.
                 if campaign_state.should_stop() {
+                    invariant_test.test_data.failures.clone_from(&failures_checkpoint);
                     // Since we never record a revert here the test is still considered
                     // successful even though it timed out. We *want*
                     // this behavior for now, so that's ok, but
@@ -1181,7 +1209,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     &mut current_run.executor,
                     current_run.inputs.last().expect("checked above"),
                 )?;
-                if campaign_state.early_exit().should_stop() {
+                if campaign_state.should_stop() {
+                    invariant_test.test_data.failures.clone_from(&failures_checkpoint);
                     break 'stop;
                 }
                 if let Some(fuzzer) = current_run.executor.inspector_mut().fuzzer.as_mut() {
@@ -1192,16 +1221,21 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 // assumes / pops below) get zero-length entries that the corpus side filters out.
                 let call_cmp_values = call_result.evm_cmp_values.take().unwrap_or_default();
                 let discarded = call_result.result.as_ref() == MAGIC_ASSUME;
-                if config.show_metrics {
-                    invariant_test.record_metrics(
+                if config.show_metrics
+                    && let Some(metric) = InvariantTest::call_metric(
                         current_run.inputs.last().expect("checked above"),
                         call_result.reverted,
                         discarded,
-                    );
+                    )
+                {
+                    current_run.metrics.push(metric);
                 }
 
                 // Collect line coverage from last fuzzed call.
-                invariant_test.merge_line_coverage(call_result.line_coverage.take());
+                HitMaps::merge_opt(
+                    &mut current_run.line_coverage,
+                    call_result.line_coverage.take(),
+                );
                 // Snapshot the edge fingerprint before `merge_edge_coverage` zeroes the
                 // buffer. Gate on `assertion_failure` to skip keccak on plain reverts.
                 let assertion_failure =
@@ -1217,19 +1251,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run.new_coverage = true;
                 }
                 let observed_calls = std::mem::take(&mut call_result.observed_calls);
-                if new_call_coverage
-                    && let Some(entry) = corpus_manager.hoist_observed_calls(
-                        &observed_calls,
-                        current_run.inputs.last().expect("checked above"),
-                        &invariant_test.targeted_contracts,
-                        if corpus_persistence.is_deferred() {
-                            CorpusInsertionMode::Deferred
-                        } else {
-                            CorpusInsertionMode::Live
-                        },
-                    )
-                {
-                    corpus_entries.push(entry);
+                if new_call_coverage && !observed_calls.is_empty() {
+                    observed_call_entries.push((
+                        observed_calls,
+                        current_run.inputs.last().expect("checked above").clone(),
+                    ));
                 }
 
                 if discarded {
@@ -1293,8 +1319,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     current_run
                         .fuzz_runs
                         .push(FuzzCase { gas: call_result.gas_used, stipend: call_result.stipend });
-                    campaign_state.record_call(call_result.gas_used);
-
                     // Determine if test can continue or should exit.
                     // Check invariants based on check_interval to improve deep run performance.
                     // - check_interval=0: only assert on the last call
@@ -1314,9 +1338,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                                 || is_last_call
                         };
 
-                    let errors_before_check = invariant_test.test_data.failures.invariant_count();
-                    let handlers_before_check = invariant_test.test_data.failures.handler_count();
-                    let (continues, broken) = if should_check_invariant {
+                    let (continues, _) = if should_check_invariant {
                         let outcome = can_continue(
                             &invariant_contract,
                             &mut invariant_test,
@@ -1387,8 +1409,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                     };
 
-                    if invariant_test.test_data.failures.handler_count() > handlers_before_check {
-                        campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
+                    // A predicate or optimization call can be interrupted after the handler
+                    // completed. Do not accept the partial run as a successful one.
+                    if campaign_state.should_stop() {
+                        invariant_test.test_data.failures.clone_from(&failures_checkpoint);
+                        break 'stop;
                     }
 
                     // Keep `cmp_seq` parallel to `inputs`: only push when the input survived the
@@ -1398,18 +1423,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                     }
 
                     if !continues || current_run.depth == run_depth - 1 {
-                        invariant_test.set_last_run_inputs(&current_run.inputs);
-                    }
-                    // Bridge newly-recorded predicate breaks into `failure_metrics` even when
-                    // `continues == true` in multi-predicate campaigns.
-                    if invariant_test.test_data.failures.invariant_count() > errors_before_check
-                        || broken.is_some()
-                    {
-                        record_new_invariant_failures(
-                            campaign_state,
-                            &invariant_contract,
-                            &invariant_test.test_data.failures,
-                        );
+                        current_run.save_last_run_inputs = true;
                     }
                     if !continues {
                         if invariant_contract.invariant_fns.len() > 1 && !config.fail_on_revert {
@@ -1430,9 +1444,62 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 )?);
             }
 
-            // Extend corpus with current run data.
-            // Materialize the optimization best prefix once at run end (avoids
-            // cloning inputs on every new in-run max).
+            // Call `afterInvariant` only if declared and the current run produced no new
+            // failure. Multi-predicate campaigns keep running after earlier failures, but the
+            // hook must still execute on subsequent runs.
+            if invariant_contract.call_after_invariant
+                && invariant_test.test_data.failures.invariant_count() == failures_before_run
+            {
+                let broken = assert_after_invariant(
+                    &invariant_contract,
+                    &mut invariant_test,
+                    &current_run,
+                    &config,
+                )
+                .map_err(|_| eyre!("Failed to call afterInvariant"))?;
+                if broken.is_some() {
+                    current_run.save_last_run_inputs = true;
+                }
+            }
+
+            // The worker which requested a terminal stop for its own failure still owns a
+            // complete failing run. All other campaign stops discard the partial run before any
+            // corpus persistence or accounting.
+            if campaign_state.should_stop() && !stop_after_run {
+                invariant_test.test_data.failures.clone_from(&failures_checkpoint);
+                break 'stop;
+            }
+
+            if invariant_test.test_data.failures.invariant_count() > failures_before_run {
+                record_new_invariant_failures(
+                    campaign_state,
+                    &invariant_contract,
+                    &invariant_test.test_data.failures,
+                );
+            }
+            if invariant_test.test_data.failures.handler_count()
+                > failures_checkpoint.handler_count()
+            {
+                campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
+            }
+
+            let insertion_mode = if corpus_persistence.is_deferred() {
+                CorpusInsertionMode::Deferred
+            } else {
+                CorpusInsertionMode::Live
+            };
+            for (observed_calls, parent_tx) in observed_call_entries {
+                if let Some(entry) = corpus_manager.hoist_observed_calls(
+                    &observed_calls,
+                    &parent_tx,
+                    &invariant_test.targeted_contracts,
+                    insertion_mode,
+                ) {
+                    corpus_entries.push(entry);
+                }
+            }
+
+            // Extend corpus only after the run and its optional hook have completed.
             let optimization = current_run.optimization_value.map(|v| {
                 let prefix = current_run.inputs[..current_run.optimization_prefix_len].to_vec();
                 (v, prefix)
@@ -1455,30 +1522,23 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 );
             }
 
-            // Call `afterInvariant` only if declared and the current run produced no new
-            // failure. Multi-predicate campaigns keep running after earlier failures, but the
-            // hook must still execute on subsequent runs.
-            if invariant_contract.call_after_invariant
-                && invariant_test.test_data.failures.invariant_count() == failures_before_run
-            {
-                let broken = assert_after_invariant(
-                    &invariant_contract,
-                    &mut invariant_test,
-                    &current_run,
-                    &config,
-                )
-                .map_err(|_| eyre!("Failed to call afterInvariant"))?;
-                if broken.is_some() {
-                    // Bridge breaks into pulse metrics, mirroring the in-run path above.
-                    record_new_invariant_failures(
-                        campaign_state,
-                        &invariant_contract,
-                        &invariant_test.test_data.failures,
-                    );
-                }
-            }
-
             // End current invariant test run.
+            if current_run.save_last_run_inputs {
+                invariant_test.set_last_run_inputs(&current_run.inputs);
+            }
+            if let Some(value) = current_run.optimization_value {
+                invariant_test.update_optimization_value(
+                    value,
+                    &current_run.inputs[..current_run.optimization_prefix_len],
+                );
+            }
+            for metric in current_run.metrics.drain(..) {
+                invariant_test.record_metric(metric);
+            }
+            invariant_test.merge_line_coverage(current_run.line_coverage.take());
+            for fuzz_run in &current_run.fuzz_runs {
+                campaign_state.record_call(fuzz_run.gas);
+            }
             current_run.drop_corpus_payloads();
             invariant_test.end_run(current_run, gas_report_samples);
             runs += 1;
@@ -1566,6 +1626,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         trace!(?fuzz_fixtures);
         invariant_test.fuzz_state.log_stats();
 
+        // Campaign-local terminal stops and deadlines must not suppress post-campaign shrinking.
+        executor.inspector_mut().set_early_exit(campaign_state.early_exit().clone());
         Self::shrink_handler_failures(
             &config,
             &executor,
@@ -2666,7 +2728,7 @@ mod tests {
     }
 
     #[test]
-    fn campaign_early_exit_interrupts_active_handler_execution() {
+    fn campaign_terminal_stop_interrupts_handler_without_accepting_run() {
         const GAS_LIMIT: u64 = 1 << 24;
         let invariant_address = Address::repeat_byte(0x11);
         let handler_address = Address::repeat_byte(0x22);
@@ -2685,7 +2747,7 @@ mod tests {
                 ])),
             )
             .unwrap();
-        // JUMPDEST; PUSH1 0; JUMP loops until the campaign interrupt reaches the inspector.
+        // JUMPDEST; PUSH1 0; JUMP loops until the campaign stop reaches the inspector.
         executor
             .set_code(
                 handler_address,
@@ -2695,7 +2757,11 @@ mod tests {
 
         let (handler_entered_tx, handler_entered_rx) = mpsc::channel();
         let (handler_release_tx, handler_release_rx) = mpsc::channel();
-        executor.inspector_mut().set_early_exit_test_gate(handler_entered_tx, handler_release_rx);
+        executor.inspector_mut().set_early_exit_test_gate(
+            handler_entered_tx,
+            handler_release_rx,
+            0,
+        );
 
         let invariant = function("invariant_ok() view returns (bool)");
         let mut invariant_abi = alloy_json_abi::JsonAbi::new();
@@ -2724,8 +2790,7 @@ mod tests {
 
         let config =
             InvariantConfig { runs: 1, depth: 1, show_metrics: false, ..Default::default() };
-        let early_exit = EarlyExit::new(false);
-        let campaign_state = InvariantCampaignState::new(early_exit.clone(), None);
+        let campaign_state = InvariantCampaignState::new(EarlyExit::new(false), None);
         let fuzz_state = EvmFuzzState::new(
             &[],
             &CacheDB::<EmptyDB>::default(),
@@ -2760,7 +2825,7 @@ mod tests {
             });
 
             let handler_entered = handler_entered_rx.recv_timeout(Duration::from_secs(1)).is_ok();
-            early_exit.record_ctrl_c();
+            campaign_state.request_terminal_stop();
             let _ = handler_release_tx.send(());
 
             let result = result_rx.recv_timeout(Duration::from_secs(1));
@@ -2771,6 +2836,15 @@ mod tests {
         let output = result.expect("invariant campaign did not observe early exit").unwrap();
         assert_eq!(output.result.runs, 0);
         assert_eq!(output.result.calls, 0);
+        assert_eq!(campaign_state.total_runs(), 0);
+        assert_eq!(campaign_state.throughput_totals(), (0, 0));
+        assert!(output.result.errors.is_empty());
+        assert!(output.result.handler_errors.is_empty());
+        assert!(output.result.last_run_inputs.is_empty());
+        assert!(output.result.line_coverage.is_none());
+        assert!(output.result.metrics.is_empty());
+        assert!(output.result.optimization_best_value.is_none());
+        assert!(output.corpus_entries.is_empty());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1267,7 +1267,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             InvariantFuzzError::MaxAssumeRejects(config.max_assume_rejects),
                         );
                         campaign_state.request_terminal_stop();
-                        break 'stop;
+                        stop_after_run = true;
+                        break;
                     }
                 } else {
                     // Commit executed call result.

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -186,7 +186,7 @@ pub(crate) fn assert_invariants<'a, FEN: FoundryEvmNetwork>(
     executor: &Executor<FEN>,
     calldata: &[BasicTxDetails],
     invariant_failures: &mut InvariantFailures,
-) -> Result<Option<&'a Function>> {
+) -> Result<(Option<&'a Function>, bool)> {
     let mut inner_sequence = None;
     let mut first_broken: Option<&'a Function> = None;
     let ctx = InvariantRunCtx {
@@ -207,8 +207,8 @@ pub(crate) fn assert_invariants<'a, FEN: FoundryEvmNetwork>(
             invariant_contract.address,
             invariant.abi_encode_input(&[])?.into(),
         )?;
-        if executor.inspector().cancellation_requested() {
-            break;
+        if call_result.execution_cancelled {
+            return Ok((first_broken, true));
         }
         if !success {
             let inner_sequence =
@@ -222,7 +222,7 @@ pub(crate) fn assert_invariants<'a, FEN: FoundryEvmNetwork>(
         }
     }
 
-    Ok(first_broken)
+    Ok((first_broken, false))
 }
 
 /// Helper function to initialize invariant inner sequence.
@@ -240,12 +240,14 @@ fn invariant_inner_sequence<FEN: FoundryEvmNetwork>(
 
 /// Outcome of a per-call invariant check.
 #[derive(Debug)]
-pub(crate) struct ContinueOutcome<'a> {
+pub(crate) struct ContinueOutcome {
     /// Whether the invariant campaign should keep running after this call.
     pub continues: bool,
-    /// First newly-broken invariant produced by this call, in declaration order. Used by the
-    /// executor to record the failure event without re-scanning the failures map.
-    pub broken: Option<&'a Function>,
+    /// Whether an invariant or optimization call was halted by cancellation.
+    pub cancelled: bool,
+    /// Whether a predicate completed and produced a finding before a later predicate was
+    /// cancelled.
+    pub completed_finding: bool,
 }
 
 /// Returns if invariant test can continue and last successful call result of the invariant test
@@ -268,9 +270,8 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
     handler_selector: Selector,
     assertion_failure: bool,
     pre_merge_edges_hash: Option<B256>,
-) -> Result<ContinueOutcome<'a>> {
+) -> Result<ContinueOutcome> {
     let is_optimization = invariant_contract.is_optimization();
-    let mut broken: Option<&'a Function> = None;
 
     // Use the handler-gate variant so a stale committed `GLOBAL_FAIL_SLOT` from a
     // previously-recorded handler bug doesn't poison this gate (which would otherwise silently
@@ -298,8 +299,12 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 invariant_contract.address,
                 invariant_contract.anchor().abi_encode_input(&[])?.into(),
             )?;
-            if invariant_run.executor.inspector().cancellation_requested() {
-                return Ok(ContinueOutcome { continues: true, broken: None });
+            if inv_result.execution_cancelled {
+                return Ok(ContinueOutcome {
+                    continues: true,
+                    cancelled: true,
+                    completed_finding: false,
+                });
             }
             if success
                 && inv_result.result.len() >= 32
@@ -314,7 +319,7 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
             }
         } else {
             // Check mode: assert invariants and fail if broken.
-            broken = assert_invariants(
+            let (broken, cancelled) = assert_invariants(
                 invariant_contract,
                 invariant_config,
                 &invariant_test.targeted_contracts,
@@ -322,6 +327,13 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 &invariant_run.inputs,
                 &mut invariant_test.test_data.failures,
             )?;
+            if cancelled {
+                return Ok(ContinueOutcome {
+                    continues: true,
+                    cancelled: true,
+                    completed_finding: broken.is_some(),
+                });
+            }
         }
     } else {
         let is_assert_failure = assertion_failure;
@@ -353,7 +365,7 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 .test_data
                 .failures
                 .can_continue(invariant_contract.invariant_fns.len());
-            return Ok(ContinueOutcome { continues, broken: None });
+            return Ok(ContinueOutcome { continues, cancelled: false, completed_finding: false });
         }
 
         // Non-assertion revert: per-invariant `fail_on_revert` still marks affected
@@ -367,7 +379,6 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
             .collect();
 
         if let Some((first_invariant, _)) = failing_invariants.first() {
-            broken = Some(*first_invariant);
             // Build a base case_data attributed to the first failing invariant; clone it for
             // each subsequent broken invariant, retagging name/selector/`fail_on_revert` so
             // every recorded failure points at its own invariant body.
@@ -416,7 +427,7 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
 
     let continues =
         invariant_test.test_data.failures.can_continue(invariant_contract.invariant_fns.len());
-    Ok(ContinueOutcome { continues, broken })
+    Ok(ContinueOutcome { continues, cancelled: false, completed_finding: false })
 }
 
 /// Given the executor state, asserts conditions within `afterInvariant` function.
@@ -428,15 +439,15 @@ pub(crate) fn assert_after_invariant<'a, FEN: FoundryEvmNetwork>(
     invariant_test: &mut InvariantTest,
     invariant_run: &InvariantTestRun<FEN>,
     invariant_config: &InvariantConfig,
-) -> Result<Option<&'a Function>> {
+) -> Result<(Option<&'a Function>, bool)> {
     let (call_result, success) =
         call_after_invariant_function(&invariant_run.executor, invariant_contract.address)?;
-    if invariant_run.executor.inspector().cancellation_requested() {
-        return Ok(None);
+    if call_result.execution_cancelled {
+        return Ok((None, true));
     }
     // Fail the test case if `afterInvariant` doesn't succeed.
     if success {
-        return Ok(None);
+        return Ok((None, false));
     }
     // `afterInvariant` failures are contract-wide (no specific invariant body executed),
     // so attribute to the campaign anchor.
@@ -452,7 +463,7 @@ pub(crate) fn assert_after_invariant<'a, FEN: FoundryEvmNetwork>(
         .test_data
         .failures
         .record_failure(anchor, InvariantFuzzError::BrokenInvariant(case_data));
-    Ok(Some(anchor))
+    Ok((Some(anchor), false))
 }
 
 #[cfg(test)]
@@ -552,7 +563,8 @@ mod tests {
         )
         .unwrap();
 
-        assert!(broken.is_none());
+        assert!(broken.0.is_none());
+        assert!(broken.1);
         assert_eq!(failures.invariant_count(), 0);
     }
 

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -207,7 +207,7 @@ pub(crate) fn assert_invariants<'a, FEN: FoundryEvmNetwork>(
             invariant_contract.address,
             invariant.abi_encode_input(&[])?.into(),
         )?;
-        if executor.inspector().early_exit_requested() {
+        if executor.inspector().cancellation_requested() {
             break;
         }
         if !success {
@@ -298,14 +298,13 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 invariant_contract.address,
                 invariant_contract.anchor().abi_encode_input(&[])?.into(),
             )?;
-            if invariant_run.executor.inspector().early_exit_requested() {
+            if invariant_run.executor.inspector().cancellation_requested() {
                 return Ok(ContinueOutcome { continues: true, broken: None });
             }
             if success
                 && inv_result.result.len() >= 32
                 && let Some(value) = I256::try_from_be_slice(&inv_result.result[..32])
             {
-                invariant_test.update_optimization_value(value, &invariant_run.inputs);
                 // Track the best value and its prefix length for this run
                 // (used for corpus persistence — materialized once at run end).
                 if invariant_run.optimization_value.is_none_or(|prev| value > prev) {
@@ -432,7 +431,7 @@ pub(crate) fn assert_after_invariant<'a, FEN: FoundryEvmNetwork>(
 ) -> Result<Option<&'a Function>> {
     let (call_result, success) =
         call_after_invariant_function(&invariant_run.executor, invariant_contract.address)?;
-    if invariant_run.executor.inspector().early_exit_requested() {
+    if invariant_run.executor.inspector().cancellation_requested() {
         return Ok(None);
     }
     // Fail the test case if `afterInvariant` doesn't succeed.

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -245,9 +245,6 @@ pub(crate) struct ContinueOutcome {
     pub continues: bool,
     /// Whether an invariant or optimization call was halted by cancellation.
     pub cancelled: bool,
-    /// Whether a predicate completed and produced a finding before a later predicate was
-    /// cancelled.
-    pub completed_finding: bool,
 }
 
 /// Returns if invariant test can continue and last successful call result of the invariant test
@@ -300,11 +297,7 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 invariant_contract.anchor().abi_encode_input(&[])?.into(),
             )?;
             if inv_result.execution_cancelled {
-                return Ok(ContinueOutcome {
-                    continues: true,
-                    cancelled: true,
-                    completed_finding: false,
-                });
+                return Ok(ContinueOutcome { continues: true, cancelled: true });
             }
             if success
                 && inv_result.result.len() >= 32
@@ -319,7 +312,7 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
             }
         } else {
             // Check mode: assert invariants and fail if broken.
-            let (broken, cancelled) = assert_invariants(
+            let (_, cancelled) = assert_invariants(
                 invariant_contract,
                 invariant_config,
                 &invariant_test.targeted_contracts,
@@ -328,11 +321,7 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 &mut invariant_test.test_data.failures,
             )?;
             if cancelled {
-                return Ok(ContinueOutcome {
-                    continues: true,
-                    cancelled: true,
-                    completed_finding: broken.is_some(),
-                });
+                return Ok(ContinueOutcome { continues: true, cancelled: true });
             }
         }
     } else {
@@ -365,7 +354,7 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 .test_data
                 .failures
                 .can_continue(invariant_contract.invariant_fns.len());
-            return Ok(ContinueOutcome { continues, cancelled: false, completed_finding: false });
+            return Ok(ContinueOutcome { continues, cancelled: false });
         }
 
         // Non-assertion revert: per-invariant `fail_on_revert` still marks affected
@@ -427,7 +416,7 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
 
     let continues =
         invariant_test.test_data.failures.can_continue(invariant_contract.invariant_fns.len());
-    Ok(ContinueOutcome { continues, cancelled: false, completed_finding: false })
+    Ok(ContinueOutcome { continues, cancelled: false })
 }
 
 /// Given the executor state, asserts conditions within `afterInvariant` function.

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -207,6 +207,9 @@ pub(crate) fn assert_invariants<'a, FEN: FoundryEvmNetwork>(
             invariant_contract.address,
             invariant.abi_encode_input(&[])?.into(),
         )?;
+        if executor.inspector().early_exit_requested() {
+            break;
+        }
         if !success {
             let inner_sequence =
                 inner_sequence.get_or_insert_with(|| invariant_inner_sequence(executor));
@@ -295,6 +298,9 @@ pub(crate) fn can_continue<'a, FEN: FoundryEvmNetwork>(
                 invariant_contract.address,
                 invariant_contract.anchor().abi_encode_input(&[])?.into(),
             )?;
+            if invariant_run.executor.inspector().early_exit_requested() {
+                return Ok(ContinueOutcome { continues: true, broken: None });
+            }
             if success
                 && inv_result.result.len() >= 32
                 && let Some(value) = I256::try_from_be_slice(&inv_result.result[..32])
@@ -426,6 +432,9 @@ pub(crate) fn assert_after_invariant<'a, FEN: FoundryEvmNetwork>(
 ) -> Result<Option<&'a Function>> {
     let (call_result, success) =
         call_after_invariant_function(&invariant_run.executor, invariant_contract.address)?;
+    if invariant_run.executor.inspector().early_exit_requested() {
+        return Ok(None);
+    }
     // Fail the test case if `afterInvariant` doesn't succeed.
     if success {
         return Ok(None);
@@ -450,14 +459,102 @@ pub(crate) fn assert_after_invariant<'a, FEN: FoundryEvmNetwork>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::Bytes;
-    use foundry_evm_core::evm::EthEvmNetwork;
+    use crate::executors::{EarlyExit, ExecutorBuilder};
+    use alloy_primitives::{Bytes, U256};
+    use alloy_sol_types::SolCall;
+    use foundry_cheatcodes::{CheatsConfig, Vm::expectRevert_0Call};
+    use foundry_config::Config;
+    use foundry_evm_core::{
+        backend::Backend,
+        constants::CALLER,
+        evm::{EthEvmNetwork, EvmEnvFor, TxEnvFor},
+        opts::EvmOpts,
+    };
+    use foundry_evm_fuzz::invariant::TargetedContracts;
+    use revm::bytecode::Bytecode;
+    use std::sync::Arc;
 
     fn panic_payload(code: u8) -> Bytes {
         let mut payload = vec![0_u8; 36];
         payload[..4].copy_from_slice(&[0x4e, 0x48, 0x7b, 0x71]);
         payload[35] = code;
         payload.into()
+    }
+
+    #[test]
+    fn cancellation_does_not_record_call_end_rewrite_as_invariant_failure() {
+        let cheats_config = Arc::new(CheatsConfig::new(
+            &Config::default(),
+            EvmOpts::default(),
+            None,
+            None,
+            None,
+            false,
+        ));
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default()
+            .inspectors(|stack| stack.cheatcodes(cheats_config))
+            .gas_limit(1 << 24)
+            .build(
+                EvmEnvFor::<EthEvmNetwork>::default(),
+                TxEnvFor::<EthEvmNetwork>::default(),
+                backend,
+            );
+        let invariant_address = Address::repeat_byte(0x11);
+        executor
+            .set_code(
+                invariant_address,
+                Bytecode::new_raw(Bytes::from_static(&[0x5b, 0x60, 0x00, 0x56])),
+            )
+            .unwrap();
+        let expect_result = executor
+            .transact_raw(
+                CALLER,
+                CHEATCODE_ADDRESS,
+                expectRevert_0Call {}.abi_encode().into(),
+                U256::ZERO,
+            )
+            .unwrap();
+        assert!(!expect_result.reverted);
+
+        let early_exit = EarlyExit::new(false);
+        executor.inspector_mut().set_early_exit(early_exit.clone());
+        early_exit.record_ctrl_c();
+
+        let invariant = Function::parse("invariant_ok() view returns (bool)").unwrap();
+        let mut abi = alloy_json_abi::JsonAbi::new();
+        abi.functions.entry(invariant.name.clone()).or_default().push(invariant.clone());
+        let invariant_contract = InvariantContract::new(
+            invariant_address,
+            "InvariantTest",
+            vec![(&invariant, false)],
+            0,
+            false,
+            &abi,
+        );
+
+        let (_, success) = call_invariant_function(
+            &executor.clone(),
+            invariant_address,
+            invariant.abi_encode_input(&[]).unwrap().into(),
+        )
+        .unwrap();
+        assert!(!success, "pending expectRevert should rewrite the interrupted call");
+
+        let targets = FuzzRunIdentifiedContracts::new(TargetedContracts::new(), false);
+        let mut failures = InvariantFailures::new();
+        let broken = assert_invariants(
+            &invariant_contract,
+            &InvariantConfig::default(),
+            &targets,
+            &executor,
+            &[],
+            &mut failures,
+        )
+        .unwrap();
+
+        assert!(broken.is_none());
+        assert_eq!(failures.invariant_count(), 0);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1527,6 +1527,7 @@ mod tests {
     use foundry_config::Config;
     use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
     use revm::context::{Cfg, TxEnv};
+    use std::{sync::mpsc, thread};
 
     fn dense_call(edge: EdgeKey) -> RawCallResult {
         RawCallResult {
@@ -1641,6 +1642,45 @@ mod tests {
             &revm::context_interface::cfg::GasParams::new_spec(SpecId::AMSTERDAM),
         );
         assert!(executor.evm_env().cfg_env.is_amsterdam_eip8037_enabled());
+    }
+
+    #[test]
+    fn early_exit_interrupts_active_evm_execution() {
+        const GAS_LIMIT: u64 = 1 << 24;
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(GAS_LIMIT).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+        );
+        let early_exit = EarlyExit::new(false);
+        executor.inspector_mut().set_early_exit(early_exit.clone());
+
+        let target = Address::repeat_byte(0x11);
+        // JUMPDEST; PUSH1 0; JUMP loops until the inspector observes the interrupt.
+        executor
+            .set_code(target, Bytecode::new_raw(Bytes::from_static(&[0x5b, 0x60, 0x00, 0x56])))
+            .unwrap();
+
+        let (started_tx, started_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let result = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO);
+            let _ = result_tx.send(result);
+        });
+
+        started_rx.recv().unwrap();
+        thread::sleep(Duration::from_millis(1));
+        early_exit.record_ctrl_c();
+
+        let result = result_rx.recv_timeout(Duration::from_secs(1));
+        handle.join().unwrap();
+        let result = result.expect("active EVM execution did not observe early exit").unwrap();
+        assert!(!result.reverted);
+        assert_eq!(result.exit_reason, Some(InstructionResult::Stop));
+        assert!(result.gas_used > 21_000, "interrupt fired before EVM execution started");
+        assert!(result.gas_used < GAS_LIMIT, "execution ran out of gas instead of exiting");
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1515,6 +1515,58 @@ impl EarlyExit {
     }
 }
 
+/// Shared cancellation state for an active EVM execution.
+#[derive(Clone, Debug)]
+pub(crate) enum EvmExecutionCancellation {
+    /// Cancellation driven only by the process-wide early-exit signal.
+    EarlyExit(EarlyExit),
+    /// Cancellation driven by the complete invariant campaign stop condition.
+    Campaign { early_exit: EarlyExit, stop: Arc<AtomicBool>, deadline: Option<Instant> },
+}
+
+impl EvmExecutionCancellation {
+    pub(crate) const fn early_exit(early_exit: EarlyExit) -> Self {
+        Self::EarlyExit(early_exit)
+    }
+
+    pub(crate) const fn campaign(
+        early_exit: EarlyExit,
+        stop: Arc<AtomicBool>,
+        deadline: Option<Instant>,
+    ) -> Self {
+        Self::Campaign { early_exit, stop, deadline }
+    }
+
+    /// Returns whether execution should stop, optionally polling a campaign deadline.
+    pub(crate) fn should_stop(&self, poll_deadline: bool) -> bool {
+        match self {
+            Self::EarlyExit(early_exit) => early_exit.should_stop(),
+            Self::Campaign { early_exit, stop, deadline } => {
+                if early_exit.should_stop() || stop.load(Ordering::Relaxed) {
+                    return true;
+                }
+                if poll_deadline && deadline.is_some_and(|deadline| Instant::now() > deadline) {
+                    stop.store(true, Ordering::Relaxed);
+                    return true;
+                }
+                false
+            }
+        }
+    }
+
+    pub(crate) fn request_stop(&self) {
+        if let Self::Campaign { stop, .. } = self {
+            stop.store(true, Ordering::Relaxed);
+        }
+    }
+
+    pub(crate) const fn early_exit_ref(&self) -> &EarlyExit {
+        match self {
+            Self::EarlyExit(early_exit) | Self::Campaign { early_exit, .. } => early_exit,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1681,6 +1733,33 @@ mod tests {
         assert_eq!(result.exit_reason, Some(InstructionResult::Stop));
         assert!(result.gas_used > 21_000, "interrupt fired before EVM execution started");
         assert!(result.gas_used < GAS_LIMIT, "execution ran out of gas instead of exiting");
+    }
+
+    #[test]
+    fn campaign_deadline_interrupts_active_evm_execution() {
+        const GAS_LIMIT: u64 = 1 << 24;
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(GAS_LIMIT).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+        );
+        let cancellation = EvmExecutionCancellation::campaign(
+            EarlyExit::new(false),
+            Arc::new(AtomicBool::new(false)),
+            Some(Instant::now()),
+        );
+        executor.inspector_mut().set_execution_cancellation(cancellation);
+
+        let target = Address::repeat_byte(0x11);
+        executor
+            .set_code(target, Bytecode::new_raw(Bytes::from_static(&[0x5b, 0x60, 0x00, 0x56])))
+            .unwrap();
+
+        let result = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO).unwrap();
+        assert!(!result.reverted);
+        assert_eq!(result.exit_reason, Some(InstructionResult::Stop));
+        assert!(result.gas_used < GAS_LIMIT, "execution ran out of gas instead of timing out");
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1063,6 +1063,8 @@ impl<FEN: FoundryEvmNetwork> From<DeployResult<FEN>> for RawCallResult<FEN> {
 pub struct RawCallResult<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// The status of the call
     pub exit_reason: Option<InstructionResult>,
+    /// Whether the call was halted by the execution cancellation inspector.
+    pub execution_cancelled: bool,
     /// Whether the call reverted or not
     pub reverted: bool,
     /// Whether the call includes a snapshot failure
@@ -1120,6 +1122,7 @@ impl<FEN: FoundryEvmNetwork> Default for RawCallResult<FEN> {
     fn default() -> Self {
         Self {
             exit_reason: None,
+            execution_cancelled: false,
             reverted: false,
             has_state_snapshot_failure: false,
             result: Bytes::new(),
@@ -1356,6 +1359,7 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
     db: &dyn DatabaseRef<Error = DatabaseError>,
     has_state_snapshot_failure: bool,
 ) -> eyre::Result<RawCallResult<FEN>> {
+    let execution_cancelled = inspector.execution_cancelled();
     let (exit_reason, gas_refunded, gas_used, out, exec_logs) = match result {
         ExecutionResult::Success { reason, gas, output, logs } => {
             (reason.into(), gas.final_refunded(), gas.tx_gas_used(), Some(output), logs)
@@ -1407,6 +1411,7 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
 
     Ok(RawCallResult {
         exit_reason: Some(exit_reason),
+        execution_cancelled,
         reverted: !matches!(exit_reason, return_ok!()),
         has_state_snapshot_failure,
         result,
@@ -1729,10 +1734,31 @@ mod tests {
         let result = result_rx.recv_timeout(Duration::from_secs(1));
         handle.join().unwrap();
         let result = result.expect("active EVM execution did not observe early exit").unwrap();
+        assert!(result.execution_cancelled);
         assert!(!result.reverted);
         assert_eq!(result.exit_reason, Some(InstructionResult::Stop));
         assert!(result.gas_used > 21_000, "interrupt fired before EVM execution started");
         assert!(result.gas_used < GAS_LIMIT, "execution ran out of gas instead of exiting");
+    }
+
+    #[test]
+    fn completed_execution_is_not_retroactively_cancelled() {
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default().gas_limit(1 << 24).build(
+            EvmEnvFor::<EthEvmNetwork>::default(),
+            TxEnvFor::<EthEvmNetwork>::default(),
+            backend,
+        );
+        let early_exit = EarlyExit::new(false);
+        executor.inspector_mut().set_early_exit(early_exit.clone());
+
+        let target = Address::repeat_byte(0x11);
+        executor.set_code(target, Bytecode::new_raw(Bytes::from_static(&[0x00]))).unwrap();
+        let result = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO).unwrap();
+        early_exit.record_ctrl_c();
+
+        assert!(!result.execution_cancelled);
+        assert!(!result.reverted);
     }
 
     #[test]
@@ -1757,6 +1783,7 @@ mod tests {
             .unwrap();
 
         let result = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO).unwrap();
+        assert!(result.execution_cancelled);
         assert!(!result.reverted);
         assert_eq!(result.exit_reason, Some(InstructionResult::Stop));
         assert!(result.gas_used < GAS_LIMIT, "execution ran out of gas instead of timing out");

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -426,6 +426,8 @@ pub struct InspectorStackInner {
     execution_cancellation: Option<EvmExecutionCancellation>,
     /// Amortizes deadline checks in the opcode hot path.
     cancellation_poll_counter: u8,
+    /// Whether this inspector halted the current execution due to cancellation.
+    execution_cancelled: bool,
     #[cfg(test)]
     early_exit_test_gate: Option<EarlyExitTestGate>,
     static_step_dispatch: OpcodeStepDispatch,
@@ -551,10 +553,10 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
         self.execution_cancellation = Some(cancellation);
     }
 
-    /// Returns whether cancellation has been requested for this execution.
+    /// Returns whether this inspector halted execution due to cancellation.
     #[inline]
-    pub(crate) fn cancellation_requested(&self) -> bool {
-        self.execution_cancellation.as_ref().is_some_and(|state| state.should_stop(true))
+    pub(crate) const fn execution_cancelled(&self) -> bool {
+        self.inner.execution_cancelled
     }
 
     #[cfg(test)]
@@ -1124,6 +1126,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
             self.inner.cancellation_poll_counter =
                 self.inner.cancellation_poll_counter.wrapping_add(1);
             if cancellation.should_stop(poll_deadline) {
+                self.inner.execution_cancelled = true;
                 interpreter.halt(InstructionResult::Stop);
                 return;
             }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -47,7 +47,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::executors::EarlyExit;
+use crate::executors::{EarlyExit, EvmExecutionCancellation};
 
 #[derive(Clone, Debug)]
 #[must_use = "builders do nothing unless you call `build` on them"]
@@ -367,6 +367,7 @@ pub struct InspectorStack<FEN: FoundryEvmNetwork = EthEvmNetwork> {
 struct EarlyExitTestGate {
     entered: std::sync::mpsc::Sender<()>,
     release: Arc<std::sync::Mutex<std::sync::mpsc::Receiver<()>>>,
+    target_pc: usize,
     notified: Arc<std::sync::atomic::AtomicBool>,
 }
 
@@ -422,7 +423,9 @@ pub struct InspectorStackInner {
     /// at identical on-chain state still produce distinct salts. Lazily initialized.
     pub batch_rewrite_process_salt: Option<u64>,
     /// Shared cancellation state for interruptible EVM execution.
-    early_exit: Option<EarlyExit>,
+    execution_cancellation: Option<EvmExecutionCancellation>,
+    /// Amortizes deadline checks in the opcode hot path.
+    cancellation_poll_counter: u8,
     #[cfg(test)]
     early_exit_test_gate: Option<EarlyExitTestGate>,
     static_step_dispatch: OpcodeStepDispatch,
@@ -539,13 +542,19 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
     /// Set the cancellation state checked during EVM execution.
     #[inline]
     pub(crate) fn set_early_exit(&mut self, early_exit: EarlyExit) {
-        self.early_exit = Some(early_exit);
+        self.execution_cancellation = Some(EvmExecutionCancellation::early_exit(early_exit));
+    }
+
+    /// Set the complete cancellation state checked during EVM execution.
+    #[inline]
+    pub(crate) fn set_execution_cancellation(&mut self, cancellation: EvmExecutionCancellation) {
+        self.execution_cancellation = Some(cancellation);
     }
 
     /// Returns whether cancellation has been requested for this execution.
     #[inline]
-    pub(crate) fn early_exit_requested(&self) -> bool {
-        self.early_exit.as_ref().is_some_and(EarlyExit::should_stop)
+    pub(crate) fn cancellation_requested(&self) -> bool {
+        self.execution_cancellation.as_ref().is_some_and(|state| state.should_stop(true))
     }
 
     #[cfg(test)]
@@ -553,10 +562,12 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
         &mut self,
         entered: std::sync::mpsc::Sender<()>,
         release: std::sync::mpsc::Receiver<()>,
+        target_pc: usize,
     ) {
         self.early_exit_test_gate = Some(EarlyExitTestGate {
             entered,
             release: Arc::new(std::sync::Mutex::new(release)),
+            target_pc,
             notified: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         });
     }
@@ -1097,6 +1108,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         #[cfg(test)]
         if interpreter.bytecode.opcode() == op::JUMPDEST
             && let Some(gate) = &self.inner.early_exit_test_gate
+            && interpreter.bytecode.pc() == gate.target_pc
             && !gate.notified.swap(true, std::sync::atomic::Ordering::Relaxed)
         {
             let _ = gate.entered.send(());
@@ -1107,9 +1119,14 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
                 .recv_timeout(std::time::Duration::from_secs(1));
         }
 
-        if self.inner.early_exit.as_ref().is_some_and(EarlyExit::should_stop) {
-            interpreter.halt(InstructionResult::Stop);
-            return;
+        if let Some(cancellation) = &self.inner.execution_cancellation {
+            let poll_deadline = self.inner.cancellation_poll_counter == 0;
+            self.inner.cancellation_poll_counter =
+                self.inner.cancellation_poll_counter.wrapping_add(1);
+            if cancellation.should_stop(poll_deadline) {
+                interpreter.halt(InstructionResult::Stop);
+                return;
+            }
         }
 
         match self.static_step_dispatch {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -362,6 +362,14 @@ pub struct InspectorStack<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     pub inner: InspectorStackInner,
 }
 
+#[cfg(test)]
+#[derive(Clone, Debug)]
+struct EarlyExitTestGate {
+    entered: std::sync::mpsc::Sender<()>,
+    release: Arc<std::sync::Mutex<std::sync::mpsc::Receiver<()>>>,
+    notified: Arc<std::sync::atomic::AtomicBool>,
+}
+
 /// All used inpectors besides [Cheatcodes].
 ///
 /// See [`InspectorStack`].
@@ -415,6 +423,8 @@ pub struct InspectorStackInner {
     pub batch_rewrite_process_salt: Option<u64>,
     /// Shared cancellation state for interruptible EVM execution.
     early_exit: Option<EarlyExit>,
+    #[cfg(test)]
+    early_exit_test_gate: Option<EarlyExitTestGate>,
     static_step_dispatch: OpcodeStepDispatch,
     has_static_step_end_inspectors: bool,
 }
@@ -530,6 +540,25 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
     #[inline]
     pub(crate) fn set_early_exit(&mut self, early_exit: EarlyExit) {
         self.early_exit = Some(early_exit);
+    }
+
+    /// Returns whether cancellation has been requested for this execution.
+    #[inline]
+    pub(crate) fn early_exit_requested(&self) -> bool {
+        self.early_exit.as_ref().is_some_and(EarlyExit::should_stop)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_early_exit_test_gate(
+        &mut self,
+        entered: std::sync::mpsc::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    ) {
+        self.early_exit_test_gate = Some(EarlyExitTestGate {
+            entered,
+            release: Arc::new(std::sync::Mutex::new(release)),
+            notified: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        });
     }
 
     /// Sets the block for the relevant inspectors.
@@ -1065,6 +1094,19 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         interpreter: &mut Interpreter,
         ecx: &mut FoundryContextFor<'_, FEN>,
     ) {
+        #[cfg(test)]
+        if interpreter.bytecode.opcode() == op::JUMPDEST
+            && let Some(gate) = &self.inner.early_exit_test_gate
+            && !gate.notified.swap(true, std::sync::atomic::Ordering::Relaxed)
+        {
+            let _ = gate.entered.send(());
+            let _ = gate
+                .release
+                .lock()
+                .expect("early-exit test gate lock poisoned")
+                .recv_timeout(std::time::Duration::from_secs(1));
+        }
+
         if self.inner.early_exit.as_ref().is_some_and(EarlyExit::should_stop) {
             interpreter.halt(InstructionResult::Stop);
             return;

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -47,6 +47,8 @@ use std::{
     sync::Arc,
 };
 
+use crate::executors::EarlyExit;
+
 #[derive(Clone, Debug)]
 #[must_use = "builders do nothing unless you call `build` on them"]
 pub struct InspectorStackBuilder<BLOCK: Clone> {
@@ -411,6 +413,8 @@ pub struct InspectorStackInner {
     /// Per-inspector random seed mixed into `--batch` CREATE2 salts, ensuring re-runs
     /// at identical on-chain state still produce distinct salts. Lazily initialized.
     pub batch_rewrite_process_salt: Option<u64>,
+    /// Shared cancellation state for interruptible EVM execution.
+    early_exit: Option<EarlyExit>,
     static_step_dispatch: OpcodeStepDispatch,
     has_static_step_end_inspectors: bool,
 }
@@ -520,6 +524,12 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
     #[inline]
     pub fn set_analysis(&mut self, analysis: Analysis) {
         self.analysis = Some(analysis);
+    }
+
+    /// Set the cancellation state checked during EVM execution.
+    #[inline]
+    pub(crate) fn set_early_exit(&mut self, early_exit: EarlyExit) {
+        self.early_exit = Some(early_exit);
     }
 
     /// Sets the block for the relevant inspectors.
@@ -1055,6 +1065,11 @@ impl<FEN: FoundryEvmNetwork> InspectorStackRefMut<'_, FEN> {
         interpreter: &mut Interpreter,
         ecx: &mut FoundryContextFor<'_, FEN>,
     ) {
+        if self.inner.early_exit.as_ref().is_some_and(EarlyExit::should_stop) {
+            interpreter.halt(InstructionResult::Stop);
+            return;
+        }
+
         match self.static_step_dispatch {
             OpcodeStepDispatch::None => {}
             OpcodeStepDispatch::FuzzerOnly => {


### PR DESCRIPTION
Allows `SIGINT` and other early-exit requests to interrupt an invariant campaign while a transaction is still executing.

Also emits handler assertion failures as deduplicated mid-run events so discovered findings are preserved if the final summary is not written.

Fixes #15684.