### PR TITLE
feat(debugger): toggle data pane

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -98,6 +98,7 @@ pub(crate) struct TUIContext<'a> {
     pub(crate) show_source: bool,
     pub(crate) show_variables: bool,
     pub(crate) show_stack: bool,
+    pub(crate) show_data: bool,
     /// The currently active buffer (memory, calldata, returndata) to be drawn.
     pub(crate) active_buffer: BufferKind,
     active_storage: Option<StorageSpace>,
@@ -127,6 +128,7 @@ impl<'a> TUIContext<'a> {
             show_source: true,
             show_variables: true,
             show_stack: true,
+            show_data: true,
             active_buffer: BufferKind::Memory,
             active_storage: None,
         }
@@ -715,6 +717,8 @@ impl TUIContext<'_> {
             self.run_pane_command(command, PaneCommand::Variables, parts);
         } else if STACK_COMMANDS.contains(&command) {
             self.run_pane_command(command, PaneCommand::Stack, parts);
+        } else if DATA_COMMANDS.contains(&command) {
+            self.run_pane_command(command, PaneCommand::Data, parts);
         } else if HELP_COMMANDS.contains(&command) {
             self.set_info(command_help());
         } else {
@@ -866,6 +870,10 @@ impl TUIContext<'_> {
             PaneCommand::Stack => {
                 self.show_stack = !self.show_stack;
                 self.show_stack
+            }
+            PaneCommand::Data => {
+                self.show_data = !self.show_data;
+                self.show_data
             }
         };
         let state = if shown { "shown" } else { "hidden" };
@@ -1098,6 +1106,7 @@ const OPCODE_COMMANDS: &[&str] = &["opcodes", "opcode", "ops"];
 const SOURCE_COMMANDS: &[&str] = &["source", "src"];
 const VARIABLES_COMMANDS: &[&str] = &["variables", "vars"];
 const STACK_COMMANDS: &[&str] = &["stack"];
+const DATA_COMMANDS: &[&str] = &["data"];
 const HELP_COMMANDS: &[&str] = &["help", "h"];
 
 #[derive(Clone, Copy)]
@@ -1106,6 +1115,7 @@ enum PaneCommand {
     Source,
     Variables,
     Stack,
+    Data,
 }
 
 impl PaneCommand {
@@ -1115,6 +1125,7 @@ impl PaneCommand {
             Self::Source => "Source",
             Self::Variables => "Variables",
             Self::Stack => "Stack",
+            Self::Data => "Data",
         }
     }
 }
@@ -1125,7 +1136,7 @@ fn command_usage(command: &str, arg: &str) -> String {
 
 fn command_help() -> String {
     format!(
-        "Commands: {} <pc>, {} <pc>, {} [<offset>], {} [<offset>], {} [<offset>], {} [<slot>], {} [<slot>], {} <line>, {}, {}, {}, {}",
+        "Commands: {} <pc>, {} <pc>, {} [<offset>], {} [<offset>], {} [<offset>], {} [<slot>], {} [<slot>], {} <line>, {}, {}, {}, {}, {}",
         command_aliases(CONTINUE_COMMANDS),
         command_aliases(PC_COMMANDS),
         command_aliases(MEMORY_COMMANDS),
@@ -1137,7 +1148,8 @@ fn command_help() -> String {
         command_aliases(OPCODE_COMMANDS),
         command_aliases(SOURCE_COMMANDS),
         command_aliases(VARIABLES_COMMANDS),
-        command_aliases(STACK_COMMANDS)
+        command_aliases(STACK_COMMANDS),
+        command_aliases(DATA_COMMANDS)
     )
 }
 
@@ -2475,6 +2487,7 @@ mod tests {
             SOURCE_COMMANDS,
             VARIABLES_COMMANDS,
             STACK_COMMANDS,
+            DATA_COMMANDS,
         ] {
             assert!(help.contains(&command_aliases(commands)));
         }
@@ -2538,6 +2551,14 @@ mod tests {
         tui.run_command_from_input(":stack");
         assert!(tui.show_stack);
         assert_eq!(tui.status.as_ref().unwrap().text, "Stack pane: shown");
+
+        tui.run_command_from_input("data");
+        assert!(!tui.show_data);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Data pane: hidden");
+
+        tui.run_command_from_input(":data");
+        assert!(tui.show_data);
+        assert_eq!(tui.status.as_ref().unwrap().text, "Data pane: shown");
 
         tui.run_command_from_input("stack extra");
         let status = tui.status.as_ref().unwrap();

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -25,9 +25,9 @@ use std::{collections::VecDeque, fmt::Write};
 
 impl TUIContext<'_> {
     pub(crate) fn draw_layout(&mut self, f: &mut Frame<'_>) {
-        // We need 100 columns to display a 32 byte word in the memory and stack panes.
+        // We need 100 columns to display a 32 byte word in the data and stack panes.
         let area = f.area();
-        let min_width = 100;
+        let min_width = if self.show_data || self.show_stack { 100 } else { 1 };
         let min_height = 16;
         if area.width < min_width || area.height < min_height {
             self.size_too_small(f, min_width, min_height);
@@ -1705,10 +1705,11 @@ mod tests {
         context.layout = DebuggerLayout::Horizontal;
         let mut tui = TUIContext::new(&mut context);
         tui.init();
+        tui.show_opcodes = false;
         tui.show_variables = false;
         tui.show_stack = false;
         tui.show_data = false;
-        let backend = TestBackend::new(220, 30);
+        let backend = TestBackend::new(80, 30);
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal.draw(|f| tui.draw_layout(f)).unwrap();

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -112,9 +112,9 @@ impl TUIContext<'_> {
 
         let opcodes_weight = if self.show_opcodes { 1 } else { 0 };
         let source_weight = if self.show_source { 3 } else { 0 };
-        let memory_weight = if self.show_source { 1 } else { 2 };
+        let data_weight = if self.show_data { if self.show_source { 1 } else { 2 } } else { 0 };
         let total_weight = opcodes_weight
-            + memory_weight
+            + data_weight
             + source_weight
             + if self.show_variables { 1 } else { 0 }
             + if self.show_stack { 1 } else { 0 };
@@ -128,7 +128,9 @@ impl TUIContext<'_> {
         if self.show_stack {
             constraints.push(Constraint::Ratio(1, total_weight));
         }
-        constraints.push(Constraint::Ratio(memory_weight, total_weight));
+        if self.show_data {
+            constraints.push(Constraint::Ratio(data_weight, total_weight));
+        }
         if self.show_source {
             constraints.push(Constraint::Ratio(source_weight, total_weight));
         }
@@ -144,8 +146,9 @@ impl TUIContext<'_> {
         if self.show_stack {
             self.draw_stack(f, *panes.next().expect("stack pane is visible"));
         }
-        let data_pane = *panes.next().expect("data pane is always visible");
-        self.draw_data(f, data_pane);
+        if self.show_data {
+            self.draw_data(f, *panes.next().expect("data pane is visible"));
+        }
         if self.show_source {
             self.draw_src(f, *panes.next().expect("source pane is visible"));
         }
@@ -178,18 +181,21 @@ impl TUIContext<'_> {
         };
 
         let has_left_pane = self.show_opcodes || self.show_source;
-        let (app_left, app_right) = if has_left_pane {
-            // Split app in 2 horizontally.
-            let [app_left, app_right] = Layout::new(
-                Direction::Horizontal,
-                [Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)],
-            )
-            .split(app)[..] else {
-                unreachable!()
-            };
-            (Some(app_left), app_right)
-        } else {
-            (None, app)
+        let has_right_pane = self.show_variables || self.show_stack || self.show_data;
+        let (app_left, app_right) = match (has_left_pane, has_right_pane) {
+            (true, true) => {
+                let [app_left, app_right] = Layout::new(
+                    Direction::Horizontal,
+                    [Constraint::Ratio(1, 2), Constraint::Ratio(1, 2)],
+                )
+                .split(app)[..] else {
+                    unreachable!()
+                };
+                (Some(app_left), Some(app_right))
+            }
+            (true, false) => (Some(app), None),
+            (false, true) => (None, Some(app)),
+            (false, false) => (None, None),
         };
 
         if footer_height > 0 {
@@ -216,26 +222,33 @@ impl TUIContext<'_> {
             }
         }
 
-        let total_weight =
-            2 + if self.show_variables { 1 } else { 0 } + if self.show_stack { 1 } else { 0 };
-        let mut constraints = Vec::with_capacity(3);
-        if self.show_variables {
-            constraints.push(Constraint::Ratio(1, total_weight));
-        }
-        if self.show_stack {
-            constraints.push(Constraint::Ratio(1, total_weight));
-        }
-        constraints.push(Constraint::Ratio(2, total_weight));
+        if let Some(app_right) = app_right {
+            let total_weight = if self.show_variables { 1 } else { 0 }
+                + if self.show_stack { 1 } else { 0 }
+                + if self.show_data { 2 } else { 0 };
+            let mut constraints = Vec::with_capacity(3);
+            if self.show_variables {
+                constraints.push(Constraint::Ratio(1, total_weight));
+            }
+            if self.show_stack {
+                constraints.push(Constraint::Ratio(1, total_weight));
+            }
+            if self.show_data {
+                constraints.push(Constraint::Ratio(2, total_weight));
+            }
 
-        let panes = Layout::new(Direction::Vertical, constraints).split(app_right);
-        let mut panes = panes.iter();
-        if self.show_variables {
-            self.draw_variables(f, *panes.next().expect("variables pane is visible"));
+            let panes = Layout::new(Direction::Vertical, constraints).split(app_right);
+            let mut panes = panes.iter();
+            if self.show_variables {
+                self.draw_variables(f, *panes.next().expect("variables pane is visible"));
+            }
+            if self.show_stack {
+                self.draw_stack(f, *panes.next().expect("stack pane is visible"));
+            }
+            if self.show_data {
+                self.draw_data(f, *panes.next().expect("data pane is visible"));
+            }
         }
-        if self.show_stack {
-            self.draw_stack(f, *panes.next().expect("stack pane is visible"));
-        }
-        self.draw_data(f, *panes.next().expect("data pane is always visible"));
     }
 
     fn footer_height(&self) -> u16 {
@@ -1684,6 +1697,31 @@ mod tests {
         assert!(!screen.contains("Stack:"));
         assert!(screen.contains("Variables"));
         assert!(screen.contains("Memory (max expansion: 0 bytes)"));
+    }
+
+    #[test]
+    fn hidden_data_pane_omits_data_panel() {
+        let mut context = context_with_arena(vec![debug_node(0, 0, vec![trace_step(Vec::new())])]);
+        context.layout = DebuggerLayout::Horizontal;
+        let mut tui = TUIContext::new(&mut context);
+        tui.init();
+        tui.show_variables = false;
+        tui.show_stack = false;
+        tui.show_data = false;
+        let backend = TestBackend::new(220, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal.draw(|f| tui.draw_layout(f)).unwrap();
+
+        let screen = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(!screen.contains("Memory (max expansion: 0 bytes)"));
+        assert!(screen.contains("Contract call"));
     }
 
     #[test]


### PR DESCRIPTION
#927 tracks pane visibility controls, but the debugger's shared data view was still always rendered even when the current memory, calldata, returndata, or storage view was not useful. This adds a `:data` command through the existing pane-command path and lets both layouts reclaim the hidden pane's space, including source-only horizontal layouts.

This PR was written primarily by Codex under my direction.

Progresses #927.
