### PR TITLE
fix(forge): fix JSON compiler errors

### DIFF
--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -233,7 +233,9 @@ impl ProjectCompiler {
                 }
             }
 
-            self.handle_output(&output)?;
+            if !(shell::is_json() && output.has_compiler_errors()) {
+                self.handle_output(&output)?;
+            }
         }
 
         Ok(output)

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -139,6 +139,9 @@ impl BuildArgs {
         if format_json && !self.names && !self.sizes {
             sh_println!("{}", serde_json::to_string_pretty(&output.output())?)?;
         }
+        if format_json && output.has_compiler_errors() {
+            std::process::exit(1);
+        }
 
         // Only run the `SolidityLinter` if lint on build and no compilation errors.
         if !self.no_lint

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -136,7 +136,7 @@ impl BuildArgs {
         // Cache project selectors.
         cache_local_signatures(&output)?;
 
-        if format_json && !self.names && !self.sizes {
+        if format_json && (!self.names && !self.sizes || output.has_compiler_errors()) {
             sh_println!("{}", serde_json::to_string_pretty(&output.output())?)?;
         }
         if format_json && output.has_compiler_errors() {

--- a/crates/forge/src/cmd/lint.rs
+++ b/crates/forge/src/cmd/lint.rs
@@ -39,6 +39,7 @@ foundry_config::impl_figment_convert!(LintArgs, build);
 
 impl LintArgs {
     pub fn run(self) -> Result<()> {
+        let format_json = shell::is_json();
         let config = self.load_config()?;
         let project = config.ephemeral_project()?;
         let path_config = config.project_paths();
@@ -102,7 +103,8 @@ impl LintArgs {
         }
 
         let linter = SolidityLinter::new(path_config)
-            .with_json_emitter(shell::is_json())
+            .with_json_emitter(format_json)
+            .with_json_emitter_stdout(format_json)
             .with_description(true)
             .with_lints(include)
             .without_lints(exclude)
@@ -111,9 +113,20 @@ impl LintArgs {
 
         let mut opts = solar::interface::config::CompileOpts::default();
         opts.unstable.typeck = true;
-        let mut compiler = solar::sema::Compiler::new(
-            solar::interface::Session::builder().opts(opts).with_stderr_emitter().build(),
-        );
+        if format_json {
+            opts.error_format = solar::interface::config::ErrorFormat::RustcJson;
+        }
+        let session = solar::interface::Session::builder().opts(opts);
+        let session =
+            if format_json { session.build() } else { session.with_stderr_emitter().build() };
+        if format_json {
+            let writer = Box::new(std::io::BufWriter::new(std::io::stdout()));
+            let emitter =
+                solar::interface::diagnostics::JsonEmitter::new(writer, session.clone_source_map())
+                    .rustc_like(true);
+            session.dcx.set_emitter(Box::new(emitter));
+        }
+        let mut compiler = solar::sema::Compiler::new(session);
 
         // Load the solar-compatible sources to the pcx before linting
         let has_sources = compiler.enter_mut(|compiler| -> Result<bool> {
@@ -127,7 +140,13 @@ impl LintArgs {
         if !has_sources {
             return Err(eyre!("unable to lint. Solar only supports Solidity versions >=0.8.0"));
         }
-        linter.lint(&input, config.deny, &mut compiler)?;
+        if let Err(err) = linter.lint(&input, config.deny, &mut compiler) {
+            if format_json && compiler.dcx().has_errors().is_err() {
+                // Solar already emitted the error, so bypass the top-level error printer.
+                std::process::exit(1);
+            }
+            return Err(err);
+        }
 
         Ok(())
     }

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -47,7 +47,7 @@ contract Dummy {
     );
 
     // set up command
-    cmd.args(["compile", "--format-json"]).assert_success().stderr_eq("").stdout_eq(str![[r#"
+    cmd.args(["compile", "--format-json"]).assert_failure().stderr_eq("").stdout_eq(str![[r#"
 {
   "errors": [
     {

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -46,8 +46,7 @@ contract Dummy {
 ",
     );
 
-    // set up command
-    cmd.args(["compile", "--format-json"]).assert_failure().stderr_eq("").stdout_eq(str![[r#"
+    let expected = str![[r#"
 {
   "errors": [
     {
@@ -68,7 +67,18 @@ contract Dummy {
   "contracts": {},
   "build_infos": "{...}"
 }
-"#]].is_json());
+"#]]
+    .is_json();
+
+    cmd.args(["compile", "--format-json"])
+        .assert_failure()
+        .stderr_eq("")
+        .stdout_eq(expected.clone());
+    cmd.forge_fuse()
+        .args(["compile", "--format-json", "--sizes"])
+        .assert_failure()
+        .stderr_eq("")
+        .stdout_eq(expected);
 });
 
 forgetest!(initcode_size_exceeds_limit, |prj, cmd| {

--- a/crates/forge/tests/cli/lint.rs
+++ b/crates/forge/tests/cli/lint.rs
@@ -1128,8 +1128,11 @@ forgetest!(lint_json_output_no_ansi_escape_codes, |prj, cmd| {
     });
 
     // should produce clean JSON without ANSI escape sequences (for the url nor the snippets)
-    cmd.arg("lint").arg("--json").assert_json_stderr(true,
-        str![[r#"
+    cmd.arg("lint")
+        .arg("--json")
+        .assert_json_stdout_with_status(
+            true,
+            str![[r#"
 {
     "$message_type": "diagnostic",
     "message": "wrap modifier logic to reduce code size",
@@ -1240,7 +1243,56 @@ forgetest!(lint_json_output_no_ansi_escape_codes, |prj, cmd| {
     "rendered": "note[unwrapped-modifier-logic]: wrap modifier logic to reduce code size\n\nhelp: wrap modifier logic to reduce code size\n 9 +                 _onlyOwner();\n10 +                 _;\n11 +             }\n12 + \n13 +             function _onlyOwner() internal {\n14 +                 require(isOwner[msg.sender], \"Not owner\");\n15 +                 require(msg.sender != address(0), \"Zero address\");\n16 +             }\n   ╭▸ src/UnwrappedModifierTest.sol:8:13\n   │\n 8 │ ┏             modifier onlyOwner() {\n 9 │ ┃                 require(isOwner[msg.sender], \"Not owner\");\n10 │ ┃                 require(msg.sender != address(0), \"Zero address\");\n11 │ ┃                 _;\n12 │ ┃             }\n   │ ┗━━━━━━━━━━━━━┛\n   │\n   ╰ help: https://getfoundry.sh/forge/linting/unwrapped-modifier-logic\n   ╭╴\n 8 ±             modifier onlyOwner() {\n   ╰╴\n"
 }
 "#]],
-);
+        )
+        .stderr_eq("");
+});
+
+forgetest!(lint_json_compiler_error, |prj, cmd| {
+    prj.add_source(
+        "Broken",
+        r#"pragma solidity ^0.8.30;
+
+contract Broken {
+    function f() public {
+        uint256 value = missing;
+    }
+}
+"#,
+    );
+
+    cmd.args(["lint", "--json"])
+        .assert_json_stdout_with_status(false, str![[r#"
+{
+  "$message_type": "diagnostic",
+  "message": "unresolved symbol `missing`",
+  "code": null,
+  "level": "error",
+  "spans": [
+    {
+      "file_name": "src/Broken.sol",
+      "byte_start": 140,
+      "byte_end": 147,
+      "line_start": 6,
+      "line_end": 6,
+      "column_start": 25,
+      "column_end": 32,
+      "is_primary": true,
+      "text": [
+        {
+          "text": "        uint256 value = missing;",
+          "highlight_start": 25,
+          "highlight_end": 32
+        }
+      ],
+      "label": null,
+      "suggested_replacement": null
+    }
+  ],
+  "children": [],
+  "rendered": "error: unresolved symbol `missing`\n  ╭▸ src/Broken.sol:6:25\n  │\n6 │         uint256 value = missing;\n  ╰╴                        ━━━━━━━\n\n"
+}
+"#]])
+        .stderr_eq("");
 });
 
 forgetest!(can_fail_on_lints, |prj, cmd| {

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -71,6 +71,7 @@ pub struct SolidityLinter<'a> {
     lints_excluded: Option<Vec<SolLint>>,
     with_description: bool,
     with_json_emitter: bool,
+    json_emitter_stdout: bool,
     // lint-specific configuration
     lint_specific: &'a LintSpecificConfig,
 }
@@ -84,6 +85,7 @@ impl<'a> SolidityLinter<'a> {
             lints_included: None,
             lints_excluded: None,
             with_json_emitter: false,
+            json_emitter_stdout: false,
             lint_specific: &DEFAULT_LINT_SPECIFIC_CONFIG,
         }
     }
@@ -110,6 +112,11 @@ impl<'a> SolidityLinter<'a> {
 
     pub const fn with_json_emitter(mut self, with: bool) -> Self {
         self.with_json_emitter = with;
+        self
+    }
+
+    pub const fn with_json_emitter_stdout(mut self, with: bool) -> Self {
+        self.json_emitter_stdout = with;
         self
     }
 
@@ -315,7 +322,11 @@ impl<'a> Linter for SolidityLinter<'a> {
 
         let sm = compiler.sess().clone_source_map();
         let prev_emitter = compiler.dcx().set_emitter(if self.with_json_emitter {
-            let writer = Box::new(std::io::BufWriter::new(std::io::stderr()));
+            let writer: Box<dyn std::io::Write + Send> = if self.json_emitter_stdout {
+                Box::new(std::io::BufWriter::new(std::io::stdout()))
+            } else {
+                Box::new(std::io::BufWriter::new(std::io::stderr()))
+            };
             let json_emitter = JsonEmitter::new(writer, sm).rustc_like(true).ui_testing(ui_testing);
             Box::new(json_emitter)
         } else {

--- a/crates/lint/src/sol/mod.rs
+++ b/crates/lint/src/sol/mod.rs
@@ -322,7 +322,8 @@ impl<'a> Linter for SolidityLinter<'a> {
 
         let sm = compiler.sess().clone_source_map();
         let prev_emitter = compiler.dcx().set_emitter(if self.with_json_emitter {
-            let writer: Box<dyn std::io::Write + Send> = if self.json_emitter_stdout {
+            let writer: Box<dyn std::io::Write + Send> = if self.json_emitter_stdout && !ui_testing
+            {
                 Box::new(std::io::BufWriter::new(std::io::stdout()))
             } else {
                 Box::new(std::io::BufWriter::new(std::io::stderr()))

--- a/crates/test-utils/src/prj.rs
+++ b/crates/test-utils/src/prj.rs
@@ -738,10 +738,23 @@ impl TestCommand {
     /// Runs the command and asserts that it resulted in success, with expected JSON data.
     #[track_caller]
     pub fn assert_json_stdout(&mut self, expected: impl IntoData) {
+        self.assert_json_stdout_with_status(true, expected);
+    }
+
+    /// Runs the command, asserts that it resulted in the expected outcome and JSON stdout, and
+    /// returns the output assertion.
+    #[track_caller]
+    pub fn assert_json_stdout_with_status(
+        &mut self,
+        success: bool,
+        expected: impl IntoData,
+    ) -> OutputAssert {
         let expected = expected.is(snapbox::data::DataFormat::Json).unordered();
-        let stdout = self.assert_success().get_output().stdout.clone();
+        let assert = if success { self.assert_success() } else { self.assert_failure() };
+        let stdout = assert.get_output().stdout.clone();
         let actual = stdout.into_data().is(snapbox::data::DataFormat::Json).unordered();
         assert_data_eq!(actual, expected);
+        assert
     }
 
     /// Runs the command and asserts that it resulted in the expected outcome and JSON data.


### PR DESCRIPTION
`forge lint --json` configured its initial Solar session with a human stderr emitter, so parse and compiler failures produced prose instead of machine-readable diagnostics. Route both Solar phases through the rustc-like JSON emitter on stdout and exit unsuccessfully after emitted compiler errors without invoking Forge's top-level prose error printer.

`forge build --json` now likewise exits unsuccessfully after emitting structured compiler errors, giving both commands a clean JSON stdout contract and a meaningful failure status. Human output and build-time lint diagnostic routing remain unchanged.

This PR was written primarily by OpenAI Codex, including code generation and tests.
