### PR TITLE
fix(coverage): anchor else branches

### DIFF
--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -128,6 +128,7 @@ impl<'gcx> SourceVisitor<'gcx> {
                 lines.push(CoverageItem {
                     kind: CoverageItemKind::Line,
                     loc: reference_item.loc.clone(),
+                    anchor_loc: None,
                     hits: 0,
                 });
             }
@@ -141,13 +142,15 @@ impl<'gcx> SourceVisitor<'gcx> {
 
     /// Creates a coverage item for a given kind and source location. Pushes item to the internal
     /// collection (plus additional coverage line if item is a statement).
-    fn push_item_kind(&mut self, kind: CoverageItemKind, span: Span) {
-        let item = CoverageItem { kind, loc: self.source_location_for(span), hits: 0 };
+    fn push_item_kind(&mut self, kind: CoverageItemKind, span: Span) -> &mut CoverageItem {
+        let item =
+            CoverageItem { kind, loc: self.source_location_for(span), anchor_loc: None, hits: 0 };
 
         debug_assert!(!matches!(item.kind, CoverageItemKind::Line));
         self.all_lines.push(item.loc.lines.start);
 
         self.items.push(item);
+        self.items.last_mut().unwrap()
     }
 
     fn source_location_for(&self, mut span: Span) -> SourceLocation {
@@ -259,18 +262,15 @@ impl<'ast> ast::Visit<'ast> for SourceVisitor<'_> {
                         CoverageItemKind::Branch { branch_id, path_id: 0, is_first_opcode: true },
                         then_stmt.span,
                     );
-                    if else_stmt.is_some() {
-                        // We use `stmt.span`, which includes `else_stmt.span`, since we need to
-                        // include the condition so that this can be marked as covered.
-                        // Initially implemented in https://github.com/foundry-rs/foundry/pull/3094.
+                    if let Some(else_stmt) = else_stmt {
+                        let is_first_opcode = stmt_has_statements(else_stmt);
+                        let anchor_loc =
+                            is_first_opcode.then(|| self.source_location_for(else_stmt.span));
                         self.push_item_kind(
-                            CoverageItemKind::Branch {
-                                branch_id,
-                                path_id: 1,
-                                is_first_opcode: false,
-                            },
+                            CoverageItemKind::Branch { branch_id, path_id: 1, is_first_opcode },
                             stmt.span,
-                        );
+                        )
+                        .anchor_loc = anchor_loc;
                     }
                 }
             }

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -22,6 +22,19 @@ pub fn find_anchors(
         .filter_map(|(item_id, item)| {
             let anchor_loc = item.anchor_loc.as_ref().unwrap_or(&item.loc);
             match item.kind {
+                CoverageItemKind::Branch { path_id, is_first_opcode: true, .. }
+                    if item.anchor_loc.is_some() =>
+                {
+                    find_anchor_simple(source_map, ic_pc_map, item_id, anchor_loc).or_else(|_| {
+                        find_anchor_branch(bytecode, source_map, item_id, &item.loc).map(
+                            |anchors| match path_id {
+                                0 => anchors.0,
+                                1 => anchors.1,
+                                _ => panic!("too many path IDs for branch"),
+                            },
+                        )
+                    })
+                }
                 CoverageItemKind::Branch { path_id, is_first_opcode: false, .. } => {
                     find_anchor_branch(bytecode, source_map, item_id, anchor_loc).map(|anchors| {
                         match path_id {

--- a/crates/evm/coverage/src/anchors.rs
+++ b/crates/evm/coverage/src/anchors.rs
@@ -20,9 +20,10 @@ pub fn find_anchors(
         .filter(|&source| seen_sources.insert(source))
         .flat_map(|source| analysis.items_for_source_enumerated(source))
         .filter_map(|(item_id, item)| {
+            let anchor_loc = item.anchor_loc.as_ref().unwrap_or(&item.loc);
             match item.kind {
                 CoverageItemKind::Branch { path_id, is_first_opcode: false, .. } => {
-                    find_anchor_branch(bytecode, source_map, item_id, &item.loc).map(|anchors| {
+                    find_anchor_branch(bytecode, source_map, item_id, anchor_loc).map(|anchors| {
                         match path_id {
                             0 => anchors.0,
                             1 => anchors.1,
@@ -30,7 +31,7 @@ pub fn find_anchors(
                         }
                     })
                 }
-                _ => find_anchor_simple(source_map, ic_pc_map, item_id, &item.loc),
+                _ => find_anchor_simple(source_map, ic_pc_map, item_id, anchor_loc),
             }
             .inspect_err(|err| warn!(%item, %err, "could not find anchor"))
             .ok()

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -399,6 +399,8 @@ pub struct CoverageItem {
     pub kind: CoverageItemKind,
     /// The location of the item in the source code.
     pub loc: SourceLocation,
+    /// An alternative source location used only to find the item's bytecode anchor.
+    pub anchor_loc: Option<SourceLocation>,
     /// The number of times this item was hit.
     pub hits: u32,
 }

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1611,6 +1611,89 @@ contract AContractTest is DSTest {
 "#]]);
 });
 
+// https://github.com/foundry-rs/foundry/issues/10792
+forgetest!(branch_with_storage_bytes_reads, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract AContract {
+    bytes public optA = bytes("optA");
+    bytes public optB = bytes("optB");
+
+    function execute(uint16 value) external view {
+        bytes memory element;
+        if (value == 4) {
+            element = optA;
+        } else {
+            element = optB;
+        }
+    }
+}
+    "#,
+    );
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import {AContract} from "./AContract.sol";
+
+contract AContractTest is DSTest {
+    AContract a = new AContract();
+
+    function testTrueCoverage() external view {
+        a.execute(4);
+    }
+
+    function testFalseCoverage() external view {
+        a.execute(5);
+    }
+}
+    "#,
+    );
+
+    cmd.arg("coverage").args(["--mt", "testTrueCoverage"]).assert_success().stdout_eq(str![[r#"
+...
+╭-------------------+--------------+--------------+--------------+---------------╮
+| File              | % Lines      | % Statements | % Branches   | % Funcs       |
++================================================================================+
+| src/AContract.sol | 80.00% (4/5) | 75.00% (3/4) | 50.00% (1/2) | 100.00% (1/1) |
+|-------------------+--------------+--------------+--------------+---------------|
+| Total             | 80.00% (4/5) | 75.00% (3/4) | 50.00% (1/2) | 100.00% (1/1) |
+╰-------------------+--------------+--------------+--------------+---------------╯
+
+"#]]);
+
+    cmd.forge_fuse()
+        .arg("coverage")
+        .args(["--mt", "testFalseCoverage"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+...
+╭-------------------+--------------+--------------+--------------+---------------╮
+| File              | % Lines      | % Statements | % Branches   | % Funcs       |
++================================================================================+
+| src/AContract.sol | 80.00% (4/5) | 75.00% (3/4) | 50.00% (1/2) | 100.00% (1/1) |
+|-------------------+--------------+--------------+--------------+---------------|
+| Total             | 80.00% (4/5) | 75.00% (3/4) | 50.00% (1/2) | 100.00% (1/1) |
+╰-------------------+--------------+--------------+--------------+---------------╯
+
+"#]]);
+
+    cmd.forge_fuse().arg("coverage").assert_success().stdout_eq(str![[r#"
+...
+╭-------------------+---------------+---------------+---------------+---------------╮
+| File              | % Lines       | % Statements  | % Branches    | % Funcs       |
++===================================================================================+
+| src/AContract.sol | 100.00% (5/5) | 100.00% (4/4) | 100.00% (2/2) | 100.00% (1/1) |
+|-------------------+---------------+---------------+---------------+---------------|
+| Total             | 100.00% (5/5) | 100.00% (4/4) | 100.00% (2/2) | 100.00% (1/1) |
+╰-------------------+---------------+---------------+---------------+---------------╯
+
+"#]]);
+});
+
 forgetest!(identical_bytecodes, |prj, cmd| {
     prj.insert_ds_test();
     prj.add_source(

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1694,6 +1694,55 @@ contract AContractTest is DSTest {
 "#]]);
 });
 
+forgetest!(branch_with_code_free_else, |prj, cmd| {
+    prj.insert_ds_test();
+    prj.add_source(
+        "AContract.sol",
+        r#"
+contract AContract {
+    uint256 public value;
+
+    function execute(bool condition) external {
+        if (condition) {
+            value = 1;
+        } else {
+            uint256 unused;
+        }
+    }
+}
+    "#,
+    );
+
+    prj.add_source(
+        "AContractTest.sol",
+        r#"
+import "./test.sol";
+import {AContract} from "./AContract.sol";
+
+contract AContractTest is DSTest {
+    AContract a = new AContract();
+
+    function testCoverage() external {
+        a.execute(true);
+        a.execute(false);
+    }
+}
+    "#,
+    );
+
+    cmd.arg("coverage").assert_success().stdout_eq(str![[r#"
+...
+╭-------------------+--------------+--------------+---------------+---------------╮
+| File              | % Lines      | % Statements | % Branches    | % Funcs       |
++=================================================================================+
+| src/AContract.sol | 75.00% (3/4) | 50.00% (1/2) | 100.00% (2/2) | 100.00% (1/1) |
+|-------------------+--------------+--------------+---------------+---------------|
+| Total             | 75.00% (3/4) | 50.00% (1/2) | 100.00% (2/2) | 100.00% (1/1) |
+╰-------------------+--------------+--------------+---------------+---------------╯
+
+"#]]);
+});
+
 forgetest!(identical_bytecodes, |prj, cmd| {
     prj.insert_ds_test();
     prj.add_source(


### PR DESCRIPTION
Fixes #10792 by anchoring non-empty `else` branches to their first executable opcode. This prevents compiler-generated jumps from storage `bytes` reads from causing incorrect branch coverage while preserving existing reporting locations and empty-branch behavior.