### PR TITLE
test(forge): normalize compiler path

### DIFF
--- a/crates/forge/tests/cli/compiler.rs
+++ b/crates/forge/tests/cli/compiler.rs
@@ -5,6 +5,7 @@ use foundry_test_utils::{
     snapbox::IntoData,
     util::{SOLC_VERSION, get_vyper},
 };
+use path_slash::PathBufExt;
 
 const CONTRACT_A: &str = r#"
 // SPDX-license-identifier: MIT
@@ -97,7 +98,7 @@ forgetest_init!(can_print_resolved_compiler_path, |prj, cmd| {
 
     cmd.args(["compiler", "resolve", "--path"])
         .assert_success()
-        .stdout_eq(format!("{}\n", solc.solc.display()));
+        .stdout_eq(format!("{}\n", solc.solc.to_slash_lossy()));
 });
 
 forgetest!(can_print_resolved_vyper_path, |prj, cmd| {


### PR DESCRIPTION
The Windows test expected the SVM compiler path with platform-native backslashes, while `forge compiler resolve --path` emits the path with forward slashes. Normalize the expected path with the same path-slash utility already used by Forge tests so the assertion remains portable. This fixes the failure in [CI job 87131316558](https://github.com/foundry-rs/foundry/actions/runs/29346440873/job/87131316558).

This PR was written with Codex, including investigation and code generation.

Prompted by: @grandizzy
