### PR TITLE
feat: support Tempo T8 CurrentCommittee

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1247,7 +1247,9 @@ impl NodeConfig {
             genesis_init: self.genesis.clone(),
         };
 
-        let mut decoder_builder = CallTraceDecoderBuilder::new();
+        let mut decoder_builder = CallTraceDecoderBuilder::new().with_tempo_hardfork(
+            self.networks.is_tempo().then(|| TempoHardfork::from(self.get_hardfork())),
+        );
         if self.print_traces {
             // if traces should get printed we configure the decoder with the signatures cache
             if let Ok(identifier) = SignaturesIdentifier::new(false) {

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -28,7 +28,7 @@ use alloy_rpc_types::{BlockId, BlockNumberOrTag, TransactionRequest, anvil::Fork
 use alloy_serde::WithOtherFields;
 use alloy_signer::Signer;
 use alloy_signer_local::PrivateKeySigner;
-use alloy_sol_types::{SolEvent, SolValue, sol};
+use alloy_sol_types::{SolError, SolEvent, SolValue, sol};
 use anvil::{NodeConfig, spawn};
 use anvil_core::eth::block::Block;
 use foundry_evm::core::tempo::{
@@ -46,6 +46,7 @@ use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, DEFAULT_FEE_TOKEN,
     RECEIVE_POLICY_GUARD_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
     TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    current_committee::{CURRENT_COMMITTEE_ADDRESS, ICurrentCommittee},
     receive_policy_guard::{IReceivePolicyGuard, InboundKind},
     tip403_registry::{ALLOW_ALL_POLICY_ID, ITIP403Registry, REJECT_ALL_POLICY_ID},
 };
@@ -665,6 +666,41 @@ async fn test_tempo_config_filters_hardfork_gated_precompiles() {
         config_t6.current.precompiles.get("ReceivePolicyGuard"),
         Some(&RECEIVE_POLICY_GUARD_ADDRESS)
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_t8_current_committee_activation_and_empty_genesis() {
+    let (api_t7, handle_t7) =
+        spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T7.into()))).await;
+    assert!(api_t7.get_code(CURRENT_COMMITTEE_ADDRESS, None).await.unwrap().is_empty());
+    assert!(!api_t7.config().unwrap().current.precompiles.contains_key("CurrentCommittee"));
+    let committee_t7 = ICurrentCommittee::new(CURRENT_COMMITTEE_ADDRESS, handle_t7.http_provider());
+    assert!(committee_t7.getCommitteeMembers().call().await.is_err());
+
+    let (api_t8, handle_t8) =
+        spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T8.into()))).await;
+    assert!(!api_t8.get_code(CURRENT_COMMITTEE_ADDRESS, None).await.unwrap().is_empty());
+    assert_eq!(
+        api_t8.config().unwrap().current.precompiles.get("CurrentCommittee"),
+        Some(&CURRENT_COMMITTEE_ADDRESS)
+    );
+
+    let provider = handle_t8.http_provider();
+    let committee = ICurrentCommittee::new(CURRENT_COMMITTEE_ADDRESS, &provider);
+    let members = committee.getCommitteeMembers().call().await.unwrap();
+    assert_eq!(members.epoch, 0);
+    assert!(members.publicKeys.is_empty());
+
+    let caller = handle_t8.dev_accounts().next().unwrap();
+    let err = committee
+        .setCommitteeMembers(1, vec![B256::repeat_byte(0x11)])
+        .from(caller)
+        .call()
+        .await
+        .unwrap_err();
+    let unauthorized =
+        alloy_primitives::hex::encode_prefixed(ICurrentCommittee::Unauthorized::SELECTOR);
+    assert!(err.to_string().contains(&unauthorized), "{err}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -41,10 +41,10 @@ use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
     core::{
         FoundryBlock as _,
-        evm::{EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
+        evm::{EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor},
     },
     executors::{EvmError, Executor, TracingExecutor},
-    hardforks::FoundryHardfork,
+    hardforks::{ExecutionSpec, FoundryHardfork},
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
 };
@@ -282,7 +282,10 @@ impl RunArgs {
                 false,
                 disable_labels,
                 self.trace_depth,
-                None,
+                config.hardfork.and_then(|hardfork| match hardfork {
+                    FoundryHardfork::Tempo(hardfork) => Some(hardfork),
+                    _ => None,
+                }),
             )
             .await?;
 
@@ -315,7 +318,13 @@ impl RunArgs {
         )?;
 
         let mut evm_version = self.evm_version;
-        let mut resolved_tempo_hardfork = chain.is_tempo().then(|| config.evm_spec_id());
+        let mut resolved_tempo_hardfork = config
+            .hardfork
+            .and_then(|hardfork| match hardfork {
+                FoundryHardfork::Tempo(hardfork) => Some(hardfork),
+                _ => None,
+            })
+            .or_else(|| (networks.is_tempo() || chain.is_tempo()).then(|| config.evm_spec_id()));
 
         evm_env.cfg_env.disable_block_gas_limit = self.disable_block_gas_limit;
 
@@ -327,16 +336,21 @@ impl RunArgs {
 
         evm_env.cfg_env.limit_contract_code_size = None;
         evm_env.block_env.set_number(U256::from(tx_block_number));
+        let configured_spec =
+            config.hardfork.and_then(<SpecFor<FEN> as ExecutionSpec>::from_foundry_hardfork);
+        if let Some(spec) = configured_spec {
+            evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec);
+        }
 
         let mut parent_beacon_block_root = None;
         if let Some(block) = &block {
             evm_env.block_env = block_env_from_header(block.header());
             parent_beacon_block_root = block.header().parent_beacon_block_root();
 
-            // Resolve the correct spec for the block using the same approach as reth: walk
-            // known chain activation conditions to find the latest active fork. Falls back
-            // to a blob-gas heuristic for unknown chains.
-            if evm_version.is_none() {
+            // Unless explicitly configured, resolve the correct spec for the block using the same
+            // approach as reth: walk known chain activation conditions to find the latest active
+            // fork. Falls back to a blob-gas heuristic for unknown chains.
+            if evm_version.is_none() && configured_spec.is_none() {
                 if let Some(hardfork) = FoundryHardfork::from_chain_and_timestamp(
                     evm_env.cfg_env.chain_id,
                     block.header().timestamp(),

--- a/crates/cast/src/debug.rs
+++ b/crates/cast/src/debug.rs
@@ -57,12 +57,13 @@ pub(crate) async fn handle_traces(
         None
     });
     let config_labels = config.labels.clone().into_iter();
+    let is_tempo = tempo_hardfork.is_some() || chain.is_tempo();
 
     let mut builder = CallTraceDecoderBuilder::new()
         .with_labels(labels.chain(config_labels))
         .with_signature_identifier(SignaturesIdentifier::from_config(config)?)
         .with_label_disabled(disable_label)
-        .with_chain_id(Some(chain.id()))
+        .with_chain_id((!is_tempo).then(|| chain.id()))
         .with_tempo_hardfork(
             tempo_hardfork
                 .or_else(|| chain.is_tempo().then(|| config.evm_spec_id::<TempoHardfork>())),

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -10,7 +10,8 @@ use anvil::NodeConfig;
 use foundry_evm::core::tempo::PATH_USD_ADDRESS;
 use foundry_test_utils::util::OutputExt;
 use tempo_contracts::precompiles::{
-    IReceivePolicyGuard, ITIP20, ITIP403Registry, TIP403_REGISTRY_ADDRESS,
+    CURRENT_COMMITTEE_ADDRESS, ICurrentCommittee, IReceivePolicyGuard, ITIP20, ITIP403Registry,
+    TIP403_REGISTRY_ADDRESS,
 };
 use tempo_hardfork::TempoHardfork;
 
@@ -665,6 +666,73 @@ casttest!(storage_credits_require_t7, async |_prj, cmd| {
         .get_output()
         .stderr_lossy();
     assert!(set_budget_err.contains(expected), "{set_budget_err}");
+});
+
+casttest!(current_committee_cast_run_decoding, async |_prj, cmd| {
+    let (_, handle) =
+        anvil::spawn(NodeConfig::test_tempo().with_hardfork(Some(TempoHardfork::T8.into()))).await;
+    let provider = handle.http_provider();
+    let caller = handle.dev_accounts().next().unwrap();
+    let committee = ICurrentCommittee::new(CURRENT_COMMITTEE_ADDRESS, &provider);
+    let public_key = B256::repeat_byte(0x11);
+
+    let getter = TransactionRequest::default()
+        .from(caller)
+        .to(CURRENT_COMMITTEE_ADDRESS)
+        .with_input(committee.getCommitteeMembers().calldata().clone())
+        .with_gas_limit(1_000_000);
+    let getter_receipt = provider
+        .send_transaction(WithOtherFields::new(getter))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(getter_receipt.status());
+
+    cmd.cast_fuse();
+    cmd.env("FOUNDRY_HARDFORK", "tempo:T8");
+    let getter_stdout = cmd
+        .args([
+            "run",
+            &getter_receipt.transaction_hash.to_string(),
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(getter_stdout.contains("CurrentCommittee::getCommitteeMembers()"), "{getter_stdout}");
+    assert!(getter_stdout.contains("← [Return] 0, []"), "{getter_stdout}");
+
+    let setter = TransactionRequest::default()
+        .from(caller)
+        .to(CURRENT_COMMITTEE_ADDRESS)
+        .with_input(committee.setCommitteeMembers(1, vec![public_key]).calldata().clone())
+        .with_gas_limit(1_000_000);
+    let setter_receipt = provider
+        .send_transaction(WithOtherFields::new(setter))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    assert!(!setter_receipt.status());
+
+    cmd.cast_fuse();
+    cmd.env("FOUNDRY_HARDFORK", "tempo:T8");
+    let setter_stdout = cmd
+        .args([
+            "run",
+            &setter_receipt.transaction_hash.to_string(),
+            "--rpc-url",
+            &handle.http_endpoint(),
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(setter_stdout.contains("CurrentCommittee::setCommitteeMembers(1"), "{setter_stdout}");
+    assert!(setter_stdout.contains("← [Revert] Unauthorized()"), "{setter_stdout}");
 });
 
 casttest!(tip20_logo_create_help_includes_logo_uri, |_prj, cmd| {

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -17,11 +17,11 @@ use foundry_evm_hardforks::{FoundryHardfork, TempoHardfork};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use tempo_contracts::precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, NONCE_PRECOMPILE_ADDRESS,
-    RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS,
-    STORAGE_CREDITS_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS,
-    TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
-    VALIDATOR_CONFIG_V2_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, CURRENT_COMMITTEE_ADDRESS,
+    NONCE_PRECOMPILE_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS,
+    STABLECOIN_DEX_ADDRESS, STORAGE_CREDITS_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
 
 pub mod arbitrum;
@@ -44,6 +44,7 @@ const TEMPO_PRECOMPILES: &[(&str, Address)] = &[
     ("TIP20ChannelReserve", TIP20_CHANNEL_RESERVE_ADDRESS),
     ("ReceivePolicyGuard", RECEIVE_POLICY_GUARD_ADDRESS),
     ("StorageCredits", STORAGE_CREDITS_ADDRESS),
+    ("CurrentCommittee", CURRENT_COMMITTEE_ADDRESS),
 ];
 
 /// All well-known Tempo precompile addresses.
@@ -61,11 +62,14 @@ pub const TEMPO_PRECOMPILE_ADDRESSES: &[Address] = &[
     TIP20_CHANNEL_RESERVE_ADDRESS,
     RECEIVE_POLICY_GUARD_ADDRESS,
     STORAGE_CREDITS_ADDRESS,
+    CURRENT_COMMITTEE_ADDRESS,
 ];
 
 /// Returns whether a well-known Tempo precompile address is active at `hardfork`.
 pub fn is_tempo_precompile_active_at(address: Address, hardfork: TempoHardfork) -> bool {
-    if address == TIP20_CHANNEL_RESERVE_ADDRESS {
+    if address == CURRENT_COMMITTEE_ADDRESS {
+        hardfork.is_t8()
+    } else if address == TIP20_CHANNEL_RESERVE_ADDRESS {
         hardfork.is_t5()
     } else if address == RECEIVE_POLICY_GUARD_ADDRESS {
         hardfork.is_t6()
@@ -449,6 +453,17 @@ mod tests {
         let cfg = NetworkConfigs { network: Some(NetworkVariant::Tempo), ..Default::default() };
         assert!(!cfg.precompiles(Some(TempoHardfork::T6)).contains_key("StorageCredits"));
         assert!(cfg.precompiles(Some(TempoHardfork::T7)).contains_key("StorageCredits"));
+    }
+
+    #[test]
+    fn current_committee_precompile_activates_at_t8() {
+        assert!(!is_tempo_precompile_active_at(CURRENT_COMMITTEE_ADDRESS, TempoHardfork::T7));
+        assert!(is_tempo_precompile_active_at(CURRENT_COMMITTEE_ADDRESS, TempoHardfork::T8));
+        assert!(TEMPO_PRECOMPILE_ADDRESSES.contains(&CURRENT_COMMITTEE_ADDRESS));
+
+        let cfg = NetworkConfigs { network: Some(NetworkVariant::Tempo), ..Default::default() };
+        assert!(!cfg.precompiles(Some(TempoHardfork::T7)).contains_key("CurrentCommittee"));
+        assert!(cfg.precompiles(Some(TempoHardfork::T8)).contains_key("CurrentCommittee"));
     }
 
     // --- resolved() / active_network_name ---

--- a/crates/evm/traces/src/decoder/mod.rs
+++ b/crates/evm/traces/src/decoder/mod.rs
@@ -31,9 +31,9 @@ use revm_inspectors::tracing::types::{DecodedCallLog, DecodedCallTrace};
 
 use std::{collections::BTreeMap, sync::OnceLock};
 use tempo_contracts::precompiles::{
-    IAccountKeychain, IAddressRegistry, IFeeManager, IReceivePolicyGuard, ISignatureVerifier,
-    IStablecoinDEX, IStorageCredits, ITIP20ChannelReserve, ITIP20Factory, ITIP403Registry,
-    IValidatorConfig,
+    CURRENT_COMMITTEE_ADDRESS, IAccountKeychain, IAddressRegistry, ICurrentCommittee, IFeeManager,
+    IReceivePolicyGuard, ISignatureVerifier, IStablecoinDEX, IStorageCredits, ITIP20ChannelReserve,
+    ITIP20Factory, ITIP403Registry, IValidatorConfig,
 };
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
@@ -443,11 +443,32 @@ impl CallTraceDecoder {
     }
 
     fn functions_for_selector(&self, address: Address, selector: &Selector) -> Option<&[Function]> {
+        if self.is_current_committee_active(address) {
+            static FUNCTIONS: OnceLock<HashMap<Selector, Vec<Function>>> = OnceLock::new();
+            if let Some(functions) = FUNCTIONS
+                .get_or_init(|| {
+                    ICurrentCommittee::abi::functions()
+                        .into_values()
+                        .flatten()
+                        .map(|function| (function.selector(), vec![function]))
+                        .collect()
+                })
+                .get(selector)
+            {
+                return Some(functions);
+            }
+        }
         self.functions_by_address
             .get(&address)
             .and_then(|functions| functions.get(selector))
             .or_else(|| self.functions.get(selector))
             .map(Vec::as_slice)
+    }
+
+    fn is_current_committee_active(&self, address: Address) -> bool {
+        address == CURRENT_COMMITTEE_ADDRESS
+            && self.tempo_hardfork.is_some_and(|hardfork| hardfork.is_t8())
+            && precompiles::is_known_precompile(address, self.chain_id, self.tempo_hardfork)
     }
 
     /// Selects the appropriate function from a list of functions with the same selector by
@@ -619,8 +640,15 @@ impl CallTraceDecoder {
 
     /// Decodes a call trace.
     pub async fn decode_function(&self, trace: &CallTrace) -> DecodedCallTrace {
-        let label =
-            if self.disable_labels { None } else { self.labels.get(&trace.address).cloned() };
+        let label = if self.disable_labels {
+            None
+        } else if let Some(label) = self.labels.get(&trace.address) {
+            Some(label.clone())
+        } else if self.is_current_committee_active(trace.address) {
+            Some("CurrentCommittee".to_string())
+        } else {
+            None
+        };
 
         if trace.kind.is_any_create() {
             return DecodedCallTrace {
@@ -667,7 +695,8 @@ impl CallTraceDecoder {
                 let return_data = if trace.success {
                     None
                 } else {
-                    let revert_msg = self.decode_revert(&trace.output, trace.status).await;
+                    let revert_msg =
+                        self.decode_revert_at(trace.address, &trace.output, trace.status).await;
 
                     if trace.output.is_empty() || revert_msg.contains("EvmError: Revert") {
                         Some(format!(
@@ -998,7 +1027,7 @@ impl CallTraceDecoder {
         if trace.status.is_none_or(|s| s.is_ok()) || trace.success {
             return None;
         }
-        Some(self.decode_revert(&trace.output, trace.status).await)
+        Some(self.decode_revert_at(trace.address, &trace.output, trace.status).await)
     }
 
     /// Decodes revert data into a human-readable representation.
@@ -1019,6 +1048,23 @@ impl CallTraceDecoder {
             return format!("{}({})", error.name, decoded.iter().map(format_token).format(", "));
         }
         self.revert_decoder.decode(output, status)
+    }
+
+    async fn decode_revert_at(
+        &self,
+        address: Address,
+        output: &[u8],
+        status: Option<InstructionResult>,
+    ) -> String {
+        if self.is_current_committee_active(address) {
+            static DECODER: OnceLock<RevertDecoder> = OnceLock::new();
+            let decoder = DECODER
+                .get_or_init(|| RevertDecoder::new().with_abi(&ICurrentCommittee::abi::contract()));
+            if let Some(reason) = decoder.maybe_decode_known(output) {
+                return reason;
+            }
+        }
+        self.decode_revert(output, status).await
     }
 
     /// Decodes an event.
@@ -2189,6 +2235,77 @@ mod tests {
             Some(&"ReceivePolicyGuard".to_string())
         );
         assert_eq!(t7_labels.get(&STORAGE_CREDITS_ADDRESS), Some(&"StorageCredits".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_current_committee_decoding_is_durable_and_context_gated() {
+        let abi = ICurrentCommittee::abi::contract();
+        let function = abi.functions.get("getCommitteeMembers").unwrap().first().unwrap();
+        let output = function
+            .abi_encode_output(&[
+                DynSolValue::Uint(U256::from(7), 64),
+                DynSolValue::Array(vec![DynSolValue::FixedBytes(B256::with_last_byte(1), 32)]),
+            ])
+            .unwrap();
+        let trace = CallTrace {
+            address: CURRENT_COMMITTEE_ADDRESS,
+            data: function.selector().to_vec().into(),
+            output: output.into(),
+            success: true,
+            ..Default::default()
+        };
+
+        let mut decoder = CallTraceDecoderBuilder::new()
+            .with_chain_id(Some(4217))
+            .with_tempo_hardfork(Some(TempoHardfork::T8))
+            .build();
+        decoder.clear_addresses();
+        let decoded = decoder.decode_function(&trace).await;
+        assert_eq!(decoded.label.as_deref(), Some("CurrentCommittee"));
+        assert_eq!(decoded.call_data.unwrap().signature, "getCommitteeMembers()");
+        assert_eq!(
+            decoded.return_data.unwrap(),
+            "7, [0x0000000000000000000000000000000000000000000000000000000000000001]"
+        );
+
+        for decoder in [
+            CallTraceDecoderBuilder::new()
+                .with_chain_id(Some(4217))
+                .with_tempo_hardfork(Some(TempoHardfork::T7))
+                .build(),
+            CallTraceDecoderBuilder::new()
+                .with_chain_id(Some(1))
+                .with_tempo_hardfork(Some(TempoHardfork::T8))
+                .build(),
+        ] {
+            let decoded = decoder.decode_function(&trace).await;
+            assert_ne!(decoded.label.as_deref(), Some("CurrentCommittee"));
+            assert!(decoded.call_data.is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_current_committee_unauthorized_is_address_scoped() {
+        let output = ICurrentCommittee::Unauthorized {}.abi_encode();
+        let trace = CallTrace {
+            address: CURRENT_COMMITTEE_ADDRESS,
+            output: output.clone().into(),
+            success: false,
+            status: Some(InstructionResult::Revert),
+            ..Default::default()
+        };
+        let decoder = CallTraceDecoderBuilder::new()
+            .with_chain_id(Some(4217))
+            .with_tempo_hardfork(Some(TempoHardfork::T8))
+            .build();
+        assert_eq!(
+            decoder.decode_function(&trace).await.return_data.as_deref(),
+            Some("Unauthorized()")
+        );
+
+        let unrelated = CallTrace { address: Address::ZERO, ..trace };
+        let baseline = CallTraceDecoder::new().decode_function(&unrelated).await;
+        assert_eq!(decoder.decode_function(&unrelated).await.return_data, baseline.return_data);
     }
 
     #[test]

--- a/crates/forge/tests/cli/precompiles.rs
+++ b/crates/forge/tests/cli/precompiles.rs
@@ -424,6 +424,63 @@ contract TempoT6KeychainHelpersTest is Test {
     assert!(stdout.contains("ReceivePolicyGuard::balanceOf"), "{stdout}");
 });
 
+forgetest_init!(tempo_t8_current_committee_decoding, |prj, cmd| {
+    prj.update_config(|config| {
+        config.networks = NetworkConfigs::with_tempo();
+        config.hardfork = Some("tempo:T8".parse::<foundry_config::FoundryHardfork>().unwrap());
+    });
+
+    prj.add_test(
+        "TempoT8CurrentCommittee.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+
+interface ICurrentCommittee {
+    error Unauthorized();
+
+    function getCommitteeMembers()
+        external
+        view
+        returns (uint64 epoch, bytes32[] memory publicKeys);
+
+    function setCommitteeMembers(uint64 epoch, bytes32[] calldata publicKeys) external;
+}
+
+contract TempoT8CurrentCommitteeTest is Test {
+    ICurrentCommittee constant committee =
+        ICurrentCommittee(0xC077e00000000000000000000000000000000000);
+
+    function test_get_current_committee() public view {
+        (uint64 epoch, bytes32[] memory publicKeys) = committee.getCommitteeMembers();
+        assertEq(epoch, 0);
+        assertEq(publicKeys.length, 0);
+    }
+
+    function test_set_current_committee_is_system_only() public {
+        bytes32[] memory publicKeys = new bytes32[](1);
+        publicKeys[0] = bytes32(uint256(0x11));
+
+        vm.expectRevert(ICurrentCommittee.Unauthorized.selector);
+        committee.setCommitteeMembers(1, publicKeys);
+    }
+}
+   "#,
+    );
+
+    let stdout = cmd
+        .args(["test", "--mc", "TempoT8CurrentCommitteeTest", "-vvvv"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(stdout.contains("CurrentCommittee::getCommitteeMembers"), "{stdout}");
+    assert!(stdout.contains("← [Return] 0, []"), "{stdout}");
+    assert!(stdout.contains("CurrentCommittee::setCommitteeMembers(1"), "{stdout}");
+    assert!(stdout.contains("← [Revert] Unauthorized()"), "{stdout}");
+});
+
 // tests transfer using celo precompile.
 // <https://github.com/foundry-rs/foundry/issues/11622>
 forgetest_init!(celo_transfer, |prj, cmd| {


### PR DESCRIPTION
Adds T8-gated CurrentCommittee support to Tempo initialization, fork warming, and trace decoding across Forge, Anvil, and Cast.

Closes OSS-530