### PR TITLE
fix(forge): clean up failed installs

### DIFF
--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -724,7 +724,7 @@ ignore them in the `.gitignore` file."
         path: impl AsRef<OsStr>,
     ) -> Result<()> {
         self.cmd()
-            .env("GIT_LITERAL_PATHSPECS", "1")
+            .arg("--literal-pathspecs")
             .stderr(self.stderr())
             .args(["submodule", "add"])
             .args(self.shallow.then_some("--depth=1"))

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -475,7 +475,7 @@ impl<'a> Git<'a> {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        self.cmd().arg("rm").args(force.then_some("--force")).arg("--").args(paths).exec().map(drop)
+        self.cmd().arg("rm").args(force.then_some("--force")).args(paths).exec().map(drop)
     }
 
     pub fn remove_index_path(self, path: &Path) -> Result<()> {
@@ -527,19 +527,6 @@ impl<'a> Git<'a> {
             .arg(path)
             .exec()
             .map(|out| out.stdout.is_empty())
-    }
-
-    /// Returns whether a path has no unstaged changes relative to the index.
-    pub fn is_path_worktree_clean(self, path: &Path) -> Result<bool> {
-        let output = self.cmd().args(["diff", "--quiet", "--"]).arg(path).output()?;
-        match output.status.code() {
-            Some(0) => Ok(true),
-            Some(1) => Ok(false),
-            _ => Err(eyre::eyre!(
-                "failed to inspect path: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            )),
-        }
     }
 
     pub fn has_branch(self, branch: impl AsRef<OsStr>, at: &Path) -> Result<bool> {
@@ -737,6 +724,7 @@ ignore them in the `.gitignore` file."
         path: impl AsRef<OsStr>,
     ) -> Result<()> {
         self.cmd()
+            .env("GIT_LITERAL_PATHSPECS", "1")
             .stderr(self.stderr())
             .args(["submodule", "add"])
             .args(self.shallow.then_some("--depth=1"))
@@ -761,13 +749,12 @@ ignore them in the `.gitignore` file."
     {
         self.cmd()
             .stderr(self.stderr())
-            .args(["--literal-pathspecs", "submodule", "update", "--progress", "--init"])
+            .args(["submodule", "update", "--progress", "--init"])
             .args(self.shallow.then_some("--depth=1"))
             .args(force.then_some("--force"))
             .args(remote.then_some("--remote"))
             .args(no_fetch.then_some("--no-fetch"))
             .args(recursive.then_some("--recursive"))
-            .arg("--")
             .args(paths)
             .exec()
             .map(drop)
@@ -797,17 +784,6 @@ ignore them in the `.gitignore` file."
         self.cmd().stderr(self.stderr()).args(["submodule", "init"]).exec().map(drop)
     }
 
-    pub fn submodule_deinit(self, force: bool, path: &Path) -> Result<()> {
-        self.cmd()
-            .stderr(self.stderr())
-            .args(["--literal-pathspecs", "submodule", "deinit"])
-            .args(force.then_some("--force"))
-            .arg("--")
-            .arg(path)
-            .exec()
-            .map(drop)
-    }
-
     pub fn submodules(&self) -> Result<Submodules> {
         self.cmd().args(["submodule", "status"]).get_stdout_lossy().map(|stdout| stdout.parse())?
     }
@@ -824,14 +800,11 @@ ignore them in the `.gitignore` file."
             .map(|url| Some(url.trim().to_string()))
     }
 
-    /// Returns whether the default section name conflicts and the mapping for an exact path.
-    pub fn submodule_mapping_for_path(
-        self,
-        path: &Path,
-    ) -> Result<(bool, Option<SubmoduleMapping>)> {
+    /// Returns whether `.gitmodules` contains the default section name or an exact path mapping.
+    pub fn has_submodule_mapping(self, path: &Path) -> Result<bool> {
         let gitmodules = self.root.join(".gitmodules");
         if !gitmodules.exists() {
-            return Ok((false, None));
+            return Ok(false);
         }
 
         let output = self
@@ -843,7 +816,6 @@ ignore them in the `.gitignore` file."
         match output.status.code() {
             Some(0) => {
                 let expected_path = path.to_slash_lossy();
-                let mut sections = HashMap::<String, (Option<String>, Option<String>)>::default();
                 for entry in
                     output.stdout.split(|byte| *byte == 0).filter(|entry| !entry.is_empty())
                 {
@@ -854,27 +826,13 @@ ignore them in the `.gitignore` file."
                     let value = std::str::from_utf8(&entry[separator + 1..])?;
                     let Some(key) = key.strip_prefix("submodule.") else { continue };
                     let Some((name, field)) = key.rsplit_once('.') else { continue };
-                    let section = sections.entry(name.to_string()).or_default();
-                    match field {
-                        "path" if section.0.is_none() => section.0 = Some(value.to_string()),
-                        "url" if section.1.is_none() => section.1 = Some(value.to_string()),
-                        _ => {}
+                    if name == expected_path || field == "path" && value == expected_path {
+                        return Ok(true);
                     }
                 }
-
-                let default_name_exists = sections.contains_key(expected_path.as_ref());
-                let mut mappings = sections
-                    .into_iter()
-                    .filter(|(_, (mapped_path, _))| mapped_path.as_deref() == Some(&expected_path))
-                    .map(|(name, (_, url))| SubmoduleMapping { name, url });
-                let mapping = mappings.next();
-                let multiple_mappings = mappings.next().is_some();
-                let name_conflict = multiple_mappings
-                    || default_name_exists
-                        && mapping.as_ref().is_none_or(|mapping| mapping.name != expected_path);
-                Ok((name_conflict, (!multiple_mappings).then_some(mapping).flatten()))
+                Ok(false)
             }
-            Some(1) => Ok((false, None)),
+            Some(1) => Ok(false),
             _ => Err(eyre::eyre!(
                 "failed to inspect .gitmodules: {}",
                 String::from_utf8_lossy(&output.stderr).trim()
@@ -906,34 +864,43 @@ ignore them in the `.gitignore` file."
             .map(|output| !output.stdout.is_empty())
     }
 
-    /// Returns whether the index contains the exact path.
-    pub fn is_tracked(self, path: &Path) -> Result<bool> {
-        self.cmd().args(["ls-files", "-z", "--"]).arg(path).exec().map(|output| {
-            let expected_path = path.to_slash_lossy();
-            output.stdout.split(|byte| *byte == 0).any(|entry| entry == expected_path.as_bytes())
-        })
+    /// Returns whether a regular stage-0 index entry has no flags and matches the worktree.
+    pub fn is_normal_tracked_file(self, path: &Path) -> Result<bool> {
+        let output = self
+            .cmd()
+            .args(["--literal-pathspecs", "ls-files", "--stage", "-v", "-z", "--"])
+            .arg(path)
+            .exec()?;
+        let mut entries = output.stdout.split(|byte| *byte == 0).filter(|entry| !entry.is_empty());
+        let Some(entry) = entries.next() else { return Ok(false) };
+        if entries.next().is_some() {
+            return Ok(false);
+        }
+        let Some(separator) = entry.iter().position(|byte| *byte == b'\t') else {
+            return Err(eyre::eyre!("invalid index entry"));
+        };
+        if entry.get(separator + 1..) != Some(path.to_slash_lossy().as_bytes()) {
+            return Ok(false);
+        }
+        let mut fields = std::str::from_utf8(&entry[..separator])?.split_ascii_whitespace();
+        if fields.next() != Some("H") || !matches!(fields.next(), Some("100644" | "100755")) {
+            return Ok(false);
+        }
+        let Some(index_hash) = fields.next() else { return Ok(false) };
+        if fields.next() != Some("0") || fields.next().is_some() {
+            return Ok(false);
+        }
+        let worktree_hash = self.cmd().args(["hash-object", "--"]).arg(path).get_stdout_lossy()?;
+        Ok(worktree_hash.trim() == index_hash)
     }
 
-    /// Returns all local config values for the given submodule.
-    pub fn submodule_config(self, path: &Path) -> Result<Vec<(String, String)>> {
+    /// Returns whether local config contains values for the given submodule.
+    pub fn has_submodule_config(self, path: &Path) -> Result<bool> {
         let pattern = format!(r"^submodule\.{}\.", regex::escape(&path.to_slash_lossy()));
-        let output =
-            self.cmd().args(["config", "--local", "--null", "--get-regexp", &pattern]).output()?;
+        let output = self.cmd().args(["config", "--local", "--get-regexp", &pattern]).output()?;
         match output.status.code() {
-            Some(0) => output
-                .stdout
-                .split(|byte| *byte == 0)
-                .filter(|entry| !entry.is_empty())
-                .map(|entry| {
-                    let Some(separator) = entry.iter().position(|byte| *byte == b'\n') else {
-                        return Err(eyre::eyre!("invalid submodule config entry"));
-                    };
-                    let (key, value) = entry.split_at(separator);
-                    let value = &value[1..];
-                    Ok((String::from_utf8(key.to_vec())?, String::from_utf8(value.to_vec())?))
-                })
-                .collect(),
-            Some(1) => Ok(Vec::new()),
+            Some(0) => Ok(true),
+            Some(1) => Ok(false),
             _ => Err(eyre::eyre!(
                 "failed to inspect submodule config: {}",
                 String::from_utf8_lossy(&output.stderr).trim()
@@ -941,14 +908,11 @@ ignore them in the `.gitignore` file."
         }
     }
 
-    /// Replaces all local config values for the given submodule.
-    pub fn restore_submodule_config(self, path: &Path, config: &[(String, String)]) -> Result<()> {
-        if !self.submodule_config(path)?.is_empty() {
+    /// Removes all local config values for the given submodule.
+    pub fn remove_submodule_config(self, path: &Path) -> Result<()> {
+        if self.has_submodule_config(path)? {
             let section = format!("submodule.{}", path.to_slash_lossy());
             self.cmd().args(["config", "--local", "--remove-section", &section]).exec()?;
-        }
-        for (key, value) in config {
-            self.cmd().args(["config", "--local", "--add", key, value]).exec()?;
         }
         Ok(())
     }
@@ -965,11 +929,7 @@ ignore them in the `.gitignore` file."
 
     /// Sets the branch for a submodule.
     pub fn set_submodule_branch(self, rel_path: &Path, branch: &str) -> Result<()> {
-        self.cmd()
-            .args(["--literal-pathspecs", "submodule", "set-branch", "-b", branch, "--"])
-            .arg(rel_path)
-            .exec()
-            .map(drop)
+        self.cmd().args(["submodule", "set-branch", "-b", branch]).arg(rel_path).exec().map(drop)
     }
 
     /// Returns remote branch names as a newline-separated string.
@@ -1019,15 +979,6 @@ ignore them in the `.gitignore` file."
     fn stderr(self) -> Stdio {
         if self.quiet { Stdio::piped() } else { Stdio::inherit() }
     }
-}
-
-/// A submodule section in `.gitmodules` resolved by its worktree path.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SubmoduleMapping {
-    /// Section name used for local config and the module Git directory.
-    pub name: String,
-    /// Registered submodule URL.
-    pub url: Option<String>,
 }
 
 /// Deserialized `git submodule status lib/dep` output.

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -449,6 +449,10 @@ impl<'a> Git<'a> {
         self.cmd().arg("add").args(paths).exec().map(drop)
     }
 
+    pub fn add_literal(self, path: &Path) -> Result<()> {
+        self.cmd().args(["--literal-pathspecs", "add", "--"]).arg(path).exec().map(drop)
+    }
+
     pub fn reset(self, hard: bool, tree: impl AsRef<OsStr>) -> Result<()> {
         self.cmd().arg("reset").args(hard.then_some("--hard")).arg(tree).exec().map(drop)
     }
@@ -472,6 +476,14 @@ impl<'a> Git<'a> {
         S: AsRef<OsStr>,
     {
         self.cmd().arg("rm").args(force.then_some("--force")).arg("--").args(paths).exec().map(drop)
+    }
+
+    pub fn remove_index_path(self, path: &Path) -> Result<()> {
+        self.cmd()
+            .args(["--literal-pathspecs", "rm", "--cached", "--force", "--"])
+            .arg(path)
+            .exec()
+            .map(drop)
     }
 
     pub fn commit(self, msg: &str) -> Result<()> {
@@ -511,7 +523,7 @@ impl<'a> Git<'a> {
 
     pub fn is_path_clean(self, path: &Path) -> Result<bool> {
         self.cmd()
-            .args(["status", "--porcelain", "--"])
+            .args(["--literal-pathspecs", "status", "--porcelain", "--"])
             .arg(path)
             .exec()
             .map(|out| out.stdout.is_empty())
@@ -749,12 +761,13 @@ ignore them in the `.gitignore` file."
     {
         self.cmd()
             .stderr(self.stderr())
-            .args(["submodule", "update", "--progress", "--init"])
+            .args(["--literal-pathspecs", "submodule", "update", "--progress", "--init"])
             .args(self.shallow.then_some("--depth=1"))
             .args(force.then_some("--force"))
             .args(remote.then_some("--remote"))
             .args(no_fetch.then_some("--no-fetch"))
             .args(recursive.then_some("--recursive"))
+            .arg("--")
             .args(paths)
             .exec()
             .map(drop)
@@ -787,7 +800,7 @@ ignore them in the `.gitignore` file."
     pub fn submodule_deinit(self, force: bool, path: &Path) -> Result<()> {
         self.cmd()
             .stderr(self.stderr())
-            .args(["submodule", "deinit"])
+            .args(["--literal-pathspecs", "submodule", "deinit"])
             .args(force.then_some("--force"))
             .arg("--")
             .arg(path)
@@ -884,6 +897,15 @@ ignore them in the `.gitignore` file."
         })
     }
 
+    /// Returns whether the index contains any entry at or below the given path.
+    pub fn has_index_entries(self, path: &Path) -> Result<bool> {
+        self.cmd()
+            .args(["--literal-pathspecs", "ls-files", "--stage", "-z", "--"])
+            .arg(path)
+            .exec()
+            .map(|output| !output.stdout.is_empty())
+    }
+
     /// Returns whether the index contains the exact path.
     pub fn is_tracked(self, path: &Path) -> Result<bool> {
         self.cmd().args(["ls-files", "-z", "--"]).arg(path).exec().map(|output| {
@@ -943,7 +965,11 @@ ignore them in the `.gitignore` file."
 
     /// Sets the branch for a submodule.
     pub fn set_submodule_branch(self, rel_path: &Path, branch: &str) -> Result<()> {
-        self.cmd().args(["submodule", "set-branch", "-b", branch]).arg(rel_path).exec().map(drop)
+        self.cmd()
+            .args(["--literal-pathspecs", "submodule", "set-branch", "-b", branch, "--"])
+            .arg(rel_path)
+            .exec()
+            .map(drop)
     }
 
     /// Returns remote branch names as a newline-separated string.

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -798,18 +798,43 @@ ignore them in the `.gitignore` file."
             .map(|url| Some(url.trim().to_string()))
     }
 
-    /// Returns whether the local config contains any values for the given submodule.
-    pub fn has_submodule_config(self, path: &Path) -> Result<bool> {
+    /// Returns all local config values for the given submodule.
+    pub fn submodule_config(self, path: &Path) -> Result<Vec<(String, String)>> {
         let pattern = format!(r"^submodule\.{}\.", regex::escape(&path.to_slash_lossy()));
-        let output = self.cmd().args(["config", "--local", "--get-regexp", &pattern]).output()?;
+        let output =
+            self.cmd().args(["config", "--local", "--null", "--get-regexp", &pattern]).output()?;
         match output.status.code() {
-            Some(0) => Ok(true),
-            Some(1) => Ok(false),
+            Some(0) => output
+                .stdout
+                .split(|byte| *byte == 0)
+                .filter(|entry| !entry.is_empty())
+                .map(|entry| {
+                    let Some(separator) = entry.iter().position(|byte| *byte == b'\n') else {
+                        return Err(eyre::eyre!("invalid submodule config entry"));
+                    };
+                    let (key, value) = entry.split_at(separator);
+                    let value = &value[1..];
+                    Ok((String::from_utf8(key.to_vec())?, String::from_utf8(value.to_vec())?))
+                })
+                .collect(),
+            Some(1) => Ok(Vec::new()),
             _ => Err(eyre::eyre!(
                 "failed to inspect submodule config: {}",
                 String::from_utf8_lossy(&output.stderr).trim()
             )),
         }
+    }
+
+    /// Replaces all local config values for the given submodule.
+    pub fn restore_submodule_config(self, path: &Path, config: &[(String, String)]) -> Result<()> {
+        if !self.submodule_config(path)?.is_empty() {
+            let section = format!("submodule.{}", path.to_slash_lossy());
+            self.cmd().args(["config", "--local", "--remove-section", &section]).exec()?;
+        }
+        for (key, value) in config {
+            self.cmd().args(["config", "--local", "--add", key, value]).exec()?;
+        }
+        Ok(())
     }
 
     /// Returns the absolute path to the repository's Git directory.

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -471,7 +471,7 @@ impl<'a> Git<'a> {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        self.cmd().arg("rm").args(force.then_some("--force")).args(paths).exec().map(drop)
+        self.cmd().arg("rm").args(force.then_some("--force")).arg("--").args(paths).exec().map(drop)
     }
 
     pub fn commit(self, msg: &str) -> Result<()> {
@@ -507,6 +507,14 @@ impl<'a> Git<'a> {
 
     pub fn is_clean(self) -> Result<bool> {
         self.cmd().args(["status", "--porcelain"]).exec().map(|out| out.stdout.is_empty())
+    }
+
+    pub fn is_path_clean(self, path: &Path) -> Result<bool> {
+        self.cmd()
+            .args(["status", "--porcelain", "--"])
+            .arg(path)
+            .exec()
+            .map(|out| out.stdout.is_empty())
     }
 
     pub fn has_branch(self, branch: impl AsRef<OsStr>, at: &Path) -> Result<bool> {
@@ -763,6 +771,17 @@ ignore them in the `.gitignore` file."
         self.cmd().stderr(self.stderr()).args(["submodule", "init"]).exec().map(drop)
     }
 
+    pub fn submodule_deinit(self, force: bool, path: &Path) -> Result<()> {
+        self.cmd()
+            .stderr(self.stderr())
+            .args(["submodule", "deinit"])
+            .args(force.then_some("--force"))
+            .arg("--")
+            .arg(path)
+            .exec()
+            .map(drop)
+    }
+
     pub fn submodules(&self) -> Result<Submodules> {
         self.cmd().args(["submodule", "status"]).get_stdout_lossy().map(|stdout| stdout.parse())?
     }
@@ -777,6 +796,25 @@ ignore them in the `.gitignore` file."
             .args(["config", "--get", &format!("submodule.{}.url", path.to_slash_lossy())])
             .get_stdout_lossy()
             .map(|url| Some(url.trim().to_string()))
+    }
+
+    /// Returns whether the local config contains any values for the given submodule.
+    pub fn has_submodule_config(self, path: &Path) -> Result<bool> {
+        let pattern = format!(r"^submodule\.{}\.", regex::escape(&path.to_slash_lossy()));
+        let output = self.cmd().args(["config", "--local", "--get-regexp", &pattern]).output()?;
+        match output.status.code() {
+            Some(0) => Ok(true),
+            Some(1) => Ok(false),
+            _ => Err(eyre::eyre!(
+                "failed to inspect submodule config: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )),
+        }
+    }
+
+    /// Returns the absolute path to the repository's Git directory.
+    pub fn absolute_git_dir(self) -> Result<PathBuf> {
+        self.cmd().args(["rev-parse", "--absolute-git-dir"]).get_stdout_lossy().map(PathBuf::from)
     }
 
     /// Returns the fetch URL of the given remote, or `None` if it doesn't exist.

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -517,6 +517,19 @@ impl<'a> Git<'a> {
             .map(|out| out.stdout.is_empty())
     }
 
+    /// Returns whether a path has no unstaged changes relative to the index.
+    pub fn is_path_worktree_clean(self, path: &Path) -> Result<bool> {
+        let output = self.cmd().args(["diff", "--quiet", "--"]).arg(path).output()?;
+        match output.status.code() {
+            Some(0) => Ok(true),
+            Some(1) => Ok(false),
+            _ => Err(eyre::eyre!(
+                "failed to inspect path: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )),
+        }
+    }
+
     pub fn has_branch(self, branch: impl AsRef<OsStr>, at: &Path) -> Result<bool> {
         self.cmd_at(at)
             .args(["branch", "--list", "--no-color"])
@@ -796,6 +809,102 @@ ignore them in the `.gitignore` file."
             .args(["config", "--get", &format!("submodule.{}.url", path.to_slash_lossy())])
             .get_stdout_lossy()
             .map(|url| Some(url.trim().to_string()))
+    }
+
+    /// Returns the URL registered for a submodule in `.gitmodules`.
+    pub fn submodule_file_url(self, path: &Path) -> Result<Option<String>> {
+        let gitmodules = self.root.join(".gitmodules");
+        if !gitmodules.exists() {
+            return Ok(None);
+        }
+
+        let output = self
+            .cmd()
+            .args(["config", "--file"])
+            .arg(gitmodules)
+            .args(["--get", &format!("submodule.{}.url", path.to_slash_lossy())])
+            .output()?;
+        match output.status.code() {
+            Some(0) => Ok(Some(String::from_utf8(output.stdout)?.trim().to_string())),
+            Some(1) => Ok(None),
+            _ => Err(eyre::eyre!(
+                "failed to inspect .gitmodules: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )),
+        }
+    }
+
+    /// Returns name conflicts, an exact default-name mapping, and any exact path mapping.
+    pub fn submodule_mapping(self, path: &Path) -> Result<(bool, bool, bool)> {
+        let gitmodules = self.root.join(".gitmodules");
+        if !gitmodules.exists() {
+            return Ok((false, false, false));
+        }
+
+        let output = self
+            .cmd()
+            .args(["config", "--null", "--file"])
+            .arg(gitmodules)
+            .args(["--get-regexp", r"^submodule\..*"])
+            .output()?;
+        match output.status.code() {
+            Some(0) => {
+                let expected_path = path.to_slash_lossy();
+                let expected_prefix = format!("submodule.{expected_path}.");
+                let mut exact_name = false;
+                let mut exact_name_path = false;
+                let mut name_path_mismatch = false;
+                let mut exact_path = false;
+                for entry in
+                    output.stdout.split(|byte| *byte == 0).filter(|entry| !entry.is_empty())
+                {
+                    let separator = entry.iter().position(|byte| *byte == b'\n');
+                    let key = separator.map_or(entry, |separator| &entry[..separator]);
+                    let value = separator.and_then(|separator| entry.get(separator + 1..));
+                    if key.starts_with(expected_prefix.as_bytes()) {
+                        exact_name = true;
+                        if key.ends_with(b".path") {
+                            let matches = value == Some(expected_path.as_bytes());
+                            exact_name_path |= matches;
+                            name_path_mismatch |= !matches;
+                        }
+                    }
+                    if key.ends_with(b".path") && value == Some(expected_path.as_bytes()) {
+                        exact_path = true;
+                    }
+                }
+                let exact_name_mapping = exact_name_path && !name_path_mismatch;
+                Ok((exact_name && !exact_name_mapping, exact_name_mapping, exact_path))
+            }
+            Some(1) => Ok((false, false, false)),
+            _ => Err(eyre::eyre!(
+                "failed to inspect .gitmodules: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )),
+        }
+    }
+
+    /// Returns whether the index contains a submodule at the given path.
+    pub fn is_gitlink(self, path: &Path) -> Result<bool> {
+        self.cmd().args(["ls-files", "--stage", "-z", "--"]).arg(path).exec().map(|output| {
+            let expected_path = path.to_slash_lossy();
+            output.stdout.split(|byte| *byte == 0).any(|entry| {
+                entry.starts_with(b"160000 ")
+                    && entry
+                        .iter()
+                        .position(|byte| *byte == b'\t')
+                        .and_then(|separator| entry.get(separator + 1..))
+                        == Some(expected_path.as_bytes())
+            })
+        })
+    }
+
+    /// Returns whether the index contains the exact path.
+    pub fn is_tracked(self, path: &Path) -> Result<bool> {
+        self.cmd().args(["ls-files", "-z", "--"]).arg(path).exec().map(|output| {
+            let expected_path = path.to_slash_lossy();
+            output.stdout.split(|byte| *byte == 0).any(|entry| entry == expected_path.as_bytes())
+        })
     }
 
     /// Returns all local config values for the given submodule.

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -811,34 +811,14 @@ ignore them in the `.gitignore` file."
             .map(|url| Some(url.trim().to_string()))
     }
 
-    /// Returns the URL registered for a submodule in `.gitmodules`.
-    pub fn submodule_file_url(self, path: &Path) -> Result<Option<String>> {
+    /// Returns whether the default section name conflicts and the mapping for an exact path.
+    pub fn submodule_mapping_for_path(
+        self,
+        path: &Path,
+    ) -> Result<(bool, Option<SubmoduleMapping>)> {
         let gitmodules = self.root.join(".gitmodules");
         if !gitmodules.exists() {
-            return Ok(None);
-        }
-
-        let output = self
-            .cmd()
-            .args(["config", "--file"])
-            .arg(gitmodules)
-            .args(["--get", &format!("submodule.{}.url", path.to_slash_lossy())])
-            .output()?;
-        match output.status.code() {
-            Some(0) => Ok(Some(String::from_utf8(output.stdout)?.trim().to_string())),
-            Some(1) => Ok(None),
-            _ => Err(eyre::eyre!(
-                "failed to inspect .gitmodules: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            )),
-        }
-    }
-
-    /// Returns name conflicts, an exact default-name mapping, and any exact path mapping.
-    pub fn submodule_mapping(self, path: &Path) -> Result<(bool, bool, bool)> {
-        let gitmodules = self.root.join(".gitmodules");
-        if !gitmodules.exists() {
-            return Ok((false, false, false));
+            return Ok((false, None));
         }
 
         let output = self
@@ -850,33 +830,38 @@ ignore them in the `.gitignore` file."
         match output.status.code() {
             Some(0) => {
                 let expected_path = path.to_slash_lossy();
-                let expected_prefix = format!("submodule.{expected_path}.");
-                let mut exact_name = false;
-                let mut exact_name_path = false;
-                let mut name_path_mismatch = false;
-                let mut exact_path = false;
+                let mut sections = HashMap::<String, (Option<String>, Option<String>)>::default();
                 for entry in
                     output.stdout.split(|byte| *byte == 0).filter(|entry| !entry.is_empty())
                 {
-                    let separator = entry.iter().position(|byte| *byte == b'\n');
-                    let key = separator.map_or(entry, |separator| &entry[..separator]);
-                    let value = separator.and_then(|separator| entry.get(separator + 1..));
-                    if key.starts_with(expected_prefix.as_bytes()) {
-                        exact_name = true;
-                        if key.ends_with(b".path") {
-                            let matches = value == Some(expected_path.as_bytes());
-                            exact_name_path |= matches;
-                            name_path_mismatch |= !matches;
-                        }
-                    }
-                    if key.ends_with(b".path") && value == Some(expected_path.as_bytes()) {
-                        exact_path = true;
+                    let Some(separator) = entry.iter().position(|byte| *byte == b'\n') else {
+                        return Err(eyre::eyre!("invalid submodule mapping entry"));
+                    };
+                    let key = std::str::from_utf8(&entry[..separator])?;
+                    let value = std::str::from_utf8(&entry[separator + 1..])?;
+                    let Some(key) = key.strip_prefix("submodule.") else { continue };
+                    let Some((name, field)) = key.rsplit_once('.') else { continue };
+                    let section = sections.entry(name.to_string()).or_default();
+                    match field {
+                        "path" if section.0.is_none() => section.0 = Some(value.to_string()),
+                        "url" if section.1.is_none() => section.1 = Some(value.to_string()),
+                        _ => {}
                     }
                 }
-                let exact_name_mapping = exact_name_path && !name_path_mismatch;
-                Ok((exact_name && !exact_name_mapping, exact_name_mapping, exact_path))
+
+                let default_name_exists = sections.contains_key(expected_path.as_ref());
+                let mut mappings = sections
+                    .into_iter()
+                    .filter(|(_, (mapped_path, _))| mapped_path.as_deref() == Some(&expected_path))
+                    .map(|(name, (_, url))| SubmoduleMapping { name, url });
+                let mapping = mappings.next();
+                let multiple_mappings = mappings.next().is_some();
+                let name_conflict = multiple_mappings
+                    || default_name_exists
+                        && mapping.as_ref().is_none_or(|mapping| mapping.name != expected_path);
+                Ok((name_conflict, (!multiple_mappings).then_some(mapping).flatten()))
             }
-            Some(1) => Ok((false, false, false)),
+            Some(1) => Ok((false, None)),
             _ => Err(eyre::eyre!(
                 "failed to inspect .gitmodules: {}",
                 String::from_utf8_lossy(&output.stderr).trim()
@@ -1008,6 +993,15 @@ ignore them in the `.gitignore` file."
     fn stderr(self) -> Stdio {
         if self.quiet { Stdio::piped() } else { Stdio::inherit() }
     }
+}
+
+/// A submodule section in `.gitmodules` resolved by its worktree path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubmoduleMapping {
+    /// Section name used for local config and the module Git directory.
+    pub name: String,
+    /// Registered submodule URL.
+    pub url: Option<String>,
 }
 
 /// Deserialized `git submodule status lib/dep` output.

--- a/crates/common/fmt/src/dynamic.rs
+++ b/crates/common/fmt/src/dynamic.rs
@@ -240,7 +240,9 @@ fn _serialize_value_as_json(
                 .map(|v| _serialize_value_as_json(v, defs, strict))
                 .collect::<Result<_>>()?,
         )),
-        DynSolValue::Function(_) => eyre::bail!("cannot serialize function pointer"),
+        DynSolValue::Function(_) => {
+            eyre::bail!("cannot serialize function pointer")
+        }
     }
 }
 
@@ -291,9 +293,11 @@ impl StructDefinitions {
         match matches.len() {
             0 => Ok(None),
             1 => Ok(Some(matches[0])),
-            _ => eyre::bail!(
-                "there are several structs with the same name. Use `<contract_name>.{key}` instead."
-            ),
+            _ => {
+                eyre::bail!(
+                    "there are several structs with the same name. Use `<contract_name>.{key}` instead."
+                )
+            }
         }
     }
 }

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -128,9 +128,10 @@ impl DependencyInstallOpts {
         if !no_git {
             lockfile = lockfile.with_git(&git);
 
-            // Initialize all existing submodules when no explicit dependencies were requested so
-            // that foundry.lock synchronization can inspect their commits and tags.
-            if dependencies.is_empty() && git.submodules_uninitialized()? {
+            // Check if submodules are uninitialized, if so, we need to fetch all submodules
+            // This is to ensure that foundry.lock syncs successfully and doesn't error out, when
+            // looking for commits/tags in submodules
+            if git.submodules_uninitialized()? {
                 trace!(lib = %libs.display(), "submodules uninitialized");
                 git.submodule_update(false, false, false, true, Some(&libs))?;
             }
@@ -170,6 +171,13 @@ impl DependencyInstallOpts {
 
         let installer = Installer { git, commit };
         for dep in dependencies {
+            if dep
+                .name()
+                .split(['/', '\\'])
+                .any(|component| component.is_empty() || matches!(component, "." | ".."))
+            {
+                eyre::bail!("invalid dependency name: {}", dep.name());
+            }
             let path = libs.join(dep.name());
             let rel_path = path
                 .strip_prefix(git.root)
@@ -191,9 +199,7 @@ impl DependencyInstallOpts {
                 if commit {
                     git.ensure_clean()?;
                 }
-                let (tag, mut transaction) =
-                    installer.install_as_submodule(&dep, &path, &config.root)?;
-                installed_tag = tag;
+                installed_tag = installer.install_as_submodule(&dep, &path)?;
 
                 let mut new_insertion = false;
                 // Pin branch to submodule if branch is used
@@ -205,8 +211,6 @@ impl DependencyInstallOpts {
                     {
                         // always work with relative paths when directly modifying submodules
                         git.set_submodule_branch(rel_path, tag_or_branch)?;
-                        let root = Git::root_of(git.root)?;
-                        git.root(&root).add(Some(".gitmodules"))?;
 
                         let rev = git.get_rev(tag_or_branch, &path)?;
 
@@ -235,9 +239,6 @@ impl DependencyInstallOpts {
                     || out_of_sync_deps.as_ref().is_some_and(|o| !o.is_empty())
                     || !lockfile.exists()
                 {
-                    if let Some(transaction) = &mut transaction {
-                        transaction.mark_lockfile_touched();
-                    }
                     lockfile.write()?;
                 }
 
@@ -261,9 +262,6 @@ impl DependencyInstallOpts {
                         git.root(&config.root).add(Some(FOUNDRY_LOCK))?;
                     }
                     git.commit(&msg)?;
-                }
-                if let Some(transaction) = &mut transaction {
-                    transaction.disarm();
                 }
             }
 
@@ -335,72 +333,46 @@ struct Installer<'a> {
     commit: bool,
 }
 
-struct NewSubmoduleTransaction {
+struct NewSubmoduleGuard {
     root: PathBuf,
     relative_path: PathBuf,
     path: PathBuf,
     module_dir: PathBuf,
     gitmodules_contents: Option<Vec<u8>>,
-    submodule_config: Vec<(String, String)>,
-    lockfile_path: PathBuf,
-    lockfile_contents: Option<Vec<u8>>,
-    stage_lockfile: bool,
-    lockfile_touched: bool,
     armed: bool,
 }
 
-impl NewSubmoduleTransaction {
-    const fn mark_lockfile_touched(&mut self) {
-        self.lockfile_touched = true;
-    }
-
+impl NewSubmoduleGuard {
     const fn disarm(&mut self) {
         self.armed = false;
     }
 
     fn rollback(&self) {
         let git = Git::new(&self.root);
-        let owns_worktree = !self.path.is_symlink()
-            && self.path.exists()
-            && Git::new(&self.path).absolute_git_dir().ok().as_deref() == Some(&self.module_dir);
-        if owns_worktree && let Err(err) = git.submodule_deinit(true, &self.relative_path) {
-            warn!(%err, "failed to remove submodule config after installation failure");
-        }
         if let Err(err) = git.remove_index_path(&self.relative_path) {
             warn!(%err, "failed to remove submodule after installation failure");
         }
-        if owns_worktree
-            && self.module_dir.exists()
-            && let Err(err) = fs::remove_dir_all(&self.module_dir)
-        {
-            warn!(%err, "failed to remove submodule Git directory after installation failure");
-        }
-        restore_file(&self.root.join(".gitmodules"), self.gitmodules_contents.as_deref());
-        if let Err(err) = git.add(Some(".gitmodules")) {
-            warn!(%err, "failed to restore staged .gitmodules after installation failure");
-        }
-        if self.lockfile_touched {
-            restore_file(&self.lockfile_path, self.lockfile_contents.as_deref());
-            if self.stage_lockfile
-                && let Err(err) = git.add(Some(&self.lockfile_path))
-            {
-                warn!(%err, "failed to restore staged lockfile after installation failure");
-            }
-        }
-        if owns_worktree
-            && self.path.exists()
+        if self.path.exists()
             && let Err(err) = fs::remove_dir_all(&self.path)
         {
             warn!(%err, "failed to remove dependency after installation failure");
         }
-        if let Err(err) = git.restore_submodule_config(&self.relative_path, &self.submodule_config)
+        if self.module_dir.exists()
+            && let Err(err) = fs::remove_dir_all(&self.module_dir)
         {
-            warn!(%err, "failed to restore submodule config after installation failure");
+            warn!(%err, "failed to remove submodule Git directory after installation failure");
+        }
+        if let Err(err) = git.remove_submodule_config(&self.relative_path) {
+            warn!(%err, "failed to remove submodule config after installation failure");
+        }
+        restore_file(&self.root.join(".gitmodules"), self.gitmodules_contents.as_deref());
+        if let Err(err) = git.add_literal(Path::new(".gitmodules")) {
+            warn!(%err, "failed to restore staged .gitmodules after installation failure");
         }
     }
 }
 
-impl Drop for NewSubmoduleTransaction {
+impl Drop for NewSubmoduleGuard {
     fn drop(&mut self) {
         if self.armed {
             self.rollback();
@@ -434,12 +406,7 @@ impl Installer<'_> {
         // checkout the tag if necessary, using recursive checkout to properly clean up
         // nested submodules that may exist on the default branch but not on the target tag.
         // See: https://github.com/foundry-rs/foundry/issues/13688
-        if let Err(err) = self.git_checkout(&dep, path, true) {
-            if let Err(cleanup_err) = fs::remove_dir_all(path) {
-                warn!(%cleanup_err, "failed to remove dependency after installation failure");
-            }
-            return Err(err);
-        }
+        self.git_checkout(&dep, path, true)?;
 
         trace!("updating dependency submodules recursively");
         self.git.root(path).submodule_update(
@@ -499,178 +466,86 @@ impl Installer<'_> {
     ///
     /// This will add the git submodule to the given dir, initialize it and checkout the tag if
     /// provided or try to find the latest semver, release tag.
-    fn install_as_submodule(
-        self,
-        dep: &Dependency,
-        path: &Path,
-        project_root: &Path,
-    ) -> Result<(Option<String>, Option<NewSubmoduleTransaction>)> {
+    fn install_as_submodule(self, dep: &Dependency, path: &Path) -> Result<Option<String>> {
         let root = Git::root_of(self.git.root)?;
         let relative_path = path.strip_prefix(&root)?;
         let git = self.git.root(&root);
         let gitmodules = root.join(".gitmodules");
-        let gitmodules_existed = gitmodules.exists();
-        let gitmodules_contents = gitmodules_existed.then(|| fs::read(&gitmodules)).transpose()?;
-        let (submodule_name_collision, mapping) = git.submodule_mapping_for_path(relative_path)?;
-        let module_name =
-            mapping.as_ref().map_or(relative_path, |mapping| Path::new(&mapping.name));
-        let module_dir = git.absolute_git_dir()?.join("modules").join(module_name);
-        let submodule_config = git.submodule_config(module_name)?;
-        if gitmodules_existed && !git.is_tracked(Path::new(".gitmodules"))? {
-            eyre::bail!(
-                "cannot safely install dependency at {} because the target or .gitmodules has existing changes",
-                relative_path.display()
-            );
-        }
-        let existing_submodule = mapping.is_some() && git.is_gitlink(relative_path)?;
-        if submodule_name_collision || mapping.is_some() && !existing_submodule {
+        let gitmodules_contents = gitmodules.exists().then(|| fs::read(&gitmodules)).transpose()?;
+        let has_mapping = git.has_submodule_mapping(relative_path)?;
+        let is_gitlink = git.is_gitlink(relative_path)?;
+        if has_mapping != is_gitlink {
             eyre::bail!(
                 "cannot safely install dependency at {} because .gitmodules already contains a matching submodule",
                 relative_path.display()
             );
         }
-        if !existing_submodule {
+        let mut guard = if is_gitlink {
+            None
+        } else {
+            let module_dir = git.absolute_git_dir()?.join("modules").join(relative_path);
+            let gitmodules_safe = !gitmodules.is_symlink()
+                && git.is_path_clean(Path::new(".gitmodules"))?
+                && if gitmodules.exists() {
+                    git.is_normal_tracked_file(Path::new(".gitmodules"))?
+                } else {
+                    !git.has_index_entries(Path::new(".gitmodules"))?
+                };
             let can_rollback = !path.is_symlink()
                 && !path.exists()
                 && !module_dir.exists()
                 && !git.has_index_entries(relative_path)?
+                && !git.has_submodule_config(relative_path)?
                 && git.is_path_clean(relative_path)?
-                && git.is_path_worktree_clean(Path::new(".gitmodules"))?;
+                && gitmodules_safe;
             if !can_rollback {
                 eyre::bail!(
                     "cannot safely install dependency at {} because the target or .gitmodules has existing changes",
                     relative_path.display()
                 );
             }
-        } else if mapping.as_ref().and_then(|mapping| mapping.url.as_deref())
-            != Some(dep.require_url()?)
-        {
-            eyre::bail!(
-                "cannot install dependency at {} because its registered URL does not match {}",
-                relative_path.display(),
-                dep.require_url()?
-            );
-        }
-        let uninitialized_worktree = existing_submodule
-            && !path.is_symlink()
-            && path.is_dir()
-            && std::fs::read_dir(path)?.next().is_none();
-        let worktree_existed = path.exists();
-        let module_dir_existed = module_dir.exists();
-        if existing_submodule && (path.is_symlink() || path.exists()) && !uninitialized_worktree {
-            self.ensure_submodule_worktree(path, &module_dir, relative_path)?;
-        }
-        let original_head = (existing_submodule && worktree_existed && !uninitialized_worktree)
-            .then(|| self.git.root(path).head())
-            .transpose()?;
-
-        let lockfile_path = project_root.join(FOUNDRY_LOCK);
-        let lockfile_contents =
-            lockfile_path.exists().then(|| fs::read(&lockfile_path)).transpose()?;
-        let mut transaction = (!existing_submodule).then(|| NewSubmoduleTransaction {
-            root: root.clone(),
-            relative_path: relative_path.to_path_buf(),
-            path: path.to_path_buf(),
-            module_dir: module_dir.clone(),
-            gitmodules_contents: gitmodules_contents.clone(),
-            submodule_config: submodule_config.clone(),
-            lockfile_path,
-            lockfile_contents,
-            stage_lockfile: self.commit,
-            lockfile_touched: false,
-            armed: true,
-        });
-        let setup = if existing_submodule {
-            if !path.exists() || uninitialized_worktree {
-                git.submodule_update(false, false, false, false, Some(relative_path))
-            } else {
-                Ok(())
-            }
-        } else {
-            self.git_submodule(dep, path)
+            Some(NewSubmoduleGuard {
+                root,
+                relative_path: relative_path.to_path_buf(),
+                path: path.to_path_buf(),
+                module_dir,
+                gitmodules_contents,
+                armed: true,
+            })
         };
-        let result = setup.and_then(|()| {
-            if existing_submodule {
-                self.ensure_submodule_worktree(path, &module_dir, relative_path)?;
-            }
 
-            let mut dep = dep.clone();
-            if dep.tag.is_none() {
-                // try to find latest semver release tag
-                dep.tag = self.last_tag(path);
-            }
+        // install the dep
+        self.git_submodule(dep, path)?;
 
-            // checkout the tag if necessary
-            self.git_checkout(&dep, path, true)?;
-
-            trace!("updating dependency submodules recursively");
-            self.git.root(path).submodule_update(
-                false,
-                false,
-                false,
-                true,
-                std::iter::empty::<PathBuf>(),
-            )?;
-
-            // sync submodules config with changes in .gitmodules, see <https://github.com/foundry-rs/foundry/issues/9611>
-            self.git.root(path).submodule_sync()?;
-
-            if self.commit {
-                self.git.add_literal(path)?;
-            }
-
-            Ok(dep.tag)
-        });
-
-        if result.is_err() && existing_submodule {
-            if let Some(head) = original_head
-                && let Err(err) = self.git.root(path).checkout(false, head)
-            {
-                warn!(%err, "failed to restore submodule HEAD after installation failure");
-            }
-            if (uninitialized_worktree || !worktree_existed)
-                && let Err(err) = git.submodule_deinit(true, relative_path)
-            {
-                warn!(%err, "failed to restore deinitialized submodule after installation failure");
-            }
-            if !worktree_existed
-                && path.exists()
-                && let Err(err) = fs::remove_dir_all(path)
-            {
-                warn!(%err, "failed to restore missing submodule worktree");
-            }
-            if !module_dir_existed
-                && module_dir.exists()
-                && let Err(err) = fs::remove_dir_all(&module_dir)
-            {
-                warn!(%err, "failed to remove created submodule Git directory");
-            }
-            if let Err(err) = git.restore_submodule_config(module_name, &submodule_config) {
-                warn!(%err, "failed to restore submodule config after installation failure");
-            }
+        let mut dep = dep.clone();
+        if dep.tag.is_none() {
+            // try to find latest semver release tag
+            dep.tag = self.last_tag(path);
         }
 
-        result.map(|tag| (tag, transaction.take()))
-    }
+        // checkout the tag if necessary
+        self.git_checkout(&dep, path, true)?;
 
-    fn ensure_submodule_worktree(
-        self,
-        path: &Path,
-        module_dir: &Path,
-        relative_path: &Path,
-    ) -> Result<()> {
-        let actual_module_dir = if path.is_symlink() || !path.join(".git").exists() {
-            None
-        } else {
-            self.git.root(path).absolute_git_dir().ok()
-        };
-        if actual_module_dir.as_deref() != Some(module_dir) {
-            eyre::bail!(
-                "cannot safely install dependency at {} because the target is not its registered submodule worktree",
-                relative_path.display()
-            );
+        trace!("updating dependency submodules recursively");
+        self.git.root(path).submodule_update(
+            false,
+            false,
+            false,
+            true,
+            std::iter::empty::<PathBuf>(),
+        )?;
+
+        // sync submodules config with changes in .gitmodules, see <https://github.com/foundry-rs/foundry/issues/9611>
+        self.git.root(path).submodule_sync()?;
+
+        if let Some(guard) = &mut guard {
+            guard.disarm();
         }
-        Ok(())
+        if self.commit {
+            self.git.add_literal(path)?;
+        }
+
+        Ok(dep.tag)
     }
 
     fn last_tag(self, path: &Path) -> Option<String> {
@@ -744,6 +619,8 @@ impl Installer<'_> {
 
         let res = self.git.root(path).checkout(recurse, &tag);
         if let Err(mut e) = res {
+            // remove dependency on failed checkout
+            fs::remove_dir_all(path)?;
             if e.to_string().contains("did not match any file(s) known to git") {
                 e = eyre::eyre!("Tag: \"{tag}\" not found for repo \"{url}\"!")
             }

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -341,7 +341,12 @@ impl Installer<'_> {
         // checkout the tag if necessary, using recursive checkout to properly clean up
         // nested submodules that may exist on the default branch but not on the target tag.
         // See: https://github.com/foundry-rs/foundry/issues/13688
-        self.git_checkout(&dep, path, true)?;
+        if let Err(err) = self.git_checkout(&dep, path, true) {
+            if let Err(cleanup_err) = fs::remove_dir_all(path) {
+                warn!(%cleanup_err, "failed to remove dependency after installation failure");
+            }
+            return Err(err);
+        }
 
         trace!("updating dependency submodules recursively");
         self.git.root(path).submodule_update(
@@ -402,35 +407,99 @@ impl Installer<'_> {
     /// This will add the git submodule to the given dir, initialize it and checkout the tag if
     /// provided or try to find the latest semver, release tag.
     fn install_as_submodule(self, dep: &Dependency, path: &Path) -> Result<Option<String>> {
+        let root = Git::root_of(self.git.root)?;
+        let relative_path = path.strip_prefix(&root)?;
+        let git = self.git.root(&root);
+        let gitmodules = root.join(".gitmodules");
+        let gitmodules_existed = gitmodules.exists();
+        let module_dir = git.absolute_git_dir()?.join("modules").join(relative_path);
+        let can_rollback = !path.exists()
+            && !module_dir.exists()
+            && !git.has_submodule_config(relative_path)?
+            && git.is_path_clean(relative_path)?
+            && git.is_path_clean(Path::new(".gitmodules"))?;
+
         // install the dep
         self.git_submodule(dep, path)?;
+        let actual_module_dir =
+            self.git.root(path).absolute_git_dir().unwrap_or_else(|_| module_dir.clone());
 
-        let mut dep = dep.clone();
-        if dep.tag.is_none() {
-            // try to find latest semver release tag
-            dep.tag = self.last_tag(path);
+        let result = (|| {
+            let mut dep = dep.clone();
+            if dep.tag.is_none() {
+                // try to find latest semver release tag
+                dep.tag = self.last_tag(path);
+            }
+
+            // checkout the tag if necessary
+            self.git_checkout(&dep, path, true)?;
+
+            trace!("updating dependency submodules recursively");
+            self.git.root(path).submodule_update(
+                false,
+                false,
+                false,
+                true,
+                std::iter::empty::<PathBuf>(),
+            )?;
+
+            // sync submodules config with changes in .gitmodules, see <https://github.com/foundry-rs/foundry/issues/9611>
+            self.git.root(path).submodule_sync()?;
+
+            if self.commit {
+                self.git.add(Some(path))?;
+            }
+
+            Ok(dep.tag)
+        })();
+
+        if result.is_err() && can_rollback && actual_module_dir == module_dir {
+            self.rollback_submodule(
+                &root,
+                relative_path,
+                path,
+                &gitmodules,
+                gitmodules_existed,
+                &actual_module_dir,
+            );
         }
 
-        // checkout the tag if necessary
-        self.git_checkout(&dep, path, true)?;
+        result
+    }
 
-        trace!("updating dependency submodules recursively");
-        self.git.root(path).submodule_update(
-            false,
-            false,
-            false,
-            true,
-            std::iter::empty::<PathBuf>(),
-        )?;
-
-        // sync submodules config with changes in .gitmodules, see <https://github.com/foundry-rs/foundry/issues/9611>
-        self.git.root(path).submodule_sync()?;
-
-        if self.commit {
-            self.git.add(Some(path))?;
+    fn rollback_submodule(
+        self,
+        root: &Path,
+        relative_path: &Path,
+        path: &Path,
+        gitmodules: &Path,
+        gitmodules_existed: bool,
+        module_dir: &Path,
+    ) {
+        let git = self.git.root(root);
+        if let Err(err) = git.submodule_deinit(true, relative_path) {
+            warn!(%err, "failed to remove submodule config after installation failure");
         }
-
-        Ok(dep.tag)
+        if let Err(err) = git.rm(true, Some(relative_path)) {
+            warn!(%err, "failed to remove submodule after installation failure");
+        }
+        if module_dir.exists()
+            && let Err(err) = fs::remove_dir_all(module_dir)
+        {
+            warn!(%err, "failed to remove submodule Git directory after installation failure");
+        }
+        if !gitmodules_existed && gitmodules.exists() {
+            if let Err(err) = fs::remove_file(gitmodules) {
+                warn!(%err, "failed to remove .gitmodules after installation failure");
+            } else if let Err(err) = git.add(Some(".gitmodules")) {
+                warn!(%err, "failed to unstage .gitmodules after installation failure");
+            }
+        }
+        if path.exists()
+            && let Err(err) = fs::remove_dir_all(path)
+        {
+            warn!(%err, "failed to remove dependency after installation failure");
+        }
     }
 
     fn last_tag(self, path: &Path) -> Option<String> {
@@ -504,8 +573,6 @@ impl Installer<'_> {
 
         let res = self.git.root(path).checkout(recurse, &tag);
         if let Err(mut e) = res {
-            // remove dependency on failed checkout
-            fs::remove_dir_all(path)?;
             if e.to_string().contains("did not match any file(s) known to git") {
                 e = eyre::eyre!("Tag: \"{tag}\" not found for repo \"{url}\"!")
             }

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -557,12 +557,12 @@ impl Installer<'_> {
             && std::fs::read_dir(path)?.next().is_none();
         let worktree_existed = path.exists();
         let module_dir_existed = module_dir.exists();
-        let original_head = (existing_submodule && worktree_existed && !uninitialized_worktree)
-            .then(|| self.git.root(path).head())
-            .transpose()?;
         if existing_submodule && (path.is_symlink() || path.exists()) && !uninitialized_worktree {
             self.ensure_submodule_worktree(path, &module_dir, relative_path)?;
         }
+        let original_head = (existing_submodule && worktree_existed && !uninitialized_worktree)
+            .then(|| self.git.root(path).head())
+            .transpose()?;
 
         let lockfile_path = project_root.join(FOUNDRY_LOCK);
         let lockfile_contents =

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -191,7 +191,9 @@ impl DependencyInstallOpts {
                 if commit {
                     git.ensure_clean()?;
                 }
-                installed_tag = installer.install_as_submodule(&dep, &path)?;
+                let (tag, mut transaction) =
+                    installer.install_as_submodule(&dep, &path, &config.root)?;
+                installed_tag = tag;
 
                 let mut new_insertion = false;
                 // Pin branch to submodule if branch is used
@@ -233,6 +235,9 @@ impl DependencyInstallOpts {
                     || out_of_sync_deps.as_ref().is_some_and(|o| !o.is_empty())
                     || !lockfile.exists()
                 {
+                    if let Some(transaction) = &mut transaction {
+                        transaction.mark_lockfile_touched();
+                    }
                     lockfile.write()?;
                 }
 
@@ -256,6 +261,9 @@ impl DependencyInstallOpts {
                         git.root(&config.root).add(Some(FOUNDRY_LOCK))?;
                     }
                     git.commit(&msg)?;
+                }
+                if let Some(transaction) = &mut transaction {
+                    transaction.disarm();
                 }
             }
 
@@ -325,6 +333,90 @@ async fn install_soldeer_deps_if_needed(dep_path: &Path) -> Result<()> {
 struct Installer<'a> {
     git: Git<'a>,
     commit: bool,
+}
+
+struct NewSubmoduleTransaction {
+    root: PathBuf,
+    relative_path: PathBuf,
+    path: PathBuf,
+    module_dir: PathBuf,
+    gitmodules_contents: Option<Vec<u8>>,
+    submodule_config: Vec<(String, String)>,
+    lockfile_path: PathBuf,
+    lockfile_contents: Option<Vec<u8>>,
+    stage_lockfile: bool,
+    lockfile_touched: bool,
+    armed: bool,
+}
+
+impl NewSubmoduleTransaction {
+    const fn mark_lockfile_touched(&mut self) {
+        self.lockfile_touched = true;
+    }
+
+    const fn disarm(&mut self) {
+        self.armed = false;
+    }
+
+    fn rollback(&self) {
+        let git = Git::new(&self.root);
+        let owns_worktree = !self.path.is_symlink()
+            && self.path.exists()
+            && Git::new(&self.path).absolute_git_dir().ok().as_deref() == Some(&self.module_dir);
+        if owns_worktree && let Err(err) = git.submodule_deinit(true, &self.relative_path) {
+            warn!(%err, "failed to remove submodule config after installation failure");
+        }
+        if let Err(err) = git.remove_index_path(&self.relative_path) {
+            warn!(%err, "failed to remove submodule after installation failure");
+        }
+        if owns_worktree
+            && self.module_dir.exists()
+            && let Err(err) = fs::remove_dir_all(&self.module_dir)
+        {
+            warn!(%err, "failed to remove submodule Git directory after installation failure");
+        }
+        restore_file(&self.root.join(".gitmodules"), self.gitmodules_contents.as_deref());
+        if let Err(err) = git.add(Some(".gitmodules")) {
+            warn!(%err, "failed to restore staged .gitmodules after installation failure");
+        }
+        if self.lockfile_touched {
+            restore_file(&self.lockfile_path, self.lockfile_contents.as_deref());
+            if self.stage_lockfile
+                && let Err(err) = git.add(Some(&self.lockfile_path))
+            {
+                warn!(%err, "failed to restore staged lockfile after installation failure");
+            }
+        }
+        if owns_worktree
+            && self.path.exists()
+            && let Err(err) = fs::remove_dir_all(&self.path)
+        {
+            warn!(%err, "failed to remove dependency after installation failure");
+        }
+        if let Err(err) = git.restore_submodule_config(&self.relative_path, &self.submodule_config)
+        {
+            warn!(%err, "failed to restore submodule config after installation failure");
+        }
+    }
+}
+
+impl Drop for NewSubmoduleTransaction {
+    fn drop(&mut self) {
+        if self.armed {
+            self.rollback();
+        }
+    }
+}
+
+fn restore_file(path: &Path, contents: Option<&[u8]>) {
+    let result = match contents {
+        Some(contents) => fs::write(path, contents),
+        None if path.exists() => fs::remove_file(path),
+        None => Ok(()),
+    };
+    if let Err(err) = result {
+        warn!(%err, path = %path.display(), "failed to restore file after installation failure");
+    }
 }
 
 impl Installer<'_> {
@@ -407,7 +499,12 @@ impl Installer<'_> {
     ///
     /// This will add the git submodule to the given dir, initialize it and checkout the tag if
     /// provided or try to find the latest semver, release tag.
-    fn install_as_submodule(self, dep: &Dependency, path: &Path) -> Result<Option<String>> {
+    fn install_as_submodule(
+        self,
+        dep: &Dependency,
+        path: &Path,
+        project_root: &Path,
+    ) -> Result<(Option<String>, Option<NewSubmoduleTransaction>)> {
         let root = Git::root_of(self.git.root)?;
         let relative_path = path.strip_prefix(&root)?;
         let git = self.git.root(&root);
@@ -436,6 +533,7 @@ impl Installer<'_> {
             let can_rollback = !path.is_symlink()
                 && !path.exists()
                 && !module_dir.exists()
+                && !git.has_index_entries(relative_path)?
                 && git.is_path_clean(relative_path)?
                 && git.is_path_worktree_clean(Path::new(".gitmodules"))?;
             if !can_rollback {
@@ -457,10 +555,31 @@ impl Installer<'_> {
             && !path.is_symlink()
             && path.is_dir()
             && std::fs::read_dir(path)?.next().is_none();
+        let worktree_existed = path.exists();
+        let module_dir_existed = module_dir.exists();
+        let original_head = (existing_submodule && worktree_existed && !uninitialized_worktree)
+            .then(|| self.git.root(path).head())
+            .transpose()?;
         if existing_submodule && (path.is_symlink() || path.exists()) && !uninitialized_worktree {
             self.ensure_submodule_worktree(path, &module_dir, relative_path)?;
         }
 
+        let lockfile_path = project_root.join(FOUNDRY_LOCK);
+        let lockfile_contents =
+            lockfile_path.exists().then(|| fs::read(&lockfile_path)).transpose()?;
+        let mut transaction = (!existing_submodule).then(|| NewSubmoduleTransaction {
+            root: root.clone(),
+            relative_path: relative_path.to_path_buf(),
+            path: path.to_path_buf(),
+            module_dir: module_dir.clone(),
+            gitmodules_contents: gitmodules_contents.clone(),
+            submodule_config: submodule_config.clone(),
+            lockfile_path,
+            lockfile_contents,
+            stage_lockfile: self.commit,
+            lockfile_touched: false,
+            armed: true,
+        });
         let setup = if existing_submodule {
             if !path.exists() || uninitialized_worktree {
                 git.submodule_update(false, false, false, false, Some(relative_path))
@@ -497,30 +616,41 @@ impl Installer<'_> {
             self.git.root(path).submodule_sync()?;
 
             if self.commit {
-                self.git.add(Some(path))?;
+                self.git.add_literal(path)?;
             }
 
             Ok(dep.tag)
         });
 
-        let actual_module_dir = if path.exists() {
-            self.git.root(path).absolute_git_dir().unwrap_or_else(|_| module_dir.clone())
-        } else {
-            module_dir.clone()
-        };
-
-        if result.is_err() && !existing_submodule && actual_module_dir == module_dir {
-            self.rollback_submodule(
-                &root,
-                relative_path,
-                path,
-                gitmodules_contents.as_deref(),
-                &actual_module_dir,
-                &submodule_config,
-            );
+        if result.is_err() && existing_submodule {
+            if let Some(head) = original_head
+                && let Err(err) = self.git.root(path).checkout(false, head)
+            {
+                warn!(%err, "failed to restore submodule HEAD after installation failure");
+            }
+            if (uninitialized_worktree || !worktree_existed)
+                && let Err(err) = git.submodule_deinit(true, relative_path)
+            {
+                warn!(%err, "failed to restore deinitialized submodule after installation failure");
+            }
+            if !worktree_existed
+                && path.exists()
+                && let Err(err) = fs::remove_dir_all(path)
+            {
+                warn!(%err, "failed to restore missing submodule worktree");
+            }
+            if !module_dir_existed
+                && module_dir.exists()
+                && let Err(err) = fs::remove_dir_all(&module_dir)
+            {
+                warn!(%err, "failed to remove created submodule Git directory");
+            }
+            if let Err(err) = git.restore_submodule_config(module_name, &submodule_config) {
+                warn!(%err, "failed to restore submodule config after installation failure");
+            }
         }
 
-        result
+        result.map(|tag| (tag, transaction.take()))
     }
 
     fn ensure_submodule_worktree(
@@ -541,55 +671,6 @@ impl Installer<'_> {
             );
         }
         Ok(())
-    }
-
-    fn rollback_submodule(
-        self,
-        root: &Path,
-        relative_path: &Path,
-        path: &Path,
-        gitmodules_contents: Option<&[u8]>,
-        module_dir: &Path,
-        submodule_config: &[(String, String)],
-    ) {
-        let git = self.git.root(root);
-        let gitmodules = root.join(".gitmodules");
-        if let Err(err) = git.submodule_deinit(true, relative_path) {
-            warn!(%err, "failed to remove submodule config after installation failure");
-        }
-        if let Err(err) = git.rm(true, Some(relative_path)) {
-            warn!(%err, "failed to remove submodule after installation failure");
-        }
-        if module_dir.exists()
-            && let Err(err) = fs::remove_dir_all(module_dir)
-        {
-            warn!(%err, "failed to remove submodule Git directory after installation failure");
-        }
-        match gitmodules_contents {
-            Some(contents) => {
-                if let Err(err) = fs::write(&gitmodules, contents) {
-                    warn!(%err, "failed to restore .gitmodules after installation failure");
-                } else if let Err(err) = git.add(Some(".gitmodules")) {
-                    warn!(%err, "failed to restore staged .gitmodules after installation failure");
-                }
-            }
-            None if gitmodules.exists() => {
-                if let Err(err) = fs::remove_file(&gitmodules) {
-                    warn!(%err, "failed to remove .gitmodules after installation failure");
-                } else if let Err(err) = git.add(Some(".gitmodules")) {
-                    warn!(%err, "failed to unstage .gitmodules after installation failure");
-                }
-            }
-            None => {}
-        }
-        if path.exists()
-            && let Err(err) = fs::remove_dir_all(path)
-        {
-            warn!(%err, "failed to remove dependency after installation failure");
-        }
-        if let Err(err) = git.restore_submodule_config(relative_path, submodule_config) {
-            warn!(%err, "failed to restore submodule config after installation failure");
-        }
     }
 
     fn last_tag(self, path: &Path) -> Option<String> {

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -413,9 +413,9 @@ impl Installer<'_> {
         let gitmodules = root.join(".gitmodules");
         let gitmodules_existed = gitmodules.exists();
         let module_dir = git.absolute_git_dir()?.join("modules").join(relative_path);
+        let submodule_config = git.submodule_config(relative_path)?;
         let can_rollback = !path.exists()
             && !module_dir.exists()
-            && !git.has_submodule_config(relative_path)?
             && git.is_path_clean(relative_path)?
             && git.is_path_clean(Path::new(".gitmodules"))?;
 
@@ -458,9 +458,9 @@ impl Installer<'_> {
                 &root,
                 relative_path,
                 path,
-                &gitmodules,
                 gitmodules_existed,
                 &actual_module_dir,
+                &submodule_config,
             );
         }
 
@@ -472,11 +472,12 @@ impl Installer<'_> {
         root: &Path,
         relative_path: &Path,
         path: &Path,
-        gitmodules: &Path,
         gitmodules_existed: bool,
         module_dir: &Path,
+        submodule_config: &[(String, String)],
     ) {
         let git = self.git.root(root);
+        let gitmodules = root.join(".gitmodules");
         if let Err(err) = git.submodule_deinit(true, relative_path) {
             warn!(%err, "failed to remove submodule config after installation failure");
         }
@@ -489,7 +490,7 @@ impl Installer<'_> {
             warn!(%err, "failed to remove submodule Git directory after installation failure");
         }
         if !gitmodules_existed && gitmodules.exists() {
-            if let Err(err) = fs::remove_file(gitmodules) {
+            if let Err(err) = fs::remove_file(&gitmodules) {
                 warn!(%err, "failed to remove .gitmodules after installation failure");
             } else if let Err(err) = git.add(Some(".gitmodules")) {
                 warn!(%err, "failed to unstage .gitmodules after installation failure");
@@ -499,6 +500,9 @@ impl Installer<'_> {
             && let Err(err) = fs::remove_dir_all(path)
         {
             warn!(%err, "failed to remove dependency after installation failure");
+        }
+        if let Err(err) = git.restore_submodule_config(relative_path, submodule_config) {
+            warn!(%err, "failed to restore submodule config after installation failure");
         }
     }
 

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -213,6 +213,8 @@ impl DependencyInstallOpts {
                     {
                         // always work with relative paths when directly modifying submodules
                         git.set_submodule_branch(rel_path, tag_or_branch)?;
+                        let root = Git::root_of(git.root)?;
+                        git.root(&root).add(Some(".gitmodules"))?;
 
                         let rev = git.get_rev(tag_or_branch, &path)?;
 

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -211,6 +211,8 @@ impl DependencyInstallOpts {
                     {
                         // always work with relative paths when directly modifying submodules
                         git.set_submodule_branch(rel_path, tag_or_branch)?;
+                        let root = Git::root_of(git.root)?;
+                        git.root(&root).add_literal(Path::new(".gitmodules"))?;
 
                         let rev = git.get_rev(tag_or_branch, &path)?;
 
@@ -485,7 +487,6 @@ impl Installer<'_> {
         } else {
             let module_dir = git.absolute_git_dir()?.join("modules").join(relative_path);
             let gitmodules_safe = !gitmodules.is_symlink()
-                && git.is_path_clean(Path::new(".gitmodules"))?
                 && if gitmodules.exists() {
                     git.is_normal_tracked_file(Path::new(".gitmodules"))?
                 } else {

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -128,16 +128,6 @@ impl DependencyInstallOpts {
         if !no_git {
             lockfile = lockfile.with_git(&git);
 
-            for dep in &dependencies {
-                let path = libs.join(dep.name());
-                if path.is_symlink() || (path.exists() && !path.join(".git").exists()) {
-                    eyre::bail!(
-                        "cannot safely install dependency at {} because the target is not its registered submodule worktree",
-                        path.display()
-                    );
-                }
-            }
-
             // Initialize all existing submodules when no explicit dependencies were requested so
             // that foundry.lock synchronization can inspect their commits and tags.
             if dependencies.is_empty() && git.submodules_uninitialized()? {
@@ -424,28 +414,27 @@ impl Installer<'_> {
         let gitmodules = root.join(".gitmodules");
         let gitmodules_existed = gitmodules.exists();
         let gitmodules_contents = gitmodules_existed.then(|| fs::read(&gitmodules)).transpose()?;
-        let module_dir = git.absolute_git_dir()?.join("modules").join(relative_path);
-        let submodule_config = git.submodule_config(relative_path)?;
-        let (submodule_name_collision, has_default_mapping, has_submodule_path) =
-            git.submodule_mapping(relative_path)?;
+        let (submodule_name_collision, mapping) = git.submodule_mapping_for_path(relative_path)?;
+        let module_name =
+            mapping.as_ref().map_or(relative_path, |mapping| Path::new(&mapping.name));
+        let module_dir = git.absolute_git_dir()?.join("modules").join(module_name);
+        let submodule_config = git.submodule_config(module_name)?;
         if gitmodules_existed && !git.is_tracked(Path::new(".gitmodules"))? {
             eyre::bail!(
                 "cannot safely install dependency at {} because the target or .gitmodules has existing changes",
                 relative_path.display()
             );
         }
-        let registered_url =
-            if has_default_mapping { git.submodule_file_url(relative_path)? } else { None };
-        let existing_submodule =
-            registered_url.is_some() && has_submodule_path && git.is_gitlink(relative_path)?;
+        let existing_submodule = mapping.is_some() && git.is_gitlink(relative_path)?;
+        if submodule_name_collision || mapping.is_some() && !existing_submodule {
+            eyre::bail!(
+                "cannot safely install dependency at {} because .gitmodules already contains a matching submodule",
+                relative_path.display()
+            );
+        }
         if !existing_submodule {
-            if submodule_name_collision || has_default_mapping || has_submodule_path {
-                eyre::bail!(
-                    "cannot safely install dependency at {} because .gitmodules already contains a matching submodule",
-                    relative_path.display()
-                );
-            }
-            let can_rollback = !path.exists()
+            let can_rollback = !path.is_symlink()
+                && !path.exists()
                 && !module_dir.exists()
                 && git.is_path_clean(relative_path)?
                 && git.is_path_worktree_clean(Path::new(".gitmodules"))?;
@@ -455,22 +444,28 @@ impl Installer<'_> {
                     relative_path.display()
                 );
             }
-        } else if registered_url.as_deref() != Some(dep.require_url()?) {
+        } else if mapping.as_ref().and_then(|mapping| mapping.url.as_deref())
+            != Some(dep.require_url()?)
+        {
             eyre::bail!(
                 "cannot install dependency at {} because its registered URL does not match {}",
                 relative_path.display(),
                 dep.require_url()?
             );
         }
-        if existing_submodule && path.exists() {
+        let uninitialized_worktree = existing_submodule
+            && !path.is_symlink()
+            && path.is_dir()
+            && std::fs::read_dir(path)?.next().is_none();
+        if existing_submodule && (path.is_symlink() || path.exists()) && !uninitialized_worktree {
             self.ensure_submodule_worktree(path, &module_dir, relative_path)?;
         }
 
         let setup = if existing_submodule {
-            if path.exists() {
-                Ok(())
-            } else {
+            if !path.exists() || uninitialized_worktree {
                 git.submodule_update(false, false, false, false, Some(relative_path))
+            } else {
+                Ok(())
             }
         } else {
             self.git_submodule(dep, path)

--- a/crates/forge/src/cmd/install.rs
+++ b/crates/forge/src/cmd/install.rs
@@ -128,10 +128,19 @@ impl DependencyInstallOpts {
         if !no_git {
             lockfile = lockfile.with_git(&git);
 
-            // Check if submodules are uninitialized, if so, we need to fetch all submodules
-            // This is to ensure that foundry.lock syncs successfully and doesn't error out, when
-            // looking for commits/tags in submodules
-            if git.submodules_uninitialized()? {
+            for dep in &dependencies {
+                let path = libs.join(dep.name());
+                if path.is_symlink() || (path.exists() && !path.join(".git").exists()) {
+                    eyre::bail!(
+                        "cannot safely install dependency at {} because the target is not its registered submodule worktree",
+                        path.display()
+                    );
+                }
+            }
+
+            // Initialize all existing submodules when no explicit dependencies were requested so
+            // that foundry.lock synchronization can inspect their commits and tags.
+            if dependencies.is_empty() && git.submodules_uninitialized()? {
                 trace!(lib = %libs.display(), "submodules uninitialized");
                 git.submodule_update(false, false, false, true, Some(&libs))?;
             }
@@ -412,19 +421,63 @@ impl Installer<'_> {
         let git = self.git.root(&root);
         let gitmodules = root.join(".gitmodules");
         let gitmodules_existed = gitmodules.exists();
+        let gitmodules_contents = gitmodules_existed.then(|| fs::read(&gitmodules)).transpose()?;
         let module_dir = git.absolute_git_dir()?.join("modules").join(relative_path);
         let submodule_config = git.submodule_config(relative_path)?;
-        let can_rollback = !path.exists()
-            && !module_dir.exists()
-            && git.is_path_clean(relative_path)?
-            && git.is_path_clean(Path::new(".gitmodules"))?;
+        let (submodule_name_collision, has_default_mapping, has_submodule_path) =
+            git.submodule_mapping(relative_path)?;
+        if gitmodules_existed && !git.is_tracked(Path::new(".gitmodules"))? {
+            eyre::bail!(
+                "cannot safely install dependency at {} because the target or .gitmodules has existing changes",
+                relative_path.display()
+            );
+        }
+        let registered_url =
+            if has_default_mapping { git.submodule_file_url(relative_path)? } else { None };
+        let existing_submodule =
+            registered_url.is_some() && has_submodule_path && git.is_gitlink(relative_path)?;
+        if !existing_submodule {
+            if submodule_name_collision || has_default_mapping || has_submodule_path {
+                eyre::bail!(
+                    "cannot safely install dependency at {} because .gitmodules already contains a matching submodule",
+                    relative_path.display()
+                );
+            }
+            let can_rollback = !path.exists()
+                && !module_dir.exists()
+                && git.is_path_clean(relative_path)?
+                && git.is_path_worktree_clean(Path::new(".gitmodules"))?;
+            if !can_rollback {
+                eyre::bail!(
+                    "cannot safely install dependency at {} because the target or .gitmodules has existing changes",
+                    relative_path.display()
+                );
+            }
+        } else if registered_url.as_deref() != Some(dep.require_url()?) {
+            eyre::bail!(
+                "cannot install dependency at {} because its registered URL does not match {}",
+                relative_path.display(),
+                dep.require_url()?
+            );
+        }
+        if existing_submodule && path.exists() {
+            self.ensure_submodule_worktree(path, &module_dir, relative_path)?;
+        }
 
-        // install the dep
-        self.git_submodule(dep, path)?;
-        let actual_module_dir =
-            self.git.root(path).absolute_git_dir().unwrap_or_else(|_| module_dir.clone());
+        let setup = if existing_submodule {
+            if path.exists() {
+                Ok(())
+            } else {
+                git.submodule_update(false, false, false, false, Some(relative_path))
+            }
+        } else {
+            self.git_submodule(dep, path)
+        };
+        let result = setup.and_then(|()| {
+            if existing_submodule {
+                self.ensure_submodule_worktree(path, &module_dir, relative_path)?;
+            }
 
-        let result = (|| {
             let mut dep = dep.clone();
             if dep.tag.is_none() {
                 // try to find latest semver release tag
@@ -451,14 +504,20 @@ impl Installer<'_> {
             }
 
             Ok(dep.tag)
-        })();
+        });
 
-        if result.is_err() && can_rollback && actual_module_dir == module_dir {
+        let actual_module_dir = if path.exists() {
+            self.git.root(path).absolute_git_dir().unwrap_or_else(|_| module_dir.clone())
+        } else {
+            module_dir.clone()
+        };
+
+        if result.is_err() && !existing_submodule && actual_module_dir == module_dir {
             self.rollback_submodule(
                 &root,
                 relative_path,
                 path,
-                gitmodules_existed,
+                gitmodules_contents.as_deref(),
                 &actual_module_dir,
                 &submodule_config,
             );
@@ -467,12 +526,32 @@ impl Installer<'_> {
         result
     }
 
+    fn ensure_submodule_worktree(
+        self,
+        path: &Path,
+        module_dir: &Path,
+        relative_path: &Path,
+    ) -> Result<()> {
+        let actual_module_dir = if path.is_symlink() || !path.join(".git").exists() {
+            None
+        } else {
+            self.git.root(path).absolute_git_dir().ok()
+        };
+        if actual_module_dir.as_deref() != Some(module_dir) {
+            eyre::bail!(
+                "cannot safely install dependency at {} because the target is not its registered submodule worktree",
+                relative_path.display()
+            );
+        }
+        Ok(())
+    }
+
     fn rollback_submodule(
         self,
         root: &Path,
         relative_path: &Path,
         path: &Path,
-        gitmodules_existed: bool,
+        gitmodules_contents: Option<&[u8]>,
         module_dir: &Path,
         submodule_config: &[(String, String)],
     ) {
@@ -489,12 +568,22 @@ impl Installer<'_> {
         {
             warn!(%err, "failed to remove submodule Git directory after installation failure");
         }
-        if !gitmodules_existed && gitmodules.exists() {
-            if let Err(err) = fs::remove_file(&gitmodules) {
-                warn!(%err, "failed to remove .gitmodules after installation failure");
-            } else if let Err(err) = git.add(Some(".gitmodules")) {
-                warn!(%err, "failed to unstage .gitmodules after installation failure");
+        match gitmodules_contents {
+            Some(contents) => {
+                if let Err(err) = fs::write(&gitmodules, contents) {
+                    warn!(%err, "failed to restore .gitmodules after installation failure");
+                } else if let Err(err) = git.add(Some(".gitmodules")) {
+                    warn!(%err, "failed to restore staged .gitmodules after installation failure");
+                }
             }
+            None if gitmodules.exists() => {
+                if let Err(err) = fs::remove_file(&gitmodules) {
+                    warn!(%err, "failed to remove .gitmodules after installation failure");
+                } else if let Err(err) = git.add(Some(".gitmodules")) {
+                    warn!(%err, "failed to unstage .gitmodules after installation failure");
+                }
+            }
+            None => {}
         }
         if path.exists()
             && let Err(err) = fs::remove_dir_all(path)

--- a/crates/forge/src/cmd/remove.rs
+++ b/crates/forge/src/cmd/remove.rs
@@ -52,6 +52,7 @@ impl RemoveArgs {
             )?;
             let _ = lockfile.remove(path);
             std::fs::remove_dir_all(git_modules.join(path))?;
+            git.remove_submodule_config(path)?;
         }
 
         lockfile.write()?;

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -5,7 +5,7 @@ use foundry_cli::utils::{Git, Submodules};
 use foundry_compilers::artifacts::Remapping;
 use foundry_config::Config;
 use foundry_test_utils::util::{
-    ExtTester, FORGE_STD_REVISION, TestCommand, pretty_err, read_string,
+    ExtTester, FORGE_STD_REVISION, OutputExt, TestCommand, pretty_err, read_string,
 };
 use semver::Version;
 use std::{
@@ -226,6 +226,198 @@ Error: Tag: "this-tag-does-not-exist" not found for repo "https://github.com/vec
     );
 });
 
+forgetest!(failed_submodule_add_leaves_repository_clean, |prj, cmd| {
+    cmd.git_init();
+    let git = Git::new(prj.root());
+    let git_dir = git.absolute_git_dir().unwrap();
+    let index_lock = git_dir.join("index.lock");
+    fs::write(&index_lock, []).unwrap();
+
+    let output = cmd
+        .forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+    assert!(output.get_output().stderr_lossy().contains("index.lock"));
+
+    assert!(index_lock.exists());
+    assert!(git.is_clean().unwrap());
+    assert!(!prj.root().join(".gitmodules").exists());
+    assert!(!prj.root().join("lib/solady").exists());
+    assert!(!git_dir.join("modules/lib/solady").exists());
+    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+});
+
+forgetest!(install_rejects_dirty_gitmodules, |prj, cmd| {
+    cmd.git_init();
+    let git = Git::new(prj.root());
+    let gitmodules = prj.root().join(".gitmodules");
+    let original = r#"[submodule "existing"]
+	path = lib/existing
+	url = https://github.com/example/existing
+"#;
+    fs::write(&gitmodules, original).unwrap();
+    cmd.git_add();
+    cmd.git_commit("add gitmodules");
+
+    let modified = format!("{original}# local edit\n");
+    fs::write(&gitmodules, &modified).unwrap();
+    let status = || {
+        Command::new("git")
+            .current_dir(prj.root())
+            .args(["status", "--porcelain", "--", ".gitmodules"])
+            .output()
+            .unwrap()
+            .stdout
+    };
+
+    let unstaged_status = status();
+    let output = cmd
+        .forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+    assert!(
+        output.get_output().stderr_lossy().contains("target or .gitmodules has existing changes")
+    );
+    assert_eq!(status(), unstaged_status);
+    assert_eq!(read_string(&gitmodules), modified);
+
+    cmd.git_add();
+    let staged_status = status();
+    cmd.forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+    assert_eq!(status(), staged_status);
+    assert_eq!(read_string(&gitmodules), modified);
+
+    assert!(!prj.root().join("lib/solady").exists());
+    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
+    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+});
+
+forgetest!(install_rejects_existing_submodule_mapping, |prj, cmd| {
+    cmd.git_init();
+    let git = Git::new(prj.root());
+    let gitmodules = prj.root().join(".gitmodules");
+    let empty_section = r#"[submodule "lib/solady"]
+	# preserve
+"#;
+    fs::write(&gitmodules, empty_section).unwrap();
+    cmd.git_add();
+    cmd.git_commit("add empty submodule section");
+
+    cmd.forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+    assert!(git.is_clean().unwrap());
+    assert_eq!(read_string(&gitmodules), empty_section);
+    assert!(!prj.root().join("lib/solady").exists());
+    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
+    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+
+    let original = r#"[submodule "lib/solady"]
+	url = https://github.com/example/solady
+"#;
+    fs::write(&gitmodules, original).unwrap();
+    cmd.git_add();
+    cmd.git_commit("add orphan submodule mapping");
+
+    let output = cmd
+        .forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+    assert!(output.get_output().stderr_lossy().contains("already contains a matching submodule"));
+    assert!(git.is_clean().unwrap());
+    assert_eq!(read_string(&gitmodules), original);
+
+    let head =
+        Command::new("git").current_dir(prj.root()).args(["rev-parse", "HEAD"]).output().unwrap();
+    let head = String::from_utf8_lossy(&head.stdout);
+    let status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["update-index", "--add", "--cacheinfo", "160000", head.trim(), "lib/solady"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+    cmd.git_commit("add orphan gitlink");
+
+    let status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap()
+        .stdout;
+    cmd.forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+
+    let after = Command::new("git")
+        .current_dir(prj.root())
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap()
+        .stdout;
+    assert_eq!(after, status);
+    assert_eq!(read_string(&gitmodules), original);
+    assert!(!prj.root().join("lib/solady").exists());
+    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
+    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+});
+
+forgetest!(install_rejects_ignored_gitmodules, |prj, cmd| {
+    cmd.git_init();
+    let git = Git::new(prj.root());
+    fs::write(prj.root().join(".gitignore"), ".gitmodules\n").unwrap();
+    cmd.git_add();
+    cmd.git_commit("ignore gitmodules");
+
+    let gitmodules = prj.root().join(".gitmodules");
+    let original = r#"[submodule "existing"]
+	path = lib/existing
+	url = https://github.com/example/existing
+"#;
+    fs::write(&gitmodules, original).unwrap();
+    assert!(git.is_clean().unwrap());
+
+    let output = cmd
+        .forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+    assert!(
+        output.get_output().stderr_lossy().contains("target or .gitmodules has existing changes")
+    );
+
+    assert!(git.is_clean().unwrap());
+    assert_eq!(read_string(&gitmodules), original);
+    assert!(!prj.root().join("lib/solady").exists());
+    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
+    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+});
+
+forgetest!(install_rejects_existing_submodule_path, |prj, cmd| {
+    cmd.git_init();
+    let git = Git::new(prj.root());
+    let gitmodules = prj.root().join(".gitmodules");
+    let original = r#"[submodule "different-name"]
+	path = lib/solady
+	url = https://github.com/example/solady
+"#;
+    fs::write(&gitmodules, original).unwrap();
+    cmd.git_add();
+    cmd.git_commit("add orphan submodule path");
+
+    let output = cmd
+        .forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+    assert!(output.get_output().stderr_lossy().contains("already contains a matching submodule"));
+
+    assert!(git.is_clean().unwrap());
+    assert_eq!(read_string(&gitmodules), original);
+    assert!(!prj.root().join("lib/solady").exists());
+    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
+    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+});
+
 // test to check we can run `forge install` in an empty dir <https://github.com/foundry-rs/foundry/issues/6519>
 forgetest!(can_install_empty, |prj, cmd| {
     // create
@@ -291,6 +483,105 @@ forgetest!(can_install_repeatedly, |_prj, cmd| {
     for _ in 0..3 {
         cmd.assert_success();
     }
+});
+
+forgetest!(can_install_multiple_submodules, |_prj, cmd| {
+    cmd.git_init();
+    cmd.forge_fuse()
+        .args(["install", "foundry-rs/forge-std", "vectorized/solady"])
+        .assert_success();
+});
+
+forgetest!(failed_reinstall_preserves_existing_submodule, |prj, cmd| {
+    cmd.git_init();
+    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
+
+    let gitmodules = prj.root().join(".gitmodules");
+    let modified_gitmodules = format!("{}# local edit\n", read_string(&gitmodules));
+    fs::write(&gitmodules, &modified_gitmodules).unwrap();
+
+    let dependency = prj.root().join("lib/forge-std");
+    let status =
+        Command::new("git").current_dir(&dependency).args(["checkout", "HEAD^"]).status().unwrap();
+    assert!(status.success());
+    let dependency_head = Command::new("git")
+        .current_dir(&dependency)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap()
+        .stdout;
+    let repository_status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap()
+        .stdout;
+
+    cmd.forge_fuse()
+        .args(["install", "foundry-rs/forge-std@this-tag-does-not-exist"])
+        .assert_failure();
+
+    let after_status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap()
+        .stdout;
+    let after_head = Command::new("git")
+        .current_dir(&dependency)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap()
+        .stdout;
+    assert_eq!(after_status, repository_status);
+    assert_eq!(after_head, dependency_head);
+    assert_eq!(read_string(&gitmodules), modified_gitmodules);
+});
+
+forgetest!(install_rejects_invalid_existing_submodule_worktree, |prj, cmd| {
+    cmd.git_init();
+    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
+
+    let dependency = prj.root().join("lib/forge-std");
+    fs::remove_dir_all(&dependency).unwrap();
+    fs::create_dir_all(&dependency).unwrap();
+    fs::write(dependency.join("preserve"), "contents").unwrap();
+
+    let head = Command::new("git")
+        .current_dir(prj.root())
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap()
+        .stdout;
+    let repository_status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap()
+        .stdout;
+
+    let output = cmd
+        .forge_fuse()
+        .args(["install", "foundry-rs/forge-std@this-tag-does-not-exist"])
+        .assert_failure();
+    let stderr = output.get_output().stderr_lossy();
+    assert!(stderr.contains("not its registered submodule worktree"), "{stderr}");
+
+    let after_head = Command::new("git")
+        .current_dir(prj.root())
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap()
+        .stdout;
+    let after_status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap()
+        .stdout;
+    assert_eq!(after_head, head);
+    assert_eq!(after_status, repository_status);
+    assert_eq!(read_string(dependency.join("preserve")), "contents");
 });
 
 // test that by default we install the latest semver release tag

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -9,7 +9,7 @@ use foundry_test_utils::util::{
 };
 use semver::Version;
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::symlink;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -218,74 +218,40 @@ forgetest!(install_rejects_assume_unchanged_orphan_gitlink, |prj, cmd| {
 forgetest!(failed_install_with_wildcard_alias_preserves_sibling, |prj, cmd| {
     cmd.git_init();
     cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
+    let sibling = prj.root().join("lib/forge-std");
+    assert!(
+        Command::new("git")
+            .current_dir(&sibling)
+            .args(["checkout", "HEAD^"])
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+    let index = fs::read(prj.root().join(".git/index")).unwrap();
 
     cmd.forge_fuse()
         .args(["install", "*=vectorized/solady@this-tag-does-not-exist"])
         .assert_failure();
 
-    assert!(prj.root().join("lib/forge-std/.git").exists());
+    assert_eq!(fs::read(prj.root().join(".git/index")).unwrap(), index);
+    assert!(sibling.join(".git").exists());
     assert!(Git::new(prj.root()).is_gitlink(Path::new("lib/forge-std")).unwrap());
 });
 
-#[cfg(unix)]
-forgetest!(failed_install_commit_rolls_back_transaction, |prj, cmd| {
+forgetest!(install_rejects_non_normal_alias, |prj, cmd| {
     cmd.git_init();
-    fs::write(prj.root().join(FOUNDRY_LOCK), b"{}\n").unwrap();
-    cmd.git_add();
-    cmd.git_commit("baseline");
-    let head = Git::new(prj.root()).head().unwrap();
-    let status = Command::new("git")
-        .current_dir(prj.root())
-        .args(["status", "--porcelain"])
-        .output()
-        .unwrap()
-        .stdout;
-    let hook = prj.root().join(".git/hooks/pre-commit");
-    fs::write(&hook, "#!/bin/sh\nexit 1\n").unwrap();
-    let mut permissions = fs::metadata(&hook).unwrap().permissions();
-    #[cfg(unix)]
-    {
-        permissions.set_mode(0o755);
-    }
-    fs::set_permissions(&hook, permissions).unwrap();
-
-    cmd.forge_fuse().args(["install", "--commit", "vectorized/solady"]).assert_failure();
-
     let git = Git::new(prj.root());
-    assert_eq!(git.head().unwrap(), head);
-    assert_eq!(fs::read(prj.root().join(FOUNDRY_LOCK)).unwrap(), b"{}\n");
-    assert_eq!(
-        Command::new("git")
-            .current_dir(prj.root())
-            .args(["status", "--porcelain"])
-            .output()
-            .unwrap()
-            .stdout,
-        status
-    );
+
+    cmd.forge_fuse()
+        .args(["install", "foo/../solady=vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+
+    assert!(git.is_clean().unwrap());
     assert!(!prj.root().join(".gitmodules").exists());
     assert!(!prj.root().join("lib/solady").exists());
-    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
-});
-
-#[cfg(unix)]
-forgetest!(failed_commit_preserves_hook_replacement, |prj, cmd| {
-    cmd.git_init();
-    let hook = prj.root().join(".git/hooks/pre-commit");
-    fs::write(
-        &hook,
-        "#!/bin/sh\nrm -rf lib/solady\nmkdir -p lib/solady\necho preserve > lib/solady/hook\nexit 1\n",
-    )
-    .unwrap();
-    let mut permissions = fs::metadata(&hook).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&hook, permissions).unwrap();
-
-    cmd.forge_fuse().args(["install", "--commit", "vectorized/solady"]).assert_failure();
-
-    assert_eq!(read_string(prj.root().join("lib/solady/hook")), "preserve\n");
-    assert!(!prj.root().join(".gitmodules").exists());
-    assert!(!Git::new(prj.root()).is_gitlink(Path::new("lib/solady")).unwrap());
+    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
+    assert!(!git.has_submodule_config(Path::new("lib/solady")).unwrap());
 });
 
 forgetest!(failed_install_preserves_gitmodules, |prj, cmd| {
@@ -307,41 +273,6 @@ forgetest!(failed_install_preserves_gitmodules, |prj, cmd| {
     assert_eq!(read_string(&gitmodules), original);
 });
 
-forgetest!(failed_install_preserves_submodule_config, |prj, cmd| {
-    cmd.git_init();
-    let git = Git::new(prj.root());
-    let key = "submodule.lib/solady.custom";
-    let status = Command::new("git")
-        .current_dir(prj.root())
-        .args(["config", "--local", key, "keep"])
-        .status()
-        .unwrap();
-    assert!(status.success());
-    assert_eq!(
-        git.submodule_config(Path::new("lib/solady")).unwrap(),
-        vec![(key.to_string(), "keep".to_string())]
-    );
-
-    cmd.forge_fuse()
-        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
-        .assert_failure()
-        .stderr_eq(str![[r#"
-Installing solady in [..] (url: https://github.com/vectorized/solady, tag: this-tag-does-not-exist)
-...
-Error: Tag: "this-tag-does-not-exist" not found for repo "https://github.com/vectorized/solady"!
-
-"#]]);
-
-    assert!(git.is_clean().unwrap());
-    assert!(!prj.root().join(".gitmodules").exists());
-    assert!(!prj.root().join("lib/solady").exists());
-    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
-    assert_eq!(
-        git.submodule_config(Path::new("lib/solady")).unwrap(),
-        vec![(key.to_string(), "keep".to_string())]
-    );
-});
-
 forgetest!(failed_submodule_add_leaves_repository_clean, |prj, cmd| {
     cmd.git_init();
     let git = Git::new(prj.root());
@@ -360,7 +291,7 @@ forgetest!(failed_submodule_add_leaves_repository_clean, |prj, cmd| {
     assert!(!prj.root().join(".gitmodules").exists());
     assert!(!prj.root().join("lib/solady").exists());
     assert!(!git_dir.join("modules/lib/solady").exists());
-    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+    assert!(!git.has_submodule_config(Path::new("lib/solady")).unwrap());
 });
 
 forgetest!(install_rejects_dirty_gitmodules, |prj, cmd| {
@@ -407,76 +338,63 @@ forgetest!(install_rejects_dirty_gitmodules, |prj, cmd| {
 
     assert!(!prj.root().join("lib/solady").exists());
     assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
-    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+    assert!(!git.has_submodule_config(Path::new("lib/solady")).unwrap());
 });
 
-forgetest!(install_rejects_existing_submodule_mapping, |prj, cmd| {
+forgetest!(install_rejects_hidden_gitmodules_changes, |prj, cmd| {
     cmd.git_init();
-    let git = Git::new(prj.root());
     let gitmodules = prj.root().join(".gitmodules");
-    let empty_section = r#"[submodule "lib/solady"]
-	# preserve
-"#;
-    fs::write(&gitmodules, empty_section).unwrap();
+    fs::write(
+        &gitmodules,
+        "[submodule \"existing\"]\n\tpath = lib/existing\n\turl = https://example.com\n",
+    )
+    .unwrap();
     cmd.git_add();
-    cmd.git_commit("add empty submodule section");
+    cmd.git_commit("add gitmodules");
 
-    cmd.forge_fuse()
-        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
-        .assert_failure();
-    assert!(git.is_clean().unwrap());
-    assert_eq!(read_string(&gitmodules), empty_section);
-    assert!(!prj.root().join("lib/solady").exists());
-    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
-    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
-
-    let original = r#"[submodule "lib/solady"]
-	url = https://github.com/example/solady
-"#;
-    fs::write(&gitmodules, original).unwrap();
-    cmd.git_add();
-    cmd.git_commit("add orphan submodule mapping");
+    fs::write(&gitmodules, "preserve\n").unwrap();
+    assert!(
+        Command::new("git")
+            .current_dir(prj.root())
+            .args(["update-index", "--assume-unchanged", ".gitmodules"])
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+    let index = fs::read(prj.root().join(".git/index")).unwrap();
 
     let output = cmd
         .forge_fuse()
         .args(["install", "vectorized/solady@this-tag-does-not-exist"])
         .assert_failure();
-    assert!(output.get_output().stderr_lossy().contains("already contains a matching submodule"));
-    assert!(git.is_clean().unwrap());
-    assert_eq!(read_string(&gitmodules), original);
+    assert!(
+        output.get_output().stderr_lossy().contains("target or .gitmodules has existing changes")
+    );
+    assert_eq!(read_string(&gitmodules), "preserve\n");
+    assert_eq!(fs::read(prj.root().join(".git/index")).unwrap(), index);
+    assert!(!prj.root().join("lib/solady").exists());
+});
 
-    let head =
-        Command::new("git").current_dir(prj.root()).args(["rev-parse", "HEAD"]).output().unwrap();
-    let head = String::from_utf8_lossy(&head.stdout);
-    let status = Command::new("git")
-        .current_dir(prj.root())
-        .args(["update-index", "--add", "--cacheinfo", "160000", head.trim(), "lib/solady"])
-        .status()
-        .unwrap();
-    assert!(status.success());
-    cmd.git_commit("add orphan gitlink");
+#[cfg(unix)]
+forgetest!(install_rejects_dangling_gitmodules_symlink, |prj, cmd| {
+    cmd.git_init();
+    fs::write(prj.root().join(".gitignore"), ".gitmodules\n").unwrap();
+    cmd.git_add();
+    cmd.git_commit("ignore gitmodules");
 
-    let status = Command::new("git")
-        .current_dir(prj.root())
-        .args(["status", "--porcelain"])
-        .output()
-        .unwrap()
-        .stdout;
+    let gitmodules = prj.root().join(".gitmodules");
+    symlink("gitmodules-target", &gitmodules).unwrap();
+    let index = fs::read(prj.root().join(".git/index")).unwrap();
+
     cmd.forge_fuse()
         .args(["install", "vectorized/solady@this-tag-does-not-exist"])
         .assert_failure();
 
-    let after = Command::new("git")
-        .current_dir(prj.root())
-        .args(["status", "--porcelain"])
-        .output()
-        .unwrap()
-        .stdout;
-    assert_eq!(after, status);
-    assert_eq!(read_string(&gitmodules), original);
+    assert_eq!(fs::read_link(&gitmodules).unwrap(), Path::new("gitmodules-target"));
+    assert!(!prj.root().join("gitmodules-target").exists());
+    assert_eq!(fs::read(prj.root().join(".git/index")).unwrap(), index);
     assert!(!prj.root().join("lib/solady").exists());
-    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
-    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
 });
 
 forgetest!(install_rejects_ignored_gitmodules, |prj, cmd| {
@@ -506,7 +424,7 @@ forgetest!(install_rejects_ignored_gitmodules, |prj, cmd| {
     assert_eq!(read_string(&gitmodules), original);
     assert!(!prj.root().join("lib/solady").exists());
     assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
-    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+    assert!(!git.has_submodule_config(Path::new("lib/solady")).unwrap());
 });
 
 forgetest!(install_rejects_existing_submodule_path, |prj, cmd| {
@@ -531,7 +449,7 @@ forgetest!(install_rejects_existing_submodule_path, |prj, cmd| {
     assert_eq!(read_string(&gitmodules), original);
     assert!(!prj.root().join("lib/solady").exists());
     assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
-    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+    assert!(!git.has_submodule_config(Path::new("lib/solady")).unwrap());
 });
 
 // test to check we can run `forge install` in an empty dir <https://github.com/foundry-rs/foundry/issues/6519>
@@ -599,189 +517,6 @@ forgetest!(can_install_repeatedly, |_prj, cmd| {
     for _ in 0..3 {
         cmd.assert_success();
     }
-});
-
-forgetest!(can_install_multiple_submodules, |_prj, cmd| {
-    cmd.git_init();
-    cmd.forge_fuse()
-        .args(["install", "foundry-rs/forge-std", "vectorized/solady"])
-        .assert_success();
-});
-
-forgetest!(can_explicitly_install_uninitialized_submodule, |prj, cmd| {
-    cmd.git_init();
-    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
-
-    let dependency = Path::new("lib/forge-std");
-    Git::new(prj.root()).submodule_deinit(true, dependency).unwrap();
-    assert!(fs::read_dir(prj.root().join(dependency)).unwrap().next().is_none());
-
-    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
-    assert!(prj.root().join(dependency).join(".git").exists());
-});
-
-forgetest!(failed_explicit_install_restores_deinitialized_submodule, |prj, cmd| {
-    cmd.git_init();
-    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
-    let dependency = Path::new("lib/forge-std");
-    let git = Git::new(prj.root());
-    git.submodule_deinit(true, dependency).unwrap();
-    let config = git.submodule_config(Path::new("lib/forge-std")).unwrap();
-    let status = Command::new("git")
-        .current_dir(prj.root())
-        .args(["status", "--porcelain"])
-        .output()
-        .unwrap()
-        .stdout;
-
-    cmd.forge_fuse()
-        .args(["install", "foundry-rs/forge-std@this-tag-does-not-exist"])
-        .assert_failure();
-
-    assert!(fs::read_dir(prj.root().join(dependency)).unwrap().next().is_none());
-    assert_eq!(git.submodule_config(Path::new("lib/forge-std")).unwrap(), config);
-    assert_eq!(
-        Command::new("git")
-            .current_dir(prj.root())
-            .args(["status", "--porcelain"])
-            .output()
-            .unwrap()
-            .stdout,
-        status
-    );
-});
-
-forgetest!(can_install_custom_named_submodule, |prj, cmd| {
-    cmd.git_init();
-    let status = Command::new("git")
-        .current_dir(prj.root())
-        .args([
-            "submodule",
-            "add",
-            "--name",
-            "forge-std",
-            "https://github.com/foundry-rs/forge-std",
-            "lib/forge-std",
-        ])
-        .status()
-        .unwrap();
-    assert!(status.success());
-
-    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
-    assert!(prj.root().join("lib/forge-std/.git").exists());
-    assert!(Git::new(prj.root()).absolute_git_dir().unwrap().join("modules/forge-std").exists());
-});
-
-forgetest!(submodule_mapping_uses_first_values, |prj, cmd| {
-    cmd.git_init();
-    fs::write(
-        prj.root().join(".gitmodules"),
-        r#"[submodule "custom.name"]
-	path = lib/forge-std
-	path = lib/other
-	url = https://github.com/foundry-rs/forge-std
-	url = https://github.com/example/other
-"#,
-    )
-    .unwrap();
-
-    let (_, mapping) =
-        Git::new(prj.root()).submodule_mapping_for_path(Path::new("lib/forge-std")).unwrap();
-    let mapping = mapping.unwrap();
-    assert_eq!(mapping.name, "custom.name");
-    assert_eq!(mapping.url.as_deref(), Some("https://github.com/foundry-rs/forge-std"));
-});
-
-forgetest!(failed_reinstall_preserves_existing_submodule, |prj, cmd| {
-    cmd.git_init();
-    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
-
-    let gitmodules = prj.root().join(".gitmodules");
-    let modified_gitmodules = format!("{}# local edit\n", read_string(&gitmodules));
-    fs::write(&gitmodules, &modified_gitmodules).unwrap();
-
-    let dependency = prj.root().join("lib/forge-std");
-    let status =
-        Command::new("git").current_dir(&dependency).args(["checkout", "HEAD^"]).status().unwrap();
-    assert!(status.success());
-    let dependency_head = Command::new("git")
-        .current_dir(&dependency)
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .unwrap()
-        .stdout;
-    let repository_status = Command::new("git")
-        .current_dir(prj.root())
-        .args(["status", "--porcelain"])
-        .output()
-        .unwrap()
-        .stdout;
-
-    cmd.forge_fuse()
-        .args(["install", "foundry-rs/forge-std@this-tag-does-not-exist"])
-        .assert_failure();
-
-    let after_status = Command::new("git")
-        .current_dir(prj.root())
-        .args(["status", "--porcelain"])
-        .output()
-        .unwrap()
-        .stdout;
-    let after_head = Command::new("git")
-        .current_dir(&dependency)
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .unwrap()
-        .stdout;
-    assert_eq!(after_status, repository_status);
-    assert_eq!(after_head, dependency_head);
-    assert_eq!(read_string(&gitmodules), modified_gitmodules);
-});
-
-forgetest!(install_rejects_invalid_existing_submodule_worktree, |prj, cmd| {
-    cmd.git_init();
-    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
-
-    let dependency = prj.root().join("lib/forge-std");
-    fs::remove_dir_all(&dependency).unwrap();
-    fs::create_dir_all(&dependency).unwrap();
-    fs::write(dependency.join("preserve"), "contents").unwrap();
-
-    let head = Command::new("git")
-        .current_dir(prj.root())
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .unwrap()
-        .stdout;
-    let repository_status = Command::new("git")
-        .current_dir(prj.root())
-        .args(["status", "--porcelain"])
-        .output()
-        .unwrap()
-        .stdout;
-
-    let output = cmd
-        .forge_fuse()
-        .args(["install", "foundry-rs/forge-std@this-tag-does-not-exist"])
-        .assert_failure();
-    let stderr = output.get_output().stderr_lossy();
-    assert!(stderr.contains("not its registered submodule worktree"), "{stderr}");
-
-    let after_head = Command::new("git")
-        .current_dir(prj.root())
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .unwrap()
-        .stdout;
-    let after_status = Command::new("git")
-        .current_dir(prj.root())
-        .args(["status", "--porcelain"])
-        .output()
-        .unwrap()
-        .stdout;
-    assert_eq!(after_head, head);
-    assert_eq!(after_status, repository_status);
-    assert_eq!(read_string(dependency.join("preserve")), "contents");
 });
 
 // test that by default we install the latest semver release tag

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -8,6 +8,8 @@ use foundry_test_utils::util::{
     ExtTester, FORGE_STD_REVISION, OutputExt, TestCommand, pretty_err, read_string,
 };
 use semver::Version;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -170,6 +172,120 @@ Error: Tag: "this-tag-does-not-exist" not found for repo "https://github.com/vec
     assert!(!prj.root().join("lib/solady").exists());
     assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
     assert!(git.submodule_url(Path::new("lib/solady")).unwrap_or(None).is_none());
+});
+
+forgetest!(install_rejects_assume_unchanged_orphan_gitlink, |prj, cmd| {
+    cmd.git_init();
+    fs::write(prj.root().join("README.md"), "baseline").unwrap();
+    cmd.git_add();
+    cmd.git_commit("baseline");
+    let head = Command::new("git")
+        .current_dir(prj.root())
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .unwrap()
+        .stdout;
+    let head = String::from_utf8(head).unwrap();
+    let git = |args: &[&str]| {
+        assert!(Command::new("git").current_dir(prj.root()).args(args).status().unwrap().success());
+    };
+    git(&["update-index", "--add", "--cacheinfo", "160000", head.trim(), "lib/solady"]);
+    git(&["update-index", "--assume-unchanged", "lib/solady"]);
+    let index = fs::read(prj.root().join(".git/index")).unwrap();
+    let status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["status", "--porcelain=v2"])
+        .output()
+        .unwrap()
+        .stdout;
+
+    cmd.forge_fuse().args(["install", "vectorized/solady"]).assert_failure();
+
+    assert_eq!(fs::read(prj.root().join(".git/index")).unwrap(), index);
+    assert_eq!(
+        Command::new("git")
+            .current_dir(prj.root())
+            .args(["status", "--porcelain=v2"])
+            .output()
+            .unwrap()
+            .stdout,
+        status
+    );
+    assert!(!prj.root().join(".gitmodules").exists());
+    assert!(!prj.root().join("lib/solady").exists());
+});
+
+forgetest!(failed_install_with_wildcard_alias_preserves_sibling, |prj, cmd| {
+    cmd.git_init();
+    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
+
+    cmd.forge_fuse()
+        .args(["install", "*=vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+
+    assert!(prj.root().join("lib/forge-std/.git").exists());
+    assert!(Git::new(prj.root()).is_gitlink(Path::new("lib/forge-std")).unwrap());
+});
+
+#[cfg(unix)]
+forgetest!(failed_install_commit_rolls_back_transaction, |prj, cmd| {
+    cmd.git_init();
+    fs::write(prj.root().join(FOUNDRY_LOCK), b"{}\n").unwrap();
+    cmd.git_add();
+    cmd.git_commit("baseline");
+    let head = Git::new(prj.root()).head().unwrap();
+    let status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap()
+        .stdout;
+    let hook = prj.root().join(".git/hooks/pre-commit");
+    fs::write(&hook, "#!/bin/sh\nexit 1\n").unwrap();
+    let mut permissions = fs::metadata(&hook).unwrap().permissions();
+    #[cfg(unix)]
+    {
+        permissions.set_mode(0o755);
+    }
+    fs::set_permissions(&hook, permissions).unwrap();
+
+    cmd.forge_fuse().args(["install", "--commit", "vectorized/solady"]).assert_failure();
+
+    let git = Git::new(prj.root());
+    assert_eq!(git.head().unwrap(), head);
+    assert_eq!(fs::read(prj.root().join(FOUNDRY_LOCK)).unwrap(), b"{}\n");
+    assert_eq!(
+        Command::new("git")
+            .current_dir(prj.root())
+            .args(["status", "--porcelain"])
+            .output()
+            .unwrap()
+            .stdout,
+        status
+    );
+    assert!(!prj.root().join(".gitmodules").exists());
+    assert!(!prj.root().join("lib/solady").exists());
+    assert!(git.submodule_config(Path::new("lib/solady")).unwrap().is_empty());
+});
+
+#[cfg(unix)]
+forgetest!(failed_commit_preserves_hook_replacement, |prj, cmd| {
+    cmd.git_init();
+    let hook = prj.root().join(".git/hooks/pre-commit");
+    fs::write(
+        &hook,
+        "#!/bin/sh\nrm -rf lib/solady\nmkdir -p lib/solady\necho preserve > lib/solady/hook\nexit 1\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&hook).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&hook, permissions).unwrap();
+
+    cmd.forge_fuse().args(["install", "--commit", "vectorized/solady"]).assert_failure();
+
+    assert_eq!(read_string(prj.root().join("lib/solady/hook")), "preserve\n");
+    assert!(!prj.root().join(".gitmodules").exists());
+    assert!(!Git::new(prj.root()).is_gitlink(Path::new("lib/solady")).unwrap());
 });
 
 forgetest!(failed_install_preserves_gitmodules, |prj, cmd| {
@@ -502,6 +618,37 @@ forgetest!(can_explicitly_install_uninitialized_submodule, |prj, cmd| {
 
     cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
     assert!(prj.root().join(dependency).join(".git").exists());
+});
+
+forgetest!(failed_explicit_install_restores_deinitialized_submodule, |prj, cmd| {
+    cmd.git_init();
+    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
+    let dependency = Path::new("lib/forge-std");
+    let git = Git::new(prj.root());
+    git.submodule_deinit(true, dependency).unwrap();
+    let config = git.submodule_config(Path::new("lib/forge-std")).unwrap();
+    let status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap()
+        .stdout;
+
+    cmd.forge_fuse()
+        .args(["install", "foundry-rs/forge-std@this-tag-does-not-exist"])
+        .assert_failure();
+
+    assert!(fs::read_dir(prj.root().join(dependency)).unwrap().next().is_none());
+    assert_eq!(git.submodule_config(Path::new("lib/forge-std")).unwrap(), config);
+    assert_eq!(
+        Command::new("git")
+            .current_dir(prj.root())
+            .args(["status", "--porcelain"])
+            .output()
+            .unwrap()
+            .stdout,
+        status
+    );
 });
 
 forgetest!(can_install_custom_named_submodule, |prj, cmd| {

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -193,25 +193,37 @@ forgetest!(failed_install_preserves_gitmodules, |prj, cmd| {
 
 forgetest!(failed_install_preserves_submodule_config, |prj, cmd| {
     cmd.git_init();
-    let key = "submodule.lib/solady.update";
+    let git = Git::new(prj.root());
+    let key = "submodule.lib/solady.custom";
     let status = Command::new("git")
         .current_dir(prj.root())
-        .args(["config", "--local", key, "none"])
+        .args(["config", "--local", key, "keep"])
         .status()
         .unwrap();
     assert!(status.success());
+    assert_eq!(
+        git.submodule_config(Path::new("lib/solady")).unwrap(),
+        vec![(key.to_string(), "keep".to_string())]
+    );
 
     cmd.forge_fuse()
         .args(["install", "vectorized/solady@this-tag-does-not-exist"])
-        .assert_failure();
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Installing solady in [..] (url: https://github.com/vectorized/solady, tag: this-tag-does-not-exist)
+...
+Error: Tag: "this-tag-does-not-exist" not found for repo "https://github.com/vectorized/solady"!
 
-    let output = Command::new("git")
-        .current_dir(prj.root())
-        .args(["config", "--local", "--get", key])
-        .output()
-        .unwrap();
-    assert!(output.status.success());
-    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "none");
+"#]]);
+
+    assert!(git.is_clean().unwrap());
+    assert!(!prj.root().join(".gitmodules").exists());
+    assert!(!prj.root().join("lib/solady").exists());
+    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
+    assert_eq!(
+        git.submodule_config(Path::new("lib/solady")).unwrap(),
+        vec![(key.to_string(), "keep".to_string())]
+    );
 });
 
 // test to check we can run `forge install` in an empty dir <https://github.com/foundry-rs/foundry/issues/6519>

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -149,6 +149,71 @@ Removing 'forge-std' in [..], (url: https://github.com/foundry-rs/forge-std, tag
     remove(&mut cmd, "lib/forge-std");
 });
 
+// https://github.com/foundry-rs/foundry/issues/6790
+forgetest!(failed_install_leaves_repository_clean, |prj, cmd| {
+    cmd.git_init();
+    let git = Git::new(prj.root());
+    assert!(git.is_clean().unwrap());
+
+    cmd.forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Installing solady in [..] (url: https://github.com/vectorized/solady, tag: this-tag-does-not-exist)
+...
+Error: Tag: "this-tag-does-not-exist" not found for repo "https://github.com/vectorized/solady"!
+
+"#]]);
+
+    assert!(git.is_clean().unwrap());
+    assert!(!prj.root().join(".gitmodules").exists());
+    assert!(!prj.root().join("lib/solady").exists());
+    assert!(!git.absolute_git_dir().unwrap().join("modules/lib/solady").exists());
+    assert!(git.submodule_url(Path::new("lib/solady")).unwrap_or(None).is_none());
+});
+
+forgetest!(failed_install_preserves_gitmodules, |prj, cmd| {
+    cmd.git_init();
+    let gitmodules = prj.root().join(".gitmodules");
+    let original = r#"[submodule "existing"]
+	path = lib/existing
+	url = https://github.com/example/existing
+"#;
+    fs::write(&gitmodules, original).unwrap();
+    cmd.git_add();
+    cmd.git_commit("add gitmodules");
+
+    cmd.forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+
+    assert!(Git::new(prj.root()).is_clean().unwrap());
+    assert_eq!(read_string(&gitmodules), original);
+});
+
+forgetest!(failed_install_preserves_submodule_config, |prj, cmd| {
+    cmd.git_init();
+    let key = "submodule.lib/solady.update";
+    let status = Command::new("git")
+        .current_dir(prj.root())
+        .args(["config", "--local", key, "none"])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    cmd.forge_fuse()
+        .args(["install", "vectorized/solady@this-tag-does-not-exist"])
+        .assert_failure();
+
+    let output = Command::new("git")
+        .current_dir(prj.root())
+        .args(["config", "--local", "--get", key])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "none");
+});
+
 // test to check we can run `forge install` in an empty dir <https://github.com/foundry-rs/foundry/issues/6519>
 forgetest!(can_install_empty, |prj, cmd| {
     // create

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -492,6 +492,59 @@ forgetest!(can_install_multiple_submodules, |_prj, cmd| {
         .assert_success();
 });
 
+forgetest!(can_explicitly_install_uninitialized_submodule, |prj, cmd| {
+    cmd.git_init();
+    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
+
+    let dependency = Path::new("lib/forge-std");
+    Git::new(prj.root()).submodule_deinit(true, dependency).unwrap();
+    assert!(fs::read_dir(prj.root().join(dependency)).unwrap().next().is_none());
+
+    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
+    assert!(prj.root().join(dependency).join(".git").exists());
+});
+
+forgetest!(can_install_custom_named_submodule, |prj, cmd| {
+    cmd.git_init();
+    let status = Command::new("git")
+        .current_dir(prj.root())
+        .args([
+            "submodule",
+            "add",
+            "--name",
+            "forge-std",
+            "https://github.com/foundry-rs/forge-std",
+            "lib/forge-std",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();
+    assert!(prj.root().join("lib/forge-std/.git").exists());
+    assert!(Git::new(prj.root()).absolute_git_dir().unwrap().join("modules/forge-std").exists());
+});
+
+forgetest!(submodule_mapping_uses_first_values, |prj, cmd| {
+    cmd.git_init();
+    fs::write(
+        prj.root().join(".gitmodules"),
+        r#"[submodule "custom.name"]
+	path = lib/forge-std
+	path = lib/other
+	url = https://github.com/foundry-rs/forge-std
+	url = https://github.com/example/other
+"#,
+    )
+    .unwrap();
+
+    let (_, mapping) =
+        Git::new(prj.root()).submodule_mapping_for_path(Path::new("lib/forge-std")).unwrap();
+    let mapping = mapping.unwrap();
+    assert_eq!(mapping.name, "custom.name");
+    assert_eq!(mapping.url.as_deref(), Some("https://github.com/foundry-rs/forge-std"));
+});
+
 forgetest!(failed_reinstall_preserves_existing_submodule, |prj, cmd| {
     cmd.git_init();
     cmd.forge_fuse().args(["install", "foundry-rs/forge-std"]).assert_success();

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -228,13 +228,21 @@ forgetest!(failed_install_with_wildcard_alias_preserves_sibling, |prj, cmd| {
             .status
             .success()
     );
-    let index = fs::read(prj.root().join(".git/index")).unwrap();
+    let index = || {
+        Command::new("git")
+            .current_dir(prj.root())
+            .args(["ls-files", "--stage", "-v", "-z"])
+            .output()
+            .unwrap()
+            .stdout
+    };
+    let index_before = index();
 
     cmd.forge_fuse()
         .args(["install", "*=vectorized/solady@this-tag-does-not-exist"])
         .assert_failure();
 
-    assert_eq!(fs::read(prj.root().join(".git/index")).unwrap(), index);
+    assert_eq!(index(), index_before);
     assert!(sibling.join(".git").exists());
     assert!(Git::new(prj.root()).is_gitlink(Path::new("lib/forge-std")).unwrap());
 });
@@ -517,6 +525,13 @@ forgetest!(can_install_repeatedly, |_prj, cmd| {
     for _ in 0..3 {
         cmd.assert_success();
     }
+});
+
+forgetest!(can_install_multiple_submodules, |_prj, cmd| {
+    cmd.git_init();
+    cmd.forge_fuse()
+        .args(["install", "foundry-rs/forge-std", "vectorized/solady"])
+        .assert_success();
 });
 
 // test that by default we install the latest semver release tag


### PR DESCRIPTION
Rolls back new submodules when `forge install` fails, leaving the repository clean. 

Fixes #6790.