### PR TITLE
perf(forge): speed up linting

### DIFF
--- a/crates/cli/src/opts/build/utils.rs
+++ b/crates/cli/src/opts/build/utils.rs
@@ -26,6 +26,28 @@ pub fn configure_pcx(
     project: Option<&Project>,
     target_paths: Option<&[PathBuf]>,
 ) -> Result<()> {
+    configure_pcx_with_sources(pcx, config, project, target_paths, false).map(drop)
+}
+
+/// Configures a Solar parsing context with all Solar-compatible project sources.
+///
+/// Returns `true` if any compatible sources were configured.
+pub fn configure_pcx_all_sources(
+    pcx: &mut ParsingContext<'_>,
+    config: &Config,
+    project: Option<&Project>,
+    target_paths: Option<&[PathBuf]>,
+) -> Result<bool> {
+    configure_pcx_with_sources(pcx, config, project, target_paths, true)
+}
+
+fn configure_pcx_with_sources(
+    pcx: &mut ParsingContext<'_>,
+    config: &Config,
+    project: Option<&Project>,
+    target_paths: Option<&[PathBuf]>,
+    all_versions: bool,
+) -> Result<bool> {
     // Process build options
     let project = match project {
         Some(project) => project,
@@ -47,9 +69,9 @@ pub fn configure_pcx(
         None => project.paths.read_input_files()?,
     };
 
-    // Only process sources with latest Solidity version to avoid conflicts.
+    // Process Solar-compatible sources and use the latest version for the compiler input.
     let graph = Graph::<MultiCompilerParser>::resolve_sources(&project.paths, sources)?;
-    let (version, sources) = graph
+    let versioned_sources = graph
         // Resolve graph into mapping language -> version -> sources
         .into_sources_by_version(project)?
         .sources
@@ -57,15 +79,26 @@ pub fn configure_pcx(
         // Only interested in Solidity sources
         .find(|(lang, _)| *lang == MultiCompilerLanguage::Solc(SolcLanguage::Solidity))
         .ok_or_else(|| eyre::eyre!("no Solidity sources"))?
-        .1
-        .into_iter()
-        // Filter unsupported versions
-        .filter(|(v, _, _)| v >= &MIN_SOLIDITY_VERSION)
-        // Always pick the latest version
-        .max_by(|(v1, _, _), (v2, _, _)| v1.cmp(v2))
-        .map_or((MIN_SOLIDITY_VERSION, Sources::default()), |(v, s, _)| (v, s));
+        .1;
 
-    if sources.is_empty() {
+    let versioned_sources =
+        versioned_sources.into_iter().filter(|(v, _, _)| v >= &MIN_SOLIDITY_VERSION);
+    let (version, sources) = if all_versions {
+        versioned_sources.fold(
+            (MIN_SOLIDITY_VERSION, Sources::default()),
+            |(version, mut sources), (source_version, version_sources, _)| {
+                sources.extend(version_sources);
+                (version.max(source_version), sources)
+            },
+        )
+    } else {
+        versioned_sources
+            .max_by(|(v1, _, _), (v2, _, _)| v1.cmp(v2))
+            .map_or((MIN_SOLIDITY_VERSION, Sources::default()), |(v, s, _)| (v, s))
+    };
+
+    let has_sources = !sources.is_empty();
+    if !all_versions && !has_sources {
         sh_warn!("no files found. Solar doesn't support Solidity versions prior to 0.8.0")?;
     }
 
@@ -78,7 +111,7 @@ pub fn configure_pcx(
 
     configure_pcx_from_solc(pcx, &project.paths, &solc, true);
 
-    Ok(())
+    Ok(has_sources)
 }
 
 /// Extracts Solar-compatible sources from a [`ProjectCompileOutput`].

--- a/crates/forge/src/cmd/lint.rs
+++ b/crates/forge/src/cmd/lint.rs
@@ -5,12 +5,12 @@ use forge_lint::{
     sol::{SolLint, SolLintError, SolidityLinter},
 };
 use foundry_cli::{
-    opts::{BuildOpts, configure_pcx_from_solc, get_solar_sources_from_compile_output},
+    opts::{BuildOpts, configure_pcx_all_sources},
     utils::{FoundryPathExt, LoadConfig},
 };
-use foundry_common::{compile::ProjectCompiler, shell};
-use foundry_compilers::{solc::SolcLanguage, utils::SOLC_EXTENSIONS};
-use foundry_config::{filter::expand_globs, lint::Severity};
+use foundry_common::shell;
+use foundry_compilers::{FileFilter, solc::SolcLanguage, utils::SOLC_EXTENSIONS};
+use foundry_config::{SkipBuildFilters, filter::expand_globs, lint::Severity};
 use std::path::PathBuf;
 
 /// CLI arguments for `forge lint`.
@@ -40,7 +40,7 @@ foundry_config::impl_figment_convert!(LintArgs, build);
 impl LintArgs {
     pub fn run(self) -> Result<()> {
         let config = self.load_config()?;
-        let project = config.solar_project()?;
+        let project = config.ephemeral_project()?;
         let path_config = config.project_paths();
 
         // Expand ignore globs and canonicalize from the get go
@@ -50,7 +50,7 @@ impl LintArgs {
             .collect::<Vec<_>>();
 
         let cwd = std::env::current_dir()?;
-        let input = match &self.paths[..] {
+        let mut input = match &self.paths[..] {
             [] => {
                 // Retrieve the project paths, and filter out the ignored ones.
                 config
@@ -75,6 +75,8 @@ impl LintArgs {
                 inputs
             }
         };
+        let skip = SkipBuildFilters::new(config.skip.clone(), config.root.clone());
+        input.retain(|path| skip.is_match(path));
 
         if input.is_empty() {
             sh_status!("nothing to lint")?;
@@ -107,15 +109,6 @@ impl LintArgs {
             .with_severity(if severity.is_empty() { None } else { Some(severity) })
             .with_lint_specific(&config.lint.lint_specific);
 
-        let output = ProjectCompiler::new().files(input.iter().cloned()).compile(&project)?;
-        let solar_sources =
-            get_solar_sources_from_compile_output(&config, &output, Some(&input), Some(&ignored))?;
-        if solar_sources.input.sources.is_empty() {
-            return Err(eyre!("unable to lint. Solar only supports Solidity versions >=0.8.0"));
-        }
-
-        // NOTE(rusowsky): Once solar can drop unsupported versions, rather than creating a new
-        // compiler, we should reuse the parser from the project output.
         let mut opts = solar::interface::config::CompileOpts::default();
         opts.unstable.typeck = true;
         let mut compiler = solar::sema::Compiler::new(
@@ -123,12 +116,17 @@ impl LintArgs {
         );
 
         // Load the solar-compatible sources to the pcx before linting
-        compiler.enter_mut(|compiler| {
+        let has_sources = compiler.enter_mut(|compiler| -> Result<bool> {
             let mut pcx = compiler.parse();
             pcx.set_resolve_imports(true);
-            configure_pcx_from_solc(&mut pcx, &config.project_paths(), &solar_sources, true);
+            let has_sources =
+                configure_pcx_all_sources(&mut pcx, &config, Some(&project), Some(&input))?;
             pcx.parse();
-        });
+            Ok(has_sources)
+        })?;
+        if !has_sources {
+            return Err(eyre!("unable to lint. Solar only supports Solidity versions >=0.8.0"));
+        }
         linter.lint(&input, config.deny, &mut compiler)?;
 
         Ok(())

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -2244,12 +2244,7 @@ forgetest_init!(test_exclude_lints_config, |prj, cmd| {
             "unwrapped-modifier-logic".to_string(),
         ]
     });
-    cmd.args(["lint"]).assert_success().stdout_eq(str![[r#"
-[COMPILING_FILES] with [SOLC_VERSION]
-[SOLC_VERSION] [ELAPSED]
-Compiler run successful!
-
-"#]]);
+    cmd.args(["lint"]).assert_success().stdout_eq("");
 });
 
 // <https://github.com/foundry-rs/foundry/issues/6529>

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -203,6 +203,22 @@ interface IToken {
 }
 "#;
 
+forgetest!(lint_does_not_write_artifacts, |prj, cmd| {
+    use std::fs;
+
+    prj.add_source("LintTarget", "contract LintTarget {}");
+    let artifact = prj.root().join("out/LintTarget.sol/LintTarget.json");
+
+    cmd.arg("lint").assert_success();
+    assert!(!artifact.exists());
+
+    fs::create_dir_all(artifact.parent().unwrap()).unwrap();
+    fs::write(&artifact, b"sentinel").unwrap();
+
+    cmd.forge_fuse().arg("lint").assert_success();
+    assert_eq!(fs::read(artifact).unwrap(), b"sentinel");
+});
+
 forgetest!(can_use_config, |prj, cmd| {
     prj.add_source("ContractWithLints", CONTRACT);
     prj.add_source("OtherContractWithLints", OTHER_CONTRACT);


### PR DESCRIPTION
## Summary

- Configure Solar directly from the project source graph for `forge lint`, avoiding the ABI-only compiler subprocess and subsequent source extraction.
- Use an ephemeral project so linting no longer writes artifacts or compiler cache entries.
- Preserve build skip filters, multi-version source selection, and the existing behavior for unsupported Solidity versions.

## Benchmarks

Measured on Solady with clean output and cache directories before every sample:

| | Mean | Range |
|---|---:|---:|
| Before | 1.340 s ± 0.014 s | 1.316–1.361 s |
| After | 68.8 ms ± 0.6 ms | 67.5–69.5 ms |
