### PR TITLE
feat(forge): verify external factory deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5157,6 +5157,7 @@ dependencies = [
  "indicatif",
  "itertools 0.15.0",
  "parking_lot",
+ "reqwest 0.13.4",
  "revm-inspectors",
  "semver 1.0.28",
  "serde",

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -837,7 +837,9 @@ contract ExternalFactory {
                     if form.get("address").is_some_and(|address| address.to_lowercase() == factory) {
                         serde_json::json!({"status":"1","message":"OK","result":[{
                             "SourceCode": source_json.to_string(), "CompilerVersion": compiler_version,
-                            "ContractName": "ExternalFactory"
+                            "ContractName": "ExternalFactory", "ABI": "[]",
+                            "OptimizationUsed": "1", "OptimizationRuns": "777",
+                            "ConstructorArguments": "", "EVMVersion": "osaka", "IsProxy": "0"
                         }]}).to_string()
                     } else {
                         r#"{"status":"0","message":"NOTOK","result":"Contract source code not verified"}"#.to_string()
@@ -898,21 +900,23 @@ contract Deploy is Script {{
 
     assert!(!prj.root().join("src/External.sol").exists());
     assert!(!prj.artifacts().join("External.sol/Child.json").exists());
-    let requests = requests.lock().unwrap();
-    assert!(requests.sources.len() >= 2, "source requests: {:?}", requests.sources);
-    let source_addresses = requests
-        .sources
-        .iter()
-        .map(|request| request["address"].to_lowercase())
-        .collect::<Vec<_>>();
-    let expected = [executor.to_lowercase(), factory.to_lowercase()];
-    assert!(
-        source_addresses.windows(2).any(|addresses| addresses == expected),
-        "source request order: {source_addresses:?}"
-    );
-    assert!(requests.sources.iter().all(|request| request["apikey"] == SOURCE_KEY));
-    assert_eq!(requests.submissions.len(), 1, "script stderr: {}", output.stderr_lossy());
-    let submission = &requests.submissions[0];
+    let submission = {
+        let requests = requests.lock().unwrap();
+        assert!(requests.sources.len() >= 2, "source requests: {:?}", requests.sources);
+        let source_addresses = requests
+            .sources
+            .iter()
+            .map(|request| request["address"].to_lowercase())
+            .collect::<Vec<_>>();
+        let expected = [executor.to_lowercase(), factory.to_lowercase()];
+        assert!(
+            source_addresses.windows(2).any(|addresses| addresses == expected),
+            "source request order: {source_addresses:?}"
+        );
+        assert!(requests.sources.iter().all(|request| request["apikey"] == SOURCE_KEY));
+        assert_eq!(requests.submissions.len(), 1, "script stderr: {}", output.stderr_lossy());
+        requests.submissions[0].clone()
+    };
     assert_eq!(submission["apikey"], SUBMISSION_KEY);
     assert_eq!(submission["contractname"], "src/External.sol:Child");
     assert_eq!(submission["codeformat"], "solidity-standard-json-input");

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -949,10 +949,9 @@ contract Deploy is Script {{
     );
     assert_eq!(submission["compilerversion"], compiler_version);
     assert_eq!(submission["constructorArguements"], format!("{:064x}", 42));
-    let broadcast =
-        std::fs::read_to_string(prj.root().join("broadcast/Deploy.s.sol/31337/run-latest.json"))
-            .unwrap();
-    let sequence: ScriptSequence<Ethereum> = serde_json::from_str(&broadcast).unwrap();
+    let broadcast_path = prj.root().join("broadcast/Deploy.s.sol/31337/run-latest.json");
+    let broadcast = std::fs::read_to_string(&broadcast_path).unwrap();
+    let mut sequence: ScriptSequence<Ethereum> = serde_json::from_str(&broadcast).unwrap();
     let child_address = submission["contractaddress"].parse::<Address>().unwrap();
     let child = sequence
         .transactions
@@ -980,6 +979,46 @@ contract Deploy is Script {{
         .await
         .unwrap();
     assert_eq!(value["result"].as_str().unwrap().parse::<U256>().unwrap(), U256::from(42));
+
+    // Old broadcast logs do not contain creator provenance. An explicitly requested external
+    // verification must report that skipped attempt as a failure rather than `All (0)` success.
+    sequence
+        .transactions
+        .iter_mut()
+        .flat_map(|transaction| &mut transaction.additional_contracts)
+        .find(|contract| contract.address == child_address)
+        .unwrap()
+        .creator_code_addresses
+        .clear();
+    std::fs::write(&broadcast_path, serde_json::to_vec_pretty(&sequence).unwrap()).unwrap();
+
+    let failed = prj
+        .forge_command()
+        .forge_fuse()
+        .args([
+            "script",
+            "script/Deploy.s.sol:Deploy",
+            "--broadcast",
+            "--resume",
+            "--verify",
+            "--verify-external",
+            "--verifier",
+            "custom",
+            "--verifier-url",
+            verifier_url.as_str(),
+            "--verifier-api-key",
+            SUBMISSION_KEY,
+            "--rpc-url",
+            rpc.as_str(),
+            "--private-key",
+            private_key.as_str(),
+        ])
+        .execute();
+    assert!(!failed.status.success(), "resume unexpectedly succeeded: {}", failed.stderr_lossy());
+    let stderr = failed.stderr_lossy();
+    assert!(stderr.contains("creator provenance is unavailable"), "{stderr}");
+    assert!(stderr.contains("Not all (0 / 1) contracts were verified"), "{stderr}");
+    assert!(!stderr.contains("All (0) contracts were verified"), "{stderr}");
 });
 
 // Tests that the preflight check passes (does not block deploy) when the verifier responds

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -5,7 +5,12 @@ use crate::utils::{self, EnvExternalities};
 use alloy_network::Ethereum;
 use alloy_primitives::{Address, U256, hex};
 use anvil::{NodeConfig, spawn};
-use axum::{Router, extract::Query};
+use axum::{
+    Router,
+    extract::Query,
+    http::{StatusCode, header},
+    response::IntoResponse,
+};
 use forge_script_sequence::ScriptSequence;
 use foundry_common::retry::Retry;
 use foundry_compilers::PathStyle;
@@ -16,7 +21,6 @@ use foundry_test_utils::{
 };
 use std::{
     collections::HashMap,
-    io::Write,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -714,7 +718,6 @@ contract Deploy is Script {
 // by the script is compiled in a different project and can only be identified from its factory's
 // verified Standard JSON input.
 forgetest_async!(script_verifies_external_create2_contract, |prj, cmd| {
-    const SOURCE_KEY: &str = "source-key";
     const SUBMISSION_KEY: &str = "submission-key";
     const GUID: &str = "external-create2-guid";
 
@@ -820,6 +823,33 @@ contract ExternalFactory {
     let source_json = standard_json.clone();
     let factory_for_server = factory.to_lowercase();
     let compiler_version_for_server = compiler_version.clone();
+
+    // Verification requests are trusted and must retain normal redirect handling. External source
+    // discovery uses the same selected endpoint, but remains on the non-redirecting client.
+    let redirect_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let redirect_url = format!("http://{}", redirect_listener.local_addr().unwrap());
+    let redirect_state = requests.clone();
+    let redirect_app = Router::new().fallback(move |uri: axum::http::Uri, body: String| {
+        let state = redirect_state.clone();
+        async move {
+            let encoded = if body.is_empty() { uri.query().unwrap_or_default() } else { &body };
+            let form = url::form_urlencoded::parse(encoded.as_bytes())
+                .into_owned().collect::<HashMap<_, _>>();
+            match form.get("action").map(String::as_str) {
+                Some("verifysourcecode") => {
+                    state.lock().unwrap().submissions.push(form);
+                    format!(r#"{{"status":"1","message":"OK","result":"{GUID}"}}"#)
+                }
+                Some("checkverifystatus") => {
+                    r#"{"status":"1","message":"OK","result":"Pass - Verified"}"#.to_string()
+                }
+                _ => r#"{"status":"0","message":"NOTOK","result":"Contract source code not verified"}"#.to_string(),
+            }
+        }
+    });
+    let _redirect_server =
+        tokio::spawn(async move { axum::serve(redirect_listener, redirect_app).await.unwrap() });
+
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let verifier_url = format!("http://{}", listener.local_addr().unwrap());
     let app = Router::new().fallback(move |uri: axum::http::Uri, body: String| {
@@ -827,6 +857,7 @@ contract ExternalFactory {
         let source_json = source_json.clone();
         let factory = factory_for_server.clone();
         let compiler_version = compiler_version_for_server.clone();
+        let redirect_url = redirect_url.clone();
         async move {
             let encoded = if body.is_empty() { uri.query().unwrap_or_default() } else { &body };
             let form = url::form_urlencoded::parse(encoded.as_bytes())
@@ -840,30 +871,22 @@ contract ExternalFactory {
                             "ContractName": "ExternalFactory", "ABI": "[]",
                             "OptimizationUsed": "1", "OptimizationRuns": "777",
                             "ConstructorArguments": "", "EVMVersion": "osaka", "IsProxy": "0"
-                        }]}).to_string()
+                        }]}).to_string().into_response()
                     } else {
-                        r#"{"status":"0","message":"NOTOK","result":"Contract source code not verified"}"#.to_string()
+                        r#"{"status":"0","message":"NOTOK","result":"Contract source code not verified"}"#.into_response()
                     }
                 }
-                Some("verifysourcecode") => {
-                    state.lock().unwrap().submissions.push(form);
-                    format!(r#"{{"status":"1","message":"OK","result":"{GUID}"}}"#)
-                }
-                Some("checkverifystatus") => r#"{"status":"1","message":"OK","result":"Pass - Verified"}"#.to_string(),
-                _ => r#"{"status":"0","message":"NOTOK","result":"Contract source code not verified"}"#.to_string(),
+                Some("verifysourcecode" | "checkverifystatus") => (
+                    StatusCode::TEMPORARY_REDIRECT,
+                    [(header::LOCATION, redirect_url)],
+                )
+                    .into_response(),
+                _ => r#"{"status":"0","message":"NOTOK","result":"Contract source code not verified"}"#.into_response(),
             }
         }
     });
     let _server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-    writeln!(
-        std::fs::OpenOptions::new().append(true).open(prj.config()).unwrap(),
-        r#"
-[etherscan]
-31337 = {{ key = "{SOURCE_KEY}", url = "{verifier_url}" }}
-"#,
-    )
-    .unwrap();
     prj.add_source(
         "IExternalFactory.sol",
         "interface IExternalFactory { function deployChild(uint256) external returns (address); }",
@@ -913,7 +936,7 @@ contract Deploy is Script {{
             source_addresses.windows(2).any(|addresses| addresses == expected),
             "source request order: {source_addresses:?}"
         );
-        assert!(requests.sources.iter().all(|request| request["apikey"] == SOURCE_KEY));
+        assert!(requests.sources.iter().all(|request| request["apikey"] == SUBMISSION_KEY));
         assert_eq!(requests.submissions.len(), 1, "script stderr: {}", output.stderr_lossy());
         requests.submissions[0].clone()
     };

--- a/crates/forge/tests/cli/verify.rs
+++ b/crates/forge/tests/cli/verify.rs
@@ -2,15 +2,24 @@
 //! and Sourcify.
 
 use crate::utils::{self, EnvExternalities};
-use alloy_primitives::hex;
+use alloy_network::Ethereum;
+use alloy_primitives::{Address, U256, hex};
 use anvil::{NodeConfig, spawn};
 use axum::{Router, extract::Query};
+use forge_script_sequence::ScriptSequence;
 use foundry_common::retry::Retry;
+use foundry_compilers::PathStyle;
+use foundry_evm::traces::CallKind;
 use foundry_test_utils::{
     forgetest, forgetest_async, str,
-    util::{OutputExt, TestCommand, TestProject},
+    util::{OutputExt, SOLC_VERSION, TestCommand, TestProject},
 };
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    io::Write,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 use tokio::net::TcpListener;
 
 /// Adds a `Unique` contract to the source directory of the project that can be imported as
@@ -699,6 +708,251 @@ contract Deploy is Script {
 
     let stderr = output.stderr_lossy();
     assert!(stderr.contains(guid), "expected verification GUID on stderr, got: {stderr}");
+});
+
+// Regression test for <https://github.com/foundry-rs/foundry/issues/10164>. The contract created
+// by the script is compiled in a different project and can only be identified from its factory's
+// verified Standard JSON input.
+forgetest_async!(script_verifies_external_create2_contract, |prj, cmd| {
+    const SOURCE_KEY: &str = "source-key";
+    const SUBMISSION_KEY: &str = "submission-key";
+    const GUID: &str = "external-create2-guid";
+
+    foundry_test_utils::util::initialize(prj.root());
+    let external = TestProject::new("external-create2", PathStyle::Dapptools);
+    foundry_test_utils::util::initialize(external.root());
+    external.add_source(
+        "External.sol",
+        r#"
+contract Child { uint256 public immutable value; constructor(uint256 value_) { value = value_; } }
+contract Executor {
+    function deploy(bytes memory initCode) external returns (address deployed) {
+        assembly { deployed := create2(0, add(initCode, 32), mload(initCode), 0) }
+        require(deployed != address(0));
+    }
+}
+contract ExternalFactory {
+    Executor public immutable executor;
+    constructor() { executor = new Executor(); }
+    function deployChild(uint256 value) external returns (address) {
+        return executor.deploy(abi.encodePacked(type(Child).creationCode, abi.encode(value)));
+    }
+}
+"#,
+    );
+    external.write_config(foundry_config::Config {
+        solc: Some(foundry_config::SolcReq::Version(SOLC_VERSION.parse().unwrap())),
+        optimizer: Some(true),
+        optimizer_runs: Some(777),
+        ..Default::default()
+    });
+
+    let (_api, anvil) = spawn(NodeConfig::test()).await;
+    let wallet = anvil.dev_wallets().next().unwrap();
+    let private_key = hex::encode(wallet.credential().to_bytes());
+    let rpc = anvil.http_endpoint();
+    let create = external
+        .forge_command()
+        .forge_fuse()
+        .args([
+            "create",
+            "src/External.sol:ExternalFactory",
+            "--broadcast",
+            "--json",
+            "--rpc-url",
+            rpc.as_str(),
+            "--private-key",
+            private_key.as_str(),
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let create: serde_json::Value = serde_json::from_str(&create).unwrap();
+    let factory = create["deployedTo"].as_str().unwrap().to_string();
+    let selector = &alloy_primitives::keccak256("executor()")[..4];
+    let call: serde_json::Value = reqwest::Client::new()
+        .post(rpc.as_str())
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "eth_call",
+            "params": [{"to": factory, "data": format!("0x{}", hex::encode(selector))}, "latest"]
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let executor_result = call["result"].as_str().unwrap();
+    let executor = format!("0x{}", &executor_result[executor_result.len() - 40..]);
+
+    let standard_json = external
+        .forge_command()
+        .forge_fuse()
+        .args([
+            "verify-contract",
+            factory.as_str(),
+            "src/External.sol:ExternalFactory",
+            "--show-standard-json-input",
+        ])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let standard_json: serde_json::Value = serde_json::from_str(standard_json.trim()).unwrap();
+    assert_eq!(standard_json["settings"]["optimizer"]["runs"], 777);
+
+    // Use the compiler build recorded by Forge's artifact, not a guessed release suffix.
+    let artifact: serde_json::Value = serde_json::from_reader(
+        std::fs::File::open(external.artifacts().join("External.sol/ExternalFactory.json"))
+            .unwrap(),
+    )
+    .unwrap();
+    let metadata: serde_json::Value =
+        serde_json::from_str(artifact["rawMetadata"].as_str().unwrap()).unwrap();
+    let compiler_version = format!("v{}", metadata["compiler"]["version"].as_str().unwrap());
+
+    #[derive(Default)]
+    struct Requests {
+        sources: Vec<HashMap<String, String>>,
+        submissions: Vec<HashMap<String, String>>,
+    }
+    let requests = Arc::new(Mutex::new(Requests::default()));
+    let state = requests.clone();
+    let source_json = standard_json.clone();
+    let factory_for_server = factory.to_lowercase();
+    let compiler_version_for_server = compiler_version.clone();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let verifier_url = format!("http://{}", listener.local_addr().unwrap());
+    let app = Router::new().fallback(move |uri: axum::http::Uri, body: String| {
+        let state = state.clone();
+        let source_json = source_json.clone();
+        let factory = factory_for_server.clone();
+        let compiler_version = compiler_version_for_server.clone();
+        async move {
+            let encoded = if body.is_empty() { uri.query().unwrap_or_default() } else { &body };
+            let form = url::form_urlencoded::parse(encoded.as_bytes())
+                .into_owned().collect::<HashMap<_, _>>();
+            match form.get("action").map(String::as_str) {
+                Some("getsourcecode") => {
+                    state.lock().unwrap().sources.push(form.clone());
+                    if form.get("address").is_some_and(|address| address.to_lowercase() == factory) {
+                        serde_json::json!({"status":"1","message":"OK","result":[{
+                            "SourceCode": source_json.to_string(), "CompilerVersion": compiler_version,
+                            "ContractName": "ExternalFactory"
+                        }]}).to_string()
+                    } else {
+                        r#"{"status":"0","message":"NOTOK","result":"Contract source code not verified"}"#.to_string()
+                    }
+                }
+                Some("verifysourcecode") => {
+                    state.lock().unwrap().submissions.push(form);
+                    format!(r#"{{"status":"1","message":"OK","result":"{GUID}"}}"#)
+                }
+                Some("checkverifystatus") => r#"{"status":"1","message":"OK","result":"Pass - Verified"}"#.to_string(),
+                _ => r#"{"status":"0","message":"NOTOK","result":"Contract source code not verified"}"#.to_string(),
+            }
+        }
+    });
+    let _server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    writeln!(
+        std::fs::OpenOptions::new().append(true).open(prj.config()).unwrap(),
+        r#"
+[etherscan]
+31337 = {{ key = "{SOURCE_KEY}", url = "{verifier_url}" }}
+"#,
+    )
+    .unwrap();
+    prj.add_source(
+        "IExternalFactory.sol",
+        "interface IExternalFactory { function deployChild(uint256) external returns (address); }",
+    );
+    prj.add_script("Deploy.s.sol", &format!(r#"
+import "forge-std/Script.sol";
+import {{IExternalFactory}} from "../src/IExternalFactory.sol";
+contract Deploy is Script {{
+    function run() external {{ vm.startBroadcast(); IExternalFactory({factory}).deployChild(42); vm.stopBroadcast(); }}
+}}
+"#));
+
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "script",
+            "script/Deploy.s.sol:Deploy",
+            "--broadcast",
+            "--verify",
+            "--verify-external",
+            "--verifier",
+            "custom",
+            "--verifier-url",
+            verifier_url.as_str(),
+            "--verifier-api-key",
+            SUBMISSION_KEY,
+            "--rpc-url",
+            rpc.as_str(),
+            "--private-key",
+            private_key.as_str(),
+        ])
+        .execute();
+    assert!(output.status.success(), "script failed: {}", output.stderr_lossy());
+
+    assert!(!prj.root().join("src/External.sol").exists());
+    assert!(!prj.artifacts().join("External.sol/Child.json").exists());
+    let requests = requests.lock().unwrap();
+    assert!(requests.sources.len() >= 2, "source requests: {:?}", requests.sources);
+    let source_addresses = requests
+        .sources
+        .iter()
+        .map(|request| request["address"].to_lowercase())
+        .collect::<Vec<_>>();
+    let expected = [executor.to_lowercase(), factory.to_lowercase()];
+    assert!(
+        source_addresses.windows(2).any(|addresses| addresses == expected),
+        "source request order: {source_addresses:?}"
+    );
+    assert!(requests.sources.iter().all(|request| request["apikey"] == SOURCE_KEY));
+    assert_eq!(requests.submissions.len(), 1, "script stderr: {}", output.stderr_lossy());
+    let submission = &requests.submissions[0];
+    assert_eq!(submission["apikey"], SUBMISSION_KEY);
+    assert_eq!(submission["contractname"], "src/External.sol:Child");
+    assert_eq!(submission["codeformat"], "solidity-standard-json-input");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&submission["sourceCode"]).unwrap(),
+        standard_json
+    );
+    assert_eq!(submission["compilerversion"], compiler_version);
+    assert_eq!(submission["constructorArguements"], format!("{:064x}", 42));
+    let broadcast =
+        std::fs::read_to_string(prj.root().join("broadcast/Deploy.s.sol/31337/run-latest.json"))
+            .unwrap();
+    let sequence: ScriptSequence<Ethereum> = serde_json::from_str(&broadcast).unwrap();
+    let child_address = submission["contractaddress"].parse::<Address>().unwrap();
+    let child = sequence
+        .transactions
+        .iter()
+        .flat_map(|transaction| &transaction.additional_contracts)
+        .find(|contract| contract.address == child_address)
+        .expect("submitted contract is not a traced nested creation");
+    assert_eq!(child.call_kind, CallKind::Create2);
+    assert_eq!(
+        &child.creator_code_addresses[..2],
+        &[executor.parse::<Address>().unwrap(), factory.parse::<Address>().unwrap()]
+    );
+
+    let value_selector = &alloy_primitives::keccak256("value()")[..4];
+    let value: serde_json::Value = reqwest::Client::new()
+        .post(rpc.as_str())
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "eth_call",
+            "params": [{"to": child_address, "data": format!("0x{}", hex::encode(value_selector))}, "latest"]
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(value["result"].as_str().unwrap().parse::<U256>().unwrap(), U256::from(42));
 });
 
 // Tests that the preflight check passes (does not block deploy) when the verifier responds

--- a/crates/script-sequence/src/transaction.rs
+++ b/crates/script-sequence/src/transaction.rs
@@ -12,6 +12,8 @@ pub struct AdditionalContract {
     pub contract_name: Option<String>,
     pub address: Address,
     pub init_code: Bytes,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub creator_code_addresses: Vec<Address>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -86,5 +88,36 @@ impl<N: Network> TransactionWithMetadata<N> {
 
     pub fn is_create2(&self) -> bool {
         self.call_kind == CallKind::Create2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn additional_contract_creator_code_addresses_are_backward_compatible() {
+        let old_json = serde_json::json!({
+            "transactionType": "CREATE",
+            "contractName": null,
+            "address": Address::repeat_byte(0x11),
+            "initCode": "0x6000"
+        });
+        let contract: AdditionalContract = serde_json::from_value(old_json.clone()).unwrap();
+        assert!(contract.creator_code_addresses.is_empty());
+        assert_eq!(serde_json::to_value(contract).unwrap(), old_json);
+
+        let creator = Address::repeat_byte(0x22);
+        let contract = AdditionalContract {
+            call_kind: CallKind::Create2,
+            contract_name: None,
+            address: Address::repeat_byte(0x33),
+            init_code: Bytes::new(),
+            creator_code_addresses: vec![creator],
+        };
+        assert_eq!(
+            serde_json::to_value(contract).unwrap()["creatorCodeAddresses"],
+            serde_json::json!([creator])
+        );
     }
 }

--- a/crates/script/Cargo.toml
+++ b/crates/script/Cargo.toml
@@ -33,11 +33,13 @@ toml.workspace = true
 serde_json.workspace = true
 dunce.workspace = true
 foundry-compilers.workspace = true
+reqwest = { workspace = true, features = ["stream"] }
 tracing.workspace = true
 clap = { version = "4", features = ["derive", "env", "unicode", "wrap_help"] }
 semver.workspace = true
 futures.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["io-util", "process", "time"] }
+tempfile.workspace = true
 
 itertools.workspace = true
 parking_lot.workspace = true
@@ -62,7 +64,6 @@ tempo-alloy.workspace = true
 tempo-primitives.workspace = true
 
 [dev-dependencies]
-tempfile.workspace = true
 anvil.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 

--- a/crates/script/src/broadcast.rs
+++ b/crates/script/src/broadcast.rs
@@ -874,6 +874,10 @@ impl<FEN: FoundryEvmNetwork> BundledState<FEN> {
     }
 
     pub async fn verify_preflight_check(&self) -> Result<()> {
+        if self.args.verify_external && self.script_config.config.offline {
+            bail!("External contract verification is unavailable in offline mode");
+        }
+
         for sequence in self.sequence.sequences() {
             let chain: Chain = sequence.chain.into();
             // Resolve the API key: CLI arg first, then per-chain config, then global fallback.

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -239,6 +239,10 @@ pub struct ScriptArgs {
     #[arg(long, requires = "broadcast")]
     pub verify: bool,
 
+    /// Opt-in verification of contracts deployed by external factories using explorer source.
+    #[arg(long, requires = "verify")]
+    pub verify_external: bool,
+
     /// Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
     /// specified in wei, or as a string with a unit type.
     ///
@@ -753,20 +757,38 @@ impl<N: Network> ScriptResult<N> {
         self.traces
             .iter()
             .flat_map(|(_, traces)| {
-                traces.nodes().iter().filter_map(|node| {
-                    if node.trace.kind.is_any_create() {
-                        let init_code = node.trace.data.clone();
-                        let contract_name = known_contracts
-                            .find_by_creation_code(init_code.as_ref())
-                            .map(|artifact| artifact.0.name.clone());
-                        return Some(AdditionalContract {
-                            call_kind: node.trace.kind,
-                            address: node.trace.address,
-                            contract_name,
-                            init_code,
-                        });
+                let nodes = traces.nodes();
+                nodes.iter().filter_map(|node| {
+                    if !node.trace.kind.is_any_create() || !node.trace.success {
+                        return None;
                     }
-                    None
+
+                    let mut creator_code_addresses = Vec::new();
+                    let mut parent = node.parent;
+                    while let Some(parent_idx) = parent {
+                        let ancestor = &nodes[parent_idx];
+                        if !ancestor.trace.success {
+                            return None;
+                        }
+                        if !ancestor.trace.kind.is_any_create()
+                            && !creator_code_addresses.contains(&ancestor.trace.address)
+                        {
+                            creator_code_addresses.push(ancestor.trace.address);
+                        }
+                        parent = ancestor.parent;
+                    }
+
+                    let init_code = node.trace.data.clone();
+                    let contract_name = known_contracts
+                        .find_by_creation_code(init_code.as_ref())
+                        .map(|artifact| artifact.0.name.clone());
+                    Some(AdditionalContract {
+                        call_kind: node.trace.kind,
+                        address: node.trace.address,
+                        contract_name,
+                        init_code,
+                        creator_code_addresses,
+                    })
                 })
             })
             .collect()
@@ -962,6 +984,9 @@ mod tests {
         upsert_session_entry,
     };
     use foundry_config::UnresolvedEnvVarError;
+    use foundry_evm::traces::{
+        CallKind, CallTrace, CallTraceArena, CallTraceNode, SparsedTraceArena, TraceKind,
+    };
     use std::{fs, sync::LazyLock};
     use tempfile::tempdir;
     use tokio::sync::{Mutex, MutexGuard};
@@ -980,6 +1005,101 @@ mod tests {
 
         let tracing = script_trace_requirements(&config, false).into_config().unwrap();
         assert!(tracing.record_state_diff);
+    }
+
+    #[test]
+    fn created_contracts_include_successful_creator_code_ancestry() {
+        let root = Address::repeat_byte(0x11);
+        let implementation = Address::repeat_byte(0x22);
+        let helper = Address::repeat_byte(0x33);
+        let created = Address::repeat_byte(0x44);
+        let init_code = Bytes::from_static(&[0x60, 0x00]);
+        let mut arena = CallTraceArena::default();
+        arena.nodes_mut()[0].trace =
+            CallTrace { success: true, address: root, kind: CallKind::Call, ..Default::default() };
+        arena.nodes_mut().extend([
+            CallTraceNode {
+                parent: Some(0),
+                idx: 1,
+                trace: CallTrace {
+                    success: true,
+                    address: implementation,
+                    kind: CallKind::DelegateCall,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            CallTraceNode {
+                parent: Some(1),
+                idx: 2,
+                trace: CallTrace {
+                    success: true,
+                    address: helper,
+                    kind: CallKind::Call,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            CallTraceNode {
+                parent: Some(2),
+                idx: 3,
+                trace: CallTrace {
+                    success: true,
+                    address: created,
+                    kind: CallKind::Create2,
+                    data: init_code.clone(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ]);
+        let result = ScriptResult::<Ethereum> {
+            traces: vec![(
+                TraceKind::Execution,
+                SparsedTraceArena { arena, ignored: Default::default() },
+            )],
+            ..Default::default()
+        };
+
+        let contracts = result.get_created_contracts(&ContractsByArtifact::default());
+        assert_eq!(contracts.len(), 1);
+        assert_eq!(contracts[0].address, created);
+        assert_eq!(contracts[0].init_code, init_code);
+        assert_eq!(contracts[0].creator_code_addresses, [helper, implementation, root]);
+    }
+
+    #[test]
+    fn created_contracts_exclude_creations_rolled_back_by_an_ancestor() {
+        let mut arena = CallTraceArena::default();
+        arena.nodes_mut()[0].trace = CallTrace { success: true, ..Default::default() };
+        arena.nodes_mut().extend([
+            CallTraceNode {
+                parent: Some(0),
+                idx: 1,
+                trace: CallTrace { success: false, kind: CallKind::Call, ..Default::default() },
+                ..Default::default()
+            },
+            CallTraceNode {
+                parent: Some(1),
+                idx: 2,
+                trace: CallTrace {
+                    success: true,
+                    kind: CallKind::Create,
+                    data: Bytes::from_static(&[0x60, 0x00]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ]);
+        let result = ScriptResult::<Ethereum> {
+            traces: vec![(
+                TraceKind::Execution,
+                SparsedTraceArena { arena, ignored: Default::default() },
+            )],
+            ..Default::default()
+        };
+
+        assert!(result.get_created_contracts(&ContractsByArtifact::default()).is_empty());
     }
 
     fn active_session_entry(
@@ -1040,6 +1160,23 @@ mod tests {
         let sig = "0x522bb704000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfFFb92266";
         let args = ScriptArgs::parse_from(["foundry-cli", "Contract.sol", "--sig", sig]);
         assert_eq!(args.sig, sig);
+    }
+
+    #[test]
+    fn verify_external_requires_verify() {
+        let err = ScriptArgs::try_parse_from(["foundry-cli", "Contract.sol", "--verify-external"])
+            .unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+
+        let args = ScriptArgs::try_parse_from([
+            "foundry-cli",
+            "Contract.sol",
+            "--broadcast",
+            "--verify",
+            "--verify-external",
+        ])
+        .unwrap();
+        assert!(args.verify_external);
     }
 
     #[test]

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -240,7 +240,7 @@ pub struct ScriptArgs {
     pub verify: bool,
 
     /// Opt-in verification of contracts deployed by external factories using explorer source.
-    #[arg(long, requires = "verify")]
+    #[arg(long, requires = "verify", conflicts_with_all = ["skip_simulation", "offline"])]
     pub verify_external: bool,
 
     /// Gas price for legacy transactions, or max fee per gas for EIP1559 transactions, either
@@ -1191,6 +1191,22 @@ mod tests {
         ])
         .unwrap();
         assert!(args.verify_external);
+    }
+
+    #[test]
+    fn verify_external_requires_simulation_and_online_mode() {
+        for conflicting_arg in ["--skip-simulation", "--offline"] {
+            let err = ScriptArgs::try_parse_from([
+                "foundry-cli",
+                "Contract.sol",
+                "--broadcast",
+                "--verify",
+                "--verify-external",
+                conflicting_arg,
+            ])
+            .unwrap_err();
+            assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict);
+        }
     }
 
     #[test]

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -4,16 +4,25 @@ use crate::{
     sequence::{ScriptSequenceKind, get_commit_hash},
 };
 use alloy_network::{Network, ReceiptResponse};
-use alloy_primitives::{Address, hex};
+use alloy_primitives::{Address, TxHash, hex};
 use eyre::{Result, eyre};
 use forge_script_sequence::{AdditionalContract, ScriptSequence};
-use forge_verify::{RetryArgs, VerifierArgs, VerifyArgs, provider::VerificationProviderType};
+use forge_verify::{
+    RetryArgs, VerifierArgs, VerifyArgs,
+    provider::{ExternalVerificationContext, VerificationProviderType},
+};
 use foundry_cli::opts::{EtherscanOpts, ProjectPathOpts};
 use foundry_common::{ContractsByArtifact, FoundryReceiptResponse};
 use foundry_compilers::{Project, artifacts::EvmVersion, info::ContractInfo};
 use foundry_config::{Chain, Config};
 use foundry_evm::core::evm::FoundryEvmNetwork;
 use semver::Version;
+
+mod external;
+
+use external::{ExternalResolver, MAX_PROVENANCE_ADDRESSES, MatchResult, match_candidates};
+
+const MAX_EXTERNAL_JOBS: usize = 32;
 
 /// State after we have broadcasted the script.
 /// It is assumed that at this point [BroadcastedState::sequence] contains receipts for all
@@ -35,6 +44,7 @@ impl<FEN: FoundryEvmNetwork> BroadcastedState<FEN> {
             build_data.known_contracts,
             args.retry,
             args.verifier,
+            args.verify_external,
         );
 
         for sequence in sequence.sequences_mut() {
@@ -55,6 +65,8 @@ pub struct VerifyBundle {
     pub retry: RetryArgs,
     pub verifier: VerifierArgs,
     pub via_ir: bool,
+    pub verify_external: bool,
+    source_api_key: Option<String>,
 }
 
 impl VerifyBundle {
@@ -64,6 +76,7 @@ impl VerifyBundle {
         known_contracts: ContractsByArtifact,
         retry: RetryArgs,
         verifier: VerifierArgs,
+        verify_external: bool,
     ) -> Self {
         let num_of_optimizations =
             if config.optimizer == Some(true) { config.optimizer_runs } else { None };
@@ -91,6 +104,8 @@ impl VerifyBundle {
             retry,
             verifier,
             via_ir,
+            verify_external,
+            source_api_key: None,
         }
     }
 
@@ -98,8 +113,10 @@ impl VerifyBundle {
     pub fn set_chain(&mut self, config: &Config, chain: Chain) {
         // If dealing with multiple chains, we need to be able to change in between the config
         // chain_id.
+        let config_key = source_api_key(config, chain);
+        self.source_api_key = config_key.clone();
         self.etherscan.key =
-            config.get_etherscan_api_key(Some(chain)).or_else(|| config.etherscan_api_key.clone());
+            self.verifier.resolve_api_key(config_key.as_deref()).map(str::to_owned);
         self.etherscan.chain = Some(chain);
     }
 
@@ -181,6 +198,149 @@ impl VerifyBundle {
     }
 }
 
+fn source_api_key(config: &Config, chain: Chain) -> Option<String> {
+    config.get_etherscan_api_key(Some(chain)).or_else(|| config.etherscan_api_key.clone())
+}
+
+enum VerificationJob {
+    Local(VerifyArgs),
+    External(VerifyArgs, ExternalVerificationContext),
+}
+
+impl VerificationJob {
+    async fn run(self) -> Result<()> {
+        match self {
+            Self::Local(args) => args.run().await,
+            Self::External(args, context) => args.run_with_external_context(context).await,
+        }
+    }
+}
+
+async fn external_job(
+    resolver: &mut Option<ExternalResolver>,
+    config: &Config,
+    chain: Chain,
+    verify: &VerifyBundle,
+    address: Address,
+    init_code: &[u8],
+    creators: &[Address],
+    creation_transaction_hash: TxHash,
+) -> Result<VerificationJob, String> {
+    if resolver.is_none() {
+        *resolver = Some(ExternalResolver::new().map_err(|err| concise(&err.to_string()))?);
+    }
+    let resolver = resolver.as_mut().unwrap();
+    let mut candidate_sets = Vec::new();
+    let mut reasons = Vec::new();
+
+    for &creator in creators.iter().take(MAX_PROVENANCE_ADDRESSES) {
+        let sources = [
+            ("Sourcify", resolver.resolve_sourcify(chain, creator).await),
+            (
+                "Etherscan",
+                resolver
+                    .resolve_etherscan(config, chain, creator, verify.source_api_key.clone())
+                    .await,
+            ),
+        ];
+        for (provider, source) in sources {
+            match source {
+                Ok(Some(source)) => match resolver.compile(&source).await {
+                    Ok(compiled) => candidate_sets.push(compiled),
+                    Err(err) => reasons.push(format!(
+                        "{} {creator}: compile failed ({})",
+                        source.provider,
+                        concise(&err)
+                    )),
+                },
+                Ok(None) => {}
+                Err(err) => reasons.push(format!("{provider} {creator}: {}", concise(&err))),
+            }
+        }
+    }
+
+    let matched = match match_candidates(
+        init_code,
+        candidate_sets.iter().flat_map(|candidates| candidates.iter()),
+    ) {
+        MatchResult::Unique(matched) => matched,
+        MatchResult::None => {
+            let context = if reasons.is_empty() {
+                "no matching candidates were found".to_string()
+            } else {
+                format!("no matching candidates were found; {}", reasons.join("; "))
+            };
+            return Err(context);
+        }
+        MatchResult::Ambiguous(matches) => {
+            let fqns = matches
+                .into_iter()
+                .map(|matched| format!("{}@{}", matched.fqn, matched.version))
+                .collect::<Vec<_>>();
+            return Err(format!("ambiguous external candidates: {}", fqns.join(", ")));
+        }
+    };
+
+    let mut pinned_config = config.clone();
+    pinned_config.chain = Some(chain);
+    let context = ExternalVerificationContext {
+        config: pinned_config,
+        compiler_version: matched.version.clone(),
+        standard_json_input: matched.input,
+        target: matched.fqn,
+    };
+    let args = VerifyArgs {
+        address,
+        contract: None,
+        compiler_version: Some(matched.version.to_string()),
+        constructor_args: Some(hex::encode(matched.constructor_args)),
+        constructor_args_path: None,
+        no_auto_detect: false,
+        use_solc: None,
+        num_of_optimizations: None,
+        etherscan: verify.etherscan.clone(),
+        rpc: Default::default(),
+        flatten: false,
+        force: false,
+        skip_is_verified_check: true,
+        watch: true,
+        print_submission_result_to_stdout: false,
+        retry: verify.retry,
+        libraries: Vec::new(),
+        root: None,
+        verifier: verify.verifier.clone(),
+        via_ir: false,
+        license_type: None,
+        evm_version: None,
+        show_standard_json_input: false,
+        guess_constructor_args: false,
+        compilation_profile: None,
+        language: None,
+        creation_transaction_hash: Some(creation_transaction_hash),
+    };
+    Ok(VerificationJob::External(args, context))
+}
+
+fn concise(reason: &str) -> String {
+    const LIMIT: usize = 160;
+    let mut chars = reason.chars().map(|ch| if ch.is_control() { ' ' } else { ch });
+    let reason = chars.by_ref().take(LIMIT).collect::<String>();
+    if chars.next().is_some() { format!("{reason}…") } else { reason }
+}
+
+fn take_matching_index<T>(
+    values: &[T],
+    consumed: &mut [bool],
+    predicate: impl Fn(&T) -> bool,
+) -> Option<usize> {
+    let index = values
+        .iter()
+        .enumerate()
+        .position(|(index, value)| !consumed[index] && predicate(value))?;
+    consumed[index] = true;
+    Some(index)
+}
+
 /// Given the broadcast log, it matches transactions with receipts, and tries to verify any
 /// created contract on etherscan.
 async fn verify_contracts<FEN: FoundryEvmNetwork>(
@@ -197,13 +357,29 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
     {
         trace!(target: "script", "prepare future verifications");
 
-        let mut future_verifications = Vec::with_capacity(sequence.receipts.len());
+        let mut verification_jobs = Vec::with_capacity(sequence.receipts.len());
         let mut unverifiable_contracts = vec![];
+        let mut resolver = None;
+        let mut external_jobs = 0;
+        let mut warned_offline = false;
+        let mut consumed_receipts = vec![false; sequence.receipts.len()];
 
-        // Make sure the receipts have the right order first.
-        sequence.sort_receipts();
-
-        for (receipt, tx) in sequence.receipts.iter_mut().zip(sequence.transactions.iter()) {
+        for tx in sequence.transactions.iter() {
+            let Some(tx_hash) = tx.hash else {
+                let _ = sh_warn!("Skipping verification for transaction without a hash.");
+                continue;
+            };
+            let Some(receipt_index) =
+                take_matching_index(&sequence.receipts, &mut consumed_receipts, |receipt| {
+                    receipt.transaction_hash() == tx_hash
+                })
+            else {
+                let _ = sh_warn!(
+                    "Skipping verification for transaction {tx_hash}: receipt unavailable."
+                );
+                continue;
+            };
+            let receipt = &mut sequence.receipts[receipt_index];
             // create2 hash offset
             let offset = if tx.is_create2()
                 && let Some(contract_address) = tx.contract_address
@@ -223,13 +399,15 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
                     &sequence.libraries,
                     config.evm_version,
                 ) {
-                    Some(verify) => future_verifications.push(verify.run()),
+                    Some(verify) => verification_jobs.push(VerificationJob::Local(verify)),
                     None => unverifiable_contracts.push(address),
                 };
             }
 
             // Verify potential contracts created during the transaction execution
-            for AdditionalContract { address, init_code, .. } in &tx.additional_contracts {
+            for AdditionalContract { address, init_code, creator_code_addresses, .. } in
+                &tx.additional_contracts
+            {
                 match verify.get_verify_args(
                     *address,
                     0,
@@ -237,21 +415,61 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
                     &sequence.libraries,
                     config.evm_version,
                 ) {
-                    Some(verify) => future_verifications.push(verify.run()),
-                    None => unverifiable_contracts.push(*address),
+                    Some(args) => verification_jobs.push(VerificationJob::Local(args)),
+                    None if !verify.verify_external => unverifiable_contracts.push(*address),
+                    None if config.offline => {
+                        if !warned_offline {
+                            let _ = sh_warn!(
+                                "Skipping external contract verification because offline mode is enabled."
+                            );
+                            warned_offline = true;
+                        }
+                    }
+                    None if creator_code_addresses.is_empty() => {
+                        let _ = sh_warn!(
+                            "Skipping external verification for {address}: creator provenance is unavailable (old broadcast logs or skipped simulation)."
+                        );
+                    }
+                    None if external_jobs >= MAX_EXTERNAL_JOBS => {
+                        let _ = sh_warn!(
+                            "Skipping external verification for {address}: external job limit exceeded."
+                        );
+                    }
+                    None => {
+                        external_jobs += 1;
+                        match external_job(
+                            &mut resolver,
+                            config,
+                            sequence.chain.into(),
+                            &verify,
+                            *address,
+                            init_code,
+                            creator_code_addresses,
+                            receipt.transaction_hash(),
+                        )
+                        .await
+                        {
+                            Ok(job) => verification_jobs.push(job),
+                            Err(reason) => {
+                                let _ = sh_warn!(
+                                    "Skipping external verification for {address}: {reason}"
+                                );
+                            }
+                        }
+                    }
                 };
             }
         }
 
-        trace!(target: "script", "collected {} verification jobs and {} unverifiable contracts", future_verifications.len(), unverifiable_contracts.len());
+        trace!(target: "script", "collected {} verification jobs and {} unverifiable contracts", verification_jobs.len(), unverifiable_contracts.len());
 
         check_unverified(sequence, unverifiable_contracts, verify);
 
-        let num_verifications = future_verifications.len();
+        let num_verifications = verification_jobs.len();
         let mut num_of_successful_verifications = 0;
         sh_status!("##\nStart verification for ({num_verifications}) contracts")?;
-        for verification in future_verifications {
-            match verification.await {
+        for verification in verification_jobs {
+            match verification.run().await {
                 Ok(_) => {
                     num_of_successful_verifications += 1;
                 }
@@ -299,5 +517,45 @@ fn check_unverified<N: Network>(
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{concise, source_api_key, take_matching_index};
+    use alloy_chains::Chain;
+    use foundry_config::Config;
+
+    #[test]
+    fn receipt_matching_is_hash_based_and_consumes_duplicate_hashes_in_order() {
+        let reversed = [(2, "second"), (1, "first")];
+        let mut consumed = [false; 2];
+        assert_eq!(take_matching_index(&reversed, &mut consumed, |(hash, _)| *hash == 1), Some(1));
+        assert_eq!(take_matching_index(&reversed, &mut consumed, |(hash, _)| *hash == 2), Some(0));
+        assert_eq!(consumed, [true, true]);
+
+        let batch = [(7, "first"), (7, "second")];
+        let mut consumed = [false; 2];
+        let first = take_matching_index(&batch, &mut consumed, |(hash, _)| *hash == 7).unwrap();
+        let second = take_matching_index(&batch, &mut consumed, |(hash, _)| *hash == 7).unwrap();
+        assert_eq!((batch[first].1, batch[second].1), ("first", "second"));
+        assert!(take_matching_index(&batch, &mut consumed, |(hash, _)| *hash == 7).is_none());
+    }
+
+    #[test]
+    fn source_key_is_only_read_from_etherscan_config() {
+        let mut config = Config { etherscan_api_key: Some("source".into()), ..Default::default() };
+        let verifier_key = "submission-only";
+        assert_eq!(source_api_key(&config, Chain::mainnet()).as_deref(), Some("source"));
+        config.etherscan_api_key = None;
+        assert_ne!(source_api_key(&config, Chain::mainnet()).as_deref(), Some(verifier_key));
+    }
+
+    #[test]
+    fn concise_sanitizes_and_bounds_remote_errors() {
+        let message = format!("remote\n\u{1b}[31m{}", "x".repeat(200));
+        let concise = concise(&message);
+        assert!(!concise.chars().any(char::is_control));
+        assert!(concise.chars().count() <= 161);
     }
 }

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -296,7 +296,15 @@ async fn external_job(
         for (provider, source) in sources {
             match source {
                 Ok(Some(source)) => match resolver.compile(&source).await {
-                    Ok(compiled) => candidate_sets.push(compiled),
+                    Ok((compiled, has_unresolved_links)) => {
+                        if has_unresolved_links {
+                            reasons.push(format!(
+                                "{} {creator}: contracts with unresolved library links are unsupported",
+                                source.provider
+                            ));
+                        }
+                        candidate_sets.push(compiled);
+                    }
                     Err(err) => reasons.push(format!(
                         "{} {creator}: compile failed ({})",
                         source.provider,

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -204,18 +204,19 @@ fn source_api_key(config: &Config, chain: Chain) -> Option<String> {
 
 enum VerificationJob {
     Local(VerifyArgs),
-    External(VerifyArgs, ExternalVerificationContext),
+    External(VerifyArgs, Box<ExternalVerificationContext>),
 }
 
 impl VerificationJob {
     async fn run(self) -> Result<()> {
         match self {
             Self::Local(args) => args.run().await,
-            Self::External(args, context) => args.run_with_external_context(context).await,
+            Self::External(args, context) => args.run_with_external_context(*context).await,
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn external_job(
     resolver: &mut Option<ExternalResolver>,
     config: &Config,
@@ -318,7 +319,7 @@ async fn external_job(
         language: None,
         creation_transaction_hash: Some(creation_transaction_hash),
     };
-    Ok(VerificationJob::External(args, context))
+    Ok(VerificationJob::External(args, Box::new(context)))
 }
 
 fn concise(reason: &str) -> String {
@@ -364,7 +365,7 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
         let mut warned_offline = false;
         let mut consumed_receipts = vec![false; sequence.receipts.len()];
 
-        for tx in sequence.transactions.iter() {
+        for tx in &sequence.transactions {
             let Some(tx_hash) = tx.hash else {
                 let _ = sh_warn!("Skipping verification for transaction without a hash.");
                 continue;

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -66,6 +66,7 @@ pub struct VerifyBundle {
     pub verifier: VerifierArgs,
     pub via_ir: bool,
     pub verify_external: bool,
+    source_api_url: Option<String>,
     source_api_key: Option<String>,
 }
 
@@ -105,19 +106,41 @@ impl VerifyBundle {
             verifier,
             via_ir,
             verify_external,
+            source_api_url: None,
             source_api_key: None,
         }
     }
 
     /// Configures the chain and sets the etherscan key, if available
-    pub fn set_chain(&mut self, config: &Config, chain: Chain) {
+    pub fn set_chain(&mut self, config: &Config, chain: Chain) -> Result<()> {
         // If dealing with multiple chains, we need to be able to change in between the config
         // chain_id.
         let config_key = source_api_key(config, chain);
-        self.source_api_key = config_key.clone();
-        self.etherscan.key =
-            self.verifier.resolve_api_key(config_key.as_deref()).map(str::to_owned);
+        let resolved_key = self.verifier.resolve_api_key(config_key.as_deref()).map(str::to_owned);
+        let provider = self.verifier.resolve(resolved_key.as_deref(), Some(chain));
+
+        // A selected Etherscan-compatible verifier is both the source and submission endpoint.
+        // Sourcify credentials must not be sent to the independent Etherscan discovery fallback.
+        if provider.is_sourcify() {
+            // Etherscan is optional when Sourcify is selected, so an invalid fallback must not
+            // prevent verification through the selected provider.
+            self.source_api_url = config
+                .get_etherscan_config_with_chain(Some(chain))
+                .ok()
+                .flatten()
+                .map(|config| config.api_url);
+            self.source_api_key = config_key;
+        } else if let Some(url) = &self.verifier.verifier_url {
+            self.source_api_url = Some(url.clone());
+            self.source_api_key = resolved_key.clone();
+        } else {
+            self.source_api_url =
+                config.get_etherscan_config_with_chain(Some(chain))?.map(|config| config.api_url);
+            self.source_api_key = resolved_key.clone();
+        }
+        self.etherscan.key = resolved_key;
         self.etherscan.chain = Some(chain);
+        Ok(())
     }
 
     /// Given a `VerifyBundle` and contract details, it tries to generate a valid `VerifyArgs` to
@@ -240,7 +263,12 @@ async fn external_job(
             (
                 "Etherscan",
                 resolver
-                    .resolve_etherscan(config, chain, creator, verify.source_api_key.clone())
+                    .resolve_etherscan(
+                        chain,
+                        creator,
+                        verify.source_api_url.as_deref(),
+                        verify.source_api_key.as_deref(),
+                    )
                     .await,
             ),
         ];
@@ -351,7 +379,7 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
 ) -> Result<()> {
     trace!(target: "script", "verifying {} contracts [{}]", verify.known_contracts.len(), sequence.chain);
 
-    verify.set_chain(config, sequence.chain.into());
+    verify.set_chain(config, sequence.chain.into())?;
 
     if verify.etherscan.has_key()
         || verify.verifier.effective_type() != VerificationProviderType::Etherscan
@@ -544,12 +572,11 @@ mod tests {
     }
 
     #[test]
-    fn source_key_is_only_read_from_etherscan_config() {
+    fn source_key_reads_etherscan_config_fallback() {
         let mut config = Config { etherscan_api_key: Some("source".into()), ..Default::default() };
-        let verifier_key = "submission-only";
         assert_eq!(source_api_key(&config, Chain::mainnet()).as_deref(), Some("source"));
         config.etherscan_api_key = None;
-        assert_ne!(source_api_key(&config, Chain::mainnet()).as_deref(), Some(verifier_key));
+        assert!(source_api_key(&config, Chain::mainnet()).is_none());
     }
 
     #[test]

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -10,6 +10,8 @@ use forge_script_sequence::{AdditionalContract, ScriptSequence};
 use forge_verify::{
     RetryArgs, VerifierArgs, VerifyArgs,
     provider::{ExternalVerificationContext, VerificationProviderType},
+    sourcify::SOURCIFY_URL,
+    verify::sourcify_api_url,
 };
 use foundry_cli::opts::{EtherscanOpts, ProjectPathOpts};
 use foundry_common::{ContractsByArtifact, FoundryReceiptResponse};
@@ -66,8 +68,9 @@ pub struct VerifyBundle {
     pub verifier: VerifierArgs,
     pub via_ir: bool,
     pub verify_external: bool,
-    source_api_url: Option<String>,
-    source_api_key: Option<String>,
+    source_etherscan_url: Option<String>,
+    source_etherscan_key: Option<String>,
+    source_sourcify_url: Option<String>,
 }
 
 impl VerifyBundle {
@@ -106,8 +109,9 @@ impl VerifyBundle {
             verifier,
             via_ir,
             verify_external,
-            source_api_url: None,
-            source_api_key: None,
+            source_etherscan_url: None,
+            source_etherscan_key: None,
+            source_sourcify_url: None,
         }
     }
 
@@ -122,21 +126,33 @@ impl VerifyBundle {
         // A selected Etherscan-compatible verifier is both the source and submission endpoint.
         // Sourcify credentials must not be sent to the independent Etherscan discovery fallback.
         if provider.is_sourcify() {
+            self.source_sourcify_url = Some(
+                self.verifier
+                    .verifier_url
+                    .clone()
+                    .or_else(|| sourcify_api_url(chain))
+                    .unwrap_or_else(|| SOURCIFY_URL.to_string()),
+            );
             // Etherscan is optional when Sourcify is selected, so an invalid fallback must not
             // prevent verification through the selected provider.
-            self.source_api_url = config
+            self.source_etherscan_url = config
                 .get_etherscan_config_with_chain(Some(chain))
                 .ok()
                 .flatten()
                 .map(|config| config.api_url);
-            self.source_api_key = config_key;
+            self.source_etherscan_key = config_key;
         } else if let Some(url) = &self.verifier.verifier_url {
-            self.source_api_url = Some(url.clone());
-            self.source_api_key = resolved_key.clone();
+            // An explicit non-Sourcify endpoint may be private. Do not disclose provenance to the
+            // public Sourcify service as an implicit fallback.
+            self.source_sourcify_url = None;
+            self.source_etherscan_url = Some(url.clone());
+            self.source_etherscan_key = resolved_key.clone();
         } else {
-            self.source_api_url =
+            self.source_sourcify_url =
+                Some(sourcify_api_url(chain).unwrap_or_else(|| SOURCIFY_URL.to_string()));
+            self.source_etherscan_url =
                 config.get_etherscan_config_with_chain(Some(chain))?.map(|config| config.api_url);
-            self.source_api_key = resolved_key.clone();
+            self.source_etherscan_key = resolved_key.clone();
         }
         self.etherscan.key = resolved_key;
         self.etherscan.chain = Some(chain);
@@ -259,15 +275,20 @@ async fn external_job(
 
     for &creator in creators.iter().take(MAX_PROVENANCE_ADDRESSES) {
         let sources = [
-            ("Sourcify", resolver.resolve_sourcify(chain, creator).await),
+            (
+                "Sourcify",
+                resolver
+                    .resolve_sourcify(chain, creator, verify.source_sourcify_url.as_deref())
+                    .await,
+            ),
             (
                 "Etherscan",
                 resolver
                     .resolve_etherscan(
                         chain,
                         creator,
-                        verify.source_api_url.as_deref(),
-                        verify.source_api_key.as_deref(),
+                        verify.source_etherscan_url.as_deref(),
+                        verify.source_etherscan_key.as_deref(),
                     )
                     .await,
             ),
@@ -390,6 +411,7 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
         let mut unverifiable_contracts = vec![];
         let mut resolver = None;
         let mut external_jobs = 0;
+        let mut skipped_external = 0;
         let mut warned_offline = false;
         let mut consumed_receipts = vec![false; sequence.receipts.len()];
 
@@ -447,6 +469,7 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
                     Some(args) => verification_jobs.push(VerificationJob::Local(args)),
                     None if !verify.verify_external => unverifiable_contracts.push(*address),
                     None if config.offline => {
+                        skipped_external += 1;
                         if !warned_offline {
                             let _ = sh_warn!(
                                 "Skipping external contract verification because offline mode is enabled."
@@ -455,11 +478,13 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
                         }
                     }
                     None if creator_code_addresses.is_empty() => {
+                        skipped_external += 1;
                         let _ = sh_warn!(
                             "Skipping external verification for {address}: creator provenance is unavailable (old broadcast logs or skipped simulation)."
                         );
                     }
                     None if external_jobs >= MAX_EXTERNAL_JOBS => {
+                        skipped_external += 1;
                         let _ = sh_warn!(
                             "Skipping external verification for {address}: external job limit exceeded."
                         );
@@ -480,6 +505,7 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
                         {
                             Ok(job) => verification_jobs.push(job),
                             Err(reason) => {
+                                skipped_external += 1;
                                 let _ = sh_warn!(
                                     "Skipping external verification for {address}: {reason}"
                                 );
@@ -495,8 +521,9 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
         check_unverified(sequence, unverifiable_contracts, verify);
 
         let num_verifications = verification_jobs.len();
+        let num_requested = num_verifications + skipped_external;
         let mut num_of_successful_verifications = 0;
-        sh_status!("##\nStart verification for ({num_verifications}) contracts")?;
+        sh_status!("##\nStart verification for ({num_requested}) contracts")?;
         for verification in verification_jobs {
             match verification.run().await {
                 Ok(_) => {
@@ -508,15 +535,34 @@ async fn verify_contracts<FEN: FoundryEvmNetwork>(
             }
         }
 
-        if num_of_successful_verifications < num_verifications {
-            return Err(eyre!(
-                "Not all ({num_of_successful_verifications} / {num_verifications}) contracts were verified!"
-            ));
-        }
+        ensure_verification_complete(
+            num_of_successful_verifications,
+            num_verifications,
+            skipped_external,
+        )?;
 
-        sh_status!("All ({num_verifications}) contracts were verified!")?;
+        sh_status!("All ({num_requested}) contracts were verified!")?;
     }
 
+    Ok(())
+}
+
+fn ensure_verification_complete(
+    successful: usize,
+    submitted: usize,
+    skipped_external: usize,
+) -> Result<()> {
+    let requested = submitted + skipped_external;
+    if successful < requested {
+        let skipped = if skipped_external == 0 {
+            String::new()
+        } else {
+            format!("; {skipped_external} external verification(s) were skipped")
+        };
+        return Err(eyre!(
+            "Not all ({successful} / {requested}) contracts were verified{skipped}!"
+        ));
+    }
     Ok(())
 }
 
@@ -551,9 +597,25 @@ fn check_unverified<N: Network>(
 
 #[cfg(test)]
 mod tests {
-    use super::{concise, source_api_key, take_matching_index};
+    use super::{
+        ContractsByArtifact, RetryArgs, SOURCIFY_URL, VerificationProviderType, VerifierArgs,
+        VerifyBundle, concise, ensure_verification_complete, source_api_key, sourcify_api_url,
+        take_matching_index,
+    };
     use alloy_chains::Chain;
     use foundry_config::Config;
+
+    fn bundle(config: &Config, verifier: VerifierArgs) -> VerifyBundle {
+        let project = config.project().unwrap();
+        VerifyBundle::new(
+            &project,
+            config,
+            ContractsByArtifact::default(),
+            RetryArgs::default(),
+            verifier,
+            true,
+        )
+    }
 
     #[test]
     fn receipt_matching_is_hash_based_and_consumes_duplicate_hashes_in_order() {
@@ -577,6 +639,47 @@ mod tests {
         assert_eq!(source_api_key(&config, Chain::mainnet()).as_deref(), Some("source"));
         config.etherscan_api_key = None;
         assert!(source_api_key(&config, Chain::mainnet()).is_none());
+    }
+
+    #[test]
+    fn source_endpoints_follow_selected_provider_privacy() {
+        let tempo = Chain::from(4217u64);
+        let config = Config { etherscan_api_key: Some("ambient".into()), ..Default::default() };
+        let mut verify = bundle(&config, VerifierArgs::default());
+        verify.set_chain(&config, tempo).unwrap();
+        assert_eq!(verify.source_sourcify_url, sourcify_api_url(tempo));
+        assert_ne!(verify.source_sourcify_url.as_deref(), Some(SOURCIFY_URL));
+
+        let config = Config::default();
+        let mut verify = bundle(
+            &config,
+            VerifierArgs {
+                verifier: Some(VerificationProviderType::Custom),
+                verifier_api_key: Some("private-key".into()),
+                verifier_url: Some("https://private.example/api".into()),
+            },
+        );
+        verify.set_chain(&config, Chain::mainnet()).unwrap();
+        assert!(verify.source_sourcify_url.is_none());
+        assert_eq!(verify.source_etherscan_url.as_deref(), Some("https://private.example/api"));
+
+        let mut verify = bundle(
+            &config,
+            VerifierArgs {
+                verifier: Some(VerificationProviderType::Etherscan),
+                ..Default::default()
+            },
+        );
+        verify.set_chain(&config, Chain::mainnet()).unwrap();
+        assert_eq!(verify.source_sourcify_url.as_deref(), Some(SOURCIFY_URL));
+    }
+
+    #[test]
+    fn skipped_external_verifications_make_the_summary_fail() {
+        let err = ensure_verification_complete(0, 0, 1).unwrap_err().to_string();
+        assert!(err.contains("0 / 1"));
+        assert!(err.contains("1 external verification(s) were skipped"));
+        ensure_verification_complete(1, 1, 0).unwrap();
     }
 
     #[test]

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -26,6 +26,13 @@ use external::{ExternalResolver, MAX_PROVENANCE_ADDRESSES, MatchResult, match_ca
 
 const MAX_EXTERNAL_JOBS: usize = 32;
 
+fn same_endpoint(left: &str, right: &str) -> bool {
+    let (Ok(left), Ok(right)) = (reqwest::Url::parse(left), reqwest::Url::parse(right)) else {
+        return false;
+    };
+    left == right
+}
+
 /// State after we have broadcasted the script.
 /// It is assumed that at this point [BroadcastedState::sequence] contains receipts for all
 /// broadcasted transactions.
@@ -141,6 +148,15 @@ impl VerifyBundle {
                 .flatten()
                 .map(|config| config.api_url);
             self.source_etherscan_key = config_key;
+            if self
+                .source_sourcify_url
+                .as_deref()
+                .zip(self.source_etherscan_url.as_deref())
+                .is_some_and(|(sourcify, etherscan)| same_endpoint(sourcify, etherscan))
+            {
+                self.source_etherscan_url = None;
+                self.source_etherscan_key = None;
+            }
         } else if let Some(url) = &self.verifier.verifier_url {
             // An explicit non-Sourcify endpoint may be private. Do not disclose provenance to the
             // public Sourcify service as an implicit fallback.
@@ -615,8 +631,8 @@ fn check_unverified<N: Network>(
 mod tests {
     use super::{
         ContractsByArtifact, RetryArgs, SOURCIFY_URL, VerificationProviderType, VerifierArgs,
-        VerifyBundle, concise, ensure_verification_complete, source_api_key, sourcify_api_url,
-        take_matching_index,
+        VerifyBundle, concise, ensure_verification_complete, same_endpoint, source_api_key,
+        sourcify_api_url, take_matching_index,
     };
     use alloy_chains::Chain;
     use foundry_config::Config;
@@ -665,6 +681,8 @@ mod tests {
         verify.set_chain(&config, tempo).unwrap();
         assert_eq!(verify.source_sourcify_url, sourcify_api_url(tempo));
         assert_ne!(verify.source_sourcify_url.as_deref(), Some(SOURCIFY_URL));
+        assert!(verify.source_etherscan_url.is_none());
+        assert!(verify.source_etherscan_key.is_none());
 
         let config = Config::default();
         let mut verify = bundle(
@@ -688,6 +706,17 @@ mod tests {
         );
         verify.set_chain(&config, Chain::mainnet()).unwrap();
         assert_eq!(verify.source_sourcify_url.as_deref(), Some(SOURCIFY_URL));
+    }
+
+    #[test]
+    fn source_endpoint_comparison_normalizes_urls_without_ignoring_routes() {
+        assert!(same_endpoint("https://CONTRACTS.tempo.xyz:443", "https://contracts.tempo.xyz/"));
+        assert!(!same_endpoint("https://contracts.tempo.xyz/api", "https://contracts.tempo.xyz/"));
+        assert!(!same_endpoint(
+            "https://contracts.tempo.xyz/?chainid=4217",
+            "https://contracts.tempo.xyz/"
+        ));
+        assert!(!same_endpoint("not a URL", "https://contracts.tempo.xyz/"));
     }
 
     #[test]

--- a/crates/script/src/verify.rs
+++ b/crates/script/src/verify.rs
@@ -150,8 +150,16 @@ impl VerifyBundle {
         } else {
             self.source_sourcify_url =
                 Some(sourcify_api_url(chain).unwrap_or_else(|| SOURCIFY_URL.to_string()));
-            self.source_etherscan_url =
-                config.get_etherscan_config_with_chain(Some(chain))?.map(|config| config.api_url);
+            self.source_etherscan_url = config
+                .get_etherscan_config_with_chain(Some(chain))?
+                .map(|config| config.api_url)
+                .or_else(|| {
+                    if provider.is_etherscan() && !chain.is_custom_sourcify() {
+                        chain.etherscan_urls().map(|(api_url, _)| api_url.to_string())
+                    } else {
+                        None
+                    }
+                });
             self.source_etherscan_key = resolved_key.clone();
         }
         self.etherscan.key = resolved_key;
@@ -680,6 +688,47 @@ mod tests {
         );
         verify.set_chain(&config, Chain::mainnet()).unwrap();
         assert_eq!(verify.source_sourcify_url.as_deref(), Some(SOURCIFY_URL));
+    }
+
+    #[test]
+    fn cli_only_etherscan_key_uses_chain_source_endpoint() {
+        let chain = Chain::mainnet();
+        let config = Config::default();
+        let mut verify = bundle(
+            &config,
+            VerifierArgs { verifier_api_key: Some("cli-key".into()), ..Default::default() },
+        );
+
+        verify.set_chain(&config, chain).unwrap();
+
+        assert_eq!(
+            verify.source_etherscan_url.as_deref(),
+            Some("https://api.etherscan.io/v2/api?chainid=1")
+        );
+        assert_eq!(verify.source_etherscan_key.as_deref(), Some("cli-key"));
+        assert_eq!(verify.etherscan.key.as_deref(), Some("cli-key"));
+    }
+
+    #[test]
+    fn chain_source_endpoint_requires_valid_etherscan_route() {
+        let config = Config::default();
+        for (chain, provider) in [
+            (Chain::mainnet(), VerificationProviderType::Custom),
+            (Chain::from(4217u64), VerificationProviderType::Etherscan),
+        ] {
+            let mut verify = bundle(
+                &config,
+                VerifierArgs {
+                    verifier: Some(provider),
+                    verifier_api_key: Some("private-key".into()),
+                    ..Default::default()
+                },
+            );
+
+            verify.set_chain(&config, chain).unwrap();
+
+            assert!(verify.source_etherscan_url.is_none());
+        }
     }
 
     #[test]

--- a/crates/script/src/verify/external.rs
+++ b/crates/script/src/verify/external.rs
@@ -91,12 +91,14 @@ struct FetchKey {
     address: Address,
 }
 
+type CompiledCandidates = Result<Arc<[Candidate]>, String>;
+
 /// Per-script-run state. Both caches deliberately retain failures, preventing repeated network or
 /// compiler work for the same provenance.
 pub(super) struct ExternalResolver {
     http: reqwest::Client,
     fetch_cache: HashMap<FetchKey, Result<Option<ExternalSource>, String>>,
-    compile_cache: HashMap<(Version, String), Result<Arc<[Candidate]>, String>>,
+    compile_cache: HashMap<(Version, String), CompiledCandidates>,
     compiler_versions: HashSet<Version>,
     compilations: usize,
     retained_source_input: usize,
@@ -550,7 +552,12 @@ fn parse_solc_version_output(output: &[u8]) -> Result<Version, String> {
         .lines()
         .find_map(|line| line.trim().strip_prefix("Version: "))
         .ok_or_else(|| "solc version output is missing Version line".to_string())
-        .and_then(|version| Version::parse(version).map_err(|_| "invalid solc version".to_string()))
+        // Linux solc builds identify GCC as `g++`, whose plus signs are invalid in SemVer build
+        // metadata. Use the same normalization as foundry-compilers' solc version parser.
+        .and_then(|version| {
+            Version::parse(&version.replace(".g++", ".gcc"))
+                .map_err(|_| "invalid solc version".to_string())
+        })
 }
 
 async fn run_bounded_command(
@@ -848,6 +855,11 @@ mod tests {
             parse_solc_version_output(output).unwrap(),
             Version::parse("0.8.30+commit.73712a01.Darwin.appleclang").unwrap()
         );
+        let linux = b"Version: 0.8.30+commit.73712a01.Linux.g++\n";
+        assert_eq!(
+            parse_solc_version_output(linux).unwrap(),
+            Version::parse("0.8.30+commit.73712a01.Linux.gcc").unwrap()
+        );
         assert!(parse_solc_version_output(b"Version: forged").is_err());
     }
 
@@ -883,7 +895,9 @@ mod tests {
         let mut observed = vec![0x60, 0x00];
         observed.extend([0; 31]);
         observed.push(7);
-        let MatchResult::Unique(found) = match_candidates(&observed, &[candidate.clone()]) else {
+        let MatchResult::Unique(found) =
+            match_candidates(&observed, std::slice::from_ref(&candidate))
+        else {
             panic!("expected match")
         };
         assert_eq!(found.constructor_args.len(), 32);
@@ -893,7 +907,10 @@ mod tests {
     #[test]
     fn no_constructor_and_zero_inputs_require_empty_suffix() {
         let none = candidate("A.sol:A", JsonAbi::default());
-        assert!(matches!(match_candidates(&[0x60, 0x00], &[none.clone()]), MatchResult::Unique(_)));
+        assert!(matches!(
+            match_candidates(&[0x60, 0x00], std::slice::from_ref(&none)),
+            MatchResult::Unique(_)
+        ));
         assert!(matches!(match_candidates(&[0x60, 0x00, 0], &[none]), MatchResult::None));
 
         let zero: JsonAbi =

--- a/crates/script/src/verify/external.rs
+++ b/crates/script/src/verify/external.rs
@@ -4,6 +4,7 @@ use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Constructor;
 use alloy_primitives::{Address, Bytes, keccak256};
 use eyre::{Result, bail, eyre};
+use forge_verify::sourcify::SOURCIFY_URL;
 use foundry_compilers::{artifacts::CompilerOutput, solc::Solc};
 use foundry_config::{Chain, NamedChain};
 use futures::StreamExt;
@@ -28,9 +29,11 @@ const MAX_COMPILER_VERSIONS: usize = 8;
 const MAX_COMPILATIONS: usize = 32;
 const MAX_CANDIDATES: usize = 512;
 const MAX_CREATION_BYTECODE: usize = 64 * 1024 * 1024;
-const MAX_CANDIDATE_METADATA: usize = 8 * 1024 * 1024;
+const MAX_RETAINED_METADATA: usize = 8 * 1024 * 1024;
 const MAX_RETAINED_SOURCE_INPUT: usize = 64 * 1024 * 1024;
 const MAX_SOURCE_PATH: usize = 4096;
+const MAX_COMPILER_VERSION: usize = 256;
+const MAX_CACHED_ERROR_CHARS: usize = 512;
 const MAX_STDOUT: usize = 32 * 1024 * 1024;
 const MAX_STDERR: usize = 1024 * 1024;
 const COMPILE_TIMEOUT: Duration = Duration::from_secs(60);
@@ -39,14 +42,22 @@ pub(super) const MAX_PROVENANCE_ADDRESSES: usize = 16;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(super) enum SourceProvider {
     Etherscan { endpoint: String },
-    Sourcify,
+    Sourcify { endpoint: String },
+}
+
+impl SourceProvider {
+    const fn metadata_len(&self) -> usize {
+        match self {
+            Self::Etherscan { endpoint } | Self::Sourcify { endpoint } => endpoint.len(),
+        }
+    }
 }
 
 impl std::fmt::Display for SourceProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Etherscan { .. } => f.write_str("Etherscan"),
-            Self::Sourcify => f.write_str("Sourcify"),
+            Self::Sourcify { .. } => f.write_str("Sourcify"),
         }
     }
 }
@@ -103,7 +114,7 @@ pub(super) struct ExternalResolver {
     compilations: usize,
     retained_source_input: usize,
     retained_candidates: usize,
-    retained_candidate_metadata: usize,
+    retained_metadata: usize,
     retained_creation_bytecode: usize,
 }
 
@@ -122,7 +133,7 @@ impl ExternalResolver {
             compilations: 0,
             retained_source_input: 0,
             retained_candidates: 0,
-            retained_candidate_metadata: 0,
+            retained_metadata: 0,
             retained_creation_bytecode: 0,
         })
     }
@@ -164,30 +175,31 @@ impl ExternalResolver {
                 return Err("Etherscan response exceeds 10 MiB".to_string());
             }
             let body = read_capped_body(response, MAX_INPUT_SIZE, "Etherscan").await?;
-            let (input, compiler_version) = parse_etherscan_response(&body)?;
-            let version = parse_compiler_version(&compiler_version).map_err(|e| e.to_string())?;
+            let (input, version) = parse_etherscan_response(&body)?;
             Ok(Some(ExternalSource { input: Arc::new(input), version, provider }))
         }
         .await;
-        let result = self.charge_source_result(result);
-        self.fetch_cache.insert(key, result.clone());
-        result
+        self.cache_source_result(key, result)
     }
 
     pub(super) async fn resolve_sourcify(
         &mut self,
         chain: Chain,
         address: Address,
+        endpoint: Option<&str>,
     ) -> Result<Option<ExternalSource>, String> {
+        let Some(endpoint) = endpoint else { return Ok(None) };
         // Canonical Sourcify cannot observe ephemeral local chains. Avoid a guaranteed external
         // request so local external-verification workflows remain hermetic.
-        if matches!(
-            chain.named(),
-            Some(NamedChain::Dev | NamedChain::AnvilHardhat | NamedChain::Cannon)
-        ) {
+        if endpoint == SOURCIFY_URL
+            && matches!(
+                chain.named(),
+                Some(NamedChain::Dev | NamedChain::AnvilHardhat | NamedChain::Cannon)
+            )
+        {
             return Ok(None);
         }
-        let provider = SourceProvider::Sourcify;
+        let provider = SourceProvider::Sourcify { endpoint: endpoint.to_string() };
         let key = FetchKey { chain: chain.id(), provider: provider.clone(), address };
         if let Some(cached) = self.fetch_cache.get(&key) {
             return cached.clone();
@@ -196,8 +208,9 @@ impl ExternalResolver {
             return Err("external source fetch limit exceeded".to_string());
         }
         let result = async {
+            let endpoint = endpoint.trim_end_matches('/');
             let url = format!(
-                "https://sourcify.dev/server/v2/contract/{}/{address}?fields=stdJsonInput,compilation.compilerVersion",
+                "{endpoint}/v2/contract/{}/{address}?fields=stdJsonInput,compilation.compilerVersion",
                 chain.id()
             );
             let response = self.http.get(url).send().await.map_err(|_| "Sourcify request failed".to_string())?;
@@ -223,9 +236,7 @@ impl ExternalResolver {
             }))
         }
         .await;
-        let result = self.charge_source_result(result);
-        self.fetch_cache.insert(key, result.clone());
-        result
+        self.cache_source_result(key, result)
     }
 
     pub(super) async fn compile(
@@ -240,15 +251,30 @@ impl ExternalResolver {
         if self.compilations >= MAX_COMPILATIONS {
             return Err("external compilation limit exceeded".to_string());
         }
-        if !self.compiler_versions.contains(&source.version)
-            && self.compiler_versions.len() >= MAX_COMPILER_VERSIONS
-        {
+        let new_version = !self.compiler_versions.contains(&source.version);
+        if new_version && self.compiler_versions.len() >= MAX_COMPILER_VERSIONS {
             return Err("external compiler version limit exceeded".to_string());
         }
+        let version_len = source.version.to_string().len();
+        let cache_metadata = key
+            .1
+            .len()
+            .saturating_add(version_len)
+            .saturating_add(if new_version { version_len } else { 0 });
         self.compilations += 1;
+        let result = match compile_source(source).await {
+            Ok(candidates) => self.charge_candidates(candidates, cache_metadata),
+            Err(err) => Err(err),
+        };
+        let result = match result {
+            Ok(candidates) => Ok(candidates),
+            Err(err) => {
+                let err = bound_cached_error(err);
+                self.charge_metadata(cache_metadata.saturating_add(err.len()))?;
+                Err(err)
+            }
+        };
         self.compiler_versions.insert(source.version.clone());
-        let result =
-            compile_source(source).await.and_then(|candidates| self.charge_candidates(candidates));
         self.compile_cache.insert(key, result.clone());
         result
     }
@@ -256,47 +282,86 @@ impl ExternalResolver {
     fn charge_candidates(
         &mut self,
         candidates: Vec<Candidate>,
+        cache_metadata: usize,
     ) -> Result<Arc<[Candidate]>, String> {
         let bytes = candidates.iter().fold(0usize, |total, candidate| {
             total.saturating_add(candidate.creation_bytecode.len())
         });
-        let metadata = candidates.iter().fold(0usize, |total, candidate| {
+        let metadata = candidates.iter().try_fold(cache_metadata, |total, candidate| {
             let constructor = candidate
                 .constructor
                 .as_ref()
-                .and_then(|constructor| serde_json::to_vec(constructor).ok())
+                .map(serde_json::to_vec)
+                .transpose()
+                .map_err(|_| "failed to measure candidate constructor".to_string())?
                 .map_or(0, |constructor| constructor.len());
-            total.saturating_add(candidate.fqn.len()).saturating_add(constructor)
-        });
+            Ok::<_, String>(
+                total
+                    .saturating_add(candidate.fqn.len())
+                    .saturating_add(candidate.fingerprint.len())
+                    .saturating_add(candidate.version.to_string().len())
+                    .saturating_add(constructor),
+            )
+        })?;
         if self.retained_candidates.saturating_add(candidates.len()) > MAX_CANDIDATES {
             return Err("external cumulative candidate limit exceeded".to_string());
         }
-        if self.retained_candidate_metadata.saturating_add(metadata) > MAX_CANDIDATE_METADATA {
-            return Err("external cumulative candidate metadata limit exceeded".to_string());
+        if self.retained_metadata.saturating_add(metadata) > MAX_RETAINED_METADATA {
+            return Err("external cumulative metadata limit exceeded".to_string());
         }
         if self.retained_creation_bytecode.saturating_add(bytes) > MAX_CREATION_BYTECODE {
             return Err("external cumulative creation bytecode limit exceeded".to_string());
         }
         self.retained_candidates += candidates.len();
-        self.retained_candidate_metadata += metadata;
+        self.retained_metadata += metadata;
         self.retained_creation_bytecode += bytes;
         Ok(Arc::from(candidates))
     }
 
-    fn charge_source_result(
+    fn cache_source_result(
         &mut self,
+        key: FetchKey,
         result: Result<Option<ExternalSource>, String>,
     ) -> Result<Option<ExternalSource>, String> {
-        let Some(source) = result? else { return Ok(None) };
-        let bytes = serde_json::to_vec(&source.input)
-            .map_err(|_| "failed to measure Standard JSON input".to_string())?
-            .len();
-        if self.retained_source_input.saturating_add(bytes) > MAX_RETAINED_SOURCE_INPUT {
+        let result = result.map_err(bound_cached_error);
+        let source_bytes = match &result {
+            Ok(Some(source)) => serde_json::to_vec(&source.input)
+                .map_err(|_| "failed to measure Standard JSON input".to_string())?
+                .len(),
+            Ok(None) | Err(_) => 0,
+        };
+        let retained = key.provider.metadata_len().saturating_add(match &result {
+            Ok(Some(source)) => {
+                source.provider.metadata_len().saturating_add(source.version.to_string().len())
+            }
+            Ok(None) => 0,
+            Err(err) => err.len(),
+        });
+        if self.retained_source_input.saturating_add(source_bytes) > MAX_RETAINED_SOURCE_INPUT {
             return Err("external cumulative source input limit exceeded".to_string());
         }
-        self.retained_source_input += bytes;
-        Ok(Some(source))
+        if self.retained_metadata.saturating_add(retained) > MAX_RETAINED_METADATA {
+            return Err("external cumulative metadata limit exceeded".to_string());
+        }
+        self.retained_source_input += source_bytes;
+        self.retained_metadata += retained;
+        self.fetch_cache.insert(key, result.clone());
+        result
     }
+
+    fn charge_metadata(&mut self, bytes: usize) -> Result<(), String> {
+        if self.retained_metadata.saturating_add(bytes) > MAX_RETAINED_METADATA {
+            return Err("external cumulative metadata limit exceeded".to_string());
+        }
+        self.retained_metadata += bytes;
+        Ok(())
+    }
+}
+
+fn bound_cached_error(error: String) -> String {
+    let mut chars = error.chars();
+    let error = chars.by_ref().take(MAX_CACHED_ERROR_CHARS).collect::<String>();
+    if chars.next().is_some() { format!("{error}…") } else { error }
 }
 
 async fn read_capped_body(
@@ -323,7 +388,7 @@ fn append_capped(output: &mut Vec<u8>, chunk: &[u8], limit: usize) -> bool {
     true
 }
 
-fn parse_etherscan_response(body: &[u8]) -> Result<(Value, String), String> {
+fn parse_etherscan_response(body: &[u8]) -> Result<(Value, Version), String> {
     let response: Value =
         serde_json::from_slice(body).map_err(|e| format!("invalid Etherscan response: {e}"))?;
     if response.get("status").and_then(Value::as_str) != Some("1") {
@@ -339,8 +404,9 @@ fn parse_etherscan_response(body: &[u8]) -> Result<(Value, String), String> {
     let compiler_version = item
         .get("CompilerVersion")
         .and_then(Value::as_str)
-        .ok_or_else(|| "Etherscan compiler version is missing".to_string())?
-        .to_string();
+        .ok_or_else(|| "Etherscan compiler version is missing".to_string())?;
+    let compiler_version =
+        parse_compiler_version(compiler_version).map_err(|err| err.to_string())?;
     let source =
         item.get("SourceCode").ok_or_else(|| "Etherscan source code is missing".to_string())?;
     let input = match source {
@@ -371,6 +437,9 @@ struct SourcifyCompilation {
 }
 
 fn parse_compiler_version(version: &str) -> Result<Version> {
+    if version.len() > MAX_COMPILER_VERSION {
+        bail!("compiler version exceeds {MAX_COMPILER_VERSION} bytes");
+    }
     Version::parse(version.trim_start_matches('v')).map_err(Into::into)
 }
 
@@ -564,6 +633,11 @@ async fn run_bounded_command(
     stderr_limit: usize,
     timeout: Duration,
 ) -> Result<(Vec<u8>, Vec<u8>, std::process::ExitStatus), String> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    // Reserve part of the caller's timeout for cancelling I/O, terminating, and reaping. This
+    // keeps the complete subprocess lifecycle within one absolute deadline.
+    let cleanup_window = std::cmp::min(timeout / 10, Duration::from_secs(1));
+    let execution_deadline = deadline - cleanup_window;
     command
         .stdin(if input.is_some() { Stdio::piped() } else { Stdio::null() })
         .stdout(Stdio::piped())
@@ -574,7 +648,7 @@ async fn run_bounded_command(
         child.stdout.take().ok_or_else(|| "failed to open subprocess stdout".to_string())?;
     let stderr =
         child.stderr.take().ok_or_else(|| "failed to open subprocess stderr".to_string())?;
-    let input_task = input.map(|input| {
+    let mut input_task = input.map(|input| {
         let mut stdin = child.stdin.take().expect("piped stdin");
         tokio::spawn(async move {
             stdin.write_all(&input).await?;
@@ -584,45 +658,70 @@ async fn run_bounded_command(
     let mut output_task = tokio::spawn(async move {
         tokio::try_join!(read_capped(stdout, stdout_limit), read_capped(stderr, stderr_limit))
     });
-    let mut completed_output = None;
-    let deadline = tokio::time::sleep(timeout);
-    tokio::pin!(deadline);
-    let status = tokio::select! {
-        result = child.wait() => result.map_err(|_| "failed to wait for subprocess".to_string())?,
-        output = &mut output_task => {
-            match output {
-                Ok(Err(err)) => {
-                    let _ = child.kill().await;
-                    let _ = child.wait().await;
-                    return Err(err)
-                }
-                Err(_) => {
-                    let _ = child.kill().await;
-                    let _ = child.wait().await;
-                    return Err("subprocess output task failed".to_string())
-                }
-                Ok(Ok(output)) => {
-                    completed_output = Some(output);
-                    child.wait().await.map_err(|_| "failed to wait for subprocess".to_string())?
+    let mut input_joined = false;
+    let mut output_joined = false;
+    let lifecycle = async {
+        let mut completed_output = None;
+        let status = tokio::select! {
+            result = child.wait() => {
+                result.map_err(|_| "failed to wait for subprocess".to_string())?
+            }
+            output = &mut output_task => {
+                output_joined = true;
+                match output {
+                    Ok(Ok(output)) => {
+                        completed_output = Some(output);
+                        child.wait().await.map_err(|_| "failed to wait for subprocess".to_string())?
+                    }
+                    Ok(Err(err)) => return Err(err),
+                    Err(_) => return Err("subprocess output task failed".to_string()),
                 }
             }
+        };
+        if let Some(task) = input_task.as_mut() {
+            let input = task.await;
+            input_joined = true;
+            input
+                .map_err(|_| "subprocess input task failed".to_string())?
+                .map_err(|_| "failed to write subprocess input".to_string())?;
         }
-        _ = &mut deadline => {
-            let _ = child.kill().await;
-            let _ = child.wait().await;
-            return Err("subprocess timed out".to_string())
-        }
+        let (stdout, stderr) = match completed_output {
+            Some(output) => output,
+            None => {
+                let output = (&mut output_task).await;
+                output_joined = true;
+                output.map_err(|_| "subprocess output task failed".to_string())??
+            }
+        };
+        Ok((stdout, stderr, status))
     };
-    if let Some(task) = input_task {
-        task.await
-            .map_err(|_| "subprocess input task failed".to_string())?
-            .map_err(|_| "failed to write subprocess input".to_string())?;
+    let result = match tokio::time::timeout_at(execution_deadline, lifecycle).await {
+        Ok(Ok(output)) => Ok(output),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err("subprocess timed out".to_string()),
+    };
+    if result.is_ok() {
+        return result;
     }
-    let (stdout, stderr) = match completed_output {
-        Some(output) => output,
-        None => output_task.await.map_err(|_| "subprocess output task failed".to_string())??,
+
+    if let Some(task) = &input_task {
+        task.abort();
+    }
+    output_task.abort();
+    let _ = child.start_kill();
+    let cleanup = async {
+        if !input_joined && let Some(task) = input_task {
+            let _ = task.await;
+        }
+        if !output_joined {
+            let _ = output_task.await;
+        }
+        let _ = child.wait().await;
     };
-    Ok((stdout, stderr, status))
+    // If the OS does not complete cleanup in its reserved window, dropping the child retains
+    // `kill_on_drop` as a final best-effort safeguard while preserving the caller's deadline.
+    let _ = tokio::time::timeout_at(deadline, cleanup).await;
+    result
 }
 
 async fn read_capped(mut reader: impl AsyncRead + Unpin, limit: usize) -> Result<Vec<u8>, String> {
@@ -752,34 +851,173 @@ mod tests {
         let source = ExternalSource {
             input: Arc::new(input()),
             version: Version::new(0, 8, 30),
-            provider: SourceProvider::Sourcify,
+            provider: SourceProvider::Sourcify { endpoint: SOURCIFY_URL.into() },
         };
-        let charged = resolver.charge_source_result(Ok(Some(source.clone()))).unwrap();
+        let key = FetchKey { chain: 1, provider: source.provider.clone(), address: Address::ZERO };
+        let charged = resolver.cache_source_result(key.clone(), Ok(Some(source))).unwrap();
         assert!(charged.is_some());
         let charged_bytes = resolver.retained_source_input;
         // A cache hit returns the retained value directly and never invokes accounting again.
-        let key = FetchKey { chain: 1, provider: SourceProvider::Sourcify, address: Address::ZERO };
-        resolver.fetch_cache.insert(key.clone(), Ok(Some(source)));
         assert!(resolver.fetch_cache.get(&key).unwrap().is_ok());
         assert_eq!(resolver.retained_source_input, charged_bytes);
 
         resolver.retained_source_input = MAX_RETAINED_SOURCE_INPUT;
-        assert!(resolver.charge_source_result(Ok(charged)).unwrap_err().contains("cumulative"));
+        let rejected_key = FetchKey { address: Address::with_last_byte(1), ..key };
+        assert!(
+            resolver
+                .cache_source_result(rejected_key.clone(), Ok(charged))
+                .unwrap_err()
+                .contains("cumulative")
+        );
+        assert!(!resolver.fetch_cache.contains_key(&rejected_key));
     }
 
     #[test]
     fn cumulative_candidate_metadata_budget_is_enforced() {
         let mut resolver = ExternalResolver::new().unwrap();
-        resolver.charge_candidates(vec![candidate("A.sol:A", JsonAbi::default())]).unwrap();
-        assert_eq!(resolver.retained_candidate_metadata, "A.sol:A".len());
+        let retained_candidate = candidate("A.sol:A", JsonAbi::default());
+        let expected = retained_candidate.fqn.len()
+            + retained_candidate.fingerprint.len()
+            + retained_candidate.version.to_string().len();
+        resolver.charge_candidates(vec![retained_candidate], 0).unwrap();
+        assert_eq!(resolver.retained_metadata, expected);
 
         let mut resolver = ExternalResolver::new().unwrap();
-        resolver.retained_candidate_metadata = MAX_CANDIDATE_METADATA;
-        let error =
-            resolver.charge_candidates(vec![candidate("A.sol:A", JsonAbi::default())]).unwrap_err();
+        resolver.retained_metadata = MAX_RETAINED_METADATA;
+        let error = resolver
+            .charge_candidates(vec![candidate("A.sol:A", JsonAbi::default())], 0)
+            .unwrap_err();
         assert!(error.contains("metadata"));
+        assert_eq!(resolver.retained_metadata, MAX_RETAINED_METADATA);
         assert_eq!(resolver.retained_candidates, 0);
         assert_eq!(resolver.retained_creation_bytecode, 0);
+
+        let mut resolver = ExternalResolver::new().unwrap();
+        resolver.retained_creation_bytecode = MAX_CREATION_BYTECODE;
+        let error = resolver
+            .charge_candidates(vec![candidate("A.sol:A", JsonAbi::default())], 0)
+            .unwrap_err();
+        assert!(error.contains("bytecode"));
+        assert_eq!(resolver.retained_metadata, 0);
+        assert_eq!(resolver.retained_candidates, 0);
+        assert_eq!(resolver.retained_creation_bytecode, MAX_CREATION_BYTECODE);
+    }
+
+    #[test]
+    fn candidate_constructor_metadata_is_charged() {
+        let abi: JsonAbi = serde_json::from_value(json!([{
+            "type": "constructor", "inputs": [{"name":"n", "type":"uint256"}]
+        }]))
+        .unwrap();
+        let candidate = candidate("A.sol:A", abi);
+        let constructor_bytes =
+            serde_json::to_vec(candidate.constructor.as_ref().unwrap()).unwrap();
+        let mut resolver = ExternalResolver::new().unwrap();
+        resolver.charge_candidates(vec![candidate], 0).unwrap();
+        assert!(resolver.retained_metadata >= constructor_bytes.len());
+    }
+
+    #[tokio::test]
+    async fn sourcify_source_discovery_uses_selected_endpoint_on_dev_chain() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}/private", listener.local_addr().unwrap());
+        let response = json!({
+            "stdJsonInput": input(),
+            "compilation": { "compilerVersion": "0.8.30+commit.73712a01" }
+        })
+        .to_string();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0; 4096];
+            let bytes_read = socket.read(&mut request).await.unwrap();
+            let request = std::str::from_utf8(&request[..bytes_read]).unwrap();
+            assert!(request.starts_with("GET /private/v2/contract/31337/"), "{request}");
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response}",
+                        response.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let source = ExternalResolver::new()
+            .unwrap()
+            .resolve_sourcify(Chain::from(31337), Address::ZERO, Some(&endpoint))
+            .await
+            .unwrap()
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(source.provider, SourceProvider::Sourcify { endpoint: endpoint.clone() });
+        assert_ne!(source.provider, SourceProvider::Sourcify { endpoint: SOURCIFY_URL.into() });
+    }
+
+    #[tokio::test]
+    async fn sourcify_cache_identity_includes_selected_endpoint() {
+        let mut resolver = ExternalResolver::new().unwrap();
+        for _ in 0..2 {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let endpoint = format!("http://{}/private", listener.local_addr().unwrap());
+            let server = tokio::spawn(async move {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = [0; 4096];
+                assert!(socket.read(&mut request).await.unwrap() > 0);
+                socket
+                    .write_all(
+                        b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    )
+                    .await
+                    .unwrap();
+            });
+            assert!(
+                resolver
+                    .resolve_sourcify(Chain::from(31337), Address::ZERO, Some(&endpoint))
+                    .await
+                    .unwrap()
+                    .is_none()
+            );
+            server.await.unwrap();
+        }
+        assert_eq!(resolver.fetch_cache.len(), 2);
+    }
+
+    #[test]
+    fn remote_versions_and_cached_errors_are_bounded_and_accounted() {
+        let long_version = format!("0.8.30+{}", "a".repeat(MAX_COMPILER_VERSION));
+        assert!(Version::parse(&long_version).is_ok());
+        assert!(parse_compiler_version(&long_version).is_err());
+
+        let mut resolver = ExternalResolver::new().unwrap();
+        let endpoint = "https://explorer.invalid/api";
+        let key = FetchKey {
+            chain: 1,
+            provider: SourceProvider::Etherscan { endpoint: endpoint.into() },
+            address: Address::ZERO,
+        };
+        let error = resolver
+            .cache_source_result(key, Err("x".repeat(MAX_CACHED_ERROR_CHARS * 2)))
+            .unwrap_err();
+        assert_eq!(error.chars().count(), MAX_CACHED_ERROR_CHARS + 1);
+        assert_eq!(resolver.retained_metadata, endpoint.len() + error.len());
+
+        let mut resolver = ExternalResolver::new().unwrap();
+        resolver.retained_metadata = MAX_RETAINED_METADATA;
+        let key = FetchKey {
+            chain: 1,
+            provider: SourceProvider::Sourcify { endpoint: SOURCIFY_URL.into() },
+            address: Address::ZERO,
+        };
+        let source = ExternalSource {
+            input: Arc::new(input()),
+            version: Version::new(0, 8, 30),
+            provider: key.provider.clone(),
+        };
+        assert!(resolver.cache_source_result(key, Ok(Some(source))).is_err());
+        assert_eq!(resolver.retained_source_input, 0);
+        assert_eq!(resolver.retained_metadata, MAX_RETAINED_METADATA);
     }
 
     #[tokio::test]
@@ -838,7 +1076,7 @@ mod tests {
             let (parsed, version) =
                 parse_etherscan_response(&serde_json::to_vec(&response).unwrap()).unwrap();
             assert_eq!(parsed, expected);
-            assert_eq!(version, "v0.8.30+commit.73712a01");
+            assert_eq!(version, Version::parse("0.8.30+commit.73712a01").unwrap());
         }
 
         let flat = json!({
@@ -861,7 +1099,7 @@ mod tests {
         let source_a = ExternalSource {
             input: Arc::new(first),
             version: Version::new(1, 2, 3),
-            provider: SourceProvider::Sourcify,
+            provider: SourceProvider::Sourcify { endpoint: SOURCIFY_URL.into() },
         };
         let source_b = ExternalSource {
             provider: SourceProvider::Etherscan { endpoint: "other".into() },
@@ -901,8 +1139,18 @@ mod tests {
     async fn bounded_process_times_out_and_caps_output() {
         let mut sleep = Command::new("sh");
         sleep.args(["-c", "sleep 2"]);
+        let started = tokio::time::Instant::now();
+        let error =
+            run_bounded_command(sleep, None, 16, 16, Duration::from_millis(20)).await.unwrap_err();
+        assert!(error.contains("timed out"));
+        assert!(started.elapsed() < Duration::from_millis(500));
+
+        // Output closes before the process exits, so the output-task branch wins first. Waiting
+        // for the process must remain subject to the original deadline.
+        let mut closed_output = Command::new("sh");
+        closed_output.args(["-c", "exec 1>&- 2>&-; sleep 2"]);
         assert!(
-            run_bounded_command(sleep, None, 16, 16, Duration::from_millis(20))
+            run_bounded_command(closed_output, None, 16, 16, Duration::from_millis(20))
                 .await
                 .unwrap_err()
                 .contains("timed out")
@@ -915,6 +1163,34 @@ mod tests {
                 .await
                 .unwrap_err()
                 .contains("output limit")
+        );
+
+        // The shell exits immediately, but its child retains the output pipe. The same absolute
+        // deadline must still cover draining output after `child.wait()` completes.
+        let mut inherited_output = Command::new("sh");
+        inherited_output.args(["-c", "sleep 2 &"]);
+        assert!(
+            run_bounded_command(inherited_output, None, 16, 16, Duration::from_millis(20))
+                .await
+                .unwrap_err()
+                .contains("timed out")
+        );
+
+        // The direct child exits while a descendant retains stdin without reading it. Awaiting a
+        // blocked writer must also remain subject to the same deadline.
+        let mut inherited_input = Command::new("sh");
+        inherited_input.args(["-c", "exec 3<&0; sleep 2 >/dev/null 2>&1 &"]);
+        assert!(
+            run_bounded_command(
+                inherited_input,
+                Some(vec![0; 1024 * 1024]),
+                16,
+                16,
+                Duration::from_millis(20)
+            )
+            .await
+            .unwrap_err()
+            .contains("timed out")
         );
     }
 

--- a/crates/script/src/verify/external.rs
+++ b/crates/script/src/verify/external.rs
@@ -82,9 +82,9 @@ pub(super) struct Candidate {
 #[derive(Clone, Debug)]
 pub(super) struct ExternalMatch {
     pub input: Arc<Value>,
-    pub fingerprint: String,
     pub version: Version,
     pub fqn: String,
+    pub creation_bytecode: Bytes,
     pub constructor_args: Bytes,
 }
 
@@ -102,7 +102,7 @@ struct FetchKey {
     address: Address,
 }
 
-type CompiledCandidates = Result<Arc<[Candidate]>, String>;
+type CompiledCandidates = Result<(Arc<[Candidate]>, bool), String>;
 
 /// Per-script-run state. Both caches deliberately retain failures, preventing repeated network or
 /// compiler work for the same provenance.
@@ -242,7 +242,7 @@ impl ExternalResolver {
     pub(super) async fn compile(
         &mut self,
         source: &ExternalSource,
-    ) -> Result<Arc<[Candidate]>, String> {
+    ) -> Result<(Arc<[Candidate]>, bool), String> {
         let fingerprint = fingerprint(&source.input).map_err(|e| e.to_string())?;
         let key = (source.version.clone(), fingerprint);
         if let Some(cached) = self.compile_cache.get(&key) {
@@ -263,7 +263,9 @@ impl ExternalResolver {
             .saturating_add(if new_version { version_len } else { 0 });
         self.compilations += 1;
         let result = match compile_source(source).await {
-            Ok(candidates) => self.charge_candidates(candidates, cache_metadata),
+            Ok((candidates, has_unresolved_links)) => self
+                .charge_candidates(candidates, cache_metadata)
+                .map(|candidates| (candidates, has_unresolved_links)),
             Err(err) => Err(err),
         };
         let result = match result {
@@ -524,7 +526,7 @@ fn compiler_identity(version: &Version) -> String {
     format!("{}.{}.{}-{}+{build}", version.major, version.minor, version.patch, version.pre)
 }
 
-async fn compile_source(source: &ExternalSource) -> Result<Vec<Candidate>, String> {
+async fn compile_source(source: &ExternalSource) -> Result<(Vec<Candidate>, bool), String> {
     let input = compilation_input(&source.input).map_err(|e| e.to_string())?;
     let svm_version =
         Version::new(source.version.major, source.version.minor, source.version.patch);
@@ -574,14 +576,23 @@ async fn compile_source(source: &ExternalSource) -> Result<Vec<Candidate>, Strin
     if output.has_error() {
         return Err("solc compilation failed".to_string());
     }
+    candidates_from_output(source, output)
+}
+
+fn candidates_from_output(
+    source: &ExternalSource,
+    output: CompilerOutput,
+) -> Result<(Vec<Candidate>, bool), String> {
     let fingerprint = fingerprint(&source.input).map_err(|e| e.to_string())?;
     let mut candidates = Vec::new();
     let mut creation_bytecode_bytes = 0usize;
+    let mut has_unresolved_links = false;
     for (path, contracts) in output.contracts {
         for (name, contract) in contracts {
             let Some(abi) = contract.abi else { continue };
             let Some(bytecode) = contract.evm.and_then(|evm| evm.bytecode) else { continue };
             if !bytecode.link_references.is_empty() || bytecode.object.is_unlinked() {
+                has_unresolved_links = true;
                 continue;
             }
             let Some(bytes) = bytecode.object.into_bytes() else { continue };
@@ -608,7 +619,7 @@ async fn compile_source(source: &ExternalSource) -> Result<Vec<Candidate>, Strin
             });
         }
     }
-    Ok(candidates)
+    Ok((candidates, has_unresolved_links))
 }
 
 fn parse_solc_version_output(output: &[u8]) -> Result<Version, String> {
@@ -772,16 +783,17 @@ pub(super) fn match_candidates<'a>(
         };
         if valid
             && !matches.iter().any(|item: &ExternalMatch| {
-                item.fingerprint == candidate.fingerprint
-                    && item.fqn == candidate.fqn
+                item.fqn == candidate.fqn
                     && compiler_identity(&item.version) == compiler_identity(&candidate.version)
+                    && item.creation_bytecode == candidate.creation_bytecode
+                    && item.constructor_args.as_ref() == suffix
             })
         {
             matches.push(ExternalMatch {
                 input: candidate.input.clone(),
-                fingerprint: candidate.fingerprint.clone(),
                 version: candidate.version.clone(),
                 fqn: candidate.fqn.clone(),
+                creation_bytecode: candidate.creation_bytecode.clone(),
                 constructor_args: Bytes::copy_from_slice(suffix),
             });
         }
@@ -1231,25 +1243,85 @@ mod tests {
     }
 
     #[test]
-    fn ambiguity_collapses_identical_fingerprint_and_fqn() {
+    fn ambiguity_collapses_equivalent_deployments_from_different_inputs() {
         let a = candidate("A.sol:A", JsonAbi::default());
+        let first_input = a.input.clone();
         let mut duplicate = a.clone();
+        duplicate.fingerprint = "different-provider-input".into();
+        duplicate.input = Arc::new(json!({ "providerSpecific": true }));
         duplicate.version = Version::parse("0.8.30+commit.73712a01.Linux.gcc").unwrap();
-        assert!(matches!(
-            match_candidates(&[0x60, 0x00], &[a.clone(), duplicate]),
-            MatchResult::Unique(_)
-        ));
+        let MatchResult::Unique(matched) = match_candidates(&[0x60, 0x00], &[a.clone(), duplicate])
+        else {
+            panic!("equivalent deployments should be deduplicated")
+        };
+        assert!(Arc::ptr_eq(&matched.input, &first_input));
         let mut other_commit = a.clone();
         other_commit.version = Version::parse("0.8.30+commit.deadbeef").unwrap();
         assert!(matches!(
             match_candidates(&[0x60, 0x00], &[a.clone(), other_commit]),
             MatchResult::Ambiguous(_)
         ));
+
+        let constructor: JsonAbi = serde_json::from_value(json!([{
+            "type": "constructor", "inputs": [{"name":"n", "type":"uint256"}]
+        }]))
+        .unwrap();
+        let prefixed = candidate("A.sol:A", constructor);
+        let mut observed = prefixed.creation_bytecode.to_vec();
+        observed.extend([0; 32]);
+        let exact = Candidate {
+            constructor: None,
+            creation_bytecode: Bytes::copy_from_slice(&observed),
+            ..prefixed.clone()
+        };
+        assert!(matches!(
+            match_candidates(&observed, &[prefixed, exact]),
+            MatchResult::Ambiguous(_)
+        ));
+
         let b = candidate("B.sol:B", JsonAbi::default());
         let MatchResult::Ambiguous(matches) = match_candidates(&[0x60, 0x00], &[a, b]) else {
             panic!("expected ambiguity")
         };
         assert_eq!(matches.len(), 2);
+    }
+
+    #[test]
+    fn unresolved_library_links_are_flagged_without_dropping_other_candidates() {
+        let placeholder = format!("__${}$__", "0".repeat(34));
+        let output = serde_json::from_value(json!({
+            "contracts": {
+                "A.sol": {
+                    "Linked": {
+                        "abi": [],
+                        "evm": { "bytecode": {
+                            "object": "6000",
+                            "linkReferences": {
+                                "Lib.sol": { "Lib": [{ "start": 0, "length": 20 }] }
+                            }
+                        }}
+                    },
+                    "Placeholder": {
+                        "abi": [],
+                        "evm": { "bytecode": { "object": placeholder } }
+                    },
+                    "Plain": {
+                        "abi": [],
+                        "evm": { "bytecode": { "object": "6001" } }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+        let source = ExternalSource {
+            input: Arc::new(input()),
+            version: Version::new(0, 8, 30),
+            provider: SourceProvider::Sourcify { endpoint: SOURCIFY_URL.into() },
+        };
+        let (candidates, has_unresolved_links) = candidates_from_output(&source, output).unwrap();
+        assert!(has_unresolved_links);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].fqn, "A.sol:Plain");
     }
 
     #[test]

--- a/crates/script/src/verify/external.rs
+++ b/crates/script/src/verify/external.rs
@@ -1,0 +1,958 @@
+//! Acquisition, compilation, and matching of external Solidity sources.
+
+use alloy_dyn_abi::JsonAbiExt;
+use alloy_json_abi::Constructor;
+use alloy_primitives::{Address, Bytes, keccak256};
+use eyre::{Result, bail, eyre};
+use foundry_compilers::{artifacts::CompilerOutput, solc::Solc};
+use foundry_config::{Chain, Config, NamedChain};
+use futures::StreamExt;
+use semver::Version;
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+use std::{
+    collections::{HashMap, HashSet},
+    process::Stdio,
+    sync::Arc,
+    time::Duration,
+};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
+    process::Command,
+};
+
+const MAX_INPUT_SIZE: usize = 10 * 1024 * 1024;
+const MAX_SOURCES: usize = 256;
+const MAX_FETCHES: usize = 64;
+const MAX_COMPILER_VERSIONS: usize = 8;
+const MAX_COMPILATIONS: usize = 32;
+const MAX_CANDIDATES: usize = 512;
+const MAX_CREATION_BYTECODE: usize = 64 * 1024 * 1024;
+const MAX_CANDIDATE_METADATA: usize = 8 * 1024 * 1024;
+const MAX_RETAINED_SOURCE_INPUT: usize = 64 * 1024 * 1024;
+const MAX_SOURCE_PATH: usize = 4096;
+const MAX_STDOUT: usize = 32 * 1024 * 1024;
+const MAX_STDERR: usize = 1024 * 1024;
+const COMPILE_TIMEOUT: Duration = Duration::from_secs(60);
+pub(super) const MAX_PROVENANCE_ADDRESSES: usize = 16;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) enum SourceProvider {
+    Etherscan { endpoint: String },
+    Sourcify,
+}
+
+impl std::fmt::Display for SourceProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Etherscan { .. } => f.write_str("Etherscan"),
+            Self::Sourcify => f.write_str("Sourcify"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ExternalSource {
+    pub input: Arc<Value>,
+    pub version: Version,
+    pub provider: SourceProvider,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Candidate {
+    pub input: Arc<Value>,
+    pub fingerprint: String,
+    pub version: Version,
+    pub fqn: String,
+    pub constructor: Option<Constructor>,
+    pub creation_bytecode: Bytes,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ExternalMatch {
+    pub input: Arc<Value>,
+    pub fingerprint: String,
+    pub version: Version,
+    pub fqn: String,
+    pub constructor_args: Bytes,
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum MatchResult {
+    None,
+    Unique(ExternalMatch),
+    Ambiguous(Vec<ExternalMatch>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct FetchKey {
+    chain: u64,
+    provider: SourceProvider,
+    address: Address,
+}
+
+/// Per-script-run state. Both caches deliberately retain failures, preventing repeated network or
+/// compiler work for the same provenance.
+pub(super) struct ExternalResolver {
+    http: reqwest::Client,
+    fetch_cache: HashMap<FetchKey, Result<Option<ExternalSource>, String>>,
+    compile_cache: HashMap<(Version, String), Result<Arc<[Candidate]>, String>>,
+    compiler_versions: HashSet<Version>,
+    compilations: usize,
+    retained_source_input: usize,
+    retained_candidates: usize,
+    retained_candidate_metadata: usize,
+    retained_creation_bytecode: usize,
+}
+
+impl ExternalResolver {
+    pub(super) fn new() -> Result<Self> {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .connect_timeout(Duration::from_secs(15))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+        Ok(Self {
+            http,
+            fetch_cache: HashMap::new(),
+            compile_cache: HashMap::new(),
+            compiler_versions: HashSet::new(),
+            compilations: 0,
+            retained_source_input: 0,
+            retained_candidates: 0,
+            retained_candidate_metadata: 0,
+            retained_creation_bytecode: 0,
+        })
+    }
+
+    pub(super) async fn resolve_etherscan(
+        &mut self,
+        config: &Config,
+        chain: Chain,
+        address: Address,
+        api_key: Option<String>,
+    ) -> Result<Option<ExternalSource>, String> {
+        let resolved = config
+            .get_etherscan_config_with_chain(Some(chain))
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "Etherscan is not configured".to_string())?;
+        let provider = SourceProvider::Etherscan { endpoint: resolved.api_url.clone() };
+        let key = FetchKey { chain: chain.id(), provider: provider.clone(), address };
+        if let Some(cached) = self.fetch_cache.get(&key) {
+            return cached.clone();
+        }
+        if self.fetch_cache.len() >= MAX_FETCHES {
+            return Err("external source fetch limit exceeded".to_string());
+        }
+        let result = async {
+            let address = address.to_string();
+            let response = self
+                .http
+                .get(&resolved.api_url)
+                .query(&[
+                    ("module", "contract"),
+                    ("action", "getsourcecode"),
+                    ("address", address.as_str()),
+                    ("apikey", api_key.as_deref().unwrap_or_default()),
+                ])
+                .send()
+                .await
+                .map_err(|_| "Etherscan request failed".to_string())?;
+            if !response.status().is_success() {
+                return Err(format!("Etherscan returned HTTP {}", response.status()));
+            }
+            if response.content_length().is_some_and(|length| length > MAX_INPUT_SIZE as u64) {
+                return Err("Etherscan response exceeds 10 MiB".to_string());
+            }
+            let body = read_capped_body(response, MAX_INPUT_SIZE, "Etherscan").await?;
+            let (input, compiler_version) = parse_etherscan_response(&body)?;
+            let version = parse_compiler_version(&compiler_version).map_err(|e| e.to_string())?;
+            Ok(Some(ExternalSource { input: Arc::new(input), version, provider }))
+        }
+        .await;
+        let result = self.charge_source_result(result);
+        self.fetch_cache.insert(key, result.clone());
+        result
+    }
+
+    pub(super) async fn resolve_sourcify(
+        &mut self,
+        chain: Chain,
+        address: Address,
+    ) -> Result<Option<ExternalSource>, String> {
+        // Canonical Sourcify cannot observe ephemeral local chains. Avoid a guaranteed external
+        // request so local external-verification workflows remain hermetic.
+        if matches!(
+            chain.named(),
+            Some(NamedChain::Dev | NamedChain::AnvilHardhat | NamedChain::Cannon)
+        ) {
+            return Ok(None);
+        }
+        let provider = SourceProvider::Sourcify;
+        let key = FetchKey { chain: chain.id(), provider: provider.clone(), address };
+        if let Some(cached) = self.fetch_cache.get(&key) {
+            return cached.clone();
+        }
+        if self.fetch_cache.len() >= MAX_FETCHES {
+            return Err("external source fetch limit exceeded".to_string());
+        }
+        let result = async {
+            let url = format!(
+                "https://sourcify.dev/server/v2/contract/{}/{address}?fields=stdJsonInput,compilation.compilerVersion",
+                chain.id()
+            );
+            let response = self.http.get(url).send().await.map_err(|_| "Sourcify request failed".to_string())?;
+            if response.status() == reqwest::StatusCode::NOT_FOUND {
+                return Ok(None)
+            }
+            if !response.status().is_success() {
+                return Err(format!("Sourcify returned HTTP {}", response.status()))
+            }
+            if response.content_length().is_some_and(|length| length > MAX_INPUT_SIZE as u64) {
+                return Err("Sourcify response exceeds 10 MiB".to_string())
+            }
+            let body = read_capped_body(response, MAX_INPUT_SIZE, "Sourcify").await?;
+            let response: SourcifyResponse =
+                serde_json::from_slice(&body).map_err(|e| format!("invalid Sourcify response: {e}"))?;
+            validate_input(&response.std_json_input).map_err(|e| e.to_string())?;
+            let version = parse_compiler_version(&response.compilation.compiler_version)
+                .map_err(|e| e.to_string())?;
+            Ok(Some(ExternalSource {
+                input: Arc::new(response.std_json_input),
+                version,
+                provider,
+            }))
+        }
+        .await;
+        let result = self.charge_source_result(result);
+        self.fetch_cache.insert(key, result.clone());
+        result
+    }
+
+    pub(super) async fn compile(
+        &mut self,
+        source: &ExternalSource,
+    ) -> Result<Arc<[Candidate]>, String> {
+        let fingerprint = fingerprint(&source.input).map_err(|e| e.to_string())?;
+        let key = (source.version.clone(), fingerprint);
+        if let Some(cached) = self.compile_cache.get(&key) {
+            return cached.clone();
+        }
+        if self.compilations >= MAX_COMPILATIONS {
+            return Err("external compilation limit exceeded".to_string());
+        }
+        if !self.compiler_versions.contains(&source.version)
+            && self.compiler_versions.len() >= MAX_COMPILER_VERSIONS
+        {
+            return Err("external compiler version limit exceeded".to_string());
+        }
+        self.compilations += 1;
+        self.compiler_versions.insert(source.version.clone());
+        let result =
+            compile_source(source).await.and_then(|candidates| self.charge_candidates(candidates));
+        self.compile_cache.insert(key, result.clone());
+        result
+    }
+
+    fn charge_candidates(
+        &mut self,
+        candidates: Vec<Candidate>,
+    ) -> Result<Arc<[Candidate]>, String> {
+        let bytes = candidates.iter().fold(0usize, |total, candidate| {
+            total.saturating_add(candidate.creation_bytecode.len())
+        });
+        let metadata = candidates.iter().fold(0usize, |total, candidate| {
+            let constructor = candidate
+                .constructor
+                .as_ref()
+                .and_then(|constructor| serde_json::to_vec(constructor).ok())
+                .map_or(0, |constructor| constructor.len());
+            total.saturating_add(candidate.fqn.len()).saturating_add(constructor)
+        });
+        if self.retained_candidates.saturating_add(candidates.len()) > MAX_CANDIDATES {
+            return Err("external cumulative candidate limit exceeded".to_string());
+        }
+        if self.retained_candidate_metadata.saturating_add(metadata) > MAX_CANDIDATE_METADATA {
+            return Err("external cumulative candidate metadata limit exceeded".to_string());
+        }
+        if self.retained_creation_bytecode.saturating_add(bytes) > MAX_CREATION_BYTECODE {
+            return Err("external cumulative creation bytecode limit exceeded".to_string());
+        }
+        self.retained_candidates += candidates.len();
+        self.retained_candidate_metadata += metadata;
+        self.retained_creation_bytecode += bytes;
+        Ok(Arc::from(candidates))
+    }
+
+    fn charge_source_result(
+        &mut self,
+        result: Result<Option<ExternalSource>, String>,
+    ) -> Result<Option<ExternalSource>, String> {
+        let Some(source) = result? else { return Ok(None) };
+        let bytes = serde_json::to_vec(&source.input)
+            .map_err(|_| "failed to measure Standard JSON input".to_string())?
+            .len();
+        if self.retained_source_input.saturating_add(bytes) > MAX_RETAINED_SOURCE_INPUT {
+            return Err("external cumulative source input limit exceeded".to_string());
+        }
+        self.retained_source_input += bytes;
+        Ok(Some(source))
+    }
+}
+
+async fn read_capped_body(
+    response: reqwest::Response,
+    limit: usize,
+    provider: &str,
+) -> Result<Vec<u8>, String> {
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|_| format!("invalid {provider} response"))?;
+        if !append_capped(&mut body, &chunk, limit) {
+            return Err(format!("{provider} response exceeds 10 MiB"));
+        }
+    }
+    Ok(body)
+}
+
+fn append_capped(output: &mut Vec<u8>, chunk: &[u8], limit: usize) -> bool {
+    if output.len().saturating_add(chunk.len()) > limit {
+        return false;
+    }
+    output.extend_from_slice(chunk);
+    true
+}
+
+fn parse_etherscan_response(body: &[u8]) -> Result<(Value, String), String> {
+    let response: Value =
+        serde_json::from_slice(body).map_err(|e| format!("invalid Etherscan response: {e}"))?;
+    if response.get("status").and_then(Value::as_str) != Some("1") {
+        let message = response.get("result").and_then(Value::as_str).unwrap_or("request failed");
+        return Err(format!("Etherscan request failed: {message}"));
+    }
+    let item = response
+        .get("result")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first())
+        .and_then(Value::as_object)
+        .ok_or_else(|| "empty Etherscan response".to_string())?;
+    let compiler_version = item
+        .get("CompilerVersion")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "Etherscan compiler version is missing".to_string())?
+        .to_string();
+    let source =
+        item.get("SourceCode").ok_or_else(|| "Etherscan source code is missing".to_string())?;
+    let input = match source {
+        Value::Object(_) => source.clone(),
+        Value::String(source) => {
+            let wrapped = source.starts_with("{{") && source.ends_with("}}");
+            let source = if wrapped { &source[1..source.len() - 1] } else { source };
+            serde_json::from_str(source)
+                .map_err(|_| "Etherscan did not return Standard JSON sources".to_string())?
+        }
+        _ => return Err("Etherscan did not return Standard JSON sources".to_string()),
+    };
+    validate_input(&input).map_err(|e| e.to_string())?;
+    Ok((input, compiler_version))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SourcifyResponse {
+    std_json_input: Value,
+    compilation: SourcifyCompilation,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SourcifyCompilation {
+    compiler_version: String,
+}
+
+fn parse_compiler_version(version: &str) -> Result<Version> {
+    Version::parse(version.trim_start_matches('v')).map_err(Into::into)
+}
+
+fn validate_input(input: &Value) -> Result<()> {
+    if serde_json::to_vec(input)?.len() > MAX_INPUT_SIZE {
+        bail!("Standard JSON input exceeds 10 MiB");
+    }
+    let object = input.as_object().ok_or_else(|| eyre!("Standard JSON input is not an object"))?;
+    if object.get("language").and_then(Value::as_str) != Some("Solidity") {
+        bail!("source language is not Solidity");
+    }
+    let sources = object
+        .get("sources")
+        .and_then(Value::as_object)
+        .ok_or_else(|| eyre!("Standard JSON sources are missing"))?;
+    if sources.is_empty() || sources.len() > MAX_SOURCES {
+        bail!("Standard JSON must contain 1 to 256 sources");
+    }
+    for (path, source) in sources {
+        validate_identifier(path, "source path")?;
+        let source = source.as_object().ok_or_else(|| eyre!("invalid source entry"))?;
+        if source.get("content").and_then(Value::as_str).is_none_or(str::is_empty) {
+            bail!("every source must contain nonempty literal content");
+        }
+    }
+    if !object.get("settings").is_some_and(Value::is_object) {
+        bail!("Standard JSON settings must be an object");
+    }
+    Ok(())
+}
+
+fn validate_identifier(value: &str, label: &str) -> Result<()> {
+    if value.is_empty() || value.len() > MAX_SOURCE_PATH {
+        bail!("{label} must contain 1 to 4096 bytes");
+    }
+    if !value.is_ascii() || value.bytes().any(|byte| byte.is_ascii_control()) {
+        bail!("{label} must contain printable ASCII characters");
+    }
+    Ok(())
+}
+
+fn compilation_input(input: &Value) -> Result<Value> {
+    validate_input(input)?;
+    let mut input = input.clone();
+    input["settings"]["outputSelection"] = json!({
+        "*": { "*": ["abi", "evm.bytecode.object", "evm.bytecode.linkReferences"] }
+    });
+    Ok(input)
+}
+
+fn canonicalize(value: &Value) -> Value {
+    match value {
+        Value::Object(object) => {
+            let mut keys = object.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            Value::Object(
+                keys.into_iter()
+                    .map(|key| (key.clone(), canonicalize(&object[key])))
+                    .collect::<Map<_, _>>(),
+            )
+        }
+        Value::Array(values) => Value::Array(values.iter().map(canonicalize).collect()),
+        value => value.clone(),
+    }
+}
+
+fn fingerprint(input: &Value) -> Result<String> {
+    validate_input(input)?;
+    Ok(keccak256(serde_json::to_vec(&canonicalize(input))?).to_string())
+}
+
+fn compiler_matches(requested: &Version, actual: &Version) -> bool {
+    requested.major == actual.major
+        && requested.minor == actual.minor
+        && requested.patch == actual.patch
+        && requested.pre == actual.pre
+        && requested.build.as_str().split('.').take(2).eq(actual.build.as_str().split('.').take(2))
+}
+
+fn compiler_identity(version: &Version) -> String {
+    let build = version.build.as_str().split('.').take(2).collect::<Vec<_>>().join(".");
+    format!("{}.{}.{}-{}+{build}", version.major, version.minor, version.patch, version.pre)
+}
+
+async fn compile_source(source: &ExternalSource) -> Result<Vec<Candidate>, String> {
+    let input = compilation_input(&source.input).map_err(|e| e.to_string())?;
+    let svm_version =
+        Version::new(source.version.major, source.version.minor, source.version.patch);
+    let solc = match Solc::find_svm_installed_version(&svm_version).map_err(|e| e.to_string())? {
+        Some(solc) => solc,
+        None => tokio::time::timeout(Duration::from_secs(60), Solc::install(&svm_version))
+            .await
+            .map_err(|_| "solc installation timed out".to_string())?
+            .map_err(|e| e.to_string())?,
+    };
+    let mut version_command = Command::new(&solc.solc);
+    version_command.arg("--version");
+    let version_output =
+        run_bounded_command(version_command, None, 64 * 1024, 64 * 1024, Duration::from_secs(10))
+            .await?;
+    let actual = parse_solc_version_output(&version_output.0)?;
+    if !compiler_matches(&source.version, &actual) {
+        return Err(format!("installed solc {actual} does not match requested {}", source.version));
+    }
+    let workdir =
+        tempfile::tempdir().map_err(|_| "failed to create compiler sandbox".to_string())?;
+    let raw_input =
+        serde_json::to_vec(&input).map_err(|_| "failed to encode compiler input".to_string())?;
+    let mut command = Command::new(&solc.solc);
+    command
+        .arg("--standard-json")
+        .arg("--base-path")
+        .arg(workdir.path())
+        .current_dir(workdir.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    // Older solc versions do not expose an import-callback switch. Literal source validation and
+    // an empty base/current directory prevent their filesystem importer from resolving a file.
+    if source.version >= Version::new(0, 8, 22) {
+        command.arg("--no-import-callback");
+    }
+    let (stdout, stderr, status) =
+        run_bounded_command(command, Some(raw_input), MAX_STDOUT, MAX_STDERR, COMPILE_TIMEOUT)
+            .await?;
+    if !status.success() {
+        return Err(format!("solc compilation failed: {}", sanitize_remote(&stderr)));
+    }
+    let output: CompilerOutput =
+        serde_json::from_slice(&stdout).map_err(|_| "solc returned invalid JSON".to_string())?;
+    if output.has_error() {
+        return Err("solc compilation failed".to_string());
+    }
+    let fingerprint = fingerprint(&source.input).map_err(|e| e.to_string())?;
+    let mut candidates = Vec::new();
+    let mut creation_bytecode_bytes = 0usize;
+    for (path, contracts) in output.contracts {
+        for (name, contract) in contracts {
+            let Some(abi) = contract.abi else { continue };
+            let Some(bytecode) = contract.evm.and_then(|evm| evm.bytecode) else { continue };
+            if !bytecode.link_references.is_empty() || bytecode.object.is_unlinked() {
+                continue;
+            }
+            let Some(bytes) = bytecode.object.into_bytes() else { continue };
+            if bytes.is_empty() {
+                continue;
+            }
+            validate_identifier(&path.to_string_lossy(), "compiler source path")
+                .map_err(|e| e.to_string())?;
+            validate_identifier(&name, "contract name").map_err(|e| e.to_string())?;
+            if candidates.len() >= MAX_CANDIDATES {
+                return Err("external candidate limit exceeded".to_string());
+            }
+            if creation_bytecode_bytes.saturating_add(bytes.len()) > MAX_CREATION_BYTECODE {
+                return Err("external creation bytecode limit exceeded".to_string());
+            }
+            creation_bytecode_bytes += bytes.len();
+            candidates.push(Candidate {
+                input: source.input.clone(),
+                fingerprint: fingerprint.clone(),
+                version: source.version.clone(),
+                fqn: format!("{}:{name}", path.display()),
+                constructor: abi.constructor().cloned(),
+                creation_bytecode: bytes,
+            });
+        }
+    }
+    Ok(candidates)
+}
+
+fn parse_solc_version_output(output: &[u8]) -> Result<Version, String> {
+    let output =
+        std::str::from_utf8(output).map_err(|_| "invalid solc version output".to_string())?;
+    output
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("Version: "))
+        .ok_or_else(|| "solc version output is missing Version line".to_string())
+        .and_then(|version| Version::parse(version).map_err(|_| "invalid solc version".to_string()))
+}
+
+async fn run_bounded_command(
+    mut command: Command,
+    input: Option<Vec<u8>>,
+    stdout_limit: usize,
+    stderr_limit: usize,
+    timeout: Duration,
+) -> Result<(Vec<u8>, Vec<u8>, std::process::ExitStatus), String> {
+    command
+        .stdin(if input.is_some() { Stdio::piped() } else { Stdio::null() })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = command.spawn().map_err(|_| "failed to start subprocess".to_string())?;
+    let stdout =
+        child.stdout.take().ok_or_else(|| "failed to open subprocess stdout".to_string())?;
+    let stderr =
+        child.stderr.take().ok_or_else(|| "failed to open subprocess stderr".to_string())?;
+    let input_task = input.map(|input| {
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        tokio::spawn(async move {
+            stdin.write_all(&input).await?;
+            stdin.shutdown().await
+        })
+    });
+    let mut output_task = tokio::spawn(async move {
+        tokio::try_join!(read_capped(stdout, stdout_limit), read_capped(stderr, stderr_limit))
+    });
+    let mut completed_output = None;
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+    let status = tokio::select! {
+        result = child.wait() => result.map_err(|_| "failed to wait for subprocess".to_string())?,
+        output = &mut output_task => {
+            match output {
+                Ok(Err(err)) => {
+                    let _ = child.kill().await;
+                    let _ = child.wait().await;
+                    return Err(err)
+                }
+                Err(_) => {
+                    let _ = child.kill().await;
+                    let _ = child.wait().await;
+                    return Err("subprocess output task failed".to_string())
+                }
+                Ok(Ok(output)) => {
+                    completed_output = Some(output);
+                    child.wait().await.map_err(|_| "failed to wait for subprocess".to_string())?
+                }
+            }
+        }
+        _ = &mut deadline => {
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err("subprocess timed out".to_string())
+        }
+    };
+    if let Some(task) = input_task {
+        task.await
+            .map_err(|_| "subprocess input task failed".to_string())?
+            .map_err(|_| "failed to write subprocess input".to_string())?;
+    }
+    let (stdout, stderr) = match completed_output {
+        Some(output) => output,
+        None => output_task.await.map_err(|_| "subprocess output task failed".to_string())??,
+    };
+    Ok((stdout, stderr, status))
+}
+
+async fn read_capped(mut reader: impl AsyncRead + Unpin, limit: usize) -> Result<Vec<u8>, String> {
+    let mut output = Vec::new();
+    let mut chunk = [0; 8192];
+    loop {
+        let read =
+            reader.read(&mut chunk).await.map_err(|_| "failed to read solc output".to_string())?;
+        if read == 0 {
+            return Ok(output);
+        }
+        if output.len().saturating_add(read) > limit {
+            return Err("solc output limit exceeded".to_string());
+        }
+        output.extend_from_slice(&chunk[..read]);
+    }
+}
+
+fn sanitize_remote(message: &[u8]) -> String {
+    let message = String::from_utf8_lossy(message);
+    let clean = message
+        .chars()
+        .map(|ch| if ch.is_control() { ' ' } else { ch })
+        .take(160)
+        .collect::<String>();
+    if clean.is_empty() { "no diagnostic".to_string() } else { clean }
+}
+
+pub(super) fn match_candidates<'a>(
+    observed: &[u8],
+    candidates: impl IntoIterator<Item = &'a Candidate>,
+) -> MatchResult {
+    let mut matches = Vec::new();
+    for candidate in candidates {
+        let bytecode = candidate.creation_bytecode.as_ref();
+        if bytecode.is_empty() {
+            continue;
+        }
+        let Some(suffix) = observed.strip_prefix(bytecode) else { continue };
+        let valid = match &candidate.constructor {
+            None => suffix.is_empty(),
+            Some(constructor) if constructor.inputs.is_empty() => suffix.is_empty(),
+            Some(constructor) => constructor
+                .abi_decode_input(suffix)
+                .ok()
+                .and_then(|values| constructor.abi_encode_input(&values).ok())
+                .is_some_and(|encoded| encoded == suffix),
+        };
+        if valid
+            && !matches.iter().any(|item: &ExternalMatch| {
+                item.fingerprint == candidate.fingerprint
+                    && item.fqn == candidate.fqn
+                    && compiler_identity(&item.version) == compiler_identity(&candidate.version)
+            })
+        {
+            matches.push(ExternalMatch {
+                input: candidate.input.clone(),
+                fingerprint: candidate.fingerprint.clone(),
+                version: candidate.version.clone(),
+                fqn: candidate.fqn.clone(),
+                constructor_args: Bytes::copy_from_slice(suffix),
+            });
+        }
+    }
+    match matches.len() {
+        0 => MatchResult::None,
+        1 => MatchResult::Unique(matches.pop().unwrap()),
+        _ => MatchResult::Ambiguous(matches),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_abi::JsonAbi;
+
+    fn input() -> Value {
+        json!({
+            "language": "Solidity",
+            "sources": { "A.sol": { "content": "contract A {}", "custom": 1 } },
+            "settings": { "optimizer": { "enabled": true }, "outputSelection": {"old": []} },
+            "unknown": { "preserved": true }
+        })
+    }
+
+    fn candidate(fqn: &str, abi: JsonAbi) -> Candidate {
+        Candidate {
+            input: Arc::new(input()),
+            fingerprint: "fingerprint".into(),
+            version: Version::parse("0.8.30+commit.73712a01").unwrap(),
+            fqn: fqn.into(),
+            constructor: abi.constructor().cloned(),
+            creation_bytecode: Bytes::from_static(&[0x60, 0x00]),
+        }
+    }
+
+    #[test]
+    fn validation_preserves_unknown_fields_and_only_changes_output_selection() {
+        let original = input();
+        let compiled = compilation_input(&original).unwrap();
+        assert_eq!(compiled["unknown"], original["unknown"]);
+        assert_eq!(compiled["sources"], original["sources"]);
+        assert_eq!(compiled["settings"]["optimizer"], original["settings"]["optimizer"]);
+        assert_ne!(
+            compiled["settings"]["outputSelection"],
+            original["settings"]["outputSelection"]
+        );
+        assert_eq!(original["settings"]["outputSelection"], json!({"old": []}));
+
+        let mut url_only = input();
+        url_only["sources"]["A.sol"] = json!({"urls": ["ipfs://source"]});
+        assert!(validate_input(&url_only).is_err());
+    }
+
+    #[test]
+    fn source_paths_are_bounded_printable_ascii() {
+        assert!(validate_identifier("src/A.sol", "path").is_ok());
+        assert!(validate_identifier("bad\npath.sol", "path").is_err());
+        assert!(validate_identifier("café.sol", "path").is_err());
+        assert!(validate_identifier(&"x".repeat(MAX_SOURCE_PATH + 1), "path").is_err());
+    }
+
+    #[test]
+    fn cumulative_source_budget_charges_success_once() {
+        let mut resolver = ExternalResolver::new().unwrap();
+        let source = ExternalSource {
+            input: Arc::new(input()),
+            version: Version::new(0, 8, 30),
+            provider: SourceProvider::Sourcify,
+        };
+        let charged = resolver.charge_source_result(Ok(Some(source.clone()))).unwrap();
+        assert!(charged.is_some());
+        let charged_bytes = resolver.retained_source_input;
+        // A cache hit returns the retained value directly and never invokes accounting again.
+        let key = FetchKey { chain: 1, provider: SourceProvider::Sourcify, address: Address::ZERO };
+        resolver.fetch_cache.insert(key.clone(), Ok(Some(source)));
+        assert!(resolver.fetch_cache.get(&key).unwrap().is_ok());
+        assert_eq!(resolver.retained_source_input, charged_bytes);
+
+        resolver.retained_source_input = MAX_RETAINED_SOURCE_INPUT;
+        assert!(resolver.charge_source_result(Ok(charged)).unwrap_err().contains("cumulative"));
+    }
+
+    #[test]
+    fn cumulative_candidate_metadata_budget_is_enforced() {
+        let mut resolver = ExternalResolver::new().unwrap();
+        resolver.charge_candidates(vec![candidate("A.sol:A", JsonAbi::default())]).unwrap();
+        assert_eq!(resolver.retained_candidate_metadata, "A.sol:A".len());
+
+        let mut resolver = ExternalResolver::new().unwrap();
+        resolver.retained_candidate_metadata = MAX_CANDIDATE_METADATA;
+        let error =
+            resolver.charge_candidates(vec![candidate("A.sol:A", JsonAbi::default())]).unwrap_err();
+        assert!(error.contains("metadata"));
+        assert_eq!(resolver.retained_candidates, 0);
+        assert_eq!(resolver.retained_creation_bytecode, 0);
+    }
+
+    #[test]
+    fn etherscan_parser_preserves_raw_standard_json() {
+        let expected = json!({
+            "language": "Solidity",
+            "sources": { "A.sol": {
+                "content": "contract A {}",
+                "urls": ["dweb:/ipfs/source"],
+                "keccak256": "0x1234"
+            } },
+            "settings": {},
+            "unknown": { "preserved": true }
+        });
+        for source in [expected.clone(), Value::String(format!("{{{expected}}}"))] {
+            let response = json!({
+                "status": "1",
+                "message": "OK",
+                "result": [{ "SourceCode": source, "CompilerVersion": "v0.8.30+commit.73712a01" }]
+            });
+            let (parsed, version) =
+                parse_etherscan_response(&serde_json::to_vec(&response).unwrap()).unwrap();
+            assert_eq!(parsed, expected);
+            assert_eq!(version, "v0.8.30+commit.73712a01");
+        }
+
+        let flat = json!({
+            "status": "1", "result": [{
+                "SourceCode": "contract A {}", "CompilerVersion": "v0.8.30+commit.73712a01"
+            }]
+        });
+        assert!(parse_etherscan_response(&serde_json::to_vec(&flat).unwrap()).is_err());
+    }
+
+    #[test]
+    fn fingerprint_ignores_object_key_order() {
+        let first = input();
+        let second: Value = serde_json::from_str(
+            r#"{"unknown":{"preserved":true},"settings":{"outputSelection":{"old":[]},"optimizer":{"enabled":true}},"sources":{"A.sol":{"custom":1,"content":"contract A {}"}},"language":"Solidity"}"#,
+        )
+        .unwrap();
+        assert_eq!(fingerprint(&first).unwrap(), fingerprint(&second).unwrap());
+
+        let source_a = ExternalSource {
+            input: Arc::new(first),
+            version: Version::new(1, 2, 3),
+            provider: SourceProvider::Sourcify,
+        };
+        let source_b = ExternalSource {
+            provider: SourceProvider::Etherscan { endpoint: "other".into() },
+            ..source_a.clone()
+        };
+        assert_eq!(fingerprint(&source_a.input).unwrap(), fingerprint(&source_b.input).unwrap());
+    }
+
+    #[test]
+    fn compiler_version_requires_commit_but_allows_platform_suffix() {
+        let requested = Version::parse("0.8.30+commit.73712a01").unwrap();
+        assert!(compiler_matches(
+            &requested,
+            &Version::parse("0.8.30+commit.73712a01.Linux.gcc").unwrap()
+        ));
+        assert!(!compiler_matches(&requested, &Version::parse("0.8.30+commit.deadbeef").unwrap()));
+        assert!(!compiler_matches(&Version::new(0, 8, 30), &requested));
+    }
+
+    #[test]
+    fn parses_real_solc_version_output() {
+        let output = b"solc, the solidity compiler commandline interface\nVersion: 0.8.30+commit.73712a01.Darwin.appleclang\n";
+        assert_eq!(
+            parse_solc_version_output(output).unwrap(),
+            Version::parse("0.8.30+commit.73712a01.Darwin.appleclang").unwrap()
+        );
+        assert!(parse_solc_version_output(b"Version: forged").is_err());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn bounded_process_times_out_and_caps_output() {
+        let mut sleep = Command::new("sh");
+        sleep.args(["-c", "sleep 2"]);
+        assert!(
+            run_bounded_command(sleep, None, 16, 16, Duration::from_millis(20))
+                .await
+                .unwrap_err()
+                .contains("timed out")
+        );
+
+        let mut output = Command::new("sh");
+        output.args(["-c", "printf 12345"]);
+        assert!(
+            run_bounded_command(output, None, 4, 16, Duration::from_secs(1))
+                .await
+                .unwrap_err()
+                .contains("output limit")
+        );
+    }
+
+    #[test]
+    fn constructor_matching_is_canonical() {
+        let constructor: JsonAbi = serde_json::from_value(json!([{
+            "type": "constructor", "inputs": [{"name":"n", "type":"uint256"}]
+        }]))
+        .unwrap();
+        let candidate = candidate("A.sol:A", constructor);
+        let mut observed = vec![0x60, 0x00];
+        observed.extend([0; 31]);
+        observed.push(7);
+        let MatchResult::Unique(found) = match_candidates(&observed, &[candidate.clone()]) else {
+            panic!("expected match")
+        };
+        assert_eq!(found.constructor_args.len(), 32);
+        assert!(matches!(match_candidates(&[0x60, 0x00, 7], &[candidate]), MatchResult::None));
+    }
+
+    #[test]
+    fn no_constructor_and_zero_inputs_require_empty_suffix() {
+        let none = candidate("A.sol:A", JsonAbi::default());
+        assert!(matches!(match_candidates(&[0x60, 0x00], &[none.clone()]), MatchResult::Unique(_)));
+        assert!(matches!(match_candidates(&[0x60, 0x00, 0], &[none]), MatchResult::None));
+
+        let zero: JsonAbi =
+            serde_json::from_value(json!([{"type":"constructor","inputs":[]}])).unwrap();
+        assert!(matches!(
+            match_candidates(&[0x60, 0x00], &[candidate("B.sol:B", zero)]),
+            MatchResult::Unique(_)
+        ));
+    }
+
+    #[test]
+    fn ambiguity_collapses_identical_fingerprint_and_fqn() {
+        let a = candidate("A.sol:A", JsonAbi::default());
+        let mut duplicate = a.clone();
+        duplicate.version = Version::parse("0.8.30+commit.73712a01.Linux.gcc").unwrap();
+        assert!(matches!(
+            match_candidates(&[0x60, 0x00], &[a.clone(), duplicate]),
+            MatchResult::Unique(_)
+        ));
+        let mut other_commit = a.clone();
+        other_commit.version = Version::parse("0.8.30+commit.deadbeef").unwrap();
+        assert!(matches!(
+            match_candidates(&[0x60, 0x00], &[a.clone(), other_commit]),
+            MatchResult::Ambiguous(_)
+        ));
+        let b = candidate("B.sol:B", JsonAbi::default());
+        let MatchResult::Ambiguous(matches) = match_candidates(&[0x60, 0x00], &[a, b]) else {
+            panic!("expected ambiguity")
+        };
+        assert_eq!(matches.len(), 2);
+    }
+
+    #[test]
+    fn capped_chunk_aggregation_rejects_limit_plus_one() {
+        let mut output = Vec::new();
+        assert!(append_capped(&mut output, b"123", 4));
+        assert!(!append_capped(&mut output, b"45", 4));
+        assert_eq!(output, b"123");
+    }
+
+    #[test]
+    fn empty_creation_bytecode_never_matches() {
+        let mut empty = candidate("A.sol:A", JsonAbi::default());
+        empty.creation_bytecode = Bytes::new();
+        assert!(matches!(match_candidates(&[], &[empty]), MatchResult::None));
+    }
+
+    #[test]
+    fn candidates_share_source_input() {
+        let first = candidate("A.sol:A", JsonAbi::default());
+        let second = Candidate { fqn: "A.sol:B".into(), ..first.clone() };
+        assert!(Arc::ptr_eq(&first.input, &second.input));
+    }
+
+    #[test]
+    fn remote_diagnostics_are_bounded_and_sanitized() {
+        let message = format!("secret\n{}", "x".repeat(300));
+        let clean = sanitize_remote(message.as_bytes());
+        assert!(!clean.contains('\n'));
+        assert_eq!(clean.chars().count(), 160);
+    }
+}

--- a/crates/script/src/verify/external.rs
+++ b/crates/script/src/verify/external.rs
@@ -5,7 +5,7 @@ use alloy_json_abi::Constructor;
 use alloy_primitives::{Address, Bytes, keccak256};
 use eyre::{Result, bail, eyre};
 use foundry_compilers::{artifacts::CompilerOutput, solc::Solc};
-use foundry_config::{Chain, Config, NamedChain};
+use foundry_config::{Chain, NamedChain};
 use futures::StreamExt;
 use semver::Version;
 use serde::Deserialize;
@@ -129,16 +129,13 @@ impl ExternalResolver {
 
     pub(super) async fn resolve_etherscan(
         &mut self,
-        config: &Config,
         chain: Chain,
         address: Address,
-        api_key: Option<String>,
+        endpoint: Option<&str>,
+        api_key: Option<&str>,
     ) -> Result<Option<ExternalSource>, String> {
-        let resolved = config
-            .get_etherscan_config_with_chain(Some(chain))
-            .map_err(|e| e.to_string())?
-            .ok_or_else(|| "Etherscan is not configured".to_string())?;
-        let provider = SourceProvider::Etherscan { endpoint: resolved.api_url.clone() };
+        let endpoint = endpoint.ok_or_else(|| "Etherscan is not configured".to_string())?;
+        let provider = SourceProvider::Etherscan { endpoint: endpoint.to_string() };
         let key = FetchKey { chain: chain.id(), provider: provider.clone(), address };
         if let Some(cached) = self.fetch_cache.get(&key) {
             return cached.clone();
@@ -150,12 +147,12 @@ impl ExternalResolver {
             let address = address.to_string();
             let response = self
                 .http
-                .get(&resolved.api_url)
+                .get(endpoint)
                 .query(&[
                     ("module", "contract"),
                     ("action", "getsourcecode"),
                     ("address", address.as_str()),
-                    ("apikey", api_key.as_deref().unwrap_or_default()),
+                    ("apikey", api_key.unwrap_or_default()),
                 ])
                 .send()
                 .await
@@ -701,6 +698,7 @@ pub(super) fn match_candidates<'a>(
 mod tests {
     use super::*;
     use alloy_json_abi::JsonAbi;
+    use tokio::net::TcpListener;
 
     fn input() -> Value {
         json!({
@@ -782,6 +780,41 @@ mod tests {
         assert!(error.contains("metadata"));
         assert_eq!(resolver.retained_candidates, 0);
         assert_eq!(resolver.retained_creation_bytecode, 0);
+    }
+
+    #[tokio::test]
+    async fn etherscan_source_discovery_does_not_follow_redirects() {
+        let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let source = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", source.local_addr().unwrap());
+        let location = format!("http://{}", target.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = source.accept().await.unwrap();
+            let mut request = [0; 4096];
+            let bytes_read = socket.read(&mut request).await.unwrap();
+            assert!(bytes_read > 0);
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 307 Temporary Redirect\r\nLocation: {location}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let error = ExternalResolver::new()
+            .unwrap()
+            .resolve_etherscan(Chain::mainnet(), Address::ZERO, Some(&endpoint), None)
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        assert!(error.contains("HTTP 307"), "unexpected discovery error: {error}");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), target.accept()).await.is_err(),
+            "external source discovery followed the redirect"
+        );
     }
 
     #[test]

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -1,6 +1,9 @@
 use crate::{
     VerifierArgs,
-    provider::{VerificationContext, VerificationProvider, VerificationProviderType},
+    provider::{
+        ExternalVerificationContext, VerificationContext, VerificationProvider,
+        VerificationProviderType,
+    },
     utils::ensure_solc_build_metadata,
     verify::{ContractLanguage, VerifyArgs, VerifyCheckArgs},
 };
@@ -24,7 +27,7 @@ use foundry_config::Config;
 use foundry_evm::constants::DEFAULT_CREATE2_DEPLOYER;
 use regex::Regex;
 use semver::BuildMetadata;
-use std::{fmt::Debug, sync::LazyLock};
+use std::{fmt::Debug, future::Future as StdFuture, pin::Pin, sync::LazyLock, time::Duration};
 
 mod flatten;
 
@@ -69,90 +72,19 @@ impl VerificationProvider for EtherscanVerificationProvider {
         context: VerificationContext,
     ) -> Result<Option<VerifyCheckArgs>> {
         let (etherscan, verify_args) = self.prepare_verify_request(&args, &context).await?;
+        self.submit_verify_request(args, etherscan, verify_args).await
+    }
 
-        if !args.skip_is_verified_check
-            && self.is_contract_verified(&etherscan, &verify_args).await?
-        {
-            sh_status!(
-                "Contract [{}] {:?} is already verified. Skipping verification.",
-                verify_args.contract_name,
-                verify_args.address.to_checksum(None)
-            )?;
-
-            return Ok(None);
-        }
-
-        trace!(?verify_args, "submitting verification request");
-
-        let resp = args
-            .retry
-            .into_retry()
-            .run_async(|| async {
-                sh_status!(
-                    "Submitting verification for [{}] {}.",
-                    verify_args.contract_name,
-                    verify_args.address
-                )?;
-                let resp = etherscan
-                    .submit_contract_verification(&verify_args)
-                    .await
-                    .wrap_err_with(|| {
-                        // valid json
-                        let args = serde_json::to_string(&verify_args).unwrap();
-                        format!("Failed to submit contract verification, payload:\n{args}")
-                    })?;
-
-                trace!(?resp, "Received verification response");
-
-                if resp.status == "0" {
-                    if resp.result == "Contract source code already verified"
-                        // specific for blockscout response
-                        || resp.result == "Smart-contract already verified."
-                    {
-                        return Ok(None);
-                    }
-
-                    if resp.result.starts_with("Unable to locate ContractCode at")
-                        || resp.result.starts_with("The address is not a smart contract")
-                        || resp.result.starts_with("Address is not a smart-contract")
-                    {
-                        warn!("{}", resp.result);
-                        return Err(eyre!("Could not detect deployment: {}", resp.result));
-                    }
-
-                    warn!("Failed verify submission: {:?}", resp);
-                    eyre::bail!(
-                        "Encountered an error verifying this contract:\nResponse: `{}`\nDetails: `{}`",
-                        resp.message,
-                        resp.result
-                    );
-                }
-
-                Ok(Some(resp))
-            })
-            .await?;
-
-        if let Some(resp) = resp {
-            let url = etherscan.address_url(args.address);
-            sh_status!(
-                "Submitted contract for verification:\n\tResponse: `{}`\n\tGUID: `{}`\n\tURL: {}",
-                resp.message,
-                resp.result,
-                url
-            )?;
-            if args.print_submission_result_to_stdout {
-                sh_println!("{}\t{}", resp.result, url)?;
-            }
-            Ok(Some(VerifyCheckArgs {
-                id: resp.result,
-                etherscan: args.etherscan,
-                retry: args.retry,
-                verifier: args.verifier,
-            }))
-        } else {
-            sh_status!("Contract source code already verified")?;
-            Ok(None)
-        }
+    fn submit_external(
+        &mut self,
+        args: VerifyArgs,
+        context: ExternalVerificationContext,
+    ) -> Pin<Box<dyn StdFuture<Output = Result<Option<VerifyCheckArgs>>> + '_>> {
+        Box::pin(async move {
+            let etherscan = self.client(&args.etherscan, &args.verifier, &context.config)?;
+            let verify_args = self.create_external_verify_request(&args, &context)?;
+            self.submit_verify_request(args, etherscan, verify_args).await
+        })
     }
 
     /// Executes the command to check verification status on Etherscan
@@ -168,12 +100,12 @@ impl VerificationProvider for EtherscanVerificationProvider {
                     .wrap_err("Failed to request verification status")
                     .map_err(RetryError::Retry)?;
 
-                trace!(?resp, "Received verification response");
+                trace!(status = %resp.status, "Received Etherscan verification response");
 
                 let _ = sh_status!(
                     "Contract verification status:\nResponse: `{}`\nDetails: `{}`",
-                    resp.message,
-                    resp.result
+                    sanitize_remote_message(&resp.message),
+                    sanitize_remote_message(&resp.result)
                 );
 
                 if resp.result == "Pending in queue"
@@ -195,7 +127,7 @@ impl VerificationProvider for EtherscanVerificationProvider {
                     return Err(RetryError::Break(eyre!(
                         "Contract verification failed:\nStatus: `{}`\nResult: `{}`",
                         resp.status,
-                        resp.result
+                        sanitize_remote_message(&resp.result)
                     )));
                 }
 
@@ -211,6 +143,118 @@ impl VerificationProvider for EtherscanVerificationProvider {
 }
 
 impl EtherscanVerificationProvider {
+    async fn submit_verify_request(
+        &self,
+        args: VerifyArgs,
+        etherscan: Client,
+        verify_args: VerifyContract,
+    ) -> Result<Option<VerifyCheckArgs>> {
+        if !args.skip_is_verified_check
+            && self.is_contract_verified(&etherscan, &verify_args).await?
+        {
+            sh_status!(
+                "Contract [{}] {:?} is already verified. Skipping verification.",
+                verify_args.contract_name,
+                verify_args.address.to_checksum(None)
+            )?;
+
+            return Ok(None);
+        }
+
+        trace!(
+            provider = "Etherscan",
+            address = %verify_args.address,
+            target = %verify_args.contract_name,
+            "submitting verification request"
+        );
+
+        let resp = args
+            .retry
+            .into_retry()
+            .run_async(|| async {
+                sh_status!(
+                    "Submitting verification for [{}] {}.",
+                    verify_args.contract_name,
+                    verify_args.address
+                )?;
+                let resp = etherscan
+                    .submit_contract_verification(&verify_args)
+                    .await
+                    .wrap_err("Failed to submit Etherscan contract verification")?;
+
+                trace!(status = %resp.status, "Received Etherscan verification response");
+
+                if resp.status == "0" {
+                    if resp.result == "Contract source code already verified"
+                        // specific for blockscout response
+                        || resp.result == "Smart-contract already verified."
+                    {
+                        return Ok(None);
+                    }
+
+                    if resp.result.starts_with("Unable to locate ContractCode at")
+                        || resp.result.starts_with("The address is not a smart contract")
+                        || resp.result.starts_with("Address is not a smart-contract")
+                    {
+                        warn!("{}", sanitize_remote_message(&resp.result));
+                        return Err(eyre!(
+                            "Could not detect deployment: {}",
+                            sanitize_remote_message(&resp.result)
+                        ));
+                    }
+
+                    warn!(status = %resp.status, "Etherscan verification submission failed");
+                    eyre::bail!(
+                        "Encountered an error verifying this contract:\nResponse: `{}`\nDetails: `{}`",
+                        sanitize_remote_message(&resp.message),
+                        sanitize_remote_message(&resp.result)
+                    );
+                }
+
+                Ok(Some(resp))
+            })
+            .await?;
+
+        if let Some(resp) = resp {
+            let url = etherscan.address_url(args.address);
+            let display_id = sanitize_remote_message(&resp.result);
+            sh_status!(
+                "Submitted contract for verification:\n\tResponse: `{}`\n\tGUID: `{}`\n\tURL: {}",
+                sanitize_remote_message(&resp.message),
+                display_id,
+                url
+            )?;
+            if args.print_submission_result_to_stdout {
+                sh_println!("{}\t{}", display_id, url)?;
+            }
+            Ok(Some(VerifyCheckArgs {
+                id: resp.result,
+                etherscan: args.etherscan,
+                retry: args.retry,
+                verifier: args.verifier,
+            }))
+        } else {
+            sh_status!("Contract source code already verified")?;
+            Ok(None)
+        }
+    }
+
+    fn create_external_verify_request(
+        &self,
+        args: &VerifyArgs,
+        context: &ExternalVerificationContext,
+    ) -> Result<VerifyContract> {
+        let source = serde_json::to_string(&context.standard_json_input)
+            .wrap_err("Failed to serialize standard json input")?;
+        let compiler_version = format!("v{}", context.compiler_version);
+        let mut request =
+            VerifyContract::new(args.address, context.target.clone(), source, compiler_version)
+                .constructor_arguments(args.constructor_args.clone())
+                .code_format(CodeFormat::StandardJsonInput);
+        apply_license_type(&mut request, args.license_type.as_deref());
+        Ok(request)
+    }
+
     /// Create a source provider
     fn source_provider(&self, args: &VerifyArgs) -> Box<dyn EtherscanSourceProvider> {
         if args.flatten {
@@ -296,7 +340,14 @@ impl EtherscanVerificationProvider {
             builder.chain(chain)?
         };
 
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .wrap_err("Failed to create hardened HTTP client")?;
         builder
+            .with_client(http)
             .with_api_key(etherscan_key.unwrap_or_default())
             .build()
             .wrap_err("Failed to create Etherscan client")
@@ -459,6 +510,10 @@ impl EtherscanVerificationProvider {
     }
 }
 
+fn sanitize_remote_message(message: &str) -> String {
+    message.chars().map(|ch| if ch.is_control() { ' ' } else { ch }).take(512).collect()
+}
+
 fn apply_license_type(verify_args: &mut VerifyContract, license_type: Option<&str>) {
     if let Some(license_type) = license_type {
         verify_args.other.insert("licenseType".to_string(), license_type.to_string());
@@ -472,6 +527,29 @@ mod tests {
     use foundry_common::fs;
     use foundry_test_utils::{forgetest_async, str};
     use tempfile::tempdir;
+
+    #[test]
+    fn external_request_preserves_raw_input_and_target() {
+        let args =
+            VerifyArgs::parse_from(["foundry-cli", "0xd8509bee9c9bf012282ad33aba0d87241baf5064"]);
+        let input = serde_json::json!({
+            "language": "Solidity",
+            "settings": { "unknownSetting": { "futureField": true } },
+            "unknownTopLevel": [1, 2, 3]
+        });
+        let context = ExternalVerificationContext {
+            config: Config::default(),
+            compiler_version: "0.8.30+commit.73712a01".parse().unwrap(),
+            standard_json_input: std::sync::Arc::new(input.clone()),
+            target: "contracts/Unknown.sol:ExactTarget".to_string(),
+        };
+
+        let request =
+            EtherscanVerificationProvider.create_external_verify_request(&args, &context).unwrap();
+        assert_eq!(serde_json::from_str::<serde_json::Value>(&request.source).unwrap(), input);
+        assert_eq!(request.contract_name, "contracts/Unknown.sol:ExactTarget");
+        assert_eq!(request.compiler_version, "v0.8.30+commit.73712a01");
+    }
 
     #[test]
     fn applies_license_type_to_verify_request() {

--- a/crates/verify/src/etherscan/mod.rs
+++ b/crates/verify/src/etherscan/mod.rs
@@ -313,7 +313,13 @@ impl EtherscanVerificationProvider {
         // API key passed.
         let is_etherscan = verifier_type.is_etherscan()
             || (verifier_type.is_sourcify() && etherscan_key.is_some());
-        let etherscan_config = config.get_etherscan_config_with_chain(Some(chain))?;
+        let etherscan_config = match config.get_etherscan_config_with_chain(Some(chain)) {
+            Ok(config) => config,
+            // The selected URL is authoritative, so an invalid lower-priority endpoint must not
+            // prevent creating the client.
+            Err(_) if verifier_url.is_some() => None,
+            Err(err) => return Err(err.into()),
+        };
 
         let api_url =
             verifier_url.or_else(|| etherscan_config.as_ref().map(|c| c.api_url.as_str()));
@@ -343,9 +349,8 @@ impl EtherscanVerificationProvider {
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .connect_timeout(Duration::from_secs(10))
-            .redirect(reqwest::redirect::Policy::none())
             .build()
-            .wrap_err("Failed to create hardened HTTP client")?;
+            .wrap_err("Failed to create Etherscan HTTP client")?;
         builder
             .with_client(http)
             .with_api_key(etherscan_key.unwrap_or_default())

--- a/crates/verify/src/provider.rs
+++ b/crates/verify/src/provider.rs
@@ -18,8 +18,11 @@ use foundry_config::{Chain, Config, EtherscanConfigError};
 use semver::Version;
 use std::{
     fmt,
+    future::Future as StdFuture,
     path::{Path, PathBuf},
+    pin::Pin,
     str::FromStr,
+    sync::Arc,
 };
 
 /// Container with data required for contract verification.
@@ -31,6 +34,15 @@ pub struct VerificationContext {
     pub target_name: String,
     pub compiler_version: Version,
     pub compiler_settings: MultiCompilerSettings,
+}
+
+/// Caller-provided source material used to verify a contract.
+#[derive(Debug, Clone)]
+pub struct ExternalVerificationContext {
+    pub config: Config,
+    pub compiler_version: Version,
+    pub standard_json_input: Arc<serde_json::Value>,
+    pub target: String,
 }
 
 impl VerificationContext {
@@ -118,6 +130,17 @@ pub trait VerificationProvider {
         args: VerifyArgs,
         context: VerificationContext,
     ) -> Result<Option<VerifyCheckArgs>>;
+
+    /// Submits caller-provided Standard JSON input.
+    fn submit_external(
+        &mut self,
+        _args: VerifyArgs,
+        _context: ExternalVerificationContext,
+    ) -> Pin<Box<dyn StdFuture<Output = Result<Option<VerifyCheckArgs>>> + '_>> {
+        Box::pin(async {
+            Err(eyre::eyre!("external verification is unsupported by this provider"))
+        })
+    }
 
     /// Convenience wrapper: [`Self::submit`]s and, if `args.watch` is set, polls
     /// [`Self::check`] until completion.

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -65,7 +65,7 @@ impl VerificationProvider for SourcifyVerificationProvider {
         args.retry
             .into_retry()
             .run_async_until_break(|| async {
-                let response = hardened_client()
+                let response = verification_client()
                     .map_err(RetryError::Break)?
                     .get(&url)
                     .send()
@@ -129,11 +129,10 @@ fn sanitize_remote_message(message: &str) -> String {
 
 const MAX_RESPONSE_BODY: usize = 1024 * 1024;
 
-fn hardened_client() -> Result<reqwest::Client> {
+fn verification_client() -> Result<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
-        .redirect(reqwest::redirect::Policy::none())
         .build()
         .wrap_err("Failed to create Sourcify HTTP client")
 }
@@ -186,7 +185,7 @@ impl SourcifyVerificationProvider {
         let chain_id = args.etherscan.chain.unwrap_or_default().id();
         let url =
             Self::get_verify_url(args.verifier.verifier_url.as_deref(), chain_id, args.address);
-        let client = hardened_client()?;
+        let client = verification_client()?;
 
         let resp = args
             .retry
@@ -352,7 +351,7 @@ impl SourcifyVerificationProvider {
         let url =
             Self::get_lookup_url(args.verifier.verifier_url.as_deref(), chain_id, args.address);
 
-        match hardened_client()?.get(&url).send().await {
+        match verification_client()?.get(&url).send().await {
             Ok(response) => {
                 if response.status().is_success() {
                     let contract_response: SourcifyContractResponse =
@@ -445,6 +444,11 @@ mod tests {
     use foundry_config::Config;
     use foundry_test_utils::forgetest_async;
     use serde_json::json;
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
 
     #[test]
     fn external_request_preserves_raw_input_and_target() {
@@ -478,6 +482,53 @@ mod tests {
         assert!(ui.ends_with(&format!("verify-ui/jobs/{encoded}")), "{ui}");
         assert_eq!(encode_path_segment("."), "%2E");
         assert_eq!(encode_path_segment(".."), "%2E%2E");
+    }
+
+    #[tokio::test]
+    async fn verification_client_follows_redirects() {
+        let target = TcpListener::bind("127.0.0.1:0").unwrap();
+        let target_url = format!("http://{}", target.local_addr().unwrap());
+        let target_thread = thread::spawn(move || {
+            let (mut socket, _) = target.accept().unwrap();
+            let mut request = [0; 4096];
+            let bytes_read = socket.read(&mut request).unwrap();
+            assert!(std::str::from_utf8(&request[..bytes_read]).unwrap().starts_with("GET "));
+            socket
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nredirected",
+                )
+                .unwrap();
+        });
+
+        let source = TcpListener::bind("127.0.0.1:0").unwrap();
+        let source_url = format!("http://{}", source.local_addr().unwrap());
+        let source_thread = thread::spawn(move || {
+            let (mut socket, _) = source.accept().unwrap();
+            let mut request = [0; 4096];
+            let bytes_read = socket.read(&mut request).unwrap();
+            assert!(bytes_read > 0);
+            socket
+                .write_all(
+                    format!(
+                        "HTTP/1.1 307 Temporary Redirect\r\nLocation: {target_url}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .unwrap();
+        });
+
+        let response = verification_client()
+            .unwrap()
+            .get(source_url)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        source_thread.join().unwrap();
+        target_thread.join().unwrap();
+        assert_eq!(response, "redirected");
     }
 
     forgetest_async!(creates_correct_verify_request_body, |prj, _cmd| {

--- a/crates/verify/src/sourcify.rs
+++ b/crates/verify/src/sourcify.rs
@@ -1,5 +1,8 @@
 use crate::{
-    provider::{VerificationContext, VerificationProvider, VerificationProviderType},
+    provider::{
+        ExternalVerificationContext, VerificationContext, VerificationProvider,
+        VerificationProviderType,
+    },
     utils::ensure_solc_build_metadata,
     verify::{ContractLanguage, VerifyArgs, VerifyCheckArgs},
 };
@@ -7,9 +10,10 @@ use alloy_primitives::Address;
 use async_trait::async_trait;
 use eyre::{Context, Result, eyre};
 use foundry_common::retry::RetryError;
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
+use std::{future::Future as StdFuture, pin::Pin, time::Duration};
 use url::Url;
 
 pub static SOURCIFY_URL: &str = "https://sourcify.dev/server/";
@@ -40,34 +44,156 @@ impl VerificationProvider for SourcifyVerificationProvider {
         context: VerificationContext,
     ) -> Result<Option<VerifyCheckArgs>> {
         let body = self.prepare_verify_request(&args, &context).await?;
-        let chain_id = args.etherscan.chain.unwrap_or_default().id();
+        self.submit_verify_request(args, body, &context.target_name).await
+    }
 
+    fn submit_external(
+        &mut self,
+        args: VerifyArgs,
+        context: ExternalVerificationContext,
+    ) -> Pin<Box<dyn StdFuture<Output = Result<Option<VerifyCheckArgs>>> + '_>> {
+        Box::pin(async move {
+            let target = context.target.clone();
+            let body = Self::prepare_external_verify_request(&args, context);
+            self.submit_verify_request(args, body, &target).await
+        })
+    }
+
+    async fn check(&self, args: VerifyCheckArgs) -> Result<()> {
+        let url = Self::get_job_status_url(args.verifier.verifier_url.as_deref(), args.id.clone());
+
+        args.retry
+            .into_retry()
+            .run_async_until_break(|| async {
+                let response = hardened_client()
+                    .map_err(RetryError::Break)?
+                    .get(&url)
+                    .send()
+                    .await
+                    .wrap_err("Failed to request verification status")
+                    .map_err(RetryError::Retry)?;
+
+                if response.status() == StatusCode::NOT_FOUND {
+                    return Err(RetryError::Break(eyre!(
+                        "No verification job found for ID {}",
+                        sanitize_remote_message(&args.id)
+                    )));
+                }
+
+                if !response.status().is_success() {
+                    return Err(RetryError::Retry(eyre!(
+                        "Failed to request verification status with status code {}",
+                        response.status()
+                    )));
+                }
+
+                let job_response: SourcifyJobResponse = serde_json::from_slice(
+                    &read_capped_body(response).await.map_err(RetryError::Retry)?,
+                )
+                .wrap_err("Failed to parse job response")
+                .map_err(RetryError::Retry)?;
+
+                if !job_response.is_job_completed {
+                    return Err(RetryError::Retry(eyre!("Verification is still pending...")));
+                }
+
+                if let Some(error) = job_response.error {
+                    if error.custom_code == "already_verified" {
+                        let _ = sh_status!("Contract source code already verified");
+                        return Ok(());
+                    }
+
+                    return Err(RetryError::Break(eyre!(
+                        "Verification job failed:\nError Code: `{}`\nMessage: `{}`",
+                        sanitize_remote_message(&error.custom_code),
+                        sanitize_remote_message(&error.message)
+                    )));
+                }
+
+                if let Some(contract_status) = job_response.contract.match_status {
+                    let _ = sh_status!(
+                        "Contract successfully verified:\nStatus: `{}`",
+                        sanitize_remote_message(&contract_status),
+                    );
+                }
+                Ok(())
+            })
+            .await
+            .wrap_err("Checking verification result failed")
+    }
+}
+
+fn sanitize_remote_message(message: &str) -> String {
+    message.chars().map(|ch| if ch.is_control() { ' ' } else { ch }).take(512).collect()
+}
+
+const MAX_RESPONSE_BODY: usize = 1024 * 1024;
+
+fn hardened_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .connect_timeout(Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .wrap_err("Failed to create Sourcify HTTP client")
+}
+
+async fn read_capped_body(response: reqwest::Response) -> Result<Vec<u8>> {
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        eyre::ensure!(
+            body.len().saturating_add(chunk.len()) <= MAX_RESPONSE_BODY,
+            "Sourcify response body exceeds 1 MiB"
+        );
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+impl SourcifyVerificationProvider {
+    fn prepare_external_verify_request(
+        args: &VerifyArgs,
+        context: ExternalVerificationContext,
+    ) -> SourcifyVerifyRequest {
+        SourcifyVerifyRequest {
+            std_json_input: (*context.standard_json_input).clone(),
+            compiler_version: context.compiler_version.to_string(),
+            contract_identifier: context.target,
+            creation_transaction_hash: args.creation_transaction_hash.map(|hash| hash.to_string()),
+        }
+    }
+
+    async fn submit_verify_request(
+        &self,
+        args: VerifyArgs,
+        body: SourcifyVerifyRequest,
+        target: &str,
+    ) -> Result<Option<VerifyCheckArgs>> {
         if !args.skip_is_verified_check && self.is_contract_verified(&args).await? {
             sh_status!(
                 "Contract [{}] {:?} is already verified. Skipping verification.",
-                context.target_name,
+                target,
                 args.address.to_string()
             )?;
 
             return Ok(None);
         }
 
-        trace!("submitting verification request {:?}", body);
+        trace!(provider = "Sourcify", address = %args.address, target, "submitting verification request");
 
-        let client = reqwest::Client::new();
+        let chain_id = args.etherscan.chain.unwrap_or_default().id();
         let url =
             Self::get_verify_url(args.verifier.verifier_url.as_deref(), chain_id, args.address);
+        let client = hardened_client()?;
 
         let resp = args
             .retry
             .into_retry()
             .run_async(|| {
                 async {
-                    sh_status!(
-                        "Submitting verification for [{}] {}.",
-                        context.target_name,
-                        args.address.to_string()
-                    )?;
+                    sh_status!("Submitting verification for [{}] {}.", target, args.address)?;
                     let response = client
                         .post(&url)
                         .header("Content-Type", "application/json")
@@ -82,18 +208,15 @@ impl VerificationProvider for SourcifyVerificationProvider {
                             Ok(None)
                         }
                         StatusCode::ACCEPTED => {
-                            let text = response.text().await?;
+                            let text = read_capped_body(response).await?;
                             let verify_response: SourcifyVerificationResponse =
-                                serde_json::from_str(&text)
+                                serde_json::from_slice(&text)
                                     .wrap_err("Failed to parse Sourcify verification response")?;
                             Ok(Some(verify_response))
                         }
                         _ => {
-                            let error: serde_json::Value = response.json().await?;
                             eyre::bail!(
-                                "Sourcify verification request for address ({}) \
-                            failed with status code {status}\n\
-                            Details: {error:#}",
+                                "Sourcify verification request for address ({}) failed with status code {status}",
                                 args.address,
                             );
                         }
@@ -104,17 +227,24 @@ impl VerificationProvider for SourcifyVerificationProvider {
             .await?;
 
         if let Some(resp) = resp {
+            eyre::ensure!(
+                !resp.verification_id.is_empty()
+                    && resp.verification_id.len() <= 512
+                    && !matches!(resp.verification_id.as_str(), "." | ".."),
+                "Sourcify returned an invalid verification job ID"
+            );
+            let display_id = sanitize_remote_message(&resp.verification_id);
             let job_url = Self::get_job_ui_url(
                 args.verifier.verifier_url.as_deref(),
                 resp.verification_id.clone(),
             );
             sh_status!(
                 "Submitted contract for verification:\n\tVerification Job ID: `{}`\n\tURL: {}",
-                resp.verification_id,
+                display_id,
                 job_url
             )?;
             if args.print_submission_result_to_stdout {
-                sh_println!("{}\t{}", resp.verification_id, job_url)?;
+                sh_println!("{}\t{}", display_id, job_url)?;
             }
             Ok(Some(VerifyCheckArgs {
                 id: resp.verification_id,
@@ -127,68 +257,6 @@ impl VerificationProvider for SourcifyVerificationProvider {
         }
     }
 
-    async fn check(&self, args: VerifyCheckArgs) -> Result<()> {
-        let url = Self::get_job_status_url(args.verifier.verifier_url.as_deref(), args.id.clone());
-
-        args.retry
-            .into_retry()
-            .run_async_until_break(|| async {
-                let response = reqwest::get(&url)
-                    .await
-                    .wrap_err("Failed to request verification status")
-                    .map_err(RetryError::Retry)?;
-
-                if response.status() == StatusCode::NOT_FOUND {
-                    return Err(RetryError::Break(eyre!(
-                        "No verification job found for ID {}",
-                        args.id
-                    )));
-                }
-
-                if !response.status().is_success() {
-                    return Err(RetryError::Retry(eyre!(
-                        "Failed to request verification status with status code {}",
-                        response.status()
-                    )));
-                }
-
-                let job_response: SourcifyJobResponse = response
-                    .json()
-                    .await
-                    .wrap_err("Failed to parse job response")
-                    .map_err(RetryError::Retry)?;
-
-                if !job_response.is_job_completed {
-                    return Err(RetryError::Retry(eyre!("Verification is still pending...")));
-                }
-
-                if let Some(error) = job_response.error {
-                    if error.custom_code == "already_verified" {
-                        let _ = sh_status!("Contract source code already verified");
-                        return Ok(());
-                    }
-
-                    return Err(RetryError::Break(eyre!(
-                        "Verification job failed:\nError Code: `{}`\nMessage: `{}`",
-                        error.custom_code,
-                        error.message
-                    )));
-                }
-
-                if let Some(contract_status) = job_response.contract.match_status {
-                    let _ = sh_status!(
-                        "Contract successfully verified:\nStatus: `{}`",
-                        contract_status,
-                    );
-                }
-                Ok(())
-            })
-            .await
-            .wrap_err("Checking verification result failed")
-    }
-}
-
-impl SourcifyVerificationProvider {
     fn get_base_url(verifier_url: Option<&str>) -> Url {
         // note(onbjerg): a little ugly but makes this infallible as we guarantee `SOURCIFY_URL` to
         // be well formatted
@@ -206,13 +274,17 @@ impl SourcifyVerificationProvider {
     }
 
     fn get_job_status_url(verifier_url: Option<&str>, job_id: String) -> String {
-        let base_url = Self::get_base_url(verifier_url);
-        format!("{base_url}v2/verify/{job_id}")
+        Self::get_job_url(verifier_url, &["v2", "verify"], &job_id)
     }
 
     fn get_job_ui_url(verifier_url: Option<&str>, job_id: String) -> String {
+        Self::get_job_url(verifier_url, &["verify-ui", "jobs"], &job_id)
+    }
+
+    fn get_job_url(verifier_url: Option<&str>, path: &[&str], job_id: &str) -> String {
         let base_url = Self::get_base_url(verifier_url);
-        format!("{base_url}verify-ui/jobs/{job_id}")
+        let job_id = encode_path_segment(job_id);
+        format!("{base_url}{}/{job_id}", path.join("/"))
     }
 
     fn get_lookup_url(
@@ -280,11 +352,12 @@ impl SourcifyVerificationProvider {
         let url =
             Self::get_lookup_url(args.verifier.verifier_url.as_deref(), chain_id, args.address);
 
-        match reqwest::get(&url).await {
+        match hardened_client()?.get(&url).send().await {
             Ok(response) => {
                 if response.status().is_success() {
                     let contract_response: SourcifyContractResponse =
-                        response.json().await.wrap_err("Failed to parse contract response")?;
+                        serde_json::from_slice(&read_capped_body(response).await?)
+                            .wrap_err("Failed to parse contract response")?;
 
                     let creation_exact = contract_response
                         .creation_match
@@ -308,6 +381,21 @@ impl SourcifyVerificationProvider {
             }),
         }
     }
+}
+
+fn encode_path_segment(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'~') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(HEX[(byte >> 4) as usize]));
+            encoded.push(char::from(HEX[(byte & 0x0f) as usize]));
+        }
+    }
+    encoded
 }
 
 #[derive(Debug, Serialize)]
@@ -354,7 +442,43 @@ pub struct SourcifyErrorResponse {
 mod tests {
     use super::*;
     use clap::Parser;
+    use foundry_config::Config;
     use foundry_test_utils::forgetest_async;
+    use serde_json::json;
+
+    #[test]
+    fn external_request_preserves_raw_input_and_target() {
+        let args =
+            VerifyArgs::parse_from(["foundry-cli", "0xd8509bee9c9bf012282ad33aba0d87241baf5064"]);
+        let input = json!({
+            "language": "Solidity",
+            "settings": { "unknownSetting": { "futureField": true } },
+            "unknownTopLevel": [1, 2, 3]
+        });
+        let context = ExternalVerificationContext {
+            config: Config::default(),
+            compiler_version: "0.8.30+commit.73712a01".parse().unwrap(),
+            standard_json_input: std::sync::Arc::new(input.clone()),
+            target: "contracts/Unknown.sol:ExactTarget".to_string(),
+        };
+
+        let request = SourcifyVerificationProvider::prepare_external_verify_request(&args, context);
+        assert_eq!(request.std_json_input, input);
+        assert_eq!(request.contract_identifier, "contracts/Unknown.sol:ExactTarget");
+        assert_eq!(request.compiler_version, "0.8.30+commit.73712a01");
+    }
+
+    #[test]
+    fn job_urls_encode_opaque_ids_as_one_path_segment() {
+        let id = "job a+b/part?query#fragment\n".to_string();
+        let status = SourcifyVerificationProvider::get_job_status_url(None, id.clone());
+        let ui = SourcifyVerificationProvider::get_job_ui_url(None, id);
+        let encoded = "job%20a%2Bb%2Fpart%3Fquery%23fragment%0A";
+        assert!(status.ends_with(&format!("v2/verify/{encoded}")), "{status}");
+        assert!(ui.ends_with(&format!("verify-ui/jobs/{encoded}")), "{ui}");
+        assert_eq!(encode_path_segment("."), "%2E");
+        assert_eq!(encode_path_segment(".."), "%2E%2E");
+    }
 
     forgetest_async!(creates_correct_verify_request_body, |prj, _cmd| {
         prj.add_source("Counter", "contract Counter {}");

--- a/crates/verify/src/utils.rs
+++ b/crates/verify/src/utils.rs
@@ -446,16 +446,22 @@ pub fn wrap_verifier_url_error(
 ) -> eyre::Error {
     let Some(verifier_url) = verifier_url else { return err };
     let url = match Url::parse(verifier_url) {
-        Ok(url) => url,
+        Ok(mut url) => {
+            let _ = url.set_username("");
+            let _ = url.set_password(None);
+            url.set_query(None);
+            url.set_fragment(None);
+            url
+        }
         Err(url_err) => {
-            return err.wrap_err(format!("Invalid URL {verifier_url} provided: {url_err}"));
+            return err.wrap_err(format!("Invalid verifier URL provided: {url_err}"));
         }
     };
     if is_host_only(&url) && using_etherscan {
         return err.wrap_err(format!(
-            "Verifier `etherscan` requires an API endpoint, but `--verifier-url` is host-only: `{verifier_url}`.\n\
+            "Verifier `etherscan` requires an API endpoint, but `--verifier-url` is host-only: `{url}`.\n\
              Fixes (pick one):\n\
-             - Append the API path, e.g. `--verifier-url {verifier_url}/api`\n\
+             - Append the API path, e.g. `--verifier-url {url}api`\n\
              - Switch verifier, e.g. `--verifier sourcify` (works with host-only URLs)"
         ));
     }
@@ -584,6 +590,22 @@ contract Broken {
         let err = eyre::eyre!("upstream failure");
         let wrapped = wrap_verifier_url_error(err, Some("not a url"), true);
         let msg = format!("{wrapped:#}");
-        assert!(msg.contains("Invalid URL"), "message: {msg}");
+        assert!(msg.contains("Invalid verifier URL"), "message: {msg}");
+        assert!(!msg.contains("not a url"), "message: {msg}");
+    }
+
+    #[test]
+    fn wrap_verifier_url_error_redacts_credentials_and_query() {
+        let err = eyre::eyre!("upstream failure");
+        let wrapped = wrap_verifier_url_error(
+            err,
+            Some("https://user:secret@example.com?api_key=secret"),
+            true,
+        );
+        let msg = format!("{wrapped:#}");
+        assert!(msg.contains("https://example.com/"));
+        assert!(!msg.contains("user"));
+        assert!(!msg.contains("secret"));
+        assert!(!msg.contains("api_key"));
     }
 }

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -3,7 +3,10 @@
 use crate::{
     RetryArgs,
     etherscan::EtherscanVerificationProvider,
-    provider::{VerificationContext, VerificationProvider, VerificationProviderType},
+    provider::{
+        ExternalVerificationContext, VerificationContext, VerificationProvider,
+        VerificationProviderType,
+    },
     sourcify::SourcifyVerificationProvider,
     utils::wrap_verifier_url_error,
 };
@@ -551,19 +554,65 @@ struct ProviderRun {
     required: bool,
 }
 
+#[derive(Clone)]
+enum RunContext {
+    Local(VerificationContext),
+    External(ExternalVerificationContext),
+}
+
 impl VerifyArgs {
     /// Run the verify command to submit the contract's source code for verification on etherscan
-    pub async fn run(mut self) -> Result<()> {
+    pub async fn run(self) -> Result<()> {
         let config = self.load_config()?;
+        let context = self.resolve_context().await?;
+        self.run_with_resolved_context(RunContext::Local(context), config).await
+    }
 
+    /// Runs verification using caller-provided Standard JSON input.
+    pub async fn run_with_external_context(
+        self,
+        context: ExternalVerificationContext,
+    ) -> Result<()> {
+        self.validate_external_args()?;
+        eyre::ensure!(
+            !context.target.is_empty()
+                && context.target.len() <= 8193
+                && context.target.is_ascii()
+                && !context.target.bytes().any(|byte| byte.is_ascii_control()),
+            "external contract identifier must contain bounded printable ASCII"
+        );
+        let config = context.config.clone();
+        self.run_with_resolved_context(RunContext::External(context), config).await
+    }
+
+    fn validate_external_args(&self) -> Result<()> {
+        eyre::ensure!(!self.flatten, "flattening is unsupported for external verification");
+        eyre::ensure!(
+            !matches!(self.language, Some(ContractLanguage::Vyper)),
+            "Vyper is unsupported for external verification"
+        );
+        eyre::ensure!(
+            !self.guess_constructor_args,
+            "constructor argument guessing is unsupported for external verification"
+        );
+        eyre::ensure!(
+            self.constructor_args_path.is_none(),
+            "constructor args paths are unsupported for external verification; provide encoded constructor args"
+        );
+        Ok(())
+    }
+
+    async fn run_with_resolved_context(
+        mut self,
+        context: RunContext,
+        config: Config,
+    ) -> Result<()> {
         if self.guess_constructor_args && config.get_rpc_url().is_none() {
             eyre::bail!(
                 "You have to provide a valid RPC URL to use --guess-constructor-args feature"
             );
         }
 
-        // If chain is not set, we try to get it from the RPC.
-        // If RPC is not set, the default chain is used.
         let chain = match config.get_rpc_url() {
             Some(_) => {
                 let provider = utils::get_provider(&config)?;
@@ -572,18 +621,18 @@ impl VerifyArgs {
             None => config.chain.unwrap_or_default(),
         };
 
-        let context = self.resolve_context().await?;
-
         // Set Etherscan options.
         self.etherscan.chain = Some(chain);
         // `get_etherscan_config_with_chain` returns None for chains with no known Etherscan API
         // URL (even when a key was explicitly passed), because `ResolvedEtherscanConfig::create`
         // requires `chain.etherscan_urls()`. Fall back to the raw `etherscan_api_key` from config
         // so that the key survives for warning/fallback logic in `client()`.
-        self.etherscan.key = config
+        let config_key = config
             .get_etherscan_config_with_chain(Some(chain))?
             .map(|c| c.key)
             .or_else(|| config.etherscan_api_key.clone());
+        self.etherscan.key =
+            self.verifier.resolve_api_key(config_key.as_deref()).map(str::to_owned);
 
         // Capture whether the user explicitly provided a verifier URL *before* any auto-injection.
         // This is passed to `client()` so that an auto-injected Sourcify URL does not look like a
@@ -606,10 +655,17 @@ impl VerifyArgs {
         }
 
         if self.show_standard_json_input {
-            let args = EtherscanVerificationProvider::default()
-                .create_verify_request(&self, &context)
-                .await?;
-            sh_println!("{}", args.source)?;
+            match &context {
+                RunContext::Local(context) => {
+                    let args = EtherscanVerificationProvider::default()
+                        .create_verify_request(&self, context)
+                        .await?;
+                    sh_println!("{}", args.source)?;
+                }
+                RunContext::External(context) => {
+                    sh_println!("{}", serde_json::to_string(&context.standard_json_input)?)?;
+                }
+            }
             return Ok(());
         }
 
@@ -639,7 +695,11 @@ impl VerifyArgs {
         for ProviderRun { label, args, mut provider, required } in runs {
             sh_status!("\nVerifying on {label}...")?;
             let watch = args.watch;
-            match provider.submit(args, context.clone()).await {
+            let submission = match context.clone() {
+                RunContext::Local(context) => provider.submit(args, context).await,
+                RunContext::External(context) => provider.submit_external(args, context).await,
+            };
+            match submission {
                 Ok(check_args) => {
                     if required
                         && watch
@@ -981,6 +1041,45 @@ const fn is_dev_chain(chain: Chain) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn verifier_api_key_takes_precedence_over_etherscan_key() {
+        let args = VerifierArgs { verifier_api_key: Some("explicit".into()), ..Default::default() };
+        assert_eq!(args.resolve_api_key(Some("config")), Some("explicit"));
+        assert_eq!(VerifierArgs::default().resolve_api_key(Some("config")), Some("config"));
+    }
+
+    #[tokio::test]
+    async fn external_context_rejects_control_characters_in_fqn() {
+        let args =
+            VerifyArgs::parse_from(["foundry-cli", "0xd8509bee9c9bf012282ad33aba0d87241baf5064"]);
+        let context = ExternalVerificationContext {
+            config: Config::default(),
+            compiler_version: semver::Version::new(0, 8, 30),
+            standard_json_input: std::sync::Arc::new(serde_json::json!({})),
+            target: "A.sol:A\nforged".into(),
+        };
+        assert!(
+            args.run_with_external_context(context)
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("printable")
+        );
+    }
+
+    #[test]
+    fn external_run_context_clone_shares_standard_json() {
+        let input = std::sync::Arc::new(serde_json::json!({"large": [1, 2, 3]}));
+        let context = RunContext::External(ExternalVerificationContext {
+            config: Config::default(),
+            compiler_version: semver::Version::new(0, 8, 30),
+            standard_json_input: input.clone(),
+            target: "A.sol:A".into(),
+        });
+        let RunContext::External(cloned) = context.clone() else { unreachable!() };
+        assert!(std::sync::Arc::ptr_eq(&input, &cloned.standard_json_input));
+    }
 
     #[test]
     fn can_parse_verify_contract() {

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -556,8 +556,8 @@ struct ProviderRun {
 
 #[derive(Clone)]
 enum RunContext {
-    Local(VerificationContext),
-    External(ExternalVerificationContext),
+    Local(Box<VerificationContext>),
+    External(Box<ExternalVerificationContext>),
 }
 
 impl VerifyArgs {
@@ -565,7 +565,7 @@ impl VerifyArgs {
     pub async fn run(self) -> Result<()> {
         let config = self.load_config()?;
         let context = self.resolve_context().await?;
-        self.run_with_resolved_context(RunContext::Local(context), config).await
+        self.run_with_resolved_context(RunContext::Local(Box::new(context)), config).await
     }
 
     /// Runs verification using caller-provided Standard JSON input.
@@ -582,7 +582,7 @@ impl VerifyArgs {
             "external contract identifier must contain bounded printable ASCII"
         );
         let config = context.config.clone();
-        self.run_with_resolved_context(RunContext::External(context), config).await
+        self.run_with_resolved_context(RunContext::External(Box::new(context)), config).await
     }
 
     fn validate_external_args(&self) -> Result<()> {
@@ -696,8 +696,8 @@ impl VerifyArgs {
             sh_status!("\nVerifying on {label}...")?;
             let watch = args.watch;
             let submission = match context.clone() {
-                RunContext::Local(context) => provider.submit(args, context).await,
-                RunContext::External(context) => provider.submit_external(args, context).await,
+                RunContext::Local(context) => provider.submit(args, *context).await,
+                RunContext::External(context) => provider.submit_external(args, *context).await,
             };
             match submission {
                 Ok(check_args) => {
@@ -1071,13 +1071,14 @@ mod tests {
     #[test]
     fn external_run_context_clone_shares_standard_json() {
         let input = std::sync::Arc::new(serde_json::json!({"large": [1, 2, 3]}));
-        let context = RunContext::External(ExternalVerificationContext {
+        let context = RunContext::External(Box::new(ExternalVerificationContext {
             config: Config::default(),
             compiler_version: semver::Version::new(0, 8, 30),
             standard_json_input: input.clone(),
             target: "A.sol:A".into(),
-        });
-        let RunContext::External(cloned) = context.clone() else { unreachable!() };
+        }));
+        let RunContext::External(context) = &context else { unreachable!() };
+        let cloned = context.clone();
         assert!(std::sync::Arc::ptr_eq(&input, &cloned.standard_json_input));
     }
 

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -627,10 +627,19 @@ impl VerifyArgs {
         // URL (even when a key was explicitly passed), because `ResolvedEtherscanConfig::create`
         // requires `chain.etherscan_urls()`. Fall back to the raw `etherscan_api_key` from config
         // so that the key survives for warning/fallback logic in `client()`.
-        let config_key = config
-            .get_etherscan_config_with_chain(Some(chain))?
-            .map(|c| c.key)
-            .or_else(|| config.etherscan_api_key.clone());
+        let config_key = match config.get_etherscan_config_with_chain(Some(chain)) {
+            Ok(config) => config.map(|config| config.key),
+            // A user-selected URL does not depend on the optional configured endpoint. Explicit
+            // Sourcify likewise must not fail because an unrelated Etherscan fallback is invalid.
+            Err(_)
+                if self.verifier.verifier_url.is_some()
+                    || self.verifier.verifier.is_some_and(|provider| provider.is_sourcify()) =>
+            {
+                None
+            }
+            Err(err) => return Err(err.into()),
+        }
+        .or_else(|| config.etherscan_api_key.clone());
         self.etherscan.key =
             self.verifier.resolve_api_key(config_key.as_deref()).map(str::to_owned);
 

--- a/crates/verify/src/verify.rs
+++ b/crates/verify/src/verify.rs
@@ -1030,7 +1030,7 @@ impl FigmentProvider for VerifyCheckArgs {
 ///
 /// Some chains register their Sourcify-compatible verification API under `etherscan_urls` in
 /// alloy-chains. This function returns the properly formatted URL for such chains.
-fn sourcify_api_url(chain: Chain) -> Option<String> {
+pub fn sourcify_api_url(chain: Chain) -> Option<String> {
     if chain.is_custom_sourcify() {
         chain.etherscan_urls().map(|(api_url, _)| {
             let api_url = api_url.trim_end_matches('/');


### PR DESCRIPTION
Adds opt-in verification of contracts created by already-deployed external factories through `forge script --verify --verify-external`.

Forge records creator provenance from execution traces, retrieves verified Standard JSON from Sourcify or Etherscan, recompiles it with the original compiler settings, matches the observed `CREATE`/`CREATE2` init code and constructor arguments, and submits unique matches through the existing verification providers. Local verification remains first, and broadcast logs remain backward-compatible.

Closes #10164