### PR TITLE
feat(anvil): support eth_sendBundle

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -2031,6 +2031,12 @@ true}]}"#;
     }
 
     #[test]
+    fn test_eth_send_bundle() {
+        let s = r#"{"method":"eth_sendBundle","params":[{"txs":["0x1234"],"blockNumber":"0x1","minTimestamp":"0x2","maxTimestamp":"0x3","revertingTxHashes":["0x0000000000000000000000000000000000000000000000000000000000000004"],"droppingTxHashes":["0x0000000000000000000000000000000000000000000000000000000000000005"],"replacementUuid":"replacement"}]}"#;
+        let _req = serde_json::from_str::<EthRequest>(s).unwrap();
+    }
+
+    #[test]
     fn test_serde_eth_balance() {
         let s = r#"{"method": "eth_getBalance", "params":
 ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "latest"]}"#;

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -17,7 +17,7 @@ use alloy_rpc_types::{
         parity::TraceType,
     },
 };
-use alloy_rpc_types_mev::EthCallBundle;
+use alloy_rpc_types_mev::{EthCallBundle, EthSendBundle};
 use alloy_serde::WithOtherFields;
 use foundry_common::serde_helpers::{
     deserialize_number, deserialize_number_opt, deserialize_number_seq, deserialize_u64_seq,
@@ -208,6 +208,9 @@ pub enum EthRequest {
 
     #[serde(rename = "eth_sendRawTransactionConditional")]
     EthSendRawTransactionConditional(Bytes, TransactionConditional),
+
+    #[serde(rename = "eth_sendBundle", with = "sequence")]
+    EthSendBundle(EthSendBundle),
 
     #[serde(rename = "anvil_classifyTransaction", with = "sequence")]
     AnvilClassifyTransaction(Bytes),

--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -2031,12 +2031,6 @@ true}]}"#;
     }
 
     #[test]
-    fn test_eth_send_bundle() {
-        let s = r#"{"method":"eth_sendBundle","params":[{"txs":["0x1234"],"blockNumber":"0x1","minTimestamp":"0x2","maxTimestamp":"0x3","revertingTxHashes":["0x0000000000000000000000000000000000000000000000000000000000000004"],"droppingTxHashes":["0x0000000000000000000000000000000000000000000000000000000000000005"],"replacementUuid":"replacement"}]}"#;
-        let _req = serde_json::from_str::<EthRequest>(s).unwrap();
-    }
-
-    #[test]
     fn test_serde_eth_balance() {
         let s = r#"{"method": "eth_getBalance", "params":
 ["0x295a70b2de5e3953354a6a8344e616ed314d7251", "latest"]}"#;

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1305,7 +1305,10 @@ impl<N: Network> EthApi<N> {
         let block_request = match &block_id {
             BlockId::Number(BlockNumber::Pending) => {
                 let pending_txs = self.pool.ready_transactions().collect();
-                BlockRequest::Pending(pending_txs)
+                BlockRequest::Pending(MiningTransactions::new(
+                    pending_txs,
+                    self.pool.private_bundles(),
+                ))
             }
             _ => {
                 let number = self.backend.ensure_block_number(Some(block_id)).await?;
@@ -1428,7 +1431,10 @@ impl EthApi<FoundryNetwork> {
         let block_request = match block_number {
             Some(BlockId::Number(BlockNumber::Pending)) => {
                 let pending_txs = self.pool.ready_transactions().collect();
-                BlockRequest::Pending(pending_txs)
+                BlockRequest::Pending(MiningTransactions::new(
+                    pending_txs,
+                    self.pool.private_bundles(),
+                ))
             }
             _ => {
                 let number = self.backend.ensure_block_number(block_number).await?;
@@ -2468,14 +2474,8 @@ impl EthApi<FoundryNetwork> {
     ) -> Result<Option<U256>> {
         node_info!("eth_getBlockTransactionCountByNumber");
         let block_request = self.block_request(Some(block_number.into())).await?;
-        if let BlockRequest::Pending(txs) = block_request {
-            let block = self
-                .backend
-                .pending_block_with_bundles(MiningTransactions::new(
-                    txs,
-                    self.pool.private_bundles(),
-                ))
-                .await;
+        if let BlockRequest::Pending(mining_transactions) = block_request {
+            let block = self.backend.pending_block_with_bundles(mining_transactions).await;
             return Ok(Some(U256::from(block.block.body.transactions.len())));
         }
         let block = self.backend.block_by_number(block_number).await?;
@@ -2752,22 +2752,22 @@ impl EthApi<FoundryNetwork> {
     pub async fn send_bundle(&self, bundle: EthSendBundle) -> Result<EthBundleHash> {
         node_info!("eth_sendBundle");
         if bundle.txs.is_empty() {
-            return Err(BlockchainError::InvalidTransactionRequest(
-                "bundle must contain at least one transaction".to_string(),
-            ));
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(
+                "bundle must contain at least one transaction",
+            )));
         }
         if bundle.block_number <= self.backend.best_number() {
-            return Err(BlockchainError::InvalidTransactionRequest(format!(
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(format!(
                 "bundle target block {} has already been mined",
-                bundle.block_number
-            )));
+                bundle.block_number,
+            ))));
         }
         if let (Some(minimum), Some(maximum)) = (bundle.min_timestamp, bundle.max_timestamp)
             && minimum > maximum
         {
-            return Err(BlockchainError::InvalidTransactionRequest(
-                "bundle minTimestamp exceeds maxTimestamp".to_string(),
-            ));
+            return Err(BlockchainError::RpcError(RpcError::invalid_params(
+                "bundle minTimestamp exceeds maxTimestamp",
+            )));
         }
 
         let bundle_hash = bundle.bundle_hash();
@@ -2779,9 +2779,12 @@ impl EthApi<FoundryNetwork> {
             let mut data = raw.as_ref();
             let transaction = FoundryTxEnvelope::decode_2718(&mut data)
                 .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?;
+            if !data.is_empty() {
+                return Err(BlockchainError::FailedToDecodeSignedTransaction);
+            }
             self.ensure_typed_transaction_supported(&transaction)?;
             let pending_transaction = PendingTransaction::new(transaction)?;
-            self.backend.validate_pool_transaction(&pending_transaction).await?;
+            self.backend.validate_transaction_chain_id(&pending_transaction.transaction)?;
             let nonce = pending_transaction.nonce();
             let sender = *pending_transaction.sender();
             transactions.push(Arc::new(PoolTransaction {
@@ -2792,15 +2795,19 @@ impl EthApi<FoundryNetwork> {
             }));
         }
 
-        self.pool.add_private_bundle(PrivateBundle {
-            hash: bundle_hash,
-            transactions,
-            block_number: bundle.block_number,
-            min_timestamp: bundle.min_timestamp,
-            max_timestamp: bundle.max_timestamp,
-            reverting_tx_hashes: bundle.reverting_tx_hashes.into_iter().collect(),
-            replacement_uuid: bundle.replacement_uuid,
-        });
+        self.pool.add_private_bundle(
+            PrivateBundle {
+                hash: bundle_hash,
+                transactions,
+                block_number: bundle.block_number,
+                min_timestamp: bundle.min_timestamp,
+                max_timestamp: bundle.max_timestamp,
+                reverting_tx_hashes: bundle.reverting_tx_hashes.into_iter().collect(),
+                dropping_tx_hashes: bundle.dropping_tx_hashes.into_iter().collect(),
+                replacement_uuid: bundle.replacement_uuid,
+            },
+            self.backend.best_number().saturating_add(1),
+        );
 
         Ok(EthBundleHash { bundle_hash })
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1305,10 +1305,7 @@ impl<N: Network> EthApi<N> {
         let block_request = match &block_id {
             BlockId::Number(BlockNumber::Pending) => {
                 let pending_txs = self.pool.ready_transactions().collect();
-                BlockRequest::Pending(MiningTransactions::new(
-                    pending_txs,
-                    self.pool.private_bundles(),
-                ))
+                BlockRequest::Pending(pending_txs)
             }
             _ => {
                 let number = self.backend.ensure_block_number(Some(block_id)).await?;
@@ -1431,10 +1428,7 @@ impl EthApi<FoundryNetwork> {
         let block_request = match block_number {
             Some(BlockId::Number(BlockNumber::Pending)) => {
                 let pending_txs = self.pool.ready_transactions().collect();
-                BlockRequest::Pending(MiningTransactions::new(
-                    pending_txs,
-                    self.pool.private_bundles(),
-                ))
+                BlockRequest::Pending(pending_txs)
             }
             _ => {
                 let number = self.backend.ensure_block_number(block_number).await?;
@@ -2474,8 +2468,14 @@ impl EthApi<FoundryNetwork> {
     ) -> Result<Option<U256>> {
         node_info!("eth_getBlockTransactionCountByNumber");
         let block_request = self.block_request(Some(block_number.into())).await?;
-        if let BlockRequest::Pending(mining_transactions) = block_request {
-            let block = self.backend.pending_block_with_bundles(mining_transactions).await;
+        if let BlockRequest::Pending(txs) = block_request {
+            let block = self
+                .backend
+                .pending_block_with_bundles(MiningTransactions::new(
+                    txs,
+                    self.pool.private_bundles(),
+                ))
+                .await;
             return Ok(Some(U256::from(block.block.body.transactions.len())));
         }
         let block = self.backend.block_by_number(block_number).await?;
@@ -2752,22 +2752,22 @@ impl EthApi<FoundryNetwork> {
     pub async fn send_bundle(&self, bundle: EthSendBundle) -> Result<EthBundleHash> {
         node_info!("eth_sendBundle");
         if bundle.txs.is_empty() {
-            return Err(BlockchainError::RpcError(RpcError::invalid_params(
-                "bundle must contain at least one transaction",
-            )));
+            return Err(BlockchainError::InvalidTransactionRequest(
+                "bundle must contain at least one transaction".to_string(),
+            ));
         }
         if bundle.block_number <= self.backend.best_number() {
-            return Err(BlockchainError::RpcError(RpcError::invalid_params(format!(
+            return Err(BlockchainError::InvalidTransactionRequest(format!(
                 "bundle target block {} has already been mined",
-                bundle.block_number,
-            ))));
+                bundle.block_number
+            )));
         }
         if let (Some(minimum), Some(maximum)) = (bundle.min_timestamp, bundle.max_timestamp)
             && minimum > maximum
         {
-            return Err(BlockchainError::RpcError(RpcError::invalid_params(
-                "bundle minTimestamp exceeds maxTimestamp",
-            )));
+            return Err(BlockchainError::InvalidTransactionRequest(
+                "bundle minTimestamp exceeds maxTimestamp".to_string(),
+            ));
         }
 
         let bundle_hash = bundle.bundle_hash();
@@ -2779,12 +2779,9 @@ impl EthApi<FoundryNetwork> {
             let mut data = raw.as_ref();
             let transaction = FoundryTxEnvelope::decode_2718(&mut data)
                 .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?;
-            if !data.is_empty() {
-                return Err(BlockchainError::FailedToDecodeSignedTransaction);
-            }
             self.ensure_typed_transaction_supported(&transaction)?;
             let pending_transaction = PendingTransaction::new(transaction)?;
-            self.backend.validate_transaction_chain_id(&pending_transaction.transaction)?;
+            self.backend.validate_pool_transaction(&pending_transaction).await?;
             let nonce = pending_transaction.nonce();
             let sender = *pending_transaction.sender();
             transactions.push(Arc::new(PoolTransaction {
@@ -2795,19 +2792,15 @@ impl EthApi<FoundryNetwork> {
             }));
         }
 
-        self.pool.add_private_bundle(
-            PrivateBundle {
-                hash: bundle_hash,
-                transactions,
-                block_number: bundle.block_number,
-                min_timestamp: bundle.min_timestamp,
-                max_timestamp: bundle.max_timestamp,
-                reverting_tx_hashes: bundle.reverting_tx_hashes.into_iter().collect(),
-                dropping_tx_hashes: bundle.dropping_tx_hashes.into_iter().collect(),
-                replacement_uuid: bundle.replacement_uuid,
-            },
-            self.backend.best_number().saturating_add(1),
-        );
+        self.pool.add_private_bundle(PrivateBundle {
+            hash: bundle_hash,
+            transactions,
+            block_number: bundle.block_number,
+            min_timestamp: bundle.min_timestamp,
+            max_timestamp: bundle.max_timestamp,
+            reverting_tx_hashes: bundle.reverting_tx_hashes.into_iter().collect(),
+            replacement_uuid: bundle.replacement_uuid,
+        });
 
         Ok(EthBundleHash { bundle_hash })
     }

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -19,7 +19,7 @@ use crate::{
         macros::node_info,
         miner::FixedBlockTimeMiner,
         pool::{
-            Pool,
+            MiningTransactions, Pool, PrivateBundle,
             transactions::{
                 PoolTransaction, TransactionOrder, TransactionPriority, TxMarker, to_marker,
             },
@@ -69,7 +69,7 @@ use alloy_rpc_types::{
     txpool::{TxpoolContent, TxpoolContentFrom, TxpoolInspect, TxpoolInspectSummary, TxpoolStatus},
 };
 use alloy_rpc_types_eth::{AccountInfo, Bundle, EthCallResponse, FillTransaction, StateContext};
-use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse};
+use alloy_rpc_types_mev::{EthBundleHash, EthCallBundle, EthCallBundleResponse, EthSendBundle};
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::{SolCall, SolValue, sol};
 use alloy_transport::TransportErrorKind;
@@ -257,7 +257,7 @@ impl<N: Network> EthApi<N> {
             }
             self.miner.set_mining_mode(MiningMode::None);
         } else if enable_automine {
-            let listener = self.pool.add_ready_listener();
+            let listener = self.pool.add_mining_listener();
             let mode = MiningMode::instant(1_000, listener);
             self.miner.set_mining_mode(mode);
         }
@@ -1811,6 +1811,7 @@ impl EthApi<FoundryNetwork> {
             EthRequest::EthSendRawTransactionConditional(tx, condition) => {
                 self.send_raw_transaction_conditional(tx, condition).await.to_rpc_result()
             }
+            EthRequest::EthSendBundle(bundle) => self.send_bundle(bundle).await.to_rpc_result(),
             EthRequest::AnvilClassifyTransaction(tx) => {
                 self.anvil_classify_transaction(tx).to_rpc_result()
             }
@@ -2468,7 +2469,13 @@ impl EthApi<FoundryNetwork> {
         node_info!("eth_getBlockTransactionCountByNumber");
         let block_request = self.block_request(Some(block_number.into())).await?;
         if let BlockRequest::Pending(txs) = block_request {
-            let block = self.backend.pending_block(txs).await;
+            let block = self
+                .backend
+                .pending_block_with_bundles(MiningTransactions::new(
+                    txs,
+                    self.pool.private_bundles(),
+                ))
+                .await;
             return Ok(Some(U256::from(block.block.body.transactions.len())));
         }
         let block = self.backend.block_by_number(block_number).await?;
@@ -2737,6 +2744,65 @@ impl EthApi<FoundryNetwork> {
         let tx = self.pool.add_transaction(pool_transaction)?;
         trace!(target: "node", "Added transaction: [{:?}] sender={:?}", tx.hash(), from);
         Ok(*tx.hash())
+    }
+
+    /// Queues an ordered private transaction bundle for an exact future block.
+    ///
+    /// Handler for ETH RPC call: `eth_sendBundle`
+    pub async fn send_bundle(&self, bundle: EthSendBundle) -> Result<EthBundleHash> {
+        node_info!("eth_sendBundle");
+        if bundle.txs.is_empty() {
+            return Err(BlockchainError::InvalidTransactionRequest(
+                "bundle must contain at least one transaction".to_string(),
+            ));
+        }
+        if bundle.block_number <= self.backend.best_number() {
+            return Err(BlockchainError::InvalidTransactionRequest(format!(
+                "bundle target block {} has already been mined",
+                bundle.block_number
+            )));
+        }
+        if let (Some(minimum), Some(maximum)) = (bundle.min_timestamp, bundle.max_timestamp)
+            && minimum > maximum
+        {
+            return Err(BlockchainError::InvalidTransactionRequest(
+                "bundle minTimestamp exceeds maxTimestamp".to_string(),
+            ));
+        }
+
+        let bundle_hash = bundle.bundle_hash();
+        let mut transactions = Vec::with_capacity(bundle.txs.len());
+        for raw in &bundle.txs {
+            if raw.is_empty() {
+                return Err(BlockchainError::EmptyRawTransactionData);
+            }
+            let mut data = raw.as_ref();
+            let transaction = FoundryTxEnvelope::decode_2718(&mut data)
+                .map_err(|_| BlockchainError::FailedToDecodeSignedTransaction)?;
+            self.ensure_typed_transaction_supported(&transaction)?;
+            let pending_transaction = PendingTransaction::new(transaction)?;
+            self.backend.validate_pool_transaction(&pending_transaction).await?;
+            let nonce = pending_transaction.nonce();
+            let sender = *pending_transaction.sender();
+            transactions.push(Arc::new(PoolTransaction {
+                requires: Vec::new(),
+                provides: vec![to_marker(nonce, sender)],
+                pending_transaction,
+                priority: TransactionPriority::default(),
+            }));
+        }
+
+        self.pool.add_private_bundle(PrivateBundle {
+            hash: bundle_hash,
+            transactions,
+            block_number: bundle.block_number,
+            min_timestamp: bundle.min_timestamp,
+            max_timestamp: bundle.max_timestamp,
+            reverting_tx_hashes: bundle.reverting_tx_hashes.into_iter().collect(),
+            replacement_uuid: bundle.replacement_uuid,
+        });
+
+        Ok(EthBundleHash { bundle_hash })
     }
 
     /// Sends a signed transaction with an ignored transaction condition.
@@ -4197,7 +4263,13 @@ impl EthApi<FoundryNetwork> {
     /// Mines exactly one block
     pub async fn mine_one(&self) {
         let transactions = self.pool.ready_transactions().collect::<Vec<_>>();
-        let outcome = self.backend.mine_block(transactions).await;
+        let outcome = self
+            .backend
+            .mine_block_with_bundles(MiningTransactions::new(
+                transactions,
+                self.pool.private_bundles(),
+            ))
+            .await;
 
         trace!(target: "node", blocknumber = ?outcome.block_number, "mined block");
         self.pool.on_mined_block(outcome);
@@ -4206,15 +4278,26 @@ impl EthApi<FoundryNetwork> {
     /// Returns the pending block with tx hashes
     async fn pending_block(&self) -> AnyRpcBlock {
         let transactions = self.pool.ready_transactions().collect::<Vec<_>>();
-        let info = self.backend.pending_block(transactions).await;
+        let info = self
+            .backend
+            .pending_block_with_bundles(MiningTransactions::new(
+                transactions,
+                self.pool.private_bundles(),
+            ))
+            .await;
         self.backend.convert_block(info.block)
     }
 
     /// Returns the full pending block with `Transaction` objects
     async fn pending_block_full(&self) -> Option<AnyRpcBlock> {
         let transactions = self.pool.ready_transactions().collect::<Vec<_>>();
-        let BlockInfo { block, transactions, receipts: _ } =
-            self.backend.pending_block(transactions).await;
+        let BlockInfo { block, transactions, receipts: _ } = self
+            .backend
+            .pending_block_with_bundles(MiningTransactions::new(
+                transactions,
+                self.pool.private_bundles(),
+            ))
+            .await;
 
         let mut partial_block = self.backend.convert_block(block.clone());
 

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -84,6 +84,28 @@ where
     fn init_from_state_snapshot(&mut self, _state_snapshot: StateSnapshot) {}
 }
 
+impl<T: MaybeFullDatabase + ?Sized> MaybeFullDatabase for &mut T {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
+        T::maybe_as_full_db(self)
+    }
+
+    fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
+        T::clear_into_state_snapshot(self)
+    }
+
+    fn read_as_state_snapshot(&self) -> StateSnapshot {
+        T::read_as_state_snapshot(self)
+    }
+
+    fn clear(&mut self) {
+        T::clear(self)
+    }
+
+    fn init_from_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
+        T::init_from_state_snapshot(self, state_snapshot)
+    }
+}
+
 /// Helper trait to reset the DB if it's forked
 pub trait MaybeForkedDatabase {
     fn maybe_reset(&mut self, _urls: Vec<String>, block_number: BlockId) -> Result<(), String>;
@@ -163,6 +185,28 @@ impl<T: DatabaseRef<Error = DatabaseError>> DatabaseRef for AnvilCacheDB<T> {
 impl<T: DatabaseRef<Error = DatabaseError> + fmt::Debug> DatabaseCommit for AnvilCacheDB<T> {
     fn commit(&mut self, changes: revm::state::EvmState) {
         self.0.commit(changes)
+    }
+}
+
+impl<T: DatabaseRef<Error = DatabaseError> + fmt::Debug> MaybeFullDatabase for AnvilCacheDB<T> {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
+        self.0.maybe_as_full_db()
+    }
+
+    fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
+        self.0.clear_into_state_snapshot()
+    }
+
+    fn read_as_state_snapshot(&self) -> StateSnapshot {
+        self.0.read_as_state_snapshot()
+    }
+
+    fn clear(&mut self) {
+        self.0.clear()
+    }
+
+    fn init_from_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
+        self.0.init_from_state_snapshot(state_snapshot)
     }
 }
 

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -61,27 +61,15 @@ pub trait MaybeFullDatabase: DatabaseRef<Error = DatabaseError> + Debug {
 
     /// Reverses `clear_into_snapshot` by initializing the db's state with the state snapshot.
     fn init_from_state_snapshot(&mut self, state_snapshot: StateSnapshot);
-}
 
-impl<'a, T: 'a + MaybeFullDatabase + ?Sized> MaybeFullDatabase for &'a T
-where
-    &'a T: DatabaseRef<Error = DatabaseError>,
-{
-    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
-        T::maybe_as_full_db(self)
+    /// Restores a checkpoint used during speculative bundle execution.
+    ///
+    /// Implementations with persistent caches should override this to avoid persistence side
+    /// effects that are appropriate for a general clear but not for an execution rollback.
+    fn restore_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
+        self.clear();
+        self.init_from_state_snapshot(state_snapshot);
     }
-
-    fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
-        unreachable!("never called for DatabaseRef")
-    }
-
-    fn read_as_state_snapshot(&self) -> StateSnapshot {
-        unreachable!("never called for DatabaseRef")
-    }
-
-    fn clear(&mut self) {}
-
-    fn init_from_state_snapshot(&mut self, _state_snapshot: StateSnapshot) {}
 }
 
 impl<T: MaybeFullDatabase + ?Sized> MaybeFullDatabase for &mut T {
@@ -104,6 +92,64 @@ impl<T: MaybeFullDatabase + ?Sized> MaybeFullDatabase for &mut T {
     fn init_from_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
         T::init_from_state_snapshot(self, state_snapshot)
     }
+
+    fn restore_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
+        T::restore_state_snapshot(self, state_snapshot)
+    }
+}
+
+/// An explicit read-only database view used by query and historical-state paths.
+///
+/// This preserves lazy fork lookups without exposing mutation through [`MaybeFullDatabase`]. Any
+/// speculative execution using this view must first layer a mutable [`CacheDB`] over it; bundle
+/// and pending-block execution use mutable database implementations directly.
+#[derive(Debug)]
+pub struct ReadOnlyDatabase<'a, T: ?Sized>(&'a T);
+
+impl<'a, T: ?Sized> ReadOnlyDatabase<'a, T> {
+    pub const fn new(db: &'a T) -> Self {
+        Self(db)
+    }
+}
+
+impl<T: MaybeFullDatabase + ?Sized> DatabaseRef for ReadOnlyDatabase<'_, T> {
+    type Error = DatabaseError;
+
+    fn basic_ref(&self, address: Address) -> DatabaseResult<Option<AccountInfo>> {
+        self.0.basic_ref(address)
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> DatabaseResult<Bytecode> {
+        self.0.code_by_hash_ref(code_hash)
+    }
+
+    fn storage_ref(&self, address: Address, index: U256) -> DatabaseResult<U256> {
+        self.0.storage_ref(address, index)
+    }
+
+    fn block_hash_ref(&self, number: u64) -> DatabaseResult<B256> {
+        self.0.block_hash_ref(number)
+    }
+}
+
+impl<T: MaybeFullDatabase + ?Sized> MaybeFullDatabase for ReadOnlyDatabase<'_, T> {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
+        self.0.maybe_as_full_db()
+    }
+
+    fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
+        self.0.read_as_state_snapshot()
+    }
+
+    fn read_as_state_snapshot(&self) -> StateSnapshot {
+        self.0.read_as_state_snapshot()
+    }
+
+    fn clear(&mut self) {}
+
+    fn init_from_state_snapshot(&mut self, _state_snapshot: StateSnapshot) {}
+
+    fn restore_state_snapshot(&mut self, _state_snapshot: StateSnapshot) {}
 }
 
 /// Helper trait to reset the DB if it's forked

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -61,15 +61,27 @@ pub trait MaybeFullDatabase: DatabaseRef<Error = DatabaseError> + Debug {
 
     /// Reverses `clear_into_snapshot` by initializing the db's state with the state snapshot.
     fn init_from_state_snapshot(&mut self, state_snapshot: StateSnapshot);
+}
 
-    /// Restores a checkpoint used during speculative bundle execution.
-    ///
-    /// Implementations with persistent caches should override this to avoid persistence side
-    /// effects that are appropriate for a general clear but not for an execution rollback.
-    fn restore_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
-        self.clear();
-        self.init_from_state_snapshot(state_snapshot);
+impl<'a, T: 'a + MaybeFullDatabase + ?Sized> MaybeFullDatabase for &'a T
+where
+    &'a T: DatabaseRef<Error = DatabaseError>,
+{
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
+        T::maybe_as_full_db(self)
     }
+
+    fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
+        unreachable!("never called for DatabaseRef")
+    }
+
+    fn read_as_state_snapshot(&self) -> StateSnapshot {
+        unreachable!("never called for DatabaseRef")
+    }
+
+    fn clear(&mut self) {}
+
+    fn init_from_state_snapshot(&mut self, _state_snapshot: StateSnapshot) {}
 }
 
 impl<T: MaybeFullDatabase + ?Sized> MaybeFullDatabase for &mut T {
@@ -92,64 +104,6 @@ impl<T: MaybeFullDatabase + ?Sized> MaybeFullDatabase for &mut T {
     fn init_from_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
         T::init_from_state_snapshot(self, state_snapshot)
     }
-
-    fn restore_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
-        T::restore_state_snapshot(self, state_snapshot)
-    }
-}
-
-/// An explicit read-only database view used by query and historical-state paths.
-///
-/// This preserves lazy fork lookups without exposing mutation through [`MaybeFullDatabase`]. Any
-/// speculative execution using this view must first layer a mutable [`CacheDB`] over it; bundle
-/// and pending-block execution use mutable database implementations directly.
-#[derive(Debug)]
-pub struct ReadOnlyDatabase<'a, T: ?Sized>(&'a T);
-
-impl<'a, T: ?Sized> ReadOnlyDatabase<'a, T> {
-    pub const fn new(db: &'a T) -> Self {
-        Self(db)
-    }
-}
-
-impl<T: MaybeFullDatabase + ?Sized> DatabaseRef for ReadOnlyDatabase<'_, T> {
-    type Error = DatabaseError;
-
-    fn basic_ref(&self, address: Address) -> DatabaseResult<Option<AccountInfo>> {
-        self.0.basic_ref(address)
-    }
-
-    fn code_by_hash_ref(&self, code_hash: B256) -> DatabaseResult<Bytecode> {
-        self.0.code_by_hash_ref(code_hash)
-    }
-
-    fn storage_ref(&self, address: Address, index: U256) -> DatabaseResult<U256> {
-        self.0.storage_ref(address, index)
-    }
-
-    fn block_hash_ref(&self, number: u64) -> DatabaseResult<B256> {
-        self.0.block_hash_ref(number)
-    }
-}
-
-impl<T: MaybeFullDatabase + ?Sized> MaybeFullDatabase for ReadOnlyDatabase<'_, T> {
-    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
-        self.0.maybe_as_full_db()
-    }
-
-    fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
-        self.0.read_as_state_snapshot()
-    }
-
-    fn read_as_state_snapshot(&self) -> StateSnapshot {
-        self.0.read_as_state_snapshot()
-    }
-
-    fn clear(&mut self) {}
-
-    fn init_from_state_snapshot(&mut self, _state_snapshot: StateSnapshot) {}
-
-    fn restore_state_snapshot(&mut self, _state_snapshot: StateSnapshot) {}
 }
 
 /// Helper trait to reset the DB if it's forked

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -1,7 +1,8 @@
 use crate::{
     eth::{
-        backend::cheats::CheatsManager, error::InvalidTransactionError,
-        pool::transactions::PoolTransaction,
+        backend::{cheats::CheatsManager, db::MaybeFullDatabase},
+        error::InvalidTransactionError,
+        pool::{PrivateBundle, transactions::PoolTransaction},
     },
     mem::inspector::{AnvilInspector, InspectorTxConfig},
 };
@@ -28,7 +29,10 @@ use alloy_primitives::{Address, B256, Bytes, U256};
 use anvil_core::eth::transaction::{
     MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo,
 };
-use foundry_evm::core::{env::FoundryTransaction, evm::IntoInstructionResult};
+use foundry_evm::{
+    backend::StateSnapshot,
+    core::{env::FoundryTransaction, evm::IntoInstructionResult},
+};
 use foundry_primitives::{FoundryReceiptEnvelope, FoundryTxEnvelope, FoundryTxType};
 use revm::{
     Database, DatabaseCommit,
@@ -146,6 +150,23 @@ impl<E> AnvilBlockExecutor<E> {
             blob_gas_used: 0,
         }
     }
+}
+
+/// State needed to discard all effects of a failed private bundle.
+pub struct BundleCheckpoint {
+    state: StateSnapshot,
+    receipts_len: usize,
+    gas_used: u64,
+    blob_gas_used: u64,
+}
+
+/// Checkpoint support required for atomic private bundle execution.
+pub trait BundleExecutor: BlockExecutor {
+    fn bundle_checkpoint(&self) -> BundleCheckpoint;
+
+    fn revert_bundle(&mut self, checkpoint: BundleCheckpoint);
+
+    fn blob_gas_used(&self) -> u64;
 }
 
 impl<E> BlockExecutor for AnvilBlockExecutor<E>
@@ -292,6 +313,36 @@ where
     }
 }
 
+impl<E> BundleExecutor for AnvilBlockExecutor<E>
+where
+    E: Evm<
+            DB: StateDB + MaybeFullDatabase,
+            Tx: FromRecoveredTx<FoundryTxEnvelope> + FromTxWithEncoded<FoundryTxEnvelope>,
+        >,
+{
+    fn bundle_checkpoint(&self) -> BundleCheckpoint {
+        BundleCheckpoint {
+            state: self.evm.db().read_as_state_snapshot(),
+            receipts_len: self.receipts.len(),
+            gas_used: self.gas_used,
+            blob_gas_used: self.blob_gas_used,
+        }
+    }
+
+    fn revert_bundle(&mut self, checkpoint: BundleCheckpoint) {
+        let db = self.evm.db_mut();
+        db.clear();
+        db.init_from_state_snapshot(checkpoint.state);
+        self.receipts.truncate(checkpoint.receipts_len);
+        self.gas_used = checkpoint.gas_used;
+        self.blob_gas_used = checkpoint.blob_gas_used;
+    }
+
+    fn blob_gas_used(&self) -> u64 {
+        self.blob_gas_used
+    }
+}
+
 /// Result of executing pool transactions against a block executor.
 pub struct ExecutedPoolTransactions<T> {
     /// Successfully included transactions.
@@ -305,6 +356,28 @@ pub struct ExecutedPoolTransactions<T> {
     pub tx_info: Vec<TransactionInfo>,
     /// The raw pending transactions that were included (in order).
     pub txs: Vec<MaybeImpersonatedTransaction<T>>,
+}
+
+impl<T> Default for ExecutedPoolTransactions<T> {
+    fn default() -> Self {
+        Self {
+            included: Vec::new(),
+            invalid: Vec::new(),
+            not_yet_valid: Vec::new(),
+            tx_info: Vec::new(),
+            txs: Vec::new(),
+        }
+    }
+}
+
+impl<T> ExecutedPoolTransactions<T> {
+    fn extend(&mut self, other: Self) {
+        self.included.extend(other.included);
+        self.invalid.extend(other.invalid);
+        self.not_yet_valid.extend(other.not_yet_valid);
+        self.tx_info.extend(other.tx_info);
+        self.txs.extend(other.txs);
+    }
 }
 
 /// Gas-related configuration for pool transaction execution.
@@ -324,8 +397,72 @@ pub struct PoolTxGasConfig {
 /// execution, commit, inspector drain, and result collection.
 ///
 /// This is the shared core of `do_mine_block` and `with_pending_block`.
-#[allow(clippy::type_complexity)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub fn execute_pool_transactions<B>(
+    executor: &mut B,
+    pool_transactions: &[Arc<PoolTransaction<B::Transaction>>],
+    private_bundles: &[Arc<PrivateBundle<B::Transaction>>],
+    block_number: u64,
+    block_timestamp: u64,
+    gas_config: &PoolTxGasConfig,
+    inspector_config: &InspectorTxConfig,
+    cheats: &CheatsManager,
+    validator: &dyn Fn(
+        &PendingTransaction<B::Transaction>,
+        &AccountInfo,
+    ) -> Result<(), InvalidTransactionError>,
+) -> ExecutedPoolTransactions<B::Transaction>
+where
+    B: BundleExecutor<
+            Transaction = FoundryTxEnvelope,
+            Evm: Evm<DB: Database + Debug, Inspector = AnvilInspector>,
+        >,
+    B::Receipt: TxReceipt,
+    <B::Result as TxResult>::HaltReason: Clone + IntoInstructionResult,
+    <B::Evm as Evm>::Tx: FromTxWithEncoded<B::Transaction> + FoundryTransaction,
+{
+    let mut executed = ExecutedPoolTransactions::default();
+
+    for bundle in private_bundles {
+        if !bundle.is_eligible(block_number, block_timestamp) {
+            continue;
+        }
+
+        let checkpoint = executor.bundle_checkpoint();
+        let bundle_result = execute_transaction_list(
+            executor,
+            &bundle.transactions,
+            gas_config,
+            inspector_config,
+            cheats,
+            validator,
+        );
+        let accepted = bundle_result.included.len() == bundle.transactions.len()
+            && bundle_result.tx_info.iter().all(|info| {
+                info.exit.is_ok() || bundle.reverting_tx_hashes.contains(&info.transaction_hash)
+            });
+
+        if accepted {
+            executed.extend(bundle_result);
+        } else {
+            executor.revert_bundle(checkpoint);
+            trace!(target: "backend", bundle = ?bundle.hash, "skipping invalid private bundle");
+        }
+    }
+
+    executed.extend(execute_transaction_list(
+        executor,
+        pool_transactions,
+        gas_config,
+        inspector_config,
+        cheats,
+        validator,
+    ));
+    executed
+}
+
+#[allow(clippy::type_complexity)]
+fn execute_transaction_list<B>(
     executor: &mut B,
     pool_transactions: &[Arc<PoolTransaction<B::Transaction>>],
     gas_config: &PoolTxGasConfig,
@@ -337,7 +474,7 @@ pub fn execute_pool_transactions<B>(
     ) -> Result<(), InvalidTransactionError>,
 ) -> ExecutedPoolTransactions<B::Transaction>
 where
-    B: BlockExecutor<
+    B: BundleExecutor<
             Transaction = FoundryTxEnvelope,
             Evm: Evm<DB: Database + Debug, Inspector = AnvilInspector>,
         >,
@@ -352,7 +489,7 @@ where
     let mut not_yet_valid = Vec::new();
     let mut tx_info: Vec<TransactionInfo> = Vec::new();
     let mut transactions = Vec::new();
-    let mut blob_gas_used = 0u64;
+    let mut blob_gas_used = executor.blob_gas_used();
 
     for pool_tx in pool_transactions {
         let pending = &pool_tx.pending_transaction;
@@ -455,7 +592,7 @@ where
                 });
 
                 // TODO: replace `TransactionInfo` with alloy receipt/transaction types
-                let transaction_index = tx_info.len() as u64;
+                let transaction_index = executor.receipts().len().saturating_sub(1) as u64;
                 let info = TransactionInfo {
                     transaction_hash: pool_tx.hash(),
                     transaction_index,

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -331,7 +331,8 @@ where
 
     fn revert_bundle(&mut self, checkpoint: BundleCheckpoint) {
         let db = self.evm.db_mut();
-        db.restore_state_snapshot(checkpoint.state);
+        db.clear();
+        db.init_from_state_snapshot(checkpoint.state);
         self.receipts.truncate(checkpoint.receipts_len);
         self.gas_used = checkpoint.gas_used;
         self.blob_gas_used = checkpoint.blob_gas_used;
@@ -401,6 +402,8 @@ pub fn execute_pool_transactions<B>(
     executor: &mut B,
     pool_transactions: &[Arc<PoolTransaction<B::Transaction>>],
     private_bundles: &[Arc<PrivateBundle<B::Transaction>>],
+    block_number: u64,
+    block_timestamp: u64,
     gas_config: &PoolTxGasConfig,
     inspector_config: &InspectorTxConfig,
     cheats: &CheatsManager,
@@ -419,8 +422,6 @@ where
     <B::Evm as Evm>::Tx: FromTxWithEncoded<B::Transaction> + FoundryTransaction,
 {
     let mut executed = ExecutedPoolTransactions::default();
-    let block_number = executor.evm().block().number().saturating_to();
-    let block_timestamp = executor.evm().block().timestamp().saturating_to();
 
     for bundle in private_bundles {
         if !bundle.is_eligible(block_number, block_timestamp) {
@@ -428,37 +429,18 @@ where
         }
 
         let checkpoint = executor.bundle_checkpoint();
-        let mut bundle_result = ExecutedPoolTransactions::default();
-        let mut accepted = true;
-
-        for transaction in &bundle.transactions {
-            let hash = transaction.hash();
-            let may_drop = bundle.dropping_tx_hashes.contains(&hash);
-            let transaction_checkpoint = may_drop.then(|| executor.bundle_checkpoint());
-            let transaction_result = execute_transaction_list(
-                executor,
-                std::slice::from_ref(transaction),
-                gas_config,
-                inspector_config,
-                cheats,
-                validator,
-            );
-            let included = transaction_result.included.len() == 1;
-            let succeeded = included
-                && transaction_result.tx_info.iter().all(|info| {
-                    info.exit.is_ok() || bundle.reverting_tx_hashes.contains(&info.transaction_hash)
-                });
-
-            if succeeded {
-                bundle_result.extend(transaction_result);
-            } else if let Some(transaction_checkpoint) = transaction_checkpoint {
-                executor.revert_bundle(transaction_checkpoint);
-                trace!(target: "backend", bundle = ?bundle.hash, transaction = ?hash, "dropping invalid private bundle transaction");
-            } else {
-                accepted = false;
-                break;
-            }
-        }
+        let bundle_result = execute_transaction_list(
+            executor,
+            &bundle.transactions,
+            gas_config,
+            inspector_config,
+            cheats,
+            validator,
+        );
+        let accepted = bundle_result.included.len() == bundle.transactions.len()
+            && bundle_result.tx_info.iter().all(|info| {
+                info.exit.is_ok() || bundle.reverting_tx_hashes.contains(&info.transaction_hash)
+            });
 
         if accepted {
             executed.extend(bundle_result);

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -331,8 +331,7 @@ where
 
     fn revert_bundle(&mut self, checkpoint: BundleCheckpoint) {
         let db = self.evm.db_mut();
-        db.clear();
-        db.init_from_state_snapshot(checkpoint.state);
+        db.restore_state_snapshot(checkpoint.state);
         self.receipts.truncate(checkpoint.receipts_len);
         self.gas_used = checkpoint.gas_used;
         self.blob_gas_used = checkpoint.blob_gas_used;
@@ -402,8 +401,6 @@ pub fn execute_pool_transactions<B>(
     executor: &mut B,
     pool_transactions: &[Arc<PoolTransaction<B::Transaction>>],
     private_bundles: &[Arc<PrivateBundle<B::Transaction>>],
-    block_number: u64,
-    block_timestamp: u64,
     gas_config: &PoolTxGasConfig,
     inspector_config: &InspectorTxConfig,
     cheats: &CheatsManager,
@@ -422,6 +419,8 @@ where
     <B::Evm as Evm>::Tx: FromTxWithEncoded<B::Transaction> + FoundryTransaction,
 {
     let mut executed = ExecutedPoolTransactions::default();
+    let block_number = executor.evm().block().number().saturating_to();
+    let block_timestamp = executor.evm().block().timestamp().saturating_to();
 
     for bundle in private_bundles {
         if !bundle.is_eligible(block_number, block_timestamp) {
@@ -429,18 +428,37 @@ where
         }
 
         let checkpoint = executor.bundle_checkpoint();
-        let bundle_result = execute_transaction_list(
-            executor,
-            &bundle.transactions,
-            gas_config,
-            inspector_config,
-            cheats,
-            validator,
-        );
-        let accepted = bundle_result.included.len() == bundle.transactions.len()
-            && bundle_result.tx_info.iter().all(|info| {
-                info.exit.is_ok() || bundle.reverting_tx_hashes.contains(&info.transaction_hash)
-            });
+        let mut bundle_result = ExecutedPoolTransactions::default();
+        let mut accepted = true;
+
+        for transaction in &bundle.transactions {
+            let hash = transaction.hash();
+            let may_drop = bundle.dropping_tx_hashes.contains(&hash);
+            let transaction_checkpoint = may_drop.then(|| executor.bundle_checkpoint());
+            let transaction_result = execute_transaction_list(
+                executor,
+                std::slice::from_ref(transaction),
+                gas_config,
+                inspector_config,
+                cheats,
+                validator,
+            );
+            let included = transaction_result.included.len() == 1;
+            let succeeded = included
+                && transaction_result.tx_info.iter().all(|info| {
+                    info.exit.is_ok() || bundle.reverting_tx_hashes.contains(&info.transaction_hash)
+                });
+
+            if succeeded {
+                bundle_result.extend(transaction_result);
+            } else if let Some(transaction_checkpoint) = transaction_checkpoint {
+                executor.revert_bundle(transaction_checkpoint);
+                trace!(target: "backend", bundle = ?bundle.hash, transaction = ?hash, "dropping invalid private bundle transaction");
+            } else {
+                accepted = false;
+                break;
+            }
+        }
 
         if accepted {
             executed.extend(bundle_result);

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -120,6 +120,12 @@ impl<N: Network> MaybeFullDatabase for ForkedDatabase<N> {
         *db.storage.write() = storage;
         *db.block_hashes.write() = block_hashes;
     }
+
+    fn restore_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
+        // Unlike a general clear, speculative execution rollback must not flush rejected bundle
+        // state into the persistent fork cache.
+        self.init_from_state_snapshot(state_snapshot);
+    }
 }
 
 impl<N: Network> MaybeFullDatabase for ForkDbStateSnapshot<N> {
@@ -151,6 +157,11 @@ impl<N: Network> MaybeFullDatabase for ForkDbStateSnapshot<N> {
     }
 
     fn init_from_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
+        self.state_snapshot = state_snapshot;
+    }
+
+    fn restore_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
+        self.local.clear();
         self.state_snapshot = state_snapshot;
     }
 }

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -120,12 +120,6 @@ impl<N: Network> MaybeFullDatabase for ForkedDatabase<N> {
         *db.storage.write() = storage;
         *db.block_hashes.write() = block_hashes;
     }
-
-    fn restore_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
-        // Unlike a general clear, speculative execution rollback must not flush rejected bundle
-        // state into the persistent fork cache.
-        self.init_from_state_snapshot(state_snapshot);
-    }
 }
 
 impl<N: Network> MaybeFullDatabase for ForkDbStateSnapshot<N> {
@@ -157,11 +151,6 @@ impl<N: Network> MaybeFullDatabase for ForkDbStateSnapshot<N> {
     }
 
     fn init_from_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
-        self.state_snapshot = state_snapshot;
-    }
-
-    fn restore_state_snapshot(&mut self, state_snapshot: StateSnapshot) {
-        self.local.clear();
         self.state_snapshot = state_snapshot;
     }
 }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -26,7 +26,7 @@ use crate::{
         error::{BlockchainError, ErrDetail, InvalidTransactionError},
         fees::{FeeDetails, FeeManager, MIN_SUGGESTED_PRIORITY_FEE},
         macros::node_info,
-        pool::transactions::PoolTransaction,
+        pool::{MiningTransactions, transactions::PoolTransaction},
         sign::build_impersonated,
     },
     mem::{
@@ -1416,7 +1416,7 @@ impl<N: Network> Backend<N> {
         evm_env: &EvmEnv,
         parent_hash: B256,
         spec_id: SpecId,
-        pool_transactions: &[Arc<PoolTransaction<FoundryTxEnvelope>>],
+        mining_transactions: &MiningTransactions<FoundryTxEnvelope>,
         gas_config: &PoolTxGasConfig,
         inspector_tx_config: &InspectorTxConfig,
         validator: &dyn Fn(
@@ -1425,7 +1425,7 @@ impl<N: Network> Backend<N> {
         ) -> Result<(), InvalidTransactionError>,
     ) -> (ExecutedPoolTransactions<FoundryTxEnvelope>, BlockExecutionResult<FoundryReceiptEnvelope>)
     where
-        DB: StateDB<Error = DatabaseError>,
+        DB: StateDB<Error = DatabaseError> + MaybeFullDatabase,
     {
         let inspector = self.build_mining_inspector();
 
@@ -1437,7 +1437,10 @@ impl<N: Network> Backend<N> {
                 executor.apply_pre_execution_changes().expect("pre-execution changes failed");
                 let pool_result = execute_pool_transactions(
                     &mut executor,
-                    pool_transactions,
+                    &mining_transactions.transactions,
+                    &mining_transactions.private_bundles,
+                    evm_env.block_env.number.saturating_to(),
+                    evm_env.block_env.timestamp.saturating_to(),
                     gas_config,
                     inspector_tx_config,
                     self.cheats(),
@@ -2908,7 +2911,15 @@ where
         &self,
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
     ) -> MinedBlockOutcome<FoundryTxEnvelope> {
-        self.do_mine_block(pool_transactions).await
+        self.do_mine_block(MiningTransactions::new(pool_transactions, Vec::new())).await
+    }
+
+    /// Mines a new block with public transactions and private bundles.
+    pub async fn mine_block_with_bundles(
+        &self,
+        mining_transactions: MiningTransactions<FoundryTxEnvelope>,
+    ) -> MinedBlockOutcome<FoundryTxEnvelope> {
+        self.do_mine_block(mining_transactions).await
     }
 
     /// Builds a [`BlockInfo`] from the EVM environment, execution results, and transactions.
@@ -2967,10 +2978,10 @@ where
 
     async fn do_mine_block(
         &self,
-        pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
+        mining_transactions: MiningTransactions<FoundryTxEnvelope>,
     ) -> MinedBlockOutcome<FoundryTxEnvelope> {
         let _mining_guard = self.mining.lock().await;
-        trace!(target: "backend", "creating new block with {} transactions", pool_transactions.len());
+        trace!(target: "backend", "creating new block with {} public transactions and {} private bundles", mining_transactions.transactions.len(), mining_transactions.private_bundles.len());
 
         let (outcome, header, block_hash) = {
             let current_base_fee = self.base_fee();
@@ -3032,7 +3043,7 @@ where
                     &evm_env,
                     best_hash,
                     spec_id,
-                    &pool_transactions,
+                    &mining_transactions,
                     &gas_config,
                     &inspector_tx_config,
                     &|pending, account| {
@@ -3180,7 +3191,8 @@ where
         // Create the new reorged chain, filling the blocks with transactions if supplied
         for i in 0..depth {
             let to_be_mined = tx_pairs.get(&i).cloned().unwrap_or_else(Vec::new);
-            let outcome = self.do_mine_block(to_be_mined).await;
+            let outcome =
+                self.do_mine_block(MiningTransactions::new(to_be_mined, Vec::new())).await;
             node_info!(
                 "    Mined reorg block number {}. With {} valid txs and with invalid {} txs",
                 outcome.block_number,
@@ -3199,7 +3211,16 @@ where
         &self,
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
     ) -> BlockInfo<N> {
-        self.with_pending_block(pool_transactions, |_, block| block).await
+        self.pending_block_with_bundles(MiningTransactions::new(pool_transactions, Vec::new()))
+            .await
+    }
+
+    /// Creates the pending block with public transactions and private bundles.
+    pub async fn pending_block_with_bundles(
+        &self,
+        mining_transactions: MiningTransactions<FoundryTxEnvelope>,
+    ) -> BlockInfo<N> {
+        self.with_pending_block_with_bundles(mining_transactions, |_, block| block).await
     }
 
     /// Creates the pending block
@@ -3208,6 +3229,22 @@ where
     pub async fn with_pending_block<F, T>(
         &self,
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
+        f: F,
+    ) -> T
+    where
+        F: FnOnce(Box<dyn MaybeFullDatabase + '_>, BlockInfo<N>) -> T,
+    {
+        self.with_pending_block_with_bundles(
+            MiningTransactions::new(pool_transactions, Vec::new()),
+            f,
+        )
+        .await
+    }
+
+    /// Executes a closure against a pending block containing private bundles.
+    pub async fn with_pending_block_with_bundles<F, T>(
+        &self,
+        mining_transactions: MiningTransactions<FoundryTxEnvelope>,
         f: F,
     ) -> T
     where
@@ -3230,7 +3267,7 @@ where
             &evm_env,
             parent_hash,
             spec_id,
-            &pool_transactions,
+            &mining_transactions,
             &gas_config,
             &inspector_tx_config,
             &|pending, account| self.validate_pool_transaction_for(pending, account, &evm_env),
@@ -3467,7 +3504,7 @@ where
                 &evm_env,
                 block.header.parent_hash,
                 spec_id,
-                &pool_txs,
+                &MiningTransactions::new(pool_txs.clone(), Vec::new()),
                 &gas_config,
                 &inspector_tx_config,
                 &|pending, account| self.validate_pool_transaction_for(pending, account, &evm_env),
@@ -3862,7 +3899,7 @@ where
                 &evm_env,
                 block.header.parent_hash,
                 spec_id,
-                &pool_txs,
+                &MiningTransactions::new(pool_txs.clone(), Vec::new()),
                 &gas_config,
                 &inspector_tx_config,
                 &|pending, account| self.validate_pool_transaction_for(pending, account, &evm_env),
@@ -4159,7 +4196,7 @@ where
                 &evm_env,
                 block.header.parent_hash,
                 spec_id,
-                &pool_txs,
+                &MiningTransactions::new(pool_txs.clone(), Vec::new()),
                 &gas_config,
                 &inspector_tx_config,
                 &|pending, account| self.validate_pool_transaction_for(pending, account, &evm_env),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -7,9 +7,7 @@ use crate::{
     eth::{
         backend::{
             cheats::{CheatEcrecover, CheatsManager},
-            db::{
-                AnvilCacheDB, Db, MaybeFullDatabase, ReadOnlyDatabase, SerializableState, StateDb,
-            },
+            db::{AnvilCacheDB, Db, MaybeFullDatabase, SerializableState, StateDb},
             executor::{
                 AnvilBlockExecutor, ExecutedPoolTransactions, PoolTxGasConfig,
                 execute_pool_transactions,
@@ -248,18 +246,14 @@ pub type State = foundry_evm::utils::StateChangeset;
 
 /// A block request, which includes the Pool Transactions if it's Pending
 pub enum BlockRequest<T> {
-    Pending(MiningTransactions<T>),
+    Pending(Vec<Arc<PoolTransaction<T>>>),
     Number(u64),
 }
 
 impl<T> fmt::Debug for BlockRequest<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Pending(txs) => f
-                .debug_struct("Pending")
-                .field("transactions", &txs.transactions.len())
-                .field("private_bundles", &txs.private_bundles.len())
-                .finish(),
+            Self::Pending(txs) => f.debug_tuple("Pending").field(&txs.len()).finish(),
             Self::Number(n) => f.debug_tuple("Number").field(n).finish(),
         }
     }
@@ -1445,6 +1439,8 @@ impl<N: Network> Backend<N> {
                     &mut executor,
                     &mining_transactions.transactions,
                     &mining_transactions.private_bundles,
+                    evm_env.block_env.number.saturating_to(),
+                    evm_env.block_env.timestamp.saturating_to(),
                     gas_config,
                     inspector_tx_config,
                     self.cheats(),
@@ -3494,8 +3490,7 @@ where
 
         let trace = |parent_state: &StateDb| -> Result<GethTrace, BlockchainError> {
             let mut cache_db =
-                AnvilCacheDB::new(Box::new(ReadOnlyDatabase::new(parent_state))
-                    as Box<dyn MaybeFullDatabase + '_>);
+                AnvilCacheDB::new(Box::new(parent_state) as Box<dyn MaybeFullDatabase + '_>);
 
             let mut evm_env = self.evm_env.read().clone();
             evm_env.block_env = block_env_from_header(&block.header);
@@ -3694,9 +3689,9 @@ where
         F: FnOnce(Box<dyn MaybeFullDatabase + '_>, BlockEnv) -> T,
     {
         let block_number = match block_request {
-            Some(BlockRequest::Pending(mining_transactions)) => {
+            Some(BlockRequest::Pending(pool_transactions)) => {
                 let result = self
-                    .with_pending_block_with_bundles(mining_transactions, |state, block| {
+                    .with_pending_block(pool_transactions, |state, block| {
                         let block = block.block;
                         f(state, block_env_from_header(&block.header))
                     })
@@ -3722,18 +3717,12 @@ where
             {
                 let read_guard = self.states.upgradable_read();
                 if let Some(state_db) = read_guard.get_state(&block_hash) {
-                    return Ok(f(
-                        Box::new(ReadOnlyDatabase::new(state_db)),
-                        block_env_from_header(&block.header),
-                    ));
+                    return Ok(f(Box::new(state_db), block_env_from_header(&block.header)));
                 }
 
                 let mut write_guard = RwLockUpgradableReadGuard::upgrade(read_guard);
                 if let Some(state) = write_guard.get_on_disk_state(&block_hash) {
-                    return Ok(f(
-                        Box::new(ReadOnlyDatabase::new(state)),
-                        block_env_from_header(&block.header),
-                    ));
+                    return Ok(f(Box::new(state), block_env_from_header(&block.header)));
                 }
             }
 
@@ -3743,7 +3732,7 @@ where
 
         let db = self.db.read().await;
         let block = self.evm_env.read().block_env.clone();
-        Ok(f(Box::new(ReadOnlyDatabase::new(&**db)), block))
+        Ok(f(Box::new(&**db), block))
     }
 
     pub async fn storage_at(
@@ -3831,7 +3820,17 @@ where
         address: Address,
         block_request: BlockRequest<FoundryTxEnvelope>,
     ) -> Result<u64, BlockchainError> {
-        self.with_database_at(Some(block_request), |db, _| {
+        if let BlockRequest::Pending(pool_transactions) = &block_request
+            && let Some(value) = get_pool_transactions_nonce(pool_transactions, address)
+        {
+            return Ok(value);
+        }
+        let final_block_request = match block_request {
+            BlockRequest::Pending(_) => BlockRequest::Number(self.best_number()),
+            BlockRequest::Number(bn) => BlockRequest::Number(bn),
+        };
+
+        self.with_database_at(Some(final_block_request), |db, _| {
             trace!(target: "backend", "get nonce for {:?}", address);
             Ok(db.basic_ref(address)?.unwrap_or_default().nonce)
         })
@@ -5394,39 +5393,24 @@ fn tempo_db_err<E: std::fmt::Display>(e: E) -> DatabaseError {
     DatabaseError::AnyRequest(Arc::new(eyre::eyre!("{e}")))
 }
 
-impl<N: Network> Backend<N>
-where
-    N: Network<TxEnvelope = FoundryTxEnvelope, ReceiptEnvelope = FoundryReceiptEnvelope>,
-{
-    /// Validates the transaction chain ID without consulting mutable account or fee state.
-    pub fn validate_transaction_chain_id(
-        &self,
-        tx: &FoundryTxEnvelope,
-    ) -> Result<(), InvalidTransactionError> {
-        self.validate_transaction_chain_id_for(tx, &self.next_evm_env())
+/// Get max nonce from transaction pool by address.
+fn get_pool_transactions_nonce(
+    pool_transactions: &[Arc<PoolTransaction<FoundryTxEnvelope>>],
+    address: Address,
+) -> Option<u64> {
+    if let Some(highest_nonce) = pool_transactions
+        .iter()
+        .filter(|tx| {
+            *tx.pending_transaction.sender() == address
+                && !tx.pending_transaction.transaction.as_ref().has_nonzero_tempo_nonce_key()
+        })
+        .map(|tx| tx.pending_transaction.nonce())
+        .max()
+    {
+        let tx_count = highest_nonce.saturating_add(1);
+        return Some(tx_count);
     }
-
-    fn validate_transaction_chain_id_for(
-        &self,
-        tx: &FoundryTxEnvelope,
-        evm_env: &EvmEnv,
-    ) -> Result<(), InvalidTransactionError> {
-        if let Some(tx_chain_id) = tx.chain_id() {
-            let chain_id = self.chain_id();
-            if chain_id.to::<u64>() != tx_chain_id {
-                if let FoundryTxEnvelope::Legacy(tx) = tx {
-                    // <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>
-                    if evm_env.cfg_env.spec >= SpecId::SPURIOUS_DRAGON && tx.chain_id().is_none() {
-                        debug!(target: "backend", ?chain_id, ?tx_chain_id, "incompatible EIP155-based V");
-                        return Err(InvalidTransactionError::IncompatibleEIP155);
-                    }
-                }
-                debug!(target: "backend", ?chain_id, ?tx_chain_id, "invalid chain id");
-                return Err(InvalidTransactionError::InvalidChainId);
-            }
-        }
-        Ok(())
-    }
+    None
 }
 
 #[async_trait::async_trait]
@@ -5504,7 +5488,21 @@ where
     ) -> Result<(), InvalidTransactionError> {
         let tx = &pending.transaction;
 
-        self.validate_transaction_chain_id_for(tx, evm_env)?;
+        if let Some(tx_chain_id) = tx.chain_id() {
+            let chain_id = self.chain_id();
+            if chain_id.to::<u64>() != tx_chain_id {
+                if let FoundryTxEnvelope::Legacy(tx) = tx.as_ref() {
+                    // <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>
+                    if evm_env.cfg_env.spec >= SpecId::SPURIOUS_DRAGON && tx.chain_id().is_none() {
+                        debug!(target: "backend", ?chain_id, ?tx_chain_id, "incompatible EIP155-based V");
+                        return Err(InvalidTransactionError::IncompatibleEIP155);
+                    }
+                } else {
+                    debug!(target: "backend", ?chain_id, ?tx_chain_id, "invalid chain id");
+                    return Err(InvalidTransactionError::InvalidChainId);
+                }
+            }
+        }
 
         // Reject native value transfers on Tempo networks
         if self.is_tempo() && !tx.value().is_zero() {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -7,7 +7,9 @@ use crate::{
     eth::{
         backend::{
             cheats::{CheatEcrecover, CheatsManager},
-            db::{AnvilCacheDB, Db, MaybeFullDatabase, SerializableState, StateDb},
+            db::{
+                AnvilCacheDB, Db, MaybeFullDatabase, ReadOnlyDatabase, SerializableState, StateDb,
+            },
             executor::{
                 AnvilBlockExecutor, ExecutedPoolTransactions, PoolTxGasConfig,
                 execute_pool_transactions,
@@ -246,14 +248,18 @@ pub type State = foundry_evm::utils::StateChangeset;
 
 /// A block request, which includes the Pool Transactions if it's Pending
 pub enum BlockRequest<T> {
-    Pending(Vec<Arc<PoolTransaction<T>>>),
+    Pending(MiningTransactions<T>),
     Number(u64),
 }
 
 impl<T> fmt::Debug for BlockRequest<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Pending(txs) => f.debug_tuple("Pending").field(&txs.len()).finish(),
+            Self::Pending(txs) => f
+                .debug_struct("Pending")
+                .field("transactions", &txs.transactions.len())
+                .field("private_bundles", &txs.private_bundles.len())
+                .finish(),
             Self::Number(n) => f.debug_tuple("Number").field(n).finish(),
         }
     }
@@ -1439,8 +1445,6 @@ impl<N: Network> Backend<N> {
                     &mut executor,
                     &mining_transactions.transactions,
                     &mining_transactions.private_bundles,
-                    evm_env.block_env.number.saturating_to(),
-                    evm_env.block_env.timestamp.saturating_to(),
                     gas_config,
                     inspector_tx_config,
                     self.cheats(),
@@ -3490,7 +3494,8 @@ where
 
         let trace = |parent_state: &StateDb| -> Result<GethTrace, BlockchainError> {
             let mut cache_db =
-                AnvilCacheDB::new(Box::new(parent_state) as Box<dyn MaybeFullDatabase + '_>);
+                AnvilCacheDB::new(Box::new(ReadOnlyDatabase::new(parent_state))
+                    as Box<dyn MaybeFullDatabase + '_>);
 
             let mut evm_env = self.evm_env.read().clone();
             evm_env.block_env = block_env_from_header(&block.header);
@@ -3689,9 +3694,9 @@ where
         F: FnOnce(Box<dyn MaybeFullDatabase + '_>, BlockEnv) -> T,
     {
         let block_number = match block_request {
-            Some(BlockRequest::Pending(pool_transactions)) => {
+            Some(BlockRequest::Pending(mining_transactions)) => {
                 let result = self
-                    .with_pending_block(pool_transactions, |state, block| {
+                    .with_pending_block_with_bundles(mining_transactions, |state, block| {
                         let block = block.block;
                         f(state, block_env_from_header(&block.header))
                     })
@@ -3717,12 +3722,18 @@ where
             {
                 let read_guard = self.states.upgradable_read();
                 if let Some(state_db) = read_guard.get_state(&block_hash) {
-                    return Ok(f(Box::new(state_db), block_env_from_header(&block.header)));
+                    return Ok(f(
+                        Box::new(ReadOnlyDatabase::new(state_db)),
+                        block_env_from_header(&block.header),
+                    ));
                 }
 
                 let mut write_guard = RwLockUpgradableReadGuard::upgrade(read_guard);
                 if let Some(state) = write_guard.get_on_disk_state(&block_hash) {
-                    return Ok(f(Box::new(state), block_env_from_header(&block.header)));
+                    return Ok(f(
+                        Box::new(ReadOnlyDatabase::new(state)),
+                        block_env_from_header(&block.header),
+                    ));
                 }
             }
 
@@ -3732,7 +3743,7 @@ where
 
         let db = self.db.read().await;
         let block = self.evm_env.read().block_env.clone();
-        Ok(f(Box::new(&**db), block))
+        Ok(f(Box::new(ReadOnlyDatabase::new(&**db)), block))
     }
 
     pub async fn storage_at(
@@ -3820,17 +3831,7 @@ where
         address: Address,
         block_request: BlockRequest<FoundryTxEnvelope>,
     ) -> Result<u64, BlockchainError> {
-        if let BlockRequest::Pending(pool_transactions) = &block_request
-            && let Some(value) = get_pool_transactions_nonce(pool_transactions, address)
-        {
-            return Ok(value);
-        }
-        let final_block_request = match block_request {
-            BlockRequest::Pending(_) => BlockRequest::Number(self.best_number()),
-            BlockRequest::Number(bn) => BlockRequest::Number(bn),
-        };
-
-        self.with_database_at(Some(final_block_request), |db, _| {
+        self.with_database_at(Some(block_request), |db, _| {
             trace!(target: "backend", "get nonce for {:?}", address);
             Ok(db.basic_ref(address)?.unwrap_or_default().nonce)
         })
@@ -5393,24 +5394,39 @@ fn tempo_db_err<E: std::fmt::Display>(e: E) -> DatabaseError {
     DatabaseError::AnyRequest(Arc::new(eyre::eyre!("{e}")))
 }
 
-/// Get max nonce from transaction pool by address.
-fn get_pool_transactions_nonce(
-    pool_transactions: &[Arc<PoolTransaction<FoundryTxEnvelope>>],
-    address: Address,
-) -> Option<u64> {
-    if let Some(highest_nonce) = pool_transactions
-        .iter()
-        .filter(|tx| {
-            *tx.pending_transaction.sender() == address
-                && !tx.pending_transaction.transaction.as_ref().has_nonzero_tempo_nonce_key()
-        })
-        .map(|tx| tx.pending_transaction.nonce())
-        .max()
-    {
-        let tx_count = highest_nonce.saturating_add(1);
-        return Some(tx_count);
+impl<N: Network> Backend<N>
+where
+    N: Network<TxEnvelope = FoundryTxEnvelope, ReceiptEnvelope = FoundryReceiptEnvelope>,
+{
+    /// Validates the transaction chain ID without consulting mutable account or fee state.
+    pub fn validate_transaction_chain_id(
+        &self,
+        tx: &FoundryTxEnvelope,
+    ) -> Result<(), InvalidTransactionError> {
+        self.validate_transaction_chain_id_for(tx, &self.next_evm_env())
     }
-    None
+
+    fn validate_transaction_chain_id_for(
+        &self,
+        tx: &FoundryTxEnvelope,
+        evm_env: &EvmEnv,
+    ) -> Result<(), InvalidTransactionError> {
+        if let Some(tx_chain_id) = tx.chain_id() {
+            let chain_id = self.chain_id();
+            if chain_id.to::<u64>() != tx_chain_id {
+                if let FoundryTxEnvelope::Legacy(tx) = tx {
+                    // <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>
+                    if evm_env.cfg_env.spec >= SpecId::SPURIOUS_DRAGON && tx.chain_id().is_none() {
+                        debug!(target: "backend", ?chain_id, ?tx_chain_id, "incompatible EIP155-based V");
+                        return Err(InvalidTransactionError::IncompatibleEIP155);
+                    }
+                }
+                debug!(target: "backend", ?chain_id, ?tx_chain_id, "invalid chain id");
+                return Err(InvalidTransactionError::InvalidChainId);
+            }
+        }
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -5488,21 +5504,7 @@ where
     ) -> Result<(), InvalidTransactionError> {
         let tx = &pending.transaction;
 
-        if let Some(tx_chain_id) = tx.chain_id() {
-            let chain_id = self.chain_id();
-            if chain_id.to::<u64>() != tx_chain_id {
-                if let FoundryTxEnvelope::Legacy(tx) = tx.as_ref() {
-                    // <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md>
-                    if evm_env.cfg_env.spec >= SpecId::SPURIOUS_DRAGON && tx.chain_id().is_none() {
-                        debug!(target: "backend", ?chain_id, ?tx_chain_id, "incompatible EIP155-based V");
-                        return Err(InvalidTransactionError::IncompatibleEIP155);
-                    }
-                } else {
-                    debug!(target: "backend", ?chain_id, ?tx_chain_id, "invalid chain id");
-                    return Err(InvalidTransactionError::InvalidChainId);
-                }
-            }
-        }
+        self.validate_transaction_chain_id_for(tx, evm_env)?;
 
         // Reject native value transfers on Tempo networks
         if self.is_tempo() && !tx.value().is_zero() {

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -1,6 +1,7 @@
 //! Mines transactions
 
-use crate::eth::pool::{MiningNotification, Pool, transactions::PoolTransaction};
+use crate::eth::pool::{Pool, transactions::PoolTransaction};
+use alloy_primitives::TxHash;
 use futures::{
     channel::mpsc::Receiver,
     stream::{Fuse, StreamExt},
@@ -162,11 +163,10 @@ pub enum MiningMode {
 }
 
 impl MiningMode {
-    pub fn instant(max_transactions: usize, listener: Receiver<MiningNotification>) -> Self {
+    pub fn instant(max_transactions: usize, listener: Receiver<TxHash>) -> Self {
         Self::Auto(ReadyTransactionMiner {
             max_transactions,
             has_pending_txs: None,
-            has_pending_bundle: false,
             rx: listener.fuse(),
             coalesce: None,
         })
@@ -176,16 +176,11 @@ impl MiningMode {
         Self::FixedBlockTime(FixedBlockTimeMiner::new(duration))
     }
 
-    pub fn mixed(
-        max_transactions: usize,
-        listener: Receiver<MiningNotification>,
-        duration: Duration,
-    ) -> Self {
+    pub fn mixed(max_transactions: usize, listener: Receiver<TxHash>, duration: Duration) -> Self {
         Self::Mixed(
             ReadyTransactionMiner {
                 max_transactions,
                 has_pending_txs: None,
-                has_pending_bundle: false,
                 rx: listener.fuse(),
                 coalesce: None,
             },
@@ -276,10 +271,8 @@ pub struct ReadyTransactionMiner {
     max_transactions: usize,
     /// stores whether there are pending transactions (if known)
     has_pending_txs: Option<bool>,
-    /// Whether a private bundle eligible for the next block woke the miner.
-    has_pending_bundle: bool,
-    /// Receives public transaction and eligible private bundle notifications.
-    rx: Fuse<Receiver<MiningNotification>>,
+    /// Receives hashes of transactions that are ready
+    rx: Fuse<Receiver<TxHash>>,
     /// Active [`INSTANT_COALESCE_WINDOW`] timer; while pending, ready txs are accumulated.
     coalesce: Option<Pin<Box<Sleep>>>,
 }
@@ -292,11 +285,8 @@ impl ReadyTransactionMiner {
     ) -> Poll<Vec<Arc<PoolTransaction<T>>>> {
         // always drain the notification stream so that we're woken up as soon as there's a new tx
         let mut saw_new_ready = false;
-        while let Poll::Ready(Some(notification)) = self.rx.poll_next_unpin(cx) {
+        while let Poll::Ready(Some(_hash)) = self.rx.poll_next_unpin(cx) {
             saw_new_ready = true;
-            if let MiningNotification::PrivateBundle { hash, block_number } = notification {
-                self.has_pending_bundle |= pool.contains_private_bundle(hash, block_number);
-            }
         }
 
         // Arm the coalescing window only on fresh notifications to avoid delaying
@@ -325,12 +315,11 @@ impl ReadyTransactionMiner {
         // there are pending transactions if we didn't drain the pool
         self.has_pending_txs = Some(transactions.len() >= self.max_transactions);
 
-        if transactions.is_empty() && !self.has_pending_bundle {
+        if transactions.is_empty() && !pool.has_private_bundles() {
             self.has_pending_txs = Some(false);
             return Poll::Pending;
         }
 
-        self.has_pending_bundle = false;
         Poll::Ready(transactions)
     }
 }

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -1,7 +1,6 @@
 //! Mines transactions
 
-use crate::eth::pool::{Pool, transactions::PoolTransaction};
-use alloy_primitives::TxHash;
+use crate::eth::pool::{MiningNotification, Pool, transactions::PoolTransaction};
 use futures::{
     channel::mpsc::Receiver,
     stream::{Fuse, StreamExt},
@@ -163,10 +162,11 @@ pub enum MiningMode {
 }
 
 impl MiningMode {
-    pub fn instant(max_transactions: usize, listener: Receiver<TxHash>) -> Self {
+    pub fn instant(max_transactions: usize, listener: Receiver<MiningNotification>) -> Self {
         Self::Auto(ReadyTransactionMiner {
             max_transactions,
             has_pending_txs: None,
+            has_pending_bundle: false,
             rx: listener.fuse(),
             coalesce: None,
         })
@@ -176,11 +176,16 @@ impl MiningMode {
         Self::FixedBlockTime(FixedBlockTimeMiner::new(duration))
     }
 
-    pub fn mixed(max_transactions: usize, listener: Receiver<TxHash>, duration: Duration) -> Self {
+    pub fn mixed(
+        max_transactions: usize,
+        listener: Receiver<MiningNotification>,
+        duration: Duration,
+    ) -> Self {
         Self::Mixed(
             ReadyTransactionMiner {
                 max_transactions,
                 has_pending_txs: None,
+                has_pending_bundle: false,
                 rx: listener.fuse(),
                 coalesce: None,
             },
@@ -271,8 +276,10 @@ pub struct ReadyTransactionMiner {
     max_transactions: usize,
     /// stores whether there are pending transactions (if known)
     has_pending_txs: Option<bool>,
-    /// Receives hashes of transactions that are ready
-    rx: Fuse<Receiver<TxHash>>,
+    /// Whether a private bundle eligible for the next block woke the miner.
+    has_pending_bundle: bool,
+    /// Receives public transaction and eligible private bundle notifications.
+    rx: Fuse<Receiver<MiningNotification>>,
     /// Active [`INSTANT_COALESCE_WINDOW`] timer; while pending, ready txs are accumulated.
     coalesce: Option<Pin<Box<Sleep>>>,
 }
@@ -285,8 +292,11 @@ impl ReadyTransactionMiner {
     ) -> Poll<Vec<Arc<PoolTransaction<T>>>> {
         // always drain the notification stream so that we're woken up as soon as there's a new tx
         let mut saw_new_ready = false;
-        while let Poll::Ready(Some(_hash)) = self.rx.poll_next_unpin(cx) {
+        while let Poll::Ready(Some(notification)) = self.rx.poll_next_unpin(cx) {
             saw_new_ready = true;
+            if let MiningNotification::PrivateBundle { hash, block_number } = notification {
+                self.has_pending_bundle |= pool.contains_private_bundle(hash, block_number);
+            }
         }
 
         // Arm the coalescing window only on fresh notifications to avoid delaying
@@ -315,11 +325,12 @@ impl ReadyTransactionMiner {
         // there are pending transactions if we didn't drain the pool
         self.has_pending_txs = Some(transactions.len() >= self.max_transactions);
 
-        if transactions.is_empty() && !pool.has_private_bundles() {
+        if transactions.is_empty() && !self.has_pending_bundle {
             self.has_pending_txs = Some(false);
             return Poll::Pending;
         }
 
+        self.has_pending_bundle = false;
         Poll::Ready(transactions)
     }
 }

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -315,7 +315,7 @@ impl ReadyTransactionMiner {
         // there are pending transactions if we didn't drain the pool
         self.has_pending_txs = Some(transactions.len() >= self.max_transactions);
 
-        if transactions.is_empty() {
+        if transactions.is_empty() && !pool.has_private_bundles() {
             self.has_pending_txs = Some(false);
             return Poll::Pending;
         }

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -53,7 +53,7 @@ pub struct Pool<T> {
     /// listeners for new ready transactions
     transaction_listener: Mutex<Vec<Sender<TxHash>>>,
     /// Listeners used exclusively to wake the miner.
-    mining_listener: Mutex<Vec<Sender<TxHash>>>,
+    mining_listener: Mutex<Vec<Sender<MiningNotification>>>,
     /// Private bundles awaiting their target block.
     private_bundles: RwLock<Vec<Arc<PrivateBundle<T>>>>,
 }
@@ -100,7 +100,7 @@ impl<T> Pool<T> {
     }
 
     /// Adds a listener that is notified for public transactions and private bundles.
-    pub fn add_mining_listener(&self) -> Receiver<TxHash> {
+    pub fn add_mining_listener(&self) -> Receiver<MiningNotification> {
         const MINING_LISTENER_BUFFER_SIZE: usize = 2048;
         let (tx, rx) = channel(MINING_LISTENER_BUFFER_SIZE);
         self.mining_listener.lock().push(tx);
@@ -112,21 +112,30 @@ impl<T> Pool<T> {
         self.private_bundles.read().clone()
     }
 
-    /// Returns whether any private bundles are waiting to be mined.
-    pub fn has_private_bundles(&self) -> bool {
-        !self.private_bundles.read().is_empty()
+    /// Returns whether a private bundle notification still refers to a queued target.
+    pub fn contains_private_bundle(&self, hash: B256, block_number: u64) -> bool {
+        self.private_bundles
+            .read()
+            .iter()
+            .any(|bundle| bundle.hash == hash && bundle.block_number == block_number)
     }
 
     /// Adds a private bundle, replacing an existing bundle with the same replacement UUID.
-    pub fn add_private_bundle(&self, bundle: PrivateBundle<T>) {
+    pub fn add_private_bundle(&self, bundle: PrivateBundle<T>, next_block_number: u64) {
         let hash = bundle.hash;
+        let is_next_block = bundle.block_number == next_block_number;
         let mut bundles = self.private_bundles.write();
         if let Some(replacement_uuid) = &bundle.replacement_uuid {
             bundles.retain(|queued| queued.replacement_uuid.as_ref() != Some(replacement_uuid));
         }
         bundles.push(Arc::new(bundle));
         drop(bundles);
-        Self::notify_listeners(&self.mining_listener, hash);
+        if is_next_block {
+            Self::notify_listeners(
+                &self.mining_listener,
+                MiningNotification::PrivateBundle { hash, block_number: next_block_number },
+            );
+        }
     }
 
     /// Removes bundles whose exact target block has already been mined.
@@ -191,10 +200,16 @@ impl<T> Pool<T> {
     fn notify_ready(&self, tx: &AddedTransaction<T>) {
         if let AddedTransaction::Ready(ready) = tx {
             self.notify_listener(ready.hash);
-            Self::notify_listeners(&self.mining_listener, ready.hash);
+            Self::notify_listeners(
+                &self.mining_listener,
+                MiningNotification::Transaction(ready.hash),
+            );
             for promoted in ready.promoted.iter().copied() {
                 self.notify_listener(promoted);
-                Self::notify_listeners(&self.mining_listener, promoted);
+                Self::notify_listeners(
+                    &self.mining_listener,
+                    MiningNotification::Transaction(promoted),
+                );
             }
         }
     }
@@ -204,19 +219,19 @@ impl<T> Pool<T> {
         Self::notify_listeners(&self.transaction_listener, hash);
     }
 
-    fn notify_listeners(listeners: &Mutex<Vec<Sender<TxHash>>>, hash: TxHash) {
+    fn notify_listeners<N: Copy + fmt::Debug>(listeners: &Mutex<Vec<Sender<N>>>, notification: N) {
         let mut listener = listeners.lock();
         // this is basically a retain but with mut reference
         for n in (0..listener.len()).rev() {
             let mut listener_tx = listener.swap_remove(n);
-            let retain = match listener_tx.try_send(hash) {
+            let retain = match listener_tx.try_send(notification) {
                 Ok(()) => true,
                 Err(e) => {
                     if e.is_full() {
                         warn!(
                             target: "txpool",
                             "[{:?}] Failed to send tx notification because channel is full",
-                            hash,
+                            notification,
                         );
                         true
                     } else {
@@ -246,6 +261,20 @@ impl<T: Transaction> Pool<T> {
         let MinedBlockOutcome { block_number, included, invalid, not_yet_valid } = outcome;
 
         self.prune_private_bundles(block_number);
+        if let Some(bundle) = self
+            .private_bundles
+            .read()
+            .iter()
+            .find(|bundle| bundle.block_number == block_number.saturating_add(1))
+        {
+            Self::notify_listeners(
+                &self.mining_listener,
+                MiningNotification::PrivateBundle {
+                    hash: bundle.hash,
+                    block_number: bundle.block_number,
+                },
+            );
+        }
 
         // remove invalid transactions from the pool
         self.remove_invalid(invalid.into_iter().map(|tx| tx.hash()).collect());
@@ -265,7 +294,10 @@ impl<T: Transaction> Pool<T> {
                 for hash in tx_hashes {
                     trace!(target: "txpool", "re-notifying for not-yet-valid tx: {:?}", hash);
                     pool.notify_listener(hash);
-                    Self::notify_listeners(&pool.mining_listener, hash);
+                    Self::notify_listeners(
+                        &pool.mining_listener,
+                        MiningNotification::Transaction(hash),
+                    );
                 }
             });
         }
@@ -316,8 +348,24 @@ pub struct PrivateBundle<T> {
     pub max_timestamp: Option<u64>,
     /// Transactions allowed to revert without invalidating the bundle.
     pub reverting_tx_hashes: HashSet<TxHash>,
+    /// Transactions allowed to be omitted if they cannot be included successfully.
+    pub dropping_tx_hashes: HashSet<TxHash>,
     /// Identifier used to replace a previously queued bundle.
     pub replacement_uuid: Option<String>,
+}
+
+/// A miner wakeup that keeps private bundles separate from public transaction listeners.
+#[derive(Clone, Copy, Debug)]
+pub enum MiningNotification {
+    /// A public transaction became ready.
+    Transaction(TxHash),
+    /// A private bundle became eligible for the next block.
+    PrivateBundle {
+        /// Bundle hash used to reject stale replacement notifications.
+        hash: B256,
+        /// Exact block for which the notification was emitted.
+        block_number: u64,
+    },
 }
 
 impl<T> PrivateBundle<T> {

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -53,7 +53,7 @@ pub struct Pool<T> {
     /// listeners for new ready transactions
     transaction_listener: Mutex<Vec<Sender<TxHash>>>,
     /// Listeners used exclusively to wake the miner.
-    mining_listener: Mutex<Vec<Sender<MiningNotification>>>,
+    mining_listener: Mutex<Vec<Sender<TxHash>>>,
     /// Private bundles awaiting their target block.
     private_bundles: RwLock<Vec<Arc<PrivateBundle<T>>>>,
 }
@@ -100,7 +100,7 @@ impl<T> Pool<T> {
     }
 
     /// Adds a listener that is notified for public transactions and private bundles.
-    pub fn add_mining_listener(&self) -> Receiver<MiningNotification> {
+    pub fn add_mining_listener(&self) -> Receiver<TxHash> {
         const MINING_LISTENER_BUFFER_SIZE: usize = 2048;
         let (tx, rx) = channel(MINING_LISTENER_BUFFER_SIZE);
         self.mining_listener.lock().push(tx);
@@ -112,30 +112,21 @@ impl<T> Pool<T> {
         self.private_bundles.read().clone()
     }
 
-    /// Returns whether a private bundle notification still refers to a queued target.
-    pub fn contains_private_bundle(&self, hash: B256, block_number: u64) -> bool {
-        self.private_bundles
-            .read()
-            .iter()
-            .any(|bundle| bundle.hash == hash && bundle.block_number == block_number)
+    /// Returns whether any private bundles are waiting to be mined.
+    pub fn has_private_bundles(&self) -> bool {
+        !self.private_bundles.read().is_empty()
     }
 
     /// Adds a private bundle, replacing an existing bundle with the same replacement UUID.
-    pub fn add_private_bundle(&self, bundle: PrivateBundle<T>, next_block_number: u64) {
+    pub fn add_private_bundle(&self, bundle: PrivateBundle<T>) {
         let hash = bundle.hash;
-        let is_next_block = bundle.block_number == next_block_number;
         let mut bundles = self.private_bundles.write();
         if let Some(replacement_uuid) = &bundle.replacement_uuid {
             bundles.retain(|queued| queued.replacement_uuid.as_ref() != Some(replacement_uuid));
         }
         bundles.push(Arc::new(bundle));
         drop(bundles);
-        if is_next_block {
-            Self::notify_listeners(
-                &self.mining_listener,
-                MiningNotification::PrivateBundle { hash, block_number: next_block_number },
-            );
-        }
+        Self::notify_listeners(&self.mining_listener, hash);
     }
 
     /// Removes bundles whose exact target block has already been mined.
@@ -200,16 +191,10 @@ impl<T> Pool<T> {
     fn notify_ready(&self, tx: &AddedTransaction<T>) {
         if let AddedTransaction::Ready(ready) = tx {
             self.notify_listener(ready.hash);
-            Self::notify_listeners(
-                &self.mining_listener,
-                MiningNotification::Transaction(ready.hash),
-            );
+            Self::notify_listeners(&self.mining_listener, ready.hash);
             for promoted in ready.promoted.iter().copied() {
                 self.notify_listener(promoted);
-                Self::notify_listeners(
-                    &self.mining_listener,
-                    MiningNotification::Transaction(promoted),
-                );
+                Self::notify_listeners(&self.mining_listener, promoted);
             }
         }
     }
@@ -219,19 +204,19 @@ impl<T> Pool<T> {
         Self::notify_listeners(&self.transaction_listener, hash);
     }
 
-    fn notify_listeners<N: Copy + fmt::Debug>(listeners: &Mutex<Vec<Sender<N>>>, notification: N) {
+    fn notify_listeners(listeners: &Mutex<Vec<Sender<TxHash>>>, hash: TxHash) {
         let mut listener = listeners.lock();
         // this is basically a retain but with mut reference
         for n in (0..listener.len()).rev() {
             let mut listener_tx = listener.swap_remove(n);
-            let retain = match listener_tx.try_send(notification) {
+            let retain = match listener_tx.try_send(hash) {
                 Ok(()) => true,
                 Err(e) => {
                     if e.is_full() {
                         warn!(
                             target: "txpool",
                             "[{:?}] Failed to send tx notification because channel is full",
-                            notification,
+                            hash,
                         );
                         true
                     } else {
@@ -261,20 +246,6 @@ impl<T: Transaction> Pool<T> {
         let MinedBlockOutcome { block_number, included, invalid, not_yet_valid } = outcome;
 
         self.prune_private_bundles(block_number);
-        if let Some(bundle) = self
-            .private_bundles
-            .read()
-            .iter()
-            .find(|bundle| bundle.block_number == block_number.saturating_add(1))
-        {
-            Self::notify_listeners(
-                &self.mining_listener,
-                MiningNotification::PrivateBundle {
-                    hash: bundle.hash,
-                    block_number: bundle.block_number,
-                },
-            );
-        }
 
         // remove invalid transactions from the pool
         self.remove_invalid(invalid.into_iter().map(|tx| tx.hash()).collect());
@@ -294,10 +265,7 @@ impl<T: Transaction> Pool<T> {
                 for hash in tx_hashes {
                     trace!(target: "txpool", "re-notifying for not-yet-valid tx: {:?}", hash);
                     pool.notify_listener(hash);
-                    Self::notify_listeners(
-                        &pool.mining_listener,
-                        MiningNotification::Transaction(hash),
-                    );
+                    Self::notify_listeners(&pool.mining_listener, hash);
                 }
             });
         }
@@ -348,24 +316,8 @@ pub struct PrivateBundle<T> {
     pub max_timestamp: Option<u64>,
     /// Transactions allowed to revert without invalidating the bundle.
     pub reverting_tx_hashes: HashSet<TxHash>,
-    /// Transactions allowed to be omitted if they cannot be included successfully.
-    pub dropping_tx_hashes: HashSet<TxHash>,
     /// Identifier used to replace a previously queued bundle.
     pub replacement_uuid: Option<String>,
-}
-
-/// A miner wakeup that keeps private bundles separate from public transaction listeners.
-#[derive(Clone, Copy, Debug)]
-pub enum MiningNotification {
-    /// A public transaction became ready.
-    Transaction(TxHash),
-    /// A private bundle became eligible for the next block.
-    PrivateBundle {
-        /// Bundle hash used to reject stale replacement notifications.
-        hash: B256,
-        /// Exact block for which the notification was emitted.
-        block_number: u64,
-    },
 }
 
 impl<T> PrivateBundle<T> {

--- a/crates/anvil/src/eth/pool/mod.rs
+++ b/crates/anvil/src/eth/pool/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     mem::storage::MinedBlockOutcome,
 };
 use alloy_consensus::Transaction;
-use alloy_primitives::{Address, TxHash};
+use alloy_primitives::{Address, B256, TxHash, map::HashSet};
 use alloy_rpc_types::txpool::TxpoolStatus;
 use anvil_core::eth::transaction::PendingTransaction;
 use futures::channel::mpsc::{Receiver, Sender, channel};
@@ -52,11 +52,20 @@ pub struct Pool<T> {
     inner: RwLock<PoolInner<T>>,
     /// listeners for new ready transactions
     transaction_listener: Mutex<Vec<Sender<TxHash>>>,
+    /// Listeners used exclusively to wake the miner.
+    mining_listener: Mutex<Vec<Sender<TxHash>>>,
+    /// Private bundles awaiting their target block.
+    private_bundles: RwLock<Vec<Arc<PrivateBundle<T>>>>,
 }
 
 impl<T> Default for Pool<T> {
     fn default() -> Self {
-        Self { inner: RwLock::new(PoolInner::default()), transaction_listener: Default::default() }
+        Self {
+            inner: RwLock::new(PoolInner::default()),
+            transaction_listener: Default::default(),
+            mining_listener: Default::default(),
+            private_bundles: Default::default(),
+        }
     }
 }
 
@@ -90,6 +99,41 @@ impl<T> Pool<T> {
         rx
     }
 
+    /// Adds a listener that is notified for public transactions and private bundles.
+    pub fn add_mining_listener(&self) -> Receiver<TxHash> {
+        const MINING_LISTENER_BUFFER_SIZE: usize = 2048;
+        let (tx, rx) = channel(MINING_LISTENER_BUFFER_SIZE);
+        self.mining_listener.lock().push(tx);
+        rx
+    }
+
+    /// Returns all private bundles without exposing them through public transaction APIs.
+    pub fn private_bundles(&self) -> Vec<Arc<PrivateBundle<T>>> {
+        self.private_bundles.read().clone()
+    }
+
+    /// Returns whether any private bundles are waiting to be mined.
+    pub fn has_private_bundles(&self) -> bool {
+        !self.private_bundles.read().is_empty()
+    }
+
+    /// Adds a private bundle, replacing an existing bundle with the same replacement UUID.
+    pub fn add_private_bundle(&self, bundle: PrivateBundle<T>) {
+        let hash = bundle.hash;
+        let mut bundles = self.private_bundles.write();
+        if let Some(replacement_uuid) = &bundle.replacement_uuid {
+            bundles.retain(|queued| queued.replacement_uuid.as_ref() != Some(replacement_uuid));
+        }
+        bundles.push(Arc::new(bundle));
+        drop(bundles);
+        Self::notify_listeners(&self.mining_listener, hash);
+    }
+
+    /// Removes bundles whose exact target block has already been mined.
+    fn prune_private_bundles(&self, block_number: u64) {
+        self.private_bundles.write().retain(|bundle| bundle.block_number > block_number);
+    }
+
     /// Returns true if this pool already contains the transaction
     pub fn contains(&self, tx_hash: &TxHash) -> bool {
         self.inner.read().contains(tx_hash)
@@ -110,6 +154,7 @@ impl<T> Pool<T> {
     pub fn clear(&self) {
         let mut pool = self.inner.write();
         pool.clear();
+        self.private_bundles.write().clear();
     }
 
     /// Remove the given transactions from the pool
@@ -146,15 +191,21 @@ impl<T> Pool<T> {
     fn notify_ready(&self, tx: &AddedTransaction<T>) {
         if let AddedTransaction::Ready(ready) = tx {
             self.notify_listener(ready.hash);
+            Self::notify_listeners(&self.mining_listener, ready.hash);
             for promoted in ready.promoted.iter().copied() {
                 self.notify_listener(promoted);
+                Self::notify_listeners(&self.mining_listener, promoted);
             }
         }
     }
 
     /// notifies all listeners about the transaction
     fn notify_listener(&self, hash: TxHash) {
-        let mut listener = self.transaction_listener.lock();
+        Self::notify_listeners(&self.transaction_listener, hash);
+    }
+
+    fn notify_listeners(listeners: &Mutex<Vec<Sender<TxHash>>>, hash: TxHash) {
+        let mut listener = listeners.lock();
         // this is basically a retain but with mut reference
         for n in (0..listener.len()).rev() {
             let mut listener_tx = listener.swap_remove(n);
@@ -194,6 +245,8 @@ impl<T: Transaction> Pool<T> {
     pub fn on_mined_block(self: &Arc<Self>, outcome: MinedBlockOutcome<T>) -> PruneResult<T> {
         let MinedBlockOutcome { block_number, included, invalid, not_yet_valid } = outcome;
 
+        self.prune_private_bundles(block_number);
+
         // remove invalid transactions from the pool
         self.remove_invalid(invalid.into_iter().map(|tx| tx.hash()).collect());
 
@@ -212,6 +265,7 @@ impl<T: Transaction> Pool<T> {
                 for hash in tx_hashes {
                     trace!(target: "txpool", "re-notifying for not-yet-valid tx: {:?}", hash);
                     pool.notify_listener(hash);
+                    Self::notify_listeners(&pool.mining_listener, hash);
                 }
             });
         }
@@ -244,6 +298,58 @@ impl<T: Transaction> Pool<T> {
         let added = self.inner.write().add_transaction(tx)?;
         self.notify_ready(&added);
         Ok(added)
+    }
+}
+
+/// A private, ordered group of transactions that is considered as one mining unit.
+#[derive(Clone, Debug)]
+pub struct PrivateBundle<T> {
+    /// Flashbots bundle hash.
+    pub hash: B256,
+    /// Transactions in their required execution order.
+    pub transactions: Vec<Arc<PoolTransaction<T>>>,
+    /// Exact block number for which this bundle is valid.
+    pub block_number: u64,
+    /// Earliest valid block timestamp.
+    pub min_timestamp: Option<u64>,
+    /// Latest valid block timestamp.
+    pub max_timestamp: Option<u64>,
+    /// Transactions allowed to revert without invalidating the bundle.
+    pub reverting_tx_hashes: HashSet<TxHash>,
+    /// Identifier used to replace a previously queued bundle.
+    pub replacement_uuid: Option<String>,
+}
+
+impl<T> PrivateBundle<T> {
+    /// Returns whether the bundle is eligible for this exact block environment.
+    pub fn is_eligible(&self, block_number: u64, timestamp: u64) -> bool {
+        self.block_number == block_number
+            && self.min_timestamp.is_none_or(|minimum| timestamp >= minimum)
+            && self.max_timestamp.is_none_or(|maximum| timestamp <= maximum)
+    }
+}
+
+/// Transactions and private bundles considered while constructing a block.
+#[derive(Clone, Debug)]
+pub struct MiningTransactions<T> {
+    /// Public transactions selected by the miner.
+    pub transactions: Vec<Arc<PoolTransaction<T>>>,
+    /// Private bundles held outside the public transaction queues.
+    pub private_bundles: Vec<Arc<PrivateBundle<T>>>,
+}
+
+impl<T> Default for MiningTransactions<T> {
+    fn default() -> Self {
+        Self { transactions: Vec::new(), private_bundles: Vec::new() }
+    }
+}
+
+impl<T> MiningTransactions<T> {
+    pub const fn new(
+        transactions: Vec<Arc<PoolTransaction<T>>>,
+        private_bundles: Vec<Arc<PrivateBundle<T>>>,
+    ) -> Self {
+        Self { transactions, private_bundles }
     }
 }
 

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -172,7 +172,7 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
 
     let mode = if let Some(block_time) = block_time {
         if mixed_mining {
-            let listener = pool.add_ready_listener();
+            let listener = pool.add_mining_listener();
             MiningMode::mixed(max_transactions, listener, block_time)
         } else {
             MiningMode::interval(block_time)
@@ -181,7 +181,7 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
         MiningMode::None
     } else {
         // get a listener for ready transactions
-        let listener = pool.add_ready_listener();
+        let listener = pool.add_mining_listener();
         MiningMode::instant(max_transactions, listener)
     };
 

--- a/crates/anvil/src/service.rs
+++ b/crates/anvil/src/service.rs
@@ -6,7 +6,7 @@ use crate::{
         backend::validate::TransactionValidator,
         fees::FeeHistoryService,
         miner::Miner,
-        pool::{Pool, transactions::PoolTransaction},
+        pool::{MiningTransactions, Pool},
     },
     filter::Filters,
     mem::{Backend, storage::MinedBlockOutcome},
@@ -94,7 +94,9 @@ where
 
             if let Poll::Ready(transactions) = pin.miner.poll(&pin.pool, cx) {
                 // miner returned a set of transaction that we feed to the producer
-                pin.block_producer.queued.push_back(transactions);
+                pin.block_producer
+                    .queued
+                    .push_back(MiningTransactions::new(transactions, pin.pool.private_bundles()));
             } else {
                 // no progress made
                 break;
@@ -125,7 +127,7 @@ struct BlockProducer<N: Network> {
     /// Single active future that mines a new block
     block_mining: Option<JoinHandle<MiningResult<N>>>,
     /// backlog of sets of transactions ready to be mined
-    queued: VecDeque<Vec<Arc<PoolTransaction<N::TxEnvelope>>>>,
+    queued: VecDeque<MiningTransactions<N::TxEnvelope>>,
 }
 
 impl<N: Network> BlockProducer<N>
@@ -159,7 +161,7 @@ where
                 let mining = tokio::task::spawn_blocking(move || {
                     handle.block_on(async move {
                         trace!(target: "miner", "creating new block");
-                        let block = backend.mine_block(transactions).await;
+                        let block = backend.mine_block_with_bundles(transactions).await;
                         trace!(target: "miner", "created new block: {}", block.block_number);
                         (block, backend)
                     })

--- a/crates/anvil/tests/it/bundle.rs
+++ b/crates/anvil/tests/it/bundle.rs
@@ -1,10 +1,8 @@
 use alloy_consensus::{SignableTransaction, TxEip1559};
-use alloy_network::{
-    AnyNetwork, AnyRpcTransaction, ReceiptResponse, TransactionBuilder, TxSignerSync,
-};
+use alloy_network::{AnyNetwork, AnyRpcTransaction, ReceiptResponse, TxSignerSync};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
 use alloy_provider::{Provider, RootProvider, ext::TxPoolApi};
-use alloy_rpc_types::{BlockId, BlockNumberOrTag, BlockTransactions, TransactionRequest};
+use alloy_rpc_types::{BlockId, BlockNumberOrTag, BlockTransactions};
 use alloy_rpc_types_mev::{EthBundleHash, EthSendBundle};
 use alloy_signer_local::PrivateKeySigner;
 use anvil::{CHAIN_ID, NodeConfig, spawn};
@@ -208,9 +206,7 @@ async fn rejects_invalid_bundle_parameters() {
         .client()
         .request("eth_sendBundle", (EthSendBundle { block_number: 1, ..Default::default() },))
         .await;
-    let err = request.unwrap_err();
-    assert_eq!(err.as_error_resp().unwrap().code, -32602);
-    assert!(err.to_string().contains("at least one transaction"));
+    assert!(request.unwrap_err().to_string().contains("at least one transaction"));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -261,193 +257,4 @@ async fn does_not_resurrect_consumed_bundle_after_revert() {
     api.mine_one().await;
     let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
     assert_eq!(block.transactions, BlockTransactions::Hashes(Vec::new()));
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn bundle_can_fund_later_sender() {
-    let (api, handle) = spawn(NodeConfig::test()).await;
-    api.anvil_set_auto_mine(false).await.unwrap();
-    let provider = handle.http_provider();
-    let wallets = handle.dev_wallets().collect::<Vec<_>>();
-    let funded = PrivateKeySigner::random();
-    let funding = U256::from(1_000_000_000_000_000_000u128);
-    let (first, first_hash) = signed_transaction(&wallets[0], 0, funded.address(), funding);
-    let (second, second_hash) = signed_transaction(&funded, 0, wallets[1].address(), U256::from(1));
-
-    send_bundle(
-        &provider,
-        EthSendBundle { txs: vec![first, second], block_number: 1, ..Default::default() },
-    )
-    .await;
-    api.mine_one().await;
-
-    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
-    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![first_hash, second_hash]));
-    assert!(provider.get_transaction_receipt(second_hash).await.unwrap().unwrap().status());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn future_bundle_waits_for_next_block_eligibility() {
-    let (_api, handle) = spawn(NodeConfig::test()).await;
-    let provider = handle.http_provider();
-    let wallets = handle.dev_wallets().collect::<Vec<_>>();
-    let (transaction, hash) =
-        signed_transaction(&wallets[0], 0, wallets[1].address(), U256::from(1));
-
-    send_bundle(
-        &provider,
-        EthSendBundle { txs: vec![transaction], block_number: 2, ..Default::default() },
-    )
-    .await;
-    tokio::time::sleep(Duration::from_millis(50)).await;
-    assert_eq!(provider.get_block_number().await.unwrap(), 0);
-
-    let public: B256 = provider
-        .client()
-        .request(
-            "eth_sendTransaction",
-            (TransactionRequest::default()
-                .with_from(wallets[1].address())
-                .with_to(wallets[2].address())
-                .with_value(U256::from(1)),),
-        )
-        .await
-        .unwrap();
-
-    timeout(Duration::from_secs(5), async {
-        loop {
-            if provider.get_transaction_receipt(hash).await.unwrap().is_some() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .unwrap();
-    assert_eq!(
-        provider.get_transaction_receipt(public).await.unwrap().unwrap().block_number(),
-        Some(1)
-    );
-    assert_eq!(
-        provider.get_transaction_receipt(hash).await.unwrap().unwrap().block_number(),
-        Some(2)
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn mines_two_bundles_in_one_block() {
-    let (api, handle) = spawn(NodeConfig::test()).await;
-    api.anvil_set_auto_mine(false).await.unwrap();
-    let provider = handle.http_provider();
-    let wallets = handle.dev_wallets().collect::<Vec<_>>();
-    let (first, first_hash) =
-        signed_transaction(&wallets[0], 0, wallets[2].address(), U256::from(1));
-    let (second, second_hash) =
-        signed_transaction(&wallets[1], 0, wallets[3].address(), U256::from(2));
-
-    send_bundle(
-        &provider,
-        EthSendBundle { txs: vec![first], block_number: 1, ..Default::default() },
-    )
-    .await;
-    send_bundle(
-        &provider,
-        EthSendBundle { txs: vec![second], block_number: 1, ..Default::default() },
-    )
-    .await;
-    api.mine_one().await;
-
-    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
-    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![first_hash, second_hash]));
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn orders_bundle_before_public_transaction() {
-    let (api, handle) = spawn(NodeConfig::test()).await;
-    api.anvil_set_auto_mine(false).await.unwrap();
-    let provider = handle.http_provider();
-    let wallets = handle.dev_wallets().collect::<Vec<_>>();
-    let public_hash: B256 = provider
-        .client()
-        .request(
-            "eth_sendTransaction",
-            (TransactionRequest::default()
-                .with_from(wallets[1].address())
-                .with_to(wallets[3].address())
-                .with_value(U256::from(2)),),
-        )
-        .await
-        .unwrap();
-    let (private, private_hash) =
-        signed_transaction(&wallets[0], 0, wallets[2].address(), U256::from(1));
-    send_bundle(
-        &provider,
-        EthSendBundle { txs: vec![private], block_number: 1, ..Default::default() },
-    )
-    .await;
-
-    api.mine_one().await;
-    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
-    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![private_hash, public_hash]));
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn drops_allowed_transaction_and_mines_remainder() {
-    let (api, handle) = spawn(NodeConfig::test()).await;
-    api.anvil_set_auto_mine(false).await.unwrap();
-    let provider = handle.http_provider();
-    let wallets = handle.dev_wallets().collect::<Vec<_>>();
-    let (first, first_hash) =
-        signed_transaction(&wallets[0], 0, wallets[1].address(), U256::from(1));
-    let (droppable, droppable_hash) =
-        signed_transaction(&wallets[0], 0, wallets[2].address(), U256::from(2));
-    let (last, last_hash) = signed_transaction(&wallets[0], 1, wallets[3].address(), U256::from(3));
-
-    send_bundle(
-        &provider,
-        EthSendBundle {
-            txs: vec![first, droppable, last],
-            block_number: 1,
-            dropping_tx_hashes: vec![droppable_hash],
-            ..Default::default()
-        },
-    )
-    .await;
-    api.mine_one().await;
-
-    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
-    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![first_hash, last_hash]));
-    assert!(provider.get_transaction_receipt(droppable_hash).await.unwrap().is_none());
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn pending_state_includes_private_bundle_effects() {
-    let (api, handle) = spawn(NodeConfig::test()).await;
-    api.anvil_set_auto_mine(false).await.unwrap();
-    let provider = handle.http_provider();
-    let wallets = handle.dev_wallets().collect::<Vec<_>>();
-    let recipient = Address::random();
-    let value = U256::from(1234);
-    let initial_balance = provider.get_balance(recipient).await.unwrap();
-    let (transaction, hash) = signed_transaction(&wallets[0], 0, recipient, value);
-    send_bundle(
-        &provider,
-        EthSendBundle { txs: vec![transaction], block_number: 1, ..Default::default() },
-    )
-    .await;
-
-    let pending_block = provider.get_block(BlockId::pending()).await.unwrap().unwrap();
-    assert_eq!(pending_block.transactions, BlockTransactions::Hashes(vec![hash]));
-    assert_eq!(
-        provider.get_balance(recipient).block_id(BlockId::pending()).await.unwrap(),
-        initial_balance + value
-    );
-    assert_eq!(
-        provider
-            .get_transaction_count(wallets[0].address())
-            .block_id(BlockId::pending())
-            .await
-            .unwrap(),
-        1
-    );
 }

--- a/crates/anvil/tests/it/bundle.rs
+++ b/crates/anvil/tests/it/bundle.rs
@@ -1,8 +1,10 @@
 use alloy_consensus::{SignableTransaction, TxEip1559};
-use alloy_network::{AnyNetwork, AnyRpcTransaction, ReceiptResponse, TxSignerSync};
+use alloy_network::{
+    AnyNetwork, AnyRpcTransaction, ReceiptResponse, TransactionBuilder, TxSignerSync,
+};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
 use alloy_provider::{Provider, RootProvider, ext::TxPoolApi};
-use alloy_rpc_types::{BlockId, BlockNumberOrTag, BlockTransactions};
+use alloy_rpc_types::{BlockId, BlockNumberOrTag, BlockTransactions, TransactionRequest};
 use alloy_rpc_types_mev::{EthBundleHash, EthSendBundle};
 use alloy_signer_local::PrivateKeySigner;
 use anvil::{CHAIN_ID, NodeConfig, spawn};
@@ -206,7 +208,9 @@ async fn rejects_invalid_bundle_parameters() {
         .client()
         .request("eth_sendBundle", (EthSendBundle { block_number: 1, ..Default::default() },))
         .await;
-    assert!(request.unwrap_err().to_string().contains("at least one transaction"));
+    let err = request.unwrap_err();
+    assert_eq!(err.as_error_resp().unwrap().code, -32602);
+    assert!(err.to_string().contains("at least one transaction"));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -257,4 +261,193 @@ async fn does_not_resurrect_consumed_bundle_after_revert() {
     api.mine_one().await;
     let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
     assert_eq!(block.transactions, BlockTransactions::Hashes(Vec::new()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bundle_can_fund_later_sender() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let funded = PrivateKeySigner::random();
+    let funding = U256::from(1_000_000_000_000_000_000u128);
+    let (first, first_hash) = signed_transaction(&wallets[0], 0, funded.address(), funding);
+    let (second, second_hash) = signed_transaction(&funded, 0, wallets[1].address(), U256::from(1));
+
+    send_bundle(
+        &provider,
+        EthSendBundle { txs: vec![first, second], block_number: 1, ..Default::default() },
+    )
+    .await;
+    api.mine_one().await;
+
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![first_hash, second_hash]));
+    assert!(provider.get_transaction_receipt(second_hash).await.unwrap().unwrap().status());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn future_bundle_waits_for_next_block_eligibility() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let (transaction, hash) =
+        signed_transaction(&wallets[0], 0, wallets[1].address(), U256::from(1));
+
+    send_bundle(
+        &provider,
+        EthSendBundle { txs: vec![transaction], block_number: 2, ..Default::default() },
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert_eq!(provider.get_block_number().await.unwrap(), 0);
+
+    let public: B256 = provider
+        .client()
+        .request(
+            "eth_sendTransaction",
+            (TransactionRequest::default()
+                .with_from(wallets[1].address())
+                .with_to(wallets[2].address())
+                .with_value(U256::from(1)),),
+        )
+        .await
+        .unwrap();
+
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if provider.get_transaction_receipt(hash).await.unwrap().is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        provider.get_transaction_receipt(public).await.unwrap().unwrap().block_number(),
+        Some(1)
+    );
+    assert_eq!(
+        provider.get_transaction_receipt(hash).await.unwrap().unwrap().block_number(),
+        Some(2)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mines_two_bundles_in_one_block() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let (first, first_hash) =
+        signed_transaction(&wallets[0], 0, wallets[2].address(), U256::from(1));
+    let (second, second_hash) =
+        signed_transaction(&wallets[1], 0, wallets[3].address(), U256::from(2));
+
+    send_bundle(
+        &provider,
+        EthSendBundle { txs: vec![first], block_number: 1, ..Default::default() },
+    )
+    .await;
+    send_bundle(
+        &provider,
+        EthSendBundle { txs: vec![second], block_number: 1, ..Default::default() },
+    )
+    .await;
+    api.mine_one().await;
+
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![first_hash, second_hash]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn orders_bundle_before_public_transaction() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let public_hash: B256 = provider
+        .client()
+        .request(
+            "eth_sendTransaction",
+            (TransactionRequest::default()
+                .with_from(wallets[1].address())
+                .with_to(wallets[3].address())
+                .with_value(U256::from(2)),),
+        )
+        .await
+        .unwrap();
+    let (private, private_hash) =
+        signed_transaction(&wallets[0], 0, wallets[2].address(), U256::from(1));
+    send_bundle(
+        &provider,
+        EthSendBundle { txs: vec![private], block_number: 1, ..Default::default() },
+    )
+    .await;
+
+    api.mine_one().await;
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![private_hash, public_hash]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn drops_allowed_transaction_and_mines_remainder() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let (first, first_hash) =
+        signed_transaction(&wallets[0], 0, wallets[1].address(), U256::from(1));
+    let (droppable, droppable_hash) =
+        signed_transaction(&wallets[0], 0, wallets[2].address(), U256::from(2));
+    let (last, last_hash) = signed_transaction(&wallets[0], 1, wallets[3].address(), U256::from(3));
+
+    send_bundle(
+        &provider,
+        EthSendBundle {
+            txs: vec![first, droppable, last],
+            block_number: 1,
+            dropping_tx_hashes: vec![droppable_hash],
+            ..Default::default()
+        },
+    )
+    .await;
+    api.mine_one().await;
+
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![first_hash, last_hash]));
+    assert!(provider.get_transaction_receipt(droppable_hash).await.unwrap().is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn pending_state_includes_private_bundle_effects() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let recipient = Address::random();
+    let value = U256::from(1234);
+    let initial_balance = provider.get_balance(recipient).await.unwrap();
+    let (transaction, hash) = signed_transaction(&wallets[0], 0, recipient, value);
+    send_bundle(
+        &provider,
+        EthSendBundle { txs: vec![transaction], block_number: 1, ..Default::default() },
+    )
+    .await;
+
+    let pending_block = provider.get_block(BlockId::pending()).await.unwrap().unwrap();
+    assert_eq!(pending_block.transactions, BlockTransactions::Hashes(vec![hash]));
+    assert_eq!(
+        provider.get_balance(recipient).block_id(BlockId::pending()).await.unwrap(),
+        initial_balance + value
+    );
+    assert_eq!(
+        provider
+            .get_transaction_count(wallets[0].address())
+            .block_id(BlockId::pending())
+            .await
+            .unwrap(),
+        1
+    );
 }

--- a/crates/anvil/tests/it/bundle.rs
+++ b/crates/anvil/tests/it/bundle.rs
@@ -1,0 +1,260 @@
+use alloy_consensus::{SignableTransaction, TxEip1559};
+use alloy_network::{AnyNetwork, AnyRpcTransaction, ReceiptResponse, TxSignerSync};
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256, keccak256};
+use alloy_provider::{Provider, RootProvider, ext::TxPoolApi};
+use alloy_rpc_types::{BlockId, BlockNumberOrTag, BlockTransactions};
+use alloy_rpc_types_mev::{EthBundleHash, EthSendBundle};
+use alloy_signer_local::PrivateKeySigner;
+use anvil::{CHAIN_ID, NodeConfig, spawn};
+use futures::StreamExt;
+use std::time::Duration;
+use tokio::time::timeout;
+
+fn signed_transaction(
+    signer: &PrivateKeySigner,
+    nonce: u64,
+    to: Address,
+    value: U256,
+) -> (Bytes, B256) {
+    let mut transaction = TxEip1559 {
+        chain_id: CHAIN_ID,
+        nonce,
+        gas_limit: 100_000,
+        max_fee_per_gas: 10_000_000_000,
+        max_priority_fee_per_gas: 1_000_000_000,
+        to: TxKind::Call(to),
+        value,
+        ..Default::default()
+    };
+    let signature = signer.sign_transaction_sync(&mut transaction).unwrap();
+    let transaction = transaction.into_signed(signature);
+    let mut encoded = Vec::new();
+    transaction.eip2718_encode(&mut encoded);
+    let encoded = Bytes::from(encoded);
+    let hash = keccak256(&encoded);
+    (encoded, hash)
+}
+
+async fn send_bundle(provider: &RootProvider<AnyNetwork>, bundle: EthSendBundle) -> EthBundleHash {
+    provider.client().request("eth_sendBundle", (bundle,)).await.unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mines_private_bundle_in_order() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let first_recipient = wallets[1].address();
+    let second_recipient = wallets[2].address();
+
+    let (first, first_hash) = signed_transaction(&wallets[0], 0, first_recipient, U256::from(1));
+    let (second, second_hash) = signed_transaction(&wallets[0], 1, second_recipient, U256::from(2));
+    let request = EthSendBundle { txs: vec![first, second], block_number: 1, ..Default::default() };
+    let expected_hash = request.bundle_hash();
+    let mut pending_listener = api.new_ready_transactions();
+    assert_eq!(send_bundle(&provider, request).await.bundle_hash, expected_hash);
+    assert!(timeout(Duration::from_millis(100), pending_listener.next()).await.is_err());
+
+    let pending: Vec<AnyRpcTransaction> =
+        provider.client().request("eth_pendingTransactions", ()).await.unwrap();
+    assert!(pending.is_empty());
+    assert!(provider.get_transaction_by_hash(first_hash).await.unwrap().is_none());
+    assert_eq!(provider.txpool_status().await.unwrap().pending, 0);
+
+    let pending_block =
+        provider.get_block(BlockId::Number(BlockNumberOrTag::Pending)).await.unwrap().unwrap();
+    assert_eq!(
+        pending_block.transactions,
+        BlockTransactions::Hashes(vec![first_hash, second_hash])
+    );
+
+    api.mine_one().await;
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![first_hash, second_hash]));
+    assert_eq!(provider.get_transaction_count(wallets[0].address()).await.unwrap(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_private_bundle_atomically() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let recipient = wallets[1].address();
+    let balance = provider.get_balance(recipient).await.unwrap();
+
+    let (first, _) = signed_transaction(&wallets[0], 0, recipient, U256::from(1));
+    let (invalid, _) = signed_transaction(&wallets[0], 0, recipient, U256::from(2));
+    send_bundle(
+        &provider,
+        EthSendBundle { txs: vec![first, invalid], block_number: 1, ..Default::default() },
+    )
+    .await;
+
+    api.mine_one().await;
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block.transactions, BlockTransactions::Hashes(Vec::new()));
+    assert_eq!(provider.get_transaction_count(wallets[0].address()).await.unwrap(), 0);
+    assert_eq!(provider.get_balance(recipient).await.unwrap(), balance);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn respects_bundle_constraints_and_replacement() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+
+    let (too_early, _) = signed_transaction(&wallets[0], 0, wallets[1].address(), U256::from(1));
+    send_bundle(
+        &provider,
+        EthSendBundle {
+            txs: vec![too_early],
+            block_number: 1,
+            min_timestamp: Some(u64::MAX),
+            ..Default::default()
+        },
+    )
+    .await;
+    let (expired, _) = signed_transaction(&wallets[0], 0, wallets[2].address(), U256::from(1));
+    send_bundle(
+        &provider,
+        EthSendBundle {
+            txs: vec![expired],
+            block_number: 1,
+            max_timestamp: Some(0),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let replacement_uuid = Some("8a8f311e-2f02-4f2f-a706-1d09b47a3dce".to_string());
+    let (replaced, replaced_hash) =
+        signed_transaction(&wallets[0], 0, wallets[3].address(), U256::from(1));
+    send_bundle(
+        &provider,
+        EthSendBundle {
+            txs: vec![replaced],
+            block_number: 2,
+            replacement_uuid: replacement_uuid.clone(),
+            ..Default::default()
+        },
+    )
+    .await;
+    let (replacement, replacement_hash) =
+        signed_transaction(&wallets[0], 0, wallets[4].address(), U256::from(1));
+    send_bundle(
+        &provider,
+        EthSendBundle {
+            txs: vec![replacement],
+            block_number: 2,
+            replacement_uuid,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    api.mine_one().await;
+    let first_block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(first_block.transactions, BlockTransactions::Hashes(Vec::new()));
+
+    api.mine_one().await;
+    let second_block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(second_block.transactions, BlockTransactions::Hashes(vec![replacement_hash]));
+    assert!(!second_block.transactions.hashes().any(|hash| hash == replaced_hash));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn permits_listed_reverting_transaction() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let reverting_contract = Address::random();
+    api.anvil_set_code(reverting_contract, Bytes::from_static(&[0x60, 0x00, 0x60, 0x00, 0xfd]))
+        .await
+        .unwrap();
+
+    let (reverting, reverting_hash) =
+        signed_transaction(&wallets[0], 0, reverting_contract, U256::ZERO);
+    let (success, success_hash) =
+        signed_transaction(&wallets[0], 1, wallets[1].address(), U256::from(1));
+    send_bundle(
+        &provider,
+        EthSendBundle {
+            txs: vec![reverting, success],
+            block_number: 1,
+            reverting_tx_hashes: vec![reverting_hash],
+            ..Default::default()
+        },
+    )
+    .await;
+
+    api.mine_one().await;
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block.transactions, BlockTransactions::Hashes(vec![reverting_hash, success_hash]));
+    assert!(!provider.get_transaction_receipt(reverting_hash).await.unwrap().unwrap().status());
+    assert!(provider.get_transaction_receipt(success_hash).await.unwrap().unwrap().status());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_invalid_bundle_parameters() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let request: Result<EthBundleHash, _> = provider
+        .client()
+        .request("eth_sendBundle", (EthSendBundle { block_number: 1, ..Default::default() },))
+        .await;
+    assert!(request.unwrap_err().to_string().contains("at least one transaction"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn automines_eligible_private_bundle() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let (transaction, hash) =
+        signed_transaction(&wallets[0], 0, wallets[1].address(), U256::from(1));
+
+    send_bundle(
+        &provider,
+        EthSendBundle { txs: vec![transaction], block_number: 1, ..Default::default() },
+    )
+    .await;
+
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if provider.get_transaction_receipt(hash).await.unwrap().is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn does_not_resurrect_consumed_bundle_after_revert() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_auto_mine(false).await.unwrap();
+    let provider = handle.http_provider();
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let snapshot = api.evm_snapshot().await.unwrap();
+    let (transaction, hash) =
+        signed_transaction(&wallets[0], 0, wallets[1].address(), U256::from(1));
+
+    send_bundle(
+        &provider,
+        EthSendBundle { txs: vec![transaction], block_number: 1, ..Default::default() },
+    )
+    .await;
+    api.mine_one().await;
+    assert!(provider.get_transaction_receipt(hash).await.unwrap().is_some());
+
+    assert!(api.evm_revert(snapshot).await.unwrap());
+    api.mine_one().await;
+    let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(block.transactions, BlockTransactions::Hashes(Vec::new()));
+}

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -3,6 +3,7 @@ mod anvil;
 mod anvil_api;
 mod api;
 mod beacon_api;
+mod bundle;
 mod eip2935;
 mod eip4844;
 mod eip7702;


### PR DESCRIPTION
Adds Flashbots-compatible `eth_sendBundle` request and response using Alloy's existing MEV RPC types. Signed transactions are decoded and validated into a dedicated private bundle queue with exact block and timestamp eligibility, allowed reverting transaction hashes, and replacement UUID semantics.

Bundles remain outside the public transaction pool, so their transactions do not appear in pending-transaction RPCs, txpool views, or pending subscriptions. Eligible bundles flow through automine, interval, manual, and pending-block construction as ordered atomic units; the executor checkpoints database, receipt, gas, and blob-gas state and restores the checkpoint whenever any non-allowed transaction fails or cannot be included. Consumed bundles follow transaction-pool lifecycle behavior across reset and snapshot reverts without being replayed.

Closes #8332.

AI assistance disclosure: This PR's implementation, tests, and description were produced with OpenAI Codex assistance.
