### PR TITLE
perf(forge): avoid compiling for doc generation

### DIFF
--- a/crates/cli/src/opts/build/utils.rs
+++ b/crates/cli/src/opts/build/utils.rs
@@ -37,9 +37,16 @@ pub fn configure_pcx(
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SolarSourceStatus {
     /// Whether any Solar-compatible sources were configured.
-    pub has_compatible_sources: bool,
+    has_compatible_sources: bool,
     /// Whether any sources require a Solidity version unsupported by Solar.
-    pub has_unsupported_sources: bool,
+    has_unsupported_sources: bool,
+}
+
+impl SolarSourceStatus {
+    /// Returns whether compatible sources were configured and no unsupported sources were found.
+    pub const fn is_fully_supported(&self) -> bool {
+        self.has_compatible_sources && !self.has_unsupported_sources
+    }
 }
 
 /// Configures a Solar parsing context with all Solar-compatible project sources.

--- a/crates/cli/src/opts/build/utils.rs
+++ b/crates/cli/src/opts/build/utils.rs
@@ -26,7 +26,20 @@ pub fn configure_pcx(
     project: Option<&Project>,
     target_paths: Option<&[PathBuf]>,
 ) -> Result<()> {
-    configure_pcx_with_sources(pcx, config, project, target_paths, false).map(drop)
+    let status = configure_pcx_with_sources(pcx, config, project, target_paths, false)?;
+    if !status.has_compatible_sources && !status.has_unsupported_sources {
+        eyre::bail!("no Solidity sources");
+    }
+    Ok(())
+}
+
+/// Describes the Solidity sources encountered while configuring Solar.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SolarSourceStatus {
+    /// Whether any Solar-compatible sources were configured.
+    pub has_compatible_sources: bool,
+    /// Whether any sources require a Solidity version unsupported by Solar.
+    pub has_unsupported_sources: bool,
 }
 
 /// Configures a Solar parsing context with all Solar-compatible project sources.
@@ -38,6 +51,21 @@ pub fn configure_pcx_all_sources(
     project: Option<&Project>,
     target_paths: Option<&[PathBuf]>,
 ) -> Result<bool> {
+    let status = configure_pcx_all_sources_with_status(pcx, config, project, target_paths)?;
+    if !status.has_compatible_sources && !status.has_unsupported_sources {
+        eyre::bail!("no Solidity sources");
+    }
+    Ok(status.has_compatible_sources)
+}
+
+/// Configures a Solar parsing context with all Solar-compatible project sources and reports
+/// whether unsupported sources were skipped.
+pub fn configure_pcx_all_sources_with_status(
+    pcx: &mut ParsingContext<'_>,
+    config: &Config,
+    project: Option<&Project>,
+    target_paths: Option<&[PathBuf]>,
+) -> Result<SolarSourceStatus> {
     configure_pcx_with_sources(pcx, config, project, target_paths, true)
 }
 
@@ -47,7 +75,7 @@ fn configure_pcx_with_sources(
     project: Option<&Project>,
     target_paths: Option<&[PathBuf]>,
     all_versions: bool,
-) -> Result<bool> {
+) -> Result<SolarSourceStatus> {
     // Process build options
     let project = match project {
         Some(project) => project,
@@ -66,23 +94,38 @@ fn configure_pcx_with_sources(
             sources
         }
         // Otherwise, process all project files
-        None => project.paths.read_input_files()?,
+        None => {
+            let mut sources = project.paths.read_input_files()?;
+            if let Some(filter) = &project.sparse_output {
+                sources.retain(|path, _| filter.is_match(path));
+            }
+            sources
+        }
     };
 
     // Process Solar-compatible sources and use the latest version for the compiler input.
     let graph = Graph::<MultiCompilerParser>::resolve_sources(&project.paths, sources)?;
-    let versioned_sources = graph
+    let Some(versioned_sources) = graph
         // Resolve graph into mapping language -> version -> sources
         .into_sources_by_version(project)?
         .sources
         .into_iter()
         // Only interested in Solidity sources
         .find(|(lang, _)| *lang == MultiCompilerLanguage::Solc(SolcLanguage::Solidity))
-        .ok_or_else(|| eyre::eyre!("no Solidity sources"))?
-        .1;
+        .map(|(_, sources)| sources)
+    else {
+        return Ok(SolarSourceStatus::default());
+    };
 
-    let versioned_sources =
-        versioned_sources.into_iter().filter(|(v, _, _)| v >= &MIN_SOLIDITY_VERSION);
+    let mut has_unsupported_sources = false;
+    let versioned_sources = versioned_sources.into_iter().filter(|(version, sources, _)| {
+        if version < &MIN_SOLIDITY_VERSION && !sources.is_empty() {
+            has_unsupported_sources = true;
+            false
+        } else {
+            true
+        }
+    });
     let (version, sources) = if all_versions {
         versioned_sources.fold(
             (MIN_SOLIDITY_VERSION, Sources::default()),
@@ -111,7 +154,7 @@ fn configure_pcx_with_sources(
 
     configure_pcx_from_solc(pcx, &project.paths, &solc, true);
 
-    Ok(has_sources)
+    Ok(SolarSourceStatus { has_compatible_sources: has_sources, has_unsupported_sources })
 }
 
 /// Extracts Solar-compatible sources from a [`ProjectCompileOutput`].

--- a/crates/forge/src/cmd/doc.rs
+++ b/crates/forge/src/cmd/doc.rs
@@ -80,14 +80,13 @@ impl DocArgs {
 
         // Solar does not support Solidity versions prior to 0.8.0. Preserve support for old,
         // mixed-version, and Solidity-free projects by using the existing compiler-backed parser.
-        let mut output =
-            if source_status.has_unsupported_sources || !source_status.has_compatible_sources {
-                let mut compile_project = config.solar_project()?;
-                compile_project.no_artifacts = true;
-                Some(ProjectCompiler::new().compile(&compile_project)?)
-            } else {
-                None
-            };
+        let mut output = if source_status.is_fully_supported() {
+            None
+        } else {
+            let mut compile_project = config.solar_project()?;
+            compile_project.no_artifacts = true;
+            Some(ProjectCompiler::new().compile(&compile_project)?)
+        };
 
         let mut doc_cfg = config.doc;
         if let Some(out) = self.out.clone() {

--- a/crates/forge/src/cmd/doc.rs
+++ b/crates/forge/src/cmd/doc.rs
@@ -4,9 +4,13 @@ use crate::cmd::{install, watch::WatchArgs};
 use clap::{Parser, ValueHint};
 use eyre::Result;
 use forge_doc::DocBuilder;
-use foundry_cli::{opts::GH_REPO_PREFIX_REGEX, utils::Git};
+use foundry_cli::{
+    opts::{GH_REPO_PREFIX_REGEX, configure_pcx_all_sources_with_status},
+    utils::Git,
+};
 use foundry_common::{compile::ProjectCompiler, shell};
 use foundry_config::{Config, load_config_with_root};
+use solar::{interface::Session, sema::Compiler};
 use std::{path::PathBuf, time::Instant};
 
 #[derive(Clone, Debug, Parser)]
@@ -63,15 +67,27 @@ impl DocArgs {
         }
 
         let root = &config.root;
-        let mut project = config.solar_project()?;
-        project.no_artifacts = true;
+        let project = config.ephemeral_project()?;
+        let mut compiler = Compiler::new(Session::builder().with_stderr_emitter().build());
+        let source_status = compiler.enter_mut(|compiler| -> Result<_> {
+            let mut pcx = compiler.parse();
+            pcx.set_resolve_imports(true);
+            let status =
+                configure_pcx_all_sources_with_status(&mut pcx, &config, Some(&project), None)?;
+            pcx.parse();
+            Ok(status)
+        })?;
 
-        // Compile the project first so the doc renderer has access to a fully
-        // resolved HIR (needed for `@inheritdoc`, cross-references, etc.).
-        // We let the standard compilation reporter print progress so users get
-        // the same visual feedback as `forge build`; pass `--quiet` to silence.
-        let mut output = ProjectCompiler::new().compile(&project)?;
-        let compiler = output.parser_mut().solc_mut().compiler_mut();
+        // Solar does not support Solidity versions prior to 0.8.0. Preserve support for old,
+        // mixed-version, and Solidity-free projects by using the existing compiler-backed parser.
+        let mut output =
+            if source_status.has_unsupported_sources || !source_status.has_compatible_sources {
+                let mut compile_project = config.solar_project()?;
+                compile_project.no_artifacts = true;
+                Some(ProjectCompiler::new().compile(&compile_project)?)
+            } else {
+                None
+            };
 
         let mut doc_cfg = config.doc;
         if let Some(out) = self.out.clone() {
@@ -113,6 +129,11 @@ impl DocArgs {
             sh_println!("Generating documentation...")?;
         }
         let started = Instant::now();
+        let compiler = if let Some(output) = &mut output {
+            output.parser_mut().solc_mut().compiler_mut()
+        } else {
+            &mut compiler
+        };
         let stats = builder.build(compiler)?;
         let elapsed = started.elapsed();
 

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -41,6 +41,61 @@ contract DocTarget {
     assert_eq!(after, b"sentinel");
 });
 
+#[cfg(unix)]
+forgetest_init!(doc_does_not_run_solc, |prj, cmd| {
+    use std::os::unix::fs::PermissionsExt;
+
+    prj.add_source(
+        "DocTarget.sol",
+        r#"
+pragma solidity ^0.8.35;
+
+contract DocTarget {
+    /// @notice Returns a value.
+    function value() external pure returns (uint256) {
+        return 1;
+    }
+}
+"#,
+    );
+    prj.add_source(
+        "Skipped.sol",
+        r#"
+pragma solidity ^0.8.35;
+
+contract Skipped {}
+"#,
+    );
+
+    let solc = prj.root().join("fake-solc");
+    let invoked = prj.root().join("fake-solc.invoked");
+    fs::write(
+        &solc,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+    echo "solc, the solidity compiler commandline interface"
+    echo "Version: 0.8.35+commit.69074fbd"
+    exit 0
+fi
+touch "$0.invoked"
+exit 1
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&solc).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&solc, permissions).unwrap();
+
+    prj.update_config(|config| {
+        config.solc = Some(foundry_config::SolcReq::Local(solc));
+        config.skip = vec!["*Skipped*".parse().unwrap()];
+    });
+
+    cmd.arg("doc").assert_success();
+    assert!(!invoked.exists(), "forge doc invoked the configured solc binary");
+    assert!(!prj.root().join("docs/src/pages/src/contract.Skipped.mdx").exists());
+});
+
 // Test that overloaded functions in interfaces inherit the correct NatSpec comments
 // fixes <https://github.com/foundry-rs/foundry/issues/11823>
 forgetest_init!(can_generate_docs_for_overloaded_functions, |prj, cmd| {

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -41,6 +41,33 @@ contract DocTarget {
     assert_eq!(after, b"sentinel");
 });
 
+forgetest_init!(doc_supports_empty_projects, |_prj, cmd| {
+    cmd.arg("doc").assert_success();
+});
+
+forgetest!(doc_supports_mixed_solidity_versions, |prj, cmd| {
+    prj.add_source(
+        "New.sol",
+        r#"
+pragma solidity ^0.8.20;
+
+contract New {}
+"#,
+    );
+    prj.add_source(
+        "Old.sol",
+        r#"
+pragma solidity 0.7.6;
+
+contract Old {}
+"#,
+    );
+
+    cmd.arg("doc").assert_success();
+    assert!(prj.root().join("docs/src/pages/src/contract.New.mdx").exists());
+    assert!(prj.root().join("docs/src/pages/src/contract.Old.mdx").exists());
+});
+
 #[cfg(unix)]
 forgetest_init!(doc_does_not_run_solc, |prj, cmd| {
     use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
## Summary

- Configure the bundled, in-process Solar parser directly for `forge doc`, avoiding the ABI-only compiler process when every Solidity source is Solar-compatible.
- Preserve existing behavior for pre-0.8, mixed-version, and Solidity-free projects through the compiler-backed fallback, and honor configured `skip` filters on the fast path.
- Add regression coverage proving the fast path neither invokes `solc` nor documents skipped sources, while empty and mixed-version projects retain their fallback behavior.

## Benchmarks

Benchmarked release builds on Solady with 277 Solidity files. Each sample removed `out`, `cache`, and both generated doc directories:

```console
hyperfine --warmup 1 --runs 10 \
  --prepare 'rm -rf out cache /tmp/solady-doc-before /tmp/solady-doc-after' \
  'forge-before doc --out /tmp/solady-doc-before --quiet' \
  'forge-after doc --out /tmp/solady-doc-after --quiet'
```

```text
Before: 1.412 s ± 0.032 s
After:  135.8 ms ± 8.9 ms
Speedup: 10.40x
```

The generated documentation is identical according to `diff -qr`.
