### PR TITLE
fix: canonicalize mutation paths

### DIFF
--- a/crates/forge/src/mutation/runner.rs
+++ b/crates/forge/src/mutation/runner.rs
@@ -222,6 +222,14 @@ pub fn run_mutations_parallel_with_progress(
 
     workspace::ensure_safe_relative_path(&source_relative, "source", &source_abs)?;
 
+    // `ProjectPathsConfig` canonicalizes its root. Create mutant workspaces beneath the canonical
+    // temp root as well so explicit compiler inputs, project-local remappings, and the project
+    // root all use the same path spelling (notably `/private/var` rather than `/var` on macOS).
+    let temp_root = std::env::temp_dir();
+    let temp_root = dunce::canonicalize(&temp_root).map_err(|err| {
+        eyre::eyre!("failed to canonicalize mutation temp root {}: {err}", temp_root.display())
+    })?;
+
     // Configure rayon thread pool
     let pool = rayon::ThreadPoolBuilder::new()
         .num_threads(num_workers)
@@ -253,6 +261,7 @@ pub fn run_mutations_parallel_with_progress(
                     &config,
                     &evm_opts,
                     &shared_state,
+                    &temp_root,
                     &filter_args,
                     &rerun_failures,
                     &selected_sources_relative,
@@ -331,6 +340,7 @@ fn test_single_mutant_isolated(
     config: &Arc<Config>,
     evm_opts: &EvmOpts,
     shared_state: &Arc<SharedMutationState>,
+    temp_root: &Path,
     filter_args: &Arc<FilterArgs>,
     rerun_failures: &Arc<Option<Vec<RerunFailure>>>,
     selected_sources_relative: &Arc<Vec<PathBuf>>,
@@ -362,10 +372,11 @@ fn test_single_mutant_isolated(
     }
 
     // Create isolated workspace using TempDir for automatic cleanup on drop
-    let temp_dir = match TempDir::with_prefix("forge_mutation_") {
+    let temp_dir = match TempDir::with_prefix_in("forge_mutation_", temp_root) {
         Ok(dir) => dir,
         Err(e) => {
-            let _ = sh_eprintln!("Failed to create temp directory: {}", e);
+            let _ =
+                sh_eprintln!("Failed to create temp directory in {}: {}", temp_root.display(), e);
             return MutantTestResult { mutant, result: MutationResult::Invalid };
         }
     };

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -1059,6 +1059,126 @@ contract FooBrokenTest {
     );
 });
 
+#[cfg(unix)]
+forgetest_init!(mutation_uses_canonical_temp_root_for_filtered_sources, |prj, cmd| {
+    let temp_parent = tempfile::tempdir().unwrap();
+    let real_temp = temp_parent.path().join("real");
+    let aliased_temp = temp_parent.path().join("alias");
+    fs::create_dir(&real_temp).unwrap();
+    std::os::unix::fs::symlink(&real_temp, &aliased_temp).unwrap();
+    assert_ne!(aliased_temp, dunce::canonicalize(&aliased_temp).unwrap());
+
+    // Preserve the failing import chain: selected test -> root-style helper -> remapped dependency.
+    let dependency_dir = prj.root().join("lib/local-dependency/src");
+    fs::create_dir_all(&dependency_dir).unwrap();
+    fs::write(
+        dependency_dir.join("Dependency.sol"),
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+library Dependency {
+    function expected() internal pure returns (uint256) {
+        return 2;
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    prj.update_config(|config| {
+        config.remappings =
+            vec![Remapping::from_str("dep/=lib/local-dependency/src/").unwrap().into()];
+    });
+
+    prj.add_source(
+        "Target.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Target {
+    function addOne(uint256 value) public pure returns (uint256) {
+        return value + 1;
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "helpers/Helper.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Dependency} from "dep/Dependency.sol";
+
+library Helper {
+    function expected() internal pure returns (uint256) {
+        return Dependency.expected();
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "Selected.t.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import {Target} from "../src/Target.sol";
+import {Helper} from "test/helpers/Helper.sol";
+
+contract SelectedTest {
+    function test_AddOne() public {
+        Target target = new Target();
+        assert(target.addOne(1) == Helper.expected());
+    }
+}
+"#,
+    );
+
+    cmd.env("TMPDIR", &aliased_temp);
+    let out = cmd
+        .args([
+            "test",
+            "--mutate",
+            "src/Target.sol",
+            "--match-path",
+            "test/Selected.t.sol",
+            "--mutation-jobs",
+            "1",
+            "--json",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let summary = mutation_summary(&out);
+    let total = summary["total"].as_u64().unwrap_or(0);
+    let invalid = summary["invalid"].as_u64().unwrap_or(u64::MAX);
+    let killed = summary["killed"].as_u64().unwrap_or(0);
+    let survived = summary["survived"].as_u64().unwrap_or(0);
+
+    assert!(total > 0, "expected mutation testing to generate mutants: summary={summary}");
+    assert!(
+        invalid < total,
+        "aliased temp root must not make every mutant Invalid: summary={summary}"
+    );
+    assert!(
+        killed + survived > 0,
+        "expected at least one Killed/Survived mutant: summary={summary}"
+    );
+    assert!(
+        fs::read_dir(&real_temp).unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .starts_with("forge_mutation_")),
+        "mutation workspaces should be removed after the run"
+    );
+});
+
 forgetest_init!(mutation_compiles_dynamic_linking_artifacts_for_selected_tests, |prj, cmd| {
     prj.add_source(
         "Target.sol",


### PR DESCRIPTION
Canonicalizes the temporary workspace root used by mutation testing so compiler inputs and project paths use the same path spelling. This prevents filtered mutation runs on macOS from incorrectly marking every mutant as invalid due to `/var` and `/private/var` aliases.

Closes #15740.