### PR TITLE
fix(chisel): persist delete expressions

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -77,6 +77,26 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
             Ok(res) => (res, None),
             Err(err) => {
                 debug!(?err, %input, "execution failed");
+                let should_execute = self
+                    .clone_with_new_line(input.to_string())
+                    .ok()
+                    .and_then(|(source, do_execute)| {
+                        if !do_execute {
+                            return None;
+                        }
+                        source.build().ok().map(|output| {
+                            output.enter(|output| {
+                                let body = output.run_func_body();
+                                let Some(last) = body.last() else { return false };
+                                let StmtKind::Expr(expr) = last.kind else { return false };
+                                should_continue(expr)
+                            })
+                        })
+                    })
+                    .unwrap_or(false);
+                if should_execute {
+                    return Ok((ControlFlow::Continue(()), None));
+                }
                 match source_without_inspector.execute().await {
                     Ok(res) => (res, Some(err)),
                     Err(_) => {
@@ -381,6 +401,8 @@ fn should_continue(expr: &Expr<'_>) -> bool {
     match &expr.kind {
         // assignments and compound assignments
         ExprKind::Assign(_, _, _) => true,
+        // Delete expressions.
+        ExprKind::Delete(_) => true,
         // ++/-- pre/post operations
         ExprKind::Unary(op, _) => matches!(
             op.kind,

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -260,6 +260,14 @@ repl_test!(enum_min_max, |repl| {
     repl.expect("Decimal: 2");
 });
 
+// Issue #7193: Test that inspected delete expressions persist in the session.
+repl_test!(delete_expression_persistence, |repl| {
+    repl.sendln("uint256 value = 42");
+    repl.sendln("delete value");
+    repl.sendln("value");
+    repl.expect("Decimal: 0");
+});
+
 // Issue #9377: Test correct hex formatting for uint256.
 repl_test!(uint256_hex_formatting, |repl| {
     repl.sendln("uint256 x = 42");


### PR DESCRIPTION
Preserves semicolon-less `delete` expressions when Chisel cannot ABI-encode them for inspection. This ensures their side effects remain part of the REPL session. 

Fixes #7193.