### PR TITLE
fix(cheatcodes): warn on internal, reject removed

### DIFF
--- a/.changelog/pr-15808.md
+++ b/.changelog/pr-15808.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+---
+
+Warn once per test suite when internal cheatcodes are used, unioning the signatures across
+multi-network passes, and reject removed cheatcodes, including calls whose symbolic target is
+constrained to the cheatcode address.

--- a/crates/cheatcodes/assets/cheatcodes.schema.json
+++ b/crates/cheatcodes/assets/cheatcodes.schema.json
@@ -322,7 +322,7 @@
           "const": "stable"
         },
         {
-          "description": "The cheatcode is unstable, meaning it may contain bugs and may break its API on any\nrelease.\n\nUse of experimental cheatcodes will result in a warning.",
+          "description": "The cheatcode is unstable, meaning it may contain bugs and may break its API on any\nrelease.\n\nThis status currently has no runtime effect.",
           "type": "string",
           "const": "experimental"
         },

--- a/crates/cheatcodes/spec/src/cheatcode.rs
+++ b/crates/cheatcodes/spec/src/cheatcode.rs
@@ -40,7 +40,7 @@ pub enum Status<'a> {
     /// The cheatcode is unstable, meaning it may contain bugs and may break its API on any
     /// release.
     ///
-    /// Use of experimental cheatcodes will result in a warning.
+    /// This status currently has no runtime effect.
     Experimental,
     /// The cheatcode has been deprecated, meaning it will be removed in a future release.
     ///
@@ -57,6 +57,31 @@ pub enum Status<'a> {
     ///
     /// Use of internal cheatcodes is discouraged and will result in a warning.
     Internal,
+}
+
+/// The runtime action associated with a cheatcode [`Status`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StatusAction {
+    /// Continue with normal cheatcode dispatch.
+    Continue,
+    /// Record use of an internal cheatcode before dispatching it.
+    RecordInternal,
+    /// Reject the cheatcode before dispatching it.
+    RejectRemoved,
+}
+
+impl Status<'_> {
+    /// Returns the runtime action for this status.
+    pub const fn action(&self) -> StatusAction {
+        match self {
+            // Experimental cheatcodes dispatch normally: the status is currently unused and its
+            // runtime behavior has not been decided. Deprecated cheatcodes are recorded
+            // separately, with their replacement.
+            Self::Stable | Self::Experimental | Self::Deprecated(_) => StatusAction::Continue,
+            Self::Internal => StatusAction::RecordInternal,
+            Self::Removed => StatusAction::RejectRemoved,
+        }
+    }
 }
 
 /// Cheatcode groups.

--- a/crates/cheatcodes/spec/src/lib.rs
+++ b/crates/cheatcodes/spec/src/lib.rs
@@ -4,10 +4,10 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, fmt};
+use std::{borrow::Cow, collections::HashMap, fmt, sync::LazyLock};
 
 mod cheatcode;
-pub use cheatcode::{Cheatcode, CheatcodeDef, Group, Safety, Status};
+pub use cheatcode::{Cheatcode, CheatcodeDef, Group, Safety, Status, StatusAction};
 
 mod function;
 pub use function::{Function, Mutability, Visibility};
@@ -108,6 +108,19 @@ impl Cheatcodes<'static> {
             cheatcodes: Vm::CHEATCODES.iter().copied().cloned().collect(),
         }
     }
+}
+
+/// Returns the cheatcode metadata for `selector`.
+pub fn cheatcode_by_selector(selector: [u8; 4]) -> Option<&'static Cheatcode<'static>> {
+    static BY_SELECTOR: LazyLock<HashMap<[u8; 4], &'static Cheatcode<'static>>> =
+        LazyLock::new(|| {
+            Vm::CHEATCODES
+                .iter()
+                .copied()
+                .map(|cheatcode| (cheatcode.func.selector_bytes, cheatcode))
+                .collect()
+        });
+    BY_SELECTOR.get(&selector).copied()
 }
 
 #[cfg(test)]

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -49,6 +49,7 @@ use foundry_evm_traces::{
 };
 use foundry_wallets::wallet_multi::MultiWallet;
 use itertools::Itertools;
+use parking_lot::Mutex;
 use proptest::test_runner::{RngAlgorithm, TestRng, TestRunner};
 use rand::Rng;
 use revm::{
@@ -80,6 +81,23 @@ mod utils;
 
 pub mod analysis;
 pub use analysis::CheatcodeAnalysis;
+
+/// Internal cheatcodes observed by all inspectors cloned from the same suite executor.
+#[derive(Clone, Debug, Default)]
+struct InternalCheatcodeUsage(Arc<Mutex<HashSet<&'static str>>>);
+
+impl InternalCheatcodeUsage {
+    #[inline]
+    fn record(&self, signature: &'static str) {
+        self.0.lock().insert(signature);
+    }
+
+    fn signatures(&self) -> Vec<&'static str> {
+        let mut signatures = self.0.lock().iter().copied().collect::<Vec<_>>();
+        signatures.sort_unstable();
+        signatures
+    }
+}
 
 /// Helper trait for running nested EVM operations from inside cheatcode implementations.
 pub trait CheatcodesExecutor<FEN: FoundryEvmNetwork> {
@@ -675,6 +693,10 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
 
     /// Deprecated cheatcodes mapped to the reason. Used to report warnings on test results.
     pub deprecated: HashMap<&'static str, Option<&'static str>>,
+    /// Internal cheatcodes observed across the current test suite. Shared by all inspectors
+    /// cloned from the same suite executor, because usage can occur outside of any test result
+    /// (e.g. in constructors or corpus replays).
+    internal_cheatcodes: InternalCheatcodeUsage,
     /// Unlocked wallets used in scripts and testing of scripts.
     pub wallets: Option<Wallets>,
     /// Parsed secp256k1 private-key signers for repeated `vm.addr` / `vm.sign` calls.
@@ -772,6 +794,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             ignored_traces: Default::default(),
             arbitrary_storage: Default::default(),
             deprecated: Default::default(),
+            internal_cheatcodes: Default::default(),
             wallets: Default::default(),
             private_key_signers: Default::default(),
             signatures_identifier: Default::default(),
@@ -781,6 +804,16 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             env_overrides_snapshots: Default::default(),
             in_isolation_context: false,
         }
+    }
+
+    /// Returns the sorted internal cheatcode signatures observed by this suite.
+    pub fn internal_cheatcodes(&self) -> Vec<&'static str> {
+        self.internal_cheatcodes.signatures()
+    }
+
+    /// Records use of an internal cheatcode in this suite.
+    pub fn record_internal_cheatcode(&self, signature: &'static str) {
+        self.internal_cheatcodes.record(signature);
     }
 
     /// Enables cheatcode analysis capabilities by providing a solar compiler instance.
@@ -3140,10 +3173,6 @@ fn apply_dispatch<FEN: FoundryEvmNetwork>(
     let _guard = debug_span!(target: "cheatcodes", "apply", id = %cheatcode_id(cheat)).entered();
     trace!(target: "cheatcodes", cheat = %cheatcode_signature(cheat), "applying");
 
-    if let spec::Status::Deprecated(replacement) = cheat.status {
-        ccx.state.deprecated.insert(cheatcode_signature(cheat), replacement);
-    }
-
     // Monomorphized dispatch: calls apply_full directly, no trait objects.
     macro_rules! dispatch {
         ($($variant:ident),*) => {
@@ -3152,7 +3181,10 @@ fn apply_dispatch<FEN: FoundryEvmNetwork>(
             }
         };
     }
-    let mut result = vm_calls!(dispatch);
+    let mut result = match record_cheatcode_status(cheat, ccx.state) {
+        Ok(()) => vm_calls!(dispatch),
+        Err(err) => Err(err),
+    };
 
     // Format the error message to include the cheatcode name.
     if let Err(e) = &mut result
@@ -3178,6 +3210,24 @@ fn apply_dispatch<FEN: FoundryEvmNetwork>(
     result
 }
 
+/// Records status metadata for the dispatched cheatcode, and rejects removed cheatcodes
+/// before they are dispatched.
+fn record_cheatcode_status<FEN: FoundryEvmNetwork>(
+    cheat: &spec::Cheatcode<'static>,
+    state: &mut Cheatcodes<FEN>,
+) -> Result<()> {
+    let signature = cheatcode_signature(cheat);
+    if let spec::Status::Deprecated(replacement) = cheat.status {
+        state.deprecated.insert(signature, replacement);
+    }
+    match cheat.status.action() {
+        spec::StatusAction::Continue => {}
+        spec::StatusAction::RecordInternal => state.record_internal_cheatcode(signature),
+        spec::StatusAction::RejectRemoved => return Err(fmt_err!("cheatcode has been removed")),
+    }
+    Ok(())
+}
+
 /// Helper function to check if frame execution will exit.
 const fn will_exit(action: &InterpreterAction) -> bool {
     match action {
@@ -3191,6 +3241,36 @@ const fn will_exit(action: &InterpreterAction) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn internal_cheatcode_usage_is_shared_and_deduplicated() {
+        let usage = InternalCheatcodeUsage::default();
+        let workers = ["first()", "second()", "first()"].map(|signature| {
+            let usage = usage.clone();
+            std::thread::spawn(move || usage.record(signature))
+        });
+        for worker in workers {
+            worker.join().unwrap();
+        }
+
+        assert_eq!(usage.signatures(), ["first()", "second()"]);
+    }
+
+    #[test]
+    fn records_internal_and_rejects_removed_cheatcodes() {
+        let internal_cheatcode =
+            <crate::Vm::_expectCheatcodeRevert_0Call as spec::CheatcodeDef>::CHEATCODE;
+        let mut state = cheats(false, None);
+
+        record_cheatcode_status(internal_cheatcode, &mut state).unwrap();
+        assert_eq!(state.internal_cheatcodes(), ["_expectCheatcodeRevert()"]);
+
+        let mut removed_cheatcode = internal_cheatcode.clone();
+        removed_cheatcode.status = spec::Status::Removed;
+        let err = record_cheatcode_status(&removed_cheatcode, &mut state).unwrap_err();
+        assert_eq!(err.to_string(), "cheatcode has been removed");
+        assert_eq!(state.internal_cheatcodes(), ["_expectCheatcodeRevert()"]);
+    }
 
     fn cheats(flag: bool, broadcast: Option<Broadcast>) -> Cheatcodes {
         let config = CheatsConfig { batch_rewrite_creates: flag, ..Default::default() };

--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -1,4 +1,5 @@
 use super::*;
+use foundry_cheatcodes_spec::{StatusAction, cheatcode_by_selector};
 
 impl SymbolicExecutor {
     pub(super) fn call(
@@ -773,6 +774,22 @@ impl SymbolicExecutor {
                 }
                 if !self.assume_expr_at_least(state, &in_size_word, min_size)? {
                     return Ok(StepOutcome::AssumeRejected);
+                }
+            }
+
+            if to == CHEATCODE_ADDRESS
+                && let Some(cheatcode) = cheatcode_by_selector(selector)
+            {
+                match cheatcode.status.action() {
+                    StatusAction::Continue => {}
+                    StatusAction::RecordInternal => {
+                        if let Some(cheatcodes) = &executor.inspector().cheatcodes {
+                            cheatcodes.record_internal_cheatcode(cheatcode.func.signature);
+                        }
+                    }
+                    StatusAction::RejectRemoved => {
+                        return Err(SymbolicError::Unsupported("removed cheatcode"));
+                    }
                 }
             }
 

--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -21,7 +21,13 @@ impl SymbolicExecutor {
         }
         let target = state.stack.pop()?;
         ensure_expr_not_gasleft(&target)?;
-        let target_address = state.world.resolve_address(&target);
+        // Path constraints are ground truth for the target: a word they force to a single
+        // value is concrete even when unresolved (or stale) in the alias table, mirroring
+        // address_or_symbolic_slot. Constants short-circuit inside constrained_word.
+        let target_address = state
+            .constrained_word(&mut self.cx, &target)
+            .map(word_to_address)
+            .or_else(|| state.world.resolve_address(&target));
         let value = match (kind, target_address) {
             (CallKind::Call, Some(to)) if is_known_cheatcode(to) => {
                 let value = state.stack.pop()?;

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -3732,6 +3732,10 @@ fn merge_outcomes(base: &mut TestOutcome, other: TestOutcome) {
                 let base_suite = e.get_mut();
                 base_suite.test_results.extend(other_suite.test_results);
                 base_suite.warnings.extend(other_suite.warnings);
+                // Suite-level warnings (deprecated or internal cheatcodes) are re-emitted by
+                // every pass; drop exact duplicates while preserving the original order.
+                let mut seen = std::collections::HashSet::new();
+                base_suite.warnings.retain(|warning| seen.insert(warning.clone()));
                 base_suite.duration = base_suite.duration.max(other_suite.duration);
             }
         }

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -76,7 +76,7 @@ use rand::Rng;
 use regex::Regex;
 use revm::{bytecode::opcode::OpCode, context::Transaction};
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     fmt::Write,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, mpsc::channel},
@@ -1985,6 +1985,10 @@ impl TestArgs {
         let override_networks =
             execution.inline_config.referenced_override_networks(&config.profile);
 
+        // Internal/deprecated cheatcode warnings are suite-level and re-derived by every network
+        // pass; track the (suite, warning) pairs already printed so each is emitted only once.
+        let mut printed_suite_warnings = HashSet::new();
+
         let (libraries, mut outcome) = if override_networks.is_empty() {
             // Single-pass: no per-test network overrides, use global network setting.
             execution.decode_internal = decode_internal;
@@ -1996,6 +2000,7 @@ impl TestArgs {
                 output,
                 &mut filter,
                 execution.clone(),
+                &mut printed_suite_warnings,
             )
             .await?
         } else {
@@ -2019,6 +2024,7 @@ impl TestArgs {
                         },
                         ..execution.clone()
                     },
+                    &mut printed_suite_warnings,
                 )
                 .await?;
 
@@ -2041,6 +2047,7 @@ impl TestArgs {
                             },
                             ..execution.clone()
                         },
+                        &mut printed_suite_warnings,
                     )
                     .await?;
                 merge_outcomes(&mut outcome, pass_outcome);
@@ -2497,6 +2504,7 @@ impl TestArgs {
         output: &ProjectCompileOutput,
         filter: &mut ProjectPathsAwareFilter,
         execution: TestExecutionOptions,
+        printed_suite_warnings: &mut HashSet<(String, String)>,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
         let verbosity = evm_opts.verbosity;
         let (evm_env, tx_env, fork_block) =
@@ -2522,7 +2530,9 @@ impl TestArgs {
             .build::<FEN, MultiCompiler>(output, evm_env, tx_env, evm_opts)?;
 
         let libraries = runner.libraries.clone();
-        let outcome = self.run_tests_inner(runner, config, verbosity, filter, output).await?;
+        let outcome = self
+            .run_tests_inner(runner, config, verbosity, filter, output, printed_suite_warnings)
+            .await?;
         Ok((libraries, outcome))
     }
 
@@ -2550,6 +2560,7 @@ impl TestArgs {
     }
 
     /// Dispatches `build_and_run_tests` to the correct network type based on `evm_opts.networks`.
+    #[expect(clippy::too_many_arguments)]
     async fn dispatch_network(
         &self,
         dispatch_opts: &EvmOpts,
@@ -2558,24 +2569,40 @@ impl TestArgs {
         output: &ProjectCompileOutput,
         filter: &mut ProjectPathsAwareFilter,
         execution: TestExecutionOptions,
+        printed_suite_warnings: &mut HashSet<(String, String)>,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
         match network_dispatch_kind(dispatch_opts) {
             NetworkDispatchKind::Tempo => {
                 self.build_and_run_tests::<TempoEvmNetwork>(
-                    config, evm_opts, output, filter, execution,
+                    config,
+                    evm_opts,
+                    output,
+                    filter,
+                    execution,
+                    printed_suite_warnings,
                 )
                 .await
             }
             #[cfg(feature = "optimism")]
             NetworkDispatchKind::Optimism => {
                 self.build_and_run_tests::<OpEvmNetwork>(
-                    config, evm_opts, output, filter, execution,
+                    config,
+                    evm_opts,
+                    output,
+                    filter,
+                    execution,
+                    printed_suite_warnings,
                 )
                 .await
             }
             NetworkDispatchKind::Eth => {
                 self.build_and_run_tests::<EthEvmNetwork>(
-                    config, evm_opts, output, filter, execution,
+                    config,
+                    evm_opts,
+                    output,
+                    filter,
+                    execution,
+                    printed_suite_warnings,
                 )
                 .await
             }
@@ -2626,6 +2653,7 @@ impl TestArgs {
         verbosity: u8,
         filter: &mut ProjectPathsAwareFilter,
         output: &ProjectCompileOutput,
+        printed_suite_warnings: &mut HashSet<(String, String)>,
     ) -> eyre::Result<TestOutcome> {
         let fuzz_seed = config.fuzz.seed;
         if self.list {
@@ -2886,8 +2914,13 @@ impl TestArgs {
             // Print suite header.
             if !silent {
                 sh_println!()?;
+                // A suite's internal/deprecated cheatcode warnings are re-derived by every
+                // network pass; emit each (suite, warning) only once across passes so a shared
+                // warning is not repeated once per pass.
                 for warning in &suite_result.warnings {
-                    sh_warn!("{warning}")?;
+                    if printed_suite_warnings.insert((contract_name.clone(), warning.clone())) {
+                        sh_warn!("{warning}")?;
+                    }
                 }
                 if has_tests {
                     let tests = if len > 1 { "tests" } else { "test" };

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -76,7 +76,7 @@ use rand::Rng;
 use regex::Regex;
 use revm::{bytecode::opcode::OpCode, context::Transaction};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
     fmt::Write,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, mpsc::channel},
@@ -1985,10 +1985,6 @@ impl TestArgs {
         let override_networks =
             execution.inline_config.referenced_override_networks(&config.profile);
 
-        // Internal/deprecated cheatcode warnings are suite-level and re-derived by every network
-        // pass; track the (suite, warning) pairs already printed so each is emitted only once.
-        let mut printed_suite_warnings = HashSet::new();
-
         let (libraries, mut outcome) = if override_networks.is_empty() {
             // Single-pass: no per-test network overrides, use global network setting.
             execution.decode_internal = decode_internal;
@@ -2000,7 +1996,6 @@ impl TestArgs {
                 output,
                 &mut filter,
                 execution.clone(),
-                &mut printed_suite_warnings,
             )
             .await?
         } else {
@@ -2024,7 +2019,6 @@ impl TestArgs {
                         },
                         ..execution.clone()
                     },
-                    &mut printed_suite_warnings,
                 )
                 .await?;
 
@@ -2047,10 +2041,20 @@ impl TestArgs {
                             },
                             ..execution.clone()
                         },
-                        &mut printed_suite_warnings,
                     )
                     .await?;
                 merge_outcomes(&mut outcome, pass_outcome);
+            }
+
+            // Emit each suite's warnings once from the merged outcome: after the passes
+            // they carry the union of every pass's signatures. JUnit never emitted the
+            // per-pass warnings, keep it silent here too.
+            if !shell::is_json() && !self.junit {
+                for suite_result in outcome.results.values() {
+                    for warning in &suite_result.warnings {
+                        sh_warn!("{warning}")?;
+                    }
+                }
             }
 
             // Print the merged summary (per-pass summaries are suppressed in `run_tests_inner`).
@@ -2504,7 +2508,6 @@ impl TestArgs {
         output: &ProjectCompileOutput,
         filter: &mut ProjectPathsAwareFilter,
         execution: TestExecutionOptions,
-        printed_suite_warnings: &mut HashSet<(String, String)>,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
         let verbosity = evm_opts.verbosity;
         let (evm_env, tx_env, fork_block) =
@@ -2530,9 +2533,7 @@ impl TestArgs {
             .build::<FEN, MultiCompiler>(output, evm_env, tx_env, evm_opts)?;
 
         let libraries = runner.libraries.clone();
-        let outcome = self
-            .run_tests_inner(runner, config, verbosity, filter, output, printed_suite_warnings)
-            .await?;
+        let outcome = self.run_tests_inner(runner, config, verbosity, filter, output).await?;
         Ok((libraries, outcome))
     }
 
@@ -2560,7 +2561,6 @@ impl TestArgs {
     }
 
     /// Dispatches `build_and_run_tests` to the correct network type based on `evm_opts.networks`.
-    #[expect(clippy::too_many_arguments)]
     async fn dispatch_network(
         &self,
         dispatch_opts: &EvmOpts,
@@ -2569,40 +2569,24 @@ impl TestArgs {
         output: &ProjectCompileOutput,
         filter: &mut ProjectPathsAwareFilter,
         execution: TestExecutionOptions,
-        printed_suite_warnings: &mut HashSet<(String, String)>,
     ) -> eyre::Result<(Libraries, TestOutcome)> {
         match network_dispatch_kind(dispatch_opts) {
             NetworkDispatchKind::Tempo => {
                 self.build_and_run_tests::<TempoEvmNetwork>(
-                    config,
-                    evm_opts,
-                    output,
-                    filter,
-                    execution,
-                    printed_suite_warnings,
+                    config, evm_opts, output, filter, execution,
                 )
                 .await
             }
             #[cfg(feature = "optimism")]
             NetworkDispatchKind::Optimism => {
                 self.build_and_run_tests::<OpEvmNetwork>(
-                    config,
-                    evm_opts,
-                    output,
-                    filter,
-                    execution,
-                    printed_suite_warnings,
+                    config, evm_opts, output, filter, execution,
                 )
                 .await
             }
             NetworkDispatchKind::Eth => {
                 self.build_and_run_tests::<EthEvmNetwork>(
-                    config,
-                    evm_opts,
-                    output,
-                    filter,
-                    execution,
-                    printed_suite_warnings,
+                    config, evm_opts, output, filter, execution,
                 )
                 .await
             }
@@ -2653,7 +2637,6 @@ impl TestArgs {
         verbosity: u8,
         filter: &mut ProjectPathsAwareFilter,
         output: &ProjectCompileOutput,
-        printed_suite_warnings: &mut HashSet<(String, String)>,
     ) -> eyre::Result<TestOutcome> {
         let fuzz_seed = config.fuzz.seed;
         if self.list {
@@ -2914,11 +2897,11 @@ impl TestArgs {
             // Print suite header.
             if !silent {
                 sh_println!()?;
-                // A suite's internal/deprecated cheatcode warnings are re-derived by every
-                // network pass; emit each (suite, warning) only once across passes so a shared
-                // warning is not repeated once per pass.
-                for warning in &suite_result.warnings {
-                    if printed_suite_warnings.insert((contract_name.clone(), warning.clone())) {
+                // In multi-pass mode each pass re-derives the suite-level cheatcode
+                // warnings from only its own signatures; their emission is deferred to the
+                // merged outcome, which carries the union across passes.
+                if !is_multi_pass {
+                    for warning in &suite_result.warnings {
                         sh_warn!("{warning}")?;
                     }
                 }
@@ -3764,11 +3747,23 @@ fn merge_outcomes(base: &mut TestOutcome, other: TestOutcome) {
             std::collections::btree_map::Entry::Occupied(mut e) => {
                 let base_suite = e.get_mut();
                 base_suite.test_results.extend(other_suite.test_results);
+                base_suite.internal_cheatcodes.extend(other_suite.internal_cheatcodes);
                 base_suite.warnings.extend(other_suite.warnings);
-                // Suite-level warnings (deprecated or internal cheatcodes) are re-emitted by
-                // every pass; drop exact duplicates while preserving the original order.
+                // Each pass renders the suite-level cheatcode warnings from only its own
+                // signatures, so the per-pass strings can both repeat and split signatures
+                // across blocks. Drop them, dedup what remains, and re-render each cheatcode
+                // warning once from the structured data merged above.
+                base_suite
+                    .warnings
+                    .retain(|warning| !crate::result::is_suite_cheatcode_warning(warning));
                 let mut seen = std::collections::HashSet::new();
                 base_suite.warnings.retain(|warning| seen.insert(warning.clone()));
+                base_suite.warnings.extend(crate::result::internal_cheatcodes_warning(
+                    &base_suite.internal_cheatcodes,
+                ));
+                base_suite
+                    .warnings
+                    .extend(crate::result::deprecated_cheatcodes_warning(&base_suite.test_results));
                 base_suite.duration = base_suite.duration.max(other_suite.duration);
             }
         }

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -807,6 +807,8 @@ impl SuiteResult {
             let mut warning =
                 "the following cheatcode(s) are deprecated and will be removed in future versions:"
                     .to_string();
+            let mut deprecated_cheatcodes = deprecated_cheatcodes.into_iter().collect::<Vec<_>>();
+            deprecated_cheatcodes.sort_unstable_by_key(|(cheatcode, _)| *cheatcode);
             for (cheatcode, reason) in deprecated_cheatcodes {
                 write!(warning, "\n  {cheatcode}").unwrap();
                 if let Some(reason) = reason {
@@ -885,6 +887,20 @@ impl SuiteResult {
             self.total_time(),
         )
     }
+}
+
+pub(crate) fn internal_cheatcodes_warning(signatures: &[&str]) -> Option<String> {
+    if signatures.is_empty() {
+        return None;
+    }
+
+    let mut warning = "the following cheatcode(s) are intended for internal use and may change or \
+                       be removed:"
+        .to_string();
+    for signature in signatures {
+        write!(warning, "\n  {signature}").unwrap();
+    }
+    Some(warning)
 }
 
 /// The result of a single test in a test suite.

--- a/crates/forge/src/result.rs
+++ b/crates/forge/src/result.rs
@@ -471,7 +471,7 @@ mod tests {
             None,
             BTreeMap::from([(
                 "suite".to_string(),
-                SuiteResult::new(Duration::ZERO, test_results, Vec::new()),
+                SuiteResult::new(Duration::ZERO, test_results, Vec::new(), Default::default()),
             )]),
             false,
             None,
@@ -491,6 +491,7 @@ mod tests {
                         .map(|(idx, result)| (format!("test{idx}()"), result))
                         .collect(),
                     Vec::new(),
+                    Default::default(),
                 ),
             )]),
             false,
@@ -790,6 +791,10 @@ pub struct SuiteResult {
     pub test_results: BTreeMap<String, TestResult>,
     /// Generated warnings.
     pub warnings: Vec<String>,
+    /// Signatures of the internal cheatcodes used in this suite. Kept structured so that
+    /// multi-network passes can be unioned before formatting the suite warning.
+    #[serde(skip)]
+    pub internal_cheatcodes: std::collections::BTreeSet<String>,
 }
 
 impl SuiteResult {
@@ -797,28 +802,14 @@ impl SuiteResult {
         duration: Duration,
         test_results: BTreeMap<String, TestResult>,
         mut warnings: Vec<String>,
+        internal_cheatcodes: std::collections::BTreeSet<String>,
     ) -> Self {
-        // Add deprecated cheatcodes warning, if any of them used in current test suite.
-        let mut deprecated_cheatcodes = HashMap::new();
-        for test_result in test_results.values() {
-            deprecated_cheatcodes.extend(test_result.deprecated_cheatcodes.clone());
-        }
-        if !deprecated_cheatcodes.is_empty() {
-            let mut warning =
-                "the following cheatcode(s) are deprecated and will be removed in future versions:"
-                    .to_string();
-            let mut deprecated_cheatcodes = deprecated_cheatcodes.into_iter().collect::<Vec<_>>();
-            deprecated_cheatcodes.sort_unstable_by_key(|(cheatcode, _)| *cheatcode);
-            for (cheatcode, reason) in deprecated_cheatcodes {
-                write!(warning, "\n  {cheatcode}").unwrap();
-                if let Some(reason) = reason {
-                    write!(warning, ": {reason}").unwrap();
-                }
-            }
-            warnings.push(warning);
-        }
+        // Add the internal cheatcodes warning, if any of them was used in this suite.
+        warnings.extend(internal_cheatcodes_warning(&internal_cheatcodes));
+        // Add the deprecated cheatcodes warning, if any of them was used in this suite.
+        warnings.extend(deprecated_cheatcodes_warning(&test_results));
 
-        Self { duration, test_results, warnings }
+        Self { duration, test_results, warnings, internal_cheatcodes }
     }
 
     /// Returns an iterator over all individual succeeding tests and their names.
@@ -889,16 +880,52 @@ impl SuiteResult {
     }
 }
 
-pub(crate) fn internal_cheatcodes_warning(signatures: &[&str]) -> Option<String> {
+pub(crate) const INTERNAL_CHEATCODES_WARNING_HEADER: &str =
+    "the following cheatcode(s) are intended for internal use and may change or be removed:";
+
+pub(crate) const DEPRECATED_CHEATCODES_WARNING_HEADER: &str =
+    "the following cheatcode(s) are deprecated and will be removed in future versions:";
+
+/// Returns `true` for the suite-level cheatcode warnings, which are re-rendered from the
+/// structured data when multi-network passes are merged.
+pub(crate) fn is_suite_cheatcode_warning(warning: &str) -> bool {
+    warning.starts_with(INTERNAL_CHEATCODES_WARNING_HEADER)
+        || warning.starts_with(DEPRECATED_CHEATCODES_WARNING_HEADER)
+}
+
+pub(crate) fn internal_cheatcodes_warning(
+    signatures: &std::collections::BTreeSet<String>,
+) -> Option<String> {
     if signatures.is_empty() {
         return None;
     }
 
-    let mut warning = "the following cheatcode(s) are intended for internal use and may change or \
-                       be removed:"
-        .to_string();
+    let mut warning = INTERNAL_CHEATCODES_WARNING_HEADER.to_string();
     for signature in signatures {
         write!(warning, "\n  {signature}").unwrap();
+    }
+    Some(warning)
+}
+
+pub(crate) fn deprecated_cheatcodes_warning(
+    test_results: &BTreeMap<String, TestResult>,
+) -> Option<String> {
+    let mut deprecated_cheatcodes = HashMap::new();
+    for test_result in test_results.values() {
+        deprecated_cheatcodes.extend(test_result.deprecated_cheatcodes.clone());
+    }
+    if deprecated_cheatcodes.is_empty() {
+        return None;
+    }
+
+    let mut warning = DEPRECATED_CHEATCODES_WARNING_HEADER.to_string();
+    let mut deprecated_cheatcodes = deprecated_cheatcodes.into_iter().collect::<Vec<_>>();
+    deprecated_cheatcodes.sort_unstable_by_key(|(cheatcode, _)| *cheatcode);
+    for (cheatcode, reason) in deprecated_cheatcodes {
+        write!(warning, "\n  {cheatcode}").unwrap();
+        if let Some(reason) = reason {
+            write!(warning, ": {reason}").unwrap();
+        }
     }
     Some(warning)
 }

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -17,7 +17,7 @@ use crate::{
         SymbolicCounterexampleReplaySemantics, SymbolicCounterexampleTestIdentity,
         SymbolicInvariantArtifactFailure, SymbolicInvariantFailureSite, SymbolicReplayMetadata,
         SymbolicReplayStatus, SymbolicResult, TestResult, TestSetup, TestStatus,
-        invariant_campaign_display_name,
+        internal_cheatcodes_warning, invariant_campaign_display_name,
     },
     symbolic_minimizer::{
         MinimizedSequence, minimize_sequence_counterexample, minimize_single_call_counterexample,
@@ -81,7 +81,7 @@ use std::{
     ops::Deref,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
-    time::Instant,
+    time::{Duration, Instant},
 };
 use tokio::signal;
 use tracing::Span;
@@ -691,6 +691,25 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         }
     }
 
+    fn suite_result(
+        &self,
+        duration: Duration,
+        test_results: BTreeMap<String, TestResult>,
+        mut warnings: Vec<String>,
+    ) -> SuiteResult {
+        if let Some(signatures) = self
+            .executor
+            .inspector()
+            .cheatcodes
+            .as_ref()
+            .map(|cheatcodes| cheatcodes.internal_cheatcodes())
+            && let Some(warning) = internal_cheatcodes_warning(&signatures)
+        {
+            warnings.push(warning);
+        }
+        SuiteResult::new(duration, test_results, warnings)
+    }
+
     /// Returns `true` if `func` should run in the current multi-network pass.
     ///
     /// In single-pass mode (no inline network overrides) every function passes.
@@ -923,7 +942,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             false
         };
         if skip_fuzz_only_suite {
-            return SuiteResult::new(start.elapsed(), BTreeMap::new(), warnings);
+            return self.suite_result(start.elapsed(), BTreeMap::new(), warnings);
         }
 
         // Check if `setUp` function with valid signature declared.
@@ -946,7 +965,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             // invariant campaigns) observe `should_stop()` and exit at their next run boundary
             // instead of running to their timeout.
             self.tcfg.early_exit.record_failure();
-            return SuiteResult::new(
+            return self.suite_result(
                 start.elapsed(),
                 [("setUp()".to_string(), TestResult::fail("multiple setUp functions".to_string()))]
                     .into(),
@@ -960,7 +979,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         if after_invariant_fns.len() > 1 {
             // Return a single test result failure if multiple functions declared.
             self.tcfg.early_exit.record_failure();
-            return SuiteResult::new(
+            return self.suite_result(
                 start.elapsed(),
                 [(
                     "afterInvariant()".to_string(),
@@ -1019,7 +1038,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             .collect();
         if !invalid_invariants.is_empty() {
             self.tcfg.early_exit.record_failure();
-            return SuiteResult::new(
+            return self.suite_result(
                 start.elapsed(),
                 invalid_invariants.into_iter().collect(),
                 warnings,
@@ -1057,7 +1076,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 "setUp()".to_string()
             };
             self.tcfg.early_exit.record_failure();
-            return SuiteResult::new(
+            return self.suite_result(
                 start.elapsed(),
                 [(fail_msg, TestResult::setup_result(setup))].into(),
                 warnings,
@@ -1113,9 +1132,9 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
             if replay_functions.is_empty() {
                 if !self.mcr.tcfg.multi_network.all_override_networks.is_empty() {
-                    return SuiteResult::new(start.elapsed(), BTreeMap::new(), warnings);
+                    return self.suite_result(start.elapsed(), BTreeMap::new(), warnings);
                 }
-                return SuiteResult::new(
+                return self.suite_result(
                     start.elapsed(),
                     [(
                         artifact.test.test.clone(),
@@ -1129,7 +1148,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 );
             }
             if replay_functions.len() > 1 {
-                return SuiteResult::new(
+                return self.suite_result(
                     start.elapsed(),
                     [(
                         artifact.test.test.clone(),
@@ -1183,7 +1202,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 })
                 .collect::<BTreeMap<_, _>>();
 
-            return SuiteResult::new(start.elapsed(), test_results, warnings);
+            return self.suite_result(start.elapsed(), test_results, warnings);
         }
 
         let test_fail_functions =
@@ -1194,7 +1213,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             };
             let test_results = test_fail_functions.map(|func| (func.signature(), fail())).collect();
             self.tcfg.early_exit.record_failure();
-            return SuiteResult::new(start.elapsed(), test_results, warnings);
+            return self.suite_result(start.elapsed(), test_results, warnings);
         }
 
         if functions.iter().any(|func| {
@@ -1309,7 +1328,7 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             .collect::<BTreeMap<_, _>>();
 
         let duration = start.elapsed();
-        SuiteResult::new(duration, test_results, warnings)
+        self.suite_result(duration, test_results, warnings)
     }
 }
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -17,7 +17,7 @@ use crate::{
         SymbolicCounterexampleReplaySemantics, SymbolicCounterexampleTestIdentity,
         SymbolicInvariantArtifactFailure, SymbolicInvariantFailureSite, SymbolicReplayMetadata,
         SymbolicReplayStatus, SymbolicResult, TestResult, TestSetup, TestStatus,
-        internal_cheatcodes_warning, invariant_campaign_display_name,
+        invariant_campaign_display_name,
     },
     symbolic_minimizer::{
         MinimizedSequence, minimize_sequence_counterexample, minimize_single_call_counterexample,
@@ -695,19 +695,22 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         &self,
         duration: Duration,
         test_results: BTreeMap<String, TestResult>,
-        mut warnings: Vec<String>,
+        warnings: Vec<String>,
     ) -> SuiteResult {
-        if let Some(signatures) = self
+        let internal_cheatcodes = self
             .executor
             .inspector()
             .cheatcodes
             .as_ref()
-            .map(|cheatcodes| cheatcodes.internal_cheatcodes())
-            && let Some(warning) = internal_cheatcodes_warning(&signatures)
-        {
-            warnings.push(warning);
-        }
-        SuiteResult::new(duration, test_results, warnings)
+            .map(|cheatcodes| {
+                cheatcodes
+                    .internal_cheatcodes()
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<std::collections::BTreeSet<String>>()
+            })
+            .unwrap_or_default();
+        SuiteResult::new(duration, test_results, warnings, internal_cheatcodes)
     }
 
     /// Returns `true` if `func` should run in the current multi-network pass.

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -599,3 +599,45 @@ Ran 3 test suites [ELAPSED]: 4 tests passed, 0 failed, 0 skipped (4 total tests)
 
 "#]]);
 });
+
+// A suite whose internal-cheatcode usage comes from a helper shared by an unannotated function
+// (default network pass) and a Tempo-annotated function (override pass) must warn only once, not
+// once per pass. Regression for the per-pass warning duplication in multi-network runs.
+forgetest_init!(internal_cheatcode_warning_not_duplicated_across_network_passes, |prj, cmd| {
+    prj.add_test(
+        "SharedInternal.t.sol",
+        r#"
+        interface VmInternal {
+            function _expectCheatcodeRevert() external;
+            function parseJsonUint(string calldata, string calldata) external returns (uint256);
+        }
+
+        contract SharedInternal {
+            address internal constant VM =
+                address(uint160(uint256(keccak256("hevm cheat code"))));
+
+            function useInternalCheatcode() internal {
+                VmInternal(VM)._expectCheatcodeRevert();
+                VmInternal(VM).parseJsonUint("invalid json", ".value");
+            }
+
+            function test_default() public {
+                useInternalCheatcode();
+            }
+
+            /// forge-config: default.networks.network = "tempo"
+            function test_tempo() public {
+                useInternalCheatcode();
+            }
+        }
+        "#,
+    );
+
+    let output = cmd.arg("test").assert_success();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert_eq!(
+        stderr.matches("intended for internal use").count(),
+        1,
+        "internal-cheatcode warning must be emitted once across network passes, got:\n{stderr}"
+    );
+});

--- a/crates/forge/tests/cli/inline_config.rs
+++ b/crates/forge/tests/cli/inline_config.rs
@@ -641,3 +641,55 @@ forgetest_init!(internal_cheatcode_warning_not_duplicated_across_network_passes,
         "internal-cheatcode warning must be emitted once across network passes, got:\n{stderr}"
     );
 });
+
+// Passes observing different internal-cheatcode overloads render different warning strings, so a
+// string-level dedup emits both blocks and repeats the shared signature. The signatures must be
+// unioned across passes and formatted as a single suite warning.
+forgetest_init!(internal_cheatcode_warning_unions_overloads_across_network_passes, |prj, cmd| {
+    prj.add_test(
+        "OverloadInternal.t.sol",
+        r#"
+        interface VmInternal {
+            function _expectCheatcodeRevert() external;
+            function _expectCheatcodeRevert(bytes4) external;
+        }
+
+        contract OverloadInternal {
+            address internal constant VM =
+                address(uint160(uint256(keccak256("hevm cheat code"))));
+
+            function sharedInternal() internal {
+                VmInternal(VM)._expectCheatcodeRevert();
+            }
+
+            function test_default() public {
+                sharedInternal();
+                VmInternal(VM)._expectCheatcodeRevert(bytes4(0x12345678));
+            }
+
+            /// forge-config: default.networks.network = "tempo"
+            function test_tempo() public {
+                sharedInternal();
+            }
+        }
+        "#,
+    );
+
+    let output = cmd.arg("test").assert_success();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert_eq!(
+        stderr.matches("intended for internal use").count(),
+        1,
+        "expected a single unioned suite warning across passes, got:\n{stderr}"
+    );
+    assert_eq!(
+        stderr.matches("_expectCheatcodeRevert()\n").count(),
+        1,
+        "the shared signature must appear exactly once, got:\n{stderr}"
+    );
+    assert_eq!(
+        stderr.matches("_expectCheatcodeRevert(bytes4)").count(),
+        1,
+        "the overload signature must appear exactly once, got:\n{stderr}"
+    );
+});

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -109,6 +109,54 @@ fn regular_file_count(root: &Path) -> usize {
         .sum()
 }
 
+forgetest_init!(forge_fuzz_corpus_observes_internal_cheatcodes, |prj, cmd| {
+    prj.update_config(|config| {
+        config.fuzz.runs = 1;
+        config.fuzz.seed = Some(U256::from(100));
+        config.fuzz.corpus.corpus_dir = Some("fuzz_corpus".into());
+        config.fuzz.corpus.corpus_gzip = false;
+    });
+    prj.add_test(
+        "InternalCorpusObservation.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+interface VmInternal {
+    function _expectCheatcodeRevert() external;
+}
+
+contract InternalCorpusObservationTest is Test {
+    function test_internal(uint256 input) public {
+        if (input == 42) {
+            VmInternal(address(vm))._expectCheatcodeRevert();
+            vm.parseJsonUint("invalid json", ".value");
+            vm.assume(false);
+        }
+    }
+}
+"#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/InternalCorpusObservation.t.sol/InternalCorpusObservationTest.json",
+    );
+    let calldata = calldata_for(&abi, "test_internal", 42);
+    let corpus = prj.root().join("fuzz_corpus/InternalCorpusObservationTest/test_internal");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &calldata);
+
+    cmd.forge_fuse()
+        .args(["test", "--mc", "InternalCorpusObservationTest"])
+        .assert_success()
+        .stderr_eq(str![[r#"
+Warning: the following cheatcode(s) are intended for internal use and may change or be removed:
+  _expectCheatcodeRevert()
+
+"#]]);
+});
+
 fn showmap_edge_ids(root: &Path) -> BTreeSet<String> {
     fn visit(path: &Path, out: &mut BTreeSet<String>) {
         if path.is_dir() {

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -1315,6 +1315,144 @@ contract GasLimitTest is Test {
     }
 );
 
+forgetest_init!(test_internal_cheatcode_suite_collector, |prj, cmd| {
+    prj.update_config(|config| {
+        config.fuzz.runs = 128;
+        config.fuzz.seed = Some(U256::from(100));
+        config.invariant.runs = 2;
+        config.invariant.depth = 1;
+    });
+    prj.add_test(
+        "InternalCheatcode.t.sol",
+        r#"
+        import "forge-std/Test.sol";
+        import {Vm} from "forge-std/Vm.sol";
+
+        interface VmInternal {
+            function _expectCheatcodeRevert() external;
+        }
+
+        abstract contract InternalCheatcodeBase is Test {
+            function useInternalCheatcode() internal {
+                VmInternal(address(vm))._expectCheatcodeRevert();
+                vm.parseJsonUint("invalid json", ".value");
+            }
+        }
+
+        contract InternalUnitTest is InternalCheatcodeBase {
+            function test_internal() public {
+                useInternalCheatcode();
+            }
+        }
+
+        contract InternalMultiworkerFuzzTest is InternalCheatcodeBase {
+            function test_internal(uint256) public {
+                useInternalCheatcode();
+            }
+        }
+
+        contract InternalSkippedInvariantTest is InternalCheatcodeBase {
+            function invariant_internal() public {
+                useInternalCheatcode();
+                vm.skip(true);
+            }
+        }
+
+        contract Handler {
+            function act() public {}
+        }
+
+        contract InternalInvariantConfigTest {
+            Vm internal constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+            address internal handler;
+
+            function useInternalCheatcode() internal {
+                VmInternal(address(vm))._expectCheatcodeRevert();
+                vm.parseJsonUint("invalid json", ".value");
+            }
+
+            function setUp() public {
+                handler = address(new Handler());
+            }
+
+            function targetContracts() public returns (address[] memory targets) {
+                useInternalCheatcode();
+                targets = new address[](1);
+                targets[0] = handler;
+            }
+
+            function invariant_internal() public pure {}
+        }
+
+        contract InternalAfterInvariantTest is InternalCheatcodeBase {
+            function setUp() public {
+                targetContract(address(new Handler()));
+            }
+
+            function invariant_internal() public pure {}
+
+            function afterInvariant() public {
+                useInternalCheatcode();
+            }
+        }
+
+        contract InternalConstructorFailureTest is InternalCheatcodeBase {
+            constructor() {
+                useInternalCheatcode();
+                assert(false);
+            }
+
+            function test_never_runs() public pure {}
+        }
+        "#,
+    );
+
+    let warning = str![[r#"
+Warning: the following cheatcode(s) are intended for internal use and may change or be removed:
+  _expectCheatcodeRevert()
+
+"#]];
+
+    cmd.args(["test", "--mc", "InternalUnitTest"]).assert_success().stderr_eq(warning.clone());
+    cmd.forge_fuse();
+    cmd.env("RAYON_NUM_THREADS", "2");
+    cmd.args(["test", "--mc", "InternalMultiworkerFuzzTest"])
+        .assert_success()
+        .stderr_eq(warning.clone());
+    cmd.forge_fuse()
+        .args(["test", "--mc", "InternalSkippedInvariantTest"])
+        .assert_success()
+        .stderr_eq(warning.clone());
+    cmd.forge_fuse()
+        .args(["test", "--mc", "InternalInvariantConfigTest"])
+        .assert_success()
+        .stderr_eq(warning.clone());
+    cmd.forge_fuse()
+        .args(["test", "--mc", "InternalAfterInvariantTest"])
+        .assert_success()
+        .stderr_eq(warning.clone());
+    cmd.forge_fuse()
+        .args(["test", "--mc", "InternalConstructorFailureTest"])
+        .assert_failure()
+        .stderr_eq(warning);
+
+    let output =
+        cmd.forge_fuse().args(["test", "--mc", "InternalUnitTest", "--json"]).assert_success();
+    assert!(output.get_output().stderr.is_empty());
+    let output: serde_json::Value = serde_json::from_slice(&output.get_output().stdout).unwrap();
+    let suite = output.as_object().unwrap().values().next().unwrap();
+    assert_eq!(
+        suite["warnings"][0],
+        "the following cheatcode(s) are intended for internal use and may change or be removed:\n  \
+         _expectCheatcodeRevert()"
+    );
+
+    cmd.forge_fuse()
+        .args(["test", "--mc", "InternalUnitTest", "--quiet"])
+        .assert_success()
+        .stderr_eq(str![""]);
+});
+
 forgetest!(test_match_path, |prj, cmd| {
     prj.add_source(
         "dummy",

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -5,6 +5,39 @@ use foundry_test_utils::{forgetest_init, util::OutputExt};
 use super::symbolic_helpers::z3_available;
 use crate::skip_unless_z3;
 
+forgetest_init!(symbolic_internal_cheatcode_records_warning, |prj, cmd| {
+    skip_unless_z3!("symbolic_internal_cheatcode_records_warning");
+
+    prj.add_test(
+        "SymbolicInternalStatus.t.sol",
+        r#"
+interface VmInternal {
+    function _expectCheatcodeRevert() external;
+}
+
+contract SymbolicInternalStatus {
+    VmInternal constant vm =
+        VmInternal(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function check_internal(uint256 input) public {
+        if (input == 0) {
+            vm._expectCheatcodeRevert();
+        }
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--match-contract", "SymbolicInternalStatus"])
+        .assert_failure();
+    assert_eq!(
+        output.get_output().stderr_lossy(),
+        "Warning: the following cheatcode(s) are intended for internal use and may change or be \
+         removed:\n  _expectCheatcodeRevert()\n"
+    );
+});
+
 forgetest_init!(symbolic_cheatcodes_accept_symbolic_address_targets, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(

--- a/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_cheatcodes.rs
@@ -38,6 +38,68 @@ contract SymbolicInternalStatus {
     );
 });
 
+forgetest_init!(symbolic_internal_cheatcode_warns_for_constrained_vm_target, |prj, cmd| {
+    skip_unless_z3!("symbolic_internal_cheatcode_warns_for_constrained_vm_target");
+
+    prj.add_test(
+        "SymbolicConstrainedVmTarget.t.sol",
+        r#"
+interface VmProbe {
+    function assume(bool) external;
+}
+
+contract SymbolicConstrainedVmTarget {
+    VmProbe constant vm =
+        VmProbe(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function check_forced_vm_target(address who) public {
+        vm.assume(who == address(vm));
+        (bool success,) = who.call(abi.encodeWithSignature("_expectCheatcodeRevert()"));
+        success;
+    }
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["test", "--symbolic", "--match-contract", "SymbolicConstrainedVmTarget"])
+        .assert_failure();
+    assert_eq!(
+        output.get_output().stderr_lossy(),
+        "Warning: the following cheatcode(s) are intended for internal use and may change or be \
+         removed:\n  _expectCheatcodeRevert()\n"
+    );
+});
+
+forgetest_init!(symbolic_stable_cheatcode_executes_for_constrained_vm_target, |prj, cmd| {
+    skip_unless_z3!("symbolic_stable_cheatcode_executes_for_constrained_vm_target");
+
+    prj.add_test(
+        "SymbolicConstrainedVmDeal.t.sol",
+        r#"
+interface VmProbe {
+    function assume(bool) external;
+}
+
+contract SymbolicConstrainedVmDeal {
+    VmProbe constant vm =
+        VmProbe(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function check_forced_vm_target_executes(address who) public {
+        vm.assume(who == address(vm));
+        (bool success,) =
+            who.call(abi.encodeWithSignature("deal(address,uint256)", address(0xBEEF), 11));
+        require(success, "deal failed");
+        require(address(0xBEEF).balance == 11, "balance not set");
+    }
+}
+"#,
+    );
+
+    cmd.args(["test", "--symbolic", "--match-contract", "SymbolicConstrainedVmDeal"])
+        .assert_success();
+});
+
 forgetest_init!(symbolic_cheatcodes_accept_symbolic_address_targets, |prj, cmd| {
     if !z3_available() {
         let _ = sh_eprintln!(


### PR DESCRIPTION
Closes #7323. Builds on the prototype in `master...mablr/cheatcode-status-handling`.

Only `Status::Deprecated` is currently acted on at dispatch: internal and removed cheatcodes are silently treated as stable, contrary to what the `Status` docs promise. Internal cheatcode usage is now recorded before dispatch and reported once per test suite as a warning. The record set is shared by all inspectors cloned from the same suite executor, because internal usage can happen outside of any test result (contract constructors, invariant `targetContracts()` or `afterInvariant()`, corpus replays) where the per-test plumbing used by deprecation warnings never sees it. Removed cheatcodes are rejected before dispatch with `vm.<name>: cheatcode has been removed`; no cheatcode currently carries this status, so that path is covered by a unit test that fabricates one. Experimental cheatcodes keep dispatching normally: the status has been unused since #10137 and its runtime behavior has not been decided, so its doc no longer promises a warning.

The symbolic executor reimplements cheatcodes from the spec, so status handling is mirrored there: internal usage is recorded into the same per-suite set, and removed cheatcodes surface as an unsupported-operation error, consistent with how the engine already treats unknown cheatcodes.

Compared to the prototype branch, the status-to-action match in the spec is exhaustive so a future status variant cannot be silently ignored again, multi-network passes dedupe repeated suite warnings without reordering existing ones, and the deprecated warning now lists cheatcodes in sorted order (previously hash-map iteration order), which also makes that dedupe reliable.
