### PR TITLE
feat(bench): add regression thresholds

### DIFF
--- a/.github/benchmark-regression-thresholds.json
+++ b/.github/benchmark-regression-thresholds.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "kind": "foundry-nightly-benchmark-thresholds",
+  "calibration": {
+    "status": "provisional",
+    "snapshot": "Six retained same-run stable/nightly artifacts from 2026-07-08 through 2026-07-13."
+  },
+  "benchmarks": {
+    "forge_build_no_cache/aave-aave-v4": {"warning_percent": 1, "regression_percent": 2, "alert": true},
+    "forge_build_with_cache/aave-aave-v4": {"warning_percent": 5, "regression_percent": 10, "alert": true},
+    "forge_test/aave-aave-v4": {"warning_percent": 5, "regression_percent": 10, "alert": true},
+    "forge_fuzz_test/aave-aave-v4": {"warning_percent": 7.5, "regression_percent": 12.5, "alert": true},
+    "forge_coverage/aave-aave-v4": {
+      "warning_percent": 5,
+      "regression_percent": 10,
+      "alert": false,
+      "note": "Advisory only: one timing sample per side."
+    }
+  }
+}

--- a/.github/scripts/compare-benchmark-thresholds.py
+++ b/.github/scripts/compare-benchmark-thresholds.py
@@ -84,7 +84,12 @@ def compare(base, candidate, rules):
         if not has_base or not has_candidate:
             present = duration(mean_of(candidate[key] if not has_base else base[key], key))
             left, right = ("N/A", present) if not has_base else (present, "N/A")
-            print(f"| `{key}` | {left} | {right} | ⚠️ Inconclusive (missing side) |")
+            if has_base and rules.get(key, {}).get("alert", False):
+                has_regression = True
+                verdict = "❌ Missing nightly result"
+            else:
+                verdict = "⚠️ Inconclusive (missing side)"
+            print(f"| `{key}` | {left} | {right} | {verdict} |")
             continue
 
         baseline = mean_of(base[key], key)
@@ -127,7 +132,8 @@ def main():
     args = parser.parse_args()
     base_path = pathlib.Path(args.base)
     base = load_object(base_path, "baseline") if base_path.is_file() else {}
-    candidate = load_object(args.candidate, "candidate")
+    candidate_path = pathlib.Path(args.candidate)
+    candidate = load_object(candidate_path, "candidate") if candidate_path.is_file() else {}
     rules = load_rules(args.thresholds)
     return compare(base, candidate, rules)
 

--- a/.github/scripts/compare-benchmark-thresholds.py
+++ b/.github/scripts/compare-benchmark-thresholds.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Compare nightly benchmark summaries using calibrated per-key thresholds."""
+
+import argparse
+import json
+import math
+import pathlib
+import sys
+
+
+def fail(message):
+    print(f"Comparator error: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def load_object(path, name):
+    try:
+        value = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"cannot read {name}: {error}")
+    if not isinstance(value, dict):
+        fail(f"{name} must be a JSON object")
+    return value
+
+
+def positive_number(value, name):
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or value <= 0
+    ):
+        fail(f"{name} must be finite and positive")
+    return float(value)
+
+
+def mean_of(value, key):
+    if isinstance(value, dict):
+        if "mean" not in value:
+            fail(f"{key}: result object has no mean")
+        value = value["mean"]
+    return positive_number(value, f"{key} mean")
+
+
+def load_rules(path):
+    config = load_object(path, "threshold config")
+    if (
+        config.get("schema_version") != 1
+        or config.get("kind") != "foundry-nightly-benchmark-thresholds"
+    ):
+        fail("threshold config has unsupported schema_version or kind")
+    rules = config.get("benchmarks")
+    if not isinstance(rules, dict):
+        fail("threshold config benchmarks must be an object")
+    for key, rule in rules.items():
+        if not isinstance(key, str) or not isinstance(rule, dict):
+            fail("each threshold rule must be a keyed object")
+        warning = positive_number(rule.get("warning_percent"), f"{key} warning_percent")
+        regression = positive_number(
+            rule.get("regression_percent"), f"{key} regression_percent"
+        )
+        if warning > regression or not isinstance(rule.get("alert"), bool):
+            fail(f"{key}: invalid threshold ordering or alert value")
+    return rules
+
+
+def duration(seconds):
+    if seconds < 0.001:
+        return f"{seconds * 1000:.2f}ms"
+    if seconds < 1:
+        return f"{seconds:.3f}s"
+    if seconds < 60:
+        return f"{seconds:.2f}s"
+    return f"{int(seconds // 60)}m {seconds % 60:.1f}s"
+
+
+def compare(base, candidate, rules):
+    print("## Nightly Benchmark Regression Report\n")
+    print("| Benchmark | Stable | Nightly | Change |")
+    print("|-----------|--------:|---------:|--------|")
+    has_regression = False
+    for key in sorted(base.keys() | candidate.keys()):
+        has_base, has_candidate = key in base, key in candidate
+        if not has_base or not has_candidate:
+            present = duration(mean_of(candidate[key] if not has_base else base[key], key))
+            left, right = ("N/A", present) if not has_base else (present, "N/A")
+            print(f"| `{key}` | {left} | {right} | ⚠️ Inconclusive (missing side) |")
+            continue
+
+        baseline = mean_of(base[key], key)
+        nightly = mean_of(candidate[key], key)
+        delta = (nightly - baseline) / baseline * 100
+        rule = rules.get(key)
+        if rule is None:
+            verdict = "⚪ Uncalibrated"
+        else:
+            warning = rule["warning_percent"]
+            regression = rule["regression_percent"]
+            alert = rule["alert"]
+            suffix = "" if alert else " (advisory)"
+            if delta >= regression:
+                verdict = "❌ Regression" + suffix
+                has_regression |= alert
+            elif delta >= warning:
+                verdict = "⚠️ Warning" + suffix
+            elif delta <= -warning:
+                verdict = "✅ Improvement" + suffix
+            else:
+                verdict = "⚪ Within threshold" + suffix
+        print(
+            f"| `{key}` | {duration(baseline)} | {duration(nightly)} | "
+            f"{delta:+.2f}% {verdict} |"
+        )
+
+    print(
+        "\nLegend: ❌ regression, ⚠️ warning/inconclusive, ✅ improvement, "
+        "⚪ within threshold or uncalibrated. Advisory results never alert."
+    )
+    return 1 if has_regression else 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("base")
+    parser.add_argument("candidate")
+    parser.add_argument("thresholds")
+    args = parser.parse_args()
+    base_path = pathlib.Path(args.base)
+    base = load_object(base_path, "baseline") if base_path.is_file() else {}
+    candidate = load_object(args.candidate, "candidate")
+    rules = load_rules(args.thresholds)
+    return compare(base, candidate, rules)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_compare_benchmark_thresholds.py
+++ b/.github/scripts/tests/test_compare_benchmark_thresholds.py
@@ -9,13 +9,14 @@ SCRIPT = pathlib.Path(__file__).parents[1] / "compare-benchmark-thresholds.py"
 
 
 class CompareBenchmarkThresholdsTests(unittest.TestCase):
-    def run_compare(self, base, candidate, rules):
+    def run_compare(self, base, candidate, rules, candidate_exists=True):
         with tempfile.TemporaryDirectory() as directory:
             directory = pathlib.Path(directory)
             base_path = directory / "base.json"
             candidate_path = directory / "candidate.json"
             base_path.write_text(json.dumps(base))
-            candidate_path.write_text(json.dumps(candidate))
+            if candidate_exists:
+                candidate_path.write_text(json.dumps(candidate))
             config_path = directory / "thresholds.json"
             config_path.write_text(json.dumps({
                 "schema_version": 1,
@@ -46,20 +47,34 @@ class CompareBenchmarkThresholdsTests(unittest.TestCase):
         self.assertEqual(warning.returncode, 0)
         self.assertIn("Warning", warning.stdout)
 
-    def test_advisory_missing_and_uncalibrated_never_alert(self):
+    def test_advisory_and_uncalibrated_never_alert(self):
         advisory = self.run_compare(
             {"coverage": 100}, {"coverage": 120}, {"coverage": self.rule(5, 10, False)}
         )
         self.assertEqual(advisory.returncode, 0)
         self.assertIn("Regression (advisory)", advisory.stdout)
 
-        missing = self.run_compare({"only-base": 1}, {"only-candidate": 1}, {})
-        self.assertEqual(missing.returncode, 0)
-        self.assertEqual(missing.stdout.count("Inconclusive (missing side)"), 2)
-
         uncalibrated = self.run_compare({"symbolic": 1}, {"symbolic": 2}, {})
         self.assertEqual(uncalibrated.returncode, 0)
         self.assertIn("Uncalibrated", uncalibrated.stdout)
+
+    def test_missing_nightly_alerts_but_missing_baseline_does_not(self):
+        rules = {
+            "alerting": self.rule(5, 10),
+            "advisory": self.rule(5, 10, False),
+        }
+        missing_nightly = self.run_compare({"alerting": 1, "advisory": 1}, {}, rules)
+        self.assertEqual(missing_nightly.returncode, 1)
+        self.assertIn("❌ Missing nightly result", missing_nightly.stdout)
+        self.assertIn("⚠️ Inconclusive (missing side)", missing_nightly.stdout)
+
+        missing_nightly_file = self.run_compare({"alerting": 1}, {}, rules, False)
+        self.assertEqual(missing_nightly_file.returncode, 1)
+        self.assertIn("❌ Missing nightly result", missing_nightly_file.stdout)
+
+        missing_baseline = self.run_compare({}, {"alerting": 1}, rules)
+        self.assertEqual(missing_baseline.returncode, 0)
+        self.assertIn("⚠️ Inconclusive (missing side)", missing_baseline.stdout)
 
     def test_malformed_config_and_input_exit_two(self):
         config = self.run_compare({"key": 1}, {"key": 2}, {"key": self.rule(10, 5)})

--- a/.github/scripts/tests/test_compare_benchmark_thresholds.py
+++ b/.github/scripts/tests/test_compare_benchmark_thresholds.py
@@ -1,0 +1,76 @@
+import json
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "compare-benchmark-thresholds.py"
+
+
+class CompareBenchmarkThresholdsTests(unittest.TestCase):
+    def run_compare(self, base, candidate, rules):
+        with tempfile.TemporaryDirectory() as directory:
+            directory = pathlib.Path(directory)
+            base_path = directory / "base.json"
+            candidate_path = directory / "candidate.json"
+            base_path.write_text(json.dumps(base))
+            candidate_path.write_text(json.dumps(candidate))
+            config_path = directory / "thresholds.json"
+            config_path.write_text(json.dumps({
+                "schema_version": 1,
+                "kind": "foundry-nightly-benchmark-thresholds",
+                "benchmarks": rules,
+            }))
+            return subprocess.run(
+                ["python3", str(SCRIPT), str(base_path), str(candidate_path), str(config_path)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    @staticmethod
+    def rule(warning, regression, alert=True):
+        return {"warning_percent": warning, "regression_percent": regression, "alert": alert}
+
+    def test_keys_use_different_thresholds_and_warning_does_not_alert(self):
+        result = self.run_compare(
+            {"strict": 100, "loose": 100}, {"strict": 103, "loose": 103},
+            {"strict": self.rule(1, 2), "loose": self.rule(5, 10)},
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("+3.00% ❌ Regression", result.stdout)
+        self.assertIn("+3.00% ⚪ Within threshold", result.stdout)
+
+        warning = self.run_compare({"key": 100}, {"key": 106}, {"key": self.rule(5, 10)})
+        self.assertEqual(warning.returncode, 0)
+        self.assertIn("Warning", warning.stdout)
+
+    def test_advisory_missing_and_uncalibrated_never_alert(self):
+        advisory = self.run_compare(
+            {"coverage": 100}, {"coverage": 120}, {"coverage": self.rule(5, 10, False)}
+        )
+        self.assertEqual(advisory.returncode, 0)
+        self.assertIn("Regression (advisory)", advisory.stdout)
+
+        missing = self.run_compare({"only-base": 1}, {"only-candidate": 1}, {})
+        self.assertEqual(missing.returncode, 0)
+        self.assertEqual(missing.stdout.count("Inconclusive (missing side)"), 2)
+
+        uncalibrated = self.run_compare({"symbolic": 1}, {"symbolic": 2}, {})
+        self.assertEqual(uncalibrated.returncode, 0)
+        self.assertIn("Uncalibrated", uncalibrated.stdout)
+
+    def test_malformed_config_and_input_exit_two(self):
+        config = self.run_compare({"key": 1}, {"key": 2}, {"key": self.rule(10, 5)})
+        self.assertEqual(config.returncode, 2)
+        rules = {"key": self.rule(1, 2)}
+        bad_mean = self.run_compare({"key": {"mean": 0}}, {"key": 2}, rules)
+        self.assertEqual(bad_mean.returncode, 2)
+        null_candidate = self.run_compare({"key": 1}, {"key": None}, rules)
+        self.assertEqual(null_candidate.returncode, 2)
+        null_baseline = self.run_compare({"key": None}, {"key": 1}, rules)
+        self.assertEqual(null_baseline.returncode, 2)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -228,12 +228,22 @@ jobs:
           DATE=$(date -u +%Y-%m-%d)
           STABLE_JSON="benches/stable-${DATE}.json"
           NIGHTLY_JSON="benches/nightly-${DATE}.json"
-          if ./.github/scripts/compare-nightly.sh "$STABLE_JSON" "$NIGHTLY_JSON" > regression.md 2>&1; then
+          set +e
+          python3 ./.github/scripts/compare-benchmark-thresholds.py \
+            "$STABLE_JSON" "$NIGHTLY_JSON" \
+            .github/benchmark-regression-thresholds.json > regression.md 2>&1
+          status=$?
+          set -e
+          if [[ $status -eq 0 ]]; then
             echo "has_regression=false" >> "$GITHUB_OUTPUT"
-          else
+          elif [[ $status -eq 1 ]]; then
             echo "has_regression=true" >> "$GITHUB_OUTPUT"
+          else
+            cat regression.md
+            exit "$status"
           fi
           cat regression.md
+          cat regression.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -248,7 +258,7 @@ jobs:
   report-regression:
     name: Report Regression
     needs: run-benchmarks
-    if: needs.run-benchmarks.outputs.has_regression == 'true'
+    if: needs.run-benchmarks.outputs.has_regression == 'true' && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -272,7 +282,7 @@ jobs:
           **Run**: [${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
           **Date**: ${DATE}
           **Repo benchmarked**: \`aave/aave-v4\` (pinned commit)
-          **Threshold**: 🔴 >=3% regression, 🟡 >=1% warning"
+          **Threshold**: Per-benchmark calibrated thresholds from \`.github/benchmark-regression-thresholds.json\`"
 
           gh issue create \
             --title "[Nightly Regression] ${DATE}" \


### PR DESCRIPTION
Adds calibrated per-benchmark thresholds to nightly benchmarks and reports meaningful regressions without failing the benchmark run. Coverage remains advisory and uncalibrated benchmarks do not alert.

Closes OSS-479