### PR TITLE
chore: normalize benchmark definitions

### DIFF
--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -8,11 +8,6 @@ on:
   workflow_dispatch: # allow manual triggering for testing
 
 env:
-  AAVE_V4_REPO: "aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35"
-  SYMBOLIC_REPOS: >-
-    Vectorized/solady:v0.1.26,
-    SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5,
-    farcasterxyz/contracts:3f37e21db8e9c6319b4a3d5f62b1c514ef01c36b
   RUSTC_WRAPPER: "sccache"
 
 jobs:
@@ -71,66 +66,31 @@ jobs:
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches --force-install \
-            --versions stable \
-            --repos "$AAVE_V4_REPO" \
-            --benchmarks forge_test \
-            --json-output "stable-${DATE}-forge_test.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly test --versions stable --output-dir ./benches
 
       - name: Run forge fuzz test benchmarks (stable)
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions stable \
-            --repos "$AAVE_V4_REPO" \
-            --benchmarks forge_fuzz_test \
-            --json-output "stable-${DATE}-forge_fuzz_test.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly fuzz --versions stable --output-dir ./benches
 
       - name: Run forge build benchmarks (stable)
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions stable \
-            --repos "$AAVE_V4_REPO" \
-            --benchmarks forge_build_no_cache,forge_build_with_cache \
-            --json-output "stable-${DATE}-forge_build.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly build --versions stable --output-dir ./benches
 
       - name: Run forge coverage benchmarks (stable)
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions stable \
-            --repos "$AAVE_V4_REPO" \
-            --benchmarks forge_coverage \
-            --json-output "stable-${DATE}-forge_coverage.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly coverage --versions stable --output-dir ./benches
 
       - name: Run forge symbolic benchmarks (stable)
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions stable \
-            --repos "$SYMBOLIC_REPOS" \
-            --benchmarks forge_symbolic_test \
-            --json-output "stable-${DATE}-forge_symbolic.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly symbolic --versions stable --output-dir ./benches
 
       # --- Nightly benchmarks ---
 
@@ -138,66 +98,31 @@ jobs:
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches --force-install \
-            --versions nightly \
-            --repos "$AAVE_V4_REPO" \
-            --benchmarks forge_test \
-            --json-output "nightly-${DATE}-forge_test.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly test --versions nightly --output-dir ./benches
 
       - name: Run forge fuzz test benchmarks (nightly)
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions nightly \
-            --repos "$AAVE_V4_REPO" \
-            --benchmarks forge_fuzz_test \
-            --json-output "nightly-${DATE}-forge_fuzz_test.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly fuzz --versions nightly --output-dir ./benches
 
       - name: Run forge build benchmarks (nightly)
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions nightly \
-            --repos "$AAVE_V4_REPO" \
-            --benchmarks forge_build_no_cache,forge_build_with_cache \
-            --json-output "nightly-${DATE}-forge_build.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly build --versions nightly --output-dir ./benches
 
       - name: Run forge coverage benchmarks (nightly)
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions nightly \
-            --repos "$AAVE_V4_REPO" \
-            --benchmarks forge_coverage \
-            --json-output "nightly-${DATE}-forge_coverage.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly coverage --versions nightly --output-dir ./benches
 
       - name: Run forge symbolic benchmarks (nightly)
         continue-on-error: true
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
-        run: |
-          DATE=$(date -u +%Y-%m-%d)
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions nightly \
-            --repos "$SYMBOLIC_REPOS" \
-            --benchmarks forge_symbolic_test \
-            --json-output "nightly-${DATE}-forge_symbolic.json" \
-            --verbose
+        run: benches/scripts/run-benchmark-suite.sh nightly symbolic --versions nightly --output-dir ./benches
 
       - name: Merge benchmark JSON results
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,40 +16,6 @@ on:
 
 env:
   DEFAULT_VERSIONS: "master,local"
-
-  # Repos to benchmark per step. Each comma-separated entry has the form
-  #   org/repo[:rev][ <extra args>]
-  # where anything after the first whitespace is appended to every benchmark
-  # command for that repo (use this to skip a broken test contract via e.g.
-  # `--nmc BrokenTest`, so a single failing test does not fail the whole CI).
-  TEST_REPOS: >-
-    ithacaxyz/account:v0.5.7,
-    vectorized/solady:v0.1.26 --nmc 'LifebuoyTest|LibBitTest|Base58Test|LibStringTest',
-    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest',
-    sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
-
-  ISOLATE_TEST_REPOS: >-
-    ithacaxyz/account:v0.5.7 --nmc SimulateExecuteTest,
-    vectorized/solady:v0.1.26 --nmc 'SafeTransferLibTest|LifebuoyTest|LibBitTest|Base58Test|LibStringTest',
-    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest',
-    sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
-
-  SYMBOLIC_REPOS: >-
-    Vectorized/solady:v0.1.26,
-    SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5,
-    farcasterxyz/contracts:3f37e21db8e9c6319b4a3d5f62b1c514ef01c36b
-
-  BUILD_REPOS: >-
-    ithacaxyz/account:v0.5.7,
-    vectorized/solady:v0.1.26,
-    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
-    sparkdotfi/spark-psm:v1.0.0
-
-  COVERAGE_REPOS: >-
-    ithacaxyz/account:v0.5.7 --nmc SimulateExecuteTest,
-    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
-    sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
-
   RUSTC_WRAPPER: "sccache"
 
 jobs:
@@ -133,29 +99,19 @@ jobs:
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ steps.prep.outputs.versions }}
-          REPOS: ${{ github.event.inputs.repos || env.TEST_REPOS }}
+          REPOS: ${{ github.event.inputs.repos }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches --force-install \
-            --versions "$VERSIONS" \
-            --repos "$REPOS" \
-            --benchmarks forge_test,forge_fuzz_test \
-            --output-file forge_test_bench.md \
-            --json-output forge_test_bench.json \
-            --verbose
+          benches/scripts/run-benchmark-suite.sh ci test \
+            --versions "$VERSIONS" --output-dir ./benches --repos "$REPOS"
 
       - name: Run forge isolate test benchmarks
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ steps.prep.outputs.versions }}
-          REPOS: ${{ github.event.inputs.repos || env.ISOLATE_TEST_REPOS }}
+          REPOS: ${{ github.event.inputs.repos }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions "$VERSIONS" \
-            --repos "$REPOS" \
-            --benchmarks forge_isolate_test \
-            --output-file forge_isolate_test_bench.md \
-            --json-output forge_isolate_test_bench.json \
-            --verbose
+          benches/scripts/run-benchmark-suite.sh ci isolate \
+            --versions "$VERSIONS" --output-dir ./benches --repos "$REPOS"
 
       # Temporarily disabled as long as the previous stable benchmark baseline
       # does not support symbolic execution.
@@ -163,42 +119,28 @@ jobs:
       #   env:
       #     FOUNDRY_DIR: ${{ github.workspace }}/.foundry
       #     VERSIONS: ${{ github.event.inputs.versions || env.DEFAULT_VERSIONS }}
-      #     REPOS: ${{ github.event.inputs.repos || env.SYMBOLIC_REPOS }}
+      #     REPOS: ${{ github.event.inputs.repos }}
       #   run: |
-      #     ./target/release/foundry-bench --output-dir ./benches \
-      #       --versions "$VERSIONS" \
-      #       --repos "$REPOS" \
-      #       --benchmarks forge_symbolic_test \
-      #       --output-file forge_symbolic_bench.md \
-      #       --verbose
+      #     benches/scripts/run-benchmark-suite.sh ci symbolic \
+      #       --versions "$VERSIONS" --output-dir ./benches --repos "$REPOS"
 
       - name: Run forge build benchmarks
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ steps.prep.outputs.versions }}
-          REPOS: ${{ github.event.inputs.repos || env.BUILD_REPOS }}
+          REPOS: ${{ github.event.inputs.repos }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions "$VERSIONS" \
-            --repos "$REPOS" \
-            --benchmarks forge_build_no_cache,forge_build_with_cache \
-            --output-file forge_build_bench.md \
-            --json-output forge_build_bench.json \
-            --verbose
+          benches/scripts/run-benchmark-suite.sh ci build \
+            --versions "$VERSIONS" --output-dir ./benches --repos "$REPOS"
 
       - name: Run forge coverage benchmarks
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ steps.prep.outputs.versions }}
-          REPOS: ${{ github.event.inputs.repos || env.COVERAGE_REPOS }}
+          REPOS: ${{ github.event.inputs.repos }}
         run: |
-          ./target/release/foundry-bench --output-dir ./benches \
-            --versions "$VERSIONS" \
-            --repos "$REPOS" \
-            --benchmarks forge_coverage \
-            --output-file forge_coverage_bench.md \
-            --json-output forge_coverage_bench.json \
-            --verbose
+          benches/scripts/run-benchmark-suite.sh ci coverage \
+            --versions "$VERSIONS" --output-dir ./benches --repos "$REPOS"
 
       - name: Combine benchmark results
         run: ./.github/scripts/combine-benchmarks.sh benches

--- a/benches/README.md
+++ b/benches/README.md
@@ -33,6 +33,46 @@ Build and install the benchmark runner:
 cargo build --release --bin foundry-bench
 ```
 
+### Run CI benchmark suites locally
+
+The canonical CI and nightly benchmark definitions live in
+`benches/scripts/run-benchmark-suite.sh`. List the available profiles and suites
+with:
+
+```bash
+benches/scripts/run-benchmark-suite.sh --list
+```
+
+| Profile | Suites run by CI |
+| --- | --- |
+| `ci` | `test`, `isolate`, `build`, `coverage` |
+| `nightly` | `test`, `fuzz`, `build`, `coverage`, `symbolic` for both stable and nightly |
+
+The `ci:symbolic` suite is also defined for local use but is currently disabled
+in the regular workflow because the previous stable baseline does not support
+symbolic execution.
+
+After building the runner, invoke a suite from the repository root. These are
+the same definitions used by CI, including pinned repositories, exclusions,
+benchmark IDs, installation behavior, and output filenames:
+
+```bash
+# Run the regular CI test suite against a local Foundry build.
+benches/scripts/run-benchmark-suite.sh ci test \
+  --versions local \
+  --output-dir ./benches
+
+# Run the stable side of the nightly symbolic suite.
+benches/scripts/run-benchmark-suite.sh nightly symbolic \
+  --versions stable \
+  --output-dir ./benches
+```
+
+Use `--dry-run` before the profile name to print the exact argument vector
+without running the benchmark. Pass `--repos "org/repo[:rev][ <extra args>]"`
+to replace a suite's repository list, matching the manual benchmark workflow's
+override. An empty `--repos` value uses the suite default.
+
 To install `foundry-bench` to your PATH:
 
 ```bash
@@ -254,12 +294,13 @@ The artifact bundle exposes:
 #### Command-line Options
 
 - `--versions <VERSIONS>` - Comma-separated list of Foundry versions (default: stable,nightly)
-- `--repos <REPOS>` - Comma-separated list of repos in org/repo[:rev] format (default: ithacaxyz/account:v0.3.2,Vectorized/solady:v0.1.22)
+- `--repos <REPOS>` - Comma-separated list of repos in org/repo[:rev] format
 - `--benchmarks <BENCHMARKS>` - Comma-separated list of benchmarks to run
 - `--force-install` - Force installation of Foundry versions
 - `--verbose` - Show detailed benchmark output
-- `--output-dir <DIR>` - Directory for output files (default: benches)
-- `--output-file <FILE_NAME.md>` - Name of the output file (default: LATEST.md)
+- `--output-dir <DIR>` - Directory for output files (default: current working directory)
+- `--output-file <FILE_NAME.md>` - Name of the Markdown output file. Defaults to `LATEST.md`
+  unless `--json-output` is set, in which case Markdown is omitted unless explicitly requested
 - `--symbolic-sidecar-output <FILE.json>` - Write the opt-in v1 symbolic samples sidecar (requires exactly one version)
 
 ## Benchmark Structure
@@ -274,16 +315,15 @@ The artifact bundle exposes:
 
 ## Configuration
 
-The benchmark binary uses command-line arguments to configure which repositories and versions to test. The default repositories are:
-
-- `ithacaxyz/account:v0.3.2`
-- `Vectorized/solady:v0.1.22`
-
-You can override these using the `--repos` flag with the format `org/repo[:rev]`.
+The benchmark binary uses command-line arguments to configure which repositories and versions to
+test. Its generic defaults track the main branches of Account and Solady. Reproducible CI repository
+pins and per-repository arguments are defined by `run-benchmark-suite.sh`; use `--list` to discover
+those suites. You can override repositories using `--repos` with the format `org/repo[:rev]`.
 
 ## Results
 
-Benchmark results are saved to `benches/LATEST.md` (or custom output file specified with `--output-file`). The report includes:
+Benchmark results are saved to `<output-dir>/LATEST.md` unless a custom output file is specified or
+Markdown output is suppressed by `--json-output`. The report includes:
 
 - Summary of versions and repositories tested
 - Performance comparison tables for each benchmark type showing:

--- a/benches/scripts/run-benchmark-suite.sh
+++ b/benches/scripts/run-benchmark-suite.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+join_repositories() {
+  local IFS=,
+  printf '%s' "$*"
+}
+
+CI_TEST_REPOSITORIES=$(join_repositories \
+  "ithacaxyz/account:v0.5.7" \
+  "vectorized/solady:v0.1.26 --nmc 'LifebuoyTest|LibBitTest|Base58Test|LibStringTest'" \
+  "uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest'" \
+  "sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting")
+
+CI_ISOLATE_REPOSITORIES=$(join_repositories \
+  "ithacaxyz/account:v0.5.7 --nmc SimulateExecuteTest" \
+  "vectorized/solady:v0.1.26 --nmc 'SafeTransferLibTest|LifebuoyTest|LibBitTest|Base58Test|LibStringTest'" \
+  "uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest'" \
+  "sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting")
+
+CI_BUILD_REPOSITORIES=$(join_repositories \
+  "ithacaxyz/account:v0.5.7" \
+  "vectorized/solady:v0.1.26" \
+  "uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75" \
+  "sparkdotfi/spark-psm:v1.0.0")
+
+CI_COVERAGE_REPOSITORIES=$(join_repositories \
+  "ithacaxyz/account:v0.5.7 --nmc SimulateExecuteTest" \
+  "uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75" \
+  "sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting")
+
+SYMBOLIC_REPOSITORIES=$(join_repositories \
+  "Vectorized/solady:v0.1.26" \
+  "SorellaLabs/angstrom:73b55b8eca667b9a50fa4d8b6a7f45ec647420f5" \
+  "farcasterxyz/contracts:3f37e21db8e9c6319b4a3d5f62b1c514ef01c36b")
+
+NIGHTLY_REPOSITORIES="aave/aave-v4:af1f0f2ba323ac6fbaaee3abf6be060c78e22d35"
+
+SUITE_PROFILES=()
+SUITE_NAMES=()
+SUITE_BENCHMARKS=()
+SUITE_REPOSITORIES=()
+SUITE_MARKDOWN_OUTPUTS=()
+SUITE_JSON_OUTPUTS=()
+SUITE_FORCE_INSTALLS=()
+
+define_suite() {
+  SUITE_PROFILES+=("$1")
+  SUITE_NAMES+=("$2")
+  SUITE_BENCHMARKS+=("$3")
+  SUITE_REPOSITORIES+=("$4")
+  SUITE_MARKDOWN_OUTPUTS+=("$5")
+  SUITE_JSON_OUTPUTS+=("$6")
+  SUITE_FORCE_INSTALLS+=("$7")
+}
+
+# Regular CI suites. Symbolic is defined for local use but currently disabled in the workflow.
+define_suite ci test \
+  "forge_test,forge_fuzz_test" "${CI_TEST_REPOSITORIES}" \
+  "forge_test_bench.md" "forge_test_bench.json" true
+define_suite ci isolate \
+  "forge_isolate_test" "${CI_ISOLATE_REPOSITORIES}" \
+  "forge_isolate_test_bench.md" "forge_isolate_test_bench.json" false
+define_suite ci build \
+  "forge_build_no_cache,forge_build_with_cache" "${CI_BUILD_REPOSITORIES}" \
+  "forge_build_bench.md" "forge_build_bench.json" false
+define_suite ci coverage \
+  "forge_coverage" "${CI_COVERAGE_REPOSITORIES}" \
+  "forge_coverage_bench.md" "forge_coverage_bench.json" false
+define_suite ci symbolic \
+  "forge_symbolic_test" "${SYMBOLIC_REPOSITORIES}" \
+  "forge_symbolic_bench.md" "" false
+
+# Nightly suites run once for stable and once for nightly.
+define_suite nightly test \
+  "forge_test" "${NIGHTLY_REPOSITORIES}" \
+  "" "{version}-{date}-forge_test.json" true
+define_suite nightly fuzz \
+  "forge_fuzz_test" "${NIGHTLY_REPOSITORIES}" \
+  "" "{version}-{date}-forge_fuzz_test.json" false
+define_suite nightly build \
+  "forge_build_no_cache,forge_build_with_cache" "${NIGHTLY_REPOSITORIES}" \
+  "" "{version}-{date}-forge_build.json" false
+define_suite nightly coverage \
+  "forge_coverage" "${NIGHTLY_REPOSITORIES}" \
+  "" "{version}-{date}-forge_coverage.json" false
+define_suite nightly symbolic \
+  "forge_symbolic_test" "${SYMBOLIC_REPOSITORIES}" \
+  "" "{version}-{date}-forge_symbolic.json" false
+
+usage() {
+  cat <<'EOF'
+Usage:
+  benches/scripts/run-benchmark-suite.sh [--dry-run] <profile> <suite> \
+    --versions <versions> --output-dir <directory> [--repos <repositories>]
+  benches/scripts/run-benchmark-suite.sh --list
+EOF
+}
+
+list_suites() {
+  local index
+  for ((index = 0; index < ${#SUITE_PROFILES[@]}; index++)); do
+    printf '%s:%s\n' "${SUITE_PROFILES[index]}" "${SUITE_NAMES[index]}"
+    printf '  benchmarks: %s\n' "${SUITE_BENCHMARKS[index]}"
+    printf '  repositories: %s\n' "${SUITE_REPOSITORIES[index]}"
+  done
+}
+
+dry_run=false
+if [[ ${1:-} == "--list" ]]; then
+  list_suites
+  exit 0
+fi
+if [[ ${1:-} == "--dry-run" ]]; then
+  dry_run=true
+  shift
+fi
+if [[ $# -lt 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+requested_profile=$1
+requested_suite=$2
+shift 2
+
+versions=
+output_dir=
+repositories_override=
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --versions)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      versions=$2
+      shift 2
+      ;;
+    --output-dir)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      output_dir=$2
+      shift 2
+      ;;
+    --repos)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      repositories_override=$2
+      shift 2
+      ;;
+    *)
+      printf 'error: unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z ${versions} || -z ${output_dir} ]]; then
+  printf 'error: --versions and --output-dir are required\n' >&2
+  usage >&2
+  exit 2
+fi
+
+found=false
+benchmarks=
+repositories=
+markdown_output=
+json_output=
+force_install=false
+for ((index = 0; index < ${#SUITE_PROFILES[@]}; index++)); do
+  if [[ ${SUITE_PROFILES[index]} == "${requested_profile}" && ${SUITE_NAMES[index]} == "${requested_suite}" ]]; then
+    benchmarks=${SUITE_BENCHMARKS[index]}
+    repositories=${SUITE_REPOSITORIES[index]}
+    markdown_output=${SUITE_MARKDOWN_OUTPUTS[index]}
+    json_output=${SUITE_JSON_OUTPUTS[index]}
+    force_install=${SUITE_FORCE_INSTALLS[index]}
+    found=true
+    break
+  fi
+done
+
+if [[ ${found} != true ]]; then
+  printf 'error: unknown benchmark suite: %s:%s\n' "${requested_profile}" "${requested_suite}" >&2
+  list_suites >&2
+  exit 2
+fi
+
+if [[ -n ${repositories_override} ]]; then
+  repositories=${repositories_override}
+fi
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+runner=${repo_root}/target/release/foundry-bench
+
+args=("${runner}" --output-dir "${output_dir}")
+if [[ ${force_install} == true ]]; then
+  args+=(--force-install)
+fi
+args+=(
+  --versions "${versions}"
+  --repos "${repositories}"
+  --benchmarks "${benchmarks}"
+)
+if [[ -n ${markdown_output} ]]; then
+  args+=(--output-file "${markdown_output}")
+fi
+if [[ -n ${json_output} ]]; then
+  date=$(date -u +%Y-%m-%d)
+  json_output=${json_output//\{version\}/${versions}}
+  json_output=${json_output//\{date\}/${date}}
+  args+=(--json-output "${json_output}")
+fi
+args+=(--verbose)
+
+if [[ ${dry_run} == true ]]; then
+  printf 'argv:\n'
+  printf '  %q\n' "${args[@]}"
+  exit 0
+fi
+
+"${args[@]}"


### PR DESCRIPTION
Centralizes benchmark suite definitions so CI and local runs use the same repositories, options, and outputs.

Closes OSS-473