### PR TITLE
test(anvil): skip invalid Base fork height

### DIFF
--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -1478,6 +1478,11 @@ async fn test_base_fork_gas_limit() {
     )
     .await;
 
+    // The public Base RPC occasionally returns block zero when it is unhealthy.
+    if api.block_number().unwrap().is_zero() {
+        return;
+    }
+
     let provider = handle.http_provider();
     let block =
         provider.get_block(BlockId::Number(BlockNumberOrTag::Latest)).await.unwrap().unwrap();


### PR DESCRIPTION
The public Base RPC intermittently reports block zero as its latest height. Anvil then forks the genesis block and the gas-limit assertion fails against its 30 million gas limit even though the current Base block limit is valid.

This returns early when the resolved Base fork height is zero, avoiding the false failure while preserving the gas-limit assertions for valid fork heads.

This change was developed with assistance from OpenAI Codex.
