### PR TITLE
chore(deps): pin tempo dependencies to v1.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,7 +1176,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1200,7 +1200,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2710,7 +2710,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3197,7 +3197,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.19",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3356,7 +3356,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4421,7 +4421,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4682,7 +4682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5527,7 +5527,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.13.0",
+ "itertools 0.15.0",
  "path-slash",
  "rand 0.10.2",
  "rayon",
@@ -7068,7 +7068,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7890,7 +7890,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9039,7 +9039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9191,7 +9191,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9650,8 +9650,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9730,8 +9730,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.5",
@@ -9744,8 +9744,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9757,8 +9757,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9781,8 +9781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9795,8 +9795,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9811,8 +9811,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9824,8 +9824,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9838,8 +9838,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.5",
@@ -9861,8 +9861,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9881,8 +9881,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9894,8 +9894,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9913,8 +9913,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9980,8 +9980,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9995,8 +9995,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10008,8 +10008,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10058,8 +10058,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10071,8 +10071,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10085,8 +10085,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.5",
@@ -10110,8 +10110,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10127,8 +10127,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10137,8 +10137,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10664,7 +10664,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10723,7 +10723,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11456,7 +11456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11582,7 +11582,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11619,7 +11619,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -12075,13 +12075,13 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12114,7 +12114,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12137,7 +12137,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12148,8 +12148,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12160,8 +12160,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12192,7 +12192,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12203,8 +12203,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12226,8 +12226,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12238,7 +12238,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12269,8 +12269,8 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.10.2"
-source = "git+https://github.com/tempoxyz/tempo?rev=8f58e3c49b18992dfc5e1184331be97adb775763#8f58e3c49b18992dfc5e1184331be97adb775763"
+version = "1.11.0"
+source = "git+https://github.com/tempoxyz/tempo?rev=fc6a69738b9789a9ba236154e8c95d0fc5d96b75#fc6a69738b9789a9ba236154e8c95d0fc5d96b75"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12296,7 +12296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13492,7 +13492,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13640,7 +13640,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,20 +515,20 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "e2e27edc17c1f8274bab9
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -618,9 +618,9 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = 
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "8f58e3c49b18992dfc5e1184331be97adb775763" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "fc6a69738b9789a9ba236154e8c95d0fc5d96b75" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -7,13 +7,12 @@
 //! This module provides a storage provider adapter for Anvil's `Db` trait and
 //! uses the shared initialization logic from `foundry-evm-core`.
 
-use alloy_primitives::{Address, B256, U256, address};
+use alloy_primitives::{Address, U256, address};
 use foundry_evm::core::tempo::{
     ALPHA_USD_ADDRESS, BETA_USD_ADDRESS, PATH_USD_ADDRESS, THETA_USD_ADDRESS,
     initialize_tempo_genesis_at_hardfork,
 };
 use revm::{
-    DatabaseRef,
     context::{BlockEnv, journaled_state::JournalCheckpoint},
     state::{AccountInfo, Bytecode},
 };
@@ -112,6 +111,7 @@ impl PrecompileStorageProvider for AnvilStorageProvider<'_> {
         address: Address,
         f: &mut dyn FnMut(&AccountInfo),
     ) -> Result<(), TempoPrecompileError> {
+        use revm::DatabaseRef;
         if let Some(info) =
             self.db.basic_ref(address).map_err(|e| TempoPrecompileError::Fatal(e.to_string()))?
         {
@@ -122,29 +122,13 @@ impl PrecompileStorageProvider for AnvilStorageProvider<'_> {
         }
     }
 
-    fn account_code(&mut self, address: Address) -> Result<(B256, Bytecode), TempoPrecompileError> {
-        let Some(info) =
-            self.db.basic_ref(address).map_err(|e| TempoPrecompileError::Fatal(e.to_string()))?
-        else {
-            return Ok((B256::ZERO, Bytecode::default()));
-        };
-        let code_hash = info.code_hash;
-        let code = if let Some(code) = info.code {
-            code
-        } else {
-            self.db
-                .code_by_hash_ref(code_hash)
-                .map_err(|e| TempoPrecompileError::Fatal(e.to_string()))?
-        };
-        Ok((code_hash, code))
-    }
-
     fn sstore(
         &mut self,
         address: Address,
         key: U256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
+        use alloy_primitives::B256;
         self.db
             .set_storage_at(address, B256::from(key), B256::from(value))
             .map_err(|e| TempoPrecompileError::Fatal(e.to_string()))


### PR DESCRIPTION
## Summary

- pin all Tempo workspace and patch dependencies to the v1.11.0 release commit (`fc6a697`)
- refresh the lockfile to the released Tempo and Reth dependency set
- remove Anvil's post-release `PrecompileStorageProvider::account_code` adapter, which is not part of v1.11.0

## Why

Tempo v1.11.0 publishes the final T8 dependency set and activation timestamps consumed by `tempo-hardfork`. Foundry's previous automated pin (`8f58e3c`) was from post-release Tempo `main` and included a T9-only storage-provider API.

Pinning the release keeps Forge, Anvil, fork configuration, and `cast run` on the supported T8 set. Their existing centralized hardfork resolution automatically selects T8 at the upstream activation boundary without duplicating activation constants, while explicit `tempo:T8` selection remains unchanged.

Linear: [OSS-531](https://linear.app/tempoxyz/issue/OSS-531)
