### PR TITLE
feat(lint): detect inconsistent type names

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -45,6 +45,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `deprecated-oz-function`: OpenZeppelin deprecated `SafeERC20.safeApprove` (use `safeIncreaseAllowance` / `safeDecreaseAllowance`) and `AccessControl._setupRole` (use `_grantRole`).
   - `empty-block`: Flags regular functions with an empty body; constructors, `receive`/`fallback`, `virtual` functions, functions with modifiers and value-less `payable` functions are exempt.
   - `incorrect-modifier`: Modifiers should not be able to finish without executing `_` or reverting.
+  - `inconsistent-type-names`: Flags shorthand `uint`/`int` declarations when the same contract also uses `uint256`/`int256`.
   - `missing-events-access-control`: Access control changes should emit events.
   - `missing-zero-check`: Address parameter is used in a state write or value transfer without a zero-address check.
   - `reentrancy-events`: Events emitted after external calls can be reordered or fabricated by a reentrant callee and mislead off-chain consumers.

--- a/crates/lint/docs/inconsistent-type-names.md
+++ b/crates/lint/docs/inconsistent-type-names.md
@@ -1,0 +1,52 @@
+# Inconsistent type names
+
+**Severity**: `Low`
+**ID**: `inconsistent-type-names`
+
+Flags mixed use of the equivalent `uint`/`uint256` or `int`/`int256` type spellings within one contract.
+
+## What it does
+
+Reports a variable declaration that uses `uint` when another declaration in the same directly
+declared contract uses `uint256`, and likewise reports `int` when the contract also uses `int256`.
+Only the shorthand declaration is reported because the explicit 256-bit spelling is preferred.
+
+The lint uses resolved HIR variable ownership and parsed elementary types rather than searching
+source text for type-like names. State variables, struct fields, event and error parameters,
+function parameters and returns, local variables, try/catch variables, and function-type
+parameters and returns are declarations in scope. Array element and mapping key/value types are
+inspected recursively. A declaration such as `mapping(uint => uint256)` is therefore inconsistent
+by itself and produces one diagnostic for the declaration.
+
+Consistency is evaluated separately for each directly declared contract. Types declared in a base
+contract or a different contract do not affect a child, and type spellings in casts, `type(...)`
+expressions, `using ... for` directives, or user-defined value type definitions are not variable
+declarations and do not affect the result. A contract that consistently uses only `uint` and `int`
+is not reported, though explicit sizes remain preferable.
+
+## Why is this bad?
+
+`uint` and `uint256` compile to the same type, as do `int` and `int256`, so mixing their spellings
+does not change runtime behavior. It does make the code less consistent and can make readers wonder
+whether an omitted size was intentional. Using the explicit spelling throughout removes that
+ambiguity.
+
+## Example
+
+### Bad
+
+```solidity
+contract Vault {
+    uint public shares;
+    uint256 public assets;
+}
+```
+
+### Good
+
+```solidity
+contract Vault {
+    uint256 public shares;
+    uint256 public assets;
+}
+```

--- a/crates/lint/src/sol/low/inconsistent_type_names.rs
+++ b/crates/lint/src/sol/low/inconsistent_type_names.rs
@@ -1,0 +1,113 @@
+use crate::{
+    linter::{Lint, ProjectLintEmitter, ProjectLintPass, ProjectSource},
+    sol::{Severity, SolLint, low::InconsistentTypeNames},
+};
+use solar::{
+    ast::ElementaryType,
+    interface::{SourceMap, source_map::FileName},
+    sema::hir::{self, TypeKind},
+};
+use std::collections::HashMap;
+
+declare_forge_lint!(
+    INCONSISTENT_TYPE_NAMES,
+    Severity::Low,
+    "inconsistent-type-names",
+    "use explicit `uint256` and `int256` type names consistently within a contract"
+);
+
+impl<'ast> ProjectLintPass<'ast> for InconsistentTypeNames {
+    fn check_project(&mut self, ctx: &ProjectLintEmitter<'_, '_>, sources: &[ProjectSource<'ast>]) {
+        if !ctx.is_lint_enabled(INCONSISTENT_TYPE_NAMES.id()) {
+            return;
+        }
+
+        let hir = &ctx.gcx().hir;
+        let source_map = ctx.gcx().sess.source_map();
+        let input_sources: HashMap<_, _> = hir
+            .sources_enumerated()
+            .filter_map(|(source_id, source)| {
+                let FileName::Real(path) = &source.file.name else { return None };
+                let source_idx = sources.iter().position(|source| &source.path == path)?;
+                Some((source_id, source_idx))
+            })
+            .collect();
+
+        let mut contracts = HashMap::<hir::ContractId, TypeNames>::new();
+        for variable in hir.variables() {
+            let Some(contract_id) = variable.contract else { continue };
+            if !input_sources.contains_key(&variable.source) {
+                continue;
+            }
+
+            contracts.entry(contract_id).or_default().merge(type_names(source_map, &variable.ty));
+        }
+
+        // HIR variable order is stable, so diagnostics remain deterministic across runs.
+        for variable in hir.variables() {
+            let Some(contract_id) = variable.contract else { continue };
+            let Some(&source_idx) = input_sources.get(&variable.source) else { continue };
+            let Some(contract_names) = contracts.get(&contract_id) else { continue };
+            let variable_names = type_names(source_map, &variable.ty);
+
+            if (variable_names.has_uint && contract_names.has_uint256)
+                || (variable_names.has_int && contract_names.has_int256)
+            {
+                ctx.emit(&sources[source_idx], &INCONSISTENT_TYPE_NAMES, variable.span);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct TypeNames {
+    has_int: bool,
+    has_int256: bool,
+    has_uint: bool,
+    has_uint256: bool,
+}
+
+impl TypeNames {
+    const fn merge(&mut self, other: Self) {
+        self.has_int |= other.has_int;
+        self.has_int256 |= other.has_int256;
+        self.has_uint |= other.has_uint;
+        self.has_uint256 |= other.has_uint256;
+    }
+}
+
+/// Collects integer spellings from a single resolved variable declaration.
+///
+/// Function-type parameters and returns are separate HIR variables, so function types are not
+/// recursed here. This keeps each shorthand declaration to one diagnostic while matching the
+/// upstream detector's treatment of arrays and mappings.
+fn type_names(source_map: &SourceMap, ty: &hir::Type<'_>) -> TypeNames {
+    let mut names = TypeNames::default();
+    match &ty.kind {
+        // Solar normalizes `int`/`uint` to their 256-bit forms in HIR. Inspect only the exact
+        // source span of an already typed 256-bit integer node to recover which spelling the
+        // declaration used. A missing or unexpected snippet is ignored conservatively.
+        TypeKind::Elementary(ElementaryType::Int(size)) if size.bits() == 256 => {
+            match source_map.span_to_snippet(ty.span).as_deref() {
+                Ok("int") => names.has_int = true,
+                Ok("int256") => names.has_int256 = true,
+                _ => {}
+            }
+        }
+        TypeKind::Elementary(ElementaryType::UInt(size)) if size.bits() == 256 => {
+            match source_map.span_to_snippet(ty.span).as_deref() {
+                Ok("uint") => names.has_uint = true,
+                Ok("uint256") => names.has_uint256 = true,
+                _ => {}
+            }
+        }
+        TypeKind::Array(array) => names.merge(type_names(source_map, &array.element)),
+        TypeKind::Mapping(mapping) => {
+            names.merge(type_names(source_map, &mapping.key));
+            names.merge(type_names(source_map, &mapping.value));
+        }
+        TypeKind::Function(_) | TypeKind::Custom(_) | TypeKind::Err(_) => {}
+        TypeKind::Elementary(_) => {}
+    }
+    names
+}

--- a/crates/lint/src/sol/low/mod.rs
+++ b/crates/lint/src/sol/low/mod.rs
@@ -18,6 +18,9 @@ use empty_block::EMPTY_BLOCK;
 pub(crate) mod incorrect_modifier;
 use incorrect_modifier::INCORRECT_MODIFIER;
 
+mod inconsistent_type_names;
+use inconsistent_type_names::INCONSISTENT_TYPE_NAMES;
+
 mod msg_value_loop;
 use msg_value_loop::MSG_VALUE_LOOP;
 
@@ -51,6 +54,7 @@ register_lints!(
     (DeprecatedOzFunction, late, (DEPRECATED_OZ_FUNCTION)),
     (EmptyBlock, early, (EMPTY_BLOCK)),
     (IncorrectModifier, late, (INCORRECT_MODIFIER)),
+    (InconsistentTypeNames, project, (INCONSISTENT_TYPE_NAMES)),
     (MsgValueLoop, late, (MSG_VALUE_LOOP)),
     (MissingEventsAccessControl, late, (MISSING_EVENTS_ACCESS_CONTROL)),
     (MissingEventsArithmetic, late, (MISSING_EVENTS_ARITHMETIC)),

--- a/crates/lint/testdata/InconsistentTypeNames.sol
+++ b/crates/lint/testdata/InconsistentTypeNames.sol
@@ -1,0 +1,61 @@
+//@compile-flags: --only-lint inconsistent-type-names
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+// Tests for `inconsistent-type-names`: shorthand `uint`/`int` declarations are reported only
+// when the same directly declared contract also contains the corresponding explicit 256-bit type.
+// The analysis follows resolved variable declarations, including nested array/mapping types, but
+// excludes expressions, directives, other contracts, and inherited declarations.
+
+contract InconsistentTypeNames {
+    uint internal shorthandUint; //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+    uint256 internal explicitUint;
+
+    int internal shorthandInt; //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+    int256 internal explicitInt;
+
+    struct Record {
+        uint[] values; //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+        mapping(uint => uint256) indexes; //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+    }
+
+    event Updated(uint oldValue, uint256 newValue); //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+    error Difference(int delta, int256 expected); //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+    function (uint) external returns (uint256) callback; //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+
+    function update(
+        uint amount, //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+        uint256 limit
+    ) external returns (int result, int256 expected) { //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+        uint[] memory values = new uint[](amount); //~WARN: use explicit `uint256` and `int256` type names consistently within a contract
+        shorthandUint = values.length + limit;
+        result = int(shorthandUint);
+        expected = explicitInt;
+    }
+}
+
+contract ConsistentlyImplicit {
+    uint internal value;
+    int internal delta;
+
+    function inspect() external view returns (uint, int) {
+        // Explicit names used by type expressions and casts are not declarations.
+        return (uint(type(uint256).max + value), int(int256(delta)));
+    }
+}
+
+contract ConsistentlyExplicit {
+    uint256 internal value;
+    int256 internal delta;
+}
+
+contract ExplicitBase {
+    uint256 internal value;
+    int256 internal delta;
+}
+
+// Resolved ownership keeps declarations in a base contract out of the child's consistency scope.
+contract ImplicitChild is ExplicitBase {
+    uint internal otherValue;
+    int internal otherDelta;
+}

--- a/crates/lint/testdata/InconsistentTypeNames.stderr
+++ b/crates/lint/testdata/InconsistentTypeNames.stderr
@@ -1,0 +1,80 @@
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │     uint internal shorthandUint;
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │     int internal shorthandInt;
+   │     ━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │         uint[] values;
+   │         ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │         mapping(uint => uint256) indexes;
+   │         ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │     error Difference(int delta, int256 expected);
+   │                      ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │     event Updated(uint oldValue, uint256 newValue);
+   │                   ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │     function (uint) external returns (uint256) callback;
+   │               ━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │         uint amount,
+   │         ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │     ) external returns (int result, int256 expected) {
+   │                         ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+
+warning[inconsistent-type-names]: use explicit `uint256` and `int256` type names consistently within a contract
+   ╭▸ ROOT/testdata/InconsistentTypeNames.sol:LL:CC
+   │
+LL │ …     uint[] memory values = new uint[](amount);
+   │       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/inconsistent-type-names
+


### PR DESCRIPTION
Adds the low-severity `inconsistent-type-names` detector from #14381. It reports shorthand `uint` or `int` declarations when the same directly declared contract also uses `uint256` or `int256`, including nested array and mapping types, while keeping inheritance and other contracts in separate consistency scopes. The implementation uses resolved Solar HIR ownership and exact typed source spans so normalized integer types do not turn into name-based guesses; focused UI coverage, a blessed snapshot, and the lint reference page are included.

The companion documentation is in [foundry-rs/book#1974](https://github.com/foundry-rs/book/pull/1974).

This PR was implemented with Codex assistance across code, tests, and documentation, then independently reviewed by a fresh Codex context. PR responses may also be drafted with Codex assistance.
