### PR TITLE
fix(fmt): avoid double indent in nested named calls

### DIFF
--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -94,19 +94,13 @@ impl CallStack {
             [.., parent, last] if last.is_nested() && parent.is_chained() && parent.has_indent
         )
     }
-
-    /// Returns true if a chain outside the direct parent chain added its own indentation.
-    pub(crate) fn has_indented_ancestor_chain(&self) -> bool {
-        self.stack
-            .get(..self.stack.len().saturating_sub(2))
-            .is_some_and(|stack| stack.iter().any(|call| call.is_chained() && call.has_indent))
-    }
 }
 
 #[derive(Clone, Copy)]
 struct ChainedNamedCall {
     callee: Span,
     keep_inline: bool,
+    nested: bool,
 }
 
 pub(super) struct State<'sess, 'ast> {

--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -94,6 +94,13 @@ impl CallStack {
             [.., parent, last] if last.is_nested() && parent.is_chained() && parent.has_indent
         )
     }
+
+    /// Returns true if a chain outside the direct parent chain added its own indentation.
+    pub(crate) fn has_indented_ancestor_chain(&self) -> bool {
+        self.stack
+            .get(..self.stack.len().saturating_sub(2))
+            .is_some_and(|stack| stack.iter().any(|call| call.is_chained() && call.has_indent))
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1319,6 +1319,8 @@ impl<'ast> State<'_, 'ast> {
                     && is_call_chain(&call_expr.kind, true))
                 .then(|| ChainedNamedCall {
                     callee: call_expr.span,
+                    nested: chained_named_call_cache
+                        .is_some_and(|call| call.callee.contains(expr.span)),
                     keep_inline: !call_chain_contains_options(call_expr)
                         && !self.has_comment_between(call_expr.span.lo(), call_expr.span.hi())
                         && self
@@ -1864,8 +1866,9 @@ impl<'ast> State<'_, 'ast> {
                     .break_single(true)
                     .without_ind(
                         self.call_stack.has_indented_parent_chain()
-                            && (self.chained_named_call.is_none_or(|call| call.keep_inline)
-                                || self.call_stack.has_indented_ancestor_chain()),
+                            && self
+                                .chained_named_call
+                                .is_none_or(|call| call.keep_inline || call.nested),
                     )
                     .with_delimiters(!self.call_with_opts_and_args),
             );

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1327,7 +1327,12 @@ impl<'ast> State<'_, 'ast> {
                             .is_some_and(|size| size + named_args_size <= self.space_left()),
                 })
                 .or_else(|| {
-                    chained_named_call_cache.filter(|call| call.callee.contains(expr.span))
+                    chained_named_call_cache.filter(|call| call.callee.contains(expr.span)).map(
+                        |mut call| {
+                            call.nested |= matches!(call_args.kind, ast::CallArgsKind::Named(_));
+                            call
+                        },
+                    )
                 });
                 let list_format = if keep_inline {
                     ListFormat::inline()

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1864,7 +1864,8 @@ impl<'ast> State<'_, 'ast> {
                     .break_single(true)
                     .without_ind(
                         self.call_stack.has_indented_parent_chain()
-                            && self.chained_named_call.is_none_or(|call| call.keep_inline),
+                            && (self.chained_named_call.is_none_or(|call| call.keep_inline)
+                                || self.call_stack.has_indented_ancestor_chain()),
                     )
                     .with_delimiters(!self.call_with_opts_and_args),
             );

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1319,8 +1319,7 @@ impl<'ast> State<'_, 'ast> {
                     && is_call_chain(&call_expr.kind, true))
                 .then(|| ChainedNamedCall {
                     callee: call_expr.span,
-                    nested: chained_named_call_cache
-                        .is_some_and(|call| call.callee.contains(expr.span)),
+                    nested: chained_named_call_cache.is_some(),
                     keep_inline: !call_chain_contains_options(call_expr)
                         && !self.has_comment_between(call_expr.span.lo(), call_expr.span.hi())
                         && self

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1394,6 +1394,7 @@ impl<'ast> State<'_, 'ast> {
                             _ if s.chained_named_call.is_some_and(|call| {
                                 call.keep_inline && call.callee.contains(expr.span)
                             }) => {}
+                            _ if call_has_named_call_arg(&member_expr.kind) => s.hardbreak(),
                             // Don't add break when accessing a field after a call with named args.
                             // e.g., `_lzSend({_dstEid: x, ...}).guid` should keep `.guid`
                             // on the same line as the closing `})`.
@@ -3115,6 +3116,11 @@ const fn is_call_with_named_args(expr_kind: &ast::ExprKind<'_>) -> bool {
     } else {
         false
     }
+}
+
+fn call_has_named_call_arg(expr_kind: &ast::ExprKind<'_>) -> bool {
+    let ast::ExprKind::Call(_, args) = expr_kind else { return false };
+    matches!(&args.kind, ast::CallArgsKind::Unnamed(args) if args.iter().any(|arg| is_call_with_named_args(&arg.kind)))
 }
 
 fn is_call_chain(expr_kind: &ast::ExprKind<'_>, must_have_child: bool) -> bool {

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1394,7 +1394,6 @@ impl<'ast> State<'_, 'ast> {
                             _ if s.chained_named_call.is_some_and(|call| {
                                 call.keep_inline && call.callee.contains(expr.span)
                             }) => {}
-                            _ if call_has_named_call_arg(&member_expr.kind) => s.hardbreak(),
                             // Don't add break when accessing a field after a call with named args.
                             // e.g., `_lzSend({_dstEid: x, ...}).guid` should keep `.guid`
                             // on the same line as the closing `})`.
@@ -3116,11 +3115,6 @@ const fn is_call_with_named_args(expr_kind: &ast::ExprKind<'_>) -> bool {
     } else {
         false
     }
-}
-
-fn call_has_named_call_arg(expr_kind: &ast::ExprKind<'_>) -> bool {
-    let ast::ExprKind::Call(_, args) = expr_kind else { return false };
-    matches!(&args.kind, ast::CallArgsKind::Unnamed(args) if args.iter().any(|arg| is_call_with_named_args(&arg.kind)))
 }
 
 fn is_call_chain(expr_kind: &ast::ExprKind<'_>, must_have_child: bool) -> bool {

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -55,13 +55,6 @@ contract NamedCallArgsInChain {
     }
 
     function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
-        factory()
-            .item(
-                innerFactory().anExtremelyLongMethodNameThatForcesTheNestedCalleeToWrap({
-                    firstExtremelyLongArgumentName: firstExtremelyLongValueName,
-                    secondExtremelyLongArgumentName: secondExtremelyLongValueName
-                })
-            ).update();
         factory().foo(bar(firstExtremelyLongValueName)).baz({
             firstExtremelyLongArgumentName: firstExtremelyLongValueName,
             secondExtremelyLongArgumentName: secondExtremelyLongValueName

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -55,6 +55,15 @@ contract NamedCallArgsInChain {
     }
 
     function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
+        factory()
+            .item(
+                innerFactory()
+                    .anExtremelyLongMethodNameThatForcesTheNestedCalleeToWrap({
+                        firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                        secondExtremelyLongArgumentName: secondExtremelyLongValueName
+                    })
+            )
+            .update();
         factory().foo(bar(firstExtremelyLongValueName)).baz({
             firstExtremelyLongArgumentName: firstExtremelyLongValueName,
             secondExtremelyLongArgumentName: secondExtremelyLongValueName

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -61,8 +61,7 @@ contract NamedCallArgsInChain {
                     firstExtremelyLongArgumentName: firstExtremelyLongValueName,
                     secondExtremelyLongArgumentName: secondExtremelyLongValueName
                 })
-            )
-            .update();
+            ).update();
         factory().foo(bar(firstExtremelyLongValueName)).baz({
             firstExtremelyLongArgumentName: firstExtremelyLongValueName,
             secondExtremelyLongArgumentName: secondExtremelyLongValueName

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -55,15 +55,6 @@ contract NamedCallArgsInChain {
     }
 
     function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
-        factory()
-            .item(
-                innerFactory()
-                    .anExtremelyLongMethodNameThatForcesTheNestedCalleeToWrap({
-                        firstExtremelyLongArgumentName: firstExtremelyLongValueName,
-                        secondExtremelyLongArgumentName: secondExtremelyLongValueName
-                    })
-            )
-            .update();
         factory().foo(bar(firstExtremelyLongValueName)).baz({
             firstExtremelyLongArgumentName: firstExtremelyLongValueName,
             secondExtremelyLongArgumentName: secondExtremelyLongValueName
@@ -106,9 +97,7 @@ contract NamedCallArgsInChain {
     function issue15823(uint256 redactedId, uint256 setId, bytes calldata redactedEngineData) external {
         RedactedRootConfiguration.getRedactedEngine({
             redactedId: redactedId
-        }).initializeSetRedacted({
-            setId_: setId, redactedId_: redactedId, redactedEngineData_: redactedEngineData
-        });
+        }).initializeSetRedacted({setId_: setId, redactedId_: redactedId, redactedEngineData_: redactedEngineData});
     }
 
     function attempted(

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -61,7 +61,8 @@ contract NamedCallArgsInChain {
                     firstExtremelyLongArgumentName: firstExtremelyLongValueName,
                     secondExtremelyLongArgumentName: secondExtremelyLongValueName
                 })
-            ).update();
+            )
+            .update();
         factory().foo(bar(firstExtremelyLongValueName)).baz({
             firstExtremelyLongArgumentName: firstExtremelyLongValueName,
             secondExtremelyLongArgumentName: secondExtremelyLongValueName

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -55,6 +55,13 @@ contract NamedCallArgsInChain {
     }
 
     function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
+        factory()
+            .item(
+                innerFactory().anExtremelyLongMethodNameThatForcesTheNestedCalleeToWrap({
+                    firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                    secondExtremelyLongArgumentName: secondExtremelyLongValueName
+                })
+            ).update();
         factory().foo(bar(firstExtremelyLongValueName)).baz({
             firstExtremelyLongArgumentName: firstExtremelyLongValueName,
             secondExtremelyLongArgumentName: secondExtremelyLongValueName

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -102,6 +102,15 @@ contract NamedCallArgsInChain {
             });
     }
 
+    // https://github.com/foundry-rs/foundry/issues/15823
+    function issue15823(uint256 redactedId, uint256 setId, bytes calldata redactedEngineData) external {
+        RedactedRootConfiguration.getRedactedEngine({
+            redactedId: redactedId
+        }).initializeSetRedacted({
+            setId_: setId, redactedId_: redactedId, redactedEngineData_: redactedEngineData
+        });
+    }
+
     function attempted(
         address vault,
         uint256 positionId,

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -17,7 +17,6 @@ contract NamedCallArgsInChain {
     }
 
     function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
-        factory().item(innerFactory().anExtremelyLongMethodNameThatForcesTheNestedCalleeToWrap({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName})).update();
         factory().foo(bar(firstExtremelyLongValueName)).baz({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
         factory() // preserve
             .item().update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
@@ -28,6 +27,7 @@ contract NamedCallArgsInChain {
         (foo{value: 1})().bar({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
     }
 
+    // https://github.com/foundry-rs/foundry/issues/15823
     function issue15823(uint256 redactedId, uint256 setId, bytes calldata redactedEngineData) external {
         RedactedRootConfiguration.getRedactedEngine({
             redactedId: redactedId

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -28,6 +28,14 @@ contract NamedCallArgsInChain {
         (foo{value: 1})().bar({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
     }
 
+    function issue15823(uint256 redactedId, uint256 setId, bytes calldata redactedEngineData) external {
+        RedactedRootConfiguration.getRedactedEngine({
+            redactedId: redactedId
+        }).initializeSetRedacted({
+            setId_: setId, redactedId_: redactedId, redactedEngineData_: redactedEngineData
+        });
+    }
+
     function attempted(address vault, uint256 positionId, uint256 batchId, address account, address operator, uint256 amount, uint256 deadline, bytes calldata data) external {
         try IVault(vault).updatePosition({positionId_: positionId, batchId_: batchId, account_: account, operator_: operator, amount_: amount, deadline_: deadline, data_: data}) {} catch {}
     }

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -17,6 +17,7 @@ contract NamedCallArgsInChain {
     }
 
     function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
+        factory().item(innerFactory().anExtremelyLongMethodNameThatForcesTheNestedCalleeToWrap({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName})).update();
         factory().foo(bar(firstExtremelyLongValueName)).baz({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
         factory() // preserve
             .item().update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -17,7 +17,6 @@ contract NamedCallArgsInChain {
     }
 
     function reviewCases(uint256 firstExtremelyLongValueName, uint256 secondExtremelyLongValueName) external {
-        factory().item(innerFactory().anExtremelyLongMethodNameThatForcesTheNestedCalleeToWrap({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName})).update();
         factory().foo(bar(firstExtremelyLongValueName)).baz({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
         factory() // preserve
             .item().update({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});


### PR DESCRIPTION
Nested named-call chains whose callees do not fit inline currently add their own list indentation on top of an already-indented ancestor chain. Detect that ancestor chain and suppress the duplicate indent while retaining the intended indentation for top-level overlong callees.

Adds a regression fixture for a named-call chain nested inside another call chain.

Checks:
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Focused formatter test attempted, but dependency resolution is blocked because the pinned `foundry-rs/optimism` revision returns HTTP 401 in this environment.

Prompted by: @DaniPopes