### PR TITLE
fix(anvil): `eth_simulateV1` normalize delegated simulations

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1,5 +1,5 @@
 use super::{
-    backend::mem::{BlockRequest, DatabaseRef, State},
+    backend::mem::{BlockRequest, DatabaseRef, State, sanitize_simulation_blocks},
     sign::build_impersonated,
 };
 use crate::{
@@ -2922,7 +2922,7 @@ impl EthApi<FoundryNetwork> {
 
     pub async fn simulate_v1(
         &self,
-        request: SimulatePayload,
+        mut request: SimulatePayload,
         block_number: Option<BlockId>,
     ) -> Result<Vec<SimulatedBlock<AnyRpcBlock>>> {
         const DEFAULT_BLOCK_INTERVAL_SECS: u64 = 12;
@@ -2949,16 +2949,6 @@ impl EthApi<FoundryNetwork> {
                 }
                 error => error,
             })?;
-        // check if the number predates the fork, if in fork mode
-        if let BlockRequest::Number(number) = block_request
-            && let Some(fork) = self.get_fork()
-            && fork.predates_fork(number)
-        {
-            return Ok(fork.simulate_v1(&request, Some(number.into())).await?);
-        }
-
-        // this can be blocking for a bit, especially in forking mode
-        // <https://github.com/foundry-rs/foundry/issues/6036>
         let block_interval = self.backend.time().block_timestamp_interval().unwrap_or_else(|| {
             self.miner
                 .block_interval()
@@ -2970,6 +2960,30 @@ impl EthApi<FoundryNetwork> {
                 })
                 .unwrap_or(DEFAULT_BLOCK_INTERVAL_SECS)
         });
+
+        // check if the number predates the fork, if in fork mode
+        if let BlockRequest::Number(number) = block_request
+            && let Some(fork) = self.get_fork()
+            && fork.predates_fork(number)
+        {
+            let base_block = fork.block_by_number(number).await?.ok_or_else(|| {
+                BlockchainError::RpcError(RpcError {
+                    code: ErrorCode::ServerError(-32000),
+                    message: "header not found".into(),
+                    data: None,
+                })
+            })?;
+            request.block_state_calls = sanitize_simulation_blocks(
+                request.block_state_calls,
+                base_block.header.number(),
+                base_block.header.timestamp(),
+                block_interval,
+            )?;
+            return Ok(fork.simulate_v1(&request, Some(number.into())).await?);
+        }
+
+        // this can be blocking for a bit, especially in forking mode
+        // <https://github.com/foundry-rs/foundry/issues/6036>
         self.on_blocking_task(|this| async move {
             let simulated_blocks =
                 this.backend.simulate(request, Some(block_request), block_interval).await?;

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2979,7 +2979,7 @@ impl EthApi<FoundryNetwork> {
                 base_block.header.timestamp(),
                 block_interval,
             )?;
-            return Ok(fork.simulate_v1(&request, Some(number.into())).await?);
+            return Ok(fork.simulate_v1(&request, Some(base_block.header.hash.into())).await?);
         }
 
         // this can be blocking for a bit, especially in forking mode

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2938,6 +2938,7 @@ impl EthApi<FoundryNetwork> {
                 data: None,
             }));
         }
+        let block_id = block_number;
         let block_request =
             self.block_request(block_number).await.map_err(|error| match error {
                 BlockchainError::BlockOutOfRange(_, _) | BlockchainError::BlockNotFound => {
@@ -2966,7 +2967,8 @@ impl EthApi<FoundryNetwork> {
             && let Some(fork) = self.get_fork()
             && fork.predates_fork(number)
         {
-            let base_block = fork.block_by_number(number).await?.ok_or_else(|| {
+            let block_id = block_id.unwrap_or_else(|| number.into());
+            let base_block = fork.fetch_block(block_id).await?.ok_or_else(|| {
                 BlockchainError::RpcError(RpcError {
                     code: ErrorCode::ServerError(-32000),
                     message: "header not found".into(),

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -676,6 +676,14 @@ impl<N: Network> ClientFork<N> {
         self.fetch_full_block(block_number).await
     }
 
+    /// Fetches a block selected by its original identifier directly from the fork provider.
+    pub async fn fetch_block(
+        &self,
+        block_id: BlockId,
+    ) -> Result<Option<N::BlockResponse>, TransportError> {
+        self.fetch_full_block(block_id).await
+    }
+
     async fn fetch_full_block(
         &self,
         block_id: impl Into<BlockId>,

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -519,11 +519,11 @@ impl<N: Network> ClientFork<N> {
     pub async fn simulate_v1(
         &self,
         request: &SimulatePayload,
-        block: Option<BlockNumber>,
+        block: Option<BlockId>,
     ) -> Result<Vec<SimulatedBlock<N::BlockResponse>>, TransportError> {
         let mut simulate_call = self.provider().simulate(request);
-        if let Some(n) = block {
-            simulate_call = simulate_call.number(n.as_number().unwrap());
+        if let Some(block) = block {
+            simulate_call = simulate_call.block_id(block);
         }
 
         let res = simulate_call.await?;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -6092,7 +6092,7 @@ fn simulate_transaction_error(error: InvalidTransactionError) -> BlockchainError
     simulate_rpc_error(code, format!("err: {error}"))
 }
 
-fn sanitize_simulation_blocks(
+pub(in crate::eth) fn sanitize_simulation_blocks(
     blocks: Vec<SimBlock>,
     base_number: u64,
     base_timestamp: u64,

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -47,6 +47,71 @@ async fn test_fork_simulate_v1() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fork_simulate_normalizes_delegated_block_sequence_rpc() {
+    let (origin_api, origin_handle) =
+        spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
+    origin_api.mine_one().await;
+    origin_api.mine_one().await;
+
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+            .with_fork_block_number(Some(2u64)),
+    )
+    .await;
+    api.evm_set_block_timestamp_interval(7).unwrap();
+
+    let endpoint = handle.http_endpoint();
+    let base = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["0x1", false])).await;
+    let base_number = quantity(&base["result"]["number"]);
+    let base_timestamp = quantity(&base["result"]["timestamp"]);
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "blockOverrides": {"number": format!("{:#x}", base_number + 3)}
+            }]
+        }, "0x1"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+
+    let blocks = response["result"].as_array().unwrap();
+    assert_eq!(blocks.len(), 3);
+    for (index, block) in blocks.iter().enumerate() {
+        let offset = index as u64 + 1;
+        assert_eq!(quantity(&block["number"]), base_number + offset);
+        assert_eq!(quantity(&block["timestamp"]), base_timestamp + 7 * offset);
+    }
+
+    let cases = [
+        (
+            json!([{"blockStateCalls": [{
+                "blockOverrides": {"number": format!("{base_number:#x}")}
+            }]}, "0x1"]),
+            -38020,
+        ),
+        (
+            json!([{"blockStateCalls": [{
+                "blockOverrides": {"time": format!("{base_timestamp:#x}")}
+            }]}, "0x1"]),
+            -38021,
+        ),
+        (
+            json!([{"blockStateCalls": [{
+                "blockOverrides": {"number": format!("{:#x}", base_number + 257)}
+            }]}, "0x1"]),
+            -38026,
+        ),
+    ];
+    for (params, code) in cases {
+        let response = rpc_request(&endpoint, "eth_simulateV1", params).await;
+        assert_eq!(response["error"]["code"], code, "{response}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_normalizes_block_sequence_rpc() {
     let (_api, handle) = spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
     let endpoint = handle.http_endpoint();

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -113,7 +113,7 @@ async fn test_fork_simulate_normalizes_delegated_block_sequence_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_fork_simulate_pins_delegated_hash_selector_rpc() {
+async fn test_fork_simulate_preserves_delegated_base_selector_rpc() {
     let (hash_api, hash_handle) =
         spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
     hash_api.evm_set_block_timestamp_interval(1).unwrap();
@@ -129,23 +129,28 @@ async fn test_fork_simulate_pins_delegated_hash_selector_rpc() {
     canonical_api.evm_set_block_timestamp_interval(1).unwrap();
     canonical_api.mine_one().await;
     canonical_api.mine_one().await;
+    let canonical_endpoint = canonical_handle.http_endpoint();
+    let canonical_base =
+        rpc_request(&canonical_endpoint, "eth_getBlockByNumber", json!(["0x1", false])).await;
+    let canonical_hash = canonical_base["result"]["hash"].clone();
 
-    let proxy_endpoint = spawn_hash_aware_rpc_proxy(
-        hash_endpoint,
-        canonical_handle.http_endpoint(),
-        hash_selector.clone(),
-    )
-    .await;
+    let proxy_endpoint =
+        spawn_hash_aware_rpc_proxy(hash_endpoint, canonical_endpoint, hash_selector.clone()).await;
     let (api, handle) = spawn(
         NodeConfig::test()
-            .with_eth_rpc_url(Some(proxy_endpoint))
+            .with_eth_rpc_url(Some(proxy_endpoint.clone()))
             .with_fork_block_number(Some(2u64)),
     )
     .await;
     api.evm_set_block_timestamp_interval(7).unwrap();
+    let endpoint = handle.http_endpoint();
+
+    // Cache the selected block, then replace the same-height cache mapping with another block.
+    rpc_request(&endpoint, "eth_getBlockByHash", json!([hash_selector, false])).await;
+    rpc_request(&endpoint, "eth_getBlockByHash", json!([canonical_hash, false])).await;
 
     let response = rpc_request(
-        &handle.http_endpoint(),
+        &endpoint,
         "eth_simulateV1",
         json!([{"blockStateCalls": [{}]}, {"blockHash": hash_selector}]),
     )
@@ -154,6 +159,25 @@ async fn test_fork_simulate_pins_delegated_hash_selector_rpc() {
     assert_eq!(
         quantity(&response["result"][0]["timestamp"]),
         quantity(&hash_base["result"]["timestamp"]) + 7
+    );
+
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(proxy_endpoint))
+            .with_fork_block_number(Some(2u64)),
+    )
+    .await;
+    api.evm_set_block_timestamp_interval(7).unwrap();
+    let endpoint = handle.http_endpoint();
+
+    // Cache a noncanonical block at the selected height before using a numeric selector.
+    rpc_request(&endpoint, "eth_getBlockByHash", json!([hash_selector, false])).await;
+    let response =
+        rpc_request(&endpoint, "eth_simulateV1", json!([{"blockStateCalls": [{}]}, "0x1"])).await;
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(
+        quantity(&response["result"][0]["timestamp"]),
+        quantity(&canonical_base["result"]["timestamp"]) + 7
     );
 }
 
@@ -1020,6 +1044,7 @@ async fn spawn_hash_aware_rpc_proxy(
             async move {
                 let method = request["method"].as_str().unwrap();
                 let endpoint = if method == "eth_getBlockByHash"
+                    && request["params"].get(0) == Some(&hash_selector)
                     || method == "eth_simulateV1"
                         && request["params"].get(1) == Some(&hash_selector)
                 {

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -9,6 +9,7 @@ use alloy_rpc_types::{
     state::{AccountOverride, StateOverridesBuilder},
 };
 use anvil::{EthereumHardfork, NodeConfig, spawn};
+use axum::{Json, Router, routing::post};
 use foundry_test_utils::rpc;
 use serde_json::{Value, json};
 use std::time::Duration;
@@ -109,6 +110,51 @@ async fn test_fork_simulate_normalizes_delegated_block_sequence_rpc() {
         let response = rpc_request(&endpoint, "eth_simulateV1", params).await;
         assert_eq!(response["error"]["code"], code, "{response}");
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_simulate_pins_delegated_hash_selector_rpc() {
+    let (hash_api, hash_handle) =
+        spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
+    hash_api.evm_set_block_timestamp_interval(1).unwrap();
+    hash_api.mine_one().await;
+    hash_api.mine_one().await;
+    let hash_endpoint = hash_handle.http_endpoint();
+    let hash_base =
+        rpc_request(&hash_endpoint, "eth_getBlockByNumber", json!(["0x1", false])).await;
+    let hash_selector = hash_base["result"]["hash"].clone();
+
+    let (canonical_api, canonical_handle) =
+        spawn(NodeConfig::test().with_genesis_timestamp(Some(2_000u64))).await;
+    canonical_api.evm_set_block_timestamp_interval(1).unwrap();
+    canonical_api.mine_one().await;
+    canonical_api.mine_one().await;
+
+    let proxy_endpoint = spawn_hash_aware_rpc_proxy(
+        hash_endpoint,
+        canonical_handle.http_endpoint(),
+        hash_selector.clone(),
+    )
+    .await;
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(proxy_endpoint))
+            .with_fork_block_number(Some(2u64)),
+    )
+    .await;
+    api.evm_set_block_timestamp_interval(7).unwrap();
+
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{"blockStateCalls": [{}]}, {"blockHash": hash_selector}]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(
+        quantity(&response["result"][0]["timestamp"]),
+        quantity(&hash_base["result"]["timestamp"]) + 7
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -958,6 +1004,46 @@ async fn rpc_request(endpoint: &str, method: &str, params: Value) -> Value {
         .unwrap();
     assert_eq!(response.status(), reqwest::StatusCode::OK);
     response.json().await.unwrap()
+}
+
+async fn spawn_hash_aware_rpc_proxy(
+    hash_endpoint: String,
+    canonical_endpoint: String,
+    hash_selector: Value,
+) -> String {
+    let router = Router::new().route(
+        "/",
+        post(move |Json(request): Json<Value>| {
+            let hash_endpoint = hash_endpoint.clone();
+            let canonical_endpoint = canonical_endpoint.clone();
+            let hash_selector = hash_selector.clone();
+            async move {
+                let method = request["method"].as_str().unwrap();
+                let endpoint = if method == "eth_getBlockByHash"
+                    || method == "eth_simulateV1"
+                        && request["params"].get(1) == Some(&hash_selector)
+                {
+                    hash_endpoint
+                } else {
+                    canonical_endpoint
+                };
+                let response = reqwest::Client::new()
+                    .post(endpoint)
+                    .json(&request)
+                    .send()
+                    .await
+                    .unwrap()
+                    .json::<Value>()
+                    .await
+                    .unwrap();
+                Json(response)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    format!("http://{address}")
 }
 
 fn quantity(value: &Value) -> u64 {


### PR DESCRIPTION
## Motivation

Closes OSS-572.

This is the next focused `eth_simulateV1` conformance step after #15770, #15784, #15792, #15828, and #15841.

Pre-fork requests delegated upstream now fetch the selected base header, normalize block numbers and timestamps using Anvil's configured interval, and pin execution to that header's hash. Gap expansion and ordering and block-count errors therefore match local simulation without allowing a reorganization or noncanonical selector to normalize and execute against different same-height blocks.

> This PR was written and tested with the assistance of Codex.
