### PR TITLE
fix(anvil): `eth_simulateV1` normalize simulated blocks

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2958,13 +2958,17 @@ impl EthApi<FoundryNetwork> {
 
         // this can be blocking for a bit, especially in forking mode
         // <https://github.com/foundry-rs/foundry/issues/6036>
-        let block_interval = self
-            .miner
-            .block_interval()
-            .map(|duration| {
-                duration.as_secs().saturating_add(u64::from(duration.subsec_nanos() != 0)).max(1)
-            })
-            .unwrap_or(DEFAULT_BLOCK_INTERVAL_SECS);
+        let block_interval = self.backend.time().block_timestamp_interval().unwrap_or_else(|| {
+            self.miner
+                .block_interval()
+                .map(|duration| {
+                    duration
+                        .as_secs()
+                        .saturating_add(u64::from(duration.subsec_nanos() != 0))
+                        .max(1)
+                })
+                .unwrap_or(DEFAULT_BLOCK_INTERVAL_SECS)
+        });
         self.on_blocking_task(|this| async move {
             let simulated_blocks =
                 this.backend.simulate(request, Some(block_request), block_interval).await?;

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2924,6 +2924,8 @@ impl EthApi<FoundryNetwork> {
         request: SimulatePayload,
         block_number: Option<BlockId>,
     ) -> Result<Vec<SimulatedBlock<AnyRpcBlock>>> {
+        const DEFAULT_BLOCK_INTERVAL_SECS: u64 = 12;
+
         node_info!("eth_simulateV1");
         if request.block_state_calls.is_empty() {
             return Err(BlockchainError::RpcError(RpcError::invalid_params("empty input")));
@@ -2956,8 +2958,16 @@ impl EthApi<FoundryNetwork> {
 
         // this can be blocking for a bit, especially in forking mode
         // <https://github.com/foundry-rs/foundry/issues/6036>
+        let block_interval = self
+            .miner
+            .block_interval()
+            .map(|duration| {
+                duration.as_secs().saturating_add(u64::from(duration.subsec_nanos() != 0)).max(1)
+            })
+            .unwrap_or(DEFAULT_BLOCK_INTERVAL_SECS);
         self.on_blocking_task(|this| async move {
-            let simulated_blocks = this.backend.simulate(request, Some(block_request)).await?;
+            let simulated_blocks =
+                this.backend.simulate(request, Some(block_request), block_interval).await?;
             trace!(target : "node", "Simulate status {:?}", simulated_blocks);
 
             Ok(simulated_blocks)

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -72,7 +72,10 @@ use alloy_rpc_types::{
     anvil::Forking,
     request::TransactionRequest,
     serde_helpers::JsonStorageKey,
-    simulate::{SimBlock, SimCallResult, SimulateError, SimulatePayload, SimulatedBlock},
+    simulate::{
+        MAX_SIMULATE_BLOCKS, SimBlock, SimCallResult, SimulateError, SimulatePayload,
+        SimulatedBlock,
+    },
     state::{EvmOverrides, StateOverride},
     trace::{
         filter::TraceFilter,
@@ -5058,16 +5061,31 @@ impl Backend<FoundryNetwork> {
         &self,
         request: SimulatePayload,
         block_request: Option<BlockRequest<FoundryTxEnvelope>>,
+        block_interval: u64,
     ) -> Result<Vec<SimulatedBlock<AnyRpcBlock>>, BlockchainError> {
-        self.with_database_at(block_request, |state, mut block_env| {
+        let simulate_at = |state: Box<dyn MaybeFullDatabase + '_>,
+                           base_block_env: BlockEnv,
+                           base_number,
+                           base_timestamp,
+                           base_hash,
+                           base_fee| {
             let SimulatePayload {
                 block_state_calls,
                 trace_transfers,
                 validation,
                 return_full_transactions,
             } = request;
+            let block_state_calls = sanitize_simulation_blocks(
+                block_state_calls,
+                base_number,
+                base_timestamp,
+                block_interval,
+            )?;
             let mut cache_db = CacheDB::new(state);
+            cache_db.cache.block_hashes.insert(U256::from(base_number), base_hash);
             let mut block_res = Vec::with_capacity(block_state_calls.len());
+            let mut parent_hash = base_hash;
+            let mut next_base_fee = base_fee;
             let (is_amsterdam, tx_gas_limit_cap) = {
                 let cfg_env = &self.evm_env.read().cfg_env;
                 (cfg_env.spec >= SpecId::AMSTERDAM, cfg_env.tx_gas_limit_cap())
@@ -5077,20 +5095,20 @@ impl Backend<FoundryNetwork> {
             // execute the blocks
             for block in block_state_calls {
                 let SimBlock { block_overrides, state_overrides, calls } = block;
+                let mut block_env = base_block_env.clone();
+                block_env.basefee = if validation { next_base_fee } else { 0 };
+                block_env.prevrandao = Some(B256::ZERO);
                 let mut call_res = Vec::with_capacity(calls.len());
                 let mut log_index = 0;
                 let mut cumulative_gas_used = 0;
                 let mut block_regular_gas_used = 0;
                 let mut block_state_gas_used = 0;
                 let mut transactions = Vec::with_capacity(calls.len());
-                let mut logs= Vec::new();
+                let mut logs = Vec::new();
 
                 // apply state overrides before executing the transactions
                 if let Some(state_overrides) = state_overrides {
                     apply_state_overrides(state_overrides, &mut cache_db)?;
-                }
-                if !validation {
-                    block_env.basefee = 0;
                 }
                 if let Some(block_overrides) = block_overrides {
                     cache_db.apply_block_overrides(block_overrides, &mut block_env);
@@ -5188,9 +5206,10 @@ impl Backend<FoundryNetwork> {
                         }
                         result => result?,
                     };
-                    if !validation && caller_nonce == u64::MAX &&
-                        matches!(request.to.as_ref(), Some(TxKind::Call(_))) &&
-                        let Some(account) = state.get_mut(&caller)
+                    if !validation
+                        && caller_nonce == u64::MAX
+                        && matches!(request.to.as_ref(), Some(TxKind::Call(_)))
+                        && let Some(account) = state.get_mut(&caller)
                     {
                         account.info.nonce = 0;
                     }
@@ -5204,12 +5223,11 @@ impl Backend<FoundryNetwork> {
                     // commit the transaction
                     cache_db.commit(state);
                     rpc_gas_budget = rpc_gas_budget.saturating_sub(result.tx_gas_used());
-                    cumulative_gas_used =
-                        cumulative_gas_used.saturating_add(result.tx_gas_used());
+                    cumulative_gas_used = cumulative_gas_used.saturating_add(result.tx_gas_used());
                     block_regular_gas_used = block_regular_gas_used
                         .saturating_add(result.gas().block_regular_gas_used());
-                    block_state_gas_used = block_state_gas_used
-                        .saturating_add(result.gas().block_state_gas_used());
+                    block_state_gas_used =
+                        block_state_gas_used.saturating_add(result.gas().block_state_gas_used());
 
                     // create the transaction from a request
                     let from = caller;
@@ -5221,9 +5239,9 @@ impl Backend<FoundryNetwork> {
                     }
                     request.prep_for_submission();
 
-                    let typed_tx = request.build_unsigned().map_err(|e| {
-                        BlockchainError::InvalidTransactionRequest(e.to_string())
-                    })?;
+                    let typed_tx = request
+                        .build_unsigned()
+                        .map_err(|e| BlockchainError::InvalidTransactionRequest(e.to_string()))?;
 
                     let tx = build_impersonated(typed_tx);
                     let tx_hash = tx.hash();
@@ -5259,20 +5277,21 @@ impl Backend<FoundryNetwork> {
                                     data: Some(output.clone()),
                                 })
                             }
-                            ExecutionResult::Halt {
-                                reason: HaltReason::OutOfGas(_), ..
-                            } => Some(SimulateError {
-                                code: SimulateError::VM_EXECUTION_ERROR_CODE,
-                                message: "out of gas".to_string(),
-                                data: None,
-                            }),
+                            ExecutionResult::Halt { reason: HaltReason::OutOfGas(_), .. } => {
+                                Some(SimulateError {
+                                    code: SimulateError::VM_EXECUTION_ERROR_CODE,
+                                    message: "out of gas".to_string(),
+                                    data: None,
+                                })
+                            }
                             _ => Some(SimulateError {
                                 code: -3200,
                                 message: "execution failed".to_string(),
                                 data: None,
                             }),
                         },
-                        logs: result.clone()
+                        logs: result
+                            .clone()
                             .into_logs()
                             .into_iter()
                             .enumerate()
@@ -5300,15 +5319,13 @@ impl Backend<FoundryNetwork> {
                     cumulative_gas_used
                 };
 
-                let transactions_envelopes: Vec<AnyTxEnvelope> = transactions
-                .iter()
-                .map(|tx| AnyTxEnvelope::from(tx.clone()))
-                .collect();
+                let transactions_envelopes: Vec<AnyTxEnvelope> =
+                    transactions.iter().map(|tx| AnyTxEnvelope::from(tx.clone())).collect();
                 let header = Header {
                     logs_bloom: logs_bloom(logs.iter()),
                     transactions_root: calculate_transaction_root(&transactions_envelopes),
                     receipts_root: calculate_receipt_root(&transactions_envelopes),
-                    parent_hash: Default::default(),
+                    parent_hash,
                     beneficiary: block_env.beneficiary,
                     state_root: Default::default(),
                     difficulty: Default::default(),
@@ -5327,9 +5344,10 @@ impl Backend<FoundryNetwork> {
                     requests_hash: None,
                     ..Default::default()
                 };
+                let block_hash = header.hash_slow();
                 let mut block = alloy_rpc_types::Block {
                     header: AnyRpcHeader {
-                        hash: header.hash_slow(),
+                        hash: block_hash,
                         inner: header.into(),
                         total_difficulty: None,
                         size: None,
@@ -5354,12 +5372,11 @@ impl Backend<FoundryNetwork> {
                     calls: call_res,
                 };
 
-                // update block env
-                block_env.number += U256::from(1);
-                block_env.timestamp += U256::from(12);
+                parent_hash = block_hash;
+                cache_db.cache.block_hashes.insert(block_env.number, block_hash);
                 // Route through the fee manager so Tempo chains use their own base fee rules.
                 let header = &simulated_block.inner.header;
-                block_env.basefee = self.fees.get_next_block_base_fee_per_gas(
+                next_base_fee = self.fees.get_next_block_base_fee_per_gas(
                     header.gas_used(),
                     header.gas_limit(),
                     header.base_fee_per_gas().unwrap_or_default(),
@@ -5369,8 +5386,53 @@ impl Backend<FoundryNetwork> {
             }
 
             Ok(block_res)
-        })
-        .await?
+        };
+
+        match block_request {
+            Some(BlockRequest::Pending(pool_transactions)) => {
+                self.with_pending_block(pool_transactions, |state, block| {
+                    let header = &block.block.header;
+                    let base_fee = self.fees.get_next_block_base_fee_per_gas(
+                        header.gas_used(),
+                        header.gas_limit(),
+                        header.base_fee_per_gas().unwrap_or_default(),
+                    );
+                    simulate_at(
+                        state,
+                        block_env_from_header(header),
+                        header.number(),
+                        header.timestamp(),
+                        header.hash_slow(),
+                        base_fee,
+                    )
+                })
+                .await
+            }
+            block_request => {
+                let base_block_number = match block_request.as_ref() {
+                    Some(BlockRequest::Number(number)) => BlockNumber::Number(*number),
+                    Some(BlockRequest::Pending(_)) => unreachable!(),
+                    None => BlockNumber::Latest,
+                };
+                let base_block = self
+                    .block_by_number(base_block_number)
+                    .await?
+                    .ok_or(BlockchainError::BlockNotFound)?;
+                let base_number = base_block.header.number();
+                let base_timestamp = base_block.header.timestamp();
+                let base_hash = base_block.header.hash;
+                let base_fee = self.fees.get_next_block_base_fee_per_gas(
+                    base_block.header.gas_used(),
+                    base_block.header.gas_limit(),
+                    base_block.header.base_fee_per_gas().unwrap_or_default(),
+                );
+
+                self.with_database_at(block_request, |state, block_env| {
+                    simulate_at(state, block_env, base_number, base_timestamp, base_hash, base_fee)
+                })
+                .await?
+            }
+        }
     }
 
     pub fn get_blob_by_tx_hash(&self, hash: B256) -> Result<Option<Vec<alloy_consensus::Blob>>> {
@@ -5982,6 +6044,14 @@ pub fn is_arbitrum(chain_id: u64) -> bool {
     false
 }
 
+fn simulate_rpc_error(code: i64, message: impl Into<String>) -> BlockchainError {
+    BlockchainError::RpcError(RpcError {
+        code: ErrorCode::from(code),
+        message: message.into().into(),
+        data: None,
+    })
+}
+
 fn simulate_transaction_error(error: InvalidTransactionError) -> BlockchainError {
     let code = match &error {
         InvalidTransactionError::NonceTooLow => -38010,
@@ -5994,11 +6064,79 @@ fn simulate_transaction_error(error: InvalidTransactionError) -> BlockchainError
         _ => return BlockchainError::InvalidTransaction(error),
     };
 
-    BlockchainError::RpcError(RpcError {
-        code: ErrorCode::from(code),
-        message: format!("err: {error}").into(),
-        data: None,
-    })
+    simulate_rpc_error(code, format!("err: {error}"))
+}
+
+fn sanitize_simulation_blocks(
+    blocks: Vec<SimBlock>,
+    base_number: u64,
+    base_timestamp: u64,
+    block_interval: u64,
+) -> Result<Vec<SimBlock>, BlockchainError> {
+    let block_interval = block_interval.max(1);
+    let mut sanitized = Vec::with_capacity(blocks.len());
+    let mut previous_number = base_number;
+    let mut previous_timestamp = base_timestamp;
+
+    for mut block in blocks {
+        let mut overrides = block.block_overrides.take().unwrap_or_default();
+        let default_number = previous_number.checked_add(1).ok_or_else(|| {
+            simulate_rpc_error(-38020, "block number overflow while constructing sequence")
+        })?;
+        let number =
+            overrides.number.map(|number| number.saturating_to()).unwrap_or(default_number);
+
+        if number <= previous_number {
+            return Err(simulate_rpc_error(
+                -38020,
+                format!("block numbers must be in order: {number} <= {previous_number}"),
+            ));
+        }
+
+        let gap = number - previous_number - 1;
+        let remaining = MAX_SIMULATE_BLOCKS as usize - sanitized.len();
+        if gap as usize >= remaining {
+            return Err(simulate_rpc_error(-38026, "too many blocks"));
+        }
+
+        for offset in 0..gap {
+            let timestamp = previous_timestamp.checked_add(block_interval).ok_or_else(|| {
+                simulate_rpc_error(-38021, "block timestamp overflow while filling number gap")
+            })?;
+            sanitized.push(SimBlock {
+                block_overrides: Some(BlockOverrides {
+                    number: Some(U256::from(default_number + offset)),
+                    time: Some(timestamp),
+                    ..Default::default()
+                }),
+                state_overrides: None,
+                calls: Vec::new(),
+            });
+            previous_timestamp = timestamp;
+        }
+
+        let timestamp = match overrides.time {
+            Some(timestamp) => timestamp,
+            None => previous_timestamp.checked_add(block_interval).ok_or_else(|| {
+                simulate_rpc_error(-38021, "block timestamp overflow while constructing sequence")
+            })?,
+        };
+        if timestamp <= previous_timestamp {
+            return Err(simulate_rpc_error(
+                -38021,
+                format!("block timestamps must be in order: {timestamp} <= {previous_timestamp}"),
+            ));
+        }
+
+        overrides.number = Some(U256::from(number));
+        overrides.time = Some(timestamp);
+        block.block_overrides = Some(overrides);
+        sanitized.push(block);
+        previous_number = number;
+        previous_timestamp = timestamp;
+    }
+
+    Ok(sanitized)
 }
 
 /// Unpacks an [`ExecutionResult`] into its exit reason, gas used, output, and logs.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5086,6 +5086,7 @@ impl Backend<FoundryNetwork> {
             let mut block_res = Vec::with_capacity(block_state_calls.len());
             let mut parent_hash = base_hash;
             let mut next_base_fee = base_fee;
+            let mut inherited_block_env = base_block_env;
             let (is_amsterdam, tx_gas_limit_cap) = {
                 let cfg_env = &self.evm_env.read().cfg_env;
                 (cfg_env.spec >= SpecId::AMSTERDAM, cfg_env.tx_gas_limit_cap())
@@ -5095,7 +5096,7 @@ impl Backend<FoundryNetwork> {
             // execute the blocks
             for block in block_state_calls {
                 let SimBlock { block_overrides, state_overrides, calls } = block;
-                let mut block_env = base_block_env.clone();
+                let mut block_env = inherited_block_env.clone();
                 block_env.basefee = if validation { next_base_fee } else { 0 };
                 block_env.prevrandao = Some(B256::ZERO);
                 let mut call_res = Vec::with_capacity(calls.len());
@@ -5395,6 +5396,9 @@ impl Backend<FoundryNetwork> {
 
                 parent_hash = block_hash;
                 cache_db.cache.block_hashes.insert(block_env.number, block_hash);
+                inherited_block_env.beneficiary = block_env.beneficiary;
+                inherited_block_env.difficulty = block_env.difficulty;
+                inherited_block_env.gas_limit = block_env.gas_limit;
                 // Route through the fee manager so Tempo chains use their own base fee rules.
                 let header = &simulated_block.inner.header;
                 next_base_fee = self.fees.calculate_next_block_base_fee_per_gas(

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5105,6 +5105,19 @@ impl Backend<FoundryNetwork> {
                 let mut block_state_gas_used = 0;
                 let mut transactions = Vec::with_capacity(calls.len());
                 let mut logs = Vec::new();
+                let overridden_block_hashes = block_overrides
+                    .as_ref()
+                    .and_then(|overrides| overrides.block_hash.as_ref())
+                    .map(|overrides| {
+                        overrides
+                            .keys()
+                            .map(|number| {
+                                let number = U256::from(*number);
+                                (number, cache_db.cache.block_hashes.get(&number).copied())
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
 
                 // apply state overrides before executing the transactions
                 if let Some(state_overrides) = state_overrides {
@@ -5313,6 +5326,14 @@ impl Backend<FoundryNetwork> {
                     call_res.push(sim_res);
                 }
 
+                for (number, hash) in overridden_block_hashes {
+                    if let Some(hash) = hash {
+                        cache_db.cache.block_hashes.insert(number, hash);
+                    } else {
+                        cache_db.cache.block_hashes.remove(&number);
+                    }
+                }
+
                 let gas_used = if is_amsterdam {
                     block_regular_gas_used.max(block_state_gas_used)
                 } else {
@@ -5376,7 +5397,7 @@ impl Backend<FoundryNetwork> {
                 cache_db.cache.block_hashes.insert(block_env.number, block_hash);
                 // Route through the fee manager so Tempo chains use their own base fee rules.
                 let header = &simulated_block.inner.header;
-                next_base_fee = self.fees.get_next_block_base_fee_per_gas(
+                next_base_fee = self.fees.calculate_next_block_base_fee_per_gas(
                     header.gas_used(),
                     header.gas_limit(),
                     header.base_fee_per_gas().unwrap_or_default(),
@@ -5392,7 +5413,7 @@ impl Backend<FoundryNetwork> {
             Some(BlockRequest::Pending(pool_transactions)) => {
                 self.with_pending_block(pool_transactions, |state, block| {
                     let header = &block.block.header;
-                    let base_fee = self.fees.get_next_block_base_fee_per_gas(
+                    let base_fee = self.fees.calculate_next_block_base_fee_per_gas(
                         header.gas_used(),
                         header.gas_limit(),
                         header.base_fee_per_gas().unwrap_or_default(),
@@ -5421,7 +5442,7 @@ impl Backend<FoundryNetwork> {
                 let base_number = base_block.header.number();
                 let base_timestamp = base_block.header.timestamp();
                 let base_hash = base_block.header.hash;
-                let base_fee = self.fees.get_next_block_base_fee_per_gas(
+                let base_fee = self.fees.calculate_next_block_base_fee_per_gas(
                     base_block.header.gas_used(),
                     base_block.header.gas_limit(),
                     base_block.header.base_fee_per_gas().unwrap_or_default(),

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -88,6 +88,11 @@ impl TimeManager {
         self.interval.write().replace(interval);
     }
 
+    /// Returns the configured block timestamp interval.
+    pub(crate) fn block_timestamp_interval(&self) -> Option<u64> {
+        *self.interval.read()
+    }
+
     /// Removes the interval if it exists
     pub fn remove_block_timestamp_interval(&self) -> bool {
         if self.interval.write().take().is_some() {

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -174,6 +174,17 @@ impl FeeManager {
         if self.base_fee() == 0 {
             return 0;
         }
+        self.calculate_next_block_base_fee_per_gas(gas_used, gas_limit, last_fee_per_gas)
+    }
+
+    /// Calculates the next block base fee from the parent block without applying the configured
+    /// zero-fee sentinel.
+    pub(crate) fn calculate_next_block_base_fee_per_gas(
+        &self,
+        gas_used: u64,
+        gas_limit: u64,
+        last_fee_per_gas: u64,
+    ) -> u64 {
         // Tempo replaces EIP-1559 with its own hardfork-specific base fee rules.
         if let Some(hardfork) = self.tempo_hardfork() {
             return tempo_next_block_base_fee(hardfork, gas_used, last_fee_per_gas);

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -94,6 +94,17 @@ impl<T> Miner<T> {
         None
     }
 
+    /// Returns the configured block interval for fixed or mixed mining.
+    pub(crate) fn block_interval(&self) -> Option<Duration> {
+        let mode = self.mode.read();
+        match &*mode {
+            MiningMode::FixedBlockTime(miner) | MiningMode::Mixed(_, miner) => {
+                Some(miner.interval.period())
+            }
+            MiningMode::None | MiningMode::Auto(_) => None,
+        }
+    }
+
     /// Sets the mining mode to operate in
     pub fn set_mining_mode(&self, mode: MiningMode) {
         let new_mode = format!("{mode:?}");

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -266,6 +266,51 @@ async fn test_simulate_scopes_block_hash_overrides_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_inherits_parent_block_context_rpc() {
+    let config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::London.into()));
+    let (_api, handle) = spawn(config).await;
+    let endpoint = handle.http_endpoint();
+    let contract = "0xc000000000000000000000000000000000000000";
+    let fee_recipient = "0xc200000000000000000000000000000000000000";
+    let gas_limit = 1_000_000;
+    let difficulty = 42;
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {
+                    "blockOverrides": {
+                        "gasLimit": format!("{gas_limit:#x}"),
+                        "feeRecipient": fee_recipient,
+                        "difficulty": format!("{difficulty:#x}")
+                    },
+                    "stateOverrides": {
+                        (contract): {"code": "0x45600052416020524460405260606000f3"}
+                    },
+                    "calls": [{"to": contract}]
+                },
+                {"calls": [{"to": contract}]}
+            ]
+        }, "latest"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+    let blocks = response["result"].as_array().unwrap();
+    let return_data = format!(
+        "0x{gas_limit:064x}{}{}{difficulty:064x}",
+        "0".repeat(24),
+        fee_recipient.trim_start_matches("0x")
+    );
+
+    for block in blocks {
+        assert_eq!(quantity(&block["gasLimit"]), gas_limit);
+        assert_eq!(block["miner"], fee_recipient);
+        assert_eq!(block["calls"][0]["returnData"], return_data);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_scopes_block_overrides_and_derives_base_fee_rpc() {
     let config = NodeConfig::test()
         .with_hardfork(Some(EthereumHardfork::Cancun.into()))

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -11,6 +11,7 @@ use alloy_rpc_types::{
 use anvil::{EthereumHardfork, NodeConfig, spawn};
 use foundry_test_utils::rpc;
 use serde_json::{Value, json};
+use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_simulate_v1() {
@@ -43,6 +44,271 @@ async fn test_fork_simulate_v1() {
         return_full_transactions: true,
     };
     let _res = api.simulate_v1(payload, None).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_normalizes_block_sequence_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
+    let endpoint = handle.http_endpoint();
+    let latest = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["latest", false])).await;
+    let base = &latest["result"];
+    let base_number = quantity(&base["number"]);
+    let base_timestamp = quantity(&base["timestamp"]);
+
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {
+                    "blockOverrides": {
+                        "number": format!("{:#x}", base_number + 3),
+                        "time": format!("{:#x}", base_timestamp + 100)
+                    }
+                },
+                {},
+                {
+                    "blockOverrides": {
+                        "number": format!("{:#x}", base_number + 7)
+                    }
+                }
+            ]
+        }, "latest"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+    let blocks = response["result"].as_array().unwrap();
+
+    let expected = [
+        (base_number + 1, base_timestamp + 12),
+        (base_number + 2, base_timestamp + 24),
+        (base_number + 3, base_timestamp + 100),
+        (base_number + 4, base_timestamp + 112),
+        (base_number + 5, base_timestamp + 124),
+        (base_number + 6, base_timestamp + 136),
+        (base_number + 7, base_timestamp + 148),
+    ];
+    let mut expected_parent = base["hash"].clone();
+    for (block, (number, timestamp)) in blocks.iter().zip(expected) {
+        assert_eq!(quantity(&block["number"]), number);
+        assert_eq!(quantity(&block["timestamp"]), timestamp);
+        assert_eq!(block["parentHash"], expected_parent);
+        expected_parent = block["hash"].clone();
+    }
+    assert!(blocks[0]["calls"].as_array().unwrap().is_empty());
+    assert!(blocks[1]["calls"].as_array().unwrap().is_empty());
+    assert!(blocks[4]["calls"].as_array().unwrap().is_empty());
+    assert!(blocks[5]["calls"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_uses_configured_block_interval_rpc() {
+    for mixed_mining in [false, true] {
+        let config = NodeConfig::test()
+            .with_genesis_timestamp(Some(1_000u64))
+            .with_mixed_mining(mixed_mining, Some(Duration::from_millis(1_500)));
+        let (api, handle) = spawn(config).await;
+        let endpoint = handle.http_endpoint();
+        let base = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["latest", false])).await;
+        let base_timestamp = quantity(&base["result"]["timestamp"]);
+
+        let response = rpc_request(
+            &endpoint,
+            "eth_simulateV1",
+            json!([{"blockStateCalls": [{}, {}]}, "latest"]),
+        )
+        .await;
+        let blocks = response["result"].as_array().unwrap();
+        assert_eq!(quantity(&blocks[0]["timestamp"]), base_timestamp + 2);
+        assert_eq!(quantity(&blocks[1]["timestamp"]), base_timestamp + 4);
+
+        api.anvil_set_interval_mining(3).unwrap();
+        let response =
+            rpc_request(&endpoint, "eth_simulateV1", json!([{"blockStateCalls": [{}]}, "latest"]))
+                .await;
+        assert_eq!(quantity(&response["result"][0]["timestamp"]), base_timestamp + 3);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_rejects_invalid_block_sequence_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
+    let endpoint = handle.http_endpoint();
+    let base = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["latest", false])).await;
+    let base_number = quantity(&base["result"]["number"]);
+    let base_timestamp = quantity(&base["result"]["timestamp"]);
+    let cases = [
+        (
+            json!([{"blockStateCalls": [{
+                "blockOverrides": {"number": format!("{base_number:#x}")}
+            }]}, "latest"]),
+            -38020,
+        ),
+        (
+            json!([{"blockStateCalls": [{
+                "blockOverrides": {"time": format!("{base_timestamp:#x}")}
+            }]}, "latest"]),
+            -38021,
+        ),
+        (
+            json!([{"blockStateCalls": [{
+                "blockOverrides": {
+                    "number": format!("{:#x}", base_number + 2),
+                    "time": format!("{:#x}", base_timestamp + 12)
+                }
+            }]}, "latest"]),
+            -38021,
+        ),
+        (
+            json!([{"blockStateCalls": [{
+                "blockOverrides": {"number": format!("{:#x}", base_number + 257)}
+            }]}, "latest"]),
+            -38026,
+        ),
+    ];
+
+    for (params, code) in cases {
+        let response = rpc_request(&endpoint, "eth_simulateV1", params).await;
+        assert_eq!(response["error"]["code"], code, "{response}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_chains_block_hashes_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let base = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["latest", false])).await;
+    let base_hash = base["result"]["hash"].clone();
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {
+                    "stateOverrides": {
+                        "0xc000000000000000000000000000000000000000": {
+                            "code": "0x5f405f5260205ff3"
+                        }
+                    },
+                    "calls": [{
+                        "to": "0xc000000000000000000000000000000000000000"
+                    }]
+                },
+                {
+                    "stateOverrides": {
+                        "0xc100000000000000000000000000000000000000": {
+                            "code": "0x6001405f5260205ff3"
+                        }
+                    },
+                    "calls": [{
+                        "to": "0xc100000000000000000000000000000000000000"
+                    }]
+                }
+            ]
+        }, "latest"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+    let blocks = response["result"].as_array().unwrap();
+
+    assert_eq!(blocks[0]["parentHash"], base_hash);
+    assert_eq!(blocks[0]["calls"][0]["returnData"], base_hash);
+    assert_eq!(blocks[1]["parentHash"], blocks[0]["hash"]);
+    assert_eq!(blocks[1]["calls"][0]["returnData"], blocks[0]["hash"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_scopes_block_overrides_and_derives_base_fee_rpc() {
+    let config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
+    let (_api, handle) = spawn(config).await;
+    let endpoint = handle.http_endpoint();
+    let random = format!("0x{:064x}", 42);
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {
+                    "blockOverrides": {
+                        "prevRandao": random,
+                        "baseFeePerGas": "0xa",
+                        "blobBaseFee": "0x15"
+                    },
+                    "stateOverrides": {
+                        "0xc100000000000000000000000000000000000000": {
+                            "code": "0x445f52486020524a60405260605ff3"
+                        }
+                    },
+                    "calls": [{
+                        "to": "0xc100000000000000000000000000000000000000"
+                    }]
+                },
+                {
+                    "calls": [{
+                        "to": "0xc100000000000000000000000000000000000000"
+                    }]
+                }
+            ]
+        }, "latest"]),
+    )
+    .await;
+    let blocks = response["result"].as_array().unwrap();
+    assert_eq!(blocks[0]["calls"][0]["returnData"], format!("0x{:064x}{:064x}{:064x}", 42, 10, 21));
+    assert_eq!(blocks[1]["calls"][0]["returnData"], format!("0x{:064x}{:064x}{:064x}", 0, 0, 1));
+
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {"blockOverrides": {"baseFeePerGas": "0x3e8"}},
+                {}
+            ],
+            "validation": true
+        }, "latest"]),
+    )
+    .await;
+    assert_eq!(response["result"][0]["baseFeePerGas"], "0x3e8");
+    assert_eq!(response["result"][1]["baseFeePerGas"], "0x36b");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_derives_from_historical_base_rpc() {
+    let (api, handle) = spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
+    api.mine_one().await;
+    let endpoint = handle.http_endpoint();
+    let genesis = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["0x0", false])).await;
+    let response =
+        rpc_request(&endpoint, "eth_simulateV1", json!([{"blockStateCalls": [{}]}, "0x0"])).await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"][0]["number"], "0x1");
+    assert_eq!(response["result"][0]["parentHash"], genesis["result"]["hash"]);
+    assert_eq!(
+        quantity(&response["result"][0]["timestamp"]),
+        quantity(&genesis["result"]["timestamp"]) + 12
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_derives_from_pending_base_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let pending = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["pending", false])).await;
+    let response =
+        rpc_request(&endpoint, "eth_simulateV1", json!([{"blockStateCalls": [{}]}, "pending"]))
+            .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(
+        quantity(&response["result"][0]["number"]),
+        quantity(&pending["result"]["number"]) + 1
+    );
+    assert_eq!(response["result"][0]["parentHash"], pending["result"]["hash"]);
+    assert_eq!(
+        quantity(&response["result"][0]["timestamp"]),
+        quantity(&pending["result"]["timestamp"]) + 12
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -492,4 +758,8 @@ async fn rpc_request(endpoint: &str, method: &str, params: Value) -> Value {
         .unwrap();
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     response.json().await.unwrap()
+}
+
+fn quantity(value: &Value) -> u64 {
+    u64::from_str_radix(value.as_str().unwrap().trim_start_matches("0x"), 16).unwrap()
 }

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -122,6 +122,18 @@ async fn test_simulate_uses_configured_block_interval_rpc() {
         assert_eq!(quantity(&blocks[0]["timestamp"]), base_timestamp + 2);
         assert_eq!(quantity(&blocks[1]["timestamp"]), base_timestamp + 4);
 
+        api.evm_set_block_timestamp_interval(7).unwrap();
+        let response = rpc_request(
+            &endpoint,
+            "eth_simulateV1",
+            json!([{"blockStateCalls": [{}, {}]}, "latest"]),
+        )
+        .await;
+        let blocks = response["result"].as_array().unwrap();
+        assert_eq!(quantity(&blocks[0]["timestamp"]), base_timestamp + 7);
+        assert_eq!(quantity(&blocks[1]["timestamp"]), base_timestamp + 14);
+        assert!(api.evm_remove_block_timestamp_interval().unwrap());
+
         api.anvil_set_interval_mining(3).unwrap();
         let response =
             rpc_request(&endpoint, "eth_simulateV1", json!([{"blockStateCalls": [{}]}, "latest"]))
@@ -218,8 +230,46 @@ async fn test_simulate_chains_block_hashes_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_scopes_block_hash_overrides_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let base = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["latest", false])).await;
+    let base_hash = base["result"]["hash"].clone();
+    let fake_hash = format!("0x{}", "42".repeat(32));
+    let contract = "0xc000000000000000000000000000000000000000";
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {
+                    "blockOverrides": {
+                        "blockHash": {"0": fake_hash}
+                    },
+                    "stateOverrides": {
+                        (contract): {"code": "0x5f405f5260205ff3"}
+                    },
+                    "calls": [{"to": contract}]
+                },
+                {
+                    "calls": [{"to": contract}]
+                }
+            ]
+        }, "latest"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+    let blocks = response["result"].as_array().unwrap();
+
+    assert_eq!(blocks[0]["calls"][0]["returnData"], fake_hash);
+    assert_eq!(blocks[1]["calls"][0]["returnData"], base_hash);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_scopes_block_overrides_and_derives_base_fee_rpc() {
-    let config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()));
+    let config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Cancun.into()))
+        .with_base_fee(Some(0));
     let (_api, handle) = spawn(config).await;
     let endpoint = handle.http_endpoint();
     let random = format!("0x{:064x}", 42);
@@ -292,7 +342,8 @@ async fn test_simulate_derives_from_historical_base_rpc() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_derives_from_pending_base_rpc() {
-    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.evm_set_block_timestamp_interval(12).unwrap();
     let endpoint = handle.http_endpoint();
     let pending = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["pending", false])).await;
     let response =


### PR DESCRIPTION
## Motivation

Closes OSS-564.

This is the next focused `eth_simulateV1` conformance step after #15770, #15784, #15792, and #15828. Local simulations now derive block numbers and timestamps from the selected base block, expand number gaps with empty blocks, reject invalid ordering with `-38020` and `-38021`, chain parent hashes for `BLOCKHASH`, scope block overrides to their target block, and derive subsequent base fees from the simulated parent. Timestamp defaults honor Anvil’s configured block interval.

Normalization of delegated pre-fork simulations remains tracked by OSS-572, while canonical response finalization remains tracked by OSS-565.