### PR TITLE
test(cast): normalize executable suffix in mktx snapshot

### DIFF
--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2338,7 +2338,7 @@ casttest!(mktx_signature_requires_from, |_prj, cmd| {
 error: the following required arguments were not provided:
   --from <ADDRESS>
 
-Usage: cast mktx --from <ADDRESS> --signature <SIGNATURE> <TO> [SIG] [ARGS]...
+Usage: cast[..] mktx --from <ADDRESS> --signature <SIGNATURE> <TO> [SIG] [ARGS]...
 
 For more information, try '--help'.
 


### PR DESCRIPTION
Fix the `mktx_signature_requires_from` snapshot on Windows, where clap renders the executable name as `cast.exe`. The existing snapbox `[..]` wildcard keeps the assertion portable while still checking the complete usage line.

Validation:
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Focused test could not run locally because the pinned `foundry-rs/optimism` dependency returned HTTP 401 during fetch.

Prompted by: @grandizzy