### PR TITLE
feat(cheatcodes): add vm.getSelectors cheatcode

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -6706,6 +6706,26 @@
     },
     {
       "func": {
+        "id": "getSelectors",
+        "description": "Gets all function selectors from a contract artifact. Takes in the relative path to the json file or the path to the\nartifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.",
+        "declaration": "function getSelectors(string calldata artifactPath) external view returns (bytes4[] memory selectors);",
+        "visibility": "external",
+        "mutability": "view",
+        "signature": "getSelectors(string)",
+        "selector": "0x13d5a709",
+        "selectorBytes": [
+          19,
+          213,
+          167,
+          9
+        ]
+      },
+      "group": "filesystem",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "getStateDiff",
         "description": "Returns state diffs from current `vm.startStateDiffRecording` session.",
         "declaration": "function getStateDiff() external view returns (string memory diff);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2049,6 +2049,11 @@ interface Vm {
     #[cheatcode(group = Filesystem)]
     function getCode(string calldata artifactPath) external view returns (bytes memory creationBytecode);
 
+    /// Gets all function selectors from a contract artifact. Takes in the relative path to the json file or the path to the
+    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    #[cheatcode(group = Filesystem)]
+    function getSelectors(string calldata artifactPath) external view returns (bytes4[] memory selectors);
+
     /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
     /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
     /// <version>/<profile> parts are optional.

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -5,9 +5,9 @@ use crate::{
     Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*, inspector::exec_create,
 };
 use alloy_dyn_abi::DynSolType;
-use alloy_json_abi::ContractObject;
+use alloy_json_abi::{ContractObject, JsonAbi};
 use alloy_network::{Network, ReceiptResponse};
-use alloy_primitives::{Bytes, U256, hex, map::Entry};
+use alloy_primitives::{Bytes, FixedBytes, U256, hex, map::Entry};
 use alloy_sol_types::SolValue;
 use dialoguer::{Input, Password};
 use forge_script_sequence::{BroadcastReader, TransactionWithMetadata};
@@ -380,6 +380,16 @@ impl Cheatcode for getDeployedCodeCall {
     }
 }
 
+impl Cheatcode for getSelectorsCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { artifactPath: path } = self;
+        let abi = get_artifact_abi(state, path)?;
+        let selectors: Vec<FixedBytes<4>> =
+            abi.functions().map(|func| func.selector().into()).collect();
+        Ok(selectors.abi_encode())
+    }
+}
+
 impl Cheatcode for deployCode_0Call {
     fn apply_full<FEN: FoundryEvmNetwork>(
         &self,
@@ -673,6 +683,136 @@ fn get_artifact_code<FEN: FoundryEvmNetwork>(
     let artifact = serde_json::from_str::<ContractObject>(&data)?;
     let maybe_bytecode = if deployed { artifact.deployed_bytecode } else { artifact.bytecode };
     maybe_bytecode.ok_or_else(|| fmt_err!("no bytecode for contract; is it abstract or unlinked?"))
+}
+
+/// Returns the ABI of a matching artifact from the given path.
+///
+/// See [`get_artifact_code`] for the supported path formats.
+fn get_artifact_abi<FEN: FoundryEvmNetwork>(
+    state: &Cheatcodes<FEN>,
+    path: &str,
+) -> Result<JsonAbi> {
+    if path.ends_with(".json") {
+        // Read JSON artifact directly from disk.
+        let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
+        let data = fs::read_to_string(path)?;
+        let json: serde_json::Value = serde_json::from_str(&data)?;
+        let abi = json.get("abi").ok_or_else(|| fmt_err!("no `abi` field in artifact JSON"))?;
+        return serde_json::from_value(abi.clone()).map_err(|e| fmt_err!("{e}"));
+    }
+
+    let mut parts = path.split(':');
+
+    let mut file = None;
+    let mut contract_name = None;
+    let mut version = None;
+
+    let path_or_name = parts.next().unwrap();
+    if path_or_name.contains('.') {
+        file = Some(PathBuf::from(path_or_name));
+        if let Some(name_or_version) = parts.next() {
+            if name_or_version.contains('.') {
+                version = Some(name_or_version);
+            } else {
+                contract_name = Some(name_or_version);
+                version = parts.next();
+            }
+        }
+    } else {
+        contract_name = Some(path_or_name);
+        version = parts.next();
+    }
+
+    let version = if let Some(version) = version {
+        Some(Version::parse(version).map_err(|e| fmt_err!("failed parsing version: {e}"))?)
+    } else {
+        None
+    };
+
+    // Use available artifacts list if present.
+    if let Some(artifacts) = &state.config.available_artifacts {
+        let filtered = artifacts
+            .iter()
+            .filter(|(id, _)| {
+                let id_name = id.name.split('.').next().unwrap();
+
+                if let Some(path) = &file
+                    && !id.source.ends_with(path)
+                {
+                    return false;
+                }
+                if let Some(name) = contract_name
+                    && id_name != name
+                {
+                    return false;
+                }
+                if let Some(ref version) = version
+                    && (id.version.minor != version.minor
+                        || id.version.major != version.major
+                        || id.version.patch != version.patch)
+                {
+                    return false;
+                }
+                true
+            })
+            .collect::<Vec<_>>();
+
+        let artifact = match &filtered[..] {
+            [] => None,
+            [artifact] => Some(Ok(*artifact)),
+            filtered => {
+                let mut filtered = filtered.to_vec();
+                Some(
+                    state
+                        .config
+                        .running_artifact
+                        .as_ref()
+                        .and_then(|running| {
+                            filtered.retain(|(id, _)| id.version == running.version);
+                            if filtered.len() == 1 {
+                                return Some(filtered[0]);
+                            }
+                            filtered.retain(|(id, _)| id.profile == running.profile);
+                            (filtered.len() == 1).then(|| filtered[0])
+                        })
+                        .ok_or_else(|| fmt_err!("multiple matching artifacts found")),
+                )
+            }
+        };
+
+        if let Some(artifact) = artifact {
+            let artifact = artifact?;
+            return Ok(artifact.1.abi.clone());
+        }
+    }
+
+    // Fallback: construct path manually and read JSON from disk.
+    let path_in_artifacts = match (file.map(|f| f.to_string_lossy().to_string()), contract_name) {
+        (Some(file), Some(contract_name)) => {
+            PathBuf::from(format!("{file}/{contract_name}.json"))
+        }
+        (None, Some(contract_name)) => {
+            PathBuf::from(format!("{contract_name}.sol/{contract_name}.json"))
+        }
+        (Some(file), None) => {
+            let name = file.replace(".sol", "");
+            PathBuf::from(format!("{file}/{name}.json"))
+        }
+        _ => bail!("invalid artifact path"),
+    };
+
+    let path = state.config.paths.artifacts.join(path_in_artifacts);
+    let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
+    let data = fs::read_to_string(path).map_err(|e| {
+        if state.config.available_artifacts.is_some() {
+            fmt_err!("no matching artifact found")
+        } else {
+            e.into()
+        }
+    })?;
+    let json: serde_json::Value = serde_json::from_str(&data)?;
+    let abi = json.get("abi").ok_or_else(|| fmt_err!("no `abi` field in artifact JSON"))?;
+    serde_json::from_value(abi.clone()).map_err(|e| fmt_err!("{e}"))
 }
 
 impl Cheatcode for ffiCall {

--- a/crates/cheatcodes/src/fs.rs
+++ b/crates/cheatcodes/src/fs.rs
@@ -5,13 +5,13 @@ use crate::{
     Cheatcode, Cheatcodes, CheatcodesExecutor, CheatsCtxt, Result, Vm::*, inspector::exec_create,
 };
 use alloy_dyn_abi::DynSolType;
-use alloy_json_abi::{ContractObject, JsonAbi};
+use alloy_json_abi::ContractObject;
 use alloy_network::{Network, ReceiptResponse};
 use alloy_primitives::{Bytes, FixedBytes, U256, hex, map::Entry};
 use alloy_sol_types::SolValue;
 use dialoguer::{Input, Password};
 use forge_script_sequence::{BroadcastReader, TransactionWithMetadata};
-use foundry_common::fs;
+use foundry_common::{contracts::ContractData, fs};
 use foundry_config::fs_permissions::FsAccessKind;
 use foundry_evm_core::evm::FoundryEvmNetwork;
 use revm::{
@@ -383,9 +383,20 @@ impl Cheatcode for getDeployedCodeCall {
 impl Cheatcode for getSelectorsCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
         let Self { artifactPath: path } = self;
-        let abi = get_artifact_abi(state, path)?;
-        let selectors: Vec<FixedBytes<4>> =
-            abi.functions().map(|func| func.selector().into()).collect();
+        let selectors: Vec<FixedBytes<4>> = match get_artifact_source(state, path)? {
+            ArtifactSource::InMemory(data) => data.abi.functions().map(|f| f.selector()).collect(),
+            ArtifactSource::Disk(path) => {
+                let data = read_artifact_file(state, &path)?;
+                // Parse as raw JSON rather than `ContractObject` so we can still read selectors
+                // from artifacts with unlinked bytecode (which `ContractObject` rejects).
+                let json: serde_json::Value = serde_json::from_str(&data)?;
+                let abi =
+                    json.get("abi").ok_or_else(|| fmt_err!("no `abi` field in artifact JSON"))?;
+                let abi: alloy_json_abi::JsonAbi =
+                    serde_json::from_value(abi.clone()).map_err(|e| fmt_err!("{e}"))?;
+                abi.functions().map(|f| f.selector()).collect()
+            }
+        };
         Ok(selectors.abi_encode())
     }
 }
@@ -528,9 +539,17 @@ fn deploy_code<FEN: FoundryEvmNetwork>(
     Ok(address.abi_encode())
 }
 
-/// Returns the bytecode from a JSON artifact file.
+/// Resolved location of an artifact referenced by a cheatcode path argument.
+enum ArtifactSource<'a> {
+    /// The artifact was matched in the in-memory `available_artifacts` list.
+    InMemory(&'a ContractData),
+    /// The artifact must be read from the given path on disk.
+    Disk(PathBuf),
+}
+
+/// Resolves a cheatcode artifact reference to its source.
 ///
-/// Can parse following input formats:
+/// Can parse the following input formats:
 /// - `path/to/artifact.json`
 /// - `path/to/contract.sol`
 /// - `path/to/contract.sol:ContractName`
@@ -541,239 +560,95 @@ fn deploy_code<FEN: FoundryEvmNetwork>(
 /// - `ContractName`
 /// - `ContractName:0.8.23`
 /// - `ContractName:profile`
-///
-/// This function is safe to use with contracts that have library dependencies.
-/// `alloy_json_abi::ContractObject` validates bytecode during JSON parsing and will
-/// reject artifacts with unlinked library placeholders.
-fn get_artifact_code<FEN: FoundryEvmNetwork>(
-    state: &Cheatcodes<FEN>,
+fn get_artifact_source<'a, FEN: FoundryEvmNetwork>(
+    state: &'a Cheatcodes<FEN>,
     path: &str,
-    deployed: bool,
-) -> Result<Bytes> {
-    let path = if path.ends_with(".json") {
-        PathBuf::from(path)
-    } else {
-        let parsed = parse_artifact_path(path)
-            .map_err(|e| fmt_err!("failed to parse artifact path: {e}"))?;
-        let ParsedArtifactPath { file, contract_name, version, profile } = parsed;
+) -> Result<ArtifactSource<'a>> {
+    if path.ends_with(".json") {
+        let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
+        return Ok(ArtifactSource::Disk(path));
+    }
 
-        // Use available artifacts list if present
-        if let Some(artifacts) = &state.config.available_artifacts {
-            let ambiguous_file_profile =
-                file.is_some() && version.is_none() && profile.is_none() && contract_name.is_some();
-            let filter_artifacts = |treat_ambiguous_as_profile: bool| -> Vec<_> {
-                artifacts
-                    .iter()
-                    .filter(|(id, _)| {
-                        // name might be in the form of "Counter.0.8.23"
-                        let id_name = id.name.split('.').next().unwrap();
+    let parsed =
+        parse_artifact_path(path).map_err(|e| fmt_err!("failed to parse artifact path: {e}"))?;
+    let ParsedArtifactPath { file, contract_name, version, profile } = parsed;
 
-                        if let Some(path) = &file
-                            && !id.source.ends_with(path)
-                        {
-                            return false;
-                        }
-                        if let Some(ref version) = version
-                            && (id.version.minor != version.minor
-                                || id.version.major != version.major
-                                || id.version.patch != version.patch)
-                        {
-                            return false;
-                        }
-                        if let Some(profile) = profile
-                            && id.profile != profile
-                        {
-                            return false;
-                        }
-                        if let Some(name) = contract_name {
-                            if treat_ambiguous_as_profile && ambiguous_file_profile {
-                                return id.profile == name;
-                            }
+    // Use available artifacts list if present
+    if let Some(artifacts) = &state.config.available_artifacts {
+        let ambiguous_file_profile =
+            file.is_some() && version.is_none() && profile.is_none() && contract_name.is_some();
+        let filter_artifacts = |treat_ambiguous_as_profile: bool| -> Vec<_> {
+            artifacts
+                .iter()
+                .filter(|(id, _)| {
+                    // name might be in the form of "Counter.0.8.23"
+                    let id_name = id.name.split('.').next().unwrap();
 
-                            return id_name == name;
+                    if let Some(path) = &file
+                        && !id.source.ends_with(path)
+                    {
+                        return false;
+                    }
+                    if let Some(ref version) = version
+                        && (id.version.minor != version.minor
+                            || id.version.major != version.major
+                            || id.version.patch != version.patch)
+                    {
+                        return false;
+                    }
+                    if let Some(profile) = profile
+                        && id.profile != profile
+                    {
+                        return false;
+                    }
+                    if let Some(name) = contract_name {
+                        if treat_ambiguous_as_profile && ambiguous_file_profile {
+                            return id.profile == name;
                         }
 
-                        true
-                    })
-                    .collect()
-            };
+                        return id_name == name;
+                    }
 
-            let mut filtered = filter_artifacts(false);
-            if filtered.is_empty() && ambiguous_file_profile {
-                filtered = filter_artifacts(true);
-            }
-
-            let artifact = match &filtered[..] {
-                [] => None,
-                [artifact] => Some(Ok(*artifact)),
-                filtered => {
-                    let mut filtered = filtered.to_vec();
-                    // If we know the current script/test contract solc version, try to filter by it
-                    Some(
-                        state
-                            .config
-                            .running_artifact
-                            .as_ref()
-                            .and_then(|running| {
-                                // Only filter by running version if user did NOT specify a version
-                                if version.is_none() {
-                                    filtered.retain(|(id, _)| id.version == running.version);
-
-                                    // Return artifact if only one matched
-                                    if filtered.len() == 1 {
-                                        return Some(filtered[0]);
-                                    }
-                                }
-
-                                // Only filter by running profile if user did NOT specify a profile
-                                if profile.is_none() {
-                                    filtered.retain(|(id, _)| id.profile == running.profile);
-
-                                    return (filtered.len() == 1).then(|| filtered[0]);
-                                }
-
-                                None
-                            })
-                            .ok_or_else(|| fmt_err!("multiple matching artifacts found")),
-                    )
-                }
-            };
-
-            if let Some(artifact) = artifact {
-                let artifact = artifact?;
-                let maybe_bytecode = if deployed {
-                    artifact.1.deployed_bytecode().cloned()
-                } else {
-                    artifact.1.bytecode().cloned()
-                };
-
-                return maybe_bytecode.ok_or_else(|| {
-                    fmt_err!("no bytecode for contract; is it abstract or unlinked?")
-                });
-            }
-        }
-
-        // Fallback: construct path manually when no artifacts list or no match found
-        let path_in_artifacts = match (file.map(|f| f.to_string_lossy().to_string()), contract_name)
-        {
-            (Some(file), Some(contract_name)) => {
-                PathBuf::from(format!("{file}/{contract_name}.json"))
-            }
-            (None, Some(contract_name)) => {
-                PathBuf::from(format!("{contract_name}.sol/{contract_name}.json"))
-            }
-            (Some(file), None) => {
-                let name = file.replace(".sol", "");
-                PathBuf::from(format!("{file}/{name}.json"))
-            }
-            _ => bail!("invalid artifact path"),
+                    true
+                })
+                .collect()
         };
 
-        state.config.paths.artifacts.join(path_in_artifacts)
-    };
-
-    let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
-    let data = fs::read_to_string(path).map_err(|e| {
-        if state.config.available_artifacts.is_some() {
-            fmt_err!("no matching artifact found")
-        } else {
-            e.into()
+        let mut filtered = filter_artifacts(false);
+        if filtered.is_empty() && ambiguous_file_profile {
+            filtered = filter_artifacts(true);
         }
-    })?;
-    let artifact = serde_json::from_str::<ContractObject>(&data)?;
-    let maybe_bytecode = if deployed { artifact.deployed_bytecode } else { artifact.bytecode };
-    maybe_bytecode.ok_or_else(|| fmt_err!("no bytecode for contract; is it abstract or unlinked?"))
-}
-
-/// Returns the ABI of a matching artifact from the given path.
-///
-/// See [`get_artifact_code`] for the supported path formats.
-fn get_artifact_abi<FEN: FoundryEvmNetwork>(
-    state: &Cheatcodes<FEN>,
-    path: &str,
-) -> Result<JsonAbi> {
-    if path.ends_with(".json") {
-        // Read JSON artifact directly from disk.
-        let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
-        let data = fs::read_to_string(path)?;
-        let json: serde_json::Value = serde_json::from_str(&data)?;
-        let abi = json.get("abi").ok_or_else(|| fmt_err!("no `abi` field in artifact JSON"))?;
-        return serde_json::from_value(abi.clone()).map_err(|e| fmt_err!("{e}"));
-    }
-
-    let mut parts = path.split(':');
-
-    let mut file = None;
-    let mut contract_name = None;
-    let mut version = None;
-
-    let path_or_name = parts.next().unwrap();
-    if path_or_name.contains('.') {
-        file = Some(PathBuf::from(path_or_name));
-        if let Some(name_or_version) = parts.next() {
-            if name_or_version.contains('.') {
-                version = Some(name_or_version);
-            } else {
-                contract_name = Some(name_or_version);
-                version = parts.next();
-            }
-        }
-    } else {
-        contract_name = Some(path_or_name);
-        version = parts.next();
-    }
-
-    let version = if let Some(version) = version {
-        Some(Version::parse(version).map_err(|e| fmt_err!("failed parsing version: {e}"))?)
-    } else {
-        None
-    };
-
-    // Use available artifacts list if present.
-    if let Some(artifacts) = &state.config.available_artifacts {
-        let filtered = artifacts
-            .iter()
-            .filter(|(id, _)| {
-                let id_name = id.name.split('.').next().unwrap();
-
-                if let Some(path) = &file
-                    && !id.source.ends_with(path)
-                {
-                    return false;
-                }
-                if let Some(name) = contract_name
-                    && id_name != name
-                {
-                    return false;
-                }
-                if let Some(ref version) = version
-                    && (id.version.minor != version.minor
-                        || id.version.major != version.major
-                        || id.version.patch != version.patch)
-                {
-                    return false;
-                }
-                true
-            })
-            .collect::<Vec<_>>();
 
         let artifact = match &filtered[..] {
             [] => None,
             [artifact] => Some(Ok(*artifact)),
             filtered => {
                 let mut filtered = filtered.to_vec();
+                // If we know the current script/test contract solc version, try to filter by it
                 Some(
                     state
                         .config
                         .running_artifact
                         .as_ref()
                         .and_then(|running| {
-                            filtered.retain(|(id, _)| id.version == running.version);
-                            if filtered.len() == 1 {
-                                return Some(filtered[0]);
+                            // Only filter by running version if user did NOT specify a version
+                            if version.is_none() {
+                                filtered.retain(|(id, _)| id.version == running.version);
+
+                                // Return artifact if only one matched
+                                if filtered.len() == 1 {
+                                    return Some(filtered[0]);
+                                }
                             }
-                            filtered.retain(|(id, _)| id.profile == running.profile);
-                            (filtered.len() == 1).then(|| filtered[0])
+
+                            // Only filter by running profile if user did NOT specify a profile
+                            if profile.is_none() {
+                                filtered.retain(|(id, _)| id.profile == running.profile);
+
+                                return (filtered.len() == 1).then(|| filtered[0]);
+                            }
+
+                            None
                         })
                         .ok_or_else(|| fmt_err!("multiple matching artifacts found")),
                 )
@@ -781,16 +656,13 @@ fn get_artifact_abi<FEN: FoundryEvmNetwork>(
         };
 
         if let Some(artifact) = artifact {
-            let artifact = artifact?;
-            return Ok(artifact.1.abi.clone());
+            return Ok(ArtifactSource::InMemory(artifact?.1));
         }
     }
 
-    // Fallback: construct path manually and read JSON from disk.
+    // Fallback: construct path manually when no artifacts list or no match found
     let path_in_artifacts = match (file.map(|f| f.to_string_lossy().to_string()), contract_name) {
-        (Some(file), Some(contract_name)) => {
-            PathBuf::from(format!("{file}/{contract_name}.json"))
-        }
+        (Some(file), Some(contract_name)) => PathBuf::from(format!("{file}/{contract_name}.json")),
         (None, Some(contract_name)) => {
             PathBuf::from(format!("{contract_name}.sol/{contract_name}.json"))
         }
@@ -803,16 +675,47 @@ fn get_artifact_abi<FEN: FoundryEvmNetwork>(
 
     let path = state.config.paths.artifacts.join(path_in_artifacts);
     let path = state.config.ensure_path_allowed(path, FsAccessKind::Read)?;
-    let data = fs::read_to_string(path).map_err(|e| {
+    Ok(ArtifactSource::Disk(path))
+}
+
+/// Reads an artifact JSON file, mapping I/O errors to a helpful message when the
+/// lookup fell through the in-memory artifacts list.
+fn read_artifact_file<FEN: FoundryEvmNetwork>(
+    state: &Cheatcodes<FEN>,
+    path: &Path,
+) -> Result<String> {
+    fs::read_to_string(path).map_err(|e| {
         if state.config.available_artifacts.is_some() {
             fmt_err!("no matching artifact found")
         } else {
             e.into()
         }
-    })?;
-    let json: serde_json::Value = serde_json::from_str(&data)?;
-    let abi = json.get("abi").ok_or_else(|| fmt_err!("no `abi` field in artifact JSON"))?;
-    serde_json::from_value(abi.clone()).map_err(|e| fmt_err!("{e}"))
+    })
+}
+
+/// Returns the bytecode from a JSON artifact file.
+///
+/// See [`get_artifact_source`] for the supported path formats.
+///
+/// This function is safe to use with contracts that have library dependencies.
+/// `alloy_json_abi::ContractObject` validates bytecode during JSON parsing and will
+/// reject artifacts with unlinked library placeholders.
+fn get_artifact_code<FEN: FoundryEvmNetwork>(
+    state: &Cheatcodes<FEN>,
+    path: &str,
+    deployed: bool,
+) -> Result<Bytes> {
+    let maybe_bytecode = match get_artifact_source(state, path)? {
+        ArtifactSource::InMemory(data) => {
+            if deployed { data.deployed_bytecode() } else { data.bytecode() }.cloned()
+        }
+        ArtifactSource::Disk(path) => {
+            let data = read_artifact_file(state, &path)?;
+            let artifact = serde_json::from_str::<ContractObject>(&data)?;
+            if deployed { artifact.deployed_bytecode } else { artifact.bytecode }
+        }
+    };
+    maybe_bytecode.ok_or_else(|| fmt_err!("no bytecode for contract; is it abstract or unlinked?"))
 }
 
 impl Cheatcode for ffiCall {

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -2264,7 +2264,7 @@ Traces:
     │   └─ ← [Return]
     └─ ← [Stop]
 
-  [558957] PauseTracingTest::test()
+  [558945] PauseTracingTest::test()
     ├─ [0] VM::resumeTracing() [staticcall]
     │   └─ ← [Return]
     ├─ [48460] TraceGenerator::generate()

--- a/testdata/default/cheats/GetSelectors.t.sol
+++ b/testdata/default/cheats/GetSelectors.t.sol
@@ -42,6 +42,11 @@ contract GetSelectorsTest is Test {
         assertEq(selectors.length, 3, "should return 3 selectors");
     }
 
+    function testGetSelectorsUnknownContractReverts() public {
+        vm._expectCheatcodeRevert("no matching artifact found");
+        vm.getSelectors("ThisContractDoesNotExist");
+    }
+
     function _contains(bytes4[] memory arr, bytes4 val) internal pure returns (bool) {
         for (uint256 i = 0; i < arr.length; i++) {
             if (arr[i] == val) return true;

--- a/testdata/default/cheats/GetSelectors.t.sol
+++ b/testdata/default/cheats/GetSelectors.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity =0.8.18;
+
+import "utils/Test.sol";
+
+contract TargetContract {
+    function foo() external pure returns (uint256) {
+        return 1;
+    }
+
+    function bar(uint256 x) external pure returns (uint256) {
+        return x;
+    }
+
+    function baz(address a, uint256 b) external pure returns (bool) {
+        return a != address(0) && b > 0;
+    }
+}
+
+contract GetSelectorsTest is Test {
+    function testGetSelectorsByName() public {
+        bytes4[] memory selectors = vm.getSelectors("TargetContract");
+        assertEq(selectors.length, 3, "should return 3 selectors");
+
+        // Verify each known selector is present.
+        bytes4 fooSel = TargetContract.foo.selector;
+        bytes4 barSel = TargetContract.bar.selector;
+        bytes4 bazSel = TargetContract.baz.selector;
+
+        assertTrue(_contains(selectors, fooSel), "should contain foo selector");
+        assertTrue(_contains(selectors, barSel), "should contain bar selector");
+        assertTrue(_contains(selectors, bazSel), "should contain baz selector");
+    }
+
+    function testGetSelectorsByNameAndVersion() public {
+        bytes4[] memory selectors = vm.getSelectors("TargetContract:0.8.18");
+        assertEq(selectors.length, 3, "should return 3 selectors");
+    }
+
+    function testGetSelectorsByFullPath() public {
+        bytes4[] memory selectors = vm.getSelectors("cheats/GetSelectors.t.sol:TargetContract");
+        assertEq(selectors.length, 3, "should return 3 selectors");
+    }
+
+    function _contains(bytes4[] memory arr, bytes4 val) internal pure returns (bool) {
+        for (uint256 i = 0; i < arr.length; i++) {
+            if (arr[i] == val) return true;
+        }
+        return false;
+    }
+}

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -328,6 +328,7 @@ interface Vm {
     function getRawBlockHeader(uint256 blockNumber) external view returns (bytes memory rlpHeader);
     function getRecordedLogs() external view returns (Log[] memory logs);
     function getRecordedLogsJson() external view returns (string memory logsJson);
+    function getSelectors(string calldata artifactPath) external view returns (bytes4[] memory selectors);
     function getStateDiff() external view returns (string memory diff);
     function getStateDiffJson() external view returns (string memory diff);
     function getStorageAccesses() external view returns (StorageAccess[] memory storageAccesses);


### PR DESCRIPTION
## Motivation

Takes over #14372 by @zacharyftw, which went stale waiting for a re-review. Retrieving function selectors from an artifact currently requires `ffi` plus `forge inspect`, or manually parsing artifact JSON with `vm.readFile`. `vm.getSelectors(artifactPath)` returns the `bytes4[]` selectors directly, accepting the same path formats as `getCode`/`getDeployedCode`.

## Solution

The two original commits are kept with their authorship:

- `vm.getSelectors` reads selectors from the artifact ABI, parsing the raw `abi` field rather than `ContractObject` so it also works on artifacts with unlinked bytecode.
- The artifact resolution shared with `getCode`/`getDeployedCode` is extracted into `get_artifact_source`, addressing the review request to not add another standalone artifact parsing function.

On top of the rebase:

- The `get_artifact_source` extraction is redone against the current `get_artifact_code`, which gained `parse_artifact_path`, build-profile support and ambiguous file/profile handling since April. The resolution logic is byte-for-byte the one on master, only split into source resolution plus bytecode extraction, so `getCode`/`getDeployedCode` behavior is unchanged.
- Adds a revert test for the unknown-artifact case, matching the `GetCode.t.sol` coverage.

Closes https://github.com/foundry-rs/foundry/issues/11484
## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
