### PR TITLE
feat(doc): configure source revision

### DIFF
--- a/crates/config/src/doc.rs
+++ b/crates/config/src/doc.rs
@@ -20,6 +20,9 @@ pub struct DocConfig {
     /// The repository url.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository: Option<String>,
+    /// The Git commit hash, tag, or branch used for source links.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
     /// The path to source code (e.g. `tree/main/packages/contracts`).
     /// Useful for monorepos or for projects with source code located in specific directories.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -36,6 +39,7 @@ impl Default for DocConfig {
             homepage: Some(PathBuf::from("README.md")),
             title: String::default(),
             repository: None,
+            commit: None,
             path: None,
             ignore: Vec::default(),
         }

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -41,8 +41,10 @@ const VYPER_KEYS: &[&str] = &[
 
 /// Allowed keys for DocConfig.
 /// Required because DocConfig uses `skip_serializing_if = "Option::is_none"` on some fields
-/// (`repository`, `path`), whose defaults are `None` and thus excluded from serialization.
-const DOC_KEYS: &[&str] = &["out", "title", "book", "homepage", "repository", "path", "ignore"];
+/// (`repository`, `commit`, `path`), whose defaults are `None` and thus excluded from
+/// serialization.
+const DOC_KEYS: &[&str] =
+    &["out", "title", "book", "homepage", "repository", "commit", "path", "ignore"];
 
 /// Allowed keys for SymbolicConfig.
 /// Required because some compatibility aliases and empty length collections are skipped by default

--- a/crates/doc/src/builder.rs
+++ b/crates/doc/src/builder.rs
@@ -40,7 +40,7 @@ pub struct DocBuilder {
     pub libraries: Vec<PathBuf>,
     /// Whether to also document files coming from external libraries.
     pub include_libraries: bool,
-    /// Optional commit hash (HEAD) used when building Git Source links.
+    /// Optional Git commit, tag, or branch used when building Git Source links.
     pub commit: Option<String>,
     /// Optional current branch name; used as the `<branch>` segment of vocs
     /// editLink URLs (which require an actual branch, not a commit/`HEAD`).

--- a/crates/forge/src/cmd/doc.rs
+++ b/crates/forge/src/cmd/doc.rs
@@ -106,7 +106,7 @@ impl DocArgs {
         }
 
         let git = Git::new(root);
-        let commit = git.commit_hash(false, "HEAD").ok();
+        let commit = doc_cfg.commit.clone().or_else(|| git.commit_hash(false, "HEAD").ok());
         // Best-effort branch detection for editLink. May yield "HEAD" when in
         // detached HEAD state; treat that as unknown.
         let branch = git.current_rev_branch(root).ok().map(|(_, b)| b).filter(|b| b != "HEAD");

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -45,6 +45,32 @@ forgetest_init!(doc_supports_empty_projects, |_prj, cmd| {
     cmd.arg("doc").assert_success();
 });
 
+forgetest_init!(doc_uses_configured_commit_for_source_links, |prj, cmd| {
+    prj.add_source(
+        "Revision.sol",
+        r#"
+pragma solidity ^0.8.20;
+
+contract Revision {}
+"#,
+    );
+    prj.update_config(|config| {
+        config.doc.repository = Some("https://github.com/foundry-rs/foundry".to_string());
+        config.doc.commit = Some("v1.2.3".to_string());
+    });
+
+    cmd.arg("doc").assert_success();
+
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Revision.mdx"), None),
+        str![[r#"
+...
+[Git Source](https://github.com/foundry-rs/foundry/blob/v1.2.3/src/Revision.sol)
+...
+"#]],
+    );
+});
+
 forgetest!(doc_supports_mixed_solidity_versions, |prj, cmd| {
     prj.add_source(
         "New.sol",


### PR DESCRIPTION
Forge Doc always used the checkout's `HEAD` hash for Git Source links. In workflows that squash generated documentation commits, that SHA may not exist in the source repository, leaving broken links.

This adds an optional `doc.commit` configuration value that accepts a commit hash, tag, or branch and takes precedence over the automatically detected `HEAD`. Generated source and README asset links therefore point to the configured revision, while projects that leave it unset retain the existing behavior.

Closes #5711.

This PR was written with Codex, including code and tests.
