### PR TITLE
fix(forge): respect Amsterdam code size limits

### DIFF
--- a/.changelog/forge-amsterdam-code-size-limits.md
+++ b/.changelog/forge-amsterdam-code-size-limits.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Applied Amsterdam's finalized EIP-7954 contract code and initcode size limits to build size reports and script deployment checks.

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -23,6 +23,7 @@ use foundry_compilers::{
     solc::SolcSettings,
 };
 use num_format::{Locale, ToFormattedString};
+use revm::primitives::{eip170, eip3860, hardfork::SpecId};
 use solar::{
     ast::{Arena, ContractKind, ItemKind},
     interface::{Session, source_map::FileName},
@@ -357,10 +358,10 @@ impl ProjectCompiler {
 
             sh_println!("{size_report}")?;
 
-            let runtime_eip = if size_report.limits.runtime == CONTRACT_RUNTIME_SIZE_LIMIT {
-                "EIP-170: "
-            } else {
-                ""
+            let runtime_eip = match size_report.limits.runtime {
+                CONTRACT_RUNTIME_SIZE_LIMIT => "EIP-170: ",
+                AMSTERDAM_CONTRACT_RUNTIME_SIZE_LIMIT => "EIP-7954: ",
+                _ => "",
             };
             eyre::ensure!(
                 !size_report.exceeds_runtime_size_limit(),
@@ -368,10 +369,10 @@ impl ProjectCompiler {
                 size_report.limits.runtime
             );
             // Check size limits only if not ignoring EIP-3860
-            let initcode_eip = if size_report.limits.initcode == CONTRACT_INITCODE_SIZE_LIMIT {
-                "EIP-3860: "
-            } else {
-                ""
+            let initcode_eip = match size_report.limits.initcode {
+                CONTRACT_INITCODE_SIZE_LIMIT => "EIP-3860: ",
+                AMSTERDAM_CONTRACT_INITCODE_SIZE_LIMIT => "EIP-7954: ",
+                _ => "",
             };
             eyre::ensure!(
                 self.ignore_eip_3860 || !size_report.exceeds_initcode_size_limit(),
@@ -385,10 +386,14 @@ impl ProjectCompiler {
 }
 
 // https://eips.ethereum.org/EIPS/eip-170
-const CONTRACT_RUNTIME_SIZE_LIMIT: usize = 24576;
+const CONTRACT_RUNTIME_SIZE_LIMIT: usize = eip170::MAX_CODE_SIZE;
 
 // https://eips.ethereum.org/EIPS/eip-3860
-const CONTRACT_INITCODE_SIZE_LIMIT: usize = 49152;
+const CONTRACT_INITCODE_SIZE_LIMIT: usize = eip3860::MAX_INITCODE_SIZE;
+
+// https://eips.ethereum.org/EIPS/eip-7954
+const AMSTERDAM_CONTRACT_RUNTIME_SIZE_LIMIT: usize = 65_536;
+const AMSTERDAM_CONTRACT_INITCODE_SIZE_LIMIT: usize = 131_072;
 
 const CONTRACT_RUNTIME_SIZE_WARN_THRESHOLD: usize = 18_000;
 const CONTRACT_INITCODE_SIZE_WARN_THRESHOLD: usize = 36_000;
@@ -411,6 +416,15 @@ impl ContractSizeLimits {
     /// Creates limits from a runtime code-size limit, using the EIP-3860 2x initcode ratio.
     pub const fn with_runtime_limit(runtime: usize) -> Self {
         Self { runtime, initcode: runtime.saturating_mul(2) }
+    }
+
+    /// Returns the protocol limits active for an EVM specification.
+    pub const fn for_spec_id(spec_id: SpecId) -> Self {
+        if spec_id.is_enabled_in(SpecId::AMSTERDAM) {
+            Self::new(AMSTERDAM_CONTRACT_RUNTIME_SIZE_LIMIT, AMSTERDAM_CONTRACT_INITCODE_SIZE_LIMIT)
+        } else {
+            Self::new(CONTRACT_RUNTIME_SIZE_LIMIT, CONTRACT_INITCODE_SIZE_LIMIT)
+        }
     }
 
     const fn runtime_warning_threshold(self) -> usize {
@@ -896,6 +910,15 @@ mod tests {
         assert_eq!(
             ContractSizeLimits::with_runtime_limit(50_000),
             ContractSizeLimits::new(50_000, 100_000)
+        );
+    }
+
+    #[test]
+    fn contract_size_limits_follow_evm_spec() {
+        assert_eq!(ContractSizeLimits::for_spec_id(SpecId::OSAKA), ContractSizeLimits::default());
+        assert_eq!(
+            ContractSizeLimits::for_spec_id(SpecId::AMSTERDAM),
+            ContractSizeLimits::new(65_536, 131_072)
         );
     }
 }

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -128,7 +128,7 @@ impl BuildArgs {
                 config
                     .code_size_limit
                     .map(ContractSizeLimits::with_runtime_limit)
-                    .unwrap_or_default(),
+                    .unwrap_or_else(|| ContractSizeLimits::for_spec_id(config.evm_spec_id())),
             )
             .bail(!format_json)
             .compile(&project)?;

--- a/crates/forge/tests/cli/build.rs
+++ b/crates/forge/tests/cli/build.rs
@@ -1,4 +1,5 @@
 use crate::utils::generate_large_init_contract;
+use foundry_compilers::artifacts::EvmVersion;
 use foundry_test_utils::{forgetest, forgetest_init, snapbox::IntoData, str};
 use globset::Glob;
 use std::fs;
@@ -182,6 +183,27 @@ forgetest!(build_sizes_respects_configured_code_size_limit, |prj, cmd| {
     "init_size": 50125,
     "runtime_margin": 63938,
     "init_margin": 77875
+  }
+}
+"#]]
+        .is_json(),
+    );
+});
+
+forgetest!(build_sizes_respects_amsterdam_code_size_limits, |prj, cmd| {
+    prj.add_source("LargeContract.sol", generate_large_init_contract(50_000).as_str());
+    prj.update_config(|config| {
+        config.evm_version = EvmVersion::Amsterdam;
+    });
+
+    cmd.args(["build", "--sizes", "--json"]).assert_success().stdout_eq(
+        str![[r#"
+{
+  "LargeContract": {
+    "runtime_size": 62,
+    "init_size": 50125,
+    "runtime_margin": 65474,
+    "init_margin": 80947
   }
 }
 "#]]

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -10,6 +10,7 @@ use alloy_primitives::{Address, Bytes, U256, address, hex};
 use anvil::{NodeConfig, spawn};
 use axum::{Router, body::Bytes as BodyBytes};
 use forge_script_sequence::ScriptSequence;
+use foundry_compilers::artifacts::EvmVersion;
 use foundry_test_utils::{
     ScriptOutcome, ScriptTester,
     rpc::{self, next_http_archive_rpc_url},
@@ -4777,6 +4778,32 @@ forgetest_async!(script_check_contract_sizes_warns_at_default_limit, |prj, cmd| 
 Error: `LargeRuntime` is above the contract size limit ([..] > 24576).
 
 "#]]);
+});
+
+forgetest_async!(script_check_contract_sizes_uses_amsterdam_code_size_limit, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    write_large_runtime_deploy_script(&prj, 50_000);
+    prj.update_config(|config| {
+        config.evm_version = EvmVersion::Amsterdam;
+    });
+
+    let (_api, handle) = spawn(NodeConfig::test().with_gas_limit(Some(1_000_000_000))).await;
+    cmd.set_current_dir(prj.root());
+    for var in ["FOUNDRY_CODE_SIZE_LIMIT", "DAPP_CODE_SIZE_LIMIT", "DAPP_TEST_CODE_SIZE_LIMIT"] {
+        cmd.unset_env(var);
+    }
+    let assert = cmd
+        .args([
+            "script",
+            "DeployLarge",
+            "--rpc-url",
+            &handle.http_endpoint(),
+            "--gas-limit",
+            "1000000000",
+        ])
+        .assert_success();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(!stderr.contains("above the contract size limit"), "{stderr}");
 });
 
 // Tests that `forge script` honors `code_size_limit` configured via foundry.toml

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -4806,6 +4806,51 @@ forgetest_async!(script_check_contract_sizes_uses_amsterdam_code_size_limit, |pr
     assert!(!stderr.contains("above the contract size limit"), "{stderr}");
 });
 
+forgetest_async!(script_check_contract_sizes_uses_network_specific_spec, |prj, cmd| {
+    foundry_test_utils::util::initialize(prj.root());
+    write_large_runtime_deploy_script(&prj, 50_000);
+
+    let (_api, handle) = spawn(NodeConfig::test().with_gas_limit(Some(1_000_000_000))).await;
+    let (_tempo_api, tempo_handle) =
+        spawn(NodeConfig::test_tempo().with_gas_limit(Some(1_000_000_000))).await;
+    let rpc = handle.http_endpoint();
+    let tempo_rpc = tempo_handle.http_endpoint();
+    cmd.set_current_dir(prj.root());
+    for (networks, hardfork, rpc_url, is_tempo) in [
+        (foundry_evm_networks::NetworkConfigs::with_optimism(), None, rpc.as_str(), false),
+        (Default::default(), Some("optimism:karst"), rpc.as_str(), false),
+        (foundry_evm_networks::NetworkConfigs::with_tempo(), None, tempo_rpc.as_str(), true),
+        (Default::default(), Some("tempo:T8"), tempo_rpc.as_str(), true),
+    ] {
+        prj.update_config(|config| {
+            config.evm_version = EvmVersion::Amsterdam;
+            config.networks = networks;
+            config.hardfork = hardfork.map(|hardfork| hardfork.parse().unwrap());
+        });
+
+        cmd.forge_fuse();
+        for var in ["FOUNDRY_CODE_SIZE_LIMIT", "DAPP_CODE_SIZE_LIMIT", "DAPP_TEST_CODE_SIZE_LIMIT"]
+        {
+            cmd.unset_env(var);
+        }
+        cmd.args(["script", "DeployLarge", "--rpc-url", rpc_url, "--gas-limit", "1000000000"]);
+        if is_tempo {
+            cmd.args([
+                "--private-key",
+                "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+                "--tempo.fee-token",
+                "0x20c0000000000000000000000000000000000000",
+            ]);
+        }
+        let assert = cmd.assert_success();
+        let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+        assert!(
+            stderr.contains("above the contract size limit (50308 > 24576)"),
+            "missing size warning for {hardfork:?}: {stderr}"
+        );
+    }
+});
+
 // Tests that `forge script` honors `code_size_limit` configured via foundry.toml
 // (the bug fix: previously only the CLI flag was honored).
 forgetest_async!(script_check_contract_sizes_honors_config_limit, |prj, cmd| {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -477,7 +477,11 @@ impl ScriptArgs {
                 .code_size_limit
                 .or(pre_simulation.script_config.config.code_size_limit)
                 .map(ContractSizeLimits::with_runtime_limit)
-                .unwrap_or_default();
+                .unwrap_or_else(|| {
+                    ContractSizeLimits::for_spec_id(
+                        pre_simulation.script_config.config.evm_spec_id(),
+                    )
+                });
             pre_simulation.args.check_contract_sizes(
                 size_limits,
                 &pre_simulation.execution_result,
@@ -592,8 +596,8 @@ impl ScriptArgs {
         Ok((func.clone(), data.into()))
     }
 
-    /// Checks if the transaction is a deployment with either a size above the default contract size
-    /// limit or specified `code_size_limit`.
+    /// Checks if the transaction is a deployment with a size above the active EVM specification's
+    /// contract size limit or the specified `code_size_limit`.
     ///
     /// If `self.broadcast` is enabled, it asks confirmation of the user. Otherwise, it just warns
     /// the user.

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -52,7 +52,7 @@ use foundry_evm::{
     backend::Backend,
     core::{
         Breakpoints, FoundryTransaction,
-        evm::{EthEvmNetwork, FoundryEvmNetwork, TempoEvmNetwork, TxEnvFor},
+        evm::{EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor},
     },
     executors::ExecutorBuilder,
     inspectors::{
@@ -478,9 +478,8 @@ impl ScriptArgs {
                 .or(pre_simulation.script_config.config.code_size_limit)
                 .map(ContractSizeLimits::with_runtime_limit)
                 .unwrap_or_else(|| {
-                    ContractSizeLimits::for_spec_id(
-                        pre_simulation.script_config.config.evm_spec_id(),
-                    )
+                    let spec_id: SpecFor<FEN> = pre_simulation.script_config.config.evm_spec_id();
+                    ContractSizeLimits::for_spec_id(spec_id.into())
                 });
             pre_simulation.args.check_contract_sizes(
                 size_limits,


### PR DESCRIPTION
## Summary

- derive default contract size-report limits from the active EVM specification
- use the EIP-170/EIP-3860 limits before Amsterdam and the finalized EIP-7954 64 KiB runtime / 128 KiB initcode limits for Amsterdam
- apply the same spec-aware fallback to script deployment warnings while preserving explicit `code_size_limit` overrides

## Motivation

Selecting `evm_version = "amsterdam"` still made `forge build --sizes` and script checks use the pre-Amsterdam 24 KiB runtime / 48 KiB initcode limits. Setting `code_size_limit` works around the reporting issue, but it is an explicit EVM override rather than the protocol default implied by the selected EVM version.

With this change, selecting Amsterdam automatically uses its finalized 64 KiB runtime and 128 KiB initcode limits. Explicit `code_size_limit` values continue to override the default for build and script checks.

The workspace currently uses revm 41, whose EIP-7954 constants still contain the earlier 32/64 KiB draft values, so the finalized limits are defined from the EIP directly. The regression tests cover a 50 KiB runtime contract and the finalized size-report margins.

Addresses https://github.com/foundry-rs/foundry/pull/14761#issuecomment-4981425557