### PR TITLE
perf(forge): speed up bytecode verification

### DIFF
--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -11,8 +11,14 @@ use foundry_block_explorers::{
     utils::lookup_compiler_version,
 };
 use foundry_cli::utils::LoadConfig;
-use foundry_common::{abi::encode_args, compile::ProjectCompiler, ignore_metadata_hash, shell};
-use foundry_compilers::artifacts::{BytecodeHash, CompactContractBytecode, EvmVersion};
+use foundry_common::{
+    abi::encode_args, compile::ProjectCompiler, find_matching_contract_artifact,
+    ignore_metadata_hash, shell,
+};
+use foundry_compilers::{
+    artifacts::{BytecodeHash, CompactContractBytecode, EvmVersion},
+    utils::canonicalize,
+};
 use foundry_config::Config;
 use foundry_evm::{
     constants::DEFAULT_CREATE2_DEPLOYER,
@@ -90,6 +96,14 @@ pub fn build_project(
 ) -> Result<CompactContractBytecode> {
     let project = config.project()?;
     let compiler = ProjectCompiler::new().quiet(true);
+
+    if let Some(path) = args.contract.path() {
+        let target_path = canonicalize(project.root().join(path))?;
+        let mut output = compiler.files([target_path.clone()]).compile(&project)?;
+        let artifact =
+            find_matching_contract_artifact(&mut output, &target_path, Some(&args.contract.name))?;
+        return Ok(artifact.into_contract_bytecode());
+    }
 
     let mut output = compiler.compile(&project)?;
 
@@ -485,6 +499,16 @@ pragma solidity 0.8.16;
 
 contract Counter {
     uint256 public number;
+}
+"#,
+        );
+        prj.add_source(
+            "Broken.sol",
+            r#"
+pragma solidity 0.8.16;
+
+contract Broken {
+    this is not valid Solidity
 }
 "#,
         );


### PR DESCRIPTION
## Summary

Path-qualified `forge verify-bytecode` invocations now compile only the requested source and its import closure instead of the entire project. The same platform-normalized target path is reused for compilation and artifact lookup, preserving relative-path behavior across platforms while avoiding unrelated tests and scripts.

The regression test adds an unrelated invalid Solidity source, so restoring a whole-project compile would fail it. Validated with the focused `forge-verify` test, `cargo +nightly fmt --all -- --check`, `git diff --check`, and `cargo +1.95.0 check -p forge`. Implemented with Codex.

## Benchmarks

Measured against Aave v4 (`af1f0f2`) using a locally deployed `WETH9` on Anvil. Each cold sample removed `out` and `cache` before `forge verify-bytecode`.

| | Mean | Range | Generated output |
| --- | ---: | ---: | ---: |
| `master` (`d280989c`) | `205.469s ± 4.430s` | `202.488s–210.559s` | `265MB`, 616 JSON files |
| This PR | `85.6ms ± 1.6ms` | `83.1ms–88.8ms` | `32KB`, 2 JSON files |
