### PR TITLE
perf(anvil): stabilize long-chain mining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,7 +1260,6 @@ dependencies = [
  "rand 0.8.6",
  "rand 0.9.4",
  "reqwest 0.13.4",
- "reth-trie-sparse",
  "revm",
  "revm-inspectors",
  "serde",
@@ -9921,7 +9920,6 @@ dependencies = [
  "modular-bitfield",
  "once_cell",
  "quanta",
- "rayon",
  "reth-codecs 0.5.2",
  "revm-bytecode 41.0.0",
  "revm-primitives 41.0.0",
@@ -10109,25 +10107,6 @@ dependencies = [
  "revm",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "reth-trie-sparse"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
-dependencies = [
- "alloy-primitives",
- "alloy-trie",
- "either",
- "rayon",
- "reth-execution-errors",
- "reth-primitives-traits 0.5.2",
- "reth-trie-common",
- "serde",
- "serde_json",
- "slotmap",
- "smallvec",
- "tracing",
 ]
 
 [[package]]
@@ -11364,15 +11343,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slotmap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "small_btree"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,6 +1251,7 @@ dependencies = [
  "foundry-test-utils",
  "futures",
  "hyper",
+ "imbl",
  "itertools 0.15.0",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
@@ -1259,6 +1260,7 @@ dependencies = [
  "rand 0.8.6",
  "rand 0.9.4",
  "reqwest 0.13.4",
+ "reth-trie-sparse",
  "revm",
  "revm-inspectors",
  "serde",
@@ -1363,6 +1365,12 @@ checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 
 [[package]]
 name = "ark-bls12-381"
@@ -2460,6 +2468,12 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -6833,6 +6847,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "imbl"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e525189e5f603908d0c6e0d402cb5de9c4b2c8866151fabc4ebd771ed2630a2e"
+dependencies = [
+ "archery",
+ "bitmaps",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro",
+ "version_check",
+ "wide",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "impl-codec"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9253,6 +9291,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rapidhash"
 version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9874,6 +9921,7 @@ dependencies = [
  "modular-bitfield",
  "once_cell",
  "quanta",
+ "rayon",
  "reth-codecs 0.5.2",
  "revm-bytecode 41.0.0",
  "revm-primitives 41.0.0",
@@ -10061,6 +10109,25 @@ dependencies = [
  "revm",
  "serde",
  "serde_with",
+]
+
+[[package]]
+name = "reth-trie-sparse"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-trie",
+ "either",
+ "rayon",
+ "reth-execution-errors",
+ "reth-primitives-traits 0.5.2",
+ "reth-trie-common",
+ "serde",
+ "serde_json",
+ "slotmap",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -10701,6 +10768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11288,6 +11364,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "small_btree"
@@ -13484,6 +13569,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,6 +341,8 @@ foundry-compilers = { version = "0.21.0", default-features = false, features = [
     "svm-solc",
 ] }
 foundry-fork-db = { version = "0.27.0", features = ["zstd"] }
+imbl = "7"
+reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", default-features = false, features = ["std"] }
 solar = { package = "solar-compiler", version = "=0.2.0", default-features = false }
 solar-cli = { version = "=0.2.0", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,7 +342,6 @@ foundry-compilers = { version = "0.21.0", default-features = false, features = [
 ] }
 foundry-fork-db = { version = "0.27.0", features = ["zstd"] }
 imbl = "7"
-reth-trie-sparse = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", default-features = false, features = ["std"] }
 solar = { package = "solar-compiler", version = "=0.2.0", default-features = false }
 solar-cli = { version = "=0.2.0", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -29,6 +29,7 @@ foundry-config.workspace = true
 foundry-evm.workspace = true
 foundry-evm-networks.workspace = true
 foundry-primitives = { workspace = true, default-features = false }
+reth-trie-sparse.workspace = true
 tempo-hardfork.workspace = true
 tempo-primitives.workspace = true
 tempo-precompiles.workspace = true
@@ -99,6 +100,7 @@ thiserror.workspace = true
 yansi.workspace = true
 tempfile.workspace = true
 itertools.workspace = true
+imbl.workspace = true
 rand_08.workspace = true
 eyre.workspace = true
 ethereum_ssz.workspace = true

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -29,7 +29,6 @@ foundry-config.workspace = true
 foundry-evm.workspace = true
 foundry-evm-networks.workspace = true
 foundry-primitives = { workspace = true, default-features = false }
-reth-trie-sparse.workspace = true
 tempo-hardfork.workspace = true
 tempo-primitives.workspace = true
 tempo-precompiles.workspace = true

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -11,7 +11,7 @@ use crate::{
         fees::{INITIAL_BASE_FEE, INITIAL_GAS_PRICE},
         pool::transactions::{PoolTransaction, TransactionOrder},
     },
-    mem::{self, in_memory_db::MemDb},
+    mem::{self, in_memory_db::StateRootDb},
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
@@ -1217,7 +1217,7 @@ impl NodeConfig {
             if let Some(eth_rpc_url) = self.fork_urls.first().cloned() {
                 self.setup_fork_db(eth_rpc_url, &mut evm_env, &fees).await?
             } else {
-                (Arc::new(TokioRwLock::new(Box::<MemDb>::default())), None)
+                (Arc::new(TokioRwLock::new(Box::<StateRootDb>::default())), None)
             };
 
         // if provided use all settings of `genesis.json`

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -13,7 +13,7 @@ use alloy_eips::eip4895::Withdrawals;
 use alloy_network::Network;
 use alloy_primitives::{
     Address, B256, Bytes, U256, keccak256,
-    map::{AddressMap, HashMap},
+    map::{AddressMap, HashMap, U256Map},
 };
 use alloy_rpc_types::BlockId;
 use anvil_core::eth::{
@@ -42,10 +42,35 @@ use serde_json::Value;
 
 use crate::mem::storage::MinedTransaction;
 
+/// Number of preceding block hashes available to the EVM's `BLOCKHASH` opcode.
+pub(crate) const BLOCKHASH_HISTORY: u64 = 256;
+
+/// Returns the cached block hash that expires when `number` is inserted.
+///
+/// Anvil also caches the just-mined block hash for the next EVM execution. Keeping that hash in
+/// addition to the 256 preceding hashes is necessary for calls against the latest block.
+pub(crate) fn expired_block_hash(number: U256) -> Option<U256> {
+    let cache_size = U256::from(BLOCKHASH_HISTORY + 1);
+    (number >= cache_size).then(|| number - cache_size)
+}
+
+/// Inserts a block hash while discarding the entry that left the EVM-visible cache.
+pub(crate) fn cache_block_hash(block_hashes: &mut U256Map<B256>, number: U256, hash: B256) {
+    if let Some(expired) = expired_block_hash(number) {
+        block_hashes.remove(&expired);
+    }
+    block_hashes.insert(number, hash);
+}
+
 /// Helper trait get access to the full state data of the database
 pub trait MaybeFullDatabase: DatabaseRef<Error = DatabaseError> + Debug {
     fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         None
+    }
+
+    /// Returns whether snapshots of this database use structural sharing.
+    fn is_persistent(&self) -> bool {
+        false
     }
 
     /// Clear the state and move it into a new `StateSnapshot`.
@@ -69,6 +94,10 @@ where
 {
     fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         T::maybe_as_full_db(self)
+    }
+
+    fn is_persistent(&self) -> bool {
+        T::is_persistent(self)
     }
 
     fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
@@ -290,7 +319,7 @@ impl<T: DatabaseRef<Error = DatabaseError> + Send + Sync + Clone + fmt::Debug> D
     }
 
     fn insert_block_hash(&mut self, number: U256, hash: B256) {
-        self.cache.block_hashes.insert(number, hash);
+        cache_block_hash(&mut self.cache.block_hashes, number, hash);
     }
 
     fn dump_state(
@@ -428,6 +457,10 @@ impl DatabaseRef for StateDb {
 impl MaybeFullDatabase for StateDb {
     fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
         self.0.maybe_as_full_db()
+    }
+
+    fn is_persistent(&self) -> bool {
+        self.0.is_persistent()
     }
 
     fn clear_into_state_snapshot(&mut self) -> StateSnapshot {

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -47,9 +47,12 @@ pub(crate) const BLOCKHASH_HISTORY: u64 = 256;
 
 /// Inserts a block hash while discarding the entry that left the EVM-visible cache.
 pub(crate) fn cache_block_hash(block_hashes: &mut U256Map<B256>, number: U256, hash: B256) {
-    let min_number = number.saturating_sub(U256::from(BLOCKHASH_HISTORY));
-    block_hashes.retain(|cached, _| *cached >= min_number && *cached <= number);
-    block_hashes.insert(number, hash);
+    let head = block_hashes.keys().copied().max().map_or(number, |head| head.max(number));
+    let min_number = head.saturating_sub(U256::from(BLOCKHASH_HISTORY));
+    block_hashes.retain(|cached, _| *cached >= min_number && *cached <= head);
+    if number >= min_number {
+        block_hashes.insert(number, hash);
+    }
 }
 
 /// Helper trait get access to the full state data of the database

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -238,6 +238,9 @@ pub trait Db:
     /// inserts a blockhash for the given number
     fn insert_block_hash(&mut self, number: U256, hash: B256);
 
+    /// Replaces all cached block hashes.
+    fn set_block_hashes(&mut self, block_hashes: Vec<(U256, B256)>);
+
     /// Write all chain data to serialized bytes buffer
     fn dump_state(
         &self,
@@ -313,6 +316,10 @@ impl<T: DatabaseRef<Error = DatabaseError> + Send + Sync + Clone + fmt::Debug> D
 
     fn insert_block_hash(&mut self, number: U256, hash: B256) {
         cache_block_hash(&mut self.cache.block_hashes, number, hash);
+    }
+
+    fn set_block_hashes(&mut self, block_hashes: Vec<(U256, B256)>) {
+        self.cache.block_hashes = block_hashes.into_iter().collect();
     }
 
     fn dump_state(

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -45,20 +45,10 @@ use crate::mem::storage::MinedTransaction;
 /// Number of preceding block hashes available to the EVM's `BLOCKHASH` opcode.
 pub(crate) const BLOCKHASH_HISTORY: u64 = 256;
 
-/// Returns the cached block hash that expires when `number` is inserted.
-///
-/// Anvil also caches the just-mined block hash for the next EVM execution. Keeping that hash in
-/// addition to the 256 preceding hashes is necessary for calls against the latest block.
-pub(crate) fn expired_block_hash(number: U256) -> Option<U256> {
-    let cache_size = U256::from(BLOCKHASH_HISTORY + 1);
-    (number >= cache_size).then(|| number - cache_size)
-}
-
 /// Inserts a block hash while discarding the entry that left the EVM-visible cache.
 pub(crate) fn cache_block_hash(block_hashes: &mut U256Map<B256>, number: U256, hash: B256) {
-    if let Some(expired) = expired_block_hash(number) {
-        block_hashes.remove(&expired);
-    }
+    let min_number = number.saturating_sub(U256::from(BLOCKHASH_HISTORY));
+    block_hashes.retain(|cached, _| *cached >= min_number && *cached <= number);
     block_hashes.insert(number, hash);
 }
 

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -1,6 +1,7 @@
 use crate::eth::backend::db::{
     Db, MaybeForkedDatabase, MaybeFullDatabase, SerializableAccountRecord, SerializableBlock,
     SerializableHistoricalStates, SerializableState, SerializableTransaction, StateDb,
+    cache_block_hash,
 };
 use alloy_network::Network;
 use alloy_primitives::{Address, B256, U256, map::AddressMap};
@@ -29,7 +30,7 @@ impl<N: Network> Db for ForkedDatabase<N> {
     }
 
     fn insert_block_hash(&mut self, number: U256, hash: B256) {
-        self.inner().block_hashes().write().insert(number, hash);
+        cache_block_hash(&mut self.inner().block_hashes().write(), number, hash);
     }
 
     fn dump_state(

--- a/crates/anvil/src/eth/backend/mem/fork_db.rs
+++ b/crates/anvil/src/eth/backend/mem/fork_db.rs
@@ -33,6 +33,10 @@ impl<N: Network> Db for ForkedDatabase<N> {
         cache_block_hash(&mut self.inner().block_hashes().write(), number, hash);
     }
 
+    fn set_block_hashes(&mut self, block_hashes: Vec<(U256, B256)>) {
+        *self.inner().block_hashes().write() = block_hashes.into_iter().collect();
+    }
+
     fn dump_state(
         &self,
         at: BlockEnv,

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -237,9 +237,11 @@ impl DatabaseRef for PersistentStateDb {
     type Error = DatabaseError;
 
     fn basic_ref(&self, address: Address) -> DatabaseResult<Option<AccountInfo>> {
-        Ok(self.accounts.get(&address).and_then(|account| {
-            (account.account_state != AccountState::NotExisting).then(|| account.info.clone())
-        }))
+        Ok(match self.accounts.get(&address) {
+            Some(account) if account.account_state == AccountState::NotExisting => None,
+            Some(account) => Some(account.info.clone()),
+            None => Some(AccountInfo::default()),
+        })
     }
 
     fn code_by_hash_ref(&self, code_hash: B256) -> DatabaseResult<Bytecode> {
@@ -743,5 +745,23 @@ mod tests {
         assert_eq!(first.storage_ref(address, slot).unwrap(), U256::ZERO);
         assert_eq!(second.basic_ref(address).unwrap().unwrap().balance, U256::from(2));
         assert_eq!(second.storage_ref(address, slot).unwrap(), U256::from(3));
+    }
+
+    #[test]
+    fn historical_missing_accounts_match_live_state() {
+        let address = Address::with_last_byte(1);
+        let db = StateRootDb::default();
+        let historical = db.current_state();
+
+        let live_account = db.basic_ref(address).unwrap();
+        assert_eq!(live_account, Some(AccountInfo::default()));
+        assert_eq!(historical.basic_ref(address).unwrap(), live_account);
+
+        let mut persistent = PersistentStateDb::default();
+        persistent.accounts.insert(
+            address,
+            PersistentAccount { account_state: AccountState::NotExisting, ..Default::default() },
+        );
+        assert_eq!(persistent.basic_ref(address).unwrap(), None);
     }
 }

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -4,21 +4,451 @@ use crate::{
     eth::backend::db::{
         Db, MaybeForkedDatabase, MaybeFullDatabase, SerializableAccountRecord, SerializableBlock,
         SerializableHistoricalStates, SerializableState, SerializableTransaction, StateDb,
+        cache_block_hash, expired_block_hash,
     },
-    mem::state::state_root,
+    mem::state::{StateRootCache, state_root},
 };
-use alloy_primitives::{Address, B256, U256, map::AddressMap};
+use alloy_primitives::{
+    Address, B256, U256,
+    map::{AddressMap, B256Map, HashSet},
+};
 use alloy_rpc_types::BlockId;
-use foundry_evm::backend::{BlockchainDb, DatabaseResult, StateSnapshot};
+use foundry_evm::backend::{BlockchainDb, DatabaseError, DatabaseResult, StateSnapshot};
+use imbl::HashMap as PersistentMap;
+use parking_lot::Mutex;
 use revm::{
+    Database, DatabaseCommit,
+    bytecode::Bytecode,
     context::BlockEnv,
-    database::{DatabaseRef, DbAccount},
-    state::AccountInfo,
+    database::{AccountState, DatabaseRef, DbAccount},
+    state::{Account, AccountInfo},
 };
+use std::sync::OnceLock;
 
 // reexport for convenience
 pub use foundry_evm::backend::MemDb;
 use foundry_evm::backend::RevertStateSnapshotAction;
+
+/// An in-memory database that incrementally maintains Anvil's mined-block state root.
+#[derive(Debug, Default)]
+pub struct StateRootDb {
+    inner: MemDb,
+    state_root: Mutex<StateRootCache>,
+    history: Mutex<HistoricalStateCache>,
+}
+
+/// Incrementally maintained, structurally shared state used by block-history snapshots.
+#[derive(Debug, Default)]
+struct HistoricalStateCache {
+    state: Option<PersistentStateDb>,
+    dirty: AddressMap<DirtyHistoricalAccount>,
+}
+
+#[derive(Debug, Default)]
+struct DirtyHistoricalAccount {
+    storage: HashSet<U256>,
+    reset_storage: bool,
+}
+
+impl HistoricalStateCache {
+    fn record_changes(&mut self, changes: &AddressMap<Account>) {
+        for (address, account) in changes {
+            if !account.is_touched() {
+                continue;
+            }
+
+            let dirty = self.dirty.entry(*address).or_default();
+            dirty.reset_storage |= account.is_created() || account.is_selfdestructed();
+            dirty.storage.extend(account.changed_storage_slots().map(|(slot, _)| *slot));
+        }
+    }
+
+    fn record_account(&mut self, address: Address) {
+        self.dirty.entry(address).or_default();
+    }
+
+    fn record_storage(&mut self, address: Address, slot: U256) {
+        self.dirty.entry(address).or_default().storage.insert(slot);
+    }
+
+    fn record_block_hash(&mut self, number: U256, hash: B256) {
+        let Some(state) = &mut self.state else { return };
+        if let Some(expired) = expired_block_hash(number) {
+            state.block_hashes.remove(&expired);
+        }
+        state.block_hashes.insert(number, hash);
+    }
+
+    fn invalidate(&mut self) {
+        self.state = None;
+        self.dirty.clear();
+    }
+
+    fn snapshot(&mut self, db: &MemDb) -> PersistentStateDb {
+        let Some(state) = &mut self.state else {
+            let state = PersistentStateDb::from_mem_db(db);
+            self.state = Some(state.clone());
+            self.dirty.clear();
+            return state;
+        };
+
+        for (address, dirty) in std::mem::take(&mut self.dirty) {
+            let Some(account) = db.inner.cache.accounts.get(&address) else {
+                state.accounts.remove(&address);
+                continue;
+            };
+
+            let mut storage = if dirty.reset_storage {
+                account.storage.iter().map(|(slot, value)| (*slot, *value)).collect()
+            } else {
+                state
+                    .accounts
+                    .get(&address)
+                    .map(|account| account.storage.clone())
+                    .unwrap_or_default()
+            };
+            if !dirty.reset_storage {
+                for slot in dirty.storage {
+                    if let Some(value) = account.storage.get(&slot) {
+                        storage.insert(slot, *value);
+                    } else {
+                        storage.remove(&slot);
+                    }
+                }
+            }
+
+            let info = account_info_with_code(&account.info, &db.inner.cache.contracts);
+            if let Some(code) = &info.code {
+                state.contracts.insert(info.code_hash, code.clone());
+            }
+            state.accounts.insert(
+                address,
+                PersistentAccount { info, account_state: account.account_state.clone(), storage },
+            );
+        }
+
+        state.full = OnceLock::new();
+        state.clone()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct PersistentAccount {
+    info: AccountInfo,
+    account_state: AccountState,
+    storage: PersistentMap<U256, U256>,
+}
+
+/// A read-only historical state whose maps are cheap structural-sharing clones.
+#[derive(Clone, Debug, Default)]
+struct PersistentStateDb {
+    accounts: PersistentMap<Address, PersistentAccount>,
+    contracts: PersistentMap<B256, Bytecode>,
+    block_hashes: PersistentMap<U256, B256>,
+    #[allow(clippy::type_complexity)]
+    full: OnceLock<AddressMap<DbAccount>>,
+}
+
+impl PersistentStateDb {
+    fn from_mem_db(db: &MemDb) -> Self {
+        let contracts = db
+            .inner
+            .cache
+            .contracts
+            .iter()
+            .map(|(hash, code)| (*hash, code.clone()))
+            .collect::<PersistentMap<_, _>>();
+        let accounts = db
+            .inner
+            .cache
+            .accounts
+            .iter()
+            .map(|(address, account)| {
+                (
+                    *address,
+                    PersistentAccount {
+                        info: account_info_with_code(&account.info, &db.inner.cache.contracts),
+                        account_state: account.account_state.clone(),
+                        storage: account
+                            .storage
+                            .iter()
+                            .map(|(slot, value)| (*slot, *value))
+                            .collect(),
+                    },
+                )
+            })
+            .collect();
+        let block_hashes =
+            db.inner.cache.block_hashes.iter().map(|(number, hash)| (*number, *hash)).collect();
+        Self { accounts, contracts, block_hashes, full: OnceLock::new() }
+    }
+
+    fn state_snapshot(&self) -> StateSnapshot {
+        StateSnapshot {
+            accounts: self
+                .accounts
+                .iter()
+                .map(|(address, account)| (*address, account.info.clone()))
+                .collect(),
+            storage: self
+                .accounts
+                .iter()
+                .map(|(address, account)| {
+                    (
+                        *address,
+                        account.storage.iter().map(|(slot, value)| (*slot, *value)).collect(),
+                    )
+                })
+                .collect(),
+            block_hashes: self.block_hashes.iter().map(|(number, hash)| (*number, *hash)).collect(),
+        }
+    }
+
+    fn full_db(&self) -> AddressMap<DbAccount> {
+        self.accounts
+            .iter()
+            .map(|(address, account)| {
+                (
+                    *address,
+                    DbAccount {
+                        info: account.info.clone(),
+                        account_state: account.account_state.clone(),
+                        storage: account
+                            .storage
+                            .iter()
+                            .map(|(slot, value)| (*slot, *value))
+                            .collect(),
+                    },
+                )
+            })
+            .collect()
+    }
+}
+
+fn account_info_with_code(info: &AccountInfo, contracts: &B256Map<Bytecode>) -> AccountInfo {
+    let mut info = info.clone();
+    if info.code.is_none() {
+        info.code = contracts.get(&info.code_hash).cloned();
+    }
+    info
+}
+
+impl DatabaseRef for PersistentStateDb {
+    type Error = DatabaseError;
+
+    fn basic_ref(&self, address: Address) -> DatabaseResult<Option<AccountInfo>> {
+        Ok(self.accounts.get(&address).and_then(|account| {
+            (account.account_state != AccountState::NotExisting).then(|| account.info.clone())
+        }))
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> DatabaseResult<Bytecode> {
+        Ok(self.contracts.get(&code_hash).cloned().unwrap_or_default())
+    }
+
+    fn storage_ref(&self, address: Address, index: U256) -> DatabaseResult<U256> {
+        Ok(self
+            .accounts
+            .get(&address)
+            .and_then(|account| account.storage.get(&index).copied())
+            .unwrap_or_default())
+    }
+
+    fn block_hash_ref(&self, number: u64) -> DatabaseResult<B256> {
+        Ok(self.block_hashes.get(&U256::from(number)).copied().unwrap_or_default())
+    }
+}
+
+impl MaybeFullDatabase for PersistentStateDb {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
+        Some(self.full.get_or_init(|| self.full_db()))
+    }
+
+    fn is_persistent(&self) -> bool {
+        true
+    }
+
+    fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
+        let snapshot = self.state_snapshot();
+        self.clear();
+        snapshot
+    }
+
+    fn read_as_state_snapshot(&self) -> StateSnapshot {
+        self.state_snapshot()
+    }
+
+    fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    fn init_from_state_snapshot(&mut self, snapshot: StateSnapshot) {
+        let StateSnapshot { accounts, mut storage, block_hashes } = snapshot;
+        let mut contracts = PersistentMap::new();
+        let accounts = accounts
+            .into_iter()
+            .map(|(address, info)| {
+                if let Some(code) = &info.code {
+                    contracts.insert(info.code_hash, code.clone());
+                }
+                let storage = storage
+                    .remove(&address)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect::<PersistentMap<_, _>>();
+                (address, PersistentAccount { info, account_state: AccountState::None, storage })
+            })
+            .collect();
+        let block_hashes = block_hashes.into_iter().collect();
+        *self = Self { accounts, contracts, block_hashes, full: OnceLock::new() };
+    }
+}
+
+impl DatabaseRef for StateRootDb {
+    type Error = <MemDb as DatabaseRef>::Error;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.inner.basic_ref(address)
+    }
+
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.inner.code_by_hash_ref(code_hash)
+    }
+
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.inner.storage_ref(address, index)
+    }
+
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        self.inner.block_hash_ref(number)
+    }
+}
+
+impl Database for StateRootDb {
+    type Error = <MemDb as Database>::Error;
+
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.state_root.get_mut().record_account(address);
+        self.history.get_mut().record_account(address);
+        self.inner.basic(address)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.inner.code_by_hash(code_hash)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.state_root.get_mut().record_storage(address, index);
+        self.history.get_mut().record_storage(address, index);
+        self.inner.storage(address, index)
+    }
+
+    fn block_hash(&mut self, number: u64) -> Result<B256, Self::Error> {
+        self.inner.block_hash(number)
+    }
+}
+
+impl DatabaseCommit for StateRootDb {
+    fn commit(&mut self, changes: revm::state::EvmState) {
+        self.state_root.get_mut().record_changes(&changes);
+        self.history.get_mut().record_changes(&changes);
+        self.inner.commit(changes);
+    }
+}
+
+impl Db for StateRootDb {
+    fn insert_account(&mut self, address: Address, account: AccountInfo) {
+        self.state_root.get_mut().record_account(address);
+        self.history.get_mut().record_account(address);
+        Db::insert_account(&mut self.inner, address, account);
+    }
+
+    fn set_storage_at(&mut self, address: Address, slot: B256, val: B256) -> DatabaseResult<()> {
+        let storage_slot = slot.into();
+        self.state_root.get_mut().record_storage(address, storage_slot);
+        self.history.get_mut().record_storage(address, storage_slot);
+        Db::set_storage_at(&mut self.inner, address, slot, val)
+    }
+
+    fn insert_block_hash(&mut self, number: U256, hash: B256) {
+        Db::insert_block_hash(&mut self.inner, number, hash);
+        self.history.get_mut().record_block_hash(number, hash);
+    }
+
+    fn dump_state(
+        &self,
+        at: BlockEnv,
+        best_number: u64,
+        blocks: Vec<SerializableBlock>,
+        transactions: Vec<SerializableTransaction>,
+        historical_states: Option<SerializableHistoricalStates>,
+    ) -> DatabaseResult<Option<SerializableState>> {
+        Db::dump_state(&self.inner, at, best_number, blocks, transactions, historical_states)
+    }
+
+    fn snapshot_state(&mut self) -> U256 {
+        Db::snapshot_state(&mut self.inner)
+    }
+
+    fn revert_state(&mut self, id: U256, action: RevertStateSnapshotAction) -> bool {
+        let reverted = Db::revert_state(&mut self.inner, id, action);
+        if reverted {
+            self.state_root.get_mut().invalidate();
+            self.history.get_mut().invalidate();
+        }
+        reverted
+    }
+
+    fn maybe_state_root(&self) -> Option<B256> {
+        Some(self.state_root.lock().root(&self.inner.inner.cache.accounts))
+    }
+
+    fn current_state(&self) -> StateDb {
+        StateDb::new(self.history.lock().snapshot(&self.inner))
+    }
+}
+
+impl MaybeFullDatabase for StateRootDb {
+    fn maybe_as_full_db(&self) -> Option<&AddressMap<DbAccount>> {
+        MaybeFullDatabase::maybe_as_full_db(&self.inner)
+    }
+
+    fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
+        self.state_root.get_mut().invalidate();
+        self.history.get_mut().invalidate();
+        MaybeFullDatabase::clear_into_state_snapshot(&mut self.inner)
+    }
+
+    fn read_as_state_snapshot(&self) -> StateSnapshot {
+        MaybeFullDatabase::read_as_state_snapshot(&self.inner)
+    }
+
+    fn clear(&mut self) {
+        self.state_root.get_mut().invalidate();
+        self.history.get_mut().invalidate();
+        MaybeFullDatabase::clear(&mut self.inner)
+    }
+
+    fn init_from_state_snapshot(&mut self, snapshot: StateSnapshot) {
+        MaybeFullDatabase::init_from_state_snapshot(&mut self.inner, snapshot);
+        self.state_root.get_mut().invalidate();
+        self.history.get_mut().invalidate();
+    }
+}
+
+impl MaybeForkedDatabase for StateRootDb {
+    fn maybe_reset(&mut self, urls: Vec<String>, block_number: BlockId) -> Result<(), String> {
+        self.inner.maybe_reset(urls, block_number)
+    }
+
+    fn maybe_flush_cache(&self) -> Result<(), String> {
+        self.inner.maybe_flush_cache()
+    }
+
+    fn maybe_inner(&self) -> Result<&BlockchainDb, String> {
+        self.inner.maybe_inner()
+    }
+}
 
 impl Db for MemDb {
     fn insert_account(&mut self, address: Address, account: AccountInfo) {
@@ -30,7 +460,7 @@ impl Db for MemDb {
     }
 
     fn insert_block_hash(&mut self, number: U256, hash: B256) {
-        self.inner.cache.block_hashes.insert(number, hash);
+        cache_block_hash(&mut self.inner.cache.block_hashes, number, hash);
     }
 
     fn dump_state(
@@ -144,8 +574,9 @@ impl MaybeForkedDatabase for MemDb {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eth::backend::db::BLOCKHASH_HISTORY;
     use alloy_primitives::{Bytes, address};
-    use revm::{bytecode::Bytecode, primitives::KECCAK_EMPTY};
+    use revm::primitives::KECCAK_EMPTY;
     use std::collections::BTreeMap;
 
     // verifies that all substantial aspects of a loaded account remain the same after an account
@@ -251,5 +682,66 @@ mod tests {
         assert_eq!(loaded_account.nonce, 1234);
         assert_eq!(db.storage_ref(test_addr, U256::from(1234567)).unwrap(), U256::from(1));
         assert_eq!(db.storage_ref(test_addr, U256::from(1234568)).unwrap(), U256::from(5));
+    }
+
+    #[test]
+    fn incremental_state_root_matches_full_rebuild() {
+        let address = address!("0000000000000000000000000000000000002935");
+        let mut db = StateRootDb::default();
+        db.insert_account(address, AccountInfo::default());
+
+        assert_eq!(db.maybe_state_root(), Some(state_root(&db.inner.inner.cache.accounts)));
+
+        // Model the EIP-2935 history contract filling one new ring-buffer slot per block.
+        for slot in 0..1_024 {
+            db.set_storage_at(address, U256::from(slot).into(), B256::from(U256::from(slot + 1)))
+                .unwrap();
+            let _ = db.maybe_state_root().unwrap();
+        }
+
+        db.set_balance(address, U256::from(42)).unwrap();
+        db.set_storage_at(address, U256::from(7).into(), B256::ZERO).unwrap();
+        db.insert_account(Address::with_last_byte(1), AccountInfo::from_balance(U256::from(1)));
+        assert_eq!(db.maybe_state_root(), Some(state_root(&db.inner.inner.cache.accounts)));
+
+        let snapshot = db.snapshot_state();
+        db.set_balance(address, U256::from(43)).unwrap();
+        assert!(db.revert_state(snapshot, RevertStateSnapshotAction::RevertRemove));
+        assert_eq!(db.maybe_state_root(), Some(state_root(&db.inner.inner.cache.accounts)));
+    }
+
+    #[test]
+    fn evm_block_hash_cache_is_bounded() {
+        let mut db = StateRootDb::default();
+        for number in 0..1_024 {
+            db.insert_block_hash(U256::from(number), B256::from(U256::from(number)));
+        }
+
+        let block_hashes = &db.inner.inner.cache.block_hashes;
+        assert_eq!(block_hashes.len(), BLOCKHASH_HISTORY as usize + 1);
+        assert!(!block_hashes.contains_key(&U256::from(766)));
+        assert!(block_hashes.contains_key(&U256::from(767)));
+        assert!(block_hashes.contains_key(&U256::from(768)));
+        assert!(block_hashes.contains_key(&U256::from(1_023)));
+    }
+
+    #[test]
+    fn historical_states_are_persistent_and_isolated() {
+        let address = address!("0000000000000000000000000000000000002935");
+        let slot = U256::from(1);
+        let mut db = StateRootDb::default();
+        db.insert_account(address, AccountInfo::from_balance(U256::from(1)));
+
+        let first = db.current_state();
+        assert!(first.is_persistent());
+
+        db.set_balance(address, U256::from(2)).unwrap();
+        db.set_storage_at(address, slot.into(), B256::from(U256::from(3))).unwrap();
+        let second = db.current_state();
+
+        assert_eq!(first.basic_ref(address).unwrap().unwrap().balance, U256::from(1));
+        assert_eq!(first.storage_ref(address, slot).unwrap(), U256::ZERO);
+        assert_eq!(second.basic_ref(address).unwrap().unwrap().balance, U256::from(2));
+        assert_eq!(second.storage_ref(address, slot).unwrap(), U256::from(3));
     }
 }

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -73,9 +73,12 @@ impl HistoricalStateCache {
 
     fn record_block_hash(&mut self, number: U256, hash: B256) {
         let Some(state) = &mut self.state else { return };
-        let min_number = number.saturating_sub(U256::from(BLOCKHASH_HISTORY));
-        state.block_hashes.retain(|cached, _| *cached >= min_number && *cached <= number);
-        state.block_hashes.insert(number, hash);
+        let head = state.block_hashes.keys().copied().max().map_or(number, |head| head.max(number));
+        let min_number = head.saturating_sub(U256::from(BLOCKHASH_HISTORY));
+        state.block_hashes.retain(|cached, _| *cached >= min_number && *cached <= head);
+        if number >= min_number {
+            state.block_hashes.insert(number, hash);
+        }
     }
 
     fn invalidate(&mut self) {
@@ -728,9 +731,20 @@ mod tests {
     #[test]
     fn evm_block_hash_cache_is_bounded_across_block_number_jumps() {
         let mut db = StateRootDb::default();
-        for number in [0, 258, 516, 774] {
+        // Initialize the persistent historical-state cache as well as the live EVM cache.
+        db.current_state();
+
+        for number in [0, 516, 400] {
             db.insert_block_hash(U256::from(number), B256::from(U256::from(number)));
         }
+
+        // An out-of-order insertion within the active window must not discard the current head.
+        let block_hashes = &db.inner.inner.cache.block_hashes;
+        assert_eq!(block_hashes.len(), 2);
+        assert!(block_hashes.contains_key(&U256::from(400)));
+        assert!(block_hashes.contains_key(&U256::from(516)));
+
+        db.insert_block_hash(U256::from(774), B256::from(U256::from(774)));
 
         let block_hashes = &db.inner.inner.cache.block_hashes;
         assert_eq!(block_hashes.len(), 1);

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -2,9 +2,9 @@
 
 use crate::{
     eth::backend::db::{
-        Db, MaybeForkedDatabase, MaybeFullDatabase, SerializableAccountRecord, SerializableBlock,
-        SerializableHistoricalStates, SerializableState, SerializableTransaction, StateDb,
-        cache_block_hash, expired_block_hash,
+        BLOCKHASH_HISTORY, Db, MaybeForkedDatabase, MaybeFullDatabase, SerializableAccountRecord,
+        SerializableBlock, SerializableHistoricalStates, SerializableState,
+        SerializableTransaction, StateDb, cache_block_hash,
     },
     mem::state::{StateRootCache, state_root},
 };
@@ -73,9 +73,8 @@ impl HistoricalStateCache {
 
     fn record_block_hash(&mut self, number: U256, hash: B256) {
         let Some(state) = &mut self.state else { return };
-        if let Some(expired) = expired_block_hash(number) {
-            state.block_hashes.remove(&expired);
-        }
+        let min_number = number.saturating_sub(U256::from(BLOCKHASH_HISTORY));
+        state.block_hashes.retain(|cached, _| *cached >= min_number && *cached <= number);
         state.block_hashes.insert(number, hash);
     }
 
@@ -576,7 +575,6 @@ impl MaybeForkedDatabase for MemDb {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eth::backend::db::BLOCKHASH_HISTORY;
     use alloy_primitives::{Bytes, address};
     use revm::primitives::KECCAK_EMPTY;
     use std::collections::BTreeMap;
@@ -725,6 +723,22 @@ mod tests {
         assert!(block_hashes.contains_key(&U256::from(767)));
         assert!(block_hashes.contains_key(&U256::from(768)));
         assert!(block_hashes.contains_key(&U256::from(1_023)));
+    }
+
+    #[test]
+    fn evm_block_hash_cache_is_bounded_across_block_number_jumps() {
+        let mut db = StateRootDb::default();
+        for number in [0, 258, 516, 774] {
+            db.insert_block_hash(U256::from(number), B256::from(U256::from(number)));
+        }
+
+        let block_hashes = &db.inner.inner.cache.block_hashes;
+        assert_eq!(block_hashes.len(), 1);
+        assert!(block_hashes.contains_key(&U256::from(774)));
+
+        let historical = db.history.get_mut().state.as_ref().unwrap();
+        assert_eq!(historical.block_hashes.len(), 1);
+        assert!(historical.block_hashes.contains_key(&U256::from(774)));
     }
 
     #[test]

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -379,6 +379,11 @@ impl Db for StateRootDb {
         self.history.get_mut().record_block_hash(number, hash);
     }
 
+    fn set_block_hashes(&mut self, block_hashes: Vec<(U256, B256)>) {
+        Db::set_block_hashes(&mut self.inner, block_hashes);
+        self.history.get_mut().invalidate();
+    }
+
     fn dump_state(
         &self,
         at: BlockEnv,
@@ -465,6 +470,10 @@ impl Db for MemDb {
 
     fn insert_block_hash(&mut self, number: U256, hash: B256) {
         cache_block_hash(&mut self.inner.cache.block_hashes, number, hash);
+    }
+
+    fn set_block_hashes(&mut self, block_hashes: Vec<(U256, B256)>) {
+        self.inner.cache.block_hashes = block_hashes.into_iter().collect();
     }
 
     fn dump_state(

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4770,22 +4770,17 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         // BLOCKHASH opcode stays consistent after loading state. Reuses the hashes already
         // computed by `load_blocks` above. Only collect the last 256 blocks since that's all
         // BLOCKHASH can access.
-        let block_hashes: Vec<_> = {
+        let block_hashes = {
             let storage = self.blockchain.storage.read();
             let min_block = storage.best_number.saturating_sub(256);
             storage
                 .hashes
                 .iter()
-                .filter(|(num, _)| **num >= min_block)
-                .map(|(&num, &hash)| (num, hash))
+                .filter(|(num, _)| (min_block..=storage.best_number).contains(*num))
+                .map(|(&num, &hash)| (U256::from(num), hash))
                 .collect()
         };
-        {
-            let mut db = self.db.write().await;
-            for (block_num, hash) in block_hashes {
-                db.insert_block_hash(U256::from(block_num), hash);
-            }
-        }
+        self.db.write().await.set_block_hashes(block_hashes);
 
         if let Some(historical_states) = state.historical_states {
             self.states.write().load_states(historical_states);

--- a/crates/anvil/src/eth/backend/mem/state.rs
+++ b/crates/anvil/src/eth/backend/mem/state.rs
@@ -2,11 +2,151 @@
 
 use alloy_primitives::{
     B256, U256, keccak256,
-    map::{AddressMap, U256Map},
+    map::{AddressMap, B256Map, HashSet, U256Map},
 };
 use alloy_rlp::Encodable;
 use alloy_trie::{HashBuilder, Nibbles};
-use revm::{database::DbAccount, state::AccountInfo};
+use reth_trie_sparse::{LeafUpdate, RevealableSparseTrie, SparseStateTrie};
+use revm::{
+    database::DbAccount,
+    state::{Account, AccountInfo},
+};
+use std::mem;
+
+/// Incrementally maintains the state trie used for mined block headers.
+///
+/// The old state-root path rebuilt and sorted every account and storage trie after each block.
+/// That made EIP-2935's block-hash storage contract turn mining into linear work as its ring was
+/// populated. This cache keeps a fully revealed in-memory trie and only rehashes paths changed by
+/// the latest block.
+#[derive(Debug, Default)]
+pub struct StateRootCache {
+    trie: Option<SparseStateTrie>,
+    dirty: AddressMap<DirtyAccount>,
+}
+
+#[derive(Debug, Default)]
+struct DirtyAccount {
+    storage: HashSet<U256>,
+    reset_storage: bool,
+}
+
+impl StateRootCache {
+    /// Records changes that will be committed to the database.
+    pub fn record_changes(&mut self, changes: &AddressMap<Account>) {
+        for (address, account) in changes {
+            if !account.is_touched() {
+                continue;
+            }
+
+            let dirty = self.dirty.entry(*address).or_default();
+            dirty.reset_storage |= account.is_created() || account.is_selfdestructed();
+            dirty.storage.extend(account.changed_storage_slots().map(|(slot, _)| *slot));
+        }
+    }
+
+    /// Records an account-info change or a database load caused by `basic`.
+    pub fn record_account(&mut self, address: alloy_primitives::Address) {
+        self.dirty.entry(address).or_default();
+    }
+
+    /// Records a storage change or a database load caused by `storage`.
+    pub fn record_storage(&mut self, address: alloy_primitives::Address, slot: U256) {
+        self.dirty.entry(address).or_default().storage.insert(slot);
+    }
+
+    /// Invalidates the trie after wholesale database replacement or clearing.
+    pub fn invalidate(&mut self) {
+        self.trie = None;
+        self.dirty.clear();
+    }
+
+    /// Returns the current root, applying only changes recorded since the previous call.
+    pub fn root(&mut self, accounts: &AddressMap<DbAccount>) -> B256 {
+        if self.trie.is_none() {
+            self.trie = Some(build_sparse_state_trie(accounts));
+            self.dirty.clear();
+            return self.trie.as_mut().unwrap().root().expect("state trie is revealed");
+        }
+
+        let trie = self.trie.as_mut().unwrap();
+        for (address, dirty) in mem::take(&mut self.dirty) {
+            let hashed_address = keccak256(address);
+            let Some(account) = accounts.get(&address) else {
+                update_leaf(trie.trie_mut(), hashed_address, Vec::new());
+                continue;
+            };
+
+            let storage_trie = trie.get_or_create_storage_trie_mut(hashed_address);
+            let storage = if dirty.reset_storage {
+                storage_trie.wipe().expect("storage trie is revealed");
+                account.storage.iter().map(|(slot, value)| (*slot, *value)).collect::<Vec<_>>()
+            } else {
+                dirty
+                    .storage
+                    .into_iter()
+                    .map(|slot| (slot, account.storage.get(&slot).copied().unwrap_or_default()))
+                    .collect::<Vec<_>>()
+            };
+            update_storage_leaves(storage_trie, storage);
+            let storage_root = storage_trie.root().expect("storage trie is revealed");
+            update_leaf(
+                trie.trie_mut(),
+                hashed_address,
+                trie_account_rlp_with_storage_root(&account.info, storage_root),
+            );
+        }
+
+        trie.root().expect("state trie is revealed")
+    }
+}
+
+fn build_sparse_state_trie(accounts: &AddressMap<DbAccount>) -> SparseStateTrie {
+    let mut trie = SparseStateTrie::new();
+    trie.set_accounts_trie(RevealableSparseTrie::revealed_empty());
+    trie.set_default_storage_trie(RevealableSparseTrie::revealed_empty());
+
+    let mut account_leaves = B256Map::default();
+    for (address, account) in accounts {
+        let hashed_address = keccak256(address);
+        let storage_trie = trie.get_or_create_storage_trie_mut(hashed_address);
+        update_storage_leaves(
+            storage_trie,
+            account.storage.iter().map(|(slot, value)| (*slot, *value)),
+        );
+        let storage_root = storage_trie.root().expect("storage trie is revealed");
+        account_leaves.insert(
+            hashed_address,
+            LeafUpdate::Changed(trie_account_rlp_with_storage_root(&account.info, storage_root)),
+        );
+    }
+    update_leaves(trie.trie_mut(), &mut account_leaves);
+    trie
+}
+
+fn update_storage_leaves(
+    trie: &mut RevealableSparseTrie,
+    storage: impl IntoIterator<Item = (U256, U256)>,
+) {
+    let mut leaves = storage
+        .into_iter()
+        .map(|(slot, value)| {
+            (keccak256(slot.to_be_bytes::<32>()), LeafUpdate::Changed(alloy_rlp::encode(value)))
+        })
+        .collect();
+    update_leaves(trie, &mut leaves);
+}
+
+fn update_leaf(trie: &mut RevealableSparseTrie, key: B256, value: Vec<u8>) {
+    let mut leaves = B256Map::from_iter([(key, LeafUpdate::Changed(value))]);
+    update_leaves(trie, &mut leaves);
+}
+
+fn update_leaves(trie: &mut RevealableSparseTrie, leaves: &mut B256Map<LeafUpdate>) {
+    trie.update_leaves(leaves, |_, _| unreachable!("the complete trie is always revealed"))
+        .expect("state trie update succeeds");
+    debug_assert!(leaves.is_empty());
+}
 
 pub fn build_root(values: impl IntoIterator<Item = (Nibbles, Vec<u8>)>) -> B256 {
     let mut builder = HashBuilder::default();
@@ -56,9 +196,13 @@ pub fn trie_accounts(accounts: &AddressMap<DbAccount>) -> Vec<(Nibbles, Vec<u8>)
 
 /// Returns the RLP for this account.
 pub fn trie_account_rlp(info: &AccountInfo, storage: &U256Map<U256>) -> Vec<u8> {
+    trie_account_rlp_with_storage_root(info, storage_root(storage))
+}
+
+/// Returns the RLP for this account with an already computed storage root.
+fn trie_account_rlp_with_storage_root(info: &AccountInfo, storage_root: B256) -> Vec<u8> {
     let mut out: Vec<u8> = Vec::new();
-    let list: [&dyn Encodable; 4] =
-        [&info.nonce, &info.balance, &storage_root(storage), &info.code_hash];
+    let list: [&dyn Encodable; 4] = [&info.nonce, &info.balance, &storage_root, &info.code_hash];
 
     alloy_rlp::encode_list::<_, dyn Encodable>(&list, &mut out);
 

--- a/crates/anvil/src/eth/backend/mem/state.rs
+++ b/crates/anvil/src/eth/backend/mem/state.rs
@@ -5,8 +5,10 @@ use alloy_primitives::{
     map::{AddressMap, B256Map, HashSet, U256Map},
 };
 use alloy_rlp::Encodable;
-use alloy_trie::{HashBuilder, Nibbles};
-use reth_trie_sparse::{LeafUpdate, RevealableSparseTrie, SparseStateTrie};
+use alloy_trie::{
+    EMPTY_ROOT_HASH, HashBuilder, Nibbles, TrieMask,
+    nodes::{BranchNodeRef, ExtensionNodeRef, LeafNodeRef, RlpNode},
+};
 use revm::{
     database::DbAccount,
     state::{Account, AccountInfo},
@@ -17,11 +19,11 @@ use std::mem;
 ///
 /// The old state-root path rebuilt and sorted every account and storage trie after each block.
 /// That made EIP-2935's block-hash storage contract turn mining into linear work as its ring was
-/// populated. This cache keeps a fully revealed in-memory trie and only rehashes paths changed by
-/// the latest block.
+/// populated. This cache keeps an in-memory Merkle Patricia trie and only rehashes paths changed
+/// by the latest block.
 #[derive(Debug, Default)]
 pub struct StateRootCache {
-    trie: Option<SparseStateTrie>,
+    trie: Option<IncrementalStateTrie>,
     dirty: AddressMap<DirtyAccount>,
 }
 
@@ -64,88 +66,293 @@ impl StateRootCache {
     /// Returns the current root, applying only changes recorded since the previous call.
     pub fn root(&mut self, accounts: &AddressMap<DbAccount>) -> B256 {
         if self.trie.is_none() {
-            self.trie = Some(build_sparse_state_trie(accounts));
+            self.trie = Some(IncrementalStateTrie::from_accounts(accounts));
             self.dirty.clear();
-            return self.trie.as_mut().unwrap().root().expect("state trie is revealed");
+            return self.trie.as_mut().unwrap().root();
         }
 
         let trie = self.trie.as_mut().unwrap();
         for (address, dirty) in mem::take(&mut self.dirty) {
             let hashed_address = keccak256(address);
             let Some(account) = accounts.get(&address) else {
-                update_leaf(trie.trie_mut(), hashed_address, Vec::new());
+                trie.accounts.remove(hashed_address);
+                trie.storage.remove(&hashed_address);
                 continue;
             };
 
-            let storage_trie = trie.get_or_create_storage_trie_mut(hashed_address);
-            let storage = if dirty.reset_storage {
-                storage_trie.wipe().expect("storage trie is revealed");
-                account.storage.iter().map(|(slot, value)| (*slot, *value)).collect::<Vec<_>>()
+            let storage_trie = if dirty.reset_storage {
+                trie.storage
+                    .entry(hashed_address)
+                    .insert_entry(IncrementalTrie::from_storage(&account.storage))
+                    .into_mut()
             } else {
-                dirty
-                    .storage
-                    .into_iter()
-                    .map(|slot| (slot, account.storage.get(&slot).copied().unwrap_or_default()))
-                    .collect::<Vec<_>>()
+                let storage_trie = trie.storage.entry(hashed_address).or_default();
+                for slot in dirty.storage {
+                    let key = keccak256(slot.to_be_bytes::<32>());
+                    if let Some(value) = account.storage.get(&slot) {
+                        storage_trie.insert(key, alloy_rlp::encode(value));
+                    } else {
+                        storage_trie.remove(key);
+                    }
+                }
+                storage_trie
             };
-            update_storage_leaves(storage_trie, storage);
-            let storage_root = storage_trie.root().expect("storage trie is revealed");
-            update_leaf(
-                trie.trie_mut(),
+            let storage_root = storage_trie.root();
+            trie.accounts.insert(
                 hashed_address,
                 trie_account_rlp_with_storage_root(&account.info, storage_root),
             );
         }
 
-        trie.root().expect("state trie is revealed")
+        trie.root()
     }
 }
 
-fn build_sparse_state_trie(accounts: &AddressMap<DbAccount>) -> SparseStateTrie {
-    let mut trie = SparseStateTrie::new();
-    trie.set_accounts_trie(RevealableSparseTrie::revealed_empty());
-    trie.set_default_storage_trie(RevealableSparseTrie::revealed_empty());
+#[derive(Debug, Default)]
+struct IncrementalStateTrie {
+    accounts: IncrementalTrie,
+    storage: B256Map<IncrementalTrie>,
+}
 
-    let mut account_leaves = B256Map::default();
-    for (address, account) in accounts {
-        let hashed_address = keccak256(address);
-        let storage_trie = trie.get_or_create_storage_trie_mut(hashed_address);
-        update_storage_leaves(
-            storage_trie,
-            account.storage.iter().map(|(slot, value)| (*slot, *value)),
-        );
-        let storage_root = storage_trie.root().expect("storage trie is revealed");
-        account_leaves.insert(
-            hashed_address,
-            LeafUpdate::Changed(trie_account_rlp_with_storage_root(&account.info, storage_root)),
-        );
+impl IncrementalStateTrie {
+    fn from_accounts(accounts: &AddressMap<DbAccount>) -> Self {
+        let mut trie = Self::default();
+        for (address, account) in accounts {
+            let hashed_address = keccak256(address);
+            let mut storage_trie = IncrementalTrie::from_storage(&account.storage);
+            let storage_root = storage_trie.root();
+            trie.accounts.insert(
+                hashed_address,
+                trie_account_rlp_with_storage_root(&account.info, storage_root),
+            );
+            trie.storage.insert(hashed_address, storage_trie);
+        }
+        trie
     }
-    update_leaves(trie.trie_mut(), &mut account_leaves);
-    trie
+
+    fn root(&mut self) -> B256 {
+        self.accounts.root()
+    }
 }
 
-fn update_storage_leaves(
-    trie: &mut RevealableSparseTrie,
-    storage: impl IntoIterator<Item = (U256, U256)>,
-) {
-    let mut leaves = storage
-        .into_iter()
-        .map(|(slot, value)| {
-            (keccak256(slot.to_be_bytes::<32>()), LeafUpdate::Changed(alloy_rlp::encode(value)))
-        })
-        .collect();
-    update_leaves(trie, &mut leaves);
+/// A mutable Merkle Patricia trie that caches the RLP reference for every unchanged node.
+#[derive(Debug, Default)]
+struct IncrementalTrie {
+    root: TrieNode,
 }
 
-fn update_leaf(trie: &mut RevealableSparseTrie, key: B256, value: Vec<u8>) {
-    let mut leaves = B256Map::from_iter([(key, LeafUpdate::Changed(value))]);
-    update_leaves(trie, &mut leaves);
+impl IncrementalTrie {
+    fn from_storage(storage: &U256Map<U256>) -> Self {
+        let mut trie = Self::default();
+        for (slot, value) in storage {
+            trie.insert(keccak256(slot.to_be_bytes::<32>()), alloy_rlp::encode(value));
+        }
+        trie
+    }
+
+    fn insert(&mut self, key: B256, value: Vec<u8>) {
+        self.root.insert(Nibbles::unpack(key), value);
+    }
+
+    fn remove(&mut self, key: B256) {
+        self.root.remove(Nibbles::unpack(key));
+    }
+
+    fn root(&mut self) -> B256 {
+        let Some(root) = self.root.rlp() else { return EMPTY_ROOT_HASH };
+        root.as_hash().unwrap_or_else(|| keccak256(root.as_ref()))
+    }
 }
 
-fn update_leaves(trie: &mut RevealableSparseTrie, leaves: &mut B256Map<LeafUpdate>) {
-    trie.update_leaves(leaves, |_, _| unreachable!("the complete trie is always revealed"))
-        .expect("state trie update succeeds");
-    debug_assert!(leaves.is_empty());
+#[derive(Debug, Default)]
+struct TrieNode {
+    kind: TrieNodeKind,
+    rlp: Option<RlpNode>,
+}
+
+#[derive(Debug, Default)]
+enum TrieNodeKind {
+    #[default]
+    Empty,
+    Leaf {
+        path: Nibbles,
+        value: Vec<u8>,
+    },
+    Extension {
+        path: Nibbles,
+        child: Box<TrieNode>,
+    },
+    Branch {
+        children: [Option<Box<TrieNode>>; 16],
+    },
+}
+
+impl TrieNode {
+    const fn leaf(path: Nibbles, value: Vec<u8>) -> Self {
+        Self { kind: TrieNodeKind::Leaf { path, value }, rlp: None }
+    }
+
+    fn extension(path: Nibbles, child: Self) -> Self {
+        debug_assert!(!path.is_empty());
+        Self { kind: TrieNodeKind::Extension { path, child: Box::new(child) }, rlp: None }
+    }
+
+    const fn branch(children: [Option<Box<Self>>; 16]) -> Self {
+        Self { kind: TrieNodeKind::Branch { children }, rlp: None }
+    }
+
+    fn empty_children() -> [Option<Box<Self>>; 16] {
+        Default::default()
+    }
+
+    fn insert(&mut self, key: Nibbles, value: Vec<u8>) {
+        let kind = mem::take(&mut self.kind);
+        self.rlp = None;
+        *self = match kind {
+            TrieNodeKind::Empty => Self::leaf(key, value),
+            TrieNodeKind::Leaf { path, value: old_value } => {
+                let common = path.common_prefix_length(&key);
+                if common == path.len() {
+                    debug_assert_eq!(common, key.len());
+                    Self::leaf(path, value)
+                } else {
+                    let mut children = Self::empty_children();
+                    let old_index = path.get(common).unwrap() as usize;
+                    let new_index = key.get(common).unwrap() as usize;
+                    children[old_index] =
+                        Some(Box::new(Self::leaf(path.slice(common + 1..), old_value)));
+                    children[new_index] =
+                        Some(Box::new(Self::leaf(key.slice(common + 1..), value)));
+                    let branch = Self::branch(children);
+                    if common == 0 { branch } else { Self::extension(path.slice(..common), branch) }
+                }
+            }
+            TrieNodeKind::Extension { path, mut child } => {
+                let common = path.common_prefix_length(&key);
+                if common == path.len() {
+                    child.insert(key.slice(common..), value);
+                    Self::extension(path, *child)
+                } else {
+                    let mut children = Self::empty_children();
+                    let old_index = path.get(common).unwrap() as usize;
+                    let old_path = path.slice(common + 1..);
+                    let old_child = if old_path.is_empty() {
+                        *child
+                    } else {
+                        Self::extension(old_path, *child)
+                    };
+                    children[old_index] = Some(Box::new(old_child));
+
+                    let new_index = key.get(common).unwrap() as usize;
+                    children[new_index] =
+                        Some(Box::new(Self::leaf(key.slice(common + 1..), value)));
+                    let branch = Self::branch(children);
+                    if common == 0 { branch } else { Self::extension(path.slice(..common), branch) }
+                }
+            }
+            TrieNodeKind::Branch { mut children } => {
+                let index = key.first().expect("trie keys have equal lengths") as usize;
+                children[index]
+                    .get_or_insert_with(|| Box::new(Self::default()))
+                    .insert(key.slice(1..), value);
+                Self::branch(children)
+            }
+        };
+    }
+
+    fn remove(&mut self, key: Nibbles) {
+        let kind = mem::take(&mut self.kind);
+        self.rlp = None;
+        *self = match kind {
+            TrieNodeKind::Empty => Self::default(),
+            TrieNodeKind::Leaf { path, value } => {
+                if path == key {
+                    Self::default()
+                } else {
+                    Self::leaf(path, value)
+                }
+            }
+            TrieNodeKind::Extension { path, mut child } => {
+                if key.starts_with(&path) {
+                    child.remove(key.slice(path.len()..));
+                    Self::normalize_extension(path, *child)
+                } else {
+                    Self::extension(path, *child)
+                }
+            }
+            TrieNodeKind::Branch { mut children } => {
+                let index = key.first().expect("trie keys have equal lengths") as usize;
+                if let Some(child) = &mut children[index] {
+                    child.remove(key.slice(1..));
+                    if matches!(child.kind, TrieNodeKind::Empty) {
+                        children[index] = None;
+                    }
+                }
+                Self::normalize_branch(children)
+            }
+        };
+    }
+
+    fn normalize_extension(path: Nibbles, child: Self) -> Self {
+        match child.kind {
+            TrieNodeKind::Empty => Self::default(),
+            TrieNodeKind::Leaf { path: child_path, value } => {
+                Self::leaf(path.join(&child_path), value)
+            }
+            TrieNodeKind::Extension { path: child_path, child } => {
+                Self::extension(path.join(&child_path), *child)
+            }
+            TrieNodeKind::Branch { children } => Self::extension(path, Self::branch(children)),
+        }
+    }
+
+    fn normalize_branch(mut children: [Option<Box<Self>>; 16]) -> Self {
+        let mut indexes =
+            children.iter().enumerate().filter_map(|(index, child)| child.as_ref().map(|_| index));
+        let Some(index) = indexes.next() else { return Self::default() };
+        if indexes.next().is_some() {
+            return Self::branch(children);
+        }
+
+        let child = *children[index].take().unwrap();
+        let prefix = Nibbles::from_nibbles([index as u8]);
+        match child.kind {
+            TrieNodeKind::Empty => unreachable!("empty branch children are removed"),
+            TrieNodeKind::Leaf { path, value } => Self::leaf(prefix.join(&path), value),
+            TrieNodeKind::Extension { path, child } => Self::extension(prefix.join(&path), *child),
+            TrieNodeKind::Branch { children } => Self::extension(prefix, Self::branch(children)),
+        }
+    }
+
+    fn rlp(&mut self) -> Option<RlpNode> {
+        if let Some(rlp) = &self.rlp {
+            return Some(rlp.clone());
+        }
+
+        let rlp = match &mut self.kind {
+            TrieNodeKind::Empty => return None,
+            TrieNodeKind::Leaf { path, value } => {
+                LeafNodeRef::new(path, value).rlp(&mut Vec::new())
+            }
+            TrieNodeKind::Extension { path, child } => {
+                let child = child.rlp().expect("extension nodes have a child");
+                ExtensionNodeRef::new(path, child.as_ref()).rlp(&mut Vec::new())
+            }
+            TrieNodeKind::Branch { children } => {
+                let mut stack = Vec::new();
+                let mut state_mask = TrieMask::default();
+                for (index, child) in children.iter_mut().enumerate() {
+                    if let Some(child) = child {
+                        stack.push(child.rlp().expect("branch children are not empty"));
+                        state_mask.set_bit(index as u8);
+                    }
+                }
+                BranchNodeRef::new(&stack, state_mask).rlp(&mut Vec::new())
+            }
+        };
+        self.rlp = Some(rlp.clone());
+        Some(rlp)
+    }
 }
 
 pub fn build_root(values: impl IntoIterator<Item = (Nibbles, Vec<u8>)>) -> B256 {
@@ -207,4 +414,48 @@ fn trie_account_rlp_with_storage_root(info: &AccountInfo, storage_root: B256) ->
     alloy_rlp::encode_list::<_, dyn Encodable>(&list, &mut out);
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rebuilt_root(values: &B256Map<Vec<u8>>) -> B256 {
+        let mut leaves = values
+            .iter()
+            .map(|(key, value)| (Nibbles::unpack(*key), value.clone()))
+            .collect::<Vec<_>>();
+        leaves.sort_by_key(|(key, _)| *key);
+        build_root(leaves)
+    }
+
+    #[test]
+    fn incremental_trie_matches_full_rebuild() {
+        let mut trie = IncrementalTrie::default();
+        let mut values = B256Map::default();
+        assert_eq!(trie.root(), EMPTY_ROOT_HASH);
+
+        for index in 0..128 {
+            let key = keccak256(U256::from(index).to_be_bytes::<32>());
+            let value = alloy_rlp::encode(U256::from(index + 1));
+            trie.insert(key, value.clone());
+            values.insert(key, value);
+            assert_eq!(trie.root(), rebuilt_root(&values));
+        }
+
+        for index in (0..128).step_by(3) {
+            let key = keccak256(U256::from(index).to_be_bytes::<32>());
+            let value = alloy_rlp::encode(U256::from(index + 1_000));
+            trie.insert(key, value.clone());
+            values.insert(key, value);
+            assert_eq!(trie.root(), rebuilt_root(&values));
+        }
+
+        for index in (0..128).rev() {
+            let key = keccak256(U256::from(index).to_be_bytes::<32>());
+            trie.remove(key);
+            values.remove(&key);
+            assert_eq!(trie.root(), rebuilt_root(&values));
+        }
+    }
 }

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -51,7 +51,10 @@ const MAX_ON_DISK_HISTORY_LIMIT: usize = 3_600;
 pub struct InMemoryBlockStates {
     /// The states at a certain block
     states: B256HashMap<StateDb>,
-    /// states which data is moved to disk
+    /// Older states in the secondary history tier.
+    ///
+    /// Structurally shared states remain here directly; other database types move their data to
+    /// disk and keep an empty state object here for loading it.
     on_disk_states: B256HashMap<StateDb>,
     /// How many states to store at most
     in_memory_limit: usize,
@@ -122,9 +125,8 @@ impl InMemoryBlockStates {
     /// When the configured limit for the number of states that can be stored in memory is reached,
     /// the oldest state is removed.
     ///
-    /// Since we keep a snapshot of the entire state as history, the size of the state will increase
-    /// with the transactions processed. To counter this, we gradually decrease the cache limit with
-    /// the number of states/blocks until we reached the `min_limit`.
+    /// Database types without structural sharing gradually move snapshots to disk as the chain
+    /// grows. Structurally shared snapshots move into the secondary tier without serialization.
     ///
     /// When a state that was previously written to disk is requested, it is simply read from disk.
     pub fn insert(&mut self, hash: B256, state: StateDb) {
@@ -152,6 +154,12 @@ impl InMemoryBlockStates {
             {
                 // only write to disk if supported
                 if !self.is_memory_only() {
+                    if state.is_persistent() {
+                        self.on_disk_states.insert(hash, state);
+                        self.oldest_on_disk.push_back(hash);
+                        continue;
+                    }
+
                     let state_snapshot = state.0.clear_into_state_snapshot();
                     if self.disk_cache.write(hash, &state_snapshot) {
                         // Write succeeded, move state to on-disk tracking
@@ -173,8 +181,9 @@ impl InMemoryBlockStates {
         // enforce on disk limit and purge the oldest state cached on disk
         while !self.is_memory_only() && self.oldest_on_disk.len() >= self.max_on_disk_limit {
             // evict the oldest block
-            if let Some(hash) = self.oldest_on_disk.pop_front() {
-                self.on_disk_states.remove(&hash);
+            if let Some(hash) = self.oldest_on_disk.pop_front()
+                && self.on_disk_states.remove(&hash).is_some_and(|state| !state.is_persistent())
+            {
                 self.disk_cache.remove(hash);
             }
         }
@@ -187,9 +196,12 @@ impl InMemoryBlockStates {
 
     /// Returns on-disk state for the given `hash` if present
     pub fn get_on_disk_state(&mut self, hash: &B256) -> Option<&StateDb> {
-        if let Some(state) = self.on_disk_states.get_mut(hash)
-            && let Some(cached) = self.disk_cache.read(*hash)
-        {
+        if let Some(state) = self.on_disk_states.get_mut(hash) {
+            if state.is_persistent() {
+                return Some(state);
+            }
+
+            let cached = self.disk_cache.read(*hash)?;
             state.init_from_state_snapshot(cached);
             return Some(state);
         }
@@ -208,10 +220,12 @@ impl InMemoryBlockStates {
     /// Clears all entries
     pub fn clear(&mut self) {
         self.states.clear();
-        self.on_disk_states.clear();
         self.present.clear();
-        for on_disk in std::mem::take(&mut self.oldest_on_disk) {
-            self.disk_cache.remove(on_disk)
+        self.oldest_on_disk.clear();
+        for (hash, state) in std::mem::take(&mut self.on_disk_states) {
+            if !state.is_persistent() {
+                self.disk_cache.remove(hash);
+            }
         }
     }
 
@@ -222,8 +236,9 @@ impl InMemoryBlockStates {
     pub fn remove_block_states(&mut self, hashes: &[B256]) {
         for hash in hashes {
             self.states.remove(hash);
-            self.on_disk_states.remove(hash);
-            self.disk_cache.remove(*hash);
+            if self.on_disk_states.remove(hash).is_some_and(|state| !state.is_persistent()) {
+                self.disk_cache.remove(*hash);
+            }
         }
         self.present.retain(|h| !hashes.contains(h));
         self.oldest_on_disk.retain(|h| !hashes.contains(h));
@@ -239,8 +254,10 @@ impl InMemoryBlockStates {
             .collect::<Vec<_>>();
 
         // Get on-disk state snapshots
-        for hash in self.on_disk_states.keys() {
-            if let Some(state_snapshot) = self.disk_cache.read(*hash) {
+        for (hash, state) in &mut self.on_disk_states {
+            if state.is_persistent() {
+                states.push((*hash, state.serialize_state()));
+            } else if let Some(state_snapshot) = self.disk_cache.read(*hash) {
                 states.push((*hash, state_snapshot));
             }
         }
@@ -646,7 +663,7 @@ pub struct MinedTransactionReceipt<N: Network> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eth::backend::db::Db;
+    use crate::eth::backend::{db::Db, mem::in_memory_db::StateRootDb};
     use alloy_primitives::{Address, hex};
     use alloy_rlp::Decodable;
     use revm::{database::DatabaseRef, state::AccountInfo};
@@ -715,6 +732,29 @@ mod tests {
 
         let acc = loaded.basic_ref(addr).unwrap().unwrap();
         assert_eq!(acc.balance, U256::from(1337u64));
+    }
+
+    #[test]
+    fn persistent_states_do_not_use_disk_cache() {
+        let mut storage = InMemoryBlockStates::new(1, MAX_ON_DISK_HISTORY_LIMIT);
+        let one = B256::from(U256::from(1));
+        let two = B256::from(U256::from(2));
+        let address = Address::random();
+        let mut db = StateRootDb::default();
+
+        db.insert_account(address, AccountInfo::from_balance(U256::from(1)));
+        storage.insert(one, db.current_state());
+        db.set_balance(address, U256::from(2)).unwrap();
+        storage.insert(two, db.current_state());
+
+        assert!(storage.disk_cache.temp_dir.is_none());
+        assert!(storage.on_disk_states.get(&one).unwrap().is_persistent());
+        assert_eq!(
+            storage.get_on_disk_state(&one).unwrap().basic_ref(address).unwrap().unwrap().balance,
+            U256::from(1)
+        );
+        storage.remove_block_states(&[one]);
+        assert!(storage.disk_cache.temp_dir.is_none());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -898,3 +898,42 @@ async fn blockhash_opcode_consistent_after_load_state() {
 
     assert_eq!(B256::from_slice(res.as_ref()), block1_hash);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blockhash_opcode_consistent_after_loading_older_state() {
+    let (source_api, _source_handle) =
+        spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000_000_u64))).await;
+    source_api.mine_one().await;
+    source_api.mine_one().await;
+
+    let block1_hash = source_api
+        .block_by_number(alloy_eips::BlockNumberOrTag::Number(1))
+        .await
+        .unwrap()
+        .unwrap()
+        .header
+        .hash;
+    let state = source_api.serialized_state(false).await.unwrap();
+
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    api.anvil_mine(Some(U256::from(258)), None).await.unwrap();
+    api.anvil_load_state(Bytes::from(serde_json::to_vec(&state).unwrap())).await.unwrap();
+
+    assert_eq!(api.block_number().unwrap(), U256::from(2));
+
+    // Runtime code returning BLOCKHASH(1):
+    // PUSH1 1, BLOCKHASH, PUSH1 0, MSTORE, PUSH1 32, PUSH1 0, RETURN
+    let code = Bytes::from_str("0x60014060005260206000f3").unwrap();
+    let target = address!("00000000000000000000000000000000000b10c4");
+
+    let mut overrides = StateOverride::default();
+    overrides.insert(target, AccountOverride { code: Some(code), ..Default::default() });
+
+    let tx = TransactionRequest::default().with_to(target);
+    let res = api
+        .call(WithOtherFields::new(tx), None, EvmOverrides::new(Some(overrides), None))
+        .await
+        .unwrap();
+
+    assert_eq!(B256::from_slice(res.as_ref()), block1_hash);
+}


### PR DESCRIPTION
Anvil rebuilt and sorted the complete account and storage tries for every mined block, while historical state retention cloned and eventually serialized the entire accumulated state; EIP-2935 made both paths progressively more expensive as its history contract filled. This change maintains the state root from dirty paths with a local mutable Merkle Patricia trie built on Alloy's canonical node encoders, without adding a Reth dependency; it also stores historical states as structurally shared snapshots and bounds the EVM block-hash cache to the current hash plus its 256-block window, preserving historical calls, dump/load, and reorg behavior without chain-height-dependent work. Codex was used for investigation, implementation, testing, and this PR description; AI-generated responses may also be used during review.

### Results

| 2,500 transaction-bearing blocks | master | this PR | change |
| --- | ---: | ---: | ---: |
| Total wall time | 3.857s | 0.826s | 4.67x faster |
| First 100 throughput | 2,479 blocks/s | 2,340 blocks/s | comparable |
| Last 100 throughput | 385 blocks/s | 3,153 blocks/s | 8.19x faster |
