### PR TITLE
fix(chisel): display raw dynamic bytes

### DIFF
--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -279,17 +279,20 @@ fn format_token(token: DynSolValue) -> String {
         DynSolValue::Bool(b) => {
             format!("Type: {}\n└ Value: {}", "bool".red(), b.cyan())
         }
-        DynSolValue::String(_) | DynSolValue::Bytes(_) => {
-            let hex = hex::encode(token.abi_encode());
-            let s = token.as_str();
+        DynSolValue::Bytes(bytes) => {
             format!(
-                "Type: {}\n{}├ Hex (Memory):\n├─ Length ({}): {}\n├─ Contents ({}): {}\n├ Hex (Tuple Encoded):\n├─ Pointer ({}): {}\n├─ Length ({}): {}\n└─ Contents ({}): {}",
-                if s.is_some() { "string" } else { "dynamic bytes" }.red(),
-                if let Some(s) = s {
-                    format!("├ UTF-8: {}\n", s.cyan())
-                } else {
-                    String::default()
-                },
+                "Type: {}\n└ Data: {}",
+                "dynamic bytes".red(),
+                hex::encode_prefixed(bytes).cyan()
+            )
+        }
+        token @ DynSolValue::String(_) => {
+            let hex = hex::encode(token.abi_encode());
+            let s = token.as_str().expect("matched string value");
+            format!(
+                "Type: {}\n├ UTF-8: {}\n├ Hex (Memory):\n├─ Length ({}): {}\n├─ Contents ({}): {}\n├ Hex (Tuple Encoded):\n├─ Pointer ({}): {}\n├─ Length ({}): {}\n└─ Contents ({}): {}",
+                "string".red(),
+                s.cyan(),
                 "[0x00:0x20]".yellow(),
                 format!("0x{}", &hex[64..128]).cyan(),
                 "[0x20:..]".yellow(),

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -35,6 +35,24 @@ repl_test!(abi_encode_decode, |repl| {
     repl.expect("hello");
 });
 
+// Issue #5253: Dynamic bytes should be displayed as their raw value.
+repl_test!(dynamic_bytes_display, |repl| {
+    repl.sendln(r#"bytes memory encoded = abi.encode("Not initialized")"#);
+    repl.sendln("bytes memory decoded = abi.decode(encoded, (bytes))");
+    repl.sendln(r#"bytes memory raw = bytes("Not initialized")"#);
+
+    repl.sendln("encoded");
+    repl.expect(
+        "Data: 0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000f4e6f7420696e697469616c697a65640000000000000000000000000000000000",
+    );
+
+    repl.sendln("decoded");
+    repl.expect("Data: 0x4e6f7420696e697469616c697a6564");
+
+    repl.sendln("raw");
+    repl.expect("Data: 0x4e6f7420696e697469616c697a6564");
+});
+
 // Test 0x prefixed strings.
 repl_test!(hex_string_interpretation, |repl| {
     repl.sendln("string memory s = \"0x1234\"");


### PR DESCRIPTION
Dynamic `bytes` inspection currently ABI-encodes the decoded value a second time before formatting it, so Chisel shows a synthetic outer memory and tuple layout instead of the actual bytes. This renders dynamic bytes directly as hex data, matching fixed bytes and Forge's `console.logBytes`, while retaining the existing rich display for strings. The regression uses the exact `abi.encode`, `abi.decode`, and `bytes(...)` case from #5253.

Closes #5253.
