### PR TITLE
perf(forge): speed up filtered tests

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1509,7 +1509,10 @@ impl TestArgs {
         }
 
         let mut project = config.create_project(true, true)?;
-        let output = compile_abi_project(&mut project, ProjectCompiler::new().quiet(true))?;
+        let output = compile_abi_project(
+            &mut project,
+            ProjectCompiler::new().dynamic_test_linking(config.dynamic_test_linking).quiet(true),
+        )?;
         if output.has_compiler_errors() {
             sh_println!("{output}")?;
             eyre::bail!("Compilation failed");

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -1,5 +1,39 @@
 //! Tests for the `forge test` with preprocessed cache.
 
+#[cfg(unix)]
+forgetest_init!(filtered_tests_reuse_preprocessed_cache, |prj, cmd| {
+    use std::{fs, os::unix::fs::PermissionsExt};
+
+    prj.initialize_default_contracts();
+    prj.update_config(|config| config.dynamic_test_linking = true);
+    cmd.arg("build").assert_success();
+
+    let solc = prj.root().join("fake-solc");
+    let invoked = prj.root().join("fake-solc.invoked");
+    fs::write(
+        &solc,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+    echo "solc, the solidity compiler commandline interface"
+    echo "Version: 0.8.35+commit.69074fbd"
+    exit 0
+fi
+touch "$0.invoked"
+exit 1
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&solc).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&solc, permissions).unwrap();
+    prj.update_config(|config| {
+        config.solc = Some(foundry_config::SolcReq::Local(solc));
+    });
+
+    cmd.forge_fuse().args(["test", "--match-contract", "CounterTest"]).assert_success();
+    assert!(!invoked.exists(), "filtered test compilation did not reuse the preprocessed cache");
+});
+
 // Test cache is invalidated when `forge build` if optimize test option toggled.
 forgetest_init!(toggle_invalidate_cache_on_build, |prj, cmd| {
     prj.initialize_default_contracts();

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -2,6 +2,7 @@
 
 #[cfg(unix)]
 forgetest_init!(filtered_tests_reuse_preprocessed_cache, |prj, cmd| {
+    use foundry_test_utils::util::OutputExt;
     use std::{fs, os::unix::fs::PermissionsExt};
 
     prj.initialize_default_contracts();
@@ -30,7 +31,13 @@ exit 1
         config.solc = Some(foundry_config::SolcReq::Local(solc));
     });
 
-    cmd.forge_fuse().args(["test", "--match-contract", "CounterTest"]).assert_success();
+    let output =
+        cmd.forge_fuse().args(["test", "--match-contract", "CounterTest"]).assert_success();
+    let stdout = output.get_output().stdout_lossy();
+    assert!(
+        stdout.contains("Ran 2 tests for test/Counter.t.sol:CounterTest"),
+        "cached ABI did not select CounterTest: {stdout}"
+    );
     assert!(!invoked.exists(), "filtered test compilation did not reuse the preprocessed cache");
 });
 


### PR DESCRIPTION
## Summary

- Preserve dynamic test linking while ABI-compiling the source set for filtered test runs.
- Reuse the existing preprocessed cache instead of recompiling the full project before `--match-test` and `--match-contract` runs.
- Add a regression test that ensures a cached filtered run does not invoke Solc.

## Benchmarks

Aave v4 with a warm dynamic-test-linking cache (`hyperfine --warmup 1 --runs 5`):

| Command | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `forge test --match-contract __NoSuchContract__ -q` | 4.757 s | 407.4 ms | 11.68x |