### PR TITLE
fix(anvil): handle `eth_simulateV1` calls without `to` as contract creation

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5181,10 +5181,16 @@ impl Backend<FoundryNetwork> {
                     // create the transaction from a request
                     let from = request.from.unwrap_or_default();
 
-                    let mut request = Into::<FoundryTransactionRequest>::into(WithOtherFields::new(request));
+                    let mut request =
+                        Into::<FoundryTransactionRequest>::into(WithOtherFields::new(request));
+                    if request.as_ref().to.is_none() {
+                        request.as_mut().to = Some(TxKind::Create);
+                    }
                     request.prep_for_submission();
 
-                    let typed_tx = request.build_unsigned().map_err(|e| BlockchainError::InvalidTransactionRequest(e.to_string()))?;
+                    let typed_tx = request.build_unsigned().map_err(|e| {
+                        BlockchainError::InvalidTransactionRequest(e.to_string())
+                    })?;
 
                     let tx = build_impersonated(typed_tx);
                     let tx_hash = tx.hash();
@@ -5197,7 +5203,11 @@ impl Backend<FoundryNetwork> {
                     );
                     transactions.push(rpc_tx);
 
-                    let return_data = result.output().cloned().unwrap_or_default();
+                    let return_data = if result.is_success() {
+                        result.output().cloned().unwrap_or_default()
+                    } else {
+                        Bytes::new()
+                    };
                     let sim_res = SimCallResult {
                         return_data,
                         gas_used: result.tx_gas_used(),
@@ -5205,6 +5215,17 @@ impl Backend<FoundryNetwork> {
                         status: result.is_success(),
                         error: match &result {
                             ExecutionResult::Success { .. } => None,
+                            ExecutionResult::Revert { output, .. } => {
+                                let message = RevertDecoder::new()
+                                    .maybe_decode(output, None)
+                                    .map(|reason| format!("execution reverted: {reason}"))
+                                    .unwrap_or_else(|| "execution reverted".to_string());
+                                Some(SimulateError {
+                                    code: SimulateError::EXECUTION_REVERTED_CODE,
+                                    message,
+                                    data: Some(output.clone()),
+                                })
+                            }
                             ExecutionResult::Halt {
                                 reason: HaltReason::OutOfGas(_), ..
                             } => Some(SimulateError {

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -10,6 +10,7 @@ use alloy_rpc_types::{
 };
 use anvil::{EthereumHardfork, NodeConfig, spawn};
 use foundry_test_utils::rpc;
+use serde_json::{Value, json};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_simulate_v1() {
@@ -181,4 +182,66 @@ async fn test_simulate_tracks_amsterdam_gas_dimensions_separately() {
     let cumulative_gas_used = block.calls.iter().map(|call| call.gas_used).sum::<u64>();
     assert!(cumulative_gas_used > gas_limit);
     assert!(block.inner.header.gas_used <= gas_limit);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_create_calls_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {},
+                {
+                    "calls": [
+                        {},
+                        {"from": "0xc000000000000000000000000000000000000000"},
+                        {"input": "0x602a5f526001601ff3"},
+                        {"input": "0x63deadbeef5f526004601cfd"}
+                    ]
+                }
+            ],
+            "returnFullTransactions": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"][0]["calls"], json!([]));
+    assert_eq!(response["result"][0]["transactions"], json!([]));
+
+    let block = &response["result"][1];
+    let calls = block["calls"].as_array().unwrap();
+    assert_eq!(calls.len(), 4);
+    assert_eq!(calls[0]["status"], "0x1");
+    assert_eq!(calls[0]["returnData"], "0x");
+    assert_eq!(calls[1]["status"], "0x1");
+    assert_eq!(calls[1]["returnData"], "0x");
+    assert_eq!(calls[2]["status"], "0x1");
+    assert_eq!(calls[2]["returnData"], "0x2a");
+    assert_eq!(calls[3]["status"], "0x0");
+    assert_eq!(calls[3]["returnData"], "0x");
+    assert_eq!(calls[3]["error"]["code"], 3);
+    assert_eq!(calls[3]["error"]["data"], "0xdeadbeef");
+
+    let transactions = block["transactions"].as_array().unwrap();
+    assert_eq!(transactions.len(), 4);
+    assert!(transactions.iter().all(|transaction| transaction["to"].is_null()));
+}
+
+async fn rpc_request(endpoint: &str, method: &str, params: Value) -> Value {
+    let response = reqwest::Client::new()
+        .post(endpoint)
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": method,
+            "params": params,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    response.json().await.unwrap()
 }


### PR DESCRIPTION
## Motivation

Close OSS-562.

This treats `eth_simulateV1` calls without `to` as contract creation, allowing empty and from-only calls to produce returned transactions. Successful creation output is preserved, while reverts expose their bytes through the simulation error response.

Omitted-nonce progression remains tracked by OSS-561. Canonical returned transaction metadata, including chain ID, and exact revert-message conformance remain tracked by OSS-565.