### PR TITLE
feat(lint): detect unsafe ecrecover

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -24,6 +24,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `boolean-cst`: Flags misuse of boolean constants.
   - `dangerous-unary-operator`: Flags an assignment whose `=` is fused to a unary operator (`=-`, `=~`), e.g. `x =- 1`, which parses as `x = -1` instead of the intended compound `x -= 1`.
   - `divide-before-multiply`: Warns against performing division before multiplication in the same expression, which can cause precision loss.
+  - `ecrecover`: Flags direct `ecrecover` calls whose signature `s` value is not proven to be canonical and non-malleable.
   - `incorrect-erc20-interface`: Flags ERC20 interfaces and implementations with non-compliant function signatures.
   - `incorrect-erc721-interface`: Flags ERC721 interfaces and implementations with non-compliant function signatures.
   - `incorrect-strict-equality`: Dangerous strict equality check on an externally-influenced value (ETH balance, ERC-20 balance).

--- a/crates/lint/docs/ecrecover.md
+++ b/crates/lint/docs/ecrecover.md
@@ -18,10 +18,10 @@ retained only when they hold on every path reaching the call.
 Checks on `v`, the recovered address, nonces, domain separators, or the top bit of an EIP-2098
 signature do not prove that `s` is canonical and do not suppress the warning.
 
-The analysis is intentionally local and requires the low-`s` guard to be established before the
-call. It does not summarize internal helpers or modifiers, prove post-call guards, recognize bound
-signature schemes that fix one recovery ID, or inspect Yul and low-level calls to precompile
-address `0x01`.
+The analysis is intentionally local. A low-`s` guard may be established before the call or after
+assigning the recovered address to a local, provided it dominates the address's first observable
+use. The analysis does not summarize internal helpers or modifiers, recognize bound signature
+schemes that fix one recovery ID, or inspect Yul and low-level calls to precompile address `0x01`.
 
 ## Why is this bad?
 

--- a/crates/lint/docs/ecrecover.md
+++ b/crates/lint/docs/ecrecover.md
@@ -12,7 +12,8 @@ The lint follows simple local aliases and recognizes low-`s` bounds established 
 `assert`, conditionals, and early-return or revert branches. It accepts the canonical maximum
 `0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0`, stricter bounds, reversed
 comparisons, and the equivalent strict comparison against that value plus one. Facts are
-invalidated by reassignment and retained only when they hold on every path reaching the call.
+invalidated by reassignment, loop-carried writes, and calls that may change mutable state. They are
+retained only when they hold on every path reaching the call.
 
 Checks on `v`, the recovered address, nonces, domain separators, or the top bit of an EIP-2098
 signature do not prove that `s` is canonical and do not suppress the warning.

--- a/crates/lint/docs/ecrecover.md
+++ b/crates/lint/docs/ecrecover.md
@@ -1,0 +1,53 @@
+# Unsafe ecrecover
+
+**Severity**: `Med`
+**ID**: `ecrecover`
+
+Flags direct calls to Solidity's `ecrecover` builtin when the signature's `s` value is not proven
+to be in the canonical lower half of the secp256k1 curve order.
+
+## What it does
+
+The lint follows simple local aliases and recognizes low-`s` bounds established by `require`,
+`assert`, conditionals, and early-return or revert branches. It accepts the canonical maximum
+`0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0`, stricter bounds, reversed
+comparisons, and the equivalent strict comparison against that value plus one. Facts are
+invalidated by reassignment and retained only when they hold on every path reaching the call.
+
+Checks on `v`, the recovered address, nonces, domain separators, or the top bit of an EIP-2098
+signature do not prove that `s` is canonical and do not suppress the warning.
+
+The analysis is intentionally local and requires the low-`s` guard to be established before the
+call. It does not summarize internal helpers or modifiers, prove post-call guards, recognize bound
+signature schemes that fix one recovery ID, or inspect Yul and low-level calls to precompile
+address `0x01`.
+
+## Why is this bad?
+
+For each valid high-`s` ECDSA signature, an attacker can derive a second signature for the same
+message and signer by replacing `s` with its complement in the curve order and flipping `v`.
+Contracts that use the signature bytes as a unique identifier can therefore have replay or
+double-use protections bypassed. The `ecrecover` precompile does not enforce the low-`s` rule that
+Ethereum transactions enforce.
+
+## Example
+
+### Bad
+
+```solidity
+function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) pure returns (address) {
+    return ecrecover(hash, v, r, s);
+}
+```
+
+### Good
+
+```solidity
+uint256 constant HALF_ORDER =
+    0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
+
+function recover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) pure returns (address) {
+    require(uint256(s) <= HALF_ORDER, "invalid signature s");
+    return ecrecover(hash, v, r, s);
+}
+```

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -49,7 +49,7 @@ impl<'hir> LateLintPass<'hir> for Ecrecover {
         let mut falls_through = true;
         for stmt in body.stmts {
             let _ = analyzer.visit_stmt(stmt);
-            if branch_always_exits(stmt) {
+            if analyzer.stmt_always_exits(stmt) {
                 falls_through = false;
                 break;
             }
@@ -349,6 +349,23 @@ impl<'hir> Analyzer<'hir> {
         }
     }
 
+    fn stmt_always_exits(&self, stmt: &'hir hir::Stmt<'hir>) -> bool {
+        match &stmt.kind {
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+                block.stmts.iter().any(|stmt| self.stmt_always_exits(stmt))
+            }
+            StmtKind::If(condition, then_stmt, else_stmt) => match self.const_bool(condition) {
+                Some(true) => self.stmt_always_exits(then_stmt),
+                Some(false) => else_stmt.is_some_and(|else_stmt| self.stmt_always_exits(else_stmt)),
+                None => {
+                    self.stmt_always_exits(then_stmt)
+                        && else_stmt.is_some_and(|else_stmt| self.stmt_always_exits(else_stmt))
+                }
+            },
+            _ => branch_always_exits(stmt),
+        }
+    }
+
     fn is_proven_low_s(&self, expr: &'hir hir::Expr<'hir>) -> bool {
         self.const_value(expr).is_some_and(|value| value <= SECP256K1_HALF_ORDER)
             || self.current_value(expr).is_some_and(|value| self.state.low_s.contains(&value))
@@ -574,7 +591,7 @@ impl<'hir> Analyzer<'hir> {
             }
             _ => {
                 self.add_stmt_effects(stmt, &mut effects);
-                (!branch_always_exits(stmt)).then_some(effects)
+                (!self.stmt_always_exits(stmt)).then_some(effects)
             }
         }
     }
@@ -809,7 +826,18 @@ impl<'hir> Analyzer<'hir> {
                 self.visit_loop_stmts(block.stmts, exits)
             }
             StmtKind::If(condition, then_stmt, else_stmt) => {
+                let constant = self.const_bool(condition);
                 let _ = self.visit_expr(condition);
+                if let Some(value) = constant {
+                    self.assume(condition, !value);
+                    return if value {
+                        self.visit_loop_stmt(then_stmt, exits)
+                    } else if let Some(else_stmt) = else_stmt {
+                        self.visit_loop_stmt(else_stmt, exits)
+                    } else {
+                        Some(self.snapshot())
+                    };
+                }
                 let baseline = self.snapshot();
 
                 self.assume(condition, false);
@@ -850,7 +878,7 @@ impl<'hir> Analyzer<'hir> {
             }
             _ => {
                 let _ = self.visit_stmt(stmt);
-                (!branch_always_exits(stmt)).then(|| self.snapshot())
+                (!self.stmt_always_exits(stmt)).then(|| self.snapshot())
             }
         }
     }
@@ -868,26 +896,36 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
             StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
                 for stmt in block.stmts {
                     let _ = self.visit_stmt(stmt);
-                    if branch_always_exits(stmt) {
+                    if self.stmt_always_exits(stmt) {
                         break;
                     }
                 }
                 return ControlFlow::Continue(());
             }
             StmtKind::If(condition, then_stmt, else_stmt) => {
+                let constant = self.const_bool(condition);
                 let _ = self.visit_expr(condition);
+                if let Some(value) = constant {
+                    self.assume(condition, !value);
+                    if value {
+                        let _ = self.visit_stmt(then_stmt);
+                    } else if let Some(else_stmt) = else_stmt {
+                        let _ = self.visit_stmt(else_stmt);
+                    }
+                    return ControlFlow::Continue(());
+                }
                 let baseline = self.snapshot();
 
                 self.assume(condition, false);
                 let _ = self.visit_stmt(then_stmt);
-                let then_exits = branch_always_exits(then_stmt);
+                let then_exits = self.stmt_always_exits(then_stmt);
                 let after_then = self.snapshot();
 
                 self.restore(baseline);
                 self.assume(condition, true);
                 let else_exits = if let Some(else_stmt) = else_stmt {
                     let _ = self.visit_stmt(else_stmt);
-                    branch_always_exits(else_stmt)
+                    self.stmt_always_exits(else_stmt)
                 } else {
                     false
                 };
@@ -920,11 +958,11 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
                     self.restore(after_call.clone());
                     for stmt in clause.block.stmts {
                         let _ = self.visit_stmt(stmt);
-                        if branch_always_exits(stmt) {
+                        if self.stmt_always_exits(stmt) {
                             break;
                         }
                     }
-                    if !clause.block.stmts.iter().any(branch_always_exits) {
+                    if !clause.block.stmts.iter().any(|stmt| self.stmt_always_exits(stmt)) {
                         fallthrough.push(self.snapshot());
                     }
                 }

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -232,6 +232,14 @@ impl<'hir> Analyzer<'hir> {
         }
     }
 
+    fn use_all_pending(&mut self) {
+        for recoveries in std::mem::take(&mut self.state.pending).into_values() {
+            for recovery in recoveries {
+                self.emit_hit(recovery.span);
+            }
+        }
+    }
+
     fn validate_pending(&mut self) {
         let low_s = &self.state.low_s;
         self.state.pending.retain(|_, recoveries| {
@@ -1118,6 +1126,9 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
                 return ControlFlow::Continue(());
             }
             StmtKind::Err(_) | StmtKind::AssemblyBlock(_) => {
+                // Inline assembly is opaque and may observe any local before changing it. Flush
+                // deferred recoveries before discarding facts so assembly cannot hide a warning.
+                self.use_all_pending();
                 self.state = FlowState::default();
             }
             StmtKind::Return(None) => {

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -1,0 +1,551 @@
+use super::Ecrecover;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{
+        Severity, SolLint,
+        analysis::primitives::{branch_always_exits, is_require_or_assert},
+    },
+};
+use alloy_primitives::{U256, uint};
+use solar::{
+    ast::{BinOpKind, ElementaryType, UnOpKind},
+    interface::{Span, data_structures::Never},
+    sema::{
+        Gcx,
+        builtins::Builtin,
+        eval::ConstantEvaluator,
+        hir::{self, ExprKind, ItemId, LoopSource, Res, StmtKind, TypeKind, Visit},
+    },
+};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::ControlFlow,
+};
+
+declare_forge_lint!(
+    ECRECOVER,
+    Severity::Med,
+    "ecrecover",
+    "ecrecover should reject malleable signatures"
+);
+
+/// Largest canonical secp256k1 `s` value, `n / 2`.
+const SECP256K1_HALF_ORDER: U256 =
+    uint!(0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0_U256);
+
+impl<'hir> LateLintPass<'hir> for Ecrecover {
+    fn check_function(
+        &mut self,
+        ctx: &LintContext,
+        gcx: Gcx<'hir>,
+        hir: &'hir hir::Hir<'hir>,
+        func: &'hir hir::Function<'hir>,
+    ) {
+        let Some(body) = func.body else { return };
+        let mut analyzer = Analyzer::new(gcx, hir);
+        for stmt in body.stmts {
+            let _ = analyzer.visit_stmt(stmt);
+            if branch_always_exits(stmt) {
+                break;
+            }
+        }
+        for span in analyzer.hits {
+            ctx.emit(&ECRECOVER, span);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum ValueId {
+    Initial(hir::VariableId),
+    Assigned(u32),
+}
+
+#[derive(Clone, Default)]
+struct FlowState {
+    values: HashMap<hir::VariableId, ValueId>,
+    low_s: HashSet<ValueId>,
+}
+
+impl FlowState {
+    fn value(&self, var: hir::VariableId) -> ValueId {
+        self.values.get(&var).copied().unwrap_or(ValueId::Initial(var))
+    }
+}
+
+struct Analyzer<'hir> {
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    state: FlowState,
+    next_value: u32,
+    hits: Vec<Span>,
+}
+
+impl<'hir> Analyzer<'hir> {
+    fn new(gcx: Gcx<'hir>, hir: &'hir hir::Hir<'hir>) -> Self {
+        Self { gcx, hir, state: FlowState::default(), next_value: 0, hits: Vec::new() }
+    }
+
+    fn fresh_value(&mut self) -> ValueId {
+        let value = ValueId::Assigned(self.next_value);
+        self.next_value += 1;
+        value
+    }
+
+    fn snapshot(&self) -> FlowState {
+        self.state.clone()
+    }
+
+    fn restore(&mut self, state: FlowState) {
+        self.state = state;
+    }
+
+    fn join(&mut self, left: FlowState, right: FlowState) -> FlowState {
+        let mut joined = FlowState {
+            low_s: left.low_s.intersection(&right.low_s).copied().collect(),
+            ..FlowState::default()
+        };
+        let vars: HashSet<_> = left.values.keys().chain(right.values.keys()).copied().collect();
+        let mut joined_values = HashMap::new();
+
+        for var in vars {
+            let left_value = left.value(var);
+            let right_value = right.value(var);
+            if left_value == right_value {
+                joined.values.insert(var, left_value);
+                continue;
+            }
+
+            let value = *joined_values
+                .entry((left_value, right_value))
+                .or_insert_with(|| self.fresh_value());
+            if left.low_s.contains(&left_value) && right.low_s.contains(&right_value) {
+                joined.low_s.insert(value);
+            }
+            joined.values.insert(var, value);
+        }
+        joined
+    }
+
+    fn current_value(&self, expr: &'hir hir::Expr<'hir>) -> Option<ValueId> {
+        match &expr.peel_parens().kind {
+            ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
+                Res::Item(ItemId::Variable(var)) => Some(self.state.value(*var)),
+                _ => None,
+            }),
+            ExprKind::Call(callee, args, _)
+                if is_transparent_signature_cast(callee) && args.len() == 1 =>
+            {
+                args.exprs().next().and_then(|arg| self.current_value(arg))
+            }
+            ExprKind::Assign(_, None, rhs) => self.current_value(rhs),
+            _ => None,
+        }
+    }
+
+    fn const_value(&self, expr: &'hir hir::Expr<'hir>) -> Option<U256> {
+        ConstantEvaluator::new(self.gcx).try_eval(expr).ok()?.as_u256()
+    }
+
+    fn is_proven_low_s(&self, expr: &'hir hir::Expr<'hir>) -> bool {
+        self.const_value(expr).is_some_and(|value| value <= SECP256K1_HALF_ORDER)
+            || self.current_value(expr).is_some_and(|value| self.state.low_s.contains(&value))
+    }
+
+    fn assign_var(&mut self, var: hir::VariableId, rhs: Option<&'hir hir::Expr<'hir>>) {
+        let value =
+            rhs.and_then(|rhs| self.current_value(rhs)).unwrap_or_else(|| self.fresh_value());
+        if rhs.is_some_and(|rhs| self.is_proven_low_s(rhs)) {
+            self.state.low_s.insert(value);
+        }
+        self.state.values.insert(var, value);
+    }
+
+    fn assign_lhs(&mut self, lhs: &'hir hir::Expr<'hir>, rhs: Option<&'hir hir::Expr<'hir>>) {
+        if let ExprKind::Tuple(lhs_elems) = &lhs.peel_parens().kind {
+            let rhs_elems = match rhs.map(|rhs| &rhs.peel_parens().kind) {
+                Some(ExprKind::Tuple(elems)) => Some(*elems),
+                _ => None,
+            };
+            for (index, lhs) in lhs_elems.iter().enumerate() {
+                let Some(lhs) = lhs else { continue };
+                let rhs = rhs_elems.and_then(|elems| elems.get(index)).copied().flatten();
+                self.assign_lhs(lhs, rhs);
+            }
+        } else if let Some(var) = underlying_var(lhs) {
+            self.assign_var(var, rhs);
+        }
+    }
+
+    fn mark_deleted(&mut self, target: &'hir hir::Expr<'hir>) {
+        let Some(var) = underlying_var(target) else { return };
+        let value = self.fresh_value();
+        self.state.values.insert(var, value);
+        self.state.low_s.insert(value);
+    }
+
+    fn invalidate(&mut self, target: &'hir hir::Expr<'hir>) {
+        let Some(var) = underlying_var(target) else { return };
+        let value = self.fresh_value();
+        self.state.values.insert(var, value);
+    }
+
+    fn add_facts(&mut self, predicate: &'hir hir::Expr<'hir>, negate: bool) {
+        if expr_has_fact_side_effect(predicate) {
+            return;
+        }
+        match &predicate.peel_parens().kind {
+            ExprKind::Binary(lhs, op, rhs) => {
+                let conjunctive =
+                    matches!((op.kind, negate), (BinOpKind::And, false) | (BinOpKind::Or, true));
+                let disjunctive =
+                    matches!((op.kind, negate), (BinOpKind::Or, false) | (BinOpKind::And, true));
+                if conjunctive {
+                    self.add_facts(lhs, negate);
+                    self.add_facts(rhs, negate);
+                } else if disjunctive {
+                    self.add_disjunctive_facts(lhs, rhs, negate);
+                } else {
+                    self.add_comparison_fact(lhs, op.kind, rhs, negate);
+                }
+            }
+            ExprKind::Unary(op, inner) if op.kind == UnOpKind::Not => {
+                self.add_facts(inner, !negate);
+            }
+            _ => {}
+        }
+    }
+
+    fn add_disjunctive_facts(
+        &mut self,
+        lhs: &'hir hir::Expr<'hir>,
+        rhs: &'hir hir::Expr<'hir>,
+        negate: bool,
+    ) {
+        let baseline = self.state.low_s.clone();
+        self.add_facts(lhs, negate);
+        let lhs_added: HashSet<_> = self.state.low_s.difference(&baseline).copied().collect();
+        self.state.low_s.clone_from(&baseline);
+        self.add_facts(rhs, negate);
+        let rhs_added: HashSet<_> = self.state.low_s.difference(&baseline).copied().collect();
+        self.state.low_s = baseline;
+        self.state.low_s.extend(lhs_added.intersection(&rhs_added).copied());
+    }
+
+    fn add_comparison_fact(
+        &mut self,
+        lhs: &'hir hir::Expr<'hir>,
+        op: BinOpKind,
+        rhs: &'hir hir::Expr<'hir>,
+        negate: bool,
+    ) {
+        let op = if negate { negate_comparison(op) } else { op };
+        for (candidate, bound, op) in [(lhs, rhs, op), (rhs, lhs, reverse_comparison(op))] {
+            let Some(value) = self.current_value(candidate) else { continue };
+            let Some(bound) = self.const_value(bound) else { continue };
+            let proves_low = match op {
+                BinOpKind::Lt => bound <= SECP256K1_HALF_ORDER + U256::from(1),
+                BinOpKind::Le => bound <= SECP256K1_HALF_ORDER,
+                BinOpKind::Eq => bound <= SECP256K1_HALF_ORDER,
+                _ => false,
+            };
+            if proves_low {
+                self.state.low_s.insert(value);
+            }
+        }
+    }
+
+    fn is_unsafe_ecrecover(&self, expr: &'hir hir::Expr<'hir>) -> bool {
+        let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
+        if !is_ecrecover_builtin(callee) || args.len() != 4 {
+            return false;
+        }
+        args.exprs().nth(3).is_some_and(|s| !self.is_proven_low_s(s))
+    }
+}
+
+impl<'hir> Visit<'hir> for Analyzer<'hir> {
+    type BreakValue = Never;
+
+    fn hir(&self) -> &'hir hir::Hir<'hir> {
+        self.hir
+    }
+
+    fn visit_stmt(&mut self, stmt: &'hir hir::Stmt<'hir>) -> ControlFlow<Self::BreakValue> {
+        match &stmt.kind {
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+                for stmt in block.stmts {
+                    let _ = self.visit_stmt(stmt);
+                    if branch_always_exits(stmt) {
+                        break;
+                    }
+                }
+                return ControlFlow::Continue(());
+            }
+            StmtKind::If(condition, then_stmt, else_stmt) => {
+                let _ = self.visit_expr(condition);
+                let baseline = self.snapshot();
+
+                self.add_facts(condition, false);
+                let _ = self.visit_stmt(then_stmt);
+                let then_exits = branch_always_exits(then_stmt);
+                let after_then = self.snapshot();
+
+                self.restore(baseline);
+                self.add_facts(condition, true);
+                let else_exits = if let Some(else_stmt) = else_stmt {
+                    let _ = self.visit_stmt(else_stmt);
+                    branch_always_exits(else_stmt)
+                } else {
+                    false
+                };
+                let after_else = self.snapshot();
+
+                let joined = match (then_exits, else_exits) {
+                    (true, false) => after_else,
+                    (false, true) => after_then,
+                    _ => self.join(after_then, after_else),
+                };
+                self.restore(joined);
+                return ControlFlow::Continue(());
+            }
+            StmtKind::Loop(block, source) => {
+                let baseline = self.snapshot();
+                for stmt in block.stmts {
+                    let _ = self.visit_stmt(stmt);
+                    if branch_always_exits(stmt) {
+                        break;
+                    }
+                }
+                if !matches!(source, LoopSource::DoWhile) {
+                    let after_loop = self.snapshot();
+                    let joined = self.join(baseline, after_loop);
+                    self.restore(joined);
+                }
+                return ControlFlow::Continue(());
+            }
+            StmtKind::Try(stmt_try) => {
+                let _ = self.visit_expr(&stmt_try.expr);
+                let baseline = self.snapshot();
+                let mut fallthrough = Vec::new();
+                for clause in stmt_try.clauses {
+                    self.restore(baseline.clone());
+                    for stmt in clause.block.stmts {
+                        let _ = self.visit_stmt(stmt);
+                        if branch_always_exits(stmt) {
+                            break;
+                        }
+                    }
+                    if !clause.block.stmts.iter().any(branch_always_exits) {
+                        fallthrough.push(self.snapshot());
+                    }
+                }
+                let joined = fallthrough
+                    .into_iter()
+                    .reduce(|left, right| self.join(left, right))
+                    .unwrap_or(baseline);
+                self.restore(joined);
+                return ControlFlow::Continue(());
+            }
+            StmtKind::DeclSingle(var) => {
+                let init = self.hir.variable(*var).initializer;
+                if let Some(init) = init {
+                    let _ = self.visit_expr(init);
+                }
+                self.assign_var(*var, init);
+                return ControlFlow::Continue(());
+            }
+            StmtKind::DeclMulti(vars, init) => {
+                let _ = self.visit_expr(init);
+                if let ExprKind::Tuple(exprs) = &init.peel_parens().kind {
+                    for (var, expr) in vars.iter().zip(exprs.iter()) {
+                        if let Some(var) = var {
+                            self.assign_var(*var, *expr);
+                        }
+                    }
+                } else {
+                    for var in vars.iter().flatten() {
+                        self.assign_var(*var, None);
+                    }
+                }
+                return ControlFlow::Continue(());
+            }
+            StmtKind::Err(_) | StmtKind::AssemblyBlock(_) => {
+                self.state = FlowState::default();
+            }
+            _ => {}
+        }
+        self.walk_stmt(stmt)
+    }
+
+    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let ExprKind::Binary(lhs, op, rhs) = &expr.kind
+            && matches!(op.kind, BinOpKind::And | BinOpKind::Or)
+        {
+            let _ = self.visit_expr(lhs);
+            let skipped_rhs = self.snapshot();
+            self.add_facts(lhs, op.kind == BinOpKind::Or);
+            let _ = self.visit_expr(rhs);
+            let ran_rhs = self.snapshot();
+            let joined = self.join(skipped_rhs, ran_rhs);
+            self.restore(joined);
+            return ControlFlow::Continue(());
+        }
+        if let ExprKind::Ternary(condition, then_expr, else_expr) = &expr.kind {
+            let _ = self.visit_expr(condition);
+            let baseline = self.snapshot();
+            self.add_facts(condition, false);
+            let _ = self.visit_expr(then_expr);
+            let after_then = self.snapshot();
+            self.restore(baseline);
+            self.add_facts(condition, true);
+            let _ = self.visit_expr(else_expr);
+            let after_else = self.snapshot();
+            let joined = self.join(after_then, after_else);
+            self.restore(joined);
+            return ControlFlow::Continue(());
+        }
+
+        match &expr.kind {
+            ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
+                let result = self.walk_expr(expr);
+                if let Some(condition) = args.exprs().next() {
+                    self.add_facts(condition, false);
+                }
+                return result;
+            }
+            ExprKind::Assign(lhs, op, rhs) => {
+                let result = self.walk_expr(expr);
+                self.assign_lhs(lhs, op.is_none().then_some(*rhs));
+                return result;
+            }
+            ExprKind::Delete(target) => {
+                let result = self.walk_expr(expr);
+                self.mark_deleted(target);
+                return result;
+            }
+            ExprKind::Unary(op, target)
+                if matches!(
+                    op.kind,
+                    UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec
+                ) =>
+            {
+                let result = self.walk_expr(expr);
+                self.invalidate(target);
+                return result;
+            }
+            _ => {}
+        }
+
+        let result = self.walk_expr(expr);
+        if self.is_unsafe_ecrecover(expr) {
+            self.hits.push(expr.span);
+        }
+        result
+    }
+}
+
+fn underlying_var(expr: &hir::Expr<'_>) -> Option<hir::VariableId> {
+    match &expr.peel_parens().kind {
+        ExprKind::Ident(reses) => reses.iter().find_map(|res| match res {
+            Res::Item(ItemId::Variable(var)) => Some(*var),
+            _ => None,
+        }),
+        ExprKind::Call(callee, args, _)
+            if is_transparent_signature_cast(callee) && args.len() == 1 =>
+        {
+            args.exprs().next().and_then(underlying_var)
+        }
+        _ => None,
+    }
+}
+
+fn is_transparent_signature_cast(callee: &hir::Expr<'_>) -> bool {
+    matches!(
+        &callee.peel_parens().kind,
+        ExprKind::Type(hir::Type {
+            kind: TypeKind::Elementary(
+                ElementaryType::UInt(size) | ElementaryType::FixedBytes(size)
+            ),
+            ..
+        }) if size.bits() == 256
+    )
+}
+
+fn is_ecrecover_builtin(callee: &hir::Expr<'_>) -> bool {
+    matches!(
+        &callee.peel_parens().kind,
+        ExprKind::Ident(reses)
+            if reses.iter().any(|res| matches!(res, Res::Builtin(Builtin::EcRecover)))
+    )
+}
+
+fn negate_comparison(op: BinOpKind) -> BinOpKind {
+    match op {
+        BinOpKind::Lt => BinOpKind::Ge,
+        BinOpKind::Le => BinOpKind::Gt,
+        BinOpKind::Gt => BinOpKind::Le,
+        BinOpKind::Ge => BinOpKind::Lt,
+        BinOpKind::Eq => BinOpKind::Ne,
+        BinOpKind::Ne => BinOpKind::Eq,
+        _ => op,
+    }
+}
+
+fn reverse_comparison(op: BinOpKind) -> BinOpKind {
+    match op {
+        BinOpKind::Lt => BinOpKind::Gt,
+        BinOpKind::Le => BinOpKind::Ge,
+        BinOpKind::Gt => BinOpKind::Lt,
+        BinOpKind::Ge => BinOpKind::Le,
+        _ => op,
+    }
+}
+
+fn expr_has_fact_side_effect(expr: &hir::Expr<'_>) -> bool {
+    match &expr.peel_parens().kind {
+        ExprKind::Assign(..) | ExprKind::Delete(_) => true,
+        ExprKind::Unary(op, inner) => {
+            matches!(
+                op.kind,
+                UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec
+            ) || expr_has_fact_side_effect(inner)
+        }
+        ExprKind::Array(exprs) => exprs.iter().any(expr_has_fact_side_effect),
+        ExprKind::Binary(lhs, _, rhs) => {
+            expr_has_fact_side_effect(lhs) || expr_has_fact_side_effect(rhs)
+        }
+        ExprKind::Call(callee, args, options) => {
+            expr_has_fact_side_effect(callee)
+                || args.exprs().any(expr_has_fact_side_effect)
+                || options.is_some_and(|options| {
+                    options.args.iter().any(|arg| expr_has_fact_side_effect(&arg.value))
+                })
+        }
+        ExprKind::Index(base, index) => {
+            expr_has_fact_side_effect(base) || index.is_some_and(expr_has_fact_side_effect)
+        }
+        ExprKind::Slice(base, start, end) => {
+            expr_has_fact_side_effect(base)
+                || start.is_some_and(expr_has_fact_side_effect)
+                || end.is_some_and(expr_has_fact_side_effect)
+        }
+        ExprKind::Member(base, _) | ExprKind::Payable(base) | ExprKind::YulMember(base, _) => {
+            expr_has_fact_side_effect(base)
+        }
+        ExprKind::Ternary(condition, then_expr, else_expr) => {
+            expr_has_fact_side_effect(condition)
+                || expr_has_fact_side_effect(then_expr)
+                || expr_has_fact_side_effect(else_expr)
+        }
+        ExprKind::Tuple(exprs) => {
+            exprs.iter().flatten().any(|expr| expr_has_fact_side_effect(expr))
+        }
+        ExprKind::Lit(_)
+        | ExprKind::Ident(_)
+        | ExprKind::New(_)
+        | ExprKind::TypeCall(_)
+        | ExprKind::Type(_)
+        | ExprKind::Err(_) => false,
+    }
+}

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -45,12 +45,17 @@ impl<'hir> LateLintPass<'hir> for Ecrecover {
         func: &'hir hir::Function<'hir>,
     ) {
         let Some(body) = func.body else { return };
-        let mut analyzer = Analyzer::new(gcx, hir);
+        let mut analyzer = Analyzer::new(gcx, hir, func.returns);
+        let mut falls_through = true;
         for stmt in body.stmts {
             let _ = analyzer.visit_stmt(stmt);
             if branch_always_exits(stmt) {
+                falls_through = false;
                 break;
             }
+        }
+        if falls_through {
+            analyzer.use_return_values();
         }
         for span in analyzer.hits {
             ctx.emit(&ECRECOVER, span);
@@ -70,10 +75,17 @@ struct AssignedValue {
     low_s: bool,
 }
 
+#[derive(Clone, Copy)]
+struct PendingRecovery {
+    signature: Option<ValueId>,
+    span: Span,
+}
+
 #[derive(Clone, Default)]
 struct FlowState {
     values: HashMap<hir::VariableId, ValueId>,
     low_s: HashSet<ValueId>,
+    pending: HashMap<ValueId, Vec<PendingRecovery>>,
 }
 
 #[derive(Clone, Default)]
@@ -100,14 +112,28 @@ impl FlowState {
 struct Analyzer<'hir> {
     gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
+    returns: &'hir [hir::VariableId],
     state: FlowState,
     next_value: u32,
     hits: Vec<Span>,
+    ignored_reads: HashSet<ValueId>,
+    deferred_calls: HashSet<hir::ExprId>,
+    stored_results: HashSet<hir::ExprId>,
 }
 
 impl<'hir> Analyzer<'hir> {
-    fn new(gcx: Gcx<'hir>, hir: &'hir hir::Hir<'hir>) -> Self {
-        Self { gcx, hir, state: FlowState::default(), next_value: 0, hits: Vec::new() }
+    fn new(gcx: Gcx<'hir>, hir: &'hir hir::Hir<'hir>, returns: &'hir [hir::VariableId]) -> Self {
+        Self {
+            gcx,
+            hir,
+            returns,
+            state: FlowState::default(),
+            next_value: 0,
+            hits: Vec::new(),
+            ignored_reads: HashSet::new(),
+            deferred_calls: HashSet::new(),
+            stored_results: HashSet::new(),
+        }
     }
 
     const fn fresh_value(&mut self) -> ValueId {
@@ -132,7 +158,8 @@ impl<'hir> Analyzer<'hir> {
         let vars: HashSet<_> = left.values.keys().chain(right.values.keys()).copied().collect();
         let mut joined_values = HashMap::new();
 
-        for var in vars {
+        for var in &vars {
+            let var = *var;
             let left_value = left.value(var);
             let right_value = right.value(var);
             if left_value == right_value {
@@ -148,7 +175,69 @@ impl<'hir> Analyzer<'hir> {
             }
             joined.values.insert(var, value);
         }
+        for var in vars {
+            let value = joined.value(var);
+            for recovery in left
+                .pending
+                .get(&left.value(var))
+                .into_iter()
+                .flatten()
+                .chain(right.pending.get(&right.value(var)).into_iter().flatten())
+                .copied()
+            {
+                let recoveries = joined.pending.entry(value).or_default();
+                if !recoveries.iter().any(|existing| {
+                    existing.span == recovery.span && existing.signature == recovery.signature
+                }) {
+                    recoveries.push(recovery);
+                }
+            }
+        }
         joined
+    }
+
+    fn emit_hit(&mut self, span: Span) {
+        if !self.hits.contains(&span) {
+            self.hits.push(span);
+        }
+    }
+
+    fn record_pending(&mut self, var: hir::VariableId, recovery: PendingRecovery) {
+        let value = self.state.value(var);
+        let recoveries = self.state.pending.entry(value).or_default();
+        if !recoveries.iter().any(|existing| {
+            existing.span == recovery.span && existing.signature == recovery.signature
+        }) {
+            recoveries.push(recovery);
+        }
+    }
+
+    fn use_value(&mut self, value: ValueId) {
+        if self.ignored_reads.contains(&value) {
+            return;
+        }
+        if let Some(recoveries) = self.state.pending.remove(&value) {
+            for recovery in recoveries {
+                self.emit_hit(recovery.span);
+            }
+        }
+    }
+
+    fn use_return_values(&mut self) {
+        let values: Vec<_> = self.returns.iter().map(|var| self.state.value(*var)).collect();
+        for value in values {
+            self.use_value(value);
+        }
+    }
+
+    fn validate_pending(&mut self) {
+        let low_s = &self.state.low_s;
+        self.state.pending.retain(|_, recoveries| {
+            recoveries.retain(|recovery| {
+                !recovery.signature.is_some_and(|signature| low_s.contains(&signature))
+            });
+            !recoveries.is_empty()
+        });
     }
 
     fn current_value(&self, expr: &'hir hir::Expr<'hir>) -> Option<ValueId> {
@@ -165,6 +254,59 @@ impl<'hir> Analyzer<'hir> {
             ExprKind::Assign(_, None, rhs) => self.current_value(rhs),
             _ => None,
         }
+    }
+
+    fn deferable_target(&self, expr: &'hir hir::Expr<'hir>) -> Option<hir::VariableId> {
+        underlying_var(expr).filter(|var| self.hir.variable(*var).is_local_variable())
+    }
+
+    fn ecrecover_call_id(&self, expr: &'hir hir::Expr<'hir>) -> Option<hir::ExprId> {
+        let expr = expr.peel_parens();
+        let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
+        (is_ecrecover_builtin(self.gcx, callee) && args.len() == 4).then_some(expr.id)
+    }
+
+    fn visit_stored_expr(&mut self, expr: &'hir hir::Expr<'hir>, store_locally: bool) {
+        let ignored_reads = self.ignored_reads.clone();
+        let deferred_calls = self.deferred_calls.clone();
+        let stored_results = self.stored_results.clone();
+        if store_locally {
+            // Local copies are not observable, and `ecrecover` itself is pure. Keep the
+            // recovered value pending until it is validated or actually read.
+            if let Some(value) = self.current_value(expr) {
+                self.ignored_reads.insert(value);
+            }
+            if let Some(call) = self.ecrecover_call_id(expr) {
+                self.deferred_calls.insert(call);
+            }
+            if matches!(expr.peel_parens().kind, ExprKind::Assign(..)) {
+                self.stored_results.insert(expr.peel_parens().id);
+            }
+        }
+        let _ = self.visit_expr(expr);
+        self.ignored_reads = ignored_reads;
+        self.deferred_calls = deferred_calls;
+        self.stored_results = stored_results;
+    }
+
+    fn visit_discarded_expr(&mut self, expr: &'hir hir::Expr<'hir>) {
+        let stored_results = self.stored_results.clone();
+        if matches!(expr.peel_parens().kind, ExprKind::Assign(..)) {
+            self.stored_results.insert(expr.peel_parens().id);
+        }
+        let _ = self.visit_expr(expr);
+        self.stored_results = stored_results;
+    }
+
+    fn visit_assignment_lhs(&mut self, lhs: &'hir hir::Expr<'hir>) {
+        let ignored_reads = self.ignored_reads.clone();
+        let mut vars = HashSet::new();
+        collect_lhs_vars(lhs, &mut vars);
+        for var in vars {
+            self.ignored_reads.insert(self.state.value(var));
+        }
+        let _ = self.visit_expr(lhs);
+        self.ignored_reads = ignored_reads;
     }
 
     fn const_value(&self, expr: &'hir hir::Expr<'hir>) -> Option<U256> {
@@ -583,6 +725,11 @@ impl<'hir> Analyzer<'hir> {
         }
     }
 
+    fn assume(&mut self, predicate: &'hir hir::Expr<'hir>, negate: bool) {
+        self.add_facts(predicate, negate);
+        self.validate_pending();
+    }
+
     fn add_disjunctive_facts(
         &mut self,
         lhs: &'hir hir::Expr<'hir>,
@@ -622,12 +769,15 @@ impl<'hir> Analyzer<'hir> {
         }
     }
 
-    fn is_unsafe_ecrecover(&self, expr: &'hir hir::Expr<'hir>) -> bool {
-        let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
+    fn pending_recovery(&self, expr: &'hir hir::Expr<'hir>) -> Option<PendingRecovery> {
+        let expr = expr.peel_parens();
+        let ExprKind::Call(callee, args, _) = &expr.kind else { return None };
         if !is_ecrecover_builtin(self.gcx, callee) || args.len() != 4 {
-            return false;
+            return None;
         }
-        args.exprs().nth(3).is_some_and(|s| !self.is_proven_low_s(s))
+        let signature = args.exprs().nth(3)?;
+        (!self.is_proven_low_s(signature))
+            .then(|| PendingRecovery { signature: self.current_value(signature), span: expr.span })
     }
 
     fn join_all(&mut self, states: Vec<FlowState>) -> Option<FlowState> {
@@ -662,11 +812,11 @@ impl<'hir> Analyzer<'hir> {
                 let _ = self.visit_expr(condition);
                 let baseline = self.snapshot();
 
-                self.add_facts(condition, false);
+                self.assume(condition, false);
                 let after_then = self.visit_loop_stmt(then_stmt, exits);
 
                 self.restore(baseline);
-                self.add_facts(condition, true);
+                self.assume(condition, true);
                 let after_else = if let Some(else_stmt) = else_stmt {
                     self.visit_loop_stmt(else_stmt, exits)
                 } else {
@@ -728,13 +878,13 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
                 let _ = self.visit_expr(condition);
                 let baseline = self.snapshot();
 
-                self.add_facts(condition, false);
+                self.assume(condition, false);
                 let _ = self.visit_stmt(then_stmt);
                 let then_exits = branch_always_exits(then_stmt);
                 let after_then = self.snapshot();
 
                 self.restore(baseline);
-                self.add_facts(condition, true);
+                self.assume(condition, true);
                 let else_exits = if let Some(else_stmt) = else_stmt {
                     let _ = self.visit_stmt(else_stmt);
                     branch_always_exits(else_stmt)
@@ -788,9 +938,12 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
             StmtKind::DeclSingle(var) => {
                 let init = self.hir.variable(*var).initializer;
                 if let Some(init) = init {
-                    let _ = self.visit_expr(init);
+                    self.visit_stored_expr(init, true);
                 }
                 self.assign_var(*var, init);
+                if let Some(recovery) = init.and_then(|init| self.pending_recovery(init)) {
+                    self.record_pending(*var, recovery);
+                }
                 return ControlFlow::Continue(());
             }
             StmtKind::DeclMulti(vars, init) => {
@@ -808,8 +961,15 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
                 }
                 return ControlFlow::Continue(());
             }
+            StmtKind::Expr(expr) => {
+                self.visit_discarded_expr(expr);
+                return ControlFlow::Continue(());
+            }
             StmtKind::Err(_) | StmtKind::AssemblyBlock(_) => {
                 self.state = FlowState::default();
+            }
+            StmtKind::Return(None) => {
+                self.use_return_values();
             }
             _ => {}
         }
@@ -817,12 +977,17 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
     }
 
     fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        if matches!(expr.kind, ExprKind::Ident(_))
+            && let Some(value) = self.current_value(expr)
+        {
+            self.use_value(value);
+        }
         if let ExprKind::Binary(lhs, op, rhs) = &expr.kind
             && matches!(op.kind, BinOpKind::And | BinOpKind::Or)
         {
             let _ = self.visit_expr(lhs);
             let skipped_rhs = self.snapshot();
-            self.add_facts(lhs, op.kind == BinOpKind::Or);
+            self.assume(lhs, op.kind == BinOpKind::Or);
             let _ = self.visit_expr(rhs);
             let ran_rhs = self.snapshot();
             let joined = self.join(skipped_rhs, ran_rhs);
@@ -832,11 +997,11 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
         if let ExprKind::Ternary(condition, then_expr, else_expr) = &expr.kind {
             let _ = self.visit_expr(condition);
             let baseline = self.snapshot();
-            self.add_facts(condition, false);
+            self.assume(condition, false);
             let _ = self.visit_expr(then_expr);
             let after_then = self.snapshot();
             self.restore(baseline);
-            self.add_facts(condition, true);
+            self.assume(condition, true);
             let _ = self.visit_expr(else_expr);
             let after_else = self.snapshot();
             let joined = self.join(after_then, after_else);
@@ -848,19 +1013,36 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
             ExprKind::Call(callee, args, _) if is_require_or_assert(callee) => {
                 let result = self.walk_expr(expr);
                 if let Some(condition) = args.exprs().next() {
-                    self.add_facts(condition, false);
+                    self.assume(condition, false);
                 }
                 return result;
             }
             ExprKind::Assign(lhs, op, rhs) => {
+                if op.is_none() {
+                    let target = self.deferable_target(lhs);
+                    let result_is_stored = self.stored_results.contains(&expr.peel_parens().id);
+                    self.visit_assignment_lhs(lhs);
+                    self.visit_stored_expr(rhs, target.is_some());
+                    let recovery = target.and_then(|_| self.pending_recovery(rhs));
+                    self.assign_lhs(lhs, Some(rhs));
+                    if let Some((target, recovery)) = target.zip(recovery) {
+                        self.record_pending(target, recovery);
+                    }
+                    if let Some(target) = target
+                        && !result_is_stored
+                    {
+                        self.use_value(self.state.value(target));
+                    }
+                    return ControlFlow::Continue(());
+                }
                 let result = self.walk_expr(expr);
-                self.assign_lhs(lhs, op.is_none().then_some(*rhs));
+                self.assign_lhs(lhs, None);
                 return result;
             }
             ExprKind::Delete(target) => {
-                let result = self.walk_expr(expr);
+                self.visit_assignment_lhs(target);
                 self.mark_deleted(target);
-                return result;
+                return ControlFlow::Continue(());
             }
             ExprKind::Unary(op, target)
                 if matches!(
@@ -881,8 +1063,10 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
         {
             self.invalidate_mutable_state();
         }
-        if self.is_unsafe_ecrecover(expr) {
-            self.hits.push(expr.span);
+        if let Some(recovery) = self.pending_recovery(expr)
+            && !self.deferred_calls.contains(&expr.peel_parens().id)
+        {
+            self.emit_hit(recovery.span);
         }
         result
     }

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -13,8 +13,11 @@ use solar::{
     sema::{
         Gcx,
         builtins::Builtin,
-        eval::ConstantEvaluator,
-        hir::{self, ExprKind, ItemId, LoopSource, Res, StmtKind, TypeKind, Visit},
+        eval::{ConstValue, ConstantEvaluator},
+        hir::{
+            self, ExprKind, ItemId, LoopSource, Res, StateMutability, StmtKind, TypeKind, Visit,
+        },
+        ty::TyKind,
     },
 };
 use std::{
@@ -61,10 +64,31 @@ enum ValueId {
     Assigned(u32),
 }
 
+#[derive(Clone, Copy, Default)]
+struct AssignedValue {
+    value: Option<ValueId>,
+    low_s: bool,
+}
+
 #[derive(Clone, Default)]
 struct FlowState {
     values: HashMap<hir::VariableId, ValueId>,
     low_s: HashSet<ValueId>,
+}
+
+#[derive(Clone, Default)]
+struct LoopEffects {
+    values: HashSet<hir::VariableId>,
+    mutable_state: bool,
+    all_values: bool,
+}
+
+impl LoopEffects {
+    fn merge(&mut self, other: Self) {
+        self.values.extend(other.values);
+        self.mutable_state |= other.mutable_state;
+        self.all_values |= other.all_values;
+    }
 }
 
 impl FlowState {
@@ -86,7 +110,7 @@ impl<'hir> Analyzer<'hir> {
         Self { gcx, hir, state: FlowState::default(), next_value: 0, hits: Vec::new() }
     }
 
-    fn fresh_value(&mut self) -> ValueId {
+    const fn fresh_value(&mut self) -> ValueId {
         let value = ValueId::Assigned(self.next_value);
         self.next_value += 1;
         value
@@ -144,24 +168,88 @@ impl<'hir> Analyzer<'hir> {
     }
 
     fn const_value(&self, expr: &'hir hir::Expr<'hir>) -> Option<U256> {
-        ConstantEvaluator::new(self.gcx).try_eval(expr).ok()?.as_u256()
+        if let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind
+            && is_transparent_signature_cast(callee)
+            && args.len() == 1
+        {
+            return args.exprs().next().and_then(|arg| self.const_value(arg));
+        }
+        if self.gcx.builtin_member(expr.peel_parens().id) == Some(Builtin::TypeMax)
+            && let Some(ty) = self.gcx.type_of_expr(expr.peel_parens().id)
+            && let TyKind::Elementary(ElementaryType::UInt(size)) = ty.kind
+        {
+            return Some(U256::MAX >> (256 - size.bits()));
+        }
+        if let ExprKind::Binary(lhs, op, rhs) = &expr.peel_parens().kind
+            && matches!(op.kind, BinOpKind::Add | BinOpKind::Sub | BinOpKind::Mul)
+        {
+            let lhs = self.const_value(lhs)?;
+            let rhs = self.const_value(rhs)?;
+            return match op.kind {
+                BinOpKind::Add => Some(lhs.wrapping_add(rhs)),
+                BinOpKind::Sub => Some(lhs.wrapping_sub(rhs)),
+                BinOpKind::Mul => Some(lhs.wrapping_mul(rhs)),
+                _ => unreachable!(),
+            };
+        }
+        if let Some(value) =
+            ConstantEvaluator::new(self.gcx).try_eval(expr).ok().and_then(|value| value.as_u256())
+        {
+            return Some(value);
+        }
+        None
+    }
+
+    fn const_bool(&self, expr: &'hir hir::Expr<'hir>) -> Option<bool> {
+        match ConstantEvaluator::new(self.gcx).try_eval_value(expr).ok()? {
+            ConstValue::Bool(value) => Some(value),
+            _ => None,
+        }
     }
 
     fn is_proven_low_s(&self, expr: &'hir hir::Expr<'hir>) -> bool {
         self.const_value(expr).is_some_and(|value| value <= SECP256K1_HALF_ORDER)
             || self.current_value(expr).is_some_and(|value| self.state.low_s.contains(&value))
+            || matches!(
+                &expr.peel_parens().kind,
+                ExprKind::Ternary(_, then_expr, else_expr)
+                    if self.is_proven_low_s(then_expr) && self.is_proven_low_s(else_expr)
+            )
     }
 
-    fn assign_var(&mut self, var: hir::VariableId, rhs: Option<&'hir hir::Expr<'hir>>) {
-        let value =
-            rhs.and_then(|rhs| self.current_value(rhs)).unwrap_or_else(|| self.fresh_value());
-        if rhs.is_some_and(|rhs| self.is_proven_low_s(rhs)) {
+    fn assigned_value(&self, rhs: Option<&'hir hir::Expr<'hir>>) -> AssignedValue {
+        AssignedValue {
+            value: rhs.and_then(|rhs| self.current_value(rhs)),
+            low_s: rhs.is_some_and(|rhs| self.is_proven_low_s(rhs)),
+        }
+    }
+
+    fn assign_var_value(&mut self, var: hir::VariableId, assigned: AssignedValue) {
+        let value = assigned.value.unwrap_or_else(|| self.fresh_value());
+        if assigned.low_s {
             self.state.low_s.insert(value);
         }
         self.state.values.insert(var, value);
     }
 
+    fn assign_var(&mut self, var: hir::VariableId, rhs: Option<&'hir hir::Expr<'hir>>) {
+        self.assign_var_value(var, self.assigned_value(rhs));
+    }
+
     fn assign_lhs(&mut self, lhs: &'hir hir::Expr<'hir>, rhs: Option<&'hir hir::Expr<'hir>>) {
+        let mut assignments = Vec::new();
+        self.collect_assignments(lhs, rhs, &mut assignments);
+        for (var, assigned) in assignments {
+            self.assign_var_value(var, assigned);
+        }
+    }
+
+    fn collect_assignments(
+        &self,
+        lhs: &'hir hir::Expr<'hir>,
+        rhs: Option<&'hir hir::Expr<'hir>>,
+        assignments: &mut Vec<(hir::VariableId, AssignedValue)>,
+    ) {
         if let ExprKind::Tuple(lhs_elems) = &lhs.peel_parens().kind {
             let rhs_elems = match rhs.map(|rhs| &rhs.peel_parens().kind) {
                 Some(ExprKind::Tuple(elems)) => Some(*elems),
@@ -170,10 +258,10 @@ impl<'hir> Analyzer<'hir> {
             for (index, lhs) in lhs_elems.iter().enumerate() {
                 let Some(lhs) = lhs else { continue };
                 let rhs = rhs_elems.and_then(|elems| elems.get(index)).copied().flatten();
-                self.assign_lhs(lhs, rhs);
+                self.collect_assignments(lhs, rhs, assignments);
             }
         } else if let Some(var) = underlying_var(lhs) {
-            self.assign_var(var, rhs);
+            assignments.push((var, self.assigned_value(rhs)));
         }
     }
 
@@ -186,12 +274,291 @@ impl<'hir> Analyzer<'hir> {
 
     fn invalidate(&mut self, target: &'hir hir::Expr<'hir>) {
         let Some(var) = underlying_var(target) else { return };
+        self.invalidate_var(var);
+    }
+
+    fn invalidate_var(&mut self, var: hir::VariableId) {
         let value = self.fresh_value();
         self.state.values.insert(var, value);
     }
 
+    fn tracked_vars(&self) -> HashSet<hir::VariableId> {
+        self.state
+            .values
+            .keys()
+            .copied()
+            .chain(self.state.low_s.iter().filter_map(|value| match value {
+                ValueId::Initial(var) => Some(*var),
+                ValueId::Assigned(_) => None,
+            }))
+            .collect()
+    }
+
+    fn invalidate_mutable_state(&mut self) {
+        let vars: Vec<_> = self
+            .tracked_vars()
+            .into_iter()
+            .filter(|var| {
+                let var = self.hir.variable(*var);
+                var.kind.is_state() && !var.is_constant() && !var.is_immutable()
+            })
+            .collect();
+        for var in vars {
+            self.invalidate_var(var);
+        }
+    }
+
+    fn invalidate_loop_carried(&mut self, block: &'hir hir::Block<'hir>, source: LoopSource) {
+        if matches!(source, LoopSource::DoWhile)
+            && block.stmts.last().is_some_and(|stmt| {
+                matches!(
+                    &stmt.kind,
+                    StmtKind::If(condition, _, _) if self.const_bool(condition) == Some(false)
+                )
+            })
+        {
+            return;
+        }
+
+        let mut backedges = Vec::new();
+        if let Some(fallthrough) =
+            self.collect_loop_effects_stmts(block.stmts, LoopEffects::default(), &mut backedges)
+        {
+            backedges.push(fallthrough);
+        }
+        let Some(mut effects) = backedges.into_iter().reduce(|mut left, right| {
+            left.merge(right);
+            left
+        }) else {
+            return;
+        };
+        if matches!(source, LoopSource::For)
+            && let Some(next) = for_loop_next_expr(block)
+        {
+            self.add_expr_effects(next, &mut effects);
+        }
+
+        if effects.all_values {
+            effects.values.extend(self.tracked_vars());
+        }
+        if effects.mutable_state {
+            self.invalidate_mutable_state();
+        }
+        for var in effects.values {
+            self.invalidate_var(var);
+        }
+    }
+
+    fn collect_loop_effects_stmts(
+        &self,
+        stmts: &'hir [hir::Stmt<'hir>],
+        mut effects: LoopEffects,
+        backedges: &mut Vec<LoopEffects>,
+    ) -> Option<LoopEffects> {
+        for stmt in stmts {
+            effects = self.collect_loop_effects_stmt(stmt, effects, backedges)?;
+        }
+        Some(effects)
+    }
+
+    fn collect_loop_effects_stmt(
+        &self,
+        stmt: &'hir hir::Stmt<'hir>,
+        mut effects: LoopEffects,
+        backedges: &mut Vec<LoopEffects>,
+    ) -> Option<LoopEffects> {
+        match &stmt.kind {
+            StmtKind::Break => None,
+            StmtKind::Continue => {
+                backedges.push(effects);
+                None
+            }
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+                self.collect_loop_effects_stmts(block.stmts, effects, backedges)
+            }
+            StmtKind::If(condition, then_stmt, else_stmt) => {
+                self.add_expr_effects(condition, &mut effects);
+                match self.const_bool(condition) {
+                    Some(true) => self.collect_loop_effects_stmt(then_stmt, effects, backedges),
+                    Some(false) => {
+                        if let Some(else_stmt) = else_stmt {
+                            self.collect_loop_effects_stmt(else_stmt, effects, backedges)
+                        } else {
+                            Some(effects)
+                        }
+                    }
+                    None => {
+                        let after_then =
+                            self.collect_loop_effects_stmt(then_stmt, effects.clone(), backedges);
+                        let after_else = if let Some(else_stmt) = else_stmt {
+                            self.collect_loop_effects_stmt(else_stmt, effects, backedges)
+                        } else {
+                            Some(effects)
+                        };
+                        merge_loop_effect_paths(after_then, after_else)
+                    }
+                }
+            }
+            StmtKind::Try(stmt_try) => {
+                self.add_expr_effects(&stmt_try.expr, &mut effects);
+                let mut fallthrough = None;
+                for clause in stmt_try.clauses {
+                    let clause_effects = self.collect_loop_effects_stmts(
+                        clause.block.stmts,
+                        effects.clone(),
+                        backedges,
+                    );
+                    fallthrough = merge_loop_effect_paths(fallthrough, clause_effects);
+                }
+                fallthrough
+            }
+            StmtKind::Loop(..) => {
+                self.add_stmt_effects(stmt, &mut effects);
+                Some(effects)
+            }
+            StmtKind::Return(expr) => {
+                if let Some(expr) = expr {
+                    self.add_expr_effects(expr, &mut effects);
+                }
+                None
+            }
+            StmtKind::Revert(expr) => {
+                self.add_expr_effects(expr, &mut effects);
+                None
+            }
+            StmtKind::AssemblyBlock(_) | StmtKind::Err(_) => {
+                effects.all_values = true;
+                Some(effects)
+            }
+            _ => {
+                self.add_stmt_effects(stmt, &mut effects);
+                (!branch_always_exits(stmt)).then_some(effects)
+            }
+        }
+    }
+
+    fn add_stmt_effects(&self, stmt: &'hir hir::Stmt<'hir>, effects: &mut LoopEffects) {
+        match &stmt.kind {
+            StmtKind::DeclSingle(var) => {
+                if let Some(initializer) = self.hir.variable(*var).initializer {
+                    self.add_expr_effects(initializer, effects);
+                }
+            }
+            StmtKind::DeclMulti(_, initializer)
+            | StmtKind::Emit(initializer)
+            | StmtKind::Revert(initializer)
+            | StmtKind::Expr(initializer) => self.add_expr_effects(initializer, effects),
+            StmtKind::Return(Some(expr)) => self.add_expr_effects(expr, effects),
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) | StmtKind::Loop(block, _) => {
+                for stmt in block.stmts {
+                    self.add_stmt_effects(stmt, effects);
+                }
+            }
+            StmtKind::AssemblyBlock(_) | StmtKind::Switch(_) | StmtKind::Err(_) => {
+                effects.all_values = true;
+            }
+            StmtKind::If(condition, then_stmt, else_stmt) => {
+                self.add_expr_effects(condition, effects);
+                self.add_stmt_effects(then_stmt, effects);
+                if let Some(else_stmt) = else_stmt {
+                    self.add_stmt_effects(else_stmt, effects);
+                }
+            }
+            StmtKind::Try(stmt_try) => {
+                self.add_expr_effects(&stmt_try.expr, effects);
+                for clause in stmt_try.clauses {
+                    for stmt in clause.block.stmts {
+                        self.add_stmt_effects(stmt, effects);
+                    }
+                }
+            }
+            StmtKind::Return(None)
+            | StmtKind::Break
+            | StmtKind::Continue
+            | StmtKind::Placeholder => {}
+        }
+    }
+
+    fn add_expr_effects(&self, expr: &'hir hir::Expr<'hir>, effects: &mut LoopEffects) {
+        match &expr.peel_parens().kind {
+            ExprKind::Assign(lhs, _, rhs) => {
+                self.add_expr_effects(lhs, effects);
+                self.add_expr_effects(rhs, effects);
+                collect_lhs_vars(lhs, &mut effects.values);
+            }
+            ExprKind::Delete(target) => {
+                self.add_expr_effects(target, effects);
+                collect_lhs_vars(target, &mut effects.values);
+            }
+            ExprKind::Unary(op, target) => {
+                self.add_expr_effects(target, effects);
+                if matches!(
+                    op.kind,
+                    UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec
+                ) {
+                    collect_lhs_vars(target, &mut effects.values);
+                }
+            }
+            ExprKind::Array(exprs) => {
+                for expr in *exprs {
+                    self.add_expr_effects(expr, effects);
+                }
+            }
+            ExprKind::Binary(lhs, _, rhs) => {
+                self.add_expr_effects(lhs, effects);
+                self.add_expr_effects(rhs, effects);
+            }
+            ExprKind::Call(callee, args, options) => {
+                self.add_expr_effects(callee, effects);
+                for arg in args.exprs() {
+                    self.add_expr_effects(arg, effects);
+                }
+                if let Some(options) = options {
+                    for arg in options.args {
+                        self.add_expr_effects(&arg.value, effects);
+                    }
+                }
+                effects.mutable_state |= call_may_mutate_state(self.gcx, self.hir, callee);
+            }
+            ExprKind::Index(base, index) => {
+                self.add_expr_effects(base, effects);
+                if let Some(index) = index {
+                    self.add_expr_effects(index, effects);
+                }
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.add_expr_effects(base, effects);
+                if let Some(start) = start {
+                    self.add_expr_effects(start, effects);
+                }
+                if let Some(end) = end {
+                    self.add_expr_effects(end, effects);
+                }
+            }
+            ExprKind::Member(base, _) | ExprKind::Payable(base) | ExprKind::YulMember(base, _) => {
+                self.add_expr_effects(base, effects);
+            }
+            ExprKind::Ternary(condition, then_expr, else_expr) => {
+                self.add_expr_effects(condition, effects);
+                self.add_expr_effects(then_expr, effects);
+                self.add_expr_effects(else_expr, effects);
+            }
+            ExprKind::Tuple(exprs) => {
+                for expr in exprs.iter().flatten() {
+                    self.add_expr_effects(expr, effects);
+                }
+            }
+            ExprKind::Lit(_)
+            | ExprKind::Ident(_)
+            | ExprKind::New(_)
+            | ExprKind::TypeCall(_)
+            | ExprKind::Type(_)
+            | ExprKind::Err(_) => {}
+        }
+    }
+
     fn add_facts(&mut self, predicate: &'hir hir::Expr<'hir>, negate: bool) {
-        if expr_has_fact_side_effect(predicate) {
+        if expr_has_fact_side_effect(self.gcx, self.hir, predicate) {
             return;
         }
         match &predicate.peel_parens().kind {
@@ -257,10 +624,85 @@ impl<'hir> Analyzer<'hir> {
 
     fn is_unsafe_ecrecover(&self, expr: &'hir hir::Expr<'hir>) -> bool {
         let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
-        if !is_ecrecover_builtin(callee) || args.len() != 4 {
+        if !is_ecrecover_builtin(self.gcx, callee) || args.len() != 4 {
             return false;
         }
         args.exprs().nth(3).is_some_and(|s| !self.is_proven_low_s(s))
+    }
+
+    fn join_all(&mut self, states: Vec<FlowState>) -> Option<FlowState> {
+        states.into_iter().reduce(|left, right| self.join(left, right))
+    }
+
+    fn visit_loop_stmts(
+        &mut self,
+        stmts: &'hir [hir::Stmt<'hir>],
+        exits: &mut Vec<FlowState>,
+    ) -> Option<FlowState> {
+        for stmt in stmts {
+            self.visit_loop_stmt(stmt, exits)?;
+        }
+        Some(self.snapshot())
+    }
+
+    fn visit_loop_stmt(
+        &mut self,
+        stmt: &'hir hir::Stmt<'hir>,
+        exits: &mut Vec<FlowState>,
+    ) -> Option<FlowState> {
+        match &stmt.kind {
+            StmtKind::Break | StmtKind::Continue => {
+                exits.push(self.snapshot());
+                None
+            }
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+                self.visit_loop_stmts(block.stmts, exits)
+            }
+            StmtKind::If(condition, then_stmt, else_stmt) => {
+                let _ = self.visit_expr(condition);
+                let baseline = self.snapshot();
+
+                self.add_facts(condition, false);
+                let after_then = self.visit_loop_stmt(then_stmt, exits);
+
+                self.restore(baseline);
+                self.add_facts(condition, true);
+                let after_else = if let Some(else_stmt) = else_stmt {
+                    self.visit_loop_stmt(else_stmt, exits)
+                } else {
+                    Some(self.snapshot())
+                };
+
+                let joined = match (after_then, after_else) {
+                    (Some(then_state), Some(else_state)) => self.join(then_state, else_state),
+                    (Some(state), None) | (None, Some(state)) => state,
+                    (None, None) => return None,
+                };
+                self.restore(joined.clone());
+                Some(joined)
+            }
+            StmtKind::Try(stmt_try) => {
+                let _ = self.visit_expr(&stmt_try.expr);
+                let after_call = self.snapshot();
+                let mut fallthrough = Vec::new();
+                for clause in stmt_try.clauses {
+                    // Argument expressions execute in the caller even when the external call
+                    // reverts, so caught paths must retain their effects. Keeping the call's
+                    // effects too is conservative for mutable state.
+                    self.restore(after_call.clone());
+                    if let Some(state) = self.visit_loop_stmts(clause.block.stmts, exits) {
+                        fallthrough.push(state);
+                    }
+                }
+                let joined = self.join_all(fallthrough)?;
+                self.restore(joined.clone());
+                Some(joined)
+            }
+            _ => {
+                let _ = self.visit_stmt(stmt);
+                (!branch_always_exits(stmt)).then(|| self.snapshot())
+            }
+        }
     }
 }
 
@@ -311,25 +753,21 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
             }
             StmtKind::Loop(block, source) => {
                 let baseline = self.snapshot();
-                for stmt in block.stmts {
-                    let _ = self.visit_stmt(stmt);
-                    if branch_always_exits(stmt) {
-                        break;
-                    }
+                self.invalidate_loop_carried(block, *source);
+                let mut exits = Vec::new();
+                if let Some(fallthrough) = self.visit_loop_stmts(block.stmts, &mut exits) {
+                    exits.push(fallthrough);
                 }
-                if !matches!(source, LoopSource::DoWhile) {
-                    let after_loop = self.snapshot();
-                    let joined = self.join(baseline, after_loop);
-                    self.restore(joined);
-                }
+                let joined = self.join_all(exits).unwrap_or(baseline);
+                self.restore(joined);
                 return ControlFlow::Continue(());
             }
             StmtKind::Try(stmt_try) => {
                 let _ = self.visit_expr(&stmt_try.expr);
-                let baseline = self.snapshot();
+                let after_call = self.snapshot();
                 let mut fallthrough = Vec::new();
                 for clause in stmt_try.clauses {
-                    self.restore(baseline.clone());
+                    self.restore(after_call.clone());
                     for stmt in clause.block.stmts {
                         let _ = self.visit_stmt(stmt);
                         if branch_always_exits(stmt) {
@@ -343,7 +781,7 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
                 let joined = fallthrough
                     .into_iter()
                     .reduce(|left, right| self.join(left, right))
-                    .unwrap_or(baseline);
+                    .unwrap_or(after_call);
                 self.restore(joined);
                 return ControlFlow::Continue(());
             }
@@ -438,6 +876,11 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
         }
 
         let result = self.walk_expr(expr);
+        if let ExprKind::Call(callee, _, _) = &expr.kind
+            && call_may_mutate_state(self.gcx, self.hir, callee)
+        {
+            self.invalidate_mutable_state();
+        }
         if self.is_unsafe_ecrecover(expr) {
             self.hits.push(expr.span);
         }
@@ -460,6 +903,45 @@ fn underlying_var(expr: &hir::Expr<'_>) -> Option<hir::VariableId> {
     }
 }
 
+fn collect_lhs_vars(expr: &hir::Expr<'_>, vars: &mut HashSet<hir::VariableId>) {
+    if let ExprKind::Tuple(exprs) = &expr.peel_parens().kind {
+        for expr in exprs.iter().flatten() {
+            collect_lhs_vars(expr, vars);
+        }
+    } else if let Some(var) = underlying_var(expr) {
+        vars.insert(var);
+    }
+}
+
+fn for_loop_next_expr<'hir>(block: &'hir hir::Block<'hir>) -> Option<&'hir hir::Expr<'hir>> {
+    let [stmt] = block.stmts else { return None };
+    let stmt = match &stmt.kind {
+        StmtKind::If(_, then_stmt, _) => *then_stmt,
+        _ => stmt,
+    };
+    let StmtKind::Block(inner) = &stmt.kind else { return None };
+    if inner.span != block.span {
+        return None;
+    }
+    let [_, next] = inner.stmts else { return None };
+    let StmtKind::Expr(next) = &next.kind else { return None };
+    Some(*next)
+}
+
+fn merge_loop_effect_paths(
+    left: Option<LoopEffects>,
+    right: Option<LoopEffects>,
+) -> Option<LoopEffects> {
+    match (left, right) {
+        (Some(mut left), Some(right)) => {
+            left.merge(right);
+            Some(left)
+        }
+        (Some(effects), None) | (None, Some(effects)) => Some(effects),
+        (None, None) => None,
+    }
+}
+
 fn is_transparent_signature_cast(callee: &hir::Expr<'_>) -> bool {
     matches!(
         &callee.peel_parens().kind,
@@ -472,7 +954,10 @@ fn is_transparent_signature_cast(callee: &hir::Expr<'_>) -> bool {
     )
 }
 
-fn is_ecrecover_builtin(callee: &hir::Expr<'_>) -> bool {
+fn is_ecrecover_builtin(gcx: Gcx<'_>, callee: &hir::Expr<'_>) -> bool {
+    if let Some(resolved) = gcx.resolved_callee(callee.peel_parens().id) {
+        return matches!(resolved.res, Res::Builtin(Builtin::EcRecover));
+    }
     matches!(
         &callee.peel_parens().kind,
         ExprKind::Ident(reses)
@@ -480,7 +965,7 @@ fn is_ecrecover_builtin(callee: &hir::Expr<'_>) -> bool {
     )
 }
 
-fn negate_comparison(op: BinOpKind) -> BinOpKind {
+const fn negate_comparison(op: BinOpKind) -> BinOpKind {
     match op {
         BinOpKind::Lt => BinOpKind::Ge,
         BinOpKind::Le => BinOpKind::Gt,
@@ -492,7 +977,7 @@ fn negate_comparison(op: BinOpKind) -> BinOpKind {
     }
 }
 
-fn reverse_comparison(op: BinOpKind) -> BinOpKind {
+const fn reverse_comparison(op: BinOpKind) -> BinOpKind {
     match op {
         BinOpKind::Lt => BinOpKind::Gt,
         BinOpKind::Le => BinOpKind::Ge,
@@ -502,44 +987,70 @@ fn reverse_comparison(op: BinOpKind) -> BinOpKind {
     }
 }
 
-fn expr_has_fact_side_effect(expr: &hir::Expr<'_>) -> bool {
+fn call_may_mutate_state(gcx: Gcx<'_>, hir: &hir::Hir<'_>, callee: &hir::Expr<'_>) -> bool {
+    let callee = callee.peel_parens();
+    if matches!(callee.kind, ExprKind::Type(_)) {
+        return false;
+    }
+    if let Some(ty) = gcx.type_of_expr(callee.id)
+        && let TyKind::Fn(function) = ty.peel_refs().kind
+    {
+        return function.state_mutability > StateMutability::View;
+    }
+    match &callee.kind {
+        ExprKind::Ident(reses) => !reses.iter().all(|res| match res {
+            Res::Builtin(_) => true,
+            Res::Item(ItemId::Function(function)) => {
+                hir.function(*function).state_mutability <= StateMutability::View
+            }
+            _ => false,
+        }),
+        _ => true,
+    }
+}
+
+fn expr_has_fact_side_effect(gcx: Gcx<'_>, hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     match &expr.peel_parens().kind {
         ExprKind::Assign(..) | ExprKind::Delete(_) => true,
         ExprKind::Unary(op, inner) => {
             matches!(
                 op.kind,
                 UnOpKind::PreInc | UnOpKind::PreDec | UnOpKind::PostInc | UnOpKind::PostDec
-            ) || expr_has_fact_side_effect(inner)
+            ) || expr_has_fact_side_effect(gcx, hir, inner)
         }
-        ExprKind::Array(exprs) => exprs.iter().any(expr_has_fact_side_effect),
+        ExprKind::Array(exprs) => {
+            exprs.iter().any(|expr| expr_has_fact_side_effect(gcx, hir, expr))
+        }
         ExprKind::Binary(lhs, _, rhs) => {
-            expr_has_fact_side_effect(lhs) || expr_has_fact_side_effect(rhs)
+            expr_has_fact_side_effect(gcx, hir, lhs) || expr_has_fact_side_effect(gcx, hir, rhs)
         }
         ExprKind::Call(callee, args, options) => {
-            expr_has_fact_side_effect(callee)
-                || args.exprs().any(expr_has_fact_side_effect)
+            call_may_mutate_state(gcx, hir, callee)
+                || expr_has_fact_side_effect(gcx, hir, callee)
+                || args.exprs().any(|expr| expr_has_fact_side_effect(gcx, hir, expr))
                 || options.is_some_and(|options| {
-                    options.args.iter().any(|arg| expr_has_fact_side_effect(&arg.value))
+                    options.args.iter().any(|arg| expr_has_fact_side_effect(gcx, hir, &arg.value))
                 })
         }
         ExprKind::Index(base, index) => {
-            expr_has_fact_side_effect(base) || index.is_some_and(expr_has_fact_side_effect)
+            expr_has_fact_side_effect(gcx, hir, base)
+                || index.is_some_and(|expr| expr_has_fact_side_effect(gcx, hir, expr))
         }
         ExprKind::Slice(base, start, end) => {
-            expr_has_fact_side_effect(base)
-                || start.is_some_and(expr_has_fact_side_effect)
-                || end.is_some_and(expr_has_fact_side_effect)
+            expr_has_fact_side_effect(gcx, hir, base)
+                || start.is_some_and(|expr| expr_has_fact_side_effect(gcx, hir, expr))
+                || end.is_some_and(|expr| expr_has_fact_side_effect(gcx, hir, expr))
         }
         ExprKind::Member(base, _) | ExprKind::Payable(base) | ExprKind::YulMember(base, _) => {
-            expr_has_fact_side_effect(base)
+            expr_has_fact_side_effect(gcx, hir, base)
         }
         ExprKind::Ternary(condition, then_expr, else_expr) => {
-            expr_has_fact_side_effect(condition)
-                || expr_has_fact_side_effect(then_expr)
-                || expr_has_fact_side_effect(else_expr)
+            expr_has_fact_side_effect(gcx, hir, condition)
+                || expr_has_fact_side_effect(gcx, hir, then_expr)
+                || expr_has_fact_side_effect(gcx, hir, else_expr)
         }
         ExprKind::Tuple(exprs) => {
-            exprs.iter().flatten().any(|expr| expr_has_fact_side_effect(expr))
+            exprs.iter().flatten().any(|expr| expr_has_fact_side_effect(gcx, hir, expr))
         }
         ExprKind::Lit(_)
         | ExprKind::Ident(_)

--- a/crates/lint/src/sol/med/ecrecover.rs
+++ b/crates/lint/src/sol/med/ecrecover.rs
@@ -118,6 +118,7 @@ struct Analyzer<'hir> {
     hits: Vec<Span>,
     ignored_reads: HashSet<ValueId>,
     deferred_calls: HashSet<hir::ExprId>,
+    captured_recoveries: HashMap<hir::ExprId, PendingRecovery>,
     stored_results: HashSet<hir::ExprId>,
 }
 
@@ -132,6 +133,7 @@ impl<'hir> Analyzer<'hir> {
             hits: Vec::new(),
             ignored_reads: HashSet::new(),
             deferred_calls: HashSet::new(),
+            captured_recoveries: HashMap::new(),
             stored_results: HashSet::new(),
         }
     }
@@ -251,7 +253,7 @@ impl<'hir> Analyzer<'hir> {
             {
                 args.exprs().next().and_then(|arg| self.current_value(arg))
             }
-            ExprKind::Assign(_, None, rhs) => self.current_value(rhs),
+            ExprKind::Assign(lhs, None, _) => self.current_value(lhs),
             _ => None,
         }
     }
@@ -266,7 +268,60 @@ impl<'hir> Analyzer<'hir> {
         (is_ecrecover_builtin(self.gcx, callee) && args.len() == 4).then_some(expr.id)
     }
 
-    fn visit_stored_expr(&mut self, expr: &'hir hir::Expr<'hir>, store_locally: bool) {
+    fn collect_result_calls(&self, expr: &'hir hir::Expr<'hir>, calls: &mut HashSet<hir::ExprId>) {
+        let expr = expr.peel_parens();
+        if let Some(call) = self.ecrecover_call_id(expr) {
+            calls.insert(call);
+            return;
+        }
+        match &expr.kind {
+            ExprKind::Ternary(condition, then_expr, else_expr) => {
+                match self.const_bool(condition) {
+                    Some(true) => self.collect_result_calls(then_expr, calls),
+                    Some(false) => self.collect_result_calls(else_expr, calls),
+                    None => {
+                        self.collect_result_calls(then_expr, calls);
+                        self.collect_result_calls(else_expr, calls);
+                    }
+                }
+            }
+            ExprKind::Assign(_, None, rhs) => self.collect_result_calls(rhs, calls),
+            _ => {}
+        }
+    }
+
+    fn collect_recovery_targets(
+        &self,
+        lhs: &'hir hir::Expr<'hir>,
+        rhs: &'hir hir::Expr<'hir>,
+        targets: &mut HashMap<hir::ExprId, hir::VariableId>,
+        observable: &mut HashSet<hir::ExprId>,
+    ) {
+        if let ExprKind::Tuple(lhs_elems) = &lhs.peel_parens().kind
+            && let ExprKind::Tuple(rhs_elems) = &rhs.peel_parens().kind
+        {
+            for (lhs, rhs) in lhs_elems.iter().zip(rhs_elems.iter()) {
+                if let (Some(lhs), Some(rhs)) = (lhs, rhs) {
+                    self.collect_recovery_targets(lhs, rhs, targets, observable);
+                }
+            }
+        } else {
+            let mut calls = HashSet::new();
+            self.collect_result_calls(rhs, &mut calls);
+            if let Some(var) = self.deferable_target(lhs) {
+                targets.extend(calls.into_iter().map(|call| (call, var)));
+            } else {
+                observable.extend(calls);
+            }
+        }
+    }
+
+    fn visit_stored_expr(
+        &mut self,
+        expr: &'hir hir::Expr<'hir>,
+        store_locally: bool,
+        targets: &HashMap<hir::ExprId, hir::VariableId>,
+    ) -> Vec<(hir::VariableId, PendingRecovery)> {
         let ignored_reads = self.ignored_reads.clone();
         let deferred_calls = self.deferred_calls.clone();
         let stored_results = self.stored_results.clone();
@@ -276,17 +331,22 @@ impl<'hir> Analyzer<'hir> {
             if let Some(value) = self.current_value(expr) {
                 self.ignored_reads.insert(value);
             }
-            if let Some(call) = self.ecrecover_call_id(expr) {
-                self.deferred_calls.insert(call);
-            }
+            self.deferred_calls.extend(targets.keys().copied());
             if matches!(expr.peel_parens().kind, ExprKind::Assign(..)) {
                 self.stored_results.insert(expr.peel_parens().id);
             }
         }
         let _ = self.visit_expr(expr);
+        let recoveries = targets
+            .iter()
+            .filter_map(|(call, var)| {
+                self.captured_recoveries.remove(call).map(|recovery| (*var, recovery))
+            })
+            .collect();
         self.ignored_reads = ignored_reads;
         self.deferred_calls = deferred_calls;
         self.stored_results = stored_results;
+        recoveries
     }
 
     fn visit_discarded_expr(&mut self, expr: &'hir hir::Expr<'hir>) {
@@ -343,10 +403,7 @@ impl<'hir> Analyzer<'hir> {
     }
 
     fn const_bool(&self, expr: &'hir hir::Expr<'hir>) -> Option<bool> {
-        match ConstantEvaluator::new(self.gcx).try_eval_value(expr).ok()? {
-            ConstValue::Bool(value) => Some(value),
-            _ => None,
-        }
+        constant_bool(self.gcx, expr)
     }
 
     fn stmt_always_exits(&self, stmt: &'hir hir::Stmt<'hir>) -> bool {
@@ -369,11 +426,16 @@ impl<'hir> Analyzer<'hir> {
     fn is_proven_low_s(&self, expr: &'hir hir::Expr<'hir>) -> bool {
         self.const_value(expr).is_some_and(|value| value <= SECP256K1_HALF_ORDER)
             || self.current_value(expr).is_some_and(|value| self.state.low_s.contains(&value))
-            || matches!(
-                &expr.peel_parens().kind,
-                ExprKind::Ternary(_, then_expr, else_expr)
-                    if self.is_proven_low_s(then_expr) && self.is_proven_low_s(else_expr)
-            )
+            || match &expr.peel_parens().kind {
+                ExprKind::Ternary(condition, then_expr, else_expr) => {
+                    match self.const_bool(condition) {
+                        Some(true) => self.is_proven_low_s(then_expr),
+                        Some(false) => self.is_proven_low_s(else_expr),
+                        None => self.is_proven_low_s(then_expr) && self.is_proven_low_s(else_expr),
+                    }
+                }
+                _ => false,
+            }
     }
 
     fn assigned_value(&self, rhs: Option<&'hir hir::Expr<'hir>>) -> AssignedValue {
@@ -663,9 +725,15 @@ impl<'hir> Analyzer<'hir> {
                     self.add_expr_effects(expr, effects);
                 }
             }
-            ExprKind::Binary(lhs, _, rhs) => {
+            ExprKind::Binary(lhs, op, rhs) => {
                 self.add_expr_effects(lhs, effects);
-                self.add_expr_effects(rhs, effects);
+                let short_circuits = matches!(op.kind, BinOpKind::And | BinOpKind::Or)
+                    && self
+                        .const_bool(lhs)
+                        .is_some_and(|value| matches!(op.kind, BinOpKind::And) != value);
+                if !short_circuits {
+                    self.add_expr_effects(rhs, effects);
+                }
             }
             ExprKind::Call(callee, args, options) => {
                 self.add_expr_effects(callee, effects);
@@ -699,8 +767,14 @@ impl<'hir> Analyzer<'hir> {
             }
             ExprKind::Ternary(condition, then_expr, else_expr) => {
                 self.add_expr_effects(condition, effects);
-                self.add_expr_effects(then_expr, effects);
-                self.add_expr_effects(else_expr, effects);
+                match self.const_bool(condition) {
+                    Some(true) => self.add_expr_effects(then_expr, effects),
+                    Some(false) => self.add_expr_effects(else_expr, effects),
+                    None => {
+                        self.add_expr_effects(then_expr, effects);
+                        self.add_expr_effects(else_expr, effects);
+                    }
+                }
             }
             ExprKind::Tuple(exprs) => {
                 for expr in exprs.iter().flatten() {
@@ -721,7 +795,28 @@ impl<'hir> Analyzer<'hir> {
             return;
         }
         match &predicate.peel_parens().kind {
+            ExprKind::Ternary(condition, then_expr, else_expr) => {
+                if let Some(value) = self.const_bool(condition) {
+                    self.add_facts(if value { then_expr } else { else_expr }, negate);
+                }
+            }
             ExprKind::Binary(lhs, op, rhs) => {
+                if matches!(op.kind, BinOpKind::And | BinOpKind::Or) {
+                    if let Some(value) = self.const_bool(lhs) {
+                        let determines_result = matches!(op.kind, BinOpKind::And) != value;
+                        if !determines_result {
+                            self.add_facts(rhs, negate);
+                        }
+                        return;
+                    }
+                    if let Some(value) = self.const_bool(rhs) {
+                        let determines_result = matches!(op.kind, BinOpKind::And) != value;
+                        if !determines_result {
+                            self.add_facts(lhs, negate);
+                        }
+                        return;
+                    }
+                }
                 let conjunctive =
                     matches!((op.kind, negate), (BinOpKind::And, false) | (BinOpKind::Or, true));
                 let disjunctive =
@@ -976,16 +1071,32 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
             StmtKind::DeclSingle(var) => {
                 let init = self.hir.variable(*var).initializer;
                 if let Some(init) = init {
-                    self.visit_stored_expr(init, true);
-                }
-                self.assign_var(*var, init);
-                if let Some(recovery) = init.and_then(|init| self.pending_recovery(init)) {
-                    self.record_pending(*var, recovery);
+                    let mut calls = HashSet::new();
+                    self.collect_result_calls(init, &mut calls);
+                    let targets: HashMap<_, _> =
+                        calls.into_iter().map(|call| (call, *var)).collect();
+                    let recoveries = self.visit_stored_expr(init, true, &targets);
+                    self.assign_var(*var, Some(init));
+                    for (var, recovery) in recoveries {
+                        self.record_pending(var, recovery);
+                    }
+                } else {
+                    self.assign_var(*var, None);
                 }
                 return ControlFlow::Continue(());
             }
             StmtKind::DeclMulti(vars, init) => {
-                let _ = self.visit_expr(init);
+                let mut targets = HashMap::new();
+                if let ExprKind::Tuple(exprs) = &init.peel_parens().kind {
+                    for (var, expr) in vars.iter().zip(exprs.iter()) {
+                        if let (Some(var), Some(expr)) = (var, expr) {
+                            let mut calls = HashSet::new();
+                            self.collect_result_calls(expr, &mut calls);
+                            targets.extend(calls.into_iter().map(|call| (call, *var)));
+                        }
+                    }
+                }
+                let recoveries = self.visit_stored_expr(init, !targets.is_empty(), &targets);
                 if let ExprKind::Tuple(exprs) = &init.peel_parens().kind {
                     for (var, expr) in vars.iter().zip(exprs.iter()) {
                         if let Some(var) = var {
@@ -996,6 +1107,9 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
                     for var in vars.iter().flatten() {
                         self.assign_var(*var, None);
                     }
+                }
+                for (var, recovery) in recoveries {
+                    self.record_pending(var, recovery);
                 }
                 return ControlFlow::Continue(());
             }
@@ -1023,7 +1137,16 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
         if let ExprKind::Binary(lhs, op, rhs) = &expr.kind
             && matches!(op.kind, BinOpKind::And | BinOpKind::Or)
         {
+            let constant = self.const_bool(lhs);
             let _ = self.visit_expr(lhs);
+            if let Some(value) = constant {
+                let short_circuits = matches!(op.kind, BinOpKind::And) != value;
+                if !short_circuits {
+                    self.assume(lhs, !value);
+                    let _ = self.visit_expr(rhs);
+                }
+                return ControlFlow::Continue(());
+            }
             let skipped_rhs = self.snapshot();
             self.assume(lhs, op.kind == BinOpKind::Or);
             let _ = self.visit_expr(rhs);
@@ -1033,7 +1156,13 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
             return ControlFlow::Continue(());
         }
         if let ExprKind::Ternary(condition, then_expr, else_expr) = &expr.kind {
+            let constant = self.const_bool(condition);
             let _ = self.visit_expr(condition);
+            if let Some(value) = constant {
+                self.assume(condition, !value);
+                let _ = self.visit_expr(if value { then_expr } else { else_expr });
+                return ControlFlow::Continue(());
+            }
             let baseline = self.snapshot();
             self.assume(condition, false);
             let _ = self.visit_expr(then_expr);
@@ -1058,13 +1187,22 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
             ExprKind::Assign(lhs, op, rhs) => {
                 if op.is_none() {
                     let target = self.deferable_target(lhs);
+                    let mut targets = HashMap::new();
+                    let mut observable = HashSet::new();
+                    self.collect_recovery_targets(lhs, rhs, &mut targets, &mut observable);
                     let result_is_stored = self.stored_results.contains(&expr.peel_parens().id);
                     self.visit_assignment_lhs(lhs);
-                    self.visit_stored_expr(rhs, target.is_some());
-                    let recovery = target.and_then(|_| self.pending_recovery(rhs));
+                    let deferred_calls = self.deferred_calls.clone();
+                    self.deferred_calls.retain(|call| !observable.contains(call));
+                    let recoveries = self.visit_stored_expr(
+                        rhs,
+                        !targets.is_empty() || target.is_some(),
+                        &targets,
+                    );
+                    self.deferred_calls = deferred_calls;
                     self.assign_lhs(lhs, Some(rhs));
-                    if let Some((target, recovery)) = target.zip(recovery) {
-                        self.record_pending(target, recovery);
+                    for (var, recovery) in recoveries {
+                        self.record_pending(var, recovery);
                     }
                     if let Some(target) = target
                         && !result_is_stored
@@ -1101,10 +1239,12 @@ impl<'hir> Visit<'hir> for Analyzer<'hir> {
         {
             self.invalidate_mutable_state();
         }
-        if let Some(recovery) = self.pending_recovery(expr)
-            && !self.deferred_calls.contains(&expr.peel_parens().id)
-        {
-            self.emit_hit(recovery.span);
+        if let Some(recovery) = self.pending_recovery(expr) {
+            if self.deferred_calls.contains(&expr.peel_parens().id) {
+                self.captured_recoveries.insert(expr.peel_parens().id, recovery);
+            } else {
+                self.emit_hit(recovery.span);
+            }
         }
         result
     }
@@ -1231,6 +1371,13 @@ fn call_may_mutate_state(gcx: Gcx<'_>, hir: &hir::Hir<'_>, callee: &hir::Expr<'_
     }
 }
 
+fn constant_bool(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> Option<bool> {
+    match ConstantEvaluator::new(gcx).try_eval_value(expr).ok()? {
+        ConstValue::Bool(value) => Some(value),
+        _ => None,
+    }
+}
+
 fn expr_has_fact_side_effect(gcx: Gcx<'_>, hir: &hir::Hir<'_>, expr: &hir::Expr<'_>) -> bool {
     match &expr.peel_parens().kind {
         ExprKind::Assign(..) | ExprKind::Delete(_) => true,
@@ -1243,8 +1390,14 @@ fn expr_has_fact_side_effect(gcx: Gcx<'_>, hir: &hir::Hir<'_>, expr: &hir::Expr<
         ExprKind::Array(exprs) => {
             exprs.iter().any(|expr| expr_has_fact_side_effect(gcx, hir, expr))
         }
-        ExprKind::Binary(lhs, _, rhs) => {
-            expr_has_fact_side_effect(gcx, hir, lhs) || expr_has_fact_side_effect(gcx, hir, rhs)
+        ExprKind::Binary(lhs, op, rhs) => {
+            if expr_has_fact_side_effect(gcx, hir, lhs) {
+                return true;
+            }
+            let short_circuits = matches!(op.kind, BinOpKind::And | BinOpKind::Or)
+                && constant_bool(gcx, lhs)
+                    .is_some_and(|value| matches!(op.kind, BinOpKind::And) != value);
+            !short_circuits && expr_has_fact_side_effect(gcx, hir, rhs)
         }
         ExprKind::Call(callee, args, options) => {
             call_may_mutate_state(gcx, hir, callee)
@@ -1267,9 +1420,17 @@ fn expr_has_fact_side_effect(gcx: Gcx<'_>, hir: &hir::Hir<'_>, expr: &hir::Expr<
             expr_has_fact_side_effect(gcx, hir, base)
         }
         ExprKind::Ternary(condition, then_expr, else_expr) => {
-            expr_has_fact_side_effect(gcx, hir, condition)
-                || expr_has_fact_side_effect(gcx, hir, then_expr)
-                || expr_has_fact_side_effect(gcx, hir, else_expr)
+            if expr_has_fact_side_effect(gcx, hir, condition) {
+                return true;
+            }
+            match constant_bool(gcx, condition) {
+                Some(true) => expr_has_fact_side_effect(gcx, hir, then_expr),
+                Some(false) => expr_has_fact_side_effect(gcx, hir, else_expr),
+                None => {
+                    expr_has_fact_side_effect(gcx, hir, then_expr)
+                        || expr_has_fact_side_effect(gcx, hir, else_expr)
+                }
+            }
         }
         ExprKind::Tuple(exprs) => {
             exprs.iter().flatten().any(|expr| expr_has_fact_side_effect(gcx, hir, expr))

--- a/crates/lint/src/sol/med/mod.rs
+++ b/crates/lint/src/sol/med/mod.rs
@@ -9,6 +9,9 @@ use dangerous_unary_operator::DANGEROUS_UNARY_OPERATOR;
 mod div_mul;
 use div_mul::DIVIDE_BEFORE_MULTIPLY;
 
+mod ecrecover;
+use ecrecover::ECRECOVER;
+
 mod incorrect_erc20_interface;
 use incorrect_erc20_interface::INCORRECT_ERC20_INTERFACE;
 
@@ -55,6 +58,7 @@ register_lints!(
     (AssertStateChange, late, (ASSERT_STATE_CHANGE)),
     (DangerousUnaryOperator, early, (DANGEROUS_UNARY_OPERATOR)),
     (DivideBeforeMultiply, late, (DIVIDE_BEFORE_MULTIPLY)),
+    (Ecrecover, late, (ECRECOVER)),
     (IncorrectERC20Interface, late, (INCORRECT_ERC20_INTERFACE)),
     (IncorrectERC721Interface, late, (INCORRECT_ERC721_INTERFACE)),
     (IncorrectStrictEquality, late, (INCORRECT_STRICT_EQUALITY)),

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -1,0 +1,153 @@
+//@compile-flags: --only-lint ecrecover
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+interface SameName {
+    function ecrecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address);
+}
+
+contract Ecrecover {
+    uint256 private constant HALF_ORDER =
+        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0;
+    uint256 private constant HALF_ORDER_PLUS_ONE = HALF_ORDER + 1;
+    uint256 private constant TOP_BIT_MASK =
+        0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+
+    function bare(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function vOnly(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(v == 27 || v == 28);
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function wrongValue(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 other
+    ) external pure returns (address) {
+        require(uint256(other) <= HALF_ORDER);
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function oneBranch(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool check
+    ) external pure returns (address) {
+        if (check) {
+            require(uint256(s) <= HALF_ORDER);
+        }
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function reassigned(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement
+    ) external pure returns (address) {
+        require(uint256(s) <= HALF_ORDER);
+        s = replacement;
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function topBitMask(bytes32 hash, uint8 v, bytes32 r, bytes32 vs) external pure returns (address) {
+        bytes32 s = bytes32(uint256(vs) & TOP_BIT_MASK);
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function guardAfterCall(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        address signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        require(uint256(s) <= HALF_ORDER);
+        return signer;
+    }
+
+    function mixedCalls(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address, address) {
+        require(uint256(s) <= HALF_ORDER);
+        address first = ecrecover(hash, v, r, s);
+        s = bytes32(uint256(s) + 1);
+        address second = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        return (first, second);
+    }
+
+    function requireGuard(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(uint256(s) <= HALF_ORDER);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function assertReversed(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        assert(HALF_ORDER >= uint256(s));
+        return ecrecover(hash, v, r, s);
+    }
+
+    function strictBound(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(uint256(s) < HALF_ORDER_PLUS_ONE);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function revertHighS(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        if (uint256(s) > HALF_ORDER) revert();
+        return ecrecover(hash, v, r, s);
+    }
+
+    function returnHighS(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        if (uint256(s) > HALF_ORDER) return address(0);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function lowBranch(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        if (uint256(s) <= HALF_ORDER) {
+            return ecrecover(hash, v, r, s);
+        }
+        return address(0);
+    }
+
+    function aliasGuard(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        bytes32 aliasS = s;
+        require(uint256(aliasS) <= HALF_ORDER);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function guardedAlias(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(uint256(s) <= HALF_ORDER);
+        bytes32 aliasS = s;
+        return ecrecover(hash, v, r, aliasS);
+    }
+
+    function bothBranches(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool flag
+    ) external pure returns (address) {
+        if (flag) {
+            require(uint256(s) <= HALF_ORDER);
+        } else {
+            require(uint256(s) < HALF_ORDER_PLUS_ONE);
+        }
+        return ecrecover(hash, v, r, s);
+    }
+
+    function ternary(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        return uint256(s) <= HALF_ORDER ? ecrecover(hash, v, r, s) : address(0);
+    }
+
+    function userDefined(
+        SameName helper,
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (address) {
+        return helper.ecrecover(hash, v, r, s);
+    }
+}

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -58,6 +58,83 @@ contract Ecrecover {
         return address(0);
     }
 
+    function unreachableShortCircuitLoopEffect(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement,
+        bool run
+    ) external pure returns (address) {
+        require(uint256(s) <= HALF_ORDER);
+        while (run) {
+            false && (s = replacement) == replacement;
+            return ecrecover(hash, v, r, s);
+        }
+        return address(0);
+    }
+
+    function unreachableTernaryLoopEffect(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement,
+        bool run
+    ) external pure returns (address) {
+        require(uint256(s) <= HALF_ORDER);
+        while (run) {
+            false ? (s = replacement) : s;
+            return ecrecover(hash, v, r, s);
+        }
+        return address(0);
+    }
+
+    function unreachableShortCircuitAnd(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (bool) {
+        return false && ecrecover(hash, v, r, s) != address(0);
+    }
+
+    function reachableShortCircuitAnd(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (bool) {
+        return true && ecrecover(hash, v, r, s) != address(0); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function unreachableShortCircuitOr(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (bool) {
+        return true || ecrecover(hash, v, r, s) != address(0);
+    }
+
+    function unreachableConstantTernary(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (address) {
+        return false ? ecrecover(hash, v, r, s) : address(0);
+    }
+
+    function reachableConstantTernary(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (address) {
+        return true ? ecrecover(hash, v, r, s) : address(0); //~WARN: ecrecover should reject malleable signatures
+    }
+
     function vOnly(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
         require(v == 27 || v == 28);
         return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
@@ -113,6 +190,81 @@ contract Ecrecover {
     function guardAfterAssignment(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
         address signer;
         signer = ecrecover(hash, v, r, s);
+        require(uint256(s) <= HALF_ORDER);
+        return signer;
+    }
+
+    function guardAfterTupleAssignment(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        address signer;
+        (signer,) = (ecrecover(hash, v, r, s), 0);
+        require(uint256(s) <= HALF_ORDER);
+        return signer;
+    }
+
+    function tupleAssignmentUsedBeforeGuard(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (address) {
+        address signer;
+        (signer,) = (ecrecover(hash, v, r, s), 0); //~WARN: ecrecover should reject malleable signatures
+        observeSigner(signer);
+        require(uint256(s) <= HALF_ORDER);
+        return signer;
+    }
+
+    function guardAfterTernaryStorage(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool useRecovery
+    ) external pure returns (address) {
+        address signer = useRecovery ? ecrecover(hash, v, r, s) : address(0);
+        require(uint256(s) <= HALF_ORDER);
+        return signer;
+    }
+
+    function unguardedTernaryStorage(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool useRecovery
+    ) external pure returns (address) {
+        address signer = useRecovery ? ecrecover(hash, v, r, s) : address(0); //~WARN: ecrecover should reject malleable signatures
+        return signer;
+    }
+
+    function guardAfterNestedAssignment(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        address first;
+        address second;
+        first = second = ecrecover(hash, v, r, s);
+        require(uint256(s) <= HALF_ORDER);
+        return first;
+    }
+
+    function nestedAssignmentUsed(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (address) {
+        address first;
+        address second;
+        first = second = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        return first;
+    }
+
+    function nestedStateAssignmentBeforeGuard(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (address) {
+        address signer;
+        signer = storedSigner = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
         require(uint256(s) <= HALF_ORDER);
         return signer;
     }
@@ -211,6 +363,64 @@ contract Ecrecover {
         return ecrecover(hash, v, r, s);
     }
 
+    function constantDisjunctionGuard(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(uint256(s) <= HALF_ORDER || false);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function constantConjunctionGuard(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(true && uint256(s) <= HALF_ORDER);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function constantThenTernaryGuard(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(true ? uint256(s) <= HALF_ORDER : false);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function constantElseTernaryGuard(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(false ? false : uint256(s) <= HALF_ORDER);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function constantTernaryGuardControl(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(false ? uint256(s) <= HALF_ORDER : true);
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function unreachableElseGuardEffect(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement
+    ) external pure returns (address) {
+        require(true ? uint256(s) <= HALF_ORDER : (s = replacement) == replacement);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function unreachableThenGuardEffect(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement
+    ) external pure returns (address) {
+        require(false ? (s = replacement) == replacement : uint256(s) <= HALF_ORDER);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function selectedGuardEffect(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement
+    ) external pure returns (address) {
+        require(true ? (s = replacement) == replacement : uint256(s) <= HALF_ORDER);
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
     function assertReversed(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
         assert(HALF_ORDER >= uint256(s));
         return ecrecover(hash, v, r, s);
@@ -271,6 +481,14 @@ contract Ecrecover {
 
     function constantS(bytes32 hash, uint8 v, bytes32 r) external pure returns (address) {
         return ecrecover(hash, v, r, bytes32(0));
+    }
+
+    function constantTernaryS(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        return ecrecover(hash, v, r, true ? bytes32(0) : s);
+    }
+
+    function constantTernaryUnsafeS(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        return ecrecover(hash, v, r, false ? bytes32(0) : s); //~WARN: ecrecover should reject malleable signatures
     }
 
     function tupleSwapSafe(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -34,6 +34,30 @@ contract Ecrecover {
         return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
     }
 
+    function unreachableConstantBranch(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        if (false) return ecrecover(hash, v, r, s);
+        return address(0);
+    }
+
+    function unreachableAfterConstantExit(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        if (true) return address(0);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function unreachableConstantLoopBranch(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool run
+    ) external pure returns (address) {
+        while (run) {
+            if (false) return ecrecover(hash, v, r, s);
+            break;
+        }
+        return address(0);
+    }
+
     function vOnly(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
         require(v == 27 || v == 28);
         return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -314,6 +314,41 @@ contract Ecrecover {
         require(uint256(s) <= HALF_ORDER);
     }
 
+    function assemblyAfterRecovery(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        address signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        assembly {
+            pop(0)
+        }
+        return signer;
+    }
+
+    function emptyAssemblyAfterRecovery(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        address signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        assembly {}
+        return signer;
+    }
+
+    function memorySafeAssemblyAfterRecovery(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (address) {
+        address signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        assembly ("memory-safe") {
+            pop(0)
+        }
+        return signer;
+    }
+
+    function assemblyBeforeRecovery(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        assembly {
+            pop(0)
+        }
+        require(uint256(s) <= HALF_ORDER);
+        return ecrecover(hash, v, r, s);
+    }
+
     function nonDominatingGuard(
         bytes32 hash,
         uint8 v,

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.18;
 
 interface SameName {
     function ecrecover(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address);
+    function observe(bytes32 value) external pure;
 }
 
 contract Ecrecover {
@@ -13,6 +14,18 @@ contract Ecrecover {
     uint256 private constant HALF_ORDER_PLUS_ONE = HALF_ORDER + 1;
     uint256 private constant TOP_BIT_MASK =
         0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
+    bytes32 private storedS;
+
+    function mutateStoredS(bytes32 replacement) internal {
+        storedS = replacement;
+    }
+
+    function mutateAndReturn(bytes32 replacement) internal returns (bytes32) {
+        storedS = replacement;
+        return replacement;
+    }
+
+    function observe(bytes32) internal pure {}
 
     function bare(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
         return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
@@ -141,6 +154,182 @@ contract Ecrecover {
         return uint256(s) <= HALF_ORDER ? ecrecover(hash, v, r, s) : address(0);
     }
 
+    function constantS(bytes32 hash, uint8 v, bytes32 r) external pure returns (address) {
+        return ecrecover(hash, v, r, bytes32(0));
+    }
+
+    function tupleSwapSafe(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        bytes32 unsafeS = s;
+        bytes32 safeS = bytes32(0);
+        (unsafeS, safeS) = (safeS, unsafeS);
+        return ecrecover(hash, v, r, unsafeS);
+    }
+
+    function tupleSwapUnsafe(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        bytes32 unsafeS = s;
+        bytes32 safeS = bytes32(0);
+        (unsafeS, safeS) = (safeS, unsafeS);
+        return ecrecover(hash, v, r, safeS); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function ternarySafe(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bool flag
+    ) external pure returns (address) {
+        bytes32 s = flag ? bytes32(0) : bytes32(1);
+        return ecrecover(hash, v, r, s);
+    }
+
+    function branchSafe(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool flag
+    ) external pure returns (address) {
+        if (flag) {
+            s = bytes32(0);
+        } else {
+            s = bytes32(1);
+        }
+        return ecrecover(hash, v, r, s);
+    }
+
+    function loopCarried(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement,
+        bool repeat
+    ) external pure returns (address signer) {
+        require(uint256(s) <= HALF_ORDER);
+        while (repeat) {
+            signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+            s = replacement;
+        }
+    }
+
+    function forContinue(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement
+    ) external pure returns (address signer) {
+        require(uint256(s) <= HALF_ORDER);
+        for (uint256 i; i < 2; s = replacement) {
+            signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+            ++i;
+            continue;
+        }
+    }
+
+    function guardedLoop(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement
+    ) external pure returns (address signer) {
+        while (uint256(s) <= HALF_ORDER) {
+            signer = ecrecover(hash, v, r, s);
+            s = replacement;
+        }
+    }
+
+    function singleIteration(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement
+    ) external pure returns (address signer) {
+        require(uint256(s) <= HALF_ORDER);
+        do {
+            signer = ecrecover(hash, v, r, s);
+            s = replacement;
+        } while (false);
+    }
+
+    function doWhileBreak(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool skipGuard
+    ) external pure returns (address) {
+        do {
+            if (skipGuard) break;
+            require(uint256(s) <= HALF_ORDER);
+        } while (false);
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function stateChangedByCall(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 replacement
+    ) external returns (address) {
+        require(uint256(storedS) <= HALF_ORDER);
+        mutateStoredS(replacement);
+        return ecrecover(hash, v, r, storedS); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function statePreservedByPureCall(bytes32 hash, uint8 v, bytes32 r) external view returns (address) {
+        require(uint256(storedS) <= HALF_ORDER);
+        observe(storedS);
+        return ecrecover(hash, v, r, storedS);
+    }
+
+    function stateChangedInTryArgument(
+        SameName helper,
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 replacement
+    ) external returns (address) {
+        require(uint256(storedS) <= HALF_ORDER);
+        try helper.observe(mutateAndReturn(replacement)) {
+            return address(0);
+        } catch {}
+        return ecrecover(hash, v, r, storedS); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function looseInclusive(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(uint256(s) <= HALF_ORDER_PLUS_ONE);
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function looseStrict(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        unchecked {
+            require(uint256(s) < HALF_ORDER_PLUS_ONE + 1);
+        }
+        return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+    }
+
+    function uncheckedWrap(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        unchecked {
+            require(uint256(s) <= type(uint256).max + 1);
+        }
+        return ecrecover(hash, v, r, s);
+    }
+
+    function safeAfterLoop(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        while (uint256(s) > HALF_ORDER) {
+            return address(0);
+        }
+        return ecrecover(hash, v, r, s);
+    }
+
+    function strictReversed(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        require(HALF_ORDER_PLUS_ONE > uint256(s));
+        return ecrecover(hash, v, r, s);
+    }
+
     function userDefined(
         SameName helper,
         bytes32 hash,
@@ -149,5 +338,20 @@ contract Ecrecover {
         bytes32 s
     ) external pure returns (address) {
         return helper.ecrecover(hash, v, r, s);
+    }
+}
+
+contract SameNameEcrecover {
+    function ecrecover(bytes32, uint8, bytes32, bytes32) internal pure returns (address) {
+        return address(1);
+    }
+
+    function userDefinedBare(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (address) {
+        return ecrecover(hash, v, r, s);
     }
 }

--- a/crates/lint/testdata/Ecrecover.sol
+++ b/crates/lint/testdata/Ecrecover.sol
@@ -15,6 +15,7 @@ contract Ecrecover {
     uint256 private constant TOP_BIT_MASK =
         0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF;
     bytes32 private storedS;
+    address private storedSigner;
 
     function mutateStoredS(bytes32 replacement) internal {
         storedS = replacement;
@@ -26,6 +27,8 @@ contract Ecrecover {
     }
 
     function observe(bytes32) internal pure {}
+
+    function observeSigner(address) internal pure {}
 
     function bare(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
         return ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
@@ -78,7 +81,95 @@ contract Ecrecover {
     }
 
     function guardAfterCall(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        address signer = ecrecover(hash, v, r, s);
+        require(uint256(s) <= HALF_ORDER);
+        return signer;
+    }
+
+    function guardAfterAssignment(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        address signer;
+        signer = ecrecover(hash, v, r, s);
+        require(uint256(s) <= HALF_ORDER);
+        return signer;
+    }
+
+    function guardAfterAlias(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
+        address signer = ecrecover(hash, v, r, s);
+        address aliasSigner = signer;
+        require(uint256(s) <= HALF_ORDER);
+        return aliasSigner;
+    }
+
+    function guardedBranchUse(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool useSigner
+    ) external pure returns (address) {
+        address signer = ecrecover(hash, v, r, s);
+        if (useSigner) {
+            require(uint256(s) <= HALF_ORDER);
+            return signer;
+        }
+        return address(0);
+    }
+
+    function guardAfterNamedReturn(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external pure returns (address signer) {
+        signer = ecrecover(hash, v, r, s);
+        require(uint256(s) <= HALF_ORDER);
+    }
+
+    function usedBeforeGuard(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external pure returns (address) {
         address signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        observeSigner(signer);
+        require(uint256(s) <= HALF_ORDER);
+        return signer;
+    }
+
+    function storedBeforeGuard(bytes32 hash, uint8 v, bytes32 r, bytes32 s) external {
+        address signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        storedSigner = signer;
+        require(uint256(s) <= HALF_ORDER);
+    }
+
+    function nonDominatingGuard(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool check
+    ) external pure returns (address) {
+        address signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        if (check) require(uint256(s) <= HALF_ORDER);
+        return signer;
+    }
+
+    function nonDominatingNamedReturn(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bool check
+    ) external pure returns (address signer) {
+        signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        if (check) require(uint256(s) <= HALF_ORDER);
+    }
+
+    function guardReassignedS(
+        bytes32 hash,
+        uint8 v,
+        bytes32 r,
+        bytes32 s,
+        bytes32 replacement
+    ) external pure returns (address) {
+        address signer = ecrecover(hash, v, r, s); //~WARN: ecrecover should reject malleable signatures
+        s = replacement;
         require(uint256(s) <= HALF_ORDER);
         return signer;
     }

--- a/crates/lint/testdata/Ecrecover.stderr
+++ b/crates/lint/testdata/Ecrecover.stderr
@@ -9,8 +9,16 @@ LL │         return ecrecover(hash, v, r, s);
 warning[ecrecover]: ecrecover should reject malleable signatures
    ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
    │
-LL │         return ecrecover(hash, v, r, s);
-   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+LL │         return true && ecrecover(hash, v, r, s) != address(0);
+   │                        ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return true ? ecrecover(hash, v, r, s) : address(0);
+   │                       ━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/ecrecover
 
@@ -43,6 +51,46 @@ warning[ecrecover]: ecrecover should reject malleable signatures
    │
 LL │         return ecrecover(hash, v, r, s);
    │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         (signer,) = (ecrecover(hash, v, r, s), 0);
+   │                      ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         address signer = useRecovery ? ecrecover(hash, v, r, s) : address(0);
+   │                                        ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         first = second = ecrecover(hash, v, r, s);
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         signer = storedSigner = ecrecover(hash, v, r, s);
+   │                                 ━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/ecrecover
 
@@ -91,6 +139,30 @@ warning[ecrecover]: ecrecover should reject malleable signatures
    │
 LL │         address second = ecrecover(hash, v, r, s);
    │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, false ? bytes32(0) : s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/ecrecover
 

--- a/crates/lint/testdata/Ecrecover.stderr
+++ b/crates/lint/testdata/Ecrecover.stderr
@@ -57,6 +57,38 @@ LL │         address signer = ecrecover(hash, v, r, s);
 warning[ecrecover]: ecrecover should reject malleable signatures
    ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
    │
+LL │         address signer = ecrecover(hash, v, r, s);
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         address signer = ecrecover(hash, v, r, s);
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         signer = ecrecover(hash, v, r, s);
+   │                  ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         address signer = ecrecover(hash, v, r, s);
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
 LL │         address second = ecrecover(hash, v, r, s);
    │                          ━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/Ecrecover.stderr
+++ b/crates/lint/testdata/Ecrecover.stderr
@@ -121,6 +121,30 @@ LL │         address signer = ecrecover(hash, v, r, s);
 warning[ecrecover]: ecrecover should reject malleable signatures
    ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
    │
+LL │         address signer = ecrecover(hash, v, r, s);
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         address signer = ecrecover(hash, v, r, s);
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         address signer = ecrecover(hash, v, r, s);
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
 LL │         signer = ecrecover(hash, v, r, s);
    │                  ━━━━━━━━━━━━━━━━━━━━━━━━
    │

--- a/crates/lint/testdata/Ecrecover.stderr
+++ b/crates/lint/testdata/Ecrecover.stderr
@@ -62,3 +62,67 @@ LL │         address second = ecrecover(hash, v, r, s);
    │
    ╰ help: https://getfoundry.sh/forge/linting/ecrecover
 
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, safeS);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │             signer = ecrecover(hash, v, r, s);
+   │                      ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │             signer = ecrecover(hash, v, r, s);
+   │                      ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, storedS);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, storedS);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+

--- a/crates/lint/testdata/Ecrecover.stderr
+++ b/crates/lint/testdata/Ecrecover.stderr
@@ -1,0 +1,64 @@
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         return ecrecover(hash, v, r, s);
+   │                ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         address signer = ecrecover(hash, v, r, s);
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+
+warning[ecrecover]: ecrecover should reject malleable signatures
+   ╭▸ ROOT/testdata/Ecrecover.sol:LL:CC
+   │
+LL │         address second = ecrecover(hash, v, r, s);
+   │                          ━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/ecrecover
+


### PR DESCRIPTION
This adds the medium-severity `ecrecover` lint from #14381. It reports direct uses of Solidity's builtin unless the signature's `s` value is proven to be in the canonical lower half of the secp256k1 order, with path-sensitive handling for guards, aliases, branches, loops, assignments, mutable calls, and Solidity constant expressions.

A locally stored recovery is deferred until its first observable use, so a dominating post-call low-s guard can validate the exact signature value before the signer affects behavior. Pending recoveries survive joins when any path remains unguarded, while pre-guard reads, state writes, reassigned signature values, and implicit named-return uses still report. The UI fixture also covers comparison polarity, control-flow exits, tuple and ternary assignments, loop-carried writes, mutable-state invalidation, builtin resolution, and safe counterexamples.

The companion Book documentation is in foundry-rs/book#1981, with the post-call guard follow-up in foundry-rs/book#1994. This PR was implemented with Codex assistance across code, tests, and lint documentation, then independently reviewed and corrected by a fresh Codex context.

