### PR TITLE
test(verify): cover blockscout verifier with etherscan api key set on unknown chain

### DIFF
--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -460,6 +460,32 @@ Verifying on blockscout...
 Contract [src/Counter.sol:Counter] "0x19b248616E4964f43F611b5871CE1250f360E9d3" is already verified. Skipping verification.
 
 "#]]);
+
+    // Unknown Etherscan chain, explicit Blockscout verifier, and ETHERSCAN_API_KEY set.
+    // This should still use the explicit verifier URL instead of trying to resolve an
+    // Etherscan API URL for the chain.
+    let cmd = cmd.forge_fuse();
+    cmd.env("ETHERSCAN_API_KEY", "dummy");
+    cmd.args([
+        "verify-contract",
+        "--rpc-url",
+        "https://rpc.sepolia-api.lisk.com",
+        "--verifier",
+        "blockscout",
+        "--verifier-url",
+        "https://sepolia-blockscout.lisk.com/api",
+        "0x19b248616E4964f43F611b5871CE1250f360E9d3",
+        "src/Counter.sol:Counter",
+    ])
+    .assert_success()
+    .stdout_eq(str![""])
+    .stderr_eq(str![[r#"
+Start verifying contract `0x19b248616E4964f43F611b5871CE1250f360E9d3` deployed on 4202
+
+Verifying on blockscout...
+Contract [src/Counter.sol:Counter] "0x19b248616E4964f43F611b5871CE1250f360E9d3" is already verified. Skipping verification.
+
+"#]]);
 });
 
 // Tests that `forge script --broadcast --verify` fails before broadcasting when


### PR DESCRIPTION
## Motivation

Adds regression coverage for the `forge verify-contract` verifier routing case from #11430. The existing test covers an unknown Etherscan chain with Blockscout and `--verifier-url`; this adds the same path with `ETHERSCAN_API_KEY` set so the explicit Blockscout verifier continues to avoid Etherscan API URL resolution.

## Solution

Extend the existing `can_validate_verifier_settings` test with the exact combination:

- unknown Etherscan chain resolved from the Lisk Sepolia RPC
- `--verifier blockscout`
- explicit `--verifier-url`
- `ETHERSCAN_API_KEY` present in the command environment

The expected result remains the Blockscout already-verified flow, not `No known Etherscan API URL`.

## Validation

- `cargo test -p forge --test cli can_validate_verifier_settings`
- `cargo test -p forge --test cli verify::`

Note: `cargo test -p forge --test verify` is not a valid target in this repo; these verify tests live under the `cli` integration test target.