### PR TITLE
feat(anvil): add eth_callBundle endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types-mev"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c635f0c45a871b55c276653e3838d1687d86282eeaf3d83a1914e02563b3f2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-rpc-types-trace"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,6 +1222,7 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-beacon",
  "alloy-rpc-types-eth",
+ "alloy-rpc-types-mev",
  "alloy-serde",
  "alloy-signer",
  "alloy-signer-local",
@@ -1273,6 +1289,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types",
+ "alloy-rpc-types-mev",
  "alloy-serde",
  "bytes",
  "foundry-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -363,6 +363,7 @@ alloy-rpc-types = { version = "2.1.0", default-features = true }
 alloy-rpc-types-beacon = { version = "2.1.0", default-features = true }
 alloy-rpc-types-engine = { version = "2.1.0", default-features = false }
 alloy-rpc-types-eth = { version = "2.1.0", default-features = false }
+alloy-rpc-types-mev = { version = "2.1.0", default-features = false }
 alloy-serde = { version = "2.1.0", default-features = false }
 alloy-signer = { version = "2.1.0", default-features = false }
 alloy-signer-aws = { version = "2.1.0", default-features = false }

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -51,6 +51,7 @@ alloy-dyn-abi = { workspace = true, features = ["std", "eip712"] }
 alloy-rpc-types = { workspace = true, features = ["anvil", "trace", "txpool"] }
 alloy-rpc-types-beacon.workspace = true
 alloy-rpc-types-eth.workspace = true
+alloy-rpc-types-mev.workspace = true
 alloy-serde.workspace = true
 alloy-provider = { workspace = true, features = [
     "reqwest",

--- a/crates/anvil/core/Cargo.toml
+++ b/crates/anvil/core/Cargo.toml
@@ -25,6 +25,7 @@ revm = { workspace = true, default-features = false, features = [
 
 alloy-primitives = { workspace = true, features = ["serde", "rlp"] }
 alloy-rpc-types = { workspace = true, features = ["anvil", "trace"] }
+alloy-rpc-types-mev.workspace = true
 alloy-serde.workspace = true
 alloy-rlp.workspace = true
 alloy-eips.workspace = true

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -17,6 +17,7 @@ use alloy_rpc_types::{
         parity::TraceType,
     },
 };
+use alloy_rpc_types_mev::EthCallBundle;
 use alloy_serde::WithOtherFields;
 use foundry_common::serde_helpers::{
     deserialize_number, deserialize_number_opt, deserialize_number_seq, deserialize_u64_seq,
@@ -225,6 +226,9 @@ pub enum EthRequest {
         #[serde(default)] Option<StateContext>,
         #[serde(default)] Option<StateOverride>,
     ),
+
+    #[serde(rename = "eth_callBundle", with = "sequence")]
+    EthCallBundle(EthCallBundle),
 
     #[serde(rename = "eth_simulateV1")]
     EthSimulateV1(SimulatePayload, #[serde(default)] Option<BlockId>),
@@ -2014,6 +2018,12 @@ true}]}"#;
     #[test]
     fn test_eth_call_many() {
         let s = r#"{"method":"eth_callMany","params":[[{"transactions":[{"from":"0xd84de507f3fada7df80908082d3239466db55a71","to":"0xcbe828fdc46e3b1c351ec90b1a5e7d9742c0398d","data":"0xcfae3217"}]}],{"blockNumber":"latest"},{"0x0000000000000000000000000000000000000001":{"balance":"0x1"}}]}"#;
+        let _req = serde_json::from_str::<EthRequest>(s).unwrap();
+    }
+
+    #[test]
+    fn test_eth_call_bundle() {
+        let s = r#"{"method":"eth_callBundle","params":[{"txs":["0x1234"],"blockNumber":"0x1","stateBlockNumber":"latest"}]}"#;
         let _req = serde_json::from_str::<EthRequest>(s).unwrap();
     }
 

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -69,6 +69,7 @@ use alloy_rpc_types::{
     txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, TxpoolInspectSummary, TxpoolStatus},
 };
 use alloy_rpc_types_eth::{AccountInfo, Bundle, EthCallResponse, FillTransaction, StateContext};
+use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse};
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::{SolCall, SolValue, sol};
 use alloy_transport::TransportErrorKind;
@@ -1820,6 +1821,7 @@ impl EthApi<FoundryNetwork> {
             EthRequest::EthCallMany(bundles, state_context, state_override) => {
                 self.call_many(bundles, state_context, state_override).await.to_rpc_result()
             }
+            EthRequest::EthCallBundle(bundle) => self.call_bundle(bundle).await.to_rpc_result(),
             EthRequest::EthSimulateV1(simulation, block) => {
                 self.simulate_v1(simulation, block).await.to_rpc_result()
             }
@@ -2867,6 +2869,51 @@ impl EthApi<FoundryNetwork> {
 
         self.on_blocking_task(|this| async move {
             this.backend.call_many(bundles, Some(block_request), state_override).await
+        })
+        .await
+    }
+
+    /// Simulates a bundle of signed transactions against the requested state.
+    ///
+    /// Handler for ETH RPC call: `eth_callBundle`.
+    pub async fn call_bundle(&self, bundle: EthCallBundle) -> Result<EthCallBundleResponse> {
+        node_info!("eth_callBundle");
+        if bundle.txs.is_empty() {
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(
+                "bundle missing txs".to_string(),
+            )));
+        }
+        if bundle.block_number == 0 {
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(
+                "bundle missing blockNumber".to_string(),
+            )));
+        }
+
+        let block_request = self.block_request(Some(bundle.state_block_number.into())).await?;
+        if let BlockRequest::Number(number) = block_request
+            && let Some(fork) = self.get_fork()
+            && fork.predates_fork(number)
+        {
+            return Ok(fork.call_bundle(bundle).await?);
+        }
+
+        let transactions = bundle
+            .txs
+            .iter()
+            .map(|raw| {
+                let mut data = raw.as_ref();
+                if data.is_empty() {
+                    return Err(BlockchainError::EmptyRawTransactionData);
+                }
+                let transaction = FoundryTxEnvelope::decode_2718(&mut data)
+                    .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?;
+                self.ensure_typed_transaction_supported(&transaction)?;
+                PendingTransaction::new(transaction).map_err(Into::into)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        self.on_blocking_task(|this| async move {
+            this.backend.call_bundle(bundle, transactions, Some(block_request)).await
         })
         .await
     }

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -31,6 +31,7 @@ use alloy_rpc_types::{
     },
 };
 use alloy_rpc_types_eth::{AccountInfo, Bundle, EthCallResponse, StateContext};
+use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse};
 use alloy_serde::WithOtherFields;
 use alloy_transport::TransportError;
 use foundry_common::provider::{ProviderBuilder, RetryProvider};
@@ -472,6 +473,14 @@ impl<N: Network> ClientFork<N> {
         self.provider()
             .raw_request("eth_callMany".into(), (bundles, state_context, state_override))
             .await
+    }
+
+    /// Sends `eth_callBundle`.
+    pub async fn call_bundle(
+        &self,
+        bundle: EthCallBundle,
+    ) -> Result<EthCallBundleResponse, TransportError> {
+        self.provider().raw_request("eth_callBundle".into(), (bundle,)).await
     }
 
     /// Sends `eth_simulateV1`

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4823,7 +4823,6 @@ impl Backend<FoundryNetwork> {
         block_request: Option<BlockRequest<FoundryTxEnvelope>>,
     ) -> Result<EthCallBundleResponse, BlockchainError> {
         let EthCallBundle {
-            txs: _,
             block_number,
             coinbase,
             timestamp,

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -88,6 +88,7 @@ use alloy_rpc_types::{
     },
 };
 use alloy_rpc_types_eth::{AccountInfo as RpcAccountInfo, Bundle, EthCallResponse};
+use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTransactionResult};
 use alloy_serde::{OtherFields, WithOtherFields};
 use alloy_trie::{HashBuilder, Nibbles, proof::ProofRetainer};
 use anvil_core::eth::{
@@ -4814,6 +4815,138 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
 }
 
 impl Backend<FoundryNetwork> {
+    /// Simulates a bundle of signed transactions and returns Flashbots-compatible results.
+    pub async fn call_bundle(
+        &self,
+        bundle: EthCallBundle,
+        transactions: Vec<PendingTransaction<FoundryTxEnvelope>>,
+        block_request: Option<BlockRequest<FoundryTxEnvelope>>,
+    ) -> Result<EthCallBundleResponse, BlockchainError> {
+        let EthCallBundle {
+            txs: _,
+            block_number,
+            coinbase,
+            timestamp,
+            gas_limit,
+            difficulty,
+            base_fee,
+            ..
+        } = bundle;
+
+        let blob_gas_used = transactions
+            .iter()
+            .filter_map(|transaction| transaction.transaction.blob_gas_used())
+            .sum::<u64>();
+        let max_blob_gas = self.blob_params().max_blob_gas_per_block();
+        if blob_gas_used > max_blob_gas {
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(format!(
+                "blob gas usage exceeds the limit of {max_blob_gas} gas per block."
+            ))));
+        }
+
+        self.with_database_at(block_request, |state, mut block_env| {
+            let state_block_number = block_env.number.to::<u64>();
+            block_env.number = U256::from(block_number);
+            block_env.timestamp = timestamp
+                .map(U256::from)
+                .unwrap_or_else(|| block_env.timestamp.saturating_add(U256::from(12)));
+            if let Some(coinbase) = coinbase {
+                block_env.beneficiary = coinbase;
+            }
+            if let Some(gas_limit) = gas_limit {
+                block_env.gas_limit = gas_limit;
+            }
+            if let Some(difficulty) = difficulty {
+                block_env.difficulty = difficulty;
+            }
+            if let Some(base_fee) = base_fee {
+                block_env.basefee = base_fee.try_into().unwrap_or(u64::MAX);
+            }
+
+            let mut evm_env = self.evm_env.read().clone();
+            evm_env.block_env = block_env;
+            let coinbase = evm_env.block_env.beneficiary;
+            let base_fee = evm_env.block_env.basefee;
+            let mut cache_db = CacheDB::new(state);
+            let initial_coinbase = revm::DatabaseRef::basic_ref(&cache_db, coinbase)?
+                .map(|account| account.balance)
+                .unwrap_or_default();
+            let mut coinbase_balance_before_tx = initial_coinbase;
+            let mut coinbase_balance_after_tx = initial_coinbase;
+            let mut total_gas_used = 0u64;
+            let mut total_gas_fees = U256::ZERO;
+            let mut bundle_hash = alloy_primitives::Keccak256::new();
+            let mut results = Vec::with_capacity(transactions.len());
+
+            for transaction in transactions {
+                let sender = *transaction.sender();
+                let tx = transaction.transaction.into_inner();
+                let tx_hash = tx.hash();
+                bundle_hash.update(tx_hash);
+
+                let mut inspector = self.build_inspector();
+                let (ResultAndState { result, state }, _) = self
+                    .transact_envelope_with_inspector_ref(
+                        &cache_db,
+                        &evm_env,
+                        &mut inspector,
+                        &tx,
+                        sender,
+                    )?;
+
+                let gas_price = tx.effective_tip_per_gas(base_fee).unwrap_or_default();
+                let gas_used = result.tx_gas_used();
+                let gas_fees = U256::from(gas_used) * U256::from(gas_price);
+                total_gas_used += gas_used;
+                total_gas_fees += gas_fees;
+
+                coinbase_balance_after_tx = state
+                    .get(&coinbase)
+                    .map(|account| account.info.balance)
+                    .unwrap_or(coinbase_balance_before_tx);
+                let coinbase_diff =
+                    coinbase_balance_after_tx.saturating_sub(coinbase_balance_before_tx);
+                let eth_sent_to_coinbase = coinbase_diff.saturating_sub(gas_fees);
+                coinbase_balance_before_tx = coinbase_balance_after_tx;
+
+                let output = result.output().cloned().unwrap_or_default();
+                let (value, revert) =
+                    if result.is_success() { (Some(output), None) } else { (None, Some(output)) };
+
+                results.push(EthCallBundleTransactionResult {
+                    coinbase_diff,
+                    eth_sent_to_coinbase,
+                    from_address: sender,
+                    gas_fees,
+                    gas_price: U256::from(gas_price),
+                    gas_used,
+                    to_address: tx.to(),
+                    tx_hash,
+                    value,
+                    revert,
+                });
+                cache_db.commit(state);
+            }
+
+            let coinbase_diff = coinbase_balance_after_tx.saturating_sub(initial_coinbase);
+            let eth_sent_to_coinbase = coinbase_diff.saturating_sub(total_gas_fees);
+            let bundle_gas_price =
+                coinbase_diff.checked_div(U256::from(total_gas_used)).unwrap_or_default();
+
+            Ok(EthCallBundleResponse {
+                bundle_hash: bundle_hash.finalize(),
+                bundle_gas_price,
+                coinbase_diff,
+                eth_sent_to_coinbase,
+                gas_fees: total_gas_fees,
+                results,
+                state_block_number,
+                total_gas_used,
+            })
+        })
+        .await?
+    }
+
     /// Executes bundles of call requests and returns each call output.
     pub async fn call_many(
         &self,

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -13,7 +13,7 @@ use alloy_network::{
     TxSignerSync,
 };
 use alloy_primitives::{
-    Address, B256, ChainId, U256, b256, bytes,
+    Address, B256, ChainId, Keccak256, U256, b256, bytes,
     map::{AddressHashMap, B256HashMap, HashMap},
 };
 use alloy_provider::{PendingTransactionConfig, Provider};
@@ -22,6 +22,7 @@ use alloy_rpc_types::{
     request::TransactionRequest, state::AccountOverride,
 };
 use alloy_rpc_types_eth::{Bundle, EthCallResponse};
+use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse};
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::SolCall;
 use anvil::{CHAIN_ID, EthereumHardfork, NodeConfig, eth::api::CLIENT_VERSION, spawn};
@@ -567,6 +568,107 @@ async fn can_call_many() {
     let output = response[0][1].clone().ensure_ok().unwrap();
     let value = SimpleStorage::getValueCall::abi_decode_returns(&output).unwrap();
     assert_eq!(value, "updated");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_call_bundle() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let sender = wallets[1].address();
+    let coinbase = wallets[2].address();
+    let initial_coinbase_balance = provider.get_balance(coinbase).await.unwrap();
+    let fees = provider.estimate_eip1559_fees().await.unwrap();
+    let base_fee = api.base_fee().unwrap().unwrap().to::<u64>();
+
+    let mut raw_transactions = Vec::new();
+    let mut transaction_hashes = Vec::new();
+    let mut expected_gas_fees = U256::ZERO;
+    for (nonce, value) in [(0, 1), (1, 2)] {
+        let mut tx = TxEip1559 {
+            chain_id: CHAIN_ID,
+            nonce,
+            gas_limit: 21_000,
+            max_fee_per_gas: fees.max_fee_per_gas,
+            max_priority_fee_per_gas: fees.max_priority_fee_per_gas,
+            to: coinbase.into(),
+            value: U256::from(value),
+            ..Default::default()
+        };
+        let signature = wallets[1].sign_transaction_sync(&mut tx).unwrap();
+        let tx = tx.into_signed(signature);
+        let gas_price = tx.effective_tip_per_gas(base_fee).unwrap();
+        expected_gas_fees += U256::from(gas_price) * U256::from(21_000);
+        transaction_hashes.push(*tx.hash());
+
+        let mut encoded = Vec::new();
+        tx.eip2718_encode(&mut encoded);
+        raw_transactions.push(encoded.into());
+    }
+
+    let response: EthCallBundleResponse = provider
+        .client()
+        .request(
+            "eth_callBundle",
+            (EthCallBundle {
+                txs: raw_transactions.clone(),
+                block_number: 1,
+                state_block_number: BlockNumberOrTag::Latest,
+                coinbase: Some(coinbase),
+                ..Default::default()
+            },),
+        )
+        .await
+        .unwrap();
+
+    let mut expected_bundle_hash = Keccak256::new();
+    for hash in transaction_hashes {
+        expected_bundle_hash.update(hash);
+    }
+    assert_eq!(response.bundle_hash, expected_bundle_hash.finalize());
+    assert_eq!(response.state_block_number, 0);
+    assert_eq!(response.total_gas_used, 42_000);
+    assert_eq!(response.gas_fees, expected_gas_fees);
+    assert_eq!(response.eth_sent_to_coinbase, U256::from(3));
+    assert_eq!(response.coinbase_diff, expected_gas_fees + U256::from(3));
+    assert_eq!(
+        response.bundle_gas_price,
+        response.coinbase_diff / U256::from(response.total_gas_used)
+    );
+    assert_eq!(response.results.len(), 2);
+    assert_eq!(response.results[0].from_address, sender);
+    assert_eq!(response.results[0].to_address, Some(coinbase));
+    assert_eq!(response.results[0].eth_sent_to_coinbase, U256::from(1));
+    assert_eq!(response.results[1].eth_sent_to_coinbase, U256::from(2));
+    assert!(response.results.iter().all(|result| result.revert.is_none()));
+
+    assert_eq!(provider.get_balance(coinbase).await.unwrap(), initial_coinbase_balance);
+
+    let empty_bundle: Result<EthCallBundleResponse, _> = provider
+        .client()
+        .request(
+            "eth_callBundle",
+            (EthCallBundle {
+                block_number: 1,
+                state_block_number: BlockNumberOrTag::Latest,
+                ..Default::default()
+            },),
+        )
+        .await;
+    assert!(empty_bundle.unwrap_err().to_string().contains("bundle missing txs"));
+
+    let zero_block: Result<EthCallBundleResponse, _> = provider
+        .client()
+        .request(
+            "eth_callBundle",
+            (EthCallBundle {
+                txs: vec![raw_transactions[0].clone()],
+                state_block_number: BlockNumberOrTag::Latest,
+                ..Default::default()
+            },),
+        )
+        .await;
+    assert!(zero_block.unwrap_err().to_string().contains("bundle missing blockNumber"));
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Adds `eth_callBundle` support to Anvil using Alloy's MEV RPC types. Signed EIP-2718 transactions are decoded and recovered, simulated sequentially against the requested state, and returned with Flashbots-compatible per-transaction and aggregate gas, coinbase, output, and bundle-hash fields. The simulation applies the request's block context overrides without persisting state, validates required inputs and aggregate blob gas, and forwards historical fork-state requests to the upstream provider.

The execution and response behavior follows reth's implementation while reusing Anvil's network-aware transaction path so Ethereum, Optimism, and Tempo transaction handling remains consistent.

AI disclosure: This PR was written primarily with OpenAI Codex, including code generation and tests.
