### PR TITLE
feat(debugger): inspect transient storage

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -1,6 +1,6 @@
 //! Debugger context and event handler implementation.
 
-use super::storage::{StorageAccess, hex_u256, storage_access_at};
+use super::storage::{StorageAccess, StorageSpace, hex_u256, storage_access_at};
 use crate::{DebugNode, DebuggerLayout, ExitReason, debugger::DebuggerContext};
 use alloy_primitives::{Address, U256, hex};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
@@ -654,7 +654,9 @@ impl TUIContext<'_> {
         } else if RETURNDATA_COMMANDS.contains(&command) {
             self.run_buffer_command(command, BufferKind::Returndata, parts);
         } else if STORAGE_COMMANDS.contains(&command) {
-            self.run_storage_command(command, parts);
+            self.run_storage_command(command, StorageSpace::Persistent, parts);
+        } else if TRANSIENT_STORAGE_COMMANDS.contains(&command) {
+            self.run_storage_command(command, StorageSpace::Transient, parts);
         } else if LINE_COMMANDS.contains(&command) {
             let Some(line) = parts.next() else {
                 return self.set_error(command_usage(command, "<line>"));
@@ -693,14 +695,19 @@ impl TUIContext<'_> {
         self.goto_buffer_offset(buffer, offset);
     }
 
-    fn run_storage_command<'a>(&mut self, command: &str, mut args: impl Iterator<Item = &'a str>) {
+    fn run_storage_command<'a>(
+        &mut self,
+        command: &str,
+        space: StorageSpace,
+        mut args: impl Iterator<Item = &'a str>,
+    ) {
         let Some(slot) = args.next() else {
             return self.set_error(command_usage(command, "<slot>"));
         };
         if args.next().is_some() {
             return self.set_error(command_usage(command, "<slot>"));
         }
-        self.goto_storage_slot_from_input(slot);
+        self.goto_storage_slot_from_input(slot, space);
     }
 
     fn goto_source_line_from_input(&mut self, input: &str) {
@@ -808,7 +815,7 @@ impl TUIContext<'_> {
         self.set_info(format!("{} pane: {state}", pane.label()));
     }
 
-    fn goto_storage_slot_from_input(&mut self, input: &str) {
+    fn goto_storage_slot_from_input(&mut self, input: &str, space: StorageSpace) {
         let slot = match parse_storage_slot(input) {
             Ok(slot) => slot,
             Err(err) => {
@@ -822,8 +829,16 @@ impl TUIContext<'_> {
             self.draw_memory.inner_call_index,
             self.current_step,
             slot,
+            space,
         ) else {
-            self.set_error(format!("Storage slot {} not accessed in current call", hex_u256(slot)));
+            let storage = match space {
+                StorageSpace::Persistent => "Storage",
+                StorageSpace::Transient => "Transient storage",
+            };
+            self.set_error(format!(
+                "{storage} slot {} not accessed in current call",
+                hex_u256(slot)
+            ));
             return;
         };
 
@@ -1008,6 +1023,7 @@ const MEMORY_COMMANDS: &[&str] = &["mem", "memory"];
 const CALLDATA_COMMANDS: &[&str] = &["calldata", "cd"];
 const RETURNDATA_COMMANDS: &[&str] = &["returndata", "ret", "rd"];
 const STORAGE_COMMANDS: &[&str] = &["storage", "store", "slot"];
+const TRANSIENT_STORAGE_COMMANDS: &[&str] = &["transient", "tslot"];
 const LINE_COMMANDS: &[&str] = &["line", "ln"];
 const OPCODE_COMMANDS: &[&str] = &["opcodes", "opcode", "ops"];
 const SOURCE_COMMANDS: &[&str] = &["source", "src"];
@@ -1040,13 +1056,14 @@ fn command_usage(command: &str, arg: &str) -> String {
 
 fn command_help() -> String {
     format!(
-        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>, {} <line>, {}, {}, {}, {}",
+        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>, {} <slot>, {} <line>, {}, {}, {}, {}",
         command_aliases(CONTINUE_COMMANDS),
         command_aliases(PC_COMMANDS),
         command_aliases(MEMORY_COMMANDS),
         command_aliases(CALLDATA_COMMANDS),
         command_aliases(RETURNDATA_COMMANDS),
         command_aliases(STORAGE_COMMANDS),
+        command_aliases(TRANSIENT_STORAGE_COMMANDS),
         command_aliases(LINE_COMMANDS),
         command_aliases(OPCODE_COMMANDS),
         command_aliases(SOURCE_COMMANDS),
@@ -1276,14 +1293,19 @@ fn find_storage_target(
     current_node_index: usize,
     current_step: usize,
     slot: U256,
+    space: StorageSpace,
 ) -> Option<StorageTarget> {
     let current_node = arena.get(current_node_index)?;
     let trace_node_idx = current_node.trace_node_idx;
     let current_absolute_step = current_node.step_offset.saturating_add(current_step);
 
-    storage_target_at(arena, current_node_index, current_step, slot)
-        .or_else(|| find_storage_target_after(arena, trace_node_idx, current_absolute_step, slot))
-        .or_else(|| find_storage_target_before(arena, trace_node_idx, current_absolute_step, slot))
+    storage_target_at(arena, current_node_index, current_step, slot, space)
+        .or_else(|| {
+            find_storage_target_after(arena, trace_node_idx, current_absolute_step, slot, space)
+        })
+        .or_else(|| {
+            find_storage_target_before(arena, trace_node_idx, current_absolute_step, slot, space)
+        })
 }
 
 fn storage_target_at(
@@ -1291,10 +1313,11 @@ fn storage_target_at(
     node_index: usize,
     step_index: usize,
     slot: U256,
+    space: StorageSpace,
 ) -> Option<StorageTarget> {
     let node = arena.get(node_index)?;
     storage_access_at(&node.steps, step_index)
-        .filter(|access| access.slot() == slot)
+        .filter(|access| access.slot() == slot && access.space() == space)
         .map(|access| StorageTarget { node_index, access })
 }
 
@@ -1303,6 +1326,7 @@ fn find_storage_target_after(
     trace_node_idx: usize,
     current_absolute_step: usize,
     slot: U256,
+    space: StorageSpace,
 ) -> Option<StorageTarget> {
     let mut best = None;
 
@@ -1317,8 +1341,8 @@ fn find_storage_target_after(
                 continue;
             }
 
-            let Some(access) =
-                storage_access_at(&node.steps, step_index).filter(|access| access.slot() == slot)
+            let Some(access) = storage_access_at(&node.steps, step_index)
+                .filter(|access| access.slot() == slot && access.space() == space)
             else {
                 continue;
             };
@@ -1339,6 +1363,7 @@ fn find_storage_target_before(
     trace_node_idx: usize,
     current_absolute_step: usize,
     slot: U256,
+    space: StorageSpace,
 ) -> Option<StorageTarget> {
     let mut best = None;
 
@@ -1353,8 +1378,8 @@ fn find_storage_target_before(
                 continue;
             }
 
-            let Some(access) =
-                storage_access_at(&node.steps, step_index).filter(|access| access.slot() == slot)
+            let Some(access) = storage_access_at(&node.steps, step_index)
+                .filter(|access| access.slot() == slot && access.space() == space)
             else {
                 continue;
             };
@@ -2108,6 +2133,37 @@ mod tests {
     }
 
     #[test]
+    fn command_prompt_jumps_to_transient_storage_slot_access() {
+        let address = Address::repeat_byte(1);
+        let steps = vec![step(1), step_with_stack(42, OpCode::TSTORE, &[0xbeef, 0x2a])];
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            steps,
+            Bytes::new(),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+
+        tui.run_command_from_input("transient 2a");
+
+        assert_eq!(tui.current_step, 1);
+        assert_eq!(
+            tui.status.as_ref().unwrap().text,
+            "Jumped to transient storage TSTORE slot 0x2a = 0xbeef at PC 0x2a (42)"
+        );
+
+        tui.run_command_from_input("storage 2a");
+        assert_eq!(tui.current_step, 1);
+        assert_eq!(
+            tui.status.as_ref().unwrap().text,
+            "Storage slot 0x2a not accessed in current call"
+        );
+    }
+
+    #[test]
     fn command_prompt_searches_storage_across_split_call_segments() {
         let address = Address::repeat_byte(1);
         let mut store = step(42);
@@ -2299,6 +2355,7 @@ mod tests {
             CALLDATA_COMMANDS,
             RETURNDATA_COMMANDS,
             STORAGE_COMMANDS,
+            TRANSIENT_STORAGE_COMMANDS,
             LINE_COMMANDS,
             OPCODE_COMMANDS,
             SOURCE_COMMANDS,

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -1963,6 +1963,20 @@ mod tests {
     }
 
     #[test]
+    fn current_storage_access_line_uses_next_stack_snapshot_for_tload() {
+        let mut step = trace_step(vec![U256::from(1)]);
+        step.op = OpCode::TLOAD;
+        let next_step = trace_step(vec![U256::from(42)]);
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![step, next_step])]);
+        let tui = TUIContext::new(&mut context);
+
+        assert_eq!(
+            line_text(&tui.current_storage_access_line().unwrap()),
+            "transient storage TLOAD slot 0x1 = 0x2a"
+        );
+    }
+
+    #[test]
     fn variable_name_falls_back_for_unnamed_values() {
         let variable = DebugVariable { name: None, declaration: 0..1, scope: 0..2 };
 

--- a/crates/debugger/src/tui/storage.rs
+++ b/crates/debugger/src/tui/storage.rs
@@ -6,14 +6,21 @@ use revm_inspectors::tracing::types::{CallTraceStep, StorageChangeReason};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum StorageAccessKind {
-    Sload,
-    Sstore,
+    Load,
+    Store,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum StorageSpace {
+    Persistent,
+    Transient,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct StorageAccess {
     step_index: usize,
     pc: usize,
+    space: StorageSpace,
     kind: StorageAccessKind,
     slot: U256,
     value: U256,
@@ -33,20 +40,30 @@ impl StorageAccess {
         self.slot
     }
 
+    pub(super) const fn space(self) -> StorageSpace {
+        self.space
+    }
+
     pub(super) fn describe(self) -> String {
-        let op = match self.kind {
-            StorageAccessKind::Sload => "SLOAD",
-            StorageAccessKind::Sstore => "SSTORE",
+        let op = match (self.space, self.kind) {
+            (StorageSpace::Persistent, StorageAccessKind::Load) => "SLOAD",
+            (StorageSpace::Persistent, StorageAccessKind::Store) => "SSTORE",
+            (StorageSpace::Transient, StorageAccessKind::Load) => "TLOAD",
+            (StorageSpace::Transient, StorageAccessKind::Store) => "TSTORE",
+        };
+        let space = match self.space {
+            StorageSpace::Persistent => "storage",
+            StorageSpace::Transient => "transient storage",
         };
 
         match (self.kind, self.previous) {
-            (StorageAccessKind::Sstore, Some(previous)) => format!(
-                "storage {op} slot {}: {} -> {}",
+            (StorageAccessKind::Store, Some(previous)) => format!(
+                "{space} {op} slot {}: {} -> {}",
                 hex_u256(self.slot),
                 hex_u256(previous),
                 hex_u256(self.value)
             ),
-            _ => format!("storage {op} slot {} = {}", hex_u256(self.slot), hex_u256(self.value)),
+            _ => format!("{space} {op} slot {} = {}", hex_u256(self.slot), hex_u256(self.value)),
         }
     }
 }
@@ -56,18 +73,21 @@ pub(super) fn storage_access_at(
     step_index: usize,
 ) -> Option<StorageAccess> {
     let step = steps.get(step_index)?;
-    if step.op.get() == opcode::SSTORE && !step.status.is_none_or(InstructionResult::is_ok) {
+    if matches!(step.op.get(), opcode::SSTORE | opcode::TSTORE)
+        && !step.status.is_none_or(InstructionResult::is_ok)
+    {
         return None;
     }
 
     if let Some(change) = step.storage_change.as_deref() {
         let kind = match change.reason {
-            StorageChangeReason::SLOAD => StorageAccessKind::Sload,
-            StorageChangeReason::SSTORE => StorageAccessKind::Sstore,
+            StorageChangeReason::SLOAD => StorageAccessKind::Load,
+            StorageChangeReason::SSTORE => StorageAccessKind::Store,
         };
         return Some(StorageAccess {
             step_index,
             pc: step.pc,
+            space: StorageSpace::Persistent,
             kind,
             slot: change.key,
             value: change.value,
@@ -75,32 +95,30 @@ pub(super) fn storage_access_at(
         });
     }
 
-    if step.op.get() == opcode::SLOAD {
+    let (space, kind) = match step.op.get() {
+        opcode::SLOAD => (StorageSpace::Persistent, StorageAccessKind::Load),
+        opcode::SSTORE => (StorageSpace::Persistent, StorageAccessKind::Store),
+        opcode::TLOAD => (StorageSpace::Transient, StorageAccessKind::Load),
+        opcode::TSTORE => (StorageSpace::Transient, StorageAccessKind::Store),
+        _ => return None,
+    };
+
+    if kind == StorageAccessKind::Load {
         return Some(StorageAccess {
             step_index,
             pc: step.pc,
-            kind: StorageAccessKind::Sload,
+            space,
+            kind,
             slot: step.stack.as_deref()?.last().copied()?,
             value: steps.get(step_index.checked_add(1)?)?.stack.as_deref()?.last().copied()?,
             previous: None,
         });
     }
 
-    if step.op.get() == opcode::SSTORE {
-        let mut stack = step.stack.as_deref()?.iter().rev();
-        let slot = stack.next().copied()?;
-        let value = stack.next().copied()?;
-        return Some(StorageAccess {
-            step_index,
-            pc: step.pc,
-            kind: StorageAccessKind::Sstore,
-            slot,
-            value,
-            previous: None,
-        });
-    }
-
-    None
+    let mut stack = step.stack.as_deref()?.iter().rev();
+    let slot = stack.next().copied()?;
+    let value = stack.next().copied()?;
+    Some(StorageAccess { step_index, pc: step.pc, space, kind, slot, value, previous: None })
 }
 
 pub(super) fn hex_u256(value: U256) -> String {


### PR DESCRIPTION
## Motivation

The debugger's storage inspection only recognizes persistent `SLOAD` and `SSTORE` accesses. Contracts using EIP-1153 transient storage therefore cannot see the current `TLOAD`/`TSTORE` slot and value or jump directly to a transient slot access.

Progresses #927.

## Changes

- distinguish persistent and transient accesses in the shared storage decoder
- recover `TLOAD` and `TSTORE` slot/value data from existing stack snapshots
- show transient storage context in the Variables pane
- add `:transient <slot>` and `:tslot <slot>` commands while keeping `:storage` persistent-only
- ignore failed `TSTORE` steps consistently with failed `SSTORE` steps

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo +1.95.0 test -p foundry-debugger` (110 passed)
- `cargo +1.95.0 clippy -p foundry-debugger --all-targets -- -D warnings`
- live debugger smoke test against a Cancun contract using `tstore(0x2a, 0xbeef)` and `tload(0x2a)`; verified command navigation and Variables pane values at both opcodes
