### PR TITLE
feat(script): add sender nonce override

### DIFF
--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2661,17 +2661,34 @@ forgetest_async!(should_set_correct_sender_nonce_via_cli, |prj, cmd| {
 });
 
 forgetest_async!(should_override_sender_nonce_via_cli, |prj, cmd| {
-    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let (_api, handle) =
+        spawn(NodeConfig::test().with_disable_default_create2_deployer(true)).await;
 
     foundry_test_utils::util::initialize(prj.root());
     prj.add_script(
         "MyScript.s.sol",
         r#"
-        import {Script, console} from "forge-std/Script.sol";
+        import {Script} from "forge-std/Script.sol";
+
+        library Lib {
+            function value() public pure returns (uint256) {
+                return 42;
+            }
+        }
+
+        contract UsesLib {
+            uint256 public immutable value;
+
+            constructor() {
+                value = Lib.value();
+            }
+        }
 
         contract MyScript is Script {
-            function run() public view {
-                console.log("sender nonce", vm.getNonce(msg.sender));
+            function run() public {
+                vm.startBroadcast();
+                new UsesLib();
+                vm.stopBroadcast();
             }
         }
         "#,
@@ -2690,9 +2707,31 @@ forgetest_async!(should_override_sender_nonce_via_cli, |prj, cmd| {
     .assert_success()
     .stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
-...
-== Logs ==
-  sender nonce 7
+Compiler run successful!
+Script ran successfully.
+
+## Setting up 1 EVM.
+
+==========================
+
+Chain 31337
+
+[ESTIMATED_MAX_FEE_PER_GAS]
+[ESTIMATED_BASE_FEE_PER_GAS]
+[ESTIMATED_PRIORITY_FEE_PER_GAS]
+
+[ESTIMATED_TOTAL_GAS_USED]
+
+[ESTIMATED_AMOUNT_REQUIRED]
+
+==========================
+
+SIMULATION COMPLETE. To broadcast these transactions, add --broadcast and wallet configuration(s) to the previous command. See forge script --help for more.
+
+[SAVED_TRANSACTIONS]
+
+[SAVED_SENSITIVE_VALUES]
+
 
 "#]]);
 });

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2660,6 +2660,43 @@ forgetest_async!(should_set_correct_sender_nonce_via_cli, |prj, cmd| {
   sender nonce 1124703[..]"#]]);
 });
 
+forgetest_async!(should_override_sender_nonce_via_cli, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_script(
+        "MyScript.s.sol",
+        r#"
+        import {Script, console} from "forge-std/Script.sol";
+
+        contract MyScript is Script {
+            function run() public view {
+                console.log("sender nonce", vm.getNonce(msg.sender));
+            }
+        }
+        "#,
+    );
+
+    cmd.args([
+        "script",
+        "MyScript",
+        "--sender",
+        "0x1000000000000000000000000000000000000000",
+        "--sender-nonce",
+        "7",
+        "--rpc-url",
+        &handle.http_endpoint(),
+    ])
+    .assert_success()
+    .stdout_eq(str![[r#"[COMPILING_FILES] with [SOLC_VERSION]
+[SOLC_VERSION] [ELAPSED]
+...
+== Logs ==
+  sender nonce 7
+
+"#]]);
+});
+
 forgetest_async!(dryrun_without_broadcast, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
 

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -166,6 +166,10 @@ pub struct ScriptArgs {
     #[arg(long, short, default_value = "130")]
     pub gas_estimate_multiplier: u64,
 
+    /// Override the sender's initial nonce for script execution and transaction generation.
+    #[arg(long, value_name = "NONCE")]
+    pub sender_nonce: Option<u64>,
+
     /// Send via `eth_sendTransaction` using the `--sender` argument as sender.
     #[arg(
         long,
@@ -321,7 +325,8 @@ impl ScriptArgs {
 
         tempo.resolve_expires();
 
-        let script_config = ScriptConfig::new(config, evm_opts, args.batch, tempo).await?;
+        let script_config =
+            ScriptConfig::new(config, evm_opts, args.batch, tempo, args.sender_nonce).await?;
         Ok(PreprocessedState { args, script_config, script_wallets, browser_wallet })
     }
 
@@ -778,6 +783,7 @@ pub struct ScriptConfig<FEN: FoundryEvmNetwork> {
     pub config: Config,
     pub evm_opts: EvmOpts,
     pub sender_nonce: u64,
+    sender_nonce_override: Option<u64>,
     /// Maps a rpc url to a backend
     pub backends: HashMap<String, Backend<FEN>>,
     /// Whether to batch all broadcast transactions into a single Tempo batch transaction.
@@ -792,19 +798,32 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         evm_opts: EvmOpts,
         batch: bool,
         tempo: TempoOpts,
+        sender_nonce_override: Option<u64>,
     ) -> Result<Self> {
-        let sender_nonce = if let Some(fork_url) = evm_opts.fork_url.as_ref() {
+        let sender_nonce = if let Some(sender_nonce) = sender_nonce_override {
+            sender_nonce
+        } else if let Some(fork_url) = evm_opts.fork_url.as_ref() {
             next_nonce(evm_opts.sender, fork_url, evm_opts.fork_block_number).await?
         } else {
             // dapptools compatibility
             1
         };
 
-        Ok(Self { config, evm_opts, sender_nonce, backends: HashMap::default(), batch, tempo })
+        Ok(Self {
+            config,
+            evm_opts,
+            sender_nonce,
+            sender_nonce_override,
+            backends: HashMap::default(),
+            batch,
+            tempo,
+        })
     }
 
     pub async fn update_sender(&mut self, sender: Address) -> Result<()> {
-        self.sender_nonce = if let Some(fork_url) = self.evm_opts.fork_url.as_ref() {
+        self.sender_nonce = if let Some(sender_nonce) = self.sender_nonce_override {
+            sender_nonce
+        } else if let Some(fork_url) = self.evm_opts.fork_url.as_ref() {
             next_nonce(sender, fork_url, None).await?
         } else {
             // dapptools compatibility

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -924,8 +924,15 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         // (e.g. script deployment, setUp) use the correct fee token for Tempo networks.
         tx_env.set_fee_token(self.tempo.fee_token);
 
-        Ok(ScriptRunner::new(builder.build(evm_env, tx_env, db), self.evm_opts.clone())
-            .with_debug_bytecodes(debug))
+        let mut runner =
+            ScriptRunner::new(builder.build(evm_env, tx_env, db), self.evm_opts.clone())
+                .with_debug_bytecodes(debug);
+
+        if self.sender_nonce_override.is_some() {
+            runner.executor.set_nonce(self.evm_opts.sender, self.sender_nonce)?;
+        }
+
+        Ok(runner)
     }
 }
 


### PR DESCRIPTION
Adds `--sender-nonce` to `forge script` so callers can override the sender nonce used for library linking, script execution, and generated transactions. The override remains authoritative if Forge discovers a different broadcast sender and reruns linking, preventing RPC nonce lookup from silently changing the requested deployment addresses.

Closes #7248.

This PR was written with Codex, which generated the implementation and tests under my direction.
