### PR TITLE
fix(anvil): enforce `eth_simulateV1` request limits

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -56,7 +56,7 @@ use alloy_rpc_types::{
     erc4337::TransactionConditional,
     pubsub::TransactionReceiptsParams,
     request::TransactionRequest,
-    simulate::{SimulatePayload, SimulatedBlock},
+    simulate::{MAX_SIMULATE_BLOCKS, SimulatePayload, SimulatedBlock},
     state::{AccountOverride, EvmOverrides, StateOverride, StateOverridesBuilder},
     trace::{
         filter::TraceFilter,
@@ -81,7 +81,10 @@ use anvil_core::{
     },
     types::{ReorgOptions, TransactionData},
 };
-use anvil_rpc::{error::RpcError, response::ResponseResult};
+use anvil_rpc::{
+    error::{ErrorCode, RpcError},
+    response::ResponseResult,
+};
 use foundry_common::{
     provider::ProviderBuilder,
     tempo::{PaymentLaneClassification, PaymentLaneReason, classify_payment_lane},
@@ -2922,7 +2925,27 @@ impl EthApi<FoundryNetwork> {
         block_number: Option<BlockId>,
     ) -> Result<Vec<SimulatedBlock<AnyRpcBlock>>> {
         node_info!("eth_simulateV1");
-        let block_request = self.block_request(block_number).await?;
+        if request.block_state_calls.is_empty() {
+            return Err(BlockchainError::RpcError(RpcError::invalid_params("empty input")));
+        }
+        if request.block_state_calls.len() > MAX_SIMULATE_BLOCKS as usize {
+            return Err(BlockchainError::RpcError(RpcError {
+                code: ErrorCode::ServerError(-38026),
+                message: "too many blocks".into(),
+                data: None,
+            }));
+        }
+        let block_request =
+            self.block_request(block_number).await.map_err(|error| match error {
+                BlockchainError::BlockOutOfRange(_, _) | BlockchainError::BlockNotFound => {
+                    BlockchainError::RpcError(RpcError {
+                        code: ErrorCode::ServerError(-32000),
+                        message: "header not found".into(),
+                        data: None,
+                    })
+                }
+                error => error,
+            })?;
         // check if the number predates the fork, if in fork mode
         if let BlockRequest::Number(number) = block_request
             && let Some(fork) = self.get_fork()

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -143,6 +143,9 @@ type OpCallDepositInfo = DepositTransactionParts;
 #[derive(Default, Clone, Debug)]
 struct OpCallDepositInfo;
 
+/// Maximum cumulative gas available to one `eth_simulateV1` request.
+const SIMULATE_GAS_CAP: u64 = 50_000_000;
+
 /// Marker trait that abstracts over the per-network inspector trait bounds
 /// required by the in-memory backend. The OP bound is only included when the
 /// `optimism` feature is enabled.
@@ -5069,6 +5072,7 @@ impl Backend<FoundryNetwork> {
                 let cfg_env = &self.evm_env.read().cfg_env;
                 (cfg_env.spec >= SpecId::AMSTERDAM, cfg_env.tx_gas_limit_cap())
             };
+            let mut rpc_gas_budget = SIMULATE_GAS_CAP;
 
             // execute the blocks
             for block in block_state_calls {
@@ -5121,7 +5125,7 @@ impl Backend<FoundryNetwork> {
                             data: None,
                         }));
                     }
-                    request.gas = Some(requested_gas);
+                    request.gas = Some(requested_gas.min(rpc_gas_budget));
 
                     let caller = request.from.unwrap_or_default();
                     let caller_nonce = RevmDatabase::basic(&mut cache_db, caller)?
@@ -5199,6 +5203,7 @@ impl Backend<FoundryNetwork> {
 
                     // commit the transaction
                     cache_db.commit(state);
+                    rpc_gas_budget = rpc_gas_budget.saturating_sub(result.tx_gas_used());
                     cumulative_gas_used =
                         cumulative_gas_used.saturating_add(result.tx_gas_used());
                     block_regular_gas_used = block_regular_gas_used

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -401,6 +401,83 @@ async fn test_simulate_maps_validation_errors() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_enforces_request_block_limits_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+
+    let response =
+        rpc_request(&endpoint, "eth_simulateV1", json!([{"blockStateCalls": []}, "latest"])).await;
+    assert_eq!(response["error"], json!({"code": -32602, "message": "empty input"}));
+
+    let blocks = vec![json!({}); 256];
+    let response =
+        rpc_request(&endpoint, "eth_simulateV1", json!([{"blockStateCalls": blocks}, "latest"]))
+            .await;
+    assert_eq!(response["result"].as_array().unwrap().len(), 256);
+
+    let blocks = vec![json!({}); 257];
+    let response =
+        rpc_request(&endpoint, "eth_simulateV1", json!([{"blockStateCalls": blocks}, "latest"]))
+            .await;
+    assert_eq!(response["error"], json!({"code": -38026, "message": "too many blocks"}));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_future_base_block_returns_header_not_found_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{"blockStateCalls": [{}]}, "0x1"]),
+    )
+    .await;
+
+    assert_eq!(response["error"], json!({"code": -32000, "message": "header not found"}));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_enforces_request_gas_budget_rpc() {
+    let config = NodeConfig::test().with_base_fee(Some(0)).with_gas_limit(Some(75_398_208));
+    let (_api, handle) = spawn(config).await;
+    let sender = "0xc000000000000000000000000000000000000000";
+    let receiver = "0xc100000000000000000000000000000000000000";
+    let reverter = "0xc200000000000000000000000000000000000000";
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {
+                    "stateOverrides": {
+                        (sender): {"balance": "0x1"},
+                        (reverter): {"code": "0x5f5ffd"}
+                    },
+                    "calls": [{"from": sender, "to": reverter}]
+                },
+                {"calls": [{"from": sender, "to": receiver}]}
+            ],
+            "validation": true,
+            "returnFullTransactions": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    let blocks = response["result"].as_array().unwrap();
+    assert_eq!(blocks[0]["calls"][0]["status"], "0x0");
+    assert_eq!(blocks[0]["transactions"][0]["gas"], "0x2faf080");
+    let failed_call_gas = u64::from_str_radix(
+        blocks[0]["calls"][0]["gasUsed"].as_str().unwrap().trim_start_matches("0x"),
+        16,
+    )
+    .unwrap();
+    assert_eq!(
+        blocks[1]["transactions"][0]["gas"],
+        format!("0x{:x}", 50_000_000 - failed_call_gas)
+    );
+}
+
 async fn rpc_request(endpoint: &str, method: &str, params: Value) -> Value {
     let response = reqwest::Client::new()
         .post(endpoint)


### PR DESCRIPTION
## Motivation

Close OSS-566.

This is the next focused `eth_simulateV1` conformance step after #15770, #15784, and #15792, continuing the split of the broader work from #15716. It rejects empty requests, enforces the 256-block limit with `-38026`, and returns `-32000 header not found` for unavailable base blocks.

The simulation now also applies a 50M request-wide gas budget across blocks. Each call is capped by the remaining budget, which is reduced by the gas consumed by every execution, including reverted calls. Block sequencing and derived block context remain scoped to the follow-up work.