### PR TITLE
perf: reuse inferred fork chain ID

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -205,7 +205,7 @@ pub enum CallSubcommands {
 }
 
 impl CallArgs {
-    pub async fn run(self) -> Result<()> {
+    pub async fn run(mut self) -> Result<()> {
         // Handle --curl mode early, before any provider interaction
         if self.rpc.curl {
             return self.run_curl().await;
@@ -221,6 +221,9 @@ impl CallArgs {
             evm_opts.networks = evm_opts.networks.with_chain_id(chain.id());
         }
         evm_opts.infer_network_from_fork().await;
+        if self.chain.is_none() {
+            self.chain = evm_opts.env.chain_id.map(Chain::from_id);
+        }
 
         if evm_opts.networks.is_tempo() {
             return self.run_with_network::<TempoEvmNetwork>().await;
@@ -647,6 +650,9 @@ impl figment::Provider for CallArgs {
         if let Some(evm_version) = self.evm_version {
             map.insert("evm_version".into(), figment::value::Value::serialize(evm_version)?);
         }
+        if let Some(chain) = self.chain {
+            map.insert("chain_id".into(), chain.id().into());
+        }
 
         Ok(Map::from([(Config::selected_profile(), map)]))
     }
@@ -666,6 +672,14 @@ mod tests {
         let data = hex::encode_prefixed("hello");
         let args = CallArgs::parse_from(["foundry-cli", "--data", data.as_str()]);
         assert_eq!(args.data, Some(data));
+    }
+
+    #[test]
+    fn chain_is_merged_into_config() {
+        let args = CallArgs::parse_from(["foundry-cli", "--chain", "1"]);
+        let config = Config::from_provider(Config::figment().merge(&args)).unwrap();
+
+        assert_eq!(config.chain, Some(Chain::mainnet()));
     }
 
     #[test]

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -133,9 +133,9 @@ impl EvmOpts {
     /// Infers the network configuration from the fork chain ID if not already set.
     ///
     /// When a fork URL is configured and the network has not been explicitly set,
-    /// this fetches the chain ID from the remote endpoint and calls
-    /// [`NetworkConfigs::with_chain_id`] to auto-enable the correct network
-    /// (e.g. Tempo, OP Stack) based on the chain ID.
+    /// this fetches the chain ID from the remote endpoint, caches it for subsequent fork setup,
+    /// and calls [`NetworkConfigs::with_chain_id`] to auto-enable the correct network (e.g. Tempo,
+    /// OP Stack) based on the chain ID.
     pub async fn infer_network_from_fork(&mut self) {
         #[cfg(feature = "optimism")]
         let already_op = self.networks.is_optimism();
@@ -147,6 +147,8 @@ impl EvmOpts {
             && let Ok(provider) = self.fork_provider_with_url::<AnyNetwork>(fork_url)
             && let Ok(chain_id) = provider.get_chain_id().await
         {
+            self.env.chain_id.get_or_insert(chain_id);
+
             // If Anvil's chain, request anvil_nodeInfo to determine if the network is Tempo.
             if chain_id == NamedChain::AnvilHardhat as u64 {
                 if let Ok(node_info) =
@@ -477,6 +479,7 @@ mod tests {
         evm_opts.infer_network_from_fork().await;
 
         // Plain anvil (chain id 31337) without tempo flag -> Ethereum (no network flags set).
+        assert_eq!(evm_opts.env.chain_id, Some(31337));
         assert!(!evm_opts.networks.is_tempo());
         #[cfg(feature = "optimism")]
         assert!(!evm_opts.networks.is_optimism());


### PR DESCRIPTION
## Summary

Cache the chain ID fetched while inferring a fork's network and reuse it during fork environment setup. `cast call` carries the inferred ID through its second config extraction, removing a redundant sequential `eth_chainId`; Forge tests, scripts, and Chisel reuse it instead of sending two additional chain ID lookups during fork setup. Explicit chain overrides are preserved, and Anvil network detection is unchanged.

## Benchmarks

Compared profiling builds of exact `master` (`14b8607ed`) and this branch against a deterministic local JSON-RPC endpoint with 200 ms response latency. Hyperfine used 3 warmups and 20 measured runs.

| Version | RPC sequence | Time (mean ± σ) | Range |
| --- | --- | ---: | ---: |
| `master` | `eth_chainId ×2 + eth_call` | 642.4 ms ± 8.0 ms | 624.5–656.2 ms |
| This PR | `eth_chainId + eth_call` | 434.8 ms ± 5.5 ms | 426.7–448.4 ms |

This PR is **1.48× faster** in this benchmark.
