### PR TITLE
fix(doc): resolve inherited member links

### DIFF
--- a/crates/doc/src/hir_ext.rs
+++ b/crates/doc/src/hir_ext.rs
@@ -1002,7 +1002,7 @@ fn slug_anchor_segment(s: &str) -> String {
         if ch.is_ascii_alphanumeric() || ch == '_' {
             out.push(ch);
             last_was_dash = false;
-        } else if !last_was_dash && !out.is_empty() {
+        } else if ch != '$' && !last_was_dash && !out.is_empty() {
             out.push('-');
             last_was_dash = true;
         }

--- a/crates/doc/src/hir_ext.rs
+++ b/crates/doc/src/hir_ext.rs
@@ -8,7 +8,9 @@
 
 use path_slash::PathBufExt;
 use solar::{
-    ast::{CommentKind, ContractKind, DocComments, FunctionKind, ItemKind, NatSpecKind},
+    ast::{
+        CommentKind, ContractKind, DocComments, FunctionKind, ItemKind, NatSpecKind, Visibility,
+    },
     interface::source_map::FileName,
     sema::{
         Gcx,
@@ -17,7 +19,7 @@ use solar::{
     },
 };
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
     path::{Path, PathBuf},
 };
 use tracing::warn;
@@ -440,30 +442,9 @@ fn extract_inherited_doc_var(gcx: Gcx<'_>, vid: VariableId) -> Option<InheritedD
 /// source spelling so inherited docs can still resolve without panicking.
 pub(crate) fn function_param_types(gcx: Gcx<'_>, fid: FunctionId) -> Option<Vec<String>> {
     let f = gcx.hir.function(fid);
-    let source_types = gcx
-        .sources
-        .get(f.source)
-        .and_then(|source| source.ast.as_ref())
-        .and_then(|ast| {
-            ast.items.iter().find_map(|item| match &item.kind {
-                ItemKind::Function(func) if item.span == f.span => Some(&func.header.parameters),
-                ItemKind::Contract(c) => c.body.iter().find_map(|m| match &m.kind {
-                    ItemKind::Function(func) if m.span == f.span => Some(&func.header.parameters),
-                    _ => None,
-                }),
-                _ => None,
-            })
-        })
-        .map(|params| {
-            let sm = gcx.sess.source_map();
-            params
-                .vars
-                .iter()
-                .map(|v| {
-                    normalize_sol_type(sm.span_to_snippet(v.ty.span).unwrap_or_default().trim())
-                })
-                .collect::<Vec<_>>()
-        });
+    let source_types = function_source_param_types(gcx, fid).map(|params| {
+        params.into_iter().map(|param| normalize_sol_type(&param)).collect::<Vec<_>>()
+    });
 
     f.parameters
         .iter()
@@ -481,6 +462,30 @@ pub(crate) fn function_param_types(gcx: Gcx<'_>, fid: FunctionId) -> Option<Vec<
             }
         })
         .collect()
+}
+
+/// Extract function parameter types exactly as spelled in source.
+fn function_source_param_types(gcx: Gcx<'_>, fid: FunctionId) -> Option<Vec<String>> {
+    let f = gcx.hir.function(fid);
+    let ast = gcx.sources.get(f.source)?.ast.as_ref()?;
+    let params = ast.items.iter().find_map(|item| match &item.kind {
+        ItemKind::Function(func) if item.span == f.span => Some(&func.header.parameters),
+        ItemKind::Contract(c) => c.body.iter().find_map(|member| match &member.kind {
+            ItemKind::Function(func) if member.span == f.span => Some(&func.header.parameters),
+            _ => None,
+        }),
+        _ => None,
+    })?;
+    let sm = gcx.sess.source_map();
+    Some(
+        params
+            .vars
+            .iter()
+            .map(|variable| {
+                sm.span_to_snippet(variable.ty.span).unwrap_or_default().trim().to_string()
+            })
+            .collect(),
+    )
 }
 
 /// Canonicalize Solidity type aliases for generated anchors and source fallbacks.
@@ -654,17 +659,126 @@ pub struct LocalMembers {
     name: String,
     /// Member names with a heading (and thus an anchor) on the current page.
     members: HashSet<String>,
+    /// Heading and exact signature anchors rendered on the current page.
+    anchors: HashSet<String>,
+    /// Effective inherited member names and their optional documentation pages.
+    inherited: HashMap<String, Option<PathBuf>>,
+    /// Inherited contracts and the members rendered on their exact pages.
+    inherited_contracts: HashMap<String, InheritedContract>,
+}
+
+#[derive(Debug)]
+enum InheritedContract {
+    Unique { id: ContractId, page: Option<PathBuf>, anchors: HashSet<String> },
+    Ambiguous,
+}
+
+/// Record the heading and exact signature anchor for a rendered Solidity function.
+fn insert_function_anchors(
+    gcx: Gcx<'_>,
+    id: FunctionId,
+    anchors: &mut HashSet<String>,
+) -> Option<String> {
+    let function = gcx.hir.function(id);
+    if function.is_yul || function.is_getter() {
+        return None;
+    }
+    let params = function_source_param_types(gcx, id)?;
+    let name = match function.kind {
+        FunctionKind::Constructor => "constructor".to_string(),
+        FunctionKind::Fallback => "fallback".to_string(),
+        FunctionKind::Receive => "receive".to_string(),
+        FunctionKind::Function | FunctionKind::Modifier => function.name?.as_str().to_string(),
+    };
+    anchors.insert(slug_anchor_segment(&name));
+    anchors.insert(function_signature_anchor(&name, &params));
+    Some(name)
 }
 
 impl LocalMembers {
     /// Create an empty member set for the contract `name`.
     pub fn new(name: &str) -> Self {
-        Self { name: name.to_string(), members: HashSet::new() }
+        Self {
+            name: name.to_string(),
+            members: HashSet::new(),
+            anchors: HashSet::new(),
+            inherited: HashMap::new(),
+            inherited_contracts: HashMap::new(),
+        }
+    }
+
+    /// Create a member set populated with members declared by base contracts.
+    pub fn for_contract(gcx: Gcx<'_>, contract_id: ContractId, name_to_page: &NameToPage) -> Self {
+        let contract = gcx.hir.contract(contract_id);
+        let mut this = Self::new(contract.name.as_str());
+
+        // Solidity's linearization lists the current contract first, followed by bases in
+        // resolution order. Reserve the first inherited declaration even if its page is not
+        // rendered so a farther declaration cannot produce a confidently incorrect link.
+        for &base_id in contract.linearized_bases.iter().filter(|&&id| id != contract_id) {
+            let base = gcx.hir.contract(base_id);
+            let page = name_to_page.get_contract(base_id).cloned();
+            let mut anchors = HashSet::new();
+
+            for &item_id in base.items {
+                let (name, is_inherited) = match item_id {
+                    ItemId::Function(id) => {
+                        let function = gcx.hir.function(id);
+                        (
+                            insert_function_anchors(gcx, id, &mut anchors),
+                            function.visibility != Visibility::Private
+                                && function.kind != FunctionKind::Constructor,
+                        )
+                    }
+                    ItemId::Variable(id) => {
+                        let variable = gcx.hir.variable(id);
+                        (
+                            variable.name.map(|name| name.as_str().to_string()),
+                            variable.visibility != Some(Visibility::Private),
+                        )
+                    }
+                    ItemId::Struct(id) => {
+                        (Some(gcx.hir.strukt(id).name.as_str().to_string()), true)
+                    }
+                    ItemId::Enum(id) => (Some(gcx.hir.enumm(id).name.as_str().to_string()), true),
+                    ItemId::Error(id) => (Some(gcx.hir.error(id).name.as_str().to_string()), true),
+                    ItemId::Event(id) => (Some(gcx.hir.event(id).name.as_str().to_string()), true),
+                    ItemId::Udvt(id) => (Some(gcx.hir.udvt(id).name.as_str().to_string()), true),
+                    ItemId::Contract(_) => (None, false),
+                };
+                if let Some(name) = name {
+                    anchors.insert(slug_anchor_segment(&name));
+                    if is_inherited {
+                        this.inherited.entry(name).or_insert_with(|| page.clone());
+                    }
+                }
+            }
+
+            match this.inherited_contracts.entry(base.name.as_str().to_string()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(InheritedContract::Unique { id: base_id, page, anchors });
+                }
+                Entry::Occupied(mut entry) => {
+                    if matches!(entry.get(), InheritedContract::Unique { id, .. } if *id != base_id)
+                    {
+                        entry.insert(InheritedContract::Ambiguous);
+                    }
+                }
+            }
+        }
+
+        this
     }
 
     /// Record a member that is rendered as a `### member` heading on the page.
     pub fn insert(&mut self, member: &str) {
         self.members.insert(member.to_string());
+        self.anchors.insert(slug_anchor_segment(member));
+    }
+
+    /// Record an exact signature anchor rendered on the current page.
+    pub fn insert_anchor(&mut self, anchor: String) {
+        self.anchors.insert(anchor);
     }
 
     /// Anchor for a bare `{member}` reference, if `member` is documented on this page.
@@ -677,8 +791,39 @@ impl LocalMembers {
     /// Anchor for a qualified `{Contract-member[-params...]}` reference, if `member` is
     /// documented on this page.
     fn xref_member_anchor(&self, part: &str) -> Option<String> {
-        let member = part.split('-').find(|piece| !piece.is_empty())?;
-        self.members.contains(member).then(|| xref_part_anchor(part))
+        let anchor = xref_part_anchor(part);
+        self.anchors.contains(&anchor).then_some(anchor)
+    }
+
+    /// Page and anchor for a bare inherited-member reference.
+    ///
+    /// The outer option indicates whether the name is inherited; the inner option is absent when
+    /// the effective declaration has no rendered page.
+    fn inherited_member_link(&self, member: &str, current_page: &Path) -> Option<Option<String>> {
+        let page = self.inherited.get(member)?;
+        Some(page.as_ref().map(|page| {
+            format!("{}#{}", page_link(page, current_page), slug_anchor_segment(member))
+        }))
+    }
+
+    /// Exact page and anchor for a qualified inherited-contract member reference.
+    ///
+    /// The outer option indicates whether the contract is an inherited base; the inner option is
+    /// absent when that base has no rendered page or the named member has no rendered heading.
+    fn inherited_contract_member_link(
+        &self,
+        contract: &str,
+        part: &str,
+        current_page: &Path,
+    ) -> Option<Option<String>> {
+        let base = self.inherited_contracts.get(contract)?;
+        let InheritedContract::Unique { page, anchors, .. } = base else {
+            return Some(None);
+        };
+        let anchor = xref_part_anchor(part);
+        Some(page.as_ref().and_then(|page| {
+            anchors.contains(&anchor).then(|| format!("{}#{anchor}", page_link(page, current_page)))
+        }))
     }
 }
 
@@ -725,22 +870,47 @@ pub fn replace_inline_links(
                 // `{member}` documented on this page, or `{Contract-member}` where
                 // `Contract` is the contract being rendered.
                 if let Some(local) = local {
-                    let anchor = match part {
-                        None => local.member_anchor(lookup_name),
+                    let local_anchor = match part {
+                        None => local.member_anchor(lookup_name).map(Some),
                         Some(member) if lookup_name == local.name => {
-                            local.xref_member_anchor(member)
+                            Some(local.xref_member_anchor(member))
                         }
                         Some(_) => None,
                     };
-                    if let Some(anchor) = anchor
-                        && !anchor.is_empty()
-                    {
-                        let default_display = match part {
-                            Some(member) => format!("{lookup_name}.{member}"),
-                            None => lookup_name.to_string(),
-                        };
-                        let display = escape_link_label(label.unwrap_or(&default_display));
-                        out.push_str(&format!("[{display}](#{anchor})"));
+                    if let Some(anchor) = local_anchor {
+                        if let Some(anchor) = anchor {
+                            let default_display = match part {
+                                Some(member) => format!("{lookup_name}.{member}"),
+                                None => lookup_name.to_string(),
+                            };
+                            let display = escape_link_label(label.unwrap_or(&default_display));
+                            out.push_str(&format!("[{display}](#{anchor})"));
+                        } else {
+                            let safe_name = lookup_name.replace('`', "'");
+                            out.push_str(&format!("`{safe_name}`"));
+                        }
+                        i += end;
+                        continue;
+                    }
+
+                    let inherited_link = match part {
+                        None => local.inherited_member_link(lookup_name, current_page),
+                        Some(member) => {
+                            local.inherited_contract_member_link(lookup_name, member, current_page)
+                        }
+                    };
+                    if let Some(link) = inherited_link {
+                        if let Some(link) = link {
+                            let default_display = match part {
+                                Some(member) => format!("{lookup_name}.{member}"),
+                                None => lookup_name.to_string(),
+                            };
+                            let display = escape_link_label(label.unwrap_or(&default_display));
+                            out.push_str(&format!("[{display}]({link})"));
+                        } else {
+                            let safe_name = lookup_name.replace('`', "'");
+                            out.push_str(&format!("`{safe_name}`"));
+                        }
                         i += end;
                         continue;
                     }

--- a/crates/doc/src/render.rs
+++ b/crates/doc/src/render.rs
@@ -199,7 +199,10 @@ fn render_contract<'ast, 'gcx>(
 
     // Index the members rendered as headings on this page so `{member}` and
     // `{Contract-member}` self-references resolve to anchor-only links.
-    let mut local = hir_ext::LocalMembers::new(name);
+    let mut local = hir_id.map_or_else(
+        || hir_ext::LocalMembers::new(name),
+        |id| hir_ext::LocalMembers::for_contract(gcx, id, name_to_page),
+    );
     for member in c.body.iter() {
         match &member.kind {
             ItemKind::Variable(v) => {
@@ -207,7 +210,12 @@ fn render_contract<'ast, 'gcx>(
                     local.insert(n.as_str());
                 }
             }
-            ItemKind::Function(f) => local.insert(&function_heading(f)),
+            ItemKind::Function(f) => {
+                local.insert(&function_heading(f));
+                if let Some(anchor) = function_signature_anchor(f, ctx) {
+                    local.insert_anchor(anchor);
+                }
+            }
             ItemKind::Event(e) => local.insert(e.name.as_str()),
             ItemKind::Error(e) => local.insert(e.name.as_str()),
             ItemKind::Struct(s) => local.insert(s.name.as_str()),

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -1565,6 +1565,7 @@ contract A {
         uint256 value;
     }
 
+    uint256 public balance$raw;
     uint256 private secret;
 
     error Failure();
@@ -1608,7 +1609,7 @@ import {A as BaseA} from "../base/A.sol";
 
 contract B is BaseA {
     /// @notice See {foo} or {A-foo}.
-    /// Also see {Payload}, {Failure}, {Fired}, and {State}.
+    /// Also see {Payload}, {Failure}, {Fired}, {State}, and {balance$raw}.
     /// The Yul function {helper} has no documentation heading.
     /// Private members {hidden} and {secret} are not inherited.
     /// The qualified Yul function {A-helper} has no documentation heading.
@@ -1626,7 +1627,7 @@ contract B is BaseA {
         str![[r#"
 ...
 See [foo](/src/base/contract.A#foo) or [A.foo](/src/base/contract.A#foo).
-Also see [Payload](/src/base/contract.A#payload), [Failure](/src/base/contract.A#failure), [Fired](/src/base/contract.A#fired), and [State](/src/base/contract.A#state).
+Also see [Payload](/src/base/contract.A#payload), [Failure](/src/base/contract.A#failure), [Fired](/src/base/contract.A#fired), [State](/src/base/contract.A#state), and [balance$raw](/src/base/contract.A#balanceraw).
 The Yul function `helper` has no documentation heading.
 Private members `hidden` and `secret` are not inherited.
 The qualified Yul function `A` has no documentation heading.

--- a/crates/forge/tests/cli/doc.rs
+++ b/crates/forge/tests/cli/doc.rs
@@ -1412,7 +1412,7 @@ library ECDSA {
     /// message and then calling {toEthSignedMessageHash} on it.
     function recover(bytes32 hash) internal pure returns (address) {}
 
-    /// @dev Overload of {ECDSA-tryRecover} that receives the fields separately.
+    /// @dev Overload of {ECDSA-tryRecover-bytes32-bytes32}; not {ECDSA-tryRecover-address}.
     function tryRecover(bytes32 hash, bytes32 r) internal pure returns (address) {}
 
     function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {}
@@ -1475,7 +1475,7 @@ function recover(bytes32 hash) internal pure returns (address);
 
 <i>
 
-Overload of [ECDSA.tryRecover](#tryrecover) that receives the fields separately.
+Overload of [ECDSA.tryRecover-bytes32-bytes32](#tryrecover-bytes32-bytes32); not `ECDSA`.
 
 </i>
 
@@ -1549,6 +1549,243 @@ function mint(address account_) external;
 | account_ | `address` |  |
 
 
+"#]],
+    );
+});
+
+forgetest_init!(inherited_member_references_resolve_to_base_page, |prj, cmd| {
+    prj.add_source(
+        "base/A.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract A {
+    struct Payload {
+        uint256 value;
+    }
+
+    uint256 private secret;
+
+    error Failure();
+    event Fired();
+    enum State { Ready }
+
+    function foo() external {}
+    function overloaded(uint256 value) external {}
+    function hidden() private {}
+
+    function withAssembly() external pure {
+        assembly {
+            function helper() {}
+        }
+    }
+}
+"#,
+    );
+    prj.add_source(
+        "consumer/A.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract A {
+    function foo() external {}
+}
+
+contract Utility {
+    function work() external {}
+}
+"#,
+    );
+    prj.add_source(
+        "consumer/B.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {A as BaseA} from "../base/A.sol";
+
+contract B is BaseA {
+    /// @notice See {foo} or {A-foo}.
+    /// Also see {Payload}, {Failure}, {Fired}, and {State}.
+    /// The Yul function {helper} has no documentation heading.
+    /// Private members {hidden} and {secret} are not inherited.
+    /// The qualified Yul function {A-helper} has no documentation heading.
+    /// Exact overload {A-overloaded-uint256}; missing overload {A-overloaded-address}.
+    /// Non-inherited qualified reference {Utility-work} still resolves globally.
+    function bar() external {}
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/consumer/contract.B.mdx"), None),
+        str![[r#"
+...
+See [foo](/src/base/contract.A#foo) or [A.foo](/src/base/contract.A#foo).
+Also see [Payload](/src/base/contract.A#payload), [Failure](/src/base/contract.A#failure), [Fired](/src/base/contract.A#fired), and [State](/src/base/contract.A#state).
+The Yul function `helper` has no documentation heading.
+Private members `hidden` and `secret` are not inherited.
+The qualified Yul function `A` has no documentation heading.
+Exact overload [A.overloaded-uint256](/src/base/contract.A#overloaded-uint256); missing overload `A`.
+Non-inherited qualified reference [Utility.work](/src/consumer/contract.Utility#work) still resolves globally.
+...
+"#]],
+    );
+});
+
+forgetest_init!(unrendered_override_does_not_link_to_ancestor, |prj, cmd| {
+    prj.add_source(
+        "ancestor/A.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract A {
+    function foo() public virtual {}
+}
+"#,
+    );
+    prj.add_source(
+        "hidden/Middle.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {A} from "../ancestor/A.sol";
+
+contract Middle is A {
+    function foo() public virtual override {}
+}
+"#,
+    );
+    prj.add_source(
+        "Middle.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract Middle {
+    function foo() public {}
+}
+"#,
+    );
+    prj.add_source(
+        "Child.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Middle} from "./hidden/Middle.sol";
+
+contract Child is Middle {
+    /// @notice See {foo} and {Middle-foo}.
+    function bar() external {}
+}
+"#,
+    );
+    prj.update_config(|config| config.doc.ignore = vec!["src/hidden/Middle.sol".to_string()]);
+
+    cmd.args(["doc"]).assert_success();
+
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Child.mdx"), None),
+        str![[r#"
+...
+See `foo` and `Middle`.
+...
+"#]],
+    );
+});
+
+forgetest_init!(ambiguous_inherited_contract_name_does_not_link, |prj, cmd| {
+    prj.add_source(
+        "left/A.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract A {
+    function left() external {}
+}
+"#,
+    );
+    prj.add_source(
+        "right/A.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract A {
+    function right() external {}
+}
+"#,
+    );
+    prj.add_source(
+        "Child.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {A as LeftA} from "./left/A.sol";
+import {A as RightA} from "./right/A.sol";
+
+contract Child is LeftA, RightA {
+    /// @notice See {A-right}.
+    function child() external {}
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Child.mdx"), None),
+        str![[r#"
+...
+See `A`.
+...
+"#]],
+    );
+});
+
+forgetest_init!(inherited_special_function_links_use_declaring_page, |prj, cmd| {
+    prj.add_source(
+        "Special.sol",
+        r#"
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract A {
+    constructor() {}
+    fallback() external payable {}
+    receive() external payable {}
+}
+
+contract Middle is A {}
+
+contract Child is Middle {
+    /// @notice Bare {constructor}, {fallback}, and {receive}.
+    /// Middle {Middle-constructor}, {Middle-fallback}, and {Middle-receive}.
+    /// A {A-constructor}, {A-fallback}, and {A-receive}.
+    function child() external {}
+}
+"#,
+    );
+
+    cmd.args(["doc"]).assert_success();
+
+    assert_data_eq!(
+        Data::read_from(&prj.root().join("docs/src/pages/src/contract.Child.mdx"), None),
+        str![[r#"
+...
+Bare `constructor`, [fallback](/src/contract.A#fallback), and [receive](/src/contract.A#receive).
+Middle `Middle`, `Middle`, and `Middle`.
+A [A.constructor](/src/contract.A#constructor), [A.fallback](/src/contract.A#fallback), and [A.receive](/src/contract.A#receive).
+...
 "#]],
     );
 });


### PR DESCRIPTION
## Motivation

Close #9506.

Index members from the linearized base contracts so bare NatSpec cross-references link to the declaring page.

