### PR TITLE
fix(fuzz): preserve stateless transactions

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1314,10 +1314,10 @@ impl WorkerCorpus {
         test_runner: &mut TestRunner,
         fuzz_state: &EvmFuzzState,
         function: &Function,
-    ) -> Result<Bytes> {
+    ) -> Result<BasicTxDetails> {
         // Early return if not running with coverage guided fuzzing.
         if !self.config.is_coverage_guided() {
-            return Ok(self.new_tx(test_runner)?.call_details.calldata);
+            return self.new_tx(test_runner);
         }
 
         self.evict_oldest_corpus()?;
@@ -1357,14 +1357,14 @@ impl WorkerCorpus {
                 None => {
                     // Stateless fuzz inputs cannot apply sequence-level mutation strategies.
                     self.current_mutated_index = None;
-                    return Ok(self.new_tx(test_runner)?.call_details.calldata);
+                    return self.new_tx(test_runner);
                 }
                 _ => {}
             }
             tx
         };
 
-        Ok(tx.call_details.calldata)
+        Ok(tx)
     }
 
     /// Generates single call from corpus strategy.
@@ -2229,7 +2229,9 @@ mod tests {
     fn stateless_new_input_honors_fresh_sequence_weight() {
         let mut config = corpus_config(temp_corpus_dir());
         config.corpus_random_sequence_weight = 100;
-        let generated = basic_tx_with_calldata(vec![0x22]);
+        let mut generated = basic_tx_with_calldata(vec![0x22]);
+        generated.call_details.value = Some(U256::from(7));
+        let generated_value = generated.call_details.value;
         let seed = WorkerCorpusSeed {
             in_memory_corpus: vec![CorpusEntry::new(vec![basic_tx_with_calldata(vec![0x11])])],
             ..Default::default()
@@ -2240,7 +2242,8 @@ mod tests {
 
         let input = manager.new_input(&mut runner, &empty_fuzz_state(), &function).unwrap();
 
-        assert_eq!(input, Bytes::from(vec![0x22]));
+        assert_eq!(input.call_details.calldata, Bytes::from(vec![0x22]));
+        assert_eq!(input.call_details.value, generated_value);
         assert!(manager.current_mutated_index.is_none());
     }
 
@@ -2268,7 +2271,8 @@ mod tests {
 
         let input = manager.new_input(&mut runner, &empty_fuzz_state(), &function).unwrap();
 
-        assert_eq!(input, Bytes::from(vec![0x44]));
+        assert_eq!(input.call_details.calldata, Bytes::from(vec![0x44]));
+        assert_eq!(input.call_details.value, None);
         assert!(manager.current_mutated_index.is_none());
     }
 

--- a/crates/evm/evm/src/executors/fuzz/frontier.rs
+++ b/crates/evm/evm/src/executors/fuzz/frontier.rs
@@ -1,11 +1,11 @@
 use crate::inspectors::CmpOperands;
 use alloy_json_abi::Function;
 use alloy_primitives::{
-    Address, Bytes, I256, U256,
+    Address, I256, U256,
     map::{Entry, HashMap},
 };
 use foundry_common::fs;
-use foundry_evm_fuzz::{BasicTxDetails, CallDetails, FuzzRunMetadata};
+use foundry_evm_fuzz::{BasicTxDetails, FuzzRunMetadata};
 use revm::bytecode::opcode;
 use serde::{Serialize, Serializer};
 use std::{
@@ -132,9 +132,7 @@ impl FuzzFrontierRecorder {
     pub(super) fn capture_stateless_call(
         &mut self,
         run: Option<&FuzzRunMetadata>,
-        sender: Address,
-        target: Address,
-        calldata: &Bytes,
+        tx: &BasicTxDetails,
         cmp_values: &[CmpOperands],
         new_coverage: Option<bool>,
     ) {
@@ -144,15 +142,8 @@ impl FuzzFrontierRecorder {
 
         let mut sequence = None;
         let mut new_frontier = |cmp: &CmpOperands, result, operand_delta| {
-            let sequence = sequence.get_or_insert_with(|| {
-                let call = BasicTxDetails {
-                    warp: None,
-                    roll: None,
-                    sender,
-                    call_details: CallDetails { target, calldata: calldata.clone(), value: None },
-                };
-                Arc::from(Vec::from([call]).into_boxed_slice())
-            });
+            let sequence = sequence
+                .get_or_insert_with(|| Arc::from(Vec::from([tx.clone()]).into_boxed_slice()));
             FuzzBranchFrontier::new(
                 run,
                 Arc::clone(sequence),
@@ -343,6 +334,40 @@ const fn opcode_name(op: u8) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_primitives::Bytes;
+    use foundry_evm_fuzz::CallDetails;
+
+    #[test]
+    fn stateless_frontier_preserves_concrete_transaction() {
+        let tx = BasicTxDetails {
+            warp: None,
+            roll: None,
+            sender: Address::with_last_byte(1),
+            call_details: CallDetails {
+                target: Address::with_last_byte(2),
+                calldata: Bytes::from_static(&[1, 2, 3, 4]),
+                value: Some(U256::from(7)),
+            },
+        };
+        let cmp = CmpOperands {
+            op1: U256::ZERO,
+            op2: U256::from(1),
+            pc: 1,
+            address: tx.call_details.target,
+            opcode: opcode::LT,
+        };
+        let mut recorder = FuzzFrontierRecorder::new(1);
+
+        recorder.capture_stateless_call(None, &tx, &[cmp], Some(true));
+
+        let frontier = recorder.into_frontiers().pop().unwrap();
+        assert_eq!(frontier.sequence.len(), 1);
+        let recorded = &frontier.sequence[0];
+        assert_eq!(recorded.sender, tx.sender);
+        assert_eq!(recorded.call_details.target, tx.call_details.target);
+        assert_eq!(recorded.call_details.calldata, tx.call_details.calldata);
+        assert_eq!(recorded.call_details.value, tx.call_details.value);
+    }
 
     #[test]
     fn operand_delta_uses_signed_distance_for_signed_comparisons() {

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -59,7 +59,7 @@ struct WorkerState<FEN: FoundryEvmNetwork> {
     /// Gas usage for all cases this worker ran
     gas_by_case: Vec<(u64, u64)>,
     /// Counterexample if this worker found one
-    counterexample: (Bytes, RawCallResult<FEN>),
+    counterexample: Option<(BasicTxDetails, RawCallResult<FEN>)>,
     /// Traces collected by this worker
     ///
     /// Stores up to `max_traces_to_collect` which is `config.gas_report_samples / num_workers`
@@ -96,7 +96,7 @@ impl<FEN: FoundryEvmNetwork> WorkerState<FEN> {
             id: worker_id,
             first_case: None,
             gas_by_case: Vec::new(),
-            counterexample: (Bytes::new(), RawCallResult::default()),
+            counterexample: None,
             traces: Vec::new(),
             debug_bytecodes: HashMap::default(),
             breakpoints: None,
@@ -293,9 +293,23 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             cheats.set_seed(Self::fuzz_run_seed(seed, worker, run));
         }
 
-        let calldata = failure.calldata.clone();
-        let mut call =
-            self.executor_f.call_raw(self.sender, address, calldata.clone(), U256::ZERO)?;
+        let mut tx = BasicTxDetails {
+            warp: None,
+            roll: None,
+            sender: self.sender,
+            call_details: CallDetails {
+                target: address,
+                calldata: failure.calldata.clone(),
+                value: failure.value,
+            },
+        };
+        self.resolve_stateless_tx(&mut tx)?;
+        let mut call = self.executor_f.call_raw(
+            tx.sender,
+            tx.call_details.target,
+            tx.call_details.calldata.clone(),
+            tx.call_details.value.unwrap_or_default(),
+        )?;
         if call.result.as_ref() == MAGIC_ASSUME {
             return Ok(FuzzTestResult {
                 skipped: true,
@@ -348,11 +362,13 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                 rd.maybe_decode(&call.result, call.exit_reason)
             };
             result.reason = reason;
-            let args = calldata
+            let args = tx
+                .call_details
+                .calldata
                 .get(4..)
                 .map_or_else(Vec::new, |data| func.abi_decode_input(data).unwrap_or_default());
             result.counterexample = Some(CounterExample::Single(
-                BaseCounterExample::from_fuzz_call(calldata, args, call.traces).with_fuzz_metadata(
+                BaseCounterExample::from_fuzz_tx(&tx, args, call.traces).with_fuzz_metadata(
                     FuzzRunMetadata::new(
                         seed,
                         failure.fuzz.run,
@@ -372,13 +388,24 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         &self,
         executor: &Executor<FEN>,
         address: Address,
-        calldata: Bytes,
+        mut tx: BasicTxDetails,
         coverage_metrics: &mut WorkerCorpus,
         frontier_recorder: &mut FuzzFrontierRecorder,
         fuzz_run: Option<&FuzzRunMetadata>,
     ) -> Result<FuzzOutcome<FEN>, TestCaseError> {
+        tx.sender = self.sender;
+        tx.call_details.target = address;
+        tx.warp = None;
+        tx.roll = None;
+        self.resolve_stateless_tx_with_executor(executor, &mut tx)
+            .map_err(|e| TestCaseError::fail(e.to_string()))?;
         let mut call = executor
-            .call_raw(self.sender, address, calldata.clone(), U256::ZERO)
+            .call_raw(
+                tx.sender,
+                tx.call_details.target,
+                tx.call_details.calldata.clone(),
+                tx.call_details.value.unwrap_or_default(),
+            )
             .map_err(|e| TestCaseError::fail(e.to_string()))?;
         let cmp_values = call.evm_cmp_values.take().unwrap_or_default();
         let new_coverage = coverage_metrics.merge_edge_coverage(&mut call);
@@ -386,29 +413,8 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         // `merge_edge_coverage` always returns `false`, so record it as unknown for frontiers.
         let frontier_new_coverage =
             self.config.corpus.collect_edge_coverage().then_some(new_coverage);
-        frontier_recorder.capture_stateless_call(
-            fuzz_run,
-            self.sender,
-            address,
-            &calldata,
-            &cmp_values,
-            frontier_new_coverage,
-        );
-        coverage_metrics.process_inputs(
-            &[BasicTxDetails {
-                warp: None,
-                roll: None,
-                sender: self.sender,
-                call_details: CallDetails {
-                    target: address,
-                    calldata: calldata.clone(),
-                    value: None,
-                },
-            }],
-            &[cmp_values],
-            new_coverage,
-            None,
-        );
+        frontier_recorder.capture_stateless_call(fuzz_run, &tx, &cmp_values, frontier_new_coverage);
+        coverage_metrics.process_inputs(&[tx.clone()], &[cmp_values], new_coverage, None);
 
         // Handle `vm.assume`.
         if call.result.as_ref() == MAGIC_ASSUME {
@@ -445,10 +451,29 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         } else {
             Ok(FuzzOutcome::CounterExample(CounterExampleOutcome {
                 exit_reason: call.exit_reason,
-                counterexample: (calldata, call),
+                counterexample: (tx, call),
                 breakpoints,
             }))
         }
+    }
+
+    fn resolve_stateless_tx(&self, tx: &mut BasicTxDetails) -> Result<()> {
+        self.resolve_stateless_tx_with_executor(&self.executor_f, tx)
+    }
+
+    fn resolve_stateless_tx_with_executor(
+        &self,
+        executor: &Executor<FEN>,
+        tx: &mut BasicTxDetails,
+    ) -> Result<()> {
+        tx.call_details.value = match tx.call_details.value {
+            Some(requested) if !requested.is_zero() => {
+                let value = requested.min(executor.get_balance(tx.sender)?);
+                (!value.is_zero()).then_some(value)
+            }
+            _ => None,
+        };
+        Ok(())
     }
 
     /// Aggregates the results from all workers
@@ -494,30 +519,33 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             let failed_worker_idx = workers.iter().position(|w| w.id == failed_worker_id).unwrap();
             let failed_worker = &mut workers[failed_worker_idx];
 
-            let (calldata, call) = std::mem::take(&mut failed_worker.counterexample);
-            result.labels = call.labels;
-            result.traces = call.traces.clone();
-            result.debug_bytecodes = call.debug_bytecodes.clone();
-            result.breakpoints = call.cheatcodes.map(|c| c.breakpoints);
+            let counterexample = failed_worker.counterexample.take();
+            if let Some((_, call)) = &counterexample {
+                result.labels.clone_from(&call.labels);
+                result.traces.clone_from(&call.traces);
+                result.debug_bytecodes.clone_from(&call.debug_bytecodes);
+                result.breakpoints = call.cheatcodes.as_ref().map(|c| c.breakpoints.clone());
+            }
 
             match &failed_worker.failure {
                 Some(TestCaseError::Fail(reason)) => {
                     let reason = reason.to_string();
                     result.reason = (!reason.is_empty()).then_some(reason);
-                    let args = if let Some(data) = calldata.get(4..) {
-                        func.abi_decode_input(data).unwrap_or_default()
-                    } else {
-                        vec![]
-                    };
-                    let fuzz = failed_worker.failure_run.unwrap_or_default();
-                    result.counterexample = Some(CounterExample::Single(
-                        BaseCounterExample::from_fuzz_call(calldata, args, call.traces)
-                            .with_fuzz_metadata(FuzzRunMetadata::new(
-                                fuzz.seed.or(self.config.seed),
-                                fuzz.run,
-                                fuzz.worker,
-                            )),
-                    ));
+                    if let Some((tx, call)) = counterexample {
+                        let args =
+                            tx.call_details.calldata.get(4..).map_or_else(Vec::new, |data| {
+                                func.abi_decode_input(data).unwrap_or_default()
+                            });
+                        let fuzz = failed_worker.failure_run.unwrap_or_default();
+                        result.counterexample = Some(CounterExample::Single(
+                            BaseCounterExample::from_fuzz_tx(&tx, args, call.traces)
+                                .with_fuzz_metadata(FuzzRunMetadata::new(
+                                    fuzz.seed.or(self.config.seed),
+                                    fuzz.run,
+                                    fuzz.worker,
+                                )),
+                        ));
+                    }
                 }
                 Some(TestCaseError::Reject(reason)) => {
                     let reason = reason.to_string();
@@ -604,12 +632,13 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         } else {
             Just(None).boxed()
         };
+        let sender = self.sender;
         let strategy =
             (calldata_strategy, value_strategy).prop_map(move |(calldata, value)| BasicTxDetails {
                 warp: None,
                 roll: None,
-                sender: Default::default(),
-                call_details: CallDetails { target: Default::default(), calldata, value },
+                sender,
+                call_details: CallDetails { target: address, calldata, value },
             });
 
         let replay_target = ReplayTarget {
@@ -694,7 +723,16 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                 }
 
                 (
-                    failure.calldata.clone(),
+                    BasicTxDetails {
+                        warp: None,
+                        roll: None,
+                        sender: self.sender,
+                        call_details: CallDetails {
+                            target: address,
+                            calldata: failure.calldata.clone(),
+                            value: failure.value,
+                        },
+                    },
                     Some(FuzzRunMetadata::new(
                         seed,
                         failure.fuzz.run,
@@ -839,7 +877,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                             rd.maybe_decode(&outcome.1.result, status)
                         };
                         worker.logs.extend(outcome.1.logs.clone());
-                        worker.counterexample = outcome;
+                        worker.counterexample = Some(outcome);
                         worker.failure = Some(TestCaseError::fail(reason.unwrap_or_default()));
                         shared_state.try_claim_failure(worker_id);
                         break 'stop;

--- a/crates/evm/evm/src/executors/fuzz/types.rs
+++ b/crates/evm/evm/src/executors/fuzz/types.rs
@@ -5,7 +5,7 @@ use alloy_primitives::{
 };
 use foundry_evm_core::{Breakpoints, evm::FoundryEvmNetwork};
 use foundry_evm_coverage::HitMaps;
-use foundry_evm_fuzz::FuzzCase;
+use foundry_evm_fuzz::{BasicTxDetails, FuzzCase};
 use foundry_evm_traces::SparsedTraceArena;
 use revm::interpreter::InstructionResult;
 
@@ -32,7 +32,7 @@ pub struct CaseOutcome {
 #[derive(Debug)]
 pub struct CounterExampleOutcome<FEN: FoundryEvmNetwork> {
     /// Minimal reproduction test case for failing test.
-    pub counterexample: (Bytes, RawCallResult<FEN>),
+    pub counterexample: (BasicTxDetails, RawCallResult<FEN>),
     /// The status of the call.
     pub exit_reason: Option<InstructionResult>,
     /// Breakpoints char pc map.

--- a/crates/evm/fuzz/src/lib.rs
+++ b/crates/evm/fuzz/src/lib.rs
@@ -217,6 +217,30 @@ impl BaseCounterExample {
         }
     }
 
+    /// Creates counter example for a fuzz test failure from the concrete executed transaction.
+    pub fn from_fuzz_tx(
+        tx: &BasicTxDetails,
+        args: Vec<DynSolValue>,
+        traces: Option<SparsedTraceArena>,
+    ) -> Self {
+        Self {
+            warp: tx.warp,
+            roll: tx.roll,
+            sender: Some(tx.sender),
+            addr: Some(tx.call_details.target),
+            calldata: tx.call_details.calldata.clone(),
+            value: tx.call_details.value,
+            contract_name: None,
+            func_name: None,
+            signature: None,
+            args: Some(foundry_common::fmt::format_tokens(&args).format(", ").to_string()),
+            raw_args: Some(foundry_common::fmt::format_tokens_raw(&args).format(", ").to_string()),
+            traces,
+            show_solidity: false,
+            fuzz: FuzzRunMetadata::default(),
+        }
+    }
+
     /// Sets fuzz metadata for reproducing this counterexample.
     pub const fn with_fuzz_metadata(mut self, fuzz: FuzzRunMetadata) -> Self {
         self.fuzz = fuzz;
@@ -265,16 +289,22 @@ impl fmt::Display for BaseCounterExample {
         }
 
         // Regular counterexample display.
-        if let Some(sender) = self.sender {
-            write!(f, "\t\tsender={sender} addr=")?
-        }
+        // Stateless fuzz targets and senders are fixed by the test configuration, so preserve the
+        // compact historical display unless value makes the transaction context relevant.
+        let show_tx_context =
+            self.fuzz.worker.is_none() || self.value.as_ref().is_some_and(|value| !value.is_zero());
+        if show_tx_context {
+            if let Some(sender) = self.sender {
+                write!(f, "\t\tsender={sender} addr=")?
+            }
 
-        if let Some(name) = &self.contract_name {
-            write!(f, "[{name}]")?
-        }
+            if let Some(name) = &self.contract_name {
+                write!(f, "[{name}]")?
+            }
 
-        if let Some(addr) = &self.addr {
-            write!(f, "{addr} ")?
+            if let Some(addr) = &self.addr {
+                write!(f, "{addr} ")?
+            }
         }
 
         if let Some(warp) = &self.warp {

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -429,6 +429,17 @@ contract ForgeFuzzReplayFailureTest {
 
     cmd.args(["fuzz", "run", "--mc", "ForgeFuzzReplayFailureTest", "-q"]).assert_failure();
 
+    // Legacy stateless failure artifacts only stored calldata and decoded arguments.
+    let failure_path =
+        prj.root().join("cache/fuzz/failures/ForgeFuzzReplayFailureTest/testFuzz_reverts");
+    let mut failure: Value =
+        serde_json::from_str(&std::fs::read_to_string(&failure_path).unwrap()).unwrap();
+    let failure = failure.as_object_mut().unwrap();
+    failure.remove("sender");
+    failure.remove("addr");
+    failure.remove("value");
+    std::fs::write(&failure_path, serde_json::to_vec_pretty(failure).unwrap()).unwrap();
+
     let replay = cmd
         .forge_fuse()
         .args(["fuzz", "replay", "--mc", "ForgeFuzzReplayFailureTest", "-vvv"])
@@ -441,6 +452,68 @@ contract ForgeFuzzReplayFailureTest {
     );
     assert!(stdout.contains("ForgeFuzzReplayFailureTest::testFuzz_reverts(200)"), "{stdout}");
     assert!(stdout.contains("[SKIP: not runnable in replay mode] test_unit()"), "{stdout}");
+});
+
+forgetest_init!(stateless_fuzz_preserves_payable_value, |prj, cmd| {
+    let corpus_root = prj.root().join("fuzz_corpus");
+    let frontier_root = prj.root().join("fuzz_frontiers");
+    prj.update_config(|config| {
+        config.initial_balance = U256::from(7);
+        config.fuzz.runs = 1;
+        config.fuzz.seed = Some(U256::from(42));
+        config.fuzz.corpus.payable_value_weight = 100;
+        config.fuzz.corpus.corpus_dir = Some(corpus_root.clone());
+        config.fuzz.corpus.frontier_dir = Some(frontier_root.clone());
+    });
+    prj.add_test(
+        "StatelessPayableValue.t.sol",
+        r#"
+contract StatelessPayableValueTest {
+    function testFuzz_payable(uint256 value) public payable {
+        value;
+        require(msg.value == 0, "received value");
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mt", "testFuzz_payable", "-q"]).assert_failure();
+
+    let failure_path =
+        prj.root().join("cache/fuzz/failures/StatelessPayableValueTest/testFuzz_payable");
+    let failure: BaseCounterExample =
+        serde_json::from_str(&std::fs::read_to_string(failure_path).unwrap()).unwrap();
+    assert_eq!(failure.value, Some(U256::from(7)));
+    let sender = failure.sender.unwrap();
+    let target = failure.addr.unwrap();
+
+    let corpus_path = find_first_json(
+        &corpus_root.join("StatelessPayableValueTest/testFuzz_payable/worker0/corpus"),
+    );
+    let corpus: Value =
+        serde_json::from_str(&std::fs::read_to_string(corpus_path).unwrap()).unwrap();
+    let corpus_tx = &corpus[0];
+    assert_eq!(corpus_tx["value"], "0x7");
+    assert_eq!(corpus_tx["sender"].as_str().unwrap().parse(), Ok(sender));
+    assert_eq!(corpus_tx["target"].as_str().unwrap().parse(), Ok(target));
+    assert_eq!(corpus_tx["calldata"], failure.calldata.to_string());
+
+    let frontier_path =
+        frontier_root.join("StatelessPayableValueTest/testFuzz_payable/branch-frontiers.json");
+    let frontier: Value =
+        serde_json::from_str(&std::fs::read_to_string(frontier_path).unwrap()).unwrap();
+    let frontier_tx = &frontier["frontiers"][0]["sequence"][0];
+    assert_eq!(frontier_tx["value"], "0x7");
+    assert_eq!(frontier_tx["sender"].as_str().unwrap().parse(), Ok(sender));
+    assert_eq!(frontier_tx["target"].as_str().unwrap().parse(), Ok(target));
+    assert_eq!(frontier_tx["calldata"], failure.calldata.to_string());
+
+    let replay = cmd
+        .forge_fuse()
+        .args(["fuzz", "replay", "--mt", "testFuzz_payable", "-vvv"])
+        .assert_failure();
+    let stdout = String::from_utf8(replay.get_output().stdout.clone()).unwrap();
+    assert!(stdout.contains("received value"), "{stdout}");
 });
 
 forgetest_init!(forge_fuzz_show_marks_selector_ambiguous_contracts, |prj, cmd| {


### PR DESCRIPTION
Stateless fuzzing generates complete transactions but previously discarded everything except calldata. This meant values such as `msg.value` were not preserved consistently across execution, corpus storage, counterexamples, and replay.

This PR carries a complete `BasicTxDetails` through the stateless fuzzing path. It also keeps existing failure artifacts replayable.

This is PR 1 because a shared transaction representation is the foundation for unifying stateless and invariant fuzzing around sequences. Follow-up PRs will unify transaction generation and dictionaries, sequence generation and mutation, and finally the execution campaign. Those architectural changes are intentionally out of scope here.

Part of OSS-252