### PR TITLE
feat(bench): add common result schema

### DIFF
--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -178,6 +178,7 @@ jobs:
           path: |
             benches/stable-*.json
             benches/nightly-*.json
+            benches/common/
             regression.md
 
   report-regression:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: depot-ubuntu-24.04-32
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       is_source_comparison: ${{ steps.prep.outputs.is_source_comparison }}
     # Source-built baseline/candidate use the profiling profile, forge only.
@@ -76,6 +77,7 @@ jobs:
       - name: Prepare comparison
         id: prep
         env:
+          GH_TOKEN: ${{ github.token }}
           REQUESTED_VERSIONS: ${{ github.event.inputs.versions || env.DEFAULT_VERSIONS }}
         run: |
           compact="${REQUESTED_VERSIONS//[[:space:]]/}"
@@ -89,6 +91,12 @@ jobs:
             printf '%s' "$base_sha" > benches/baseline-ref.txt
             printf '%s' "$candidate_sha" > benches/candidate-ref.txt
             git rev-list --count "${candidate_sha}..${base_sha}" > benches/behind-count.txt
+            pr_number=$(gh api --method GET "repos/$GITHUB_REPOSITORY/pulls" \
+              -f "head=$GITHUB_REPOSITORY_OWNER:$GITHUB_REF_NAME" -f state=open \
+              --jq '.[0].number // empty')
+            if [[ -n "$pr_number" ]]; then
+              echo "BENCHMARK_PR_NUMBER=$pr_number" >> "$GITHUB_ENV"
+            fi
             echo "Comparing origin/master ($base_sha) against this branch."
           else
             echo "versions=$REQUESTED_VERSIONS" >> "$GITHUB_OUTPUT"
@@ -178,6 +186,7 @@ jobs:
             benches/LATEST.md
             benches/base-summary.json
             benches/candidate-summary.json
+            benches/common/
             benches/baseline-ref.txt
             benches/candidate-ref.txt
             benches/behind-count.txt

--- a/benches/README.md
+++ b/benches/README.md
@@ -301,6 +301,8 @@ The artifact bundle exposes:
 - `--output-dir <DIR>` - Directory for output files (default: current working directory)
 - `--output-file <FILE_NAME.md>` - Name of the Markdown output file. Defaults to `LATEST.md`
   unless `--json-output` is set, in which case Markdown is omitted unless explicitly requested
+- `--common-json-output <FILE.json>` - Write results using the common benchmark schema in
+  `benches/schema/benchmark-result-v1.schema.json`
 - `--symbolic-sidecar-output <FILE.json>` - Write the opt-in v1 symbolic samples sidecar (requires exactly one version)
 
 ## Benchmark Structure

--- a/benches/schema/README.md
+++ b/benches/schema/README.md
@@ -1,0 +1,13 @@
+# Benchmark result schema
+
+`benchmark-result-v1.schema.json` defines a common benchmark result format.
+
+Each document identifies the repository and commit being measured, optional pull request metadata, the runner, and one or more named benchmarks. Each benchmark has wall time and may include memory, custom counters, gas, solver, and compiler metrics.
+
+Every metric records a numeric `value`, its `unit`, and the `statistic` represented by the value. Unknown or unmeasured fields are omitted rather than set to `null` or zero.
+
+Recommended units are `second` for wall time, `byte` for memory and sizes, `gas` for gas, and `count` for counters. Metric names within each group should be stable snake_case identifiers.
+
+`memory` represents peak resident memory for the benchmarked process tree.
+
+Consumers should vendor the schema at a pinned Foundry commit so validation does not depend on network access. Incompatible changes require a new schema version.

--- a/benches/schema/benchmark-result-v1.schema.json
+++ b/benches/schema/benchmark-result-v1.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/foundry-rs/foundry/benches/schema/benchmark-result-v1.schema.json",
+  "title": "Benchmark result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "repo", "commit", "runner", "benchmarks"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "repo": { "$ref": "#/$defs/nonEmptyString" },
+    "commit": { "$ref": "#/$defs/nonEmptyString" },
+    "pr": { "type": "integer", "minimum": 1 },
+    "runner": { "$ref": "#/$defs/runner" },
+    "benchmarks": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/benchmark" }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "arch"],
+      "properties": {
+        "os": { "$ref": "#/$defs/nonEmptyString" },
+        "arch": { "$ref": "#/$defs/nonEmptyString" },
+        "image": { "$ref": "#/$defs/nonEmptyString" },
+        "cpu": { "$ref": "#/$defs/nonEmptyString" },
+        "logical_cpus": { "type": "integer", "minimum": 1 },
+        "total_memory_bytes": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "benchmark": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "wall_time"],
+      "properties": {
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "wall_time": { "$ref": "#/$defs/metric" },
+        "memory": { "$ref": "#/$defs/metric" },
+        "counters": { "$ref": "#/$defs/metricMap" },
+        "gas": { "$ref": "#/$defs/metricMap" },
+        "solver": { "$ref": "#/$defs/metricMap" },
+        "compiler": { "$ref": "#/$defs/metricMap" }
+      }
+    },
+    "metricMap": {
+      "type": "object",
+      "minProperties": 1,
+      "propertyNames": { "pattern": "^[a-z][a-z0-9_]*$" },
+      "additionalProperties": { "$ref": "#/$defs/metric" }
+    },
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["value", "unit", "statistic"],
+      "properties": {
+        "value": { "type": "number" },
+        "unit": { "$ref": "#/$defs/nonEmptyString" },
+        "statistic": { "enum": ["mean", "median", "min", "max", "total", "point"] }
+      }
+    }
+  }
+}

--- a/benches/scripts/run-benchmark-suite.sh
+++ b/benches/scripts/run-benchmark-suite.sh
@@ -202,12 +202,16 @@ args+=(
 if [[ -n ${markdown_output} ]]; then
   args+=(--output-file "${markdown_output}")
 fi
+date=$(date -u +%Y-%m-%d)
 if [[ -n ${json_output} ]]; then
-  date=$(date -u +%Y-%m-%d)
   json_output=${json_output//\{version\}/${versions}}
   json_output=${json_output//\{date\}/${date}}
   args+=(--json-output "${json_output}")
+  common_json_output=${json_output}
+else
+  common_json_output="${requested_profile}-${requested_suite}-${versions}-${date}.json"
 fi
+args+=(--common-json-output "common/${common_json_output}")
 args+=(--verbose)
 
 if [[ ${dry_run} == true ]]; then

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -810,6 +810,39 @@ pub fn get_forge_version() -> Result<String> {
     Ok(version.lines().next().unwrap_or("unknown").to_string())
 }
 
+/// Get the commit of the active Forge binary.
+pub fn get_forge_commit() -> Result<String> {
+    let output = Command::new("forge")
+        .args(["--version"])
+        .output()
+        .wrap_err("Failed to get forge version")?;
+    if !output.status.success() {
+        eyre::bail!("forge --version failed");
+    }
+    let output =
+        String::from_utf8(output.stdout).wrap_err("Invalid UTF-8 in forge version output")?;
+    parse_forge_commit(&output)
+        .map(str::to_owned)
+        .ok_or_else(|| eyre::eyre!("forge --version did not report a commit"))
+}
+
+fn parse_forge_commit(output: &str) -> Option<&str> {
+    output
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("Commit SHA: "))
+        .filter(|commit| !commit.is_empty())
+        .or_else(|| {
+            output
+                .lines()
+                .next()?
+                .split_once('(')?
+                .1
+                .split_whitespace()
+                .next()
+                .filter(|commit| !commit.is_empty())
+        })
+}
+
 /// Get the full forge version details including commit hash and date
 pub fn get_forge_version_details() -> Result<String> {
     let output = Command::new("forge")
@@ -863,5 +896,17 @@ mod tests {
         );
         assert!(parse_version_specs(&["../master=/tmp/foundry".to_string()]).is_err());
         assert!(parse_version_specs(&["master=".to_string()]).is_err());
+    }
+
+    #[test]
+    fn parses_modern_and_legacy_forge_commits() {
+        assert_eq!(
+            parse_forge_commit("forge Version: 1.3.1\nCommit SHA: abcdef123456\n"),
+            Some("abcdef123456")
+        );
+        assert_eq!(
+            parse_forge_commit("forge 0.2.0 (123456abcdef 2023-01-01T00:00:00Z)"),
+            Some("123456abcdef")
+        );
     }
 }

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use eyre::{Result, WrapErr};
 use foundry_bench::{
-    BENCHMARK_REPOS, BenchmarkProject, FOUNDRY_VERSIONS, RUNS, RepoConfig, get_forge_version,
-    get_forge_version_details, install_local_workspace, parse_version_specs,
+    BENCHMARK_REPOS, BenchmarkProject, FOUNDRY_VERSIONS, RUNS, RepoConfig, get_forge_commit,
+    get_forge_version, get_forge_version_details, install_local_workspace, parse_version_specs,
     results::{BenchmarkResults, versioned_summary_filename},
     switch_foundry_version,
 };
@@ -55,6 +55,11 @@ struct Cli {
     /// Consumed by the nightly regression comparison script.
     #[clap(long)]
     json_output: Option<PathBuf>,
+
+    /// Filename for results using the common benchmark JSON schema.
+    /// Resolved relative to --output-dir.
+    #[clap(long)]
+    common_json_output: Option<PathBuf>,
 
     /// Filename for the opt-in versioned symbolic benchmark sidecar.
     #[clap(long)]
@@ -173,6 +178,8 @@ fn main() -> Result<()> {
     sh_println!("Running benchmarks: {}", benchmarks.join(", "));
 
     let mut results = BenchmarkResults::new();
+    let mut version_commits = std::collections::HashMap::new();
+    let write_common_json = cli.common_json_output.is_some();
     // Set the first version as baseline
     if let Some(first_version) = versions.first() {
         results.set_baseline_version(first_version.clone());
@@ -216,6 +223,9 @@ fn main() -> Result<()> {
         sh_println!("Current version: {}", current.trim());
 
         // Get and store the full version details with commit hash and date
+        if write_common_json {
+            version_commits.insert(version.clone(), get_forge_commit()?);
+        }
         let version_details = get_forge_version_details()?;
         results.add_version_details(version, version_details);
 
@@ -323,6 +333,31 @@ fn main() -> Result<()> {
         }
     }
 
+    if let Some(filename) = cli.common_json_output {
+        let repo =
+            std::env::var("GITHUB_REPOSITORY").unwrap_or_else(|_| "foundry-rs/foundry".to_string());
+        let pr = github_pull_request();
+        for version in &versions {
+            let commit = version_commits
+                .get(version)
+                .expect("commit captured for every benchmarked version")
+                .clone();
+            let common = results.generate_common_result(version, repo.clone(), commit, pr);
+            if common.benchmarks.is_empty() {
+                eyre::bail!("no benchmark results produced for {version}");
+            }
+            let output = if versions.len() == 1 {
+                filename.clone()
+            } else {
+                filename.with_file_name(versioned_summary_filename(&filename, version))
+            };
+            let path = cli.output_dir.join(output);
+            fs::create_dir_all(path.parent().unwrap_or(&cli.output_dir))?;
+            fs::write(&path, serde_json::to_string_pretty(&common)?)?;
+            sh_println!("✅ Common JSON result written to: {}", path.display());
+        }
+    }
+
     if let Some(filename) = cli.symbolic_sidecar_output {
         let mut sidecars = std::collections::BTreeMap::new();
         for (benchmark, version_data) in &results.data {
@@ -349,6 +384,10 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn github_pull_request() -> Option<u64> {
+    std::env::var("BENCHMARK_PR_NUMBER").ok()?.parse().ok()
 }
 
 #[allow(unused_must_use)]

--- a/benches/src/results.rs
+++ b/benches/src/results.rs
@@ -1,7 +1,12 @@
 use crate::{RepoConfig, symbolic::Sidecar};
 use eyre::Result;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::Path, process::Command, thread};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::Path,
+    process::Command,
+    thread,
+};
 
 /// Hyperfine benchmark result
 #[derive(Debug, Deserialize, Serialize)]
@@ -65,6 +70,55 @@ pub struct BenchmarkResults {
     pub version_details: HashMap<String, String>,
 }
 
+/// Common benchmark result format.
+#[derive(Debug, Serialize)]
+pub struct CommonBenchmarkResult {
+    pub schema_version: u8,
+    pub repo: String,
+    pub commit: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr: Option<u64>,
+    pub runner: RunnerMetadata,
+    pub benchmarks: Vec<CommonBenchmark>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RunnerMetadata {
+    pub os: &'static str,
+    pub arch: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    pub logical_cpus: usize,
+}
+
+impl Default for RunnerMetadata {
+    fn default() -> Self {
+        Self {
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            image: std::env::var("ImageOS").ok(),
+            logical_cpus: thread::available_parallelism().map_or(1, |n| n.get()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct CommonBenchmark {
+    pub name: String,
+    pub wall_time: Metric,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub counters: BTreeMap<String, Metric>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub solver: BTreeMap<String, Metric>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Metric {
+    pub value: f64,
+    pub unit: &'static str,
+    pub statistic: &'static str,
+}
+
 impl BenchmarkResults {
     pub fn new() -> Self {
         Self::default()
@@ -111,6 +165,105 @@ impl BenchmarkResults {
             }
         }
         summary
+    }
+
+    /// Generate one version's results in the common benchmark schema.
+    pub fn generate_common_result(
+        &self,
+        version: &str,
+        repo: String,
+        commit: String,
+        pr: Option<u64>,
+    ) -> CommonBenchmarkResult {
+        let mut benchmarks = Vec::new();
+        for (benchmark_name, version_data) in &self.data {
+            if let Some(repo_data) = version_data.get(version) {
+                for (repo_name, result) in repo_data {
+                    let mut counters = BTreeMap::new();
+                    let mut solver = BTreeMap::new();
+                    if let Some(symbolic) = &result.symbolic {
+                        for (name, value) in [
+                            ("tests", symbolic.tests as f64),
+                            ("passed", symbolic.passed as f64),
+                            ("failed", symbolic.failed as f64),
+                            ("incomplete", symbolic.incomplete as f64),
+                            ("symbolic_paths", symbolic.paths as f64),
+                        ] {
+                            counters.insert(name.to_string(), Metric::total(value, "count"));
+                        }
+                        for (name, value, unit) in [
+                            ("queries", symbolic.solver_queries as f64, "count"),
+                            ("smt_queries", symbolic.smt_queries as f64, "count"),
+                            ("sat_queries", symbolic.sat_queries as f64, "count"),
+                            ("model_queries", symbolic.model_queries as f64, "count"),
+                            ("sat_cache_hits", symbolic.sat_cache_hits as f64, "count"),
+                            ("model_cache_hits", symbolic.model_cache_hits as f64, "count"),
+                            ("heuristic_witnesses", symbolic.heuristic_witnesses as f64, "count"),
+                            ("time", symbolic.solver_time_ms as f64 / 1000.0, "second"),
+                        ] {
+                            if value != 0.0 {
+                                solver.insert(name.to_string(), Metric::total(value, unit));
+                            }
+                        }
+                        if let Some(metrics) = result
+                            .symbolic_sidecar
+                            .as_ref()
+                            .and_then(|sidecar| {
+                                sidecar
+                                    .samples
+                                    .iter()
+                                    .find(|sample| sample.wall_time_seconds == result.median)
+                            })
+                            .map(|sample| &sample.run.metrics)
+                        {
+                            for (name, value, unit, divisor) in [
+                                ("smt_input_size", metrics.smt_input_bytes, "byte", 1.0),
+                                ("smt_build_time", metrics.smt_build_time_ms, "second", 1000.0),
+                            ] {
+                                if let Some(value) = value {
+                                    solver.insert(
+                                        name.to_string(),
+                                        Metric::total(value as f64 / divisor, unit),
+                                    );
+                                }
+                            }
+                            for (name, value, unit, divisor) in [
+                                ("smt_max_query_size", metrics.smt_max_query_bytes, "byte", 1.0),
+                                (
+                                    "smt_max_query_time",
+                                    metrics.smt_max_query_time_ms,
+                                    "second",
+                                    1000.0,
+                                ),
+                            ] {
+                                if let Some(value) = value {
+                                    solver.insert(
+                                        name.to_string(),
+                                        Metric::max(value as f64 / divisor, unit),
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    benchmarks.push(CommonBenchmark {
+                        name: format!("{benchmark_name}/{repo_name}"),
+                        wall_time: Metric::mean(result.mean, "second"),
+                        counters,
+                        solver,
+                    });
+                }
+            }
+        }
+        benchmarks.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+
+        CommonBenchmarkResult {
+            schema_version: 1,
+            repo,
+            commit,
+            pr,
+            runner: RunnerMetadata::default(),
+            benchmarks,
+        }
     }
 
     pub fn generate_markdown(&self, versions: &[String], repos: &[RepoConfig]) -> String {
@@ -224,6 +377,20 @@ impl BenchmarkResults {
         output.push('\n');
 
         output
+    }
+}
+
+impl Metric {
+    const fn mean(value: f64, unit: &'static str) -> Self {
+        Self { value, unit, statistic: "mean" }
+    }
+
+    const fn total(value: f64, unit: &'static str) -> Self {
+        Self { value, unit, statistic: "total" }
+    }
+
+    const fn max(value: f64, unit: &'static str) -> Self {
+        Self { value, unit, statistic: "max" }
     }
 }
 
@@ -480,5 +647,19 @@ mod tests {
         let plain = &summary["forge_test/solady"];
         assert_eq!(plain.mean, 2.5);
         assert!(plain.symbolic.is_none());
+
+        let common = results.generate_common_result(
+            "local",
+            "foundry-rs/foundry".to_string(),
+            "0123456789abcdef".to_string(),
+            None,
+        );
+        let common = serde_json::to_value(common).unwrap();
+        assert_eq!(common["schema_version"], 1);
+        assert_eq!(common["repo"], "foundry-rs/foundry");
+        assert_eq!(common["benchmarks"][0]["name"], "forge_symbolic_test/solady");
+        assert_eq!(common["benchmarks"][0]["wall_time"]["unit"], "second");
+        assert_eq!(common["benchmarks"][0]["solver"]["queries"]["value"], 100.0);
+        assert!(common.get("pr").is_none());
     }
 }


### PR DESCRIPTION
Defines a common benchmark result JSON schema and wires Foundry benchmarks to emit and retain it alongside existing outputs.

Part of OSS-475