### PR TITLE
fix(ci): make Tempo devnet checks toggleable

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -69,6 +69,14 @@ jobs:
         env:
           TEMPO_MAINNET_RPC_URL: ${{ secrets.TEMPO_MAINNET_RPC_URL }}
           TEMPO_TESTNET_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
+        run: |
+          cargo test --locked -p foundry-common --lib tempo::tests::test_fork_schedule_parses_configured_rpcs -- --exact --nocapture
+
+      - name: Check Tempo devnet fork schedule compatibility
+        if: |
+          github.event.inputs.network == 'devnet' ||
+          github.event.inputs.network == 'all'
+        env:
           TEMPO_DEVNET_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
         run: |
           cargo test --locked -p foundry-common --lib tempo::tests::test_fork_schedule_parses_configured_rpcs -- --exact --nocapture
@@ -110,8 +118,6 @@ jobs:
 
       - name: Run Tempo check on devnet
         if: |
-          github.event_name == 'push' ||
-          github.event_name == 'pull_request' ||
           github.event.inputs.network == 'devnet' ||
           github.event.inputs.network == 'all'
         env:
@@ -127,8 +133,6 @@ jobs:
 
       - name: Run Tempo wallet tests on devnet
         if: |
-          github.event_name == 'push' ||
-          github.event_name == 'pull_request' ||
           github.event.inputs.network == 'devnet' ||
           github.event.inputs.network == 'all'
         env:

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -69,15 +69,7 @@ jobs:
         env:
           TEMPO_MAINNET_RPC_URL: ${{ secrets.TEMPO_MAINNET_RPC_URL }}
           TEMPO_TESTNET_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
-        run: |
-          cargo test --locked -p foundry-common --lib tempo::tests::test_fork_schedule_parses_configured_rpcs -- --exact --nocapture
-
-      - name: Check Tempo devnet fork schedule compatibility
-        if: |
-          github.event.inputs.network == 'devnet' ||
-          github.event.inputs.network == 'all'
-        env:
-          TEMPO_DEVNET_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
+          TEMPO_DEVNET_RPC_URL: ${{ vars.TEMPO_DEVNET_CI != 'false' && secrets.TEMPO_DEVNET_RPC_URL || '' }}
         run: |
           cargo test --locked -p foundry-common --lib tempo::tests::test_fork_schedule_parses_configured_rpcs -- --exact --nocapture
 
@@ -117,9 +109,7 @@ jobs:
           fi
 
       - name: Run Tempo check on devnet
-        if: |
-          github.event.inputs.network == 'devnet' ||
-          github.event.inputs.network == 'all'
+        if: vars.TEMPO_DEVNET_CI != 'false' && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event.inputs.network == 'devnet' || github.event.inputs.network == 'all')
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
           SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
@@ -132,9 +122,7 @@ jobs:
           fi
 
       - name: Run Tempo wallet tests on devnet
-        if: |
-          github.event.inputs.network == 'devnet' ||
-          github.event.inputs.network == 'all'
+        if: vars.TEMPO_DEVNET_CI != 'false' && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event.inputs.network == 'devnet' || github.event.inputs.network == 'all')
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
         run: ./.github/scripts/tempo-wallet.sh


### PR DESCRIPTION
## Summary
- keep Tempo devnet CI enabled by default
- allow maintainers to disable devnet-dependent checks by setting the `TEMPO_DEVNET_CI` repository variable to `false`
- preserve manual and automatic devnet test coverage whenever the toggle is enabled

## Motivation
The Tempo devnet RPC began returning `-32002: no healthy upstreams available` on July 12 at 19:05 UTC, making unrelated Foundry PRs fail. The previous successful run started at 13:58 UTC. This provides an incident toggle without requiring another code change or permanently disabling coverage.

## Validation
- `git diff --check`
- verified the final PR diff contains only the three workflow condition changes

Prompted by: @DaniPopes