### PR TITLE
fix(script): skip unused library deployments

### DIFF
--- a/crates/cheatcodes/src/config.rs
+++ b/crates/cheatcodes/src/config.rs
@@ -20,6 +20,8 @@ use std::{
 pub struct CheatsConfig {
     /// Whether the FFI cheatcode is enabled.
     pub ffi: bool,
+    /// Cheatcode selectors rejected before dispatch for restricted executions.
+    pub blocked_cheatcodes: Vec<[u8; 4]>,
     /// Use the create 2 factory in all cases including tests and non-broadcasting scripts.
     pub always_use_create_2_factory: bool,
     /// Rewrite plain CREATE to CREATE2 for `forge script --batch`.
@@ -85,6 +87,7 @@ impl CheatsConfig {
 
         Self {
             ffi: evm_opts.ffi,
+            blocked_cheatcodes: Vec::new(),
             always_use_create_2_factory: evm_opts.always_use_create_2_factory,
             batch_rewrite_creates,
             prompt_timeout: Duration::from_secs(config.prompt_timeout),
@@ -110,14 +113,16 @@ impl CheatsConfig {
 
     /// Returns a new `CheatsConfig` configured with the given `Config` and `EvmOpts`.
     pub fn clone_with(&self, config: &Config, evm_opts: EvmOpts) -> Self {
-        Self::new(
+        let mut cloned = Self::new(
             config,
             evm_opts,
             self.available_artifacts.clone(),
             self.running_artifact.clone(),
             self.fee_token,
             self.batch_rewrite_creates,
-        )
+        );
+        cloned.blocked_cheatcodes.clone_from(&self.blocked_cheatcodes);
+        cloned
     }
 
     /// Attempts to canonicalize (see [std::fs::canonicalize]) the path.
@@ -228,6 +233,7 @@ impl Default for CheatsConfig {
     fn default() -> Self {
         Self {
             ffi: false,
+            blocked_cheatcodes: Vec::new(),
             always_use_create_2_factory: false,
             batch_rewrite_creates: false,
             prompt_timeout: Duration::from_secs(120),

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -3191,7 +3191,11 @@ fn apply_dispatch<FEN: FoundryEvmNetwork>(
             }
         };
     }
-    let mut result = vm_calls!(dispatch);
+    let mut result = if ccx.state.config.blocked_cheatcodes.contains(&cheat.func.selector_bytes) {
+        Err(fmt_err!("disabled during restricted execution"))
+    } else {
+        vm_calls!(dispatch)
+    };
 
     // Format the error message to include the cheatcode name.
     if let Err(e) = &mut result

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -3,7 +3,7 @@
 use crate::{compile::PathOrContractInfo, find_metadata_start, strip_bytecode_placeholders};
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::{Event, Function, JsonAbi};
-use alloy_primitives::{Address, B256, Bytes, Selector, hex};
+use alloy_primitives::{Address, B256, Bytes, Selector, address, hex};
 use eyre::{OptionExt, Result};
 use foundry_compilers::{
     ArtifactId, Project, ProjectCompileOutput,
@@ -28,6 +28,26 @@ use std::{
 /// See: <https://docs.soliditylang.org/en/latest/contracts.html#call-protection-for-libraries>
 const CALL_PROTECTION_BYTECODE_PREFIX: [u8; 21] =
     hex!("730000000000000000000000000000000000000000");
+
+/// Isolated account used to deploy libraries needed only while executing locally.
+///
+/// `address(uint160(uint256(keccak256("foundry library deployer"))))`
+pub const LIBRARY_DEPLOYER: Address = address!("0x1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
+
+/// Returns whether `creation_code` is exactly this contract's linked creation bytecode followed by
+/// a complete, canonically encoded constructor argument tuple.
+pub fn matches_contract_creation(contract: &ContractData, creation_code: &[u8]) -> bool {
+    let Some(bytecode) = contract.bytecode() else { return false };
+    let Some(arguments) = creation_code.strip_prefix(bytecode.as_ref()) else { return false };
+    match contract.abi.constructor() {
+        Some(constructor) => constructor
+            .abi_decode_input(arguments)
+            .ok()
+            .and_then(|values| constructor.abi_encode_input(&values).ok())
+            .is_some_and(|encoded| encoded == arguments),
+        None => arguments.is_empty(),
+    }
+}
 
 /// Subset of [CompactBytecode] excluding sourcemaps.
 #[expect(missing_docs)]
@@ -645,6 +665,36 @@ pub fn find_matching_contract_artifact(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_dyn_abi::DynSolValue;
+    use alloy_primitives::U256;
+
+    #[test]
+    fn exact_creation_match_requires_canonical_constructor_suffix() {
+        let abi = JsonAbi::parse(["constructor(uint256 value)"]).unwrap();
+        let bytecode = Bytes::from_static(&[0x60, 0x00]);
+        let contract = ContractData {
+            name: "C".to_owned(),
+            abi,
+            bytecode: Some(BytecodeData {
+                object: Some(BytecodeObject::Bytecode(bytecode.clone())),
+                link_references: BTreeMap::new(),
+                immutable_references: BTreeMap::new(),
+            }),
+            deployed_bytecode: None,
+            storage_layout: None,
+        };
+        let arguments = contract
+            .abi
+            .constructor()
+            .unwrap()
+            .abi_encode_input(&[DynSolValue::Uint(U256::from(1), 256)])
+            .unwrap();
+        let creation = [bytecode.as_ref(), &arguments].concat();
+
+        assert!(matches_contract_creation(&contract, &creation));
+        assert!(!matches_contract_creation(&contract, &creation[..creation.len() - 1]));
+        assert!(!matches_contract_creation(&contract, &[creation, vec![0]].concat()));
+    }
 
     #[test]
     fn bytecode_diffing() {

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -5,8 +5,7 @@ use crate::{
     progress::TestsProgress,
     result::{SuiteResult, SymbolicCounterexampleArtifact, SymbolicCounterexampleArtifactKind},
     runner::{
-        ContractRunnerContext, InvariantCampaignScope, LIBRARY_DEPLOYER,
-        count_runnable_invariant_campaign_anchors,
+        ContractRunnerContext, InvariantCampaignScope, count_runnable_invariant_campaign_anchors,
     },
     symbolic_regression::SYMBOLIC_REGRESSION_MARKER,
 };
@@ -15,8 +14,8 @@ use alloy_primitives::{Address, Bytes, U256};
 use eyre::Result;
 use foundry_cli::opts::configure_pcx_from_compile_output;
 use foundry_common::{
-    ContractsByArtifact, ContractsByArtifactBuilder, EmptyTestFilter, TestFunctionKind,
-    get_contract_name,
+    ContractsByArtifact, ContractsByArtifactBuilder, EmptyTestFilter, LIBRARY_DEPLOYER,
+    TestFunctionKind, get_contract_name,
 };
 use foundry_compilers::{
     Artifact, ArtifactId, Compiler, ProjectCompileOutput,

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -29,7 +29,9 @@ use alloy_primitives::{
     Address, B256, Bytes, Selector, U256, address, hex, keccak256, map::HashMap,
 };
 use eyre::Result;
-use foundry_common::{TestFunctionExt, TestFunctionKind, contracts::ContractsByAddress};
+use foundry_common::{
+    LIBRARY_DEPLOYER, TestFunctionExt, TestFunctionKind, contracts::ContractsByAddress,
+};
 use foundry_compilers::utils::canonicalized;
 use foundry_config::{
     Config, FuzzConfig, FuzzCorpusConfig, FuzzDictionaryConfig, InlineConfig, InvariantConfig,
@@ -86,13 +88,6 @@ use std::{
 };
 use tokio::signal;
 use tracing::Span;
-
-/// When running tests, we deploy all external libraries present in the project. To avoid additional
-/// libraries affecting nonces of senders used in tests, we are using separate address to
-/// predeploy libraries.
-///
-/// `address(uint160(uint256(keccak256("foundry library deployer"))))`
-pub const LIBRARY_DEPLOYER: Address = address!("0x1F95D37F27EA0dEA9C252FC09D5A6eaA97647353");
 
 fn should_symbolically_seed_fuzz_corpus(config: &Config, func: &Function) -> bool {
     config.symbolic.seed_corpus && func.test_function_kind().is_fuzz_test()

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3124,6 +3124,58 @@ contract UnusedLibraries is Script {
     assert!(sequence.libraries[0].contains(":Lib1:"));
 });
 
+forgetest_async!(wallet_signing_skips_library_optimization, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_source(
+        "WalletSigningLibraries",
+        r#"
+import "forge-std/Script.sol";
+library SignLib1 { function value() external pure returns (uint256) { return 1; } }
+library SignLib2 { function value() external pure returns (uint256) { return 2; } }
+contract UsesSignLib1 { function value() external view returns (uint256) { return SignLib1.value(); } }
+contract UsesSignLib2 { function value() external view returns (uint256) { return SignLib2.value(); } }
+contract WalletSigningLibraries is Script {
+    function run(uint256 overload) external {
+        bytes32 digest = keccak256("digest");
+        address signer = vm.rememberKey(1);
+        bytes32 r;
+        if (overload == 0) (, r,) = vm.sign(digest);
+        else if (overload == 1) (, r,) = vm.sign(signer, digest);
+        else if (overload == 2) (r,) = vm.signCompact(digest);
+        else (r,) = vm.signCompact(signer, digest);
+        require(r != bytes32(0));
+
+        vm.startBroadcast(1);
+        if (overload < 4) new UsesSignLib1();
+        else new UsesSignLib2();
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+    for overload in 0..4 {
+        cmd.forge_fuse()
+            .arg("script")
+            .args(["WalletSigningLibraries", "--sig", "run(uint256)"])
+            .arg(overload.to_string())
+            .args([
+                "--rpc-url",
+                handle.http_endpoint().as_str(),
+                "--sender",
+                "0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+            ])
+            .assert_success();
+        let sequence = latest_dry_run_sequence(prj.root());
+        let names = sequence
+            .transactions
+            .iter()
+            .filter_map(|tx| tx.contract_name.as_deref())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["SignLib1", "SignLib2", "UsesSignLib1"], "overload {overload}");
+    }
+});
+
 forgetest_async!(library_optimization_skips_changed_fork_block, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     foundry_test_utils::util::initialize(prj.root());

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -17,7 +17,17 @@ use foundry_test_utils::{
 };
 use regex::Regex;
 use serde_json::Value;
-use std::{env, fs, path::PathBuf};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+fn latest_dry_run_sequence(root: &Path) -> ScriptSequence<Ethereum> {
+    let path = foundry_common::fs::json_files(&root.join("broadcast"))
+        .find(|path| path.ends_with("dry-run/run-latest.json"))
+        .unwrap();
+    foundry_common::fs::read_json_file(&path).unwrap()
+}
 
 // Tests that fork cheat codes can be used in script
 forgetest_init!(
@@ -3076,6 +3086,112 @@ SIMULATION COMPLETE. To broadcast these transactions, add --broadcast and wallet
 
 
 "#]]);
+});
+
+forgetest_async!(unused_libraries_conditional_6215, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_source(
+        "UnusedLibraries",
+        r#"
+import "forge-std/Script.sol";
+library Lib1 { function value() external pure returns (uint256) { return 1; } }
+library Lib2 { function value() external pure returns (uint256) { return 2; } }
+contract ContractUsingLib1 { function value() external view returns (uint256) { return Lib1.value(); } }
+contract ContractUsingLib2 { function value() external view returns (uint256) { return Lib2.value(); } }
+contract UnusedLibraries is Script {
+    function run(uint256 which) external {
+        vm.startBroadcast();
+        if (which == 1) new ContractUsingLib1();
+        else new ContractUsingLib2();
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+    cmd.arg("script")
+        .args(["UnusedLibraries", "--sig", "run(uint256)", "1", "--rpc-url"])
+        .arg(handle.http_endpoint())
+        .assert_success();
+    let sequence = latest_dry_run_sequence(prj.root());
+    let names = sequence
+        .transactions
+        .iter()
+        .filter_map(|tx| tx.contract_name.as_deref())
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["Lib1", "ContractUsingLib1"]);
+    assert_eq!(sequence.libraries.len(), 1);
+    assert!(sequence.libraries[0].contains(":Lib1:"));
+});
+
+forgetest_async!(library_optimization_skips_changed_fork_block, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_source(
+        "ChangedForkLibraries",
+        r#"
+import "forge-std/Script.sol";
+library ForkLib1 { function value() external pure returns (uint256) { return 1; } }
+library ForkLib2 { function value() external pure returns (uint256) { return 2; } }
+contract UsesForkLib1 { function value() external view returns (uint256) { return ForkLib1.value(); } }
+contract UsesForkLib2 { function value() external view returns (uint256) { return ForkLib2.value(); } }
+contract ChangedForkLibraries is Script {
+    function run(uint256 which) external {
+        vm.rollFork(block.number);
+        vm.startBroadcast();
+        if (which == 1) new UsesForkLib1();
+        else new UsesForkLib2();
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+    cmd.arg("script")
+        .args(["ChangedForkLibraries", "--sig", "run(uint256)", "1", "--rpc-url"])
+        .arg(handle.http_endpoint())
+        .assert_success();
+    let sequence = latest_dry_run_sequence(prj.root());
+    let names = sequence
+        .transactions
+        .iter()
+        .filter_map(|tx| tx.contract_name.as_deref())
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["ForkLib1", "ForkLib2", "UsesForkLib1"]);
+});
+
+forgetest_async!(unused_library_called_locally_before_direct_create, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_source(
+        "OutsideLibrary",
+        r#"
+import "forge-std/Script.sol";
+library OutsideLib { function value() external pure returns (uint256) { return 1; } }
+library RequiredLib { function value() external pure returns (uint256) { return 2; } }
+contract UsesRequiredLib { function value() external view returns (uint256) { return RequiredLib.value(); } }
+contract OutsideLibrary is Script {
+    function run() external {
+        OutsideLib.value();
+        vm.startBroadcast();
+        new UsesRequiredLib();
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+    cmd.arg("script")
+        .args(["OutsideLibrary", "--rpc-url"])
+        .arg(handle.http_endpoint())
+        .assert_success();
+    let sequence = latest_dry_run_sequence(prj.root());
+    let names = sequence
+        .transactions
+        .iter()
+        .filter_map(|tx| tx.contract_name.as_deref())
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["RequiredLib", "UsesRequiredLib"]);
+    assert_eq!(sequence.libraries.len(), 1);
+    assert!(sequence.libraries[0].contains(":RequiredLib:"));
 });
 
 // Tests warn when artifact source file no longer exists.

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -3176,6 +3176,51 @@ contract WalletSigningLibraries is Script {
     }
 });
 
+forgetest_async!(candidate_rpc_side_effect_is_blocked, |prj, cmd| {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    foundry_test_utils::util::initialize(prj.root());
+    assert_eq!(
+        foundry_common::LIBRARY_DEPLOYER.create(0),
+        address!("0x5F65cD7D792E9746EF82929D60de9a1C526f93A5")
+    );
+    prj.add_source(
+        "CandidateRpcSideEffect",
+        r#"
+import "forge-std/Script.sol";
+library LocalLib { function value() external pure returns (uint256) { return 2; } }
+library RequiredLib { function value() external pure returns (uint256) { return 1; } }
+contract UsesRequiredLib { function value() external view returns (uint256) { return RequiredLib.value(); } }
+contract CandidateRpcSideEffect is Script {
+    address constant LOCAL_LIB = 0x5F65cD7D792E9746EF82929D60de9a1C526f93A5;
+    address constant MUTATED = 0x0000000000000000000000000000000000001234;
+
+    function run() external {
+        if (address(LocalLib) == LOCAL_LIB) {
+            vm.rpc("anvil_setBalance", string.concat("[\"", vm.toString(MUTATED), "\", \"0x1\"]"));
+        }
+        vm.startBroadcast();
+        new UsesRequiredLib();
+        vm.stopBroadcast();
+    }
+}
+"#,
+    );
+    cmd.arg("script")
+        .args(["CandidateRpcSideEffect", "--rpc-url"])
+        .arg(handle.http_endpoint())
+        .assert_success();
+
+    let sequence = latest_dry_run_sequence(prj.root());
+    let names = sequence
+        .transactions
+        .iter()
+        .filter_map(|tx| tx.contract_name.as_deref())
+        .collect::<Vec<_>>();
+    assert_eq!(names, ["LocalLib", "RequiredLib", "UsesRequiredLib"]);
+    let mutated = address!("0x0000000000000000000000000000000000001234");
+    assert_eq!(api.balance(mutated, None).await.unwrap(), U256::ZERO);
+});
+
 forgetest_async!(library_optimization_skips_changed_fork_block, |prj, cmd| {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     foundry_test_utils::util::initialize(prj.root());

--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -54,6 +54,25 @@ pub struct LinkOutput {
     pub libs_to_deploy: Vec<Bytes>,
 }
 
+/// Detailed linker output for callers that need metadata about auto-linked libraries.
+pub struct DetailedLinkOutput {
+    /// The backwards-compatible linker output.
+    pub output: LinkOutput,
+    /// Auto-linked libraries, preserving their artifact identity and linked creation bytecode.
+    pub linked_libraries: Vec<LinkedLibrary>,
+}
+
+/// An auto-linked library and the data used to deploy and classify it.
+#[derive(Clone, Debug)]
+pub struct LinkedLibrary {
+    /// Compilation artifact for the library.
+    pub id: ArtifactId,
+    /// Address assigned by the linker.
+    pub address: Address,
+    /// Fully linked creation bytecode.
+    pub bytecode: Bytes,
+}
+
 impl<'a> Linker<'a> {
     pub fn new(
         root: impl Into<PathBuf>,
@@ -258,6 +277,28 @@ impl<'a> Linker<'a> {
             .collect()
     }
 
+    /// Returns the transitive set of libraries referenced by `target`.
+    pub fn dependencies(
+        &'a self,
+        target: &'a ArtifactId,
+    ) -> Result<BTreeSet<ArtifactId>, LinkerError> {
+        let mut dependencies = BTreeSet::new();
+        self.collect_dependencies(target, &mut dependencies)?;
+        Ok(dependencies.into_iter().cloned().collect())
+    }
+
+    fn linked_creation_bytecode(
+        &self,
+        target: &ArtifactId,
+        libraries: &Libraries,
+    ) -> Result<Bytes, LinkerError> {
+        let contract = self.link(target, libraries)?;
+        self.ensure_linked(&contract, target)?;
+        contract.get_bytecode_bytes().map(|code| code.into_owned()).ok_or_else(|| {
+            LinkerError::LinkingFailed { artifact: target.source.to_string_lossy().into_owned() }
+        })
+    }
+
     /// Links given artifact with either given library addresses or address computed from sender and
     /// nonce.
     ///
@@ -271,9 +312,20 @@ impl<'a> Linker<'a> {
         &'a self,
         libraries: Libraries,
         sender: Address,
-        mut nonce: u64,
+        nonce: u64,
         targets: impl IntoIterator<Item = &'a ArtifactId>,
     ) -> Result<LinkOutput, LinkerError> {
+        Ok(self.link_with_nonce_or_address_detailed(libraries, sender, nonce, targets)?.output)
+    }
+
+    /// Links like [`Self::link_with_nonce_or_address`] and includes auto-linked library metadata.
+    pub fn link_with_nonce_or_address_detailed(
+        &'a self,
+        libraries: Libraries,
+        sender: Address,
+        mut nonce: u64,
+        targets: impl IntoIterator<Item = &'a ArtifactId>,
+    ) -> Result<DetailedLinkOutput, LinkerError> {
         // Library paths in `link_references` keys are always stripped, so we have to strip
         // user-provided paths to be able to match them correctly.
         let mut libraries = libraries.with_stripped_file_prefixes(self.root.as_path());
@@ -301,15 +353,21 @@ impl<'a> Linker<'a> {
         }
 
         // Link and collect bytecodes for `libs_to_deploy`.
-        let libs_to_deploy = libs_to_deploy
+        let linked_libraries = libs_to_deploy
             .into_par_iter()
-            .map(|(id, _)| {
-                Ok(self.link(id, &libraries)?.get_bytecode_bytes().unwrap().into_owned())
+            .map(|(id, address)| {
+                let bytecode =
+                    self.link(id, &libraries)?.get_bytecode_bytes().unwrap().into_owned();
+                Ok(LinkedLibrary { id: id.clone(), address, bytecode })
             })
             .collect::<Result<Vec<_>, LinkerError>>()?;
+        let libs_to_deploy = linked_libraries.iter().map(|lib| lib.bytecode.clone()).collect();
 
         let library_addresses = self.library_addresses(&library_keys, &libraries)?;
-        Ok(LinkOutput { libraries, library_addresses, libs_to_deploy })
+        Ok(DetailedLinkOutput {
+            output: LinkOutput { libraries, library_addresses, libs_to_deploy },
+            linked_libraries,
+        })
     }
 
     pub fn link_with_create2(
@@ -319,6 +377,17 @@ impl<'a> Linker<'a> {
         salt: B256,
         targets: impl IntoIterator<Item = &'a ArtifactId>,
     ) -> Result<LinkOutput, LinkerError> {
+        Ok(self.link_with_create2_detailed(libraries, sender, salt, targets)?.output)
+    }
+
+    /// Links like [`Self::link_with_create2`] and includes auto-linked library metadata.
+    pub fn link_with_create2_detailed(
+        &'a self,
+        libraries: Libraries,
+        sender: Address,
+        salt: B256,
+        targets: impl IntoIterator<Item = &'a ArtifactId>,
+    ) -> Result<DetailedLinkOutput, LinkerError> {
         // Library paths in `link_references` keys are always stripped, so we have to strip
         // user-provided paths to be able to match them correctly.
         let mut libraries = libraries.with_stripped_file_prefixes(self.root.as_path());
@@ -346,7 +415,7 @@ impl<'a> Linker<'a> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut libs_to_deploy = Vec::new();
+        let mut linked_libraries = Vec::new();
 
         // Iteratively compute addresses and link libraries until we have no unlinked libraries
         // left.
@@ -366,7 +435,11 @@ impl<'a> Linker<'a> {
                 artifact: id.source.to_string_lossy().into(),
             })?;
             let address = sender.create2_from_code(salt, code);
-            libs_to_deploy.push(code.clone());
+            linked_libraries.push(LinkedLibrary {
+                id: id.clone(),
+                address,
+                bytecode: code.clone(),
+            });
 
             let (file, name) = self.convert_artifact_id_to_lib_path(id);
 
@@ -377,8 +450,163 @@ impl<'a> Linker<'a> {
             libraries.libs.entry(file).or_default().insert(name, address.to_checksum(None));
         }
 
+        let libs_to_deploy = linked_libraries.iter().map(|lib| lib.bytecode.clone()).collect();
         let library_addresses = self.library_addresses(&library_keys, &libraries)?;
-        Ok(LinkOutput { libraries, library_addresses, libs_to_deploy })
+        Ok(DetailedLinkOutput {
+            output: LinkOutput { libraries, library_addresses, libs_to_deploy },
+            linked_libraries,
+        })
+    }
+
+    /// Relinks a target while assigning libraries not needed onchain to an isolated deployer.
+    pub fn link_with_partition(
+        &'a self,
+        libraries: Libraries,
+        sender: Address,
+        mut sender_nonce: u64,
+        local_deployer: Address,
+        required: &BTreeSet<ArtifactId>,
+        target: &'a ArtifactId,
+    ) -> Result<(DetailedLinkOutput, Vec<LinkedLibrary>), LinkerError> {
+        let mut libraries = libraries.with_stripped_file_prefixes(self.root.as_path());
+        let mut needed = BTreeSet::new();
+        self.collect_dependencies(target, &mut needed)?;
+        let library_keys = self.collect_library_keys(&needed, &libraries)?;
+        let mut required_with_dependencies = required.clone();
+        for id in required {
+            required_with_dependencies.extend(self.dependencies(id)?);
+        }
+        let mut local_nonce = 0;
+        let mut assigned = Vec::new();
+        for id in needed {
+            let (file, name) = self.convert_artifact_id_to_lib_path(id);
+            libraries.libs.entry(file).or_default().entry(name).or_insert_with(|| {
+                let onchain = required_with_dependencies.contains(id);
+                let address = if onchain {
+                    let address = sender.create(sender_nonce);
+                    sender_nonce += 1;
+                    address
+                } else {
+                    let address = local_deployer.create(local_nonce);
+                    local_nonce += 1;
+                    address
+                };
+                assigned.push((id, address, onchain));
+                address.to_checksum(None)
+            });
+        }
+        let linked = assigned
+            .into_iter()
+            .map(|(id, address, onchain)| {
+                let bytecode = self.linked_creation_bytecode(id, &libraries)?;
+                Ok((LinkedLibrary { id: id.clone(), address, bytecode }, onchain))
+            })
+            .collect::<Result<Vec<_>, LinkerError>>()?;
+        let libs_to_deploy = linked
+            .iter()
+            .filter(|(_, onchain)| *onchain)
+            .map(|(lib, _)| lib.bytecode.clone())
+            .collect();
+        let local =
+            linked.iter().filter(|(_, onchain)| !*onchain).map(|(lib, _)| lib.clone()).collect();
+        let linked_libraries = linked.into_iter().map(|(lib, _)| lib).collect();
+        let library_addresses = self.library_addresses(&library_keys, &libraries)?;
+        Ok((
+            DetailedLinkOutput {
+                output: LinkOutput { libraries, library_addresses, libs_to_deploy },
+                linked_libraries,
+            },
+            local,
+        ))
+    }
+
+    /// Relinks a target with CREATE2 onchain assignments and isolated local assignments.
+    pub fn link_with_create2_partition(
+        &'a self,
+        libraries: Libraries,
+        create2_deployer: Address,
+        salt: B256,
+        local_deployer: Address,
+        required: &BTreeSet<ArtifactId>,
+        target: &'a ArtifactId,
+    ) -> Result<(DetailedLinkOutput, Vec<LinkedLibrary>), LinkerError> {
+        let mut libraries = libraries.with_stripped_file_prefixes(self.root.as_path());
+        let mut needed = BTreeSet::new();
+        self.collect_dependencies(target, &mut needed)?;
+        let library_keys = self.collect_library_keys(&needed, &libraries)?;
+        let mut required_with_dependencies = required.clone();
+        for id in required {
+            required_with_dependencies.extend(self.dependencies(id)?);
+        }
+        let mut local_ids = Vec::new();
+        let mut required_ids = Vec::new();
+        for id in needed {
+            let (file, name) = self.convert_artifact_id_to_lib_path(id);
+            if libraries.libs.get(&file).is_some_and(|libs| libs.contains_key(&name)) {
+                continue;
+            }
+            if required_with_dependencies.contains(id) {
+                required_ids.push(id);
+            } else {
+                let address = local_deployer.create(local_ids.len() as u64);
+                libraries.libs.entry(file).or_default().insert(name, address.to_checksum(None));
+                local_ids.push((id, address));
+            }
+        }
+
+        let mut pending = required_ids
+            .into_iter()
+            .map(|id| {
+                let contract = self.link(id, &libraries)?;
+                let bytecode = contract.bytecode.ok_or_else(|| LinkerError::LinkingFailed {
+                    artifact: id.source.to_string_lossy().into_owned(),
+                })?;
+                Ok((id, bytecode))
+            })
+            .collect::<Result<Vec<_>, LinkerError>>()?;
+        let mut onchain = Vec::new();
+        while !pending.is_empty() {
+            let Some(index) = pending.iter().position(|(_, code)| !code.object.is_unlinked())
+            else {
+                return Err(LinkerError::CyclicDependency);
+            };
+            let (id, code) = pending.swap_remove(index);
+            let bytecode = code.bytes().cloned().ok_or_else(|| LinkerError::LinkingFailed {
+                artifact: id.source.to_string_lossy().into_owned(),
+            })?;
+            let address = create2_deployer.create2_from_code(salt, &bytecode);
+            let (file, name) = self.convert_artifact_id_to_lib_path(id);
+            libraries
+                .libs
+                .entry(file.clone())
+                .or_default()
+                .insert(name.clone(), address.to_checksum(None));
+            for (_, pending_code) in &mut pending {
+                pending_code.to_mut().link(&file.to_string_lossy(), &name, address);
+            }
+            onchain.push(LinkedLibrary { id: id.clone(), address, bytecode });
+        }
+
+        let local_bytecodes = local_ids
+            .iter()
+            .map(|(id, _)| self.linked_creation_bytecode(id, &libraries))
+            .collect::<Result<Vec<_>, LinkerError>>()?;
+        let mut linked_libraries = onchain.clone();
+        let local = local_ids
+            .into_iter()
+            .zip(local_bytecodes)
+            .map(|((id, address), bytecode)| LinkedLibrary { id: id.clone(), address, bytecode })
+            .collect::<Vec<_>>();
+        linked_libraries.extend(local.iter().cloned());
+        let libs_to_deploy = onchain.into_iter().map(|lib| lib.bytecode).collect();
+        let library_addresses = self.library_addresses(&library_keys, &libraries)?;
+        Ok((
+            DetailedLinkOutput {
+                output: LinkOutput { libraries, library_addresses, libs_to_deploy },
+                linked_libraries,
+            },
+            local,
+        ))
     }
 
     /// Links given artifact with given libraries.
@@ -1090,6 +1318,118 @@ mod tests {
 
         assert_eq!(output.library_addresses.len(), 1);
         assert!(!output.library_addresses.contains(&unrelated));
+    }
+
+    #[test]
+    fn partition_with_nonce_assigns_required_and_local_libraries() {
+        let test = LinkerTest::new(&testdata().join("default/linking/samefile_union"), true);
+        let linker = Linker::new(test.project.root(), test.output.artifact_ids().collect());
+        let find = |name| linker.contracts.keys().find(|id| id.name == name).unwrap();
+        let (target, required_id) = (find("UsesBoth"), find("LInit").clone());
+        let sender = address!("0x1000000000000000000000000000000000000000");
+        let local_deployer = address!("0x2000000000000000000000000000000000000000");
+        let required = BTreeSet::from([required_id.clone()]);
+        let (detailed, local) = linker
+            .link_with_partition(Libraries::default(), sender, 7, local_deployer, &required, target)
+            .unwrap();
+
+        assert_eq!(detailed.linked_libraries.len(), 2);
+        assert_eq!(detailed.output.libs_to_deploy.len(), 1);
+        assert_eq!(local.len(), 1);
+        assert_eq!(
+            detailed.linked_libraries.iter().find(|lib| lib.id == required_id).unwrap().address,
+            sender.create(7)
+        );
+        assert_eq!(local[0].address, local_deployer.create(0));
+        linker
+            .ensure_linked(&linker.link(target, &detailed.output.libraries).unwrap(), target)
+            .unwrap();
+        for library in &detailed.linked_libraries {
+            assert!(!library.bytecode.is_empty());
+        }
+
+        let mut configured = Libraries::default();
+        let (file, name) = linker.convert_artifact_id_to_lib_path(find("LRun"));
+        configured.libs.entry(file).or_default().insert(name, Address::ZERO.to_checksum(None));
+        let (configured, local) = linker
+            .link_with_partition(configured, sender, 7, local_deployer, &required, target)
+            .unwrap();
+        assert_eq!(configured.linked_libraries.len(), 1);
+        assert!(local.is_empty());
+    }
+
+    #[test]
+    fn partition_with_create2_assigns_required_and_local_libraries() {
+        let test = LinkerTest::new(&testdata().join("default/linking/samefile_union"), true);
+        let linker = Linker::new(test.project.root(), test.output.artifact_ids().collect());
+        let find = |name| linker.contracts.keys().find(|id| id.name == name).unwrap();
+        let (target, required_id) = (find("UsesBoth"), find("LInit").clone());
+        let required = BTreeSet::from([required_id.clone()]);
+        let deployer = address!("0x3000000000000000000000000000000000000000");
+        let local_deployer = address!("0x4000000000000000000000000000000000000000");
+        let salt = fixed_bytes!("19bf59b7b67ae8edcbc6e53616080f61fa99285c061450ad601b0bc40c9adfc9");
+        let (detailed, local) = linker
+            .link_with_create2_partition(
+                Libraries::default(),
+                deployer,
+                salt,
+                local_deployer,
+                &required,
+                target,
+            )
+            .unwrap();
+
+        assert_eq!(detailed.output.libs_to_deploy.len(), 1);
+        assert_eq!(local.len(), 1);
+        let onchain =
+            detailed.linked_libraries.iter().find(|library| library.id == required_id).unwrap();
+        assert_eq!(onchain.address, deployer.create2_from_code(salt, &onchain.bytecode));
+        assert_eq!(detailed.output.libs_to_deploy[0], onchain.bytecode);
+        assert_eq!(local[0].address, local_deployer.create(0));
+        linker
+            .ensure_linked(&linker.link(target, &detailed.output.libraries).unwrap(), target)
+            .unwrap();
+    }
+
+    #[test]
+    fn partition_with_create2_keeps_transitive_order_deterministic() {
+        let test = LinkerTest::new(&testdata().join("default/linking/nested"), true);
+        let linker = Linker::new(test.project.root(), test.output.artifact_ids().collect());
+        let find = |name| linker.contracts.keys().find(|id| id.name == name).unwrap();
+        let target = find("LibraryConsumer");
+        let required = BTreeSet::from([find("NestedLib").clone()]);
+        let deployer = address!("0x3000000000000000000000000000000000000000");
+        let local_deployer = address!("0x4000000000000000000000000000000000000000");
+        let salt = fixed_bytes!("19bf59b7b67ae8edcbc6e53616080f61fa99285c061450ad601b0bc40c9adfc9");
+        let link = || {
+            linker
+                .link_with_create2_partition(
+                    Libraries::default(),
+                    deployer,
+                    salt,
+                    local_deployer,
+                    &required,
+                    target,
+                )
+                .unwrap()
+        };
+        let (first, local) = link();
+        let (second, _) = link();
+
+        assert!(local.is_empty());
+        assert_eq!(first.output.libs_to_deploy.len(), 2);
+        assert_eq!(
+            first.linked_libraries.iter().map(|lib| (&lib.id, lib.address)).collect::<Vec<_>>(),
+            second.linked_libraries.iter().map(|lib| (&lib.id, lib.address)).collect::<Vec<_>>()
+        );
+        assert_eq!(first.linked_libraries[0].id.name, "Lib");
+        assert_eq!(first.linked_libraries[1].id.name, "NestedLib");
+        for library in &first.linked_libraries {
+            assert_eq!(library.address, deployer.create2_from_code(salt, &library.bytecode));
+        }
+        linker
+            .ensure_linked(&linker.link(target, &first.output.libraries).unwrap(), target)
+            .unwrap();
     }
 
     #[test]

--- a/crates/script/src/build.rs
+++ b/crates/script/src/build.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 use alloy_network::AnyNetwork;
-use alloy_primitives::{Address, B256, Bytes, map::AddressHashSet};
+use alloy_primitives::{Address, B256, map::AddressHashSet};
 use alloy_provider::Provider;
 use eyre::{OptionExt, Result};
 use forge_script_sequence::ScriptSequence;
@@ -57,7 +57,7 @@ fn has_available_script_signers(
 }
 
 /// Container for the compiled contracts.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BuildData {
     /// Root of the project.
     pub project_root: PathBuf,
@@ -89,7 +89,7 @@ impl BuildData {
         let maybe_create2_link_output = can_use_create2
             .then(|| {
                 self.get_linker()
-                    .link_with_create2(
+                    .link_with_create2_detailed(
                         known_libraries.clone(),
                         create2_deployer,
                         script_config.config.create2_library_salt,
@@ -101,21 +101,28 @@ impl BuildData {
 
         let (libraries, predeploy_libs) = if let Some(output) = maybe_create2_link_output {
             (
-                output.libraries,
-                ScriptPredeployLibraries::Create2(
-                    output.libs_to_deploy,
-                    script_config.config.create2_library_salt,
-                ),
+                output.output.libraries,
+                ScriptPredeployLibraries::Create2 {
+                    onchain: output.linked_libraries,
+                    salt: script_config.config.create2_library_salt,
+                    local: Vec::new(),
+                },
             )
         } else {
-            let output = self.get_linker().link_with_nonce_or_address(
+            let output = self.get_linker().link_with_nonce_or_address_detailed(
                 known_libraries,
                 script_config.evm_opts.sender,
                 script_config.sender_nonce,
                 [&self.target],
             )?;
 
-            (output.libraries, ScriptPredeployLibraries::Default(output.libs_to_deploy))
+            (
+                output.output.libraries,
+                ScriptPredeployLibraries::Default {
+                    onchain: output.linked_libraries,
+                    local: Vec::new(),
+                },
+            )
         };
 
         LinkedBuildData::new(libraries, predeploy_libs, self)
@@ -124,27 +131,38 @@ impl BuildData {
     /// Links the build data with the given libraries. Expects supplied libraries set being enough
     /// to fully link target contract.
     pub fn link_with_libraries(self, libraries: Libraries) -> Result<LinkedBuildData> {
-        LinkedBuildData::new(libraries, ScriptPredeployLibraries::Default(Vec::new()), self)
+        LinkedBuildData::new(
+            libraries,
+            ScriptPredeployLibraries::Default { onchain: Vec::new(), local: Vec::new() },
+            self,
+        )
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ScriptPredeployLibraries {
-    Default(Vec<Bytes>),
-    Create2(Vec<Bytes>, B256),
+    Default {
+        onchain: Vec<foundry_linking::LinkedLibrary>,
+        local: Vec<foundry_linking::LinkedLibrary>,
+    },
+    Create2 {
+        onchain: Vec<foundry_linking::LinkedLibrary>,
+        salt: B256,
+        local: Vec<foundry_linking::LinkedLibrary>,
+    },
 }
 
 impl ScriptPredeployLibraries {
     pub const fn libraries_count(&self) -> usize {
         match self {
-            Self::Default(libs) => libs.len(),
-            Self::Create2(libs, _) => libs.len(),
+            Self::Default { onchain, .. } => onchain.len(),
+            Self::Create2 { onchain, .. } => onchain.len(),
         }
     }
 }
 
 /// Container for the linked contracts and their dependencies
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LinkedBuildData {
     /// Original build data, might be used to relink this object with different libraries.
     pub build_data: BuildData,

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -298,6 +298,16 @@ pub struct ExecutedState<FEN: FoundryEvmNetwork> {
 impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
     /// Collects the data we need for simulation and various post-execution tasks.
     pub async fn prepare_simulation(self) -> Result<PreSimulationState<FEN>> {
+        self.prepare_simulation_inner(false).await
+    }
+
+    /// Collects simulation data without emitting warnings for an optimization candidate that may
+    /// be discarded.
+    pub(crate) async fn prepare_simulation_silent(self) -> Result<PreSimulationState<FEN>> {
+        self.prepare_simulation_inner(true).await
+    }
+
+    async fn prepare_simulation_inner(self, silent: bool) -> Result<PreSimulationState<FEN>> {
         let returns = self.get_returns()?;
 
         let decoder = self.build_trace_decoder(&self.build_data.known_contracts).await?;
@@ -316,7 +326,7 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
         }
         let rpc_data = RpcData::from_transactions(&txs);
 
-        if rpc_data.is_multi_chain() {
+        if rpc_data.is_multi_chain() && !silent {
             sh_warn!("Multi chain deployment is still under development. Use with caution.")?;
             if !self.build_data.libraries.is_empty() {
                 eyre::bail!(
@@ -324,7 +334,9 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
                 );
             }
         }
-        rpc_data.check_shanghai_support().await?;
+        if !silent {
+            rpc_data.check_shanghai_support().await?;
+        }
 
         Ok(PreSimulationState {
             args: self.args,

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -108,7 +108,16 @@ pub struct PreExecutionState<FEN: FoundryEvmNetwork> {
 impl<FEN: FoundryEvmNetwork> PreExecutionState<FEN> {
     /// Executes the script and returns the state after execution.
     /// Might require executing script twice in cases when we determine sender from execution.
-    pub async fn execute(mut self) -> Result<ExecutedState<FEN>> {
+    pub async fn execute(self) -> Result<ExecutedState<FEN>> {
+        self.execute_inner(false).await
+    }
+
+    /// Executes an optimization candidate while blocking externally observable cheatcodes.
+    pub(crate) async fn execute_restricted(self) -> Result<ExecutedState<FEN>> {
+        self.execute_inner(true).await
+    }
+
+    async fn execute_inner(mut self, restricted: bool) -> Result<ExecutedState<FEN>> {
         let mut runner = self
             .script_config
             .get_runner_with_cheatcodes(
@@ -116,6 +125,7 @@ impl<FEN: FoundryEvmNetwork> PreExecutionState<FEN> {
                 self.script_wallets.clone(),
                 self.args.debug,
                 self.build_data.build_data.target.clone(),
+                restricted,
             )
             .await?;
         let result = self.execute_with_runner(&mut runner).await?;
@@ -134,7 +144,10 @@ impl<FEN: FoundryEvmNetwork> PreExecutionState<FEN> {
                 build_data: self.build_data.build_data,
             };
 
-            return Box::pin(state.link().await?.prepare_execution().await?.execute()).await;
+            return Box::pin(
+                state.link().await?.prepare_execution().await?.execute_inner(restricted),
+            )
+            .await;
         }
 
         Ok(ExecutedState {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -71,6 +71,7 @@ use std::path::PathBuf;
 mod broadcast;
 mod build;
 mod execute;
+mod library_deployments;
 mod multi_sequence;
 mod progress;
 mod providers;
@@ -417,6 +418,8 @@ impl ScriptArgs {
                 .execute()
                 .await?
                 .prepare_simulation()
+                .await?
+                .optimize_library_deployments()
                 .await?;
 
             if pre_simulation.args.debug {
@@ -874,6 +877,9 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
     ) -> Result<ScriptRunner<FEN>> {
         trace!("preparing script runner");
         let (evm_env, mut tx_env, fork_block) = self.evm_opts.env::<_, _, TxEnvFor<FEN>>().await?;
+        if self.evm_opts.fork_url.is_some() && self.evm_opts.fork_block_number.is_none() {
+            self.evm_opts.fork_block_number = fork_block;
+        }
 
         let db = if let Some(fork_url) = self.evm_opts.fork_url.as_ref() {
             match self.backends.get(fork_url) {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -857,7 +857,7 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
     }
 
     async fn get_runner(&mut self) -> Result<ScriptRunner<FEN>> {
-        self._get_runner(None, false).await
+        self._get_runner(None, false, false).await
     }
 
     async fn get_runner_with_cheatcodes(
@@ -866,14 +866,16 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         script_wallets: Wallets,
         debug: bool,
         target: ArtifactId,
+        restricted: bool,
     ) -> Result<ScriptRunner<FEN>> {
-        self._get_runner(Some((known_contracts, script_wallets, target)), debug).await
+        self._get_runner(Some((known_contracts, script_wallets, target)), debug, restricted).await
     }
 
     async fn _get_runner(
         &mut self,
         cheats_data: Option<(ContractsByArtifact, Wallets, ArtifactId)>,
         debug: bool,
+        restricted: bool,
     ) -> Result<ScriptRunner<FEN>> {
         trace!("preparing script runner");
         let (evm_env, mut tx_env, fork_block) = self.evm_opts.env::<_, _, TxEnvFor<FEN>>().await?;
@@ -914,18 +916,20 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
 
         if let Some((known_contracts, script_wallets, target)) = cheats_data {
             builder = builder.inspectors(|stack| {
+                let mut cheats_config = CheatsConfig::new(
+                    &self.config,
+                    self.evm_opts.clone(),
+                    Some(known_contracts),
+                    Some(target),
+                    self.tempo.fee_token,
+                    self.batch,
+                );
+                if restricted {
+                    cheats_config.blocked_cheatcodes =
+                        library_deployments::rerun_unsafe_cheatcode_selectors();
+                }
                 stack
-                    .cheatcodes(
-                        CheatsConfig::new(
-                            &self.config,
-                            self.evm_opts.clone(),
-                            Some(known_contracts),
-                            Some(target),
-                            self.tempo.fee_token,
-                            self.batch,
-                        )
-                        .into(),
-                    )
+                    .cheatcodes(cheats_config.into())
                     .wallets(script_wallets)
                     .enable_isolation(self.evm_opts.isolate)
             });

--- a/crates/script/src/library_deployments.rs
+++ b/crates/script/src/library_deployments.rs
@@ -287,6 +287,10 @@ impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
     fn used_rerun_unsafe_cheatcode(&self) -> bool {
         const SIGNATURES: &[&str] = &[
             "setEnv(string,string)",
+            "sign(bytes32)",
+            "sign(address,bytes32)",
+            "signCompact(bytes32)",
+            "signCompact(address,bytes32)",
             "rpc(string,string)",
             "rpc(string,string,string)",
             "rpcJson(string,string)",

--- a/crates/script/src/library_deployments.rs
+++ b/crates/script/src/library_deployments.rs
@@ -1,0 +1,349 @@
+use crate::{
+    build::{LinkedBuildData, ScriptPredeployLibraries},
+    execute::LinkedState,
+    simulate::PreSimulationState,
+};
+use alloy_network::TransactionBuilder;
+use alloy_primitives::{Address, keccak256};
+use eyre::Result;
+use foundry_common::{LIBRARY_DEPLOYER, matches_contract_creation, shell};
+use foundry_compilers::ArtifactId;
+use foundry_evm::{constants::CHEATCODE_ADDRESS, core::evm::FoundryEvmNetwork};
+use std::collections::BTreeSet;
+
+struct EligibleTransactions {
+    required: BTreeSet<ArtifactId>,
+    artifacts: Vec<ArtifactId>,
+    rpc: String,
+    baseline_count: usize,
+}
+
+impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
+    /// Reruns narrowly eligible scripts with libraries unused by direct broadcasts deployed only
+    /// in the local EVM.
+    pub async fn optimize_library_deployments(self) -> Result<Self> {
+        let Ok(Some(EligibleTransactions { required, artifacts, rpc, baseline_count })) =
+            self.eligible()
+        else {
+            return Ok(self);
+        };
+        let onchain = match &self.build_data.predeploy_libraries {
+            ScriptPredeployLibraries::Default { onchain, .. }
+            | ScriptPredeployLibraries::Create2 { onchain, .. } => onchain,
+        };
+        if required.len() == onchain.len() {
+            return Ok(self);
+        }
+
+        let Ok(libraries) = self.script_config.config.libraries_with_remappings() else {
+            return Ok(self);
+        };
+        let linker = self.build_data.build_data.get_linker();
+        let linked = match &self.build_data.predeploy_libraries {
+            ScriptPredeployLibraries::Default { .. } => linker
+                .link_with_partition(
+                    libraries,
+                    self.script_config.evm_opts.sender,
+                    self.script_config.sender_nonce,
+                    LIBRARY_DEPLOYER,
+                    &required,
+                    &self.build_data.build_data.target,
+                )
+                .map(|(output, local)| {
+                    let onchain = onchain_libraries(&output, &local);
+                    (output.output, ScriptPredeployLibraries::Default { onchain, local })
+                }),
+            ScriptPredeployLibraries::Create2 { salt, .. } => linker
+                .link_with_create2_partition(
+                    libraries,
+                    self.script_config.evm_opts.create2_deployer,
+                    *salt,
+                    LIBRARY_DEPLOYER,
+                    &required,
+                    &self.build_data.build_data.target,
+                )
+                .map(|(output, local)| {
+                    let onchain = onchain_libraries(&output, &local);
+                    (
+                        output.output,
+                        ScriptPredeployLibraries::Create2 { onchain, salt: *salt, local },
+                    )
+                }),
+        };
+        let Ok((output, predeploy_libraries)) = linked else { return Ok(self) };
+        let Ok(build_data) = LinkedBuildData::new(
+            output.libraries,
+            predeploy_libraries,
+            self.build_data.build_data.clone(),
+        ) else {
+            return Ok(self);
+        };
+        let candidate = LinkedState {
+            args: self.args.clone(),
+            script_config: self.script_config.clone(),
+            script_wallets: self.script_wallets.clone(),
+            browser_wallet: self.browser_wallet.clone(),
+            build_data,
+        }
+        .prepare_execution()
+        .await;
+        let Ok(candidate) = candidate else { return Ok(self) };
+        let candidate = candidate.execute().await;
+        let Ok(candidate) = candidate else { return Ok(self) };
+        if !candidate.execution_result.success {
+            return Ok(self);
+        }
+        let candidate = candidate.prepare_simulation_silent().await;
+        let Ok(candidate) = candidate else { return Ok(self) };
+        if self.execution_result.returned != candidate.execution_result.returned
+            || self.execution_result.logs != candidate.execution_result.logs
+            || !self.equivalent_candidate(&candidate, &artifacts, &rpc, baseline_count)
+        {
+            return Ok(self);
+        }
+        Ok(candidate)
+    }
+
+    fn eligible(&self) -> Result<Option<EligibleTransactions>> {
+        if !self.execution_result.success
+            || self.args.skip_simulation
+            || self.args.debug
+            || self.args.dump.is_some()
+            || self.args.batch
+            || self.args.slow
+            || self.script_config.config.ffi
+            || self.script_config.config.live_logs
+            || shell::is_json()
+            || shell::verbosity() > 3
+            || self.script_config.evm_opts.env.gas_price.is_some()
+            || self.execution_artifacts.rpc_data.missing_rpc
+            || self.execution_artifacts.rpc_data.is_multi_chain()
+            || self.script_config.evm_opts.sender == LIBRARY_DEPLOYER
+            || self.script_config.config.fs_permissions.permissions.iter().any(|permission| {
+                matches!(
+                    permission.access,
+                    foundry_config::fs_permissions::FsAccessPermission::Write
+                        | foundry_config::fs_permissions::FsAccessPermission::ReadWrite
+                )
+            })
+            || self.used_rerun_unsafe_cheatcode()
+        {
+            return Ok(None);
+        }
+        let Some(rpc) = self.script_config.evm_opts.fork_url.clone() else { return Ok(None) };
+        if self.script_config.evm_opts.fork_block_number.is_none()
+            || self.execution_artifacts.rpc_data.total_rpcs.len() != 1
+            || !self.execution_artifacts.rpc_data.total_rpcs.contains(&rpc)
+        {
+            return Ok(None);
+        }
+        let onchain = match &self.build_data.predeploy_libraries {
+            ScriptPredeployLibraries::Default { onchain, .. }
+            | ScriptPredeployLibraries::Create2 { onchain, .. } => onchain,
+        };
+        if onchain.is_empty() {
+            return Ok(None);
+        }
+        let Some(transactions) = &self.execution_result.transactions else { return Ok(None) };
+        if transactions.len() <= onchain.len()
+            || transactions.iter().any(|tx| {
+                !tx.transaction.is_unsigned()
+                    || tx.transaction.authorization_list().is_some_and(|list| !list.is_empty())
+            })
+        {
+            return Ok(None);
+        }
+        for (index, (tx, library)) in transactions.iter().zip(onchain).enumerate() {
+            let input = tx.transaction.input().map(|input| input.as_ref()).unwrap_or_default();
+            let deployment_matches = match &self.build_data.predeploy_libraries {
+                ScriptPredeployLibraries::Default { .. } => {
+                    tx.transaction.to().is_none() && input == library.bytecode.as_ref()
+                }
+                ScriptPredeployLibraries::Create2 { salt, .. } => {
+                    tx.transaction.to() == Some(self.script_config.evm_opts.create2_deployer)
+                        && input.get(..32) == Some(salt.as_slice())
+                        && input.get(32..) == Some(library.bytecode.as_ref())
+                }
+            };
+            let exact = deployment_matches
+                && tx.rpc.as_ref() == Some(&rpc)
+                && tx.transaction.from() == Some(self.script_config.evm_opts.sender)
+                && tx.transaction.nonce() == Some(self.script_config.sender_nonce + index as u64);
+            if !exact {
+                return Ok(None);
+            }
+        }
+
+        let library_ids = onchain.iter().map(|library| library.id.clone()).collect::<BTreeSet<_>>();
+        let linker = self.build_data.build_data.get_linker();
+        let mut required = BTreeSet::new();
+        let mut artifacts = Vec::new();
+        for tx in transactions.iter().skip(onchain.len()) {
+            if tx.rpc.as_ref() != Some(&rpc)
+                || tx.transaction.from() != Some(self.script_config.evm_opts.sender)
+                || tx.transaction.to().is_some()
+            {
+                return Ok(None);
+            }
+            let Some(input) = tx.transaction.input() else { return Ok(None) };
+            let matches = self
+                .build_data
+                .known_contracts
+                .iter()
+                .filter(|(_, contract)| matches_contract_creation(contract, input))
+                .map(|(id, _)| id)
+                .collect::<Vec<_>>();
+            let [artifact] = matches.as_slice() else { return Ok(None) };
+            artifacts.push((*artifact).clone());
+            required.extend(
+                linker.dependencies(artifact)?.into_iter().filter(|id| library_ids.contains(id)),
+            );
+        }
+        Ok(Some(EligibleTransactions { required, artifacts, rpc, baseline_count: onchain.len() }))
+    }
+
+    fn equivalent_candidate(
+        &self,
+        candidate: &Self,
+        artifacts: &[ArtifactId],
+        rpc: &str,
+        baseline_count: usize,
+    ) -> bool {
+        let Some(baseline) = self.execution_result.transactions.as_ref() else { return false };
+        let Some(candidate_txs) = candidate.execution_result.transactions.as_ref() else {
+            return false;
+        };
+        let candidate_count = candidate.build_data.predeploy_libraries.libraries_count();
+        let baseline = baseline.iter().skip(baseline_count).collect::<Vec<_>>();
+        let candidate_txs = candidate_txs.iter().skip(candidate_count).collect::<Vec<_>>();
+        if baseline.len() != artifacts.len() || candidate_txs.len() != artifacts.len() {
+            return false;
+        }
+        let mut remaps = Vec::new();
+        let baseline_libraries = match &self.build_data.predeploy_libraries {
+            ScriptPredeployLibraries::Default { onchain, .. }
+            | ScriptPredeployLibraries::Create2 { onchain, .. } => onchain,
+        };
+        let candidate_libraries = match &candidate.build_data.predeploy_libraries {
+            ScriptPredeployLibraries::Default { onchain, .. }
+            | ScriptPredeployLibraries::Create2 { onchain, .. } => onchain,
+        };
+        for library in baseline_libraries {
+            if let Some(other) = candidate_libraries.iter().find(|other| other.id == library.id) {
+                remaps.push((library.address, other.address));
+            }
+        }
+        for ((baseline, candidate_tx), artifact) in
+            baseline.iter().zip(&candidate_txs).zip(artifacts)
+        {
+            let (Some(mut old), Some(new)) = (
+                baseline.transaction.clone().as_unsigned_mut().cloned(),
+                candidate_tx.transaction.clone().as_unsigned_mut().cloned(),
+            ) else {
+                return false;
+            };
+            if baseline.rpc.as_deref() != Some(rpc)
+                || candidate_tx.rpc.as_deref() != Some(rpc)
+                || old.from() != new.from()
+                || old.to().is_some()
+                || new.to().is_some()
+            {
+                return false;
+            }
+            let (Some(old_nonce), Some(new_nonce)) = (old.nonce(), new.nonce()) else {
+                return false;
+            };
+            if old_nonce.checked_sub(baseline_count as u64)
+                != new_nonce.checked_sub(candidate_count as u64)
+            {
+                return false;
+            }
+            let mut input = old.input().cloned().unwrap_or_default().to_vec();
+            for (from, to) in &remaps {
+                replace_addresses(&mut input, *from, *to);
+            }
+            old.set_nonce(new_nonce);
+            old.set_input(input);
+            let (Ok(old_value), Ok(new_value)) =
+                (serde_json::to_value(&old), serde_json::to_value(&new))
+            else {
+                return false;
+            };
+            if old_value != new_value
+                || !candidate.build_data.known_contracts.get(artifact).is_some_and(|contract| {
+                    new.input().is_some_and(|input| matches_contract_creation(contract, input))
+                })
+            {
+                return false;
+            }
+            remaps.push((
+                old.from().unwrap().create(old_nonce),
+                new.from().unwrap().create(new_nonce),
+            ));
+        }
+        true
+    }
+
+    fn used_rerun_unsafe_cheatcode(&self) -> bool {
+        const SIGNATURES: &[&str] = &[
+            "setEnv(string,string)",
+            "rpc(string,string)",
+            "rpc(string,string,string)",
+            "rpcJson(string,string)",
+            "rpcJson(string,string,string)",
+            "sleep(uint256)",
+            "prompt(string)",
+            "promptSecret(string)",
+            "promptSecretUint(string)",
+            "promptAddress(string)",
+            "promptUint(string)",
+            "dumpState(string)",
+            "createFork(string)",
+            "createFork(string,uint256)",
+            "createFork(string,bytes32)",
+            "createSelectFork(string)",
+            "createSelectFork(string,uint256)",
+            "createSelectFork(string,bytes32)",
+            "rollFork(uint256)",
+            "rollFork(bytes32)",
+            "rollFork(uint256,uint256)",
+            "rollFork(uint256,bytes32)",
+            "selectFork(uint256)",
+            "transact(bytes32)",
+            "transact(uint256,bytes32)",
+        ];
+        self.execution_result.traces.iter().any(|(_, traces)| {
+            traces.nodes().iter().any(|node| {
+                node.trace.address == CHEATCODE_ADDRESS
+                    && node.trace.data.get(..4).is_some_and(|selector| {
+                        SIGNATURES
+                            .iter()
+                            .any(|signature| &keccak256(signature.as_bytes())[..4] == selector)
+                    })
+            })
+        })
+    }
+}
+
+fn onchain_libraries(
+    output: &foundry_linking::DetailedLinkOutput,
+    local: &[foundry_linking::LinkedLibrary],
+) -> Vec<foundry_linking::LinkedLibrary> {
+    output
+        .linked_libraries
+        .iter()
+        .filter(|library| !local.iter().any(|local| local.id == library.id))
+        .cloned()
+        .collect()
+}
+
+fn replace_addresses(input: &mut [u8], from: Address, to: Address) {
+    let mut offset = 0;
+    while let Some(index) =
+        input[offset..].windows(Address::len_bytes()).position(|window| window == from.as_slice())
+    {
+        let start = offset + index;
+        input[start..start + Address::len_bytes()].copy_from_slice(to.as_slice());
+        offset = start + Address::len_bytes();
+    }
+}

--- a/crates/script/src/library_deployments.rs
+++ b/crates/script/src/library_deployments.rs
@@ -18,6 +18,48 @@ struct EligibleTransactions {
     baseline_count: usize,
 }
 
+const RERUN_UNSAFE_CHEATCODE_SIGNATURES: &[&str] = &[
+    "setEnv(string,string)",
+    "sign(bytes32)",
+    "sign(address,bytes32)",
+    "signCompact(bytes32)",
+    "signCompact(address,bytes32)",
+    "rpc(string,string)",
+    "rpc(string,string,string)",
+    "rpcJson(string,string)",
+    "rpcJson(string,string,string)",
+    "sleep(uint256)",
+    "prompt(string)",
+    "promptSecret(string)",
+    "promptSecretUint(string)",
+    "promptAddress(string)",
+    "promptUint(string)",
+    "dumpState(string)",
+    "createFork(string)",
+    "createFork(string,uint256)",
+    "createFork(string,bytes32)",
+    "createSelectFork(string)",
+    "createSelectFork(string,uint256)",
+    "createSelectFork(string,bytes32)",
+    "rollFork(uint256)",
+    "rollFork(bytes32)",
+    "rollFork(uint256,uint256)",
+    "rollFork(uint256,bytes32)",
+    "selectFork(uint256)",
+    "transact(bytes32)",
+    "transact(uint256,bytes32)",
+];
+
+pub(crate) fn rerun_unsafe_cheatcode_selectors() -> Vec<[u8; 4]> {
+    RERUN_UNSAFE_CHEATCODE_SIGNATURES
+        .iter()
+        .map(|signature| {
+            let hash = keccak256(signature.as_bytes());
+            [hash[0], hash[1], hash[2], hash[3]]
+        })
+        .collect()
+}
+
 impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
     /// Reruns narrowly eligible scripts with libraries unused by direct broadcasts deployed only
     /// in the local EVM.
@@ -88,7 +130,7 @@ impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
         .prepare_execution()
         .await;
         let Ok(candidate) = candidate else { return Ok(self) };
-        let candidate = candidate.execute().await;
+        let candidate = candidate.execute_restricted().await;
         let Ok(candidate) = candidate else { return Ok(self) };
         if !candidate.execution_result.success {
             return Ok(self);
@@ -285,44 +327,12 @@ impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
     }
 
     fn used_rerun_unsafe_cheatcode(&self) -> bool {
-        const SIGNATURES: &[&str] = &[
-            "setEnv(string,string)",
-            "sign(bytes32)",
-            "sign(address,bytes32)",
-            "signCompact(bytes32)",
-            "signCompact(address,bytes32)",
-            "rpc(string,string)",
-            "rpc(string,string,string)",
-            "rpcJson(string,string)",
-            "rpcJson(string,string,string)",
-            "sleep(uint256)",
-            "prompt(string)",
-            "promptSecret(string)",
-            "promptSecretUint(string)",
-            "promptAddress(string)",
-            "promptUint(string)",
-            "dumpState(string)",
-            "createFork(string)",
-            "createFork(string,uint256)",
-            "createFork(string,bytes32)",
-            "createSelectFork(string)",
-            "createSelectFork(string,uint256)",
-            "createSelectFork(string,bytes32)",
-            "rollFork(uint256)",
-            "rollFork(bytes32)",
-            "rollFork(uint256,uint256)",
-            "rollFork(uint256,bytes32)",
-            "selectFork(uint256)",
-            "transact(bytes32)",
-            "transact(uint256,bytes32)",
-        ];
+        let selectors = rerun_unsafe_cheatcode_selectors();
         self.execution_result.traces.iter().any(|(_, traces)| {
             traces.nodes().iter().any(|node| {
                 node.trace.address == CHEATCODE_ADDRESS
                     && node.trace.data.get(..4).is_some_and(|selector| {
-                        SIGNATURES
-                            .iter()
-                            .any(|signature| &keccak256(signature.as_bytes())[..4] == selector)
+                        selectors.iter().any(|blocked| blocked.as_slice() == selector)
                     })
             })
         })

--- a/crates/script/src/runner.rs
+++ b/crates/script/src/runner.rs
@@ -6,7 +6,7 @@ use alloy_network::TransactionBuilder;
 use alloy_primitives::{Address, Bytes, U256, map::AddressHashMap};
 use eyre::Result;
 use foundry_cheatcodes::BroadcastableTransaction;
-use foundry_common::TransactionMaybeSigned;
+use foundry_common::{LIBRARY_DEPLOYER, TransactionMaybeSigned};
 use foundry_config::Config;
 use foundry_evm::{
     constants::CALLER,
@@ -56,6 +56,34 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
         }
     }
 
+    fn deploy_local_libraries(
+        &mut self,
+        libraries: &[foundry_linking::LinkedLibrary],
+        debug_bytecodes: &mut AddressHashMap<Bytes>,
+    ) -> Result<()> {
+        if libraries.is_empty() {
+            return Ok(());
+        }
+        let balance = self.executor.get_balance(LIBRARY_DEPLOYER)?;
+        let nonce = self.executor.get_nonce(LIBRARY_DEPLOYER)?;
+        self.executor.set_balance(LIBRARY_DEPLOYER, U256::MAX)?;
+        self.executor.set_nonce(LIBRARY_DEPLOYER, 0)?;
+        for library in libraries {
+            let DeployResult { address, raw } = self
+                .executor
+                .deploy(LIBRARY_DEPLOYER, library.bytecode.clone(), U256::ZERO, None)
+                .map_err(|err| eyre::eyre!("couldn't deploy local library: {err}"))?;
+            eyre::ensure!(
+                library.address == address,
+                "local library deployed at an unexpected address"
+            );
+            self.extend_debug_bytecodes(debug_bytecodes, raw.debug_bytecodes);
+        }
+        self.executor.set_balance(LIBRARY_DEPLOYER, balance)?;
+        self.executor.set_nonce(LIBRARY_DEPLOYER, nonce)?;
+        Ok(())
+    }
+
     /// Deploys the libraries and broadcast contract. Calls setUp method if requested.
     pub fn setup(
         &mut self,
@@ -92,8 +120,10 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
 
         // Deploy libraries
         match libraries {
-            ScriptPredeployLibraries::Default(libraries) => {
-                for code in libraries {
+            ScriptPredeployLibraries::Default { onchain, local } => {
+                self.deploy_local_libraries(local, &mut debug_bytecodes)?;
+                for library in onchain {
+                    let code = &library.bytecode;
                     let RawCallResult {
                         traces: deploy_traces,
                         debug_bytecodes: deploy_debug_bytecodes,
@@ -101,7 +131,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                     } = self
                         .executor
                         .deploy(self.evm_opts.sender, code.clone(), U256::ZERO, None)
-                        .expect("couldn't deploy library")
+                        .map_err(|err| eyre::eyre!("couldn't deploy library: {err}"))?
                         .raw;
 
                     self.extend_debug_bytecodes(&mut debug_bytecodes, deploy_debug_bytecodes);
@@ -123,15 +153,17 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                     })
                 }
             }
-            ScriptPredeployLibraries::Create2(libraries, salt) => {
+            ScriptPredeployLibraries::Create2 { onchain, salt, local } => {
+                self.deploy_local_libraries(local, &mut debug_bytecodes)?;
                 let create2_deployer = self.executor.create2_deployer();
-                for library in libraries {
-                    let address = create2_deployer.create2_from_code(salt, library.as_ref());
+                for library in onchain {
+                    let address =
+                        create2_deployer.create2_from_code(salt, library.bytecode.as_ref());
                     // Skip if already deployed
                     if !self.executor.is_empty_code(address)? {
                         continue;
                     }
-                    let calldata = [salt.as_ref(), library.as_ref()].concat();
+                    let calldata = [salt.as_ref(), library.bytecode.as_ref()].concat();
                     let RawCallResult {
                         traces: deploy_traces,
                         debug_bytecodes: deploy_debug_bytecodes,
@@ -144,7 +176,7 @@ impl<FEN: FoundryEvmNetwork> ScriptRunner<FEN> {
                             calldata.clone().into(),
                             U256::from(0),
                         )
-                        .expect("couldn't deploy library");
+                        .map_err(|err| eyre::eyre!("couldn't deploy library: {err}"))?;
 
                     self.extend_debug_bytecodes(&mut debug_bytecodes, deploy_debug_bytecodes);
 

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -519,6 +519,14 @@ impl<FEN: FoundryEvmNetwork> FilledTransactionsState<FEN> {
 
         let commit = get_commit_hash(&self.script_config.config.root);
 
+        let local_addresses = match &self.build_data.predeploy_libraries {
+            crate::build::ScriptPredeployLibraries::Default { local, .. }
+            | crate::build::ScriptPredeployLibraries::Create2 { local, .. } => local.as_slice(),
+        };
+        let local_addresses = local_addresses
+            .iter()
+            .map(|library| library.address.to_checksum(None))
+            .collect::<Vec<_>>();
         let libraries = self
             .build_data
             .libraries
@@ -526,6 +534,7 @@ impl<FEN: FoundryEvmNetwork> FilledTransactionsState<FEN> {
             .iter()
             .flat_map(|(file, libs)| {
                 libs.iter()
+                    .filter(|(_, address)| !local_addresses.contains(address))
                     .map(|(name, address)| format!("{}:{name}:{address}", file.to_string_lossy()))
             })
             .collect();


### PR DESCRIPTION
Avoid deploying unused libraries when `forge script` broadcasts direct contract creations. Required libraries are determined from the created artifacts, while omitted libraries remain available during local execution. Unsupported transaction shapes retain the existing deploy-all behavior.

Closes #6215 