### PR TITLE
fix(anvil): propagate simulated prevRandao

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5356,7 +5356,7 @@ impl Backend<FoundryNetwork> {
                     gas_used,
                     timestamp: block_env.timestamp.saturating_to(),
                     extra_data: Default::default(),
-                    mix_hash: Default::default(),
+                    mix_hash: block_env.prevrandao.unwrap_or_default(),
                     nonce: Default::default(),
                     base_fee_per_gas: Some(block_env.basefee),
                     withdrawals_root: None,

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -230,6 +230,45 @@ async fn test_simulate_chains_block_hashes_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_includes_prevrandao_in_chained_hash_rpc() {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let contract = "0xc000000000000000000000000000000000000000";
+    let mut hashes = Vec::new();
+
+    for random in [42, 43] {
+        let random = format!("0x{random:064x}");
+        let response = rpc_request(
+            &endpoint,
+            "eth_simulateV1",
+            json!([{
+                "blockStateCalls": [
+                    {
+                        "blockOverrides": {"prevRandao": random}
+                    },
+                    {
+                        "stateOverrides": {
+                            (contract): {"code": "0x6001405f5260205ff3"}
+                        },
+                        "calls": [{"to": contract}]
+                    }
+                ]
+            }, "latest"]),
+        )
+        .await;
+        assert!(response.get("error").is_none(), "{response}");
+        let blocks = response["result"].as_array().unwrap();
+
+        assert_eq!(blocks[0]["mixHash"], random);
+        assert_eq!(blocks[1]["parentHash"], blocks[0]["hash"]);
+        assert_eq!(blocks[1]["calls"][0]["returnData"], blocks[0]["hash"]);
+        hashes.push(blocks[0]["hash"].clone());
+    }
+
+    assert_ne!(hashes[0], hashes[1]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_scopes_block_hash_overrides_rpc() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let endpoint = handle.http_endpoint();


### PR DESCRIPTION
`eth_simulateV1` applied `prevRandao` during execution but omitted it from the synthetic block header, causing different `prevRandao` values to produce the same block hash and subsequent `BLOCKHASH` result.

Populate `mixHash` from the simulated block environment so chained hashes reflect the context used during execution.