### PR TITLE
feat(fuzz): keep observed calls out of corpus

### DIFF
--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -1365,7 +1365,6 @@ impl WorkerCorpus {
             let targets = targeted_contracts.targets();
             sequence_from_observed(observed, &targets, depth, None)
         };
-
         calls.into_iter().filter(|call| self.sequence_generator.observe_call(call.clone())).count()
     }
 
@@ -1383,6 +1382,12 @@ impl WorkerCorpus {
         }
 
         let mut added = 0;
+        // Test traces may nominate useful observed-call shapes, but they are not campaign
+        // executions. Keep their coverage accounting isolated so a later fuzzed execution can
+        // still discover and persist the same coverage.
+        let mut test_history_map = self.history_map.clone();
+        let mut test_edge_indices = self.edge_indices.clone();
+        let mut test_sancov_history_map = self.sancov_history_map.clone();
 
         for func in invariant_contract.abi.functions() {
             if !func.is_unit_test() {
@@ -1403,15 +1408,28 @@ impl WorkerCorpus {
 
             let exec = executor.clone();
 
-            let raw = match exec.call_raw(CALLER, invariant_contract.address, calldata, U256::ZERO)
-            {
-                Ok(raw) => raw,
-                Err(_) => continue,
-            };
+            let mut raw =
+                match exec.call_raw(CALLER, invariant_contract.address, calldata, U256::ZERO) {
+                    Ok(raw) => raw,
+                    Err(_) => continue,
+                };
             if raw.reverted {
                 continue;
             }
 
+            // Retain only shapes that add coverage to the test-seed snapshot. Do not merge that
+            // coverage into the campaign state: otherwise subsequent fuzzed calls are no longer
+            // novel and never enter the persisted corpus.
+            let (new_coverage, _) = raw.merge_all_coverage_with_edges_into(
+                &mut test_history_map,
+                &mut test_edge_indices,
+                &mut test_sancov_history_map,
+                SANCOV_EDGE_OFFSET,
+                &mut Vec::new(),
+            );
+            if !new_coverage {
+                continue;
+            }
             let observed = raw.observed_calls;
             if observed.is_empty() {
                 continue;

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -413,7 +413,6 @@ fn accept_synced_corpus_file(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CorpusInsertionMode {
     Live,
-    MemoryOnly,
     WorkerSync,
 }
 
@@ -1110,7 +1109,7 @@ impl WorkerCorpus {
         edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
     ) {
-        let _ = self.process_inputs_inner(
+        self.process_inputs_inner(
             inputs,
             cmp_seq,
             new_coverage,
@@ -1130,7 +1129,7 @@ impl WorkerCorpus {
         edges_covered: Vec<usize>,
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
     ) {
-        let _ = self.process_inputs_inner(
+        self.process_inputs_inner(
             inputs,
             cmp_seq,
             new_coverage,
@@ -1149,8 +1148,6 @@ impl WorkerCorpus {
         optimization: Option<(I256, Vec<BasicTxDetails>)>,
         insertion_mode: CorpusInsertionMode,
     ) {
-        let persist_now =
-            matches!(insertion_mode, CorpusInsertionMode::Live | CorpusInsertionMode::WorkerSync);
         // Check if this run improved the optimization value.
         let improved_optimization = optimization.as_ref().is_some_and(|(value, _)| {
             self.optimization_best_value.is_none_or(|best| *value > best)
@@ -1161,9 +1158,7 @@ impl WorkerCorpus {
         {
             self.optimization_best_value = Some(value);
             self.optimization_best_sequence = best_seq;
-            if persist_now {
-                self.persist_optimization_state();
-            }
+            self.persist_optimization_state();
         }
 
         if !self.config.is_coverage_guided() {
@@ -1208,9 +1203,7 @@ impl WorkerCorpus {
     }
 
     fn insert_corpus_entry(&mut self, corpus: CorpusEntry, insertion_mode: CorpusInsertionMode) {
-        if matches!(insertion_mode, CorpusInsertionMode::Live | CorpusInsertionMode::WorkerSync)
-            && let Some(worker_dir) = &self.worker_dir
-        {
+        if let Some(worker_dir) = &self.worker_dir {
             let worker_corpus = worker_dir.join(CORPUS_DIR);
             let disk_entry = CorpusDirEntry {
                 path: worker_corpus.join(corpus.file_name(self.config.corpus_gzip)),
@@ -1356,38 +1349,29 @@ impl WorkerCorpus {
     pub(crate) fn time_since_new_edge(&self) -> Option<Duration> {
         self.last_new_edge_at.map(|at| at.elapsed())
     }
-    /// Converts replayable observed sub-calls into one normal multi-transaction corpus entry.
-    ///
-    /// This captures calls shaped by a handler or another target call and lets the existing corpus
-    /// machinery mutate, evict, sync, and persist them like any other interesting sequence.
-    pub fn hoist_observed_calls(
+    /// Adds replayable observed calls to the generation dictionary without promoting them to the
+    /// coverage corpus.
+    pub(crate) fn observe_calls(
         &mut self,
         observed: &[ObservedCall],
-        parent_tx: &BasicTxDetails,
         targeted_contracts: &FuzzRunIdentifiedContracts,
-        insertion_mode: CorpusInsertionMode,
-    ) {
+        depth: ObservedCallDepth,
+    ) -> usize {
         if !self.config.is_coverage_guided() || observed.is_empty() {
-            return;
+            return 0;
         }
 
-        let tx_seq = {
+        let calls = {
             let targets = targeted_contracts.targets();
-            sequence_from_observed(
-                observed,
-                &targets,
-                ObservedCallDepth::All,
-                Some((parent_tx.warp, parent_tx.roll)),
-            )
+            sequence_from_observed(observed, &targets, depth, None)
         };
 
-        self.push_observed_sequence(tx_seq, insertion_mode)
+        calls.into_iter().filter(|call| self.sequence_generator.observe_call(call.clone())).count()
     }
 
-    /// Seeds the corpus from sibling zero-input unit tests by replaying them on a clone of the
-    /// post-setUp executor and keeping the direct replayable calls made by each test.
+    /// Seeds the observed-call dictionary from sibling zero-input unit tests.
     ///
-    /// Returns the number of test-derived corpus entries added.
+    /// Returns the number of test-derived calls added. These are not corpus entries.
     pub fn seed_from_test_traces<FEN: FoundryEvmNetwork>(
         &mut self,
         invariant_contract: &InvariantContract<'_>,
@@ -1433,39 +1417,15 @@ impl WorkerCorpus {
                 continue;
             }
 
-            let seq = {
-                let targets = targeted_contracts.targets();
-                sequence_from_observed(&observed, &targets, ObservedCallDepth::DirectOnly, None)
-            };
-
-            let insertion_mode = if self.id == 0 {
-                CorpusInsertionMode::Live
-            } else {
-                CorpusInsertionMode::MemoryOnly
-            };
-            let len_before = self.in_memory_corpus.len();
-            let _ = self.push_observed_sequence(seq, insertion_mode);
-            if self.in_memory_corpus.len() > len_before {
-                debug!(target: "corpus", test = %func.name, "seeded corpus sequence from test trace");
-                added += 1;
+            let count =
+                self.observe_calls(&observed, targeted_contracts, ObservedCallDepth::DirectOnly);
+            if count > 0 {
+                debug!(target: "corpus", test = %func.name, count, "seeded observed calls from test trace");
+                added += count;
             }
         }
 
         Ok(added)
-    }
-
-    fn push_observed_sequence(
-        &mut self,
-        tx_seq: Vec<BasicTxDetails>,
-        insertion_mode: CorpusInsertionMode,
-    ) {
-        if !self.config.is_coverage_guided() || tx_seq.is_empty() {
-            return;
-        }
-
-        let corpus = CorpusEntry::new(tx_seq);
-
-        self.insert_corpus_entry(corpus, insertion_mode)
     }
 
     /// Flush non-favored entries from memory when the corpus size exceeds the minimum.
@@ -1939,7 +1899,7 @@ impl WorkerCorpus {
 }
 
 #[derive(Clone, Copy)]
-enum ObservedCallDepth {
+pub(crate) enum ObservedCallDepth {
     DirectOnly,
     All,
 }
@@ -3059,10 +3019,9 @@ mod tests {
     }
 
     #[test]
-    fn hoist_observed_calls_bundles_replayable_subcalls_into_one_corpus_entry() {
+    fn observed_calls_seed_generation_without_entering_corpus() {
         let target = Address::from([0x42; 20]);
         let other = Address::from([0x43; 20]);
-        let sender = Address::from([0xaa; 20]);
         let observed_caller = Address::from([0xbb; 20]);
         let foo = Function::parse("foo(uint256)").unwrap();
         let bar = Function::parse("bar()").unwrap();
@@ -3118,48 +3077,34 @@ mod tests {
                 value: None,
             },
         ];
-        let parent_tx = BasicTxDetails {
-            warp: Some(U256::from(123)),
-            roll: Some(U256::from(456)),
-            sender,
-            call_details: CallDetails {
-                target: Address::from([0x99; 20]),
-                calldata: Bytes::new(),
-                value: None,
-            },
-        };
         let mut manager = empty_worker_corpus(0, temp_corpus_dir());
 
-        manager.hoist_observed_calls(
-            &observed,
-            &parent_tx,
-            &targeted_contracts,
-            CorpusInsertionMode::Live,
+        assert_eq!(
+            manager.observe_calls(&observed, &targeted_contracts, ObservedCallDepth::All),
+            2
         );
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(manager.metrics.corpus_count, 1);
+        assert!(manager.in_memory_corpus.is_empty());
+        assert_eq!(manager.metrics.corpus_count, 0);
+        assert_eq!(manager.sequence_generator.observed_call_count(), 2);
 
-        let entry = manager.in_memory_corpus.last().unwrap();
-        assert_eq!(entry.tx_seq.len(), 2);
-        let tx = &entry.tx_seq[0];
-        assert_eq!(tx.warp, parent_tx.warp);
-        assert_eq!(tx.roll, parent_tx.roll);
-        assert_eq!(tx.sender, observed_caller);
-        assert_eq!(tx.call_details.target, target);
-        assert_eq!(&tx.call_details.calldata[..4], &foo_selector[..]);
-        assert_eq!(tx.call_details.value, None);
-
-        let tx = &entry.tx_seq[1];
+        let mut runner = TestRunner::deterministic();
+        let tx = (0..100)
+            .map(|_| manager.new_sequence(&mut runner).unwrap().into_first())
+            .find(|tx| tx.sender == observed_caller)
+            .expect("observed call should be sampled");
         assert_eq!(tx.warp, None);
         assert_eq!(tx.roll, None);
         assert_eq!(tx.sender, observed_caller);
         assert_eq!(tx.call_details.target, target);
-        assert_eq!(&tx.call_details.calldata[..4], &bar_selector[..]);
-        assert_eq!(tx.call_details.value, None);
+        assert!(
+            [foo_selector, bar_selector]
+                .iter()
+                .any(|selector| tx.call_details.calldata[..4] == selector[..])
+        );
     }
 
     #[test]
-    fn hoist_observed_calls_persists_immediately() {
+    fn observed_calls_are_not_persisted() {
         let target = Address::from([0x42; 20]);
         let foo = Function::parse("foo()").unwrap();
         let selector = foo.selector();
@@ -3175,19 +3120,15 @@ mod tests {
         let worker_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        manager.hoist_observed_calls(
-            &observed,
-            &basic_tx(),
-            &targeted_contracts,
-            CorpusInsertionMode::Live,
-        );
+        manager.observe_calls(&observed, &targeted_contracts, ObservedCallDepth::All);
 
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker_corpus_dir).count(), 1);
+        assert!(manager.in_memory_corpus.is_empty());
+        assert_eq!(manager.sequence_generator.observed_call_count(), 1);
+        assert_eq!(read_corpus_dir(&worker_corpus_dir).count(), 0);
     }
 
     #[test]
-    fn hoist_observed_calls_skips_empty_or_non_coverage_guided_inputs() {
+    fn observed_calls_skip_empty_or_non_coverage_guided_inputs() {
         let target = Address::from([0x42; 20]);
         let foo = Function::parse("foo()").unwrap();
         let selector = foo.selector();
@@ -3207,22 +3148,14 @@ mod tests {
         let mut manager =
             WorkerCorpus::from_seed(0, no_corpus_config, generator, WorkerCorpusSeed::default())
                 .unwrap();
-        manager.hoist_observed_calls(
-            &observed,
-            &basic_tx(),
-            &targeted_contracts,
-            CorpusInsertionMode::Live,
-        );
+        manager.observe_calls(&observed, &targeted_contracts, ObservedCallDepth::All);
         assert!(manager.in_memory_corpus.is_empty());
+        assert_eq!(manager.sequence_generator.observed_call_count(), 0);
 
         let mut manager = empty_worker_corpus(0, temp_corpus_dir());
-        manager.hoist_observed_calls(
-            &[],
-            &basic_tx(),
-            &targeted_contracts,
-            CorpusInsertionMode::Live,
-        );
+        manager.observe_calls(&[], &targeted_contracts, ObservedCallDepth::All);
         assert!(manager.in_memory_corpus.is_empty());
+        assert_eq!(manager.sequence_generator.observed_call_count(), 0);
     }
 
     #[test]
@@ -3279,23 +3212,6 @@ mod tests {
         assert_eq!(seq[0].sender, sender);
         assert_eq!(seq[0].call_details.target, target);
         assert_eq!(&seq[0].call_details.calldata[..4], &foo_selector[..]);
-    }
-
-    #[test]
-    fn push_observed_sequence_persists_for_every_worker() {
-        let corpus_root = temp_corpus_dir();
-        let worker0_corpus_dir = corpus_root.join("worker0").join(CORPUS_DIR);
-        let mut manager = empty_worker_corpus(0, corpus_root.clone());
-
-        manager.push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::Live);
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker0_corpus_dir).count(), 1);
-
-        let mut manager = empty_worker_corpus(1, corpus_root.clone());
-        let worker1_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
-        manager.push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::Live);
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker1_corpus_dir).count(), 1);
     }
 
     #[test]
@@ -3379,24 +3295,6 @@ mod tests {
         assert!(manager.in_memory_corpus.iter().all(|c| c.uuid != non_favored_uuid));
         assert_eq!(manager.disk_corpus.cache.len(), 1);
         assert_eq!(manager.disk_corpus.cache[0].uuid, non_favored_uuid);
-    }
-
-    #[test]
-    fn invariant_insertions_do_not_disable_culling() {
-        let mut live = empty_worker_corpus(0, temp_corpus_dir());
-        let mut memory_only = empty_worker_corpus(1, temp_corpus_dir());
-
-        for idx in 0..32 {
-            let tx = basic_tx_with_calldata(vec![idx]);
-            live.process_inputs(std::slice::from_ref(&tx), &[], true, vec![1], None);
-            memory_only.push_observed_sequence(vec![tx], CorpusInsertionMode::MemoryOnly);
-        }
-
-        for manager in [&live, &memory_only] {
-            assert_eq!(manager.in_memory_corpus.len(), 1);
-            assert_eq!(manager.metrics.corpus_count, manager.in_memory_corpus.len());
-            assert!(manager.pending_sync_uuids.is_empty());
-        }
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -286,7 +286,6 @@ fn accept_synced_corpus_file(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CorpusInsertionMode {
     Live,
-    MemoryOnly,
 }
 
 struct ReplayOutcome {
@@ -1121,38 +1120,28 @@ impl WorkerCorpus {
     pub(crate) fn time_since_new_edge(&self) -> Option<Duration> {
         self.last_new_edge_at.map(|at| at.elapsed())
     }
-    /// Converts replayable observed sub-calls into one normal multi-transaction corpus entry.
-    ///
-    /// This captures calls shaped by a handler or another target call and lets the existing corpus
-    /// machinery mutate, evict, sync, and persist them like any other interesting sequence.
-    pub fn hoist_observed_calls(
+    /// Adds replayable observed calls to the generation dictionary without promoting them to the
+    /// coverage corpus.
+    pub(crate) fn observe_calls(
         &mut self,
         observed: &[ObservedCall],
-        parent_tx: &BasicTxDetails,
         targeted_contracts: &FuzzRunIdentifiedContracts,
-        insertion_mode: CorpusInsertionMode,
-    ) {
+        depth: ObservedCallDepth,
+    ) -> usize {
         if !self.config.is_coverage_guided() || observed.is_empty() {
-            return;
+            return 0;
         }
 
-        let tx_seq = {
+        let calls = {
             let targets = targeted_contracts.targets();
-            sequence_from_observed(
-                observed,
-                &targets,
-                ObservedCallDepth::All,
-                Some((parent_tx.warp, parent_tx.roll)),
-            )
+            sequence_from_observed(observed, &targets, depth, None)
         };
-
-        self.push_observed_sequence(tx_seq, insertion_mode)
+        calls.into_iter().filter(|call| self.sequence_generator.observe_call(call.clone())).count()
     }
 
-    /// Seeds the corpus from sibling zero-input unit tests by replaying them on a clone of the
-    /// post-setUp executor and keeping the direct replayable calls made by each test.
+    /// Seeds the observed-call dictionary from sibling zero-input unit tests.
     ///
-    /// Returns the number of test-derived corpus entries added.
+    /// Returns the number of test-derived calls added. These are not corpus entries.
     pub fn seed_from_test_traces<FEN: FoundryEvmNetwork>(
         &mut self,
         invariant_contract: &InvariantContract<'_>,
@@ -1164,6 +1153,12 @@ impl WorkerCorpus {
         }
 
         let mut added = 0;
+        // Test traces may nominate useful observed-call shapes, but they are not campaign
+        // executions. Keep their coverage accounting isolated so a later fuzzed execution can
+        // still discover and persist the same coverage.
+        let mut test_history_map = self.history_map.clone();
+        let mut test_edge_indices = self.edge_indices.clone();
+        let mut test_sancov_history_map = self.sancov_history_map.clone();
 
         for func in invariant_contract.abi.functions() {
             if !func.is_unit_test() {
@@ -1184,54 +1179,42 @@ impl WorkerCorpus {
 
             let exec = executor.clone();
 
-            let raw = match exec.call_raw(CALLER, invariant_contract.address, calldata, U256::ZERO)
-            {
-                Ok(raw) => raw,
-                Err(_) => continue,
-            };
+            let mut raw =
+                match exec.call_raw(CALLER, invariant_contract.address, calldata, U256::ZERO) {
+                    Ok(raw) => raw,
+                    Err(_) => continue,
+                };
             if raw.reverted {
                 continue;
             }
 
+            // Retain only shapes that add coverage to the test-seed snapshot. Do not merge that
+            // coverage into the campaign state: otherwise subsequent fuzzed calls are no longer
+            // novel and never enter the persisted corpus.
+            let (new_coverage, _) = raw.merge_all_coverage(
+                &mut test_history_map,
+                &mut test_edge_indices,
+                &mut test_sancov_history_map,
+            );
+            if !new_coverage {
+                continue;
+            }
             let observed = raw.observed_calls;
             if observed.is_empty() {
                 continue;
             }
 
-            let seq = {
-                let targets = targeted_contracts.targets();
-                sequence_from_observed(&observed, &targets, ObservedCallDepth::DirectOnly, None)
-            };
-
-            let insertion_mode = if self.id == 0 {
-                CorpusInsertionMode::Live
-            } else {
-                CorpusInsertionMode::MemoryOnly
-            };
-            let len_before = self.in_memory_corpus.len();
-            self.push_observed_sequence(seq, insertion_mode);
-            if self.in_memory_corpus.len() > len_before {
-                debug!(target: "corpus", test = %func.name, "seeded corpus sequence from test trace");
-                added += 1;
+            let count =
+                self.observe_calls(&observed, targeted_contracts, ObservedCallDepth::DirectOnly);
+            if count > 0 {
+                debug!(target: "corpus", test = %func.name, count, "seeded observed calls from test trace");
+                added += count;
             }
         }
 
         Ok(added)
     }
 
-    fn push_observed_sequence(
-        &mut self,
-        tx_seq: Vec<BasicTxDetails>,
-        insertion_mode: CorpusInsertionMode,
-    ) {
-        if !self.config.is_coverage_guided() || tx_seq.is_empty() {
-            return;
-        }
-
-        let corpus = CorpusEntry::new(tx_seq);
-
-        self.insert_corpus_entry(corpus, insertion_mode)
-    }
     /// Flush the oldest corpus mutated more than configured max mutations unless it is favored
     /// or pending synchronization.
     fn evict_oldest_corpus(&mut self) -> Result<()> {
@@ -1704,7 +1687,7 @@ impl WorkerCorpus {
 }
 
 #[derive(Clone, Copy)]
-enum ObservedCallDepth {
+pub(crate) enum ObservedCallDepth {
     DirectOnly,
     All,
 }
@@ -2753,10 +2736,9 @@ mod tests {
     }
 
     #[test]
-    fn hoist_observed_calls_bundles_replayable_subcalls_into_one_corpus_entry() {
+    fn observed_calls_seed_generation_without_entering_corpus() {
         let target = Address::from([0x42; 20]);
         let other = Address::from([0x43; 20]);
-        let sender = Address::from([0xaa; 20]);
         let observed_caller = Address::from([0xbb; 20]);
         let foo = Function::parse("foo(uint256)").unwrap();
         let bar = Function::parse("bar()").unwrap();
@@ -2812,49 +2794,34 @@ mod tests {
                 value: None,
             },
         ];
-        let parent_tx = BasicTxDetails {
-            warp: Some(U256::from(123)),
-            roll: Some(U256::from(456)),
-            sender,
-            call_details: CallDetails {
-                target: Address::from([0x99; 20]),
-                calldata: Bytes::new(),
-                value: None,
-            },
-        };
         let mut manager = empty_worker_corpus(0, temp_corpus_dir());
 
-        manager.hoist_observed_calls(
-            &observed,
-            &parent_tx,
-            &targeted_contracts,
-            CorpusInsertionMode::Live,
+        assert_eq!(
+            manager.observe_calls(&observed, &targeted_contracts, ObservedCallDepth::All),
+            2
         );
+        assert!(manager.in_memory_corpus.is_empty());
+        assert_eq!(manager.metrics.corpus_count, 0);
+        assert_eq!(manager.sequence_generator.observed_call_count(), 2);
 
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(manager.metrics.corpus_count, 1);
-
-        let entry = manager.in_memory_corpus.last().unwrap();
-        assert_eq!(entry.tx_seq.len(), 2);
-        let tx = &entry.tx_seq[0];
-        assert_eq!(tx.warp, parent_tx.warp);
-        assert_eq!(tx.roll, parent_tx.roll);
-        assert_eq!(tx.sender, observed_caller);
-        assert_eq!(tx.call_details.target, target);
-        assert_eq!(&tx.call_details.calldata[..4], &foo_selector[..]);
-        assert_eq!(tx.call_details.value, None);
-
-        let tx = &entry.tx_seq[1];
+        let mut runner = TestRunner::deterministic();
+        let tx = (0..100)
+            .map(|_| manager.new_sequence(&mut runner).unwrap().into_first())
+            .find(|tx| tx.sender == observed_caller)
+            .expect("observed call should be sampled");
         assert_eq!(tx.warp, None);
         assert_eq!(tx.roll, None);
         assert_eq!(tx.sender, observed_caller);
         assert_eq!(tx.call_details.target, target);
-        assert_eq!(&tx.call_details.calldata[..4], &bar_selector[..]);
-        assert_eq!(tx.call_details.value, None);
+        assert!(
+            [foo_selector, bar_selector]
+                .iter()
+                .any(|selector| tx.call_details.calldata[..4] == selector[..])
+        );
     }
 
     #[test]
-    fn hoist_observed_calls_persists_immediately() {
+    fn observed_calls_are_not_persisted() {
         let target = Address::from([0x42; 20]);
         let foo = Function::parse("foo()").unwrap();
         let selector = foo.selector();
@@ -2870,19 +2837,15 @@ mod tests {
         let worker_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
         let mut manager = empty_worker_corpus(1, corpus_root);
 
-        manager.hoist_observed_calls(
-            &observed,
-            &basic_tx(),
-            &targeted_contracts,
-            CorpusInsertionMode::Live,
-        );
+        manager.observe_calls(&observed, &targeted_contracts, ObservedCallDepth::All);
 
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker_corpus_dir).count(), 1);
+        assert!(manager.in_memory_corpus.is_empty());
+        assert_eq!(manager.sequence_generator.observed_call_count(), 1);
+        assert_eq!(read_corpus_dir(&worker_corpus_dir).count(), 0);
     }
 
     #[test]
-    fn hoist_observed_calls_skips_empty_or_non_coverage_guided_inputs() {
+    fn observed_calls_skip_empty_or_non_coverage_guided_inputs() {
         let target = Address::from([0x42; 20]);
         let foo = Function::parse("foo()").unwrap();
         let selector = foo.selector();
@@ -2902,22 +2865,14 @@ mod tests {
         let mut manager =
             WorkerCorpus::from_seed(0, no_corpus_config, generator, WorkerCorpusSeed::default())
                 .unwrap();
-        manager.hoist_observed_calls(
-            &observed,
-            &basic_tx(),
-            &targeted_contracts,
-            CorpusInsertionMode::Live,
-        );
+        manager.observe_calls(&observed, &targeted_contracts, ObservedCallDepth::All);
         assert!(manager.in_memory_corpus.is_empty());
+        assert_eq!(manager.sequence_generator.observed_call_count(), 0);
 
         let mut manager = empty_worker_corpus(0, temp_corpus_dir());
-        manager.hoist_observed_calls(
-            &[],
-            &basic_tx(),
-            &targeted_contracts,
-            CorpusInsertionMode::Live,
-        );
+        manager.observe_calls(&[], &targeted_contracts, ObservedCallDepth::All);
         assert!(manager.in_memory_corpus.is_empty());
+        assert_eq!(manager.sequence_generator.observed_call_count(), 0);
     }
 
     #[test]
@@ -2974,23 +2929,6 @@ mod tests {
         assert_eq!(seq[0].sender, sender);
         assert_eq!(seq[0].call_details.target, target);
         assert_eq!(&seq[0].call_details.calldata[..4], &foo_selector[..]);
-    }
-
-    #[test]
-    fn push_observed_sequence_live_persists_and_memory_only_does_not() {
-        let corpus_root = temp_corpus_dir();
-        let worker0_corpus_dir = corpus_root.join("worker0").join(CORPUS_DIR);
-        let mut manager = empty_worker_corpus(0, corpus_root.clone());
-
-        manager.push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::Live);
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker0_corpus_dir).count(), 1);
-
-        let mut manager = empty_worker_corpus(1, corpus_root.clone());
-        let worker1_corpus_dir = corpus_root.join("worker1").join(CORPUS_DIR);
-        manager.push_observed_sequence(vec![basic_tx()], CorpusInsertionMode::MemoryOnly);
-        assert_eq!(manager.in_memory_corpus.len(), 1);
-        assert_eq!(read_corpus_dir(&worker1_corpus_dir).count(), 0);
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     executors::{
         DURATION_BETWEEN_METRICS_REPORT, EarlyExit, EvmError, Executor, RawCallResult,
         corpus::{
-            CorpusInsertionMode, DynamicTargetCtx, ReplayTarget, WorkerCorpus, WorkerCorpusSeed,
+            DynamicTargetCtx, ObservedCallDepth, ReplayTarget, WorkerCorpus, WorkerCorpusSeed,
             finalize_corpus_after_campaign, persist_campaign_optimization,
             prepare_corpus_for_campaign,
         },
@@ -1131,7 +1131,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             let failures_revision = failures_checkpoint.revision();
             let mut stop_after_run = false;
             let mut run_cancelled = false;
-            let mut observed_call_entries = Vec::<(Vec<ObservedCall>, BasicTxDetails)>::new();
+            let mut observed_call_entries = Vec::<Vec<ObservedCall>>::new();
 
             let sequence_plan =
                 corpus_manager.new_sequence(&mut invariant_test.test_data.branch_runner)?;
@@ -1232,10 +1232,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 }
                 let observed_calls = std::mem::take(&mut call_result.observed_calls);
                 if new_call_coverage && !observed_calls.is_empty() {
-                    observed_call_entries.push((
-                        observed_calls,
-                        current_run.inputs.last().expect("checked above").clone(),
-                    ));
+                    observed_call_entries.push(observed_calls);
                 }
 
                 if discarded {
@@ -1491,12 +1488,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
             }
 
-            for (observed_calls, parent_tx) in observed_call_entries {
-                corpus_manager.hoist_observed_calls(
+            for observed_calls in observed_call_entries {
+                corpus_manager.observe_calls(
                     &observed_calls,
-                    &parent_tx,
                     &invariant_test.targeted_contracts,
-                    CorpusInsertionMode::Live,
+                    ObservedCallDepth::All,
                 );
             }
 

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -6,7 +6,7 @@ use crate::{
             FuzzCampaign, FuzzCampaignMode,
         },
         corpus::{
-            CorpusInsertionMode, DynamicTargetCtx, ReplayTarget, WorkerCorpus, WorkerCorpusSeed,
+            DynamicTargetCtx, ObservedCallDepth, ReplayTarget, WorkerCorpus, WorkerCorpusSeed,
             persist_campaign_optimization,
         },
         fuzz::{
@@ -1148,7 +1148,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             let failures_revision = failures_checkpoint.revision();
             let mut stop_after_run = false;
             let mut run_cancelled = false;
-            let mut observed_call_entries = Vec::<(Vec<ObservedCall>, BasicTxDetails)>::new();
+            let mut observed_call_entries = Vec::<Vec<ObservedCall>>::new();
 
             let call_campaign = FuzzCampaign::new(FuzzCampaignMode::Invariant {
                 check_interval: config.check_interval,
@@ -1238,7 +1238,7 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                             }
                             let observed_calls = std::mem::take(&mut call_result.observed_calls);
                             if new_call_coverage && !observed_calls.is_empty() {
-                                observed_call_entries.push((observed_calls, current_tx.clone()));
+                                observed_call_entries.push(observed_calls);
                             }
                         }
                         CampaignEvent::Check { result, kind, should_check } => {
@@ -1470,12 +1470,11 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
                 campaign_state.sync_handler_failures(&invariant_test.test_data.failures);
             }
 
-            for (observed_calls, parent_tx) in observed_call_entries {
-                corpus_manager.hoist_observed_calls(
+            for observed_calls in observed_call_entries {
+                corpus_manager.observe_calls(
                     &observed_calls,
-                    &parent_tx,
                     &invariant_test.targeted_contracts,
-                    CorpusInsertionMode::Live,
+                    ObservedCallDepth::All,
                 );
             }
 

--- a/crates/evm/fuzz/src/sequence.rs
+++ b/crates/evm/fuzz/src/sequence.rs
@@ -50,6 +50,7 @@ enum SequenceMode {
 #[derive(Clone)]
 pub struct SequenceGenerator {
     tx: TxGenerator,
+    observed_calls: Vec<BasicTxDetails>,
     state: FuzzState,
     fixtures: FuzzFixtures,
     mode: SequenceMode,
@@ -65,6 +66,7 @@ pub struct SequenceGenerator {
 pub struct SequencePlan {
     initial: InitialSequence,
     tx: TxGenerator,
+    observed_calls: Vec<BasicTxDetails>,
     fresh_weight: u32,
     has_corpus_dir: bool,
     stateless: bool,
@@ -112,11 +114,11 @@ impl SequencePlan {
             return Err(eyre!("stateless sequence is limited to one transaction"));
         }
         if !self.has_corpus_dir || discarded {
-            return self.tx.next_tx(runner);
+            return next_tx(&self.tx, &self.observed_calls, runner);
         }
         let fresh = self.fresh_weight > 0 && runner.rng().random_ratio(self.fresh_weight, 100);
         if depth >= self.initial.as_slice().len() || fresh {
-            self.tx.next_tx(runner)
+            next_tx(&self.tx, &self.observed_calls, runner)
         } else {
             Ok(self.initial.as_slice()[depth].clone())
         }
@@ -216,6 +218,7 @@ impl SequenceGenerator {
         };
         Ok(Self {
             tx,
+            observed_calls: Vec::new(),
             state,
             fixtures,
             mode,
@@ -226,6 +229,20 @@ impl SequenceGenerator {
             payable_weight: config.payable_value_weight,
             has_corpus_dir: config.corpus_dir.is_some(),
         })
+    }
+
+    /// Adds a replayable call shape to the generation dictionary.
+    pub fn observe_call(&mut self, call: BasicTxDetails) -> bool {
+        if self.observed_calls.iter().any(|existing| same_tx(existing, &call)) {
+            return false;
+        }
+        self.observed_calls.push(call);
+        true
+    }
+
+    /// Returns the number of call shapes in the generation dictionary.
+    pub const fn observed_call_count(&self) -> usize {
+        self.observed_calls.len()
     }
 
     pub fn start<'a, F>(
@@ -249,6 +266,7 @@ impl SequenceGenerator {
         Ok(SequencePlan {
             initial,
             tx: self.tx.clone(),
+            observed_calls: self.observed_calls.clone(),
             fresh_weight: self.fresh_weight,
             has_corpus_dir: self.has_corpus_dir,
             stateless: matches!(self.mode, SequenceMode::Stateless(_)),
@@ -268,7 +286,7 @@ impl SequenceGenerator {
             || corpus_len == 0
             || (self.fresh_weight > 0 && runner.rng().random_ratio(self.fresh_weight, 100))
         {
-            return Ok((InitialSequence::Single(self.tx.next_tx(runner)?), None));
+            return Ok((InitialSequence::Single(self.next_tx(runner)?), None));
         }
         let index = runner.rng().random_range(0..corpus_len);
         let entry = entry_at(index)?;
@@ -309,7 +327,7 @@ impl SequenceGenerator {
                 let _ =
                     SequenceMutator::cmp_mutate(&mut tx, function, hints, runner, &self.fixtures)?;
             }
-            None => return Ok((InitialSequence::Single(self.tx.next_tx(runner)?), None)),
+            None => return Ok((InitialSequence::Single(self.next_tx(runner)?), None)),
             _ => {}
         }
         Ok((InitialSequence::Single(tx), Some(index)))
@@ -324,7 +342,7 @@ impl SequenceGenerator {
         targets: &FuzzRunIdentifiedContracts,
     ) -> Result<(InitialSequence, Option<usize>)> {
         if !coverage || corpus_len == 0 {
-            return Ok((InitialSequence::Multiple(vec![self.tx.next_tx(runner)?]), None));
+            return Ok((InitialSequence::Multiple(vec![self.next_tx(runner)?]), None));
         }
         let kind = match self.mutations.sample(runner.rng()) {
             0 => MutationType::Splice,
@@ -367,7 +385,7 @@ impl SequenceGenerator {
                 };
                 let mut r = Vec::with_capacity(len);
                 for _ in 0..len {
-                    r.push(self.tx.next_tx(runner)?)
+                    r.push(self.next_tx(runner)?)
                 }
                 (
                     if matches!(kind, MutationType::Prefix) {
@@ -455,7 +473,7 @@ impl SequenceGenerator {
                 let base = if i == a { primary } else { secondary };
                 let mut seq = base.transactions.to_vec();
                 let index = runner.rng().random_range(0..=seq.len());
-                seq.insert(index, self.tx.next_tx(runner)?);
+                seq.insert(index, self.next_tx(runner)?);
                 (seq, i)
             }
             MutationType::Delete => {
@@ -484,10 +502,34 @@ impl SequenceGenerator {
             }
         };
         if seq.is_empty() {
-            seq.push(self.tx.next_tx(runner)?)
+            seq.push(self.next_tx(runner)?)
         }
         Ok((InitialSequence::Multiple(seq), Some(source)))
     }
+
+    fn next_tx(&self, runner: &mut TestRunner) -> Result<BasicTxDetails> {
+        next_tx(&self.tx, &self.observed_calls, runner)
+    }
+}
+
+fn same_tx(left: &BasicTxDetails, right: &BasicTxDetails) -> bool {
+    left.warp == right.warp
+        && left.roll == right.roll
+        && left.sender == right.sender
+        && left.call_details.target == right.call_details.target
+        && left.call_details.calldata == right.call_details.calldata
+        && left.call_details.value == right.call_details.value
+}
+
+fn next_tx(
+    generator: &TxGenerator,
+    observed_calls: &[BasicTxDetails],
+    runner: &mut TestRunner,
+) -> Result<BasicTxDetails> {
+    if !observed_calls.is_empty() && runner.rng().random_ratio(1, 2) {
+        return Ok(observed_calls[runner.rng().random_range(0..observed_calls.len())].clone());
+    }
+    generator.next_tx(runner)
 }
 
 /// An EVM comparison observed while executing an input.
@@ -858,6 +900,7 @@ mod tests {
         let plan = SequencePlan {
             initial: InitialSequence::Multiple(vec![tx(1), tx(2)]),
             tx: generator.tx,
+            observed_calls: Vec::new(),
             fresh_weight: generator.fresh_weight,
             has_corpus_dir: generator.has_corpus_dir,
             stateless: false,
@@ -880,6 +923,7 @@ mod tests {
             let plan = SequencePlan {
                 initial: InitialSequence::Multiple(vec![tx(1), tx(2)]),
                 tx: generator_tx(9),
+                observed_calls: Vec::new(),
                 fresh_weight,
                 has_corpus_dir: true,
                 stateless: false,

--- a/crates/evm/fuzz/src/sequence.rs
+++ b/crates/evm/fuzz/src/sequence.rs
@@ -50,6 +50,7 @@ enum SequenceMode {
 #[derive(Clone)]
 pub struct SequenceGenerator {
     tx: TxGenerator,
+    observed_calls: Vec<BasicTxDetails>,
     state: FuzzState,
     fixtures: FuzzFixtures,
     mode: SequenceMode,
@@ -65,6 +66,7 @@ pub struct SequenceGenerator {
 pub struct SequencePlan {
     initial: InitialSequence,
     tx: TxGenerator,
+    observed_calls: Vec<BasicTxDetails>,
     fresh_weight: u32,
     has_corpus_dir: bool,
     stateless: bool,
@@ -112,11 +114,11 @@ impl SequencePlan {
             return Err(eyre!("stateless sequence is limited to one transaction"));
         }
         if !self.has_corpus_dir || discarded {
-            return self.tx.next_tx(runner);
+            return next_tx(&self.tx, &self.observed_calls, runner);
         }
         let fresh = self.fresh_weight > 0 && runner.rng().random_ratio(self.fresh_weight, 100);
         if depth >= self.initial.as_slice().len() || fresh {
-            self.tx.next_tx(runner)
+            next_tx(&self.tx, &self.observed_calls, runner)
         } else {
             Ok(self.initial.as_slice()[depth].clone())
         }
@@ -206,6 +208,7 @@ impl SequenceGenerator {
         };
         Ok(Self {
             tx,
+            observed_calls: Vec::new(),
             state,
             fixtures,
             mode,
@@ -216,6 +219,20 @@ impl SequenceGenerator {
             payable_weight: config.payable_value_weight,
             has_corpus_dir: config.corpus_dir.is_some(),
         })
+    }
+
+    /// Adds a replayable call shape to the generation dictionary.
+    pub fn observe_call(&mut self, call: BasicTxDetails) -> bool {
+        if self.observed_calls.iter().any(|existing| same_tx(existing, &call)) {
+            return false;
+        }
+        self.observed_calls.push(call);
+        true
+    }
+
+    /// Returns the number of call shapes in the generation dictionary.
+    pub const fn observed_call_count(&self) -> usize {
+        self.observed_calls.len()
     }
 
     pub fn start<'a, F>(
@@ -239,6 +256,7 @@ impl SequenceGenerator {
         Ok(SequencePlan {
             initial,
             tx: self.tx.clone(),
+            observed_calls: self.observed_calls.clone(),
             fresh_weight: self.fresh_weight,
             has_corpus_dir: self.has_corpus_dir,
             stateless: matches!(self.mode, SequenceMode::Stateless(_)),
@@ -258,7 +276,7 @@ impl SequenceGenerator {
             || corpus_len == 0
             || (self.fresh_weight > 0 && runner.rng().random_ratio(self.fresh_weight, 100))
         {
-            return Ok((InitialSequence::Single(self.tx.next_tx(runner)?), None));
+            return Ok((InitialSequence::Single(self.next_tx(runner)?), None));
         }
         let index = runner.rng().random_range(0..corpus_len);
         let entry = entry_at(index)?;
@@ -299,7 +317,7 @@ impl SequenceGenerator {
                 let _ =
                     SequenceMutator::cmp_mutate(&mut tx, function, hints, runner, &self.fixtures)?;
             }
-            None => return Ok((InitialSequence::Single(self.tx.next_tx(runner)?), None)),
+            None => return Ok((InitialSequence::Single(self.next_tx(runner)?), None)),
             _ => {}
         }
         Ok((InitialSequence::Single(tx), Some(index)))
@@ -314,7 +332,7 @@ impl SequenceGenerator {
         targets: &FuzzRunIdentifiedContracts,
     ) -> Result<(InitialSequence, Option<usize>)> {
         if !coverage || corpus_len == 0 {
-            return Ok((InitialSequence::Multiple(vec![self.tx.next_tx(runner)?]), None));
+            return Ok((InitialSequence::Multiple(vec![self.next_tx(runner)?]), None));
         }
         let kind = match self.mutations.sample(runner.rng()) {
             0 => MutationType::Splice,
@@ -352,7 +370,7 @@ impl SequenceGenerator {
                 };
                 let mut r = Vec::with_capacity(len);
                 for _ in 0..len {
-                    r.push(self.tx.next_tx(runner)?)
+                    r.push(self.next_tx(runner)?)
                 }
                 (
                     if matches!(kind, MutationType::Prefix) {
@@ -420,10 +438,34 @@ impl SequenceGenerator {
             }
         };
         if seq.is_empty() {
-            seq.push(self.tx.next_tx(runner)?)
+            seq.push(self.next_tx(runner)?)
         }
         Ok((InitialSequence::Multiple(seq), Some(source)))
     }
+
+    fn next_tx(&self, runner: &mut TestRunner) -> Result<BasicTxDetails> {
+        next_tx(&self.tx, &self.observed_calls, runner)
+    }
+}
+
+fn same_tx(left: &BasicTxDetails, right: &BasicTxDetails) -> bool {
+    left.warp == right.warp
+        && left.roll == right.roll
+        && left.sender == right.sender
+        && left.call_details.target == right.call_details.target
+        && left.call_details.calldata == right.call_details.calldata
+        && left.call_details.value == right.call_details.value
+}
+
+fn next_tx(
+    generator: &TxGenerator,
+    observed_calls: &[BasicTxDetails],
+    runner: &mut TestRunner,
+) -> Result<BasicTxDetails> {
+    if !observed_calls.is_empty() && runner.rng().random_ratio(1, 2) {
+        return Ok(observed_calls[runner.rng().random_range(0..observed_calls.len())].clone());
+    }
+    generator.next_tx(runner)
 }
 
 /// An EVM comparison observed while executing an input.
@@ -830,6 +872,7 @@ mod tests {
         let plan = SequencePlan {
             initial: InitialSequence::Multiple(vec![tx(1), tx(2)]),
             tx: generator.tx,
+            observed_calls: Vec::new(),
             fresh_weight: generator.fresh_weight,
             has_corpus_dir: generator.has_corpus_dir,
             stateless: false,
@@ -852,6 +895,7 @@ mod tests {
             let plan = SequencePlan {
                 initial: InitialSequence::Multiple(vec![tx(1), tx(2)]),
                 tx: generator_tx(9),
+                observed_calls: Vec::new(),
                 fresh_weight,
                 has_corpus_dir: true,
                 stateless: false,


### PR DESCRIPTION
Keep observed calls in a generation dictionary instead of promoting them directly into the coverage corpus. Sibling-test seed coverage stays separate from campaign coverage so a later fuzz execution can earn normal corpus promotion. This refresh ports the existing proposal directly onto master and retains the persistence behavior from #16065.

The existing unbounded dictionary, per-plan cloning, fixed sampling rate, and dynamic-target lifetime handling remain review questions; this refresh does not redesign them. Derek comparison baseline: master `bfe6e9a17`.

Originally prompted by @0xalpharush. AI assistance was used to refresh the existing code, resolve conflicts, and update this description.
