### PR TITLE
feat(forge): add compiler path output

### DIFF
--- a/crates/forge/src/cmd/compiler.rs
+++ b/crates/forge/src/cmd/compiler.rs
@@ -1,7 +1,14 @@
 use clap::{Parser, Subcommand, ValueHint};
 use eyre::Result;
 use foundry_common::shell;
-use foundry_compilers::{Graph, artifacts::EvmVersion};
+use foundry_compilers::{
+    Graph, Project,
+    artifacts::EvmVersion,
+    compilers::{
+        multi::{MultiCompiler, MultiCompilerLanguage},
+        solc::{Solc, SolcCompiler},
+    },
+};
 use foundry_config::Config;
 use semver::Version;
 use serde::Serialize;
@@ -32,6 +39,9 @@ pub enum CompilerSubcommands {
 /// Resolved compiler within the project.
 #[derive(Serialize)]
 struct ResolvedCompiler {
+    /// Compiler language.
+    #[serde(skip)]
+    language: MultiCompilerLanguage,
     /// Compiler version.
     version: Version,
     /// Max supported EVM version of compiler.
@@ -52,11 +62,15 @@ pub struct ResolveArgs {
     /// Skip files that match the given regex pattern.
     #[arg(long, short, value_name = "REGEX")]
     skip: Option<regex::Regex>,
+
+    /// Print only the executable path for a single resolved compiler.
+    #[arg(long)]
+    path: bool,
 }
 
 impl ResolveArgs {
     pub fn run(self) -> Result<()> {
-        let Self { root, skip } = self;
+        let Self { root, skip, path } = self;
 
         let root = root.unwrap_or_else(|| PathBuf::from("."));
         let config = Config::load_with_root(&root)?;
@@ -96,7 +110,7 @@ impl ResolveArgs {
                         EvmVersion::default().normalize_version_solc(version).unwrap_or_default()
                     });
 
-                    ResolvedCompiler { version: version.clone(), evm_version, paths }
+                    ResolvedCompiler { language, version: version.clone(), evm_version, paths }
                 })
                 .filter(|version| !version.paths.is_empty())
                 .collect();
@@ -116,6 +130,25 @@ impl ResolveArgs {
 
                 output.insert(language.to_string(), versions_with_paths);
             }
+        }
+
+        if path {
+            let mut compilers = output.values().flatten();
+            let Some(compiler) = compilers.next() else {
+                eyre::bail!("no compiler resolved");
+            };
+            eyre::ensure!(
+                compilers.next().is_none(),
+                "multiple compilers resolved; use `forge compiler resolve` to inspect them"
+            );
+
+            let path = resolved_compiler_path(&project, compiler)?;
+            if shell::is_json() {
+                sh_println!("{}", serde_json::to_string(&path)?)?;
+            } else {
+                sh_println!("{}", path.display())?;
+            }
+            return Ok(());
         }
 
         if shell::is_json() {
@@ -160,5 +193,34 @@ impl ResolveArgs {
         }
 
         Ok(())
+    }
+}
+
+fn resolved_compiler_path(
+    project: &Project<MultiCompiler>,
+    compiler: &ResolvedCompiler,
+) -> Result<PathBuf> {
+    match compiler.language {
+        MultiCompilerLanguage::Solc(_) => {
+            let solc = project
+                .compiler
+                .solc
+                .as_ref()
+                .ok_or_else(|| eyre::eyre!("Solidity compiler is not available"))?;
+            match solc {
+                SolcCompiler::AutoDetect => Solc::find_svm_installed_version(&compiler.version)?
+                    .map(|solc| solc.solc)
+                    .ok_or_else(|| {
+                        eyre::eyre!("Solidity compiler {} is not installed", compiler.version)
+                    }),
+                SolcCompiler::Specific(solc) => Ok(solc.solc.clone()),
+            }
+        }
+        MultiCompilerLanguage::Vyper(_) => project
+            .compiler
+            .vyper
+            .as_ref()
+            .map(|vyper| vyper.path.clone())
+            .ok_or_else(|| eyre::eyre!("Vyper compiler is not available")),
     }
 }

--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -1,6 +1,10 @@
 //! Tests for the `forge compiler` command.
 
-use foundry_test_utils::snapbox::IntoData;
+use foundry_compilers::compilers::solc::Solc;
+use foundry_test_utils::{
+    snapbox::IntoData,
+    util::{SOLC_VERSION, get_vyper},
+};
 
 const CONTRACT_A: &str = r#"
 // SPDX-license-identifier: MIT
@@ -85,6 +89,35 @@ Solidity:
 
 
 "#]]);
+});
+
+forgetest_init!(can_print_resolved_compiler_path, |prj, cmd| {
+    prj.add_source("Contract", "contract Contract {}");
+    let solc = Solc::find_svm_installed_version(&SOLC_VERSION.parse().unwrap()).unwrap().unwrap();
+
+    cmd.args(["compiler", "resolve", "--path"])
+        .assert_success()
+        .stdout_eq(format!("{}\n", solc.solc.display()));
+});
+
+forgetest!(can_print_resolved_vyper_path, |prj, cmd| {
+    let vyper = get_vyper();
+    prj.add_raw_source("ICounter.vyi", VYPER_INTERFACE);
+    prj.add_raw_source("Counter.vy", VYPER_CONTRACT);
+    prj.update_config(|config| config.vyper.path = Some(vyper.path.clone()));
+
+    cmd.args(["compiler", "resolve", "--path"])
+        .assert_success()
+        .stdout_eq(format!("{}\n", vyper.path.display()));
+});
+
+forgetest!(compiler_path_requires_single_version, |prj, cmd| {
+    prj.add_source("ContractA", CONTRACT_A);
+    prj.add_source("ContractB", CONTRACT_B);
+
+    cmd.args(["compiler", "resolve", "--path"]).assert_failure().stdout_eq("").stderr_eq(
+        "Error: multiple compilers resolved; use `forge compiler resolve` to inspect them\n",
+    );
 });
 
 forgetest!(can_list_resolved_compiler_versions_json, |prj, cmd| {


### PR DESCRIPTION
`forge compiler resolve --path` now prints the executable path when a project resolves to exactly one compiler, enabling integrations such as `SOLC=$(forge compiler resolve --path)`. It supports installed auto-detected Solidity compilers as well as explicitly configured Solidity and Vyper binaries, while ambiguous multi-compiler projects receive an actionable error instead of a multi-line value.

Closes #5429.

This PR was developed with assistance from OpenAI Codex. I reviewed the implementation and test coverage and take responsibility for the changes.