### PR TITLE
feat(script): include full signatures in broadcast logs

### DIFF
--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -1065,7 +1065,10 @@ contract SessionForgeScript is Script {{
     let tx = &broadcast["transactions"][0];
 
     assert_eq!(tx["transactionType"], "CALL", "unexpected forge broadcast tx: {tx}");
-    assert_eq!(tx["function"], "transfer(address,uint256)", "unexpected forge broadcast tx: {tx}");
+    assert_eq!(
+        tx["function"], "function transfer(address to, uint256 amount) returns (bool)",
+        "unexpected forge broadcast tx: {tx}"
+    );
     assert_eq!(
         tx["contractAddress"].as_str().map(str::to_ascii_lowercase),
         Some(path_usd.to_ascii_lowercase()),

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -1065,8 +1065,9 @@ contract SessionForgeScript is Script {{
     let tx = &broadcast["transactions"][0];
 
     assert_eq!(tx["transactionType"], "CALL", "unexpected forge broadcast tx: {tx}");
+    assert_eq!(tx["function"], "transfer(address,uint256)", "unexpected forge broadcast tx: {tx}");
     assert_eq!(
-        tx["function"], "function transfer(address to, uint256 amount) returns (bool)",
+        tx["functionAbi"], "function transfer(address to, uint256 amount) returns (bool)",
         "unexpected forge broadcast tx: {tx}"
     );
     assert_eq!(

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1223,6 +1223,64 @@ forgetest_async!(test_custom_sender_balance, |prj, cmd| {
         .simulate(ScriptOutcome::OkSimulation);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/3887>
+forgetest_async!(broadcast_log_uses_full_function_signature, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let script = prj.add_script(
+        "FullSignature.s.sol",
+        r#"
+interface Vm {
+    function startBroadcast() external;
+    function stopBroadcast() external;
+}
+
+contract Target {
+    uint256 configuredAmount;
+    address configuredRecipient;
+
+    function configure(uint256 amount, address recipient)
+        external
+        returns (bool accepted)
+    {
+        configuredAmount = amount;
+        configuredRecipient = recipient;
+        return amount > 0 && recipient != address(0);
+    }
+}
+
+contract SignatureScript {
+    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function run() external {
+        vm.startBroadcast();
+        Target target = new Target();
+        target.configure(1, address(1));
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+
+    cmd.forge_fuse()
+        .arg("script")
+        .arg(script)
+        .args(["--tc", "SignatureScript", "--rpc-url", &handle.http_endpoint()])
+        .assert_success();
+
+    let run_latest = foundry_common::fs::json_files(&prj.root().join("broadcast"))
+        .find(|path| path.ends_with("run-latest.json"))
+        .expect("No broadcast artifacts");
+    let sequence: ScriptSequence<Ethereum> =
+        foundry_common::fs::read_json_file(&run_latest).unwrap();
+
+    assert_eq!(sequence.transactions.len(), 2);
+    assert_eq!(
+        sequence.transactions[1].function.as_deref(),
+        Some("function configure(uint256 amount, address recipient) returns (bool accepted)")
+    );
+});
+
 #[derive(serde::Deserialize)]
 struct Transactions {
     transactions: Vec<Transaction>,

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -1224,7 +1224,7 @@ forgetest_async!(test_custom_sender_balance, |prj, cmd| {
 });
 
 // <https://github.com/foundry-rs/foundry/issues/3887>
-forgetest_async!(broadcast_log_uses_full_function_signature, |prj, cmd| {
+forgetest_async!(broadcast_log_includes_full_function_abi, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let script = prj.add_script(
@@ -1275,8 +1275,9 @@ contract SignatureScript {
         foundry_common::fs::read_json_file(&run_latest).unwrap();
 
     assert_eq!(sequence.transactions.len(), 2);
+    assert_eq!(sequence.transactions[1].function.as_deref(), Some("configure(uint256,address)"));
     assert_eq!(
-        sequence.transactions[1].function.as_deref(),
+        sequence.transactions[1].function_abi.as_deref(),
         Some("function configure(uint256 amount, address recipient) returns (bool accepted)")
     );
 });

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2781,7 +2781,7 @@ to                   0x5FbDB2315678afecb367f032d93F642f64180aa3
 type                 EIP-1559
 value                0
 contract: Called(0x5FbDB2315678afecb367f032d93F642f64180aa3)
-data (decoded): run(uint256,uint256)(
+data (decoded): function run(uint256 _x, uint256 _y)(
   123,
   456
 )

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2672,10 +2672,11 @@ contract Called {
     event log_string(string);
     uint256 public x;
     uint256 public y;
-    function run(uint256 _x, uint256 _y) external {
+    function run(uint256 _x, uint256 _y) external returns (uint256 result) {
         x = _x;
         y = _y;
         emit log_string("script ran");
+        return _x + _y;
     }
 }
 
@@ -2708,10 +2709,10 @@ Traces:
     ├─ [0] VM::startBroadcast()
     │   └─ ← [Return]
     ├─ [..] → new Called@0x5FbDB2315678afecb367f032d93F642f64180aa3
-    │   └─ ← [Return] 567 bytes of code
+    │   └─ ← [Return] 700 bytes of code
     ├─ [..] Called::run(123, 456)
     │   ├─ emit log_string(val: "script ran")
-    │   └─ ← [Stop]
+    │   └─ ← [Return] 579
     └─ ← [Stop]
 
 
@@ -2724,12 +2725,12 @@ Script ran successfully.
 ==========================
 Simulated On-chain Traces:
 
-  [113557] → new Called@0x5FbDB2315678afecb367f032d93F642f64180aa3
-    └─ ← [Return] 567 bytes of code
+  [140181] → new Called@0x5FbDB2315678afecb367f032d93F642f64180aa3
+    └─ ← [Return] 700 bytes of code
 
-  [46595] Called::run(123, 456)
+  [46966] Called::run(123, 456)
     ├─ emit log_string(val: "script ran")
-    └─ ← [Stop]
+    └─ ← [Return] 579
 
 
 ==========================
@@ -2770,7 +2771,7 @@ value                0
 
 accessList           []
 chainId              31337
-gasLimit             93856
+gasLimit             99920
 gasPrice             
 input                0x7357f5d2000000000000000000000000000000000000000000000000000000000000007b00000000000000000000000000000000000000000000000000000000000001c8
 maxFeePerBlobGas     
@@ -2781,7 +2782,7 @@ to                   0x5FbDB2315678afecb367f032d93F642f64180aa3
 type                 EIP-1559
 value                0
 contract: Called(0x5FbDB2315678afecb367f032d93F642f64180aa3)
-data (decoded): function run(uint256 _x, uint256 _y)(
+data (decoded): run(
   123,
   456
 )

--- a/crates/script-sequence/src/transaction.rs
+++ b/crates/script-sequence/src/transaction.rs
@@ -32,6 +32,7 @@ pub struct TransactionWithMetadata<N: Network> {
     pub contract_address: Option<Address>,
     #[serde(default = "default_string")]
     pub function: Option<String>,
+    pub function_abi: Option<String>,
     #[serde(skip)]
     pub display_function: Option<String>,
     #[serde(default = "default_vec_of_strings")]
@@ -66,6 +67,7 @@ impl<N: Network> TransactionWithMetadata<N> {
             contract_name: Default::default(),
             contract_address: Default::default(),
             function: Default::default(),
+            function_abi: Default::default(),
             display_function: Default::default(),
             arguments: Default::default(),
             is_fixed_gas_limit: Default::default(),

--- a/crates/script-sequence/src/transaction.rs
+++ b/crates/script-sequence/src/transaction.rs
@@ -32,6 +32,8 @@ pub struct TransactionWithMetadata<N: Network> {
     pub contract_address: Option<Address>,
     #[serde(default = "default_string")]
     pub function: Option<String>,
+    #[serde(skip)]
+    pub display_function: Option<String>,
     #[serde(default = "default_vec_of_strings")]
     pub arguments: Option<Vec<String>>,
     #[serde(skip)]
@@ -64,6 +66,7 @@ impl<N: Network> TransactionWithMetadata<N> {
             contract_name: Default::default(),
             contract_address: Default::default(),
             function: Default::default(),
+            display_function: Default::default(),
             arguments: Default::default(),
             is_fixed_gas_limit: Default::default(),
             additional_contracts: Default::default(),

--- a/crates/script/src/sequence.rs
+++ b/crates/script/src/sequence.rs
@@ -33,7 +33,7 @@ where
     }
 
     // Show decoded function if available
-    if let (Some(func), Some(args)) = (&tx.function, &tx.arguments) {
+    if let (Some(func), Some(args)) = (&tx.display_function, &tx.arguments) {
         if args.is_empty() {
             writeln!(output, "data (decoded): {func}()")?;
         } else {

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -67,7 +67,8 @@ impl<N: Network> ScriptTransactionBuilder<N> {
                 };
 
                 if let Some(function) = function {
-                    self.transaction.function = Some(function.full_signature());
+                    self.transaction.function = Some(function.signature());
+                    self.transaction.function_abi = Some(function.full_signature());
                     self.transaction.display_function = Some(function.name.clone());
 
                     let values = function.abi_decode_input(data).inspect_err(|_| {

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -68,6 +68,7 @@ impl<N: Network> ScriptTransactionBuilder<N> {
 
                 if let Some(function) = function {
                     self.transaction.function = Some(function.full_signature());
+                    self.transaction.display_function = Some(function.name.clone());
 
                     let values = function.abi_decode_input(data).inspect_err(|_| {
                         error!(

--- a/crates/script/src/transaction.rs
+++ b/crates/script/src/transaction.rs
@@ -67,7 +67,7 @@ impl<N: Network> ScriptTransactionBuilder<N> {
                 };
 
                 if let Some(function) = function {
-                    self.transaction.function = Some(function.signature());
+                    self.transaction.function = Some(function.full_signature());
 
                     let values = function.abi_decode_input(data).inspect_err(|_| {
                         error!(


### PR DESCRIPTION
## Motivation

Broadcast logs expose selector-oriented function metadata in the `function` field, which drops argument and return names and cannot be reused as a complete human-readable ABI fragment. Changing that existing field would break consumers that expect the canonical `name(types)` format.

## Solution

Keep `function` unchanged and add an optional `functionAbi` field containing Alloy's full human-readable declaration, including parameter names, mutability, and standard `returns` syntax. Terminal display metadata remains separate so decoded calls render as calls rather than declaration/call hybrids.

Closes #3887.

> This PR was written with Codex.
