### PR TITLE
fix(anvil): enforce simulate block gas limit

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5049,13 +5049,19 @@ impl Backend<FoundryNetwork> {
             } = request;
             let mut cache_db = CacheDB::new(state);
             let mut block_res = Vec::with_capacity(block_state_calls.len());
+            let (is_amsterdam, tx_gas_limit_cap) = {
+                let cfg_env = &self.evm_env.read().cfg_env;
+                (cfg_env.spec >= SpecId::AMSTERDAM, cfg_env.tx_gas_limit_cap())
+            };
 
             // execute the blocks
             for block in block_state_calls {
                 let SimBlock { block_overrides, state_overrides, calls } = block;
                 let mut call_res = Vec::with_capacity(calls.len());
                 let mut log_index = 0;
-                let mut gas_used = 0;
+                let mut cumulative_gas_used = 0;
+                let mut block_regular_gas_used = 0;
+                let mut block_state_gas_used = 0;
                 let mut transactions = Vec::with_capacity(calls.len());
                 let mut logs= Vec::new();
 
@@ -5069,9 +5075,24 @@ impl Backend<FoundryNetwork> {
 
                 // execute all calls in that block
                 for (req_idx, mut request) in calls.into_iter().enumerate() {
-                    let remaining_gas = block_env.gas_limit.saturating_sub(gas_used);
+                    let remaining_regular_gas =
+                        block_env.gas_limit.saturating_sub(block_regular_gas_used);
+                    let remaining_state_gas =
+                        block_env.gas_limit.saturating_sub(block_state_gas_used);
+                    let remaining_gas = if is_amsterdam {
+                        remaining_regular_gas.min(remaining_state_gas)
+                    } else {
+                        block_env.gas_limit.saturating_sub(cumulative_gas_used)
+                    };
                     let requested_gas = request.gas.unwrap_or(remaining_gas);
-                    if requested_gas > remaining_gas {
+                    let exceeds_gas_limit = if is_amsterdam {
+                        let requested_regular_gas = requested_gas.min(tx_gas_limit_cap);
+                        requested_regular_gas > remaining_regular_gas
+                            || requested_gas > remaining_state_gas
+                    } else {
+                        requested_gas > remaining_gas
+                    };
+                    if exceeds_gas_limit {
                         return Err(BlockchainError::RpcError(RpcError {
                             code: ErrorCode::ServerError(-38015),
                             message: format!(
@@ -5096,6 +5117,12 @@ impl Backend<FoundryNetwork> {
                         fee_details,
                         block_env.clone(),
                     );
+
+                    if is_amsterdam {
+                        // Ensure simulated Amsterdam calls use EIP-8037's split gas schedule.
+                        let spec = evm_env.cfg_env.spec;
+                        evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec);
+                    }
 
                     // Always disable EIP-3607
                     evm_env.cfg_env.disable_eip3607 = true;
@@ -5128,7 +5155,12 @@ impl Backend<FoundryNetwork> {
 
                     // commit the transaction
                     cache_db.commit(state);
-                    gas_used += result.tx_gas_used();
+                    cumulative_gas_used =
+                        cumulative_gas_used.saturating_add(result.tx_gas_used());
+                    block_regular_gas_used = block_regular_gas_used
+                        .saturating_add(result.gas().block_regular_gas_used());
+                    block_state_gas_used = block_state_gas_used
+                        .saturating_add(result.gas().block_state_gas_used());
 
                     // create the transaction from a request
                     let from = request.from.unwrap_or_default();
@@ -5191,6 +5223,12 @@ impl Backend<FoundryNetwork> {
                     log_index += sim_res.logs.len();
                     call_res.push(sim_res);
                 }
+
+                let gas_used = if is_amsterdam {
+                    block_regular_gas_used.max(block_state_gas_used)
+                } else {
+                    cumulative_gas_used
+                };
 
                 let transactions_envelopes: Vec<AnyTxEnvelope> = transactions
                 .iter()

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -72,7 +72,7 @@ use alloy_rpc_types::{
     anvil::Forking,
     request::TransactionRequest,
     serde_helpers::JsonStorageKey,
-    simulate::{SimBlock, SimCallResult, SimulatePayload, SimulatedBlock},
+    simulate::{SimBlock, SimCallResult, SimulateError, SimulatePayload, SimulatedBlock},
     state::{EvmOverrides, StateOverride},
     trace::{
         filter::TraceFilter,
@@ -95,7 +95,7 @@ use anvil_core::eth::{
     block::{Block, BlockInfo, canonical_block, create_block},
     transaction::{MaybeImpersonatedTransaction, PendingTransaction, TransactionInfo},
 };
-use anvil_rpc::error::RpcError;
+use anvil_rpc::error::{ErrorCode, RpcError};
 use chrono::Datelike;
 use eyre::{Context, Result};
 use flate2::{Compression, read::GzDecoder, write::GzEncoder};
@@ -185,7 +185,7 @@ use std::{
     collections::BTreeMap,
     fmt::{self, Debug},
     io::{Read, Write},
-    ops::{Mul, Not},
+    ops::Mul,
     path::PathBuf,
     sync::Arc,
     time::Duration,
@@ -5068,7 +5068,21 @@ impl Backend<FoundryNetwork> {
                 }
 
                 // execute all calls in that block
-                for (req_idx, request) in calls.into_iter().enumerate() {
+                for (req_idx, mut request) in calls.into_iter().enumerate() {
+                    let remaining_gas = block_env.gas_limit.saturating_sub(gas_used);
+                    let requested_gas = request.gas.unwrap_or(remaining_gas);
+                    if requested_gas > remaining_gas {
+                        return Err(BlockchainError::RpcError(RpcError {
+                            code: ErrorCode::ServerError(-38015),
+                            message: format!(
+                                "block gas limit exceeded: remaining {remaining_gas}, requested {requested_gas}"
+                            )
+                            .into(),
+                            data: None,
+                        }));
+                    }
+                    request.gas = Some(requested_gas);
+
                     let fee_details = FeeDetails::new(
                         request.gas_price,
                         request.max_fee_per_gas,
@@ -5141,13 +5155,21 @@ impl Backend<FoundryNetwork> {
                         gas_used: result.tx_gas_used(),
                         max_used_gas: None,
                         status: result.is_success(),
-                        error: result.is_success().not().then(|| {
-                            alloy_rpc_types::simulate::SimulateError {
+                        error: match &result {
+                            ExecutionResult::Success { .. } => None,
+                            ExecutionResult::Halt {
+                                reason: HaltReason::OutOfGas(_), ..
+                            } => Some(SimulateError {
+                                code: SimulateError::VM_EXECUTION_ERROR_CODE,
+                                message: "out of gas".to_string(),
+                                data: None,
+                            }),
+                            _ => Some(SimulateError {
                                 code: -3200,
                                 message: "execution failed".to_string(),
                                 data: None,
-                            }
-                        }),
+                            }),
+                        },
                         logs: result.clone()
                             .into_logs()
                             .into_iter()

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -8,7 +8,7 @@ use alloy_rpc_types::{
     simulate::{SimBlock, SimulatePayload},
     state::{AccountOverride, StateOverridesBuilder},
 };
-use anvil::{NodeConfig, spawn};
+use anvil::{EthereumHardfork, NodeConfig, spawn};
 use foundry_test_utils::rpc;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -131,4 +131,54 @@ async fn test_simulate_rejects_call_above_remaining_block_gas() {
         provider.client().request("eth_simulateV1", (payload,)).await;
     let error = response.unwrap_err();
     assert_eq!(error.as_error_resp().unwrap().code, -38015);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_tracks_amsterdam_gas_dimensions_separately() {
+    let (api, _) =
+        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Amsterdam.into()))).await;
+    let sender = address!("0xc000000000000000000000000000000000000000");
+    let receiver = address!("0xc100000000000000000000000000000000000000");
+    let storage = address!("0xc200000000000000000000000000000000000000");
+    let gas_limit = 130_000;
+    let payload = SimulatePayload {
+        block_state_calls: vec![SimBlock {
+            block_overrides: Some(BlockOverrides {
+                gas_limit: Some(gas_limit),
+                ..Default::default()
+            }),
+            state_overrides: Some(
+                StateOverridesBuilder::with_capacity(1)
+                    .append(
+                        storage,
+                        AccountOverride {
+                            code: Some(Bytes::from_static(&[0x60, 0x01, 0x60, 0x00, 0x55, 0x00])),
+                            ..Default::default()
+                        },
+                    )
+                    .build(),
+            ),
+            calls: vec![
+                TransactionRequest {
+                    from: Some(sender),
+                    to: Some(TxKind::Call(storage)),
+                    ..Default::default()
+                },
+                TransactionRequest {
+                    from: Some(sender),
+                    to: Some(TxKind::Call(receiver)),
+                    ..Default::default()
+                },
+            ],
+        }],
+        ..Default::default()
+    };
+
+    let blocks = api.simulate_v1(payload, None).await.unwrap();
+    let block = &blocks[0];
+
+    assert!(block.calls.iter().all(|call| call.status));
+    let cumulative_gas_used = block.calls.iter().map(|call| call.gas_used).sum::<u64>();
+    assert!(cumulative_gas_used > gas_limit);
+    assert!(block.inner.header.gas_used <= gas_limit);
 }

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -1,6 +1,7 @@
 //! general eth api tests
 
-use alloy_primitives::{TxKind, U256, address};
+use alloy_primitives::{Bytes, TxKind, U256, address};
+use alloy_provider::Provider;
 use alloy_rpc_types::{
     BlockOverrides,
     request::TransactionRequest,
@@ -41,4 +42,93 @@ async fn test_fork_simulate_v1() {
         return_full_transactions: true,
     };
     let _res = api.simulate_v1(payload, None).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_enforces_block_gas_limit() {
+    let (api, _) = spawn(NodeConfig::test()).await;
+    let sender = address!("0xc000000000000000000000000000000000000000");
+    let receiver = address!("0xc100000000000000000000000000000000000000");
+    let gas_burner = address!("0xc200000000000000000000000000000000000000");
+    let gas_limit = 100_000;
+    let state_overrides = Some(
+        StateOverridesBuilder::with_capacity(1)
+            .append(
+                gas_burner,
+                AccountOverride {
+                    code: Some(Bytes::from_static(&[0x5b, 0x5f, 0x56])),
+                    ..Default::default()
+                },
+            )
+            .build(),
+    );
+    let calls = vec![
+        TransactionRequest {
+            from: Some(sender),
+            to: Some(TxKind::Call(receiver)),
+            ..Default::default()
+        },
+        TransactionRequest {
+            from: Some(sender),
+            to: Some(TxKind::Call(gas_burner)),
+            ..Default::default()
+        },
+    ];
+    let payload = SimulatePayload {
+        block_state_calls: vec![SimBlock {
+            block_overrides: Some(BlockOverrides {
+                gas_limit: Some(gas_limit),
+                ..Default::default()
+            }),
+            state_overrides,
+            calls,
+        }],
+        ..Default::default()
+    };
+
+    let blocks = api.simulate_v1(payload, None).await.unwrap();
+    let block = &blocks[0];
+
+    assert!(block.calls[0].status);
+    assert!(!block.calls[1].status);
+    assert_eq!(block.inner.header.gas_used, gas_limit);
+    assert_eq!(block.calls[1].gas_used, gas_limit - block.calls[0].gas_used);
+    assert_eq!(block.calls[1].error.as_ref().unwrap().code, -32015);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_rejects_call_above_remaining_block_gas() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let sender = address!("0xc000000000000000000000000000000000000000");
+    let receiver = address!("0xc100000000000000000000000000000000000000");
+    let gas_limit = 100_000;
+    let payload = SimulatePayload {
+        block_state_calls: vec![SimBlock {
+            block_overrides: Some(BlockOverrides {
+                gas_limit: Some(gas_limit),
+                ..Default::default()
+            }),
+            calls: vec![
+                TransactionRequest {
+                    from: Some(sender),
+                    to: Some(TxKind::Call(receiver)),
+                    ..Default::default()
+                },
+                TransactionRequest {
+                    from: Some(sender),
+                    to: Some(TxKind::Call(receiver)),
+                    gas: Some(gas_limit),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let provider = handle.http_provider();
+    let response: Result<serde_json::Value, _> =
+        provider.client().request("eth_simulateV1", (payload,)).await;
+    let error = response.unwrap_err();
+    assert_eq!(error.as_error_resp().unwrap().code, -38015);
 }


### PR DESCRIPTION
## Motivation

This addresses the block gas accounting portion of #13823 as the first targeted step toward full `eth_simulateV1` conformance. Calls without an explicit gas limit now receive the remaining block gas, calls requesting more than the remainder return `-38015`, and calls exhausting that budget report an execution failure with `-32015` without allowing reported block gas to exceed its limit.

The remaining parts of #13823 will be handled through separate focused PRs (superseding #15716). Closes OSS-563