### PR TITLE
feat(lint): add protected-vars

### DIFF
--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -18,6 +18,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `encode-packed-collision`: Flags `abi.encodePacked()` calls with multiple dynamic-type arguments (`string`, `bytes`, dynamic arrays) that can produce hash collisions.
   - `rtlo`: Flags Unicode bidirectional override characters ("Trojan Source", CVE-2021-42574) that can hide malicious code.
   - `reentrancy-eth`: Flags uncapped ETH-transferring low-level calls followed by writes to state that was read before the call.
+  - `protected-vars`: Flags public or external entry points that write a state variable without its required `@custom:security write-protection` function or modifier.
   - `unprotected-initializer`: Upgradeable initializers should not be callable on the implementation contract.
 - **Medium Severity:**
   - `assert-state-change`: Flags state-modifying expressions inside `assert()` arguments.

--- a/crates/lint/README.md
+++ b/crates/lint/README.md
@@ -18,7 +18,7 @@ It helps enforce best practices and improve code quality within Foundry projects
   - `encode-packed-collision`: Flags `abi.encodePacked()` calls with multiple dynamic-type arguments (`string`, `bytes`, dynamic arrays) that can produce hash collisions.
   - `rtlo`: Flags Unicode bidirectional override characters ("Trojan Source", CVE-2021-42574) that can hide malicious code.
   - `reentrancy-eth`: Flags uncapped ETH-transferring low-level calls followed by writes to state that was read before the call.
-  - `protected-vars`: Flags public or external entry points that write a state variable without its required `@custom:security write-protection` function or modifier.
+  - `protected-vars`: Flags externally callable entry points that write a state variable without its required `@custom:security write-protection` function or modifier.
   - `unprotected-initializer`: Upgradeable initializers should not be callable on the implementation contract.
 - **Medium Severity:**
   - `assert-state-change`: Flags state-modifying expressions inside `assert()` arguments.

--- a/crates/lint/docs/protected-vars.md
+++ b/crates/lint/docs/protected-vars.md
@@ -1,0 +1,69 @@
+# Protected variables
+
+**Severity**: `High`
+**ID**: `protected-vars`
+
+Flags externally callable functions that can write a state variable without invoking the function
+or modifier named by its `@custom:security write-protection` annotation.
+
+## What it does
+
+A state variable can declare a required protection with an exact function or modifier signature:
+
+```solidity
+/// @custom:security write-protection="onlyOwner()"
+address owner;
+```
+
+The lint follows modifiers and resolved internal call paths from public, external, and fallback
+entry points. If an entry point writes the variable directly or through a reachable helper, the
+required function or modifier must also be reachable from that entry point. Inherited variables,
+entry points, functions, and modifiers are resolved in the most-derived contract. External calls
+such as `this.onlyOwner()` do not satisfy an internal write-protection requirement.
+
+Like Slither's annotation semantics, this rule is reachability-based rather than order- or
+path-sensitive: the annotation identifies a required internal call, not a proof that the call
+dominates every write.
+
+## Why is this bad?
+
+Writing security-sensitive state without its declared access check can let an untrusted caller
+change ownership, authorization, or other protected configuration.
+
+## Example
+
+### Bad
+
+```solidity
+contract Registry {
+    /// @custom:security write-protection="onlyOwner()"
+    address public owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function setOwner(address newOwner) external {
+        owner = newOwner;
+    }
+}
+```
+
+### Good
+
+```solidity
+contract Registry {
+    /// @custom:security write-protection="onlyOwner()"
+    address public owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function setOwner(address newOwner) external onlyOwner {
+        owner = newOwner;
+    }
+}
+```

--- a/crates/lint/docs/protected-vars.md
+++ b/crates/lint/docs/protected-vars.md
@@ -15,11 +15,17 @@ A state variable can declare a required protection with an exact function or mod
 address owner;
 ```
 
-The lint follows modifiers and resolved internal call paths from public, external, and fallback
-entry points. If an entry point writes the variable directly or through a reachable helper, the
-required function or modifier must also be reachable from that entry point. Inherited variables,
-entry points, functions, and modifiers are resolved in the most-derived contract. External calls
-such as `this.onlyOwner()` do not satisfy an internal write-protection requirement.
+The lint follows modifiers, library calls, and resolved internal call paths from public, external,
+fallback, and receive entry points. If an entry point writes the variable directly or through a
+reachable helper, the required function or modifier must also be reachable from that entry point.
+This includes writes through storage references, returned storage locations, collection
+`push`/`pop` operations, and resolvable inline-assembly storage slots.
+
+Overloads are matched by their exact signature. Inherited variables, entry points, functions, and
+modifiers are resolved in the most-derived contract, including virtual dispatch. External calls
+such as `this.onlyOwner()` do not satisfy an internal write-protection requirement. An unresolved
+signature or malformed `write-protection` value is treated as unsatisfied so an invalid annotation
+cannot silently disable the lint.
 
 Like Slither's annotation semantics, this rule is reachability-based rather than order- or
 path-sensitive: the annotation identifies a required internal call, not a proof that the call

--- a/crates/lint/docs/protected-vars.md
+++ b/crates/lint/docs/protected-vars.md
@@ -17,8 +17,8 @@ address owner;
 
 The lint follows modifiers, library calls, and resolved internal call paths from public, external,
 fallback, and receive entry points. If an entry point writes the variable directly or through a
-reachable helper, the required function or modifier must also be reachable from that entry point.
-This includes writes through storage references, returned storage locations, collection
+reachable helper, the required function or modifier must dominate every path to that write. This
+includes writes through storage references, returned storage locations, collection
 `push`/`pop` operations, and resolvable inline-assembly storage slots.
 
 Overloads are matched by their exact signature. Inherited variables, entry points, functions, and
@@ -27,9 +27,9 @@ such as `this.onlyOwner()` do not satisfy an internal write-protection requireme
 signature or malformed `write-protection` value is treated as unsatisfied so an invalid annotation
 cannot silently disable the lint.
 
-Like Slither's annotation semantics, this rule is reachability-based rather than order- or
-path-sensitive: the annotation identifies a required internal call, not a proof that the call
-dominates every write.
+Like Slither's annotation semantics, the annotation identifies a required internal function or
+modifier by its exact signature. The lint additionally checks control-flow order so a call after a
+write or on only one branch does not satisfy the requirement.
 
 ## Why is this bad?
 

--- a/crates/lint/src/sol/high/mod.rs
+++ b/crates/lint/src/sol/high/mod.rs
@@ -6,6 +6,7 @@ mod controlled_delegatecall;
 mod encode_packed_collision;
 mod incorrect_exp;
 mod incorrect_shift;
+mod protected_vars;
 mod reentrancy;
 mod rtlo;
 mod unchecked_calls;
@@ -17,6 +18,7 @@ use controlled_delegatecall::CONTROLLED_DELEGATECALL;
 use encode_packed_collision::ENCODE_PACKED_COLLISION;
 use incorrect_exp::INCORRECT_EXP;
 use incorrect_shift::INCORRECT_SHIFT;
+use protected_vars::PROTECTED_VARS;
 use reentrancy::{REENTRANCY_ETH, REENTRANCY_NO_ETH};
 use rtlo::RTLO;
 use unchecked_calls::{ERC20_UNCHECKED_TRANSFER, UNCHECKED_CALL};
@@ -29,6 +31,7 @@ register_lints!(
     (EncodedPackedCollision, late, (ENCODE_PACKED_COLLISION)),
     (IncorrectExp, late, (INCORRECT_EXP)),
     (IncorrectShift, early, (INCORRECT_SHIFT)),
+    (ProtectedVars, late, (PROTECTED_VARS)),
     (ReentrancyEth, late, (REENTRANCY_ETH, REENTRANCY_NO_ETH)),
     (UncheckedCall, early, (UNCHECKED_CALL)),
     (UncheckedTransferERC20, late, (ERC20_UNCHECKED_TRANSFER)),

--- a/crates/lint/src/sol/high/protected_vars.rs
+++ b/crates/lint/src/sol/high/protected_vars.rs
@@ -1,0 +1,588 @@
+use super::ProtectedVars;
+use crate::{
+    linter::{LateLintPass, LintContext},
+    sol::{Severity, SolLint},
+};
+use solar::{
+    ast::{ContractKind, DataLocation, ElementaryType, FunctionKind, Visibility},
+    interface::sym,
+    sema::{
+        Gcx,
+        hir::{
+            self, ContractId, ExprKind, FunctionId, ItemId, NatSpecKind, Res, StmtKind, VariableId,
+        },
+        ty::TyKind,
+    },
+};
+use std::collections::{HashMap, HashSet};
+
+declare_forge_lint!(
+    PROTECTED_VARS,
+    Severity::High,
+    "protected-vars",
+    "protected variable is written without its required protection"
+);
+
+impl<'hir> LateLintPass<'hir> for ProtectedVars {
+    fn check_nested_contract(
+        &mut self,
+        ctx: &LintContext,
+        gcx: Gcx<'hir>,
+        hir: &'hir hir::Hir<'hir>,
+        contract_id: ContractId,
+    ) {
+        let contract = hir.contract(contract_id);
+        if !matches!(contract.kind, ContractKind::Contract | ContractKind::AbstractContract)
+            || contract.linearization_failed()
+            || !is_most_derived_contract(hir, contract_id)
+        {
+            return;
+        }
+
+        let protected = protected_variables(gcx, hir, contract.linearized_bases);
+        if protected.is_empty() {
+            return;
+        }
+
+        let targets = ProtectionTargets::new(gcx, hir, contract.linearized_bases);
+        for entry_id in effective_entry_points(gcx, hir, contract.linearized_bases) {
+            let mut analyzer = EntryAnalyzer::new(gcx, hir, contract.linearized_bases);
+            let (writes, calls) = analyzer.analyze(entry_id);
+
+            for var_id in writes {
+                let Some(requirements) = protected.get(&var_id) else { continue };
+                for requirement in requirements {
+                    let Some(target_id) = targets.resolve(requirement) else { continue };
+                    if calls.contains(&target_id) {
+                        continue;
+                    }
+
+                    let entry = hir.function(entry_id);
+                    let span = entry.name.map_or(entry.keyword_span(), |name| name.span);
+                    let variable = hir
+                        .variable(var_id)
+                        .name
+                        .map_or_else(|| "<unnamed>".to_string(), |name| name.as_str().to_string());
+                    ctx.emit_with_msg(
+                        &PROTECTED_VARS,
+                        span,
+                        format!(
+                            "protected variable `{variable}` is written without `{requirement}`"
+                        ),
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// Slither analyzes the effective entry points of leaf contracts so inherited declarations are
+/// interpreted in the context in which they are ultimately deployed.
+fn is_most_derived_contract(hir: &hir::Hir<'_>, contract_id: ContractId) -> bool {
+    !hir.contract_ids().any(|candidate_id| {
+        candidate_id != contract_id
+            && hir
+                .contract(candidate_id)
+                .linearized_bases
+                .get(1..)
+                .is_some_and(|bases| bases.contains(&contract_id))
+    })
+}
+
+fn protected_variables(
+    gcx: Gcx<'_>,
+    hir: &hir::Hir<'_>,
+    bases: &[ContractId],
+) -> HashMap<VariableId, Vec<String>> {
+    let mut protected = HashMap::new();
+
+    for &contract_id in bases {
+        for var_id in hir.contract(contract_id).variables() {
+            let var = hir.variable(var_id);
+            if !var.kind.is_state() {
+                continue;
+            }
+
+            let requirements: Vec<_> = gcx
+                .natspec_doc_comments(var.doc)
+                .iter()
+                .filter_map(|item| {
+                    let NatSpecKind::Custom { name } = item.kind else { return None };
+                    if name.as_str() != "security" {
+                        return None;
+                    }
+                    parse_write_protection(item.content()).map(str::to_owned)
+                })
+                .collect();
+            if !requirements.is_empty() {
+                protected.insert(var_id, requirements);
+            }
+        }
+    }
+
+    protected
+}
+
+fn parse_write_protection(content: &str) -> Option<&str> {
+    let value = content.split_once("write-protection=\"")?.1;
+    let (signature, _) = value.split_once('"')?;
+    (!signature.is_empty()).then_some(signature)
+}
+
+struct ProtectionTargets {
+    functions: HashMap<String, FunctionId>,
+    modifiers: HashMap<String, FunctionId>,
+}
+
+impl ProtectionTargets {
+    fn new(gcx: Gcx<'_>, hir: &hir::Hir<'_>, bases: &[ContractId]) -> Self {
+        let mut this = Self { functions: HashMap::new(), modifiers: HashMap::new() };
+
+        // Linearization starts at the most-derived contract. Keeping the first signature excludes
+        // shadowed base members, matching the effective member set used by Slither.
+        for &contract_id in bases {
+            for function_id in hir.contract(contract_id).functions() {
+                let function = hir.function(function_id);
+                if function.name.is_none() {
+                    continue;
+                }
+                let signature = gcx.item_signature(ItemId::Function(function_id)).to_string();
+                match function.kind {
+                    FunctionKind::Function => {
+                        this.functions.entry(signature).or_insert(function_id);
+                    }
+                    FunctionKind::Modifier => {
+                        this.modifiers.entry(signature).or_insert(function_id);
+                    }
+                    FunctionKind::Constructor | FunctionKind::Fallback | FunctionKind::Receive => {}
+                }
+            }
+        }
+
+        this
+    }
+
+    fn resolve(&self, signature: &str) -> Option<FunctionId> {
+        self.functions.get(signature).or_else(|| self.modifiers.get(signature)).copied()
+    }
+}
+
+fn effective_entry_points(
+    gcx: Gcx<'_>,
+    hir: &hir::Hir<'_>,
+    bases: &[ContractId],
+) -> Vec<FunctionId> {
+    let mut seen_functions = HashSet::new();
+    let mut seen_fallback = false;
+    let mut seen_receive = false;
+    let mut entries = Vec::new();
+
+    for &contract_id in bases {
+        for function_id in hir.contract(contract_id).all_functions() {
+            let function = hir.function(function_id);
+            match function.kind {
+                FunctionKind::Function => {
+                    if !matches!(function.visibility, Visibility::Public | Visibility::External) {
+                        continue;
+                    }
+                    let signature = gcx.item_signature(ItemId::Function(function_id));
+                    if seen_functions.insert(signature) {
+                        entries.push(function_id);
+                    }
+                }
+                FunctionKind::Fallback if !seen_fallback => {
+                    seen_fallback = true;
+                    entries.push(function_id);
+                }
+                FunctionKind::Receive if !seen_receive => {
+                    seen_receive = true;
+                    entries.push(function_id);
+                }
+                FunctionKind::Constructor
+                | FunctionKind::Modifier
+                | FunctionKind::Fallback
+                | FunctionKind::Receive => {}
+            }
+        }
+    }
+
+    entries
+}
+
+struct EntryAnalyzer<'hir> {
+    gcx: Gcx<'hir>,
+    hir: &'hir hir::Hir<'hir>,
+    bases: &'hir [ContractId],
+    writes: HashSet<VariableId>,
+    calls: HashSet<FunctionId>,
+    storage_aliases: HashMap<VariableId, VariableId>,
+    stack: Vec<FunctionId>,
+}
+
+impl<'hir> EntryAnalyzer<'hir> {
+    fn new(gcx: Gcx<'hir>, hir: &'hir hir::Hir<'hir>, bases: &'hir [ContractId]) -> Self {
+        Self {
+            gcx,
+            hir,
+            bases,
+            writes: HashSet::new(),
+            calls: HashSet::new(),
+            storage_aliases: HashMap::new(),
+            stack: Vec::new(),
+        }
+    }
+
+    fn analyze(&mut self, entry_id: FunctionId) -> (HashSet<VariableId>, HashSet<FunctionId>) {
+        self.analyze_function(entry_id);
+        (std::mem::take(&mut self.writes), std::mem::take(&mut self.calls))
+    }
+
+    fn analyze_function(&mut self, function_id: FunctionId) {
+        if self.stack.contains(&function_id) {
+            return;
+        }
+
+        let function = self.hir.function(function_id);
+        let Some(body) = function.body else { return };
+        self.stack.push(function_id);
+        self.analyze_modifiers(function);
+        self.analyze_block(body);
+        self.stack.pop();
+    }
+
+    fn analyze_modifiers(&mut self, function: &'hir hir::Function<'hir>) {
+        for modifier in function.modifiers {
+            for argument in modifier.args.exprs() {
+                self.analyze_expr(argument);
+            }
+
+            let Some(modifier_id) = modifier.id.as_function() else { continue };
+            self.calls.insert(modifier_id);
+            self.analyze_call(modifier_id, &modifier.args);
+        }
+    }
+
+    fn analyze_call(&mut self, function_id: FunctionId, args: &hir::CallArgs<'hir>) {
+        if self.stack.contains(&function_id) {
+            return;
+        }
+
+        let function = self.hir.function(function_id);
+        let saved_aliases = std::mem::take(&mut self.storage_aliases);
+        for (parameter, argument) in function.parameters.iter().copied().zip(args.exprs()) {
+            if self.hir.variable(parameter).data_location == Some(DataLocation::Storage)
+                && let Some(root) =
+                    state_lhs_vars(self.hir, argument, &saved_aliases).into_iter().next()
+            {
+                self.storage_aliases.insert(parameter, root);
+            }
+        }
+
+        self.analyze_function(function_id);
+        self.storage_aliases = saved_aliases;
+    }
+
+    fn analyze_block(&mut self, block: hir::Block<'hir>) {
+        for statement in block.stmts {
+            self.analyze_stmt(statement);
+        }
+    }
+
+    fn analyze_stmt(&mut self, statement: &'hir hir::Stmt<'hir>) {
+        match statement.kind {
+            StmtKind::DeclSingle(variable_id) => {
+                let variable = self.hir.variable(variable_id);
+                if let Some(initializer) = variable.initializer {
+                    self.analyze_expr(initializer);
+                    self.set_storage_alias(variable_id, initializer);
+                }
+            }
+            StmtKind::DeclMulti(_, expression)
+            | StmtKind::Emit(expression)
+            | StmtKind::Revert(expression)
+            | StmtKind::Expr(expression) => self.analyze_expr(expression),
+            StmtKind::Return(Some(expression)) => self.analyze_expr(expression),
+            StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => self.analyze_block(block),
+            StmtKind::Loop(block, _) => {
+                let aliases = self.storage_aliases.clone();
+                self.analyze_block(block);
+                self.storage_aliases = aliases;
+            }
+            StmtKind::If(condition, then_statement, else_statement) => {
+                self.analyze_expr(condition);
+                let aliases = self.storage_aliases.clone();
+                self.analyze_stmt(then_statement);
+                self.storage_aliases = aliases.clone();
+                if let Some(else_statement) = else_statement {
+                    self.analyze_stmt(else_statement);
+                }
+                self.storage_aliases = aliases;
+            }
+            StmtKind::Try(try_statement) => {
+                self.analyze_expr(&try_statement.expr);
+                let aliases = self.storage_aliases.clone();
+                for clause in try_statement.clauses {
+                    self.storage_aliases = aliases.clone();
+                    self.analyze_block(clause.block);
+                }
+                self.storage_aliases = aliases;
+            }
+            StmtKind::Return(None)
+            | StmtKind::Break
+            | StmtKind::Continue
+            | StmtKind::Placeholder
+            | StmtKind::AssemblyBlock(_)
+            | StmtKind::Switch(_)
+            | StmtKind::Err(_) => {}
+        }
+    }
+
+    fn analyze_expr(&mut self, expression: &'hir hir::Expr<'hir>) {
+        match &expression.peel_parens().kind {
+            ExprKind::Assign(lhs, _, rhs) => {
+                self.analyze_expr(rhs);
+                self.record_write(lhs);
+                if let Some(local) = lhs_local_var(self.hir, lhs) {
+                    self.set_storage_alias(local, rhs);
+                } else {
+                    self.analyze_lhs(lhs);
+                }
+            }
+            ExprKind::Delete(inner) => {
+                self.record_write(inner);
+                self.analyze_lhs(inner);
+            }
+            ExprKind::Unary(operator, inner) => {
+                if operator.kind.has_side_effects() {
+                    self.record_write(inner);
+                }
+                self.analyze_expr(inner);
+            }
+            ExprKind::Call(callee, args, options) => {
+                if let ExprKind::Member(base, member) = &callee.peel_parens().kind
+                    && matches!(member.as_str(), "push" | "pop")
+                    && is_dynamic_array_or_bytes(self.gcx, base)
+                {
+                    self.record_write(base);
+                }
+
+                self.analyze_expr(callee);
+                if let Some(options) = options {
+                    for option in options.args {
+                        self.analyze_expr(&option.value);
+                    }
+                }
+                for argument in args.exprs() {
+                    self.analyze_expr(argument);
+                }
+
+                for function_id in
+                    resolved_internal_functions(self.hir, callee, args.len(), self.bases)
+                {
+                    self.calls.insert(function_id);
+                    self.analyze_call(function_id, args);
+                }
+            }
+            ExprKind::Binary(lhs, _, rhs) => {
+                self.analyze_expr(lhs);
+                self.analyze_expr(rhs);
+            }
+            ExprKind::Index(base, index) => {
+                self.analyze_expr(base);
+                if let Some(index) = index {
+                    self.analyze_expr(index);
+                }
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.analyze_expr(base);
+                if let Some(start) = start {
+                    self.analyze_expr(start);
+                }
+                if let Some(end) = end {
+                    self.analyze_expr(end);
+                }
+            }
+            ExprKind::Member(base, _) | ExprKind::Payable(base) => self.analyze_expr(base),
+            ExprKind::Ternary(condition, if_true, if_false) => {
+                self.analyze_expr(condition);
+                self.analyze_expr(if_true);
+                self.analyze_expr(if_false);
+            }
+            ExprKind::Array(expressions) => {
+                for expression in *expressions {
+                    self.analyze_expr(expression);
+                }
+            }
+            ExprKind::Tuple(expressions) => {
+                for expression in expressions.iter().copied().flatten() {
+                    self.analyze_expr(expression);
+                }
+            }
+            ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
+            ExprKind::Ident(_) | ExprKind::Lit(_) | ExprKind::YulMember(..) | ExprKind::Err(_) => {}
+        }
+    }
+
+    fn analyze_lhs(&mut self, expression: &'hir hir::Expr<'hir>) {
+        match &expression.peel_parens().kind {
+            ExprKind::Index(base, index) => {
+                self.analyze_lhs(base);
+                if let Some(index) = index {
+                    self.analyze_expr(index);
+                }
+            }
+            ExprKind::Slice(base, start, end) => {
+                self.analyze_lhs(base);
+                if let Some(start) = start {
+                    self.analyze_expr(start);
+                }
+                if let Some(end) = end {
+                    self.analyze_expr(end);
+                }
+            }
+            ExprKind::Member(base, _) | ExprKind::Payable(base) => self.analyze_lhs(base),
+            ExprKind::Tuple(expressions) => {
+                for expression in expressions.iter().copied().flatten() {
+                    self.analyze_lhs(expression);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn record_write(&mut self, expression: &hir::Expr<'_>) {
+        self.writes.extend(state_lhs_vars(self.hir, expression, &self.storage_aliases));
+    }
+
+    fn set_storage_alias(&mut self, variable_id: VariableId, initializer: &'hir hir::Expr<'hir>) {
+        let variable = self.hir.variable(variable_id);
+        if variable.kind.is_state() || variable.data_location != Some(DataLocation::Storage) {
+            self.storage_aliases.remove(&variable_id);
+            return;
+        }
+
+        if let Some(root) =
+            state_lhs_vars(self.hir, initializer, &self.storage_aliases).into_iter().next()
+        {
+            self.storage_aliases.insert(variable_id, root);
+        } else {
+            self.storage_aliases.remove(&variable_id);
+        }
+    }
+}
+
+fn lhs_local_var(hir: &hir::Hir<'_>, expression: &hir::Expr<'_>) -> Option<VariableId> {
+    let ExprKind::Ident(resolutions) = &expression.peel_parens().kind else { return None };
+    resolutions.iter().find_map(|resolution| match resolution {
+        Res::Item(ItemId::Variable(variable_id)) if !hir.variable(*variable_id).kind.is_state() => {
+            Some(*variable_id)
+        }
+        _ => None,
+    })
+}
+
+fn state_lhs_vars(
+    hir: &hir::Hir<'_>,
+    expression: &hir::Expr<'_>,
+    storage_aliases: &HashMap<VariableId, VariableId>,
+) -> Vec<VariableId> {
+    let mut variables = Vec::new();
+    collect_state_lhs_vars(hir, expression, storage_aliases, &mut variables);
+    variables
+}
+
+fn collect_state_lhs_vars(
+    hir: &hir::Hir<'_>,
+    expression: &hir::Expr<'_>,
+    storage_aliases: &HashMap<VariableId, VariableId>,
+    variables: &mut Vec<VariableId>,
+) {
+    match &expression.peel_parens().kind {
+        ExprKind::Ident(resolutions) => {
+            for resolution in *resolutions {
+                let Res::Item(ItemId::Variable(variable_id)) = resolution else { continue };
+                let root = if hir.variable(*variable_id).kind.is_state() {
+                    Some(*variable_id)
+                } else {
+                    storage_aliases.get(variable_id).copied()
+                };
+                if let Some(root) = root
+                    && !variables.contains(&root)
+                {
+                    variables.push(root);
+                }
+            }
+        }
+        ExprKind::Index(base, _) | ExprKind::Slice(base, ..) | ExprKind::Member(base, _) => {
+            collect_state_lhs_vars(hir, base, storage_aliases, variables);
+        }
+        ExprKind::Payable(base) | ExprKind::Unary(_, base) | ExprKind::Delete(base) => {
+            collect_state_lhs_vars(hir, base, storage_aliases, variables);
+        }
+        ExprKind::Tuple(expressions) => {
+            for expression in expressions.iter().copied().flatten() {
+                collect_state_lhs_vars(hir, expression, storage_aliases, variables);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_dynamic_array_or_bytes(gcx: Gcx<'_>, expression: &hir::Expr<'_>) -> bool {
+    gcx.type_of_expr(expression.peel_parens().id).is_some_and(|ty| {
+        matches!(
+            ty.peel_refs().kind,
+            TyKind::DynArray(_) | TyKind::Array(..) | TyKind::Elementary(ElementaryType::Bytes)
+        )
+    })
+}
+
+fn resolved_internal_functions(
+    hir: &hir::Hir<'_>,
+    callee: &hir::Expr<'_>,
+    argument_count: usize,
+    bases: &[ContractId],
+) -> Vec<FunctionId> {
+    match &callee.peel_parens().kind {
+        ExprKind::Ident(resolutions) => resolutions
+            .iter()
+            .filter_map(|resolution| match resolution {
+                Res::Item(ItemId::Function(function_id))
+                    if hir.function(*function_id).parameters.len() == argument_count =>
+                {
+                    Some(*function_id)
+                }
+                _ => None,
+            })
+            .collect(),
+        ExprKind::Member(base, member) => {
+            let ExprKind::Ident(resolutions) = &base.peel_parens().kind else { return Vec::new() };
+            let is_super = resolutions.iter().any(
+                |resolution| matches!(resolution, Res::Builtin(builtin) if builtin.name() == sym::super_),
+            );
+            let contracts: Vec<_> = if is_super {
+                bases.get(1..).unwrap_or_default().to_vec()
+            } else {
+                resolutions
+                    .iter()
+                    .filter_map(|resolution| match resolution {
+                        Res::Item(ItemId::Contract(contract_id)) => Some(*contract_id),
+                        _ => None,
+                    })
+                    .collect()
+            };
+
+            contracts
+                .into_iter()
+                .flat_map(|contract_id| hir.contract(contract_id).functions())
+                .filter(|&function_id| {
+                    let function = hir.function(function_id);
+                    function.kind == FunctionKind::Function
+                        && function.parameters.len() == argument_count
+                        && function.name.is_some_and(|name| name.as_str() == member.as_str())
+                })
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}

--- a/crates/lint/src/sol/high/protected_vars.rs
+++ b/crates/lint/src/sol/high/protected_vars.rs
@@ -366,12 +366,19 @@ struct CallContext {
 struct LoopFlow {
     breaks: Option<FlowState>,
     continues: Option<FlowState>,
+    completes: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 struct CallSummary {
     returns: Vec<StorageRoots>,
     guards: HashSet<FunctionId>,
+    completes: bool,
+}
+
+struct FunctionSummary {
+    returns: Vec<StorageRoots>,
+    completes: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -415,6 +422,7 @@ struct EntryAnalyzer<'hir> {
     call_returns: HashMap<ExprId, Vec<StorageRoots>>,
     call_summaries: HashMap<CallContext, CallSummary>,
     seen_calls: HashSet<CallContext>,
+    evaluated_calls: HashSet<CallContext>,
     stack: Vec<FunctionId>,
     return_stack: Vec<Vec<StorageRoots>>,
     return_flow: Vec<Option<FlowState>>,
@@ -435,6 +443,7 @@ impl<'hir> EntryAnalyzer<'hir> {
             call_returns: HashMap::new(),
             call_summaries: HashMap::new(),
             seen_calls: HashSet::new(),
+            evaluated_calls: HashSet::new(),
             stack: Vec::new(),
             return_stack: Vec::new(),
             return_flow: Vec::new(),
@@ -445,14 +454,40 @@ impl<'hir> EntryAnalyzer<'hir> {
     }
 
     fn analyze(&mut self, entry_id: FunctionId) -> HashMap<VariableId, HashSet<FunctionId>> {
-        let _ = self.analyze_function(entry_id);
-        std::mem::take(&mut self.writes)
+        let mut previous_writes = HashMap::new();
+        loop {
+            self.reset_analysis_pass();
+            let previous_summaries = self.call_summaries.clone();
+            let _ = self.analyze_function(entry_id);
+            if self.writes == previous_writes && self.call_summaries == previous_summaries {
+                return std::mem::take(&mut self.writes);
+            }
+            previous_writes = self.writes.clone();
+        }
     }
 
-    fn analyze_function(&mut self, function_id: FunctionId) -> Vec<StorageRoots> {
+    fn reset_analysis_pass(&mut self) {
+        self.writes.clear();
+        self.aliases = AliasState::default();
+        self.guards.clear();
+        self.call_returns.clear();
+        self.seen_calls.clear();
+        self.evaluated_calls.clear();
+        self.stack.clear();
+        self.return_stack.clear();
+        self.return_flow.clear();
+        self.loop_flow.clear();
+        self.modifier_continuations.clear();
+        self.assembly_depth = 0;
+    }
+
+    fn analyze_function(&mut self, function_id: FunctionId) -> FunctionSummary {
         let function = self.hir.function(function_id);
         let Some(body) = function.body else {
-            return function.returns.iter().map(|_| StorageRoots::new()).collect();
+            return FunctionSummary {
+                returns: function.returns.iter().map(|_| StorageRoots::new()).collect(),
+                completes: true,
+            };
         };
         self.stack.push(function_id);
         self.return_stack.push(function.returns.iter().map(|_| StorageRoots::new()).collect());
@@ -462,10 +497,11 @@ impl<'hir> EntryAnalyzer<'hir> {
         if falls_through {
             self.capture_named_returns();
         }
+        let completes = completes || self.return_flow.last().is_some_and(Option::is_some);
         let returns = self.return_stack.pop().expect("return frame must exist");
         self.return_flow.pop().expect("return flow frame must exist");
         self.stack.pop();
-        returns
+        FunctionSummary { returns, completes }
     }
 
     fn analyze_modifier_chain(
@@ -479,11 +515,12 @@ impl<'hir> EntryAnalyzer<'hir> {
             let falls_through = self.analyze_block(body);
             let body_returns = self.return_flow.last_mut().and_then(Option::take);
 
-            let mut all_returns = previous_returns;
-            if let Some(state) = &body_returns {
-                merge_flow_state_into(&mut all_returns, state);
-            }
-            *self.return_flow.last_mut().expect("return flow frame must exist") = all_returns;
+            // Returns from the function body resume in each enclosing modifier postlude. They
+            // therefore become ordinary placeholder completions here and must not also escape
+            // the whole modifier chain through `return_flow`: a reverting postlude can still
+            // prevent the call from completing. Keep only returns captured in modifier prefixes
+            // outside the body continuation.
+            *self.return_flow.last_mut().expect("return flow frame must exist") = previous_returns;
 
             let mut completions = body_returns;
             if falls_through {
@@ -496,7 +533,9 @@ impl<'hir> EntryAnalyzer<'hir> {
             return false;
         };
         for argument in modifier.args.exprs() {
-            self.analyze_expr(argument);
+            if !self.analyze_expr(argument) {
+                return false;
+            }
         }
 
         let Some(declared_id) = modifier.id.as_function() else { return false };
@@ -517,27 +556,40 @@ impl<'hir> EntryAnalyzer<'hir> {
         &mut self,
         function_id: FunctionId,
         arguments: &[&'hir hir::Expr<'hir>],
-    ) -> Vec<StorageRoots> {
+    ) -> CallSummary {
         let function = self.hir.function(function_id);
         let saved_aliases = std::mem::take(&mut self.aliases);
         self.bind_call_arguments(function_id, arguments, &saved_aliases);
 
         let context = CallContext::new(function_id, function, &self.aliases, &self.guards);
-        if let Some(summary) = self.call_summaries.get(&context).cloned() {
+        if self.seen_calls.contains(&context) {
+            let summary = self.call_summaries.get(&context).cloned().unwrap_or_else(|| {
+                CallSummary { returns: Vec::new(), guards: self.guards.clone(), completes: false }
+            });
             self.aliases = saved_aliases;
-            self.guards = summary.guards;
-            return summary.returns;
+            self.guards = summary.guards.clone();
+            return summary;
         }
-        if !self.seen_calls.insert(context.clone()) {
+        if self.evaluated_calls.contains(&context)
+            && let Some(summary) = self.call_summaries.get(&context).cloned()
+        {
             self.aliases = saved_aliases;
-            return Vec::new();
+            self.guards = summary.guards.clone();
+            return summary;
         }
 
-        let returns = self.analyze_function(function_id);
-        self.call_summaries
-            .insert(context, CallSummary { returns: returns.clone(), guards: self.guards.clone() });
+        self.seen_calls.insert(context.clone());
+        self.evaluated_calls.insert(context.clone());
+        let function_summary = self.analyze_function(function_id);
+        let summary = CallSummary {
+            returns: function_summary.returns,
+            guards: self.guards.clone(),
+            completes: function_summary.completes,
+        };
+        self.seen_calls.remove(&context);
+        self.call_summaries.insert(context, summary.clone());
         self.aliases = saved_aliases;
-        returns
+        summary
     }
 
     fn bind_call_arguments(
@@ -588,7 +640,9 @@ impl<'hir> EntryAnalyzer<'hir> {
             StmtKind::DeclSingle(variable_id) => {
                 let variable = self.hir.variable(variable_id);
                 if let Some(initializer) = variable.initializer {
-                    self.analyze_expr(initializer);
+                    if !self.analyze_expr(initializer) {
+                        return false;
+                    }
                     self.set_storage_alias(variable_id, initializer);
                     if self.assembly_depth > 0 {
                         self.set_slot_alias(variable_id, initializer);
@@ -597,22 +651,24 @@ impl<'hir> EntryAnalyzer<'hir> {
                 true
             }
             StmtKind::DeclMulti(variables, expression) => {
-                self.analyze_expr(expression);
+                if !self.analyze_expr(expression) {
+                    return false;
+                }
                 self.set_decl_aliases(variables, expression);
                 true
             }
             StmtKind::Emit(expression) | StmtKind::Expr(expression) => {
-                self.analyze_expr(expression);
-                !branch_always_exits(statement)
+                self.analyze_expr(expression) && !branch_always_exits(statement)
             }
             StmtKind::Revert(expression) => {
-                self.analyze_expr(expression);
+                let _ = self.analyze_expr(expression);
                 false
             }
             StmtKind::Return(Some(expression)) => {
-                self.analyze_expr(expression);
-                self.set_return_aliases(expression);
-                self.capture_return_flow();
+                if self.analyze_expr(expression) {
+                    self.set_return_aliases(expression);
+                    self.capture_return_flow();
+                }
                 false
             }
             StmtKind::Return(None) => {
@@ -628,33 +684,60 @@ impl<'hir> EntryAnalyzer<'hir> {
                 continues
             }
             StmtKind::Loop(block, source) => {
-                let before = self.flow_state();
-                let flow = self.analyze_loop_iteration(block);
-                let iteration = merge_optional_flow_state(&self.flow_state(), &flow.continues);
-                let exits = if source == hir::LoopSource::DoWhile {
-                    iteration
-                } else {
-                    merge_flow_states(&before, &iteration)
-                };
-                let mut input = merge_optional_flow_state(&exits, &flow.breaks);
+                let mut head = self.flow_state();
+                let mut exits = None;
                 loop {
-                    self.set_flow_state(input.clone());
+                    self.set_flow_state(head.clone());
                     let flow = self.analyze_loop_iteration(block);
-                    let iteration = merge_optional_flow_state(&self.flow_state(), &flow.continues);
-                    let next = merge_optional_flow_state(
-                        &merge_flow_states(&exits, &iteration),
-                        &flow.breaks,
-                    );
-                    if next == input {
-                        self.set_flow_state(next);
+                    let normal = flow.completes.then(|| self.flow_state());
+                    let continue_flow = if source == hir::LoopSource::DoWhile {
+                        flow.continues.as_ref().and_then(|continues| {
+                            self.analyze_do_while_continue(block, continues.clone())
+                        })
+                    } else {
+                        None
+                    };
+                    if let Some(breaks) = &flow.breaks {
+                        merge_flow_state_into(&mut exits, breaks);
+                    }
+                    if let Some((continue_flow, _)) = &continue_flow
+                        && let Some(breaks) = &continue_flow.breaks
+                    {
+                        merge_flow_state_into(&mut exits, breaks);
+                    }
+
+                    let mut backedges = None;
+                    if let Some(normal) = &normal {
+                        merge_flow_state_into(&mut backedges, normal);
+                    }
+                    if let Some((continue_flow, completion)) = &continue_flow {
+                        if let Some(completion) = completion {
+                            merge_flow_state_into(&mut backedges, completion);
+                        }
+                        if let Some(continues) = &continue_flow.continues {
+                            merge_flow_state_into(&mut backedges, continues);
+                        }
+                    } else if let Some(continues) = &flow.continues {
+                        merge_flow_state_into(&mut backedges, continues);
+                    }
+                    let Some(backedges) = backedges else { break };
+                    let next = merge_flow_states(&head, &backedges);
+                    if next == head {
                         break;
                     }
-                    input = next;
+                    head = next;
                 }
-                true
+                if let Some(exits) = exits {
+                    self.set_flow_state(exits);
+                    true
+                } else {
+                    false
+                }
             }
             StmtKind::If(condition, then_statement, else_statement) => {
-                self.analyze_expr(condition);
+                if !self.analyze_expr(condition) {
+                    return false;
+                }
                 let before = self.flow_state();
                 let then_continues = self.analyze_stmt(then_statement);
                 let then_state = self.flow_state();
@@ -674,7 +757,9 @@ impl<'hir> EntryAnalyzer<'hir> {
                 then_continues || else_continues
             }
             StmtKind::Try(try_statement) => {
-                self.analyze_expr(&try_statement.expr);
+                if !self.analyze_expr(&try_statement.expr) {
+                    return false;
+                }
                 let before = self.flow_state();
                 let mut merged = None;
                 for clause in try_statement.clauses {
@@ -691,7 +776,9 @@ impl<'hir> EntryAnalyzer<'hir> {
                 }
             }
             StmtKind::Switch(switch) => {
-                self.analyze_expr(switch.selector);
+                if !self.analyze_expr(switch.selector) {
+                    return false;
+                }
                 let before = self.flow_state();
                 let has_default = switch.cases.last().is_some_and(|case| case.constant.is_none());
                 let mut merged = (!has_default).then_some(before.clone());
@@ -739,8 +826,25 @@ impl<'hir> EntryAnalyzer<'hir> {
 
     fn analyze_loop_iteration(&mut self, block: hir::Block<'hir>) -> LoopFlow {
         self.loop_flow.push(LoopFlow::default());
-        let _ = self.analyze_block(block);
-        self.loop_flow.pop().expect("loop flow frame must exist")
+        let completes = self.analyze_block(block);
+        let mut flow = self.loop_flow.pop().expect("loop flow frame must exist");
+        flow.completes = completes;
+        flow
+    }
+
+    fn analyze_do_while_continue(
+        &mut self,
+        block: hir::Block<'hir>,
+        state: FlowState,
+    ) -> Option<(LoopFlow, Option<FlowState>)> {
+        let epilogue = block.stmts.last().filter(|stmt| is_loop_termination_if(stmt))?;
+        self.set_flow_state(state);
+        self.loop_flow.push(LoopFlow::default());
+        let completes = self.analyze_stmt(epilogue);
+        let completion = completes.then(|| self.flow_state());
+        let mut flow = self.loop_flow.pop().expect("loop flow frame must exist");
+        flow.completes = completes;
+        Some((flow, completion))
     }
 
     fn flow_state(&self) -> FlowState {
@@ -759,32 +863,49 @@ impl<'hir> EntryAnalyzer<'hir> {
         }
     }
 
-    fn analyze_expr(&mut self, expression: &'hir hir::Expr<'hir>) {
+    fn analyze_expr(&mut self, expression: &'hir hir::Expr<'hir>) -> bool {
         match &expression.peel_parens().kind {
             ExprKind::Assign(lhs, operator, rhs) => {
-                self.analyze_expr(rhs);
-                self.analyze_lhs(lhs);
+                if !self.analyze_expr(rhs) {
+                    return false;
+                }
+                if !self.analyze_lhs(lhs) {
+                    return false;
+                }
                 self.apply_assignment(lhs, rhs, operator.is_some());
+                true
             }
             ExprKind::Delete(inner) => {
-                self.analyze_lhs(inner);
+                if !self.analyze_lhs(inner) {
+                    return false;
+                }
                 self.record_write(inner);
+                true
             }
             ExprKind::Unary(operator, inner) => {
-                self.analyze_expr(inner);
+                if !self.analyze_expr(inner) {
+                    return false;
+                }
                 if operator.kind.has_side_effects() {
                     self.record_write(inner);
                 }
+                true
             }
             ExprKind::Call(callee, args, options) => {
-                self.analyze_expr(callee);
+                if !self.analyze_expr(callee) {
+                    return false;
+                }
                 if let Some(options) = options {
                     for option in options.args {
-                        self.analyze_expr(&option.value);
+                        if !self.analyze_expr(&option.value) {
+                            return false;
+                        }
                     }
                 }
                 for argument in args.exprs() {
-                    self.analyze_expr(argument);
+                    if !self.analyze_expr(argument) {
+                        return false;
+                    }
                 }
 
                 if let ExprKind::Member(base, member) = &callee.peel_parens().kind
@@ -816,91 +937,122 @@ impl<'hir> EntryAnalyzer<'hir> {
                 {
                     self.guards.insert(function_id);
                     let arguments = self.ordered_call_arguments(declared_id, *args, receiver);
-                    let returns = self.analyze_call(function_id, &arguments);
-                    self.store_call_returns(expression.id, returns);
+                    let summary = self.analyze_call(function_id, &arguments);
+                    self.store_call_returns(expression.id, summary.returns);
+                    return summary.completes;
                 }
+                true
             }
             ExprKind::Binary(lhs, operator, rhs) => {
-                self.analyze_expr(lhs);
+                if !self.analyze_expr(lhs) {
+                    return false;
+                }
                 if matches!(operator.kind, BinOpKind::And | BinOpKind::Or) {
                     let short_circuit = self.flow_state();
-                    self.analyze_expr(rhs);
-                    let evaluated = self.flow_state();
-                    self.set_flow_state(merge_flow_states(&short_circuit, &evaluated));
+                    if self.analyze_expr(rhs) {
+                        let evaluated = self.flow_state();
+                        self.set_flow_state(merge_flow_states(&short_circuit, &evaluated));
+                    } else {
+                        self.set_flow_state(short_circuit);
+                    }
+                    true
                 } else {
-                    self.analyze_expr(rhs);
+                    self.analyze_expr(rhs)
                 }
             }
             ExprKind::Index(base, index) => {
-                self.analyze_expr(base);
-                if let Some(index) = index {
-                    self.analyze_expr(index);
+                if !self.analyze_expr(base) {
+                    return false;
                 }
+                if let Some(index) = index { self.analyze_expr(index) } else { true }
             }
             ExprKind::Slice(base, start, end) => {
-                self.analyze_expr(base);
+                if !self.analyze_expr(base) {
+                    return false;
+                }
                 if let Some(start) = start {
-                    self.analyze_expr(start);
+                    if !self.analyze_expr(start) {
+                        return false;
+                    }
                 }
-                if let Some(end) = end {
-                    self.analyze_expr(end);
-                }
+                if let Some(end) = end { self.analyze_expr(end) } else { true }
             }
             ExprKind::Member(base, _) | ExprKind::YulMember(base, _) | ExprKind::Payable(base) => {
                 self.analyze_expr(base)
             }
             ExprKind::Ternary(condition, if_true, if_false) => {
-                self.analyze_expr(condition);
+                if !self.analyze_expr(condition) {
+                    return false;
+                }
                 let before = self.flow_state();
-                self.analyze_expr(if_true);
+                let true_completes = self.analyze_expr(if_true);
                 let true_state = self.flow_state();
                 self.set_flow_state(before);
-                self.analyze_expr(if_false);
+                let false_completes = self.analyze_expr(if_false);
                 let false_state = self.flow_state();
-                self.set_flow_state(merge_flow_states(&true_state, &false_state));
+                match (true_completes, false_completes) {
+                    (true, true) => {
+                        self.set_flow_state(merge_flow_states(&true_state, &false_state))
+                    }
+                    (true, false) => self.set_flow_state(true_state),
+                    (false, true) => self.set_flow_state(false_state),
+                    (false, false) => {}
+                }
+                true_completes || false_completes
             }
             ExprKind::Array(expressions) => {
                 for expression in *expressions {
-                    self.analyze_expr(expression);
+                    if !self.analyze_expr(expression) {
+                        return false;
+                    }
                 }
+                true
             }
             ExprKind::Tuple(expressions) => {
                 for expression in expressions.iter().copied().flatten() {
-                    self.analyze_expr(expression);
+                    if !self.analyze_expr(expression) {
+                        return false;
+                    }
                 }
+                true
             }
-            ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
-            ExprKind::Ident(_) | ExprKind::Lit(_) | ExprKind::Err(_) => {}
+            ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => true,
+            ExprKind::Ident(_) | ExprKind::Lit(_) | ExprKind::Err(_) => true,
         }
     }
 
-    fn analyze_lhs(&mut self, expression: &'hir hir::Expr<'hir>) {
+    fn analyze_lhs(&mut self, expression: &'hir hir::Expr<'hir>) -> bool {
         match &expression.peel_parens().kind {
             ExprKind::Index(base, index) => {
-                self.analyze_lhs(base);
-                if let Some(index) = index {
-                    self.analyze_expr(index);
+                if !self.analyze_lhs(base) {
+                    return false;
                 }
+                if let Some(index) = index { self.analyze_expr(index) } else { true }
             }
             ExprKind::Slice(base, start, end) => {
-                self.analyze_lhs(base);
+                if !self.analyze_lhs(base) {
+                    return false;
+                }
                 if let Some(start) = start {
-                    self.analyze_expr(start);
+                    if !self.analyze_expr(start) {
+                        return false;
+                    }
                 }
-                if let Some(end) = end {
-                    self.analyze_expr(end);
-                }
+                if let Some(end) = end { self.analyze_expr(end) } else { true }
             }
             ExprKind::Member(base, _) | ExprKind::YulMember(base, _) | ExprKind::Payable(base) => {
                 self.analyze_lhs(base)
             }
             ExprKind::Tuple(expressions) => {
                 for expression in expressions.iter().copied().flatten() {
-                    self.analyze_lhs(expression);
+                    if !self.analyze_lhs(expression) {
+                        return false;
+                    }
                 }
+                true
             }
             ExprKind::Call(..) => self.analyze_expr(expression),
-            _ => {}
+            _ => true,
         }
     }
 
@@ -1370,16 +1522,28 @@ fn merge_flow_states(lhs: &FlowState, rhs: &FlowState) -> FlowState {
     }
 }
 
-fn merge_optional_flow_state(state: &FlowState, other: &Option<FlowState>) -> FlowState {
-    other.as_ref().map_or_else(|| state.clone(), |other| merge_flow_states(state, other))
-}
-
 fn merge_flow_state_into(destination: &mut Option<FlowState>, state: &FlowState) {
     *destination = Some(
         destination
             .as_ref()
             .map_or_else(|| state.clone(), |current| merge_flow_states(current, state)),
     );
+}
+
+fn is_loop_termination_if(statement: &hir::Stmt<'_>) -> bool {
+    let StmtKind::If(_, then_statement, else_statement) = &statement.kind else { return false };
+    is_break_stmt(then_statement)
+        || else_statement.as_ref().is_some_and(|statement| is_break_stmt(statement))
+}
+
+fn is_break_stmt(statement: &hir::Stmt<'_>) -> bool {
+    match &statement.kind {
+        StmtKind::Break => true,
+        StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => {
+            block.stmts.len() == 1 && is_break_stmt(&block.stmts[0])
+        }
+        _ => false,
+    }
 }
 
 fn merge_root_maps(lhs: &RootMap, rhs: &RootMap) -> RootMap {

--- a/crates/lint/src/sol/high/protected_vars.rs
+++ b/crates/lint/src/sol/high/protected_vars.rs
@@ -676,26 +676,37 @@ impl<'hir> EntryAnalyzer<'hir> {
             StmtKind::Try(try_statement) => {
                 self.analyze_expr(&try_statement.expr);
                 let before = self.flow_state();
-                let mut merged = before.clone();
+                let mut merged = None;
                 for clause in try_statement.clauses {
                     self.set_flow_state(before.clone());
-                    let _ = self.analyze_block(clause.block);
-                    merged = merge_flow_states(&merged, &self.flow_state());
+                    if self.analyze_block(clause.block) {
+                        merge_flow_state_into(&mut merged, &self.flow_state());
+                    }
                 }
-                self.set_flow_state(merged);
-                true
+                if let Some(merged) = merged {
+                    self.set_flow_state(merged);
+                    true
+                } else {
+                    false
+                }
             }
             StmtKind::Switch(switch) => {
                 self.analyze_expr(switch.selector);
                 let before = self.flow_state();
-                let mut merged = before.clone();
+                let has_default = switch.cases.last().is_some_and(|case| case.constant.is_none());
+                let mut merged = (!has_default).then_some(before.clone());
                 for case in switch.cases {
                     self.set_flow_state(before.clone());
-                    let _ = self.analyze_block(case.body);
-                    merged = merge_flow_states(&merged, &self.flow_state());
+                    if self.analyze_block(case.body) {
+                        merge_flow_state_into(&mut merged, &self.flow_state());
+                    }
                 }
-                self.set_flow_state(merged);
-                true
+                if let Some(merged) = merged {
+                    self.set_flow_state(merged);
+                    true
+                } else {
+                    false
+                }
             }
             StmtKind::Break => {
                 let state = self.flow_state();

--- a/crates/lint/src/sol/high/protected_vars.rs
+++ b/crates/lint/src/sol/high/protected_vars.rs
@@ -1,7 +1,12 @@
+//! Slither-compatible protected-variable reachability analysis.
+//!
+//! Storage references are tracked as may-alias sets across internal calls and control-flow joins.
+//! Calls are memoized by their storage/slot context so recursive alias propagation terminates.
+
 use super::ProtectedVars;
 use crate::{
     linter::{LateLintPass, LintContext},
-    sol::{Severity, SolLint},
+    sol::{Severity, SolLint, analysis::primitives::branch_always_exits},
 };
 use solar::{
     ast::{ContractKind, DataLocation, ElementaryType, FunctionKind, Visibility},
@@ -9,12 +14,16 @@ use solar::{
     sema::{
         Gcx,
         hir::{
-            self, ContractId, ExprKind, FunctionId, ItemId, NatSpecKind, Res, StmtKind, VariableId,
+            self, ContractId, ExprId, ExprKind, FunctionId, ItemId, NatSpecKind, Res, StmtKind,
+            VariableId,
         },
-        ty::TyKind,
+        ty::{Ty, TyAbiPrinter, TyAbiPrinterMode, TyKind},
     },
 };
 use std::collections::{HashMap, HashSet};
+
+type StorageRoots = HashSet<VariableId>;
+type RootMap = HashMap<VariableId, StorageRoots>;
 
 declare_forge_lint!(
     PROTECTED_VARS,
@@ -49,27 +58,46 @@ impl<'hir> LateLintPass<'hir> for ProtectedVars {
             let mut analyzer = EntryAnalyzer::new(gcx, hir, contract.linearized_bases);
             let (writes, calls) = analyzer.analyze(entry_id);
 
+            let mut writes: Vec<_> = writes.into_iter().collect();
+            writes.sort_unstable();
             for var_id in writes {
                 let Some(requirements) = protected.get(&var_id) else { continue };
                 for requirement in requirements {
-                    let Some(target_id) = targets.resolve(requirement) else { continue };
-                    if calls.contains(&target_id) {
-                        continue;
-                    }
-
                     let entry = hir.function(entry_id);
                     let span = entry.name.map_or(entry.keyword_span(), |name| name.span);
+                    let contract_context = if entry.contract == Some(contract_id) {
+                        String::new()
+                    } else {
+                        format!(" in most-derived contract `{}`", contract.name)
+                    };
                     let variable = hir
                         .variable(var_id)
                         .name
                         .map_or_else(|| "<unnamed>".to_string(), |name| name.as_str().to_string());
-                    ctx.emit_with_msg(
-                        &PROTECTED_VARS,
-                        span,
-                        format!(
-                            "protected variable `{variable}` is written without `{requirement}`"
+                    match requirement {
+                        ProtectionRequirement::Signature(signature) => {
+                            if targets
+                                .resolve(signature)
+                                .is_some_and(|target_id| calls.contains(&target_id))
+                            {
+                                continue;
+                            }
+                            ctx.emit_with_msg(
+                                &PROTECTED_VARS,
+                                span,
+                                format!(
+                                    "protected variable `{variable}` is written without `{signature}`{contract_context}"
+                                ),
+                            );
+                        }
+                        ProtectionRequirement::Malformed => ctx.emit_with_msg(
+                            &PROTECTED_VARS,
+                            span,
+                            format!(
+                                "protected variable `{variable}` has a malformed write-protection annotation{contract_context}"
+                            ),
                         ),
-                    );
+                    }
                 }
             }
         }
@@ -93,7 +121,7 @@ fn protected_variables(
     gcx: Gcx<'_>,
     hir: &hir::Hir<'_>,
     bases: &[ContractId],
-) -> HashMap<VariableId, Vec<String>> {
+) -> HashMap<VariableId, Vec<ProtectionRequirement>> {
     let mut protected = HashMap::new();
 
     for &contract_id in bases {
@@ -103,17 +131,24 @@ fn protected_variables(
                 continue;
             }
 
-            let requirements: Vec<_> = gcx
-                .natspec_doc_comments(var.doc)
-                .iter()
-                .filter_map(|item| {
-                    let NatSpecKind::Custom { name } = item.kind else { return None };
-                    if name.as_str() != "security" {
-                        return None;
-                    }
-                    parse_write_protection(item.content()).map(str::to_owned)
-                })
-                .collect();
+            let mut requirements = Vec::new();
+            for item in gcx.natspec_doc_comments(var.doc) {
+                let NatSpecKind::Custom { name } = item.kind else { continue };
+                if name.as_str() != "security" {
+                    continue;
+                }
+                let content = item.content();
+                let requirement = if let Some(signature) = parse_write_protection(content) {
+                    ProtectionRequirement::Signature(signature.to_owned())
+                } else if has_write_protection_token(content) {
+                    ProtectionRequirement::Malformed
+                } else {
+                    continue;
+                };
+                if !requirements.contains(&requirement) {
+                    requirements.push(requirement);
+                }
+            }
             if !requirements.is_empty() {
                 protected.insert(var_id, requirements);
             }
@@ -123,10 +158,33 @@ fn protected_variables(
     protected
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ProtectionRequirement {
+    Signature(String),
+    Malformed,
+}
+
 fn parse_write_protection(content: &str) -> Option<&str> {
-    let value = content.split_once("write-protection=\"")?.1;
+    let index = write_protection_token(content)?;
+    let value = content[index + "write-protection".len()..].strip_prefix("=\"")?;
     let (signature, _) = value.split_once('"')?;
     (!signature.is_empty()).then_some(signature)
+}
+
+fn has_write_protection_token(content: &str) -> bool {
+    write_protection_token(content).is_some()
+}
+
+fn write_protection_token(content: &str) -> Option<usize> {
+    content.match_indices("write-protection").find_map(|(index, token)| {
+        let before = content[..index].chars().next_back();
+        let after = content[index + token.len()..].chars().next();
+        let is_token_character =
+            |character: char| character.is_alphanumeric() || matches!(character, '_' | '-');
+        (before.is_none_or(|character| !is_token_character(character))
+            && after.is_none_or(|character| !is_token_character(character)))
+        .then_some(index)
+    })
 }
 
 struct ProtectionTargets {
@@ -146,12 +204,13 @@ impl ProtectionTargets {
                 if function.name.is_none() {
                     continue;
                 }
-                let signature = gcx.item_signature(ItemId::Function(function_id)).to_string();
                 match function.kind {
                     FunctionKind::Function => {
+                        let signature = callable_signature(gcx, hir, function_id);
                         this.functions.entry(signature).or_insert(function_id);
                     }
                     FunctionKind::Modifier => {
+                        let signature = callable_signature(gcx, hir, function_id);
                         this.modifiers.entry(signature).or_insert(function_id);
                     }
                     FunctionKind::Constructor | FunctionKind::Fallback | FunctionKind::Receive => {}
@@ -164,6 +223,81 @@ impl ProtectionTargets {
 
     fn resolve(&self, signature: &str) -> Option<FunctionId> {
         self.functions.get(signature).or_else(|| self.modifiers.get(signature)).copied()
+    }
+}
+
+fn callable_signature(gcx: Gcx<'_>, hir: &hir::Hir<'_>, function_id: FunctionId) -> String {
+    let function = hir.function(function_id);
+    let mut signature = function.name.unwrap().as_str().to_owned();
+    signature.push('(');
+    for (index, &parameter) in function.parameters.iter().enumerate() {
+        if index > 0 {
+            signature.push(',');
+        }
+        let ty = gcx.type_of_item(parameter.into());
+        if function.kind == FunctionKind::Modifier {
+            signature.push_str(&source_type_signature(gcx, ty));
+        } else {
+            signature.push_str(&slither_function_parameter(gcx, ty, &mut HashSet::new()));
+        }
+    }
+    signature.push(')');
+    signature
+}
+
+/// Formats the source-level types used by Slither modifier signatures.
+fn source_type_signature<'gcx>(gcx: Gcx<'gcx>, ty: Ty<'gcx>) -> String {
+    ty.display(gcx)
+        .to_string()
+        .replace("contract ", "")
+        .replace("struct ", "")
+        .replace("enum ", "")
+        .replace(" storage", "")
+        .replace(" memory", "")
+        .replace(" calldata", "")
+        .replace(" external", "")
+        .replace(" internal", "")
+        .replace(" pure", "")
+        .replace(" view", "")
+        .replace(" payable", "")
+        .replace("function ", "function")
+        .replace("returns ", "returns")
+}
+
+/// Formats the Solidity-signature types used by Slither function lookup.
+fn slither_function_parameter<'gcx>(
+    gcx: Gcx<'gcx>,
+    ty: Ty<'gcx>,
+    seen_structs: &mut HashSet<hir::StructId>,
+) -> String {
+    match ty.kind {
+        TyKind::Fn(_) | TyKind::Mapping(..) => source_type_signature(gcx, ty),
+        TyKind::Ref(inner, _) => slither_function_parameter(gcx, inner, seen_structs),
+        TyKind::DynArray(inner) => {
+            format!("{}[]", slither_function_parameter(gcx, inner, seen_structs))
+        }
+        TyKind::Array(inner, length) => {
+            format!("{}[{length}]", slither_function_parameter(gcx, inner, seen_structs))
+        }
+        TyKind::Struct(struct_id) => {
+            if !seen_structs.insert(struct_id) {
+                return source_type_signature(gcx, ty);
+            }
+            let fields = gcx
+                .struct_field_types(struct_id)
+                .iter()
+                .map(|&field| slither_function_parameter(gcx, field, seen_structs))
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("({fields})")
+        }
+        _ => {
+            let mut signature = String::new();
+            TyAbiPrinter::new(gcx, &mut signature, TyAbiPrinterMode::Signature)
+                .print(ty)
+                .expect("writing to a String cannot fail");
+            signature
+        }
     }
 }
 
@@ -209,14 +343,57 @@ fn effective_entry_points(
     entries
 }
 
+#[derive(Clone, Default, PartialEq, Eq)]
+struct AliasState {
+    storage: RootMap,
+    slots: RootMap,
+}
+
+/// A finite call-graph key that distinguishes storage aliases without depending on values.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct CallContext {
+    function_id: FunctionId,
+    storage: Vec<(VariableId, Vec<VariableId>)>,
+    slots: Vec<(VariableId, Vec<VariableId>)>,
+}
+
+#[derive(Clone, Default)]
+struct LoopAliases {
+    breaks: Option<AliasState>,
+    continues: Option<AliasState>,
+}
+
+impl CallContext {
+    fn new(function_id: FunctionId, function: &hir::Function<'_>, aliases: &AliasState) -> Self {
+        let roots = |aliases: &RootMap| {
+            function
+                .parameters
+                .iter()
+                .filter_map(|&parameter| {
+                    let mut roots: Vec<_> = aliases.get(&parameter)?.iter().copied().collect();
+                    roots.sort_unstable();
+                    Some((parameter, roots))
+                })
+                .collect()
+        };
+        Self { function_id, storage: roots(&aliases.storage), slots: roots(&aliases.slots) }
+    }
+}
+
 struct EntryAnalyzer<'hir> {
     gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
     bases: &'hir [ContractId],
     writes: HashSet<VariableId>,
     calls: HashSet<FunctionId>,
-    storage_aliases: HashMap<VariableId, VariableId>,
+    aliases: AliasState,
+    call_returns: HashMap<ExprId, Vec<StorageRoots>>,
+    call_summaries: HashMap<CallContext, Vec<StorageRoots>>,
+    seen_calls: HashSet<CallContext>,
     stack: Vec<FunctionId>,
+    return_stack: Vec<Vec<StorageRoots>>,
+    loop_aliases: Vec<LoopAliases>,
+    assembly_depth: usize,
 }
 
 impl<'hir> EntryAnalyzer<'hir> {
@@ -227,27 +404,37 @@ impl<'hir> EntryAnalyzer<'hir> {
             bases,
             writes: HashSet::new(),
             calls: HashSet::new(),
-            storage_aliases: HashMap::new(),
+            aliases: AliasState::default(),
+            call_returns: HashMap::new(),
+            call_summaries: HashMap::new(),
+            seen_calls: HashSet::new(),
             stack: Vec::new(),
+            return_stack: Vec::new(),
+            loop_aliases: Vec::new(),
+            assembly_depth: 0,
         }
     }
 
     fn analyze(&mut self, entry_id: FunctionId) -> (HashSet<VariableId>, HashSet<FunctionId>) {
-        self.analyze_function(entry_id);
+        let _ = self.analyze_function(entry_id);
         (std::mem::take(&mut self.writes), std::mem::take(&mut self.calls))
     }
 
-    fn analyze_function(&mut self, function_id: FunctionId) {
-        if self.stack.contains(&function_id) {
-            return;
-        }
-
+    fn analyze_function(&mut self, function_id: FunctionId) -> Vec<StorageRoots> {
         let function = self.hir.function(function_id);
-        let Some(body) = function.body else { return };
+        let Some(body) = function.body else {
+            return function.returns.iter().map(|_| StorageRoots::new()).collect();
+        };
         self.stack.push(function_id);
+        self.return_stack.push(function.returns.iter().map(|_| StorageRoots::new()).collect());
         self.analyze_modifiers(function);
         self.analyze_block(body);
+        if !body.stmts.iter().any(branch_always_exits) {
+            self.capture_named_returns();
+        }
+        let returns = self.return_stack.pop().expect("return frame must exist");
         self.stack.pop();
+        returns
     }
 
     fn analyze_modifiers(&mut self, function: &'hir hir::Function<'hir>) {
@@ -256,35 +443,65 @@ impl<'hir> EntryAnalyzer<'hir> {
                 self.analyze_expr(argument);
             }
 
-            let Some(modifier_id) = modifier.id.as_function() else { continue };
+            let Some(declared_id) = modifier.id.as_function() else { continue };
+            let modifier_id = self.dispatch_function(declared_id);
             self.calls.insert(modifier_id);
-            self.analyze_call(modifier_id, &modifier.args);
+            let arguments = self.ordered_call_arguments(declared_id, modifier.args, None);
+            self.analyze_call(modifier_id, &arguments);
         }
     }
 
-    fn analyze_call(&mut self, function_id: FunctionId, args: &hir::CallArgs<'hir>) {
-        if self.stack.contains(&function_id) {
-            return;
-        }
-
+    fn analyze_call(
+        &mut self,
+        function_id: FunctionId,
+        arguments: &[&'hir hir::Expr<'hir>],
+    ) -> Vec<StorageRoots> {
         let function = self.hir.function(function_id);
-        let saved_aliases = std::mem::take(&mut self.storage_aliases);
-        for (parameter, argument) in function.parameters.iter().copied().zip(args.exprs()) {
-            if self.hir.variable(parameter).data_location == Some(DataLocation::Storage)
-                && let Some(root) =
-                    state_lhs_vars(self.hir, argument, &saved_aliases).into_iter().next()
-            {
-                self.storage_aliases.insert(parameter, root);
+        let saved_aliases = std::mem::take(&mut self.aliases);
+        for (parameter, &argument) in function.parameters.iter().copied().zip(arguments) {
+            if self.hir.variable(parameter).data_location == Some(DataLocation::Storage) {
+                let roots =
+                    state_lhs_vars(self.hir, argument, &saved_aliases.storage, &self.call_returns);
+                if !roots.is_empty() {
+                    self.aliases.storage.insert(parameter, roots);
+                }
+            }
+            if function.is_yul {
+                let roots = slot_roots(
+                    self.hir,
+                    argument,
+                    &saved_aliases.storage,
+                    &saved_aliases.slots,
+                    &self.call_returns,
+                );
+                if !roots.is_empty() {
+                    self.aliases.slots.insert(parameter, roots);
+                }
             }
         }
 
-        self.analyze_function(function_id);
-        self.storage_aliases = saved_aliases;
+        let context = CallContext::new(function_id, function, &self.aliases);
+        if let Some(returns) = self.call_summaries.get(&context).cloned() {
+            self.aliases = saved_aliases;
+            return returns;
+        }
+        if !self.seen_calls.insert(context.clone()) {
+            self.aliases = saved_aliases;
+            return Vec::new();
+        }
+
+        let returns = self.analyze_function(function_id);
+        self.call_summaries.insert(context, returns.clone());
+        self.aliases = saved_aliases;
+        returns
     }
 
     fn analyze_block(&mut self, block: hir::Block<'hir>) {
         for statement in block.stmts {
             self.analyze_stmt(statement);
+            if branch_always_exits(statement) {
+                break;
+            }
         }
     }
 
@@ -295,77 +512,134 @@ impl<'hir> EntryAnalyzer<'hir> {
                 if let Some(initializer) = variable.initializer {
                     self.analyze_expr(initializer);
                     self.set_storage_alias(variable_id, initializer);
+                    if self.assembly_depth > 0 {
+                        self.set_slot_alias(variable_id, initializer);
+                    }
                 }
             }
-            StmtKind::DeclMulti(_, expression)
-            | StmtKind::Emit(expression)
+            StmtKind::DeclMulti(variables, expression) => {
+                self.analyze_expr(expression);
+                self.set_decl_aliases(variables, expression);
+            }
+            StmtKind::Emit(expression)
             | StmtKind::Revert(expression)
             | StmtKind::Expr(expression) => self.analyze_expr(expression),
-            StmtKind::Return(Some(expression)) => self.analyze_expr(expression),
+            StmtKind::Return(Some(expression)) => {
+                self.analyze_expr(expression);
+                self.set_return_aliases(expression);
+            }
+            StmtKind::Return(None) => self.capture_named_returns(),
             StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => self.analyze_block(block),
-            StmtKind::Loop(block, _) => {
-                let aliases = self.storage_aliases.clone();
+            StmtKind::AssemblyBlock(block) => {
+                self.assembly_depth += 1;
                 self.analyze_block(block);
-                self.storage_aliases = aliases;
+                self.assembly_depth -= 1;
+            }
+            StmtKind::Loop(block, source) => {
+                let before = self.aliases.clone();
+                let flow = self.analyze_loop_iteration(block);
+                let iteration = merge_optional_alias_state(&self.aliases, &flow.continues);
+                let exits = if source == hir::LoopSource::DoWhile {
+                    iteration
+                } else {
+                    merge_alias_states(&before, &iteration)
+                };
+                let mut input = merge_optional_alias_state(&exits, &flow.breaks);
+                loop {
+                    self.aliases = input.clone();
+                    let flow = self.analyze_loop_iteration(block);
+                    let iteration = merge_optional_alias_state(&self.aliases, &flow.continues);
+                    let next = merge_optional_alias_state(
+                        &merge_alias_states(&exits, &iteration),
+                        &flow.breaks,
+                    );
+                    if next == input {
+                        self.aliases = next;
+                        break;
+                    }
+                    input = next;
+                }
             }
             StmtKind::If(condition, then_statement, else_statement) => {
                 self.analyze_expr(condition);
-                let aliases = self.storage_aliases.clone();
+                let before = self.aliases.clone();
                 self.analyze_stmt(then_statement);
-                self.storage_aliases = aliases.clone();
-                if let Some(else_statement) = else_statement {
+                let then_aliases = self.aliases.clone();
+                let then_exits = branch_always_exits(then_statement);
+                self.aliases = before;
+                let else_exits = if let Some(else_statement) = else_statement {
                     self.analyze_stmt(else_statement);
-                }
-                self.storage_aliases = aliases;
+                    branch_always_exits(else_statement)
+                } else {
+                    false
+                };
+                let else_aliases = self.aliases.clone();
+                self.aliases = match (then_exits, else_exits) {
+                    (true, false) => else_aliases,
+                    (false, true) => then_aliases,
+                    _ => merge_alias_states(&then_aliases, &else_aliases),
+                };
             }
             StmtKind::Try(try_statement) => {
                 self.analyze_expr(&try_statement.expr);
-                let aliases = self.storage_aliases.clone();
+                let before = self.aliases.clone();
+                let mut merged = before.clone();
                 for clause in try_statement.clauses {
-                    self.storage_aliases = aliases.clone();
+                    self.aliases = before.clone();
                     self.analyze_block(clause.block);
+                    merged = merge_alias_states(&merged, &self.aliases);
                 }
-                self.storage_aliases = aliases;
+                self.aliases = merged;
             }
-            StmtKind::Return(None)
-            | StmtKind::Break
-            | StmtKind::Continue
-            | StmtKind::Placeholder
-            | StmtKind::AssemblyBlock(_)
-            | StmtKind::Switch(_)
-            | StmtKind::Err(_) => {}
+            StmtKind::Switch(switch) => {
+                self.analyze_expr(switch.selector);
+                let before = self.aliases.clone();
+                let mut merged = before.clone();
+                for case in switch.cases {
+                    self.aliases = before.clone();
+                    self.analyze_block(case.body);
+                    merged = merge_alias_states(&merged, &self.aliases);
+                }
+                self.aliases = merged;
+            }
+            StmtKind::Break => {
+                if let Some(flow) = self.loop_aliases.last_mut() {
+                    merge_alias_state_into(&mut flow.breaks, &self.aliases);
+                }
+            }
+            StmtKind::Continue => {
+                if let Some(flow) = self.loop_aliases.last_mut() {
+                    merge_alias_state_into(&mut flow.continues, &self.aliases);
+                }
+            }
+            StmtKind::Placeholder | StmtKind::Err(_) => {}
         }
+    }
+
+    fn analyze_loop_iteration(&mut self, block: hir::Block<'hir>) -> LoopAliases {
+        self.loop_aliases.push(LoopAliases::default());
+        self.analyze_block(block);
+        self.loop_aliases.pop().expect("loop alias frame must exist")
     }
 
     fn analyze_expr(&mut self, expression: &'hir hir::Expr<'hir>) {
         match &expression.peel_parens().kind {
-            ExprKind::Assign(lhs, _, rhs) => {
+            ExprKind::Assign(lhs, operator, rhs) => {
                 self.analyze_expr(rhs);
-                self.record_write(lhs);
-                if let Some(local) = lhs_local_var(self.hir, lhs) {
-                    self.set_storage_alias(local, rhs);
-                } else {
-                    self.analyze_lhs(lhs);
-                }
+                self.analyze_lhs(lhs);
+                self.apply_assignment(lhs, rhs, operator.is_some());
             }
             ExprKind::Delete(inner) => {
-                self.record_write(inner);
                 self.analyze_lhs(inner);
+                self.record_write(inner);
             }
             ExprKind::Unary(operator, inner) => {
+                self.analyze_expr(inner);
                 if operator.kind.has_side_effects() {
                     self.record_write(inner);
                 }
-                self.analyze_expr(inner);
             }
             ExprKind::Call(callee, args, options) => {
-                if let ExprKind::Member(base, member) = &callee.peel_parens().kind
-                    && matches!(member.as_str(), "push" | "pop")
-                    && is_dynamic_array_or_bytes(self.gcx, base)
-                {
-                    self.record_write(base);
-                }
-
                 self.analyze_expr(callee);
                 if let Some(options) = options {
                     for option in options.args {
@@ -376,11 +650,37 @@ impl<'hir> EntryAnalyzer<'hir> {
                     self.analyze_expr(argument);
                 }
 
-                for function_id in
-                    resolved_internal_functions(self.hir, callee, args.len(), self.bases)
+                if let ExprKind::Member(base, member) = &callee.peel_parens().kind
+                    && matches!(member.as_str(), "push" | "pop")
+                    && is_dynamic_array_or_bytes(self.gcx, base)
+                {
+                    self.record_write(base);
+                    if member.as_str() == "push" && args.is_empty() {
+                        let roots = self.storage_roots(base);
+                        self.store_call_returns(expression.id, vec![roots]);
+                    }
+                }
+
+                if is_storage_write_builtin(callee)
+                    && let Some(slot) = args.exprs().next()
+                {
+                    let roots = slot_roots(
+                        self.hir,
+                        slot,
+                        &self.aliases.storage,
+                        &self.aliases.slots,
+                        &self.call_returns,
+                    );
+                    self.writes.extend(roots);
+                }
+
+                if let Some((declared_id, function_id, receiver)) =
+                    self.resolved_internal_call(callee)
                 {
                     self.calls.insert(function_id);
-                    self.analyze_call(function_id, args);
+                    let arguments = self.ordered_call_arguments(declared_id, *args, receiver);
+                    let returns = self.analyze_call(function_id, &arguments);
+                    self.store_call_returns(expression.id, returns);
                 }
             }
             ExprKind::Binary(lhs, _, rhs) => {
@@ -402,7 +702,9 @@ impl<'hir> EntryAnalyzer<'hir> {
                     self.analyze_expr(end);
                 }
             }
-            ExprKind::Member(base, _) | ExprKind::Payable(base) => self.analyze_expr(base),
+            ExprKind::Member(base, _) | ExprKind::YulMember(base, _) | ExprKind::Payable(base) => {
+                self.analyze_expr(base)
+            }
             ExprKind::Ternary(condition, if_true, if_false) => {
                 self.analyze_expr(condition);
                 self.analyze_expr(if_true);
@@ -419,7 +721,7 @@ impl<'hir> EntryAnalyzer<'hir> {
                 }
             }
             ExprKind::New(_) | ExprKind::TypeCall(_) | ExprKind::Type(_) => {}
-            ExprKind::Ident(_) | ExprKind::Lit(_) | ExprKind::YulMember(..) | ExprKind::Err(_) => {}
+            ExprKind::Ident(_) | ExprKind::Lit(_) | ExprKind::Err(_) => {}
         }
     }
 
@@ -440,34 +742,267 @@ impl<'hir> EntryAnalyzer<'hir> {
                     self.analyze_expr(end);
                 }
             }
-            ExprKind::Member(base, _) | ExprKind::Payable(base) => self.analyze_lhs(base),
+            ExprKind::Member(base, _) | ExprKind::YulMember(base, _) | ExprKind::Payable(base) => {
+                self.analyze_lhs(base)
+            }
             ExprKind::Tuple(expressions) => {
                 for expression in expressions.iter().copied().flatten() {
                     self.analyze_lhs(expression);
                 }
             }
+            ExprKind::Call(..) => self.analyze_expr(expression),
             _ => {}
         }
     }
 
     fn record_write(&mut self, expression: &hir::Expr<'_>) {
-        self.writes.extend(state_lhs_vars(self.hir, expression, &self.storage_aliases));
+        self.writes.extend(self.storage_roots(expression));
+    }
+
+    fn storage_roots(&self, expression: &hir::Expr<'_>) -> StorageRoots {
+        state_lhs_vars(self.hir, expression, &self.aliases.storage, &self.call_returns)
     }
 
     fn set_storage_alias(&mut self, variable_id: VariableId, initializer: &'hir hir::Expr<'hir>) {
         let variable = self.hir.variable(variable_id);
         if variable.kind.is_state() || variable.data_location != Some(DataLocation::Storage) {
-            self.storage_aliases.remove(&variable_id);
+            self.aliases.storage.remove(&variable_id);
             return;
         }
 
-        if let Some(root) =
-            state_lhs_vars(self.hir, initializer, &self.storage_aliases).into_iter().next()
+        let roots = self.storage_roots(initializer);
+        self.set_storage_alias_roots(variable_id, roots);
+    }
+
+    fn set_storage_alias_roots(&mut self, variable_id: VariableId, roots: StorageRoots) {
+        let variable = self.hir.variable(variable_id);
+        if !variable.kind.is_state()
+            && variable.data_location == Some(DataLocation::Storage)
+            && !roots.is_empty()
         {
-            self.storage_aliases.insert(variable_id, root);
+            self.aliases.storage.insert(variable_id, roots);
         } else {
-            self.storage_aliases.remove(&variable_id);
+            self.aliases.storage.remove(&variable_id);
         }
+    }
+
+    fn set_slot_alias(&mut self, variable_id: VariableId, initializer: &'hir hir::Expr<'hir>) {
+        let roots = slot_roots(
+            self.hir,
+            initializer,
+            &self.aliases.storage,
+            &self.aliases.slots,
+            &self.call_returns,
+        );
+        if roots.is_empty() {
+            self.aliases.slots.remove(&variable_id);
+        } else {
+            self.aliases.slots.insert(variable_id, roots);
+        }
+    }
+
+    fn apply_assignment(
+        &mut self,
+        lhs: &'hir hir::Expr<'hir>,
+        rhs: &'hir hir::Expr<'hir>,
+        compound: bool,
+    ) {
+        if !compound && let ExprKind::Tuple(expressions) = &lhs.peel_parens().kind {
+            let outputs = expressions.len();
+            for (index, expression) in expressions.iter().copied().enumerate() {
+                let Some(expression) = expression else { continue };
+                if let Some(local) = lhs_local_var(self.hir, expression) {
+                    let roots = self.storage_roots_for_output(rhs, index, outputs);
+                    self.set_storage_alias_roots(local, roots);
+                    if self.assembly_depth > 0 {
+                        self.set_slot_alias(local, rhs);
+                    }
+                } else {
+                    self.record_write(expression);
+                }
+            }
+            return;
+        }
+
+        if !compound && let Some(local) = lhs_local_var(self.hir, lhs) {
+            self.set_storage_alias(local, rhs);
+            if self.assembly_depth > 0 {
+                self.set_slot_alias(local, rhs);
+            }
+            return;
+        }
+
+        self.record_write(lhs);
+    }
+
+    fn set_decl_aliases(
+        &mut self,
+        variables: &[Option<VariableId>],
+        expression: &'hir hir::Expr<'hir>,
+    ) {
+        for (index, variable_id) in variables.iter().copied().enumerate() {
+            let Some(variable_id) = variable_id else { continue };
+            let roots = self.storage_roots_for_output(expression, index, variables.len());
+            self.set_storage_alias_roots(variable_id, roots);
+            if self.assembly_depth > 0 {
+                self.set_slot_alias(variable_id, expression);
+            }
+        }
+    }
+
+    fn set_return_aliases(&mut self, expression: &'hir hir::Expr<'hir>) {
+        let Some(&function_id) = self.stack.last() else { return };
+        let returns = self.hir.function(function_id).returns;
+        let roots: Vec<_> = returns
+            .iter()
+            .enumerate()
+            .map(|(index, _)| self.storage_roots_for_output(expression, index, returns.len()))
+            .collect();
+        let Some(frame) = self.return_stack.last_mut() else { return };
+        for (returned, roots) in frame.iter_mut().zip(roots) {
+            returned.extend(roots);
+        }
+    }
+
+    fn capture_named_returns(&mut self) {
+        let Some(&function_id) = self.stack.last() else { return };
+        let function = self.hir.function(function_id);
+        let aliases = if function.is_yul { &self.aliases.slots } else { &self.aliases.storage };
+        let roots: Vec<_> = function
+            .returns
+            .iter()
+            .map(|return_id| aliases.get(return_id).cloned().unwrap_or_default())
+            .collect();
+        let Some(frame) = self.return_stack.last_mut() else { return };
+        for (returned, roots) in frame.iter_mut().zip(roots) {
+            returned.extend(roots);
+        }
+    }
+
+    fn storage_roots_for_output(
+        &self,
+        expression: &hir::Expr<'_>,
+        index: usize,
+        outputs: usize,
+    ) -> StorageRoots {
+        if let ExprKind::Tuple(expressions) = &expression.peel_parens().kind
+            && outputs > 1
+        {
+            return expressions
+                .get(index)
+                .and_then(|expression| *expression)
+                .map_or_else(StorageRoots::new, |expression| self.storage_roots(expression));
+        }
+        if let ExprKind::Call(..) = expression.peel_parens().kind {
+            return self
+                .call_returns
+                .get(&expression.id)
+                .and_then(|returns| returns.get(index))
+                .cloned()
+                .unwrap_or_default();
+        }
+        if outputs == 1 && index == 0 {
+            self.storage_roots(expression)
+        } else {
+            StorageRoots::new()
+        }
+    }
+
+    fn store_call_returns(&mut self, expression_id: ExprId, returns: Vec<StorageRoots>) {
+        if returns.is_empty() {
+            return;
+        }
+        let stored = self.call_returns.entry(expression_id).or_default();
+        if stored.len() < returns.len() {
+            stored.resize_with(returns.len(), StorageRoots::new);
+        }
+        for (stored, returned) in stored.iter_mut().zip(returns) {
+            stored.extend(returned);
+        }
+    }
+
+    fn ordered_call_arguments(
+        &self,
+        declared_id: FunctionId,
+        arguments: hir::CallArgs<'hir>,
+        receiver: Option<&'hir hir::Expr<'hir>>,
+    ) -> Vec<&'hir hir::Expr<'hir>> {
+        let function = self.hir.function(declared_id);
+        let parameters = &function.parameters[usize::from(receiver.is_some())..];
+        let mut ordered = Vec::with_capacity(arguments.len() + usize::from(receiver.is_some()));
+        ordered.extend(receiver);
+        match arguments.kind {
+            hir::CallArgsKind::Unnamed(expressions) => ordered.extend(expressions),
+            hir::CallArgsKind::Named(named) => {
+                for &parameter in parameters {
+                    let Some(parameter_name) = self.hir.variable(parameter).name else { continue };
+                    if let Some(argument) = named.iter().find(|arg| arg.name == parameter_name) {
+                        ordered.push(&argument.value);
+                    }
+                }
+            }
+        }
+        ordered
+    }
+
+    fn resolved_internal_call(
+        &self,
+        callee: &'hir hir::Expr<'hir>,
+    ) -> Option<(FunctionId, FunctionId, Option<&'hir hir::Expr<'hir>>)> {
+        let resolved = self.gcx.resolved_callee(callee.id);
+        let (function_id, attached) = if let Some(resolved) = resolved {
+            let Res::Item(ItemId::Function(function_id)) = resolved.res else { return None };
+            (function_id, resolved.attached)
+        } else {
+            let ExprKind::Ident(resolutions) = &callee.peel_parens().kind else { return None };
+            let mut functions = resolutions.iter().filter_map(|resolution| match resolution {
+                Res::Item(ItemId::Function(function_id)) => Some(*function_id),
+                _ => None,
+            });
+            let function_id = functions.next()?;
+            if functions.next().is_some() {
+                return None;
+            }
+            (function_id, false)
+        };
+
+        match &callee.peel_parens().kind {
+            ExprKind::Ident(_) => Some((function_id, self.dispatch_function(function_id), None)),
+            ExprKind::Member(base, _) if attached => Some((function_id, function_id, Some(base))),
+            ExprKind::Member(base, _)
+                if self.is_library_function(function_id) || is_static_internal_base(base) =>
+            {
+                Some((function_id, function_id, None))
+            }
+            _ => None,
+        }
+    }
+
+    fn is_library_function(&self, function_id: FunctionId) -> bool {
+        self.hir
+            .function(function_id)
+            .contract
+            .is_some_and(|contract_id| self.hir.contract(contract_id).kind.is_library())
+    }
+
+    fn dispatch_function(&self, function_id: FunctionId) -> FunctionId {
+        let function = self.hir.function(function_id);
+        if !function.virtual_ {
+            return function_id;
+        }
+
+        let signature = callable_signature(self.gcx, self.hir, function_id);
+        for &contract_id in self.bases {
+            for candidate_id in self.hir.contract(contract_id).functions() {
+                let candidate = self.hir.function(candidate_id);
+                if candidate.kind == function.kind
+                    && callable_signature(self.gcx, self.hir, candidate_id) == signature
+                {
+                    return candidate_id;
+                }
+            }
+        }
+        function_id
     }
 }
 
@@ -484,105 +1019,221 @@ fn lhs_local_var(hir: &hir::Hir<'_>, expression: &hir::Expr<'_>) -> Option<Varia
 fn state_lhs_vars(
     hir: &hir::Hir<'_>,
     expression: &hir::Expr<'_>,
-    storage_aliases: &HashMap<VariableId, VariableId>,
-) -> Vec<VariableId> {
-    let mut variables = Vec::new();
-    collect_state_lhs_vars(hir, expression, storage_aliases, &mut variables);
+    storage_aliases: &RootMap,
+    call_returns: &HashMap<ExprId, Vec<StorageRoots>>,
+) -> StorageRoots {
+    let mut variables = StorageRoots::new();
+    collect_state_lhs_vars(hir, expression, storage_aliases, call_returns, &mut variables);
     variables
 }
 
 fn collect_state_lhs_vars(
     hir: &hir::Hir<'_>,
     expression: &hir::Expr<'_>,
-    storage_aliases: &HashMap<VariableId, VariableId>,
-    variables: &mut Vec<VariableId>,
+    storage_aliases: &RootMap,
+    call_returns: &HashMap<ExprId, Vec<StorageRoots>>,
+    variables: &mut StorageRoots,
 ) {
     match &expression.peel_parens().kind {
         ExprKind::Ident(resolutions) => {
             for resolution in *resolutions {
                 let Res::Item(ItemId::Variable(variable_id)) = resolution else { continue };
-                let root = if hir.variable(*variable_id).kind.is_state() {
-                    Some(*variable_id)
-                } else {
-                    storage_aliases.get(variable_id).copied()
-                };
-                if let Some(root) = root
-                    && !variables.contains(&root)
-                {
-                    variables.push(root);
+                if hir.variable(*variable_id).kind.is_state() {
+                    variables.insert(*variable_id);
+                } else if let Some(roots) = storage_aliases.get(variable_id) {
+                    variables.extend(roots);
                 }
             }
         }
-        ExprKind::Index(base, _) | ExprKind::Slice(base, ..) | ExprKind::Member(base, _) => {
-            collect_state_lhs_vars(hir, base, storage_aliases, variables);
+        ExprKind::Index(base, _)
+        | ExprKind::Slice(base, ..)
+        | ExprKind::Member(base, _)
+        | ExprKind::YulMember(base, _) => {
+            collect_state_lhs_vars(hir, base, storage_aliases, call_returns, variables);
         }
         ExprKind::Payable(base) | ExprKind::Unary(_, base) | ExprKind::Delete(base) => {
-            collect_state_lhs_vars(hir, base, storage_aliases, variables);
+            collect_state_lhs_vars(hir, base, storage_aliases, call_returns, variables);
         }
         ExprKind::Tuple(expressions) => {
             for expression in expressions.iter().copied().flatten() {
-                collect_state_lhs_vars(hir, expression, storage_aliases, variables);
+                collect_state_lhs_vars(hir, expression, storage_aliases, call_returns, variables);
+            }
+        }
+        ExprKind::Ternary(_, if_true, if_false) => {
+            collect_state_lhs_vars(hir, if_true, storage_aliases, call_returns, variables);
+            collect_state_lhs_vars(hir, if_false, storage_aliases, call_returns, variables);
+        }
+        ExprKind::Call(..) => {
+            if let Some(returns) = call_returns.get(&expression.id) {
+                for roots in returns {
+                    variables.extend(roots);
+                }
             }
         }
         _ => {}
     }
 }
 
-fn is_dynamic_array_or_bytes(gcx: Gcx<'_>, expression: &hir::Expr<'_>) -> bool {
-    gcx.type_of_expr(expression.peel_parens().id).is_some_and(|ty| {
+fn slot_roots(
+    hir: &hir::Hir<'_>,
+    expression: &hir::Expr<'_>,
+    storage_aliases: &RootMap,
+    slot_aliases: &RootMap,
+    call_returns: &HashMap<ExprId, Vec<StorageRoots>>,
+) -> StorageRoots {
+    let mut variables = StorageRoots::new();
+    collect_slot_roots(
+        hir,
+        expression,
+        storage_aliases,
+        slot_aliases,
+        call_returns,
+        &mut variables,
+    );
+    variables
+}
+
+fn collect_slot_roots(
+    hir: &hir::Hir<'_>,
+    expression: &hir::Expr<'_>,
+    storage_aliases: &RootMap,
+    slot_aliases: &RootMap,
+    call_returns: &HashMap<ExprId, Vec<StorageRoots>>,
+    variables: &mut StorageRoots,
+) {
+    if let ExprKind::Call(..) = &expression.peel_parens().kind
+        && let Some(returns) = call_returns.get(&expression.id)
+    {
+        for roots in returns {
+            variables.extend(roots);
+        }
+    }
+    let mut recurse = |expression| {
+        collect_slot_roots(hir, expression, storage_aliases, slot_aliases, call_returns, variables)
+    };
+    match &expression.peel_parens().kind {
+        ExprKind::Ident(resolutions) => {
+            for resolution in *resolutions {
+                let Res::Item(ItemId::Variable(variable_id)) = resolution else { continue };
+                if let Some(roots) = slot_aliases.get(variable_id) {
+                    variables.extend(roots);
+                }
+            }
+        }
+        ExprKind::YulMember(base, member) if member.as_str() == "slot" => {
+            variables.extend(state_lhs_vars(hir, base, storage_aliases, call_returns));
+        }
+        ExprKind::Array(expressions) => {
+            for expression in *expressions {
+                recurse(expression);
+            }
+        }
+        ExprKind::Assign(lhs, _, rhs) | ExprKind::Binary(lhs, _, rhs) => {
+            recurse(lhs);
+            recurse(rhs);
+        }
+        ExprKind::Call(callee, args, options) => {
+            recurse(callee);
+            if let Some(options) = options {
+                for option in options.args {
+                    recurse(&option.value);
+                }
+            }
+            for argument in args.exprs() {
+                recurse(argument);
+            }
+        }
+        ExprKind::Index(base, index) => {
+            recurse(base);
+            if let Some(index) = index {
+                recurse(index);
+            }
+        }
+        ExprKind::Slice(base, start, end) => {
+            recurse(base);
+            if let Some(start) = start {
+                recurse(start);
+            }
+            if let Some(end) = end {
+                recurse(end);
+            }
+        }
+        ExprKind::Member(base, _)
+        | ExprKind::YulMember(base, _)
+        | ExprKind::Payable(base)
+        | ExprKind::Unary(_, base)
+        | ExprKind::Delete(base) => recurse(base),
+        ExprKind::Ternary(condition, if_true, if_false) => {
+            recurse(condition);
+            recurse(if_true);
+            recurse(if_false);
+        }
+        ExprKind::Tuple(expressions) => {
+            for expression in expressions.iter().copied().flatten() {
+                recurse(expression);
+            }
+        }
+        ExprKind::New(_)
+        | ExprKind::TypeCall(_)
+        | ExprKind::Type(_)
+        | ExprKind::Lit(_)
+        | ExprKind::Err(_) => {}
+    }
+}
+
+fn merge_alias_states(lhs: &AliasState, rhs: &AliasState) -> AliasState {
+    AliasState {
+        storage: merge_root_maps(&lhs.storage, &rhs.storage),
+        slots: merge_root_maps(&lhs.slots, &rhs.slots),
+    }
+}
+
+fn merge_optional_alias_state(state: &AliasState, other: &Option<AliasState>) -> AliasState {
+    other.as_ref().map_or_else(|| state.clone(), |other| merge_alias_states(state, other))
+}
+
+fn merge_alias_state_into(destination: &mut Option<AliasState>, state: &AliasState) {
+    *destination = Some(
+        destination
+            .as_ref()
+            .map_or_else(|| state.clone(), |current| merge_alias_states(current, state)),
+    );
+}
+
+fn merge_root_maps(lhs: &RootMap, rhs: &RootMap) -> RootMap {
+    let mut merged = lhs.clone();
+    for (&variable_id, roots) in rhs {
+        merged.entry(variable_id).or_default().extend(roots);
+    }
+    merged
+}
+
+fn is_storage_write_builtin(callee: &hir::Expr<'_>) -> bool {
+    let ExprKind::Ident(resolutions) = &callee.peel_parens().kind else { return false };
+    resolutions.iter().any(|resolution| {
         matches!(
-            ty.peel_refs().kind,
-            TyKind::DynArray(_) | TyKind::Array(..) | TyKind::Elementary(ElementaryType::Bytes)
+            resolution,
+            Res::Builtin(builtin) if matches!(builtin.name().as_str(), "sstore" | "tstore")
         )
     })
 }
 
-fn resolved_internal_functions(
-    hir: &hir::Hir<'_>,
-    callee: &hir::Expr<'_>,
-    argument_count: usize,
-    bases: &[ContractId],
-) -> Vec<FunctionId> {
-    match &callee.peel_parens().kind {
-        ExprKind::Ident(resolutions) => resolutions
-            .iter()
-            .filter_map(|resolution| match resolution {
-                Res::Item(ItemId::Function(function_id))
-                    if hir.function(*function_id).parameters.len() == argument_count =>
-                {
-                    Some(*function_id)
-                }
-                _ => None,
-            })
-            .collect(),
-        ExprKind::Member(base, member) => {
-            let ExprKind::Ident(resolutions) = &base.peel_parens().kind else { return Vec::new() };
-            let is_super = resolutions.iter().any(
-                |resolution| matches!(resolution, Res::Builtin(builtin) if builtin.name() == sym::super_),
-            );
-            let contracts: Vec<_> = if is_super {
-                bases.get(1..).unwrap_or_default().to_vec()
-            } else {
-                resolutions
-                    .iter()
-                    .filter_map(|resolution| match resolution {
-                        Res::Item(ItemId::Contract(contract_id)) => Some(*contract_id),
-                        _ => None,
-                    })
-                    .collect()
-            };
+fn is_static_internal_base(base: &hir::Expr<'_>) -> bool {
+    let ExprKind::Ident(resolutions) = &base.peel_parens().kind else { return false };
+    resolutions.iter().any(|resolution| {
+        matches!(resolution, Res::Item(ItemId::Contract(_)) | Res::Namespace(_))
+            || matches!(
+                resolution,
+                Res::Builtin(builtin) if builtin.name() == sym::super_
+            )
+    })
+}
 
-            contracts
-                .into_iter()
-                .flat_map(|contract_id| hir.contract(contract_id).functions())
-                .filter(|&function_id| {
-                    let function = hir.function(function_id);
-                    function.kind == FunctionKind::Function
-                        && function.parameters.len() == argument_count
-                        && function.name.is_some_and(|name| name.as_str() == member.as_str())
-                })
-                .collect()
-        }
-        _ => Vec::new(),
-    }
+fn is_dynamic_array_or_bytes(gcx: Gcx<'_>, expression: &hir::Expr<'_>) -> bool {
+    gcx.type_of_expr(expression.peel_parens().id).is_some_and(|ty| {
+        matches!(
+            ty.peel_refs().kind,
+            TyKind::DynArray(_) | TyKind::Elementary(ElementaryType::Bytes)
+        )
+    })
 }

--- a/crates/lint/src/sol/high/protected_vars.rs
+++ b/crates/lint/src/sol/high/protected_vars.rs
@@ -1,7 +1,8 @@
-//! Slither-compatible protected-variable reachability analysis.
+//! Slither-compatible protected-variable control-flow analysis.
 //!
 //! Storage references are tracked as may-alias sets across internal calls and control-flow joins.
-//! Calls are memoized by their storage/slot context so recursive alias propagation terminates.
+//! Calls are memoized by their storage, slot, and guard context so recursive propagation
+//! terminates.
 
 use super::ProtectedVars;
 use crate::{
@@ -9,7 +10,7 @@ use crate::{
     sol::{Severity, SolLint, analysis::primitives::branch_always_exits},
 };
 use solar::{
-    ast::{ContractKind, DataLocation, ElementaryType, FunctionKind, Visibility},
+    ast::{BinOpKind, ContractKind, DataLocation, ElementaryType, FunctionKind, Visibility},
     interface::sym,
     sema::{
         Gcx,
@@ -56,11 +57,11 @@ impl<'hir> LateLintPass<'hir> for ProtectedVars {
         let targets = ProtectionTargets::new(gcx, hir, contract.linearized_bases);
         for entry_id in effective_entry_points(gcx, hir, contract.linearized_bases) {
             let mut analyzer = EntryAnalyzer::new(gcx, hir, contract.linearized_bases);
-            let (writes, calls) = analyzer.analyze(entry_id);
+            let writes = analyzer.analyze(entry_id);
 
             let mut writes: Vec<_> = writes.into_iter().collect();
-            writes.sort_unstable();
-            for var_id in writes {
+            writes.sort_unstable_by_key(|(variable_id, _)| *variable_id);
+            for (var_id, guards) in writes {
                 let Some(requirements) = protected.get(&var_id) else { continue };
                 for requirement in requirements {
                     let entry = hir.function(entry_id);
@@ -76,10 +77,7 @@ impl<'hir> LateLintPass<'hir> for ProtectedVars {
                         .map_or_else(|| "<unnamed>".to_string(), |name| name.as_str().to_string());
                     match requirement {
                         ProtectionRequirement::Signature(signature) => {
-                            if targets
-                                .resolve(signature)
-                                .is_some_and(|target_id| calls.contains(&target_id))
-                            {
+                            if targets.resolve(signature).is_some_and(|target| guards.contains(&target)) {
                                 continue;
                             }
                             ctx.emit_with_msg(
@@ -349,22 +347,47 @@ struct AliasState {
     slots: RootMap,
 }
 
+#[derive(Clone, Default, PartialEq, Eq)]
+struct FlowState {
+    aliases: AliasState,
+    guards: HashSet<FunctionId>,
+}
+
 /// A finite call-graph key that distinguishes storage aliases without depending on values.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct CallContext {
     function_id: FunctionId,
     storage: Vec<(VariableId, Vec<VariableId>)>,
     slots: Vec<(VariableId, Vec<VariableId>)>,
+    guards: Vec<FunctionId>,
 }
 
 #[derive(Clone, Default)]
-struct LoopAliases {
-    breaks: Option<AliasState>,
-    continues: Option<AliasState>,
+struct LoopFlow {
+    breaks: Option<FlowState>,
+    continues: Option<FlowState>,
+}
+
+#[derive(Clone)]
+struct CallSummary {
+    returns: Vec<StorageRoots>,
+    guards: HashSet<FunctionId>,
+}
+
+#[derive(Clone, Copy)]
+struct ModifierContinuation<'hir> {
+    modifiers: &'hir [hir::Modifier<'hir>],
+    next: usize,
+    body: hir::Block<'hir>,
 }
 
 impl CallContext {
-    fn new(function_id: FunctionId, function: &hir::Function<'_>, aliases: &AliasState) -> Self {
+    fn new(
+        function_id: FunctionId,
+        function: &hir::Function<'_>,
+        aliases: &AliasState,
+        guards: &HashSet<FunctionId>,
+    ) -> Self {
         let roots = |aliases: &RootMap| {
             function
                 .parameters
@@ -376,7 +399,9 @@ impl CallContext {
                 })
                 .collect()
         };
-        Self { function_id, storage: roots(&aliases.storage), slots: roots(&aliases.slots) }
+        let mut guards: Vec<_> = guards.iter().copied().collect();
+        guards.sort_unstable();
+        Self { function_id, storage: roots(&aliases.storage), slots: roots(&aliases.slots), guards }
     }
 }
 
@@ -384,15 +409,17 @@ struct EntryAnalyzer<'hir> {
     gcx: Gcx<'hir>,
     hir: &'hir hir::Hir<'hir>,
     bases: &'hir [ContractId],
-    writes: HashSet<VariableId>,
-    calls: HashSet<FunctionId>,
+    writes: HashMap<VariableId, HashSet<FunctionId>>,
     aliases: AliasState,
+    guards: HashSet<FunctionId>,
     call_returns: HashMap<ExprId, Vec<StorageRoots>>,
-    call_summaries: HashMap<CallContext, Vec<StorageRoots>>,
+    call_summaries: HashMap<CallContext, CallSummary>,
     seen_calls: HashSet<CallContext>,
     stack: Vec<FunctionId>,
     return_stack: Vec<Vec<StorageRoots>>,
-    loop_aliases: Vec<LoopAliases>,
+    return_flow: Vec<Option<FlowState>>,
+    loop_flow: Vec<LoopFlow>,
+    modifier_continuations: Vec<ModifierContinuation<'hir>>,
     assembly_depth: usize,
 }
 
@@ -402,22 +429,24 @@ impl<'hir> EntryAnalyzer<'hir> {
             gcx,
             hir,
             bases,
-            writes: HashSet::new(),
-            calls: HashSet::new(),
+            writes: HashMap::new(),
             aliases: AliasState::default(),
+            guards: HashSet::new(),
             call_returns: HashMap::new(),
             call_summaries: HashMap::new(),
             seen_calls: HashSet::new(),
             stack: Vec::new(),
             return_stack: Vec::new(),
-            loop_aliases: Vec::new(),
+            return_flow: Vec::new(),
+            loop_flow: Vec::new(),
+            modifier_continuations: Vec::new(),
             assembly_depth: 0,
         }
     }
 
-    fn analyze(&mut self, entry_id: FunctionId) -> (HashSet<VariableId>, HashSet<FunctionId>) {
+    fn analyze(&mut self, entry_id: FunctionId) -> HashMap<VariableId, HashSet<FunctionId>> {
         let _ = self.analyze_function(entry_id);
-        (std::mem::take(&mut self.writes), std::mem::take(&mut self.calls))
+        std::mem::take(&mut self.writes)
     }
 
     fn analyze_function(&mut self, function_id: FunctionId) -> Vec<StorageRoots> {
@@ -427,28 +456,61 @@ impl<'hir> EntryAnalyzer<'hir> {
         };
         self.stack.push(function_id);
         self.return_stack.push(function.returns.iter().map(|_| StorageRoots::new()).collect());
-        self.analyze_modifiers(function);
-        self.analyze_block(body);
-        if !body.stmts.iter().any(branch_always_exits) {
+        self.return_flow.push(None);
+        let completes = self.analyze_modifier_chain(function.modifiers, 0, body);
+        let falls_through = completes && !body.stmts.iter().any(branch_always_exits);
+        if falls_through {
             self.capture_named_returns();
         }
         let returns = self.return_stack.pop().expect("return frame must exist");
+        self.return_flow.pop().expect("return flow frame must exist");
         self.stack.pop();
         returns
     }
 
-    fn analyze_modifiers(&mut self, function: &'hir hir::Function<'hir>) {
-        for modifier in function.modifiers {
-            for argument in modifier.args.exprs() {
-                self.analyze_expr(argument);
-            }
+    fn analyze_modifier_chain(
+        &mut self,
+        modifiers: &'hir [hir::Modifier<'hir>],
+        index: usize,
+        body: hir::Block<'hir>,
+    ) -> bool {
+        let Some(modifier) = modifiers.get(index) else {
+            let previous_returns = self.return_flow.last_mut().and_then(Option::take);
+            let falls_through = self.analyze_block(body);
+            let body_returns = self.return_flow.last_mut().and_then(Option::take);
 
-            let Some(declared_id) = modifier.id.as_function() else { continue };
-            let modifier_id = self.dispatch_function(declared_id);
-            self.calls.insert(modifier_id);
-            let arguments = self.ordered_call_arguments(declared_id, modifier.args, None);
-            self.analyze_call(modifier_id, &arguments);
+            let mut all_returns = previous_returns;
+            if let Some(state) = &body_returns {
+                merge_flow_state_into(&mut all_returns, state);
+            }
+            *self.return_flow.last_mut().expect("return flow frame must exist") = all_returns;
+
+            let mut completions = body_returns;
+            if falls_through {
+                merge_flow_state_into(&mut completions, &self.flow_state());
+            }
+            if let Some(state) = completions {
+                self.set_flow_state(state);
+                return true;
+            }
+            return false;
+        };
+        for argument in modifier.args.exprs() {
+            self.analyze_expr(argument);
         }
+
+        let Some(declared_id) = modifier.id.as_function() else { return false };
+        let modifier_id = self.dispatch_function(declared_id);
+        self.guards.insert(modifier_id);
+        let arguments = self.ordered_call_arguments(declared_id, modifier.args, None);
+        let source_aliases = self.aliases.clone();
+        self.bind_call_arguments(modifier_id, &arguments, &source_aliases);
+
+        let Some(modifier_body) = self.hir.function(modifier_id).body else { return false };
+        self.modifier_continuations.push(ModifierContinuation { modifiers, next: index + 1, body });
+        let completes = self.analyze_block(modifier_body);
+        self.modifier_continuations.pop();
+        completes
     }
 
     fn analyze_call(
@@ -458,32 +520,13 @@ impl<'hir> EntryAnalyzer<'hir> {
     ) -> Vec<StorageRoots> {
         let function = self.hir.function(function_id);
         let saved_aliases = std::mem::take(&mut self.aliases);
-        for (parameter, &argument) in function.parameters.iter().copied().zip(arguments) {
-            if self.hir.variable(parameter).data_location == Some(DataLocation::Storage) {
-                let roots =
-                    state_lhs_vars(self.hir, argument, &saved_aliases.storage, &self.call_returns);
-                if !roots.is_empty() {
-                    self.aliases.storage.insert(parameter, roots);
-                }
-            }
-            if function.is_yul {
-                let roots = slot_roots(
-                    self.hir,
-                    argument,
-                    &saved_aliases.storage,
-                    &saved_aliases.slots,
-                    &self.call_returns,
-                );
-                if !roots.is_empty() {
-                    self.aliases.slots.insert(parameter, roots);
-                }
-            }
-        }
+        self.bind_call_arguments(function_id, arguments, &saved_aliases);
 
-        let context = CallContext::new(function_id, function, &self.aliases);
-        if let Some(returns) = self.call_summaries.get(&context).cloned() {
+        let context = CallContext::new(function_id, function, &self.aliases, &self.guards);
+        if let Some(summary) = self.call_summaries.get(&context).cloned() {
             self.aliases = saved_aliases;
-            return returns;
+            self.guards = summary.guards;
+            return summary.returns;
         }
         if !self.seen_calls.insert(context.clone()) {
             self.aliases = saved_aliases;
@@ -491,21 +534,56 @@ impl<'hir> EntryAnalyzer<'hir> {
         }
 
         let returns = self.analyze_function(function_id);
-        self.call_summaries.insert(context, returns.clone());
+        self.call_summaries
+            .insert(context, CallSummary { returns: returns.clone(), guards: self.guards.clone() });
         self.aliases = saved_aliases;
         returns
     }
 
-    fn analyze_block(&mut self, block: hir::Block<'hir>) {
-        for statement in block.stmts {
-            self.analyze_stmt(statement);
-            if branch_always_exits(statement) {
-                break;
+    fn bind_call_arguments(
+        &mut self,
+        function_id: FunctionId,
+        arguments: &[&'hir hir::Expr<'hir>],
+        source_aliases: &AliasState,
+    ) {
+        let function = self.hir.function(function_id);
+        for (parameter, &argument) in function.parameters.iter().copied().zip(arguments) {
+            if self.hir.variable(parameter).data_location == Some(DataLocation::Storage) {
+                let roots =
+                    state_lhs_vars(self.hir, argument, &source_aliases.storage, &self.call_returns);
+                if roots.is_empty() {
+                    self.aliases.storage.remove(&parameter);
+                } else {
+                    self.aliases.storage.insert(parameter, roots);
+                }
+            }
+            if function.is_yul {
+                let roots = slot_roots(
+                    self.hir,
+                    argument,
+                    &source_aliases.storage,
+                    &source_aliases.slots,
+                    &self.call_returns,
+                );
+                if roots.is_empty() {
+                    self.aliases.slots.remove(&parameter);
+                } else {
+                    self.aliases.slots.insert(parameter, roots);
+                }
             }
         }
     }
 
-    fn analyze_stmt(&mut self, statement: &'hir hir::Stmt<'hir>) {
+    fn analyze_block(&mut self, block: hir::Block<'hir>) -> bool {
+        for statement in block.stmts {
+            if !self.analyze_stmt(statement) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn analyze_stmt(&mut self, statement: &'hir hir::Stmt<'hir>) -> bool {
         match statement.kind {
             StmtKind::DeclSingle(variable_id) => {
                 let variable = self.hir.variable(variable_id);
@@ -516,110 +594,158 @@ impl<'hir> EntryAnalyzer<'hir> {
                         self.set_slot_alias(variable_id, initializer);
                     }
                 }
+                true
             }
             StmtKind::DeclMulti(variables, expression) => {
                 self.analyze_expr(expression);
                 self.set_decl_aliases(variables, expression);
+                true
             }
-            StmtKind::Emit(expression)
-            | StmtKind::Revert(expression)
-            | StmtKind::Expr(expression) => self.analyze_expr(expression),
+            StmtKind::Emit(expression) | StmtKind::Expr(expression) => {
+                self.analyze_expr(expression);
+                !branch_always_exits(statement)
+            }
+            StmtKind::Revert(expression) => {
+                self.analyze_expr(expression);
+                false
+            }
             StmtKind::Return(Some(expression)) => {
                 self.analyze_expr(expression);
                 self.set_return_aliases(expression);
+                self.capture_return_flow();
+                false
             }
-            StmtKind::Return(None) => self.capture_named_returns(),
+            StmtKind::Return(None) => {
+                self.capture_named_returns();
+                self.capture_return_flow();
+                false
+            }
             StmtKind::Block(block) | StmtKind::UncheckedBlock(block) => self.analyze_block(block),
             StmtKind::AssemblyBlock(block) => {
                 self.assembly_depth += 1;
-                self.analyze_block(block);
+                let continues = self.analyze_block(block);
                 self.assembly_depth -= 1;
+                continues
             }
             StmtKind::Loop(block, source) => {
-                let before = self.aliases.clone();
+                let before = self.flow_state();
                 let flow = self.analyze_loop_iteration(block);
-                let iteration = merge_optional_alias_state(&self.aliases, &flow.continues);
+                let iteration = merge_optional_flow_state(&self.flow_state(), &flow.continues);
                 let exits = if source == hir::LoopSource::DoWhile {
                     iteration
                 } else {
-                    merge_alias_states(&before, &iteration)
+                    merge_flow_states(&before, &iteration)
                 };
-                let mut input = merge_optional_alias_state(&exits, &flow.breaks);
+                let mut input = merge_optional_flow_state(&exits, &flow.breaks);
                 loop {
-                    self.aliases = input.clone();
+                    self.set_flow_state(input.clone());
                     let flow = self.analyze_loop_iteration(block);
-                    let iteration = merge_optional_alias_state(&self.aliases, &flow.continues);
-                    let next = merge_optional_alias_state(
-                        &merge_alias_states(&exits, &iteration),
+                    let iteration = merge_optional_flow_state(&self.flow_state(), &flow.continues);
+                    let next = merge_optional_flow_state(
+                        &merge_flow_states(&exits, &iteration),
                         &flow.breaks,
                     );
                     if next == input {
-                        self.aliases = next;
+                        self.set_flow_state(next);
                         break;
                     }
                     input = next;
                 }
+                true
             }
             StmtKind::If(condition, then_statement, else_statement) => {
                 self.analyze_expr(condition);
-                let before = self.aliases.clone();
-                self.analyze_stmt(then_statement);
-                let then_aliases = self.aliases.clone();
-                let then_exits = branch_always_exits(then_statement);
-                self.aliases = before;
-                let else_exits = if let Some(else_statement) = else_statement {
-                    self.analyze_stmt(else_statement);
-                    branch_always_exits(else_statement)
+                let before = self.flow_state();
+                let then_continues = self.analyze_stmt(then_statement);
+                let then_state = self.flow_state();
+                self.set_flow_state(before);
+                let else_continues = if let Some(else_statement) = else_statement {
+                    self.analyze_stmt(else_statement)
                 } else {
-                    false
+                    true
                 };
-                let else_aliases = self.aliases.clone();
-                self.aliases = match (then_exits, else_exits) {
-                    (true, false) => else_aliases,
-                    (false, true) => then_aliases,
-                    _ => merge_alias_states(&then_aliases, &else_aliases),
+                let else_state = self.flow_state();
+                let merged = match (then_continues, else_continues) {
+                    (false, true) => else_state,
+                    (true, false) => then_state,
+                    _ => merge_flow_states(&then_state, &else_state),
                 };
+                self.set_flow_state(merged);
+                then_continues || else_continues
             }
             StmtKind::Try(try_statement) => {
                 self.analyze_expr(&try_statement.expr);
-                let before = self.aliases.clone();
+                let before = self.flow_state();
                 let mut merged = before.clone();
                 for clause in try_statement.clauses {
-                    self.aliases = before.clone();
-                    self.analyze_block(clause.block);
-                    merged = merge_alias_states(&merged, &self.aliases);
+                    self.set_flow_state(before.clone());
+                    let _ = self.analyze_block(clause.block);
+                    merged = merge_flow_states(&merged, &self.flow_state());
                 }
-                self.aliases = merged;
+                self.set_flow_state(merged);
+                true
             }
             StmtKind::Switch(switch) => {
                 self.analyze_expr(switch.selector);
-                let before = self.aliases.clone();
+                let before = self.flow_state();
                 let mut merged = before.clone();
                 for case in switch.cases {
-                    self.aliases = before.clone();
-                    self.analyze_block(case.body);
-                    merged = merge_alias_states(&merged, &self.aliases);
+                    self.set_flow_state(before.clone());
+                    let _ = self.analyze_block(case.body);
+                    merged = merge_flow_states(&merged, &self.flow_state());
                 }
-                self.aliases = merged;
+                self.set_flow_state(merged);
+                true
             }
             StmtKind::Break => {
-                if let Some(flow) = self.loop_aliases.last_mut() {
-                    merge_alias_state_into(&mut flow.breaks, &self.aliases);
+                let state = self.flow_state();
+                if let Some(flow) = self.loop_flow.last_mut() {
+                    merge_flow_state_into(&mut flow.breaks, &state);
                 }
+                false
             }
             StmtKind::Continue => {
-                if let Some(flow) = self.loop_aliases.last_mut() {
-                    merge_alias_state_into(&mut flow.continues, &self.aliases);
+                let state = self.flow_state();
+                if let Some(flow) = self.loop_flow.last_mut() {
+                    merge_flow_state_into(&mut flow.continues, &state);
+                }
+                false
+            }
+            StmtKind::Placeholder => {
+                if let Some(continuation) = self.modifier_continuations.last().copied() {
+                    self.analyze_modifier_chain(
+                        continuation.modifiers,
+                        continuation.next,
+                        continuation.body,
+                    )
+                } else {
+                    true
                 }
             }
-            StmtKind::Placeholder | StmtKind::Err(_) => {}
+            StmtKind::Err(_) => true,
         }
     }
 
-    fn analyze_loop_iteration(&mut self, block: hir::Block<'hir>) -> LoopAliases {
-        self.loop_aliases.push(LoopAliases::default());
-        self.analyze_block(block);
-        self.loop_aliases.pop().expect("loop alias frame must exist")
+    fn analyze_loop_iteration(&mut self, block: hir::Block<'hir>) -> LoopFlow {
+        self.loop_flow.push(LoopFlow::default());
+        let _ = self.analyze_block(block);
+        self.loop_flow.pop().expect("loop flow frame must exist")
+    }
+
+    fn flow_state(&self) -> FlowState {
+        FlowState { aliases: self.aliases.clone(), guards: self.guards.clone() }
+    }
+
+    fn set_flow_state(&mut self, state: FlowState) {
+        self.aliases = state.aliases;
+        self.guards = state.guards;
+    }
+
+    fn capture_return_flow(&mut self) {
+        let state = self.flow_state();
+        if let Some(exits) = self.return_flow.last_mut() {
+            merge_flow_state_into(exits, &state);
+        }
     }
 
     fn analyze_expr(&mut self, expression: &'hir hir::Expr<'hir>) {
@@ -661,7 +787,7 @@ impl<'hir> EntryAnalyzer<'hir> {
                     }
                 }
 
-                if is_storage_write_builtin(callee)
+                if is_persistent_storage_write_builtin(callee)
                     && let Some(slot) = args.exprs().next()
                 {
                     let roots = slot_roots(
@@ -671,21 +797,28 @@ impl<'hir> EntryAnalyzer<'hir> {
                         &self.aliases.slots,
                         &self.call_returns,
                     );
-                    self.writes.extend(roots);
+                    self.record_roots(roots);
                 }
 
                 if let Some((declared_id, function_id, receiver)) =
                     self.resolved_internal_call(callee)
                 {
-                    self.calls.insert(function_id);
+                    self.guards.insert(function_id);
                     let arguments = self.ordered_call_arguments(declared_id, *args, receiver);
                     let returns = self.analyze_call(function_id, &arguments);
                     self.store_call_returns(expression.id, returns);
                 }
             }
-            ExprKind::Binary(lhs, _, rhs) => {
+            ExprKind::Binary(lhs, operator, rhs) => {
                 self.analyze_expr(lhs);
-                self.analyze_expr(rhs);
+                if matches!(operator.kind, BinOpKind::And | BinOpKind::Or) {
+                    let short_circuit = self.flow_state();
+                    self.analyze_expr(rhs);
+                    let evaluated = self.flow_state();
+                    self.set_flow_state(merge_flow_states(&short_circuit, &evaluated));
+                } else {
+                    self.analyze_expr(rhs);
+                }
             }
             ExprKind::Index(base, index) => {
                 self.analyze_expr(base);
@@ -707,8 +840,13 @@ impl<'hir> EntryAnalyzer<'hir> {
             }
             ExprKind::Ternary(condition, if_true, if_false) => {
                 self.analyze_expr(condition);
+                let before = self.flow_state();
                 self.analyze_expr(if_true);
+                let true_state = self.flow_state();
+                self.set_flow_state(before);
                 self.analyze_expr(if_false);
+                let false_state = self.flow_state();
+                self.set_flow_state(merge_flow_states(&true_state, &false_state));
             }
             ExprKind::Array(expressions) => {
                 for expression in *expressions {
@@ -756,7 +894,16 @@ impl<'hir> EntryAnalyzer<'hir> {
     }
 
     fn record_write(&mut self, expression: &hir::Expr<'_>) {
-        self.writes.extend(self.storage_roots(expression));
+        self.record_roots(self.storage_roots(expression));
+    }
+
+    fn record_roots(&mut self, roots: StorageRoots) {
+        for variable_id in roots {
+            self.writes
+                .entry(variable_id)
+                .and_modify(|guards| guards.retain(|guard| self.guards.contains(guard)))
+                .or_insert_with(|| self.guards.clone());
+        }
     }
 
     fn storage_roots(&self, expression: &hir::Expr<'_>) -> StorageRoots {
@@ -807,6 +954,22 @@ impl<'hir> EntryAnalyzer<'hir> {
         rhs: &'hir hir::Expr<'hir>,
         compound: bool,
     ) {
+        if !compound
+            && let ExprKind::YulMember(base, member) = &lhs.peel_parens().kind
+            && member.as_str() == "slot"
+            && let Some(local) = lhs_local_var(self.hir, base)
+        {
+            let roots = slot_roots(
+                self.hir,
+                rhs,
+                &self.aliases.storage,
+                &self.aliases.slots,
+                &self.call_returns,
+            );
+            self.set_storage_alias_roots(local, roots);
+            return;
+        }
+
         if !compound && let ExprKind::Tuple(expressions) = &lhs.peel_parens().kind {
             let outputs = expressions.len();
             for (index, expression) in expressions.iter().copied().enumerate() {
@@ -1107,6 +1270,7 @@ fn collect_slot_roots(
         for roots in returns {
             variables.extend(roots);
         }
+        return;
     }
     let mut recurse = |expression| {
         collect_slot_roots(hir, expression, storage_aliases, slot_aliases, call_returns, variables)
@@ -1188,15 +1352,22 @@ fn merge_alias_states(lhs: &AliasState, rhs: &AliasState) -> AliasState {
     }
 }
 
-fn merge_optional_alias_state(state: &AliasState, other: &Option<AliasState>) -> AliasState {
-    other.as_ref().map_or_else(|| state.clone(), |other| merge_alias_states(state, other))
+fn merge_flow_states(lhs: &FlowState, rhs: &FlowState) -> FlowState {
+    FlowState {
+        aliases: merge_alias_states(&lhs.aliases, &rhs.aliases),
+        guards: lhs.guards.intersection(&rhs.guards).copied().collect(),
+    }
 }
 
-fn merge_alias_state_into(destination: &mut Option<AliasState>, state: &AliasState) {
+fn merge_optional_flow_state(state: &FlowState, other: &Option<FlowState>) -> FlowState {
+    other.as_ref().map_or_else(|| state.clone(), |other| merge_flow_states(state, other))
+}
+
+fn merge_flow_state_into(destination: &mut Option<FlowState>, state: &FlowState) {
     *destination = Some(
         destination
             .as_ref()
-            .map_or_else(|| state.clone(), |current| merge_alias_states(current, state)),
+            .map_or_else(|| state.clone(), |current| merge_flow_states(current, state)),
     );
 }
 
@@ -1208,13 +1379,10 @@ fn merge_root_maps(lhs: &RootMap, rhs: &RootMap) -> RootMap {
     merged
 }
 
-fn is_storage_write_builtin(callee: &hir::Expr<'_>) -> bool {
+fn is_persistent_storage_write_builtin(callee: &hir::Expr<'_>) -> bool {
     let ExprKind::Ident(resolutions) = &callee.peel_parens().kind else { return false };
     resolutions.iter().any(|resolution| {
-        matches!(
-            resolution,
-            Res::Builtin(builtin) if matches!(builtin.name().as_str(), "sstore" | "tstore")
-        )
+        matches!(resolution, Res::Builtin(builtin) if builtin.name().as_str() == "sstore")
     })
 }
 

--- a/crates/lint/src/sol/high/protected_vars.rs
+++ b/crates/lint/src/sol/high/protected_vars.rs
@@ -970,10 +970,10 @@ impl<'hir> EntryAnalyzer<'hir> {
                 if !self.analyze_expr(base) {
                     return false;
                 }
-                if let Some(start) = start {
-                    if !self.analyze_expr(start) {
-                        return false;
-                    }
+                if let Some(start) = start
+                    && !self.analyze_expr(start)
+                {
+                    return false;
                 }
                 if let Some(end) = end { self.analyze_expr(end) } else { true }
             }
@@ -1033,10 +1033,10 @@ impl<'hir> EntryAnalyzer<'hir> {
                 if !self.analyze_lhs(base) {
                     return false;
                 }
-                if let Some(start) = start {
-                    if !self.analyze_expr(start) {
-                        return false;
-                    }
+                if let Some(start) = start
+                    && !self.analyze_expr(start)
+                {
+                    return false;
                 }
                 if let Some(end) = end { self.analyze_expr(end) } else { true }
             }
@@ -1104,6 +1104,10 @@ impl<'hir> EntryAnalyzer<'hir> {
             &self.aliases.slots,
             &self.call_returns,
         );
+        self.set_slot_alias_roots(variable_id, roots);
+    }
+
+    fn set_slot_alias_roots(&mut self, variable_id: VariableId, roots: StorageRoots) {
         if roots.is_empty() {
             self.aliases.slots.remove(&variable_id);
         } else {
@@ -1139,10 +1143,10 @@ impl<'hir> EntryAnalyzer<'hir> {
                 let Some(expression) = expression else { continue };
                 if let Some(local) = lhs_local_var(self.hir, expression) {
                     let roots = self.storage_roots_for_output(rhs, index, outputs);
-                    self.set_storage_alias_roots(local, roots);
                     if self.assembly_depth > 0 {
-                        self.set_slot_alias(local, rhs);
+                        self.set_slot_alias_roots(local, roots.clone());
                     }
+                    self.set_storage_alias_roots(local, roots);
                 } else {
                     self.record_write(expression);
                 }
@@ -1169,10 +1173,10 @@ impl<'hir> EntryAnalyzer<'hir> {
         for (index, variable_id) in variables.iter().copied().enumerate() {
             let Some(variable_id) = variable_id else { continue };
             let roots = self.storage_roots_for_output(expression, index, variables.len());
-            self.set_storage_alias_roots(variable_id, roots);
             if self.assembly_depth > 0 {
-                self.set_slot_alias(variable_id, expression);
+                self.set_slot_alias_roots(variable_id, roots.clone());
             }
+            self.set_storage_alias_roots(variable_id, roots);
         }
     }
 

--- a/crates/lint/testdata/ProtectedVars.sol
+++ b/crates/lint/testdata/ProtectedVars.sol
@@ -193,15 +193,55 @@ contract ReachabilitySemantics {
         require(msg.sender == owner);
     }
 
-    // Slither's annotation is reachability-based, so the call need not dominate the write.
-    function branchGuard(bool guard, address newOwner) external {
+    function branchGuard(bool guard, address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
         if (guard) checkOwner();
         owner = newOwner;
     }
 
-    function guardAfterWrite(address newOwner) external {
+    function guardAfterWrite(address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
         owner = newOwner;
         checkOwner();
+    }
+
+    function guardBeforeWrite(address newOwner) external {
+        checkOwner();
+        owner = newOwner;
+    }
+
+    function guardOnEveryBranch(bool branch, address newOwner) external {
+        if (branch) checkOwner();
+        else checkOwner();
+        owner = newOwner;
+    }
+
+    function guardOnOneReturnPath(bool skip, address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
+        maybeGuard(skip);
+        owner = newOwner;
+    }
+
+    function ternaryGuard(bool guard, address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
+        guard ? checkOwnerBool() : true;
+        owner = newOwner;
+    }
+
+    function shortCircuitGuard(bool guard, address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
+        guard && checkOwnerBool();
+        owner = newOwner;
+    }
+
+    function guardOnEveryTernaryArm(bool guard, address newOwner) external {
+        guard ? checkOwnerBool() : checkOwnerBool();
+        owner = newOwner;
+    }
+
+    function maybeGuard(bool skip) internal view {
+        if (skip) return;
+        checkOwner();
+    }
+
+    function checkOwnerBool() internal view returns (bool) {
+        checkOwner();
+        return true;
     }
 }
 
@@ -256,5 +296,126 @@ contract MalformedProtection {
 
     function setUnprotected(address newValue) external {
         unprotected = newValue;
+    }
+}
+
+contract ModifierContinuations {
+    /// @custom:security write-protection="checkOwner()"
+    address public owner;
+
+    modifier blocked() {
+        revert();
+        _;
+    }
+
+    modifier passthrough() {
+        _;
+    }
+
+    modifier checkAfter() {
+        _;
+        checkOwner();
+    }
+
+    modifier writeAfter(address newOwner) {
+        _;
+        owner = newOwner;
+    }
+
+    function checkOwner() internal view {
+        require(msg.sender == owner);
+    }
+
+    function unreachableWrite(address newOwner) external blocked {
+        owner = newOwner;
+    }
+
+    function reachableWrite(address newOwner) external passthrough { //~WARN: protected variable `owner` is written without `checkOwner()`
+        owner = newOwner;
+    }
+
+    function guardAfterBody(address newOwner) external checkAfter { //~WARN: protected variable `owner` is written without `checkOwner()`
+        owner = newOwner;
+    }
+
+    function unreachableOuterPost(address newOwner) external writeAfter(newOwner) blocked {}
+
+    function reachableOuterPost(address newOwner) external writeAfter(newOwner) passthrough {} //~WARN: protected variable `owner` is written without `checkOwner()`
+
+    function returnBeforeOuterPost(address newOwner) external writeAfter(newOwner) { //~WARN: protected variable `owner` is written without `checkOwner()`
+        return;
+    }
+
+    function conditionalReturnBeforeOuterPost(bool skip, address newOwner) //~WARN: protected variable `owner` is written without `checkOwner()`
+        external
+        writeAfter(newOwner)
+    {
+        if (skip) return;
+        checkOwner();
+    }
+}
+
+contract YulStoragePointerRetargeting {
+    /// @custom:security write-protection="onlyOwner()"
+    uint256[] internal protectedValues;
+
+    uint256[] internal ordinaryValues;
+
+    function retargetAwayFromProtected() external {
+        uint256[] storage pointer = protectedValues;
+        assembly {
+            pointer.slot := ordinaryValues.slot
+        }
+        pointer.push(1);
+    }
+
+    function retargetToProtected() external { //~WARN: protected variable `protectedValues` is written without `onlyOwner()`
+        uint256[] storage pointer = ordinaryValues;
+        assembly {
+            pointer.slot := protectedValues.slot
+        }
+        pointer.push(1);
+    }
+}
+
+contract TransientStorageWrites {
+    /// @custom:security write-protection="onlyOwner()"
+    uint256 internal protectedValue;
+
+    function writeTransientStorage() external {
+        assembly {
+            tstore(protectedValue.slot, 1)
+        }
+    }
+
+    function writePersistentStorage() external { //~WARN: protected variable `protectedValue` is written without `onlyOwner()`
+        assembly {
+            sstore(protectedValue.slot, 1)
+        }
+    }
+}
+
+contract YulCallReturnSummaries {
+    /// @custom:security write-protection="onlyOwner()"
+    uint256 internal protectedValue;
+
+    uint256 internal ordinaryValue;
+
+    function storeAtSecondArgument() external {
+        assembly {
+            function pickSecond(first, second) -> result {
+                result := second
+            }
+            sstore(pickSecond(protectedValue.slot, ordinaryValue.slot), 1)
+        }
+    }
+
+    function storeAtFirstArgument() external { //~WARN: protected variable `protectedValue` is written without `onlyOwner()`
+        assembly {
+            function pickFirst(first, second) -> result {
+                result := first
+            }
+            sstore(pickFirst(protectedValue.slot, ordinaryValue.slot), 1)
+        }
     }
 }

--- a/crates/lint/testdata/ProtectedVars.sol
+++ b/crates/lint/testdata/ProtectedVars.sol
@@ -1,0 +1,244 @@
+//@compile-flags: --only-lint protected-vars
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract DirectWrites {
+    /// @custom:security write-protection="onlyOwner()"
+    address public owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function setOwner(address newOwner) external { //~WARN: protected variable `owner` is written without `onlyOwner()`
+        owner = newOwner;
+    }
+
+    function setOwnerProtected(address newOwner) external onlyOwner {
+        owner = newOwner;
+    }
+}
+
+contract InternalCalls {
+    /// @custom:security write-protection="checkOwner()"
+    address public owner;
+
+    function checkOwner() internal view {
+        require(msg.sender == owner);
+    }
+
+    function setThroughHelper(address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
+        writeOwner(newOwner);
+    }
+
+    function setThroughProtectedHelper(address newOwner) external {
+        protectedWriteOwner(newOwner);
+    }
+
+    function protectedWriteOwner(address newOwner) internal {
+        checkOwner();
+        writeOwner(newOwner);
+    }
+
+    function writeOwner(address newOwner) internal {
+        owner = newOwner;
+    }
+}
+
+contract ModifierPaths {
+    /// @custom:security write-protection="onlyOwner()"
+    address public owner;
+
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    modifier writeOwner(address newOwner) {
+        owner = newOwner;
+        _;
+    }
+
+    function _checkOwner() internal view {
+        require(msg.sender == owner);
+    }
+
+    function writeInUnprotectedModifier(address newOwner) //~WARN: protected variable `owner` is written without `onlyOwner()`
+        external
+        writeOwner(newOwner)
+    {}
+
+    function writeInProtectedHelper(address newOwner) external {
+        _writeInProtectedHelper(newOwner);
+    }
+
+    function _writeInProtectedHelper(address newOwner) internal onlyOwner {
+        owner = newOwner;
+    }
+}
+
+contract FunctionFromModifier {
+    /// @custom:security write-protection="checkOwner()"
+    address public owner;
+
+    modifier checked() {
+        checkOwner();
+        _;
+    }
+
+    function checkOwner() internal view {
+        require(msg.sender == owner);
+    }
+
+    function setOwner(address newOwner) external checked {
+        owner = newOwner;
+    }
+}
+
+contract ExactSignatures {
+    /// @custom:security write-protection="onlyRole(bytes32)"
+    bytes32 public role;
+
+    modifier onlyRole(bytes32 expected) {
+        require(role == expected);
+        _;
+    }
+
+    function setRole(bytes32 oldRole, bytes32 newRole) external onlyRole(oldRole) {
+        role = newRole;
+    }
+
+    function setRoleUnprotected(bytes32 newRole) external { //~WARN: protected variable `role` is written without `onlyRole(bytes32)`
+        role = newRole;
+    }
+}
+
+contract ExternalGuardCall {
+    /// @custom:security write-protection="checkOwner()"
+    address public owner;
+
+    function checkOwner() external view {
+        require(msg.sender == owner);
+    }
+
+    function setOwner(address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
+        this.checkOwner();
+        owner = newOwner;
+    }
+}
+
+contract CollectionWrites {
+    /// @custom:security write-protection="onlyOwner()"
+    address[] public members;
+
+    /// @custom:security write-protection="onlyOwner()"
+    mapping(address => bool) public allowed;
+
+    address public owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function addMember(address member) external { //~WARN: protected variable `members` is written without `onlyOwner()`
+        members.push(member);
+    }
+
+    function clearMember(address member) external { //~WARN: protected variable `allowed` is written without `onlyOwner()`
+        delete allowed[member];
+    }
+
+    function removeMember() external onlyOwner {
+        members.pop();
+    }
+}
+
+contract StorageAliases {
+    struct Settings {
+        address operator;
+    }
+
+    /// @custom:security write-protection="onlyOwner()"
+    Settings internal settings;
+
+    address public owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function setOperator(address operator) external { //~WARN: protected variable `settings` is written without `onlyOwner()`
+        Settings storage current = settings;
+        current.operator = operator;
+    }
+
+    function setOperatorThroughParameter(address operator) external { //~WARN: protected variable `settings` is written without `onlyOwner()`
+        writeSettings(settings, operator);
+    }
+
+    function writeSettings(Settings storage current, address operator) internal {
+        current.operator = operator;
+    }
+}
+
+contract ReachabilitySemantics {
+    /// @custom:security write-protection="checkOwner()"
+    address public owner;
+
+    function checkOwner() internal view {
+        require(msg.sender == owner);
+    }
+
+    // Slither's annotation is reachability-based, so the call need not dominate the write.
+    function branchGuard(bool guard, address newOwner) external {
+        if (guard) checkOwner();
+        owner = newOwner;
+    }
+
+    function guardAfterWrite(address newOwner) external {
+        owner = newOwner;
+        checkOwner();
+    }
+}
+
+contract BaseProtection {
+    /// @custom:security write-protection="onlyOwner()"
+    address public owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == owner);
+        _;
+    }
+
+    function inheritedUnsafe(address newOwner) public { //~WARN: protected variable `owner` is written without `onlyOwner()`
+        owner = newOwner;
+    }
+
+    function inheritedSafe(address newOwner) public onlyOwner {
+        owner = newOwner;
+    }
+}
+
+contract DerivedProtection is BaseProtection {
+    function derivedUnsafe(address newOwner) external { //~WARN: protected variable `owner` is written without `onlyOwner()`
+        owner = newOwner;
+    }
+
+    function derivedSafe(address newOwner) external onlyOwner {
+        owner = newOwner;
+    }
+}
+
+contract UnresolvedProtection {
+    /// @custom:security write-protection="notDeclared()"
+    address public owner;
+
+    // An unresolved annotation is ignored instead of guessing from a name.
+    function setOwner(address newOwner) external {
+        owner = newOwner;
+    }
+}

--- a/crates/lint/testdata/ProtectedVars.sol
+++ b/crates/lint/testdata/ProtectedVars.sol
@@ -237,8 +237,24 @@ contract UnresolvedProtection {
     /// @custom:security write-protection="notDeclared()"
     address public owner;
 
-    // An unresolved annotation is ignored instead of guessing from a name.
-    function setOwner(address newOwner) external {
+    // Invalid requirements fail closed instead of silently disabling the security annotation.
+    function setOwner(address newOwner) external { //~WARN: protected variable `owner` is written without `notDeclared()`
         owner = newOwner;
+    }
+}
+
+contract MalformedProtection {
+    /// @custom:security write-protection="onlyOwner()
+    address public owner;
+
+    /// @custom:security no-write-protection
+    address public unprotected;
+
+    function setOwner(address newOwner) external { //~WARN: protected variable `owner` has a malformed write-protection annotation
+        owner = newOwner;
+    }
+
+    function setUnprotected(address newValue) external {
+        unprotected = newValue;
     }
 }

--- a/crates/lint/testdata/ProtectedVars.sol
+++ b/crates/lint/testdata/ProtectedVars.sol
@@ -214,6 +214,15 @@ contract ReachabilitySemantics {
         owner = newOwner;
     }
 
+    function guardOnEveryTryClause(address newOwner) external {
+        try this.externalCall() {
+            checkOwner();
+        } catch {
+            checkOwner();
+        }
+        owner = newOwner;
+    }
+
     function guardOnOneReturnPath(bool skip, address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
         maybeGuard(skip);
         owner = newOwner;
@@ -243,6 +252,8 @@ contract ReachabilitySemantics {
         checkOwner();
         return true;
     }
+
+    function externalCall() external pure {}
 }
 
 contract BaseProtection {
@@ -373,6 +384,16 @@ contract YulStoragePointerRetargeting {
         uint256[] storage pointer = ordinaryValues;
         assembly {
             pointer.slot := protectedValues.slot
+        }
+        pointer.push(1);
+    }
+
+    function retargetAwayOnExhaustiveSwitch(uint256 selector) external {
+        uint256[] storage pointer = protectedValues;
+        assembly {
+            switch selector
+            case 0 { pointer.slot := ordinaryValues.slot }
+            default { pointer.slot := ordinaryValues.slot }
         }
         pointer.push(1);
     }

--- a/crates/lint/testdata/ProtectedVars.sol
+++ b/crates/lint/testdata/ProtectedVars.sol
@@ -189,6 +189,9 @@ contract ReachabilitySemantics {
     /// @custom:security write-protection="checkOwner()"
     address public owner;
 
+    /// @custom:security write-protection="checkOwner()"
+    mapping(address => address) public owners;
+
     function checkOwner() internal view {
         require(msg.sender == owner);
     }
@@ -243,6 +246,49 @@ contract ReachabilitySemantics {
         owner = newOwner;
     }
 
+    function writeAfterRevertingHelper(address newOwner) external {
+        alwaysReverts();
+        owner = newOwner;
+    }
+
+    function writeAfterRecursiveHelper(address newOwner) external {
+        recursiveLoop();
+        owner = newOwner;
+    }
+
+    function deleteWithRevertingIndex() external {
+        delete owners[revertingAddress()];
+    }
+
+    function writeAfterRevertingDoWhile(bool repeat, address newOwner) external {
+        do {
+            alwaysReverts();
+        } while (repeat);
+        owner = newOwner;
+    }
+
+    function writeAfterRevertingWhileCondition(address newOwner) external {
+        while (revertingBool()) {}
+        owner = newOwner;
+    }
+
+    function writeAfterMutualRecursion(address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
+        recursiveB();
+        recursiveB();
+        owner = newOwner;
+    }
+
+    function writeAfterConditionalRecursion(bool stop, address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
+        recursiveMaybeWrite(stop, newOwner);
+    }
+
+    function writeAfterDoWhileContinue(bool repeat, address newOwner) external { //~WARN: protected variable `owner` is written without `checkOwner()`
+        do {
+            continue;
+        } while (repeat);
+        owner = newOwner;
+    }
+
     function maybeGuard(bool skip) internal view {
         if (skip) return;
         checkOwner();
@@ -251,6 +297,37 @@ contract ReachabilitySemantics {
     function checkOwnerBool() internal view returns (bool) {
         checkOwner();
         return true;
+    }
+
+    function alwaysReverts() internal pure {
+        revert();
+    }
+
+    function recursiveLoop() internal pure {
+        recursiveLoop();
+    }
+
+    function revertingAddress() internal pure returns (address) {
+        revert();
+    }
+
+    function revertingBool() internal pure returns (bool) {
+        revert();
+    }
+
+    function recursiveA(bool stop) internal pure {
+        if (stop) return;
+        recursiveB();
+    }
+
+    function recursiveB() internal pure {
+        recursiveA(true);
+    }
+
+    function recursiveMaybeWrite(bool stop, address newOwner) internal {
+        if (stop) return;
+        recursiveMaybeWrite(true, newOwner);
+        owner = newOwner;
     }
 
     function externalCall() external pure {}
@@ -333,6 +410,11 @@ contract ModifierContinuations {
         owner = newOwner;
     }
 
+    modifier revertAfter() {
+        _;
+        revert();
+    }
+
     function checkOwner() internal view {
         require(msg.sender == owner);
     }
@@ -363,6 +445,15 @@ contract ModifierContinuations {
     {
         if (skip) return;
         checkOwner();
+    }
+
+    function returningHelper() internal revertAfter {
+        return;
+    }
+
+    function unreachableAfterReturningHelper(address newOwner) external {
+        returningHelper();
+        owner = newOwner;
     }
 }
 

--- a/crates/lint/testdata/ProtectedVars.stderr
+++ b/crates/lint/testdata/ProtectedVars.stderr
@@ -1,0 +1,88 @@
+warning[protected-vars]: protected variable `owner` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function setOwner(address newOwner) external {
+   │              ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function setThroughHelper(address newOwner) external {
+   │              ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function writeInUnprotectedModifier(address newOwner)
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `role` is written without `onlyRole(bytes32)`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function setRoleUnprotected(bytes32 newRole) external {
+   │              ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function setOwner(address newOwner) external {
+   │              ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `members` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function addMember(address member) external {
+   │              ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `allowed` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function clearMember(address member) external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `settings` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function setOperator(address operator) external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `settings` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function setOperatorThroughParameter(address operator) external {
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function derivedUnsafe(address newOwner) external {
+   │              ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function inheritedUnsafe(address newOwner) public {
+   │              ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+

--- a/crates/lint/testdata/ProtectedVars.stderr
+++ b/crates/lint/testdata/ProtectedVars.stderr
@@ -70,6 +70,46 @@ LL │     function setOperatorThroughParameter(address operator) external {
    │
    ╰ help: https://getfoundry.sh/forge/linting/protected-vars
 
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function branchGuard(bool guard, address newOwner) external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function guardAfterWrite(address newOwner) external {
+   │              ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function guardOnOneReturnPath(bool skip, address newOwner) external {
+   │              ━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function ternaryGuard(bool guard, address newOwner) external {
+   │              ━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function shortCircuitGuard(bool guard, address newOwner) external {
+   │              ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
 warning[protected-vars]: protected variable `owner` is written without `onlyOwner()`
    ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
    │
@@ -99,6 +139,70 @@ warning[protected-vars]: protected variable `owner` has a malformed write-protec
    │
 LL │     function setOwner(address newOwner) external {
    │              ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function reachableWrite(address newOwner) external passthrough {
+   │              ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function guardAfterBody(address newOwner) external checkAfter {
+   │              ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function reachableOuterPost(address newOwner) external writeAfter(newOwner) passthrough {}
+   │              ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function returnBeforeOuterPost(address newOwner) external writeAfter(newOwner) {
+   │              ━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function conditionalReturnBeforeOuterPost(bool skip, address newOwner)
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValues` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function retargetToProtected() external {
+   │              ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function writePersistentStorage() external {
+   │              ━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `onlyOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function storeAtFirstArgument() external {
+   │              ━━━━━━━━━━━━━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/protected-vars
 

--- a/crates/lint/testdata/ProtectedVars.stderr
+++ b/crates/lint/testdata/ProtectedVars.stderr
@@ -78,11 +78,27 @@ LL │     function derivedUnsafe(address newOwner) external {
    │
    ╰ help: https://getfoundry.sh/forge/linting/protected-vars
 
-warning[protected-vars]: protected variable `owner` is written without `onlyOwner()`
+warning[protected-vars]: protected variable `owner` is written without `onlyOwner()` in most-derived contract `DerivedProtection`
    ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
    │
 LL │     function inheritedUnsafe(address newOwner) public {
    │              ━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `notDeclared()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function setOwner(address newOwner) external {
+   │              ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` has a malformed write-protection annotation
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function setOwner(address newOwner) external {
+   │              ━━━━━━━━
    │
    ╰ help: https://getfoundry.sh/forge/linting/protected-vars
 

--- a/crates/lint/testdata/ProtectedVars.stderr
+++ b/crates/lint/testdata/ProtectedVars.stderr
@@ -110,6 +110,30 @@ LL │     function shortCircuitGuard(bool guard, address newOwner) external {
    │
    ╰ help: https://getfoundry.sh/forge/linting/protected-vars
 
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function writeAfterMutualRecursion(address newOwner) external {
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function writeAfterConditionalRecursion(bool stop, address newOwner) external {
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `owner` is written without `checkOwner()`
+   ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
+   │
+LL │     function writeAfterDoWhileContinue(bool repeat, address newOwner) external {
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
 warning[protected-vars]: protected variable `owner` is written without `onlyOwner()`
    ╭▸ ROOT/testdata/ProtectedVars.sol:LL:CC
    │

--- a/crates/lint/testdata/ProtectedVarsAdvanced.sol
+++ b/crates/lint/testdata/ProtectedVarsAdvanced.sol
@@ -321,6 +321,54 @@ contract AssemblyWrites {
             sstore(getSlot(root), 1)
         }
     }
+
+    function multiReturnDeclaration() external {
+        assembly {
+            function pair(first, second) -> a, b {
+                a := first
+                b := second
+            }
+            let protectedSlot, ordinarySlot := pair(protectedValue.slot, 0)
+            sstore(ordinarySlot, 1)
+        }
+    }
+
+    function multiReturnDeclarationWrite() external { //~WARN: protected variable `protectedValue` is written without `guard()`
+        assembly {
+            function pair(first, second) -> a, b {
+                a := first
+                b := second
+            }
+            let protectedSlot, ordinarySlot := pair(protectedValue.slot, 0)
+            sstore(protectedSlot, 1)
+        }
+    }
+
+    function multiReturnAssignment() external {
+        assembly {
+            function pair(first, second) -> a, b {
+                a := first
+                b := second
+            }
+            let protectedSlot := 0
+            let ordinarySlot := 0
+            protectedSlot, ordinarySlot := pair(protectedValue.slot, 0)
+            sstore(ordinarySlot, 1)
+        }
+    }
+
+    function multiReturnAssignmentWrite() external { //~WARN: protected variable `protectedValue` is written without `guard()`
+        assembly {
+            function pair(first, second) -> a, b {
+                a := first
+                b := second
+            }
+            let protectedSlot := 0
+            let ordinarySlot := 0
+            protectedSlot, ordinarySlot := pair(protectedValue.slot, 0)
+            sstore(protectedSlot, 1)
+        }
+    }
 }
 
 contract SharedInheritedEntry {

--- a/crates/lint/testdata/ProtectedVarsAdvanced.sol
+++ b/crates/lint/testdata/ProtectedVarsAdvanced.sol
@@ -1,0 +1,356 @@
+//@compile-flags: --only-lint protected-vars
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.18;
+
+contract ExactOverloads {
+    /// @custom:security write-protection="guard(uint256)"
+    uint256 protectedValue;
+
+    function guard(uint256) internal pure {}
+
+    function guard(address) internal pure {}
+
+    function unsafeWrongOverload() external { //~WARN: protected variable `protectedValue` is written without `guard(uint256)`
+        guard(address(0));
+        protectedValue = 1;
+    }
+
+    function safeExactOverload() external {
+        guard(1);
+        protectedValue = 2;
+    }
+}
+
+contract VirtualGuardBase {
+    /// @custom:security write-protection="guard()"
+    uint256 internal protectedValue;
+
+    function guard() internal pure {}
+
+    function hook() internal virtual {
+        guard();
+    }
+
+    function writeThroughHook() external { //~WARN: protected variable `protectedValue` is written without `guard()`
+        hook();
+        protectedValue = 1;
+    }
+}
+
+contract VirtualGuardRemoved is VirtualGuardBase {
+    function hook() internal pure override {}
+}
+
+contract VirtualGuardAddedBase {
+    /// @custom:security write-protection="guard()"
+    uint256 internal protectedValue;
+
+    function guard() internal pure {}
+
+    function hook() internal virtual {}
+
+    function writeThroughHook() external {
+        hook();
+        protectedValue = 1;
+    }
+}
+
+contract VirtualGuardAdded is VirtualGuardAddedBase {
+    function hook() internal pure override {
+        guard();
+    }
+}
+
+contract ModifierGuardBase {
+    /// @custom:security write-protection="guard()"
+    uint256 internal protectedValue;
+
+    function guard() internal pure {}
+
+    modifier checked() virtual {
+        guard();
+        _;
+    }
+
+    function writeWithModifier() external checked { //~WARN: protected variable `protectedValue` is written without `guard()`
+        protectedValue = 1;
+    }
+}
+
+contract ModifierGuardRemoved is ModifierGuardBase {
+    modifier checked() override {
+        _;
+    }
+}
+
+contract ModifierGuardAddedBase {
+    /// @custom:security write-protection="guard()"
+    uint256 internal protectedValue;
+
+    function guard() internal pure {}
+
+    modifier checked() virtual {
+        _;
+    }
+
+    function writeWithModifier() external checked {
+        protectedValue = 1;
+    }
+}
+
+contract ModifierGuardAdded is ModifierGuardAddedBase {
+    modifier checked() override {
+        guard();
+        _;
+    }
+}
+
+struct LibrarySettings {
+    uint256 value;
+}
+
+library SettingsLib {
+    function mutate(LibrarySettings storage settings) internal {
+        settings.value = 1;
+    }
+}
+
+contract AttachedLibraryWrite {
+    using SettingsLib for LibrarySettings;
+
+    /// @custom:security write-protection="guard()"
+    LibrarySettings protectedSettings;
+
+    function guard() internal pure {}
+
+    function unsafeWrite() external { //~WARN: protected variable `protectedSettings` is written without `guard()`
+        protectedSettings.mutate();
+    }
+}
+
+contract AdvancedStorageAliases {
+    struct Settings {
+        uint256 value;
+    }
+
+    /// @custom:security write-protection="guard()"
+    Settings protectedSettings;
+    Settings otherSettings;
+
+    /// @custom:security write-protection="guard()"
+    Settings[] protectedList;
+
+    function guard() internal pure {}
+
+    function settings() internal view returns (Settings storage result) {
+        result = protectedSettings;
+    }
+
+    function selectedSettings(bool chooseProtected) internal view returns (Settings storage) {
+        if (chooseProtected) return protectedSettings;
+        return otherSettings;
+    }
+
+    function returnedAlias() external { //~WARN: protected variable `protectedSettings` is written without `guard()`
+        settings().value = 1;
+    }
+
+    function earlyReturnedAlias(bool chooseProtected) external { //~WARN: protected variable `protectedSettings` is written without `guard()`
+        selectedSettings(chooseProtected).value = 1;
+    }
+
+    function pushedAlias() external { //~WARN: protected variable `protectedList` is written without `guard()`
+        protectedList.push().value = 1;
+    }
+
+    function conditionalAlias(bool chooseProtected) external { //~WARN: protected variable `protectedSettings` is written without `guard()`
+        Settings storage selected = chooseProtected ? protectedSettings : otherSettings;
+        selected.value = 1;
+    }
+
+    function exitedAlias(bool stop) external {
+        Settings storage selected = otherSettings;
+        if (stop) {
+            selected = protectedSettings;
+            return;
+        }
+        selected.value = 1;
+    }
+
+    function reassignOnly() external {
+        Settings storage selected = protectedSettings;
+        selected = otherSettings;
+    }
+
+    function loopAlias() external { //~WARN: protected variable `protectedSettings` is written without `guard()`
+        Settings storage first = otherSettings;
+        Settings storage second = otherSettings;
+        for (uint256 i; i < 2; ++i) {
+            first = second;
+            second = protectedSettings;
+        }
+        first.value = 1;
+    }
+
+    function breakAlias(bool shouldIterate, bool shouldBreak) external { //~WARN: protected variable `protectedSettings` is written without `guard()`
+        Settings storage selected = otherSettings;
+        while (shouldIterate) {
+            selected = protectedSettings;
+            if (shouldBreak) break;
+            selected = otherSettings;
+            shouldIterate = false;
+        }
+        selected.value = 1;
+    }
+
+    function continueAlias(bool shouldIterate, bool shouldContinue) external { //~WARN: protected variable `protectedSettings` is written without `guard()`
+        Settings storage selected = otherSettings;
+        while (shouldIterate) {
+            selected = protectedSettings;
+            if (shouldContinue) {
+                shouldIterate = false;
+                continue;
+            }
+            selected = otherSettings;
+            shouldIterate = false;
+        }
+        selected.value = 1;
+    }
+
+    function recurse(Settings storage current, bool again) internal {
+        if (again) recurse(protectedSettings, false);
+        current.value = 1;
+    }
+
+    function recursiveAlias() external { //~WARN: protected variable `protectedSettings` is written without `guard()`
+        recurse(otherSettings, true);
+    }
+
+    function mutate(Settings storage safe, Settings storage target) internal {
+        if (safe.value == type(uint256).max) revert();
+        target.value = 1;
+    }
+
+    function namedArguments() external { //~WARN: protected variable `protectedSettings` is written without `guard()`
+        mutate({target: protectedSettings, safe: otherSettings});
+    }
+}
+
+contract SignatureType {}
+
+contract ModifierSourceSignature {
+    /// @custom:security write-protection="modifierGuard(SignatureType)"
+    uint256 protectedValue;
+
+    modifier modifierGuard(SignatureType) {
+        _;
+    }
+
+    function safeWrite(SignatureType value) external modifierGuard(value) {
+        protectedValue = 1;
+    }
+
+    function unsafeWrite() external { //~WARN: protected variable `protectedValue` is written without `modifierGuard(SignatureType)`
+        protectedValue = 2;
+    }
+}
+
+contract ModifierFunctionSignature {
+    /// @custom:security write-protection="modifierGuard(function(uint256) returns(bool))"
+    uint256 protectedValue;
+
+    /// @custom:security write-protection="functionGuard(function(uint256) returns(bool))"
+    uint256 functionProtected;
+
+    modifier modifierGuard(function(uint256) external returns (bool)) {
+        _;
+    }
+
+    function functionGuard(function(uint256) external returns (bool)) internal pure {}
+
+    function callback(uint256) external pure returns (bool) {
+        return true;
+    }
+
+    function safeWrite() external modifierGuard(this.callback) {
+        protectedValue = 1;
+    }
+
+    function unsafeWrite() external { //~WARN: protected variable `protectedValue` is written without `modifierGuard(function(uint256) returns(bool))`
+        protectedValue = 2;
+    }
+
+    function safeFunctionWrite() external {
+        functionGuard(this.callback);
+        functionProtected = 1;
+    }
+
+    function unsafeFunctionWrite() external { //~WARN: protected variable `functionProtected` is written without `functionGuard(function(uint256) returns(bool))`
+        functionProtected = 2;
+    }
+}
+
+contract AssemblyWrites {
+    /// @custom:security write-protection="guard()"
+    uint256 protectedValue;
+
+    function guard() internal pure {}
+
+    function directWrite() external { //~WARN: protected variable `protectedValue` is written without `guard()`
+        assembly {
+            sstore(protectedValue.slot, 1)
+        }
+    }
+
+    function helperParameterWrite() external { //~WARN: protected variable `protectedValue` is written without `guard()`
+        assembly {
+            function write(slot) {
+                sstore(slot, 1)
+            }
+            write(protectedValue.slot)
+        }
+    }
+
+    function helperReturnWrite() external { //~WARN: protected variable `protectedValue` is written without `guard()`
+        assembly {
+            let root := protectedValue.slot
+            function getSlot(input) -> slot {
+                slot := input
+            }
+            sstore(getSlot(root), 1)
+        }
+    }
+}
+
+contract SharedInheritedEntry {
+    /// @custom:security write-protection="guard()"
+    uint256 protectedValue;
+
+    function guard() internal pure {}
+
+    function unsafeWrite() external {
+        //~^WARN: protected variable `protectedValue` is written without `guard()` in most-derived contract `SharedLeafOne`
+        //~|WARN: protected variable `protectedValue` is written without `guard()` in most-derived contract `SharedLeafTwo`
+        protectedValue = 1;
+    }
+}
+
+contract SharedLeafOne is SharedInheritedEntry {}
+
+contract SharedLeafTwo is SharedInheritedEntry {}
+
+contract SpecialEntryPoints {
+    /// @custom:security write-protection="guard()"
+    uint256 protectedValue;
+
+    function guard() internal pure {}
+
+    fallback() external { //~WARN: protected variable `protectedValue` is written without `guard()`
+        protectedValue = 1;
+    }
+
+    receive() external payable { //~WARN: protected variable `protectedValue` is written without `guard()`
+        protectedValue = 2;
+    }
+}

--- a/crates/lint/testdata/ProtectedVarsAdvanced.stderr
+++ b/crates/lint/testdata/ProtectedVarsAdvanced.stderr
@@ -150,6 +150,22 @@ LL │     function helperReturnWrite() external {
    │
    ╰ help: https://getfoundry.sh/forge/linting/protected-vars
 
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function multiReturnDeclarationWrite() external {
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function multiReturnAssignmentWrite() external {
+   │              ━━━━━━━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
 warning[protected-vars]: protected variable `protectedValue` is written without `guard()` in most-derived contract `SharedLeafOne`
    ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
    │

--- a/crates/lint/testdata/ProtectedVarsAdvanced.stderr
+++ b/crates/lint/testdata/ProtectedVarsAdvanced.stderr
@@ -1,0 +1,184 @@
+warning[protected-vars]: protected variable `protectedValue` is written without `guard(uint256)`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function unsafeWrongOverload() external {
+   │              ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()` in most-derived contract `VirtualGuardRemoved`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function writeThroughHook() external {
+   │              ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()` in most-derived contract `ModifierGuardRemoved`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function writeWithModifier() external checked {
+   │              ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedSettings` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function unsafeWrite() external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedSettings` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function returnedAlias() external {
+   │              ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedSettings` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function earlyReturnedAlias(bool chooseProtected) external {
+   │              ━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedList` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function pushedAlias() external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedSettings` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function conditionalAlias(bool chooseProtected) external {
+   │              ━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedSettings` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function loopAlias() external {
+   │              ━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedSettings` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function breakAlias(bool shouldIterate, bool shouldBreak) external {
+   │              ━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedSettings` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function continueAlias(bool shouldIterate, bool shouldContinue) external {
+   │              ━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedSettings` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function recursiveAlias() external {
+   │              ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedSettings` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function namedArguments() external {
+   │              ━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `modifierGuard(SignatureType)`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function unsafeWrite() external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `modifierGuard(function(uint256) returns(bool))`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function unsafeWrite() external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `functionProtected` is written without `functionGuard(function(uint256) returns(bool))`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function unsafeFunctionWrite() external {
+   │              ━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function directWrite() external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function helperParameterWrite() external {
+   │              ━━━━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function helperReturnWrite() external {
+   │              ━━━━━━━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()` in most-derived contract `SharedLeafOne`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function unsafeWrite() external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()` in most-derived contract `SharedLeafTwo`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     function unsafeWrite() external {
+   │              ━━━━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     fallback() external {
+   │     ━━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+
+warning[protected-vars]: protected variable `protectedValue` is written without `guard()`
+   ╭▸ ROOT/testdata/ProtectedVarsAdvanced.sol:LL:CC
+   │
+LL │     receive() external payable {
+   │     ━━━━━━━
+   │
+   ╰ help: https://getfoundry.sh/forge/linting/protected-vars
+


### PR DESCRIPTION
This adds the high-severity `protected-vars` lint from #14381. It enforces Solidity's `@custom:security write-protection` annotations by tracing writes from externally callable leaf-contract entry points through reachable modifier continuations, resolved internal and library calls, storage aliases, returned storage locations, collection mutations, and resolvable assembly slots.

Protection is tracked as must-flow state at each write, so a guard must dominate that occurrence across branches, short-circuit expressions, loops, returns, and modifier expansion. The analysis also retargets Yul storage-pointer `.slot` assignments, distinguishes persistent `sstore` from transient `tstore`, and uses resolved Yul return summaries without contaminating results with unrelated argument roots. Exact overload signatures and virtual dispatch remain respected, while malformed or unresolved annotations stay unsatisfied.

The companion Book documentation is in foundry-rs/book#1982, with the dominance and Yul follow-up in foundry-rs/book#1995. This PR was implemented with Codex assistance across code, tests, and lint documentation, then independently reviewed and corrected by a fresh Codex context.

