### PR TITLE
fix(anvil): serve pre-fork debug_getRawTransactions

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3348,15 +3348,44 @@ impl EthApi<FoundryNetwork> {
     /// Handler for RPC call: `debug_getRawTransactions`.
     pub async fn raw_transactions(&self, block: BlockId) -> Result<Vec<Bytes>> {
         node_info!("debug_getRawTransactions");
-        let Some(block) = self.backend.get_block(block) else {
+
+        if let Some(block) = self.backend.get_block(block) {
+            return Ok(block
+                .body
+                .transactions
+                .into_iter()
+                .map(|tx| canonical_block_transaction(tx.into_inner()).encoded_2718().into())
+                .collect());
+        }
+
+        // In fork mode, serve pre-fork blocks from the upstream provider. Genuinely unknown or
+        // out-of-range blocks yield an empty result, mirroring reth; transport errors propagate.
+        let Some(fork) = self.get_fork() else {
             return Ok(Vec::new());
         };
-        Ok(block
-            .body
-            .transactions
-            .into_iter()
-            .map(|tx| canonical_block_transaction(tx.into_inner()).encoded_2718().into())
-            .collect())
+        let block = match block {
+            BlockId::Number(BlockNumber::Pending) => None,
+            BlockId::Number(number) => {
+                let number = self.backend.convert_block_number(Some(number));
+                if !fork.predates_fork_inclusive(number) {
+                    return Ok(Vec::new());
+                }
+                fork.block_by_number_full(number).await?
+            }
+            BlockId::Hash(hash) => fork
+                .block_by_hash_full(hash.block_hash)
+                .await?
+                .filter(|block| fork.predates_fork_inclusive(block.header().number())),
+        };
+        let Some(block) = block else {
+            return Ok(Vec::new());
+        };
+        let BlockTransactions::Full(txs) = block.transactions() else {
+            return Err(BlockchainError::Internal(
+                "fork provider returned a non-full block for a full block request".to_string(),
+            ));
+        };
+        Ok(txs.iter().map(|tx| tx.as_ref().encoded_2718().into()).collect())
     }
 
     /// Returns RLP encoded raw block header.

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -138,6 +138,39 @@ async fn test_fork_debug_get_raw_receipts() {
     }
 }
 
+// `debug_getRawTransactions` must serve pre-fork blocks from the upstream provider.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_debug_get_raw_transactions() {
+    let (_api, handle) = spawn(fork_config()).await;
+    let provider = handle.http_provider();
+
+    // A pre-fork block known to contain transactions.
+    let block_number = BLOCK_NUMBER - 1;
+    let block = provider.get_block(BlockId::number(block_number)).full().await.unwrap().unwrap();
+    assert!(!block.transactions.is_empty());
+
+    let raw_by_number: Vec<Bytes> = provider
+        .client()
+        .request("debug_getRawTransactions", (BlockId::number(block_number),))
+        .await
+        .unwrap();
+    let raw_by_hash: Vec<Bytes> = provider
+        .client()
+        .request("debug_getRawTransactions", (BlockId::hash(block.header.hash),))
+        .await
+        .unwrap();
+
+    assert_eq!(raw_by_number, raw_by_hash);
+    assert_eq!(raw_by_number.len(), block.transactions.len());
+
+    // Each entry matches the single-transaction raw encoding path for the same hash.
+    for (raw, hash) in raw_by_number.iter().zip(block.transactions.hashes()) {
+        let single: Bytes =
+            provider.client().request("debug_getRawTransaction", (hash,)).await.unwrap();
+        assert_eq!(*raw, single);
+    }
+}
+
 // `debug_accountInfoAt` must delegate pre-fork blocks to the upstream and resolve block tags
 // against the fork's frozen head, not the upstream's advancing head.
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
In fork mode, `debug_getRawTransactions` only read anvil's in-memory blocks, so pre-fork blocks returned an empty array despite having transactions. It now falls back to the upstream provider like `debug_getRawReceipts` and the trace-block endpoints, while still returning empty for genuinely unknown blocks.