### PR TITLE
feat(cast): extend call block overrides

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -1,6 +1,6 @@
 use super::run::{fetch_contracts_bytecode_from_trace, fetch_contracts_bytecode_via_rpc};
 use crate::{
-    Cast,
+    Cast, RpcBlockOverrides,
     debug::handle_traces,
     rpc_trace::{call_frame_to_arena, is_method_not_found_error, is_missing_state_error},
     traces::TraceKind,
@@ -12,7 +12,7 @@ use alloy_primitives::{
     Address, B256, Bytes, TxKind, U256, hex,
     map::{AddressHashMap, HashMap},
 };
-use alloy_provider::{Provider, ext::DebugApi};
+use alloy_provider::Provider;
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, BlockOverrides,
     state::{StateOverride, StateOverridesBuilder},
@@ -54,12 +54,34 @@ use foundry_evm::{
 };
 use foundry_wallets::WalletOpts;
 use regex::Regex;
+use serde::{Serialize, Serializer};
 use std::{str::FromStr, sync::LazyLock};
 
 // matches override pattern <address>:<slot>:<value>
 // e.g. 0x123:0x1:0x1234
 static OVERRIDE_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^([^:]+):([^:]+):([^:]+)$").unwrap());
+
+#[derive(Clone, Debug)]
+struct RpcDebugTracingCallOptions(GethDebugTracingCallOptions);
+
+impl Serialize for RpcDebugTracingCallOptions {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut value = serde_json::to_value(&self.0).map_err(serde::ser::Error::custom)?;
+        if let Some(block_overrides) =
+            value.as_object_mut().and_then(|options| options.get_mut("blockOverrides"))
+        {
+            *block_overrides = serde_json::to_value(RpcBlockOverrides(
+                self.0.block_overrides.clone().unwrap_or_default(),
+            ))
+            .map_err(serde::ser::Error::custom)?;
+        }
+        value.serialize(serializer)
+    }
+}
 
 /// CLI arguments for `cast call`.
 ///
@@ -206,6 +228,13 @@ pub struct CallArgs {
     #[arg(long = "override-state-diff", value_name = "ADDRESS:SLOT:VALUE", value_delimiter = ',')]
     pub state_diff_overrides: Option<Vec<String>>,
 
+    #[command(flatten)]
+    pub block_overrides: Box<BlockOverrideOpts>,
+}
+
+/// Block context overrides for `cast call`.
+#[derive(Debug, clap::Args)]
+pub struct BlockOverrideOpts {
     /// Override the block timestamp.
     #[arg(long = "block.time", value_name = "TIME")]
     pub block_time: Option<u64>,
@@ -213,6 +242,30 @@ pub struct CallArgs {
     /// Override the block number.
     #[arg(long = "block.number", value_name = "NUMBER")]
     pub block_number: Option<u64>,
+
+    /// Override the block gas limit.
+    #[arg(long = "block.gas-limit", value_name = "GAS_LIMIT")]
+    pub block_gas_limit: Option<u64>,
+
+    /// Override the block fee recipient.
+    #[arg(long = "block.fee-recipient", visible_alias = "block.coinbase", value_name = "ADDRESS")]
+    pub block_fee_recipient: Option<Address>,
+
+    /// Override the block base fee per gas.
+    #[arg(
+        long = "block.base-fee",
+        visible_alias = "block.base-fee-per-gas",
+        value_name = "BASE_FEE"
+    )]
+    pub block_base_fee: Option<U256>,
+
+    /// Override the block base fee per blob gas.
+    #[arg(
+        long = "block.blob-base-fee",
+        visible_alias = "block.blob-base-fee-per-gas",
+        value_name = "BLOB_BASE_FEE"
+    )]
+    pub block_blob_base_fee: Option<U256>,
 }
 
 #[derive(Debug, Parser)]
@@ -361,8 +414,11 @@ impl CallArgs {
                 call_options = call_options.with_block_overrides(block_overrides);
             }
 
-            let geth_trace = provider
-                .debug_trace_call(tx, block, call_options)
+            let geth_trace: GethTrace = provider
+                .raw_request(
+                    "debug_traceCall".into(),
+                    (tx, block, RpcDebugTracingCallOptions(call_options)),
+                )
                 .await
                 .map_err(|err| -> eyre::Report {
                     // Two RPC rejections deserve an actionable hint instead of the raw transport
@@ -435,6 +491,8 @@ impl CallArgs {
         }
 
         if trace {
+            let preserve_block_base_fee =
+                block_overrides.as_ref().is_some_and(|overrides| overrides.base_fee.is_some());
             if let Some(BlockId::Number(BlockNumberOrTag::Number(block_number))) = self.block {
                 // Override Config `fork_block_number` (if set) with CLI value.
                 config.fork_block_number = Some(block_number);
@@ -456,6 +514,18 @@ impl CallArgs {
                 }
                 if let Some(time) = block_overrides.time {
                     evm_env.block_env.set_timestamp(U256::from(time));
+                }
+                if let Some(gas_limit) = block_overrides.gas_limit {
+                    evm_env.block_env.set_gas_limit(gas_limit);
+                }
+                if let Some(fee_recipient) = block_overrides.coinbase {
+                    evm_env.block_env.set_beneficiary(fee_recipient);
+                }
+                if let Some(base_fee) = block_overrides.base_fee {
+                    evm_env.block_env.set_basefee(base_fee.try_into()?);
+                }
+                if let Some(blob_base_fee) = block_overrides.blob_base_fee {
+                    evm_env.block_env.set_blob_gasprice(blob_base_fee.try_into()?);
                 }
             }
 
@@ -523,12 +593,36 @@ impl CallArgs {
                 env_tx.set_signed_authorization(auth);
             }
 
-            let trace = match tx_kind {
-                TxKind::Create => {
+            // The test executor normally zeros the block base fee together with the transaction
+            // gas price. An explicit call override must remain visible to the BASEFEE opcode, so
+            // execute with the configured environments in that case.
+            let call_env = preserve_block_base_fee.then(|| {
+                let mut evm_env = executor.evm_env().clone();
+                evm_env.cfg_env.disable_balance_check = true;
+                let mut tx_env = executor.tx_env().clone();
+                tx_env.set_caller(from);
+                tx_env.set_kind(tx_kind);
+                tx_env.set_data(input.clone());
+                tx_env.set_value(value);
+                tx_env.set_gas_limit(executor.gas_limit());
+                tx_env.set_chain_id(Some(evm_env.cfg_env.chain_id));
+                (evm_env, tx_env)
+            });
+
+            let trace = match (tx_kind, call_env) {
+                (TxKind::Create, Some((evm_env, tx_env))) => {
+                    let deploy_result = executor.deploy_with_env(evm_env, tx_env, None)?;
+                    TraceResult::from(deploy_result)
+                }
+                (TxKind::Create, None) => {
                     let deploy_result = executor.deploy(from, input, value, None);
                     TraceResult::try_from(deploy_result)?
                 }
-                TxKind::Call(to) => TraceResult::from_raw(
+                (TxKind::Call(_), Some((evm_env, tx_env))) => TraceResult::from_raw(
+                    executor.transact_with_env(evm_env, tx_env)?,
+                    TraceKind::Execution,
+                ),
+                (TxKind::Call(to), None) => TraceResult::from_raw(
                     executor.transact_raw(from, to, input, value)?,
                     TraceKind::Execution,
                 ),
@@ -644,9 +738,29 @@ impl CallArgs {
             if let Some(block_overrides) = self.get_block_overrides()? {
                 call_options = call_options.with_block_overrides(block_overrides);
             }
-            ("debug_traceCall", serde_json::json!([call_object, block_param, call_options]))
+            (
+                "debug_traceCall",
+                serde_json::json!([
+                    call_object,
+                    block_param,
+                    RpcDebugTracingCallOptions(call_options)
+                ]),
+            )
         } else {
-            ("eth_call", serde_json::json!([call_object, block_param]))
+            let state_overrides = self.get_state_overrides()?;
+            let params = if let Some(block_overrides) = self.get_block_overrides()? {
+                serde_json::json!([
+                    call_object,
+                    block_param,
+                    state_overrides.unwrap_or_default(),
+                    RpcBlockOverrides(block_overrides)
+                ])
+            } else if let Some(state_overrides) = state_overrides {
+                serde_json::json!([call_object, block_param, state_overrides])
+            } else {
+                serde_json::json!([call_object, block_param])
+            };
+            ("eth_call", params)
         };
 
         let curl_cmd = generate_curl_command(
@@ -730,11 +844,23 @@ impl CallArgs {
     /// Parse block overrides from command line arguments.
     pub fn get_block_overrides(&self) -> eyre::Result<Option<BlockOverrides>> {
         let mut overrides = BlockOverrides::default();
-        if let Some(number) = self.block_number {
+        if let Some(number) = self.block_overrides.block_number {
             overrides = overrides.with_number(U256::from(number));
         }
-        if let Some(time) = self.block_time {
+        if let Some(time) = self.block_overrides.block_time {
             overrides = overrides.with_time(time);
+        }
+        if let Some(gas_limit) = self.block_overrides.block_gas_limit {
+            overrides = overrides.with_gas_limit(gas_limit);
+        }
+        if let Some(fee_recipient) = self.block_overrides.block_fee_recipient {
+            overrides = overrides.with_coinbase(fee_recipient);
+        }
+        if let Some(base_fee) = self.block_overrides.block_base_fee {
+            overrides = overrides.with_base_fee(base_fee);
+        }
+        if let Some(blob_base_fee) = self.block_overrides.block_blob_base_fee {
+            overrides = overrides.with_blob_base_fee(blob_base_fee);
         }
         if overrides.is_empty() { Ok(None) } else { Ok(Some(overrides)) }
     }
@@ -840,12 +966,28 @@ mod tests {
 
     #[test]
     fn test_get_block_overrides() {
-        let mut call_args = CallArgs::parse_from([""]);
-        call_args.block_number = Some(1);
-        call_args.block_time = Some(2);
+        let call_args = CallArgs::parse_from([
+            "foundry-cli",
+            "--block.number",
+            "1",
+            "--block.time",
+            "2",
+            "--block.gas-limit",
+            "3",
+            "--block.coinbase",
+            "0x0000000000000000000000000000000000000004",
+            "--block.base-fee",
+            "5",
+            "--block.blob-base-fee",
+            "6",
+        ]);
         let overrides = call_args.get_block_overrides().unwrap().unwrap();
         assert_eq!(overrides.number, Some(U256::from(1)));
         assert_eq!(overrides.time, Some(2));
+        assert_eq!(overrides.gas_limit, Some(3));
+        assert_eq!(overrides.coinbase, Some(address!("0000000000000000000000000000000000000004")));
+        assert_eq!(overrides.base_fee, Some(U256::from(5)));
+        assert_eq!(overrides.blob_base_fee, Some(U256::from(6)));
     }
 
     #[test]

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -19,7 +19,7 @@ use alloy_json_abi::Function;
 use alloy_json_rpc::RpcError;
 use alloy_network::{AnyNetwork, BlockResponse, Network, TransactionBuilder};
 use alloy_primitives::{
-    Address, B256, I256, Keccak256, LogData, Selector, TxHash, U64, U256, hex,
+    Address, B256, Bytes, I256, Keccak256, LogData, Selector, TxHash, U64, U256, hex,
     utils::{ParseUnits, Unit, keccak256},
 };
 use alloy_provider::{PendingTransactionBuilder, Provider, network::eip2718::Decodable2718};
@@ -82,6 +82,28 @@ use rlp_converter::Item;
 pub struct Cast<P, N = AnyNetwork> {
     provider: P,
     _phantom: PhantomData<N>,
+}
+
+/// Serializes block overrides using the field names accepted by execution clients.
+#[derive(Clone, Debug)]
+pub(crate) struct RpcBlockOverrides(pub BlockOverrides);
+
+impl Serialize for RpcBlockOverrides {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut value = serde_json::to_value(&self.0).map_err(serde::ser::Error::custom)?;
+        if let Some(overrides) = value.as_object_mut() {
+            if let Some(fee_recipient) = overrides.remove("coinbase") {
+                overrides.insert("feeRecipient".to_string(), fee_recipient);
+            }
+            if let Some(base_fee) = overrides.remove("baseFee") {
+                overrides.insert("baseFeePerGas".to_string(), base_fee);
+            }
+        }
+        value.serialize(serializer)
+    }
 }
 
 impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
@@ -152,16 +174,26 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
         state_override: Option<StateOverride>,
         block_override: Option<BlockOverrides>,
     ) -> Result<String> {
-        let mut call = self
-            .provider
-            .call(req.clone())
-            .block(block.unwrap_or_default())
-            .with_block_overrides_opt(block_override);
-        if let Some(state_override) = state_override {
-            call = call.overrides(state_override)
-        }
-
-        let res = call.await?;
+        let block = block.unwrap_or_default();
+        let res: Bytes = if let Some(block_override) = block_override {
+            self.provider
+                .raw_request(
+                    "eth_call".into(),
+                    (
+                        req.clone(),
+                        block,
+                        state_override.unwrap_or_default(),
+                        RpcBlockOverrides(block_override),
+                    ),
+                )
+                .await?
+        } else {
+            let mut call = self.provider.call(req.clone()).block(block);
+            if let Some(state_override) = state_override {
+                call = call.overrides(state_override)
+            }
+            call.await?
+        };
         let decoded = if let Some(func) = func {
             // decode args into tokens
             match func.abi_decode_output(res.as_ref()) {
@@ -171,11 +203,7 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
                     if res.is_empty() {
                         // check that the recipient is a contract that can be called
                         if let Some(addr) = req.to() {
-                            if let Ok(code) = self
-                                .provider
-                                .get_code_at(addr)
-                                .block_id(block.unwrap_or_default())
-                                .await
+                            if let Ok(code) = self.provider.get_code_at(addr).block_id(block).await
                                 && code.is_empty()
                             {
                                 eyre::bail!("contract {addr:?} does not have any code")
@@ -2505,6 +2533,36 @@ fn explorer_client(
     }
 
     builder.build().map_err(Into::into)
+}
+
+#[cfg(test)]
+mod rpc_block_overrides_tests {
+    use super::RpcBlockOverrides;
+    use alloy_primitives::{U256, address};
+    use alloy_rpc_types::BlockOverrides;
+
+    #[test]
+    fn serializes_execution_client_field_names() {
+        let overrides = BlockOverrides::default()
+            .with_number(U256::from(1))
+            .with_time(2)
+            .with_gas_limit(3)
+            .with_coinbase(address!("0000000000000000000000000000000000000004"))
+            .with_base_fee(U256::from(5))
+            .with_blob_base_fee(U256::from(6));
+
+        assert_eq!(
+            serde_json::to_value(RpcBlockOverrides(overrides)).unwrap(),
+            serde_json::json!({
+                "number": "0x1",
+                "time": "0x2",
+                "gasLimit": "0x3",
+                "feeRecipient": "0x0000000000000000000000000000000000000004",
+                "baseFeePerGas": "0x5",
+                "blobBaseFee": "0x6",
+            })
+        );
+    }
 }
 
 /// Tests for the `eth_getLogs` chunking/bisection helpers, kept in a separate module so they can

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4374,6 +4374,51 @@ Transaction successfully executed.
 "#]]);
 });
 
+// Block context overrides are forwarded to `eth_call` and applied when executing a local trace.
+casttest!(cast_call_applies_block_context_overrides, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    let args = [
+        "call",
+        "0x00000000000000000000000000000000000000cc",
+        "context()(address,uint256,uint256,uint256)",
+        "--override-code",
+        "0x00000000000000000000000000000000000000cc:0x4160005245602052486040524a60605260806000f3",
+        "--block.gas-limit",
+        "100000",
+        "--block.fee-recipient",
+        "0x000000000000000000000000000000000000beef",
+        "--block.base-fee",
+        "5",
+        "--block.blob-base-fee",
+        "6",
+        "--rpc-url",
+        &rpc,
+    ];
+
+    cmd.cast_fuse().args(args).assert_success().stdout_eq(str![[r#"
+0x000000000000000000000000000000000000bEEF
+100000 [1e5]
+5
+6
+
+"#]]);
+
+    cmd.cast_fuse()
+        .args(args.into_iter().chain(["--trace"]))
+        .assert_success()
+        .stdout_eq(str![[r#"
+Traces:
+  [..] 0x00000000000000000000000000000000000000cc::context()
+    └─ ← [Return] 0x000000000000000000000000000000000000000000000000000000000000beef00000000000000000000000000000000000000000000000000000000000186a000000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000006
+
+
+Transaction successfully executed.
+[GAS]
+
+"#]]);
+});
+
 // https://github.com/foundry-rs/foundry/issues/10189
 // `cast call --debug-trace-call` fetches the call trace from the node via `debug_traceCall`
 // (callTracer) and renders it with the same decoding/rendering machinery as `--trace`. The call
@@ -4439,10 +4484,7 @@ Transaction successfully executed.
 "#]]);
 });
 
-// `--debug-trace-call` must also forward block overrides: override an address with a runtime that
-// returns `block.number` and pass `--block.number`, then check the traced call returns that number.
-// If `with_block_overrides` were not forwarded to `debug_traceCall`, the call would run at anvil's
-// real block number and the return would differ, so this test can fail.
+// `--debug-trace-call` forwards the configured block context to the remote execution.
 casttest!(cast_call_debug_trace_call_applies_block_overrides, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test()).await;
 
@@ -4450,21 +4492,29 @@ casttest!(cast_call_debug_trace_call_applies_block_overrides, async |_prj, cmd| 
         .args([
             "call",
             "0x00000000000000000000000000000000000000bb",
-            "number()(uint256)",
+            "context()(uint256,uint256,address,uint256,uint256)",
             "--debug-trace-call",
-            // runtime: NUMBER PUSH1 0 MSTORE PUSH1 0x20 PUSH1 0 RETURN
+            // Return NUMBER, GASLIMIT, COINBASE, BASEFEE, and BLOBBASEFEE.
             "--override-code",
-            "0x00000000000000000000000000000000000000bb:0x4360005260206000f3",
+            "0x00000000000000000000000000000000000000bb:0x436000524560205241604052486060524a60805260a06000f3",
             "--block.number",
             "1234",
+            "--block.gas-limit",
+            "100000",
+            "--block.fee-recipient",
+            "0x000000000000000000000000000000000000beef",
+            "--block.base-fee",
+            "5",
+            "--block.blob-base-fee",
+            "6",
             "--rpc-url",
             &handle.http_endpoint(),
         ])
         .assert_success()
         .stdout_eq(str![[r#"
 Traces:
-  [21160] 0x00000000000000000000000000000000000000bb::number()
-    └─ ← [Return] 0x00000000000000000000000000000000000000000000000000000000000004d2
+  [..] 0x00000000000000000000000000000000000000bb::context()
+    └─ ← [Return] 0x00000000000000000000000000000000000000000000000000000000000004d200000000000000000000000000000000000000000000000000000000000186a0000000000000000000000000000000000000000000000000000000000000beef00000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000006
 
 
 Transaction successfully executed.
@@ -6322,6 +6372,10 @@ casttest!(curl_call_debug_trace_call_forwards_overrides, |_prj, cmd| {
             "0x00000000000000000000000000000000000000aa:0x60005460005260206000f3",
             "--block.number",
             "1234",
+            "--block.fee-recipient",
+            "0x000000000000000000000000000000000000beef",
+            "--block.base-fee",
+            "5",
             "--curl",
         ])
         .assert_success()
@@ -6335,6 +6389,77 @@ casttest!(curl_call_debug_trace_call_forwards_overrides, |_prj, cmd| {
         "expected the override code in params:\n{output}"
     );
     assert!(output.contains("blockOverrides"), "expected block overrides in params:\n{output}");
+    assert!(output.contains("feeRecipient"), "expected fee recipient in params:\n{output}");
+    assert!(output.contains("baseFeePerGas"), "expected base fee in params:\n{output}");
+    assert!(!output.contains("coinbase"), "unexpected legacy fee recipient field:\n{output}");
+    assert!(!output.contains("baseFee\""), "unexpected legacy base fee field:\n{output}");
+});
+
+// A plain `eth_call` curl request retains both override parameters and uses the execution-client
+// field names for the block context.
+casttest!(curl_call_forwards_overrides, |_prj, cmd| {
+    let rpc = "https://eth.example.com";
+    let to = "0xdead000000000000000000000000000000000000";
+
+    let output = cmd
+        .args([
+            "call",
+            to,
+            "--data",
+            "0x",
+            "--rpc-url",
+            rpc,
+            "--override-balance",
+            "0x00000000000000000000000000000000000000aa:1",
+            "--block.number",
+            "1",
+            "--block.time",
+            "2",
+            "--block.gas-limit",
+            "3",
+            "--block.fee-recipient",
+            "0x0000000000000000000000000000000000000004",
+            "--block.base-fee",
+            "5",
+            "--block.blob-base-fee",
+            "6",
+            "--curl",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let payload = output
+        .split("--data-raw '")
+        .nth(1)
+        .and_then(|payload| payload.split("' '").next())
+        .expect("missing curl JSON payload");
+    let request: serde_json::Value = serde_json::from_str(payload).unwrap();
+
+    assert_eq!(
+        request,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "eth_call",
+            "params": [
+                { "to": to, "data": "0x" },
+                "latest",
+                {
+                    "0x00000000000000000000000000000000000000aa": {
+                        "balance": "0x1"
+                    }
+                },
+                {
+                    "number": "0x1",
+                    "time": "0x2",
+                    "gasLimit": "0x3",
+                    "feeRecipient": "0x0000000000000000000000000000000000000004",
+                    "baseFeePerGas": "0x5",
+                    "blobBaseFee": "0x6"
+                }
+            ],
+            "id": 1
+        })
+    );
 });
 
 // tests that `--curl` forwards the scalar transaction fields into the call object, so the

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -12,6 +12,7 @@ use revm::{
     context::{Block, BlockEnv, Cfg, CfgEnv, Transaction, TxEnv},
     context_interface::{
         ContextTr,
+        block::BlobExcessGasAndPrice,
         either::Either,
         transaction::{AccessList, RecoveredAuthorization, SignedAuthorization},
     },
@@ -51,6 +52,9 @@ pub trait FoundryBlock: Block {
         _excess_blob_gas: u64,
         _base_fee_update_fraction: u64,
     );
+
+    /// Sets the blob gas price directly.
+    fn set_blob_gasprice(&mut self, _blob_gasprice: u128) {}
 
     // Tempo methods
 
@@ -98,6 +102,12 @@ impl FoundryBlock for BlockEnv {
         base_fee_update_fraction: u64,
     ) {
         self.set_blob_excess_gas_and_price(excess_blob_gas, base_fee_update_fraction);
+    }
+
+    fn set_blob_gasprice(&mut self, blob_gasprice: u128) {
+        self.blob_excess_gas_and_price
+            .get_or_insert(BlobExcessGasAndPrice { excess_blob_gas: 0, blob_gasprice })
+            .blob_gasprice = blob_gasprice;
     }
 }
 


### PR DESCRIPTION
Adds block gas limit, fee recipient, base fee, and blob base fee options to `cast call`, applying them consistently to regular calls, remote debug traces, local traces, and generated curl requests. Outbound block overrides use the execution-client field names, and ordinary curl requests now retain supplied state and block overrides.

This change was developed with AI assistance.
