### PR TITLE
feat(cheatcodes): add JSON array length

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -7630,6 +7630,26 @@
     },
     {
       "func": {
+        "id": "parseJsonArrayLength",
+        "description": "Returns the length of the JSON array at `key`.",
+        "declaration": "function parseJsonArrayLength(string calldata json, string calldata key) external pure returns (uint256 length);",
+        "visibility": "external",
+        "mutability": "pure",
+        "signature": "parseJsonArrayLength(string,string)",
+        "selector": "0xcdb6e4ac",
+        "selectorBytes": [
+          205,
+          182,
+          228,
+          172
+        ]
+      },
+      "group": "json",
+      "status": "stable",
+      "safety": "safe"
+    },
+    {
+      "func": {
         "id": "parseJsonBool",
         "description": "Parses a string of JSON data at `key` and coerces it to `bool`.",
         "declaration": "function parseJsonBool(string calldata json, string calldata key) external pure returns (bool);",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -2576,6 +2576,9 @@ interface Vm {
     /// Parses a string of JSON data at `key` and coerces it to `string[]`.
     #[cheatcode(group = Json)]
     function parseJsonStringArray(string calldata json, string calldata key) external pure returns (string[] memory);
+    /// Returns the length of the JSON array at `key`.
+    #[cheatcode(group = Json)]
+    function parseJsonArrayLength(string calldata json, string calldata key) external pure returns (uint256 length);
     /// Parses a string of JSON data at `key` and coerces it to `bytes`.
     #[cheatcode(group = Json)]
     function parseJsonBytes(string calldata json, string calldata key) external pure returns (bytes memory);

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -111,6 +111,13 @@ impl Cheatcode for parseJsonStringArrayCall {
     }
 }
 
+impl Cheatcode for parseJsonArrayLengthCall {
+    fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
+        let Self { json, key } = self;
+        parse_json_array_length(json, key)
+    }
+}
+
 impl Cheatcode for parseJsonBytesCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, _state: &mut Cheatcodes<FEN>) -> Result {
         let Self { json, key } = self;
@@ -467,6 +474,18 @@ pub(super) fn parse_json_keys(json: &str, key: &str) -> Result {
     };
     let keys = object.keys().collect::<Vec<_>>();
     Ok(keys.abi_encode())
+}
+
+pub(super) fn parse_json_array_length(json: &str, key: &str) -> Result {
+    let json = parse_json_str(json)?;
+    let values = select(&json, key)?;
+    let [value] = values[..] else {
+        bail!("key {key:?} must return exactly one JSON array");
+    };
+    let Value::Array(array) = value else {
+        bail!("JSON value at {key:?} is not an array");
+    };
+    Ok(U256::from(array.len()).abi_encode())
 }
 
 fn parse_json_str(json: &str) -> Result<Value> {

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -2264,7 +2264,7 @@ Traces:
     │   └─ ← [Return]
     └─ ← [Stop]
 
-  [558945] PauseTracingTest::test()
+  [558957] PauseTracingTest::test()
     ├─ [0] VM::resumeTracing() [staticcall]
     │   └─ ← [Return]
     ├─ [48460] TraceGenerator::generate()

--- a/testdata/default/cheats/Json.t.sol
+++ b/testdata/default/cheats/Json.t.sol
@@ -388,7 +388,7 @@ contract ParseJsonTest is Test {
     function test_parseJsonArrayLength() public {
         string memory jsonString = '{"array":[1,{"nested":true},"three"],"empty":[],"object":{"array":[1,2]}}';
 
-        assertEq(vm.parseJsonArrayLength('[1,2,3]', "$"), 3);
+        assertEq(vm.parseJsonArrayLength("[1,2,3]", "$"), 3);
         assertEq(vm.parseJsonArrayLength(jsonString, ".array"), 3);
         assertEq(vm.parseJsonArrayLength(jsonString, ".empty"), 0);
         assertEq(vm.parseJsonArrayLength(jsonString, ".object.array"), 2);

--- a/testdata/default/cheats/Json.t.sol
+++ b/testdata/default/cheats/Json.t.sol
@@ -385,6 +385,27 @@ contract ParseJsonTest is Test {
         vm.parseJsonKeys(jsonString, ".*");
     }
 
+    function test_parseJsonArrayLength() public {
+        string memory jsonString = '{"array":[1,{"nested":true},"three"],"empty":[],"object":{"array":[1,2]}}';
+
+        assertEq(vm.parseJsonArrayLength('[1,2,3]', "$"), 3);
+        assertEq(vm.parseJsonArrayLength(jsonString, ".array"), 3);
+        assertEq(vm.parseJsonArrayLength(jsonString, ".empty"), 0);
+        assertEq(vm.parseJsonArrayLength(jsonString, ".object.array"), 2);
+
+        vm._expectCheatcodeRevert('JSON value at ".object" is not an array');
+        vm.parseJsonArrayLength(jsonString, ".object");
+
+        vm._expectCheatcodeRevert('JSON value at ".array[0]" is not an array');
+        vm.parseJsonArrayLength(jsonString, ".array[0]");
+
+        vm._expectCheatcodeRevert('key ".missing" must return exactly one JSON array');
+        vm.parseJsonArrayLength(jsonString, ".missing");
+
+        vm._expectCheatcodeRevert('key ".array[*]" must return exactly one JSON array');
+        vm.parseJsonArrayLength(jsonString, ".array[*]");
+    }
+
     // forge eip712 testdata/default/cheats/Json.t.sol -R 'cheats=testdata/cheats' -R 'ds-test=testdata/lib/ds-test/src' | grep ^FlatJson
     string constant schema_FlatJson =
         "FlatJson(uint256 a,int24[][] arr,string str,bytes b,address addr,bytes32 fixedBytes)";

--- a/testdata/utils/Vm.sol
+++ b/testdata/utils/Vm.sol
@@ -374,6 +374,7 @@ interface Vm {
     function parseInt(string calldata stringifiedValue) external pure returns (int256 parsedValue);
     function parseJsonAddress(string calldata json, string calldata key) external pure returns (address);
     function parseJsonAddressArray(string calldata json, string calldata key) external pure returns (address[] memory);
+    function parseJsonArrayLength(string calldata json, string calldata key) external pure returns (uint256 length);
     function parseJsonBool(string calldata json, string calldata key) external pure returns (bool);
     function parseJsonBoolArray(string calldata json, string calldata key) external pure returns (bool[] memory);
     function parseJsonBytes(string calldata json, string calldata key) external pure returns (bytes memory);


### PR DESCRIPTION
## Motivation

Close #8467.

Adds `vm.parseJsonArrayLength(string json, string key)` for type-independent JSON array introspection. The cheatcode requires the JSONPath to select exactly one array and returns its length, while missing, multi-selection, object, and scalar results produce clear errors. This keeps `parseJsonStringArray` strict instead of restoring its previous object coercion behavior.