### PR TITLE
chore: bump `alloy-core` to 1.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
+checksum = "e8421a5ee9019b6d89f92935d0f8facd9f6ca088b41d7cc47244a02ccde4545f"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
+checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
+checksum = "6cee30dd4c2f4b23f434fdf675e7bf9681b86768141277266c6f548ef25cba0a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -487,6 +487,7 @@ dependencies = [
  "cfg-if",
  "const-hex",
  "derive_more",
+ "fixed-cache",
  "foldhash",
  "getrandom 0.4.3",
  "hashbrown 0.17.1",
@@ -917,13 +918,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
+checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -931,16 +932,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
+checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
  "indexmap 2.14.0",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "sha3 0.11.0",
@@ -950,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
+checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -968,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
+checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
 dependencies = [
  "serde",
  "winnow 1.0.4",
@@ -978,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
+checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4901,6 +4902,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+ "rapidhash",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -8864,12 +8875,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82366fd7d8b7a440d66d13418820c69df9b3908bcb1a0476d7f5ce5d12f5a04d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro-error2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
  "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b511283ea8a74b4b39447b128c5d00f03a356b7424554b13e298a5550100d9ac"
+dependencies = [
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -11929,9 +11962,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
+checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,17 +381,17 @@ alloy-hardforks = { version = "0.4.7", default-features = false }
 alloy-op-hardforks = { version = "0.4.7", default-features = false }
 
 ## alloy-core
-alloy-dyn-abi = "1.6.0"
-alloy-json-abi = "1.6.0"
-alloy-primitives = { version = "1.6.0", features = [
+alloy-dyn-abi = "1.6.1"
+alloy-json-abi = "1.6.1"
+alloy-primitives = { version = "1.6.1", features = [
     "getrandom",
     "rand",
     "map-fxhash",
     "map-foldhash",
 ] }
-alloy-sol-macro-expander = "1.6.0"
-alloy-sol-macro-input = "1.6.0"
-alloy-sol-types = "1.6.0"
+alloy-sol-macro-expander = "1.6.1"
+alloy-sol-macro-input = "1.6.1"
+alloy-sol-types = "1.6.1"
 
 alloy-chains = "0.2"
 alloy-rlp = "0.3"

--- a/crates/cheatcodes/src/crypto.rs
+++ b/crates/cheatcodes/src/crypto.rs
@@ -290,7 +290,7 @@ fn create_wallet<FEN: FoundryEvmNetwork>(
 
 fn encode_full_sig(sig: alloy_primitives::Signature) -> Vec<u8> {
     // Retrieve v, r and s from signature.
-    let v = U256::from(sig.v() as u64 + 27);
+    let v = U256::from(sig.v_byte());
     let r = B256::from(sig.r());
     let s = B256::from(sig.s());
     (v, r, s).abi_encode()

--- a/crates/evm/symbolic/src/runtime/cheatcodes.rs
+++ b/crates/evm/symbolic/src/runtime/cheatcodes.rs
@@ -963,7 +963,7 @@ pub(crate) fn sign_hash_words(
         .sign_hash_sync(&digest)
         .map_err(|_| SymbolicError::Unsupported("symbolic vm.sign"))?;
     Ok(vec![
-        SymExpr::constant(cx, U256::from(sig.v() as u64 + 27)),
+        SymExpr::constant(cx, U256::from(sig.v_byte())),
         SymExpr::constant(cx, sig.r()),
         SymExpr::constant(cx, sig.s()),
     ])

--- a/crates/forge/tests/cli/bind.rs
+++ b/crates/forge/tests/cli/bind.rs
@@ -1,9 +1,9 @@
 use foundry_compilers::utils::read_json_file;
-use std::{path::Path, process::Command};
+use std::{fs, path::Path, process::Command};
 
 fn assert_bindings_compile(bindings_path: &Path) {
     let out = Command::new("cargo")
-        .arg("check")
+        .args(["check", "--tests"])
         .current_dir(bindings_path)
         .output()
         .expect("failed to run cargo check");
@@ -161,6 +161,84 @@ Bindings have been generated to [..]
 "#]]);
 
     let bindings_path = prj.root().join("out/bindings");
+    assert_bindings_compile(&bindings_path);
+});
+
+// <https://github.com/foundry-rs/foundry/issues/11538>
+forgetest!(bind_dedups_canonical_event_signatures, |prj, cmd| {
+    prj.add_source(
+        "DuplicateEvents.sol",
+        r#"
+interface IERC20Events {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}
+
+library EventsLib {
+    event Transfer(address indexed from, address indexed to, uint256 shares);
+}
+
+contract DuplicateEvents is IERC20Events {
+    function emitTransfer() external {
+        emit EventsLib.Transfer(msg.sender, address(0), 0);
+    }
+}
+"#,
+    );
+
+    cmd.args(["bind", "--select", "^DuplicateEvents$"]).assert_success();
+
+    let bindings_path = prj.root().join("out/bindings");
+    assert_bindings_compile(&bindings_path);
+});
+
+// <https://github.com/foundry-rs/foundry/issues/10353>
+forgetest!(bind_namespaced_custom_type_derives, |prj, cmd| {
+    prj.add_source(
+        "External.sol",
+        r#"
+library External {
+    struct Something {
+        AnotherThing value;
+    }
+
+    struct AnotherThing {
+        uint64 number;
+    }
+}
+"#,
+    );
+    prj.add_source(
+        "MyContract.sol",
+        r#"
+import {External} from "./External.sol";
+
+contract MyContract {
+    event EmittedLog(External.Something value);
+}
+"#,
+    );
+
+    cmd.args(["bind", "--select", "^MyContract$"]).assert_success();
+
+    let bindings_path = prj.root().join("out/bindings");
+    let tests_path = bindings_path.join("tests");
+    fs::create_dir_all(&tests_path).unwrap();
+    fs::write(
+        tests_path.join("derives.rs"),
+        r#"
+use foundry_contracts::my_contract::MyContract::EmittedLog;
+use std::{fmt::Debug, hash::Hash};
+
+fn assert_all_derives<T: Default + Debug + PartialEq + Eq + Hash>() {}
+
+#[test]
+fn event_has_all_derives() {
+    assert_all_derives::<EmittedLog>();
+}
+"#,
+    )
+    .unwrap();
+
     assert_bindings_compile(&bindings_path);
 });
 


### PR DESCRIPTION
Bump the complete Alloy Core crate family from 1.6.0 to the crates.io 1.6.1 release. This picks up alloy-rs/core#1151 and alloy-rs/core#1152, so `forge bind` deduplicates canonical-equivalent ABI events instead of panicking and preserves the built-in derives for events containing namespaced custom types. The release's ABI and EIP-712 correctness fixes flow through automatically, while Foundry's ordinary and symbolic `vm.sign` paths now use the new `Signature::v_byte()` helper instead of open-coding the Electrum `v` conversion. The workspace minimum versions and lockfile move together without a git patch.

Fixes #11538.
Fixes #10353.

AI disclosure: Codex assisted with the release audit, code changes, tests, and PR text; I reviewed the resulting implementation.
