### PR TITLE
revert(ci): restore unconditional Tempo devnet checks

### DIFF
--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           TEMPO_MAINNET_RPC_URL: ${{ secrets.TEMPO_MAINNET_RPC_URL }}
           TEMPO_TESTNET_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
-          TEMPO_DEVNET_RPC_URL: ${{ vars.TEMPO_DEVNET_CI != 'false' && secrets.TEMPO_DEVNET_RPC_URL || '' }}
+          TEMPO_DEVNET_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
         run: |
           cargo test --locked -p foundry-common --lib tempo::tests::test_fork_schedule_parses_configured_rpcs -- --exact --nocapture
 
@@ -109,7 +109,11 @@ jobs:
           fi
 
       - name: Run Tempo check on devnet
-        if: vars.TEMPO_DEVNET_CI != 'false' && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event.inputs.network == 'devnet' || github.event.inputs.network == 'all')
+        if: |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request' ||
+          github.event.inputs.network == 'devnet' ||
+          github.event.inputs.network == 'all'
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
           SCRIPTS: ${{ github.event.inputs.scripts || 'both' }}
@@ -122,7 +126,11 @@ jobs:
           fi
 
       - name: Run Tempo wallet tests on devnet
-        if: vars.TEMPO_DEVNET_CI != 'false' && (github.event_name == 'push' || github.event_name == 'pull_request' || github.event.inputs.network == 'devnet' || github.event.inputs.network == 'all')
+        if: |
+          github.event_name == 'push' ||
+          github.event_name == 'pull_request' ||
+          github.event.inputs.network == 'devnet' ||
+          github.event.inputs.network == 'all'
         env:
           ETH_RPC_URL: ${{ secrets.TEMPO_DEVNET_RPC_URL }}
         run: ./.github/scripts/tempo-wallet.sh


### PR DESCRIPTION
## Summary

- revert #15717
- restore unconditional Tempo devnet CI checks
- restore direct use of `TEMPO_DEVNET_RPC_URL` in fork schedule tests

## Motivation

The devnet outage was caused by network policy and devnet is back online, so the temporary repository-variable toggle is no longer needed.

## Validation

- `git diff HEAD^ --check`
- verified the diff is the exact inverse of #15717

Prompted by: @grandizzy