### PR TITLE
feat(primitives): add variant predicates

### DIFF
--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -4338,7 +4338,7 @@ impl EthApi<FoundryNetwork> {
         let transaction_type = request.transaction_type;
         let mut request: FoundryTransactionRequest =
             request.try_into().map_err(|_| BlockchainError::FailedToDecodeTransaction)?;
-        if matches!(&request, FoundryTransactionRequest::Tempo(_))
+        if request.is_tempo()
             && self.backend.is_tempo()
             && transaction_type.is_some_and(|ty| ty != TEMPO_TX_TYPE_ID)
         {
@@ -4367,7 +4367,7 @@ impl EthApi<FoundryNetwork> {
                     block_gas_limit
                 }
             };
-            let estimated_gas = if matches!(&request, FoundryTransactionRequest::Tempo(_)) {
+            let estimated_gas = if request.is_tempo() {
                 fallback_gas_limit
             } else {
                 self.do_estimate_gas(request.as_ref().clone().into(), None, EvmOverrides::default())

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -130,7 +130,7 @@ use foundry_primitives::{
 };
 use futures::channel::mpsc::{UnboundedSender, unbounded};
 #[cfg(feature = "optimism")]
-use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, OpTransaction as OpTransactionTrait};
+use op_alloy_consensus::DEPOSIT_TX_TYPE_ID;
 #[cfg(feature = "optimism")]
 use op_revm::{OpTransaction, transaction::deposit::DepositTransactionParts};
 

--- a/crates/evm/networks/src/lib.rs
+++ b/crates/evm/networks/src/lib.rs
@@ -161,6 +161,23 @@ impl std::str::FromStr for NetworkVariant {
 }
 
 impl NetworkVariant {
+    /// Returns `true` if this is the Ethereum network variant.
+    pub const fn is_ethereum(&self) -> bool {
+        matches!(self, Self::Ethereum)
+    }
+
+    /// Returns `true` if this is the Optimism network variant.
+    #[cfg(feature = "optimism")]
+    pub const fn is_optimism(&self) -> bool {
+        matches!(self, Self::Optimism)
+    }
+
+    /// Returns `true` if this is the Tempo network variant.
+    pub const fn is_tempo(&self) -> bool {
+        matches!(self, Self::Tempo)
+    }
+
+    /// Returns the network variant name.
     pub const fn name(&self) -> &'static str {
         match self {
             Self::Ethereum => "ethereum",
@@ -247,7 +264,7 @@ impl NetworkConfigs {
     }
 
     pub const fn is_tempo(&self) -> bool {
-        matches!(self.resolved_network(), Some(NetworkVariant::Tempo))
+        if let Some(network) = self.resolved_network() { network.is_tempo() } else { false }
     }
 
     pub const fn is_celo(&self) -> bool {
@@ -450,6 +467,21 @@ mod tests {
     };
 
     // --- Equivalence: new flag == legacy flag ---
+
+    #[test]
+    fn network_variant_predicates() {
+        assert!(NetworkVariant::Ethereum.is_ethereum());
+        assert!(!NetworkVariant::Ethereum.is_tempo());
+        assert!(NetworkVariant::Tempo.is_tempo());
+        assert!(!NetworkVariant::Tempo.is_ethereum());
+
+        #[cfg(feature = "optimism")]
+        {
+            assert!(NetworkVariant::Optimism.is_optimism());
+            assert!(!NetworkVariant::Optimism.is_ethereum());
+            assert!(!NetworkVariant::Optimism.is_tempo());
+        }
+    }
 
     #[test]
     fn new_tempo_flag_equivalent_to_legacy() {

--- a/crates/evm/networks/src/optimism.rs
+++ b/crates/evm/networks/src/optimism.rs
@@ -10,7 +10,7 @@ impl NetworkConfigs {
     }
 
     pub const fn is_optimism(&self) -> bool {
-        matches!(self.resolved_network(), Some(NetworkVariant::Optimism))
+        if let Some(network) = self.resolved_network() { network.is_optimism() } else { false }
     }
 
     /// Optimism-specific base fee parameters, picking Canyon vs pre-Canyon based on `timestamp`.

--- a/crates/forge/src/cmd/init.rs
+++ b/crates/forge/src/cmd/init.rs
@@ -84,7 +84,7 @@ impl InitArgs {
         } = self;
         let DependencyInstallOpts { shallow, no_git, commit } = install;
 
-        let tempo = matches!(network, Some(NetworkVariant::Tempo));
+        let tempo = network.is_some_and(|network| network.is_tempo());
 
         // create the root dir if it does not exist
         if !root.exists() {

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -69,6 +69,50 @@ pub enum FoundryTxEnvelope {
 }
 
 impl FoundryTxEnvelope {
+    /// Returns `true` if this is a legacy transaction.
+    #[inline]
+    pub const fn is_legacy(&self) -> bool {
+        matches!(self, Self::Legacy(_))
+    }
+
+    /// Returns `true` if this is an EIP-2930 transaction.
+    #[inline]
+    pub const fn is_eip2930(&self) -> bool {
+        matches!(self, Self::Eip2930(_))
+    }
+
+    /// Returns `true` if this is an EIP-1559 transaction.
+    #[inline]
+    pub const fn is_eip1559(&self) -> bool {
+        matches!(self, Self::Eip1559(_))
+    }
+
+    /// Returns `true` if this is an EIP-4844 transaction.
+    #[inline]
+    pub const fn is_eip4844(&self) -> bool {
+        matches!(self, Self::Eip4844(_))
+    }
+
+    /// Returns `true` if this is an EIP-7702 transaction.
+    #[inline]
+    pub const fn is_eip7702(&self) -> bool {
+        matches!(self, Self::Eip7702(_))
+    }
+
+    /// Returns `true` if this is an OP stack deposit transaction.
+    #[cfg(feature = "optimism")]
+    #[inline]
+    pub const fn is_deposit(&self) -> bool {
+        matches!(self, Self::Deposit(_))
+    }
+
+    /// Returns `true` if this is an OP stack post-execution synthetic transaction.
+    #[cfg(feature = "optimism")]
+    #[inline]
+    pub const fn is_post_exec(&self) -> bool {
+        matches!(self, Self::PostExec(_))
+    }
+
     /// Converts the transaction into an Ethereum [`TxEnvelope`].
     ///
     /// Returns an error if the transaction is not part of the standard Ethereum transaction types.
@@ -142,6 +186,44 @@ impl FoundryTxEnvelope {
             Self::PostExec(tx) => tx.inner().signer_address(),
             Self::Tempo(tx) => tx.signature().recover_signer(&tx.signature_hash())?,
         })
+    }
+}
+
+impl FoundryTxType {
+    /// Returns `true` if this is an OP stack deposit transaction type.
+    #[cfg(feature = "optimism")]
+    pub const fn is_deposit(&self) -> bool {
+        matches!(self, Self::Deposit)
+    }
+
+    /// Returns `true` if this is an OP stack post-execution synthetic transaction type.
+    #[cfg(feature = "optimism")]
+    pub const fn is_post_exec(&self) -> bool {
+        matches!(self, Self::PostExec)
+    }
+
+    /// Returns `true` if this is a Tempo transaction type.
+    pub const fn is_tempo(&self) -> bool {
+        matches!(self, Self::Tempo)
+    }
+}
+
+impl FoundryTypedTx {
+    /// Returns `true` if this is an OP stack deposit transaction.
+    #[cfg(feature = "optimism")]
+    pub const fn is_deposit(&self) -> bool {
+        matches!(self, Self::Deposit(_))
+    }
+
+    /// Returns `true` if this is an OP stack post-execution synthetic transaction.
+    #[cfg(feature = "optimism")]
+    pub const fn is_post_exec(&self) -> bool {
+        matches!(self, Self::PostExec(_))
+    }
+
+    /// Returns `true` if this is a Tempo transaction.
+    pub const fn is_tempo(&self) -> bool {
+        matches!(self, Self::Tempo(_))
     }
 }
 
@@ -398,6 +480,64 @@ mod tests {
     use alloy_signer::Signature;
 
     use super::*;
+
+    fn signed<T>(tx: T) -> Signed<T> {
+        Signed::new_unchecked(tx, Signature::test_signature(), B256::ZERO)
+    }
+
+    #[test]
+    fn tx_type_predicates() {
+        assert!(FoundryTxType::Legacy.is_legacy());
+        assert!(FoundryTxType::Eip2930.is_eip2930());
+        assert!(FoundryTxType::Eip1559.is_eip1559());
+        assert!(FoundryTxType::Eip4844.is_eip4844());
+        assert!(FoundryTxType::Eip7702.is_eip7702());
+        assert!(FoundryTxType::Tempo.is_tempo());
+        assert!(!FoundryTxType::Tempo.is_legacy());
+
+        #[cfg(feature = "optimism")]
+        {
+            assert!(FoundryTxType::Deposit.is_deposit());
+            assert!(FoundryTxType::PostExec.is_post_exec());
+            assert!(!FoundryTxType::Deposit.is_post_exec());
+        }
+    }
+
+    #[test]
+    fn typed_tx_predicates() {
+        assert!(FoundryTypedTx::Legacy(TxLegacy::default()).is_legacy());
+        assert!(FoundryTypedTx::Eip2930(TxEip2930::default()).is_eip2930());
+        assert!(FoundryTypedTx::Eip1559(TxEip1559::default()).is_eip1559());
+        assert!(
+            FoundryTypedTx::Eip4844(TxEip4844Variant::TxEip4844(Default::default())).is_eip4844()
+        );
+        assert!(FoundryTypedTx::Eip7702(TxEip7702::default()).is_eip7702());
+        assert!(FoundryTypedTx::Tempo(TempoTransaction::default()).is_tempo());
+
+        #[cfg(feature = "optimism")]
+        {
+            assert!(FoundryTypedTx::Deposit(TxDeposit::default()).is_deposit());
+            assert!(FoundryTypedTx::PostExec(TxPostExec::default()).is_post_exec());
+        }
+    }
+
+    #[test]
+    fn tx_envelope_predicates() {
+        assert!(FoundryTxEnvelope::Legacy(signed(TxLegacy::default())).is_legacy());
+        assert!(FoundryTxEnvelope::Eip2930(signed(TxEip2930::default())).is_eip2930());
+        assert!(FoundryTxEnvelope::Eip1559(signed(TxEip1559::default())).is_eip1559());
+        assert!(
+            FoundryTxEnvelope::Eip4844(signed(TxEip4844Variant::TxEip4844(Default::default())))
+                .is_eip4844()
+        );
+        assert!(FoundryTxEnvelope::Eip7702(signed(TxEip7702::default())).is_eip7702());
+
+        #[cfg(feature = "optimism")]
+        {
+            assert!(FoundryTxEnvelope::Deposit(Sealed::new(TxDeposit::default())).is_deposit());
+            assert!(FoundryTxEnvelope::PostExec(Sealed::new(TxPostExec::default())).is_post_exec());
+        }
+    }
 
     #[test]
     fn test_decode_call() {

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -15,7 +15,7 @@ use super::{FoundryReceiptEnvelope, FoundryTransactionRequest, FoundryTxEnvelope
 
 impl OpTransactionTrait for FoundryTxEnvelope {
     fn is_deposit(&self) -> bool {
-        matches!(self, Self::Deposit(_))
+        FoundryTxEnvelope::is_deposit(self)
     }
 
     fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {

--- a/crates/primitives/src/transaction/optimism.rs
+++ b/crates/primitives/src/transaction/optimism.rs
@@ -15,7 +15,7 @@ use super::{FoundryReceiptEnvelope, FoundryTransactionRequest, FoundryTxEnvelope
 
 impl OpTransactionTrait for FoundryTxEnvelope {
     fn is_deposit(&self) -> bool {
-        FoundryTxEnvelope::is_deposit(self)
+        Self::is_deposit(self)
     }
 
     fn as_deposit(&self) -> Option<&Sealed<TxDeposit>> {

--- a/crates/primitives/src/transaction/receipt.rs
+++ b/crates/primitives/src/transaction/receipt.rs
@@ -135,6 +135,23 @@ impl FoundryReceiptEnvelope<Log> {
 }
 
 impl<T> FoundryReceiptEnvelope<T> {
+    /// Returns `true` if this is an OP stack deposit receipt.
+    #[cfg(feature = "optimism")]
+    pub const fn is_deposit(&self) -> bool {
+        matches!(self, Self::Deposit(_))
+    }
+
+    /// Returns `true` if this is an OP stack post-execution synthetic receipt.
+    #[cfg(feature = "optimism")]
+    pub const fn is_post_exec(&self) -> bool {
+        matches!(self, Self::PostExec(_))
+    }
+
+    /// Returns `true` if this is a Tempo receipt.
+    pub const fn is_tempo(&self) -> bool {
+        matches!(self, Self::Tempo(_))
+    }
+
     /// Return the [`FoundryTxType`] of the inner receipt.
     pub const fn tx_type(&self) -> FoundryTxType {
         match self {
@@ -502,6 +519,35 @@ mod tests {
     use super::*;
     use alloy_primitives::{Address, B256, Bytes, LogData, hex};
     use std::str::FromStr;
+
+    fn receipt_for(tx_type: FoundryTxType) -> FoundryReceiptEnvelope {
+        FoundryReceiptEnvelope::<alloy_rpc_types::Log>::from_parts(
+            true,
+            0,
+            Vec::new(),
+            tx_type,
+            None,
+            None,
+        )
+        .map_logs(|log| log.inner)
+    }
+
+    #[test]
+    fn receipt_predicates() {
+        assert!(receipt_for(FoundryTxType::Legacy).is_legacy());
+        assert!(receipt_for(FoundryTxType::Eip2930).is_eip2930());
+        assert!(receipt_for(FoundryTxType::Eip1559).is_eip1559());
+        assert!(receipt_for(FoundryTxType::Eip4844).is_eip4844());
+        assert!(receipt_for(FoundryTxType::Eip7702).is_eip7702());
+        assert!(receipt_for(FoundryTxType::Tempo).is_tempo());
+        assert!(!receipt_for(FoundryTxType::Tempo).is_legacy());
+
+        #[cfg(feature = "optimism")]
+        {
+            assert!(receipt_for(FoundryTxType::Deposit).is_deposit());
+            assert!(receipt_for(FoundryTxType::PostExec).is_post_exec());
+        }
+    }
 
     #[test]
     fn encode_legacy_receipt() {

--- a/crates/primitives/src/transaction/request.rs
+++ b/crates/primitives/src/transaction/request.rs
@@ -5,7 +5,9 @@ use alloy_network::{
 };
 use alloy_primitives::{Address, ChainId, TxKind, U256};
 use alloy_rpc_types::{AccessList, TransactionInputKind, TransactionRequest};
-use alloy_serde::{OtherFields, WithOtherFields};
+#[cfg(any(test, feature = "optimism"))]
+use alloy_serde::OtherFields;
+use alloy_serde::WithOtherFields;
 use core::num::NonZeroU64;
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, POST_EXEC_TX_TYPE_ID, TxDeposit};
@@ -56,6 +58,22 @@ const TEMPO_REQUEST_FIELDS: &[&str] = &[
 ];
 
 impl FoundryTransactionRequest {
+    /// Returns `true` if this is an Ethereum transaction request.
+    pub const fn is_ethereum(&self) -> bool {
+        matches!(self, Self::Ethereum(_))
+    }
+
+    /// Returns `true` if this is an OP stack transaction request.
+    #[cfg(feature = "optimism")]
+    pub const fn is_op(&self) -> bool {
+        matches!(self, Self::Op(_))
+    }
+
+    /// Returns `true` if this is a Tempo transaction request.
+    pub const fn is_tempo(&self) -> bool {
+        matches!(self, Self::Tempo(_))
+    }
+
     /// Create a new [`FoundryTransactionRequest`] from given
     /// [`WithOtherFields<TransactionRequest>`].
     #[inline]
@@ -649,11 +667,30 @@ mod tests {
     }
 
     #[test]
+    fn request_predicates() {
+        let ethereum = FoundryTransactionRequest::default();
+        assert!(ethereum.is_ethereum());
+        assert!(!ethereum.is_tempo());
+
+        let tempo = FoundryTransactionRequest::Tempo(Box::default());
+        assert!(tempo.is_tempo());
+        assert!(!tempo.is_ethereum());
+
+        #[cfg(feature = "optimism")]
+        {
+            let op = FoundryTransactionRequest::Op(WithOtherFields::default());
+            assert!(op.is_op());
+            assert!(!op.is_ethereum());
+            assert!(!op.is_tempo());
+        }
+    }
+
+    #[test]
     fn test_routing_ethereum_default() {
         let tx = default_tx_req();
         let req: FoundryTransactionRequest = WithOtherFields::new(tx).try_into().unwrap();
 
-        assert!(matches!(req, FoundryTransactionRequest::Ethereum(_)));
+        assert!(req.is_ethereum());
         assert!(matches!(req.build_unsigned(), Ok(FoundryTypedTx::Eip1559(_))));
     }
 
@@ -666,7 +703,7 @@ mod tests {
         let req: FoundryTransactionRequest =
             WithOtherFields { inner: tx, other }.try_into().unwrap();
 
-        assert!(matches!(req, FoundryTransactionRequest::Tempo(_)));
+        assert!(req.is_tempo());
         assert!(matches!(req.build_unsigned(), Ok(FoundryTypedTx::Tempo(_))));
     }
 
@@ -682,7 +719,7 @@ mod tests {
         let req: FoundryTransactionRequest =
             WithOtherFields { inner: tx, other }.try_into().unwrap();
 
-        assert!(matches!(req, FoundryTransactionRequest::Op(_)));
+        assert!(req.is_op());
         assert!(matches!(req.build_unsigned(), Ok(FoundryTypedTx::Deposit(_))));
     }
 
@@ -697,7 +734,7 @@ mod tests {
         let req: FoundryTransactionRequest =
             WithOtherFields { inner: tx, other }.try_into().unwrap();
 
-        assert!(matches!(req, FoundryTransactionRequest::Ethereum(_)));
+        assert!(req.is_ethereum());
         assert!(matches!(req.build_unsigned(), Ok(FoundryTypedTx::Eip1559(_))));
     }
 
@@ -710,7 +747,7 @@ mod tests {
         let req: FoundryTransactionRequest =
             WithOtherFields { inner: tx, other }.try_into().unwrap();
 
-        assert!(matches!(req, FoundryTransactionRequest::Ethereum(_)));
+        assert!(req.is_ethereum());
         assert!(matches!(req.build_unsigned(), Ok(FoundryTypedTx::Eip1559(_))));
     }
 
@@ -722,7 +759,7 @@ mod tests {
         let serialized = serde_json::to_string(&original).unwrap();
         let deserialized: FoundryTransactionRequest = serde_json::from_str(&serialized).unwrap();
 
-        assert!(matches!(deserialized, FoundryTransactionRequest::Ethereum(_)));
+        assert!(deserialized.is_ethereum());
     }
 
     #[test]
@@ -740,7 +777,7 @@ mod tests {
         let serialized = serde_json::to_string(&original).unwrap();
         let deserialized: FoundryTransactionRequest = serde_json::from_str(&serialized).unwrap();
 
-        assert!(matches!(deserialized, FoundryTransactionRequest::Op(_)));
+        assert!(deserialized.is_op());
     }
 
     #[test]
@@ -756,7 +793,7 @@ mod tests {
         let serialized = serde_json::to_string(&original).unwrap();
         let deserialized: FoundryTransactionRequest = serde_json::from_str(&serialized).unwrap();
 
-        assert!(matches!(deserialized, FoundryTransactionRequest::Tempo(_)));
+        assert!(deserialized.is_tempo());
     }
 
     #[test]
@@ -878,7 +915,7 @@ mod tests {
 
         let req: FoundryTransactionRequest = FoundryTypedTx::Deposit(deposit_tx.clone()).into();
 
-        assert!(matches!(req, FoundryTransactionRequest::Op(_)));
+        assert!(req.is_op());
 
         let parts = req.get_deposit_tx_parts().expect("should parse deposit parts");
         assert_eq!(parts.source_hash, deposit_tx.source_hash);

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -161,10 +161,10 @@ impl VerifyBytecodeArgs {
         } else {
             let network = {
                 let provider = ProviderBuilder::<AnyNetwork>::from_config(&config)?.build()?;
-                provider.get_chain_id().await?.into()
+                NetworkVariant::from(provider.get_chain_id().await?)
             };
 
-            if !matches!(network, NetworkVariant::Ethereum) {
+            if !network.is_ethereum() {
                 config.networks = network.into();
             }
 


### PR DESCRIPTION
This adds documented const variant predicates across Foundry's network and transaction enums, including the feature-gated Optimism variants. Standard EIP predicates continue to come from `Typed2718` where that API is already ergonomic, while transaction envelopes follow Alloy and OP conventions with inherent helpers. Exact single-variant checks now use the named predicates, making the network and transaction surface consistent without changing guarded or multi-variant logic.

This PR was written with Codex, which implemented the code and tests under my direction.
