### PR TITLE
feat(debugger): add storage explorer

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -1,8 +1,10 @@
 //! Debugger context and event handler implementation.
 
-use super::storage::{StorageAccess, StorageSpace, hex_u256, storage_access_at};
+use super::storage::{
+    StorageAccess, StorageSpace, hex_u256, storage_access_at, storage_accesses_until,
+};
 use crate::{DebugNode, DebuggerLayout, ExitReason, debugger::DebuggerContext};
-use alloy_primitives::{Address, U256, hex};
+use alloy_primitives::{Address, U256, hex, map::IndexMap};
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
 use foundry_compilers::artifacts::sourcemap::SourceElement;
 use foundry_evm_core::buffer::{BufferKind, get_buffer_accesses};
@@ -60,6 +62,7 @@ impl ActiveInternalCallCache {
 pub(crate) struct DrawMemory {
     pub(crate) inner_call_index: usize,
     pub(crate) current_buf_startline: usize,
+    pub(crate) current_storage_startline: usize,
     pub(crate) current_stack_startline: usize,
     pub(crate) active_internal_call: Option<ActiveInternalCallCache>,
 }
@@ -97,6 +100,7 @@ pub(crate) struct TUIContext<'a> {
     pub(crate) show_stack: bool,
     /// The currently active buffer (memory, calldata, returndata) to be drawn.
     pub(crate) active_buffer: BufferKind,
+    active_storage: Option<StorageSpace>,
 }
 
 impl<'a> TUIContext<'a> {
@@ -124,6 +128,7 @@ impl<'a> TUIContext<'a> {
             show_variables: true,
             show_stack: true,
             active_buffer: BufferKind::Memory,
+            active_storage: None,
         }
     }
 
@@ -181,6 +186,26 @@ impl<'a> TUIContext<'a> {
 
     fn active_buffer(&self) -> &[u8] {
         self.buffer(&self.active_buffer)
+    }
+
+    pub(super) const fn active_storage(&self) -> Option<StorageSpace> {
+        self.active_storage
+    }
+
+    pub(super) fn storage_accesses(&self, space: StorageSpace) -> IndexMap<U256, StorageAccess> {
+        storage_accesses_until(
+            self.debug_arena(),
+            self.draw_memory.inner_call_index,
+            self.current_step,
+            space,
+        )
+    }
+
+    fn active_data_len(&self) -> usize {
+        self.active_storage.map_or_else(
+            || self.active_buffer().len().div_ceil(32),
+            |space| self.storage_accesses(space).len(),
+        )
     }
 
     fn buffer(&self, buffer: &BufferKind) -> &[u8] {
@@ -261,15 +286,24 @@ impl TUIContext<'_> {
             // Exit
             KeyCode::Char('q') => return ControlFlow::Break(ExitReason::CharExit),
 
-            // Scroll up the memory buffer
+            // Scroll up the active data pane
             KeyCode::Char('k') | KeyCode::Up if control => self.repeat(|this| {
-                this.draw_memory.current_buf_startline =
-                    this.draw_memory.current_buf_startline.saturating_sub(1);
+                if this.active_storage.is_some() {
+                    this.draw_memory.current_storage_startline =
+                        this.draw_memory.current_storage_startline.saturating_sub(1);
+                } else {
+                    this.draw_memory.current_buf_startline =
+                        this.draw_memory.current_buf_startline.saturating_sub(1);
+                }
             }),
-            // Scroll down the memory buffer
+            // Scroll down the active data pane
             KeyCode::Char('j') | KeyCode::Down if control => self.repeat(|this| {
-                let max_buf = this.active_buffer().len().div_ceil(32).saturating_sub(1);
-                if this.draw_memory.current_buf_startline < max_buf {
+                let max_line = this.active_data_len().saturating_sub(1);
+                if this.active_storage.is_some() {
+                    if this.draw_memory.current_storage_startline < max_line {
+                        this.draw_memory.current_storage_startline += 1;
+                    }
+                } else if this.draw_memory.current_buf_startline < max_line {
                     this.draw_memory.current_buf_startline += 1;
                 }
             }),
@@ -295,7 +329,9 @@ impl TUIContext<'_> {
 
             // Cycle buffers
             KeyCode::Char('b') => {
-                self.active_buffer = self.active_buffer.next();
+                if self.active_storage.take().is_none() {
+                    self.active_buffer = self.active_buffer.next();
+                }
                 self.draw_memory.current_buf_startline = 0;
                 self.set_info(format!("Active buffer: {}", self.active_buffer_name()));
             }
@@ -387,7 +423,11 @@ impl TUIContext<'_> {
             KeyCode::Char('o') => {
                 self.key_buffer.clear();
                 self.status = None;
-                self.buffer_offset_input = Some(String::new());
+                if let Some(space) = self.active_storage {
+                    self.command_input = Some(format!("{} ", space.command()));
+                } else {
+                    self.buffer_offset_input = Some(String::new());
+                }
             }
 
             // Run debugger command
@@ -625,6 +665,7 @@ impl TUIContext<'_> {
         }
 
         self.active_buffer = buffer;
+        self.active_storage = None;
         self.apply_buffer_offset(offset);
     }
 
@@ -686,7 +727,8 @@ impl TUIContext<'_> {
         mut args: impl Iterator<Item = &'a str>,
     ) {
         let Some(offset) = args.next() else {
-            return self.set_error(command_usage(command, "<offset>"));
+            self.select_buffer(buffer);
+            return;
         };
         if args.next().is_some() {
             return self.set_error(command_usage(command, "<offset>"));
@@ -701,12 +743,26 @@ impl TUIContext<'_> {
         mut args: impl Iterator<Item = &'a str>,
     ) {
         let Some(slot) = args.next() else {
-            return self.set_error(command_usage(command, "<slot>"));
+            self.select_storage(space);
+            return;
         };
         if args.next().is_some() {
             return self.set_error(command_usage(command, "<slot>"));
         }
         self.goto_storage_slot_from_input(slot, space);
+    }
+
+    fn select_buffer(&mut self, buffer: BufferKind) {
+        self.active_buffer = buffer;
+        self.active_storage = None;
+        self.draw_memory.current_buf_startline = 0;
+        self.set_info(format!("Active buffer: {}", self.active_buffer_name()));
+    }
+
+    fn select_storage(&mut self, space: StorageSpace) {
+        self.active_storage = Some(space);
+        self.draw_memory.current_storage_startline = 0;
+        self.set_info(format!("Active data: {}", space.noun()));
     }
 
     fn goto_source_line_from_input(&mut self, input: &str) {
@@ -830,12 +886,9 @@ impl TUIContext<'_> {
             slot,
             space,
         ) else {
-            let storage = match space {
-                StorageSpace::Persistent => "Storage",
-                StorageSpace::Transient => "Transient storage",
-            };
             self.set_error(format!(
-                "{storage} slot {} not accessed in current call",
+                "{} slot {} not accessed in current call",
+                space.label(),
                 hex_u256(slot)
             ));
             return;
@@ -846,6 +899,9 @@ impl TUIContext<'_> {
         self.current_step = access.step_index();
         self.draw_memory.current_buf_startline = 0;
         self.draw_memory.current_stack_startline = 0;
+        self.active_storage = Some(space);
+        self.draw_memory.current_storage_startline =
+            self.storage_accesses(space).get_index_of(&access.slot()).unwrap_or_default();
         self.scroll_memory_to_current_write();
         self.key_buffer.clear();
         self.set_info(format!(
@@ -1055,7 +1111,7 @@ fn command_usage(command: &str, arg: &str) -> String {
 
 fn command_help() -> String {
     format!(
-        "Commands: {} <pc>, {} <pc>, {} <offset>, {} <offset>, {} <offset>, {} <slot>, {} <slot>, {} <line>, {}, {}, {}, {}",
+        "Commands: {} <pc>, {} <pc>, {} [<offset>], {} [<offset>], {} [<offset>], {} [<slot>], {} [<slot>], {} <line>, {}, {}, {}, {}",
         command_aliases(CONTINUE_COMMANDS),
         command_aliases(PC_COMMANDS),
         command_aliases(MEMORY_COMMANDS),
@@ -2122,6 +2178,13 @@ mod tests {
     #[test]
     fn command_prompt_jumps_to_storage_slot_access() {
         let address = Address::repeat_byte(1);
+        let mut first_store = step(2);
+        first_store.storage_change = Some(Box::new(StorageChange {
+            key: U256::ZERO,
+            value: U256::from(7),
+            had_value: None,
+            reason: StorageChangeReason::SSTORE,
+        }));
         let mut store = step(42);
         store.storage_change = Some(Box::new(StorageChange {
             key: U256::from(1),
@@ -2132,7 +2195,7 @@ mod tests {
         let mut context = context_with_arena(vec![DebugNode::new(
             address,
             CallKind::Call,
-            vec![step(1), store],
+            vec![step(1), first_store, store],
             Bytes::new(),
             0,
             None,
@@ -2142,7 +2205,9 @@ mod tests {
 
         tui.run_command_from_input("storage 1");
 
-        assert_eq!(tui.current_step, 1);
+        assert_eq!(tui.current_step, 2);
+        assert_eq!(tui.active_storage, Some(StorageSpace::Persistent));
+        assert_eq!(tui.storage_accesses(StorageSpace::Persistent).len(), 2);
         assert_eq!(
             tui.status.as_ref().unwrap().text,
             "Jumped to storage SSTORE slot 0x1: 0x7 -> 0x2a at PC 0x2a (42)"
@@ -2167,6 +2232,7 @@ mod tests {
         tui.run_command_from_input("transient 2a");
 
         assert_eq!(tui.current_step, 1);
+        assert_eq!(tui.active_storage, Some(StorageSpace::Transient));
         assert_eq!(
             tui.status.as_ref().unwrap().text,
             "Jumped to transient storage TSTORE slot 0x2a = 0xbeef at PC 0x2a (42)"
@@ -2191,15 +2257,29 @@ mod tests {
             reason: StorageChangeReason::SSTORE,
         }));
 
+        let mut first_store = step(1);
+        first_store.storage_change = Some(Box::new(StorageChange {
+            key: U256::ZERO,
+            value: U256::from(7),
+            had_value: None,
+            reason: StorageChangeReason::SSTORE,
+        }));
         let mut first =
-            DebugNode::new(address, CallKind::Call, vec![step(1)], Bytes::new(), 0, None);
+            DebugNode::new(address, CallKind::Call, vec![first_store], Bytes::new(), 0, None);
         first.trace_node_idx = 7;
         first.step_offset = 0;
 
+        let mut child_store = step(2);
+        child_store.storage_change = Some(Box::new(StorageChange {
+            key: U256::from(9),
+            value: U256::from(99),
+            had_value: None,
+            reason: StorageChangeReason::SSTORE,
+        }));
         let mut child = DebugNode::new(
             Address::repeat_byte(2),
             CallKind::Call,
-            vec![step(2)],
+            vec![child_store],
             Bytes::new(),
             0,
             None,
@@ -2220,6 +2300,9 @@ mod tests {
 
         assert_eq!(tui.draw_memory.inner_call_index, 2);
         assert_eq!(tui.current_step, 0);
+        let accesses = tui.storage_accesses(StorageSpace::Persistent);
+        assert_eq!(accesses.len(), 2);
+        assert!(!accesses.contains_key(&U256::from(9)));
         assert_eq!(
             tui.status.as_ref().unwrap().text,
             "Jumped to storage SSTORE slot 0x1 = 0x2a at PC 0x2a (42)"
@@ -2384,10 +2467,15 @@ mod tests {
 
         tui.run_command_from_input("mem");
         let status = tui.status.as_ref().unwrap();
-        assert_eq!(status.kind, StatusKind::Error);
-        assert_eq!(status.text, "Usage: :mem <offset>");
+        assert_eq!(status.kind, StatusKind::Info);
+        assert_eq!(status.text, "Active buffer: memory");
 
         tui.run_command_from_input("store");
+        let status = tui.status.as_ref().unwrap();
+        assert_eq!(status.kind, StatusKind::Info);
+        assert_eq!(status.text, "Active data: storage");
+
+        tui.run_command_from_input("store 1 2");
         let status = tui.status.as_ref().unwrap();
         assert_eq!(status.kind, StatusKind::Error);
         assert_eq!(status.text, "Usage: :store <slot>");

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -2,7 +2,7 @@
 
 use super::{
     context::{ActiveInternalCallCache, ActiveInternalCallLocation, StatusKind, TUIContext},
-    storage::{StorageAccess, storage_access_at},
+    storage::{StorageAccess, StorageSpace, hex_u256, storage_access_at},
 };
 use crate::{DebuggerLayout, debugger::DebuggerStats, op::OpcodeParam};
 use alloy_dyn_abi::{DynSolType, Specifier, parser::Parameters};
@@ -144,8 +144,8 @@ impl TUIContext<'_> {
         if self.show_stack {
             self.draw_stack(f, *panes.next().expect("stack pane is visible"));
         }
-        let memory_pane = *panes.next().expect("memory pane is always visible");
-        self.draw_buffer(f, memory_pane);
+        let data_pane = *panes.next().expect("data pane is always visible");
+        self.draw_data(f, data_pane);
         if self.show_source {
             self.draw_src(f, *panes.next().expect("source pane is visible"));
         }
@@ -235,7 +235,7 @@ impl TUIContext<'_> {
         if self.show_stack {
             self.draw_stack(f, *panes.next().expect("stack pane is visible"));
         }
-        self.draw_buffer(f, *panes.next().expect("memory pane is always visible"));
+        self.draw_data(f, *panes.next().expect("data pane is always visible"));
     }
 
     fn footer_height(&self) -> u16 {
@@ -610,6 +610,47 @@ impl TUIContext<'_> {
 
     fn current_storage_access_line(&self) -> Option<Line<'static>> {
         storage_access_at(self.debug_steps(), self.current_step).map(storage_access_line)
+    }
+
+    fn draw_data(&mut self, f: &mut Frame<'_>, area: Rect) {
+        if let Some(space) = self.active_storage() {
+            self.draw_storage(f, area, space);
+        } else {
+            self.draw_buffer(f, area);
+        }
+    }
+
+    fn draw_storage(&mut self, f: &mut Frame<'_>, area: Rect, space: StorageSpace) {
+        let accesses = self.storage_accesses(space);
+        let current_slot = storage_access_at(self.debug_steps(), self.current_step)
+            .filter(|access| access.space() == space)
+            .map(StorageAccess::slot);
+        self.draw_memory.current_storage_startline =
+            self.draw_memory.current_storage_startline.min(accesses.len().saturating_sub(1));
+
+        let index_width = decimal_digits(accesses.len()).max(2);
+        let mut lines = accesses
+            .values()
+            .copied()
+            .enumerate()
+            .skip(self.draw_memory.current_storage_startline)
+            .flat_map(|(index, access)| {
+                storage_slot_lines(index, index_width, access, current_slot == Some(access.slot()))
+            })
+            .collect::<Vec<_>>();
+        if lines.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("No {} accessed in current call", space.noun()),
+                Style::new().add_modifier(Modifier::DIM),
+            )));
+        }
+
+        let count = accesses.len();
+        let suffix = if count == 1 { "slot" } else { "slots" };
+        let title = format!("{}: {count} accessed {suffix}", space.label());
+        let block = Block::default().title(title).borders(Borders::ALL);
+        let paragraph = Paragraph::new(lines).block(block).wrap(Wrap { trim: false });
+        f.render_widget(paragraph, area);
     }
 
     fn draw_buffer(&self, f: &mut Frame<'_>, area: Rect) {
@@ -1034,7 +1075,7 @@ fn shortcut_lines() -> Vec<Line<'static>> {
             dimmed,
         )),
         Line::from(Span::styled(
-            "[t] labels | [m] decode | [h] help | [J/K] stack scroll | [ctrl+j/k] buffer scroll | ['<char>] breakpoint",
+            "[t] labels | [m] decode | [h] help | [J/K] stack scroll | [ctrl+j/k] data scroll | ['<char>] breakpoint",
             dimmed,
         )),
     ]
@@ -1119,6 +1160,33 @@ fn scope_variable_line(variable: ScopeVariable) -> Line<'static> {
 
 fn storage_access_line(access: StorageAccess) -> Line<'static> {
     Line::from(Span::styled(access.describe(), Style::new().fg(Color::Yellow)))
+}
+
+fn storage_slot_lines(
+    index: usize,
+    index_width: usize,
+    access: StorageAccess,
+    current: bool,
+) -> [Line<'static>; 2] {
+    let value_style = if current {
+        Style::new().fg(Color::Yellow).add_modifier(Modifier::BOLD)
+    } else {
+        Style::new().fg(Color::White)
+    };
+    let prefix_width = index_width + 2;
+    [
+        Line::from(vec![
+            Span::styled(format!("{index:0index_width$}| "), Style::new().fg(Color::Gray)),
+            Span::styled(access.op(), value_style),
+            Span::raw(" slot "),
+            Span::styled(hex_u256(access.slot()), value_style),
+        ]),
+        Line::from(vec![
+            Span::raw(" ".repeat(prefix_width)),
+            Span::raw("value "),
+            Span::styled(hex_u256(access.value()), value_style),
+        ]),
+    ]
 }
 
 fn variable_name(variable: &DebugVariable, index: usize, fallback_prefix: &str) -> String {
@@ -1474,6 +1542,53 @@ mod tests {
             .map(|cell| cell.symbol())
             .collect::<String>();
         assert!(screen.contains("Memory (max expansion: 0 bytes)"));
+    }
+
+    #[test]
+    fn storage_explorer_draws_accessed_slots() {
+        let mut first = trace_step(Vec::new());
+        first.storage_change = Some(Box::new(StorageChange {
+            key: U256::ZERO,
+            value: U256::from(42),
+            had_value: None,
+            reason: StorageChangeReason::SSTORE,
+        }));
+        let mut second = trace_step(Vec::new());
+        second.storage_change = Some(Box::new(StorageChange {
+            key: U256::from(1),
+            value: U256::from(0xbeef),
+            had_value: None,
+            reason: StorageChangeReason::SSTORE,
+        }));
+        let mut latest = trace_step(Vec::new());
+        latest.storage_change = Some(Box::new(StorageChange {
+            key: U256::ZERO,
+            value: U256::from(43),
+            had_value: Some(U256::from(42)),
+            reason: StorageChangeReason::SSTORE,
+        }));
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![first, second, latest])]);
+        let mut tui = TUIContext::new(&mut context);
+        tui.current_step = 2;
+        let backend = TestBackend::new(100, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|f| tui.draw_storage(f, Rect::new(0, 0, 100, 6), super::StorageSpace::Persistent))
+            .unwrap();
+
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(screen.contains("Storage: 2 accessed slots"));
+        assert!(screen.contains("SSTORE slot 0x0"));
+        assert!(screen.contains("value 0x2b"));
+        assert!(screen.contains("SSTORE slot 0x1"));
+        assert!(screen.contains("value 0xbeef"));
     }
 
     #[test]

--- a/crates/debugger/src/tui/storage.rs
+++ b/crates/debugger/src/tui/storage.rs
@@ -1,6 +1,7 @@
 //! Storage access helpers for debugger TUI views and commands.
 
-use alloy_primitives::U256;
+use crate::DebugNode;
+use alloy_primitives::{U256, map::IndexMap};
 use revm::{bytecode::opcode, interpreter::InstructionResult};
 use revm_inspectors::tracing::types::{CallTraceStep, StorageChangeReason};
 
@@ -14,6 +15,29 @@ enum StorageAccessKind {
 pub(super) enum StorageSpace {
     Persistent,
     Transient,
+}
+
+impl StorageSpace {
+    pub(super) const fn noun(self) -> &'static str {
+        match self {
+            Self::Persistent => "storage",
+            Self::Transient => "transient storage",
+        }
+    }
+
+    pub(super) const fn label(self) -> &'static str {
+        match self {
+            Self::Persistent => "Storage",
+            Self::Transient => "Transient storage",
+        }
+    }
+
+    pub(super) const fn command(self) -> &'static str {
+        match self {
+            Self::Persistent => "storage",
+            Self::Transient => "transient",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -44,17 +68,22 @@ impl StorageAccess {
         self.space
     }
 
-    pub(super) fn describe(self) -> String {
-        let op = match (self.space, self.kind) {
+    pub(super) const fn value(self) -> U256 {
+        self.value
+    }
+
+    pub(super) const fn op(self) -> &'static str {
+        match (self.space, self.kind) {
             (StorageSpace::Persistent, StorageAccessKind::Load) => "SLOAD",
             (StorageSpace::Persistent, StorageAccessKind::Store) => "SSTORE",
             (StorageSpace::Transient, StorageAccessKind::Load) => "TLOAD",
             (StorageSpace::Transient, StorageAccessKind::Store) => "TSTORE",
-        };
-        let space = match self.space {
-            StorageSpace::Persistent => "storage",
-            StorageSpace::Transient => "transient storage",
-        };
+        }
+    }
+
+    pub(super) fn describe(self) -> String {
+        let op = self.op();
+        let space = self.space.noun();
 
         match (self.kind, self.previous) {
             (StorageAccessKind::Store, Some(previous)) => format!(
@@ -66,6 +95,32 @@ impl StorageAccess {
             _ => format!("{space} {op} slot {} = {}", hex_u256(self.slot), hex_u256(self.value)),
         }
     }
+}
+
+pub(super) fn storage_accesses_until(
+    arena: &[DebugNode],
+    current_node_index: usize,
+    current_step_index: usize,
+    space: StorageSpace,
+) -> IndexMap<U256, StorageAccess> {
+    let current_node = &arena[current_node_index];
+    let current_absolute_step = current_node.step_offset.saturating_add(current_step_index);
+    let mut accesses = IndexMap::default();
+
+    for node in arena.iter().filter(|node| node.trace_node_idx == current_node.trace_node_idx) {
+        for (step_index, _) in node.steps.iter().enumerate() {
+            if node.step_offset.saturating_add(step_index) > current_absolute_step {
+                break;
+            }
+            if let Some(access) = storage_access_at(&node.steps, step_index)
+                && access.space() == space
+            {
+                accesses.insert(access.slot(), access);
+            }
+        }
+    }
+
+    accesses
 }
 
 pub(super) fn storage_access_at(


### PR DESCRIPTION
## Motivation

#927 asks for a storage pane that can inspect larger contract state, including transient storage. Today the debugger can describe only the `SLOAD`/`SSTORE`/`TLOAD`/`TSTORE` at the current step and jump to an access by slot, so users cannot scan the slots already observed in the current call.

## Solution

- turn the existing data pane into a persistent or transient storage explorer through `:storage` and `:transient`
- list slots accessed in the current logical call up to the current replay step, preserving first-access order while showing each slot's latest observed value
- keep `:storage <slot>` and `:transient <slot>` navigation, then focus the selected slot in the explorer
- reuse data-pane scrolling, `b` to return to the previous byte buffer, and `o` to prefill a slot query

The explorer intentionally reflects recorded accesses, not an exhaustive query of unaccessed EVM state.

## Testing

- `cargo +1.95.0 test -p foundry-debugger`
- `cargo +1.95.0 clippy -p foundry-debugger --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- live `forge test --debug` smoke test covering persistent and transient slot selection, scrolling, command prefill, and return to memory

Progresses #927.