### PR TITLE
fix(anvil): preserve fork cache on reset

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1247,9 +1247,7 @@ impl NodeConfig {
             genesis_init: self.genesis.clone(),
         };
 
-        let mut decoder_builder = CallTraceDecoderBuilder::new().with_tempo_hardfork(
-            self.networks.is_tempo().then(|| TempoHardfork::from(self.get_hardfork())),
-        );
+        let mut decoder_builder = CallTraceDecoderBuilder::new();
         if self.print_traces {
             // if traces should get printed we configure the decoder with the signatures cache
             if let Ok(identifier) = SignaturesIdentifier::new(false) {

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1247,7 +1247,9 @@ impl NodeConfig {
             genesis_init: self.genesis.clone(),
         };
 
-        let mut decoder_builder = CallTraceDecoderBuilder::new();
+        let mut decoder_builder = CallTraceDecoderBuilder::new().with_tempo_hardfork(
+            self.networks.is_tempo().then(|| TempoHardfork::from(self.get_hardfork())),
+        );
         if self.print_traces {
             // if traces should get printed we configure the decoder with the signatures cache
             if let Ok(identifier) = SignaturesIdentifier::new(false) {
@@ -1396,6 +1398,10 @@ latest block number: {latest_block}"
         let gas_limit = self.fork_gas_limit(&block);
         self.gas_limit = Some(gas_limit);
 
+        // Cache identity must describe the remote fork block, not local execution overrides that
+        // can change after mining (for example, the locally advanced base fee).
+        let cache_block_env: BlockEnv = block_env_from_header(&block.header);
+
         evm_env.block_env = BlockEnv {
             gas_limit,
             // Keep previous `coinbase` and `basefee` value
@@ -1492,7 +1498,7 @@ latest block number: {latest_block}"
             self.networks,
         );
 
-        let meta = BlockchainDbMeta::new(evm_env.block_env.clone(), eth_rpc_url.clone());
+        let meta = BlockchainDbMeta::new(cache_block_env, eth_rpc_url.clone());
         let block_chain_db = if self.fork_chain_id.is_some() {
             BlockchainDb::new_skip_check(meta, self.block_cache_path(fork_block_number))
         } else {

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -416,6 +416,21 @@ impl<N: Network> ClientFork<N> {
                 .map_err(BlockchainError::Internal)?;
         }
 
+        self.prepare_reset(urls, block_number).await?;
+
+        let number = self.block_number();
+        let block_hash = self.block_hash();
+        self.database.write().await.insert_block_hash(U256::from(number), block_hash);
+
+        Ok(())
+    }
+
+    /// Updates the fork configuration for a reset without modifying the current database.
+    pub(crate) async fn prepare_reset(
+        &self,
+        urls: Vec<String>,
+        block_number: BlockId,
+    ) -> Result<(), BlockchainError> {
         if !urls.is_empty() {
             self.config.write().update_urls(urls)?;
             let override_chain_id = self.config.read().override_chain_id;
@@ -445,8 +460,6 @@ impl<N: Network> ClientFork<N> {
         );
 
         self.clear_cached_storage();
-
-        self.database.write().await.insert_block_hash(U256::from(number), block_hash);
 
         Ok(())
     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2486,7 +2486,10 @@ impl<N: Network> Backend<N> {
             // reset the fork entirely and reapply the genesis config
             let reset_urls =
                 forking.json_rpc_url.as_ref().map(|url| vec![url.clone()]).unwrap_or_default();
-            fork.reset(reset_urls, block_number).await?;
+            // Persist fetched remote state before rebuilding the fork database so the new
+            // block-specific database can load it from disk.
+            fork.database.read().await.maybe_flush_cache().map_err(BlockchainError::Internal)?;
+            fork.prepare_reset(reset_urls, block_number.into()).await?;
             let fork_block_number = fork.block_number();
             let fork_block = fork
                 .block_by_number(fork_block_number)
@@ -2549,7 +2552,6 @@ impl<N: Network> Backend<N> {
                 fork.total_difficulty(),
             );
             self.states.write().clear();
-            self.db.write().await.clear();
 
             self.apply_genesis().await?;
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2552,7 +2552,6 @@ impl<N: Network> Backend<N> {
                 fork.total_difficulty(),
             );
             self.states.write().clear();
-
             self.apply_genesis().await?;
 
             trace!(target: "backend", "reset fork");

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1779,6 +1779,40 @@ async fn test_reset_updates_cache_path_when_rpc_url_not_provided() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_reuses_cached_remote_state() {
+    let address = Address::random();
+    let balance = U256::from(1337u64);
+    let chain_id =
+        u64::from_be_bytes(address.as_slice()[12..].try_into().unwrap()) % 1_000_000 + 1_000_000;
+    let cache_dir = Config::foundry_chain_cache_dir(chain_id).unwrap();
+    let _ = std::fs::remove_dir_all(&cache_dir);
+
+    let origin_config = NodeConfig::test()
+        .with_chain_id(Some(chain_id))
+        .with_funded_accounts([(address, balance)].into_iter().collect());
+    let (_origin_api, origin_handle) = spawn(origin_config).await;
+    let fork_config = NodeConfig::test()
+        .with_chain_id(Some(chain_id))
+        .with_eth_rpc_url(Some(origin_handle.http_endpoint()));
+    let (api, handle) = spawn(fork_config).await;
+    let provider = handle.http_provider();
+    let fork_block_number = api.anvil_node_info().await.unwrap().fork_config.fork_block_number;
+
+    assert_eq!(provider.get_balance(address).await.unwrap(), balance);
+
+    for _ in 0..2 {
+        api.anvil_reset(Some(Forking { json_rpc_url: None, block_number: fork_block_number }))
+            .await
+            .unwrap();
+
+        let db = api.backend.get_db().read().await;
+        assert!(db.maybe_inner().unwrap().accounts().read().contains_key(&address));
+    }
+
+    let _ = std::fs::remove_dir_all(cache_dir);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fork_get_account() {
     let (_api, handle) = spawn(fork_config()).await;
     let provider = handle.http_provider();

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1799,6 +1799,7 @@ async fn test_fork_reset_reuses_cached_remote_state() {
     let fork_block_number = api.anvil_node_info().await.unwrap().fork_config.fork_block_number;
 
     assert_eq!(provider.get_balance(address).await.unwrap(), balance);
+    api.mine_one().await;
 
     for _ in 0..2 {
         api.anvil_reset(Some(Forking { json_rpc_url: None, block_number: fork_block_number }))


### PR DESCRIPTION
Fixes #7966.

`anvil_reset` rebuilt the fork database with the correct per-block cache, but then cleared the newly loaded cache. It also cleared the outgoing database before its fetched remote state could be persisted. This change separates fork metadata preparation from destructive database reset, flushes remote state before rebuilding, and retains the block-specific cache in the replacement database while continuing to discard local overlay mutations. A local-origin regression covers repeated resets to the same fork block.

This pull request was developed with AI assistance.
