### PR TITLE
fix(cast): replay Nitro transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,7 +2893,6 @@ dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
  "alloy-ens",
- "alloy-evm",
  "alloy-hardforks",
  "alloy-json-abi",
  "alloy-json-rpc",

--- a/crates/cast/Cargo.toml
+++ b/crates/cast/Cargo.toml
@@ -53,6 +53,7 @@ alloy-rlp.workspace = true
 alloy-rpc-client.workspace = true
 alloy-rpc-types = { workspace = true, features = ["eth", "trace"] }
 alloy-rpc-types-beacon.workspace = true
+alloy-serde.workspace = true
 alloy-signer-local = { workspace = true, features = ["mnemonic", "keystore"] }
 alloy-signer.workspace = true
 alloy-sol-types.workspace = true
@@ -62,8 +63,6 @@ alloy-eips.workspace = true
 tempo-alloy.workspace = true
 tempo-contracts.workspace = true
 tempo-primitives.workspace = true
-alloy-evm.workspace = true
-
 op-alloy-consensus = { workspace = true, features = ["k256"], optional = true }
 op-alloy-flz = { workspace = true, optional = true }
 op-alloy-network = { workspace = true, optional = true }
@@ -109,7 +108,6 @@ windows-sys = { version = "0.61", features = [
 
 [dev-dependencies]
 alloy-hardforks.workspace = true
-alloy-serde.workspace = true
 dirs.workspace = true
 anvil.workspace = true
 foundry-test-utils.workspace = true

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -8,17 +8,19 @@ use crate::{
 };
 use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
 
-use alloy_evm::FromRecoveredTx;
-use alloy_network::{BlockResponse, Network, ReceiptResponse, TransactionResponse};
+use alloy_network::{
+    AnyNetwork, AnyRpcTransaction, BlockResponse, Network, ReceiptResponse, TransactionResponse,
+};
 use alloy_primitives::{
     Address, B256, Bytes, U256,
-    map::{AddressHashMap, AddressSet},
+    map::{AddressHashMap, AddressSet, B256HashMap},
 };
 use alloy_provider::{Provider, ext::DebugApi};
 use alloy_rpc_types::{
     BlockId, BlockTransactions,
     trace::geth::{CallConfig, GethDebugTracingOptions, GethTrace, PreStateConfig},
 };
+use alloy_serde::OtherFields;
 use clap::Parser;
 use eyre::{Result, WrapErr};
 use foundry_cli::{
@@ -40,7 +42,7 @@ use foundry_config::{
 use foundry_evm::core::evm::OpEvmNetwork;
 use foundry_evm::{
     core::{
-        FoundryBlock as _,
+        FoundryBlock as _, FoundryTransaction, FromAnyRpcTransaction,
         evm::{EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor},
     },
     executors::{EvmError, Executor, TracingExecutor},
@@ -48,6 +50,7 @@ use foundry_evm::{
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
 };
+use foundry_evm_networks::arbitrum::is_arbitrum_chain;
 use futures::TryFutureExt;
 use revm::{DatabaseRef, context::Block, primitives::hardfork::SpecId};
 
@@ -184,7 +187,10 @@ impl RunArgs {
             self.rpc.common.compute_units_per_second
         };
 
-        let provider = ProviderBuilder::<FEN::Network>::from_config(&config)?
+        // Full blocks can contain chain-specific system transaction types (for example Nitro's
+        // `0x6a`) even when the target transaction uses a standard Ethereum envelope. Decode RPC
+        // responses through `AnyNetwork` so those transactions can be identified and skipped.
+        let provider = ProviderBuilder::<AnyNetwork>::from_config(&config)?
             .compute_units_per_second_opt(compute_units_per_second)
             .build()?;
 
@@ -364,12 +370,26 @@ impl RunArgs {
                     evm_version = Some(EvmVersion::Cancun);
                 }
             }
-            apply_chain_and_block_specific_env_changes::<FEN::Network, _, _>(
+            apply_chain_and_block_specific_env_changes::<AnyNetwork, _, _>(
                 &mut evm_env,
                 block,
                 config.networks,
             );
         }
+
+        let l1_gas_used_by_tx = if is_arbitrum_chain(evm_env.cfg_env.chain_id) {
+            provider
+                .get_block_receipts(tx_block_number.into())
+                .await?
+                .ok_or_else(|| eyre::eyre!("block receipts not found: {tx_block_number}"))?
+                .into_iter()
+                .map(|receipt| {
+                    (receipt.transaction_hash(), arbitrum_l1_gas_used(receipt.other_fields()))
+                })
+                .collect::<B256HashMap<_>>()
+        } else {
+            B256HashMap::default()
+        };
 
         let trace_requirements = TraceRequirements::none()
             .with_calls(true)
@@ -394,9 +414,11 @@ impl RunArgs {
 
         let spec_id = (*evm_env.cfg_env.spec()).into();
 
-        if let Some(parent_beacon_block_root) =
-            parent_beacon_block_root_for_spec(spec_id, parent_beacon_block_root)?
-        {
+        if let Some(parent_beacon_block_root) = parent_beacon_block_root_for_spec(
+            spec_id,
+            parent_beacon_block_root,
+            evm_env.cfg_env.chain_id,
+        )? {
             executor.apply_beacon_root(parent_beacon_block_root)?;
         }
 
@@ -459,7 +481,10 @@ impl RunArgs {
                         break;
                     }
 
-                    let tx_env = TxEnvFor::<FEN>::from_recovered_tx(tx.as_ref(), tx.from());
+                    let tx_env = replay_tx_env::<FEN>(
+                        tx,
+                        l1_gas_used_by_tx.get(&tx.tx_hash()).copied().unwrap_or_default(),
+                    )?;
 
                     evm_env.cfg_env.disable_balance_check = true;
 
@@ -504,19 +529,26 @@ impl RunArgs {
         let result = {
             executor.set_trace_printer(self.trace_printer);
 
-            let tx_env = TxEnvFor::<FEN>::from_recovered_tx(tx.as_ref(), tx.from());
+            let l1_gas_used = l1_gas_used_by_tx.get(&tx.tx_hash()).copied().unwrap_or_default();
+            let tx_env = replay_tx_env::<FEN>(&tx, l1_gas_used)?;
 
-            if tx.as_ref().recover_signer().is_ok_and(|signer| signer != tx.from()) {
+            let from = tx.from();
+            if tx
+                .as_envelope()
+                .is_some_and(|tx| tx.recover_signer().is_ok_and(|signer| signer != from))
+            {
                 evm_env.cfg_env.disable_balance_check = true;
             }
 
-            if let Some(to) = Transaction::to(&tx) {
+            let mut result = if let Some(to) = Transaction::to(&tx) {
                 trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
                 TraceResult::from(executor.transact_with_env(evm_env, tx_env)?)
             } else {
                 trace!(tx=?tx.tx_hash(), "executing create transaction");
                 TraceResult::try_from(executor.deploy_with_env(evm_env, tx_env, None))?
-            }
+            };
+            result.gas_used = result.gas_used.saturating_add(l1_gas_used);
+            result
         };
 
         let contracts_bytecode = fetch_contracts_bytecode_from_trace(&executor, &result)?;
@@ -539,11 +571,34 @@ impl RunArgs {
     }
 }
 
+/// Builds a transaction environment with Nitro's L1 poster gas removed from the gas available to
+/// the EVM. Nitro charges this component before execution and reports it separately on the receipt.
+fn replay_tx_env<FEN: FoundryEvmNetwork>(
+    tx: &AnyRpcTransaction,
+    l1_gas_used: u64,
+) -> Result<TxEnvFor<FEN>> {
+    let mut tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(tx)?;
+    tx_env.set_gas_limit(tx.gas_limit().saturating_sub(l1_gas_used));
+    Ok(tx_env)
+}
+
+fn arbitrum_l1_gas_used(other_fields: &OtherFields) -> u64 {
+    other_fields
+        .get_deserialized::<U256>("gasUsedForL1")
+        .and_then(|value| value.ok())
+        .map(|value| value.saturating_to())
+        .unwrap_or_default()
+}
+
 fn parent_beacon_block_root_for_spec(
     spec_id: SpecId,
     parent_beacon_block_root: Option<B256>,
+    chain_id: u64,
 ) -> Result<Option<B256>> {
     if !spec_id.is_enabled_in(SpecId::CANCUN) {
+        return Ok(None);
+    }
+    if is_arbitrum_chain(chain_id) && parent_beacon_block_root.is_none() {
         return Ok(None);
     }
 
@@ -723,6 +778,13 @@ mod tests {
     }
 
     #[test]
+    fn parses_arbitrum_l1_gas_used() {
+        let mut other_fields = OtherFields::default();
+        other_fields.insert_value("gasUsedForL1".to_string(), "0x26ed52").unwrap();
+        assert_eq!(arbitrum_l1_gas_used(&other_fields), 2_551_122);
+    }
+
+    #[test]
     fn debug_trace_transaction_accepts_label_and_render_flags() {
         let args = RunArgs::try_parse_from([
             "foundry-cli",
@@ -740,15 +802,24 @@ mod tests {
 
     #[test]
     fn parent_beacon_block_root_is_required_for_cancun() {
-        let err = parent_beacon_block_root_for_spec(SpecId::CANCUN, None).unwrap_err();
+        let err = parent_beacon_block_root_for_spec(SpecId::CANCUN, None, 1).unwrap_err();
         assert!(err.to_string().contains("MissingParentBeaconBlockRoot"));
 
         let root = B256::repeat_byte(0x42);
         assert_eq!(
-            parent_beacon_block_root_for_spec(SpecId::CANCUN, Some(root)).unwrap(),
+            parent_beacon_block_root_for_spec(SpecId::CANCUN, Some(root), 1).unwrap(),
             Some(root),
         );
-        assert_eq!(parent_beacon_block_root_for_spec(SpecId::SHANGHAI, Some(root)).unwrap(), None);
-        assert_eq!(parent_beacon_block_root_for_spec(SpecId::SHANGHAI, None).unwrap(), None);
+        assert_eq!(
+            parent_beacon_block_root_for_spec(SpecId::SHANGHAI, Some(root), 1).unwrap(),
+            None
+        );
+        assert_eq!(parent_beacon_block_root_for_spec(SpecId::SHANGHAI, None, 1).unwrap(), None);
+    }
+
+    #[test]
+    fn parent_beacon_block_root_is_optional_on_arbitrum() {
+        assert_eq!(parent_beacon_block_root_for_spec(SpecId::CANCUN, None, 42161).unwrap(), None);
+        assert_eq!(parent_beacon_block_root_for_spec(SpecId::CANCUN, None, 4663).unwrap(), None);
     }
 }

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -12,7 +12,7 @@ use alloy_network::{
     AnyNetwork, AnyRpcTransaction, BlockResponse, Network, ReceiptResponse, TransactionResponse,
 };
 use alloy_primitives::{
-    Address, B256, Bytes, U256,
+    Address, B256, Bytes, TxKind, U256,
     map::{AddressHashMap, AddressSet, B256HashMap},
 };
 use alloy_provider::{Provider, ext::DebugApi};
@@ -52,7 +52,11 @@ use foundry_evm::{
 };
 use foundry_evm_networks::arbitrum::is_arbitrum_chain;
 use futures::TryFutureExt;
-use revm::{DatabaseRef, context::Block, primitives::hardfork::SpecId};
+use revm::{
+    DatabaseRef,
+    context::{Block, Transaction as _},
+    primitives::hardfork::SpecId,
+};
 
 /// CLI arguments for `cast run`.
 #[derive(Clone, Debug, Parser)]
@@ -488,33 +492,36 @@ impl RunArgs {
 
                     evm_env.cfg_env.disable_balance_check = true;
 
-                    if let Some(to) = Transaction::to(tx) {
-                        trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
-                        executor.transact_with_env(evm_env.clone(), tx_env.clone()).wrap_err_with(
-                            || {
-                                format!(
-                                    "Failed to execute transaction: {:?} in block {}",
-                                    tx.tx_hash(),
-                                    evm_env.block_env.number()
-                                )
-                            },
-                        )?;
-                    } else {
-                        trace!(tx=?tx.tx_hash(), "executing previous create transaction");
-                        if let Err(error) =
-                            executor.deploy_with_env(evm_env.clone(), tx_env.clone(), None)
-                        {
-                            match error {
-                                // Reverted transactions should be skipped
-                                EvmError::Execution(_) => (),
-                                error => {
-                                    return Err(error).wrap_err_with(|| {
-                                        format!(
-                                            "Failed to deploy transaction: {:?} in block {}",
-                                            tx.tx_hash(),
-                                            evm_env.block_env.number()
-                                        )
-                                    });
+                    match tx_env.kind() {
+                        TxKind::Call(to) => {
+                            trace!(tx=?tx.tx_hash(),?to, "executing previous call transaction");
+                            executor
+                                .transact_with_env(evm_env.clone(), tx_env.clone())
+                                .wrap_err_with(|| {
+                                    format!(
+                                        "Failed to execute transaction: {:?} in block {}",
+                                        tx.tx_hash(),
+                                        evm_env.block_env.number()
+                                    )
+                                })?;
+                        }
+                        TxKind::Create => {
+                            trace!(tx=?tx.tx_hash(), "executing previous create transaction");
+                            if let Err(error) =
+                                executor.deploy_with_env(evm_env.clone(), tx_env.clone(), None)
+                            {
+                                match error {
+                                    // Reverted transactions should be skipped
+                                    EvmError::Execution(_) => (),
+                                    error => {
+                                        return Err(error).wrap_err_with(|| {
+                                            format!(
+                                                "Failed to deploy transaction: {:?} in block {}",
+                                                tx.tx_hash(),
+                                                evm_env.block_env.number()
+                                            )
+                                        });
+                                    }
                                 }
                             }
                         }
@@ -540,12 +547,15 @@ impl RunArgs {
                 evm_env.cfg_env.disable_balance_check = true;
             }
 
-            let mut result = if let Some(to) = Transaction::to(&tx) {
-                trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
-                TraceResult::from(executor.transact_with_env(evm_env, tx_env)?)
-            } else {
-                trace!(tx=?tx.tx_hash(), "executing create transaction");
-                TraceResult::try_from(executor.deploy_with_env(evm_env, tx_env, None))?
+            let mut result = match tx_env.kind() {
+                TxKind::Call(to) => {
+                    trace!(tx=?tx.tx_hash(), to=?to, "executing call transaction");
+                    TraceResult::from(executor.transact_with_env(evm_env, tx_env)?)
+                }
+                TxKind::Create => {
+                    trace!(tx=?tx.tx_hash(), "executing create transaction");
+                    TraceResult::try_from(executor.deploy_with_env(evm_env, tx_env, None))?
+                }
             };
             result.gas_used = result.gas_used.saturating_add(l1_gas_used);
             result

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -382,17 +382,17 @@ impl RunArgs {
         }
 
         let l1_gas_used_by_tx = if is_arbitrum_chain(evm_env.cfg_env.chain_id) {
-            provider
-                .get_block_receipts(tx_block_number.into())
-                .await?
-                .ok_or_else(|| eyre::eyre!("block receipts not found: {tx_block_number}"))?
-                .into_iter()
-                .map(|receipt| {
-                    (receipt.transaction_hash(), arbitrum_l1_gas_used(receipt.other_fields()))
-                })
-                .collect::<B256HashMap<_>>()
+            Some(
+                provider
+                    .get_block_receipts(tx_block_number.into())
+                    .await?
+                    .ok_or_else(|| eyre::eyre!("block receipts not found: {tx_block_number}"))?
+                    .into_iter()
+                    .map(|receipt| (receipt.transaction_hash(), receipt.other_fields().clone()))
+                    .collect::<B256HashMap<_>>(),
+            )
         } else {
-            B256HashMap::default()
+            None
         };
 
         let trace_requirements = TraceRequirements::none()
@@ -485,10 +485,9 @@ impl RunArgs {
                         break;
                     }
 
-                    let tx_env = replay_tx_env::<FEN>(
-                        tx,
-                        l1_gas_used_by_tx.get(&tx.tx_hash()).copied().unwrap_or_default(),
-                    )?;
+                    let l1_gas_used =
+                        arbitrum_l1_gas_used_for_tx(l1_gas_used_by_tx.as_ref(), tx.tx_hash())?;
+                    let tx_env = replay_tx_env::<FEN>(tx, l1_gas_used)?;
 
                     evm_env.cfg_env.disable_balance_check = true;
 
@@ -536,7 +535,8 @@ impl RunArgs {
         let result = {
             executor.set_trace_printer(self.trace_printer);
 
-            let l1_gas_used = l1_gas_used_by_tx.get(&tx.tx_hash()).copied().unwrap_or_default();
+            let l1_gas_used =
+                arbitrum_l1_gas_used_for_tx(l1_gas_used_by_tx.as_ref(), tx.tx_hash())?;
             let tx_env = replay_tx_env::<FEN>(&tx, l1_gas_used)?;
 
             let from = tx.from();
@@ -557,7 +557,7 @@ impl RunArgs {
                     TraceResult::try_from(executor.deploy_with_env(evm_env, tx_env, None))?
                 }
             };
-            result.gas_used = result.gas_used.saturating_add(l1_gas_used);
+            result.gas_used = total_gas_used(tx.tx_hash(), result.gas_used, l1_gas_used)?;
             result
         };
 
@@ -588,16 +588,50 @@ fn replay_tx_env<FEN: FoundryEvmNetwork>(
     l1_gas_used: u64,
 ) -> Result<TxEnvFor<FEN>> {
     let mut tx_env = TxEnvFor::<FEN>::from_any_rpc_transaction(tx)?;
-    tx_env.set_gas_limit(tx.gas_limit().saturating_sub(l1_gas_used));
+    let gas_limit = tx.gas_limit();
+    let execution_gas_limit = execution_gas_limit(tx.tx_hash(), gas_limit, l1_gas_used)?;
+    tx_env.set_gas_limit(execution_gas_limit);
     Ok(tx_env)
 }
 
-fn arbitrum_l1_gas_used(other_fields: &OtherFields) -> u64 {
-    other_fields
+fn execution_gas_limit(tx_hash: B256, gas_limit: u64, l1_gas_used: u64) -> Result<u64> {
+    gas_limit.checked_sub(l1_gas_used).ok_or_else(|| {
+        eyre::eyre!(
+            "Nitro poster gas {l1_gas_used} exceeds gas limit {gas_limit} for transaction {:?}",
+            tx_hash
+        )
+    })
+}
+
+fn total_gas_used(tx_hash: B256, execution_gas_used: u64, l1_gas_used: u64) -> Result<u64> {
+    execution_gas_used.checked_add(l1_gas_used).ok_or_else(|| {
+        eyre::eyre!(
+            "gas used overflow for transaction {tx_hash:?}: execution gas {execution_gas_used}, Nitro poster gas {l1_gas_used}"
+        )
+    })
+}
+
+fn arbitrum_l1_gas_used_for_tx(
+    receipt_fields_by_tx: Option<&B256HashMap<OtherFields>>,
+    tx_hash: B256,
+) -> Result<u64> {
+    let Some(receipt_fields_by_tx) = receipt_fields_by_tx else { return Ok(0) };
+    let other_fields = receipt_fields_by_tx
+        .get(&tx_hash)
+        .ok_or_else(|| eyre::eyre!("receipt not found for Nitro transaction {tx_hash:?}"))?;
+    arbitrum_l1_gas_used(other_fields)
+        .wrap_err_with(|| format!("invalid Nitro poster gas for transaction {tx_hash:?}"))
+}
+
+fn arbitrum_l1_gas_used(other_fields: &OtherFields) -> Result<u64> {
+    let value = other_fields
         .get_deserialized::<U256>("gasUsedForL1")
-        .and_then(|value| value.ok())
-        .map(|value| value.saturating_to())
-        .unwrap_or_default()
+        .ok_or_else(|| eyre::eyre!("missing `gasUsedForL1` receipt field"))?
+        .wrap_err("malformed `gasUsedForL1` receipt field")?;
+    if value > U256::from(u64::MAX) {
+        eyre::bail!("`gasUsedForL1` value {value} exceeds u64::MAX");
+    }
+    Ok(value.to())
 }
 
 fn parent_beacon_block_root_for_spec(
@@ -791,7 +825,46 @@ mod tests {
     fn parses_arbitrum_l1_gas_used() {
         let mut other_fields = OtherFields::default();
         other_fields.insert_value("gasUsedForL1".to_string(), "0x26ed52").unwrap();
-        assert_eq!(arbitrum_l1_gas_used(&other_fields), 2_551_122);
+        assert_eq!(arbitrum_l1_gas_used(&other_fields).unwrap(), 2_551_122);
+
+        other_fields.insert_value("gasUsedForL1".to_string(), "0x0").unwrap();
+        assert_eq!(arbitrum_l1_gas_used(&other_fields).unwrap(), 0);
+    }
+
+    #[test]
+    fn rejects_invalid_arbitrum_l1_gas_used() {
+        let mut other_fields = OtherFields::default();
+        let err = arbitrum_l1_gas_used(&other_fields).unwrap_err();
+        assert!(err.to_string().contains("missing `gasUsedForL1`"));
+
+        other_fields.insert_value("gasUsedForL1".to_string(), "invalid").unwrap();
+        let err = arbitrum_l1_gas_used(&other_fields).unwrap_err();
+        assert!(err.to_string().contains("malformed `gasUsedForL1`"));
+
+        other_fields
+            .insert_value("gasUsedForL1".to_string(), U256::from(u64::MAX) + U256::from(1))
+            .unwrap();
+        let err = arbitrum_l1_gas_used(&other_fields).unwrap_err();
+        assert!(err.to_string().contains("exceeds u64::MAX"));
+    }
+
+    #[test]
+    fn requires_matching_arbitrum_receipt() {
+        let tx_hash = B256::repeat_byte(0x42);
+        let receipt_fields_by_tx = B256HashMap::default();
+        let err = arbitrum_l1_gas_used_for_tx(Some(&receipt_fields_by_tx), tx_hash).unwrap_err();
+        assert!(err.to_string().contains("receipt not found for Nitro transaction"));
+        assert_eq!(arbitrum_l1_gas_used_for_tx(None, tx_hash).unwrap(), 0);
+    }
+
+    #[test]
+    fn rejects_invalid_nitro_gas_accounting() {
+        let tx_hash = B256::repeat_byte(0x42);
+        let err = execution_gas_limit(tx_hash, 100, 101).unwrap_err();
+        assert!(err.to_string().contains("poster gas 101 exceeds gas limit 100"));
+
+        let err = total_gas_used(tx_hash, u64::MAX, 1).unwrap_err();
+        assert!(err.to_string().contains("gas used overflow"));
     }
 
     #[test]

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -1,6 +1,8 @@
 use std::fmt::Debug;
 
 use alloy_consensus::Typed2718;
+#[cfg(feature = "optimism")]
+use alloy_eips::Encodable2718;
 pub use alloy_evm::EvmEnv;
 use alloy_evm::FromRecoveredTx;
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
@@ -751,7 +753,7 @@ mod optimism {
             if let Some(envelope) = tx.as_envelope() {
                 return Ok(Self(OpTransaction::<TxEnv> {
                     base: TxEnv::from_recovered_tx(envelope, tx.from()),
-                    enveloped_tx: None,
+                    enveloped_tx: Some(envelope.encoded_2718().into()),
                     deposit: Default::default(),
                 }));
             }
@@ -1029,6 +1031,7 @@ mod tests {
         fn from_any_rpc_transaction_for_op() {
             let from = Address::random();
             let signed_tx = make_signed_eip1559();
+            let expected_enveloped_tx = signed_tx.encoded_2718();
 
             // Build the eth TxEnv to compare against op base
             let rpc_tx = RpcTransaction::from_transaction(
@@ -1040,6 +1043,7 @@ mod tests {
 
             let op_tx_env = OpTx::from_any_rpc_transaction(&any_tx).unwrap();
             assert_eq!(op_tx_env.base, expected_base);
+            assert_eq!(op_tx_env.enveloped_tx, Some(expected_enveloped_tx.into()));
         }
 
         #[test]

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -20,6 +20,7 @@ use revm::{
     inspector::JournalExt,
     primitives::{TxKind, hardfork::SpecId},
 };
+use tempo_alloy::primitives::{AASigned, TempoSignature, TempoTransaction};
 use tempo_revm::{TempoBlockEnv, TempoTxEnv};
 
 use crate::backend::JournaledState;
@@ -527,7 +528,6 @@ impl FromAnyRpcTransaction for TxEnv {
 
 impl FromAnyRpcTransaction for TempoTxEnv {
     fn from_any_rpc_transaction(tx: &AnyRpcTransaction) -> eyre::Result<Self> {
-        use alloy_consensus::Transaction as _;
         if let Some(envelope) = tx.as_envelope() {
             return Ok(TxEnv::from_recovered_tx(envelope, tx.from()).into());
         }
@@ -536,23 +536,21 @@ impl FromAnyRpcTransaction for TempoTxEnv {
         if let AnyTxEnvelope::Unknown(unknown) = &*tx.inner.inner
             && unknown.ty() == tempo_alloy::primitives::TEMPO_TX_TYPE_ID
         {
-            let base = TxEnv {
-                tx_type: unknown.ty(),
-                caller: tx.from(),
-                gas_limit: unknown.gas_limit(),
-                gas_price: unknown.max_fee_per_gas(),
-                gas_priority_fee: unknown.max_priority_fee_per_gas(),
-                kind: unknown.kind(),
-                value: unknown.value(),
-                data: unknown.input().clone(),
-                nonce: unknown.nonce(),
-                chain_id: unknown.chain_id(),
-                access_list: unknown.access_list().cloned().unwrap_or_default(),
-                ..Default::default()
-            };
-            let fee_token =
-                unknown.inner.fields.get_deserialized::<Address>("feeToken").and_then(Result::ok);
-            return Ok(Self { inner: base, fee_token, ..Default::default() });
+            let tempo_tx = unknown
+                .inner
+                .fields
+                .clone()
+                .deserialize_into::<TempoTransaction>()
+                .map_err(|err| eyre::eyre!("failed to deserialize Tempo transaction: {err}"))?;
+            let signature = unknown
+                .inner
+                .fields
+                .get_deserialized::<TempoSignature>("signature")
+                .transpose()
+                .map_err(|err| eyre::eyre!("failed to deserialize Tempo signature: {err}"))?
+                .ok_or_else(|| eyre::eyre!("missing Tempo transaction signature"))?;
+            let signed = AASigned::new_unchecked(tempo_tx, signature, unknown.hash);
+            return Ok(Self::from_recovered_tx(&signed, tx.from()));
         }
 
         eyre::bail!("cannot convert unknown transaction type to TempoTxEnv")
@@ -789,7 +787,7 @@ mod tests {
     use foundry_evm_hardforks::TempoHardfork;
     use revm::database::EmptyDB;
     use tempo_alloy::primitives::{
-        AASigned, TempoSignature, TempoTransaction, TempoTxEnvelope,
+        TempoTxEnvelope,
         transaction::{Call, PrimitiveSignature},
     };
     use tempo_evm::TempoEvmFactory;
@@ -965,6 +963,20 @@ mod tests {
             gas_limit: 424242,
             fee_token,
             nonce_key: U256::from(4242),
+            calls: vec![
+                Call {
+                    to: Address::repeat_byte(0x11).into(),
+                    value: U256::from(101),
+                    input: Bytes::from_static(b"first"),
+                },
+                Call {
+                    to: Address::repeat_byte(0x22).into(),
+                    value: U256::from(202),
+                    input: Bytes::from_static(b"second"),
+                },
+            ],
+            fee_payer_signature: Some(Signature::new(U256::from(1), U256::from(2), false)),
+            valid_before: NonZeroU64::new(1800000100),
             valid_after: NonZeroU64::new(1800000000),
             ..Default::default()
         };
@@ -976,6 +988,7 @@ mod tests {
                 false,
             ))),
         );
+        let expected = TempoTxEnv::from_recovered_tx(&aa_signed, from);
 
         // Build a concrete Tempo RPC transaction, serialize to JSON, deserialize as
         // AnyRpcTransaction.
@@ -987,11 +1000,20 @@ mod tests {
         let any_tx: AnyRpcTransaction = serde_json::from_value(json).unwrap();
 
         let tx_env = TempoTxEnv::from_any_rpc_transaction(&any_tx).unwrap();
-        assert_eq!(tx_env.inner.caller, from);
-        assert_eq!(tx_env.inner.nonce, 42);
-        assert_eq!(tx_env.inner.gas_limit, 424242);
-        assert_eq!(tx_env.inner.chain_id, Some(42431));
-        assert_eq!(tx_env.fee_token, fee_token);
+        assert_eq!(tx_env.inner, expected.inner);
+        assert_eq!(tx_env.fee_token, expected.fee_token);
+        assert_eq!(tx_env.unique_tx_identifier, expected.unique_tx_identifier);
+        assert_eq!(tx_env.fee_payer, expected.fee_payer);
+
+        let tx_aa = tx_env.tempo_tx_env.unwrap();
+        let expected_aa = expected.tempo_tx_env.unwrap();
+        assert_eq!(tx_aa.signature, expected_aa.signature);
+        assert_eq!(tx_aa.valid_before, expected_aa.valid_before);
+        assert_eq!(tx_aa.valid_after, expected_aa.valid_after);
+        assert_eq!(tx_aa.aa_calls, expected_aa.aa_calls);
+        assert_eq!(tx_aa.nonce_key, expected_aa.nonce_key);
+        assert_eq!(tx_aa.signature_hash, expected_aa.signature_hash);
+        assert_eq!(tx_aa.tx_hash, expected_aa.tx_hash);
     }
 
     #[cfg(feature = "optimism")]

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -6,7 +6,7 @@ use alloy_json_abi::{Function, JsonAbi};
 use alloy_primitives::{B256, ChainId, Selector, U256};
 use alloy_provider::{Network, network::BlockResponse};
 use foundry_config::NamedChain;
-use foundry_evm_networks::NetworkConfigs;
+use foundry_evm_networks::{NetworkConfigs, arbitrum::is_arbitrum_chain};
 use revm::primitives::hardfork::SpecId;
 pub use revm::state::EvmState as StateChangeset;
 
@@ -48,6 +48,18 @@ pub fn apply_chain_and_block_specific_env_changes<
 ) {
     use NamedChain::{BinanceSmartChain, BinanceSmartChainTestnet, Mainnet};
 
+    if is_arbitrum_chain(evm_env.cfg_env.chain_id) {
+        // On Arbitrum `block.number` is the L1 block which is included in the
+        // `l1BlockNumber` field.
+        if let Some(l1_block_number) = block
+            .other_fields()
+            .and_then(|other| other.get("l1BlockNumber").cloned())
+            .and_then(|l1_block_number| serde_json::from_value::<U256>(l1_block_number).ok())
+        {
+            evm_env.block_env.set_number(l1_block_number);
+        }
+    }
+
     if let Ok(chain) = NamedChain::try_from(evm_env.cfg_env.chain_id) {
         let block_number = block.header().number();
 
@@ -71,19 +83,6 @@ pub fn apply_chain_and_block_specific_env_changes<
                 // failure.
                 evm_env.block_env.set_prevrandao(Some(evm_env.block_env.difficulty().into()));
                 return;
-            }
-            c if c.is_arbitrum() => {
-                // on arbitrum `block.number` is the L1 block which is included in the
-                // `l1BlockNumber` field
-                if let Some(l1_block_number) = block
-                    .other_fields()
-                    .and_then(|other| other.get("l1BlockNumber").cloned())
-                    .and_then(|l1_block_number| {
-                        serde_json::from_value::<U256>(l1_block_number).ok()
-                    })
-                {
-                    evm_env.block_env.set_number(l1_block_number);
-                }
             }
             _ => {}
         }

--- a/crates/evm/networks/src/arbitrum.rs
+++ b/crates/evm/networks/src/arbitrum.rs
@@ -10,6 +10,12 @@ use revm::precompile::{PrecompileHalt, PrecompileId, PrecompileOutput, Precompil
 /// ArbSys system contract address.
 pub const ARB_SYS_ADDRESS: Address = address!("0000000000000000000000000000000000000064");
 
+/// Robinhood Chain mainnet chain ID.
+pub const ROBINHOOD_MAINNET_CHAIN_ID: u64 = 4663;
+
+/// Robinhood Chain testnet chain ID.
+pub const ROBINHOOD_TESTNET_CHAIN_ID: u64 = 46630;
+
 /// `ArbSys.arbBlockNumber()` selector.
 pub const ARB_BLOCK_NUMBER_SELECTOR: [u8; 4] = hex!("a3b1b31d");
 
@@ -22,6 +28,7 @@ pub static PRECOMPILE_ID_ARB_SYS: PrecompileId = PrecompileId::Custom(Cow::Borro
 /// Returns whether `chain_id` is an Arbitrum chain.
 pub fn is_arbitrum_chain(chain_id: u64) -> bool {
     Chain::from_id(chain_id).is_arbitrum()
+        || matches!(chain_id, ROBINHOOD_MAINNET_CHAIN_ID | ROBINHOOD_TESTNET_CHAIN_ID)
 }
 
 /// Returns the ABI-encoded result for `ArbSys.arbBlockNumber()`.
@@ -55,4 +62,15 @@ fn arb_sys_precompile_call(input: PrecompileInput<'_>, block_number: u64) -> Pre
     };
 
     Ok(PrecompileOutput::new(gas_cost, output, input.reservoir))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifies_robinhood_as_arbitrum() {
+        assert!(is_arbitrum_chain(ROBINHOOD_MAINNET_CHAIN_ID));
+        assert!(is_arbitrum_chain(ROBINHOOD_TESTNET_CHAIN_ID));
+    }
 }


### PR DESCRIPTION
`cast run` decoded full blocks with the selected Ethereum or OP network type, so Nitro's `0x6a` system transaction made otherwise standard Arbitrum and Robinhood blocks fail before replay. This decodes RPC blocks through `AnyNetwork` while preserving OP envelope bytes during conversion.

Nitro charges the L1 poster-gas component before EVM execution and reports it separately in receipts. Local replay previously exposed that gas to the transaction, which could change execution results. The replay now deducts receipt-reported poster gas before execution and adds it back to the displayed total. Robinhood's chain IDs are also recognized for Nitro block-number semantics, and Nitro Cancun blocks may omit the parent beacon root.

Fixes #7514. Closes OSS-556.

This PR was written with Codex, including investigation, code generation, and test generation.