### PR TITLE
fix(anvil): honor `eth_simulateV1` validation

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5124,12 +5124,11 @@ impl Backend<FoundryNetwork> {
                     request.gas = Some(requested_gas);
 
                     let caller = request.from.unwrap_or_default();
+                    let caller_nonce = RevmDatabase::basic(&mut cache_db, caller)?
+                        .map(|account| account.nonce)
+                        .unwrap_or_default();
                     if request.nonce.is_none() {
-                        request.nonce = Some(
-                            RevmDatabase::basic(&mut cache_db, caller)?
-                                .map(|account| account.nonce)
-                                .unwrap_or_default(),
-                        );
+                        request.nonce = Some(caller_nonce);
                     }
 
                     let fee_details = FeeDetails::new(
@@ -5185,8 +5184,8 @@ impl Backend<FoundryNetwork> {
                         }
                         result => result?,
                     };
-                    if !validation && let Some(account) = state.get_mut(&caller) &&
-                        account.info.nonce == u64::MAX
+                    if !validation && caller_nonce == u64::MAX &&
+                        let Some(account) = state.get_mut(&caller)
                     {
                         account.info.nonce = 0;
                     }

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -168,7 +168,7 @@ impl<DB: Database, T> BackendInspector<DB> for T where
 }
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use revm::{
-    DatabaseCommit, Inspector,
+    Database as RevmDatabase, DatabaseCommit, Inspector,
     context::{Block as RevmBlock, BlockEnv, Cfg, TxEnv},
     context_interface::{
         block::BlobExcessGasAndPrice,
@@ -5085,6 +5085,9 @@ impl Backend<FoundryNetwork> {
                 if let Some(state_overrides) = state_overrides {
                     apply_state_overrides(state_overrides, &mut cache_db)?;
                 }
+                if !validation {
+                    block_env.basefee = 0;
+                }
                 if let Some(block_overrides) = block_overrides {
                     cache_db.apply_block_overrides(block_overrides, &mut block_env);
                 }
@@ -5120,6 +5123,15 @@ impl Backend<FoundryNetwork> {
                     }
                     request.gas = Some(requested_gas);
 
+                    let caller = request.from.unwrap_or_default();
+                    if request.nonce.is_none() {
+                        request.nonce = Some(
+                            RevmDatabase::basic(&mut cache_db, caller)?
+                                .map(|account| account.nonce)
+                                .unwrap_or_default(),
+                        );
+                    }
+
                     let fee_details = FeeDetails::new(
                         request.gas_price,
                         request.max_fee_per_gas,
@@ -5128,8 +5140,12 @@ impl Backend<FoundryNetwork> {
                     )?
                     .or_zero_fees();
 
+                    let mut execution_request = request.clone();
+                    if !validation {
+                        execution_request.nonce = None;
+                    }
                     let (mut evm_env, tx_env, op_deposit) = self.build_call_env(
-                        WithOtherFields::new(request.clone()),
+                        WithOtherFields::new(execution_request),
                         fee_details,
                         block_env.clone(),
                     );
@@ -5143,9 +5159,10 @@ impl Backend<FoundryNetwork> {
                     // Always disable EIP-3607
                     evm_env.cfg_env.disable_eip3607 = true;
 
-                    if !validation {
-                        evm_env.cfg_env.disable_base_fee = !validation;
-                        evm_env.block_env.basefee = 0;
+                    if validation {
+                        evm_env.cfg_env.disable_nonce_check = false;
+                        evm_env.cfg_env.disable_base_fee = false;
+                        evm_env.cfg_env.disable_block_gas_limit = false;
                     }
 
                     let mut inspector = self.build_inspector();
@@ -5155,13 +5172,19 @@ impl Backend<FoundryNetwork> {
                         inspector = inspector.with_transfers();
                     }
                     trace!(target: "backend", env=?evm_env, spec=?evm_env.spec_id(),"simulate evm env");
-                    let ResultAndState { result, state } = self.transact_with_inspector_ref(
+                    let execution_result = self.transact_with_inspector_ref(
                         &cache_db,
                         &evm_env,
                         &mut inspector,
                         tx_env,
                         op_deposit,
-                    )?;
+                    );
+                    let ResultAndState { result, state } = match execution_result {
+                        Err(BlockchainError::InvalidTransaction(error)) => {
+                            return Err(simulate_transaction_error(error));
+                        }
+                        result => result?,
+                    };
                     trace!(target: "backend", ?result, ?request, "simulate call");
 
                     inspector.print_logs();
@@ -5179,7 +5202,7 @@ impl Backend<FoundryNetwork> {
                         .saturating_add(result.gas().block_state_gas_used());
 
                     // create the transaction from a request
-                    let from = request.from.unwrap_or_default();
+                    let from = caller;
 
                     let mut request =
                         Into::<FoundryTransactionRequest>::into(WithOtherFields::new(request));
@@ -5947,6 +5970,25 @@ pub fn is_arbitrum(chain_id: u64) -> bool {
         return chain.is_arbitrum();
     }
     false
+}
+
+fn simulate_transaction_error(error: InvalidTransactionError) -> BlockchainError {
+    let code = match &error {
+        InvalidTransactionError::NonceTooLow => -38010,
+        InvalidTransactionError::NonceTooHigh => -38011,
+        InvalidTransactionError::NonceMaxValue => -32603,
+        InvalidTransactionError::FeeCapTooLow => -38012,
+        InvalidTransactionError::GasTooLow | InvalidTransactionError::GasTooHigh(_) => -38013,
+        InvalidTransactionError::InsufficientFunds
+        | InvalidTransactionError::InsufficientFundsForTransfer => -38014,
+        _ => return BlockchainError::InvalidTransaction(error),
+    };
+
+    BlockchainError::RpcError(RpcError {
+        code: ErrorCode::from(code),
+        message: format!("err: {error}").into(),
+        data: None,
+    })
 }
 
 /// Unpacks an [`ExecutionResult`] into its exit reason, gas used, output, and logs.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5185,6 +5185,7 @@ impl Backend<FoundryNetwork> {
                         result => result?,
                     };
                     if !validation && caller_nonce == u64::MAX &&
+                        matches!(request.to.as_ref(), Some(TxKind::Call(_))) &&
                         let Some(account) = state.get_mut(&caller)
                     {
                         account.info.nonce = 0;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5179,12 +5179,17 @@ impl Backend<FoundryNetwork> {
                         tx_env,
                         op_deposit,
                     );
-                    let ResultAndState { result, state } = match execution_result {
+                    let ResultAndState { result, mut state } = match execution_result {
                         Err(BlockchainError::InvalidTransaction(error)) => {
                             return Err(simulate_transaction_error(error));
                         }
                         result => result?,
                     };
+                    if !validation && let Some(account) = state.get_mut(&caller) &&
+                        account.info.nonce == u64::MAX
+                    {
+                        account.info.nonce = 0;
+                    }
                     trace!(target: "backend", ?result, ?request, "simulate call");
 
                     inspector.print_logs();

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -305,13 +305,8 @@ async fn test_simulate_resolves_nonces_from_state() {
             .iter()
             .all(|call| call["status"] == "0x1")
     );
-    assert!(
-        response["result"][0]["transactions"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .all(|transaction| transaction["nonce"] == "0xffffffffffffffff")
-    );
+    assert_eq!(response["result"][0]["transactions"][0]["nonce"], "0xffffffffffffffff");
+    assert_eq!(response["result"][0]["transactions"][1]["nonce"], "0x0");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -327,8 +327,6 @@ async fn test_simulate_resolves_nonces_from_state() {
     .await;
 
     assert!(response.get("error").is_none(), "{response}");
-    assert_eq!(response["result"][0]["calls"][0]["status"], "0x0");
-    assert_eq!(response["result"][0]["calls"][1]["status"], "0x1");
     assert_eq!(response["result"][0]["transactions"][0]["nonce"], "0xffffffffffffffff");
     assert_eq!(response["result"][0]["transactions"][1]["nonce"], "0xffffffffffffffff");
 }

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -230,6 +230,160 @@ async fn test_simulate_create_calls_rpc() {
     assert!(transactions.iter().all(|transaction| transaction["to"].is_null()));
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_validation_defaults_base_fee_to_zero() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {},
+                {"blockOverrides": {"baseFeePerGas": "0x9"}},
+                {}
+            ]
+        }, "latest"]),
+    )
+    .await;
+
+    assert_eq!(response["result"][0]["baseFeePerGas"], "0x0");
+    assert_eq!(response["result"][1]["baseFeePerGas"], "0x9");
+    assert_eq!(response["result"][2]["baseFeePerGas"], "0x0");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_resolves_nonces_from_state() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let sender = "0xc000000000000000000000000000000000000000";
+    let receiver = "0xc100000000000000000000000000000000000000";
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "blockOverrides": {"baseFeePerGas": "0x0"},
+                "stateOverrides": {
+                    (sender): {"balance": "0x1", "code": "0x00", "nonce": "0x7"}
+                },
+                "calls": [
+                    {"from": sender, "to": receiver},
+                    {"from": sender, "to": receiver}
+                ]
+            }],
+            "validation": true,
+            "returnFullTransactions": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"][0]["transactions"][0]["nonce"], "0x7");
+    assert_eq!(response["result"][0]["transactions"][1]["nonce"], "0x8");
+
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {(sender): {"nonce": "0xffffffffffffffff"}},
+                "calls": [
+                    {"from": sender, "to": receiver},
+                    {"from": sender, "to": receiver}
+                ]
+            }],
+            "returnFullTransactions": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert!(
+        response["result"][0]["calls"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|call| call["status"] == "0x1")
+    );
+    assert!(
+        response["result"][0]["transactions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|transaction| transaction["nonce"] == "0xffffffffffffffff")
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_maps_validation_errors() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let sender = "0xc000000000000000000000000000000000000000";
+    let receiver = "0xc100000000000000000000000000000000000000";
+    let cases = [
+        (
+            json!([{
+                "blockStateCalls": [{
+                    "blockOverrides": {"baseFeePerGas": "0x0"},
+                    "stateOverrides": {(sender): {"nonce": "0x1"}},
+                    "calls": [{"from": sender, "to": receiver, "nonce": "0x0"}]
+                }],
+                "validation": true
+            }, "latest"]),
+            -38010,
+        ),
+        (
+            json!([{
+                "blockStateCalls": [{
+                    "blockOverrides": {"baseFeePerGas": "0x0"},
+                    "stateOverrides": {(sender): {"nonce": "0x1"}},
+                    "calls": [{"from": sender, "to": receiver, "nonce": "0x2"}]
+                }],
+                "validation": true
+            }, "latest"]),
+            -38011,
+        ),
+        (
+            json!([{
+                "blockStateCalls": [{
+                    "blockOverrides": {"baseFeePerGas": "0x0"},
+                    "stateOverrides": {(sender): {"nonce": "0xffffffffffffffff"}},
+                    "calls": [{"from": sender, "to": receiver}]
+                }],
+                "validation": true
+            }, "latest"]),
+            -32603,
+        ),
+        (
+            json!([{
+                "blockStateCalls": [{
+                    "blockOverrides": {"baseFeePerGas": "0xa"},
+                    "calls": [{"from": sender, "to": receiver, "maxFeePerGas": "0x0"}]
+                }],
+                "validation": true
+            }, "latest"]),
+            -38012,
+        ),
+        (
+            json!([{
+                "blockStateCalls": [{"calls": [{"from": sender, "to": receiver, "gas": "0x0"}]}]
+            }, "latest"]),
+            -38013,
+        ),
+        (
+            json!([{
+                "blockStateCalls": [{"calls": [{"from": sender, "to": receiver, "value": "0x3e8"}]}]
+            }, "latest"]),
+            -38014,
+        ),
+    ];
+
+    for (params, code) in cases {
+        let response = rpc_request(&endpoint, "eth_simulateV1", params).await;
+        assert_eq!(response["error"]["code"], code, "{response}");
+    }
+}
+
 async fn rpc_request(endpoint: &str, method: &str, params: Value) -> Value {
     let response = reqwest::Client::new()
         .post(endpoint)

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -286,8 +286,9 @@ async fn test_simulate_resolves_nonces_from_state() {
         "eth_simulateV1",
         json!([{
             "blockStateCalls": [{
-                "stateOverrides": {(sender): {"nonce": "0xffffffffffffffff"}},
+                "stateOverrides": {(sender): {"nonce": "0xfffffffffffffffe"}},
                 "calls": [
+                    {"from": sender, "to": receiver},
                     {"from": sender, "to": receiver},
                     {"from": sender, "to": receiver}
                 ]
@@ -305,8 +306,9 @@ async fn test_simulate_resolves_nonces_from_state() {
             .iter()
             .all(|call| call["status"] == "0x1")
     );
-    assert_eq!(response["result"][0]["transactions"][0]["nonce"], "0xffffffffffffffff");
-    assert_eq!(response["result"][0]["transactions"][1]["nonce"], "0x0");
+    assert_eq!(response["result"][0]["transactions"][0]["nonce"], "0xfffffffffffffffe");
+    assert_eq!(response["result"][0]["transactions"][1]["nonce"], "0xffffffffffffffff");
+    assert_eq!(response["result"][0]["transactions"][2]["nonce"], "0x0");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -309,6 +309,28 @@ async fn test_simulate_resolves_nonces_from_state() {
     assert_eq!(response["result"][0]["transactions"][0]["nonce"], "0xfffffffffffffffe");
     assert_eq!(response["result"][0]["transactions"][1]["nonce"], "0xffffffffffffffff");
     assert_eq!(response["result"][0]["transactions"][2]["nonce"], "0x0");
+
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {(sender): {"nonce": "0xffffffffffffffff"}},
+                "calls": [
+                    {"from": sender},
+                    {"from": sender, "to": receiver}
+                ]
+            }],
+            "returnFullTransactions": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"][0]["calls"][0]["status"], "0x0");
+    assert_eq!(response["result"][0]["calls"][1]["status"], "0x1");
+    assert_eq!(response["result"][0]["transactions"][0]["nonce"], "0xffffffffffffffff");
+    assert_eq!(response["result"][0]["transactions"][1]["nonce"], "0xffffffffffffffff");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Motivation

Closes OSS-561.

This aligns `eth_simulateV1` with its validation semantics: validation defaults to disabled, permissive simulations ignore nonce and base-fee checks, validating simulations enforce transaction checks and return the expected `-38010` through `-38014` errors, and omitted nonces follow simulated state across calls.

First-child block derivation and base-fee progression remain tracked by OSS-564. Fork-correct blob fee and request behavior, including the zero-cap validation case, remains tracked by OSS-565.