### PR TITLE
fix(config): resolve absolute lib remappings

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -808,7 +808,9 @@ impl Config {
     /// that may not define all profiles the main project uses.
     #[track_caller]
     pub fn load_with_root_and_fallback(root: impl AsRef<Path>) -> Result<Self, ExtractConfigError> {
-        let figment = Self::figment_with_root(root.as_ref());
+        // Nested configs must use their own library paths. Inheriting an absolute `FOUNDRY_LIBS`
+        // or `DAPP_LIBS` value would make remapping discovery recurse into the same directory.
+        let figment = Self::with_root(root.as_ref()).to_figment_inner(FigmentProviders::All, true);
         Self::from_figment_fallback(Figment::from(figment))
     }
 
@@ -951,6 +953,10 @@ impl Config {
     /// This will merge various providers, such as env,toml,remappings into the figment if
     /// requested.
     pub fn to_figment(&self, providers: FigmentProviders) -> Figment {
+        self.to_figment_inner(providers, false)
+    }
+
+    fn to_figment_inner(&self, providers: FigmentProviders, ignore_libs_env: bool) -> Figment {
         // Note that `Figment::from` here is a method on `Figment` rather than the `From` impl below
 
         if providers.is_none() {
@@ -960,6 +966,16 @@ impl Config {
         let root = self.root.as_path();
         let profile = Self::selected_profile();
         let mut figment = Figment::default().merge(DappHardhatDirProvider(root));
+        let dapp_ignored: &[&str] = if ignore_libs_env {
+            &["REMAPPINGS", "LIBRARIES", "FFI", "FS_PERMISSIONS", "LIBS"]
+        } else {
+            &["REMAPPINGS", "LIBRARIES", "FFI", "FS_PERMISSIONS"]
+        };
+        let foundry_ignored: &[&str] = if ignore_libs_env {
+            &["PROFILE", "REMAPPINGS", "LIBRARIES", "FFI", "FS_PERMISSIONS", "LIBS"]
+        } else {
+            &["PROFILE", "REMAPPINGS", "LIBRARIES", "FFI", "FS_PERMISSIONS"]
+        };
 
         // merge global foundry.toml file
         if let Some(global_toml) = Self::foundry_dir_toml().filter(|p| p.exists()) {
@@ -978,11 +994,7 @@ impl Config {
 
         // merge environment variables
         figment = figment
-            .merge(
-                Env::prefixed("DAPP_")
-                    .ignore(&["REMAPPINGS", "LIBRARIES", "FFI", "FS_PERMISSIONS"])
-                    .global(),
-            )
+            .merge(Env::prefixed("DAPP_").ignore(dapp_ignored).global())
             .merge(
                 Env::prefixed("DAPP_TEST_")
                     .ignore(&["CACHE", "FUZZ_RUNS", "DEPTH", "FFI", "FS_PERMISSIONS"])
@@ -992,7 +1004,7 @@ impl Config {
             .merge(EtherscanEnvProvider::default())
             .merge(
                 Env::prefixed("FOUNDRY_")
-                    .ignore(&["PROFILE", "REMAPPINGS", "LIBRARIES", "FFI", "FS_PERMISSIONS"])
+                    .ignore(foundry_ignored)
                     .map(|key| {
                         let key = key.as_str();
                         if Self::STANDALONE_SECTIONS.iter().any(|section| {

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -248,7 +248,7 @@ impl RemappingsProvider<'_> {
     fn find_nested_foundry_remappings(&self) -> impl Iterator<Item = Remapping> + '_ {
         self.lib_paths
             .par_iter()
-            .map(|p| if p.is_absolute() { self.root.join("lib") } else { self.root.join(p) })
+            .map(|p| self.root.join(p))
             .flat_map(foundry_toml_dirs)
             .flat_map_iter(|lib| {
                 trace!(?lib, "find all remappings of nested foundry.toml");

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -987,6 +987,36 @@ forgetest_init!(can_detect_lib_foundry_toml, |prj, cmd| {
     );
 });
 
+forgetest!(can_detect_nested_remappings_from_absolute_lib, |prj, cmd| {
+    let external_lib = prj.root().parent().unwrap().join("external-lib");
+    let nested_lib = external_lib.join("nested-lib");
+    pretty_err(&nested_lib, fs::create_dir_all(&nested_lib));
+
+    let nested_config = Config {
+        src: "custom-source-dir".into(),
+        remappings: vec![Remapping::from_str("nested-alias/=vendor").unwrap().into()],
+        ..Default::default()
+    };
+    let toml_file = nested_lib.join(Config::FILE_NAME);
+    pretty_err(&toml_file, fs::write(&toml_file, nested_config.to_string_pretty().unwrap()));
+
+    cmd.env("FOUNDRY_LIBS", serde_json::to_string(&[external_lib]).unwrap());
+    let config = cmd.config();
+    let remappings = config
+        .remappings
+        .into_iter()
+        .map(Remapping::from)
+        .map(|remapping| remapping.to_string())
+        .collect::<Vec<_>>();
+    similar_asserts::assert_eq!(
+        remappings,
+        vec![
+            format!("nested-alias/={}/", nested_lib.join("vendor").to_slash_lossy()),
+            format!("nested-lib/={}/", nested_lib.join("custom-source-dir").to_slash_lossy()),
+        ]
+    );
+});
+
 // test remappings with closer paths are prioritised
 // so that `dep/=lib/a/src` will take precedent over  `dep/=lib/a/lib/b/src`
 forgetest_init!(can_prioritise_closer_lib_remappings, |prj, cmd| {


### PR DESCRIPTION

## Motivation

Absolute library paths were skipped when discovering remappings from nested foundry.toml files, causing shared or external dependencies to lose their configured remappings. This scans the configured absolute path while preventing inherited FOUNDRY_LIBS and DAPP_LIBS values from recursively re-entering the same library tree.

Addresses the absolute-path issue reported in #15721.