### PR TITLE
fix(fuzz): gate minimization predicates

### DIFF
--- a/crates/evm/evm/src/executors/showmap.rs
+++ b/crates/evm/evm/src/executors/showmap.rs
@@ -40,6 +40,7 @@ use foundry_evm_core::{
 use foundry_evm_coverage::HitMaps;
 use foundry_evm_fuzz::{BasicTxDetails, invariant::FuzzRunIdentifiedContracts};
 use std::{
+    borrow::Cow,
     collections::HashMap,
     fmt,
     fs::File,
@@ -457,6 +458,7 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
     let mut created = Vec::new();
     let mut accepted = 0usize;
     let mut last_accepted_checked_invariant = false;
+    let mut last_accepted_handlers_succeeded = false;
     for tx in input.sequence {
         if !WorkerCorpus::can_replay_tx(tx, target.stateless, target.fuzzed_contracts) {
             observation.unmatched += 1;
@@ -494,6 +496,8 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
         if target.fuzzed_contracts.is_some() {
             accepted += 1;
             last_accepted_checked_invariant = false;
+            last_accepted_handlers_succeeded =
+                invariant_handlers_succeeded(&executor, &target, &call_result);
             if let Some(failure) = invariant_handler_failure(
                 target_addr,
                 selector,
@@ -513,7 +517,8 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
                 accepted,
                 target.invariant_replay.check_interval,
                 target.invariant_replay.is_optimization,
-            ) {
+            ) && last_accepted_handlers_succeeded
+            {
                 last_accepted_checked_invariant = true;
                 if !target.invariant_replay.is_optimization
                     && !observation.failure.as_ref().is_some_and(ReplayFailure::is_predicate)
@@ -556,11 +561,13 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
         && let Some(address) = target.invariant_address
     {
         if !target.invariant_replay.is_optimization
+            && last_accepted_handlers_succeeded
             && !last_accepted_checked_invariant
             && let Some(failure) = broken_invariant(&executor, address, target.invariant_fns)?
         {
             record_replay_failure(&mut observation, failure);
-        } else if target.invariant_replay.call_after_invariant
+        } else if last_accepted_handlers_succeeded
+            && target.invariant_replay.call_after_invariant
             && let Some(failure) = broken_after_invariant(&executor, address)?
         {
             record_replay_failure(&mut observation, failure);
@@ -569,6 +576,37 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
 
     rollback_replay_created(target.fuzzed_contracts, created);
     Ok(observation)
+}
+
+/// Whether the just-executed handler call passed the campaign's success gate.
+fn invariant_handlers_succeeded<FEN: FoundryEvmNetwork>(
+    executor: &Executor<FEN>,
+    target: &ShowmapReplayTarget<'_>,
+    call_result: &crate::executors::RawCallResult<FEN>,
+) -> bool {
+    if call_result.reverted {
+        return false;
+    }
+
+    if !executor.legacy_assertions() {
+        return target.invariant_address.is_some_and(|address| {
+            executor.is_success_handler_gate(
+                address,
+                false,
+                Cow::Borrowed(&call_result.state_changeset),
+            )
+        });
+    }
+
+    target.fuzzed_contracts.is_some_and(|contracts| {
+        contracts.targets().keys().all(|address| {
+            executor.is_success_handler_gate(
+                *address,
+                false,
+                Cow::Borrowed(&call_result.state_changeset),
+            )
+        })
+    })
 }
 
 fn replay_failure_report(replay_failures: &[String], failed_entries: usize) -> String {

--- a/crates/evm/evm/src/executors/showmap.rs
+++ b/crates/evm/evm/src/executors/showmap.rs
@@ -182,7 +182,7 @@ impl ReplayFailure {
     }
 
     /// Whether this failure is a broken invariant predicate.
-    const fn is_predicate(&self) -> bool {
+    pub const fn is_predicate(&self) -> bool {
         matches!(self, Self::Invariant { .. } | Self::AfterInvariant)
     }
 }

--- a/crates/evm/evm/src/executors/showmap.rs
+++ b/crates/evm/evm/src/executors/showmap.rs
@@ -566,8 +566,7 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
             && let Some(failure) = broken_invariant(&executor, address, target.invariant_fns)?
         {
             record_replay_failure(&mut observation, failure);
-        } else if last_accepted_handlers_succeeded
-            && target.invariant_replay.call_after_invariant
+        } else if target.invariant_replay.call_after_invariant
             && let Some(failure) = broken_after_invariant(&executor, address)?
         {
             record_replay_failure(&mut observation, failure);

--- a/crates/evm/evm/src/executors/showmap.rs
+++ b/crates/evm/evm/src/executors/showmap.rs
@@ -182,17 +182,18 @@ impl ReplayFailure {
     }
 
     /// Whether this failure is a broken invariant predicate.
-    pub const fn is_predicate(&self) -> bool {
+    const fn is_predicate(&self) -> bool {
         matches!(self, Self::Invariant { .. } | Self::AfterInvariant)
     }
 }
 
 /// Records `failure` as the representative failure for an observation, preferring
 /// terminal failures over non-terminal handler bugs and keeping the first of each class.
-fn record_replay_failure(slot: &mut Option<ReplayFailure>, failure: ReplayFailure) {
-    match slot {
-        None => *slot = Some(failure),
-        Some(existing) if !existing.is_terminal() && failure.is_terminal() => *slot = Some(failure),
+fn record_replay_failure(observation: &mut ReplayObservation, failure: ReplayFailure) {
+    observation.has_non_predicate_failure |= !failure.is_predicate();
+    match &mut observation.failure {
+        slot @ None => *slot = Some(failure),
+        Some(existing) if !existing.is_terminal() && failure.is_terminal() => *existing = failure,
         Some(_) => {}
     }
 }
@@ -206,6 +207,8 @@ pub struct ReplayObservation {
     pub sancov_edges: Vec<u8>,
     /// Comparable failure identity, if replaying this candidate fails.
     pub failure: Option<ReplayFailure>,
+    /// Whether replay observed a stateless fuzz or invariant handler failure.
+    pub has_non_predicate_failure: bool,
     /// Number of replayable transactions executed.
     pub replayed: usize,
     /// Number of transactions that do not target this fuzz/invariant context.
@@ -500,7 +503,7 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
                 fingerprint,
             ) {
                 let terminal = failure.is_terminal();
-                record_replay_failure(&mut observation.failure, failure);
+                record_replay_failure(&mut observation, failure);
                 if terminal {
                     break;
                 }
@@ -518,7 +521,7 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
                     && let Some(failure) =
                         broken_invariant(&executor, address, target.invariant_fns)?
                 {
-                    record_replay_failure(&mut observation.failure, failure);
+                    record_replay_failure(&mut observation, failure);
                 }
             }
         } else if !fuzz_replay_call_succeeded(
@@ -528,7 +531,7 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
             target.fuzz_fail_on_revert,
         ) {
             record_replay_failure(
-                &mut observation.failure,
+                &mut observation,
                 ReplayFailure::Fuzz {
                     selector,
                     fingerprint,
@@ -538,7 +541,11 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
             break;
         }
 
-        if observation.failure.as_ref().is_some_and(ReplayFailure::is_terminal) {
+        if observation
+            .failure
+            .as_ref()
+            .is_some_and(|failure| failure.is_terminal() && !failure.is_predicate())
+        {
             break;
         }
     }
@@ -552,11 +559,11 @@ pub fn replay_sequence_for_minimization<FEN: FoundryEvmNetwork>(
             && !last_accepted_checked_invariant
             && let Some(failure) = broken_invariant(&executor, address, target.invariant_fns)?
         {
-            record_replay_failure(&mut observation.failure, failure);
+            record_replay_failure(&mut observation, failure);
         } else if target.invariant_replay.call_after_invariant
             && let Some(failure) = broken_after_invariant(&executor, address)?
         {
-            record_replay_failure(&mut observation.failure, failure);
+            record_replay_failure(&mut observation, failure);
         }
     }
 

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -397,7 +397,7 @@ impl FuzzCminArgs {
             let mut entry_unmatched_txs = 0usize;
             let mut entry_rejected_txs = 0usize;
             for FuzzMinimizeObservation { target, observation } in observations {
-                if observation.failure.is_some() {
+                if observation.failure.as_ref().is_some_and(|failure| !failure.is_predicate()) {
                     entry_failed = true;
                     entry_failed_replays += observation.replayed;
                     continue;

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -397,7 +397,7 @@ impl FuzzCminArgs {
             let mut entry_unmatched_txs = 0usize;
             let mut entry_rejected_txs = 0usize;
             for FuzzMinimizeObservation { target, observation } in observations {
-                if observation.failure.as_ref().is_some_and(|failure| !failure.is_predicate()) {
+                if observation.has_non_predicate_failure {
                     entry_failed = true;
                     entry_failed_replays += observation.replayed;
                     continue;

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1571,6 +1571,75 @@ contract ForgeFuzzCminInvariantTargetTest is Test {
     assert_eq!(regular_file_count(&prj.root().join("min-invariant-corpus")), 2);
 });
 
+forgetest_init!(forge_fuzz_cmin_minimizes_broken_invariant_corpus, |prj, cmd| {
+    prj.add_test(
+        "ForgeFuzzCminBrokenInvariant.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzCminBrokenInvariantTest is Test {
+    bool broken;
+    uint256 left;
+    uint256 right;
+
+    function setUp() public {
+        targetContract(address(this));
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = this.breakInvariant.selector;
+        targetSelector(FuzzSelector({addr: address(this), selectors: selectors}));
+    }
+
+    function breakInvariant(uint256 input) external {
+        broken = true;
+        if (input == 1) {
+            left = 1;
+        } else {
+            right = 1;
+        }
+    }
+
+    function invariant_canary() public view {
+        assertFalse(broken);
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminBrokenInvariant.t.sol/ForgeFuzzCminBrokenInvariantTest.json",
+    );
+    let one = calldata_for(&abi, "breakInvariant", 1);
+    let two = calldata_for(&abi, "breakInvariant", 2);
+    let corpus = prj.root().join("broken-invariant-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000002-2.json", &one);
+    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000003-3.json", &two);
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminBrokenInvariantTest",
+            "--mt",
+            "invariant_canary",
+            "broken-invariant-corpus",
+            "--corpus-out",
+            "min-broken-invariant-corpus",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("minimized corpus: kept 2/3 entries in min-broken-invariant-corpus"),
+        "{stdout}"
+    );
+    assert_eq!(regular_file_count(&prj.root().join("min-broken-invariant-corpus")), 2);
+});
+
 forgetest_init!(forge_fuzz_tmin_removes_redundant_transactions, |prj, cmd| {
     prj.add_test(
         "ForgeFuzzTminRemoveTarget.t.sol",

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1819,6 +1819,79 @@ contract ForgeFuzzTminRemoveTargetTest {
     assert_eq!(output.as_array().unwrap().len(), 1);
 });
 
+forgetest_init!(forge_fuzz_tmin_gates_predicate_after_handler_failure, |prj, cmd| {
+    prj.update_config(|config| {
+        config.assertions_revert = false;
+        config.invariant.check_interval = 0;
+    });
+    prj.add_test(
+        "ForgeFuzzTminHandlerGate.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzTminHandlerGateTest is Test {
+    bool broken;
+
+    function setUp() public {
+        targetContract(address(this));
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = this.breakInvariant.selector;
+        selectors[1] = this.assertHandler.selector;
+        targetSelector(FuzzSelector({addr: address(this), selectors: selectors}));
+    }
+
+    function breakInvariant(uint256) external {
+        broken = true;
+    }
+
+    function assertHandler(uint256) external {
+        assertTrue(false);
+    }
+
+    function invariant_ok() public view {
+        assertFalse(broken);
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzTminHandlerGate.t.sol/ForgeFuzzTminHandlerGateTest.json",
+    );
+    let break_invariant = calldata_for(&abi, "breakInvariant", 0);
+    let assert_handler = calldata_for(&abi, "assertHandler", 0);
+    let corpus = prj.root().join("tmin-handler-gate-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_sequence_entry(
+        &corpus,
+        "00000000-0000-0000-0000-000000000001-1.json",
+        &[&break_invariant, &assert_handler],
+    );
+
+    cmd.forge_fuse()
+        .args([
+            "fuzz",
+            "tmin",
+            "--mc",
+            "ForgeFuzzTminHandlerGateTest",
+            "--mt",
+            "invariant_ok",
+            "tmin-handler-gate-corpus/00000000-0000-0000-0000-000000000001-1.json",
+            "--corpus-out",
+            "tmin-handler-gate-output.json",
+        ])
+        .assert_success();
+
+    let output: Value = serde_json::from_str(
+        &std::fs::read_to_string(prj.root().join("tmin-handler-gate-output.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(output.as_array().unwrap().len(), 1);
+    assert_eq!(output[0]["calldata"].as_str().unwrap(), assert_handler);
+});
+
 forgetest_init!(forge_fuzz_tmin_simplifies_abi_calldata, |prj, cmd| {
     prj.add_test(
         "ForgeFuzzTminAbiTarget.t.sol",

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1584,13 +1584,17 @@ contract ForgeFuzzCminBrokenInvariantTest is Test {
 
     function setUp() public {
         targetContract(address(this));
-        bytes4[] memory selectors = new bytes4[](1);
+        bytes4[] memory selectors = new bytes4[](2);
         selectors[0] = this.breakInvariant.selector;
+        selectors[1] = this.laterBranch.selector;
         targetSelector(FuzzSelector({addr: address(this), selectors: selectors}));
     }
 
-    function breakInvariant(uint256 input) external {
+    function breakInvariant(uint256) external {
         broken = true;
+    }
+
+    function laterBranch(uint256 input) external {
         if (input == 1) {
             left = 1;
         } else {
@@ -1610,13 +1614,42 @@ contract ForgeFuzzCminBrokenInvariantTest is Test {
         prj.root(),
         "out/ForgeFuzzCminBrokenInvariant.t.sol/ForgeFuzzCminBrokenInvariantTest.json",
     );
-    let one = calldata_for(&abi, "breakInvariant", 1);
-    let two = calldata_for(&abi, "breakInvariant", 2);
+    let break_invariant = calldata_for(&abi, "breakInvariant", 0);
+    let one = calldata_for(&abi, "laterBranch", 1);
+    let two = calldata_for(&abi, "laterBranch", 2);
     let corpus = prj.root().join("broken-invariant-corpus");
     std::fs::create_dir_all(&corpus).unwrap();
-    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000001-1.json", &one);
-    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000002-2.json", &one);
-    write_corpus_entry(&corpus, "00000000-0000-0000-0000-000000000003-3.json", &two);
+    write_corpus_sequence_entry(
+        &corpus,
+        "00000000-0000-0000-0000-000000000001-1.json",
+        &[&break_invariant, &one],
+    );
+    write_corpus_sequence_entry(
+        &corpus,
+        "00000000-0000-0000-0000-000000000002-2.json",
+        &[&break_invariant, &one],
+    );
+    write_corpus_sequence_entry(
+        &corpus,
+        "00000000-0000-0000-0000-000000000003-3.json",
+        &[&break_invariant, &two],
+    );
+
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--mc",
+            "ForgeFuzzCminBrokenInvariantTest",
+            "--mt",
+            "invariant_canary",
+            "--showmap-out",
+            "showmap-before-broken-invariant-cmin",
+            "--showmap-corpus-dir",
+            "broken-invariant-corpus",
+            "--showmap-trial",
+            "t",
+        ])
+        .assert_success();
 
     let assert = cmd
         .forge_fuse()
@@ -1638,6 +1671,92 @@ contract ForgeFuzzCminBrokenInvariantTest is Test {
         "{stdout}"
     );
     assert_eq!(regular_file_count(&prj.root().join("min-broken-invariant-corpus")), 2);
+
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--mc",
+            "ForgeFuzzCminBrokenInvariantTest",
+            "--mt",
+            "invariant_canary",
+            "--showmap-out",
+            "showmap-after-broken-invariant-cmin",
+            "--showmap-corpus-dir",
+            "min-broken-invariant-corpus",
+            "--showmap-trial",
+            "t",
+        ])
+        .assert_success();
+    assert_eq!(
+        showmap_edge_ids(&prj.root().join("showmap-before-broken-invariant-cmin")),
+        showmap_edge_ids(&prj.root().join("showmap-after-broken-invariant-cmin"))
+    );
+});
+
+forgetest_init!(forge_fuzz_cmin_rejects_masked_handler_failure, |prj, cmd| {
+    prj.update_config(|config| config.invariant.check_interval = 0);
+    prj.add_test(
+        "ForgeFuzzCminMaskedHandler.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzCminMaskedHandlerTest is Test {
+    bool broken;
+
+    function setUp() public {
+        targetContract(address(this));
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = this.breakInvariant.selector;
+        selectors[1] = this.assertHandler.selector;
+        targetSelector(FuzzSelector({addr: address(this), selectors: selectors}));
+    }
+
+    function breakInvariant(uint256) external {
+        broken = true;
+    }
+
+    function assertHandler(uint256) external {
+        assertTrue(false);
+    }
+
+    function invariant_canary() public view {
+        assertFalse(broken);
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzCminMaskedHandler.t.sol/ForgeFuzzCminMaskedHandlerTest.json",
+    );
+    let break_invariant = calldata_for(&abi, "breakInvariant", 0);
+    let assert_handler = calldata_for(&abi, "assertHandler", 0);
+    let corpus = prj.root().join("masked-handler-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_sequence_entry(
+        &corpus,
+        "00000000-0000-0000-0000-000000000001-1.json",
+        &[&break_invariant, &assert_handler],
+    );
+
+    let assert = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "cmin",
+            "--mc",
+            "ForgeFuzzCminMaskedHandlerTest",
+            "--mt",
+            "invariant_canary",
+            "masked-handler-corpus",
+            "--corpus-out",
+            "min-masked-handler-corpus",
+        ])
+        .assert_failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.contains("1 corpus entries failed during replay"), "{stderr}");
 });
 
 forgetest_init!(forge_fuzz_tmin_removes_redundant_transactions, |prj, cmd| {

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1892,6 +1892,83 @@ contract ForgeFuzzTminHandlerGateTest is Test {
     assert_eq!(output[0]["calldata"].as_str().unwrap(), assert_handler);
 });
 
+forgetest_init!(forge_fuzz_tmin_checks_after_invariant_after_handler_failure, |prj, cmd| {
+    prj.update_config(|config| {
+        config.assertions_revert = false;
+        config.invariant.check_interval = 0;
+    });
+    prj.add_test(
+        "ForgeFuzzTminAfterInvariant.t.sol",
+        r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ForgeFuzzTminAfterInvariantTest is Test {
+    bool afterFails;
+
+    function setUp() public {
+        targetContract(address(this));
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = this.armAfterInvariant.selector;
+        selectors[1] = this.assertHandler.selector;
+        targetSelector(FuzzSelector({addr: address(this), selectors: selectors}));
+    }
+
+    function armAfterInvariant(uint256) external {
+        afterFails = true;
+    }
+
+    function assertHandler(uint256) external {
+        assertTrue(false);
+    }
+
+    function invariant_ok() public pure {}
+
+    function afterInvariant() external view {
+        if (afterFails) {
+            revert("after");
+        }
+    }
+}
+   "#,
+    );
+    cmd.args(["build", "-q"]).assert_success();
+
+    let abi = artifact_abi(
+        prj.root(),
+        "out/ForgeFuzzTminAfterInvariant.t.sol/ForgeFuzzTminAfterInvariantTest.json",
+    );
+    let arm_after_invariant = calldata_for(&abi, "armAfterInvariant", 0);
+    let assert_handler = calldata_for(&abi, "assertHandler", 0);
+    let corpus = prj.root().join("tmin-after-invariant-corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    write_corpus_sequence_entry(
+        &corpus,
+        "00000000-0000-0000-0000-000000000001-1.json",
+        &[&arm_after_invariant, &assert_handler],
+    );
+
+    cmd.forge_fuse()
+        .args([
+            "fuzz",
+            "tmin",
+            "--mc",
+            "ForgeFuzzTminAfterInvariantTest",
+            "--mt",
+            "invariant_ok",
+            "tmin-after-invariant-corpus/00000000-0000-0000-0000-000000000001-1.json",
+            "--corpus-out",
+            "tmin-after-invariant-output.json",
+        ])
+        .assert_success();
+
+    let output: Value = serde_json::from_str(
+        &std::fs::read_to_string(prj.root().join("tmin-after-invariant-output.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(output.as_array().unwrap().len(), 1);
+    assert_eq!(output[0]["calldata"].as_str().unwrap(), arm_after_invariant);
+});
+
 forgetest_init!(forge_fuzz_tmin_simplifies_abi_calldata, |prj, cmd| {
     prj.add_test(
         "ForgeFuzzTminAbiTarget.t.sol",


### PR DESCRIPTION
Invariant minimization replay evaluated invariant predicates after handler outcomes that the campaign handler-success gate would reject. This mirrors the campaign gate for periodic and final invariant checks, so tmin preserves the campaign-visible failure identity without changing which observations cmin treats as execution errors. `afterInvariant` remains evaluated under its separate campaign semantics, including after a handler failure.

Addresses OSS-579.

This PR was written primarily by OpenAI Codex.
