### PR TITLE
fix(forge): reject invalid coverage modes

### DIFF
--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -40,6 +40,12 @@ foundry_config::impl_figment_convert!(CoverageArgs, test);
 /// option in `foundry.toml`. CLI flags take precedence over config; the helper
 /// `resolve_with` merges them after the config is loaded.
 #[derive(Parser)]
+#[command(after_long_help = r#"Compatibility:
+  `forge coverage` supports test filters and `--watch`, but not test-only output or
+  execution modes such as `--json`, `--junit`, `--list`, `--debug`, flame profiles,
+  symbolic artifact replay, showmap replay, brutalization, or mutation testing. Use
+  `--report lcov` for interoperable coverage data or `--report attribution` for
+  Foundry's per-test JSON attribution report."#)]
 pub struct CoverageArgs {
     /// The report type to use for coverage.
     ///
@@ -121,7 +127,13 @@ impl CoverageArgs {
         usize::from(has_lcov) + usize::from(has_attribution)
     }
 
+    pub(crate) fn ensure_mode_compatible(&self) -> Result<()> {
+        self.test.ensure_coverage_mode_compatible()
+    }
+
     pub async fn run(mut self) -> Result<()> {
+        self.ensure_mode_compatible()?;
+
         let (mut config, evm_opts) = self.load_config_and_evm_opts()?;
 
         // install missing dependencies
@@ -140,7 +152,6 @@ impl CoverageArgs {
         // Merge CLI args with `[profile.<name>.coverage]` config values. CLI
         // flags take precedence; unset CLI flags fall back to the config.
         self.resolve_with(&config.coverage);
-        self.test.ensure_mutation_mode_compatible(true)?;
 
         let (paths, mut output) = {
             let (project, output) = self.build(&config)?;

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1174,6 +1174,52 @@ impl TestArgs {
         Ok(())
     }
 
+    pub(crate) fn ensure_coverage_mode_compatible(&self) -> Result<()> {
+        self.ensure_mutation_mode_compatible(true)?;
+
+        let mut conflicts = Vec::new();
+        if shell::is_json() {
+            conflicts.push("--json");
+        }
+        if self.junit {
+            conflicts.push("--junit");
+        }
+        if self.list {
+            conflicts.push("--list");
+        }
+        if self.debug {
+            conflicts.push("--debug");
+        }
+        if self.flamegraph {
+            conflicts.push("--flamegraph");
+        }
+        if self.flamechart {
+            conflicts.push("--flamechart");
+        }
+        if self.evm_profile.is_some() {
+            conflicts.push("--evm-profile");
+        }
+        if self.showmap_out.is_some() {
+            conflicts.push("--showmap-out");
+        }
+        if self.brutalize {
+            conflicts.push("--brutalize");
+        }
+        if self.replay_symbolic_artifact.is_some() {
+            conflicts.push("--replay-symbolic-artifact");
+        }
+        if !conflicts.is_empty() {
+            bail!(
+                "`forge coverage` cannot be combined with: {}. Use `--report lcov` for an \
+                 interoperable coverage report or `--report attribution` for per-test JSON \
+                 attribution.",
+                conflicts.join(", ")
+            )
+        }
+
+        Ok(())
+    }
+
     /// Builds a `ShowmapConfig` from the showmap CLI flags, if `--showmap-out` is set.
     fn showmap_config(&self) -> Result<Option<ShowmapConfig>> {
         if let Some(showmap) = self.showmap_override.clone() {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -1212,9 +1212,9 @@ impl TestArgs {
             bail!(
                 "`forge coverage` cannot be combined with: {}. Use `--report lcov` for an \
                  interoperable coverage report or `--report attribution` for per-test JSON \
-                 attribution.",
+                attribution.",
                 conflicts.join(", ")
-            )
+            );
         }
 
         Ok(())

--- a/crates/forge/src/cmd/watch.rs
+++ b/crates/forge/src/cmd/watch.rs
@@ -369,6 +369,8 @@ pub async fn watch_test(args: TestArgs) -> Result<()> {
 }
 
 pub async fn watch_coverage(args: CoverageArgs) -> Result<()> {
+    args.ensure_mode_compatible()?;
+
     let config = args.watch().watchexec_config(|| {
         let config = args.load_config()?;
         Ok([config.test, config.src])

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1,3 +1,5 @@
+use clap::CommandFactory;
+use forge::cmd::coverage::CoverageArgs;
 use foundry_common::fs::{self, files_with_ext};
 use foundry_test_utils::{
     TestCommand, TestProject,
@@ -2864,3 +2866,56 @@ contract Broken {
         "mutation/coverage conflict should be reported before compile errors:\n{stderr}"
     );
 });
+
+forgetest_init!(coverage_rejects_test_only_modes_before_compile, |prj, cmd| {
+    prj.add_source(
+        "Broken.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+contract Broken {
+    function broken() public pure returns (uint256) {
+        return;
+    }
+}
+"#,
+    );
+
+    for args in [
+        &["--json"][..],
+        &["--junit"],
+        &["--list"],
+        &["--debug"],
+        &["--flamegraph"],
+        &["--flamechart"],
+        &["--evm-profile"],
+        &["--showmap-out", "showmap"],
+        &["--brutalize"],
+        &["--replay-symbolic-artifact", "counterexample.json"],
+        &["--watch", "--json"],
+    ] {
+        let output = cmd.forge_fuse().arg("coverage").args(args).assert_failure();
+        let stderr = output.get_output().stderr_lossy();
+
+        assert!(
+            stderr.contains("`forge coverage` cannot be combined with:"),
+            "unexpected stderr for {args:?}:\n{stderr}"
+        );
+        assert!(
+            !stderr.contains("Compiler run failed"),
+            "coverage conflict should be reported before compile errors for {args:?}:\n{stderr}"
+        );
+    }
+});
+
+#[test]
+fn coverage_help_renders_compatibility_note() {
+    let help = CoverageArgs::command().render_long_help().to_string();
+
+    assert!(help.contains(concat!(
+        "Compatibility:\n",
+        "  `forge coverage` supports test filters and `--watch`, but not test-only output"
+    )));
+    assert!(!help.contains("\\n"));
+}


### PR DESCRIPTION
## Motivation

`forge coverage` inherits `forge test` arguments, including output and execution modes that bypass or conflict with coverage collection. This rejects those combinations before compilation or watcher startup and documents LCOV and attribution JSON as the supported report alternatives.

Closes #9525.