### PR TITLE
fix(forge): profile tests after beforeTestSetup

### DIFF
--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -2700,6 +2700,11 @@ impl TestResult {
         extend!(self, call_result, TraceKind::Execution);
     }
 
+    /// Merges the given pre-test setup result into `self`.
+    pub(crate) fn extend_setup<FEN: FoundryEvmNetwork>(&mut self, call_result: RawCallResult<FEN>) {
+        extend!(self, call_result, TraceKind::Setup);
+    }
+
     /// Merges the given coverage result into `self`.
     pub fn merge_coverages(&mut self, other_coverage: Option<HitMaps>) {
         HitMaps::merge_opt(&mut self.line_coverage, other_coverage);

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -4939,7 +4939,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                         let reverted = call_result.reverted;
 
                         // Merge tx result traces in unit test result.
-                        self.result.extend(call_result);
+                        self.result.extend_setup(call_result);
 
                         // To continue unit test execution the call should not revert.
                         if reverted {

--- a/crates/forge/tests/cli/test_cmd/core.rs
+++ b/crates/forge/tests/cli/test_cmd/core.rs
@@ -286,6 +286,46 @@ Error: cannot generate flamegraph for FlamegraphNoExecutionTraceTest::setUp: no 
 "#]]);
 });
 
+forgetest_init!(flame_outputs_profile_test_after_before_test_setup, |prj, cmd| {
+    prj.add_test(
+        "FlameBeforeTestSetup.t.sol",
+        r#"
+contract FlameBeforeTestSetupTest {
+    function beforeTestSetup(bytes4 testSelector)
+        public
+        view
+        returns (bytes[] memory beforeTestCalldata)
+    {
+        if (testSelector == this.testProfile.selector) {
+            beforeTestCalldata = new bytes[](1);
+            beforeTestCalldata[0] = abi.encodeCall(this.beforeOnly, ());
+        }
+    }
+
+    function beforeOnly() public {}
+
+    function testProfile() public {}
+}
+"#,
+    );
+
+    cmd.args(["test", "--match-test", "testProfile", "--flamegraph"]).assert_success();
+    let flamegraph = std::fs::read_to_string(
+        prj.root().join("cache/flamegraph_FlameBeforeTestSetupTest_testProfile.svg"),
+    )
+    .unwrap();
+    assert!(flamegraph.contains("FlameBeforeTestSetupTest.testProfile()"));
+    assert!(!flamegraph.contains("FlameBeforeTestSetupTest.beforeOnly()"));
+
+    cmd.forge_fuse().args(["test", "--match-test", "testProfile", "--flamechart"]).assert_success();
+    let flamechart = std::fs::read_to_string(
+        prj.root().join("cache/flamechart_FlameBeforeTestSetupTest_testProfile.svg"),
+    )
+    .unwrap();
+    assert!(flamechart.contains("FlameBeforeTestSetupTest.testProfile()"));
+    assert!(!flamechart.contains("FlameBeforeTestSetupTest.beforeOnly()"));
+});
+
 forgetest_init!(payment_failure, |prj, cmd| {
     prj.add_test(
         "PaymentFailure.t.sol",


### PR DESCRIPTION
Classify transactions returned by `beforeTestSetup()` as setup traces so flamegraphs and flamecharts profile the selected test rather than the preceding setup transaction. 

Fixes #9920 