### PR TITLE
fix(fuzz): warn on bool invariant returns

### DIFF
--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1057,6 +1057,15 @@ impl<'a, FEN: FoundryEvmNetwork> ContractRunner<'a, FEN> {
             );
         }
 
+        for invariant in &invariant_fns {
+            if invariant.outputs.len() == 1 && invariant.outputs[0].ty == "bool" {
+                warnings.push(format!(
+                    "Invariant function `{}` returns `bool`, but its return value is ignored; use assertions or revert to indicate failure.",
+                    invariant.signature()
+                ));
+            }
+        }
+
         // Invariant testing requires tracing to figure out what contracts were created.
         // For regular test runs we disable debug-level setup traces as an optimization.
         // In `forge test --debug`, keep setup traces in debug mode so setup failures are

--- a/crates/forge/tests/cli/test_cmd/invariant/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/mod.rs
@@ -16,6 +16,81 @@ fn assert_invariant(cmd: &mut TestCommand) -> OutputAssert {
     ])
 }
 
+forgetest_init!(warns_for_ignored_bool_invariant_return, |prj, cmd| {
+    prj.update_config(|config| {
+        config.invariant.runs = 2;
+        config.invariant.depth = 2;
+    });
+    prj.add_test(
+        "InvariantReturns.t.sol",
+        r#"
+contract Handler {
+    uint256 public value;
+
+    function increment() external {
+        value++;
+    }
+}
+
+contract BoolInvariantTest {
+    Handler handler;
+
+    function setUp() public {
+        handler = new Handler();
+    }
+
+    function invariant_returnsFalse() public pure returns (bool) {
+        return false;
+    }
+}
+
+contract NoReturnInvariantTest {
+    Handler handler;
+
+    function setUp() public {
+        handler = new Handler();
+    }
+
+    function invariant_noReturn() public pure {}
+}
+
+contract OptimizationInvariantTest {
+    Handler handler;
+
+    function setUp() public {
+        handler = new Handler();
+    }
+
+    function invariant_optimization() public view returns (int256) {
+        return int256(handler.value());
+    }
+}
+   "#,
+    );
+
+    assert_invariant(cmd.args(["test", "--mc", "BoolInvariantTest"]))
+        .success()
+        .stdout_eq(str![[r#"
+...
+[PASS] invariant_returnsFalse() ([RUNS])
+...
+"#]])
+        .stderr_eq(str![[r#"
+Warning: Invariant function `invariant_returnsFalse()` returns `bool`, but its return value is ignored; use assertions or revert to indicate failure.
+
+"#]]);
+
+    cmd.forge_fuse()
+        .args(["test", "--mc", "NoReturnInvariantTest"])
+        .assert_success()
+        .stderr_eq(str![""]);
+
+    cmd.forge_fuse()
+        .args(["test", "--mc", "OptimizationInvariantTest"])
+        .assert_success()
+        .stderr_eq(str![""]);
+});
+
 // Tests that a persisted failure doesn't fail due to assume revert if test driver is changed.
 forgetest_init!(should_not_fail_replay_assume, |prj, cmd| {
     prj.update_config(|config| {


### PR DESCRIPTION
Boolean-returning invariant functions currently compile and run, but Forge ignores their return value, allowing `return false` to appear to pass silently. This adds a warning directing users to assertions or reverts while preserving existing pass/fail behavior and `int256` optimization invariants.

Closes OSS-577

This change was implemented with AI assistance.
