### PR TITLE
feat(anvil): activity simulation (`--activity`)

### DIFF
--- a/crates/anvil/core/src/eth/mod.rs
+++ b/crates/anvil/core/src/eth/mod.rs
@@ -1,4 +1,7 @@
-use crate::{eth::subscription::SubscriptionId, types::ReorgOptions};
+use crate::{
+    eth::subscription::SubscriptionId,
+    types::{ActivityOptions, ReorgOptions},
+};
 use alloy_primitives::{
     Address, B64, B256, Bytes, TxHash, U64, U256,
     map::{HashMap, HashSet},
@@ -534,6 +537,14 @@ pub enum EthRequest {
     /// Gets the current mining behavior
     #[serde(rename = "anvil_getIntervalMining", with = "empty_params")]
     GetIntervalMining(()),
+
+    /// Sets or disables (`null`) activity simulation
+    #[serde(rename = "anvil_setActivity", with = "sequence")]
+    SetActivity(Option<ActivityOptions>),
+
+    /// Gets the current activity simulation config
+    #[serde(rename = "anvil_getActivity", with = "empty_params")]
+    GetActivity(()),
 
     /// Removes transactions from the pool
     #[serde(rename = "anvil_dropTransaction", alias = "hardhat_dropTransaction", with = "sequence")]
@@ -1153,6 +1164,22 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
         let s = r#"{"method": "evm_setIntervalMining", "params": [100]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+    }
+
+    #[test]
+    fn test_custom_activity() {
+        let s = r#"{"method": "anvil_setActivity", "params": [{"txs":{"min":1,"max":4},"reverted":20}]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        let _req = serde_json::from_value::<EthRequest>(value).unwrap();
+        let s = r#"{"method": "anvil_setActivity", "params": [null]}"#;
+        let value: serde_json::Value = serde_json::from_str(s).unwrap();
+        match serde_json::from_value::<EthRequest>(value).unwrap() {
+            EthRequest::SetActivity(options) => assert_eq!(options, None),
+            _ => unreachable!(),
+        }
+        let s = r#"{"method": "anvil_getActivity", "params": []}"#;
         let value: serde_json::Value = serde_json::from_str(s).unwrap();
         let _req = serde_json::from_value::<EthRequest>(value).unwrap();
     }

--- a/crates/anvil/core/src/types.rs
+++ b/crates/anvil/core/src/types.rs
@@ -1,6 +1,7 @@
-use alloy_primitives::Bytes;
+use alloy_primitives::{Bytes, U256, utils::parse_ether};
 use alloy_rpc_types::TransactionRequest;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 /// Represents the options used in `anvil_reorg`
 #[derive(Debug, Clone, Deserialize)]
@@ -17,4 +18,123 @@ pub struct ReorgOptions {
 pub enum TransactionData {
     JSON(TransactionRequest),
     Raw(Bytes),
+}
+
+/// Options for `anvil_setActivity`, also used as the node's activity simulation config.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct ActivityOptions {
+    /// Number of transactions injected per block.
+    pub txs: ActivityRange<u64>,
+    /// Percentage of transactions that revert.
+    pub reverted: u8,
+    /// Percentage of transactions left pending indefinitely.
+    pub pending: u8,
+    /// Number of events emitted per contract-call transaction.
+    pub logs: ActivityRange<u64>,
+    /// Transfer value range in wei.
+    pub value: ActivityRange<U256>,
+    /// Enabled transaction kinds. `None` selects a network-appropriate default.
+    pub mix: Option<Vec<ActivityKind>>,
+    /// RNG seed for deterministic activity.
+    pub seed: Option<u64>,
+}
+
+impl Default for ActivityOptions {
+    fn default() -> Self {
+        Self {
+            txs: ActivityRange { min: 3, max: 8 },
+            reverted: 10,
+            pending: 5,
+            logs: ActivityRange { min: 0, max: 3 },
+            value: ActivityRange {
+                min: parse_ether("0.0001").expect("valid ether"),
+                max: parse_ether("0.1").expect("valid ether"),
+            },
+            mix: None,
+            seed: None,
+        }
+    }
+}
+
+/// Inclusive `min..=max` range for activity knobs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActivityRange<T> {
+    pub min: T,
+    pub max: T,
+}
+
+impl<T: FromStr + Copy + PartialOrd> ActivityRange<T> {
+    /// Parses `N` or `N-M`.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let parse = |s: &str| s.trim().parse::<T>().map_err(|_| format!("invalid value: `{s}`"));
+        let (min, max) = match s.split_once('-') {
+            Some((min, max)) => (parse(min)?, parse(max)?),
+            None => {
+                let value = parse(s)?;
+                (value, value)
+            }
+        };
+        if min > max {
+            return Err(format!("invalid range: `{s}`"));
+        }
+        Ok(Self { min, max })
+    }
+}
+
+/// A kind of generated activity transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ActivityKind {
+    /// Plain native transfers between dev accounts.
+    Transfer,
+    /// Activity contract calls (events, storage churn, gas burn).
+    Contract,
+    /// Mock ERC20 transfer/approve traffic.
+    Erc20,
+    /// Storage-write heavy activity contract calls.
+    State,
+    /// TIP-20 precompile activity (Tempo networks).
+    Tip20,
+}
+
+impl FromStr for ActivityKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "transfer" => Ok(Self::Transfer),
+            "contract" => Ok(Self::Contract),
+            "erc20" => Ok(Self::Erc20),
+            "state" => Ok(Self::State),
+            "tip20" => Ok(Self::Tip20),
+            other => Err(format!("unknown activity kind: `{other}`")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_activity_range() {
+        assert_eq!(ActivityRange::<u64>::parse("5").unwrap(), ActivityRange { min: 5, max: 5 });
+        assert_eq!(ActivityRange::<u64>::parse("3-8").unwrap(), ActivityRange { min: 3, max: 8 });
+        assert!(ActivityRange::<u64>::parse("8-3").is_err());
+        assert!(ActivityRange::<u64>::parse("abc").is_err());
+    }
+
+    #[test]
+    fn activity_options_serde_roundtrip() {
+        let options = ActivityOptions { seed: Some(1), ..Default::default() };
+        let json = serde_json::to_string(&options).unwrap();
+        assert_eq!(serde_json::from_str::<ActivityOptions>(&json).unwrap(), options);
+        // Partial objects fall back to defaults.
+        let partial: ActivityOptions =
+            serde_json::from_str(r#"{"txs":{"min":1,"max":2},"reverted":50}"#).unwrap();
+        assert_eq!(partial.txs, ActivityRange { min: 1, max: 2 });
+        assert_eq!(partial.reverted, 50);
+        assert_eq!(partial.pending, ActivityOptions::default().pending);
+    }
 }

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -5,8 +5,13 @@ use crate::{
 };
 use alloy_genesis::Genesis;
 use alloy_network::Network;
-use alloy_primitives::{Address, B256, U256, map::HashMap, utils::Unit};
+use alloy_primitives::{
+    Address, B256, U256,
+    map::HashMap,
+    utils::{Unit, parse_ether},
+};
 use alloy_signer_local::coins_bip39::{English, Mnemonic};
+use anvil_core::types::{ActivityKind, ActivityOptions, ActivityRange};
 use anvil_server::ServerConfig;
 use clap::Parser;
 use core::fmt;
@@ -109,6 +114,54 @@ pub struct NodeArgs {
     /// but also whenever a transaction is submitted. Requires `--block-time` to be set.
     #[arg(long, requires = "block_time")]
     pub mixed_mining: bool,
+
+    /// Enable activity simulation: generate realistic transactions, logs and state changes
+    /// every block. Implies `--block-time 2` unless set.
+    #[arg(long, conflicts_with = "no_mining", help_heading = "Activity simulation")]
+    pub activity: bool,
+
+    /// Number of activity transactions injected per block.
+    #[arg(long = "activity.txs", requires = "activity", value_name = "N|N-M", value_parser = ActivityRange::<u64>::parse, help_heading = "Activity simulation")]
+    pub activity_txs: Option<ActivityRange<u64>>,
+
+    /// Percentage of activity transactions that revert.
+    #[arg(
+        long = "activity.reverted",
+        requires = "activity",
+        value_name = "PCT",
+        help_heading = "Activity simulation"
+    )]
+    pub activity_reverted: Option<u8>,
+
+    /// Percentage of activity transactions left pending indefinitely.
+    #[arg(
+        long = "activity.pending",
+        requires = "activity",
+        value_name = "PCT",
+        help_heading = "Activity simulation"
+    )]
+    pub activity_pending: Option<u8>,
+
+    /// Number of events emitted per activity contract-call transaction.
+    #[arg(long = "activity.logs", requires = "activity", value_name = "N|N-M", value_parser = ActivityRange::<u64>::parse, help_heading = "Activity simulation")]
+    pub activity_logs: Option<ActivityRange<u64>>,
+
+    /// Transfer value range in ether.
+    #[arg(long = "activity.value", requires = "activity", value_name = "MIN-MAX", value_parser = ether_range, help_heading = "Activity simulation")]
+    pub activity_value: Option<ActivityRange<U256>>,
+
+    /// Enabled activity kinds. [default: network-appropriate]
+    #[arg(long = "activity.mix", requires = "activity", value_name = "KINDS", value_delimiter = ',', value_parser = ActivityKind::from_str, help_heading = "Activity simulation")]
+    pub activity_mix: Option<Vec<ActivityKind>>,
+
+    /// RNG seed for deterministic activity.
+    #[arg(
+        long = "activity.seed",
+        requires = "activity",
+        value_name = "SEED",
+        help_heading = "Activity simulation"
+    )]
+    pub activity_seed: Option<u64>,
 
     /// The hosts the server will listen on.
     #[arg(
@@ -278,6 +331,7 @@ impl NodeArgs {
             .with_blocktime(self.block_time)
             .with_no_mining(self.no_mining)
             .with_mixed_mining(self.mixed_mining, self.block_time)
+            .with_activity(self.activity_options())
             .with_account_generator(self.account_generator())?
             .with_genesis_balance(genesis_balance)
             .with_genesis_timestamp(self.timestamp)
@@ -353,6 +407,22 @@ impl NodeArgs {
             accounts.insert(address, balance);
         }
         Ok(accounts)
+    }
+
+    fn activity_options(&self) -> Option<ActivityOptions> {
+        if !self.activity {
+            return None;
+        }
+        let defaults = ActivityOptions::default();
+        Some(ActivityOptions {
+            txs: self.activity_txs.unwrap_or(defaults.txs),
+            reverted: self.activity_reverted.unwrap_or(defaults.reverted),
+            pending: self.activity_pending.unwrap_or(defaults.pending),
+            logs: self.activity_logs.unwrap_or(defaults.logs),
+            value: self.activity_value.unwrap_or(defaults.value),
+            mix: self.activity_mix.clone(),
+            seed: self.activity_seed,
+        })
     }
 
     fn account_generator(&self) -> AccountGenerator {
@@ -914,6 +984,22 @@ fn read_genesis_file(path: &str) -> Result<Genesis, String> {
     foundry_common::fs::read_json_file(path.as_ref()).map_err(|err| err.to_string())
 }
 
+/// Parses an ether-denominated `MIN-MAX` range (e.g. `0.0001-0.1`) into wei.
+fn ether_range(s: &str) -> Result<ActivityRange<U256>, String> {
+    let parse = |s: &str| parse_ether(s.trim()).map_err(|e| e.to_string());
+    let (min, max) = match s.split_once('-') {
+        Some((min, max)) => (parse(min)?, parse(max)?),
+        None => {
+            let value = parse(s)?;
+            (value, value)
+        }
+    };
+    if min > max {
+        return Err(format!("invalid range: `{s}`"));
+    }
+    Ok(ActivityRange { min, max })
+}
+
 fn duration_from_secs_f64(s: &str) -> Result<Duration, String> {
     let s = s.parse::<f64>().map_err(|e| e.to_string())?;
     if s == 0.0 {
@@ -970,6 +1056,44 @@ mod tests {
             NodeArgs::parse_from(["anvil", "--optimism", "--hardfork", "Regolith"]);
         let config = args.into_node_config().unwrap();
         assert_eq!(config.hardfork, Some(OpHardfork::Regolith.into()));
+    }
+
+    #[test]
+    fn can_parse_activity_args() {
+        let args: NodeArgs = NodeArgs::parse_from([
+            "anvil",
+            "--activity",
+            "--activity.txs",
+            "2-5",
+            "--activity.reverted",
+            "20",
+            "--activity.value",
+            "0.001-1",
+            "--activity.mix",
+            "transfer,contract",
+            "--activity.seed",
+            "7",
+        ]);
+        let config = args.into_node_config().unwrap();
+        let activity = config.activity.unwrap();
+        assert_eq!(activity.txs, ActivityRange { min: 2, max: 5 });
+        assert_eq!(activity.reverted, 20);
+        assert_eq!(activity.pending, ActivityOptions::default().pending);
+        assert_eq!(
+            activity.value,
+            ActivityRange { min: parse_ether("0.001").unwrap(), max: parse_ether("1").unwrap() }
+        );
+        assert_eq!(activity.mix, Some(vec![ActivityKind::Transfer, ActivityKind::Contract]));
+        assert_eq!(activity.seed, Some(7));
+        // Activity implies interval mining.
+        assert_eq!(config.block_time, Some(Duration::from_secs(2)));
+
+        let args: NodeArgs = NodeArgs::parse_from(["anvil"]);
+        assert_eq!(args.into_node_config().unwrap().activity, None);
+
+        // Activity knobs require `--activity`.
+        assert!(NodeArgs::try_parse_from(["anvil", "--activity.txs", "2-5"]).is_err());
+        assert!(NodeArgs::try_parse_from(["anvil", "--activity", "--no-mining"]).is_err());
     }
 
     #[test]

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1,6 +1,7 @@
 use crate::{
     EthereumHardfork, FeeManager, PrecompileFactory,
     eth::{
+        activity,
         backend::{
             db::{Db, SerializableState},
             fork::{ClientFork, ClientForkConfig},
@@ -28,6 +29,7 @@ use alloy_signer_local::{
     coins_bip39::{English, Mnemonic},
 };
 use alloy_transport::TransportError;
+use anvil_core::types::ActivityOptions;
 use anvil_server::ServerConfig;
 use eyre::{Context, Result};
 use foundry_common::{
@@ -138,6 +140,8 @@ pub struct NodeConfig {
     pub no_mining: bool,
     /// Enables auto and interval mining mode
     pub mixed_mining: bool,
+    /// Activity simulation config. `Some` enables generated network activity.
+    pub activity: Option<ActivityOptions>,
     /// port to use for the server
     pub port: u16,
     /// maximum number of transactions in a block
@@ -483,6 +487,7 @@ impl Default for NodeConfig {
             block_time: None,
             no_mining: false,
             mixed_mining: false,
+            activity: None,
             port: NODE_PORT,
             max_transactions: 1_000,
             fork_urls: vec![],
@@ -852,6 +857,17 @@ impl NodeConfig {
     ) -> Self {
         self.block_time = block_time.map(Into::into);
         self.mixed_mining = mixed_mining;
+        self
+    }
+
+    /// Sets the activity simulation config. Defaults `block_time` to 2s when interval
+    /// mining is not otherwise configured, since activity is generated per block.
+    #[must_use]
+    pub fn with_activity(mut self, activity: Option<ActivityOptions>) -> Self {
+        if activity.is_some() && self.block_time.is_none() && !self.no_mining {
+            self.block_time = Some(Duration::from_secs(2));
+        }
+        self.activity = activity;
         self
     }
 
@@ -1309,6 +1325,17 @@ impl NodeConfig {
                     .wrap_err_with(|| format!("failed to fund account {address}"))?;
             }
         }
+
+        // Installs the built-in activity contracts so activity simulation can also be
+        // enabled at runtime via `anvil_setActivity`.
+        backend
+            .set_code(activity::ACTIVITY_ADDRESS, activity::ACTIVITY_RUNTIME_CODE)
+            .await
+            .wrap_err("failed to install activity contract")?;
+        backend
+            .set_code(activity::ACTIVITY_TOKEN_ADDRESS, activity::ACTIVITY_TOKEN_RUNTIME_CODE)
+            .await
+            .wrap_err("failed to install activity token contract")?;
 
         Ok(backend)
     }

--- a/crates/anvil/src/eth/activity.rs
+++ b/crates/anvil/src/eth/activity.rs
@@ -1,0 +1,343 @@
+//! Activity simulation: generates realistic on-chain traffic every block.
+//!
+//! When enabled (`--activity` or `anvil_setActivity`), a background task injects real signed
+//! transactions from the dev accounts: native transfers, calls to a built-in activity contract
+//! (events, storage churn, reverts, gas burn) and mock ERC20 traffic, with configurable
+//! per-block volume and outcome weights.
+
+use crate::eth::{EthApi, error::Result};
+use alloy_primitives::{Address, Bytes, TxKind, U256, address, bytes};
+use alloy_rpc_types::TransactionRequest;
+use alloy_serde::WithOtherFields;
+use alloy_sol_types::{SolCall, sol};
+use anvil_core::types::{ActivityKind, ActivityOptions};
+use foundry_common::tempo::{
+    ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
+};
+use foundry_primitives::FoundryNetwork;
+use futures::StreamExt;
+use rand_08::{Rng, SeedableRng, rngs::StdRng};
+use std::time::Duration;
+
+/// Address of the built-in activity contract, installed when activity is enabled.
+pub const ACTIVITY_ADDRESS: Address = address!("0x00000000000000000000000000000000000ac717");
+
+/// Address of the built-in mock ERC20, installed when activity is enabled.
+pub const ACTIVITY_TOKEN_ADDRESS: Address = address!("0x00000000000000000000000000000000000ac720");
+
+// Runtime bytecode of `Activity.sol` / `ActivityToken.sol` (solc 0.8.30, default forge profile).
+// Sources live in `contracts/` next to this module; recompile with `forge build --use 0.8.30`.
+pub(crate) const ACTIVITY_RUNTIME_CODE: Bytes = bytes!(
+    "0x608060405234801561000f575f5ffd5b5060043610610091575f3560e01c80637dacda03116100645780637dacda031461012f5780639c0e3f7a1461014b578063c74e820e14610167578063d408eb6e14610185578063d7d58f5b146101a157610091565b80632abc3d4e146100955780634ad5d16f146100c55780635e383d21146100e157806361bc221a14610111575b5f5ffd5b6100af60048036038101906100aa9190610548565b6101bd565b6040516100bc91906105e3565b60405180910390f35b6100df60048036038101906100da9190610548565b610263565b005b6100fb60048036038101906100f69190610548565b6102ba565b6040516101089190610612565b60405180910390f35b6101196102cf565b6040516101269190610612565b60405180910390f35b6101496004803603810190610144919061068c565b6102d4565b005b610165600480360381019061016091906106d7565b610313565b005b61016f61032d565b60405161017c919061072d565b60405180910390f35b61019f600480360381019061019a919061079b565b610333565b005b6101bb60048036038101906101b69190610548565b610372565b005b600281815481106101cc575f80fd5b905f5260205f20015f9150905080546101e490610813565b80601f016020809104026020016040519081016040528092919081815260200182805461021090610813565b801561025b5780601f106102325761010080835404028352916020019161025b565b820191905f5260205f20905b81548152906001019060200180831161023e57829003601f168201915b505050505081565b5f60035490505f5f90505b828110156102ae578181604051602001610289929190610883565b604051602081830303815290604052805190602001209150808060010191505061026e565b50806003819055505050565b6001602052805f5260405f205f915090505481565b5f5481565b6002828290918060018154018082558091505060019003905f5260205f20015f90919290919290919290919250918261030e929190610a85565b505050565b8060015f8481526020019081526020015f20819055505050565b60035481565b81816040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610369929190610b9c565b60405180910390fd5b5f5f5490505f5f90505b828110156104f7575f600382846103939190610beb565b61039d9190610c4b565b90505f81036103fa573373ffffffffffffffffffffffffffffffffffffffff1682846103c99190610beb565b7fc05b373e05c47417d9c7204807552389e512c0e21cbc01a03d1554561080ac6e60405160405180910390a36104e9565b6001810361047657818361040e9190610beb565b7f44836be0fd3b72cff7564f074fc591a00c481717a3b2875a766197662df53247838561043b9190610beb565b3360405160200161044d929190610cf0565b60405160208183030381529060405260405161046991906105e3565b60405180910390a26104e8565b81836104829190610beb565b3073ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f6ca16b72f6875e6f006f27693d2789f0058dfe87daeada50ca257e17b411d1b4436040516104df9190610612565b60405180910390a45b5b50808060010191505061037c565b5081816105049190610beb565b5f819055505050565b5f5ffd5b5f5ffd5b5f819050919050565b61052781610515565b8114610531575f5ffd5b50565b5f813590506105428161051e565b92915050565b5f6020828403121561055d5761055c61050d565b5b5f61056a84828501610534565b91505092915050565b5f81519050919050565b5f82825260208201905092915050565b8281835e5f83830152505050565b5f601f19601f8301169050919050565b5f6105b582610573565b6105bf818561057d565b93506105cf81856020860161058d565b6105d88161059b565b840191505092915050565b5f6020820190508181035f8301526105fb81846105ab565b905092915050565b61060c81610515565b82525050565b5f6020820190506106255f830184610603565b92915050565b5f5ffd5b5f5ffd5b5f5ffd5b5f5f83601f84011261064c5761064b61062b565b5b8235905067ffffffffffffffff8111156106695761066861062f565b5b60208301915083600182028301111561068557610684610633565b5b9250929050565b5f5f602083850312156106a2576106a161050d565b5b5f83013567ffffffffffffffff8111156106bf576106be610511565b5b6106cb85828601610637565b92509250509250929050565b5f5f604083850312156106ed576106ec61050d565b5b5f6106fa85828601610534565b925050602061070b85828601610534565b9150509250929050565b5f819050919050565b61072781610715565b82525050565b5f6020820190506107405f83018461071e565b92915050565b5f5f83601f84011261075b5761075a61062b565b5b8235905067ffffffffffffffff8111156107785761077761062f565b5b60208301915083600182028301111561079457610793610633565b5b9250929050565b5f5f602083850312156107b1576107b061050d565b5b5f83013567ffffffffffffffff8111156107ce576107cd610511565b5b6107da85828601610746565b92509250509250929050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b5f600282049050600182168061082a57607f821691505b60208210810361083d5761083c6107e6565b5b50919050565b5f819050919050565b61085d61085882610715565b610843565b82525050565b5f819050919050565b61087d61087882610515565b610863565b82525050565b5f61088e828561084c565b60208201915061089e828461086c565b6020820191508190509392505050565b5f82905092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b5f819050815f5260205f209050919050565b5f6020601f8301049050919050565b5f82821b905092915050565b5f600883026109417fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff82610906565b61094b8683610906565b95508019841693508086168417925050509392505050565b5f819050919050565b5f61098661098161097c84610515565b610963565b610515565b9050919050565b5f819050919050565b61099f8361096c565b6109b36109ab8261098d565b848454610912565b825550505050565b5f5f905090565b6109ca6109bb565b6109d5818484610996565b505050565b5b818110156109f8576109ed5f826109c2565b6001810190506109db565b5050565b601f821115610a3d57610a0e816108e5565b610a17846108f7565b81016020851015610a26578190505b610a3a610a32856108f7565b8301826109da565b50505b505050565b5f82821c905092915050565b5f610a5d5f1984600802610a42565b1980831691505092915050565b5f610a758383610a4e565b9150826002028217905092915050565b610a8f83836108ae565b67ffffffffffffffff811115610aa857610aa76108b8565b5b610ab28254610813565b610abd8282856109fc565b5f601f831160018114610aea575f8415610ad8578287013590505b610ae28582610a6a565b865550610b49565b601f198416610af8866108e5565b5f5b82811015610b1f57848901358255600182019150602085019450602081019050610afa565b86831015610b3c5784890135610b38601f891682610a4e565b8355505b6001600288020188555050505b50505050505050565b5f82825260208201905092915050565b828183375f83830152505050565b5f610b7b8385610b52565b9350610b88838584610b62565b610b918361059b565b840190509392505050565b5f6020820190508181035f830152610bb5818486610b70565b90509392505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f610bf582610515565b9150610c0083610515565b9250828201905080821115610c1857610c17610bbe565b5b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601260045260245ffd5b5f610c5582610515565b9150610c6083610515565b925082610c7057610c6f610c1e565b5b828206905092915050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f610ca482610c7b565b9050919050565b5f8160601b9050919050565b5f610cc182610cab565b9050919050565b5f610cd282610cb7565b9050919050565b610cea610ce582610c9a565b610cc8565b82525050565b5f610cfb828561086c565b602082019150610d0b8284610cd9565b601482019150819050939250505056fea26469706673582212204cf7552c3f1b155e79be963f952ddb51380ce31b818eaf18e8ba904997f7286f64736f6c634300081e0033"
+);
+pub(crate) const ACTIVITY_TOKEN_RUNTIME_CODE: Bytes = bytes!(
+    "0x608060405234801561000f575f5ffd5b506004361061009c575f3560e01c806340c10f191161006457806340c10f191461015a57806370a082311461017657806395d89b41146101a6578063a9059cbb146101c4578063dd62ed3e146101f45761009c565b806306fdde03146100a0578063095ea7b3146100be57806318160ddd146100ee57806323b872dd1461010c578063313ce5671461013c575b5f5ffd5b6100a8610224565b6040516100b591906107c0565b60405180910390f35b6100d860048036038101906100d39190610871565b61025d565b6040516100e591906108c9565b60405180910390f35b6100f661034a565b60405161010391906108f1565b60405180910390f35b6101266004803603810190610121919061090a565b61034f565b60405161013391906108c9565b60405180910390f35b6101446104f4565b6040516101519190610975565b60405180910390f35b610174600480360381019061016f9190610871565b6104f9565b005b610190600480360381019061018b919061098e565b6105cc565b60405161019d91906108f1565b60405180910390f35b6101ae6105e1565b6040516101bb91906107c0565b60405180910390f35b6101de60048036038101906101d99190610871565b61061a565b6040516101eb91906108c9565b60405180910390f35b61020e600480360381019061020991906109b9565b610730565b60405161021b91906108f1565b60405180910390f35b6040518060400160405280600e81526020017f416374697669747920546f6b656e00000000000000000000000000000000000081525081565b5f8160025f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f20819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167f8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b9258460405161033891906108f1565b60405180910390a36001905092915050565b5f5481565b5f8160025f8673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8282546103d79190610a24565b925050819055508160015f8673ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f82825461042a9190610a24565b925050819055508160015f8573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f82825461047d9190610a57565b925050819055508273ffffffffffffffffffffffffffffffffffffffff168473ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef846040516104e191906108f1565b60405180910390a3600190509392505050565b601281565b805f5f8282546105099190610a57565b925050819055508060015f8473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f82825461055c9190610a57565b925050819055508173ffffffffffffffffffffffffffffffffffffffff165f73ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef836040516105c091906108f1565b60405180910390a35050565b6001602052805f5260405f205f915090505481565b6040518060400160405280600381526020017f414354000000000000000000000000000000000000000000000000000000000081525081565b5f8160015f3373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8282546106679190610a24565b925050819055508160015f8573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020015f205f8282546106ba9190610a57565b925050819055508273ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef8460405161071e91906108f1565b60405180910390a36001905092915050565b6002602052815f5260405f20602052805f5260405f205f91509150505481565b5f81519050919050565b5f82825260208201905092915050565b8281835e5f83830152505050565b5f601f19601f8301169050919050565b5f61079282610750565b61079c818561075a565b93506107ac81856020860161076a565b6107b581610778565b840191505092915050565b5f6020820190508181035f8301526107d88184610788565b905092915050565b5f5ffd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f61080d826107e4565b9050919050565b61081d81610803565b8114610827575f5ffd5b50565b5f8135905061083881610814565b92915050565b5f819050919050565b6108508161083e565b811461085a575f5ffd5b50565b5f8135905061086b81610847565b92915050565b5f5f60408385031215610887576108866107e0565b5b5f6108948582860161082a565b92505060206108a58582860161085d565b9150509250929050565b5f8115159050919050565b6108c3816108af565b82525050565b5f6020820190506108dc5f8301846108ba565b92915050565b6108eb8161083e565b82525050565b5f6020820190506109045f8301846108e2565b92915050565b5f5f5f60608486031215610921576109206107e0565b5b5f61092e8682870161082a565b935050602061093f8682870161082a565b92505060406109508682870161085d565b9150509250925092565b5f60ff82169050919050565b61096f8161095a565b82525050565b5f6020820190506109885f830184610966565b92915050565b5f602082840312156109a3576109a26107e0565b5b5f6109b08482850161082a565b91505092915050565b5f5f604083850312156109cf576109ce6107e0565b5b5f6109dc8582860161082a565b92505060206109ed8582860161082a565b9150509250929050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f610a2e8261083e565b9150610a398361083e565b9250828203905081811115610a5157610a506109f7565b5b92915050565b5f610a618261083e565b9150610a6c8361083e565b9250828201905080821115610a8457610a836109f7565b5b9291505056fea2646970667358221220050322c53eefa020bf4ecc58ef08f2e26996e36f181d23079147b6ee543e12dd64736f6c634300081e0033"
+);
+
+sol! {
+    interface IActivity {
+        function emitEvents(uint256 n);
+        function write(uint256 slot, uint256 value);
+        function push(bytes data);
+        function revertWith(string reason);
+        function burnGas(uint256 rounds);
+    }
+
+    interface IActivityToken {
+        function mint(address to, uint256 value);
+        function transfer(address to, uint256 value) returns (bool);
+        function approve(address spender, uint256 value) returns (bool);
+    }
+}
+
+/// Generates a batch of activity transactions per mined block.
+pub struct ActivityGenerator {
+    api: EthApi<FoundryNetwork>,
+    rng: StdRng,
+    accounts: Vec<Address>,
+    /// Whether the mock ERC20 has been seeded with balances.
+    seeded: bool,
+    /// Number of intentionally-pending (gapped-nonce) transactions submitted so far.
+    pending_submitted: usize,
+}
+
+/// Cap on intentionally-pending transactions, so the pool does not grow unbounded.
+const MAX_PENDING: usize = 64;
+
+/// Gas limit for generated contract calls; skips estimation (which fails for reverts).
+const CALL_GAS: u64 = 300_000;
+
+/// Gas limit for TIP-20 precompile transfers, covering T1+ transaction accounting.
+const TIP20_GAS: u64 = 1_000_000;
+
+/// TIP-20 fee tokens available in anvil's Tempo genesis.
+const TIP20_TOKENS: &[Address] =
+    &[PATH_USD_ADDRESS, ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, THETA_USD_ADDRESS];
+
+impl ActivityGenerator {
+    pub fn new(api: EthApi<FoundryNetwork>) -> Self {
+        let seed = api.activity_config().read().as_ref().and_then(|config| config.seed);
+        Self {
+            api,
+            rng: seed.map_or_else(StdRng::from_entropy, StdRng::seed_from_u64),
+            accounts: Vec::new(),
+            seeded: false,
+            pending_submitted: 0,
+        }
+    }
+
+    /// Drives activity generation: on every new block (or idle tick), injects the next batch.
+    pub async fn run(mut self) {
+        let mut notifications = self.api.backend.new_block_notifications();
+        let mut tick = tokio::time::interval(Duration::from_secs(2));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                block = notifications.next() => if block.is_none() { return },
+                _ = tick.tick() => {}
+            }
+            let Some(config) = self.api.activity_config().read().clone() else { continue };
+            // Wait until the previous batch has been mined before topping up.
+            if self.api.has_ready_pool_transactions() {
+                continue;
+            }
+            self.inject_batch(&config).await;
+        }
+    }
+
+    async fn inject_batch(&mut self, config: &ActivityOptions) {
+        if self.accounts.is_empty() {
+            self.accounts = self.api.accounts().unwrap_or_default();
+            if self.accounts.len() < 2 {
+                return;
+            }
+        }
+        if !self.seeded {
+            self.seed_token_balances().await;
+            self.seeded = true;
+        }
+
+        let kinds = self.kinds(config);
+        if kinds.is_empty() {
+            return;
+        }
+        let count = self.rng.gen_range(config.txs.min..=config.txs.max);
+        for _ in 0..count {
+            let outcome = self.rng.gen_range(0..100u8);
+            let result = if outcome < config.reverted {
+                self.send_reverting().await
+            } else if outcome < config.reverted.saturating_add(config.pending)
+                && self.pending_submitted < MAX_PENDING
+            {
+                self.pending_submitted += 1;
+                self.send_pending().await
+            } else {
+                let kind = kinds[self.rng.gen_range(0..kinds.len())];
+                self.send_kind(kind, config).await
+            };
+            if let Err(err) = result {
+                trace!(target: "node::activity", %err, "failed to inject activity transaction");
+            }
+        }
+    }
+
+    /// Returns the enabled kinds, defaulting per network.
+    fn kinds(&self, config: &ActivityOptions) -> Vec<ActivityKind> {
+        let is_tempo = self.api.backend.is_tempo();
+        match &config.mix {
+            Some(mix) if !mix.is_empty() => mix
+                .iter()
+                .copied()
+                .filter(|kind| match kind {
+                    ActivityKind::Transfer | ActivityKind::Erc20 => !is_tempo,
+                    ActivityKind::Tip20 => is_tempo,
+                    ActivityKind::Contract | ActivityKind::State => true,
+                })
+                .collect(),
+            _ if is_tempo => {
+                vec![ActivityKind::Tip20, ActivityKind::Contract, ActivityKind::State]
+            }
+            _ => vec![
+                ActivityKind::Transfer,
+                ActivityKind::Contract,
+                ActivityKind::Erc20,
+                ActivityKind::State,
+            ],
+        }
+    }
+
+    async fn send_kind(
+        &mut self,
+        kind: ActivityKind,
+        config: &ActivityOptions,
+    ) -> Result<()> {
+        match kind {
+            ActivityKind::Transfer => {
+                let (from, to) = self.pick_pair();
+                let value = self.sample_value(config);
+                self.send(
+                    from,
+                    TransactionRequest {
+                        to: Some(TxKind::Call(to)),
+                        value: Some(value),
+                        ..Default::default()
+                    },
+                )
+                .await
+            }
+            ActivityKind::Contract => {
+                let n = self.rng.gen_range(config.logs.min..=config.logs.max);
+                let input = IActivity::emitEventsCall { n: U256::from(n) }.abi_encode();
+                self.call(ACTIVITY_ADDRESS, input).await
+            }
+            ActivityKind::State => {
+                let input = match self.rng.gen_range(0..3u8) {
+                    0 => IActivity::writeCall {
+                        slot: U256::from(self.rng.gen_range(0..1024u64)),
+                        value: U256::from(self.rng.r#gen::<u64>()),
+                    }
+                    .abi_encode(),
+                    1 => IActivity::pushCall { data: Bytes::from(self.rng.r#gen::<[u8; 32]>()) }
+                        .abi_encode(),
+                    _ => {
+                        IActivity::burnGasCall { rounds: U256::from(self.rng.gen_range(1..64u64)) }
+                            .abi_encode()
+                    }
+                };
+                self.call(ACTIVITY_ADDRESS, input).await
+            }
+            ActivityKind::Erc20 => {
+                let to = self.pick_account();
+                let value = self.sample_value(config);
+                let input = if self.rng.gen_bool(0.8) {
+                    IActivityToken::transferCall { to, value }.abi_encode()
+                } else {
+                    IActivityToken::approveCall { spender: to, value }.abi_encode()
+                };
+                self.call(ACTIVITY_TOKEN_ADDRESS, input).await
+            }
+            ActivityKind::Tip20 => {
+                let token = TIP20_TOKENS[self.rng.gen_range(0..TIP20_TOKENS.len())];
+                let (from, to) = self.pick_pair();
+                let value = self.sample_value(config);
+                let input = IActivityToken::transferCall { to, value }.abi_encode();
+                self.send(
+                    from,
+                    TransactionRequest {
+                        to: Some(TxKind::Call(token)),
+                        input: Bytes::from(input).into(),
+                        gas: Some(TIP20_GAS),
+                        ..Default::default()
+                    },
+                )
+                .await
+            }
+        }
+    }
+
+    async fn send_reverting(&mut self) -> Result<()> {
+        let input = IActivity::revertWithCall { reason: "activity: intentional revert".into() }
+            .abi_encode();
+        self.call(ACTIVITY_ADDRESS, input).await
+    }
+
+    /// Sends a contract call with a gapped nonce so it stays pending indefinitely.
+    async fn send_pending(&mut self) -> Result<()> {
+        let from = self.pick_account();
+        let nonce = self.api.transaction_count(from, None).await?;
+        let gap = self.rng.gen_range(100..1_000u64);
+        let input = IActivity::writeCall {
+            slot: U256::from(self.rng.gen_range(0..1024u64)),
+            value: U256::from(self.rng.r#gen::<u64>()),
+        }
+        .abi_encode();
+        self.send(
+            from,
+            TransactionRequest {
+                to: Some(TxKind::Call(ACTIVITY_ADDRESS)),
+                input: Bytes::from(input).into(),
+                gas: Some(CALL_GAS),
+                nonce: Some(nonce.saturating_to::<u64>() + gap),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    async fn call(
+        &mut self,
+        to: Address,
+        input: Vec<u8>,
+    ) -> Result<()> {
+        let from = self.pick_account();
+        self.send(
+            from,
+            TransactionRequest {
+                to: Some(TxKind::Call(to)),
+                input: Bytes::from(input).into(),
+                gas: Some(CALL_GAS),
+                ..Default::default()
+            },
+        )
+        .await
+    }
+
+    async fn send(
+        &mut self,
+        from: Address,
+        request: TransactionRequest,
+    ) -> Result<()> {
+        let request = TransactionRequest { from: Some(from), ..request };
+        self.api.send_transaction(WithOtherFields::new(request)).await?;
+        Ok(())
+    }
+
+    /// Seeds token balances for every dev account: TIP-20 fee tokens on Tempo,
+    /// mock ERC20 mints otherwise.
+    async fn seed_token_balances(&mut self) {
+        let balance = U256::from(1_000_000u64) * U256::from(10u64).pow(U256::from(18));
+        if self.api.backend.is_tempo() {
+            for account in self.accounts.clone() {
+                for token in TIP20_TOKENS {
+                    let _ = self.api.anvil_deal_tip20(account, *token, balance).await;
+                }
+            }
+            return;
+        }
+        for account in self.accounts.clone() {
+            let input = IActivityToken::mintCall { to: account, value: balance }.abi_encode();
+            let _ = self
+                .send(
+                    account,
+                    TransactionRequest {
+                        to: Some(TxKind::Call(ACTIVITY_TOKEN_ADDRESS)),
+                        input: Bytes::from(input).into(),
+                        gas: Some(CALL_GAS),
+                        ..Default::default()
+                    },
+                )
+                .await;
+        }
+    }
+
+    fn pick_account(&mut self) -> Address {
+        self.accounts[self.rng.gen_range(0..self.accounts.len())]
+    }
+
+    fn pick_pair(&mut self) -> (Address, Address) {
+        let from = self.pick_account();
+        let mut to = self.pick_account();
+        while to == from {
+            to = self.pick_account();
+        }
+        (from, to)
+    }
+
+    fn sample_value(&mut self, config: &ActivityOptions) -> U256 {
+        let span = config.value.max.saturating_sub(config.value.min);
+        if span.is_zero() {
+            return config.value.min;
+        }
+        config.value.min + span * U256::from(self.rng.r#gen::<u64>()) / U256::from(u64::MAX)
+    }
+}

--- a/crates/anvil/src/eth/activity/Activity.sol
+++ b/crates/anvil/src/eth/activity/Activity.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+/// @notice Anvil activity-simulation target: emits events, churns storage, reverts on demand.
+contract Activity {
+    event Ping(uint256 indexed id, address indexed sender);
+    event Data(uint256 indexed id, bytes payload);
+    event Multi(address indexed a, address indexed b, uint256 indexed c, uint256 d);
+
+    uint256 public counter;
+    mapping(uint256 => uint256) public values;
+    bytes[] public blobs;
+    bytes32 public sink;
+
+    function emitEvents(uint256 n) external {
+        uint256 id = counter;
+        for (uint256 i = 0; i < n; i++) {
+            uint256 shape = (id + i) % 3;
+            if (shape == 0) emit Ping(id + i, msg.sender);
+            else if (shape == 1) emit Data(id + i, abi.encodePacked(id + i, msg.sender));
+            else emit Multi(msg.sender, address(this), id + i, block.number);
+        }
+        counter = id + n;
+    }
+
+    function write(uint256 slot, uint256 value) external {
+        values[slot] = value;
+    }
+
+    function push(bytes calldata data) external {
+        blobs.push(data);
+    }
+
+    function revertWith(string calldata reason) external pure {
+        revert(reason);
+    }
+
+    function burnGas(uint256 rounds) external {
+        bytes32 acc = sink;
+        for (uint256 i = 0; i < rounds; i++) {
+            acc = keccak256(abi.encodePacked(acc, i));
+        }
+        sink = acc;
+    }
+}

--- a/crates/anvil/src/eth/activity/ActivityToken.sol
+++ b/crates/anvil/src/eth/activity/ActivityToken.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.30;
+
+/// @notice Minimal mock ERC20 for anvil activity simulation. Open mint; dev use only.
+contract ActivityToken {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    string public constant name = "Activity Token";
+    string public constant symbol = "ACT";
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 value) external {
+        totalSupply += value;
+        balanceOf[to] += value;
+        emit Transfer(address(0), to, value);
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        balanceOf[msg.sender] -= value;
+        balanceOf[to] += value;
+        emit Transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        allowance[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        allowance[from][msg.sender] -= value;
+        balanceOf[from] -= value;
+        balanceOf[to] += value;
+        emit Transfer(from, to, value);
+        return true;
+    }
+}

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -79,7 +79,7 @@ use anvil_core::{
         block::{BlockInfo, canonical_block, canonical_block_transaction},
         transaction::{MaybeImpersonatedTransaction, PendingTransaction},
     },
-    types::{ReorgOptions, TransactionData},
+    types::{ActivityOptions, ReorgOptions, TransactionData},
 };
 use anvil_rpc::{error::RpcError, response::ResponseResult};
 use foundry_common::{
@@ -149,6 +149,8 @@ pub struct EthApi<N: Network> {
     net_listening: bool,
     /// The instance ID. Changes on every reset.
     instance_id: Arc<RwLock<B256>>,
+    /// Activity simulation config, `None` when disabled. Read by the activity generator task.
+    activity: Arc<RwLock<Option<ActivityOptions>>>,
 }
 
 impl<N: Network> Clone for EthApi<N> {
@@ -166,6 +168,7 @@ impl<N: Network> Clone for EthApi<N> {
             transaction_order: self.transaction_order.clone(),
             net_listening: self.net_listening,
             instance_id: self.instance_id.clone(),
+            activity: self.activity.clone(),
         }
     }
 }
@@ -185,6 +188,7 @@ impl<N: Network> EthApi<N> {
         logger: LoggingManager,
         filters: Filters<N>,
         transactions_order: TransactionOrder,
+        activity: Option<ActivityOptions>,
     ) -> Self {
         Self {
             pool,
@@ -199,6 +203,7 @@ impl<N: Network> EthApi<N> {
             net_listening: true,
             transaction_order: Arc::new(RwLock::new(transactions_order)),
             instance_id: Arc::new(RwLock::new(B256::random())),
+            activity: Arc::new(RwLock::new(activity)),
         }
     }
 
@@ -244,6 +249,33 @@ impl<N: Network> EthApi<N> {
     pub fn anvil_get_interval_mining(&self) -> Result<Option<u64>> {
         node_info!("anvil_getIntervalMining");
         Ok(self.miner.get_interval())
+    }
+
+    /// Sets or disables (`None`) activity simulation.
+    ///
+    /// Handler for ETH RPC call: `anvil_setActivity`.
+    pub fn anvil_set_activity(&self, options: Option<ActivityOptions>) -> Result<()> {
+        node_info!("anvil_setActivity");
+        *self.activity.write() = options;
+        Ok(())
+    }
+
+    /// Returns the current activity simulation config, if enabled.
+    ///
+    /// Handler for ETH RPC call: `anvil_getActivity`.
+    pub fn anvil_get_activity(&self) -> Result<Option<ActivityOptions>> {
+        node_info!("anvil_getActivity");
+        Ok(self.activity.read().clone())
+    }
+
+    /// Returns a handle to the shared activity simulation config.
+    pub(crate) fn activity_config(&self) -> Arc<RwLock<Option<ActivityOptions>>> {
+        self.activity.clone()
+    }
+
+    /// Whether the pool currently holds transactions ready to be mined.
+    pub(crate) fn has_ready_pool_transactions(&self) -> bool {
+        self.pool.ready_transactions().next().is_some()
     }
 
     /// Enables or disables, based on the single boolean argument, the automatic mining of new
@@ -1975,6 +2007,8 @@ impl EthApi<FoundryNetwork> {
                 self.anvil_set_interval_mining(interval).to_rpc_result()
             }
             EthRequest::GetIntervalMining(()) => self.anvil_get_interval_mining().to_rpc_result(),
+            EthRequest::SetActivity(options) => self.anvil_set_activity(options).to_rpc_result(),
+            EthRequest::GetActivity(()) => self.anvil_get_activity().to_rpc_result(),
             EthRequest::DropTransaction(tx) => {
                 self.anvil_drop_transaction(tx).await.to_rpc_result()
             }

--- a/crates/anvil/src/eth/mod.rs
+++ b/crates/anvil/src/eth/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity;
 pub mod api;
 pub mod otterscan;
 pub mod sign;

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -232,7 +232,11 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
         logger,
         filters.clone(),
         transaction_order,
+        config.activity.clone(),
     );
+
+    // spawn the activity generator; it idles until activity is configured
+    tokio::task::spawn(eth::activity::ActivityGenerator::new(api.clone()).run());
 
     // spawn the node service
     let node_service =

--- a/crates/anvil/tests/it/activity.rs
+++ b/crates/anvil/tests/it/activity.rs
@@ -1,0 +1,116 @@
+//! Tests for activity simulation (`--activity` / `anvil_setActivity`).
+
+use alloy_network::ReceiptResponse;
+use alloy_rpc_types::{BlockNumberOrTag, Filter};
+use anvil::{
+    NodeConfig,
+    eth::activity::{ACTIVITY_ADDRESS, ACTIVITY_TOKEN_ADDRESS},
+    spawn,
+};
+use anvil_core::types::{ActivityOptions, ActivityRange};
+use std::time::Duration;
+
+fn activity_config() -> ActivityOptions {
+    ActivityOptions {
+        txs: ActivityRange { min: 4, max: 8 },
+        reverted: 25,
+        pending: 15,
+        seed: Some(42),
+        ..Default::default()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn generates_activity() {
+    let (api, _handle) = spawn(
+        NodeConfig::test()
+            .with_blocktime(Some(Duration::from_millis(300)))
+            .with_activity(Some(activity_config())),
+    )
+    .await;
+
+    // Let a few blocks of activity accumulate.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let height = api.block_number().unwrap().to::<u64>();
+    assert!(height > 3, "expected blocks to be mined, got {height}");
+
+    // Blocks contain generated transactions.
+    let mut total_txs = 0;
+    let mut failed = 0;
+    for number in 1..=height {
+        let receipts =
+            api.block_receipts(BlockNumberOrTag::Number(number).into()).await.unwrap().unwrap();
+        total_txs += receipts.len();
+        failed += receipts.iter().filter(|receipt| !receipt.status()).count();
+    }
+    assert!(total_txs > 10, "expected generated transactions, got {total_txs}");
+    assert!(failed > 0, "expected reverted transactions among {total_txs}");
+
+    // Activity contract and mock ERC20 emit logs.
+    let filter = Filter::new().address(ACTIVITY_ADDRESS).from_block(0);
+    assert!(!api.logs(filter).await.unwrap().is_empty());
+    let filter = Filter::new().address(ACTIVITY_TOKEN_ADDRESS).from_block(0);
+    assert!(!api.logs(filter).await.unwrap().is_empty());
+
+    // Gapped-nonce transactions stay queued and never mine.
+    let content = api.txpool_content().await.unwrap();
+    assert!(!content.queued.is_empty(), "expected queued (pending-forever) transactions");
+
+    // Disabling stops injection.
+    api.anvil_set_activity(None).unwrap();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let stop_height = api.block_number().unwrap().to::<u64>();
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let final_height = api.block_number().unwrap().to::<u64>();
+    let mut new_txs = 0;
+    for number in (stop_height + 1)..=final_height {
+        let receipts =
+            api.block_receipts(BlockNumberOrTag::Number(number).into()).await.unwrap().unwrap();
+        new_txs += receipts.len();
+    }
+    assert_eq!(new_txs, 0, "expected no new transactions after disabling activity");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn generates_tempo_activity() {
+    let (api, _handle) = spawn(
+        NodeConfig::test_tempo()
+            .with_blocktime(Some(Duration::from_millis(300)))
+            .with_activity(Some(activity_config())),
+    )
+    .await;
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let height = api.block_number().unwrap().to::<u64>();
+    let mut total_txs = 0;
+    for number in 1..=height {
+        let receipts =
+            api.block_receipts(BlockNumberOrTag::Number(number).into()).await.unwrap().unwrap();
+        total_txs += receipts.len();
+    }
+    assert!(total_txs > 10, "expected generated transactions, got {total_txs}");
+
+    // TIP-20 fee tokens emit Transfer logs from generated traffic.
+    let filter = Filter::new().address(foundry_common::tempo::PATH_USD_ADDRESS).from_block(0);
+    assert!(!api.logs(filter).await.unwrap().is_empty(), "expected TIP-20 transfer logs");
+
+    // Activity contract still emits logs on Tempo.
+    let filter = Filter::new().address(ACTIVITY_ADDRESS).from_block(0);
+    assert!(!api.logs(filter).await.unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn activity_rpc_roundtrip() {
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+
+    assert_eq!(api.anvil_get_activity().unwrap(), None);
+
+    let config = activity_config();
+    api.anvil_set_activity(Some(config.clone())).unwrap();
+    assert_eq!(api.anvil_get_activity().unwrap(), Some(config));
+
+    api.anvil_set_activity(None).unwrap();
+    assert_eq!(api.anvil_get_activity().unwrap(), None);
+}

--- a/crates/anvil/tests/it/main.rs
+++ b/crates/anvil/tests/it/main.rs
@@ -1,4 +1,5 @@
 mod abi;
+mod activity;
 mod anvil;
 mod anvil_api;
 mod api;


### PR DESCRIPTION
Adds activity simulation to anvil: `--activity` generates real signed transactions every block (transfers, contract events, state churn, reverts, pending txs) with configurable rates and outcome weights, plus runtime control via `anvil_setActivity` / `anvil_getActivity`.

Addresses the activity-generation side of https://github.com/foundry-rs/foundry/issues/3788.
