### PR TITLE
perf(cast): speed up read-only commands

### DIFF
--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -1,7 +1,7 @@
 use crate::{Cast, opts::parse_slot};
 use alloy_ens::NameOrAddress;
 use alloy_network::AnyNetwork;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockId;
 use clap::Parser;
@@ -18,7 +18,7 @@ use foundry_common::{
     shell,
 };
 use foundry_compilers::{
-    Artifact, Project,
+    Artifact, ArtifactId, Project, ProjectCompileOutput,
     artifacts::{ConfigurableContractArtifact, Contract, StorageLayout},
     compilers::{
         Compiler,
@@ -126,16 +126,12 @@ impl StorageArgs {
         }
 
         // Check if we're in a forge project and if we can find the address' code
-        let mut project = build.project()?;
+        let project = build.project()?;
         if project.paths.has_input_files() {
-            // Find in artifacts and pretty print
-            add_storage_layout_output(&mut project);
-            let out = ProjectCompiler::new().quiet(shell::is_json()).compile(&project)?;
-            let artifact = out.artifacts().find(|(_, artifact)| {
-                artifact.get_deployed_bytecode_bytes().is_some_and(|b| *b == address_code)
-            });
-            if let Some((_, artifact)) = artifact {
-                return fetch_and_print_storage(provider, address, block, artifact).await;
+            if let Some(artifact) =
+                compile_local_storage_layout(&project, &address_code, shell::is_json())?
+            {
+                return fetch_and_print_storage(provider, address, block, &artifact).await;
             }
         }
 
@@ -238,6 +234,78 @@ impl StorageArgs {
         drop(temp_dir);
         fetch_and_print_storage(provider, address, block, artifact).await
     }
+}
+
+/// Finds the local artifact matching `address_code`, then compiles only its source for the storage
+/// layout if the normal project output does not already contain one.
+fn compile_local_storage_layout(
+    project: &Project,
+    address_code: &Bytes,
+    quiet: bool,
+) -> Result<Option<ConfigurableContractArtifact>> {
+    if project.build_info {
+        let output = compile_full_storage_layout(project, quiet)?;
+        return Ok(find_artifact_by_code(output, address_code).map(|(_, artifact)| artifact));
+    }
+
+    let output = ProjectCompiler::new().quiet(quiet).compile(project)?;
+    let Some((target, artifact)) = find_artifact_by_code(output, address_code) else {
+        return Ok(None);
+    };
+
+    if artifact.storage_layout.is_some() {
+        return Ok(Some(artifact));
+    }
+
+    if let Ok(output) = compile_target_storage_layout(project, &target)
+        && let Some(artifact) = output.into_artifacts().find_map(|(id, artifact)| {
+            (same_artifact(&id, &target) && artifact.storage_layout.is_some()).then_some(artifact)
+        })
+    {
+        return Ok(Some(artifact));
+    }
+
+    let output = compile_full_storage_layout(project, quiet)?;
+    Ok(find_artifact_by_code(output, address_code).map(|(_, artifact)| artifact))
+}
+
+fn find_artifact_by_code(
+    output: ProjectCompileOutput,
+    address_code: &Bytes,
+) -> Option<(ArtifactId, ConfigurableContractArtifact)> {
+    output.into_artifacts().find(|(_, artifact)| {
+        artifact
+            .get_deployed_bytecode_bytes()
+            .is_some_and(|bytecode| bytecode.as_ref() == address_code)
+    })
+}
+
+fn compile_target_storage_layout(
+    project: &Project,
+    target: &ArtifactId,
+) -> Result<ProjectCompileOutput> {
+    let mut project = project.clone();
+    project.no_artifacts = true;
+    add_storage_layout_output(&mut project);
+    ProjectCompiler::new().quiet(true).files([target.source.clone()]).compile(&project)
+}
+
+fn compile_full_storage_layout(project: &Project, quiet: bool) -> Result<ProjectCompileOutput> {
+    let mut project = project.clone();
+    add_storage_layout_output(&mut project);
+    ProjectCompiler::new().quiet(quiet).compile(&project)
+}
+
+/// Returns whether two artifact IDs identify the same contract across compiler runs.
+///
+/// Changing the output selection changes the build ID, and compiling fewer files can change an
+/// artifact path that was disambiguated due to a name collision. Neither can be used to match the
+/// normal compile against the targeted storage-layout compile.
+fn same_artifact(left: &ArtifactId, right: &ArtifactId) -> bool {
+    left.name == right.name
+        && left.source == right.source
+        && left.version == right.version
+        && left.profile == right.profile
 }
 
 /// Represents the value of a storage slot `eth_getStorageAt` call.
@@ -396,6 +464,43 @@ const fn is_storage_layout_empty(storage_layout: &Option<StorageLayout>) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
+    use foundry_compilers::PathStyle;
+    use foundry_test_utils::TestProject;
+
+    #[test]
+    fn local_storage_layout_compiles_only_target_source() {
+        let prj = TestProject::new("cast-storage-target", PathStyle::Dapptools);
+        foundry_test_utils::util::initialize(prj.root());
+        let unrelated_path = prj.add_source("Target", "contract Target { uint256 unrelated; }");
+        let target_path = prj.add_source(
+            "nested/Target",
+            "contract Target { uint256 value; function marker() external pure returns (bool) { return true; } }",
+        );
+        let project = Config::with_root(prj.root()).canonic_at(prj.root()).project().unwrap();
+        assert!(project.paths.has_input_files(), "{:?}", project.paths);
+
+        let output = ProjectCompiler::new().quiet(true).compile(&project).unwrap();
+        let (target, artifact) =
+            output.artifact_ids().find(|(id, _)| id.source == target_path).unwrap();
+        let address_code = artifact.get_deployed_bytecode_bytes().unwrap().into_owned();
+        let artifact_before = std::fs::read(&target.path).unwrap();
+        let cache_before = std::fs::read(project.cache_path()).unwrap();
+
+        let output = compile_target_storage_layout(&project, &target).unwrap();
+        let (compiled, artifact) = output
+            .artifact_ids()
+            .find(|(id, _)| same_artifact(id, &target))
+            .expect("target artifact should be present");
+        assert_ne!(compiled.path, target.path);
+        assert!(artifact.storage_layout.is_some());
+        assert!(!output.artifact_ids().any(|(id, _)| id.source == unrelated_path));
+
+        let artifact =
+            compile_local_storage_layout(&project, &address_code, true).unwrap().unwrap();
+        assert!(artifact.storage_layout.is_some());
+        assert_eq!(std::fs::read(&target.path).unwrap(), artifact_before);
+        assert_eq!(std::fs::read(project.cache_path()).unwrap(), cache_before);
+    }
 
     #[test]
     fn parse_storage_etherscan_api_key() {

--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -127,12 +127,11 @@ impl StorageArgs {
 
         // Check if we're in a forge project and if we can find the address' code
         let project = build.project()?;
-        if project.paths.has_input_files() {
-            if let Some(artifact) =
+        if project.paths.has_input_files()
+            && let Some(artifact) =
                 compile_local_storage_layout(&project, &address_code, shell::is_json())?
-            {
-                return fetch_and_print_storage(provider, address, block, &artifact).await;
-            }
+        {
+            return fetch_and_print_storage(provider, address, block, &artifact).await;
         }
 
         let chain = utils::get_chain(config.chain, &provider).await?;

--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -1,7 +1,7 @@
 use crate::{Cast, opts::parse_slot};
 use alloy_ens::NameOrAddress;
 use alloy_network::AnyNetwork;
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, U256};
 use alloy_provider::Provider;
 use alloy_rpc_types::BlockId;
 use clap::Parser;
@@ -18,7 +18,7 @@ use foundry_common::{
     shell,
 };
 use foundry_compilers::{
-    Artifact, ArtifactId, Project, ProjectCompileOutput,
+    Artifact, Project,
     artifacts::{ConfigurableContractArtifact, Contract, StorageLayout},
     compilers::{
         Compiler,
@@ -126,12 +126,17 @@ impl StorageArgs {
         }
 
         // Check if we're in a forge project and if we can find the address' code
-        let project = build.project()?;
-        if project.paths.has_input_files()
-            && let Some(artifact) =
-                compile_local_storage_layout(&project, &address_code, shell::is_json())?
-        {
-            return fetch_and_print_storage(provider, address, block, &artifact).await;
+        let mut project = build.project()?;
+        if project.paths.has_input_files() {
+            // Find in artifacts and pretty print
+            add_storage_layout_output(&mut project);
+            let out = ProjectCompiler::new().quiet(shell::is_json()).compile(&project)?;
+            let artifact = out.artifacts().find(|(_, artifact)| {
+                artifact.get_deployed_bytecode_bytes().is_some_and(|b| *b == address_code)
+            });
+            if let Some((_, artifact)) = artifact {
+                return fetch_and_print_storage(provider, address, block, artifact).await;
+            }
         }
 
         let chain = utils::get_chain(config.chain, &provider).await?;
@@ -233,78 +238,6 @@ impl StorageArgs {
         drop(temp_dir);
         fetch_and_print_storage(provider, address, block, artifact).await
     }
-}
-
-/// Finds the local artifact matching `address_code`, then compiles only its source for the storage
-/// layout if the normal project output does not already contain one.
-fn compile_local_storage_layout(
-    project: &Project,
-    address_code: &Bytes,
-    quiet: bool,
-) -> Result<Option<ConfigurableContractArtifact>> {
-    if project.build_info {
-        let output = compile_full_storage_layout(project, quiet)?;
-        return Ok(find_artifact_by_code(output, address_code).map(|(_, artifact)| artifact));
-    }
-
-    let output = ProjectCompiler::new().quiet(quiet).compile(project)?;
-    let Some((target, artifact)) = find_artifact_by_code(output, address_code) else {
-        return Ok(None);
-    };
-
-    if artifact.storage_layout.is_some() {
-        return Ok(Some(artifact));
-    }
-
-    if let Ok(output) = compile_target_storage_layout(project, &target)
-        && let Some(artifact) = output.into_artifacts().find_map(|(id, artifact)| {
-            (same_artifact(&id, &target) && artifact.storage_layout.is_some()).then_some(artifact)
-        })
-    {
-        return Ok(Some(artifact));
-    }
-
-    let output = compile_full_storage_layout(project, quiet)?;
-    Ok(find_artifact_by_code(output, address_code).map(|(_, artifact)| artifact))
-}
-
-fn find_artifact_by_code(
-    output: ProjectCompileOutput,
-    address_code: &Bytes,
-) -> Option<(ArtifactId, ConfigurableContractArtifact)> {
-    output.into_artifacts().find(|(_, artifact)| {
-        artifact
-            .get_deployed_bytecode_bytes()
-            .is_some_and(|bytecode| bytecode.as_ref() == address_code)
-    })
-}
-
-fn compile_target_storage_layout(
-    project: &Project,
-    target: &ArtifactId,
-) -> Result<ProjectCompileOutput> {
-    let mut project = project.clone();
-    project.no_artifacts = true;
-    add_storage_layout_output(&mut project);
-    ProjectCompiler::new().quiet(true).files([target.source.clone()]).compile(&project)
-}
-
-fn compile_full_storage_layout(project: &Project, quiet: bool) -> Result<ProjectCompileOutput> {
-    let mut project = project.clone();
-    add_storage_layout_output(&mut project);
-    ProjectCompiler::new().quiet(quiet).compile(&project)
-}
-
-/// Returns whether two artifact IDs identify the same contract across compiler runs.
-///
-/// Changing the output selection changes the build ID, and compiling fewer files can change an
-/// artifact path that was disambiguated due to a name collision. Neither can be used to match the
-/// normal compile against the targeted storage-layout compile.
-fn same_artifact(left: &ArtifactId, right: &ArtifactId) -> bool {
-    left.name == right.name
-        && left.source == right.source
-        && left.version == right.version
-        && left.profile == right.profile
 }
 
 /// Represents the value of a storage slot `eth_getStorageAt` call.
@@ -463,43 +396,6 @@ const fn is_storage_layout_empty(storage_layout: &Option<StorageLayout>) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use foundry_compilers::PathStyle;
-    use foundry_test_utils::TestProject;
-
-    #[test]
-    fn local_storage_layout_compiles_only_target_source() {
-        let prj = TestProject::new("cast-storage-target", PathStyle::Dapptools);
-        foundry_test_utils::util::initialize(prj.root());
-        let unrelated_path = prj.add_source("Target", "contract Target { uint256 unrelated; }");
-        let target_path = prj.add_source(
-            "nested/Target",
-            "contract Target { uint256 value; function marker() external pure returns (bool) { return true; } }",
-        );
-        let project = Config::with_root(prj.root()).canonic_at(prj.root()).project().unwrap();
-        assert!(project.paths.has_input_files(), "{:?}", project.paths);
-
-        let output = ProjectCompiler::new().quiet(true).compile(&project).unwrap();
-        let (target, artifact) =
-            output.artifact_ids().find(|(id, _)| id.source == target_path).unwrap();
-        let address_code = artifact.get_deployed_bytecode_bytes().unwrap().into_owned();
-        let artifact_before = std::fs::read(&target.path).unwrap();
-        let cache_before = std::fs::read(project.cache_path()).unwrap();
-
-        let output = compile_target_storage_layout(&project, &target).unwrap();
-        let (compiled, artifact) = output
-            .artifact_ids()
-            .find(|(id, _)| same_artifact(id, &target))
-            .expect("target artifact should be present");
-        assert_ne!(compiled.path, target.path);
-        assert!(artifact.storage_layout.is_some());
-        assert!(!output.artifact_ids().any(|(id, _)| id.source == unrelated_path));
-
-        let artifact =
-            compile_local_storage_layout(&project, &address_code, true).unwrap().unwrap();
-        assert!(artifact.storage_layout.is_some());
-        assert_eq!(std::fs::read(&target.path).unwrap(), artifact_before);
-        assert_eq!(std::fs::read(project.cache_path()).unwrap(), cache_before);
-    }
 
     #[test]
     fn parse_storage_etherscan_api_key() {

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -589,8 +589,12 @@ where
         self.tx.clear_batch_to();
 
         // resolve
-        let tx_nonce = self.resolve_nonce(sender.address(), fill).await?;
-        self.resolve_auth(&sender, tx_nonce).await?;
+        // Read-only calls do not need a nonce unless it is required to sign an authorization.
+        // Avoid an otherwise unused `eth_getTransactionCount` request for raw transactions.
+        if fill || !self.auth.is_empty() {
+            let tx_nonce = self.resolve_nonce(sender.address(), fill).await?;
+            self.resolve_auth(&sender, tx_nonce).await?;
+        }
         if let Some(access_key) = access_key {
             self.tx
                 .prepare_access_key_authorization(
@@ -850,4 +854,35 @@ async fn decode_execution_revert(data: &RawValue) -> Result<Option<String>> {
         return Ok(Some(decoded_error));
     }
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_network::Ethereum;
+    use alloy_provider::{ProviderBuilder, mock::Asserter};
+    use clap::Parser;
+
+    #[tokio::test]
+    async fn raw_build_skips_nonce_request() {
+        // No responses are queued, so any RPC request would fail this test. In particular, this
+        // guards against restoring the unused `eth_getTransactionCount` request.
+        let provider =
+            ProviderBuilder::new_with_network::<Ethereum>().connect_mocked_client(Asserter::new());
+        let config = Config { chain: Some(Chain::mainnet()), ..Default::default() };
+
+        CastTxBuilder::new(&provider, TransactionOpts::parse_from(["test"]), &config)
+            .await
+            .unwrap()
+            .with_to(Some(Address::repeat_byte(0x11).into()))
+            .await
+            .unwrap()
+            .with_code_sig_and_args(None, None, Vec::new())
+            .await
+            .unwrap()
+            .raw()
+            .build(Address::repeat_byte(0x22))
+            .await
+            .unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

Read-only `CastTxBuilder` calls currently fetch an account nonce even when no authorization needs it, then discard the result because raw transactions do not fill nonce fields. This skips that unused `eth_getTransactionCount` request for `cast call`, `cast estimate`, and `cast access-list`; transaction sends and every authorization path retain the existing nonce resolution. A mocked-provider regression test queues no responses, so any RPC during a raw build fails the test. This PR was developed with OpenAI Codex assistance.

## Benchmarks

Measured exact `master` (`5b9ce7810`) and PR profiling binaries against a deterministic local JSON-RPC endpoint that delays every response by 100ms. Hyperfine used 3 warmups and 20 measured runs; command output was identical before and after. The only removed request was `eth_getTransactionCount`.

| Command | RPC requests | `master` | This PR | Speedup |
| --- | ---: | ---: | ---: | ---: |
| `cast call` | 3 → 2 | 336.18ms ± 6.51ms | 231.93ms ± 3.69ms | 1.45× |
| `cast estimate` | 2 → 1 | 229.85ms ± 5.21ms | 123.11ms ± 0.62ms | 1.87× |
| `cast access-list` | 2 → 1 | 230.02ms ± 4.15ms | 122.54ms ± 2.61ms | 1.88× |
