### PR TITLE
perf(anvil): speed up block mining

### DIFF
--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -45,14 +45,15 @@ use crate::mem::storage::MinedTransaction;
 /// Number of preceding block hashes available to the EVM's `BLOCKHASH` opcode.
 pub(crate) const BLOCKHASH_HISTORY: u64 = 256;
 
-/// Inserts a block hash while discarding the entry that left the EVM-visible cache.
-pub(crate) fn cache_block_hash(block_hashes: &mut U256Map<B256>, number: U256, hash: B256) {
+/// Inserts a block hash, discards entries outside the EVM-visible cache, and returns its head.
+pub(crate) fn cache_block_hash(block_hashes: &mut U256Map<B256>, number: U256, hash: B256) -> U256 {
     let head = block_hashes.keys().copied().max().map_or(number, |head| head.max(number));
     let min_number = head.saturating_sub(U256::from(BLOCKHASH_HISTORY));
     block_hashes.retain(|cached, _| *cached >= min_number && *cached <= head);
     if number >= min_number {
         block_hashes.insert(number, hash);
     }
+    head
 }
 
 /// Helper trait get access to the full state data of the database

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -35,6 +35,8 @@ pub struct StateRootDb {
     inner: MemDb,
     state_root: Mutex<StateRootCache>,
     history: Mutex<HistoricalStateCache>,
+    /// Live cache head used to make sequential block-hash insertion constant-time.
+    block_hash_head: Option<U256>,
 }
 
 impl StateRootDb {
@@ -100,11 +102,20 @@ impl HistoricalStateCache {
         self.dirty.entry(address).or_default().storage.insert(slot);
     }
 
-    fn record_block_hash(&mut self, number: U256, hash: B256) {
+    fn record_block_hash(&mut self, number: U256, hash: B256, is_next: bool) {
         if self.disabled {
             return;
         }
         let Some(state) = &mut self.state else { return };
+        if is_next {
+            let min_number = number.saturating_sub(U256::from(BLOCKHASH_HISTORY));
+            if min_number > U256::ZERO {
+                state.block_hashes.remove(&(min_number - U256::from(1)));
+            }
+            state.block_hashes.insert(number, hash);
+            return;
+        }
+
         let head = state.block_hashes.keys().copied().max().map_or(number, |head| head.max(number));
         let min_number = head.saturating_sub(U256::from(BLOCKHASH_HISTORY));
         state.block_hashes.retain(|cached, _| *cached >= min_number && *cached <= head);
@@ -410,12 +421,25 @@ impl Db for StateRootDb {
     }
 
     fn insert_block_hash(&mut self, number: U256, hash: B256) {
-        Db::insert_block_hash(&mut self.inner, number, hash);
-        self.history.get_mut().record_block_hash(number, hash);
+        let is_next =
+            self.block_hash_head.is_some_and(|head| number == head.saturating_add(U256::from(1)));
+        if is_next {
+            let min_number = number.saturating_sub(U256::from(BLOCKHASH_HISTORY));
+            if min_number > U256::ZERO {
+                self.inner.inner.cache.block_hashes.remove(&(min_number - U256::from(1)));
+            }
+            self.inner.inner.cache.block_hashes.insert(number, hash);
+            self.block_hash_head = Some(number);
+        } else {
+            self.block_hash_head =
+                Some(cache_block_hash(&mut self.inner.inner.cache.block_hashes, number, hash));
+        }
+        self.history.get_mut().record_block_hash(number, hash, is_next);
     }
 
     fn set_block_hashes(&mut self, block_hashes: Vec<(U256, B256)>) {
         Db::set_block_hashes(&mut self.inner, block_hashes);
+        self.block_hash_head = self.inner.inner.cache.block_hashes.keys().copied().max();
         self.history.get_mut().invalidate();
     }
 
@@ -439,6 +463,7 @@ impl Db for StateRootDb {
         if reverted {
             self.state_root.get_mut().invalidate();
             self.history.get_mut().invalidate();
+            self.block_hash_head = self.inner.inner.cache.block_hashes.keys().copied().max();
         }
         reverted
     }
@@ -460,6 +485,7 @@ impl MaybeFullDatabase for StateRootDb {
     fn clear_into_state_snapshot(&mut self) -> StateSnapshot {
         self.state_root.get_mut().invalidate();
         self.history.get_mut().invalidate();
+        self.block_hash_head = None;
         MaybeFullDatabase::clear_into_state_snapshot(&mut self.inner)
     }
 
@@ -470,6 +496,7 @@ impl MaybeFullDatabase for StateRootDb {
     fn clear(&mut self) {
         self.state_root.get_mut().invalidate();
         self.history.get_mut().invalidate();
+        self.block_hash_head = None;
         MaybeFullDatabase::clear(&mut self.inner)
     }
 
@@ -477,6 +504,7 @@ impl MaybeFullDatabase for StateRootDb {
         MaybeFullDatabase::init_from_state_snapshot(&mut self.inner, snapshot);
         self.state_root.get_mut().invalidate();
         self.history.get_mut().invalidate();
+        self.block_hash_head = self.inner.inner.cache.block_hashes.keys().copied().max();
     }
 }
 
@@ -770,6 +798,17 @@ mod tests {
         assert!(block_hashes.contains_key(&U256::from(767)));
         assert!(block_hashes.contains_key(&U256::from(768)));
         assert!(block_hashes.contains_key(&U256::from(1_023)));
+
+        let snapshot = db.snapshot_state();
+        db.insert_block_hash(U256::from(1_024), B256::from(U256::from(1_024)));
+        assert!(db.revert_state(snapshot, RevertStateSnapshotAction::RevertRemove));
+        db.insert_block_hash(U256::from(1_024), B256::from(U256::from(1_024)));
+
+        let block_hashes = &db.inner.inner.cache.block_hashes;
+        assert_eq!(block_hashes.len(), BLOCKHASH_HISTORY as usize + 1);
+        assert!(!block_hashes.contains_key(&U256::from(767)));
+        assert!(block_hashes.contains_key(&U256::from(768)));
+        assert!(block_hashes.contains_key(&U256::from(1_024)));
     }
 
     #[test]

--- a/crates/anvil/src/eth/backend/mem/in_memory_db.rs
+++ b/crates/anvil/src/eth/backend/mem/in_memory_db.rs
@@ -55,6 +55,17 @@ impl StateRootDb {
             ..Default::default()
         }
     }
+
+    fn normalize_block_hashes(&mut self) {
+        let block_hashes = &mut self.inner.inner.cache.block_hashes;
+        let Some(head) = block_hashes.keys().copied().max() else {
+            self.block_hash_head = None;
+            return;
+        };
+        let min_number = head.saturating_sub(U256::from(BLOCKHASH_HISTORY));
+        block_hashes.retain(|cached, _| *cached >= min_number && *cached <= head);
+        self.block_hash_head = Some(head);
+    }
 }
 
 /// Incrementally maintained, structurally shared state used by block-history snapshots.
@@ -439,7 +450,7 @@ impl Db for StateRootDb {
 
     fn set_block_hashes(&mut self, block_hashes: Vec<(U256, B256)>) {
         Db::set_block_hashes(&mut self.inner, block_hashes);
-        self.block_hash_head = self.inner.inner.cache.block_hashes.keys().copied().max();
+        self.normalize_block_hashes();
         self.history.get_mut().invalidate();
     }
 
@@ -504,7 +515,7 @@ impl MaybeFullDatabase for StateRootDb {
         MaybeFullDatabase::init_from_state_snapshot(&mut self.inner, snapshot);
         self.state_root.get_mut().invalidate();
         self.history.get_mut().invalidate();
-        self.block_hash_head = self.inner.inner.cache.block_hashes.keys().copied().max();
+        self.normalize_block_hashes();
     }
 }
 
@@ -809,6 +820,40 @@ mod tests {
         assert!(!block_hashes.contains_key(&U256::from(767)));
         assert!(block_hashes.contains_key(&U256::from(768)));
         assert!(block_hashes.contains_key(&U256::from(1_024)));
+    }
+
+    #[test]
+    fn oversized_seeded_block_hash_caches_are_normalized() {
+        let block_hashes = (0..=1_000)
+            .map(|number| (U256::from(number), B256::from(U256::from(number))))
+            .collect::<Vec<_>>();
+
+        let mut db = StateRootDb::default();
+        db.set_block_hashes(block_hashes.clone());
+        assert_block_hash_window(&db, 744, 1_000);
+        db.insert_block_hash(U256::from(1_001), B256::from(U256::from(1_001)));
+        assert_block_hash_window(&db, 745, 1_001);
+
+        let mut snapshot_source = MemDb::default();
+        snapshot_source.set_block_hashes(block_hashes);
+        let snapshot = snapshot_source.read_as_state_snapshot();
+        let mut restored = StateRootDb::default();
+        restored.init_from_state_snapshot(snapshot);
+        assert_block_hash_window(&restored, 744, 1_000);
+        restored.insert_block_hash(U256::from(1_001), B256::from(U256::from(1_001)));
+        assert_block_hash_window(&restored, 745, 1_001);
+    }
+
+    fn assert_block_hash_window(db: &StateRootDb, min: u64, head: u64) {
+        let block_hashes = &db.inner.inner.cache.block_hashes;
+        assert_eq!(block_hashes.len(), BLOCKHASH_HISTORY as usize + 1);
+        assert!(
+            block_hashes
+                .keys()
+                .all(|number| *number >= U256::from(min) && *number <= U256::from(head))
+        );
+        assert!(block_hashes.contains_key(&U256::from(min)));
+        assert!(block_hashes.contains_key(&U256::from(head)));
     }
 
     #[test]

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3000,14 +3000,14 @@ where
 
             let best_hash = self.blockchain.storage.read().best_hash;
 
-            let mut input = Vec::with_capacity(40);
-            input.extend_from_slice(best_hash.as_slice());
-            input.extend_from_slice(&block_number.to_le_bytes());
+            let mut input = [0u8; 40];
+            input[..32].copy_from_slice(best_hash.as_slice());
+            input[32..].copy_from_slice(&block_number.to_le_bytes());
             // Use the `prevrandao` value set via `anvil_setNextBlockPrevRandao` for this block if
             // one was provided, otherwise derive it from the parent hash and block number. The
             // manual override is consumed here so it only applies to this single block.
             evm_env.block_env.prevrandao =
-                Some(self.cheats.take_next_block_prevrandao().unwrap_or_else(|| keccak256(&input)));
+                Some(self.cheats.take_next_block_prevrandao().unwrap_or_else(|| keccak256(input)));
 
             if self.prune_state_history_config.is_state_history_supported() {
                 let db = self.db.read().await.current_state();

--- a/crates/anvil/src/eth/backend/mem/state.rs
+++ b/crates/anvil/src/eth/backend/mem/state.rs
@@ -13,7 +13,7 @@ use revm::{
     database::DbAccount,
     state::{Account, AccountInfo},
 };
-use std::mem;
+use std::{array, mem};
 
 /// Incrementally maintains the state trie used for mined block headers.
 ///
@@ -25,6 +25,8 @@ use std::mem;
 pub struct StateRootCache {
     trie: Option<IncrementalStateTrie>,
     dirty: AddressMap<DirtyAccount>,
+    /// Reused while encoding dirty trie nodes.
+    rlp_buf: Vec<u8>,
 }
 
 #[derive(Debug, Default)]
@@ -65,14 +67,15 @@ impl StateRootCache {
 
     /// Returns the current root, applying only changes recorded since the previous call.
     pub fn root(&mut self, accounts: &AddressMap<DbAccount>) -> B256 {
-        if self.trie.is_none() {
-            self.trie = Some(IncrementalStateTrie::from_accounts(accounts));
-            self.dirty.clear();
-            return self.trie.as_mut().unwrap().root();
+        let Self { trie, dirty, rlp_buf } = self;
+        if trie.is_none() {
+            *trie = Some(IncrementalStateTrie::from_accounts(accounts, rlp_buf));
+            dirty.clear();
+            return trie.as_mut().unwrap().root(rlp_buf);
         }
 
-        let trie = self.trie.as_mut().unwrap();
-        for (address, dirty) in mem::take(&mut self.dirty) {
+        let trie = trie.as_mut().unwrap();
+        for (address, dirty) in mem::take(dirty) {
             let hashed_address = keccak256(address);
             let Some(account) = accounts.get(&address) else {
                 trie.accounts.remove(hashed_address);
@@ -97,14 +100,14 @@ impl StateRootCache {
                 }
                 storage_trie
             };
-            let storage_root = storage_trie.root();
+            let storage_root = storage_trie.root_with_buf(rlp_buf);
             trie.accounts.insert(
                 hashed_address,
                 trie_account_rlp_with_storage_root(&account.info, storage_root),
             );
         }
 
-        trie.root()
+        trie.root(rlp_buf)
     }
 }
 
@@ -115,12 +118,12 @@ struct IncrementalStateTrie {
 }
 
 impl IncrementalStateTrie {
-    fn from_accounts(accounts: &AddressMap<DbAccount>) -> Self {
+    fn from_accounts(accounts: &AddressMap<DbAccount>, rlp_buf: &mut Vec<u8>) -> Self {
         let mut trie = Self::default();
         for (address, account) in accounts {
             let hashed_address = keccak256(address);
             let mut storage_trie = IncrementalTrie::from_storage(&account.storage);
-            let storage_root = storage_trie.root();
+            let storage_root = storage_trie.root_with_buf(rlp_buf);
             trie.accounts.insert(
                 hashed_address,
                 trie_account_rlp_with_storage_root(&account.info, storage_root),
@@ -130,8 +133,8 @@ impl IncrementalStateTrie {
         trie
     }
 
-    fn root(&mut self) -> B256 {
-        self.accounts.root()
+    fn root(&mut self, rlp_buf: &mut Vec<u8>) -> B256 {
+        self.accounts.root_with_buf(rlp_buf)
     }
 }
 
@@ -158,8 +161,13 @@ impl IncrementalTrie {
         self.root.remove(Nibbles::unpack(key));
     }
 
+    #[cfg(test)]
     fn root(&mut self) -> B256 {
-        let Some(root) = self.root.rlp() else { return EMPTY_ROOT_HASH };
+        self.root_with_buf(&mut Vec::new())
+    }
+
+    fn root_with_buf(&mut self, rlp_buf: &mut Vec<u8>) -> B256 {
+        let Some(root) = self.root.rlp(rlp_buf) else { return EMPTY_ROOT_HASH };
         root.as_hash().unwrap_or_else(|| keccak256(root.as_ref()))
     }
 }
@@ -324,7 +332,7 @@ impl TrieNode {
         }
     }
 
-    fn rlp(&mut self) -> Option<RlpNode> {
+    fn rlp(&mut self, out: &mut Vec<u8>) -> Option<RlpNode> {
         if let Some(rlp) = &self.rlp {
             return Some(rlp.clone());
         }
@@ -332,22 +340,27 @@ impl TrieNode {
         let rlp = match &mut self.kind {
             TrieNodeKind::Empty => return None,
             TrieNodeKind::Leaf { path, value } => {
-                LeafNodeRef::new(path, value).rlp(&mut Vec::new())
+                out.clear();
+                LeafNodeRef::new(path, value).rlp(out)
             }
             TrieNodeKind::Extension { path, child } => {
-                let child = child.rlp().expect("extension nodes have a child");
-                ExtensionNodeRef::new(path, child.as_ref()).rlp(&mut Vec::new())
+                let child = child.rlp(out).expect("extension nodes have a child");
+                out.clear();
+                ExtensionNodeRef::new(path, child.as_ref()).rlp(out)
             }
             TrieNodeKind::Branch { children } => {
-                let mut stack = Vec::new();
+                let mut stack: [RlpNode; 16] = array::from_fn(|_| RlpNode::default());
+                let mut stack_len = 0;
                 let mut state_mask = TrieMask::default();
                 for (index, child) in children.iter_mut().enumerate() {
                     if let Some(child) = child {
-                        stack.push(child.rlp().expect("branch children are not empty"));
+                        stack[stack_len] = child.rlp(out).expect("branch children are not empty");
+                        stack_len += 1;
                         state_mask.set_bit(index as u8);
                     }
                 }
-                BranchNodeRef::new(&stack, state_mask).rlp(&mut Vec::new())
+                out.clear();
+                BranchNodeRef::new(&stack[..stack_len], state_mask).rlp(out)
             }
         };
         self.rlp = Some(rlp.clone());


### PR DESCRIPTION
This removes three recurring costs from Anvil block mining: prevrandao input now uses fixed stack storage, sequential block-hash eviction uses a tracked head instead of rescanning the 257-entry EVM window, and incremental trie encoding reuses RLP scratch storage while keeping branch children on the stack. Out-of-order block-hash writes retain the existing full-scan fallback, so snapshot and revert behavior remains unchanged. This PR was developed with AI assistance.

### Results

| 2,500 single-transfer blocks | `master` | This PR | Improvement |
| --- | ---: | ---: | ---: |
| Mean wall time | 163.2 ms | 142.9 ms | 12.4% |
| Median wall time | 161.9 ms | 142.0 ms | 12.3% |
