### PR TITLE
fix(forge): default invariant workers to auto

### DIFF
--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -8,18 +8,13 @@ use serde::{
 use std::{fmt, num::NonZeroUsize, path::PathBuf, str::FromStr};
 
 /// Worker selection mode for invariant campaign sharding.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum InvariantWorkers {
     /// Automatically derive invariant workers from the active `--jobs` / rayon thread pool.
+    #[default]
     Auto,
     /// Explicit user override for invariant campaign sharding.
     Fixed(NonZeroUsize),
-}
-
-impl Default for InvariantWorkers {
-    fn default() -> Self {
-        Self::Fixed(NonZeroUsize::MIN)
-    }
 }
 
 impl Serialize for InvariantWorkers {
@@ -136,8 +131,8 @@ pub struct InvariantConfig {
     pub depth_mode: InvariantDepthMode,
     /// Worker selection mode used to shard invariant runs.
     ///
-    /// Defaults to `1` for reproducible seeded campaigns. Use `auto` to derive the worker count
-    /// from `--jobs`, or a positive integer for an explicit worker count.
+    /// Defaults to `auto`, which derives the worker count from `--jobs`. Use a positive integer
+    /// for an explicit worker count.
     pub workers: InvariantWorkers,
     /// Fails the invariant fuzzing if a revert occurs
     pub fail_on_revert: bool,
@@ -249,9 +244,9 @@ mod tests {
     }
 
     #[test]
-    fn invariant_workers_default_to_one() {
-        assert_eq!(InvariantWorkers::default(), InvariantWorkers::Fixed(NonZeroUsize::MIN));
-        assert_eq!(InvariantConfig::default().workers, InvariantWorkers::Fixed(NonZeroUsize::MIN));
+    fn invariant_workers_default_to_auto() {
+        assert_eq!(InvariantWorkers::default(), InvariantWorkers::Auto);
+        assert_eq!(InvariantConfig::default().workers, InvariantWorkers::Auto);
     }
 
     #[test]

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1623,8 +1623,6 @@ impl TestArgs {
     }
 
     async fn compile_project(&mut self) -> Result<CompiledTestProject> {
-        let should_default_fuzz_run_workers_to_auto =
-            self.fuzz_only.is_enabled() && self.invariant_workers.is_none();
         // Merge all configs.
         let (mut config, evm_opts) = self.load_config_and_evm_opts()?;
 
@@ -1635,10 +1633,6 @@ impl TestArgs {
             // need to re-configure here to also catch additional remappings
             config = self.load_config()?;
         }
-        if should_default_fuzz_run_workers_to_auto && !config.invariant.workers_configured {
-            config.invariant.workers = InvariantWorkers::Auto;
-        }
-
         if should_mutate {
             // Force dyn test linking and cache usage for mutation testing after any config reload.
             config.dynamic_test_linking = true;

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -218,7 +218,7 @@ runs = 256
 depth = 500
 min_depth = 1
 depth_mode = "fixed"
-workers = 1
+workers = "auto"
 fail_on_revert = false
 call_override = false
 dictionary_weight = 80
@@ -1517,7 +1517,7 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "depth": 500,
     "min_depth": 1,
     "depth_mode": "fixed",
-    "workers": 1,
+    "workers": "auto",
     "fail_on_revert": false,
     "call_override": false,
     "dictionary_weight": 80,

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -1436,6 +1436,46 @@ contract JsonInvariantReportTest is Test {
     assert!(safe.get("reason").is_none());
 });
 
+forgetest_init!(forge_test_defaults_invariant_workers_to_auto, |prj, cmd| {
+    prj.add_test(
+        "AutoInvariantWorkers.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract AutoInvariantWorkersHandler {
+    uint256 public counter;
+
+    function inc() external {
+        counter++;
+    }
+}
+
+contract AutoInvariantWorkersTest is Test {
+    AutoInvariantWorkersHandler handler;
+
+    function setUp() public {
+        handler = new AutoInvariantWorkersHandler();
+        targetContract(address(handler));
+    }
+
+    function invariant_break() public view {
+        require(handler.counter() == 0, "broken");
+    }
+}
+   "#,
+    );
+
+    cmd.unset_env("FOUNDRY_INVARIANT_WORKERS");
+    cmd.env("FOUNDRY_INVARIANT_RUNS", "20000");
+    cmd.env("FOUNDRY_INVARIANT_DEPTH", "500");
+    cmd.env("FOUNDRY_INVARIANT_SHRINK_RUN_LIMIT", "0");
+    let output = cmd.args(["test", "--json", "--threads", "2"]).assert_failure();
+    let json: serde_json::Value = serde_json::from_slice(&output.get_output().stdout).unwrap();
+    let suite = json.as_object().unwrap().values().next().unwrap();
+    let result = suite["test_results"].as_object().unwrap().values().next().unwrap();
+    assert_eq!(result["kind"]["Invariant"]["workers"], 2, "{json}");
+});
+
 forgetest_init!(invariant_campaign_reports_secondary_skip, |prj, cmd| {
     prj.update_config(|config| {
         config.invariant.runs = 1;

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -1465,6 +1465,9 @@ contract AutoInvariantWorkersTest is Test {
    "#,
     );
 
+    prj.update_config(|config| {
+        config.invariant.workers = foundry_config::InvariantWorkers::default();
+    });
     cmd.unset_env("FOUNDRY_INVARIANT_WORKERS");
     cmd.env("FOUNDRY_INVARIANT_RUNS", "20000");
     cmd.env("FOUNDRY_INVARIANT_DEPTH", "500");


### PR DESCRIPTION
Defaults invariant campaign workers to `auto` across the shared configuration so `forge test` uses the active Rayon pool consistently with `forge fuzz run`. Explicit numeric worker settings remain authoritative.

This removes the command-specific fallback and adds regression coverage proving the default behavior is isolated from environment overrides.

I don't think this is a breaking change but we need to be careful.