### PR TITLE
fix(fmt): indent chained named call args

### DIFF
--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -96,6 +96,12 @@ impl CallStack {
     }
 }
 
+#[derive(Clone, Copy)]
+struct ChainedNamedCall {
+    callee: Span,
+    keep_inline: bool,
+}
+
 pub(super) struct State<'sess, 'ast> {
     // CORE COMPONENTS
     pub(super) s: pp::Printer,
@@ -125,6 +131,8 @@ pub(super) struct State<'sess, 'ast> {
     return_bin_expr: bool,
     // Whether inside a call with call options and at least one argument.
     call_with_opts_and_args: bool,
+    // Callee of the current chained call with named arguments, if any.
+    chained_named_call: Option<ChainedNamedCall>,
     // Whether to skip the index soft breaks because the callee fits inline.
     skip_index_break: bool,
     // Whether inside an `emit` or `revert` call with a qualified path, or not.
@@ -216,6 +224,7 @@ impl<'sess> State<'sess, '_> {
             contract: None,
             single_line_stmt: None,
             call_with_opts_and_args: false,
+            chained_named_call: None,
             skip_index_break: false,
             binary_expr: None,
             return_bin_expr: false,

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1315,7 +1315,7 @@ impl<'ast> State<'_, 'ast> {
                 .then(|| ChainedNamedCall {
                     callee: call_expr.span,
                     keep_inline: !call_chain_contains_options(call_expr)
-                        && !self.call_chain_contains_arg_comments(call_expr)
+                        && !self.has_comment_between(call_expr.span.lo(), call_expr.span.hi())
                         && self.estimate_size(call_expr.span)
                             + if call_args.is_empty() { 4 } else { 2 }
                             <= self.space_left(),
@@ -1448,19 +1448,6 @@ impl<'ast> State<'_, 'ast> {
             ast::ExprKind::Err(_) => self.print_span(span),
         }
         self.cursor.advance_to(span.hi(), true);
-    }
-
-    fn call_chain_contains_arg_comments(&self, expr: &'ast ast::Expr<'ast>) -> bool {
-        match &expr.peel_parens().kind {
-            ast::ExprKind::Call(expr, args) => {
-                self.has_comments_between_elements(args.span, args.exprs())
-                    || self.call_chain_contains_arg_comments(expr)
-            }
-            ast::ExprKind::CallOptions(expr, ..)
-            | ast::ExprKind::Index(expr, ..)
-            | ast::ExprKind::Member(expr, ..) => self.call_chain_contains_arg_comments(expr),
-            _ => false,
-        }
     }
 
     /// Prints a simple assignment expression of the form `lhs = rhs`.

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1314,9 +1314,13 @@ impl<'ast> State<'_, 'ast> {
                     && is_call_chain(&call_expr.kind, true))
                 .then(|| ChainedNamedCall {
                     callee: call_expr.span,
-                    keep_inline: self.estimate_size(call_expr.span)
-                        + if call_args.is_empty() { 4 } else { 2 }
-                        <= self.space_left(),
+                    keep_inline: !call_chain_contains_options(call_expr)
+                        && self.estimate_size(call_expr.span)
+                            + if call_args.is_empty() { 4 } else { 2 }
+                            <= self.space_left(),
+                })
+                .or_else(|| {
+                    chained_named_call_cache.filter(|call| call.callee.contains(expr.span))
                 });
                 let list_format = if keep_inline {
                     ListFormat::inline()
@@ -1376,7 +1380,7 @@ impl<'ast> State<'_, 'ast> {
                             ast::ExprKind::Ident(_) | ast::ExprKind::Type(_) => (),
                             ast::ExprKind::Index(..) if s.skip_index_break => (),
                             _ if s.chained_named_call.is_some_and(|call| {
-                                call.keep_inline && call.callee == expr.span
+                                call.keep_inline && call.callee.contains(expr.span)
                             }) => {}
                             // Don't add break when accessing a field after a call with named args.
                             // e.g., `_lzSend({_dstEid: x, ...}).guid` should keep `.guid`
@@ -3055,6 +3059,16 @@ fn is_call_chain(expr_kind: &ast::ExprKind<'_>, must_have_child: bool) -> bool {
         is_call_chain(&child.kind, false)
     } else {
         !must_have_child && is_call(expr_kind)
+    }
+}
+
+fn call_chain_contains_options(expr: &ast::Expr<'_>) -> bool {
+    match &expr.peel_parens().kind {
+        ast::ExprKind::CallOptions(..) => true,
+        ast::ExprKind::Call(expr, ..)
+        | ast::ExprKind::Index(expr, ..)
+        | ast::ExprKind::Member(expr, ..) => call_chain_contains_options(expr),
+        _ => false,
     }
 }
 

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1314,7 +1314,9 @@ impl<'ast> State<'_, 'ast> {
                     && is_call_chain(&call_expr.kind, true))
                 .then(|| ChainedNamedCall {
                     callee: call_expr.span,
-                    keep_inline: self.estimate_size(call_expr.span) <= self.space_left(),
+                    keep_inline: self.estimate_size(call_expr.span)
+                        + if call_args.is_empty() { 4 } else { 2 }
+                        <= self.space_left(),
                 });
                 let list_format = if keep_inline {
                     ListFormat::inline()

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::too_many_arguments)]
 
 use super::{
-    CommentConfig, Separator, State,
+    ChainedNamedCall, CommentConfig, Separator, State,
     common::{BlockFormat, ListFormat},
 };
 use crate::{
@@ -1303,7 +1303,24 @@ impl<'ast> State<'_, 'ast> {
             ast::ExprKind::Binary(lhs, op, rhs) => self.print_bin_expr(lhs, op, rhs, false),
             ast::ExprKind::Call(call_expr, call_args) => {
                 let cache = self.call_with_opts_and_args;
+                let chained_named_call_cache = self.chained_named_call;
+                // Keep calls within a chained callee inline when they fit, so a multiline named
+                // argument list does not force an earlier break inside the callee.
+                let keep_inline = chained_named_call_cache
+                    .is_some_and(|call| call.keep_inline && call.callee.contains(expr.span))
+                    && !self.has_comments_between_elements(call_args.span, call_args.exprs());
                 self.call_with_opts_and_args = is_call_with_opts_and_args(&expr.kind);
+                self.chained_named_call = (matches!(call_args.kind, ast::CallArgsKind::Named(_))
+                    && is_call_chain(&call_expr.kind, true))
+                .then(|| ChainedNamedCall {
+                    callee: call_expr.span,
+                    keep_inline: self.estimate_size(call_expr.span) <= self.space_left(),
+                });
+                let list_format = if keep_inline {
+                    ListFormat::inline()
+                } else {
+                    ListFormat::compact().break_cmnts().break_single(true)
+                };
                 self.print_member_or_call_chain(
                     call_expr,
                     MemberOrCallArgs::CallArgs(
@@ -1313,9 +1330,7 @@ impl<'ast> State<'_, 'ast> {
                     |s| {
                         s.print_call_args(
                             call_args,
-                            ListFormat::compact()
-                                .break_cmnts()
-                                .break_single(true)
+                            list_format
                                 .without_ind(s.return_bin_expr)
                                 .with_delimiters(!s.call_with_opts_and_args),
                             get_callee_head_size(call_expr),
@@ -1323,6 +1338,7 @@ impl<'ast> State<'_, 'ast> {
                     },
                 );
                 self.call_with_opts_and_args = cache;
+                self.chained_named_call = chained_named_call_cache;
             }
             ast::ExprKind::CallOptions(expr, named_args) => {
                 // the flag is only meant to be used to format the call args
@@ -1357,6 +1373,9 @@ impl<'ast> State<'_, 'ast> {
                         match member_expr.kind {
                             ast::ExprKind::Ident(_) | ast::ExprKind::Type(_) => (),
                             ast::ExprKind::Index(..) if s.skip_index_break => (),
+                            _ if s.chained_named_call.is_some_and(|call| {
+                                call.keep_inline && call.callee == expr.span
+                            }) => {}
                             // Don't add break when accessing a field after a call with named args.
                             // e.g., `_lzSend({_dstEid: x, ...}).guid` should keep `.guid`
                             // on the same line as the closing `})`.
@@ -1701,7 +1720,7 @@ impl<'ast> State<'_, 'ast> {
             let no_cmnt_or_mixed =
                 self.peek_comment_before(child_expr.span.hi()).is_none_or(|c| c.style.is_mixed());
 
-            // If call with options, add an extra box to prioritize breaking the call args
+            // If call with options, add an extra box to prioritize breaking the call args.
             if self.call_with_opts_and_args {
                 self.cbox(0);
                 extra_box = true;
@@ -1827,7 +1846,10 @@ impl<'ast> State<'_, 'ast> {
                 list_format
                     .break_cmnts()
                     .break_single(true)
-                    .without_ind(self.call_stack.has_indented_parent_chain())
+                    .without_ind(
+                        self.call_stack.has_indented_parent_chain()
+                            && self.chained_named_call.is_none_or(|call| call.keep_inline),
+                    )
                     .with_delimiters(!self.call_with_opts_and_args),
             );
         } else if self.config.bracket_spacing {
@@ -2246,7 +2268,9 @@ impl<'ast> State<'_, 'ast> {
             {
                 let current_block_multiline = self.is_multiline_block(block, false, true);
                 if !pos.is_first || !skip_ind {
-                    if prev_block_multiline && (current_block_multiline || pos.is_last) {
+                    if (pos.is_first && block.is_empty() && is_call_with_named_args(&expr.kind))
+                        || (prev_block_multiline && (current_block_multiline || pos.is_last))
+                    {
                         self.nbsp();
                     } else {
                         self.space();

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1310,15 +1310,20 @@ impl<'ast> State<'_, 'ast> {
                     .is_some_and(|call| call.keep_inline && call.callee.contains(expr.span))
                     && !self.has_comments_between_elements(call_args.span, call_args.exprs());
                 self.call_with_opts_and_args = is_call_with_opts_and_args(&expr.kind);
+                let named_args_size = if call_args.is_empty() {
+                    4 + usize::from(self.config.bracket_spacing)
+                } else {
+                    2
+                };
                 self.chained_named_call = (matches!(call_args.kind, ast::CallArgsKind::Named(_))
                     && is_call_chain(&call_expr.kind, true))
                 .then(|| ChainedNamedCall {
                     callee: call_expr.span,
                     keep_inline: !call_chain_contains_options(call_expr)
                         && !self.has_comment_between(call_expr.span.lo(), call_expr.span.hi())
-                        && self.estimate_size(call_expr.span)
-                            + if call_args.is_empty() { 4 } else { 2 }
-                            <= self.space_left(),
+                        && self
+                            .estimate_call_chain_size(call_expr)
+                            .is_some_and(|size| size + named_args_size <= self.space_left()),
                 })
                 .or_else(|| {
                     chained_named_call_cache.filter(|call| call.callee.contains(expr.span))
@@ -2790,6 +2795,51 @@ impl<'ast> State<'_, 'ast> {
                 self.estimate_lhs_size(lhs, op)
             }
             _ => self.estimate_size(expr.span),
+        }
+    }
+
+    fn estimate_call_chain_size(&self, expr: &ast::Expr<'_>) -> Option<usize> {
+        match &expr.kind {
+            ast::ExprKind::Call(callee, args) => {
+                let ast::CallArgsKind::Unnamed(args) = &args.kind else { return None };
+                let mut size = self.estimate_call_chain_size(callee)? + 2;
+                for arg in args.iter() {
+                    size += self.estimate_call_chain_size(arg)?;
+                }
+                Some(size + args.len().saturating_sub(1) * 2)
+            }
+            ast::ExprKind::Ident(ident) => Some(ident.to_string().len()),
+            ast::ExprKind::Index(expr, kind) => {
+                let index_size = match kind {
+                    ast::IndexKind::Index(Some(index)) => self.estimate_call_chain_size(index)?,
+                    ast::IndexKind::Index(None) => 0,
+                    ast::IndexKind::Range(start, end) => {
+                        let start = match start {
+                            Some(start) => self.estimate_call_chain_size(start)?,
+                            None => 0,
+                        };
+                        let end = match end {
+                            Some(end) => self.estimate_call_chain_size(end)?,
+                            None => 0,
+                        };
+                        start + end + 1
+                    }
+                };
+                Some(self.estimate_call_chain_size(expr)? + index_size + 2)
+            }
+            // Zero is invariant under all number underscore configurations.
+            ast::ExprKind::Lit(lit, None)
+                if matches!(lit.kind, ast::LitKind::Number(_)) && lit.symbol.as_str() == "0" =>
+            {
+                Some(1)
+            }
+            ast::ExprKind::Member(expr, ident) => {
+                Some(self.estimate_call_chain_size(expr)? + ident.to_string().len() + 1)
+            }
+            ast::ExprKind::Tuple(exprs) if let [SpannedOption::Some(expr)] = exprs.as_ref() => {
+                Some(self.estimate_call_chain_size(expr)? + 2)
+            }
+            _ => None,
         }
     }
 

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1315,6 +1315,7 @@ impl<'ast> State<'_, 'ast> {
                 .then(|| ChainedNamedCall {
                     callee: call_expr.span,
                     keep_inline: !call_chain_contains_options(call_expr)
+                        && !self.call_chain_contains_arg_comments(call_expr)
                         && self.estimate_size(call_expr.span)
                             + if call_args.is_empty() { 4 } else { 2 }
                             <= self.space_left(),
@@ -1447,6 +1448,19 @@ impl<'ast> State<'_, 'ast> {
             ast::ExprKind::Err(_) => self.print_span(span),
         }
         self.cursor.advance_to(span.hi(), true);
+    }
+
+    fn call_chain_contains_arg_comments(&self, expr: &'ast ast::Expr<'ast>) -> bool {
+        match &expr.peel_parens().kind {
+            ast::ExprKind::Call(expr, args) => {
+                self.has_comments_between_elements(args.span, args.exprs())
+                    || self.call_chain_contains_arg_comments(expr)
+            }
+            ast::ExprKind::CallOptions(expr, ..)
+            | ast::ExprKind::Index(expr, ..)
+            | ast::ExprKind::Member(expr, ..) => self.call_chain_contains_arg_comments(expr),
+            _ => false,
+        }
     }
 
     /// Prints a simple assignment expression of the form `lhs = rhs`.
@@ -1733,12 +1747,16 @@ impl<'ast> State<'_, 'ast> {
             }
 
             // Determine if this chain will add its own indentation
-            let chain_has_indent = is_call_chain(&child_expr.kind, true)
-                || !(no_cmnt_or_mixed
-                    || matches!(&child_expr.kind, ast::ExprKind::CallOptions(..)))
-                || !callee_fits_line
-                || (member_depth(0, child_expr) >= 2
-                    && (!total_fits_line || member_or_args.has_comments()));
+            let keep_chain_inline = self
+                .chained_named_call
+                .is_some_and(|call| call.keep_inline && call.callee.contains(child_expr.span));
+            let chain_has_indent = !keep_chain_inline
+                && (is_call_chain(&child_expr.kind, true)
+                    || !(no_cmnt_or_mixed
+                        || matches!(&child_expr.kind, ast::ExprKind::CallOptions(..)))
+                    || !callee_fits_line
+                    || (member_depth(0, child_expr) >= 2
+                        && (!total_fits_line || member_or_args.has_comments())));
 
             // Start a new chain if needed
             if is_call_chain(&child_expr.kind, false) {
@@ -3055,10 +3073,14 @@ const fn is_call_with_named_args(expr_kind: &ast::ExprKind<'_>) -> bool {
 }
 
 fn is_call_chain(expr_kind: &ast::ExprKind<'_>, must_have_child: bool) -> bool {
-    if let ast::ExprKind::Member(child, ..) = expr_kind {
-        is_call_chain(&child.kind, false)
-    } else {
-        !must_have_child && is_call(expr_kind)
+    match expr_kind {
+        ast::ExprKind::Index(child, ..) | ast::ExprKind::Member(child, ..) => {
+            is_call_chain(&child.kind, false)
+        }
+        ast::ExprKind::Tuple(exprs) if let [SpannedOption::Some(child)] = exprs.as_ref() => {
+            is_call_chain(&child.kind, must_have_child)
+        }
+        _ => !must_have_child && is_call(expr_kind),
     }
 }
 

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -1,0 +1,70 @@
+// config: line_length = 120
+// https://github.com/foundry-rs/foundry/issues/15755
+interface IVault {
+    function updatePosition(
+        uint256 positionId_,
+        uint256 batchId_,
+        address account_,
+        address operator_,
+        uint256 amount_,
+        uint256 deadline_,
+        bytes calldata data_
+    ) external;
+}
+
+contract NamedCallArgsInChain {
+    function regular(
+        address vault,
+        uint256 positionId,
+        uint256 batchId,
+        address account,
+        address operator,
+        uint256 amount,
+        uint256 deadline,
+        bytes calldata data
+    ) external {
+        IVault(vault).updatePosition({
+            positionId_: positionId,
+            batchId_: batchId,
+            account_: account,
+            operator_: operator,
+            amount_: amount,
+            deadline_: deadline,
+            data_: data
+        });
+    }
+
+    function overlongCallee(address vault, uint256 positionId, uint256 batchId) external {
+        IExtremelyLongVaultInterfaceNameThatStillFits(vault)
+            .updateAnExtremelyLongPositionNameThatMakesTheCombinedCalleeOverflow({
+                positionId_: positionId,
+                batchId_: batchId,
+                account_: address(0),
+                operator_: address(0),
+                amount_: 0,
+                deadline_: 0,
+                data_: ""
+            });
+    }
+
+    function attempted(
+        address vault,
+        uint256 positionId,
+        uint256 batchId,
+        address account,
+        address operator,
+        uint256 amount,
+        uint256 deadline,
+        bytes calldata data
+    ) external {
+        try IVault(vault).updatePosition({
+            positionId_: positionId,
+            batchId_: batchId,
+            account_: account,
+            operator_: operator,
+            amount_: amount,
+            deadline_: deadline,
+            data_: data
+        }) {} catch {}
+    }
+}

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -47,6 +47,13 @@ contract NamedCallArgsInChain {
             });
     }
 
+    function calleeAtLineBoundary(address vault, uint256 positionId, uint256 batchId) external {
+        IVault(vault)
+            .updatePositionAtTheExactConfiguredLineLengthBoundaryWithoutForcingTheBaseInterfaceConversionToWrap({
+                positionId_: positionId, batchId_: batchId
+            });
+    }
+
     function attempted(
         address vault,
         uint256 positionId,

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -54,6 +54,23 @@ contract NamedCallArgsInChain {
             });
     }
 
+    function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
+        factory().foo(bar(firstExtremelyLongValueName)).baz({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        foo{value: 1}()
+            .bar({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        (foo{value: 1})()
+            .bar({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+    }
+
     function attempted(
         address vault,
         uint256 positionId,

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -59,6 +59,12 @@ contract NamedCallArgsInChain {
             firstExtremelyLongArgumentName: firstExtremelyLongValueName,
             secondExtremelyLongArgumentName: secondExtremelyLongValueName
         });
+        factory() // preserve
+            .item()
+            .update({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
         factory()
             .item( /* preserve */
                 firstExtremelyLongValueName

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -59,6 +59,22 @@ contract NamedCallArgsInChain {
             firstExtremelyLongArgumentName: firstExtremelyLongValueName,
             secondExtremelyLongArgumentName: secondExtremelyLongValueName
         });
+        factory()
+            .item( /* preserve */
+                firstExtremelyLongValueName
+            )
+            .update({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        factory().items()[0].update({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        (factory().item()).update({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
         foo{value: 1}()
             .bar({
                 firstExtremelyLongArgumentName: firstExtremelyLongValueName,

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -12,6 +12,10 @@ contract NamedCallArgsInChain {
         IExtremelyLongVaultInterfaceNameThatStillFits(vault).updateAnExtremelyLongPositionNameThatMakesTheCombinedCalleeOverflow({positionId_: positionId, batchId_: batchId, account_: address(0), operator_: address(0), amount_: 0, deadline_: 0, data_: ""});
     }
 
+    function calleeAtLineBoundary(address vault, uint256 positionId, uint256 batchId) external {
+        IVault(vault).updatePositionAtTheExactConfiguredLineLengthBoundaryWithoutForcingTheBaseInterfaceConversionToWrap({positionId_: positionId, batchId_: batchId});
+    }
+
     function attempted(address vault, uint256 positionId, uint256 batchId, address account, address operator, uint256 amount, uint256 deadline, bytes calldata data) external {
         try IVault(vault).updatePosition({positionId_: positionId, batchId_: batchId, account_: account, operator_: operator, amount_: amount, deadline_: deadline, data_: data}) {} catch {}
     }

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -16,6 +16,12 @@ contract NamedCallArgsInChain {
         IVault(vault).updatePositionAtTheExactConfiguredLineLengthBoundaryWithoutForcingTheBaseInterfaceConversionToWrap({positionId_: positionId, batchId_: batchId});
     }
 
+    function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
+        factory().foo(bar(firstExtremelyLongValueName)).baz({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
+        foo{value: 1}().bar({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
+        (foo{value: 1})().bar({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
+    }
+
     function attempted(address vault, uint256 positionId, uint256 batchId, address account, address operator, uint256 amount, uint256 deadline, bytes calldata data) external {
         try IVault(vault).updatePosition({positionId_: positionId, batchId_: batchId, account_: account, operator_: operator, amount_: amount, deadline_: deadline, data_: data}) {} catch {}
     }

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -18,6 +18,8 @@ contract NamedCallArgsInChain {
 
     function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
         factory().foo(bar(firstExtremelyLongValueName)).baz({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
+        factory() // preserve
+            .item().update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
         factory().item(/* preserve */ firstExtremelyLongValueName).update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
         factory().items()[0].update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
         (factory().item()).update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -18,6 +18,9 @@ contract NamedCallArgsInChain {
 
     function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
         factory().foo(bar(firstExtremelyLongValueName)).baz({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
+        factory().item(/* preserve */ firstExtremelyLongValueName).update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
+        factory().items()[0].update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
+        (factory().item()).update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
         foo{value: 1}().bar({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
         (foo{value: 1})().bar({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
     }

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -1,0 +1,18 @@
+// https://github.com/foundry-rs/foundry/issues/15755
+interface IVault {
+    function updatePosition(uint256 positionId_, uint256 batchId_, address account_, address operator_, uint256 amount_, uint256 deadline_, bytes calldata data_) external;
+}
+
+contract NamedCallArgsInChain {
+    function regular(address vault, uint256 positionId, uint256 batchId, address account, address operator, uint256 amount, uint256 deadline, bytes calldata data) external {
+        IVault(vault).updatePosition({positionId_: positionId, batchId_: batchId, account_: account, operator_: operator, amount_: amount, deadline_: deadline, data_: data});
+    }
+
+    function overlongCallee(address vault, uint256 positionId, uint256 batchId) external {
+        IExtremelyLongVaultInterfaceNameThatStillFits(vault).updateAnExtremelyLongPositionNameThatMakesTheCombinedCalleeOverflow({positionId_: positionId, batchId_: batchId, account_: address(0), operator_: address(0), amount_: 0, deadline_: 0, data_: ""});
+    }
+
+    function attempted(address vault, uint256 positionId, uint256 batchId, address account, address operator, uint256 amount, uint256 deadline, bytes calldata data) external {
+        try IVault(vault).updatePosition({positionId_: positionId, batchId_: batchId, account_: account, operator_: operator, amount_: amount, deadline_: deadline, data_: data}) {} catch {}
+    }
+}

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -26,6 +26,41 @@ fn assert_eof(content: &str) {
     assert!(!content.ends_with("\n\n"), "extra trailing newline");
 }
 
+#[test]
+fn chained_named_call_layout_ignores_source_spacing() {
+    let path = Path::new("test.sol");
+
+    for (line_length, bracket_spacing, compact, spaced) in [
+        (
+            40,
+            false,
+            "factory().foo(a,b,c).baz({value: result});",
+            "factory().foo(a, b, c).baz({value: result});",
+        ),
+        (
+            32,
+            false,
+            "factory().foo(a+b).baz({value: result});",
+            "factory().foo(a + b).baz({value: result});",
+        ),
+        (
+            34,
+            false,
+            "factory().foo([a,b]).baz({value: result});",
+            "factory().foo([a, b]).baz({value: result});",
+        ),
+        (38, true, "factory().foo(a,b,c).baz({});", "factory().foo(a, b, c).baz({ });"),
+    ] {
+        let config =
+            Arc::new(FormatterConfig { line_length, bracket_spacing, ..Default::default() });
+        let source = |expr| format!("contract C {{ function f() external {{ {expr} }} }}");
+        assert_eq!(
+            format(&source(compact), path, config.clone()),
+            format(&source(spaced), path, config.clone()),
+        );
+    }
+}
+
 fn tests_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("testdata")
 }

--- a/crates/fmt/tests/formatter.rs
+++ b/crates/fmt/tests/formatter.rs
@@ -196,6 +196,7 @@ fmt_tests! {
     LiteralExpression,
     MappingType,
     ModifierDefinition,
+    NamedCallArgsInChain,
     NamedFunctionCallExpression,
     NonKeywords,
     NumberLiteralUnderscore,


### PR DESCRIPTION
## Motivation

Close #15755.

Keep fitting chained callees together so their multiline named arguments retain their own indentation. Preserve inline empty catch clauses for the same call shape and add formatter regression coverage.