### PR TITLE
feat(cast): accept mktx signatures

### DIFF
--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -69,7 +69,12 @@ pub struct MakeTxArgs {
     ethsign: bool,
 
     /// Generate a raw signed transaction using the provided 65-byte signature.
-    #[arg(long, value_name = "SIGNATURE", conflicts_with_all = ["raw_unsigned", "ethsign"])]
+    #[arg(
+        long,
+        value_name = "SIGNATURE",
+        requires = "from",
+        conflicts_with_all = ["raw_unsigned", "ethsign"]
+    )]
     signature: Option<Signature>,
 }
 
@@ -231,18 +236,8 @@ impl MakeTxArgs {
         }
 
         if let Some(signature) = signature {
-            if eth.wallet.from.is_none() && tx.nonce.is_none() {
-                eyre::bail!(
-                    "Missing required parameters for signed transaction. When --from is not provided, you must specify: --nonce"
-                );
-            }
-            if tempo_sponsor.is_some() && eth.wallet.from.is_none() {
-                eyre::bail!(
-                    "--tempo.sponsor requires --from for --signature because the sponsor digest commits to the sender"
-                );
-            }
-
-            let from = eth.wallet.from.unwrap_or(Address::ZERO);
+            let signature = signature.normalized_s();
+            let from = eth.wallet.from.expect("required by clap");
             let (mut tx, _) = tx_builder.build(from).await?;
             maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
             if let Some(sponsor) = &tempo_sponsor {
@@ -268,9 +263,7 @@ impl MakeTxArgs {
 
             let tx = tx.build_unsigned()?;
             let recovered = signature.recover_address_from_prehash(&tx.signature_hash())?;
-            if let Some(from) = eth.wallet.from
-                && recovered != from
-            {
+            if recovered != from {
                 eyre::bail!(
                     "The provided signature recovers to {recovered}, which does not match the specified sender {from}"
                 );

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -67,6 +67,10 @@ pub struct MakeTxArgs {
     /// Call `eth_signTransaction` using the `--from` argument or $ETH_FROM as sender
     #[arg(long, requires = "from", conflicts_with = "raw_unsigned")]
     ethsign: bool,
+
+    /// Generate a raw signed transaction using the provided 65-byte signature.
+    #[arg(long, value_name = "SIGNATURE", conflicts_with_all = ["raw_unsigned", "ethsign"])]
+    signature: Option<Signature>,
 }
 
 #[derive(Debug, Parser)]
@@ -101,8 +105,18 @@ impl MakeTxArgs {
         N::UnsignedTx: SignableTransaction<Signature>,
         N::TransactionRequest: FoundryTransactionBuilder<N>,
     {
-        let Self { to, mut sig, mut args, command, mut tx, path, eth, raw_unsigned, ethsign } =
-            self;
+        let Self {
+            to,
+            mut sig,
+            mut args,
+            command,
+            mut tx,
+            path,
+            eth,
+            raw_unsigned,
+            ethsign,
+            signature,
+        } = self;
 
         let print_sponsor_hash = tx.tempo.print_sponsor_hash;
         let sponsor_fee_payer = tx.tempo.sponsor;
@@ -213,6 +227,57 @@ impl MakeTxArgs {
             let raw_tx = hex::encode_prefixed(tx.build_unsigned()?.encoded_for_signing());
 
             print_scalar(raw_tx)?;
+            return Ok(());
+        }
+
+        if let Some(signature) = signature {
+            if eth.wallet.from.is_none() && tx.nonce.is_none() {
+                eyre::bail!(
+                    "Missing required parameters for signed transaction. When --from is not provided, you must specify: --nonce"
+                );
+            }
+            if tempo_sponsor.is_some() && eth.wallet.from.is_none() {
+                eyre::bail!(
+                    "--tempo.sponsor requires --from for --signature because the sponsor digest commits to the sender"
+                );
+            }
+
+            let from = eth.wallet.from.unwrap_or(Address::ZERO);
+            let (mut tx, _) = tx_builder.build(from).await?;
+            maybe_print_resolved_lane(resolved_lane.as_ref(), tx.nonce().unwrap_or_default())?;
+            if let Some(sponsor) = &tempo_sponsor {
+                sponsor
+                    .resolve_and_set_fee_token(
+                        (!config.eth_rpc_curl).then_some(&provider),
+                        Some(chain),
+                        &mut tx,
+                    )
+                    .await?;
+                sponsor.attach_and_print::<N>(&mut tx, from).await?;
+            } else {
+                let fee_token = resolve_and_set_fee_token(
+                    (!config.eth_rpc_curl).then_some(&provider),
+                    Some(chain),
+                    &mut tx,
+                    Some(from),
+                )
+                .await?;
+                maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token)
+                    .await?;
+            }
+
+            let tx = tx.build_unsigned()?;
+            let recovered = signature.recover_address_from_prehash(&tx.signature_hash())?;
+            if let Some(from) = eth.wallet.from
+                && recovered != from
+            {
+                eyre::bail!(
+                    "The provided signature recovers to {recovered}, which does not match the specified sender {from}"
+                );
+            }
+
+            let tx = N::TxEnvelope::from(tx.into_signed(signature));
+            print_scalar(hex::encode_prefixed(tx.encoded_2718()))?;
             return Ok(());
         }
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2298,6 +2298,60 @@ casttest!(mktx, |_prj, cmd| {
 "#]]);
 });
 
+casttest!(mktx_signature, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--signature",
+        "0x70d55e79ed3ac9fc8f51e78eb91fd054720d943d66633f2eb1bc960f0126b0ec52eda05a792680de3181e49bab4093541f75b49d1ecbe443077b3660c836016a01",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--value",
+        "100",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+0x02f86b0180843b9aca008502540be4008252089400000000000000000000000000000000000000016480c001a070d55e79ed3ac9fc8f51e78eb91fd054720d943d66633f2eb1bc960f0126b0eca052eda05a792680de3181e49bab4093541f75b49d1ecbe443077b3660c836016a
+
+"#]]);
+});
+
+casttest!(mktx_signature_from_mismatch, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--signature",
+        "0x70d55e79ed3ac9fc8f51e78eb91fd054720d943d66633f2eb1bc960f0126b0ec52eda05a792680de3181e49bab4093541f75b49d1ecbe443077b3660c836016a01",
+        "--from",
+        "0x0000000000000000000000000000000000000001",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--value",
+        "100",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+Error: The provided signature recovers to 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf, which does not match the specified sender 0x0000000000000000000000000000000000000001
+
+"#]]);
+});
+
 // ensure recipient or code is required
 casttest!(mktx_requires_to, |_prj, cmd| {
     cmd.args([

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2303,6 +2303,55 @@ casttest!(mktx_signature, |_prj, cmd| {
         "mktx",
         "--signature",
         "0x70d55e79ed3ac9fc8f51e78eb91fd054720d943d66633f2eb1bc960f0126b0ec52eda05a792680de3181e49bab4093541f75b49d1ecbe443077b3660c836016a01",
+        "--from",
+        "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+        "--chain",
+        "1",
+        "--nonce",
+        "0",
+        "--value",
+        "100",
+        "--gas-limit",
+        "21000",
+        "--gas-price",
+        "10000000000",
+        "--priority-gas-price",
+        "1000000000",
+        "0x0000000000000000000000000000000000000001",
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"
+0x02f86b0180843b9aca008502540be4008252089400000000000000000000000000000000000000016480c001a070d55e79ed3ac9fc8f51e78eb91fd054720d943d66633f2eb1bc960f0126b0eca052eda05a792680de3181e49bab4093541f75b49d1ecbe443077b3660c836016a
+
+"#]]);
+});
+
+casttest!(mktx_signature_requires_from, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--signature",
+        "0x70d55e79ed3ac9fc8f51e78eb91fd054720d943d66633f2eb1bc960f0126b0ec52eda05a792680de3181e49bab4093541f75b49d1ecbe443077b3660c836016a01",
+        "0x0000000000000000000000000000000000000001",
+    ])
+    .assert_failure()
+    .stderr_eq(str![[r#"
+error: the following required arguments were not provided:
+  --from <ADDRESS>
+
+Usage: cast mktx --from <ADDRESS> --signature <SIGNATURE> <TO> [SIG] [ARGS]...
+
+For more information, try '--help'.
+
+"#]]);
+});
+
+casttest!(mktx_signature_normalizes_high_s, |_prj, cmd| {
+    cmd.args([
+        "mktx",
+        "--signature",
+        "0x70d55e79ed3ac9fc8f51e78eb91fd054720d943d66633f2eb1bc960f0126b0ecad125fa586d97f21ce7e1b6454bf6caa9b392849907cbbf8b857282c08003fd700",
+        "--from",
+        "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
         "--chain",
         "1",
         "--nonce",


### PR DESCRIPTION
Adds `--signature` to `cast mktx` so an externally produced 65-byte signature can be attached to a fully resolved transaction and encoded as a signed EIP-2718 envelope. The command recovers the signer from the final signing hash and rejects an explicit `--from` that does not match, while preserving existing fee-token and sponsor resolution.

Closes #10167.

This PR was written with Codex, which generated the implementation and tests under my direction.
