### PR TITLE
feat(cast): support balance call overrides

### DIFF
--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -370,18 +370,21 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             );
             print_scalar(out)?;
         }
-        CastSubcommand::Balance { block, who, ether, rpc, erc20 } => {
+        CastSubcommand::Balance { block, who, ether, rpc, erc20, overrides } => {
+            if erc20.is_none() && !overrides.is_empty() {
+                eyre::bail!("call overrides require `--erc20` when using `cast balance`");
+            }
             let config = rpc.load_config()?;
             let provider = utils::get_provider(&config)?;
             let account_addr = who.resolve(&provider).await?;
 
             match erc20 {
                 Some(token) => {
-                    let balance = IERC20::new(token, &provider)
-                        .balanceOf(account_addr)
-                        .block(block.unwrap_or_default())
-                        .call()
-                        .await?;
+                    let token = IERC20::new(token, &provider);
+                    let balance_call =
+                        token.balanceOf(account_addr).block(block.unwrap_or_default());
+                    let call = balance_call.call();
+                    let balance = overrides.apply(call)?.await?;
 
                     sh_warn!("--erc20 flag is deprecated, use `cast erc20 balance` instead")?;
                     print_scalar(format_uint_exp(balance))?;

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -1,4 +1,7 @@
-use super::run::{fetch_contracts_bytecode_from_trace, fetch_contracts_bytecode_via_rpc};
+use super::{
+    call_overrides::CallOverrideOpts,
+    run::{fetch_contracts_bytecode_from_trace, fetch_contracts_bytecode_via_rpc},
+};
 use crate::{
     Cast,
     debug::handle_traces,
@@ -8,14 +11,11 @@ use crate::{
 };
 use alloy_ens::NameOrAddress;
 use alloy_network::{Network, NetworkTransactionBuilder, TransactionBuilder};
-use alloy_primitives::{
-    Address, B256, Bytes, TxKind, U256, hex,
-    map::{AddressHashMap, HashMap},
-};
+use alloy_primitives::{Bytes, TxKind, U256, hex, map::AddressHashMap};
 use alloy_provider::{Provider, ext::DebugApi};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, BlockOverrides,
-    state::{StateOverride, StateOverridesBuilder},
+    state::StateOverride,
     trace::geth::{
         CallConfig, GethDebugBuiltInTracerType, GethDebugTracerType, GethDebugTracingCallOptions,
         GethDebugTracingOptions, GethTrace,
@@ -53,13 +53,7 @@ use foundry_evm::{
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements},
 };
 use foundry_wallets::WalletOpts;
-use regex::Regex;
-use std::{str::FromStr, sync::LazyLock};
-
-// matches override pattern <address>:<slot>:<value>
-// e.g. 0x123:0x1:0x1234
-static OVERRIDE_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^([^:]+):([^:]+):([^:]+)$").unwrap());
+use std::str::FromStr;
 
 /// CLI arguments for `cast call`.
 ///
@@ -181,38 +175,8 @@ pub struct CallArgs {
     #[arg(long, visible_alias = "la")]
     pub with_local_artifacts: bool,
 
-    /// Override the accounts balance.
-    /// Format: "address:balance,address:balance"
-    #[arg(long = "override-balance", value_name = "ADDRESS:BALANCE", value_delimiter = ',')]
-    pub balance_overrides: Option<Vec<String>>,
-
-    /// Override the accounts nonce.
-    /// Format: "address:nonce,address:nonce"
-    #[arg(long = "override-nonce", value_name = "ADDRESS:NONCE", value_delimiter = ',')]
-    pub nonce_overrides: Option<Vec<String>>,
-
-    /// Override the accounts code.
-    /// Format: "address:code,address:code"
-    #[arg(long = "override-code", value_name = "ADDRESS:CODE", value_delimiter = ',')]
-    pub code_overrides: Option<Vec<String>>,
-
-    /// Override the accounts state and replace the current state entirely with the new one.
-    /// Format: "address:slot:value,address:slot:value"
-    #[arg(long = "override-state", value_name = "ADDRESS:SLOT:VALUE", value_delimiter = ',')]
-    pub state_overrides: Option<Vec<String>>,
-
-    /// Override the accounts state specific slots and preserve the rest of the state.
-    /// Format: "address:slot:value,address:slot:value"
-    #[arg(long = "override-state-diff", value_name = "ADDRESS:SLOT:VALUE", value_delimiter = ',')]
-    pub state_diff_overrides: Option<Vec<String>>,
-
-    /// Override the block timestamp.
-    #[arg(long = "block.time", value_name = "TIME")]
-    pub block_time: Option<u64>,
-
-    /// Override the block number.
-    #[arg(long = "block.number", value_name = "NUMBER")]
-    pub block_number: Option<u64>,
+    #[command(flatten)]
+    pub overrides: CallOverrideOpts,
 }
 
 #[derive(Debug, Parser)]
@@ -661,82 +625,14 @@ impl CallArgs {
         Ok(())
     }
 
-    /// Parse state overrides from command line arguments.
-    pub fn get_state_overrides(&self) -> eyre::Result<Option<StateOverride>> {
-        // Early return if no override set - <https://github.com/foundry-rs/foundry/issues/10705>
-        if [
-            self.balance_overrides.as_ref(),
-            self.nonce_overrides.as_ref(),
-            self.code_overrides.as_ref(),
-            self.state_overrides.as_ref(),
-            self.state_diff_overrides.as_ref(),
-        ]
-        .iter()
-        .all(Option::is_none)
-        {
-            return Ok(None);
-        }
-
-        let mut state_overrides_builder = StateOverridesBuilder::default();
-
-        // Parse balance overrides
-        for override_str in self.balance_overrides.iter().flatten() {
-            let (addr, balance) = address_value_override(override_str)?;
-            state_overrides_builder =
-                state_overrides_builder.with_balance(addr.parse()?, balance.parse()?);
-        }
-
-        // Parse nonce overrides
-        for override_str in self.nonce_overrides.iter().flatten() {
-            let (addr, nonce) = address_value_override(override_str)?;
-            state_overrides_builder =
-                state_overrides_builder.with_nonce(addr.parse()?, nonce.parse()?);
-        }
-
-        // Parse code overrides
-        for override_str in self.code_overrides.iter().flatten() {
-            let (addr, code_str) = address_value_override(override_str)?;
-            state_overrides_builder =
-                state_overrides_builder.with_code(addr.parse()?, Bytes::from_str(code_str)?);
-        }
-
-        type StateOverrides = HashMap<Address, HashMap<B256, B256>>;
-        let parse_state_overrides =
-            |overrides: &Option<Vec<String>>| -> Result<StateOverrides, eyre::Report> {
-                let mut state_overrides: StateOverrides = StateOverrides::default();
-
-                overrides.iter().flatten().try_for_each(|s| -> Result<(), eyre::Report> {
-                    let (addr, slot, value) = address_slot_value_override(s)?;
-                    state_overrides.entry(addr).or_default().insert(slot.into(), value.into());
-                    Ok(())
-                })?;
-
-                Ok(state_overrides)
-            };
-
-        // Parse and apply state overrides
-        for (addr, entries) in parse_state_overrides(&self.state_overrides)? {
-            state_overrides_builder = state_overrides_builder.with_state(addr, entries);
-        }
-
-        // Parse and apply state diff overrides
-        for (addr, entries) in parse_state_overrides(&self.state_diff_overrides)? {
-            state_overrides_builder = state_overrides_builder.with_state_diff(addr, entries)
-        }
-
-        Ok(Some(state_overrides_builder.build()))
+    /// Parses state overrides from command line arguments.
+    pub fn get_state_overrides(&self) -> Result<Option<StateOverride>> {
+        self.overrides.get_state_overrides()
     }
 
-    /// Parse block overrides from command line arguments.
-    pub fn get_block_overrides(&self) -> eyre::Result<Option<BlockOverrides>> {
-        let mut overrides = BlockOverrides::default();
-        if let Some(number) = self.block_number {
-            overrides = overrides.with_number(U256::from(number));
-        }
-        if let Some(time) = self.block_time {
-            overrides = overrides.with_time(time);
-        }
-        if overrides.is_empty() { Ok(None) } else { Ok(Some(overrides)) }
+    /// Parses block overrides from command line arguments.
+    pub fn get_block_overrides(&self) -> Result<Option<BlockOverrides>> {
+        self.overrides.get_block_overrides()
     }
 }
 
@@ -756,138 +652,10 @@ impl figment::Provider for CallArgs {
     }
 }
 
-/// Parse an override string in the format address:value.
-fn address_value_override(address_override: &str) -> Result<(&str, &str)> {
-    address_override.split_once(':').ok_or_else(|| {
-        eyre::eyre!("Invalid override {address_override}. Expected <address>:<value>")
-    })
-}
-
-/// Parse an override string in the format address:slot:value.
-fn address_slot_value_override(address_override: &str) -> Result<(Address, U256, U256)> {
-    let captures = OVERRIDE_PATTERN.captures(address_override).ok_or_else(|| {
-        eyre::eyre!("Invalid override {address_override}. Expected <address>:<slot>:<value>")
-    })?;
-
-    Ok((
-        captures[1].parse()?, // Address
-        captures[2].parse()?, // Slot (U256)
-        captures[3].parse()?, // Value (U256)
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{U64, address, b256, fixed_bytes};
-
-    #[test]
-    fn test_get_state_overrides() {
-        let call_args = CallArgs::parse_from([
-            "foundry-cli",
-            "--override-balance",
-            "0x0000000000000000000000000000000000000001:2",
-            "--override-nonce",
-            "0x0000000000000000000000000000000000000001:3",
-            "--override-code",
-            "0x0000000000000000000000000000000000000001:0x04",
-            "--override-state",
-            "0x0000000000000000000000000000000000000001:5:6",
-            "--override-state-diff",
-            "0x0000000000000000000000000000000000000001:7:8",
-        ]);
-        let overrides = call_args.get_state_overrides().unwrap().unwrap();
-        let address = address!("0x0000000000000000000000000000000000000001");
-        if let Some(account_override) = overrides.get(&address) {
-            if let Some(balance) = account_override.balance {
-                assert_eq!(balance, U256::from(2));
-            }
-            if let Some(nonce) = account_override.nonce {
-                assert_eq!(nonce, 3);
-            }
-            if let Some(code) = &account_override.code {
-                assert_eq!(*code, Bytes::from([0x04]));
-            }
-            if let Some(state) = &account_override.state
-                && let Some(value) = state.get(&b256!(
-                    "0x0000000000000000000000000000000000000000000000000000000000000005"
-                ))
-            {
-                assert_eq!(
-                    *value,
-                    b256!("0x0000000000000000000000000000000000000000000000000000000000000006")
-                );
-            }
-            if let Some(state_diff) = &account_override.state_diff
-                && let Some(value) = state_diff.get(&b256!(
-                    "0x0000000000000000000000000000000000000000000000000000000000000007"
-                ))
-            {
-                assert_eq!(
-                    *value,
-                    b256!("0x0000000000000000000000000000000000000000000000000000000000000008")
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_get_state_overrides_empty() {
-        let call_args = CallArgs::parse_from([""]);
-        let overrides = call_args.get_state_overrides().unwrap();
-        assert_eq!(overrides, None);
-    }
-
-    #[test]
-    fn test_get_block_overrides() {
-        let mut call_args = CallArgs::parse_from([""]);
-        call_args.block_number = Some(1);
-        call_args.block_time = Some(2);
-        let overrides = call_args.get_block_overrides().unwrap().unwrap();
-        assert_eq!(overrides.number, Some(U256::from(1)));
-        assert_eq!(overrides.time, Some(2));
-    }
-
-    #[test]
-    fn test_get_block_overrides_empty() {
-        let call_args = CallArgs::parse_from([""]);
-        let overrides = call_args.get_block_overrides().unwrap();
-        assert_eq!(overrides, None);
-    }
-
-    #[test]
-    fn test_address_value_override_success() {
-        let text = "0x0000000000000000000000000000000000000001:2";
-        let (address, value) = address_value_override(text).unwrap();
-        assert_eq!(address, "0x0000000000000000000000000000000000000001");
-        assert_eq!(value, "2");
-    }
-
-    #[test]
-    fn test_address_value_override_error() {
-        let text = "invalid_value";
-        let error = address_value_override(text).unwrap_err();
-        assert_eq!(error.to_string(), "Invalid override invalid_value. Expected <address>:<value>");
-    }
-
-    #[test]
-    fn test_address_slot_value_override_success() {
-        let text = "0x0000000000000000000000000000000000000001:2:3";
-        let (address, slot, value) = address_slot_value_override(text).unwrap();
-        assert_eq!(*address, fixed_bytes!("0x0000000000000000000000000000000000000001"));
-        assert_eq!(slot, U256::from(2));
-        assert_eq!(value, U256::from(3));
-    }
-
-    #[test]
-    fn test_address_slot_value_override_error() {
-        let text = "invalid_value";
-        let error = address_slot_value_override(text).unwrap_err();
-        assert_eq!(
-            error.to_string(),
-            "Invalid override invalid_value. Expected <address>:<slot>:<value>"
-        );
-    }
+    use alloy_primitives::U64;
 
     #[test]
     fn can_parse_call_data() {
@@ -914,10 +682,10 @@ mod tests {
             "0x123:0x1:0x1234",
         ]);
 
-        assert_eq!(args.balance_overrides, Some(vec!["0x123:0x1234".to_string()]));
-        assert_eq!(args.nonce_overrides, Some(vec!["0x123:1".to_string()]));
-        assert_eq!(args.code_overrides, Some(vec!["0x123:0x1234".to_string()]));
-        assert_eq!(args.state_overrides, Some(vec!["0x123:0x1:0x1234".to_string()]));
+        assert_eq!(args.overrides.balance_overrides, Some(vec!["0x123:0x1234".to_string()]));
+        assert_eq!(args.overrides.nonce_overrides, Some(vec!["0x123:1".to_string()]));
+        assert_eq!(args.overrides.code_overrides, Some(vec!["0x123:0x1234".to_string()]));
+        assert_eq!(args.overrides.state_overrides, Some(vec!["0x123:0x1:0x1234".to_string()]));
     }
 
     #[test]
@@ -943,16 +711,19 @@ mod tests {
         ]);
 
         assert_eq!(
-            args.balance_overrides,
-            Some(vec!["0x123:0x1234".to_string(), "0x456:0x5678".to_string()])
-        );
-        assert_eq!(args.nonce_overrides, Some(vec!["0x123:1".to_string(), "0x456:2".to_string()]));
-        assert_eq!(
-            args.code_overrides,
+            args.overrides.balance_overrides,
             Some(vec!["0x123:0x1234".to_string(), "0x456:0x5678".to_string()])
         );
         assert_eq!(
-            args.state_overrides,
+            args.overrides.nonce_overrides,
+            Some(vec!["0x123:1".to_string(), "0x456:2".to_string()])
+        );
+        assert_eq!(
+            args.overrides.code_overrides,
+            Some(vec!["0x123:0x1234".to_string(), "0x456:0x5678".to_string()])
+        );
+        assert_eq!(
+            args.overrides.state_overrides,
             Some(vec!["0x123:0x1:0x1234".to_string(), "0x456:0x2:0x5678".to_string()])
         );
     }

--- a/crates/cast/src/cmd/call_overrides.rs
+++ b/crates/cast/src/cmd/call_overrides.rs
@@ -1,0 +1,279 @@
+//! Shared `eth_call` state and block override options.
+
+use alloy_contract::{CallDecoder, EthCall};
+use alloy_network::Network;
+use alloy_primitives::{Address, B256, Bytes, U256, map::HashMap};
+use alloy_rpc_types::{
+    BlockOverrides,
+    state::{StateOverride, StateOverridesBuilder},
+};
+use clap::Args;
+use eyre::Result;
+use regex::Regex;
+use std::{str::FromStr, sync::LazyLock};
+
+// Matches override pattern <address>:<slot>:<value>.
+// e.g. 0x123:0x1:0x1234.
+static OVERRIDE_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^([^:]+):([^:]+):([^:]+)$").unwrap());
+
+/// State and block overrides for an `eth_call`.
+#[derive(Args, Clone, Debug, Default)]
+pub struct CallOverrideOpts {
+    /// Override account balances.
+    /// Format: "address:balance,address:balance".
+    #[arg(long = "override-balance", value_name = "ADDRESS:BALANCE", value_delimiter = ',')]
+    pub balance_overrides: Option<Vec<String>>,
+
+    /// Override account nonces.
+    /// Format: "address:nonce,address:nonce".
+    #[arg(long = "override-nonce", value_name = "ADDRESS:NONCE", value_delimiter = ',')]
+    pub nonce_overrides: Option<Vec<String>>,
+
+    /// Override account code.
+    /// Format: "address:code,address:code".
+    #[arg(long = "override-code", value_name = "ADDRESS:CODE", value_delimiter = ',')]
+    pub code_overrides: Option<Vec<String>>,
+
+    /// Override account state and replace the current state entirely with the new one.
+    /// Format: "address:slot:value,address:slot:value".
+    #[arg(long = "override-state", value_name = "ADDRESS:SLOT:VALUE", value_delimiter = ',')]
+    pub state_overrides: Option<Vec<String>>,
+
+    /// Override specific account storage slots and preserve the rest of the state.
+    /// Format: "address:slot:value,address:slot:value".
+    #[arg(long = "override-state-diff", value_name = "ADDRESS:SLOT:VALUE", value_delimiter = ',')]
+    pub state_diff_overrides: Option<Vec<String>>,
+
+    /// Override the block timestamp.
+    #[arg(long = "block.time", value_name = "TIME")]
+    pub block_time: Option<u64>,
+
+    /// Override the block number.
+    #[arg(long = "block.number", value_name = "NUMBER")]
+    pub block_number: Option<u64>,
+}
+
+impl CallOverrideOpts {
+    /// Returns true when no state or block override was provided.
+    pub const fn is_empty(&self) -> bool {
+        self.balance_overrides.is_none()
+            && self.nonce_overrides.is_none()
+            && self.code_overrides.is_none()
+            && self.state_overrides.is_none()
+            && self.state_diff_overrides.is_none()
+            && self.block_time.is_none()
+            && self.block_number.is_none()
+    }
+
+    /// Applies the configured overrides to an `eth_call`.
+    pub fn apply<'a, D, N>(&self, mut call: EthCall<'a, D, N>) -> Result<EthCall<'a, D, N>>
+    where
+        D: CallDecoder,
+        N: Network,
+    {
+        if let Some(state_overrides) = self.get_state_overrides()? {
+            call = call.overrides(state_overrides);
+        }
+        if let Some(block_overrides) = self.get_block_overrides()? {
+            call = call.with_block_overrides(block_overrides);
+        }
+        Ok(call)
+    }
+
+    /// Parses state overrides from command line arguments.
+    pub fn get_state_overrides(&self) -> Result<Option<StateOverride>> {
+        // Early return if no override set - <https://github.com/foundry-rs/foundry/issues/10705>.
+        if [
+            self.balance_overrides.as_ref(),
+            self.nonce_overrides.as_ref(),
+            self.code_overrides.as_ref(),
+            self.state_overrides.as_ref(),
+            self.state_diff_overrides.as_ref(),
+        ]
+        .iter()
+        .all(Option::is_none)
+        {
+            return Ok(None);
+        }
+
+        let mut state_overrides_builder = StateOverridesBuilder::default();
+
+        for override_str in self.balance_overrides.iter().flatten() {
+            let (addr, balance) = address_value_override(override_str)?;
+            state_overrides_builder =
+                state_overrides_builder.with_balance(addr.parse()?, balance.parse()?);
+        }
+
+        for override_str in self.nonce_overrides.iter().flatten() {
+            let (addr, nonce) = address_value_override(override_str)?;
+            state_overrides_builder =
+                state_overrides_builder.with_nonce(addr.parse()?, nonce.parse()?);
+        }
+
+        for override_str in self.code_overrides.iter().flatten() {
+            let (addr, code_str) = address_value_override(override_str)?;
+            state_overrides_builder =
+                state_overrides_builder.with_code(addr.parse()?, Bytes::from_str(code_str)?);
+        }
+
+        type StateOverrides = HashMap<Address, HashMap<B256, B256>>;
+        let parse_state_overrides = |overrides: &Option<Vec<String>>| -> Result<StateOverrides> {
+            let mut state_overrides = StateOverrides::default();
+
+            overrides.iter().flatten().try_for_each(|s| -> Result<()> {
+                let (addr, slot, value) = address_slot_value_override(s)?;
+                state_overrides.entry(addr).or_default().insert(slot.into(), value.into());
+                Ok(())
+            })?;
+
+            Ok(state_overrides)
+        };
+
+        for (addr, entries) in parse_state_overrides(&self.state_overrides)? {
+            state_overrides_builder = state_overrides_builder.with_state(addr, entries);
+        }
+
+        for (addr, entries) in parse_state_overrides(&self.state_diff_overrides)? {
+            state_overrides_builder = state_overrides_builder.with_state_diff(addr, entries)
+        }
+
+        Ok(Some(state_overrides_builder.build()))
+    }
+
+    /// Parses block overrides from command line arguments.
+    pub fn get_block_overrides(&self) -> Result<Option<BlockOverrides>> {
+        let mut overrides = BlockOverrides::default();
+        if let Some(number) = self.block_number {
+            overrides = overrides.with_number(U256::from(number));
+        }
+        if let Some(time) = self.block_time {
+            overrides = overrides.with_time(time);
+        }
+        if overrides.is_empty() { Ok(None) } else { Ok(Some(overrides)) }
+    }
+}
+
+/// Parses an override string in the format address:value.
+fn address_value_override(address_override: &str) -> Result<(&str, &str)> {
+    address_override.split_once(':').ok_or_else(|| {
+        eyre::eyre!("Invalid override {address_override}. Expected <address>:<value>")
+    })
+}
+
+/// Parses an override string in the format address:slot:value.
+fn address_slot_value_override(address_override: &str) -> Result<(Address, U256, U256)> {
+    let captures = OVERRIDE_PATTERN.captures(address_override).ok_or_else(|| {
+        eyre::eyre!("Invalid override {address_override}. Expected <address>:<slot>:<value>")
+    })?;
+
+    Ok((captures[1].parse()?, captures[2].parse()?, captures[3].parse()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{address, b256, fixed_bytes};
+    use clap::Parser;
+
+    #[derive(Debug, Parser)]
+    struct TestArgs {
+        #[command(flatten)]
+        overrides: CallOverrideOpts,
+    }
+
+    #[test]
+    fn test_get_state_overrides() {
+        let args = TestArgs::parse_from([
+            "foundry-cli",
+            "--override-balance",
+            "0x0000000000000000000000000000000000000001:2",
+            "--override-nonce",
+            "0x0000000000000000000000000000000000000001:3",
+            "--override-code",
+            "0x0000000000000000000000000000000000000001:0x04",
+            "--override-state",
+            "0x0000000000000000000000000000000000000001:5:6",
+            "--override-state-diff",
+            "0x0000000000000000000000000000000000000001:7:8",
+        ]);
+        let overrides = args.overrides.get_state_overrides().unwrap().unwrap();
+        let address = address!("0x0000000000000000000000000000000000000001");
+        let account = overrides.get(&address).unwrap();
+
+        assert_eq!(account.balance, Some(U256::from(2)));
+        assert_eq!(account.nonce, Some(3));
+        assert_eq!(account.code, Some(Bytes::from([0x04])));
+        assert_eq!(
+            account
+                .state
+                .as_ref()
+                .unwrap()
+                .get(&b256!("0x0000000000000000000000000000000000000000000000000000000000000005")),
+            Some(&b256!("0x0000000000000000000000000000000000000000000000000000000000000006"))
+        );
+        assert_eq!(
+            account
+                .state_diff
+                .as_ref()
+                .unwrap()
+                .get(&b256!("0x0000000000000000000000000000000000000000000000000000000000000007")),
+            Some(&b256!("0x0000000000000000000000000000000000000000000000000000000000000008"))
+        );
+    }
+
+    #[test]
+    fn test_get_state_overrides_empty() {
+        let args = TestArgs::parse_from([""]);
+        assert_eq!(args.overrides.get_state_overrides().unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_block_overrides() {
+        let args =
+            TestArgs::parse_from(["foundry-cli", "--block.number", "1", "--block.time", "2"]);
+        let overrides = args.overrides.get_block_overrides().unwrap().unwrap();
+        assert_eq!(overrides.number, Some(U256::from(1)));
+        assert_eq!(overrides.time, Some(2));
+    }
+
+    #[test]
+    fn test_get_block_overrides_empty() {
+        let args = TestArgs::parse_from([""]);
+        assert_eq!(args.overrides.get_block_overrides().unwrap(), None);
+    }
+
+    #[test]
+    fn test_address_value_override_success() {
+        let text = "0x0000000000000000000000000000000000000001:2";
+        let (address, value) = address_value_override(text).unwrap();
+        assert_eq!(address, "0x0000000000000000000000000000000000000001");
+        assert_eq!(value, "2");
+    }
+
+    #[test]
+    fn test_address_value_override_error() {
+        let text = "invalid_value";
+        let error = address_value_override(text).unwrap_err();
+        assert_eq!(error.to_string(), "Invalid override invalid_value. Expected <address>:<value>");
+    }
+
+    #[test]
+    fn test_address_slot_value_override_success() {
+        let text = "0x0000000000000000000000000000000000000001:2:3";
+        let (address, slot, value) = address_slot_value_override(text).unwrap();
+        assert_eq!(*address, fixed_bytes!("0x0000000000000000000000000000000000000001"));
+        assert_eq!(slot, U256::from(2));
+        assert_eq!(value, U256::from(3));
+    }
+
+    #[test]
+    fn test_address_slot_value_override_error() {
+        let text = "invalid_value";
+        let error = address_slot_value_override(text).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Invalid override invalid_value. Expected <address>:<slot>:<value>"
+        );
+    }
+}

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -1,7 +1,10 @@
 use std::{str::FromStr, time::Duration};
 
 use crate::{
-    cmd::send::{cast_send, cast_send_with_access_key},
+    cmd::{
+        call_overrides::CallOverrideOpts,
+        send::{cast_send, cast_send_with_access_key},
+    },
     format_uint_exp, tempo,
     tx::{CastTxSender, SendTxOpts, TxParams, fill_transaction_gas_fees},
 };
@@ -86,6 +89,9 @@ pub enum Erc20Subcommand {
 
         #[command(flatten)]
         rpc: RpcOpts,
+
+        #[command(flatten)]
+        overrides: CallOverrideOpts,
     },
 
     /// Transfer ERC20 tokens.
@@ -624,16 +630,15 @@ impl Erc20Subcommand {
                     sh_println!("{}", format_uint_exp(allowance))?;
                 }
             }
-            Self::Balance { token, owner, block, .. } => {
+            Self::Balance { token, owner, block, overrides, .. } => {
                 let provider = get_provider(&config)?;
                 let token = token.resolve(&provider).await?;
                 let owner = owner.resolve(&provider).await?;
 
-                let balance = IERC20::new(token, &provider)
-                    .balanceOf(owner)
-                    .block(block.unwrap_or_default())
-                    .call()
-                    .await?;
+                let token = IERC20::new(token, &provider);
+                let balance_call = token.balanceOf(owner).block(block.unwrap_or_default());
+                let call = balance_call.call();
+                let balance = overrides.apply(call)?.await?;
 
                 if shell::is_json() {
                     print_json_success(balance.to_string())?;

--- a/crates/cast/src/cmd/mod.rs
+++ b/crates/cast/src/cmd/mod.rs
@@ -12,6 +12,7 @@ pub mod batch_mktx;
 pub mod batch_send;
 pub mod bind;
 pub mod call;
+pub mod call_overrides;
 pub mod constructor_args;
 pub mod create2;
 pub mod creation_code;

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -8,6 +8,7 @@ use crate::cmd::{
     batch_send::BatchSendArgs,
     bind::BindArgs,
     call::CallArgs,
+    call_overrides::CallOverrideOpts,
     constructor_args::ConstructorArgsArgs,
     create2::Create2Args,
     creation_code::CreationCodeArgs,
@@ -859,6 +860,9 @@ pub enum CastSubcommand {
         /// with '--erc721'
         #[arg(long, alias = "erc721")]
         erc20: Option<Address>,
+
+        #[command(flatten)]
+        overrides: CallOverrideOpts,
     },
 
     /// Get the basefee of a block.

--- a/crates/cast/tests/cli/erc20.rs
+++ b/crates/cast/tests/cli/erc20.rs
@@ -2,7 +2,7 @@
 
 use alloy_primitives::U256;
 use anvil::{NodeConfig, NodeHandle};
-use foundry_test_utils::util::OutputExt;
+use foundry_test_utils::{str, util::OutputExt};
 
 mod anvil_const {
     /// First Anvil account
@@ -79,6 +79,79 @@ async fn setup_token_test(
 
     (rpc, token, handle)
 }
+
+casttest!(erc20_balance_applies_call_overrides, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    let token = "0x00000000000000000000000000000000000000aa";
+
+    cmd.cast_fuse()
+        .args([
+            "erc20-token",
+            "balance",
+            token,
+            anvil_const::ADDR1,
+            "--block",
+            "latest",
+            "--override-code",
+            // Runtime that returns the current block number.
+            &format!("{token}:0x4360005260206000f3"),
+            "--block.number",
+            "1234",
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+1234
+
+"#]]);
+});
+
+casttest!(deprecated_erc20_balance_applies_call_overrides, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    let token = "0x00000000000000000000000000000000000000aa";
+
+    cmd.cast_fuse()
+        .args([
+            "balance",
+            anvil_const::ADDR1,
+            "--erc20",
+            token,
+            "--block",
+            "latest",
+            "--override-code",
+            // Runtime that returns the current block number.
+            &format!("{token}:0x4360005260206000f3"),
+            "--block.number",
+            "1234",
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+1234
+
+"#]]);
+});
+
+casttest!(native_balance_rejects_call_overrides, |_prj, cmd| {
+    cmd.cast_fuse()
+        .args([
+            "balance",
+            anvil_const::ADDR1,
+            "--block.number",
+            "1234",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+        ])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: call overrides require `--erc20` when using `cast balance`
+
+"#]]);
+});
 
 // tests that `balance` and `transfer` commands works correctly
 forgetest_async!(erc20_transfer_approve_success, |prj, cmd| {


### PR DESCRIPTION
Adds a shared `CallOverrideOpts` for Cast `eth_call` commands and uses it for both `cast erc20-token balance` and the deprecated `cast balance --erc20` path. State and block overrides now compose with the selected block, while native balance queries reject these flags because `eth_getBalance` cannot apply them. This makes balance queries capable of simulating account state and block context without changing their existing output behavior.

The implementation and tests were written with OpenAI Codex assistance.
