### PR TITLE
fix(fmt): preserve nested call indentation

### DIFF
--- a/crates/fmt/src/state/mod.rs
+++ b/crates/fmt/src/state/mod.rs
@@ -100,7 +100,6 @@ impl CallStack {
 struct ChainedNamedCall {
     callee: Span,
     keep_inline: bool,
-    nested: bool,
 }
 
 pub(super) struct State<'sess, 'ast> {
@@ -971,6 +970,13 @@ impl<'sess> State<'sess, '_> {
 
     fn has_comment_between(&self, start_pos: BytePos, end_pos: BytePos) -> bool {
         self.comments.iter().filter(|c| c.pos() > start_pos && c.pos() < end_pos).any(|_| true)
+    }
+
+    fn has_breakable_comment_between(&self, start_pos: BytePos, end_pos: BytePos) -> bool {
+        self.comments
+            .iter()
+            .filter(|comment| comment.pos() >= start_pos && comment.pos() < end_pos)
+            .any(|comment| !comment.style.is_blank())
     }
 
     pub(crate) fn next_comment(&mut self) -> Option<Comment> {

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1319,7 +1319,6 @@ impl<'ast> State<'_, 'ast> {
                     && is_call_chain(&call_expr.kind, true))
                 .then(|| ChainedNamedCall {
                     callee: call_expr.span,
-                    nested: chained_named_call_cache.is_some(),
                     keep_inline: !call_chain_contains_options(call_expr)
                         && !self.has_comment_between(call_expr.span.lo(), call_expr.span.hi())
                         && self
@@ -1327,18 +1326,25 @@ impl<'ast> State<'_, 'ast> {
                             .is_some_and(|size| size + named_args_size <= self.space_left()),
                 })
                 .or_else(|| {
-                    chained_named_call_cache.filter(|call| call.callee.contains(expr.span)).map(
-                        |mut call| {
-                            call.nested |= matches!(call_args.kind, ast::CallArgsKind::Named(_));
-                            call
-                        },
-                    )
+                    chained_named_call_cache.filter(|call| call.callee.contains(expr.span))
                 });
                 let list_format = if keep_inline {
                     ListFormat::inline()
                 } else {
                     ListFormat::compact().break_cmnts().break_single(true)
                 };
+                let terminal_callee = call_expr.peel_parens();
+                let callee_has_breakable_comment = self
+                    .has_breakable_comment_between(call_expr.span.lo(), terminal_callee.span.lo())
+                    || self.has_breakable_comment_between(
+                        terminal_callee.span.hi(),
+                        call_expr.span.hi(),
+                    )
+                    || if let ast::ExprKind::Member(member_expr, ident) = &terminal_callee.kind {
+                        self.has_breakable_comment_between(member_expr.span.hi(), ident.span.lo())
+                    } else {
+                        false
+                    };
                 self.print_member_or_call_chain(
                     call_expr,
                     MemberOrCallArgs::CallArgs(
@@ -1346,12 +1352,21 @@ impl<'ast> State<'_, 'ast> {
                         self.has_comments_between_elements(call_args.span, call_args.exprs()),
                     ),
                     |s| {
+                        let callee_suffix_can_break = callee_has_breakable_comment
+                            || match &terminal_callee.kind {
+                                ast::ExprKind::Member(member_expr, _) => {
+                                    s.member_suffix_emits_break(terminal_callee, member_expr)
+                                }
+                                ast::ExprKind::Index(..) => !s.skip_index_break,
+                                _ => false,
+                            };
                         s.print_call_args(
                             call_args,
                             list_format
                                 .without_ind(s.return_bin_expr)
                                 .with_delimiters(!s.call_with_opts_and_args),
                             get_callee_head_size(call_expr),
+                            callee_suffix_can_break,
                         );
                     },
                 );
@@ -1364,7 +1379,7 @@ impl<'ast> State<'_, 'ast> {
                 self.call_with_opts_and_args = false;
 
                 self.print_expr(expr);
-                self.print_named_args(named_args, span.hi());
+                self.print_named_args(named_args, span.hi(), false);
 
                 // restore cached value
                 self.call_with_opts_and_args = cache;
@@ -1387,19 +1402,19 @@ impl<'ast> State<'_, 'ast> {
                     member_expr,
                     MemberOrCallArgs::Member(self.estimate_size(ident.span)),
                     |s| {
-                        s.print_trailing_comment(member_expr.span.hi(), Some(ident.span.lo()));
-                        match member_expr.kind {
-                            ast::ExprKind::Ident(_) | ast::ExprKind::Type(_) => (),
-                            ast::ExprKind::Index(..) if s.skip_index_break => (),
-                            _ if s.chained_named_call.is_some_and(|call| {
-                                call.keep_inline && call.callee.contains(expr.span)
-                            }) => {}
-                            // Don't add break when accessing a field after a call with named args.
-                            // e.g., `_lzSend({_dstEid: x, ...}).guid` should keep `.guid`
-                            // on the same line as the closing `})`.
-                            // See: https://github.com/foundry-rs/foundry/issues/12399
-                            _ if is_call_with_named_args(&member_expr.kind) => (),
-                            _ => s.zerobreak(),
+                        let has_mixed_comment = s
+                            .peek_comment_between(member_expr.span.hi(), ident.span.lo())
+                            .is_some_and(|comment| comment.style.is_mixed());
+                        if has_mixed_comment {
+                            s.print_comments(
+                                ident.span.lo(),
+                                CommentConfig::skip_ws().mixed_no_break().mixed_prev_space(),
+                            );
+                        } else {
+                            s.print_trailing_comment(member_expr.span.hi(), Some(ident.span.lo()));
+                        }
+                        if has_mixed_comment || s.member_suffix_emits_break(expr, member_expr) {
+                            s.zerobreak();
                         }
                         s.word(".");
                         s.print_ident(ident);
@@ -1412,7 +1427,7 @@ impl<'ast> State<'_, 'ast> {
             }
             ast::ExprKind::Payable(args) => {
                 self.word("payable");
-                self.print_call_args(args, ListFormat::compact().break_cmnts(), 7);
+                self.print_call_args(args, ListFormat::compact().break_cmnts(), 7, false);
             }
             ast::ExprKind::Ternary(cond, then, els) => self.print_ternary_expr(cond, then, els),
             ast::ExprKind::Tuple(exprs) => self.print_tuple(
@@ -1706,7 +1721,27 @@ impl<'ast> State<'_, 'ast> {
                 arguments,
                 ListFormat::compact().break_cmnts(),
                 name.to_string().len(),
+                false,
             );
+        }
+    }
+
+    fn member_suffix_emits_break(&self, expr: &ast::Expr<'_>, member_expr: &ast::Expr<'_>) -> bool {
+        match member_expr.kind {
+            ast::ExprKind::Ident(_) | ast::ExprKind::Type(_) => false,
+            ast::ExprKind::Index(..) if self.skip_index_break => false,
+            _ if self
+                .chained_named_call
+                .is_some_and(|call| call.keep_inline && call.callee.contains(expr.span)) =>
+            {
+                false
+            }
+            // Don't add a break when accessing a field after a call with named args.
+            // e.g., `_lzSend({_dstEid: x, ...}).guid` should keep `.guid`
+            // on the same line as the closing `})`.
+            // See: https://github.com/foundry-rs/foundry/issues/12399
+            _ if is_call_with_named_args(&member_expr.kind) => false,
+            _ => true,
         }
     }
 
@@ -1799,6 +1834,7 @@ impl<'ast> State<'_, 'ast> {
         args: &'ast ast::CallArgs<'ast>,
         format: ListFormat,
         callee_size: usize,
+        callee_suffix_can_break: bool,
     ) {
         let ast::CallArgs { span, ref kind } = *args;
         if self.handle_span(span, true) {
@@ -1822,7 +1858,11 @@ impl<'ast> State<'_, 'ast> {
                 );
             }
             ast::CallArgsKind::Named(named_args) => {
-                self.print_inside_parens(|state| state.print_named_args(named_args, span.hi()));
+                let without_ind =
+                    self.call_stack.has_indented_parent_chain() && !callee_suffix_can_break;
+                self.print_inside_parens(|state| {
+                    state.print_named_args(named_args, span.hi(), without_ind)
+                });
             }
         }
 
@@ -1831,7 +1871,12 @@ impl<'ast> State<'_, 'ast> {
         self.call_stack.pop();
     }
 
-    fn print_named_args(&mut self, args: &'ast [ast::NamedArg<'ast>], pos_hi: BytePos) {
+    fn print_named_args(
+        &mut self,
+        args: &'ast [ast::NamedArg<'ast>],
+        pos_hi: BytePos,
+        without_ind: bool,
+    ) {
         let list_format = match (self.config.bracket_spacing, self.config.prefer_compact.calls()) {
             (false, true) => ListFormat::compact(),
             (false, false) => ListFormat::consistent(),
@@ -1868,12 +1913,7 @@ impl<'ast> State<'_, 'ast> {
                 list_format
                     .break_cmnts()
                     .break_single(true)
-                    .without_ind(
-                        self.call_stack.has_indented_parent_chain()
-                            && self
-                                .chained_named_call
-                                .is_none_or(|call| call.keep_inline || call.nested),
-                    )
+                    .without_ind(without_ind)
                     .with_delimiters(!self.call_with_opts_and_args),
             );
         } else if self.config.bracket_spacing {
@@ -2403,7 +2443,7 @@ impl<'ast> State<'_, 'ast> {
         } else {
             ListFormat::consistent()
         };
-        self.print_call_args(args, format.break_cmnts(), path.to_string().len());
+        self.print_call_args(args, format.break_cmnts(), path.to_string().len(), false);
         self.emit_or_revert = false;
         self.end();
     }

--- a/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/fmt.sol
@@ -47,6 +47,15 @@ contract NamedCallArgsInChain {
             });
     }
 
+    function parenthesizedOverlongCallee(address vault, uint256 positionId, uint256 batchId) external {
+        (IExtremelyLongVaultInterfaceNameThatStillFits(vault)
+                .updateAnExtremelyLongPositionNameThatMakesTheCombinedCalleeOverflow)({
+                extremelyLongPositionIdentifier_: extremelyLongPositionIdentifier,
+                extremelyLongBatchIdentifier_: extremelyLongBatchIdentifier,
+                extremelyLongAccountIdentifier_: extremelyLongAccountIdentifier
+            });
+    }
+
     function calleeAtLineBoundary(address vault, uint256 positionId, uint256 batchId) external {
         IVault(vault)
             .updatePositionAtTheExactConfiguredLineLengthBoundaryWithoutForcingTheBaseInterfaceConversionToWrap({
@@ -119,5 +128,81 @@ contract NamedCallArgsInChain {
             deadline_: deadline,
             data_: data
         }) {} catch {}
+    }
+
+    // https://github.com/foundry-rs/foundry/issues/15823
+    function nestedNamedCalls(
+        uint256 extremelyLongRedactedIdentifier,
+        uint256 extremelyLongSetIdentifier,
+        bytes calldata extremelyLongRedactedEngineData
+    ) external {
+        RedactedRootConfiguration.getRedactedEngine({
+            extremelyLongRedactedIdentifier_: extremelyLongRedactedIdentifier
+        }).initializeSetRedacted({
+            extremelyLongSetIdentifier_: extremelyLongSetIdentifier,
+            extremelyLongRedactedIdentifier_: extremelyLongRedactedIdentifier,
+            extremelyLongRedactedEngineData_: extremelyLongRedactedEngineData
+        });
+        Root.first({
+            a: a
+        }).second({
+            b: b
+        }).third({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        Root.first({a: a}) // preserve
+            .second({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        (
+                Root.first({a: a}).second // preserve
+            )({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        Root.first({a: a}).
+            /* preserve */
+            second({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        Root.first({a: a}) /* preserve */
+            .second({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        Root.first({a: a}) /* adjacent */
+            .second({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        (
+                Root.first({a: a}).second /* preserve */
+            )({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        (
+                Root.first({a: a}).second /* adjacent */
+            )({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        (
+                /* preserve */
+                Root.first({a: a}).second
+            )({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
+        factory()
+            .anExtremelyLongHandlersArrayNameThatForcesTheIndexSuffixToWrap[
+                anExtremelyLongIndexExpressionNameThatAlsoForcesTheIndexSuffixToWrap
+            ]({
+                firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+                secondExtremelyLongArgumentName: secondExtremelyLongValueName
+            });
     }
 }

--- a/crates/fmt/testdata/NamedCallArgsInChain/original.sol
+++ b/crates/fmt/testdata/NamedCallArgsInChain/original.sol
@@ -12,6 +12,15 @@ contract NamedCallArgsInChain {
         IExtremelyLongVaultInterfaceNameThatStillFits(vault).updateAnExtremelyLongPositionNameThatMakesTheCombinedCalleeOverflow({positionId_: positionId, batchId_: batchId, account_: address(0), operator_: address(0), amount_: 0, deadline_: 0, data_: ""});
     }
 
+    function parenthesizedOverlongCallee(address vault, uint256 positionId, uint256 batchId) external {
+        (IExtremelyLongVaultInterfaceNameThatStillFits(vault)
+            .updateAnExtremelyLongPositionNameThatMakesTheCombinedCalleeOverflow)({
+            extremelyLongPositionIdentifier_: extremelyLongPositionIdentifier,
+            extremelyLongBatchIdentifier_: extremelyLongBatchIdentifier,
+            extremelyLongAccountIdentifier_: extremelyLongAccountIdentifier
+        });
+    }
+
     function calleeAtLineBoundary(address vault, uint256 positionId, uint256 batchId) external {
         IVault(vault).updatePositionAtTheExactConfiguredLineLengthBoundaryWithoutForcingTheBaseInterfaceConversionToWrap({positionId_: positionId, batchId_: batchId});
     }
@@ -38,5 +47,52 @@ contract NamedCallArgsInChain {
 
     function attempted(address vault, uint256 positionId, uint256 batchId, address account, address operator, uint256 amount, uint256 deadline, bytes calldata data) external {
         try IVault(vault).updatePosition({positionId_: positionId, batchId_: batchId, account_: account, operator_: operator, amount_: amount, deadline_: deadline, data_: data}) {} catch {}
+    }
+
+    // https://github.com/foundry-rs/foundry/issues/15823
+    function nestedNamedCalls(uint256 extremelyLongRedactedIdentifier, uint256 extremelyLongSetIdentifier, bytes calldata extremelyLongRedactedEngineData) external {
+        RedactedRootConfiguration.getRedactedEngine({
+            extremelyLongRedactedIdentifier_: extremelyLongRedactedIdentifier
+        }).initializeSetRedacted({
+            extremelyLongSetIdentifier_: extremelyLongSetIdentifier, extremelyLongRedactedIdentifier_: extremelyLongRedactedIdentifier, extremelyLongRedactedEngineData_: extremelyLongRedactedEngineData
+        });
+        Root.first({a: a}).second({b: b}).third({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
+        Root.first({a: a}) // preserve
+            .second({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
+        (Root.first({a: a}).second // preserve
+        )({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        Root.first({a: a})
+        /* preserve */
+        .second({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        Root.first({a: a}) /* preserve */ .second({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        Root.first({a: a})/* adjacent */.second({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        (Root.first({a: a}).second /* preserve */)({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        (Root.first({a: a}).second/* adjacent */)({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        (
+            /* preserve */
+            Root.first({a: a}).second
+        )({
+            firstExtremelyLongArgumentName: firstExtremelyLongValueName,
+            secondExtremelyLongArgumentName: secondExtremelyLongValueName
+        });
+        factory().anExtremelyLongHandlersArrayNameThatForcesTheIndexSuffixToWrap[anExtremelyLongIndexExpressionNameThatAlsoForcesTheIndexSuffixToWrap]({firstExtremelyLongArgumentName: firstExtremelyLongValueName, secondExtremelyLongArgumentName: secondExtremelyLongValueName});
     }
 }


### PR DESCRIPTION
## Motivation

#15824 fixed the double indentation reported in #15823 by tracking whether a chained named call was nested. That ancestry-based classification is too coarse: it can suppress required indentation when the immediate callee suffix wraps, while retaining duplicate indentation for multiline outer named calls.

This follow-up bases the decision on indentation ownership instead. Named arguments suppress their own indentation only when the parent chain fully owns it and the immediate callee suffix cannot introduce another break. The handling covers member and index suffixes, transparent parentheses, and breakable comments (including comments adjacent to span boundaries) while preserving inline field access after named calls.