### PR TITLE
fix(anvil): use latest active Tempo hardfork

### DIFF
--- a/.github/scripts/tempo-check.sh
+++ b/.github/scripts/tempo-check.sh
@@ -6,8 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Non-verification tempo checks: local tests, fork tests, cast commands, DEX operations
 
-# Hardfork version, defaults to T7.
-HARDFORK="${TEMPO_HARDFORK:-T7}"
+# Optional hardfork override. When unset, tools resolve the latest active Tempo hardfork.
+HARDFORK="${TEMPO_HARDFORK:-latest}"
 HARDFORK_UPPER=$(echo "$HARDFORK" | tr '[:lower:]' '[:upper:]')
 
 # Fee token address, defaults to native fee token
@@ -870,9 +870,13 @@ echo -e "\n=== ANVIL LOCAL TESTS ==="
 
 ANVIL_PORT=8546
 echo "Starting local anvil..."
-# Pass hardfork to anvil (lowercase for CLI compatibility)
-ANVIL_HARDFORK=$(echo "$HARDFORK" | tr '[:upper:]' '[:lower:]')
-anvil --tempo --hardfork "$ANVIL_HARDFORK" --port $ANVIL_PORT &
+# Exercise Anvil's latest-active Tempo default unless a historical hardfork was explicitly selected.
+ANVIL_HARDFORK_ARGS=()
+if [[ -n "${TEMPO_HARDFORK:-}" ]]; then
+  ANVIL_HARDFORK=$(echo "$HARDFORK" | tr '[:upper:]' '[:lower:]')
+  ANVIL_HARDFORK_ARGS=(--hardfork "$ANVIL_HARDFORK")
+fi
+anvil --tempo "${ANVIL_HARDFORK_ARGS[@]}" --port $ANVIL_PORT &
 ANVIL_PID=$!
 
 # Ensure anvil is stopped on script exit
@@ -947,9 +951,7 @@ cast send --rpc-url "$ETH_RPC_URL" 0xfeec000000000000000000000000000000000000 \
 
 ANVIL_PORT=8547
 echo "Starting forked anvil..."
-# Pass hardfork to anvil (lowercase for CLI compatibility)
-ANVIL_HARDFORK=$(echo "$HARDFORK" | tr '[:upper:]' '[:lower:]')
-anvil --tempo --hardfork "$ANVIL_HARDFORK" --fork-url "$ETH_RPC_URL" --port $ANVIL_PORT --retries 10 --timeout 60000 &
+anvil --tempo "${ANVIL_HARDFORK_ARGS[@]}" --fork-url "$ETH_RPC_URL" --port $ANVIL_PORT --retries 10 --timeout 60000 &
 ANVIL_PID=$!
 
 # Ensure anvil is stopped on script exit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11966,7 +11966,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11999,7 +11999,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12022,7 +12022,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12034,7 +12034,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12046,7 +12046,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12077,7 +12077,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12089,7 +12089,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12112,7 +12112,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12123,7 +12123,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12155,7 +12155,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=96cec1ee6735834d1674f282ef317b708ec6de53#96cec1ee6735834d1674f282ef317b708ec6de53"
+source = "git+https://github.com/tempoxyz/tempo?rev=e52745eb327605aaee8da9ff9e7416df0b6bc69e#e52745eb327605aaee8da9ff9e7416df0b6bc69e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,20 +514,20 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6540a5ac3c6f3848684eb
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -617,9 +617,9 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = 
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "96cec1ee6735834d1674f282ef317b708ec6de53" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "e52745eb327605aaee8da9ff9e7416df0b6bc69e" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -38,6 +38,7 @@ use foundry_evm::{
     backend::{BlockchainDb, BlockchainDbMeta, SharedBackend},
     constants::DEFAULT_CREATE2_DEPLOYER,
     hardfork::FoundryHardfork,
+    hardforks::latest_active_tempo_hardfork,
     utils::{
         apply_chain_and_block_specific_env_changes, block_env_from_header,
         get_blob_base_fee_update_fraction,
@@ -616,7 +617,7 @@ impl NodeConfig {
             return foundry_evm::hardforks::OpHardfork::default().into();
         }
         if self.networks.is_tempo() {
-            return TempoHardfork::default().into();
+            return latest_active_tempo_hardfork().into();
         }
         EthereumHardfork::default().into()
     }
@@ -1860,5 +1861,12 @@ mod tests {
 
         assert!(config.networks.is_tempo());
         assert!(matches!(config.get_hardfork(), FoundryHardfork::Tempo(_)));
+    }
+
+    #[test]
+    fn get_hardfork_on_local_tempo_defaults_to_latest_active() {
+        let config = NodeConfig::test_tempo();
+
+        assert_eq!(config.get_hardfork(), FoundryHardfork::Tempo(latest_active_tempo_hardfork()));
     }
 }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5278,7 +5278,8 @@ impl Backend<FoundryNetwork> {
         validator_token: Address,
         amount: U256,
     ) -> DatabaseResult<()> {
-        let admin = Address::ZERO;
+        // T3+ rejects minting to the zero address.
+        let admin = Address::repeat_byte(0x11);
         self.with_tempo_storage(|| {
             // Mint the required tokens to admin so it can provide liquidity.
             // grant_role_internal bypasses the caller check, matching genesis seeding.

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -23,6 +23,7 @@ use anvil_core::{
 };
 use foundry_common::version::{COMMIT_SHA, SEMVER_VERSION};
 use foundry_evm::hardfork::EthereumHardfork;
+use tempo_hardfork::TempoHardfork;
 
 use std::{
     str::FromStr,
@@ -1303,7 +1304,8 @@ async fn test_anvil_reset_fork_to_non_fork() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_node_info_tempo_t0() {
-    let (api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let config = NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T0.into()));
+    let (api, handle) = spawn(config).await;
 
     let node_info = api.anvil_node_info().await.unwrap();
 
@@ -1337,8 +1339,6 @@ async fn can_get_node_info_tempo_t0() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_node_info_tempo_t5_from_chain_timestamp() {
-    use tempo_hardfork::TempoHardfork;
-
     let timestamp = TempoHardfork::T5.mainnet_activation_timestamp().unwrap();
     let config = NodeConfig::test_tempo()
         .with_chain_id(Some(4217u64))
@@ -1352,8 +1352,6 @@ async fn can_get_node_info_tempo_t5_from_chain_timestamp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_node_info_tempo_t1() {
-    use tempo_hardfork::TempoHardfork;
-
     let config = NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T1.into()));
     let (api, handle) = spawn(config).await;
 
@@ -1388,8 +1386,9 @@ async fn can_get_node_info_tempo_t1() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn can_get_default_base_fee_tempo() {
-    let (api, handle) = spawn(NodeConfig::test_tempo()).await;
+async fn can_get_default_base_fee_tempo_t0() {
+    let config = NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T0.into()));
+    let (api, handle) = spawn(config).await;
     let provider = handle.http_provider();
 
     api.mine_one().await;

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -61,8 +61,8 @@ const THETA_USD: Address = THETA_USD_ADDRESS;
 const TEMPO_ADMIN: Address = address!("0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f");
 const DEX_MIN_ORDER_AMOUNT: u128 = 100_000_000;
 
-/// Gas limit for TIP20 transfer calls (precompile interactions need more gas).
-const TIP20_TRANSFER_GAS: u64 = 300_000;
+/// Gas limit for TIP20 transfer calls, including T1+ transaction accounting.
+const TIP20_TRANSFER_GAS: u64 = 1_000_000;
 const T5_PRECOMPILE_GAS: u64 = 10_000_000;
 
 fn assert_tempo_header_fields(header: &TempoHeaderResponse) {
@@ -1843,7 +1843,7 @@ async fn test_contract_deployment() {
     let bytecode = Bytes::from(vec![0x60, 0x00, 0x60, 0x00, 0xf3]);
 
     let tx =
-        TransactionRequest::default().from(sender).with_input(bytecode).with_gas_limit(100_000);
+        TransactionRequest::default().from(sender).with_input(bytecode).with_gas_limit(1_000_000);
 
     let tx = WithOtherFields::new(tx);
     let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
@@ -3745,7 +3745,8 @@ async fn test_gas_estimation_tempo_aa_transaction() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gas_estimation_tempo_aa_with_2d_nonce() {
-    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let config = NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T0.into()));
+    let (_api, handle) = spawn(config).await;
     let provider = handle.http_provider();
 
     let accounts: Vec<Address> = handle.dev_accounts().collect();
@@ -3799,7 +3800,8 @@ async fn test_gas_estimation_tempo_aa_with_2d_nonce() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gas_estimation_tempo_aa_expiring_nonce() {
-    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let config = NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T0.into()));
+    let (_api, handle) = spawn(config).await;
     let provider = handle.http_provider();
 
     let accounts: Vec<Address> = handle.dev_accounts().collect();


### PR DESCRIPTION
## Summary

- update Foundry's Tempo dependencies to the latest pinned revision
- default local Tempo Anvil chains to the latest active Tempo hardfork
- exercise automatic hardfork selection in Tempo CI while preserving explicit historical overrides

## Context

`anvil --network tempo` uses local chain ID 31337, which is not present in Tempo's chain-aware activation schedules. The unresolved schedule previously fell back to `TempoHardfork::default()`, or T0, even though the currently active fork is T7. This disabled hardfork-gated precompile selectors, including the T2+ TIP-403 authorization methods used by ZonePortal deposits.

Tempo CI always supplied `--hardfork T7`, which masked the default local path. The fallback now reuses Foundry's existing `latest_active_tempo_hardfork()` resolver, and CI omits the override unless `TEMPO_HARDFORK` is explicitly set. Future Tempo activations therefore flow through the shared schedule without another Anvil-specific default update.

## Impact

Developers can run `anvil --network tempo` without an additional hardfork flag and get the latest valid Tempo behavior. Explicit hardfork selection remains available for historical compatibility testing.
