### PR TITLE
fix: correctly encode JSON static arrays

### DIFF
--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -537,18 +537,33 @@ fn _json_value_to_token(value: &Value, defs: &StructDefinitions) -> Result<DynSo
         Value::Object(map) => {
             // Try to find a struct definition that matches the object keys.
             let keys: BTreeSet<_> = map.keys().map(|s| s.as_str()).collect();
-            let matching_def = defs.values().find(|fields| {
-                fields.len() == keys.len()
-                    && fields.iter().map(|(name, _)| name.as_str()).collect::<BTreeSet<_>>() == keys
-            });
+            let matching_defs = defs
+                .values()
+                .filter(|fields| {
+                    fields.len() == keys.len()
+                        && fields.iter().map(|(name, _)| name.as_str()).collect::<BTreeSet<_>>()
+                            == keys
+                })
+                .collect::<Vec<_>>();
 
-            if let Some(fields) = matching_def {
+            if let Some(fields) = matching_defs.first() {
                 // Found a struct with matching field names, use the order from the definition.
                 fields
                     .iter()
-                    .map(|(name, _)| {
+                    .map(|(name, type_description)| {
                         // unwrap is safe because we know the key exists.
-                        _json_value_to_token(map.get(name).unwrap(), defs)
+                        let value = map.get(name).unwrap();
+                        let unambiguous = matching_defs.iter().all(|fields| {
+                            fields
+                                .iter()
+                                .find(|(field, _)| field == name)
+                                .is_some_and(|(_, ty)| ty == type_description)
+                        });
+                        if unambiguous && let Some(ty) = fixed_array_type(type_description, defs) {
+                            parse_json_as(value, &ty)
+                        } else {
+                            _json_value_to_token(value, defs)
+                        }
                     })
                     .collect::<Result<_>>()
                     .map(DynSolValue::Tuple)
@@ -643,6 +658,23 @@ fn _json_value_to_token(value: &Value, defs: &StructDefinitions) -> Result<DynSo
             // Otherwise, treat as a regular string
             Ok(DynSolValue::String(string.to_owned()))
         }
+    }
+}
+
+fn fixed_array_type(type_description: &str, defs: &StructDefinitions) -> Option<DynSolType> {
+    let root = type_description.split('[').next()?;
+    if !matches!(defs.get(root), Ok(None)) {
+        return None;
+    }
+
+    DynSolType::parse(type_description).ok().filter(contains_fixed_array)
+}
+
+fn contains_fixed_array(ty: &DynSolType) -> bool {
+    match ty {
+        DynSolType::FixedArray(_, _) => true,
+        DynSolType::Array(inner) => contains_fixed_array(inner),
+        _ => false,
     }
 }
 
@@ -978,6 +1010,26 @@ mod tests {
             return Ok(());
         }
         panic!("Expected Person to be CustomStruct");
+    }
+
+    #[test]
+    fn test_fixed_array_type() {
+        let mut struct_defs = TypeDefMap::new();
+        struct_defs.insert(
+            "Contract.Child".to_string(),
+            vec![("value".to_string(), "uint256".to_string())],
+        );
+        let struct_defs = StructDefinitions::from(struct_defs);
+
+        assert_eq!(
+            fixed_array_type("uint256[1][]", &struct_defs),
+            Some(DynSolType::Array(Box::new(DynSolType::FixedArray(
+                Box::new(DynSolType::Uint(256)),
+                1,
+            ))))
+        );
+        assert!(fixed_array_type("uint256[", &struct_defs).is_none());
+        assert!(fixed_array_type("Contract.Child[1]", &struct_defs).is_none());
     }
 
     #[test]

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -559,8 +559,10 @@ fn _json_value_to_token(value: &Value, defs: &StructDefinitions) -> Result<DynSo
                                 .find(|(field, _)| field == name)
                                 .is_some_and(|(_, ty)| ty == type_description)
                         });
-                        if unambiguous && let Some(ty) = fixed_array_type(type_description, defs) {
-                            parse_json_as(value, &ty)
+                        if unambiguous
+                            && let Some(parsed) = parse_fixed_array(value, type_description, defs)
+                        {
+                            parsed
                         } else {
                             _json_value_to_token(value, defs)
                         }
@@ -661,13 +663,50 @@ fn _json_value_to_token(value: &Value, defs: &StructDefinitions) -> Result<DynSo
     }
 }
 
-fn fixed_array_type(type_description: &str, defs: &StructDefinitions) -> Option<DynSolType> {
-    let root = type_description.split('[').next()?;
-    if !matches!(defs.get(root), Ok(None)) {
+fn parse_fixed_array(
+    value: &Value,
+    type_description: &str,
+    defs: &StructDefinitions,
+) -> Option<Result<DynSolValue>> {
+    let root_end = type_description.find('[')?;
+    let root = &type_description[..root_end];
+    let (ty, custom) = match defs.get(root) {
+        Ok(Some(_)) => {
+            (DynSolType::parse(&format!("bool{}", &type_description[root_end..])).ok()?, true)
+        }
+        Ok(None) if root.contains('.') => return None,
+        Ok(None) => (DynSolType::parse(type_description).ok()?, false),
+        Err(_) => return None,
+    };
+    if !contains_fixed_array(&ty) {
         return None;
     }
 
-    DynSolType::parse(type_description).ok().filter(contains_fixed_array)
+    Some(if custom { parse_json_custom_array(value, &ty, defs) } else { parse_json_as(value, &ty) })
+}
+
+fn parse_json_custom_array(
+    value: &Value,
+    ty: &DynSolType,
+    defs: &StructDefinitions,
+) -> Result<DynSolValue> {
+    match (value, ty) {
+        (Value::Array(values), DynSolType::Array(inner)) => values
+            .iter()
+            .map(|value| parse_json_custom_array(value, inner, defs))
+            .collect::<Result<_>>()
+            .map(DynSolValue::Array),
+        (Value::Array(values), DynSolType::FixedArray(inner, len)) => {
+            ensure!(values.len() == *len, "array length mismatch");
+            values
+                .iter()
+                .map(|value| parse_json_custom_array(value, inner, defs))
+                .collect::<Result<_>>()
+                .map(DynSolValue::FixedArray)
+        }
+        (_, DynSolType::Bool) => _json_value_to_token(value, defs),
+        _ => bail!("expected array"),
+    }
 }
 
 fn contains_fixed_array(ty: &DynSolType) -> bool {
@@ -1013,7 +1052,7 @@ mod tests {
     }
 
     #[test]
-    fn test_fixed_array_type() {
+    fn test_parse_fixed_array() {
         let mut struct_defs = TypeDefMap::new();
         struct_defs.insert(
             "Contract.Child".to_string(),
@@ -1021,15 +1060,36 @@ mod tests {
         );
         let struct_defs = StructDefinitions::from(struct_defs);
 
-        assert_eq!(
-            fixed_array_type("uint256[1][]", &struct_defs),
-            Some(DynSolType::Array(Box::new(DynSolType::FixedArray(
-                Box::new(DynSolType::Uint(256)),
-                1,
-            ))))
-        );
-        assert!(fixed_array_type("uint256[", &struct_defs).is_none());
-        assert!(fixed_array_type("Contract.Child[1]", &struct_defs).is_none());
+        let value = serde_json::json!([[1], [2]]);
+        assert!(parse_fixed_array(&value, "uint256[1][]", &struct_defs).unwrap().is_ok());
+        assert!(parse_fixed_array(&value, "uint256[", &struct_defs).is_none());
+        assert!(parse_fixed_array(&value, "uint256[0]", &struct_defs).is_none());
+        assert!(parse_fixed_array(&value, "Contract.Child[", &struct_defs).is_none());
+        assert!(parse_fixed_array(&value, "Missing.Child[1]", &struct_defs).is_none());
+
+        let value = serde_json::json!([[{"value": 1}, {"value": 2}]]);
+        let parsed =
+            parse_fixed_array(&value, "Contract.Child[2][1]", &struct_defs).unwrap().unwrap();
+        assert!(matches!(
+            parsed,
+            DynSolValue::FixedArray(outer)
+                if matches!(&outer[..], [DynSolValue::FixedArray(inner)] if matches!(&inner[..], [DynSolValue::Tuple(_), DynSolValue::Tuple(_)]))
+        ));
+
+        let value = serde_json::json!([[{"value": 1}], [{"value": 2}]]);
+        assert!(parse_fixed_array(&value, "Contract.Child[1][]", &struct_defs).unwrap().is_ok());
+        let value = serde_json::json!([[]]);
+        assert!(parse_fixed_array(&value, "Contract.Child[][1]", &struct_defs).unwrap().is_ok());
+
+        let mut ambiguous_defs = TypeDefMap::new();
+        ambiguous_defs
+            .insert("A.Child".to_string(), vec![("value".to_string(), "uint256".to_string())]);
+        ambiguous_defs
+            .insert("B.Child".to_string(), vec![("value".to_string(), "uint256".to_string())]);
+        let ambiguous_defs = StructDefinitions::from(ambiguous_defs);
+        let value = serde_json::json!([{"value": 1}]);
+        assert!(parse_fixed_array(&value, "Child[1]", &ambiguous_defs).is_none());
+        assert!(parse_fixed_array(&value, "A.Child[1]", &ambiguous_defs).unwrap().is_ok());
     }
 
     #[test]

--- a/testdata/default/cheats/Json.t.sol
+++ b/testdata/default/cheats/Json.t.sol
@@ -67,6 +67,31 @@ library JsonStructs {
 contract ParseJsonTest is Test {
     using JsonStructs for *;
 
+    struct StaticArray {
+        uint256[1] timestamp;
+    }
+
+    struct NestedStaticArray {
+        uint256[2][1] matrix;
+    }
+
+    struct AmbiguousAStaticArray {
+        uint256[1] ambiguousValues;
+    }
+
+    struct AmbiguousZDynamicArray {
+        uint256[] ambiguousValues;
+    }
+
+    struct StaticBytesArray {
+        bytes4[1] selectors;
+    }
+
+    struct SelectiveStaticArray {
+        uint256[1] fixedValues;
+        string inferredAddress;
+    }
+
     struct FlatJson {
         uint256 a;
         int24[][] arr;
@@ -152,6 +177,45 @@ contract ParseJsonTest is Test {
         uint256[] memory decodedData = abi.decode(data, (uint256[]));
         assertEq(42, decodedData[0]);
         assertEq(43, decodedData[1]);
+    }
+
+    function test_staticArray() public {
+        bytes memory data = vm.parseJson('{"timestamp":[1655140035]}');
+        StaticArray memory decodedData = abi.decode(data, (StaticArray));
+        assertEq(1655140035, decodedData.timestamp[0]);
+    }
+
+    function test_nestedStaticArray() public {
+        bytes memory data = vm.parseJson('{"matrix":[[42,43]]}');
+        NestedStaticArray memory decodedData = abi.decode(data, (NestedStaticArray));
+        assertEq(42, decodedData.matrix[0][0]);
+        assertEq(43, decodedData.matrix[0][1]);
+    }
+
+    function test_staticArrayLengthMismatch() public {
+        vm._expectCheatcodeRevert("array length mismatch");
+        vm.parseJson('{"timestamp":[1,2]}');
+    }
+
+    function test_ambiguousArrayFallsBackToDynamic() public {
+        bytes memory data = vm.parseJson('{"ambiguousValues":[42]}');
+        AmbiguousZDynamicArray memory decodedData = abi.decode(data, (AmbiguousZDynamicArray));
+        assertEq(42, decodedData.ambiguousValues[0]);
+    }
+
+    function test_staticArrayUsesElementType() public {
+        bytes memory data = vm.parseJson('{"selectors":["0x12345678"]}');
+        StaticBytesArray memory decodedData = abi.decode(data, (StaticBytesArray));
+        assertEq(bytes32(decodedData.selectors[0]), bytes32(bytes4(0x12345678)));
+    }
+
+    function test_staticArrayPreservesSiblingInference() public {
+        address inferredAddress = address(0x1234);
+        bytes memory data = vm.parseJson(
+            string.concat('{"fixedValues":[42],"inferredAddress":"', vm.toString(inferredAddress), '"}')
+        );
+        uint256[1] memory fixedValues = [uint256(42)];
+        assertEq(data, abi.encode(fixedValues, inferredAddress));
     }
 
     // Object keys are sorted alphabetically, regardless of input.

--- a/testdata/default/cheats/Json.t.sol
+++ b/testdata/default/cheats/Json.t.sol
@@ -211,9 +211,8 @@ contract ParseJsonTest is Test {
 
     function test_staticArrayPreservesSiblingInference() public {
         address inferredAddress = address(0x1234);
-        bytes memory data = vm.parseJson(
-            string.concat('{"fixedValues":[42],"inferredAddress":"', vm.toString(inferredAddress), '"}')
-        );
+        bytes memory data =
+            vm.parseJson(string.concat('{"fixedValues":[42],"inferredAddress":"', vm.toString(inferredAddress), '"}'));
         uint256[1] memory fixedValues = [uint256(42)];
         assertEq(data, abi.encode(fixedValues, inferredAddress));
     }

--- a/testdata/default/cheats/Json.t.sol
+++ b/testdata/default/cheats/Json.t.sol
@@ -92,6 +92,23 @@ contract ParseJsonTest is Test {
         string inferredAddress;
     }
 
+    struct StaticStructChild {
+        uint256 value;
+        string label;
+    }
+
+    struct StaticStructParent {
+        StaticStructChild[1] children;
+    }
+
+    struct NestedStaticStructChild {
+        uint256[1] values;
+    }
+
+    struct NestedStaticStructParent {
+        NestedStaticStructChild[2][1] nestedChildren;
+    }
+
     struct FlatJson {
         uint256 a;
         int24[][] arr;
@@ -215,6 +232,25 @@ contract ParseJsonTest is Test {
             vm.parseJson(string.concat('{"fixedValues":[42],"inferredAddress":"', vm.toString(inferredAddress), '"}'));
         uint256[1] memory fixedValues = [uint256(42)];
         assertEq(data, abi.encode(fixedValues, inferredAddress));
+    }
+
+    function test_staticStructArray() public {
+        bytes memory data = vm.parseJson('{"children":[{"label":"child","value":42}]}');
+        StaticStructParent memory decodedData = abi.decode(data, (StaticStructParent));
+        assertEq(42, decodedData.children[0].value);
+        assertEq("child", decodedData.children[0].label);
+    }
+
+    function test_nestedStaticStructArray() public {
+        bytes memory data = vm.parseJson('{"nestedChildren":[[{"values":[42]},{"values":[43]}]]}');
+        NestedStaticStructParent memory decodedData = abi.decode(data, (NestedStaticStructParent));
+        assertEq(42, decodedData.nestedChildren[0][0].values[0]);
+        assertEq(43, decodedData.nestedChildren[0][1].values[0]);
+    }
+
+    function test_staticStructArrayLengthMismatch() public {
+        vm._expectCheatcodeRevert("array length mismatch");
+        vm.parseJson('{"children":[]}');
     }
 
     // Object keys are sorted alphabetically, regardless of input.


### PR DESCRIPTION
Uses unambiguous Solidity struct metadata to correctly ABI-encode fixed arrays in `vm.parseJson` while preserving existing dynamic-array inference. Adds coverage for nested arrays, element types, length validation, and ambiguous struct definitions. 

Closes #5424.