### PR TITLE
fix(forge): preserve revert data when tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,6 +5903,7 @@ dependencies = [
  "reqwest 0.13.4",
  "revm",
  "revm-inspectors",
+ "ron",
  "serde",
  "serde_json",
  "snapbox",
@@ -10485,6 +10486,20 @@ checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "ron"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "typeid",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -474,6 +474,7 @@ ratatui = { version = "0.30", default-features = false }
 rayon = "1"
 regex = { version = "1", default-features = false }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+ron = "0.12"
 rustls = "0.23"
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -153,7 +153,8 @@ fn print_traces(tracer: TracingInspector, decoder: Arc<CallTraceDecoder>) {
         })
     });
 
-    let traces = SparsedTraceArena { arena, ignored: Default::default() };
+    let traces =
+        SparsedTraceArena { arena, ignored: Default::default(), diagnostics: Default::default() };
     let trace = render_trace_arena_inner(&traces, false, true);
     node_info!(Traces = %format!("\n{}", trace));
 }

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -360,6 +360,7 @@ impl CallArgs {
             let arena = SparsedTraceArena {
                 arena: call_frame_to_arena(&frame),
                 ignored: Default::default(),
+                diagnostics: Default::default(),
             };
             let result = TraceResult {
                 success,

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -247,6 +247,7 @@ impl RunArgs {
             let arena = SparsedTraceArena {
                 arena: call_frame_to_arena_with_root_address(&frame, root_create_address),
                 ignored: Default::default(),
+                diagnostics: Default::default(),
             };
             let result = TraceResult {
                 success,

--- a/crates/evm/evm/src/inspectors/revert_diagnostic.rs
+++ b/crates/evm/evm/src/inspectors/revert_diagnostic.rs
@@ -1,42 +1,18 @@
-use alloy_primitives::{Address, U256};
-use alloy_sol_types::SolValue;
+use alloy_primitives::{Address, U256, map::HashMap};
 use foundry_evm_core::constants::{CHEATCODE_ADDRESS, HARDHAT_CONSOLE_ADDRESS};
+use foundry_evm_traces::RevertDiagnostic as DetailedRevertReason;
 use revm::{
     Inspector,
     bytecode::opcode,
     context::{ContextTr, JournalTr},
-    interpreter::{
-        CallInputs, CallOutcome, CallScheme, InstructionResult, Interpreter, InterpreterAction,
-        interpreter_types::{Jumps, LoopControl},
-    },
+    interpreter::{CallInputs, CallOutcome, CallScheme, Interpreter, interpreter_types::Jumps},
 };
-use std::fmt;
 
 const IGNORE: [Address; 2] = [HARDHAT_CONSOLE_ADDRESS, CHEATCODE_ADDRESS];
 
 /// Checks if the call scheme corresponds to any sort of delegate call
 pub const fn is_delegatecall(scheme: CallScheme) -> bool {
     matches!(scheme, CallScheme::DelegateCall | CallScheme::CallCode)
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum DetailedRevertReason {
-    CallToNonContract(Address),
-    DelegateCallToNonContract(Address),
-}
-
-impl fmt::Display for DetailedRevertReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::CallToNonContract(addr) => {
-                write!(f, "call to non-contract address {addr}")
-            }
-            Self::DelegateCallToNonContract(addr) => write!(
-                f,
-                "delegatecall to non-contract address {addr} (usually an unliked library)"
-            ),
-        }
-    }
 }
 
 /// An inspector that tracks call context to enhances revert diagnostics.
@@ -63,6 +39,12 @@ pub struct RevertDiagnostic {
     non_contract_size_check: Option<(Address, usize)>,
     /// Whether the step opcode is EXTCODESIZE or not.
     is_extcodesize_step: bool,
+    /// Diagnostic detected for the currently executing frame.
+    pending: Option<DetailedRevertReason>,
+    /// Trace nodes for active frames. `None` means the tracer did not create a node.
+    active_trace_nodes: Vec<Option<usize>>,
+    /// Presentation-only revert diagnostics keyed by trace node.
+    diagnostics: HashMap<usize, DetailedRevertReason>,
 }
 
 impl RevertDiagnostic {
@@ -92,22 +74,41 @@ impl RevertDiagnostic {
         None
     }
 
-    /// Injects the revert diagnostic into the debug traces. Should only be called after a revert.
-    fn broadcast_diagnostic(&self, interpreter: &mut Interpreter) {
-        if let Some(reason) = self.reason() {
-            interpreter.bytecode.set_action(InterpreterAction::new_return(
-                InstructionResult::Revert,
-                reason.to_string().abi_encode().into(),
-                interpreter.gas,
-            ));
+    /// Starts tracking a frame before its inspectors can short-circuit execution.
+    pub fn frame_start(&mut self) {
+        self.active_trace_nodes.push(None);
+    }
+
+    /// Associates the active frame with the node created by the tracer.
+    pub fn set_trace_node(&mut self, trace_node: usize) {
+        let frame = self.active_trace_nodes.last_mut();
+        debug_assert!(frame.is_some(), "missing active revert diagnostic frame");
+        if let Some(frame) = frame {
+            *frame = Some(trace_node);
         }
     }
 
-    /// When a `REVERT` opcode with zero data size occurs:
-    ///  - if `non_contract_call` was set at the current depth, `broadcast_diagnostic` is called.
-    ///    Otherwise, it is cleared.
-    ///  - if `non_contract_size_check` was set at the current depth, `broadcast_diagnostic` is
-    ///    called. Otherwise, it is cleared.
+    /// Finishes tracking a frame and associates any pending diagnostic with its trace node.
+    pub fn frame_end(&mut self) {
+        let frame = self.active_trace_nodes.pop();
+        debug_assert!(frame.is_some(), "revert diagnostic frame stack underflow");
+        let diagnostic = self.pending.take();
+        if let Some(node_idx) = frame.flatten()
+            && let Some(diagnostic) = diagnostic
+        {
+            self.diagnostics.insert(node_idx, diagnostic);
+        }
+    }
+
+    /// Consumes the inspector and returns its presentation-only diagnostics.
+    pub fn into_diagnostics(self) -> HashMap<usize, DetailedRevertReason> {
+        debug_assert!(self.active_trace_nodes.is_empty(), "unclosed revert diagnostic frames");
+        self.diagnostics
+    }
+
+    /// When a `REVERT` opcode with zero data size occurs, records a diagnostic if a matching
+    /// non-contract call or size check was observed at the current depth. Stale observations from
+    /// other depths are cleared.
     #[cold]
     fn handle_revert<CTX: ContextTr>(&mut self, interp: &mut Interpreter, ctx: &mut CTX) {
         // REVERT (offset, size)
@@ -117,7 +118,7 @@ impl RevertDiagnostic {
             // Check empty revert with same depth as a non-contract call
             if let Some((_, _, depth)) = self.non_contract_call {
                 if ctx.journal_ref().depth() == depth {
-                    self.broadcast_diagnostic(interp);
+                    self.pending = self.reason();
                 } else {
                     self.non_contract_call = None;
                 }
@@ -127,7 +128,7 @@ impl RevertDiagnostic {
             // Check empty revert with same depth as a non-contract size check
             if let Some((_, depth)) = self.non_contract_size_check {
                 if depth == ctx.journal_ref().depth() {
-                    self.broadcast_diagnostic(interp);
+                    self.pending = self.reason();
                 } else {
                     self.non_contract_size_check = None;
                 }

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -740,10 +740,14 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
                     log_collector,
                     tempo_labels,
                     tracer,
+                    revert_diag,
                     reverter,
                     ..
                 },
         } = self;
+
+        let trace_diagnostics =
+            revert_diag.map(|revert_diag| revert_diag.into_diagnostics()).unwrap_or_default();
 
         let traces = tracer.map(|tracer| tracer.into_traces()).map(|arena| {
             let ignored = cheatcodes
@@ -760,7 +764,7 @@ impl<FEN: FoundryEvmNetwork> InspectorStack<FEN> {
                 })
                 .unwrap_or_default();
 
-            SparsedTraceArena { arena, ignored }
+            SparsedTraceArena { arena, ignored, diagnostics: trace_diagnostics }
         });
 
         let (edge_coverage, evm_cmp_values) = edge_coverage
@@ -1398,16 +1402,13 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             self.top_level_frame_start(ecx);
         }
 
+        if let Some(revert_diag) = self.revert_diag.as_deref_mut() {
+            revert_diag.frame_start();
+        }
+
         call_inspectors!(
             #[ret]
-            [
-                &mut self.fuzzer,
-                &mut self.tracer,
-                &mut self.log_collector,
-                &mut self.printer,
-                &mut self.revert_diag,
-                &mut self.tempo_labels
-            ],
+            [&mut self.fuzzer],
             |inspector| {
                 let mut out = None;
                 if let Some(output) = inspector.call(ecx, call) {
@@ -1415,6 +1416,32 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                 }
                 out
             },
+        );
+
+        if self.tracer.is_some() {
+            crate::utils::cold_path();
+            let (output, trace_idx) = {
+                let tracer = self.tracer.as_deref_mut().unwrap();
+                let output = tracer.call(ecx, call);
+                (output, tracer.traces().nodes().len() - 1)
+            };
+            if let Some(revert_diag) = self.revert_diag.as_deref_mut() {
+                revert_diag.set_trace_node(trace_idx);
+            }
+            if output.is_some() {
+                return output;
+            }
+        }
+
+        call_inspectors!(
+            #[ret]
+            [
+                &mut self.log_collector,
+                &mut self.printer,
+                &mut self.revert_diag,
+                &mut self.tempo_labels
+            ],
+            |inspector| inspector.call(ecx, call).map(Some),
         );
 
         // The tracer records call inputs before cheatcodes apply caller overrides such as pranks
@@ -1530,6 +1557,10 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
 
         self.do_call_end(ecx, inputs, outcome);
 
+        if let Some(revert_diag) = self.revert_diag.as_deref_mut() {
+            revert_diag.frame_end();
+        }
+
         if ecx.journal().depth() == 0 {
             self.top_level_frame_end(ecx, outcome.result.result);
         }
@@ -1549,9 +1580,28 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             self.top_level_frame_start(ecx);
         }
 
+        if let Some(revert_diag) = self.revert_diag.as_deref_mut() {
+            revert_diag.frame_start();
+        }
+
+        if self.tracer.is_some() {
+            crate::utils::cold_path();
+            let (output, trace_idx) = {
+                let tracer = self.tracer.as_deref_mut().unwrap();
+                let output = tracer.create(ecx, create);
+                (output, tracer.traces().nodes().len() - 1)
+            };
+            if let Some(revert_diag) = self.revert_diag.as_deref_mut() {
+                revert_diag.set_trace_node(trace_idx);
+            }
+            if output.is_some() {
+                return output;
+            }
+        }
+
         call_inspectors!(
             #[ret]
-            [&mut self.tracer, &mut self.line_coverage],
+            [&mut self.line_coverage],
             |inspector| inspector.create(ecx, create).map(Some),
         );
 
@@ -1634,6 +1684,10 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
         }
 
         self.do_create_end(ecx, call, outcome);
+
+        if let Some(revert_diag) = self.revert_diag.as_deref_mut() {
+            revert_diag.frame_end();
+        }
 
         if ecx.journal().depth() == 0 {
             self.top_level_frame_end(ecx, outcome.result.result);
@@ -1920,7 +1974,7 @@ fn compute_batch_create_salt(process_salt: u64, chain_id: u64, nonce: u64, count
 #[cfg(test)]
 mod tests {
     use super::{
-        Address, Fuzzer, InspectorStack, InspectorStackInner, OpcodeStepDispatch,
+        Address, Fuzzer, InspectorStack, InspectorStackInner, OpcodeStepDispatch, RevertDiagnostic,
         TraceRequirements, compute_batch_create_salt,
     };
     use foundry_evm_core::evm::EthEvmNetwork;
@@ -1986,6 +2040,19 @@ mod tests {
         assert_eq!(stack.inner.static_step_dispatch, OpcodeStepDispatch::General);
         stack.collect_edge_coverage(false);
         assert_eq!(stack.inner.static_step_dispatch, OpcodeStepDispatch::None);
+    }
+
+    #[test]
+    fn revert_diagnostic_frames_remain_balanced() {
+        let mut inspector = RevertDiagnostic::default();
+        inspector.frame_start();
+        inspector.set_trace_node(0);
+        inspector.frame_start();
+        inspector.set_trace_node(1);
+        inspector.frame_end();
+        inspector.frame_end();
+
+        assert!(inspector.into_diagnostics().is_empty());
     }
 
     #[test]

--- a/crates/evm/traces/Cargo.toml
+++ b/crates/evm/traces/Cargo.toml
@@ -53,6 +53,7 @@ tracing.workspace = true
 yansi.workspace = true
 
 [dev-dependencies]
+ron.workspace = true
 snapbox.workspace = true
 
 [features]

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -21,10 +21,11 @@ use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet},
+    fmt,
     ops::{Deref, DerefMut},
 };
 
-use alloy_primitives::{U256, map::HashMap};
+use alloy_primitives::{Address, U256, map::HashMap};
 use tempo_contracts::precompiles::TIP20_CHANNEL_RESERVE_ADDRESS;
 
 pub use revm_inspectors::tracing::{
@@ -55,6 +56,27 @@ pub mod speedscope;
 
 pub type Traces = Vec<(TraceKind, SparsedTraceArena)>;
 
+/// Presentation-only detail for an otherwise empty EVM revert.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum RevertDiagnostic {
+    /// A call targeted an address without code.
+    CallToNonContract(Address),
+    /// A delegate call targeted an address without code.
+    DelegateCallToNonContract(Address),
+}
+
+impl fmt::Display for RevertDiagnostic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CallToNonContract(addr) => write!(f, "call to non-contract address {addr}"),
+            Self::DelegateCallToNonContract(addr) => write!(
+                f,
+                "delegatecall to non-contract address {addr} (usually an unliked library)"
+            ),
+        }
+    }
+}
+
 /// Trace arena keeping track of ignored trace items.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SparsedTraceArena {
@@ -65,12 +87,15 @@ pub struct SparsedTraceArena {
     /// See `foundry_cheatcodes::utils::IgnoredTraces` for more information.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub ignored: HashMap<(usize, usize), (usize, usize)>,
+    /// Presentation-only revert diagnostics, keyed by trace node index.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub diagnostics: HashMap<usize, RevertDiagnostic>,
 }
 
 impl SparsedTraceArena {
     /// Goes over entire trace arena and removes ignored trace items.
     fn resolve_arena(&self) -> Cow<'_, CallTraceArena> {
-        if self.ignored.is_empty() {
+        if self.ignored.is_empty() && self.diagnostics.is_empty() {
             Cow::Borrowed(&self.arena)
         } else {
             let mut arena = self.arena.clone();
@@ -152,7 +177,16 @@ impl SparsedTraceArena {
                 }
             }
 
-            clear_node(arena.nodes_mut(), 0, &self.ignored, &mut None);
+            if !self.ignored.is_empty() {
+                clear_node(arena.nodes_mut(), 0, &self.ignored, &mut None);
+            }
+
+            for (&node_idx, diagnostic) in &self.diagnostics {
+                if let Some(node) = arena.nodes_mut().get_mut(node_idx) {
+                    node.trace.decoded.get_or_insert_default().return_data =
+                        Some(diagnostic.to_string());
+                }
+            }
 
             Cow::Owned(arena)
         }
@@ -596,13 +630,38 @@ mod tests {
         };
 
         let rendered = render_trace_arena_inner(
-            &SparsedTraceArena { arena, ignored: Default::default() },
+            &SparsedTraceArena {
+                arena,
+                ignored: Default::default(),
+                diagnostics: Default::default(),
+            },
             false,
             true,
         );
 
         assert!(rendered.contains("\nDecoded TIP20ChannelReserve storage:\n"));
         assert!(!rendered.contains("\n\nDecoded TIP20ChannelReserve storage:\n"));
+    }
+
+    #[test]
+    fn revert_diagnostic_only_changes_resolved_trace() {
+        let traces = SparsedTraceArena {
+            arena: CallTraceArena::default(),
+            ignored: Default::default(),
+            diagnostics: HashMap::from_iter([(
+                0,
+                RevertDiagnostic::CallToNonContract(alloy_primitives::Address::ZERO),
+            )]),
+        };
+
+        let resolved = traces.resolve_arena();
+        assert_eq!(
+            resolved.nodes()[0].trace.decoded.as_ref().unwrap().return_data.as_deref(),
+            Some("call to non-contract address 0x0000000000000000000000000000000000000000")
+        );
+        assert!(resolved.nodes()[0].trace.output.is_empty());
+        assert!(traces.arena.nodes()[0].trace.decoded.is_none());
+        assert!(traces.arena.nodes()[0].trace.output.is_empty());
     }
 
     #[test]

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -105,15 +105,37 @@ impl Serialize for SparsedTraceArena {
             ignored: &'a HashMap<(usize, usize), (usize, usize)>,
         }
 
-        ResolvedArena { arena: &self.resolve_arena(), ignored: &self.ignored }.serialize(serializer)
+        ResolvedArena { arena: &self.resolve_diagnostics(), ignored: &self.ignored }
+            .serialize(serializer)
     }
 }
 
 impl SparsedTraceArena {
+    /// Applies presentation-only diagnostics to the provided arena.
+    fn apply_diagnostics(&self, arena: &mut CallTraceArena) {
+        for (&node_idx, diagnostic) in &self.diagnostics {
+            if let Some(node) = arena.nodes_mut().get_mut(node_idx) {
+                node.trace.decoded.get_or_insert_default().return_data =
+                    Some(diagnostic.to_string());
+            }
+        }
+    }
+
+    /// Applies presentation-only diagnostics without consuming ignored trace ranges.
+    fn resolve_diagnostics(&self) -> Cow<'_, CallTraceArena> {
+        if self.diagnostics.is_empty() {
+            Cow::Borrowed(&self.arena)
+        } else {
+            let mut arena = self.arena.clone();
+            self.apply_diagnostics(&mut arena);
+            Cow::Owned(arena)
+        }
+    }
+
     /// Goes over entire trace arena and removes ignored trace items.
     fn resolve_arena(&self) -> Cow<'_, CallTraceArena> {
-        if self.ignored.is_empty() && self.diagnostics.is_empty() {
-            Cow::Borrowed(&self.arena)
+        if self.ignored.is_empty() {
+            self.resolve_diagnostics()
         } else {
             let mut arena = self.arena.clone();
 
@@ -194,16 +216,9 @@ impl SparsedTraceArena {
                 }
             }
 
-            if !self.ignored.is_empty() {
-                clear_node(arena.nodes_mut(), 0, &self.ignored, &mut None);
-            }
+            clear_node(arena.nodes_mut(), 0, &self.ignored, &mut None);
 
-            for (&node_idx, diagnostic) in &self.diagnostics {
-                if let Some(node) = arena.nodes_mut().get_mut(node_idx) {
-                    node.trace.decoded.get_or_insert_default().return_data =
-                        Some(diagnostic.to_string());
-                }
-            }
+            self.apply_diagnostics(&mut arena);
 
             Cow::Owned(arena)
         }
@@ -679,6 +694,46 @@ mod tests {
         assert!(resolved.nodes()[0].trace.output.is_empty());
         assert!(traces.arena.nodes()[0].trace.decoded.is_none());
         assert!(traces.arena.nodes()[0].trace.output.is_empty());
+    }
+
+    #[test]
+    fn serialization_resolves_diagnostics_without_consuming_ignored_ranges() {
+        let mut arena = CallTraceArena::default();
+        let root = &mut arena.nodes_mut()[0];
+        root.logs = vec![CallLog::default(), CallLog::default(), CallLog::default()];
+        root.ordering =
+            vec![TraceMemberOrder::Log(0), TraceMemberOrder::Log(1), TraceMemberOrder::Log(2)];
+
+        let traces = SparsedTraceArena {
+            arena,
+            ignored: HashMap::from_iter([((0, 1), (0, 2))]),
+            diagnostics: HashMap::from_iter([(
+                0,
+                RevertDiagnostic::CallToNonContract(alloy_primitives::Address::ZERO),
+            )]),
+        };
+
+        let serialized = ron::to_string(&traces).unwrap();
+        let deserialized: SparsedTraceArena = ron::from_str(&serialized).unwrap();
+        assert_eq!(
+            deserialized.arena.nodes()[0].ordering,
+            [TraceMemberOrder::Log(0), TraceMemberOrder::Log(1), TraceMemberOrder::Log(2)]
+        );
+        assert_eq!(deserialized.ignored, traces.ignored);
+        assert!(deserialized.diagnostics.is_empty());
+        assert_eq!(
+            deserialized.arena.nodes()[0].trace.decoded.as_ref().unwrap().return_data.as_deref(),
+            Some("call to non-contract address 0x0000000000000000000000000000000000000000")
+        );
+        assert!(deserialized.arena.nodes()[0].trace.output.is_empty());
+
+        let resolved = deserialized.resolve_arena();
+        assert_eq!(resolved.nodes()[0].ordering, [TraceMemberOrder::Log(2)]);
+        assert_eq!(
+            resolved.nodes()[0].trace.decoded.as_ref().unwrap().return_data.as_deref(),
+            Some("call to non-contract address 0x0000000000000000000000000000000000000000")
+        );
+        assert!(render_trace_arena(&deserialized).contains("call to non-contract address"));
     }
 
     #[test]

--- a/crates/evm/traces/src/lib.rs
+++ b/crates/evm/traces/src/lib.rs
@@ -78,7 +78,7 @@ impl fmt::Display for RevertDiagnostic {
 }
 
 /// Trace arena keeping track of ignored trace items.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct SparsedTraceArena {
     /// Full trace arena.
     #[serde(flatten)]
@@ -90,6 +90,23 @@ pub struct SparsedTraceArena {
     /// Presentation-only revert diagnostics, keyed by trace node index.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub diagnostics: HashMap<usize, RevertDiagnostic>,
+}
+
+impl Serialize for SparsedTraceArena {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct ResolvedArena<'a> {
+            #[serde(flatten)]
+            arena: &'a CallTraceArena,
+            #[serde(skip_serializing_if = "HashMap::is_empty")]
+            ignored: &'a HashMap<(usize, usize), (usize, usize)>,
+        }
+
+        ResolvedArena { arena: &self.resolve_arena(), ignored: &self.ignored }.serialize(serializer)
+    }
 }
 
 impl SparsedTraceArena {

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3628,7 +3628,8 @@ Traces:
 
 "#]])
     .stderr_eq(str![[r#"
-Error: script failed: call to non-contract address [..]
+Error: script failed: EvmError: Revert
+
 "#]]);
 });
 

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -5298,6 +5298,35 @@ Tip: Run `forge test --rerun` to retry only the 1 failed test
 Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--mc",
+            "NonContractCallRevertTest",
+            "--mt",
+            "test_revert_data_exact_diagnostic",
+            "-vvvv",
+            "--json",
+            "--no-dynamic-test-linking",
+        ])
+        .assert_failure();
+    let json: serde_json::Value = serde_json::from_slice(&output.get_output().stdout).unwrap();
+    let result = &json.as_object().unwrap().values().next().unwrap()["test_results"]["test_revert_data_exact_diagnostic()"];
+    let traces = result["traces"].as_array().unwrap();
+    assert!(traces.iter().all(|trace| trace[1].get("diagnostics").is_none()));
+
+    let diagnostic_nodes = traces
+        .iter()
+        .flat_map(|trace| trace[1]["arena"].as_array().unwrap())
+        .filter(|node| {
+            node["trace"]["decoded"]["return_data"]
+                == "call to non-contract address 0xdEADBEeF00000000000000000000000000000000"
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(diagnostic_nodes.len(), 1);
+    assert_eq!(diagnostic_nodes[0]["trace"]["output"], "0x");
 });
 
 forgetest_init!(detailed_revert_when_delegatecalling_unlinked_library, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -5101,11 +5101,30 @@ contract NonContractCallRevertTest is Test {
         console.log("test non contract (void) call failure");
         ICounter(ADDRESS).increment();
     }
+
+    function test_revert_data_exact_diagnostic() public {
+        vm.expectRevert(
+            abi.encodePacked("call to non-contract address ", vm.toString(ADDRESS))
+        );
+        this.call_non_contract(ADDRESS);
+    }
+
+    function call_non_contract(address target) external {
+        ICounter(target).number();
+    }
 }
      "#,
     );
 
-    cmd.args(["test", "--mc", "NonContractCallRevertTest", "-vvvvv", "--no-dynamic-test-linking"])
+    cmd.args([
+        "test",
+        "--mc",
+        "NonContractCallRevertTest",
+        "--no-match-test",
+        "test_revert_data_",
+        "-vvvvv",
+        "--no-dynamic-test-linking",
+    ])
         .assert_failure()
         .stdout_eq(str![[r#"
 [COMPILING_FILES] with [SOLC_VERSION]
@@ -5113,7 +5132,7 @@ contract NonContractCallRevertTest is Test {
 Compiler run successful!
 
 Ran 3 tests for test/NonContractCallRevertTest.t.sol:NonContractCallRevertTest
-[FAIL: call to non-contract address 0xdEADBEeF00000000000000000000000000000000] test_non_contract_call_failure() ([GAS])
+[FAIL: EvmError: Revert] test_non_contract_call_failure() ([GAS])
 Logs:
   test non contract call failure
 
@@ -5125,7 +5144,7 @@ Traces:
     │   └─ ← [Stop]
     └─ ← [Stop]
 
-  [27510] NonContractCallRevertTest::test_non_contract_call_failure()
+  [27488] NonContractCallRevertTest::test_non_contract_call_failure()
     ├─ [0] console::log("test non contract call failure") [staticcall]
     │   └─ ← [Stop]
     ├─ [21160] 0xdEADBEeF00000000000000000000000000000000::number()
@@ -5135,7 +5154,7 @@ Traces:
 Backtrace:
   at NonContractCallRevertTest.test_non_contract_call_failure
 
-[FAIL: call to non-contract address 0xdEADBEeF00000000000000000000000000000000] test_non_contract_void_call_failure() ([GAS])
+[FAIL: EvmError: Revert] test_non_contract_void_call_failure() ([GAS])
 Logs:
   test non contract (void) call failure
 
@@ -5147,7 +5166,7 @@ Traces:
     │   └─ ← [Stop]
     └─ ← [Stop]
 
-  [6215] NonContractCallRevertTest::test_non_contract_void_call_failure()
+  [6303] NonContractCallRevertTest::test_non_contract_void_call_failure()
     ├─ [0] console::log("test non contract (void) call failure") [staticcall]
     │   └─ ← [Stop]
     └─ ← [Revert] call to non-contract address 0xdEADBEeF00000000000000000000000000000000
@@ -5184,13 +5203,98 @@ Ran 1 test suite [ELAPSED]: 0 tests passed, 3 failed, 0 skipped (3 total tests)
 
 Failing tests:
 Encountered 3 failing tests in test/NonContractCallRevertTest.t.sol:NonContractCallRevertTest
-[FAIL: call to non-contract address 0xdEADBEeF00000000000000000000000000000000] test_non_contract_call_failure() ([GAS])
-[FAIL: call to non-contract address 0xdEADBEeF00000000000000000000000000000000] test_non_contract_void_call_failure() ([GAS])
+[FAIL: EvmError: Revert] test_non_contract_call_failure() ([GAS])
+[FAIL: EvmError: Revert] test_non_contract_void_call_failure() ([GAS])
 [FAIL: EvmError: Revert] test_non_supported_selector_call_failure() ([GAS])
 
 Encountered a total of 3 failing tests, 0 tests succeeded
 
 Tip: Run `forge test --rerun` to retry only the 3 failed tests
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
+
+"#]]);
+
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--mc",
+            "NonContractCallRevertTest",
+            "--mt",
+            "test_revert_data_exact_diagnostic",
+            "-vv",
+            "--no-dynamic-test-linking",
+        ])
+        .assert_failure()
+        .stdout_eq(str![[r#"
+No files changed, compilation skipped
+
+Ran 1 test for test/NonContractCallRevertTest.t.sol:NonContractCallRevertTest
+[FAIL: call reverted as expected, but without data] test_revert_data_exact_diagnostic() ([GAS])
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/NonContractCallRevertTest.t.sol:NonContractCallRevertTest
+[FAIL: call reverted as expected, but without data] test_revert_data_exact_diagnostic() ([GAS])
+
+Encountered a total of 1 failing tests, 0 tests succeeded
+
+Tip: Run `forge test --rerun` to retry only the 1 failed test
+Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
+
+"#]]);
+
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--mc",
+            "NonContractCallRevertTest",
+            "--mt",
+            "test_revert_data_exact_diagnostic",
+            "-vvvv",
+            "--no-dynamic-test-linking",
+        ])
+        .assert_failure()
+        .stdout_eq(str![[r#"
+No files changed, compilation skipped
+
+Ran 1 test for test/NonContractCallRevertTest.t.sol:NonContractCallRevertTest
+[FAIL: call reverted as expected, but without data] test_revert_data_exact_diagnostic() ([GAS])
+Traces:
+  [238803] NonContractCallRevertTest::setUp()
+    ├─ [156801] → new Counter@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
+    │   └─ ← [Return] 481 bytes of code
+    ├─ [43696] Counter::setNumber(1)
+    │   └─ ← [Stop]
+    └─ ← [Stop]
+
+  [30284] NonContractCallRevertTest::test_revert_data_exact_diagnostic()
+    ├─ [0] VM::toString(0xdEADBEeF00000000000000000000000000000000) [staticcall]
+    │   └─ ← [Return] "0xdEADBEeF00000000000000000000000000000000"
+    ├─ [0] VM::expectRevert(call to non-contract address 0xdEADBEeF00000000000000000000000000000000)
+    │   └─ ← [Return]
+    ├─ [24558] NonContractCallRevertTest::call_non_contract(0xdEADBEeF00000000000000000000000000000000)
+    │   ├─ [0] 0xdEADBEeF00000000000000000000000000000000::number()
+    │   │   └─ ← [Stop]
+    │   └─ ← [Revert] call to non-contract address 0xdEADBEeF00000000000000000000000000000000
+    └─ ← [Revert] call reverted as expected, but without data
+
+Backtrace:
+  at NonContractCallRevertTest.call_non_contract
+  at NonContractCallRevertTest.test_revert_data_exact_diagnostic
+
+Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
+
+Failing tests:
+Encountered 1 failing test in test/NonContractCallRevertTest.t.sol:NonContractCallRevertTest
+[FAIL: call reverted as expected, but without data] test_revert_data_exact_diagnostic() ([GAS])
+
+Encountered a total of 1 failing tests, 0 tests succeeded
+
+Tip: Run `forge test --rerun` to retry only the 1 failed test
 Tip: Run `forge test --debug --match-test <TEST_NAME>` to inspect one failing test in the debugger
 
 "#]]);
@@ -5244,12 +5348,12 @@ contract NonContractDelegateCallRevertTest is Test {
 Compiler run successful!
 
 Ran 1 test for test/NonContractDelegateCallRevertTest.t.sol:NonContractDelegateCallRevertTest
-[FAIL: delegatecall to non-contract address 0xdEADBEeF00000000000000000000000000000000 (usually an unliked library)] test_unlinked_library_call_failure() ([GAS])
+[FAIL: EvmError: Revert] test_unlinked_library_call_failure() ([GAS])
 Logs:
   Test: Simulating call to unlinked library
 
 Traces:
-  [350691] NonContractDelegateCallRevertTest::test_unlinked_library_call_failure()
+  [350673] NonContractDelegateCallRevertTest::test_unlinked_library_call_failure()
     ├─ [0] console::log("Test: Simulating call to unlinked library") [staticcall]
     │   └─ ← [Stop]
     ├─ [286930] → new LibraryCaller@0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f
@@ -5260,7 +5364,7 @@ Traces:
     │   ├─ [0] 0xdEADBEeF00000000000000000000000000000000::foo(10) [delegatecall]
     │   │   └─ ← [Stop]
     │   └─ ← [Revert] delegatecall to non-contract address 0xdEADBEeF00000000000000000000000000000000 (usually an unliked library)
-    └─ ← [Revert] delegatecall to non-contract address 0xdEADBEeF00000000000000000000000000000000 (usually an unliked library)
+    └─ ← [Revert] EvmError: Revert
 
 Backtrace:
   at LibraryCaller.foobar
@@ -5272,7 +5376,7 @@ Ran 1 test suite [ELAPSED]: 0 tests passed, 1 failed, 0 skipped (1 total tests)
 
 Failing tests:
 Encountered 1 failing test in test/NonContractDelegateCallRevertTest.t.sol:NonContractDelegateCallRevertTest
-[FAIL: delegatecall to non-contract address 0xdEADBEeF00000000000000000000000000000000 (usually an unliked library)] test_unlinked_library_call_failure() ([GAS])
+[FAIL: EvmError: Revert] test_unlinked_library_call_failure() ([GAS])
 
 Encountered a total of 1 failing tests, 0 tests succeeded
 

--- a/testdata/default/repros/Issue11559.t.sol
+++ b/testdata/default/repros/Issue11559.t.sol
@@ -18,11 +18,14 @@ contract Issue11559Test is Test {
         IERC20(address(0)).totalSupply();
     }
 
-    // Same test but with a specific revert message check
-    /// forge-config: default.allow_internal_expect_revert = true
-    function testExpectRevertCallToNonContractAddressWithMessage() public {
-        // The revert message is injected by the RevertDiagnostic inspector
-        vm.expectRevert("call to non-contract address 0x0000000000000000000000000000000000000000");
-        IERC20(address(0)).totalSupply();
+    function testCallerObservesEmptyRevertData() public {
+        (bool success, bytes memory data) =
+            address(this).call(abi.encodeCall(this.callNonContract, (address(0))));
+        assertEq(success, false);
+        assertEq(data.length, 0);
+    }
+
+    function callNonContract(address target) external view returns (uint256) {
+        return IERC20(target).totalSupply();
     }
 }

--- a/testdata/default/repros/Issue11559.t.sol
+++ b/testdata/default/repros/Issue11559.t.sol
@@ -19,8 +19,7 @@ contract Issue11559Test is Test {
     }
 
     function testCallerObservesEmptyRevertData() public {
-        (bool success, bytes memory data) =
-            address(this).call(abi.encodeCall(this.callNonContract, (address(0))));
+        (bool success, bytes memory data) = address(this).call(abi.encodeCall(this.callNonContract, (address(0))));
         assertEq(success, false);
         assertEq(data.length, 0);
     }


### PR DESCRIPTION
Keeps inferred non-contract call diagnostics as trace-only metadata instead of injecting them into EVM revert data. This makes `vm.expectRevert` behavior consistent across verbosity levels while preserving helpful diagnostics in verbose traces.

Fixes #11344.