### PR TITLE
fix(lint): catch cache-array-length in compound conditions

### DIFF
--- a/crates/lint/docs/cache-array-length.md
+++ b/crates/lint/docs/cache-array-length.md
@@ -8,8 +8,9 @@ instead of comparing against a cached local length.
 
 ## What it does
 
-Reports simple comparison expressions in `for` loop conditions when either side reads `.length`
-from a state dynamic array, such as `i < values.length` or `values.length > i`.
+Reports comparison expressions in `for` loop conditions when either side reads `.length` from a
+state dynamic array, such as `i < values.length` or `values.length > i`, including comparisons
+nested inside `&&` / `||` conditions.
 
 The lint does not report loops that already compare against a local cached length variable.
 It also skips loops that mutate an array length in the loop body, such as calling `push()` or

--- a/crates/lint/src/sol/gas/cache_array_length.rs
+++ b/crates/lint/src/sol/gas/cache_array_length.rs
@@ -97,6 +97,10 @@ fn collect_condition_length_reads<'hir>(
     reads: &mut Vec<LengthRead<'hir>>,
 ) {
     match &expr.peel_parens().kind {
+        ExprKind::Binary(lhs, op, rhs) if matches!(op.kind, BinOpKind::And | BinOpKind::Or) => {
+            collect_condition_length_reads(gcx, lhs, reads);
+            collect_condition_length_reads(gcx, rhs, reads);
+        }
         ExprKind::Binary(lhs, op, rhs) if is_comparison(op.kind) => {
             if matches!(lhs.peel_parens().kind, ExprKind::Ident(_)) {
                 collect_state_array_length_read(gcx, rhs, reads);

--- a/crates/lint/testdata/CacheArrayLength.sol
+++ b/crates/lint/testdata/CacheArrayLength.sol
@@ -26,6 +26,26 @@ contract CacheArrayLength {
         }
     }
 
+    function compoundConditionStorageArrayLength(uint256 cap)
+        external
+        view
+        returns (uint256 sum)
+    {
+        for (uint256 i = 0; i < items.length && i < cap; ++i) { //~NOTE: array length read in loop condition
+            sum += items[i];
+        }
+    }
+
+    function reversedCompoundConditionStorageArrayLength(uint256 cap)
+        external
+        view
+        returns (uint256 sum)
+    {
+        for (uint256 i = 0; i < cap && items.length > i; ++i) { //~NOTE: array length read in loop condition
+            sum += items[i];
+        }
+    }
+
     function memoryArrayLength(uint256[] memory values) public pure returns (uint256 sum) {
         for (uint256 i = 0; i <= values.length; ++i) {
             if (i < values.length) {
@@ -134,6 +154,12 @@ contract CacheArrayLength {
         }
     }
 
+    function conditionHelperMutation(uint256 cap) external returns (uint256 sum) {
+        for (uint256 i = 0; i < items.length && mutateAndContinue(i, cap); ++i) {
+            sum += i;
+        }
+    }
+
     function loopVariantNestedArrayLength(uint256[][] memory values)
         public
         pure
@@ -166,6 +192,11 @@ contract CacheArrayLength {
 
     function mutateItems(uint256 value) internal {
         items.push(value);
+    }
+
+    function mutateAndContinue(uint256 value, uint256 cap) internal returns (bool) {
+        items.push(value);
+        return value < cap;
     }
 
     function mutatingValues() internal returns (uint256[] memory values) {

--- a/crates/lint/testdata/CacheArrayLength.stderr
+++ b/crates/lint/testdata/CacheArrayLength.stderr
@@ -6,3 +6,19 @@ LL │         for (uint256 i = 0; i < items.length; ++i) {
    │
    ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
 
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < items.length && i < cap; ++i) {
+   │                                 ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+
+note[cache-array-length]: array length read in loop condition should be cached outside the loop
+   ╭▸ ROOT/testdata/CacheArrayLength.sol:LL:CC
+   │
+LL │         for (uint256 i = 0; i < cap && items.length > i; ++i) {
+   │                                        ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/cache-array-length
+


### PR DESCRIPTION
Refs #14381

## Summary

- Recurse through `&&` / `||` expressions when collecting `cache-array-length` condition reads.
- Add regression coverage for storage array `.length` reads nested inside compound `for` conditions.
- Keep the existing skip behavior for loops whose condition/body may mutate array length.
- Update the lint docs to mention compound boolean conditions.

## Tests

- `cargo test -p forge --test ui -- CacheArrayLength`
- `cargo test -p forge-lint`
- `cargo fmt --check`

Note: `cargo fmt --check` passes, but stable rustfmt prints warnings for the repo's nightly-only formatting options.
