### PR TITLE
fix: trace pranked caller

### DIFF
--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1417,6 +1417,11 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             },
         );
 
+        // The tracer records call inputs before cheatcodes apply caller overrides such as pranks
+        // and broadcasts. Keep the trace lifecycle ordering, but remember the node so its caller
+        // can be synchronized with the inputs that are actually executed.
+        let trace_idx = self.tracer.as_ref().map(|tracer| tracer.traces().nodes().len() - 1);
+        let mut cheatcode_outcome = None;
         if let Some(cheatcodes) = self.cheatcodes.as_deref_mut() {
             // Handle mocked functions, replace bytecode address with mock if matched.
             if let Some(mocks) = cheatcodes.mocked_functions.get(&call.bytecode_address) {
@@ -1438,9 +1443,23 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                 }
             }
 
-            if let Some(output) = cheatcodes.call_with_executor(ecx, call, self.inner) {
-                return Some(output);
-            }
+            cheatcode_outcome = cheatcodes.call_with_executor(ecx, call, self.inner);
+        }
+
+        if let Some(trace_idx) = trace_idx
+            && let Some(tracer) = self.tracer.as_deref_mut()
+        {
+            let caller = match call.scheme {
+                CallScheme::DelegateCall | CallScheme::CallCode => call.target_address,
+                CallScheme::Call | CallScheme::StaticCall => call.caller,
+            };
+            let node = &mut tracer.traces_mut().nodes_mut()[trace_idx];
+            debug_assert_eq!(node.trace.depth, ecx.journal().depth());
+            node.trace.caller = caller;
+        }
+
+        if let Some(output) = cheatcode_outcome {
+            return Some(output);
         }
 
         if let Some(outcome) = handle_arbitrum_system_call::<FEN>(ecx, call) {

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1551,9 +1551,27 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
 
         call_inspectors!(
             #[ret]
-            [&mut self.tracer, &mut self.line_coverage, &mut self.cheatcodes],
+            [&mut self.tracer, &mut self.line_coverage],
             |inspector| inspector.create(ecx, create).map(Some),
         );
+
+        let trace_idx = self.tracer.as_ref().map(|tracer| tracer.traces().nodes().len() - 1);
+        let mut cheatcode_outcome = None;
+        if let Some(cheatcodes) = self.cheatcodes.as_deref_mut() {
+            cheatcode_outcome = cheatcodes.create(ecx, create);
+        }
+
+        if let Some(trace_idx) = trace_idx
+            && let Some(tracer) = self.tracer.as_deref_mut()
+        {
+            let node = &mut tracer.traces_mut().nodes_mut()[trace_idx];
+            debug_assert_eq!(node.trace.depth, ecx.journal().depth());
+            node.trace.caller = create.caller();
+        }
+
+        if let Some(output) = cheatcode_outcome {
+            return Some(output);
+        }
 
         // If frame_start detected an invalid CREATE2 deployer, return the error here
         // (after sub-inspectors have been notified) so tracing stays balanced.

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2136,12 +2136,70 @@ contract SimpleScript is Script {
     ])
     .assert_success()
     .stdout_eq(str![[r#"
-{"logs":[],"returns":{"success":{"internal_type":"bool","value":"true"}},"success":true,"raw_logs":[],"traces":[["Deployment",{"arena":[{"parent":null,"children":[],"idx":0,"trace":{"depth":0,"success":true,"caller":"0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38","address":"0x5b73c5498c1e3b4dba84de0f1833c4a029d90519","maybe_precompile":false,"selfdestruct_address":null,"selfdestruct_refund_target":null,"selfdestruct_transferred_value":null,"kind":"CREATE","value":"0x0","data":"[..]","output":"[..]","gas_used":"{...}","gas_limit":"{...}","gas_refund_counter":0,"status":"Return","steps":[],"decoded":{"label":"SimpleScript","return_data":null,"call_data":null}},"logs":[],"ordering":[]}]}],["Execution",{"arena":[{"parent":null,"children":[1,2],"idx":0,"trace":{"depth":0,"success":true,"caller":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","address":"0x5b73c5498c1e3b4dba84de0f1833c4a029d90519","maybe_precompile":null,"selfdestruct_address":null,"selfdestruct_refund_target":null,"selfdestruct_transferred_value":null,"kind":"CALL","value":"0x0","data":"0xc0406226","output":"0x0000000000000000000000000000000000000000000000000000000000000001","gas_used":"{...}","gas_limit":1073720760,"gas_refund_counter":0,"status":"Return","steps":[],"decoded":{"label":"SimpleScript","return_data":"true","call_data":{"signature":"run()","args":[]}}},"logs":[],"ordering":[{"Call":0},{"Call":1}]},{"parent":0,"children":[],"idx":1,"trace":{"depth":1,"success":true,"caller":"0x5b73c5498c1e3b4dba84de0f1833c4a029d90519","address":"0x7109709ecfa91a80626ff3989d68f67f5b1dd12d","maybe_precompile":null,"selfdestruct_address":null,"selfdestruct_refund_target":null,"selfdestruct_transferred_value":null,"kind":"CALL","value":"0x0","data":"0x7fb5297f","output":"0x","gas_used":"{...}","gas_limit":1056940999,"gas_refund_counter":0,"status":"Return","steps":[],"decoded":{"label":"VM","return_data":null,"call_data":{"signature":"startBroadcast()","args":[]}}},"logs":[],"ordering":[]},{"parent":0,"children":[],"idx":2,"trace":{"depth":1,"success":true,"caller":"0x5b73c5498c1e3b4dba84de0f1833c4a029d90519","address":"0x0000000000000000000000000000000000000000","maybe_precompile":null,"selfdestruct_address":null,"selfdestruct_refund_target":null,"selfdestruct_transferred_value":null,"kind":"CALL","value":"0x0","data":"0x","output":"0x","gas_used":"{...}","gas_limit":1056940650,"gas_refund_counter":0,"status":"Stop","steps":[],"decoded":{"label":null,"return_data":null,"call_data":null}},"logs":[],"ordering":[]}]}]],"gas_used":"{...}","labeled_addresses":{},"returned":"0x0000000000000000000000000000000000000000000000000000000000000001","address":null}
+{"logs":[],"returns":{"success":{"internal_type":"bool","value":"true"}},"success":true,"raw_logs":[],"traces":[["Deployment",{"arena":[{"parent":null,"children":[],"idx":0,"trace":{"depth":0,"success":true,"caller":"0x1804c8ab1f12e6bbf3894d4083f33e07309d1f38","address":"0x5b73c5498c1e3b4dba84de0f1833c4a029d90519","maybe_precompile":false,"selfdestruct_address":null,"selfdestruct_refund_target":null,"selfdestruct_transferred_value":null,"kind":"CREATE","value":"0x0","data":"[..]","output":"[..]","gas_used":"{...}","gas_limit":"{...}","gas_refund_counter":0,"status":"Return","steps":[],"decoded":{"label":"SimpleScript","return_data":null,"call_data":null}},"logs":[],"ordering":[]}]}],["Execution",{"arena":[{"parent":null,"children":[1,2],"idx":0,"trace":{"depth":0,"success":true,"caller":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","address":"0x5b73c5498c1e3b4dba84de0f1833c4a029d90519","maybe_precompile":null,"selfdestruct_address":null,"selfdestruct_refund_target":null,"selfdestruct_transferred_value":null,"kind":"CALL","value":"0x0","data":"0xc0406226","output":"0x0000000000000000000000000000000000000000000000000000000000000001","gas_used":"{...}","gas_limit":1073720760,"gas_refund_counter":0,"status":"Return","steps":[],"decoded":{"label":"SimpleScript","return_data":"true","call_data":{"signature":"run()","args":[]}}},"logs":[],"ordering":[{"Call":0},{"Call":1}]},{"parent":0,"children":[],"idx":1,"trace":{"depth":1,"success":true,"caller":"0x5b73c5498c1e3b4dba84de0f1833c4a029d90519","address":"0x7109709ecfa91a80626ff3989d68f67f5b1dd12d","maybe_precompile":null,"selfdestruct_address":null,"selfdestruct_refund_target":null,"selfdestruct_transferred_value":null,"kind":"CALL","value":"0x0","data":"0x7fb5297f","output":"0x","gas_used":"{...}","gas_limit":1056940999,"gas_refund_counter":0,"status":"Return","steps":[],"decoded":{"label":"VM","return_data":null,"call_data":{"signature":"startBroadcast()","args":[]}}},"logs":[],"ordering":[]},{"parent":0,"children":[],"idx":2,"trace":{"depth":1,"success":true,"caller":"0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266","address":"0x0000000000000000000000000000000000000000","maybe_precompile":null,"selfdestruct_address":null,"selfdestruct_refund_target":null,"selfdestruct_transferred_value":null,"kind":"CALL","value":"0x0","data":"0x","output":"0x","gas_used":"{...}","gas_limit":1056940650,"gas_refund_counter":0,"status":"Stop","steps":[],"decoded":{"label":null,"return_data":null,"call_data":null}},"logs":[],"ordering":[]}]}]],"gas_used":"{...}","labeled_addresses":{},"returned":"0x0000000000000000000000000000000000000000000000000000000000000001","address":null}
 {"chain":31337,"estimated_gas_price":"{...}","estimated_total_gas_used":"{...}","estimated_amount_required":"{...}","token_symbol":"ETH","estimated_max_fee_per_gas":"{...}","estimated_base_fee_per_gas":"{...}","estimated_max_priority_fee_per_gas":"{...}"}
 {"chain":"anvil-hardhat","status":"success","tx_hash":"0x4f78afe915fceb282c7625a68eb350bc0bf78acb59ad893e5c62b710a37f3156","contract_address":null,"block_number":1,"gas_used":"{...}","gas_price":"{...}"}
 {"status":"success","transactions":"[..]/broadcast/Foo.sol/31337/run-latest.json","sensitive":"[..]/cache/Foo.sol/31337/run-latest.json"}
 
 "#]].is_jsonlines());
+});
+
+// https://github.com/foundry-rs/foundry/issues/10050
+forgetest_init!(json_trace_uses_pranked_caller, |prj, cmd| {
+    prj.add_source(
+        "Target",
+        r#"
+contract Target {
+    address public observedCaller;
+
+    function increment() external {
+        observedCaller = msg.sender;
+    }
+}
+   "#,
+    );
+    prj.add_script(
+        "PrankTrace",
+        r#"
+import "forge-std/Script.sol";
+import {Target} from "../src/Target.sol";
+
+contract PrankTrace is Script {
+    function run() external {
+        vm.startPrank(address(0x1234));
+        Target target = Target(vm.deployCode("src/Target.sol:Target"));
+        target.increment();
+        require(target.observedCaller() == address(0x1234));
+        vm.stopPrank();
+    }
+}
+   "#,
+    );
+
+    let output = cmd
+        .args(["script", "PrankTrace", "-vvvv", "--json"])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+    let output: Value = serde_json::from_slice(&output).unwrap();
+    let execution =
+        output["traces"].as_array().unwrap().iter().find(|trace| trace[0] == "Execution").unwrap();
+    let increment = execution[1]["arena"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|node| node["trace"]["data"] == "0xd09de08a")
+        .unwrap();
+    let deployment = execution[1]["arena"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|node| node["trace"]["kind"] == "CREATE")
+        .unwrap();
+
+    assert_eq!(increment["trace"]["caller"], "0x0000000000000000000000000000000000001234");
+    assert_eq!(deployment["trace"]["caller"], "0x0000000000000000000000000000000000001234");
 });
 
 // https://github.com/foundry-rs/foundry/pull/7742

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -2202,6 +2202,54 @@ contract PrankTrace is Script {
     assert_eq!(deployment["trace"]["caller"], "0x0000000000000000000000000000000000001234");
 });
 
+forgetest_init!(json_trace_uses_pranked_create_caller, |prj, cmd| {
+    prj.add_script(
+        "PrankCreateTrace",
+        r#"
+import "forge-std/Script.sol";
+
+contract Target {
+    address public creator = msg.sender;
+}
+
+contract PrankCreateTrace is Script {
+    function run() external {
+        vm.startPrank(address(0x1234));
+        Target created = new Target();
+        Target created2 = new Target{salt: bytes32(uint256(1))}();
+        require(created.creator() == address(0x1234));
+        require(created2.creator() == address(0x1234));
+        vm.stopPrank();
+    }
+}
+   "#,
+    );
+
+    let output = cmd
+        .args(["script", "PrankCreateTrace", "-vvvv", "--json"])
+        .assert_success()
+        .get_output()
+        .stdout
+        .clone();
+    let output: Value = serde_json::from_slice(&output).unwrap();
+    let execution =
+        output["traces"].as_array().unwrap().iter().find(|trace| trace[0] == "Execution").unwrap();
+    let deployments = execution[1]["arena"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|node| matches!(node["trace"]["kind"].as_str(), Some("CREATE" | "CREATE2")))
+        .collect::<Vec<_>>();
+
+    assert_eq!(deployments.len(), 2);
+    assert!(deployments.iter().any(|node| node["trace"]["kind"] == "CREATE2"));
+    assert!(
+        deployments
+            .iter()
+            .all(|node| node["trace"]["caller"] == "0x0000000000000000000000000000000000001234")
+    );
+});
+
 // https://github.com/foundry-rs/foundry/pull/7742
 forgetest_async!(unlocked_no_sender, |prj, cmd| {
     foundry_test_utils::util::initialize(prj.root());


### PR DESCRIPTION
Updates call traces after cheatcode processing so the caller reflects `prank` and `broadcast` overrides while preserving trace ordering for nested cheatcodes. Closes #10050.