### PR TITLE
fix(forge): skip libraries during test discovery

### DIFF
--- a/crates/cli/src/opts/build/utils.rs
+++ b/crates/cli/src/opts/build/utils.rs
@@ -176,6 +176,10 @@ pub fn get_solar_sources_from_compile_output(
     target_paths: Option<&[PathBuf]>,
     ignored_paths: Option<&[PathBuf]>,
 ) -> Result<SolcVersionedInput> {
+    let canonicalize = |path: &Path| {
+        let path = if path.is_absolute() { path.to_path_buf() } else { config.root.join(path) };
+        dunce::canonicalize(path)
+    };
     let is_solidity_file = |path: &Path| -> bool {
         path.extension().and_then(|s| s.to_str()).is_some_and(|ext| SOLC_EXTENSIONS.contains(&ext))
     };
@@ -195,9 +199,7 @@ pub fn get_solar_sources_from_compile_output(
         let mut source_paths = HashSet::new();
         let mut queue: VecDeque<PathBuf> = targets
             .iter()
-            .filter_map(|path| {
-                is_solidity_file(path).then(|| dunce::canonicalize(path).ok()).flatten()
-            })
+            .filter_map(|path| is_solidity_file(path).then(|| canonicalize(path).ok()).flatten())
             .collect();
 
         while let Some(path) = queue.pop_front() {
@@ -227,7 +229,7 @@ pub fn get_solar_sources_from_compile_output(
     let (version, sources) = {
         let (mut max_version, mut sources) = (MIN_SOLIDITY_VERSION, Sources::new());
         for (id, _) in output.artifact_ids() {
-            if let Ok(path) = dunce::canonicalize(&id.source)
+            if let Ok(path) = canonicalize(&id.source)
                 && source_paths.remove(&path)
             {
                 if id.version < MIN_SOLIDITY_VERSION {

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -11,7 +11,10 @@ use crate::{
     symbolic_regression::SYMBOLIC_REGRESSION_MARKER,
 };
 use alloy_json_abi::{Function, JsonAbi};
-use alloy_primitives::{Address, Bytes, U256};
+use alloy_primitives::{
+    Address, Bytes, U256,
+    map::{HashMap, HashSet},
+};
 use eyre::Result;
 use foundry_cli::opts::configure_pcx_from_compile_output;
 use foundry_common::{
@@ -41,6 +44,7 @@ use foundry_evm_networks::NetworkVariant;
 
 use foundry_linking::{LinkOutput, Linker};
 use rayon::prelude::*;
+use solar::sema::interface::source_map::FileName;
 use std::{
     borrow::Borrow,
     collections::BTreeMap,
@@ -755,6 +759,50 @@ impl MultiContractRunnerBuilder {
         let linked_contracts = linker.get_linked_artifacts_cow(&libraries)?;
         let inline_config = self.inline_config;
 
+        // Initialize and configure the solar compiler.
+        let mut analysis = solar::sema::Compiler::new(
+            solar::interface::Session::builder().with_stderr_emitter().build(),
+        );
+        let dcx = analysis.dcx_mut();
+        dcx.set_emitter(Box::new(
+            solar::interface::diagnostics::HumanEmitter::stderr(Default::default())
+                .source_map(Some(dcx.source_map().unwrap())),
+        ));
+        dcx.set_flags_mut(|f| f.track_diagnostics = false);
+
+        // Populate solar's global context by parsing and lowering the sources.
+        let files: Vec<_> = output.output().sources.as_ref().keys().cloned().collect();
+        let mut library_contracts = HashMap::<PathBuf, HashSet<String>>::default();
+
+        analysis.enter_mut(|compiler| -> Result<()> {
+            let mut pcx = compiler.parse();
+            configure_pcx_from_compile_output(
+                &mut pcx,
+                &self.config,
+                output,
+                if files.is_empty() { None } else { Some(&files) },
+            )?;
+            pcx.parse();
+            let _ = compiler.lower_asts();
+
+            let hir = &compiler.gcx().hir;
+            for contract_id in hir.contract_ids() {
+                let contract = hir.contract(contract_id);
+                if !contract.kind.is_library() {
+                    continue;
+                }
+                let FileName::Real(path) = &hir.source(contract.source).file.name else {
+                    continue;
+                };
+                let path = path.strip_prefix(root).unwrap_or(path).to_path_buf();
+                library_contracts
+                    .entry(path)
+                    .or_default()
+                    .insert(contract.name.as_str().to_string());
+            }
+            Ok(())
+        })?;
+
         // Create a mapping of name => (abi, deployment code, Vec<library deployment code>)
         let mut deployable_contracts = DeployableContracts::default();
         let test_matcher = TestFunctionMatcher::new(
@@ -766,6 +814,9 @@ impl MultiContractRunnerBuilder {
 
         for (id, contract) in linked_contracts.iter() {
             let Some(abi) = contract.abi.as_ref() else { continue };
+            if library_contracts.get(&id.source).is_some_and(|names| names.contains(&id.name)) {
+                continue;
+            }
 
             // if it's a test, link it and add to deployable contracts
             if abi.constructor.as_ref().map(|c| c.inputs.is_empty()).unwrap_or(true)
@@ -787,33 +838,6 @@ impl MultiContractRunnerBuilder {
         // Create known contracts from linked contracts and storage layout information (if any).
         let known_contracts =
             ContractsByArtifactBuilder::new(linked_contracts).with_output(output, root).build();
-
-        // Initialize and configure the solar compiler.
-        let mut analysis = solar::sema::Compiler::new(
-            solar::interface::Session::builder().with_stderr_emitter().build(),
-        );
-        let dcx = analysis.dcx_mut();
-        dcx.set_emitter(Box::new(
-            solar::interface::diagnostics::HumanEmitter::stderr(Default::default())
-                .source_map(Some(dcx.source_map().unwrap())),
-        ));
-        dcx.set_flags_mut(|f| f.track_diagnostics = false);
-
-        // Populate solar's global context by parsing and lowering the sources.
-        let files: Vec<_> = output.output().sources.as_ref().keys().cloned().collect();
-
-        analysis.enter_mut(|compiler| -> Result<()> {
-            let mut pcx = compiler.parse();
-            configure_pcx_from_compile_output(
-                &mut pcx,
-                &self.config,
-                output,
-                if files.is_empty() { None } else { Some(&files) },
-            )?;
-            pcx.parse();
-            let _ = compiler.lower_asts();
-            Ok(())
-        })?;
 
         let analysis = Arc::new(analysis);
         // Enum variant counts used to constrain fuzzed enum inputs to valid values.

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -44,7 +44,7 @@ use foundry_evm_networks::NetworkVariant;
 
 use foundry_linking::{LinkOutput, Linker};
 use rayon::prelude::*;
-use solar::sema::interface::source_map::FileName;
+use solar::ast::ItemKind;
 use std::{
     borrow::Borrow,
     collections::BTreeMap,
@@ -759,6 +759,31 @@ impl MultiContractRunnerBuilder {
         let linked_contracts = linker.get_linked_artifacts_cow(&libraries)?;
         let inline_config = self.inline_config;
 
+        // Collect libraries from the source graph's parsed ASTs. Unlike the semantic analysis
+        // below, this includes sources compiled with Solidity versions older than Solar's minimum
+        // supported version.
+        let source_paths: HashSet<_> = output.artifact_ids().map(|(id, _)| id.source).collect();
+        let mut library_contracts = HashMap::<PathBuf, HashSet<String>>::default();
+        output.parser().solc().compiler().enter_sequential(|compiler| {
+            for path in source_paths {
+                let Some((_, source)) = compiler.gcx().get_ast_source(root.join(&path)) else {
+                    continue;
+                };
+                let Some(ast) = &source.ast else { continue };
+                let artifact_path = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+
+                for item in ast.items.iter() {
+                    let ItemKind::Contract(contract) = &item.kind else { continue };
+                    if contract.kind.is_library() {
+                        library_contracts
+                            .entry(artifact_path.clone())
+                            .or_default()
+                            .insert(contract.name.as_str().to_string());
+                    }
+                }
+            }
+        });
+
         // Initialize and configure the solar compiler.
         let mut analysis = solar::sema::Compiler::new(
             solar::interface::Session::builder().with_stderr_emitter().build(),
@@ -772,7 +797,6 @@ impl MultiContractRunnerBuilder {
 
         // Populate solar's global context by parsing and lowering the sources.
         let files: Vec<_> = output.output().sources.as_ref().keys().cloned().collect();
-        let mut library_contracts = HashMap::<PathBuf, HashSet<String>>::default();
 
         analysis.enter_mut(|compiler| -> Result<()> {
             let mut pcx = compiler.parse();
@@ -784,22 +808,6 @@ impl MultiContractRunnerBuilder {
             )?;
             pcx.parse();
             let _ = compiler.lower_asts();
-
-            let hir = &compiler.gcx().hir;
-            for contract_id in hir.contract_ids() {
-                let contract = hir.contract(contract_id);
-                if !contract.kind.is_library() {
-                    continue;
-                }
-                let FileName::Real(path) = &hir.source(contract.source).file.name else {
-                    continue;
-                };
-                let path = path.strip_prefix(root).unwrap_or(path).to_path_buf();
-                library_contracts
-                    .entry(path)
-                    .or_default()
-                    .insert(contract.name.as_str().to_string());
-            }
             Ok(())
         })?;
 

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -2311,6 +2311,46 @@ contract ArrayConditionTest is DSTest {
 "#]]);
 });
 
+forgetest_init!(does_not_run_library_functions_as_tests, |prj, cmd| {
+    prj.add_test(
+        "Library.t.sol",
+        r#"
+library InternalLib {
+    function invariantProtocol() public pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract InternalLibTest {
+    function testInternalLibInvariantProtocol() public pure {
+        require(InternalLib.invariantProtocol() == 1);
+    }
+}
+"#,
+    );
+
+    cmd.arg("coverage").assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+Analysing contracts...
+Running tests...
+
+Ran 1 test for test/Library.t.sol:InternalLibTest
+[PASS] testInternalLibInvariantProtocol() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+╭-------+---------------+---------------+---------------+---------------╮
+| File  | % Lines       | % Statements  | % Branches    | % Funcs       |
++=======================================================================+
+| Total | 100.00% (0/0) | 100.00% (0/0) | 100.00% (0/0) | 100.00% (0/0) |
+╰-------+---------------+---------------+---------------+---------------╯
+
+"#]]);
+});
+
 // https://github.com/foundry-rs/foundry/issues/11432
 // Test coverage for linked libraries.
 forgetest!(linked_library, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -610,6 +610,53 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
+forgetest_init!(does_not_run_legacy_library_functions_as_tests, |prj, cmd| {
+    prj.update_config(|config| config.solc = Some("0.7.6".into()));
+    prj.add_raw_test(
+        "LegacyLibrary.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity =0.7.6;
+
+library LegacyInternalLib {
+    function invariantProtocol() public pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract LegacyInternalLibTest {
+    function testInternalLibInvariantProtocol() public pure {
+        require(LegacyInternalLib.invariantProtocol() == 1);
+    }
+}
+"#,
+    );
+
+    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/LegacyLibrary.t.sol:LegacyInternalLibTest
+[PASS] testInternalLibInvariantProtocol() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+
+    cmd.assert_success().stdout_eq(str![[r#"
+No files changed, compilation skipped
+
+Ran 1 test for test/LegacyLibrary.t.sol:LegacyInternalLibTest
+[PASS] testInternalLibInvariantProtocol() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+});
+
 // tests that libraries are handled correctly in multiforking mode
 forgetest_init!(can_use_libs_in_multi_fork, |prj, cmd| {
     prj.add_source(

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -567,6 +567,49 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
+forgetest_init!(does_not_run_library_functions_as_tests, |prj, cmd| {
+    prj.add_test(
+        "Library.t.sol",
+        r#"
+library InternalLib {
+    function invariantProtocol() public pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract InternalLibTest {
+    function testInternalLibInvariantProtocol() public pure {
+        require(InternalLib.invariantProtocol() == 1);
+    }
+}
+"#,
+    );
+
+    cmd.arg("test").assert_success().stdout_eq(str![[r#"
+[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+Compiler run successful!
+
+Ran 1 test for test/Library.t.sol:InternalLibTest
+[PASS] testInternalLibInvariantProtocol() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+
+    cmd.assert_success().stdout_eq(str![[r#"
+No files changed, compilation skipped
+
+Ran 1 test for test/Library.t.sol:InternalLibTest
+[PASS] testInternalLibInvariantProtocol() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+});
+
 // tests that libraries are handled correctly in multiforking mode
 forgetest_init!(can_use_libs_in_multi_fork, |prj, cmd| {
     prj.add_source(


### PR DESCRIPTION
Library artifacts are now excluded from Forge's deployable test-contract map using Solar's actual contract kind, while remaining available for linking, deployment, revert decoding, and coverage attribution. This prevents public library functions named `invariant*` or `test*` from being executed as test suites. Compile-output source paths are resolved from the project root so the same classification works after coverage strips artifact prefixes.

Closes #10418.
