### PR TITLE
feat(fuzz): persist worker corpus immediately

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -2248,6 +2248,223 @@ mod tests {
         assert_eq!((ok, err), (1, 1), "the corrupt file must read as Err, the valid one as Ok");
     }
 
+    fn empty_targeted_contracts() -> FuzzRunIdentifiedContracts {
+        FuzzRunIdentifiedContracts::new(TargetedContracts::new(), false)
+    }
+
+    #[test]
+    fn invariant_crossover_insert_loads_tx_from_persisted_corpus() {
+        let corpus_root = temp_corpus_dir();
+        let mut config = corpus_config(corpus_root.clone());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 1,
+            mutation_weight_crossover_replace: 0,
+            mutation_weight_insert: 0,
+            mutation_weight_delete: 0,
+            mutation_weight_swap: 0,
+        };
+
+        let base = basic_tx_with_calldata(vec![0xaa]);
+        let donor = basic_tx_with_calldata(vec![0xbb]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![base.clone()])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, basic_tx(), seed);
+        let worker_corpus_dir = corpus_root.join(format!("{WORKER}0")).join(CORPUS_DIR);
+        CorpusEntry::new(vec![donor.clone()]).write_to_disk_in(&worker_corpus_dir, false).unwrap();
+
+        let mut runner = TestRunner::default();
+        let sequence = manager
+            .new_inputs(
+                &mut runner,
+                &empty_fuzz_state().into_invariant(),
+                &empty_targeted_contracts(),
+            )
+            .unwrap();
+
+        assert_eq!(sequence.len(), 2);
+        assert!(sequence.iter().any(|tx| tx.call_details.calldata == base.call_details.calldata));
+        assert!(sequence.iter().any(|tx| tx.call_details.calldata == donor.call_details.calldata));
+        assert_eq!(manager.current_mutated_index, Some(0));
+    }
+
+    #[test]
+    fn invariant_crossover_replace_loads_tx_from_persisted_corpus() {
+        let corpus_root = temp_corpus_dir();
+        let mut config = corpus_config(corpus_root.clone());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 1,
+            mutation_weight_insert: 0,
+            mutation_weight_delete: 0,
+            mutation_weight_swap: 0,
+        };
+
+        let donor = basic_tx_with_calldata(vec![0xcc]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![basic_tx_with_calldata(vec![0xdd])])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, basic_tx(), seed);
+        let worker_corpus_dir = corpus_root.join(format!("{WORKER}0")).join(CORPUS_DIR);
+        CorpusEntry::new(vec![donor.clone()]).write_to_disk_in(&worker_corpus_dir, false).unwrap();
+
+        let mut runner = TestRunner::default();
+        let sequence = manager
+            .new_inputs(
+                &mut runner,
+                &empty_fuzz_state().into_invariant(),
+                &empty_targeted_contracts(),
+            )
+            .unwrap();
+
+        assert_eq!(sequence.len(), 1);
+        assert_eq!(sequence[0].call_details.calldata, donor.call_details.calldata);
+        assert_eq!(manager.current_mutated_index, Some(0));
+    }
+
+    #[test]
+    fn invariant_insert_adds_generated_tx_to_sequence() {
+        let mut config = corpus_config(temp_corpus_dir());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
+            mutation_weight_insert: 1,
+            mutation_weight_delete: 0,
+            mutation_weight_swap: 0,
+        };
+
+        let base = basic_tx_with_calldata(vec![0xaa]);
+        let generated = basic_tx_with_calldata(vec![0xbb]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![base.clone()])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, generated.clone(), seed);
+        let mut runner = TestRunner::default();
+
+        let sequence = manager
+            .new_inputs(
+                &mut runner,
+                &empty_fuzz_state().into_invariant(),
+                &empty_targeted_contracts(),
+            )
+            .unwrap();
+
+        assert_eq!(sequence.len(), 2);
+        assert!(sequence.iter().any(|tx| tx.call_details.calldata == base.call_details.calldata));
+        assert!(
+            sequence.iter().any(|tx| tx.call_details.calldata == generated.call_details.calldata)
+        );
+        assert_eq!(manager.current_mutated_index, Some(0));
+    }
+
+    #[test]
+    fn invariant_delete_removes_tx_from_sequence() {
+        let mut config = corpus_config(temp_corpus_dir());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
+            mutation_weight_insert: 0,
+            mutation_weight_delete: 1,
+            mutation_weight_swap: 0,
+        };
+
+        let first = basic_tx_with_calldata(vec![0xaa]);
+        let second = basic_tx_with_calldata(vec![0xbb]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![first.clone(), second.clone()])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, basic_tx(), seed);
+        let mut runner = TestRunner::default();
+
+        let sequence = manager
+            .new_inputs(
+                &mut runner,
+                &empty_fuzz_state().into_invariant(),
+                &empty_targeted_contracts(),
+            )
+            .unwrap();
+
+        assert_eq!(sequence.len(), 1);
+        assert!(
+            sequence[0].call_details.calldata == first.call_details.calldata
+                || sequence[0].call_details.calldata == second.call_details.calldata
+        );
+        assert_eq!(manager.current_mutated_index, Some(0));
+    }
+
+    #[test]
+    fn invariant_swap_exchanges_two_txs() {
+        let mut config = corpus_config(temp_corpus_dir());
+        config.mutation_weights = FuzzCorpusMutationWeights {
+            mutation_weight_splice: 0,
+            mutation_weight_repeat: 0,
+            mutation_weight_interleave: 0,
+            mutation_weight_prefix: 0,
+            mutation_weight_suffix: 0,
+            mutation_weight_abi: 0,
+            mutation_weight_cmp: 0,
+            mutation_weight_crossover_insert: 0,
+            mutation_weight_crossover_replace: 0,
+            mutation_weight_insert: 0,
+            mutation_weight_delete: 0,
+            mutation_weight_swap: 1,
+        };
+
+        let first = basic_tx_with_calldata(vec![0xaa]);
+        let second = basic_tx_with_calldata(vec![0xbb]);
+        let seed = WorkerCorpusSeed {
+            in_memory_corpus: vec![CorpusEntry::new(vec![first.clone(), second.clone()])],
+            ..Default::default()
+        };
+        let mut manager = worker_corpus_with_config(0, config, basic_tx(), seed);
+        let mut runner = TestRunner::default();
+
+        let sequence = manager
+            .new_inputs(
+                &mut runner,
+                &empty_fuzz_state().into_invariant(),
+                &empty_targeted_contracts(),
+            )
+            .unwrap();
+
+        assert_eq!(sequence.len(), 2);
+        assert_eq!(sequence[0].call_details.calldata, second.call_details.calldata);
+        assert_eq!(sequence[1].call_details.calldata, first.call_details.calldata);
+        assert_eq!(manager.current_mutated_index, Some(0));
+    }
+
     #[test]
     fn sync_inbox_loads_entries_regardless_of_timestamp() {
         let corpus_root = temp_corpus_dir();

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -313,13 +313,6 @@ impl CachedDiskCorpus {
     }
 }
 
-/// Corpus entry selected by a worker and returned for logical-campaign persistence.
-#[derive(Debug, Clone)]
-pub(crate) struct CampaignCorpusEntry {
-    tx_seq: Vec<BasicTxDetails>,
-    dedupe_by_coverage: bool,
-}
-
 /// Persists one call sequence as a corpus seed in the canonical worker0 corpus directory.
 pub fn persist_corpus_seed(
     config: &FuzzCorpusConfig,
@@ -420,9 +413,67 @@ fn accept_synced_corpus_file(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CorpusInsertionMode {
     Live,
-    Deferred,
     MemoryOnly,
     WorkerSync,
+}
+
+/// Expands compressed corpus entries before a campaign so workers can share and mutate regular
+/// files while the campaign is running.
+pub(crate) fn prepare_corpus_for_campaign(config: &FuzzCorpusConfig) -> Result<()> {
+    if !config.corpus_gzip {
+        return Ok(());
+    }
+    rewrite_campaign_corpus(config, false)
+}
+
+/// Compresses eligible corpus entries after a campaign has stopped writing them.
+pub(crate) fn finalize_corpus_after_campaign(config: &FuzzCorpusConfig) -> Result<()> {
+    if !config.corpus_gzip {
+        return Ok(());
+    }
+    rewrite_campaign_corpus(config, true)
+}
+
+fn rewrite_campaign_corpus(config: &FuzzCorpusConfig, gzip: bool) -> Result<()> {
+    let Some(root) = &config.corpus_dir else { return Ok(()) };
+    for dir in canonical_replay_dirs(root) {
+        for entry in read_corpus_dir(&dir) {
+            let is_gzip = entry
+                .path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("gz"));
+            if is_gzip == gzip {
+                continue;
+            }
+            let tx_seq = entry.read_tx_seq()?;
+            if gzip
+                && tx_seq.iter().map(|tx| tx.estimate_serialized_size()).sum::<usize>()
+                    <= GZIP_THRESHOLD
+            {
+                continue;
+            }
+
+            let target = if gzip {
+                PathBuf::from(format!("{}.gz", entry.path.display()))
+            } else {
+                entry.path.with_extension("")
+            };
+            let temp = target.with_file_name(format!(
+                ".{}.{}.tmp",
+                target.file_name().unwrap().to_string_lossy(),
+                Uuid::new_v4()
+            ));
+            if gzip {
+                foundry_common::fs::write_json_gzip_file(&temp, &tx_seq)?;
+            } else {
+                foundry_common::fs::write_json_file(&temp, &tx_seq)?;
+            }
+            std::fs::rename(&temp, &target)?;
+            std::fs::remove_file(&entry.path)?;
+        }
+    }
+    Ok(())
 }
 
 struct ReplayOutcome {
@@ -673,50 +724,6 @@ impl WorkerCorpusSeed {
         );
 
         Ok(seed)
-    }
-
-    /// Filters and persists logical-campaign corpus entries after worker results have merged.
-    ///
-    /// This consumes the deferred entries and writes each retained entry as soon as replay proves
-    /// it contributes new coverage. Keeping this path streaming avoids building a second filtered
-    /// copy of every campaign entry during invariant finalization.
-    pub(crate) fn persist_filtered_campaign_outputs<FEN: FoundryEvmNetwork>(
-        &self,
-        config: &FuzzCorpusConfig,
-        entries: impl IntoIterator<Item = CampaignCorpusEntry>,
-        executor: &Executor<FEN>,
-        target: ReplayTarget<'_>,
-        optimization_best: Option<(I256, &[BasicTxDetails])>,
-    ) -> Result<()> {
-        let mut history_map = self.history_map.clone();
-        let mut edge_indices = self.edge_indices.clone();
-        let mut sancov_history_map = self.sancov_history_map.clone();
-
-        let mut output_dir_ready = false;
-        for entry in entries {
-            if entry.dedupe_by_coverage {
-                let coverage = ReplayCoverage {
-                    history_map: &mut history_map,
-                    edge_indices: &mut edge_indices,
-                    sancov_history_map: &mut sancov_history_map,
-                    metrics: None,
-                };
-                let ReplayOutcome { keep_entry, new_coverage, .. } =
-                    replay_corpus_sequence(&entry.tx_seq, executor, target, coverage)?;
-                if !keep_entry || !new_coverage {
-                    continue;
-                }
-            }
-
-            if !output_dir_ready {
-                prepare_campaign_output_dir(config);
-                output_dir_ready = true;
-            }
-            persist_campaign_entry(config, entry);
-        }
-
-        persist_optimization_output(config, optimization_best);
-        Ok(())
     }
 }
 
@@ -1133,27 +1140,6 @@ impl WorkerCorpus {
         );
     }
 
-    /// Updates worker-local corpus state and returns any corpus entry to persist after the
-    /// logical campaign has merged worker outputs.
-    #[instrument(skip_all)]
-    pub fn process_inputs_for_campaign(
-        &mut self,
-        inputs: &[BasicTxDetails],
-        cmp_seq: &[Vec<CmpOperands>],
-        new_coverage: bool,
-        edges_covered: Vec<usize>,
-        optimization: Option<(I256, Vec<BasicTxDetails>)>,
-    ) -> Option<CampaignCorpusEntry> {
-        self.process_inputs_inner(
-            inputs,
-            cmp_seq,
-            new_coverage,
-            edges_covered,
-            optimization,
-            CorpusInsertionMode::Deferred,
-        )
-    }
-
     fn process_inputs_inner(
         &mut self,
         inputs: &[BasicTxDetails],
@@ -1162,7 +1148,7 @@ impl WorkerCorpus {
         edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
         insertion_mode: CorpusInsertionMode,
-    ) -> Option<CampaignCorpusEntry> {
+    ) {
         let persist_now =
             matches!(insertion_mode, CorpusInsertionMode::Live | CorpusInsertionMode::WorkerSync);
         // Check if this run improved the optimization value.
@@ -1181,12 +1167,12 @@ impl WorkerCorpus {
         }
 
         if !self.config.is_coverage_guided() {
-            return None;
+            return;
         }
 
         // Collect inputs if current run produced new coverage or improved optimization.
         if !new_coverage && !improved_optimization {
-            return None;
+            return;
         }
 
         // When the run is interesting only because of optimization (no new coverage),
@@ -1201,7 +1187,7 @@ impl WorkerCorpus {
             inputs.to_vec()
         };
         if corpus_inputs.is_empty() {
-            return None;
+            return;
         }
         let corpus_cmp_seq = cmp_seq
             .iter()
@@ -1218,18 +1204,10 @@ impl WorkerCorpus {
         );
         self.update_top_rated(&corpus);
 
-        self.insert_corpus_entry(corpus, insertion_mode, new_coverage)
+        self.insert_corpus_entry(corpus, insertion_mode)
     }
 
-    fn insert_corpus_entry(
-        &mut self,
-        corpus: CorpusEntry,
-        insertion_mode: CorpusInsertionMode,
-        dedupe_by_coverage: bool,
-    ) -> Option<CampaignCorpusEntry> {
-        let campaign_entry = matches!(insertion_mode, CorpusInsertionMode::Deferred)
-            .then(|| CampaignCorpusEntry { tx_seq: corpus.tx_seq.clone(), dedupe_by_coverage });
-
+    fn insert_corpus_entry(&mut self, corpus: CorpusEntry, insertion_mode: CorpusInsertionMode) {
         if matches!(insertion_mode, CorpusInsertionMode::Live | CorpusInsertionMode::WorkerSync)
             && let Some(worker_dir) = &self.worker_dir
         {
@@ -1254,7 +1232,6 @@ impl WorkerCorpus {
         }
 
         self.push_corpus_entry(corpus, matches!(insertion_mode, CorpusInsertionMode::WorkerSync));
-        campaign_entry
     }
 
     fn push_corpus_entry(&mut self, corpus: CorpusEntry, track_for_worker_sync: bool) {
@@ -1278,7 +1255,7 @@ impl WorkerCorpus {
         let optimization_best = self
             .optimization_best_value
             .map(|value| (value, self.optimization_best_sequence.as_slice()));
-        Self::persist_campaign_outputs(&self.config, Vec::new(), optimization_best);
+        persist_optimization_output(&self.config, optimization_best);
     }
 
     fn update_top_rated(&mut self, corpus: &CorpusEntry) {
@@ -1347,24 +1324,6 @@ impl WorkerCorpus {
         self.cull_corpus()
     }
 
-    /// Persists logical-campaign corpus and optimization outputs after worker results have merged.
-    pub(crate) fn persist_campaign_outputs(
-        config: &FuzzCorpusConfig,
-        entries: impl IntoIterator<Item = CampaignCorpusEntry>,
-        optimization_best: Option<(I256, &[BasicTxDetails])>,
-    ) {
-        let mut output_dir_ready = false;
-        for entry in entries {
-            if !output_dir_ready {
-                prepare_campaign_output_dir(config);
-                output_dir_ready = true;
-            }
-            persist_campaign_entry(config, entry);
-        }
-
-        persist_optimization_output(config, optimization_best);
-    }
-
     pub fn merge_edge_coverage_with_edges_into<FEN: FoundryEvmNetwork>(
         &mut self,
         call_result: &mut RawCallResult<FEN>,
@@ -1407,9 +1366,9 @@ impl WorkerCorpus {
         parent_tx: &BasicTxDetails,
         targeted_contracts: &FuzzRunIdentifiedContracts,
         insertion_mode: CorpusInsertionMode,
-    ) -> Option<CampaignCorpusEntry> {
+    ) {
         if !self.config.is_coverage_guided() || observed.is_empty() {
-            return None;
+            return;
         }
 
         let tx_seq = {
@@ -1499,14 +1458,14 @@ impl WorkerCorpus {
         &mut self,
         tx_seq: Vec<BasicTxDetails>,
         insertion_mode: CorpusInsertionMode,
-    ) -> Option<CampaignCorpusEntry> {
+    ) {
         if !self.config.is_coverage_guided() || tx_seq.is_empty() {
-            return None;
+            return;
         }
 
         let corpus = CorpusEntry::new(tx_seq);
 
-        self.insert_corpus_entry(corpus, insertion_mode, false)
+        self.insert_corpus_entry(corpus, insertion_mode)
     }
 
     /// Flush non-favored entries from memory when the corpus size exceeds the minimum.
@@ -2016,35 +1975,6 @@ fn sequence_from_observed(
         .collect()
 }
 
-fn prepare_campaign_output_dir(config: &FuzzCorpusConfig) {
-    let Some(root) = &config.corpus_dir else {
-        return;
-    };
-    let corpus_dir = root.join(format!("{WORKER}0")).join(CORPUS_DIR);
-    if let Err(err) = foundry_common::fs::create_dir_all(&corpus_dir) {
-        debug!(target: "corpus", %err, "failed to create campaign corpus dir");
-    }
-}
-
-fn persist_campaign_entry(config: &FuzzCorpusConfig, entry: CampaignCorpusEntry) {
-    let Some(root) = &config.corpus_dir else {
-        return;
-    };
-    let corpus_dir = root.join(format!("{WORKER}0")).join(CORPUS_DIR);
-    let corpus = CorpusEntry::new(entry.tx_seq);
-    let write_result = corpus.write_to_disk_in(&corpus_dir, config.corpus_gzip);
-    if let Err(err) = write_result {
-        debug!(target: "corpus", %err, "failed to record call sequence {:?}", corpus.tx_seq);
-    } else {
-        trace!(
-            target: "corpus",
-            "persisted {} inputs for new coverage for {} corpus",
-            corpus.tx_seq.len(),
-            corpus.uuid,
-        );
-    }
-}
-
 fn persist_optimization_output(
     config: &FuzzCorpusConfig,
     optimization_best: Option<(I256, &[BasicTxDetails])>,
@@ -2067,6 +1997,14 @@ fn persist_optimization_output(
             sequence.len()
         );
     }
+}
+
+pub(crate) fn persist_campaign_optimization(
+    config: &FuzzCorpusConfig,
+    value: Option<I256>,
+    sequence: &[BasicTxDetails],
+) {
+    persist_optimization_output(config, value.map(|value| (value, sequence)));
 }
 
 fn has_legacy_invariant_corpus_dirs(path: &Path) -> bool {
@@ -2246,10 +2184,6 @@ mod tests {
             }
         }
         assert_eq!((ok, err), (1, 1), "the corrupt file must read as Err, the valid one as Ok");
-    }
-
-    fn empty_targeted_contracts() -> FuzzRunIdentifiedContracts {
-        FuzzRunIdentifiedContracts::new(TargetedContracts::new(), false)
     }
 
     #[test]
@@ -2685,18 +2619,15 @@ mod tests {
     }
 
     #[test]
-    fn campaign_processing_returns_corpus_without_writing_worker_file() {
+    fn campaign_processing_writes_worker_file_immediately() {
         let corpus_root = temp_corpus_dir();
         let worker_subdir = corpus_root.join("worker1");
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        let record = manager.process_inputs_for_campaign(&[basic_tx()], &[], true, vec![1], None);
-
-        let record = record.unwrap();
-        assert!(record.dedupe_by_coverage);
+        manager.process_inputs(&[basic_tx()], &[], true, vec![1], None);
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert_eq!(manager.metrics.corpus_count, 1);
-        assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
+        assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 1);
     }
 
     /// `RawCallResult` carrying a single edge hit, to drive `merge_edge_coverage` without the EVM.
@@ -2750,9 +2681,7 @@ mod tests {
         let worker_subdir = corpus_root.join("worker1");
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        let record = manager.process_inputs_for_campaign(&[], &[], true, Vec::new(), None);
-
-        assert!(record.is_none());
+        manager.process_inputs(&[], &[], true, Vec::new(), None);
         assert_eq!(manager.in_memory_corpus.len(), 0);
         assert_eq!(manager.metrics.corpus_count, 0);
         assert_eq!(read_corpus_dir(&worker_subdir.join(CORPUS_DIR)).count(), 0);
@@ -2764,28 +2693,20 @@ mod tests {
     }
 
     #[test]
-    fn merged_campaign_outputs_write_corpus_and_optimization_to_master_dir() {
+    fn processing_writes_corpus_and_optimization_to_worker_dir() {
         let corpus_root = temp_corpus_dir();
         let mut manager = empty_worker_corpus(1, corpus_root.clone());
         let sequence = vec![basic_tx()];
-        let record = manager
-            .process_inputs_for_campaign(
-                &sequence,
-                &[],
-                false,
-                Vec::new(),
-                Some((I256::try_from(7).unwrap(), sequence.clone())),
-            )
-            .unwrap();
-        let inputs = vec![record];
-        WorkerCorpus::persist_campaign_outputs(
-            &corpus_config(corpus_root.clone()),
-            inputs,
-            Some((I256::try_from(7).unwrap(), &sequence)),
+        manager.process_inputs(
+            &sequence,
+            &[],
+            false,
+            Vec::new(),
+            Some((I256::try_from(7).unwrap(), sequence.clone())),
         );
 
-        let master_corpus_dir = corpus_root.join("worker0").join(CORPUS_DIR);
-        let entries = read_corpus_dir(&master_corpus_dir).collect::<Vec<_>>();
+        let worker_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
+        let entries = read_corpus_dir(&worker_corpus_dir).collect::<Vec<_>>();
         assert_eq!(entries.len(), 1);
         let persisted_sequence = entries[0].read_tx_seq().unwrap();
         assert_eq!(persisted_sequence.len(), sequence.len());
@@ -2840,6 +2761,27 @@ mod tests {
     }
 
     #[test]
+    fn campaign_expands_then_recompresses_corpus_entries() {
+        let corpus_root = temp_corpus_dir();
+        let corpus_dir = corpus_root.join("worker0").join(CORPUS_DIR);
+        fs::create_dir_all(&corpus_dir).unwrap();
+        let mut config = corpus_config(corpus_root);
+        config.corpus_gzip = true;
+        let compressed = CorpusEntry::new(vec![basic_tx_with_calldata(vec![0; 5000])])
+            .write_to_disk_in(&corpus_dir, true)
+            .unwrap();
+        assert_eq!(compressed.extension().unwrap(), "gz");
+
+        prepare_corpus_for_campaign(&config).unwrap();
+        let expanded = read_corpus_dir(&corpus_dir).next().unwrap().path;
+        assert_eq!(expanded.extension().unwrap(), "json");
+
+        finalize_corpus_after_campaign(&config).unwrap();
+        let recompressed = read_corpus_dir(&corpus_dir).next().unwrap().path;
+        assert_eq!(recompressed.extension().unwrap(), "gz");
+    }
+
+    #[test]
     fn persist_corpus_seed_skips_duplicate_sequence() {
         let corpus_root = temp_corpus_dir();
         let config = corpus_config(corpus_root.clone());
@@ -2880,24 +2822,22 @@ mod tests {
         .unwrap();
 
         let worse_sequence = vec![basic_tx()];
-        let worse = manager.process_inputs_for_campaign(
+        manager.process_inputs(
             &worse_sequence,
             &[],
             false,
             Vec::new(),
             Some((I256::try_from(50).unwrap(), worse_sequence.clone())),
         );
-        assert!(worse.is_none());
 
         let better_sequence = vec![basic_tx()];
-        let better = manager.process_inputs_for_campaign(
+        manager.process_inputs(
             &better_sequence,
             &[],
             false,
             Vec::new(),
             Some((I256::try_from(150).unwrap(), better_sequence.clone())),
         );
-        assert!(better.is_some());
     }
 
     #[test]
@@ -3190,14 +3130,12 @@ mod tests {
         };
         let mut manager = empty_worker_corpus(0, temp_corpus_dir());
 
-        let campaign_entry = manager.hoist_observed_calls(
+        manager.hoist_observed_calls(
             &observed,
             &parent_tx,
             &targeted_contracts,
             CorpusInsertionMode::Live,
         );
-
-        assert!(campaign_entry.is_none());
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert_eq!(manager.metrics.corpus_count, 1);
 
@@ -3221,7 +3159,7 @@ mod tests {
     }
 
     #[test]
-    fn hoist_observed_calls_returns_deferred_campaign_entry_without_persisting() {
+    fn hoist_observed_calls_persists_immediately() {
         let target = Address::from([0x42; 20]);
         let foo = Function::parse("foo()").unwrap();
         let selector = foo.selector();
@@ -3237,18 +3175,15 @@ mod tests {
         let worker_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        let campaign_entry = manager.hoist_observed_calls(
+        manager.hoist_observed_calls(
             &observed,
             &basic_tx(),
             &targeted_contracts,
-            CorpusInsertionMode::Deferred,
+            CorpusInsertionMode::Live,
         );
 
-        let campaign_entry = campaign_entry.expect("deferred hoist should return campaign entry");
-        assert!(!campaign_entry.dedupe_by_coverage);
-        assert_eq!(campaign_entry.tx_seq.len(), 1);
         assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker_corpus_dir).count(), 0);
+        assert_eq!(read_corpus_dir(&worker_corpus_dir).count(), 1);
     }
 
     #[test]
@@ -3272,28 +3207,20 @@ mod tests {
         let mut manager =
             WorkerCorpus::from_seed(0, no_corpus_config, generator, WorkerCorpusSeed::default())
                 .unwrap();
-        assert!(
-            manager
-                .hoist_observed_calls(
-                    &observed,
-                    &basic_tx(),
-                    &targeted_contracts,
-                    CorpusInsertionMode::Live
-                )
-                .is_none()
+        manager.hoist_observed_calls(
+            &observed,
+            &basic_tx(),
+            &targeted_contracts,
+            CorpusInsertionMode::Live,
         );
         assert!(manager.in_memory_corpus.is_empty());
 
         let mut manager = empty_worker_corpus(0, temp_corpus_dir());
-        assert!(
-            manager
-                .hoist_observed_calls(
-                    &[],
-                    &basic_tx(),
-                    &targeted_contracts,
-                    CorpusInsertionMode::Live
-                )
-                .is_none()
+        manager.hoist_observed_calls(
+            &[],
+            &basic_tx(),
+            &targeted_contracts,
+            CorpusInsertionMode::Live,
         );
         assert!(manager.in_memory_corpus.is_empty());
     }
@@ -3355,26 +3282,20 @@ mod tests {
     }
 
     #[test]
-    fn push_observed_sequence_live_persists_and_memory_only_does_not() {
+    fn push_observed_sequence_persists_for_every_worker() {
         let corpus_root = temp_corpus_dir();
         let worker0_corpus_dir = corpus_root.join("worker0").join(CORPUS_DIR);
         let mut manager = empty_worker_corpus(0, corpus_root.clone());
 
-        assert!(
-            manager.push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::Live).is_none()
-        );
+        manager.push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::Live);
         assert_eq!(manager.in_memory_corpus.len(), 1);
         assert_eq!(read_corpus_dir(&worker0_corpus_dir).count(), 1);
 
         let mut manager = empty_worker_corpus(1, corpus_root.clone());
         let worker1_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
-        assert!(
-            manager
-                .push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::MemoryOnly)
-                .is_none()
-        );
+        manager.push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::Live);
         assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker1_corpus_dir).count(), 0);
+        assert_eq!(read_corpus_dir(&worker1_corpus_dir).count(), 1);
     }
 
     #[test]
@@ -3462,24 +3383,16 @@ mod tests {
 
     #[test]
     fn invariant_insertions_do_not_disable_culling() {
-        let mut deferred = empty_worker_corpus(1, temp_corpus_dir());
         let mut live = empty_worker_corpus(0, temp_corpus_dir());
         let mut memory_only = empty_worker_corpus(1, temp_corpus_dir());
 
         for idx in 0..32 {
             let tx = basic_tx_with_calldata(vec![idx]);
-            let _ = deferred.process_inputs_for_campaign(
-                std::slice::from_ref(&tx),
-                &[],
-                true,
-                vec![1],
-                None,
-            );
             live.process_inputs(std::slice::from_ref(&tx), &[], true, vec![1], None);
-            let _ = memory_only.push_observed_sequence(vec![tx], CorpusInsertionMode::MemoryOnly);
+            memory_only.push_observed_sequence(vec![tx], CorpusInsertionMode::MemoryOnly);
         }
 
-        for manager in [&deferred, &live, &memory_only] {
+        for manager in [&live, &memory_only] {
             assert_eq!(manager.in_memory_corpus.len(), 1);
             assert_eq!(manager.metrics.corpus_count, manager.in_memory_corpus.len());
             assert!(manager.pending_sync_uuids.is_empty());

--- a/crates/evm/evm/src/executors/invariant/campaign.rs
+++ b/crates/evm/evm/src/executors/invariant/campaign.rs
@@ -2,7 +2,7 @@ use super::{
     FailureKey, InvariantFailureMetrics, InvariantFailures, InvariantFuzzError,
     InvariantFuzzTestResult, InvariantMetrics,
 };
-use crate::executors::{EarlyExit, EvmExecutionCancellation, corpus::CampaignCorpusEntry};
+use crate::executors::{EarlyExit, EvmExecutionCancellation};
 use alloy_primitives::{Address, I256, Selector};
 use eyre::{Result, ensure};
 use foundry_evm_coverage::HitMaps;
@@ -206,13 +206,12 @@ impl InvariantCampaignState {
 pub struct InvariantWorkerOutput {
     pub plan: InvariantWorkerPlan,
     pub result: InvariantFuzzTestResult,
-    pub corpus_entries: Vec<CampaignCorpusEntry>,
 }
 
 impl InvariantWorkerOutput {
     #[cfg(test)]
     pub const fn new(plan: InvariantWorkerPlan, result: InvariantFuzzTestResult) -> Self {
-        Self { plan, result, corpus_entries: Vec::new() }
+        Self { plan, result }
     }
 }
 
@@ -245,14 +244,10 @@ impl InvariantCampaignAggregator {
     /// Validates the collected worker ranges and folds them into one logical campaign result.
     #[cfg(test)]
     pub fn finish(self) -> Result<InvariantFuzzTestResult> {
-        Ok(self.finish_with_corpus_entries()?.0)
+        self.finish_campaign()
     }
 
-    /// Validates the collected worker ranges and folds them into one logical campaign result with
-    /// corpus artifacts selected in logical worker order.
-    pub fn finish_with_corpus_entries(
-        mut self,
-    ) -> Result<(InvariantFuzzTestResult, Vec<CampaignCorpusEntry>)> {
+    pub fn finish_campaign(mut self) -> Result<InvariantFuzzTestResult> {
         ensure!(!self.outputs.is_empty(), "missing invariant worker output");
 
         self.outputs.sort_by_key(|output| output.plan.first_global_run);
@@ -266,9 +261,7 @@ impl InvariantCampaignAggregator {
     /// worker may have completed fewer than its assigned runs, so the original static ranges can
     /// contain gaps. The merge still validates worker identity and preserves deterministic worker
     /// order, but final run count is derived from the completed worker counters.
-    pub fn finish_partial_with_corpus_entries(
-        mut self,
-    ) -> Result<(InvariantFuzzTestResult, Vec<CampaignCorpusEntry>)> {
+    pub fn finish_partial(mut self) -> Result<InvariantFuzzTestResult> {
         ensure!(!self.outputs.is_empty(), "missing invariant worker output");
 
         self.outputs.sort_by_key(|output| output.plan.first_global_run);
@@ -277,9 +270,7 @@ impl InvariantCampaignAggregator {
     }
 }
 
-fn fold_outputs(
-    outputs: Vec<InvariantWorkerOutput>,
-) -> Result<(InvariantFuzzTestResult, Vec<CampaignCorpusEntry>)> {
+fn fold_outputs(outputs: Vec<InvariantWorkerOutput>) -> Result<InvariantFuzzTestResult> {
     let workers = outputs.len();
     let mut errors = HashMap::default();
     let mut handler_errors = HashMap::default();
@@ -290,11 +281,10 @@ fn fold_outputs(
     let mut gas_report_traces = Vec::new();
     let mut line_coverage = None;
     let mut metrics = HashMap::default();
-    let mut corpus_entries = Vec::new();
     let mut failed_corpus_replays = 0;
     let mut optimization_best = None;
 
-    for InvariantWorkerOutput { plan, result, corpus_entries: worker_entries } in outputs {
+    for InvariantWorkerOutput { plan, result } in outputs {
         if plan.worker_id == 0 {
             failed_corpus_replays = result.failed_corpus_replays;
         }
@@ -302,7 +292,6 @@ fn fold_outputs(
             errors.entry(invariant).or_insert(error);
         }
         merge_handler_errors(&mut handler_errors, result.handler_errors);
-        corpus_entries.extend(worker_entries);
         runs += result.runs;
         calls += result.calls;
         reverts += result.reverts;
@@ -320,23 +309,20 @@ fn fold_outputs(
     }
     let (optimization_best_value, optimization_best_sequence) =
         optimization_best.map(|(value, sequence)| (Some(value), sequence)).unwrap_or_default();
-    Ok((
-        InvariantFuzzTestResult::new(
-            errors,
-            handler_errors,
-            runs,
-            calls,
-            reverts,
-            last_run_inputs,
-            gas_report_traces,
-            line_coverage,
-            metrics,
-            failed_corpus_replays,
-            workers,
-            optimization_best_value,
-            optimization_best_sequence,
-        ),
-        corpus_entries,
+    Ok(InvariantFuzzTestResult::new(
+        errors,
+        handler_errors,
+        runs,
+        calls,
+        reverts,
+        last_run_inputs,
+        gas_report_traces,
+        line_coverage,
+        metrics,
+        failed_corpus_replays,
+        workers,
+        optimization_best_value,
+        optimization_best_sequence,
     ))
 }
 
@@ -833,12 +819,11 @@ mod tests {
             result_with_counts(1, 10, true, 0),
         ));
 
-        let (result, corpus_entries) = partial.finish_partial_with_corpus_entries().unwrap();
+        let result = partial.finish_partial().unwrap();
 
         assert_eq!(result.runs, 3);
         assert_eq!(result.calls, 30);
         assert_eq!(result.failed_corpus_replays, 5);
-        assert!(corpus_entries.is_empty());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -3,6 +3,8 @@ use crate::{
         DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, RawCallResult,
         corpus::{
             CorpusInsertionMode, DynamicTargetCtx, ReplayTarget, WorkerCorpus, WorkerCorpusSeed,
+            finalize_corpus_after_campaign, persist_campaign_optimization,
+            prepare_corpus_for_campaign,
         },
     },
     inspectors::Fuzzer,
@@ -241,6 +243,8 @@ const fn invariant_worker_config(
     worker_id: u32,
     worker_count: usize,
 ) -> InvariantConfig {
+    // Corpus compression is a campaign-boundary operation, not a worker write operation.
+    config.corpus.corpus_gzip = false;
     // Keep one- and two-worker campaigns on the stable default, but let one extra worker explore
     // the broader fresh-input setting once the user has enough workers to keep the exploratory
     // share below half of the campaign. The last worker does not receive remainder runs from
@@ -430,20 +434,6 @@ fn invariant_focus_seed(
         let mut rng = runner.new_rng();
         Some(U256::from_be_bytes(rng.random::<[u8; 32]>()))
     })
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum InvariantCorpusPersistence {
-    /// Preserve the legacy single-worker behavior: each interesting input is written immediately.
-    Live,
-    /// Parallel workers return interesting inputs to the campaign coordinator for merged writes.
-    Deferred,
-}
-
-impl InvariantCorpusPersistence {
-    const fn is_deferred(self) -> bool {
-        matches!(self, Self::Deferred)
-    }
 }
 
 /// Converts a cumulative campaign total into an average per-second rate.
@@ -943,6 +933,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             InvariantFuzzError,
         >,
     ) -> Result<InvariantFuzzTestResult> {
+        prepare_corpus_for_campaign(&self.config.corpus)?;
         let campaign_spec = InvariantCampaignSpec::new(self.config.runs);
         let worker_plans = campaign_spec.worker_plans(invariant_worker_count_with_threads(
             &self.config,
@@ -970,11 +961,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 dynamic: Some(&dynamic),
             },
         )?;
-        let corpus_persistence = if actual_worker_count > 1 {
-            InvariantCorpusPersistence::Deferred
-        } else {
-            InvariantCorpusPersistence::Live
-        };
         let mut runner = self.runner.clone();
         let config = self.config.clone();
         let setup_contracts = self.setup_contracts;
@@ -984,7 +970,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         let campaign_state =
             Arc::new(InvariantCampaignState::new(early_exit.clone(), self.config.timeout));
 
-        let worker_outputs = if corpus_persistence.is_deferred() {
+        let worker_outputs = if actual_worker_count > 1 {
             let worker_jobs = worker_plans
                 .into_iter()
                 .map(|worker_plan| {
@@ -1032,7 +1018,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         &campaign_state,
                         worker_campaign_seed,
                         worker_corpus_seed,
-                        corpus_persistence,
                         actual_worker_count,
                         gas_report_samples,
                     );
@@ -1073,7 +1058,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 &campaign_state,
                 worker_campaign_seed,
                 worker_corpus_seed,
-                corpus_persistence,
                 actual_worker_count,
                 gas_report_samples,
             )?]
@@ -1083,27 +1067,17 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         for worker_output in worker_outputs {
             aggregator.push(worker_output);
         }
-        let (result, corpus_entries) = if campaign_state.is_timed_campaign() {
-            aggregator.finish_partial_with_corpus_entries()?
+        let result = if campaign_state.is_timed_campaign() {
+            aggregator.finish_partial()?
         } else {
-            aggregator.finish_with_corpus_entries()?
+            aggregator.finish_campaign()?
         };
-        if corpus_persistence.is_deferred() {
-            let dynamic_target_ctx = self.dynamic_target_ctx();
-            corpus_seed.persist_filtered_campaign_outputs(
-                &self.config.corpus,
-                corpus_entries,
-                &self.executor,
-                ReplayTarget {
-                    stateless: None,
-                    fuzzed_contracts: Some(&replay_targets),
-                    dynamic: Some(&dynamic_target_ctx),
-                },
-                result
-                    .optimization_best_value
-                    .map(|value| (value, result.optimization_best_sequence.as_slice())),
-            )?;
-        }
+        persist_campaign_optimization(
+            &self.config.corpus,
+            result.optimization_best_value,
+            &result.optimization_best_sequence,
+        );
+        finalize_corpus_after_campaign(&self.config.corpus)?;
         Ok(result)
     }
 
@@ -1123,7 +1097,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
         campaign_state: &InvariantCampaignState,
         campaign_seed: InvariantCampaignSeed,
         corpus_seed: WorkerCorpusSeed,
-        corpus_persistence: InvariantCorpusPersistence,
         worker_count: usize,
         gas_report_samples: usize,
     ) -> Result<InvariantWorkerOutput> {
@@ -1145,8 +1118,6 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             &campaign_seed,
             corpus_seed,
         )?;
-        let mut corpus_entries = Vec::new();
-
         let mut runs = 0;
         campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
 
@@ -1520,20 +1491,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
             }
 
-            let insertion_mode = if corpus_persistence.is_deferred() {
-                CorpusInsertionMode::Deferred
-            } else {
-                CorpusInsertionMode::Live
-            };
             for (observed_calls, parent_tx) in observed_call_entries {
-                if let Some(entry) = corpus_manager.hoist_observed_calls(
+                corpus_manager.hoist_observed_calls(
                     &observed_calls,
                     &parent_tx,
                     &invariant_test.targeted_contracts,
-                    insertion_mode,
-                ) {
-                    corpus_entries.push(entry);
-                }
+                    CorpusInsertionMode::Live,
+                );
             }
 
             // Extend corpus only after the run and its optional hook have completed.
@@ -1541,25 +1505,13 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 let prefix = current_run.inputs[..current_run.optimization_prefix_len].to_vec();
                 (v, prefix)
             });
-            if corpus_persistence.is_deferred() {
-                if let Some(input) = corpus_manager.process_inputs_for_campaign(
-                    &current_run.inputs,
-                    &current_run.cmp_seq,
-                    current_run.new_coverage,
-                    std::mem::take(&mut current_run.corpus_edges),
-                    optimization,
-                ) {
-                    corpus_entries.push(input);
-                }
-            } else {
-                corpus_manager.process_inputs(
-                    &current_run.inputs,
-                    &current_run.cmp_seq,
-                    current_run.new_coverage,
-                    std::mem::take(&mut current_run.corpus_edges),
-                    optimization,
-                );
-            }
+            corpus_manager.process_inputs(
+                &current_run.inputs,
+                &current_run.cmp_seq,
+                current_run.new_coverage,
+                std::mem::take(&mut current_run.corpus_edges),
+                optimization,
+            );
 
             // End current invariant test run.
             if current_run.save_last_run_inputs {
@@ -1622,11 +1574,8 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                         }
                         msg.push_str(&format!("⚠ {handler_bugs} handler bug(s)"));
                     }
-                    let msg = if corpus_persistence.is_deferred() {
-                        format!("[w{}] {msg}", plan.worker_id)
-                    } else {
-                        msg
-                    };
+                    let msg =
+                        if worker_count > 1 { format!("[w{}] {msg}", plan.worker_id) } else { msg };
                     progress.set_message(msg);
                 }
             } else if edge_coverage_enabled
@@ -1703,7 +1652,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             // `first_global_run` offsets were computed from the original partition.
             plan
         };
-        Ok(InvariantWorkerOutput { plan: reported_plan, result: worker_result, corpus_entries })
+        Ok(InvariantWorkerOutput { plan: reported_plan, result: worker_result })
     }
 
     fn shrink_handler_failures(
@@ -2926,7 +2875,6 @@ mod tests {
                     &campaign_state,
                     campaign_seed,
                     WorkerCorpusSeed::default(),
-                    InvariantCorpusPersistence::Live,
                     1,
                     1,
                 );
@@ -2953,7 +2901,6 @@ mod tests {
         assert!(output.result.line_coverage.is_none());
         assert!(output.result.metrics.is_empty());
         assert!(output.result.optimization_best_value.is_none());
-        assert!(output.corpus_entries.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- remove live/deferred corpus insertion modes and write interesting entries directly to each worker corpus
- stop carrying corpus artifacts through end-of-run aggregation
- expand configured gzip corpus files before invariant campaigns and recompress eligible entries after workers finish
- keep the aggregated optimization best as the final persisted optimization state

## Validation
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1`
- `cargo check -p foundry-evm --lib` could not start because fetching `foundry-rs/optimism` returned HTTP 401

Stacked on #15763. Closes OSS-574

Prompted by: @0xalpharush