### PR TITLE
fix(anvil): preserve tempo calls in tx requests

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -4255,10 +4255,16 @@ impl EthApi<FoundryNetwork> {
             request.set_from(from);
         }
 
+        // Tempo batch requests keep `to` empty; `build_aa` appends `to` as an extra call.
+        let is_tempo_batch =
+            matches!(&request, FoundryTransactionRequest::Tempo(tx) if !tx.calls.is_empty());
+
         // Fill common fields for all tx types
         request.chain_id().is_none().then(|| request.set_chain_id(self.chain_id()));
         request.nonce().is_none().then(|| request.set_nonce(nonce));
-        request.kind().is_none().then(|| request.set_kind(TxKind::default()));
+        if request.kind().is_none() && !is_tempo_batch {
+            request.set_kind(TxKind::default());
+        }
         if request.gas_limit().is_none() {
             let fallback_gas_limit = {
                 let evm_env = self.backend.evm_env().read();
@@ -4269,8 +4275,13 @@ impl EthApi<FoundryNetwork> {
                     block_gas_limit
                 }
             };
+            // Serialize the full request so Tempo fields (`calls`, ...) reach estimation.
+            let estimate_request = serde_json::to_value(&request)
+                .ok()
+                .and_then(|value| serde_json::from_value(value).ok())
+                .unwrap_or_else(|| request.as_ref().clone().into());
             let estimated_gas = self
-                .do_estimate_gas(request.as_ref().clone().into(), None, EvmOverrides::default())
+                .do_estimate_gas(estimate_request, None, EvmOverrides::default())
                 .await
                 .map(|v| v as u64)
                 .unwrap_or_else(|_| {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -200,7 +200,7 @@ use tempo_precompiles::{
     tip20::{ISSUER_ROLE, ITIP20, TIP20Token},
     tip20_factory::TIP20Factory,
 };
-use tempo_primitives::TEMPO_TX_TYPE_ID;
+use tempo_primitives::{TEMPO_TX_TYPE_ID, transaction::Call};
 use tempo_revm::{
     TempoBatchCallEnv, TempoBlockEnv, TempoHaltReason, TempoTxEnv, evm::TempoContext,
     gas_params::tempo_gas_params,
@@ -1635,25 +1635,39 @@ impl<N: Network> Backend<N> {
                 .get_deserialized::<U256>("validAfter")
                 .and_then(|r| r.ok())
                 .map(|v| v.saturating_to::<u64>());
-            (fee_token, nonce_key, valid_before, valid_after)
+            let calls = request
+                .other
+                .get_deserialized::<Vec<Call>>("calls")
+                .and_then(|r| r.ok())
+                .unwrap_or_default();
+            (fee_token, nonce_key, valid_before, valid_after, calls)
         });
+        let explicit_to = request.to.is_some();
 
         let (evm_env, tx_env, op_deposit) = self.build_call_env(request, fee_details, block_env);
 
         let ResultAndState { result, state } =
-            if let Some((fee_token, nonce_key, valid_before, valid_after)) = tempo_overrides {
-                use tempo_primitives::transaction::Call;
-
+            if let Some((fee_token, nonce_key, valid_before, valid_after, calls)) = tempo_overrides
+            {
                 let base = tx_env;
                 let mut tempo_tx = TempoTxEnv::from(base.clone());
                 tempo_tx.fee_token = fee_token;
 
-                if !nonce_key.is_zero() || valid_before.is_some() || valid_after.is_some() {
+                if !nonce_key.is_zero()
+                    || valid_before.is_some()
+                    || valid_after.is_some()
+                    || !calls.is_empty()
+                {
                     // For gas estimation we don't have a signed tx, so generate a
                     // unique hash for expiring-nonce replay protection.  The nonce
                     // manager needs a non-zero hash; the actual value doesn't matter
                     // because the state is discarded after estimation.
                     let estimation_hash = keccak256(base.data.as_ref());
+                    // The batch is the request's `calls` plus `to`/`value`/`input` as final call.
+                    let mut aa_calls = calls;
+                    if explicit_to || aa_calls.is_empty() {
+                        aa_calls.push(Call { to: base.kind, value: base.value, input: base.data });
+                    }
                     // T1B+ uses `TempoTxEnv::unique_tx_identifier` (sender-scoped) as
                     // the expiring-nonce replay hash; pre-T1B uses `tx_hash`.
                     // Set both so the synthetic env works across hardforks.
@@ -1662,7 +1676,7 @@ impl<N: Network> Backend<N> {
                         nonce_key,
                         valid_before,
                         valid_after,
-                        aa_calls: vec![Call { to: base.kind, value: base.value, input: base.data }],
+                        aa_calls,
                         tx_hash: estimation_hash,
                         expiring_nonce_idx: Some(0),
                         ..Default::default()

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -21,7 +21,9 @@ use alloy_consensus::{BlockHeader, Sealable, Typed2718};
 use alloy_eips::eip2718::Encodable2718;
 use alloy_genesis::Genesis;
 use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
-use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, aliases::U96, keccak256};
+use alloy_primitives::{
+    Address, B256, Bytes, TxKind, U256, address, aliases::U96, bytes, keccak256,
+};
 use alloy_provider::{Provider, ext::TxPoolApi};
 use alloy_rlp::Decodable;
 use alloy_rpc_types::{BlockId, BlockNumberOrTag, TransactionRequest, anvil::Forking};
@@ -1990,6 +1992,141 @@ async fn test_tempo_aa_transaction_basic() {
         recipient_balance_after,
         recipient_balance_before + transfer_amount,
         "Recipient should receive transfer amount"
+    );
+}
+
+/// Builds a node-signed AA batch request: `calls` rides in `other`, no top-level `to`.
+fn tempo_calls_request(from: Address, calls: &[Call]) -> WithOtherFields<TransactionRequest> {
+    let mut tx = WithOtherFields::new(TransactionRequest::default().from(from));
+    tx.inner.transaction_type = Some(0x76);
+    tx.other.insert("calls".to_string(), serde_json::to_value(calls).unwrap());
+    tx
+}
+
+/// Minimal repro: `eth_sendTransaction` silently dropped the `calls` batch of a Tempo
+/// request, mining a single empty call instead.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_send_transaction_with_calls() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+    let from = handle.dev_accounts().next().unwrap();
+
+    // Data-only calls, as sent by Tempo clients (viem, ...): no top-level `to`/`value`/`input`.
+    let calls = vec![
+        Call { to: TxKind::Call(Address::random()), value: U256::ZERO, input: bytes!("dead") },
+        Call { to: TxKind::Call(Address::random()), value: U256::ZERO, input: bytes!("beef") },
+    ];
+
+    let tx = tempo_calls_request(from, &calls);
+    let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+    assert!(receipt.status(), "Tempo AA batch via eth_sendTransaction should succeed");
+
+    // The mined transaction carries the full batch, not a single empty call.
+    let tx_json = provider
+        .raw_request::<_, serde_json::Value>(
+            "eth_getTransactionByHash".into(),
+            (receipt.transaction_hash,),
+        )
+        .await
+        .unwrap();
+    let rpc_calls = tx_json["calls"]
+        .as_array()
+        .unwrap_or_else(|| panic!("tempo tx should include calls: {tx_json}"));
+    assert_eq!(rpc_calls.len(), 2, "calls batch was dropped: {rpc_calls:?}");
+    for (rpc_call, call) in rpc_calls.iter().zip(&calls) {
+        assert_eq!(rpc_call["to"], serde_json::to_value(call.to.to().unwrap()).unwrap());
+        assert_eq!(rpc_call["input"], serde_json::to_value(&call.input).unwrap());
+    }
+    assert_eq!(tx_json["type"], "0x76");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_send_transaction_with_calls_executes_batch() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let (from, recipient_a, recipient_b) = (accounts[0], accounts[1], accounts[2]);
+
+    let token = IERC20::new(PATH_USD, &provider);
+    let balance_a_before = token.balanceOf(recipient_a).call().await.unwrap();
+    let balance_b_before = token.balanceOf(recipient_b).call().await.unwrap();
+
+    let (amount_a, amount_b) = (U256::from(100_000), U256::from(200_000));
+    let calls = vec![
+        Call {
+            to: TxKind::Call(PATH_USD),
+            value: U256::ZERO,
+            input: token.transfer(recipient_a, amount_a).calldata().clone(),
+        },
+        Call {
+            to: TxKind::Call(PATH_USD),
+            value: U256::ZERO,
+            input: token.transfer(recipient_b, amount_b).calldata().clone(),
+        },
+    ];
+
+    let tx = tempo_calls_request(from, &calls);
+    let receipt = provider.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
+    assert!(receipt.status(), "Tempo AA batch via eth_sendTransaction should succeed");
+
+    assert_eq!(
+        token.balanceOf(recipient_a).call().await.unwrap(),
+        balance_a_before + amount_a,
+        "first call should execute"
+    );
+    assert_eq!(
+        token.balanceOf(recipient_b).call().await.unwrap(),
+        balance_b_before + amount_b,
+        "second call should execute"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_estimate_gas_with_calls() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let (from, recipient) = (accounts[0], accounts[1]);
+
+    let token = IERC20::new(PATH_USD, &provider);
+    let calls: Vec<Call> = (1..=2u64)
+        .map(|i| Call {
+            to: TxKind::Call(PATH_USD),
+            value: U256::ZERO,
+            input: token.transfer(recipient, U256::from(i)).calldata().clone(),
+        })
+        .collect();
+
+    let estimate = async |calls: &[Call]| {
+        provider
+            .raw_request::<_, U256>("eth_estimateGas".into(), (tempo_calls_request(from, calls),))
+            .await
+            .unwrap()
+    };
+
+    // Estimation covers the batch: two calls need more gas than one.
+    assert!(estimate(&calls).await > estimate(&calls[..1]).await);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tempo_send_transaction_with_calls_rejects_value() {
+    let (_api, handle) = spawn(NodeConfig::test_tempo()).await;
+    let provider = handle.http_provider();
+
+    let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let (from, recipient) = (accounts[0], accounts[1]);
+
+    let calls =
+        vec![Call { to: TxKind::Call(recipient), value: U256::ONE, input: Bytes::default() }];
+    let mut tx = tempo_calls_request(from, &calls);
+    tx.inner = tx.inner.with_gas_limit(TIP20_TRANSFER_GAS);
+
+    let err = provider.send_transaction(tx).await.unwrap_err().to_string();
+    assert!(
+        err.contains("native value transfer not allowed"),
+        "Expected 'native value transfer not allowed' error, got: {err}"
     );
 }
 

--- a/crates/primitives/src/transaction/request.rs
+++ b/crates/primitives/src/transaction/request.rs
@@ -27,8 +27,8 @@ use crate::FoundryNetwork;
 /// - **Ethereum**: Default variant when no special fields are present
 /// - **Op**: When `sourceHash`, `mint`, and `isSystemTx` fields are present, or transaction type is
 ///   `DEPOSIT_TX_TYPE_ID`
-/// - **Tempo**: When `feeToken` or `nonceKey` fields are present, or transaction type is
-///   `TEMPO_TX_TYPE_ID`
+/// - **Tempo**: When any Tempo-specific field ([`TEMPO_REQUEST_KEYS`]) is present, or transaction
+///   type is `TEMPO_TX_TYPE_ID`
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
 pub enum FoundryTransactionRequest {
@@ -245,23 +245,30 @@ impl AsMut<TransactionRequest> for FoundryTransactionRequest {
     }
 }
 
+/// JSON keys of the Tempo-specific [`TempoTransactionRequest`] extension fields.
+const TEMPO_REQUEST_KEYS: &[&str] = &[
+    "feeToken",
+    "nonceKey",
+    "calls",
+    "keyType",
+    "keyData",
+    "keyId",
+    "aaAuthorizationList",
+    "keyAuthorization",
+    "validBefore",
+    "validAfter",
+    "feePayerSignature",
+];
+
 impl From<WithOtherFields<TransactionRequest>> for FoundryTransactionRequest {
     fn from(tx: WithOtherFields<TransactionRequest>) -> Self {
         if tx.transaction_type == Some(TEMPO_TX_TYPE_ID)
-            || tx.other.contains_key("feeToken")
-            || tx.other.contains_key("nonceKey")
+            || TEMPO_REQUEST_KEYS.iter().any(|key| tx.other.contains_key(*key))
         {
-            let mut tempo_tx_req: TempoTransactionRequest = tx.inner.into();
-            if let Some(fee_token) =
-                tx.other.get_deserialized::<Address>("feeToken").transpose().ok().flatten()
-            {
-                tempo_tx_req.fee_token = Some(fee_token);
-            }
-            if let Some(nonce_key) =
-                tx.other.get_deserialized::<U256>("nonceKey").transpose().ok().flatten()
-            {
-                tempo_tx_req.set_nonce_key(nonce_key);
-            }
+            // Serde round-trip to pick up all Tempo fields carried in `other`.
+            let tempo_tx_req = serde_json::to_value(&tx)
+                .and_then(serde_json::from_value::<TempoTransactionRequest>)
+                .unwrap_or_else(|_| tx.inner.into());
             return Self::Tempo(Box::new(tempo_tx_req));
         }
         #[cfg(feature = "optimism")]
@@ -304,16 +311,14 @@ impl From<FoundryTypedTx> for FoundryTransactionRequest {
                     other.insert("feeToken".to_string(), serde_json::to_value(fee_token).unwrap());
                 }
                 other.insert("nonceKey".to_string(), serde_json::to_value(tx.nonce_key).unwrap());
-                let first_call = tx.calls.first();
+                // Carry the full batch; `to` stays empty as `build_aa` appends it as a call.
+                other.insert("calls".to_string(), serde_json::to_value(&tx.calls).unwrap());
                 let mut inner = TransactionRequest::default()
                     .with_chain_id(tx.chain_id)
                     .with_nonce(tx.nonce)
                     .with_gas_limit(tx.gas_limit)
                     .with_max_fee_per_gas(tx.max_fee_per_gas)
                     .with_max_priority_fee_per_gas(tx.max_priority_fee_per_gas)
-                    .with_kind(first_call.map(|c| c.to).unwrap_or_default())
-                    .with_value(first_call.map(|c| c.value).unwrap_or_default())
-                    .with_input(first_call.map(|c| c.input.clone()).unwrap_or_default())
                     .with_access_list(tx.access_list);
                 inner.transaction_type = Some(TEMPO_TX_TYPE_ID);
                 WithOtherFields { inner, other }.into()
@@ -592,6 +597,7 @@ impl TransactionBuilder4844 for FoundryTransactionRequest {
 #[cfg(test)]
 mod tests {
     use alloy_primitives::B256;
+    use tempo_primitives::{TempoTransaction, transaction::Call};
 
     use super::*;
 
@@ -624,6 +630,57 @@ mod tests {
 
         assert!(matches!(req, FoundryTransactionRequest::Tempo(_)));
         assert!(matches!(req.build_unsigned(), Ok(FoundryTypedTx::Tempo(_))));
+    }
+
+    #[test]
+    fn test_routing_tempo_by_calls() {
+        let calls = vec![
+            Call { to: TxKind::Call(Address::random()), value: U256::ZERO, input: vec![1].into() },
+            Call { to: TxKind::Call(Address::random()), value: U256::ZERO, input: vec![2].into() },
+        ];
+        // Batch request shape: `calls` only, no top-level `to`/`value`/`input`.
+        let tx = TransactionRequest::default()
+            .with_nonce(1)
+            .with_gas_limit(1000000)
+            .with_max_fee_per_gas(1000000)
+            .with_max_priority_fee_per_gas(1000000);
+        let mut other = OtherFields::default();
+        other.insert("calls".to_string(), serde_json::to_value(&calls).unwrap());
+
+        let req: FoundryTransactionRequest = WithOtherFields { inner: tx, other }.into();
+
+        let FoundryTransactionRequest::Tempo(tempo_req) = &req else {
+            panic!("expected Tempo request, got {req:?}");
+        };
+        assert_eq!(tempo_req.calls, calls);
+
+        let Ok(FoundryTypedTx::Tempo(tempo_tx)) = req.build_unsigned() else {
+            panic!("expected Tempo typed tx");
+        };
+        assert_eq!(tempo_tx.calls, calls);
+    }
+
+    #[test]
+    fn test_tempo_typed_tx_request_round_trip_preserves_calls() {
+        let calls = vec![
+            Call { to: TxKind::Call(Address::random()), value: U256::ZERO, input: vec![1].into() },
+            Call { to: TxKind::Call(Address::random()), value: U256::ZERO, input: vec![2].into() },
+        ];
+        let tempo_tx = TempoTransaction {
+            chain_id: 1,
+            max_fee_per_gas: 1000000,
+            max_priority_fee_per_gas: 1000000,
+            gas_limit: 1000000,
+            calls: calls.clone(),
+            ..Default::default()
+        };
+
+        let req: FoundryTransactionRequest = FoundryTypedTx::Tempo(tempo_tx).into();
+
+        let Ok(FoundryTypedTx::Tempo(rebuilt)) = req.build_unsigned() else {
+            panic!("expected Tempo typed tx");
+        };
+        assert_eq!(rebuilt.calls, calls);
     }
 
     #[test]


### PR DESCRIPTION
`anvil --network tempo` silently drops `calls`.

Minimal repro against `anvil --network tempo`:

```bash
cast rpc eth_sendTransaction '{
  "from": "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
  "type": "0x76",
  "calls": [
    {"to": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", "data": "0xdead"},
    {"to": "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", "data": "0xbeef"}
  ]
}'
```
