### PR TITLE
fix(chisel): clean up stale session cache file on rename

### DIFF
--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -289,7 +289,13 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
             self.session.id = Some(id);
         }
 
-        let new_cache_file = self.session.write()?;
+        let new_cache_file = match self.session.write() {
+            Ok(path) => path,
+            Err(error) => {
+                self.session.id = previous_id.clone();
+                return Err(error);
+            }
+        };
 
         if let (Some(previous_id), Some(current_id)) = (previous_id, self.session.id.as_deref())
             && previous_id != current_id

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -289,12 +289,18 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
             self.session.id = Some(id);
         }
 
-        self.session.write()?;
+        let new_cache_file = self.session.write()?;
 
         if let (Some(previous_id), Some(current_id)) = (previous_id, self.session.id.as_deref())
             && previous_id != current_id
         {
-            ChiselSession::<FEN>::remove_cached_session(&previous_id)?;
+            let old_cache_file =
+                format!("{}chisel-{previous_id}.json", ChiselSession::<FEN>::cache_dir()?);
+            let same_cache_file = std::fs::canonicalize(&old_cache_file).ok()
+                == std::fs::canonicalize(&new_cache_file).ok();
+            if !same_cache_file {
+                ChiselSession::<FEN>::remove_cached_session(&previous_id)?;
+            }
         }
 
         sh_println!("Saved session to cache with ID = {}", self.session.id.as_ref().unwrap())

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -282,13 +282,21 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
     }
 
     pub(crate) fn save_session(&mut self, id: Option<String>) -> Result<()> {
+        let previous_id = self.session.id.clone();
+
         // If a new name was supplied, overwrite the ID of the current session.
         if let Some(id) = id {
-            // TODO: Should we delete the old cache file if the id of the session changes?
             self.session.id = Some(id);
         }
 
         self.session.write()?;
+
+        if let (Some(previous_id), Some(current_id)) = (previous_id, self.session.id.as_deref())
+            && previous_id != current_id
+        {
+            ChiselSession::<FEN>::remove_cached_session(&previous_id)?;
+        }
+
         sh_println!("Saved session to cache with ID = {}", self.session.id.as_ref().unwrap())
     }
 

--- a/crates/chisel/src/dispatcher.rs
+++ b/crates/chisel/src/dispatcher.rs
@@ -292,7 +292,7 @@ impl<FEN: FoundryEvmNetwork> ChiselDispatcher<FEN> {
         let new_cache_file = match self.session.write() {
             Ok(path) => path,
             Err(error) => {
-                self.session.id = previous_id.clone();
+                self.session.id = previous_id;
                 return Err(error);
             }
         };

--- a/crates/chisel/src/session.rs
+++ b/crates/chisel/src/session.rs
@@ -70,6 +70,16 @@ impl<FEN: FoundryEvmNetwork> ChiselSession<FEN> {
         Ok(())
     }
 
+    /// Removes a cached session if it exists.
+    pub fn remove_cached_session(id: &str) -> Result<()> {
+        let cache_file = format!("{}chisel-{id}.json", Self::cache_dir()?);
+        match std::fs::remove_file(cache_file) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     /// Writes the ChiselSession to a file by serializing it to a JSON string
     ///
     /// ### Returns

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -25,6 +25,21 @@ repl_test!(repl_help, |repl| {
     repl.expect_prompt();
 });
 
+repl_test!(save_renamed_session_removes_stale_cache, |repl| {
+    repl.sendln("!save rename-old");
+    repl.sendln("!save rename-new");
+    repl.sendln("!list");
+
+    // A renamed session must not leave the previous cache entry loadable.
+    repl.sendln_raw("!load rename-old");
+    repl.expect("failed to load session");
+    repl.expect_prompt();
+
+    repl.sendln_raw("!load latest");
+    repl.expect("Loaded Chisel session! (ID = rename-new)");
+    repl.expect_prompt();
+});
+
 // Test abi encode/decode.
 repl_test!(abi_encode_decode, |repl| {
     repl.sendln("bytes memory encoded = abi.encode(42, \"hello\")");

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -1,5 +1,23 @@
 mod session;
+use chisel::session::ChiselSession as CachedChiselSession;
+use foundry_evm::core::evm::EthEvmNetwork;
 use session::ChiselSession;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct CacheCleanup(Vec<String>);
+
+impl Drop for CacheCleanup {
+    fn drop(&mut self) {
+        for id in &self.0 {
+            let _ = CachedChiselSession::<EthEvmNetwork>::remove_cached_session(id);
+        }
+    }
+}
+
+fn unique_cache_id(prefix: &str) -> String {
+    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    format!("{prefix}-{}-{timestamp}", std::process::id())
+}
 
 macro_rules! repl_test {
     ($name:ident, | $cmd:ident | $test:expr) => {
@@ -26,17 +44,37 @@ repl_test!(repl_help, |repl| {
 });
 
 repl_test!(save_renamed_session_removes_stale_cache, |repl| {
-    repl.sendln("!save rename-old");
-    repl.sendln("!save rename-new");
-    repl.sendln("!list");
+    let old_id = unique_cache_id("rename-old");
+    let new_id = unique_cache_id("rename-new");
+    let _cleanup = CacheCleanup(vec![old_id.clone(), new_id.clone()]);
+
+    repl.sendln(&format!("!save {old_id}"));
+    repl.sendln(&format!("!save {new_id}"));
+    repl.sendln_raw("!list");
+    repl.expect(&format!("chisel-{new_id}.json"));
+    repl.expect_prompt();
 
     // A renamed session must not leave the previous cache entry loadable.
-    repl.sendln_raw("!load rename-old");
+    repl.sendln_raw(&format!("!load {old_id}"));
     repl.expect("failed to load session");
     repl.expect_prompt();
 
-    repl.sendln_raw("!load latest");
-    repl.expect("Loaded Chisel session! (ID = rename-new)");
+    repl.sendln_raw(&format!("!load {new_id}"));
+    repl.expect(&format!("Loaded Chisel session! (ID = {new_id})"));
+    repl.expect_prompt();
+});
+
+repl_test!(save_case_only_rename_preserves_destination, |repl| {
+    let old_id = unique_cache_id("rename-case").to_ascii_lowercase();
+    let new_id = old_id.to_ascii_uppercase();
+    let _cleanup = CacheCleanup(vec![old_id.clone(), new_id.clone()]);
+
+    repl.sendln(&format!("!save {old_id}"));
+    repl.sendln(&format!("!save {new_id}"));
+
+    // On case-insensitive filesystems, both IDs resolve to the same cache path.
+    repl.sendln_raw(&format!("!load {new_id}"));
+    repl.expect(&format!("Loaded Chisel session! (ID = {new_id})"));
     repl.expect_prompt();
 });
 

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -2,7 +2,10 @@ mod session;
 use chisel::session::ChiselSession as CachedChiselSession;
 use foundry_evm::core::evm::EthEvmNetwork;
 use session::ChiselSession;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 struct CacheCleanup(Vec<String>);
 
@@ -17,6 +20,13 @@ impl Drop for CacheCleanup {
 fn unique_cache_id(prefix: &str) -> String {
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     format!("{prefix}-{}-{timestamp}", std::process::id())
+}
+
+fn cache_file(id: &str) -> PathBuf {
+    PathBuf::from(format!(
+        "{}chisel-{id}.json",
+        CachedChiselSession::<EthEvmNetwork>::cache_dir().unwrap()
+    ))
 }
 
 macro_rules! repl_test {
@@ -70,22 +80,35 @@ repl_test!(save_case_only_rename_preserves_destination, |repl| {
     let _cleanup = CacheCleanup(vec![old_id.clone(), new_id.clone()]);
 
     repl.sendln(&format!("!save {old_id}"));
+    let old_cache_file = cache_file(&old_id);
+    let new_cache_file = cache_file(&new_id);
+    let paths_alias =
+        std::fs::canonicalize(&old_cache_file).ok() == std::fs::canonicalize(&new_cache_file).ok();
+
     repl.sendln(&format!("!save {new_id}"));
 
     // On case-insensitive filesystems, both IDs resolve to the same cache path.
     repl.sendln_raw(&format!("!load {new_id}"));
     repl.expect(&format!("Loaded Chisel session! (ID = {new_id})"));
     repl.expect_prompt();
+
+    if !paths_alias {
+        repl.sendln_raw(&format!("!load {old_id}"));
+        repl.expect("failed to load session");
+        repl.expect_prompt();
+    }
 });
 
 repl_test!(failed_save_restores_previous_session_id, |repl| {
     let first_id = unique_cache_id("failed-save-first");
     let second_id = unique_cache_id("failed-save-second");
     let _cleanup = CacheCleanup(vec![first_id.clone(), second_id.clone()]);
+    let invalid_id = format!("{}/id", unique_cache_id("failed-save-invalid"));
 
     repl.sendln(&format!("!save {first_id}"));
     // The nested path makes the write fail without touching the existing cache file.
-    repl.sendln_raw("!save invalid/id");
+    repl.sendln_raw(&format!("!save {invalid_id}"));
+    repl.expect("No such file or directory");
     repl.expect_prompt();
 
     // A failed rename must not lose the ID of the last successfully saved file.

--- a/crates/chisel/tests/it/repl/mod.rs
+++ b/crates/chisel/tests/it/repl/mod.rs
@@ -78,6 +78,27 @@ repl_test!(save_case_only_rename_preserves_destination, |repl| {
     repl.expect_prompt();
 });
 
+repl_test!(failed_save_restores_previous_session_id, |repl| {
+    let first_id = unique_cache_id("failed-save-first");
+    let second_id = unique_cache_id("failed-save-second");
+    let _cleanup = CacheCleanup(vec![first_id.clone(), second_id.clone()]);
+
+    repl.sendln(&format!("!save {first_id}"));
+    // The nested path makes the write fail without touching the existing cache file.
+    repl.sendln_raw("!save invalid/id");
+    repl.expect_prompt();
+
+    // A failed rename must not lose the ID of the last successfully saved file.
+    repl.sendln(&format!("!save {second_id}"));
+    repl.sendln_raw("!list");
+    repl.expect(&format!("chisel-{second_id}.json"));
+    repl.expect_prompt();
+
+    repl.sendln_raw(&format!("!load {first_id}"));
+    repl.expect("failed to load session");
+    repl.expect_prompt();
+});
+
 // Test abi encode/decode.
 repl_test!(abi_encode_decode, |repl| {
     repl.sendln("bytes memory encoded = abi.encode(42, \"hello\")");


### PR DESCRIPTION
Closes #15796

## What

When a saved Chisel session is saved again under a different ID, the new cache file is written but the old `chisel-<id>.json` file remains. This makes `!list` show a stale session and allows the old ID to be loaded.

This change removes the previous cache file after the renamed session is successfully written. Re-saving with the same ID is unchanged, and a missing old file is treated as a no-op.

## Tests

- Added a REPL regression test covering `!save` with two IDs, `!list`, `!load <old-id>`, and `!load latest`.
- `cargo test -p chisel --test it -- save_renamed_session_removes_stale_cache -- --exact`
- `cargo test -p chisel`
- `cargo fmt --all --check`
- `git diff --check`

The full package test was also run with network access for the Solc/Foundry fixtures.