### PR TITLE
perf(forge): record only required library deployments

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -735,14 +735,17 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
 
         let mut result = TestSetup::default();
         let mut pending_account_diffs = Vec::new();
-        for code in &self.mcr.libs_to_deploy {
-            let recording_library_deployment = !self.contract.library_addresses.is_empty()
-                && self
-                    .executor
-                    .inspector_mut()
-                    .cheatcodes
-                    .as_deref_mut()
-                    .is_some_and(|cheats| cheats.start_internal_state_diff_recording());
+        for (nonce, code) in self.mcr.libs_to_deploy.iter().enumerate() {
+            // Libraries are linked from nonce zero in the same order they are deployed.
+            let expected_address = LIBRARY_DEPLOYER.create(nonce as u64);
+            let recording_library_deployment =
+                self.contract.library_addresses.contains(&expected_address)
+                    && self
+                        .executor
+                        .inspector_mut()
+                        .cheatcodes
+                        .as_deref_mut()
+                        .is_some_and(|cheats| cheats.start_internal_state_diff_recording());
             let deploy_result = self.executor.deploy(
                 LIBRARY_DEPLOYER,
                 code.clone(),


### PR DESCRIPTION
Enables state-diff recording only for linked libraries required by the current test contract, avoiding recording and discarding unrelated library deployments.
https://github.com/foundry-rs/foundry/pull/15848#discussion_r3628386361