### PR TITLE
fix(tempo): preserve contract creation transaction type

### DIFF
--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -98,6 +98,13 @@ where
     let is_aa = tx.is_tempo_aa();
     let tx_from = tx.from();
 
+    // A stored fee-token preference would classify a contract creation as Tempo AA, but AA
+    // transactions require a non-empty call list. Leave CREATE requests as Ethereum transactions;
+    // the protocol still applies the account's stored fee-token preference when charging fees.
+    if !has_call_list && calls.iter().any(|(to, _)| matches!(to, TxKind::Create)) {
+        return Ok(None);
+    }
+
     let immediate_user_token =
         infer_fee_token_from_set_user_token_call(&calls, is_aa, tx_from, fee_payer);
     let stored_fee_token = if immediate_user_token.is_none()

--- a/crates/common/src/tempo/tests.rs
+++ b/crates/common/src/tempo/tests.rs
@@ -203,6 +203,36 @@ async fn unset_user_token_does_not_stamp_default_fee_token() -> eyre::Result<()>
 }
 
 #[tokio::test]
+async fn contract_creation_does_not_stamp_stored_fee_token() -> eyre::Result<()> {
+    let asserter = Asserter::new();
+    let provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_mocked_client(asserter);
+    let fee_payer = Address::repeat_byte(0x11);
+    let mut tx = TempoTransactionRequest {
+        inner: TransactionRequest {
+            from: Some(fee_payer),
+            to: Some(TxKind::Create),
+            input: vec![0x60, 0x00].into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    assert_eq!(
+        resolve_and_set_fee_token::<TempoNetwork>(
+            Some(&provider),
+            Some(Chain::from_named(NamedChain::Tempo)),
+            &mut tx,
+            Some(fee_payer),
+        )
+        .await?,
+        None
+    );
+    assert_eq!(tx.fee_token, None);
+    Ok(())
+}
+
+#[tokio::test]
 async fn sponsor_fee_token_resolution_uses_sponsor_address() -> eyre::Result<()> {
     let asserter = Asserter::new();
     let provider =


### PR DESCRIPTION
Tempo devnet now treats a request with `feeToken` as an AA transaction during gas estimation. Foundry inferred the sender's stored fee token for a contract creation, producing an AA request with an empty `calls` list and failing with RPC `-32602`.

Keep inferred stored fee tokens off CREATE requests so they remain Ethereum contract-creation transactions; Tempo still applies the account's stored fee-token preference when charging fees. Adds a regression test that also verifies no stored-token lookup occurs.

Validation:
- `cargo +nightly fmt --check -- crates/common/src/tempo/mod.rs crates/common/src/tempo/tests.rs`
- `git diff --check`
- Focused test compilation was blocked by invalid sandbox Git credentials while fetching `foundry-rs/optimism`.

Prompted by: @DaniPopes