### PR TITLE
fix(forge): compile filtered test fixtures

### DIFF
--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -379,6 +379,9 @@ fn sources_to_compile_from_artifacts(
     artifacts: &ProjectCompileOutput,
     test_matcher: &TestFunctionMatcher<'_>,
 ) -> BTreeSet<PathBuf> {
+    let paths = config.project_paths::<MultiCompilerLanguage>();
+    let empty_filter = EmptyTestFilter::default();
+
     // `MultiContractRunner::build` strips the root prefix from artifact source paths so the
     // identifiers it constructs are project-relative. Match that here for the filter check
     // (notably for the `--rerun` failure list, which is persisted relative) but return the
@@ -387,11 +390,15 @@ fn sources_to_compile_from_artifacts(
         .artifact_ids()
         .filter_map(|(id, artifact)| artifact.abi.as_ref().map(|abi| (id, abi)))
         .filter(|(id, abi)| {
-            if id.source.starts_with(&config.src) {
+            if id.source.starts_with(&paths.sources) {
                 return true;
             }
+            if paths.is_script(&id.source) && !paths.is_test(&id.source) {
+                return false;
+            }
             let stripped = id.clone().with_stripped_file_prefixes(&config.root);
-            test_matcher.matches_contract(test_filter, &stripped, abi)
+            !test_matcher.matches_contract(&empty_filter, &stripped, abi)
+                || test_matcher.matches_contract(test_filter, &stripped, abi)
         })
         .map(|(id, _)| id.source)
         .collect()
@@ -1471,9 +1478,9 @@ impl TestArgs {
     /// Returns a list of files that need to be compiled in order to run all the tests that match
     /// the given filter.
     ///
-    /// This means that it will return all sources that are not test contracts or that match the
-    /// filter. We want to compile all non-test sources always because tests might depend on them
-    /// dynamically through cheatcodes.
+    /// For filtered runs, this includes all configured source files, non-test artifacts outside
+    /// script-only paths, and runnable tests that match the filter. Non-test artifacts remain
+    /// available because tests may resolve them dynamically through cheatcodes.
     #[instrument(target = "forge::test", skip_all)]
     fn get_sources_to_compile(
         &self,
@@ -1493,27 +1500,16 @@ impl TestArgs {
             ));
         }
 
-        let filter_args = test_filter.args();
-        let has_contract_or_test_filter = filter_args.test_pattern.is_some()
-            || filter_args.test_pattern_inverse.is_some()
-            || filter_args.contract_pattern.is_some()
-            || filter_args.contract_pattern_inverse.is_some();
-        if !has_contract_or_test_filter {
-            return Ok((
-                source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
-                    .chain(
-                        source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS)
-                            .filter(|path| test_filter.matches_path(path)),
-                    )
-                    .collect(),
-                None,
-            ));
-        }
-
         let mut project = config.create_project(true, true)?;
+        let sources = source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
+            .chain(source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS))
+            .collect::<BTreeSet<_>>();
         let output = compile_abi_project(
             &mut project,
-            ProjectCompiler::new().dynamic_test_linking(config.dynamic_test_linking).quiet(true),
+            ProjectCompiler::new()
+                .files(sources)
+                .dynamic_test_linking(config.dynamic_test_linking)
+                .quiet(true),
         )?;
         if output.has_compiler_errors() {
             sh_println!("{output}")?;

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -33,7 +33,7 @@ use dialoguer::{Select, console::Term};
 use eyre::{Context, OptionExt, Result, bail};
 use foundry_cli::{
     opts::{BuildOpts, EvmArgs, GlobalArgs},
-    utils::{self, LoadConfig},
+    utils::{self, FoundryPathExt, LoadConfig},
 };
 use foundry_common::{
     EmptyTestFilter, TestFilter, TestFunctionExt, TestFunctionKind,
@@ -381,6 +381,11 @@ fn sources_to_compile_from_artifacts(
 ) -> BTreeSet<PathBuf> {
     let paths = config.project_paths::<MultiCompilerLanguage>();
     let empty_filter = EmptyTestFilter::default();
+    let filter_args = test_filter.args();
+    let has_contract_or_test_filter = filter_args.test_pattern.is_some()
+        || filter_args.test_pattern_inverse.is_some()
+        || filter_args.contract_pattern.is_some()
+        || filter_args.contract_pattern_inverse.is_some();
 
     // `MultiContractRunner::build` strips the root prefix from artifact source paths so the
     // identifiers it constructs are project-relative. Match that here for the filter check
@@ -397,6 +402,16 @@ fn sources_to_compile_from_artifacts(
                 return false;
             }
             let stripped = id.clone().with_stripped_file_prefixes(&config.root);
+            // ABI-only compilation can omit test functions with invalid bodies, so preserve the
+            // existing filter behavior for conventional test files instead of treating them as
+            // fixtures.
+            if stripped.source.is_sol_test() {
+                return if has_contract_or_test_filter {
+                    test_matcher.matches_contract(test_filter, &stripped, abi)
+                } else {
+                    test_filter.matches_path(&stripped.source)
+                };
+            }
             !test_matcher.matches_contract(&empty_filter, &stripped, abi)
                 || test_matcher.matches_contract(test_filter, &stripped, abi)
         })
@@ -1502,7 +1517,12 @@ impl TestArgs {
 
         let mut project = config.create_project(true, true)?;
         let sources = source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
-            .chain(source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS))
+            .chain(
+                source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS)
+                    // Preserve path-filter behavior for conventional test files while still
+                    // scanning non-test fixtures under the test root.
+                    .filter(|path| !path.is_sol_test() || test_filter.matches_path(path)),
+            )
             .collect::<BTreeSet<_>>();
         let output = compile_abi_project(
             &mut project,

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -41,6 +41,160 @@ exit 1
     assert!(!invoked.exists(), "filtered test compilation did not reuse the preprocessed cache");
 });
 
+// <https://github.com/foundry-rs/foundry/issues/8842>
+forgetest_init!(filtered_tests_compile_unimported_test_fixtures, |prj, cmd| {
+    prj.update_config(|config| config.solc = None);
+    prj.add_raw_test(
+        "fixtures/Fixture.sol",
+        r#"
+pragma solidity 0.7.6;
+
+contract Fixture {
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+}
+"#,
+    );
+    prj.add_test(
+        "Fixture.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+interface IFixture {
+    function version() external pure returns (uint256);
+}
+
+contract FixtureTest is Test {
+    function testFixture() public {
+        address fixture = vm.deployCode("test/fixtures/Fixture.sol:Fixture");
+        assertEq(IFixture(fixture).version(), 1);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--match-contract", "FixtureTest"]).assert_success().stdout_eq(str![[r#"
+...
+Ran 1 test for test/Fixture.t.sol:FixtureTest
+[PASS] testFixture() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+
+    prj.add_raw_test(
+        "fixtures/Fixture.sol",
+        r#"
+pragma solidity 0.7.6;
+
+contract Fixture {
+    function version() external pure returns (uint256) {
+        return 2;
+    }
+}
+"#,
+    );
+    prj.add_test(
+        "Fixture.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+interface IFixture {
+    function version() external pure returns (uint256);
+}
+
+contract FixtureTest is Test {
+    function testFixture() public {
+        address fixture = vm.deployCode("test/fixtures/Fixture.sol:Fixture");
+        assertEq(IFixture(fixture).version(), 2);
+    }
+}
+"#,
+    );
+
+    cmd.assert_success().stdout_eq(str![[r#"
+...
+Ran 1 test for test/Fixture.t.sol:FixtureTest
+[PASS] testFixture() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+});
+
+// <https://github.com/foundry-rs/foundry/issues/8842>
+forgetest_init!(path_filtered_tests_compile_unimported_test_fixtures, |prj, cmd| {
+    prj.update_config(|config| {
+        config.solc = None;
+        config.dynamic_test_linking = false;
+    });
+    prj.add_raw_script("Broken.s.sol", "this is not valid Solidity");
+    prj.add_raw_test(
+        "fixtures/Fixture.sol",
+        r#"
+pragma solidity 0.7.6;
+
+contract Fixture {}
+"#,
+    );
+    prj.add_test(
+        "Fixture.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract FixtureTest is Test {
+    function testFixture() public {
+        assertGt(vm.getCode("test/fixtures/Fixture.sol:Fixture").length, 0);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--match-path", "test/Fixture.t.sol"]).assert_success().stdout_eq(str![[
+        r#"
+...
+Ran 1 test for test/Fixture.t.sol:FixtureTest
+[PASS] testFixture() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#
+    ]]);
+});
+
+forgetest_init!(filtered_tests_support_overlapping_source_roots, |prj, cmd| {
+    prj.update_config(|config| config.script = ".".into());
+    prj.add_source("SourceFixture.sol", "contract SourceFixture {}");
+    prj.add_test("fixtures/Fixture.sol", "contract Fixture {}");
+    prj.add_test(
+        "Fixture.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract FixtureTest is Test {
+    function testFixture() public {
+        assertGt(vm.getCode("test/fixtures/Fixture.sol:Fixture").length, 0);
+        assertGt(vm.getCode("src/SourceFixture.sol:SourceFixture").length, 0);
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--match-contract", "FixtureTest"]).assert_success().stdout_eq(str![[r#"
+...
+Ran 1 test for test/Fixture.t.sol:FixtureTest
+[PASS] testFixture() ([GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+});
+
 // Test cache is invalidated when `forge build` if optimize test option toggled.
 forgetest_init!(toggle_invalidate_cache_on_build, |prj, cmd| {
     prj.initialize_default_contracts();


### PR DESCRIPTION
Filtered test runs could omit unimported fixtures under `test/`, causing `vm.getCode` and `vm.deployCode` to fail even when the artifact was otherwise valid. This restores ABI-based source selection so non-test fixtures remain available while unmatched test contracts and standalone scripts remain excluded.

This also applies consistent selection to path filters and handles overlapping source roots.

Fixes #8842 