### PR TITLE
fix(lint): handle masked casts and denials

### DIFF
--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -1,7 +1,10 @@
 use super::{install, watch::WatchArgs};
 use clap::Parser;
 use eyre::Result;
-use forge_lint::{linter::Linter, sol::SolidityLinter};
+use forge_lint::{
+    linter::Linter,
+    sol::{DeniedLintDiagnostics, SolidityLinter},
+};
 use foundry_cli::{
     opts::{BuildOpts, configure_pcx_from_solc, get_solar_sources_from_compile_output},
     utils::{Git, LoadConfig, cache_local_signatures},
@@ -143,7 +146,9 @@ impl BuildArgs {
             && !output.output().errors.iter().any(|e| e.is_error())
             && let Err(err) = self.lint(&project, &config, self.paths.as_deref(), &mut output)
         {
-            emit_lint_failure_notice();
+            if err.downcast_ref::<DeniedLintDiagnostics>().is_none() {
+                emit_lint_failure_notice();
+            }
             return Err(err.wrap_err("post-build lint step failed"));
         }
 

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -940,9 +940,8 @@ Warning (2018): Function state mutability can be restricted to pure
     ]]);
 });
 
-// `deny = notes` + an info-level lint forces the linter to return Err, exercising the same
-// failure-notice path an unhandled solar edge case would take.
-forgetest!(build_emits_lint_failure_notice_on_failure, |prj, cmd| {
+// Denied lint diagnostics are expected failures and must not be presented as internal errors.
+forgetest!(build_denied_lints_do_not_emit_internal_failure_notice, |prj, cmd| {
     prj.add_source("CounterAWithLints", COUNTER_A);
 
     prj.update_config(|config| {
@@ -959,19 +958,55 @@ note[mixed-case-variable]: mutable variables should use mixedCase
   │
   ╰ help: https://getfoundry.sh/forge/linting/mixed-case-variable
 
-
-note: internal lint engine failure (compilation itself succeeded).
-note: please file a bug report at
-      https://github.com/foundry-rs/foundry/issues/new?template=BUG-FORM.yml
-      and attach the full output above.
-help: rerun with `--no-lint` to skip linting for this build, or consider temporarily
-      disabling forge lint on build:
-      https://getfoundry.sh/forge/linting#disable-linting-on-build
-
 Error: post-build lint step failed
 
 Context:
 - aborting due to 1 linter note(s)
+
+"#]]);
+});
+
+// Solar currently rejects enum `@param` tags while solc accepts them. This recoverable frontend
+// diagnostic must not prevent type-dependent late lints from running.
+forgetest!(build_lints_after_recoverable_solar_diagnostic, |prj, cmd| {
+    prj.add_source(
+        "RecoverableSolarDiagnostic",
+        r#"
+/// @param First The first choice.
+enum Choice { First }
+
+contract RecoverableSolarDiagnostic {
+    function chainId() public view returns (uint64) {
+        return uint64(block.chainid);
+    }
+}
+"#,
+    );
+
+    prj.update_config(|config| {
+        config.lint.severity = vec![LintSeverity::Med];
+        config.deny = DenyLevel::Warnings;
+    });
+
+    cmd.arg("build").assert_failure().stderr_eq(str![[r#"
+warning[unsafe-typecast]: typecasts that can truncate values should be checked
+  [FILE]:9:16
+  │
+9 │         return uint64(block.chainid);
+  │                ━━━━━━━━━━━━━━━━━━━━━
+  │
+  ├ note: consider disabling this lint if you're certain the cast is safe
+  │ [..]
+  │       // casting to 'uint64' is safe because [explain why]
+  │       // forge-lint: disable-next-line(unsafe-typecast)
+  │ [..]
+  │ [..]
+  ╰ help: https://getfoundry.sh/forge/linting/unsafe-typecast
+
+Error: post-build lint step failed
+
+Context:
+- aborting due to 1 linter warning(s)
 
 "#]]);
 });

--- a/crates/lint/src/sol/med/unsafe_typecast.rs
+++ b/crates/lint/src/sol/med/unsafe_typecast.rs
@@ -4,7 +4,7 @@ use crate::{
     sol::{Severity, SolLint},
 };
 use solar::{
-    ast::{LitKind, StrKind},
+    ast::{BinOpKind, LitKind, StrKind},
     sema::{
         Gcx,
         hir::{self, ElementaryType, ExprKind, TypeKind},
@@ -52,6 +52,10 @@ fn is_unsafe_typecast_hir<'hir>(
     source_expr: &hir::Expr<'hir>,
     target_type: &hir::ElementaryType,
 ) -> bool {
+    if is_bounded_by_mask(source_expr, target_type) {
+        return false;
+    }
+
     let mut source_types = Vec::<ElementaryType>::new();
     infer_source_types(Some(&mut source_types), gcx, source_expr);
 
@@ -60,6 +64,23 @@ fn is_unsafe_typecast_hir<'hir>(
     };
 
     source_types.iter().any(|source_ty| is_unsafe_elementary_typecast(source_ty, target_type))
+}
+
+/// Returns whether a bitmask bounds an unsigned integer expression to the target type's range.
+fn is_bounded_by_mask(source_expr: &hir::Expr<'_>, target_type: &ElementaryType) -> bool {
+    let ElementaryType::UInt(target_size) = target_type else { return false };
+    let ExprKind::Binary(lhs, op, rhs) = &source_expr.peel_parens().kind else { return false };
+    if op.kind != BinOpKind::BitAnd {
+        return false;
+    }
+
+    [lhs, rhs].into_iter().any(|expr| {
+        matches!(
+            expr.peel_parens().kind,
+            ExprKind::Lit(hir::Lit { kind: LitKind::Number(mask), .. })
+                if mask.bit_len() <= target_size.bits() as usize
+        )
+    })
 }
 
 /// Infers the elementary source type(s) of an expression.

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -406,19 +406,25 @@ impl<'a> Linter for SolidityLinter<'a> {
             // Deny warnings.
             (DenyLevel::Warnings, w, n) if w > 0 => {
                 if n > 0 {
-                    Err(eyre::eyre!("{MSG}{w} linter warning(s); {n} note(s) were also emitted\n"))
+                    Err(DeniedLintDiagnostics(format!(
+                        "{MSG}{w} linter warning(s); {n} note(s) were also emitted\n"
+                    ))
+                    .into())
                 } else {
-                    Err(eyre::eyre!("{MSG}{w} linter warning(s)\n"))
+                    Err(DeniedLintDiagnostics(format!("{MSG}{w} linter warning(s)\n")).into())
                 }
             }
 
             // Deny any diagnostic.
             (DenyLevel::Notes, w, n) if w > 0 || n > 0 => match (w, n) {
-                (w, n) if w > 0 && n > 0 => {
-                    Err(eyre::eyre!("{MSG}{w} linter warning(s) and {n} note(s)\n"))
+                (w, n) if w > 0 && n > 0 => Err(DeniedLintDiagnostics(format!(
+                    "{MSG}{w} linter warning(s) and {n} note(s)\n"
+                ))
+                .into()),
+                (w, 0) => {
+                    Err(DeniedLintDiagnostics(format!("{MSG}{w} linter warning(s)\n")).into())
                 }
-                (w, 0) => Err(eyre::eyre!("{MSG}{w} linter warning(s)\n")),
-                (0, n) => Err(eyre::eyre!("{MSG}{n} linter note(s)\n")),
+                (0, n) => Err(DeniedLintDiagnostics(format!("{MSG}{n} linter note(s)\n")).into()),
                 _ => unreachable!(),
             },
 
@@ -460,6 +466,10 @@ pub enum SolLintError {
     #[error("Unknown lint ID: {0}")]
     InvalidId(String),
 }
+
+#[derive(Error, Debug)]
+#[error("{0}")]
+pub struct DeniedLintDiagnostics(String);
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct SolLint {

--- a/crates/lint/testdata/UnsafeTypecast.sol
+++ b/crates/lint/testdata/UnsafeTypecast.sol
@@ -439,6 +439,13 @@ contract UnsafeTypecast {
 }
 
 contract Repros {
+    function downcastBoundedByMaskSafe(uint256 value, uint256 length) public pure {
+        uint8(value & 0xff);
+        uint8(0x7f & value);
+        uint8((0x80 + length) & 0xfe);
+        uint16(value & 0xffff);
+    }
+
     function longDynamicBytesDoNotPanic() public pure {
         bytes memory stringToBytes = bytes("Initializable: contract is already initialized");
     }


### PR DESCRIPTION
## Description
Treat unsigned casts as safe when a literal bitmask bounds the result to the destination width, eliminating false positives such as `uint8(value & 0xff)`.

This also distinguishes diagnostics rejected by `deny` from genuine lint engine failures, so `forge build` no longer displays the internal-error bug-report notice for expected lint failures. The regression coverage ensures type-dependent late lints still run after recoverable Solar frontend diagnostics.

Fixes part of regression https://github.com/tempoxyz/tempo-std/actions/runs/29244890442/job/86799327897?pr=128
The remaining warnings are not safely fixable as generic Foundry false positives.
- `uint64(block.chainid)` is a real narrowing conversion. Foundry cannot assume every chain ID fits in 64 bits. Tempo must validate that invariant or suppress the lint with an explanation.
- `abi.encodePacked` warnings are intentionally conservative. Foundry sees multiple dynamic values and cannot generally prove that RLP framing or WebAuthn’s surrounding structure prevents ambiguity. Teaching the lint about those application-specific protocols would risk false negatives elsewhere.

Ref: #15611 & https://github.com/paradigmxyz/solar/pull/838