### PR TITLE
fix(debugger): clamp pane scroll positions

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -307,21 +307,21 @@ impl TUIContext<'_> {
             KeyCode::Char('g') => {
                 self.draw_memory.inner_call_index = 0;
                 self.current_step = 0;
-                self.scroll_memory_to_current_write();
+                self.update_scroll_positions();
             }
 
             // Go to bottom of file
             KeyCode::Char('G') => {
                 self.draw_memory.inner_call_index = self.debug_arena().len() - 1;
                 self.current_step = self.n_steps() - 1;
-                self.scroll_memory_to_current_write();
+                self.update_scroll_positions();
             }
 
             // Go to previous call
             KeyCode::Char('c') if self.draw_memory.inner_call_index > 0 => {
                 self.draw_memory.inner_call_index -= 1;
                 self.current_step = self.n_steps() - 1;
-                self.scroll_memory_to_current_write();
+                self.update_scroll_positions();
             }
 
             // Go to next call
@@ -330,7 +330,7 @@ impl TUIContext<'_> {
             {
                 self.draw_memory.inner_call_index += 1;
                 self.current_step = 0;
-                self.scroll_memory_to_current_write();
+                self.update_scroll_positions();
             }
 
             // Step forward
@@ -343,7 +343,7 @@ impl TUIContext<'_> {
                     })
                 {
                     this.current_step += i;
-                    this.scroll_memory_to_current_write();
+                    this.update_scroll_positions();
                 }
             }),
 
@@ -361,7 +361,7 @@ impl TUIContext<'_> {
                     })
                     .map(|(i, _)| i)
                     .unwrap_or_default();
-                this.scroll_memory_to_current_write();
+                this.update_scroll_positions();
             }),
 
             // Toggle stack labels
@@ -516,7 +516,7 @@ impl TUIContext<'_> {
         };
 
         self.current_step = step_index;
-        self.scroll_memory_to_current_write();
+        self.update_scroll_positions();
 
         let pc = self.current_step().pc;
         let opcode = self.opcode_list.get(step_index).map(String::as_str).unwrap_or_default();
@@ -585,7 +585,7 @@ impl TUIContext<'_> {
         self.current_step = target.step_index;
         self.draw_memory.current_buf_startline = 0;
         self.draw_memory.current_stack_startline = 0;
-        self.scroll_memory_to_current_write();
+        self.update_scroll_positions();
         self.key_buffer.clear();
 
         let pc = candidate.pc;
@@ -775,7 +775,7 @@ impl TUIContext<'_> {
         self.current_step = target.step_index;
         self.draw_memory.current_buf_startline = 0;
         self.draw_memory.current_stack_startline = 0;
-        self.scroll_memory_to_current_write();
+        self.update_scroll_positions();
         self.key_buffer.clear();
 
         let pc = self.current_step().pc;
@@ -846,7 +846,7 @@ impl TUIContext<'_> {
         self.current_step = access.step_index();
         self.draw_memory.current_buf_startline = 0;
         self.draw_memory.current_stack_startline = 0;
-        self.scroll_memory_to_current_write();
+        self.update_scroll_positions();
         self.key_buffer.clear();
         self.set_info(format!(
             "Jumped to {} at PC 0x{:x} ({})",
@@ -897,7 +897,7 @@ impl TUIContext<'_> {
 
         self.draw_memory.inner_call_index = inner_call_index;
         self.current_step = step_index;
-        self.scroll_memory_to_current_write();
+        self.update_scroll_positions();
 
         let action = if already_at_target { "Already at" } else { "Jumped to" };
         self.set_info(format!("{action} breakpoint '{c}' at PC 0x{pc:x} ({pc})"));
@@ -928,7 +928,7 @@ impl TUIContext<'_> {
             self.draw_memory.inner_call_index -= 1;
             self.current_step = self.n_steps() - 1;
         }
-        self.scroll_memory_to_current_write();
+        self.update_scroll_positions();
     }
 
     fn step(&mut self) {
@@ -938,16 +938,26 @@ impl TUIContext<'_> {
             self.draw_memory.inner_call_index += 1;
             self.current_step = 0;
         }
-        self.scroll_memory_to_current_write();
+        self.update_scroll_positions();
     }
 
-    fn scroll_memory_to_current_write(&mut self) {
-        if self.active_buffer != BufferKind::Memory {
-            return;
+    fn update_scroll_positions(&mut self) {
+        if let Some(stack) = &self.current_step().stack {
+            self.draw_memory.current_stack_startline =
+                self.draw_memory.current_stack_startline.min(stack.len().saturating_sub(1));
         }
 
-        if let Some(line) = self.current_memory_write_line() {
+        if self.active_buffer == BufferKind::Memory
+            && let Some(line) = self.current_memory_write_line()
+        {
             self.draw_memory.current_buf_startline = line;
+        }
+
+        let buffer_len = self.active_buffer().len();
+        if buffer_len > 0 {
+            let max_line = buffer_len.div_ceil(32) - 1;
+            self.draw_memory.current_buf_startline =
+                self.draw_memory.current_buf_startline.min(max_line);
         }
     }
 
@@ -2790,7 +2800,7 @@ mod tests {
             address,
             CallKind::Call,
             vec![step_with_stack(1, OpCode::MSTORE, &[0, 128]), step(2)],
-            Bytes::new(),
+            Bytes::from(vec![0; 256]),
             0,
             None,
         )]);
@@ -2803,5 +2813,39 @@ mod tests {
 
         assert_eq!(tui.current_step, 1);
         assert_eq!(tui.draw_memory.current_buf_startline, 7);
+    }
+
+    #[test]
+    fn navigation_clamps_scroll_positions_to_non_empty_data() {
+        let address = Address::repeat_byte(1);
+        let mut context = context_with_arena(vec![
+            DebugNode::new(
+                address,
+                CallKind::Call,
+                vec![step_with_stack(1, OpCode::STOP, &[0, 1, 2])],
+                Bytes::from(vec![0; 64]),
+                0,
+                None,
+            ),
+            DebugNode::new(
+                address,
+                CallKind::Call,
+                vec![step_with_stack(2, OpCode::STOP, &[0])],
+                Bytes::from(vec![0; 4]),
+                0,
+                None,
+            ),
+        ]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.active_buffer = BufferKind::Calldata;
+        tui.draw_memory.current_buf_startline = 1;
+        tui.draw_memory.current_stack_startline = 2;
+
+        let _ = tui.handle_key_event(key(KeyCode::Char('C')));
+
+        assert_eq!(tui.draw_memory.inner_call_index, 1);
+        assert_eq!(tui.draw_memory.current_buf_startline, 0);
+        assert_eq!(tui.draw_memory.current_stack_startline, 0);
     }
 }

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -942,7 +942,9 @@ impl TUIContext<'_> {
     }
 
     fn update_scroll_positions(&mut self) {
-        if let Some(stack) = &self.current_step().stack {
+        if let Some(stack) = &self.current_step().stack
+            && !stack.is_empty()
+        {
             self.draw_memory.current_stack_startline =
                 self.draw_memory.current_stack_startline.min(stack.len().saturating_sub(1));
         }
@@ -2847,5 +2849,33 @@ mod tests {
         assert_eq!(tui.draw_memory.inner_call_index, 1);
         assert_eq!(tui.draw_memory.current_buf_startline, 0);
         assert_eq!(tui.draw_memory.current_stack_startline, 0);
+    }
+
+    #[test]
+    fn navigation_preserves_stack_scroll_across_empty_snapshot() {
+        let address = Address::repeat_byte(1);
+        let mut empty_stack = step(2);
+        empty_stack.stack = Some(Vec::new().into_boxed_slice());
+        let mut context = context_with_arena(vec![DebugNode::new(
+            address,
+            CallKind::Call,
+            vec![
+                step_with_stack(1, OpCode::STOP, &[0, 1, 2]),
+                empty_stack,
+                step_with_stack(3, OpCode::STOP, &[0, 1, 2]),
+            ],
+            Bytes::new(),
+            0,
+            None,
+        )]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.draw_memory.current_stack_startline = 2;
+
+        tui.step();
+        assert_eq!(tui.draw_memory.current_stack_startline, 2);
+
+        tui.step();
+        assert_eq!(tui.draw_memory.current_stack_startline, 2);
     }
 }


### PR DESCRIPTION
## Motivation

Pane scroll offsets persist while navigating between debugger steps and calls. When the current stack or active buffer is shorter than the previous one, the stale offset can skip every available row and make a non-empty pane appear blank.

## Solution

- centralize post-navigation scroll position updates
- clamp stack and active-buffer offsets to shorter non-empty data
- preserve memory-write autoscroll and empty-snapshot behavior

Progresses #927.
