### PR TITLE
fix: nightly clippy

### DIFF
--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -578,7 +578,9 @@ impl BenchmarkProject {
             "forge_coverage" => self.bench_forge_coverage(version, runs, verbose),
             "forge_isolate_test" => self.bench_forge_isolate_test(version, runs, verbose),
             "forge_symbolic_test" => self.bench_forge_symbolic_test(version, runs, verbose),
-            _ => eyre::bail!("Unknown benchmark: {}", benchmark),
+            _ => {
+                eyre::bail!("Unknown benchmark: {}", benchmark);
+            }
         }
     }
 }
@@ -631,7 +633,9 @@ pub fn parse_version_specs(specs: &[String]) -> Result<Vec<(String, Option<PathB
                 Some((name, path)) if !name.is_empty() && !path.is_empty() => {
                     (name, Some(PathBuf::from(path)))
                 }
-                Some(_) => eyre::bail!("invalid source version '{spec}'; expected name=path"),
+                Some(_) => {
+                    eyre::bail!("invalid source version '{spec}'; expected name=path");
+                }
                 None => (spec, None),
             };
             if name.is_empty()

--- a/benches/src/symbolic.rs
+++ b/benches/src/symbolic.rs
@@ -76,7 +76,7 @@ impl Overlay {
         }
         let path = root.join(FARCASTER_PATH);
         if path.exists() {
-            eyre::bail!("refusing to overwrite existing {}", path.display())
+            eyre::bail!("refusing to overwrite existing {}", path.display());
         }
         if let Err(write_err) = fs::write(&path, FARCASTER_TEST) {
             if let Err(cleanup_err) = fs::remove_file(&path)
@@ -85,7 +85,7 @@ impl Overlay {
                 eyre::bail!(
                     "failed to install Farcaster symbolic fixture: {write_err}; failed to remove partially written {}: {cleanup_err}",
                     path.display()
-                )
+                );
             }
             return Err(write_err).wrap_err("failed to install Farcaster symbolic fixture");
         }
@@ -239,7 +239,7 @@ pub fn parse(stdout: &[u8]) -> Result<ParsedRun> {
             let (stats, status) = if stable {
                 let Some(symbolic) = result.get("symbolic") else { continue };
                 if symbolic.get("schema_version").and_then(Value::as_u64) != Some(1) {
-                    eyre::bail!("unknown or missing symbolic schema_version")
+                    eyre::bail!("unknown or missing symbolic schema_version");
                 }
                 let status = symbolic
                     .get("status")
@@ -249,7 +249,9 @@ pub fn parse(stdout: &[u8]) -> Result<ParsedRun> {
                     "pass" => OutcomeStatus::Passed,
                     "fail_counterexample" => OutcomeStatus::Failed,
                     "incomplete" => OutcomeStatus::Incomplete,
-                    _ => eyre::bail!("unknown symbolic.status {status}"),
+                    _ => {
+                        eyre::bail!("unknown symbolic.status {status}");
+                    }
                 };
                 let stats = symbolic
                     .pointer("/solver/stats")
@@ -278,7 +280,7 @@ pub fn parse(stdout: &[u8]) -> Result<ParsedRun> {
         }
     }
     if run.outcomes.is_empty() {
-        eyre::bail!("forge symbolic benchmark produced no symbolic test results")
+        eyre::bail!("forge symbolic benchmark produced no symbolic test results");
     }
     run.outcomes.sort_by_key(TestOutcome::identity);
     run.passed =

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1405,7 +1405,7 @@ latest block number: {latest_block}"
                 }
                 eyre::bail!("{message}");
             }
-            eyre::bail!("failed to get block for block number: {fork_block_number}")
+            eyre::bail!("failed to get block for block number: {fork_block_number}");
         };
 
         let gas_limit = self.fork_gas_limit(&block);

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -306,7 +306,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                     get_event(event.signature().as_str())?
                         .decode_log_parts(core::iter::once(selector), &hex::decode(data)?)?
                 } else {
-                    eyre::bail!("No matching event signature found for selector `{selector}`")
+                    eyre::bail!("No matching event signature found for selector `{selector}`");
                 }
             };
             print_tokens(&decoded_event.body)?;
@@ -323,7 +323,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
                     let _ = sh_println!("{}", error.signature());
                     error
                 } else {
-                    eyre::bail!("No matching error signature found for selector `{selector}`")
+                    eyre::bail!("No matching error signature found for selector `{selector}`");
                 }
             };
             let decoded_error = error.decode_error(&hex::decode(data)?)?;
@@ -781,7 +781,9 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             });
 
             let sig = match sigs.len() {
-                0 => eyre::bail!("No signatures found"),
+                0 => {
+                    eyre::bail!("No signatures found");
+                }
                 1 => sigs.first().unwrap(),
                 _ => {
                     let i: usize = prompt!("Select a function signature by number: ")?;

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -564,7 +564,7 @@ impl CallArgs {
         let to = self.to.as_ref().map(|n| match n {
             NameOrAddress::Address(addr) => Ok(*addr),
             NameOrAddress::Name(name) => {
-                eyre::bail!("ENS names are not supported with --curl. Please use a raw address instead of '{}'", name)
+                eyre::bail!("ENS names are not supported with --curl. Please use a raw address instead of '{}'", name);
             }
         }).transpose()?;
 

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -3027,10 +3027,12 @@ fn decode_and_validate_key_authorization(
             }
             Err(signed_err) => match tempo::decode_key_authorization::<KeyAuthorization>(raw) {
                 Ok(unsigned) => (unsigned, false, None),
-                Err(unsigned_err) => eyre::bail!(
-                    "could not decode key authorization as signed ({signed_err}) or unsigned \
+                Err(unsigned_err) => {
+                    eyre::bail!(
+                        "could not decode key authorization as signed ({signed_err}) or unsigned \
                  ({unsigned_err})"
-                ),
+                    );
+                }
             },
         };
 
@@ -3060,12 +3062,16 @@ fn decode_and_validate_key_authorization(
     if let Some(expected) = expected_account {
         match auth.account {
             Some(account) if account == expected => {}
-            Some(account) => eyre::bail!(
-                "key authorization is bound to account {account} but {expected} was expected"
-            ),
-            None => eyre::bail!(
-                "expected key authorization bound to account {expected} but it has no account field"
-            ),
+            Some(account) => {
+                eyre::bail!(
+                    "key authorization is bound to account {account} but {expected} was expected"
+                );
+            }
+            None => {
+                eyre::bail!(
+                    "expected key authorization bound to account {expected} but it has no account field"
+                );
+            }
         }
     }
 
@@ -4109,7 +4115,7 @@ fn load_keys_file() -> Result<KeysFile> {
             let path = tempo_keys_path()
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|| "(unknown)".to_string());
-            eyre::bail!("could not read keys file at {path}")
+            eyre::bail!("could not read keys file at {path}");
         }
     }
 }

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -640,10 +640,12 @@ pub(crate) fn validate_sponsor_url(raw: &str) -> Result<()> {
                  The sponsor relay is a trusted third party; use an encrypted channel."
             );
         }
-        _ => eyre::bail!(
-            "--sponsor-url must start with https:// (got {raw}). \
+        _ => {
+            eyre::bail!(
+                "--sponsor-url must start with https:// (got {raw}). \
              The sponsor relay is a trusted third party; use an encrypted channel."
-        ),
+            );
+        }
     }
 }
 

--- a/crates/cast/src/cmd/storage.rs
+++ b/crates/cast/src/cmd/storage.rs
@@ -159,7 +159,7 @@ impl StorageArgs {
         };
         let metadata = source.items.first().unwrap();
         if metadata.is_vyper() {
-            eyre::bail!("Contract at provided address is not a valid Solidity contract")
+            eyre::bail!("Contract at provided address is not a valid Solidity contract");
         }
 
         // Create or reuse a persistent cache for Etherscan sources; fall back to a temp dir

--- a/crates/cast/src/cmd/tip20/create.rs
+++ b/crates/cast/src/cmd/tip20/create.rs
@@ -143,7 +143,7 @@ where
         Err(err) if is_t5_create_logo_unknown_selector(&err) => {
             eyre::bail!(
                 "--logo-uri requires a T5-compatible TIP20Factory; the configured RPC rejected the 7-arg createToken selector 0x5323d222"
-            )
+            );
         }
         Err(_) => Ok(()),
     }

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -593,7 +593,9 @@ impl WalletSubcommands {
                                 }
                             }
                         }
-                        _ => eyre::bail!("Only local wallets are supported by this command"),
+                        _ => {
+                            eyre::bail!("Only local wallets are supported by this command");
+                        }
                     }
                 }
 
@@ -613,7 +615,9 @@ impl WalletSubcommands {
 
                 let public_key = match wallet {
                     WalletSigner::Local(wallet) => wallet.public_key(),
-                    _ => eyre::bail!("Only local wallets are supported by this command"),
+                    _ => {
+                        eyre::bail!("Only local wallets are supported by this command");
+                    }
                 };
 
                 print_scalar(format!("0x{}", hex::encode(public_key)))?;

--- a/crates/cast/src/cmd/wallet/session.rs
+++ b/crates/cast/src/cmd/wallet/session.rs
@@ -620,7 +620,9 @@ async fn run_revoke_with_policy(
             .await?
         {
             KeychainTxOutcome::Submitted => {}
-            KeychainTxOutcome::PrintedSponsorHash => eyre::bail!(PRINT_SPONSOR_HASH_REVOKE_ERROR),
+            KeychainTxOutcome::PrintedSponsorHash => {
+                eyre::bail!(PRINT_SPONSOR_HASH_REVOKE_ERROR);
+            }
         }
         Ok(())
     }
@@ -651,7 +653,7 @@ fn handle_unprovisioned_revoke(
                 "session key is not provisioned on-chain yet; pending transactions from the \
                  wrapped command may still provision it. Wait for pending transactions to settle, \
                  then run `cast wallet session revoke {session_id}`."
-            )
+            );
         }
     }
 }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -178,7 +178,7 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
                                 .await
                                 && code.is_empty()
                             {
-                                eyre::bail!("contract {addr:?} does not have any code")
+                                eyre::bail!("contract {addr:?} does not have any code");
                             }
                         } else if req.to().is_none() {
                             eyre::bail!("tx req is a contract deployment");
@@ -999,7 +999,7 @@ where
     ) -> Result<String> {
         let block = block.into();
         if fields.contains(&"transactions".into()) && !full {
-            eyre::bail!("use --full to view transactions")
+            eyre::bail!("use --full to view transactions");
         }
 
         let block = self
@@ -1212,7 +1212,7 @@ where
                     eyre::eyre!("tx not found for sender {from} and nonce {:?}", nonce.to::<u64>())
                 })?
         } else {
-            eyre::bail!("tx hash or from address is required")
+            eyre::bail!("tx hash or from address is required");
         };
 
         Ok(if raw {
@@ -1935,7 +1935,9 @@ impl SimpleCast {
         let func = get_func(sig)?;
         match encode_function_args(&func, args) {
             Ok(res) => Ok(hex::encode_prefixed(&res[4..])),
-            Err(e) => eyre::bail!("Could not ABI encode the function and arguments: {e}"),
+            Err(e) => {
+                eyre::bail!("Could not ABI encode the function and arguments: {e}");
+            }
         }
     }
 
@@ -1965,7 +1967,9 @@ impl SimpleCast {
         let func = get_func(sig.as_str())?;
         let encoded = match encode_function_args_packed(&func, args) {
             Ok(res) => hex::encode(res),
-            Err(e) => eyre::bail!("Could not ABI encode the function and arguments: {e}"),
+            Err(e) => {
+                eyre::bail!("Could not ABI encode the function and arguments: {e}");
+            }
         };
         Ok(format!("0x{encoded}"))
     }
@@ -2122,7 +2126,7 @@ impl SimpleCast {
             | DynSolType::FixedArray(..)
             | DynSolType::Tuple(..)
             | DynSolType::CustomStruct { .. } => {
-                eyre::bail!("Type `{k_ty}` is not supported as a mapping key")
+                eyre::bail!("Type `{k_ty}` is not supported as a mapping key");
             }
         }
 
@@ -2313,7 +2317,7 @@ impl SimpleCast {
         let client = explorer_client(chain, etherscan_api_key, explorer_api_url, explorer_url)?;
         let metadata = client.contract_source_code(contract_address.parse()?).await?;
         let Some(metadata) = metadata.items.first() else {
-            eyre::bail!("Empty contract source code")
+            eyre::bail!("Empty contract source code");
         };
 
         let tmp = tempfile::tempdir()?;
@@ -2405,7 +2409,9 @@ impl SimpleCast {
 
         match result {
             Some((_nonce, selector, signature)) => Ok((selector, signature)),
-            None => eyre::bail!("No selector found"),
+            None => {
+                eyre::bail!("No selector found");
+            }
         }
     }
 

--- a/crates/cast/src/rlp_converter.rs
+++ b/crates/cast/src/rlp_converter.rs
@@ -50,7 +50,7 @@ impl Item {
         match value {
             Value::Null => Ok(Self::Data(vec![])),
             Value::Bool(_) => {
-                eyre::bail!("RLP input can not contain booleans")
+                eyre::bail!("RLP input can not contain booleans");
             }
             Value::Number(n) => {
                 Ok(Self::Data(n.to_string().parse::<U256>()?.to_be_bytes_trimmed_vec()))
@@ -58,7 +58,7 @@ impl Item {
             Value::String(s) => Ok(Self::Data(hex::decode(s).wrap_err("Could not decode hex")?)),
             Value::Array(values) => values.iter().map(Self::value_to_item).collect(),
             Value::Object(_) => {
-                eyre::bail!("RLP input can not contain objects")
+                eyre::bail!("RLP input can not contain objects");
             }
         }
     }

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -189,7 +189,7 @@ The specified sender via CLI/env vars does not match the sender configured via
 the hardware wallet's HD Path.
 Please use the `--hd-path <PATH>` parameter to specify the BIP32 Path which
 corresponds to the sender, or let foundry automatically detect it by not specifying any sender address."
-            )
+            );
     }
     Ok(())
 }
@@ -343,7 +343,7 @@ where
                     // if the async flag is provided, immediately exit if no tx is found, otherwise
                     // try to poll for it
                     if cast_async {
-                        eyre::bail!("tx not found: {:?}", tx_hash)
+                        eyre::bail!("tx not found: {:?}", tx_hash);
                     }
                     PendingTransactionBuilder::<N>::new(self.provider.root().clone(), tx_hash)
                         .with_required_confirmations(confs)
@@ -752,10 +752,10 @@ where
                         && let Some(data) = &payload.data
                         && let Ok(Some(decoded_error)) = decode_execution_revert(data).await
                     {
-                        eyre::bail!("Failed to estimate gas: {}: {}", err, decoded_error)
+                        eyre::bail!("Failed to estimate gas: {}: {}", err, decoded_error);
                     }
                 }
-                eyre::bail!("Failed to estimate gas: {}", err)
+                eyre::bail!("Failed to estimate gas: {}", err);
             }
         }
     }

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -112,7 +112,9 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         if let Some(command) = input.strip_prefix(COMMAND_LEADER) {
             return match ChiselCommand::parse(command) {
                 Ok(cmd) => self.dispatch_command(cmd).await,
-                Err(e) => eyre::bail!("unrecognized command: {e}"),
+                Err(e) => {
+                    eyre::bail!("unrecognized command: {e}");
+                }
             };
         }
 
@@ -401,7 +403,7 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
                 sh_println!("Set calldata to '{}'", arg.yellow())
             }
             Err(e) => {
-                eyre::bail!("Invalid calldata: {e}")
+                eyre::bail!("Invalid calldata: {e}");
             }
         }
     }
@@ -514,7 +516,7 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
             return Ok(());
         }
 
-        eyre::bail!("Variable must exist within `run()` function.")
+        eyre::bail!("Variable must exist within `run()` function.");
     }
 }
 

--- a/crates/chisel/src/executor.rs
+++ b/crates/chisel/src/executor.rs
@@ -185,7 +185,7 @@ impl<FEN: FoundryEvmNetwork> SessionSource<FEN> {
             memory.get(offset..offset + len)
         })();
         let Some(data) = data else {
-            eyre::bail!("Failed to inspect last expression: could not retrieve data from memory")
+            eyre::bail!("Failed to inspect last expression: could not retrieve data from memory");
         };
         let token = ty.abi_decode(data).wrap_err("Could not decode inspected values")?;
         let c = if cont { ControlFlow::Continue(()) } else { ControlFlow::Break(()) };

--- a/crates/cli/src/opts/transaction.rs
+++ b/crates/cli/src/opts/transaction.rs
@@ -28,7 +28,7 @@ impl FromStr for CliAuthorizationList {
         } else if let Ok(auth) = SignedAuthorization::decode(&mut hex::decode(s)?.as_ref()) {
             Ok(Self::Signed(auth))
         } else {
-            eyre::bail!("Failed to decode authorization")
+            eyre::bail!("Failed to decode authorization");
         }
     }
 }

--- a/crates/cli/src/utils/abi.rs
+++ b/crates/cli/src/utils/abi.rs
@@ -37,7 +37,7 @@ pub async fn parse_function_args<N: Network, P: Provider<N>>(
     etherscan_api_url: Option<&str>,
 ) -> Result<(Vec<u8>, Option<Function>)> {
     if sig.trim().is_empty() {
-        eyre::bail!("Function signature or calldata must be provided.")
+        eyre::bail!("Function signature or calldata must be provided.");
     }
 
     let args = resolve_name_args(&args, provider).await;

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -47,7 +47,7 @@ pub fn find_contract_artifacts(
         Did you mean `{suggestion}`?"#
             );
         }
-        eyre::bail!(err)
+        eyre::bail!(err);
     };
 
     let abi = contract

--- a/crates/common/fmt/src/dynamic.rs
+++ b/crates/common/fmt/src/dynamic.rs
@@ -240,7 +240,9 @@ fn _serialize_value_as_json(
                 .map(|v| _serialize_value_as_json(v, defs, strict))
                 .collect::<Result<_>>()?,
         )),
-        DynSolValue::Function(_) => eyre::bail!("cannot serialize function pointer"),
+        DynSolValue::Function(_) => {
+            eyre::bail!("cannot serialize function pointer");
+        }
     }
 }
 
@@ -291,9 +293,11 @@ impl StructDefinitions {
         match matches.len() {
             0 => Ok(None),
             1 => Ok(Some(matches[0])),
-            _ => eyre::bail!(
-                "there are several structs with the same name. Use `<contract_name>.{key}` instead."
-            ),
+            _ => {
+                eyre::bail!(
+                    "there are several structs with the same name. Use `<contract_name>.{key}` instead."
+                );
+            }
         }
     }
 }

--- a/crates/common/src/abi.rs
+++ b/crates/common/src/abi.rs
@@ -16,7 +16,7 @@ where
     let args: Vec<S> = args.into_iter().collect();
 
     if inputs.len() != args.len() {
-        eyre::bail!("encode length mismatch: expected {} types, got {}", inputs.len(), args.len())
+        eyre::bail!("encode length mismatch: expected {} types, got {}", inputs.len(), args.len());
     }
 
     std::iter::zip(inputs, args)
@@ -92,7 +92,7 @@ pub fn abi_decode_calldata(
 
     // in case the decoding worked but nothing was decoded
     if res.is_empty() {
-        eyre::bail!("no data was decoded")
+        eyre::bail!("no data was decoded");
     }
 
     Ok(res)

--- a/crates/common/src/compile.rs
+++ b/crates/common/src/compile.rs
@@ -220,7 +220,7 @@ impl ProjectCompiler {
         })?;
 
         if bail && output.has_compiler_errors() {
-            eyre::bail!("{output}")
+            eyre::bail!("{output}");
         }
 
         if !quiet {

--- a/crates/common/src/errors/mod.rs
+++ b/crates/common/src/errors/mod.rs
@@ -45,14 +45,16 @@ fn all_sources<E: private::ErrorChain + ?Sized>(err: &E) -> Vec<String> {
 pub fn convert_solar_errors(dcx: &solar::interface::diagnostics::DiagCtxt) -> eyre::Result<()> {
     match dcx.emitted_errors() {
         Some(Ok(())) => Ok(()),
-        Some(Err(e)) if !e.is_empty() => eyre::bail!("solar reported errors:\n\n{e}"),
+        Some(Err(e)) if !e.is_empty() => {
+            eyre::bail!("solar reported errors:\n\n{e}");
+        }
         _ if dcx.has_errors().is_err() => {
             // Non-buffer emitter: diagnostics already went to stderr; include the count.
             let n = dcx.err_count();
             let plural = if n == 1 { "" } else { "s" };
             eyre::bail!(
                 "solar reported {n} error{plural}; see the diagnostic{plural} printed above"
-            )
+            );
         }
         _ => Ok(()),
     }

--- a/crates/common/src/selectors.rs
+++ b/crates/common/src/selectors.rs
@@ -124,7 +124,7 @@ impl OpenChainClient {
 
     fn ensure_not_spurious(&self) -> eyre::Result<()> {
         if self.is_spurious() {
-            eyre::bail!("Spurious connection detected")
+            eyre::bail!("Spurious connection detected");
         }
         Ok(())
     }
@@ -173,7 +173,9 @@ impl OpenChainClient {
         let text = self.get_text(url).await?;
         let SignatureResponse { ok, result } = match serde_json::from_str(&text) {
             Ok(response) => response,
-            Err(err) => eyre::bail!("could not decode response: {err}: {text}"),
+            Err(err) => {
+                eyre::bail!("could not decode response: {err}: {text}");
+            }
         };
         if !ok {
             eyre::bail!("OpenChain returned an error: {text}");
@@ -214,7 +216,7 @@ impl OpenChainClient {
             eyre::bail!(
                 "Calldata too short: expected at least 8 characters (excluding 0x prefix), got {}.",
                 calldata.len()
-            )
+            );
         }
 
         let mut sigs = self.decode_function_selector(calldata[..8].parse()?).await?;
@@ -265,7 +267,7 @@ impl OpenChainClient {
         let (_, data) = calldata.split_at(8);
 
         if !data.len().is_multiple_of(64) {
-            eyre::bail!("\nInvalid calldata size")
+            eyre::bail!("\nInvalid calldata size");
         }
 
         let row_length = data.len() / 64;

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -350,7 +350,7 @@ impl TempoSponsor {
         } else if let Some(signer) = &self.signer {
             signer.sign_hash(&digest).await.context("failed to sign Tempo sponsor digest")?
         } else {
-            eyre::bail!("missing Tempo sponsor signature or signer")
+            eyre::bail!("missing Tempo sponsor signature or signer");
         };
 
         let recovered = signature
@@ -456,10 +456,12 @@ pub async fn resolve_tempo_sponsor_signer(spec: &str) -> Result<WalletSigner> {
         "browser" => {
             eyre::bail!(
                 "browser:// sponsor signing is not supported by the current browser wallet API; use --tempo.sponsor-sig or another sponsor signer"
-            )
+            );
         }
-        _ => eyre::bail!(
-            "unsupported Tempo sponsor signer `{spec}`; expected env://VAR, keystore://PATH, account://NAME, ledger://, trezor://, aws://, gcp://, turnkey://, or private-key://KEY"
-        ),
+        _ => {
+            eyre::bail!(
+                "unsupported Tempo sponsor signer `{spec}`; expected env://VAR, keystore://PATH, account://NAME, ledger://, trezor://, aws://, gcp://, turnkey://, or private-key://KEY"
+            );
+        }
     }
 }

--- a/crates/common/src/transactions/builder.rs
+++ b/crates/common/src/transactions/builder.rs
@@ -308,7 +308,9 @@ pub trait FoundryTransactionBuilder<N: Network>: NetworkTransactionBuilder<N> {
         _key_address: Address,
         _key_authorization: Option<&SignedKeyAuthorization>,
     ) -> impl Future<Output = Result<Vec<u8>>> + Send {
-        async { eyre::bail!("access key signing is not supported for this network") }
+        async {
+            eyre::bail!("access key signing is not supported for this network");
+        }
     }
 }
 

--- a/crates/common/src/transactions/receipt.rs
+++ b/crates/common/src/transactions/receipt.rs
@@ -78,10 +78,12 @@ where
             call_request.set_from(transaction.from());
             match provider.call(call_request).block(BlockId::Hash(block_hash.into())).await {
                 Err(e) => return Ok(extract_revert_reason(e.to_string())),
-                Ok(_) => eyre::bail!("no revert reason as transaction succeeded"),
+                Ok(_) => {
+                    eyre::bail!("no revert reason as transaction succeeded");
+                }
             }
         }
-        eyre::bail!("unable to fetch block_hash")
+        eyre::bail!("unable to fetch block_hash");
     }
 }
 

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -1466,9 +1466,13 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
             if self.inner.issued_local_fork_ids.contains_key(&id) {
                 return Ok(id);
             }
-            eyre::bail!("Requested fork `{}` does not exist", id)
+            eyre::bail!("Requested fork `{}` does not exist", id);
         }
-        if let Some(id) = self.active_fork_id() { Ok(id) } else { eyre::bail!("No fork active") }
+        if let Some(id) = self.active_fork_id() {
+            Ok(id)
+        } else {
+            eyre::bail!("No fork active");
+        }
     }
 
     fn ensure_fork_id(&self, id: LocalForkId) -> eyre::Result<&ForkId> {

--- a/crates/evm/core/src/env.rs
+++ b/crates/evm/core/src/env.rs
@@ -518,7 +518,7 @@ impl FromAnyRpcTransaction for TxEnv {
         if let Some(envelope) = tx.as_envelope() {
             Ok(Self::from_recovered_tx(envelope, tx.from()))
         } else {
-            eyre::bail!("cannot convert unknown transaction type to TxEnv")
+            eyre::bail!("cannot convert unknown transaction type to TxEnv");
         }
     }
 }
@@ -553,7 +553,7 @@ impl FromAnyRpcTransaction for TempoTxEnv {
             return Ok(Self { inner: base, fee_token, ..Default::default() });
         }
 
-        eyre::bail!("cannot convert unknown transaction type to TempoTxEnv")
+        eyre::bail!("cannot convert unknown transaction type to TempoTxEnv");
     }
 }
 
@@ -768,7 +768,7 @@ mod optimism {
                 return Ok(Self::from_recovered_tx(&deposit_tx, deposit_tx.from));
             }
 
-            eyre::bail!("cannot convert unknown transaction type to OpTransaction")
+            eyre::bail!("cannot convert unknown transaction type to OpTransaction");
         }
     }
 }

--- a/crates/evm/traces/src/identifier/external.rs
+++ b/crates/evm/traces/src/identifier/external.rs
@@ -107,7 +107,7 @@ impl ExternalIdentifier {
                 let project = etherscan_project(metadata, root_path)?;
                 let output = project.compile()?;
                 if output.has_compiler_errors() {
-                    eyre::bail!("{output}")
+                    eyre::bail!("{output}");
                 }
 
                 Ok((project, output, root))

--- a/crates/forge/src/brutalizer/mod.rs
+++ b/crates/forge/src/brutalizer/mod.rs
@@ -37,7 +37,9 @@ pub fn brutalize_source(path: &Path, source: &str) -> eyre::Result<String> {
 
     let transforms = match result {
         Ok(t) => t,
-        Err(_) => eyre::bail!("failed to parse {}", path.display()),
+        Err(_) => {
+            eyre::bail!("failed to parse {}", path.display());
+        }
     };
 
     Ok(apply_transforms(source, transforms))

--- a/crates/forge/src/cmd/build.rs
+++ b/crates/forge/src/cmd/build.rs
@@ -112,7 +112,7 @@ impl BuildArgs {
                 files.extend(source_files_iter(path, MultiCompilerLanguage::FILE_EXTENSIONS));
             }
             if files.is_empty() {
-                eyre::bail!("No source files found in specified build paths.")
+                eyre::bail!("No source files found in specified build paths.");
             }
         }
 

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -201,7 +201,7 @@ impl CreateArgs {
                 eyre::bail!(
                     "Dynamic linking not supported in `create` command - deploy the following library contracts first, then provide the address to link at compile time\n{}",
                     link_refs
-                )
+                );
             }
         };
 
@@ -437,7 +437,7 @@ impl CreateArgs {
 
         let bin = bin.into_bytes().unwrap_or_default();
         if bin.is_empty() {
-            eyre::bail!("no bytecode found in bin object for {}", self.contract.name)
+            eyre::bail!("no bytecode found in bin object for {}", self.contract.name);
         }
 
         let provider = Arc::new(provider);

--- a/crates/forge/src/cmd/selectors.rs
+++ b/crates/forge/src/cmd/selectors.rs
@@ -107,7 +107,7 @@ impl SelectorsSubcommands {
                 let mut project = project_from_paths(project_paths)?;
                 let output = if let Some(contract_info) = &contract {
                     let Some(contract_name) = contract_info.name() else {
-                        eyre::bail!("No contract name provided.")
+                        eyre::bail!("No contract name provided.");
                     };
 
                     let target_path = contract_info

--- a/crates/forge/src/mutation/mutators/binary_op_mutator.rs
+++ b/crates/forge/src/mutation/mutators/binary_op_mutator.rs
@@ -119,7 +119,9 @@ fn get_bin_op_parts<'a>(
     match &expr.kind {
         ExprKind::Assign(lhs, Some(op), rhs) => Ok((*op, op.span, lhs, rhs, true)),
         ExprKind::Binary(lhs, op, rhs) => Ok((*op, op.span, lhs, rhs, false)),
-        _ => eyre::bail!("BinaryOpMutator: unexpected expression kind"),
+        _ => {
+            eyre::bail!("BinaryOpMutator: unexpected expression kind");
+        }
     }
 }
 

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -84,7 +84,7 @@ fn parse_verification_result(cmd: &mut TestCommand, retries: u32) -> eyre::Resul
         if stderr.contains("Contract successfully verified") {
             return Ok(());
         }
-        eyre::bail!("Failed to get verification, stdout: {stdout}, stderr: {stderr}")
+        eyre::bail!("Failed to get verification, stdout: {stdout}, stderr: {stderr}");
     })
 }
 

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -148,13 +148,13 @@ where
                     Ordering::Greater => {
                         bail!(
                             "EOA nonce changed unexpectedly while sending transactions. Expected {tx_nonce} got {nonce} from provider."
-                        )
+                        );
                     }
                     Ordering::Less => {
                         if attempt == 4 {
                             bail!(
                                 "After 5 attempts, provider nonce ({nonce}) is still behind expected nonce ({tx_nonce})."
-                            )
+                            );
                         }
                         warn!(
                             "Expected nonce ({tx_nonce}) is ahead of provider nonce ({nonce}). Retrying in 1 second..."
@@ -415,7 +415,7 @@ impl<N: Network> SendTransactionsKind<N> {
         match self {
             Self::Unlocked(unlocked) => {
                 if !unlocked.contains(addr) {
-                    bail!("Sender address {:?} is not unlocked", addr)
+                    bail!("Sender address {:?} is not unlocked", addr);
                 }
                 Ok(SendTransactionKind::Unlocked(tx))
             }
@@ -429,7 +429,7 @@ impl<N: Network> SendTransactionsKind<N> {
                 {
                     Ok(SendTransactionKind::Browser(tx, b))
                 } else {
-                    bail!("No matching signer for {:?} found", addr)
+                    bail!("No matching signer for {:?} found", addr);
                 }
             }
         }
@@ -1183,11 +1183,13 @@ impl BundledState<TempoEvmNetwork> {
             // inspector before broadcast, so tx.to() should always be Some here.
             let to = match tx.to() {
                 Some(addr) => TxKind::Call(addr),
-                None => bail!(
-                    "Unexpected raw CREATE in --batch mode at position {} — \
+                None => {
+                    bail!(
+                        "Unexpected raw CREATE in --batch mode at position {} — \
                      this is a bug; CREATEs should have been rewritten by the inspector.",
-                    call_index + 1
-                ),
+                        call_index + 1
+                    );
+                }
             };
             let value = tx.value().unwrap_or(U256::ZERO);
             let input = tx.input().cloned().unwrap_or_default();

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -260,7 +260,7 @@ impl<FEN: FoundryEvmNetwork> PreprocessedState<FEN> {
                 if target_name != id_name {
                     eyre::bail!(
                         "Multiple contracts in the target path. Please specify the contract name with `--tc ContractName`"
-                    )
+                    );
                 }
             }
             target_id = Some(id);

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -320,7 +320,7 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
             if !self.build_data.libraries.is_empty() {
                 eyre::bail!(
                     "Multi chain deployment does not support library linking at the moment."
-                )
+                );
             }
         }
         rpc_data.check_shanghai_support().await?;

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -552,12 +552,16 @@ impl ScriptArgs {
             let matching_functions =
                 abi.functions().filter(|func| func.name == self.sig).collect::<Vec<_>>();
             match matching_functions.len() {
-                0 => eyre::bail!("Function `{}` not found in the ABI", self.sig),
+                0 => {
+                    eyre::bail!("Function `{}` not found in the ABI", self.sig);
+                }
                 1 => matching_functions[0],
-                2.. => eyre::bail!(
-                    "Multiple functions with the same name `{}` found in the ABI",
-                    self.sig
-                ),
+                2.. => {
+                    eyre::bail!(
+                        "Multiple functions with the same name `{}` found in the ABI",
+                        self.sig
+                    );
+                }
             }
         };
         let data = encode_function_args(func, &self.args)?;

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -331,7 +331,9 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                     sh_err!("Failed with `{reason}`:\n")?;
                     (Address::ZERO, raw)
                 }
-                Err(e) => eyre::bail!("Failed deploying contract: {e:?}"),
+                Err(e) => {
+                    eyre::bail!("Failed deploying contract: {e:?}");
+                }
             };
 
             Ok(ScriptResult {

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -212,7 +212,7 @@ impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
         }
 
         if abort {
-            eyre::bail!("Simulated execution failed.")
+            eyre::bail!("Simulated execution failed.");
         }
 
         Ok(final_txs)

--- a/crates/script/src/wallet_session.rs
+++ b/crates/script/src/wallet_session.rs
@@ -213,8 +213,12 @@ impl ScriptArgs {
             Ok(())
         } else {
             match status.code() {
-                Some(code) => eyre::bail!("forge script wallet session exited with code {code}"),
-                None => eyre::bail!("forge script wallet session terminated by a signal"),
+                Some(code) => {
+                    eyre::bail!("forge script wallet session exited with code {code}");
+                }
+                None => {
+                    eyre::bail!("forge script wallet session terminated by a signal");
+                }
             }
         }
     }

--- a/crates/test-utils/src/etherscan.rs
+++ b/crates/test-utils/src/etherscan.rs
@@ -21,7 +21,7 @@ pub async fn fetch_etherscan_source_flattened(
     let address = Address::from_str(address)?;
     let metadata = client.contract_source_code(address).await?;
     let Some(metadata) = metadata.items.first() else {
-        eyre::bail!("Empty contract source code for {address}")
+        eyre::bail!("Empty contract source code for {address}");
     };
 
     let tmp = tempfile::tempdir()?;

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -385,7 +385,9 @@ impl VerifyBytecodeArgs {
             } else {
                 match self.block {
                     Some(BlockId::Number(BlockNumberOrTag::Number(block))) => block,
-                    Some(_) => eyre::bail!("Invalid block number"),
+                    Some(_) => {
+                        eyre::bail!("Invalid block number");
+                    }
                     None => provider.get_block_number().await?,
                 }
             };
@@ -483,7 +485,9 @@ impl VerifyBytecodeArgs {
         let transaction = provider
             .get_transaction_by_hash(creation_data.transaction_hash)
             .await
-            .or_else(|e| eyre::bail!("Couldn't fetch transaction from RPC: {:?}", e))?
+            .or_else(|e| {
+                eyre::bail!("Couldn't fetch transaction from RPC: {:?}", e);
+            })?
             .ok_or_else(|| {
                 eyre::eyre!("Transaction not found for hash {}", creation_data.transaction_hash)
             })?;
@@ -491,7 +495,9 @@ impl VerifyBytecodeArgs {
         let receipt = provider
             .get_transaction_receipt(creation_data.transaction_hash)
             .await
-            .or_else(|e| eyre::bail!("Couldn't fetch transaction receipt from RPC: {:?}", e))?;
+            .or_else(|e| {
+                eyre::bail!("Couldn't fetch transaction receipt from RPC: {:?}", e);
+            })?;
         let receipt = if let Some(receipt) = receipt {
             receipt
         } else {
@@ -619,7 +625,7 @@ impl VerifyBytecodeArgs {
             // Get contract creation block.
             let simulation_block = match self.block {
                 Some(BlockId::Number(BlockNumberOrTag::Number(block))) => block,
-                Some(_) => eyre::bail!("Invalid block number"),
+                Some(_) => { eyre::bail!("Invalid block number"); },
                 None => {
                     creation_block.ok_or_else(|| {
                         eyre::eyre!("Failed to get block number of the contract creation tx, specify using the --block flag")

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -430,7 +430,7 @@ impl EtherscanVerificationProvider {
         } else {
             eyre::bail!(
                 "Fetching of constructor arguments is not supported for contracts created by contracts"
-            )
+            );
         };
 
         let output = context.project.compile_file(&context.target_path)?;
@@ -454,7 +454,7 @@ impl EtherscanVerificationProvider {
             sh_status!("Identified constructor arguments: {constructor_args}")?;
             Ok(constructor_args)
         } else {
-            eyre::bail!("Local bytecode doesn't match on-chain bytecode")
+            eyre::bail!("Local bytecode doesn't match on-chain bytecode");
         }
     }
 }

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -212,10 +212,10 @@ impl VerificationProviderType {
                 eyre::bail!(EtherscanConfigError::UnknownChain(
                     "when using Etherscan verifier".to_string(),
                     chain
-                ))
+                ));
             }
             if !has_key {
-                eyre::bail!("ETHERSCAN_API_KEY must be set to use Etherscan as a verifier")
+                eyre::bail!("ETHERSCAN_API_KEY must be set to use Etherscan as a verifier");
             }
             return Ok(Box::<EtherscanVerificationProvider>::default());
         }
@@ -263,7 +263,7 @@ impl VerificationProviderType {
         // 6. No valid provider.
         eyre::bail!(
             "No valid verification provider specified. Pass the --verifier flag to specify a provider or set the ETHERSCAN_API_KEY environment variable to use Etherscan as a verifier."
-        )
+        );
     }
 
     pub const fn is_sourcify(&self) -> bool {

--- a/crates/verify/src/types.rs
+++ b/crates/verify/src/types.rs
@@ -20,7 +20,9 @@ impl FromStr for VerificationType {
         match s {
             "full" => Ok(Self::Full),
             "partial" => Ok(Self::Partial),
-            _ => eyre::bail!("Invalid verification type"),
+            _ => {
+                eyre::bail!("Invalid verification type");
+            }
         }
     }
 }

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -220,7 +220,9 @@ pub fn maybe_predeploy_contract(
             maybe_predeploy = true;
             Ok((None, maybe_predeploy))
         }
-        Err(e) => eyre::bail!("Error fetching creation data from verifier-url: {:?}", e),
+        Err(e) => {
+            eyre::bail!("Error fetching creation data from verifier-url: {:?}", e);
+        }
     }
 }
 

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -235,7 +235,7 @@ impl VerifierArgs {
                             | VerifierCredentialProbe::Inconclusive,
                         ) => {}
                         Ok(VerifierCredentialProbe::InvalidApiKey) => {
-                            eyre::bail!("verifier credential check failed: invalid API key")
+                            eyre::bail!("verifier credential check failed: invalid API key");
                         }
                     }
                 }
@@ -559,7 +559,7 @@ impl VerifyArgs {
         if self.guess_constructor_args && config.get_rpc_url().is_none() {
             eyre::bail!(
                 "You have to provide a valid RPC URL to use --guess-constructor-args feature"
-            )
+            );
         }
 
         // If chain is not set, we try to get it from the RPC.
@@ -782,14 +782,14 @@ impl VerifyArgs {
                     );
                     eyre::bail!(
                         "Compiler version has to be set in `foundry.toml`. If the project was not deployed with foundry, specify the version through `--compiler-version` flag."
-                    )
+                    );
                 }
 
                 unique_versions.into_iter().next().unwrap().to_owned()
             } else {
                 eyre::bail!(
                     "If cache is disabled, compiler version must be either provided with `--compiler-version` option or set in foundry.toml"
-                )
+                );
             };
 
             let settings = if let Some(profile) = &self.compilation_profile {
@@ -798,7 +798,7 @@ impl VerifyArgs {
                 } else if let Some(settings) = project.additional_settings.get(profile.as_str()) {
                     settings
                 } else {
-                    eyre::bail!("Unknown compilation profile: {}", profile)
+                    eyre::bail!("Unknown compilation profile: {}", profile);
                 }
             } else if let Some((cache, entry)) = cache
                 .as_ref()
@@ -836,7 +836,7 @@ impl VerifyArgs {
                     eyre::bail!(
                         "Ambiguous compilation profiles found in cache: {}, please specify the profile through `--compilation-profile` flag",
                         profiles.iter().join(", ")
-                    )
+                    );
                 }
 
                 let profile = profiles.into_iter().next().unwrap().to_owned();
@@ -846,7 +846,7 @@ impl VerifyArgs {
             } else {
                 eyre::bail!(
                     "If cache is disabled, compilation profile must be provided with `--compilation-profile` option or set in foundry.toml"
-                )
+                );
             };
 
             VerificationContext::new(
@@ -858,7 +858,7 @@ impl VerifyArgs {
             )
         } else {
             if config.get_rpc_url().is_none() {
-                eyre::bail!("You have to provide a contract name or a valid RPC URL")
+                eyre::bail!("You have to provide a contract name or a valid RPC URL");
             }
             let provider = utils::get_provider(&config)?;
             let code = provider.get_code_at(self.address).await?;
@@ -872,7 +872,7 @@ impl VerifyArgs {
                 eyre::bail!(format!(
                     "Bytecode at {} does not match any local contracts",
                     self.address
-                ))
+                ));
             };
 
             let settings = project


### PR DESCRIPTION
Updates `bail!` call sites to avoid expression-position trailing semicolons rejected by the latest nightly Clippy. This preserves existing error behavior while restoring workspace-wide Clippy compatibility.

This PR was written with AI assistance.