### PR TITLE
perf(forge): speed up eip712

### DIFF
--- a/crates/forge/src/cmd/eip712.rs
+++ b/crates/forge/src/cmd/eip712.rs
@@ -3,6 +3,7 @@ use clap::{Parser, ValueHint};
 use eyre::Result;
 use foundry_cli::{opts::BuildOpts, utils::LoadConfig};
 use foundry_common::{compile::ProjectCompiler, shell};
+use foundry_compilers::{Graph, artifacts::Source, multi::MultiCompilerParser};
 use serde::Serialize;
 use solar::sema::{
     Gcx, Hir,
@@ -48,9 +49,29 @@ impl Display for Eip712Output {
 impl Eip712Args {
     pub fn run(self) -> Result<()> {
         let config = self.build.load_config()?;
-        let project = config.solar_project()?;
-        let mut output = ProjectCompiler::new().files([self.target_path]).compile(&project)?;
-        let compiler = output.parser_mut().solc_mut().compiler_mut();
+        let artifacts_requested = self.build.out_path.is_some()
+            || config.force
+            || config.ast
+            || config.build_info
+            || config.build_info_path.is_some()
+            || config.out != config.root.join("out")
+            || !config.extra_output.is_empty()
+            || !config.extra_output_files.is_empty();
+
+        if artifacts_requested {
+            let project = config.solar_project()?;
+            let mut output = ProjectCompiler::new().files([self.target_path]).compile(&project)?;
+            Self::run_with_compiler(output.parser_mut().solc_mut().compiler_mut())
+        } else {
+            let sources = Source::read_all([self.target_path])?;
+            let graph =
+                Graph::<MultiCompilerParser>::resolve_sources(&config.project_paths(), sources)?;
+            let (_, mut edges) = graph.into_sources();
+            Self::run_with_compiler(edges.parser_mut().solc_mut().compiler_mut())
+        }
+    }
+
+    fn run_with_compiler(compiler: &mut solar::sema::Compiler) -> Result<()> {
         compiler.enter_mut(|compiler| -> Result<()> {
             let Ok(ControlFlow::Continue(())) = compiler.lower_asts() else { return Ok(()) };
             let gcx = compiler.gcx();

--- a/crates/forge/src/cmd/eip712.rs
+++ b/crates/forge/src/cmd/eip712.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{B256, keccak256};
 use clap::{Parser, ValueHint};
 use eyre::Result;
 use foundry_cli::{opts::BuildOpts, utils::LoadConfig};
-use foundry_common::{compile::ProjectCompiler, shell};
+use foundry_common::shell;
 use foundry_compilers::{Graph, artifacts::Source, multi::MultiCompilerParser};
 use serde::Serialize;
 use solar::sema::{
@@ -49,26 +49,11 @@ impl Display for Eip712Output {
 impl Eip712Args {
     pub fn run(self) -> Result<()> {
         let config = self.build.load_config()?;
-        let artifacts_requested = self.build.out_path.is_some()
-            || config.force
-            || config.ast
-            || config.build_info
-            || config.build_info_path.is_some()
-            || config.out != config.root.join("out")
-            || !config.extra_output.is_empty()
-            || !config.extra_output_files.is_empty();
-
-        if artifacts_requested {
-            let project = config.solar_project()?;
-            let mut output = ProjectCompiler::new().files([self.target_path]).compile(&project)?;
-            Self::run_with_compiler(output.parser_mut().solc_mut().compiler_mut())
-        } else {
-            let sources = Source::read_all([self.target_path])?;
-            let graph =
-                Graph::<MultiCompilerParser>::resolve_sources(&config.project_paths(), sources)?;
-            let (_, mut edges) = graph.into_sources();
-            Self::run_with_compiler(edges.parser_mut().solc_mut().compiler_mut())
-        }
+        let sources = Source::read_all([self.target_path])?;
+        let graph =
+            Graph::<MultiCompilerParser>::resolve_sources(&config.project_paths(), sources)?;
+        let (_, mut edges) = graph.into_sources();
+        Self::run_with_compiler(edges.parser_mut().solc_mut().compiler_mut())
     }
 
     fn run_with_compiler(compiler: &mut solar::sema::Compiler) -> Result<()> {
@@ -100,7 +85,7 @@ impl Eip712Args {
             Ok(())
         })?;
 
-        // `compiler.sess()` inside of `ProjectCompileOutput` is built with `with_buffer_emitter`.
+        // The source graph's Solar parser uses a buffer emitter.
         let diags = compiler.sess().dcx.emitted_diagnostics().unwrap();
         if compiler.sess().dcx.has_errors().is_err() {
             eyre::bail!("{diags}");

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -160,8 +160,11 @@ Structs.sol > Structs2 > FooBar:
     assert!(std::fs::read_dir(prj.artifacts()).map(|mut dir| dir.next().is_none()).unwrap_or(true));
     assert!(!prj.cache().exists());
 
-    // Explicit artifact settings retain the compiler-backed path.
+    // Explicit artifact settings do not make this analysis command write compiler output.
     let custom_out = prj.root().join("eip712-out");
+    std::fs::create_dir(&custom_out).unwrap();
+    let sentinel = custom_out.join("sentinel");
+    std::fs::write(&sentinel, b"sentinel").unwrap();
     cmd.forge_fuse()
         .args([
             "eip712",
@@ -170,7 +173,9 @@ Structs.sol > Structs2 > FooBar:
             custom_out.to_string_lossy().as_ref(),
         ])
         .assert_success();
-    assert!(std::fs::read_dir(custom_out).unwrap().next().is_some());
+    assert_eq!(std::fs::read(&sentinel).unwrap(), b"sentinel");
+    assert_eq!(std::fs::read_dir(custom_out).unwrap().count(), 1);
+    assert!(!prj.cache().exists());
 
     cmd.forge_fuse().arg("test").assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]

--- a/crates/forge/tests/cli/eip712.rs
+++ b/crates/forge/tests/cli/eip712.rs
@@ -62,12 +62,7 @@ contract DummyTest {
     cmd.forge_fuse()
         .args(["eip712", path.to_string_lossy().as_ref()])
         .assert_success()
-        .stdout_eq(str![[r#"
-[COMPILING_FILES] with [SOLC_VERSION]
-[SOLC_VERSION] [ELAPSED]
-Compiler run successful!
-
-"#]])
+        .stdout_eq("")
         .stderr_eq(str![[r#"
 Structs.sol > Structs > Foo:
  - type: Foo(Bar bar)Art(uint256 id)Bar(Art art)
@@ -161,7 +156,22 @@ Structs.sol > Structs2 > FooBar:
 "#]],
     );
 
-    // Testing `solar_project` doesn't mess up cache.
+    // EIP-712 analysis only needs the source graph and must not emit compiler output.
+    assert!(std::fs::read_dir(prj.artifacts()).map(|mut dir| dir.next().is_none()).unwrap_or(true));
+    assert!(!prj.cache().exists());
+
+    // Explicit artifact settings retain the compiler-backed path.
+    let custom_out = prj.root().join("eip712-out");
+    cmd.forge_fuse()
+        .args([
+            "eip712",
+            path.to_string_lossy().as_ref(),
+            "--out",
+            custom_out.to_string_lossy().as_ref(),
+        ])
+        .assert_success();
+    assert!(std::fs::read_dir(custom_out).unwrap().next().is_some());
+
     cmd.forge_fuse().arg("test").assert_failure().stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
@@ -212,12 +222,7 @@ library InsideLibrary {
     cmd.forge_fuse()
         .args(["eip712", path.to_string_lossy().as_ref()])
         .assert_success()
-        .stdout_eq(str![[r#"
-[COMPILING_FILES] with [SOLC_VERSION]
-[SOLC_VERSION] [ELAPSED]
-Compiler run successful!
-
-"#]])
+        .stdout_eq("")
         .stderr_eq(str![[r#"
 FreeStanding:
  - type: FreeStanding(uint256 id,string name)


### PR DESCRIPTION
## Summary

- Resolve the target source graph directly for `forge eip712` and reuse its Solar parser, avoiding an ABI-only `solc` build that the command never consumes.
- Treat EIP-712 generation as analysis-only and leave compiler artifacts and cache untouched, including when a custom output directory is configured.
- Cover both the default path and custom `--out` behavior in the EIP-712 CLI test.

## Benchmarks

Measured release builds with `hyperfine --warmup 3 --runs 30`, removing `out` and `cache` before every sample:

```console
$ forge eip712 testdata/utils/Vm.sol --json
before  34.3 ms ± 1.9 ms
after    9.2 ms ± 0.3 ms
```

This is a **3.73x speedup** (73.2% less time). JSON output is identical. Disk output drops from 148 KiB of artifacts plus the compiler cache to no generated compiler output.