### PR TITLE
fix(anvil): canonicalize blob tx roots

### DIFF
--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -2,8 +2,8 @@ use super::transaction::TransactionInfo;
 #[cfg(test)]
 use alloy_consensus::Header;
 use alloy_consensus::{
-    BlockBody, EMPTY_OMMER_ROOT_HASH, Typed2718, proofs::ordered_trie_root_with_encoder,
-    transaction::RlpEcdsaEncodableTx,
+    BlockBody, EMPTY_OMMER_ROOT_HASH, TxEip4844Variant, Typed2718,
+    proofs::ordered_trie_root_with_encoder, transaction::RlpEcdsaEncodableTx,
 };
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::Network;
@@ -38,6 +38,23 @@ impl EncodableBlockTransaction for FoundryTxEnvelope {
             self.encode_2718(out);
         }
     }
+}
+
+/// Drops pooled sidecars so a transaction uses its canonical block-body representation.
+pub fn canonical_block_transaction(tx: FoundryTxEnvelope) -> FoundryTxEnvelope {
+    match tx {
+        FoundryTxEnvelope::Eip4844(tx) => {
+            FoundryTxEnvelope::Eip4844(tx.map(TxEip4844Variant::drop_sidecar))
+        }
+        tx => tx,
+    }
+}
+
+/// Returns a block whose transactions use canonical block-body representations.
+pub fn canonical_block(mut block: Block) -> Block {
+    block.body.transactions =
+        block.body.transactions.into_iter().map(|tx| tx.map(canonical_block_transaction)).collect();
+    block
 }
 
 /// Helper function to create a new block with Header and Anvil transactions, generic over the

--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -1,7 +1,10 @@
 use super::transaction::TransactionInfo;
 #[cfg(test)]
 use alloy_consensus::Header;
-use alloy_consensus::{BlockBody, EMPTY_OMMER_ROOT_HASH, proofs::calculate_transaction_root};
+use alloy_consensus::{
+    BlockBody, EMPTY_OMMER_ROOT_HASH, Typed2718, proofs::ordered_trie_root_with_encoder,
+    transaction::RlpEcdsaEncodableTx,
+};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::Network;
 use foundry_primitives::{FoundryHeader, FoundryTxEnvelope};
@@ -20,6 +23,23 @@ pub struct BlockInfo<N: Network> {
     pub receipts: Vec<N::ReceiptEnvelope>,
 }
 
+/// A transaction that can be encoded for inclusion in a block body.
+pub trait EncodableBlockTransaction: Encodable2718 {
+    /// Encodes the transaction in its canonical block-body form.
+    fn encode_2718_for_block(&self, out: &mut dyn bytes::BufMut);
+}
+
+impl EncodableBlockTransaction for FoundryTxEnvelope {
+    fn encode_2718_for_block(&self, out: &mut dyn bytes::BufMut) {
+        if let Self::Eip4844(tx) = self {
+            out.put_u8(self.ty());
+            tx.tx().tx().rlp_encode_signed(tx.signature(), out);
+        } else {
+            self.encode_2718(out);
+        }
+    }
+}
+
 /// Helper function to create a new block with Header and Anvil transactions, generic over the
 /// transaction envelope with a default of [`FoundryTxEnvelope`].
 ///
@@ -30,11 +50,13 @@ pub fn create_block<T, Tx>(
     transactions: impl IntoIterator<Item = T>,
 ) -> Block<Tx>
 where
-    Tx: Encodable2718,
+    Tx: EncodableBlockTransaction,
     T: Into<MaybeImpersonatedTransaction<Tx>>,
 {
     let transactions: Vec<_> = transactions.into_iter().map(Into::into).collect();
-    let transactions_root = calculate_transaction_root(&transactions);
+    let transactions_root = ordered_trie_root_with_encoder(&transactions, |tx, out| {
+        tx.as_ref().encode_2718_for_block(out)
+    });
 
     header.set_transactions_root(transactions_root);
     header.set_ommers_hash(EMPTY_OMMER_ROOT_HASH);
@@ -45,14 +67,60 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloy_consensus::{
+        BlobTransactionSidecar, BlobTransactionSidecarVariant, BlockHeader, SignableTransaction,
+        TxEip4844, proofs::calculate_transaction_root, transaction::eip4844::TxEip4844Variant,
+    };
     use alloy_primitives::{
-        Address, B64, B256, Bloom, U256, b256,
+        Address, B64, B256, Bloom, Signature, U256, b256,
         hex::{self, FromHex},
     };
     use alloy_rlp::Decodable;
 
     use super::*;
     use std::str::FromStr;
+
+    fn assert_blob_transaction_root(sidecar: BlobTransactionSidecarVariant) {
+        let tx = TxEip4844 {
+            chain_id: 1,
+            nonce: 0,
+            gas_limit: 21_000,
+            max_fee_per_gas: 1,
+            max_priority_fee_per_gas: 1,
+            to: Address::ZERO,
+            value: U256::ZERO,
+            access_list: Default::default(),
+            blob_versioned_hashes: vec![B256::ZERO],
+            max_fee_per_blob_gas: 1,
+            input: Default::default(),
+        };
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let canonical = FoundryTxEnvelope::Eip4844(
+            TxEip4844Variant::TxEip4844(tx.clone()).into_signed(signature),
+        );
+        let pooled = FoundryTxEnvelope::Eip4844(
+            TxEip4844Variant::TxEip4844WithSidecar(tx.with_sidecar(sidecar)).into_signed(signature),
+        );
+
+        let canonical_root = calculate_transaction_root(&[canonical]);
+        let pooled_root = calculate_transaction_root(std::slice::from_ref(&pooled));
+        let block = create_block(FoundryHeader::default(), [pooled]);
+
+        assert_ne!(canonical_root, pooled_root);
+        assert_eq!(block.header.transactions_root(), canonical_root);
+    }
+
+    #[test]
+    fn blob_transaction_root_uses_canonical_encoding() {
+        assert_blob_transaction_root(BlobTransactionSidecarVariant::Eip4844(
+            BlobTransactionSidecar::new(
+                vec![Default::default()],
+                vec![Default::default()],
+                vec![Default::default()],
+            ),
+        ));
+        assert_blob_transaction_root(BlobTransactionSidecarVariant::Eip7594(Default::default()));
+    }
 
     #[test]
     fn header_rlp_roundtrip() {

--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -86,7 +86,7 @@ where
 mod tests {
     use alloy_consensus::{
         BlobTransactionSidecar, BlobTransactionSidecarVariant, BlockHeader, SignableTransaction,
-        TxEip4844, proofs::calculate_transaction_root, transaction::eip4844::TxEip4844Variant,
+        TxEip4844, proofs::calculate_transaction_root,
     };
     use alloy_primitives::{
         Address, B64, B256, Bloom, Signature, U256, b256,

--- a/crates/anvil/core/src/eth/transaction/mod.rs
+++ b/crates/anvil/core/src/eth/transaction/mod.rs
@@ -51,6 +51,14 @@ impl<T> MaybeImpersonatedTransaction<T> {
     pub fn into_inner(self) -> T {
         self.transaction
     }
+
+    /// Maps the inner transaction while preserving impersonation metadata.
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> MaybeImpersonatedTransaction<U> {
+        MaybeImpersonatedTransaction {
+            transaction: f(self.transaction),
+            impersonated_sender: self.impersonated_sender,
+        }
+    }
 }
 
 impl<T: SignerRecoverable + TxHashRef + Encodable> MaybeImpersonatedTransaction<T> {

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -76,7 +76,7 @@ use alloy_transport::TransportErrorKind;
 use anvil_core::{
     eth::{
         EthRequest,
-        block::BlockInfo,
+        block::{BlockInfo, canonical_block, canonical_block_transaction},
         transaction::{MaybeImpersonatedTransaction, PendingTransaction},
     },
     types::{ReorgOptions, TransactionData},
@@ -3353,7 +3353,12 @@ impl EthApi<FoundryNetwork> {
         let Some(block) = self.backend.get_block(block) else {
             return Ok(Vec::new());
         };
-        Ok(block.body.transactions.into_iter().map(|tx| tx.encoded_2718().into()).collect())
+        Ok(block
+            .body
+            .transactions
+            .into_iter()
+            .map(|tx| canonical_block_transaction(tx.into_inner()).encoded_2718().into())
+            .collect())
     }
 
     /// Returns RLP encoded raw block header.
@@ -3371,7 +3376,7 @@ impl EthApi<FoundryNetwork> {
     pub async fn raw_block(&self, block: BlockId) -> Result<Bytes> {
         node_info!("debug_getRawBlock");
         let block = self.backend.get_block(block).ok_or(BlockchainError::BlockNotFound)?;
-        Ok(alloy_rlp::encode(&block).into())
+        Ok(alloy_rlp::encode(canonical_block(block)).into())
     }
 
     /// Returns EIP-2718 encoded raw transaction by block hash and index

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -37,7 +37,7 @@ use crate::{
 use alloy_chains::NamedChain;
 use alloy_consensus::{
     Blob, BlockHeader, EnvKzgSettings, Header, Signed, Transaction as TransactionTrait,
-    TrieAccount, TxEnvelope, TxReceipt, Typed2718,
+    TrieAccount, TxEip4844Variant, TxEnvelope, TxReceipt, Typed2718,
     constants::EMPTY_WITHDRAWALS,
     proofs::{calculate_receipt_root, calculate_transaction_root},
     transaction::Recovered,
@@ -5226,15 +5226,18 @@ impl Backend<FoundryNetwork> {
     }
 
     pub fn get_blob_by_tx_hash(&self, hash: B256) -> Result<Option<Vec<alloy_consensus::Blob>>> {
-        // Try to get the mined transaction by hash
-        if let Some(tx) = self.mined_transaction_by_hash(hash)
-            && let Ok(typed_tx) = FoundryTxEnvelope::try_from(tx)
-            && let Some(sidecar) = typed_tx.sidecar()
-        {
-            return Ok(Some(sidecar.sidecar.blobs().to_vec()));
-        }
-
-        Ok(None)
+        let storage = self.blockchain.storage.read();
+        Ok(storage.transactions.get(&hash).and_then(|mined| {
+            storage
+                .blocks
+                .get(&mined.block_hash)?
+                .body
+                .transactions
+                .get(mined.info.transaction_index as usize)?
+                .as_ref()
+                .sidecar()
+                .map(|sidecar| sidecar.sidecar.blobs().to_vec())
+        }))
     }
 
     /// Sets the fee token for a user address (Tempo-only).
@@ -5771,7 +5774,10 @@ pub fn transaction_build(
         TxEnvelope::Legacy(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Legacy(rehash(s, hash))),
         TxEnvelope::Eip1559(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip1559(rehash(s, hash))),
         TxEnvelope::Eip2930(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip2930(rehash(s, hash))),
-        TxEnvelope::Eip4844(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip4844(rehash(s, hash))),
+        TxEnvelope::Eip4844(s) => {
+            let s = if block.is_some() { s.map(TxEip4844Variant::drop_sidecar) } else { s };
+            AnyTxEnvelope::Ethereum(TxEnvelope::Eip4844(rehash(s, hash)))
+        }
         TxEnvelope::Eip7702(s) => AnyTxEnvelope::Ethereum(TxEnvelope::Eip7702(rehash(s, hash))),
     };
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -92,7 +92,7 @@ use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse, EthCallBundleTra
 use alloy_serde::{OtherFields, WithOtherFields};
 use alloy_trie::{HashBuilder, Nibbles, proof::ProofRetainer};
 use anvil_core::eth::{
-    block::{Block, BlockInfo, create_block},
+    block::{Block, BlockInfo, canonical_block, create_block},
     transaction::{MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo},
 };
 use anvil_rpc::error::RpcError;
@@ -1047,7 +1047,7 @@ impl<N: Network> Backend<N> {
     /// Takes a block as it's stored internally and returns the eth api conform block format.
     /// If `known_hash` is provided, it will be used instead of computing `hash_slow()`.
     pub fn convert_block_with_hash(&self, block: Block, known_hash: Option<B256>) -> AnyRpcBlock {
-        let size = U256::from(alloy_rlp::encode(&block).len() as u32);
+        let size = U256::from(alloy_rlp::encode(canonical_block(block.clone())).len() as u32);
 
         let header = block.header.clone();
         let transactions = block.body.transactions;

--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -67,6 +67,25 @@ async fn can_send_eip4844_transaction() {
     for field in ["blobs", "commitments", "proofs", "cellProofs"] {
         assert!(tx.get(field).is_none());
     }
+
+    let raw_transactions: Vec<Bytes> = provider
+        .client()
+        .request("debug_getRawTransactions", (BlockId::number(block.header.number),))
+        .await
+        .unwrap();
+    assert_eq!(raw_transactions.len(), 1);
+    EthereumTxEnvelope::<TxEip4844>::decode_2718(&mut raw_transactions[0].as_ref()).unwrap();
+
+    let raw_block: Bytes = provider
+        .client()
+        .request("debug_getRawBlock", (BlockId::number(block.header.number),))
+        .await
+        .unwrap();
+    assert_eq!(block.header.size, Some(U256::from(raw_block.len())));
+    let decoded: alloy_consensus::Block<EthereumTxEnvelope<TxEip4844>> =
+        alloy_rlp::Decodable::decode(&mut raw_block.as_ref()).unwrap();
+    assert_eq!(decoded.body.transactions.len(), 1);
+
     assert!(api.anvil_get_blob_by_tx_hash(receipt.transaction_hash).unwrap().is_some());
 }
 

--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -1,11 +1,14 @@
 use crate::utils::{http_provider, http_provider_with_signer};
-use alloy_consensus::{BlobTransactionSidecar, SidecarBuilder, SimpleCoder, Transaction};
+use alloy_consensus::{
+    BlobTransactionSidecar, EthereumTxEnvelope, SidecarBuilder, SimpleCoder, Transaction,
+    TxEip4844, proofs::calculate_transaction_root,
+};
 use alloy_eips::{
-    Typed2718,
+    Decodable2718, Typed2718,
     eip4844::{BLOB_TX_MIN_BLOB_GASPRICE, DATA_GAS_PER_BLOB, MAX_DATA_GAS_PER_BLOCK_DENCUN},
 };
 use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder, TransactionBuilder4844};
-use alloy_primitives::{Address, U256, b256};
+use alloy_primitives::{Address, Bytes, U256, b256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::{BlockId, TransactionRequest};
 use alloy_serde::WithOtherFields;
@@ -16,7 +19,7 @@ use foundry_test_utils::rpc;
 #[tokio::test(flavor = "multi_thread")]
 async fn can_send_eip4844_transaction() {
     let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
-    let (_api, handle) = spawn(node_config).await;
+    let (api, handle) = spawn(node_config).await;
 
     let wallets = handle.dev_wallets().collect::<Vec<_>>();
     let from = wallets[0].address();
@@ -45,6 +48,26 @@ async fn can_send_eip4844_transaction() {
 
     assert_eq!(receipt.blob_gas_used, Some(131072));
     assert_eq!(receipt.blob_gas_price, Some(0x1)); // 1 wei
+
+    let raw: Bytes = provider
+        .client()
+        .request("eth_getRawTransactionByHash", (receipt.transaction_hash,))
+        .await
+        .unwrap();
+    let canonical = EthereumTxEnvelope::<TxEip4844>::decode_2718(&mut raw.as_ref()).unwrap();
+    let block = provider
+        .get_block_by_number(receipt.block_number.unwrap().into())
+        .full()
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(block.header.transactions_root, calculate_transaction_root(&[canonical]));
+    let tx = serde_json::to_value(&block.transactions.as_transactions().unwrap()[0]).unwrap();
+    for field in ["blobs", "commitments", "proofs", "cellProofs"] {
+        assert!(tx.get(field).is_none());
+    }
+    assert!(api.anvil_get_blob_by_tx_hash(receipt.transaction_hash).unwrap().is_some());
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Closes #15132. This is a smaller alternative to #15133.

Anvil used the pooled EIP-4844 encoding both when building transaction trie leaves and when materializing mined RPC transactions. This keeps the pooled transaction in internal storage, where existing blob lookup and replay code already depend on its sidecar, but introduces canonical block-body encoding for trie calculation and drops the sidecar only from mined RPC views. The resulting transaction root and block hash are canonical, mined raw and full transaction responses no longer expose the sidecar, and the `anvil_getBlobs*` behavior remains intact.

This avoids a separate sidecar store and changes to execution, snapshots, reorgs, state serialization, and trace replay. Focused coverage checks both EIP-4844 and EIP-7594 roots, then exercises the mined RPC representation and blob retrieval end to end.

Developed with AI assistance under my direction and review.
