### PR TITLE
fix(forge): include linked library deployments in state diffs

### DIFF
--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1051,7 +1051,7 @@ impl Cheatcode for deleteStateSnapshotsCall {
 impl Cheatcode for startStateDiffRecordingCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
         let Self {} = self;
-        state.recorded_account_diffs_stack = Some(Default::default());
+        state.start_state_diff_recording();
         // Enable mapping recording to track mapping slot accesses
         state.mapping_slots.get_or_insert_default();
         Ok(Default::default())
@@ -1171,10 +1171,8 @@ impl Cheatcode for getStorageAccessesCall {
     fn apply<FEN: FoundryEvmNetwork>(&self, state: &mut Cheatcodes<FEN>) -> Result {
         let mut storage_accesses = Vec::new();
 
-        if let Some(recorded_diffs) = &state.recorded_account_diffs_stack {
-            for account_accesses in recorded_diffs.iter().flatten() {
-                storage_accesses.extend(account_accesses.storageAccesses.clone());
-            }
+        for account_access in state.recorded_account_diffs() {
+            storage_accesses.extend(account_access.storageAccesses.clone());
         }
 
         Ok(storage_accesses.abi_encode())
@@ -1952,13 +1950,15 @@ const fn string_chunks(byte_length: usize) -> usize {
 /// depth than `startStateDiffRecording`, multiple `Vec<RecordedAccountAccesses>`
 /// will be flattened, preserving the order of the accesses.
 fn get_state_diff<FEN: FoundryEvmNetwork>(state: &mut Cheatcodes<FEN>) -> Result {
-    let res = state
-        .recorded_account_diffs_stack
-        .replace(Default::default())
-        .unwrap_or_default()
-        .into_iter()
-        .flatten()
-        .collect::<Vec<_>>();
+    let mut res = state.take_recorded_account_diffs_prefix();
+    res.extend(
+        state
+            .recorded_account_diffs_stack
+            .replace(Default::default())
+            .unwrap_or_default()
+            .into_iter()
+            .flatten(),
+    );
     Ok(res.abi_encode())
 }
 
@@ -1987,16 +1987,14 @@ fn get_recorded_state_diffs<FEN: FoundryEvmNetwork>(
 
     // First, collect all unique addresses we need to look up
     let mut addresses_to_lookup = HashSet::new();
-    if let Some(records) = &ccx.state.recorded_account_diffs_stack {
-        for account_access in records.iter().flatten() {
-            if !account_access.storageAccesses.is_empty()
-                || account_access.oldBalance != account_access.newBalance
-            {
-                addresses_to_lookup.insert(account_access.account);
-                for storage_access in &account_access.storageAccesses {
-                    if storage_access.isWrite && !storage_access.reverted {
-                        addresses_to_lookup.insert(storage_access.account);
-                    }
+    for account_access in ccx.state.recorded_account_diffs() {
+        if !account_access.storageAccesses.is_empty()
+            || account_access.oldBalance != account_access.newBalance
+        {
+            addresses_to_lookup.insert(account_access.account);
+            for storage_access in &account_access.storageAccesses {
+                if storage_access.isWrite && !storage_access.reverted {
+                    addresses_to_lookup.insert(storage_access.account);
                 }
             }
         }
@@ -2017,138 +2015,133 @@ fn get_recorded_state_diffs<FEN: FoundryEvmNetwork>(
     }
 
     // Now process the records
-    if let Some(records) = &ccx.state.recorded_account_diffs_stack {
-        records
-            .iter()
-            .flatten()
-            .filter(|account_access| {
-                !account_access.storageAccesses.is_empty()
-                    || account_access.oldBalance != account_access.newBalance
-                    || (!account_access.reverted
-                        && account_access.oldNonce != account_access.newNonce)
-            })
-            .for_each(|account_access| {
-                // Record account balance diffs.
-                if account_access.oldBalance != account_access.newBalance {
-                    let account_diff =
-                        state_diffs.entry(account_access.account).or_insert_with(|| {
-                            AccountStateDiffs {
-                                label: ccx.state.labels.get(&account_access.account).cloned(),
-                                contract: contract_names.get(&account_access.account).cloned(),
-                                ..Default::default()
-                            }
-                        });
-                    // Update balance diff. Do not overwrite the initial balance if already set.
-                    if let Some(diff) = &mut account_diff.balance_diff {
-                        diff.new_value = account_access.newBalance;
-                    } else {
-                        account_diff.balance_diff = Some(BalanceDiff {
-                            previous_value: account_access.oldBalance,
-                            new_value: account_access.newBalance,
-                        });
+    ccx.state
+        .recorded_account_diffs()
+        .filter(|account_access| {
+            !account_access.storageAccesses.is_empty()
+                || account_access.oldBalance != account_access.newBalance
+                || (!account_access.reverted && account_access.oldNonce != account_access.newNonce)
+        })
+        .for_each(|account_access| {
+            // Record account balance diffs.
+            if account_access.oldBalance != account_access.newBalance {
+                let account_diff = state_diffs.entry(account_access.account).or_insert_with(|| {
+                    AccountStateDiffs {
+                        label: ccx.state.labels.get(&account_access.account).cloned(),
+                        contract: contract_names.get(&account_access.account).cloned(),
+                        ..Default::default()
                     }
+                });
+                // Update balance diff. Do not overwrite the initial balance if already set.
+                if let Some(diff) = &mut account_diff.balance_diff {
+                    diff.new_value = account_access.newBalance;
+                } else {
+                    account_diff.balance_diff = Some(BalanceDiff {
+                        previous_value: account_access.oldBalance,
+                        new_value: account_access.newBalance,
+                    });
                 }
+            }
 
-                // Record account nonce diffs.
-                if account_access.oldNonce != account_access.newNonce && !account_access.reverted {
-                    let account_diff =
-                        state_diffs.entry(account_access.account).or_insert_with(|| {
-                            AccountStateDiffs {
-                                label: ccx.state.labels.get(&account_access.account).cloned(),
-                                contract: contract_names.get(&account_access.account).cloned(),
-                                ..Default::default()
-                            }
-                        });
-                    // Update nonce diff. Do not overwrite the initial nonce if already set.
-                    if let Some(diff) = &mut account_diff.nonce_diff {
-                        diff.new_value = account_access.newNonce;
-                    } else {
-                        account_diff.nonce_diff = Some(NonceDiff {
-                            previous_value: account_access.oldNonce,
-                            new_value: account_access.newNonce,
-                        });
+            // Record account nonce diffs.
+            if account_access.oldNonce != account_access.newNonce && !account_access.reverted {
+                let account_diff = state_diffs.entry(account_access.account).or_insert_with(|| {
+                    AccountStateDiffs {
+                        label: ccx.state.labels.get(&account_access.account).cloned(),
+                        contract: contract_names.get(&account_access.account).cloned(),
+                        ..Default::default()
                     }
+                });
+                // Update nonce diff. Do not overwrite the initial nonce if already set.
+                if let Some(diff) = &mut account_diff.nonce_diff {
+                    diff.new_value = account_access.newNonce;
+                } else {
+                    account_diff.nonce_diff = Some(NonceDiff {
+                        previous_value: account_access.oldNonce,
+                        new_value: account_access.newNonce,
+                    });
                 }
+            }
 
-                // Collect all storage accesses for this account
-                let raw_changes_by_slot = account_access
-                    .storageAccesses
-                    .iter()
-                    .filter_map(|access| {
-                        (access.isWrite && !access.reverted)
-                            .then_some((access.slot, (access.previousValue, access.newValue)))
-                    })
-                    .collect::<BTreeMap<_, _>>();
+            // Collect all storage accesses for this account
+            let raw_changes_by_slot = account_access
+                .storageAccesses
+                .iter()
+                .filter_map(|access| {
+                    (access.isWrite && !access.reverted)
+                        .then_some((access.slot, (access.previousValue, access.newValue)))
+                })
+                .collect::<BTreeMap<_, _>>();
 
-                // Record account state diffs.
-                for storage_access in &account_access.storageAccesses {
-                    if storage_access.isWrite && !storage_access.reverted {
-                        let account_diff = state_diffs
-                            .entry(storage_access.account)
-                            .or_insert_with(|| AccountStateDiffs {
+            // Record account state diffs.
+            for storage_access in &account_access.storageAccesses {
+                if storage_access.isWrite && !storage_access.reverted {
+                    let account_diff =
+                        state_diffs.entry(storage_access.account).or_insert_with(|| {
+                            AccountStateDiffs {
                                 label: ccx.state.labels.get(&storage_access.account).cloned(),
                                 contract: contract_names.get(&storage_access.account).cloned(),
                                 ..Default::default()
+                            }
+                        });
+                    let layout = storage_layouts.get(&storage_access.account);
+                    // Update state diff. Do not overwrite the initial value if already set.
+                    let entry = match account_diff.state_diff.entry(storage_access.slot) {
+                        Entry::Vacant(slot_state_diff) => {
+                            // Get storage layout info for this slot
+                            // Include mapping slots if available for the account
+                            let mapping_slots = ccx
+                                .state
+                                .mapping_slots
+                                .as_ref()
+                                .and_then(|slots| slots.get(&storage_access.account));
+
+                            let slot_info = layout.and_then(|layout| {
+                                let decoder = SlotIdentifier::new(layout.clone());
+                                decoder.identify(&storage_access.slot, mapping_slots).or_else(
+                                    || {
+                                        // Create a map of new values for bytes/string
+                                        // identification. These values are used to determine
+                                        // the length of the data which helps determine how many
+                                        // slots to search
+                                        let current_base_slot_values = raw_changes_by_slot
+                                            .iter()
+                                            .map(|(slot, (_, new_val))| (*slot, *new_val))
+                                            .collect::<B256Map<_>>();
+                                        decoder.identify_bytes_or_string(
+                                            &storage_access.slot,
+                                            &current_base_slot_values,
+                                        )
+                                    },
+                                )
                             });
-                        let layout = storage_layouts.get(&storage_access.account);
-                        // Update state diff. Do not overwrite the initial value if already set.
-                        let entry = match account_diff.state_diff.entry(storage_access.slot) {
-                            Entry::Vacant(slot_state_diff) => {
-                                // Get storage layout info for this slot
-                                // Include mapping slots if available for the account
-                                let mapping_slots = ccx
-                                    .state
-                                    .mapping_slots
-                                    .as_ref()
-                                    .and_then(|slots| slots.get(&storage_access.account));
 
-                                let slot_info = layout.and_then(|layout| {
-                                    let decoder = SlotIdentifier::new(layout.clone());
-                                    decoder.identify(&storage_access.slot, mapping_slots).or_else(
-                                        || {
-                                            // Create a map of new values for bytes/string
-                                            // identification. These values are used to determine
-                                            // the length of the data which helps determine how many
-                                            // slots to search
-                                            let current_base_slot_values = raw_changes_by_slot
-                                                .iter()
-                                                .map(|(slot, (_, new_val))| (*slot, *new_val))
-                                                .collect::<B256Map<_>>();
-                                            decoder.identify_bytes_or_string(
-                                                &storage_access.slot,
-                                                &current_base_slot_values,
-                                            )
-                                        },
-                                    )
-                                });
+                            slot_state_diff.insert(SlotStateDiff {
+                                previous_value: storage_access.previousValue,
+                                new_value: storage_access.newValue,
+                                slot_info,
+                            })
+                        }
+                        Entry::Occupied(slot_state_diff) => {
+                            let entry = slot_state_diff.into_mut();
+                            entry.new_value = storage_access.newValue;
+                            entry
+                        }
+                    };
 
-                                slot_state_diff.insert(SlotStateDiff {
-                                    previous_value: storage_access.previousValue,
-                                    new_value: storage_access.newValue,
-                                    slot_info,
-                                })
-                            }
-                            Entry::Occupied(slot_state_diff) => {
-                                let entry = slot_state_diff.into_mut();
-                                entry.new_value = storage_access.newValue;
-                                entry
-                            }
-                        };
-
-                        // Update decoded values if we have slot info
-                        if let Some(slot_info) = &mut entry.slot_info {
-                            slot_info.decode_values(entry.previous_value, storage_access.newValue);
-                            if slot_info.is_bytes_or_string() {
-                                slot_info.decode_bytes_or_string_values(
-                                    &storage_access.slot,
-                                    &raw_changes_by_slot,
-                                );
-                            }
+                    // Update decoded values if we have slot info
+                    if let Some(slot_info) = &mut entry.slot_info {
+                        slot_info.decode_values(entry.previous_value, storage_access.newValue);
+                        if slot_info.is_bytes_or_string() {
+                            slot_info.decode_bytes_or_string_values(
+                                &storage_access.slot,
+                                &raw_changes_by_slot,
+                            );
                         }
                     }
                 }
-            });
-    }
+            }
+        });
     state_diffs
 }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -595,6 +595,12 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// merged into the previous vector.
     pub recorded_account_diffs_stack: Option<Vec<Vec<AccountAccess>>>,
 
+    /// Account accesses performed by the test runner before user code can start recording.
+    pending_account_diffs: Option<Arc<[AccountAccess]>>,
+
+    /// Completed account accesses prepended to the active user recording session.
+    recorded_account_diffs_prefix: Option<Arc<[AccountAccess]>>,
+
     /// The information of the debug step recording.
     pub record_debug_steps_info: Option<RecordDebugStepInfo>,
 
@@ -748,6 +754,8 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             accesses: Default::default(),
             recording_accesses: Default::default(),
             recorded_account_diffs_stack: Default::default(),
+            pending_account_diffs: Default::default(),
+            recorded_account_diffs_prefix: Default::default(),
             recorded_logs: Default::default(),
             record_debug_steps_info: Default::default(),
             mocked_calls: Default::default(),
@@ -786,6 +794,49 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
     /// Enables cheatcode analysis capabilities by providing a solar compiler instance.
     pub fn set_analysis(&mut self, analysis: CheatcodeAnalysis) {
         self.analysis = Some(analysis);
+    }
+
+    /// Starts an internal account diff recording session for test runner setup.
+    pub fn start_internal_state_diff_recording(&mut self) -> bool {
+        if self.recorded_account_diffs_stack.is_some()
+            || self.recorded_account_diffs_prefix.is_some()
+        {
+            return false;
+        }
+        self.recorded_account_diffs_stack = Some(Default::default());
+        true
+    }
+
+    /// Stops an internal account diff recording session without leaving recording enabled.
+    pub fn stop_internal_state_diff_recording(&mut self) -> Vec<AccountAccess> {
+        self.recorded_account_diffs_stack.take().unwrap_or_default().into_iter().flatten().collect()
+    }
+
+    /// Makes account accesses captured by the test runner available to the next recording session.
+    pub fn set_pending_account_diffs(&mut self, accesses: Vec<AccountAccess>) {
+        self.pending_account_diffs = (!accesses.is_empty()).then(|| Arc::from(accesses));
+    }
+
+    /// Starts a user account diff recording session, including pending test runner accesses.
+    pub fn start_state_diff_recording(&mut self) {
+        self.recorded_account_diffs_prefix = self.pending_account_diffs.take();
+        self.recorded_account_diffs_stack = Some(Default::default());
+    }
+
+    /// Returns completed and active account accesses in execution order.
+    pub fn recorded_account_diffs(&self) -> impl Iterator<Item = &AccountAccess> {
+        self.recorded_account_diffs_prefix
+            .iter()
+            .flat_map(|prefix| prefix.iter())
+            .chain(self.recorded_account_diffs_stack.iter().flatten().flatten())
+    }
+
+    /// Takes completed account accesses from the active user recording session.
+    pub fn take_recorded_account_diffs_prefix(&mut self) -> Vec<AccountAccess> {
+        self.recorded_account_diffs_prefix
+            .take()
+            .map(|prefix| prefix.as_ref().to_vec())
+            .unwrap_or_default()
     }
 
     /// Returns the env overrides for the given fork (`None` = no-fork / local).
@@ -2350,58 +2401,46 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         }
 
         // If `startStateDiffRecording` has been called, update the `reverted` status of the
-        // previous call depth's recorded accesses, if any
-        if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack {
-            // The root call cannot be recorded.
-            if curr_depth > 0
-                && let Some(last_depth) = &mut recorded_account_diffs_stack.pop()
-            {
-                // Update the reverted status of all deeper calls if this call reverted, in
-                // accordance with EVM behavior
-                if outcome.result.is_revert() {
-                    for element in &mut *last_depth {
-                        element.reverted = true;
-                        for storage_access in &mut element.storageAccesses {
-                            storage_access.reverted = true;
-                        }
+        // previous call depth's recorded accesses, if any.
+        if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack
+            && let Some(mut last_depth) = recorded_account_diffs_stack.pop()
+        {
+            // Update the reverted status of all deeper calls if this call reverted, in
+            // accordance with EVM behavior.
+            if outcome.result.is_revert() {
+                for element in &mut *last_depth {
+                    element.reverted = true;
+                    for storage_access in &mut element.storageAccesses {
+                        storage_access.reverted = true;
                     }
                 }
+            }
 
-                if let Some(create_access) = last_depth.first_mut() {
-                    // Assert that we're at the correct depth before recording post-create state
-                    // changes. Depending on what depth the cheat was called at, there
-                    // may not be any pending calls to update if execution has
-                    // percolated up to a higher depth.
-                    let depth = ecx.journal().depth();
-                    if create_access.depth == depth as u64 {
-                        debug_assert_eq!(
-                            create_access.kind as u8,
-                            crate::Vm::AccountAccessKind::Create as u8
-                        );
-                        if let Some(address) = outcome.address
-                            && let Ok(created_acc) = ecx.journal_mut().load_account(address)
-                        {
-                            create_access.newBalance = created_acc.data.info.balance;
-                            create_access.newNonce = created_acc.data.info.nonce;
-                            create_access.deployedCode = created_acc
-                                .data
-                                .info
-                                .code
-                                .clone()
-                                .unwrap_or_default()
-                                .original_bytes();
-                        }
-                    }
-                    // Merge the last depth's AccountAccesses into the AccountAccesses at the
-                    // current depth, or push them back onto the pending
-                    // vector if higher depths were not recorded. This
-                    // preserves ordering of accesses.
-                    if let Some(last) = recorded_account_diffs_stack.last_mut() {
-                        last.append(last_depth);
-                    } else {
-                        recorded_account_diffs_stack.push(last_depth.clone());
+            if let Some(create_access) = last_depth.first_mut() {
+                // Update post-create state only if recording began before this frame.
+                if create_access.depth == curr_depth as u64 {
+                    debug_assert_eq!(
+                        create_access.kind as u8,
+                        crate::Vm::AccountAccessKind::Create as u8
+                    );
+                    if let Some(address) = outcome.address
+                        && let Ok(created_acc) = ecx.journal_mut().load_account(address)
+                    {
+                        create_access.newBalance = created_acc.data.info.balance;
+                        create_access.newNonce = created_acc.data.info.nonce;
+                        create_access.deployedCode =
+                            created_acc.data.info.code.clone().unwrap_or_default().original_bytes();
                     }
                 }
+            }
+            // Merge the last depth's AccountAccesses into the AccountAccesses at the
+            // current depth, or push them back onto the pending
+            // vector if higher depths were not recorded. This
+            // preserves ordering of accesses.
+            if let Some(last) = recorded_account_diffs_stack.last_mut() {
+                last.append(&mut last_depth);
+            } else {
+                recorded_account_diffs_stack.push(last_depth);
             }
         }
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -43,7 +43,7 @@ use foundry_linking::{LinkOutput, Linker};
 use rayon::prelude::*;
 use std::{
     borrow::Borrow,
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     sync::{Arc, Mutex, mpsc},
@@ -54,6 +54,7 @@ use std::{
 pub struct TestContract {
     pub abi: JsonAbi,
     pub bytecode: Bytes,
+    pub library_addresses: BTreeSet<Address>,
 }
 
 pub type DeployableContracts = BTreeMap<ArtifactId, TestContract>;
@@ -794,8 +795,12 @@ impl MultiContractRunnerBuilder {
                     continue;
                 };
 
-                deployable_contracts
-                    .insert(id.clone(), TestContract { abi: abi.clone().into_owned(), bytecode });
+                let library_addresses = linker.linked_library_addresses(id, &libraries)?;
+
+                deployable_contracts.insert(
+                    id.clone(),
+                    TestContract { abi: abi.clone().into_owned(), bytecode, library_addresses },
+                );
             }
         }
 

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -60,6 +60,7 @@ use foundry_evm::{
         },
         strategies::EvmFuzzState,
     },
+    inspectors::cheatcodes::Vm::AccountAccess,
     revm::{bytecode::opcode, primitives::hardfork::SpecId},
     traces::{TraceKind, TraceRequirements, load_contracts},
 };
@@ -733,17 +734,33 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
         self.executor.set_balance(LIBRARY_DEPLOYER, U256::MAX)?;
 
         let mut result = TestSetup::default();
+        let mut pending_account_diffs = Vec::new();
         for code in &self.mcr.libs_to_deploy {
+            let recording_library_deployment = !self.contract.library_addresses.is_empty()
+                && self
+                    .executor
+                    .inspector_mut()
+                    .cheatcodes
+                    .as_deref_mut()
+                    .is_some_and(|cheats| cheats.start_internal_state_diff_recording());
             let deploy_result = self.executor.deploy(
                 LIBRARY_DEPLOYER,
                 code.clone(),
                 U256::ZERO,
                 Some(&self.mcr.revert_decoder),
             );
+            let recorded_account_diffs = if recording_library_deployment {
+                self.finish_library_deployment_recording()
+            } else {
+                Vec::new()
+            };
 
             // Record deployed library address.
             if let Ok(deployed) = &deploy_result {
                 result.deployed_libs.push(deployed.address);
+                if self.contract.library_addresses.contains(&deployed.address) {
+                    pending_account_diffs.extend(recorded_account_diffs);
+                }
             }
 
             let (raw, reason) = RawCallResult::from_evm_result(deploy_result.map(Into::into))?;
@@ -753,6 +770,11 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
                 result.reason = reason;
                 return Ok(result);
             }
+        }
+        if !pending_account_diffs.is_empty()
+            && let Some(cheats) = self.executor.inspector_mut().cheatcodes.as_deref_mut()
+        {
+            cheats.set_pending_account_diffs(pending_account_diffs);
         }
 
         let address = self.sender.create(self.executor.get_nonce(self.sender)?);
@@ -804,6 +826,15 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
     fn initial_balance(&self) -> U256 {
         self.evm_opts.initial_balance
+    }
+
+    fn finish_library_deployment_recording(&mut self) -> Vec<AccountAccess> {
+        self.executor
+            .inspector_mut()
+            .cheatcodes
+            .as_deref_mut()
+            .map(|cheats| cheats.stop_internal_state_diff_recording())
+            .unwrap_or_default()
     }
 
     /// Configures this runner with the inline configuration for the contract.

--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -183,6 +183,30 @@ impl<'a> Linker<'a> {
         Ok(())
     }
 
+    /// Returns the resolved addresses of all libraries required by `target`.
+    pub fn linked_library_addresses(
+        &'a self,
+        target: &'a ArtifactId,
+        libraries: &Libraries,
+    ) -> Result<BTreeSet<Address>, LinkerError> {
+        let mut dependencies = BTreeSet::new();
+        self.collect_dependencies(target, &mut dependencies)?;
+
+        dependencies
+            .into_iter()
+            .map(|id| {
+                let (file, name) = self.convert_artifact_id_to_lib_path(id);
+                libraries
+                    .libs
+                    .get(&file)
+                    .and_then(|libs| libs.get(&name))
+                    .ok_or_else(|| LinkerError::LinkingFailed { artifact: id.identifier() })?
+                    .parse()
+                    .map_err(LinkerError::InvalidAddress)
+            })
+            .collect()
+    }
+
     /// Links given artifact with either given library addresses or address computed from sender and
     /// nonce.
     ///

--- a/testdata/default/repros/Issue6636.t.sol
+++ b/testdata/default/repros/Issue6636.t.sol
@@ -51,10 +51,7 @@ abstract contract Issue6636Assertions is Test {
 
         bool libraryCallRecorded;
         for (uint256 i = 1; i < accesses.length; ++i) {
-            if (
-                accesses[i].kind == Vm.AccountAccessKind.DelegateCall
-                    && accesses[i].account == deployment.account
-            ) {
+            if (accesses[i].kind == Vm.AccountAccessKind.DelegateCall && accesses[i].account == deployment.account) {
                 libraryCallRecorded = true;
                 break;
             }
@@ -77,9 +74,7 @@ contract Issue6636Test is Issue6636Assertions {
 
     function testLibraryDeploymentNotRevertedWithRecordingCall() public {
         Issue6636Reverter reverter = new Issue6636Reverter();
-        (bool success,) = address(reverter).call(
-            abi.encodeCall(Issue6636Reverter.startRecordingAndRevert, ())
-        );
+        (bool success,) = address(reverter).call(abi.encodeCall(Issue6636Reverter.startRecordingAndRevert, ()));
         assertTrue(!success);
 
         assertEq(Issue6636Lib.addOne(2), 3);

--- a/testdata/default/repros/Issue6636.t.sol
+++ b/testdata/default/repros/Issue6636.t.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+import "utils/Test.sol";
+
+library Issue6636Lib {
+    function addOne(uint256 value) external pure returns (uint256) {
+        return value + 1;
+    }
+}
+
+contract Issue6636Reverter is Test {
+    function startRecordingAndRevert() external {
+        vm.startStateDiffRecording();
+        revert("expected");
+    }
+}
+
+abstract contract Issue6636Assertions is Test {
+    address internal constant LIBRARY_DEPLOYER = 0x1F95D37F27EA0dEA9C252FC09D5A6eaA97647353;
+
+    function recordLibraryCall(uint256 value) internal returns (Vm.AccountAccess[] memory accesses) {
+        vm.startStateDiffRecording();
+        assertGt(bytes(vm.getStateDiff()).length, 0);
+        assertGt(bytes(vm.getStateDiffJson()).length, 2);
+        assertEq(vm.getStorageAccesses().length, 0);
+        assertEq(Issue6636Lib.addOne(value), value + 1);
+        accesses = vm.stopAndReturnStateDiff();
+    }
+
+    function assertLibraryDeployment(Vm.AccountAccess[] memory accesses) internal {
+        assertGt(accesses.length, 1);
+
+        Vm.AccountAccess memory deployment = accesses[0];
+        assertEq(uint256(deployment.kind), uint256(Vm.AccountAccessKind.Create));
+        assertEq(deployment.accessor, LIBRARY_DEPLOYER);
+        assertEq(deployment.chainInfo.forkId, 0);
+        assertEq(deployment.chainInfo.chainId, block.chainid);
+        assertTrue(deployment.initialized);
+        assertEq(deployment.oldBalance, 0);
+        assertEq(deployment.newBalance, 0);
+        assertEq(deployment.value, 0);
+        assertTrue(!deployment.reverted);
+        assertEq(deployment.storageAccesses.length, 0);
+        assertEq(deployment.depth, 0);
+        assertEq(deployment.oldNonce, 0);
+        assertEq(deployment.newNonce, 1);
+        assertEq(keccak256(deployment.data), keccak256(type(Issue6636Lib).creationCode));
+        assertGt(deployment.deployedCode.length, 0);
+        assertEq(keccak256(deployment.deployedCode), deployment.account.codehash);
+
+        bool libraryCallRecorded;
+        for (uint256 i = 1; i < accesses.length; ++i) {
+            if (
+                accesses[i].kind == Vm.AccountAccessKind.DelegateCall
+                    && accesses[i].account == deployment.account
+            ) {
+                libraryCallRecorded = true;
+                break;
+            }
+        }
+        assertTrue(libraryCallRecorded);
+    }
+}
+
+contract Issue6636Test is Issue6636Assertions {
+    function testLibraryDeploymentRecorded() public {
+        assertLibraryDeployment(recordLibraryCall(1));
+
+        vm.startStateDiffRecording();
+        assertEq(vm.stopAndReturnStateDiff().length, 0);
+    }
+
+    function testLibraryDeploymentRecordedPerTest() public {
+        assertLibraryDeployment(recordLibraryCall(2));
+    }
+
+    function testLibraryDeploymentNotRevertedWithRecordingCall() public {
+        Issue6636Reverter reverter = new Issue6636Reverter();
+        (bool success,) = address(reverter).call(
+            abi.encodeCall(Issue6636Reverter.startRecordingAndRevert, ())
+        );
+        assertTrue(!success);
+
+        assertEq(Issue6636Lib.addOne(2), 3);
+        assertLibraryDeployment(vm.stopAndReturnStateDiff());
+    }
+
+    /// forge-config: default.fuzz.runs = 2
+    function testFuzzLibraryDeploymentRecordedPerInput(uint256 value) public {
+        value = vm.bound(value, 0, type(uint256).max - 1);
+        assertLibraryDeployment(recordLibraryCall(value));
+    }
+}
+
+contract Issue6636ConstructorTest is Issue6636Assertions {
+    constructor() {
+        vm.startStateDiffRecording();
+    }
+
+    function testConstructorRecordingDoesNotOverwriteLibraryDeployment() public {
+        assertEq(Issue6636Lib.addOne(1), 2);
+        assertLibraryDeployment(vm.stopAndReturnStateDiff());
+    }
+}


### PR DESCRIPTION
Records Forge’s automatic linked-library deployments in the first state-diff recording session for each test. This ensures `startStateDiffRecording` reports the actual library `CREATE` access while preserving test isolation and normal recording reset behavior. Fixes #6636.