### PR TITLE
fix(script): reject mismatched sequence caches

### DIFF
--- a/crates/script-sequence/src/sequence.rs
+++ b/crates/script-sequence/src/sequence.rs
@@ -104,7 +104,7 @@ impl<N: Network> ScriptSequence<N> {
         )
         .wrap_err(format!("Deployment's sensitive details not found for chain `{chain_id}`."))?;
 
-        script_sequence.fill_sensitive(&sensitive_script_sequence);
+        script_sequence.fill_sensitive(&sensitive_script_sequence)?;
 
         script_sequence.paths = Some((path, sensitive_path));
 
@@ -233,11 +233,21 @@ impl<N: Network> ScriptSequence<N> {
         self.transactions.iter().map(|tx| tx.tx())
     }
 
-    pub fn fill_sensitive(&mut self, sensitive: &SensitiveScriptSequence) {
+    pub fn fill_sensitive(&mut self, sensitive: &SensitiveScriptSequence) -> Result<()> {
+        if self.transactions.len() != sensitive.transactions.len() {
+            eyre::bail!(
+                "Transaction count mismatch between deployment sequence ({}) and sensitive cache ({})",
+                self.transactions.len(),
+                sensitive.transactions.len()
+            );
+        }
+
         self.transactions
             .iter_mut()
-            .enumerate()
-            .for_each(|(i, tx)| tx.rpc.clone_from(&sensitive.transactions[i].rpc));
+            .zip(&sensitive.transactions)
+            .for_each(|(tx, sensitive_tx)| tx.rpc.clone_from(&sensitive_tx.rpc));
+
+        Ok(())
     }
 }
 
@@ -269,6 +279,11 @@ pub fn now() -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_network::Ethereum;
+
+    fn transaction() -> TransactionWithMetadata<Ethereum> {
+        TransactionWithMetadata::from_tx_request(TransactionMaybeSigned::new(Default::default()))
+    }
 
     #[test]
     fn can_convert_sig() {
@@ -295,5 +310,21 @@ mod tests {
         assert_eq!(sig_to_file_name("0xnotahex").as_str(), "0xnotahex");
         // non-hex non-signature: should return input as-is
         assert_eq!(sig_to_file_name("not_a_sig_or_hex").as_str(), "not_a_sig_or_hex");
+    }
+
+    #[test]
+    fn rejects_mismatched_sensitive_transactions() {
+        let mut sequence = ScriptSequence::<Ethereum> {
+            transactions: VecDeque::from([transaction()]),
+            ..Default::default()
+        };
+        let sensitive = SensitiveScriptSequence::default();
+
+        let err = sequence.fill_sensitive(&sensitive).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Transaction count mismatch between deployment sequence (1) and sensitive cache (0)"
+        );
     }
 }

--- a/crates/script/src/multi_sequence.rs
+++ b/crates/script/src/multi_sequence.rs
@@ -104,14 +104,26 @@ impl<N: Network> MultiChainSequence<N> {
             foundry_compilers::utils::read_json_file(&sensitive_path)
                 .wrap_err("Multi-chain deployment sensitive details not found.")?;
 
-        sequence.deployments.iter_mut().enumerate().for_each(|(i, sequence)| {
-            sequence.fill_sensitive(&sensitive_sequence.deployments[i]);
-        });
+        sequence.fill_sensitive(&sensitive_sequence)?;
 
         sequence.path = path;
         sequence.sensitive_path = sensitive_path;
 
         Ok(sequence)
+    }
+
+    fn fill_sensitive(&mut self, sensitive: &SensitiveMultiChainSequence) -> Result<()> {
+        if self.deployments.len() != sensitive.deployments.len() {
+            eyre::bail!(
+                "Deployment count mismatch between multi-chain sequence ({}) and sensitive cache ({})",
+                self.deployments.len(),
+                sensitive.deployments.len()
+            );
+        }
+
+        self.deployments.iter_mut().zip(&sensitive.deployments).try_for_each(
+            |(sequence, sensitive_sequence)| sequence.fill_sensitive(sensitive_sequence),
+        )
     }
 
     /// Saves the transactions as file if it's a standalone deployment.
@@ -166,5 +178,27 @@ impl<N: Network> MultiChainSequence<N> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_network::Ethereum;
+
+    #[test]
+    fn rejects_mismatched_sensitive_deployments() {
+        let mut sequence = MultiChainSequence::<Ethereum> {
+            deployments: vec![ScriptSequence::default()],
+            ..Default::default()
+        };
+        let sensitive = SensitiveMultiChainSequence::default();
+
+        let err = sequence.fill_sensitive(&sensitive).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Deployment count mismatch between multi-chain sequence (1) and sensitive cache (0)"
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Script sequence restoration assumed that the public deployment file and sensitive cache always contained the same number of transactions. Multi-chain restoration made the same assumption about deployments. Partially written, corrupted, or manually edited cache files could therefore trigger an out-of-bounds panic.



## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This validates both counts before restoring sensitive RPC data and uses zipped iteration after validation. Mismatched cache files now produce a descriptive error without partially updating the sequence.

Partially addresses #15779.


## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
