### PR TITLE
fix(anvil): isolate fork cache on RPC reset

### DIFF
--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -59,12 +59,20 @@ pub struct ClientFork<N: Network = AnyNetwork> {
     pub config: Arc<RwLock<ClientForkConfig<N>>>,
     /// This also holds a handle to the underlying database
     pub database: Arc<AsyncRwLock<Box<dyn Db>>>,
+    /// The RPC URL associated with the state in the underlying database.
+    database_rpc_url: Arc<RwLock<Option<String>>>,
 }
 
 impl<N: Network> ClientFork<N> {
     /// Creates a new instance of the fork
     pub fn new(config: ClientForkConfig<N>, database: Arc<AsyncRwLock<Box<dyn Db>>>) -> Self {
-        Self { storage: Default::default(), config: Arc::new(RwLock::new(config)), database }
+        let database_rpc_url = config.eth_rpc_url().map(ToOwned::to_owned);
+        Self {
+            storage: Default::default(),
+            config: Arc::new(RwLock::new(config)),
+            database,
+            database_rpc_url: Arc::new(RwLock::new(database_rpc_url)),
+        }
     }
 
     /// Removes all data cached from previous responses
@@ -109,6 +117,14 @@ impl<N: Network> ClientFork<N> {
 
     pub fn eth_rpc_url(&self) -> Option<String> {
         self.config.read().eth_rpc_url().map(|s| s.to_string())
+    }
+
+    pub(crate) fn database_rpc_url(&self) -> Option<String> {
+        self.database_rpc_url.read().clone()
+    }
+
+    pub(crate) fn set_database_rpc_url(&self, url: Option<String>) {
+        *self.database_rpc_url.write() = url;
     }
 
     pub fn chain_id(&self) -> u64 {
@@ -421,6 +437,7 @@ impl<N: Network> ClientFork<N> {
         let number = self.block_number();
         let block_hash = self.block_hash();
         self.database.write().await.insert_block_hash(U256::from(number), block_hash);
+        self.set_database_rpc_url(self.eth_rpc_url());
 
         Ok(())
     }

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -437,7 +437,6 @@ impl<N: Network> ClientFork<N> {
         let number = self.block_number();
         let block_hash = self.block_hash();
         self.database.write().await.insert_block_hash(U256::from(number), block_hash);
-        self.set_database_rpc_url(self.eth_rpc_url());
 
         Ok(())
     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2486,14 +2486,12 @@ impl<N: Network> Backend<N> {
             // reset the fork entirely and reapply the genesis config
             let reset_urls =
                 forking.json_rpc_url.as_ref().map(|url| vec![url.clone()]).unwrap_or_default();
-            let rpc_url_changed = forking
-                .json_rpc_url
-                .as_ref()
-                .is_some_and(|url| fork.eth_rpc_url().as_ref() != Some(url));
+            let target_rpc_url = forking.json_rpc_url.clone().or_else(|| fork.eth_rpc_url());
+            let rpc_url_changed = target_rpc_url != fork.database_rpc_url();
             fork.prepare_reset(reset_urls, block_number.into()).await?;
             if rpc_url_changed {
                 // Clear state fetched from the previous RPC URL before persisting the cache.
-                fork.database.write().await.clear();
+                fork.database.write().await.clear_into_state_snapshot();
             }
             // Persist fetched remote state before rebuilding the fork database so the new
             // block-specific database can load it from disk.
@@ -2561,6 +2559,7 @@ impl<N: Network> Backend<N> {
             );
             self.states.write().clear();
             self.apply_genesis().await?;
+            fork.set_database_rpc_url(target_rpc_url);
 
             trace!(target: "backend", "reset fork");
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2497,6 +2497,18 @@ impl<N: Network> Backend<N> {
             // block-specific database can load it from disk.
             fork.database.read().await.maybe_flush_cache().map_err(BlockchainError::Internal)?;
             let fork_block_number = fork.block_number();
+            if rpc_url_changed {
+                let cache_path = self.node_config.read().await.block_cache_path(fork_block_number);
+                if let Some(cache_path) = cache_path
+                    && let Err(err) = std::fs::remove_file(&cache_path)
+                    && err.kind() != std::io::ErrorKind::NotFound
+                {
+                    return Err(BlockchainError::Internal(format!(
+                        "failed to invalidate fork cache at {}: {err}",
+                        cache_path.display()
+                    )));
+                }
+            }
             let fork_block = fork
                 .block_by_number(fork_block_number)
                 .await?
@@ -2508,12 +2520,8 @@ impl<N: Network> Backend<N> {
                 } else {
                     // If rpc url is unspecified, then update the fork with the new block number and
                     // existing rpc url, this updates the cache path
-                    {
-                        let maybe_fork_url =
-                            { self.node_config.read().await.fork_urls.first().cloned() };
-                        if let Some(fork_url) = maybe_fork_url {
-                            self.reset_block_number(fork_url, fork_block_number).await?;
-                        }
+                    if let Some(fork_url) = target_rpc_url.clone() {
+                        self.reset_block_number(fork_url, fork_block_number).await?;
                     }
 
                     let gas_limit = self.node_config.read().await.fork_gas_limit(&fork_block);

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2486,10 +2486,18 @@ impl<N: Network> Backend<N> {
             // reset the fork entirely and reapply the genesis config
             let reset_urls =
                 forking.json_rpc_url.as_ref().map(|url| vec![url.clone()]).unwrap_or_default();
+            let rpc_url_changed = forking
+                .json_rpc_url
+                .as_ref()
+                .is_some_and(|url| fork.eth_rpc_url().as_ref() != Some(url));
+            fork.prepare_reset(reset_urls, block_number.into()).await?;
+            if rpc_url_changed {
+                // Clear state fetched from the previous RPC URL before persisting the cache.
+                fork.database.write().await.clear();
+            }
             // Persist fetched remote state before rebuilding the fork database so the new
             // block-specific database can load it from disk.
             fork.database.read().await.maybe_flush_cache().map_err(BlockchainError::Internal)?;
-            fork.prepare_reset(reset_urls, block_number.into()).await?;
             let fork_block_number = fork.block_number();
             let fork_block = fork
                 .block_by_number(fork_block_number)

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -2498,14 +2498,21 @@ impl<N: Network> Backend<N> {
             fork.database.read().await.maybe_flush_cache().map_err(BlockchainError::Internal)?;
             let fork_block_number = fork.block_number();
             if rpc_url_changed {
-                let cache_path = self.node_config.read().await.block_cache_path(fork_block_number);
-                if let Some(cache_path) = cache_path
-                    && let Err(err) = std::fs::remove_file(&cache_path)
+                let cache_dir = {
+                    let config = self.node_config.read().await;
+                    if config.no_storage_caching || config.fork_urls.is_empty() {
+                        None
+                    } else {
+                        foundry_config::Config::foundry_chain_cache_dir(config.get_chain_id())
+                    }
+                };
+                if let Some(cache_dir) = cache_dir
+                    && let Err(err) = std::fs::remove_dir_all(&cache_dir)
                     && err.kind() != std::io::ErrorKind::NotFound
                 {
                     return Err(BlockchainError::Internal(format!(
                         "failed to invalidate fork cache at {}: {err}",
-                        cache_path.display()
+                        cache_dir.display()
                     )));
                 }
             }

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1814,6 +1814,76 @@ async fn test_fork_reset_reuses_cached_remote_state() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_does_not_reuse_cache_for_new_rpc_url() {
+    let address = Address::random();
+    let first_balance = U256::from(1337u64);
+    let second_balance = U256::from(42u64);
+    let timestamp = 1_000_000u64;
+    let chain_id =
+        u64::from_be_bytes(address.as_slice()[12..].try_into().unwrap()) % 1_000_000 + 1_000_000;
+    let cache_dir = Config::foundry_chain_cache_dir(chain_id).unwrap();
+    let _ = std::fs::remove_dir_all(&cache_dir);
+
+    async {
+        let first_origin = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_genesis_timestamp(Some(timestamp))
+            .with_funded_accounts([(address, first_balance)].into_iter().collect());
+        let (_first_origin_api, first_origin_handle) = spawn(first_origin).await;
+        let second_origin = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_genesis_timestamp(Some(timestamp))
+            .with_funded_accounts([(address, second_balance)].into_iter().collect());
+        let (_second_origin_api, second_origin_handle) = spawn(second_origin).await;
+        let fork_config = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_eth_rpc_url(Some(first_origin_handle.http_endpoint()));
+        let (api, handle) = spawn(fork_config).await;
+        let provider = handle.http_provider();
+        let fork_block_number = api.anvil_node_info().await.unwrap().fork_config.fork_block_number;
+
+        assert_eq!(provider.get_balance(address).await.unwrap(), first_balance);
+        api.anvil_reset(Some(Forking { json_rpc_url: None, block_number: fork_block_number }))
+            .await
+            .unwrap();
+        assert_eq!(provider.get_balance(address).await.unwrap(), first_balance);
+
+        let local_balance = U256::from(9001u64);
+        api.anvil_set_balance(address, local_balance).await.unwrap();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let unavailable_url = format!("http://{}", listener.local_addr().unwrap());
+        drop(listener);
+        assert!(
+            api.anvil_reset(Some(Forking {
+                json_rpc_url: Some(unavailable_url),
+                block_number: fork_block_number,
+            }))
+            .await
+            .is_err()
+        );
+        assert_eq!(provider.get_balance(address).await.unwrap(), local_balance);
+
+        api.anvil_reset(Some(Forking {
+            json_rpc_url: Some(second_origin_handle.http_endpoint()),
+            block_number: fork_block_number,
+        }))
+        .await
+        .unwrap();
+
+        assert_eq!(provider.get_balance(address).await.unwrap(), second_balance);
+
+        let second_fork_config = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_eth_rpc_url(Some(second_origin_handle.http_endpoint()));
+        let (_second_fork_api, second_fork_handle) = spawn(second_fork_config).await;
+        let second_fork_provider = second_fork_handle.http_provider();
+        assert_eq!(second_fork_provider.get_balance(address).await.unwrap(), second_balance);
+    }
+    .await;
+    let _ = std::fs::remove_dir_all(cache_dir);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fork_get_account() {
     let (_api, handle) = spawn(fork_config()).await;
     let provider = handle.http_provider();

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1829,23 +1829,26 @@ async fn test_fork_reset_does_not_reuse_cache_for_new_rpc_url() {
             .with_chain_id(Some(chain_id))
             .with_genesis_timestamp(Some(timestamp))
             .with_funded_accounts([(address, first_balance)].into_iter().collect());
-        let (_first_origin_api, first_origin_handle) = spawn(first_origin).await;
+        let (first_origin_api, first_origin_handle) = spawn(first_origin).await;
         let second_origin = NodeConfig::test()
             .with_chain_id(Some(chain_id))
             .with_genesis_timestamp(Some(timestamp))
             .with_funded_accounts([(address, second_balance)].into_iter().collect());
-        let (_second_origin_api, second_origin_handle) = spawn(second_origin).await;
+        let (second_origin_api, second_origin_handle) = spawn(second_origin).await;
+        first_origin_api.mine_one().await;
+        first_origin_api.mine_one().await;
+        second_origin_api.mine_one().await;
+        second_origin_api.mine_one().await;
         let fork_config = NodeConfig::test()
             .with_chain_id(Some(chain_id))
-            .with_eth_rpc_url(Some(first_origin_handle.http_endpoint()));
+            .with_eth_rpc_url(Some(first_origin_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64));
         let (api, handle) = spawn(fork_config).await;
         let provider = handle.http_provider();
         let fork_block_number = api.anvil_node_info().await.unwrap().fork_config.fork_block_number;
 
         assert_eq!(provider.get_balance(address).await.unwrap(), first_balance);
-        api.anvil_reset(Some(Forking { json_rpc_url: None, block_number: fork_block_number }))
-            .await
-            .unwrap();
+        api.anvil_reset(Some(Forking { json_rpc_url: None, block_number: Some(2) })).await.unwrap();
         assert_eq!(provider.get_balance(address).await.unwrap(), first_balance);
 
         let local_balance = U256::from(9001u64);
@@ -1914,6 +1917,46 @@ async fn test_fork_reset_after_set_rpc_url_does_not_reuse_old_cache() {
         assert_eq!(provider.get_balance(address).await.unwrap(), first_balance);
 
         api.anvil_set_rpc_url(second_origin_handle.http_endpoint()).await.unwrap();
+        api.anvil_reset(Some(Forking::default())).await.unwrap();
+
+        assert_eq!(provider.get_balance(address).await.unwrap(), second_balance);
+    }
+    .await;
+    let _ = std::fs::remove_dir_all(cache_dir);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_client_fork_reset_then_backend_reset_rebuilds_database() {
+    let address = Address::random();
+    let first_balance = U256::from(1337u64);
+    let second_balance = U256::from(42u64);
+    let timestamp = 1_000_000u64;
+    let chain_id =
+        u64::from_be_bytes(address.as_slice()[12..].try_into().unwrap()) % 1_000_000 + 1_000_000;
+    let cache_dir = Config::foundry_chain_cache_dir(chain_id).unwrap();
+    let _ = std::fs::remove_dir_all(&cache_dir);
+
+    async {
+        let first_origin = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_genesis_timestamp(Some(timestamp))
+            .with_funded_accounts([(address, first_balance)].into_iter().collect());
+        let (_first_origin_api, first_origin_handle) = spawn(first_origin).await;
+        let second_origin = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_genesis_timestamp(Some(timestamp))
+            .with_funded_accounts([(address, second_balance)].into_iter().collect());
+        let (_second_origin_api, second_origin_handle) = spawn(second_origin).await;
+        let fork_config = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_eth_rpc_url(Some(first_origin_handle.http_endpoint()));
+        let (api, handle) = spawn(fork_config).await;
+        let provider = handle.http_provider();
+
+        assert_eq!(provider.get_balance(address).await.unwrap(), first_balance);
+
+        let fork = api.get_fork().unwrap();
+        fork.reset(vec![second_origin_handle.http_endpoint()], fork.block_number()).await.unwrap();
         api.anvil_reset(Some(Forking::default())).await.unwrap();
 
         assert_eq!(provider.get_balance(address).await.unwrap(), second_balance);

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1884,6 +1884,45 @@ async fn test_fork_reset_does_not_reuse_cache_for_new_rpc_url() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fork_reset_after_set_rpc_url_does_not_reuse_old_cache() {
+    let address = Address::random();
+    let first_balance = U256::from(1337u64);
+    let second_balance = U256::from(42u64);
+    let timestamp = 1_000_000u64;
+    let chain_id =
+        u64::from_be_bytes(address.as_slice()[12..].try_into().unwrap()) % 1_000_000 + 1_000_000;
+    let cache_dir = Config::foundry_chain_cache_dir(chain_id).unwrap();
+    let _ = std::fs::remove_dir_all(&cache_dir);
+
+    async {
+        let first_origin = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_genesis_timestamp(Some(timestamp))
+            .with_funded_accounts([(address, first_balance)].into_iter().collect());
+        let (_first_origin_api, first_origin_handle) = spawn(first_origin).await;
+        let second_origin = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_genesis_timestamp(Some(timestamp))
+            .with_funded_accounts([(address, second_balance)].into_iter().collect());
+        let (_second_origin_api, second_origin_handle) = spawn(second_origin).await;
+        let fork_config = NodeConfig::test()
+            .with_chain_id(Some(chain_id))
+            .with_eth_rpc_url(Some(first_origin_handle.http_endpoint()));
+        let (api, handle) = spawn(fork_config).await;
+        let provider = handle.http_provider();
+
+        assert_eq!(provider.get_balance(address).await.unwrap(), first_balance);
+
+        api.anvil_set_rpc_url(second_origin_handle.http_endpoint()).await.unwrap();
+        api.anvil_reset(Some(Forking::default())).await.unwrap();
+
+        assert_eq!(provider.get_balance(address).await.unwrap(), second_balance);
+    }
+    .await;
+    let _ = std::fs::remove_dir_all(cache_dir);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_fork_get_account() {
     let (_api, handle) = spawn(fork_config()).await;
     let provider = handle.http_provider();

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1868,10 +1868,16 @@ async fn test_fork_reset_does_not_reuse_cache_for_new_rpc_url() {
 
         api.anvil_reset(Some(Forking {
             json_rpc_url: Some(second_origin_handle.http_endpoint()),
-            block_number: fork_block_number,
+            block_number: Some(2),
         }))
         .await
         .unwrap();
+
+        assert_eq!(provider.get_balance(address).await.unwrap(), second_balance);
+
+        api.anvil_reset(Some(Forking { json_rpc_url: None, block_number: fork_block_number }))
+            .await
+            .unwrap();
 
         assert_eq!(provider.get_balance(address).await.unwrap(), second_balance);
 


### PR DESCRIPTION


## Motivation


https://github.com/foundry-rs/foundry/pull/15713#discussion_r3578296667 follow-up

Clear persisted remote state only after a replacement RPC endpoint has been validated. This prevents resets between origins with colliding block environments from reusing the previous origin's accounts while preserving same-origin cache reuse.
