### PR TITLE
feat(anvil): `eth_simulateV1` support moved precompiles

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -51,7 +51,7 @@ use alloy_evm::{
     block::{BlockExecutionResult, BlockExecutor, StateDB},
     eth::EthEvmContext,
     overrides::{OverrideBlockHashes, apply_state_overrides},
-    precompiles::{DynPrecompile, Precompile, PrecompilesMap},
+    precompiles::{DynPrecompile, MovePrecompileError, Precompile, PrecompilesMap},
 };
 use alloy_network::{
     AnyHeader, AnyRpcBlock, AnyRpcHeader, AnyRpcTransaction, AnyTxEnvelope, AnyTxType, Network,
@@ -175,8 +175,9 @@ impl<DB: Database, T> BackendInspector<DB> for T where
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use revm::{
     Database as RevmDatabase, DatabaseCommit, Inspector,
-    context::{Block as RevmBlock, BlockEnv, Cfg, TxEnv},
+    context::{Block as RevmBlock, BlockEnv, Cfg, ContextTr, TxEnv},
     context_interface::{
+        JournalTr,
         block::BlobExcessGasAndPrice,
         result::{ExecutionResult, HaltReason, Output, ResultAndState},
     },
@@ -249,6 +250,11 @@ fn call_config_from_tracer_config(
 }
 
 pub type State = foundry_evm::utils::StateChangeset;
+
+#[derive(Clone, Debug, Default)]
+struct SimulationPrecompileOverrides {
+    moves: Vec<(Address, Address)>,
+}
 
 /// A block request, which includes the Pool Transactions if it's Pending
 pub enum BlockRequest<T> {
@@ -1273,6 +1279,93 @@ impl<N: Network> Backend<N> {
         });
     }
 
+    fn simulation_precompile_overrides(
+        &self,
+        state_overrides: Option<&StateOverride>,
+        evm_env: &EvmEnv,
+    ) -> Result<SimulationPrecompileOverrides, BlockchainError> {
+        let mut moves = state_overrides
+            .into_iter()
+            .flatten()
+            .filter_map(|(source, account)| {
+                account.move_precompile_to.map(|destination| (*source, destination))
+            })
+            .collect::<Vec<_>>();
+        moves.sort_unstable();
+        if moves.is_empty() {
+            return Ok(SimulationPrecompileOverrides::default());
+        }
+        if self.is_optimism() || self.is_tempo() {
+            return Err(simulate_rpc_error(
+                -32000,
+                "precompile moves are not supported on this network",
+            ));
+        }
+
+        let mut precompiles = PrecompilesMap::from_static(Precompiles::new(
+            PrecompileSpecId::from_spec_id(*evm_env.spec_id()),
+        ));
+        self.inject_precompiles(&mut precompiles, evm_env);
+        self.inject_arbitrum_precompile(&mut precompiles, evm_env);
+        let precompile_addresses = precompiles.addresses().copied().collect::<HashSet<_>>();
+
+        // Validate every source first so invalid-source errors take precedence over the more
+        // specific move errors below.
+        for (source, _) in &moves {
+            if !precompile_addresses.contains(source) {
+                return Err(simulate_rpc_error(
+                    -32000,
+                    format!("account {source} is not a precompile"),
+                ));
+            }
+        }
+        for (source, destination) in &moves {
+            if source == destination {
+                return Err(simulate_rpc_error(
+                    -38022,
+                    format!("cannot move precompile {source} to itself"),
+                ));
+            }
+        }
+        let mut destinations = Vec::with_capacity(moves.len());
+        for (_, destination) in &moves {
+            if destinations.contains(destination) {
+                return Err(simulate_rpc_error(
+                    -38023,
+                    format!("multiple precompiles moved to {destination}"),
+                ));
+            }
+            destinations.push(*destination);
+        }
+
+        Ok(SimulationPrecompileOverrides { moves })
+    }
+
+    fn apply_simulation_precompile_overrides(
+        &self,
+        precompiles: &mut PrecompilesMap,
+        overrides: &SimulationPrecompileOverrides,
+    ) -> Result<alloy_primitives::map::AddressSet, BlockchainError> {
+        let warm_addresses = precompiles.addresses().copied().collect();
+        precompiles.move_precompiles(overrides.moves.iter().copied()).map_err(
+            |MovePrecompileError::NotAPrecompile(address)| {
+                simulate_rpc_error(-32000, format!("account {address} is not a precompile"))
+            },
+        )?;
+
+        // A dynamic lookup must not restore a precompile removed from its protocol address.
+        let moved_sources =
+            Arc::new(overrides.moves.iter().map(|(source, _)| *source).collect::<HashSet<_>>());
+        precompiles.map_precompile_lookup(move |address, previous| {
+            if moved_sources.contains(address) {
+                None
+            } else {
+                previous.and_then(|lookup| lookup.lookup(address))
+            }
+        });
+        Ok(warm_addresses)
+    }
+
     fn inject_tempo_precompiles<DB, I>(
         &self,
         evm: &mut tempo_evm::evm::TempoEvm<DB, I>,
@@ -1338,6 +1431,28 @@ impl<N: Network> Backend<N> {
         I: Inspector<EthEvmContext<WrapDatabaseRef<&'db DB>>>,
         WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
     {
+        self.transact_eth_with_inspector_ref_and_precompile_overrides(
+            db,
+            evm_env,
+            inspector,
+            tx_env,
+            &SimulationPrecompileOverrides::default(),
+        )
+    }
+
+    fn transact_eth_with_inspector_ref_and_precompile_overrides<'db, I, DB>(
+        &self,
+        db: &'db DB,
+        evm_env: &EvmEnv,
+        inspector: &mut I,
+        tx_env: TxEnv,
+        overrides: &SimulationPrecompileOverrides,
+    ) -> Result<ResultAndState<HaltReason>, BlockchainError>
+    where
+        DB: DatabaseRef + ?Sized,
+        I: Inspector<EthEvmContext<WrapDatabaseRef<&'db DB>>>,
+        WrapDatabaseRef<&'db DB>: Database<Error = DatabaseError>,
+    {
         let mut evm = EthEvmFactory::default().create_evm_with_inspector(
             WrapDatabaseRef(db),
             evm_env.clone(),
@@ -1345,6 +1460,12 @@ impl<N: Network> Backend<N> {
         );
         self.inject_precompiles(evm.precompiles_mut(), evm_env);
         self.inject_arbitrum_precompile(evm.precompiles_mut(), evm_env);
+        if !overrides.moves.is_empty() {
+            let warm_addresses =
+                self.apply_simulation_precompile_overrides(evm.precompiles_mut(), overrides)?;
+            // EIP-2929 warms protocol precompile addresses, not simulation-only destinations.
+            evm.ctx_mut().journal_mut().warm_precompiles(&warm_addresses);
+        }
         Ok(evm.transact(tx_env)?)
     }
 
@@ -5120,12 +5241,20 @@ impl Backend<FoundryNetwork> {
                     })
                     .unwrap_or_default();
 
-                // apply state overrides before executing the transactions
-                if let Some(state_overrides) = state_overrides {
-                    apply_state_overrides(state_overrides, &mut cache_db)?;
-                }
                 if let Some(block_overrides) = block_overrides {
                     cache_db.apply_block_overrides(block_overrides, &mut block_env);
+                }
+                let simulation_evm_env =
+                    EvmEnv::new(self.evm_env.read().cfg_env.clone(), block_env.clone());
+                let precompile_overrides = self.simulation_precompile_overrides(
+                    state_overrides.as_ref(),
+                    &simulation_evm_env,
+                )?;
+
+                // Apply state overrides after validating precompile moves against this block's
+                // active precompile set.
+                if let Some(state_overrides) = state_overrides {
+                    apply_state_overrides(state_overrides, &mut cache_db)?;
                 }
 
                 // execute all calls in that block
@@ -5207,13 +5336,23 @@ impl Backend<FoundryNetwork> {
                         inspector = inspector.with_transfers();
                     }
                     trace!(target: "backend", env=?evm_env, spec=?evm_env.spec_id(),"simulate evm env");
-                    let execution_result = self.transact_with_inspector_ref(
-                        &cache_db,
-                        &evm_env,
-                        &mut inspector,
-                        tx_env,
-                        op_deposit,
-                    );
+                    let execution_result = if precompile_overrides.moves.is_empty() {
+                        self.transact_with_inspector_ref(
+                            &cache_db,
+                            &evm_env,
+                            &mut inspector,
+                            tx_env,
+                            op_deposit,
+                        )
+                    } else {
+                        self.transact_eth_with_inspector_ref_and_precompile_overrides(
+                            &cache_db,
+                            &evm_env,
+                            &mut inspector,
+                            tx_env,
+                            &precompile_overrides,
+                        )
+                    };
                     let ResultAndState { result, mut state } = match execution_result {
                         Err(BlockchainError::InvalidTransaction(error)) => {
                             return Err(simulate_transaction_error(error));

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -1,6 +1,7 @@
 //! general eth api tests
 
-use alloy_primitives::{Bytes, TxKind, U256, address};
+use alloy_evm::precompiles::{DynPrecompile, PrecompileInput, PrecompilesMap};
+use alloy_primitives::{Address, Bytes, TxKind, U256, address};
 use alloy_provider::Provider;
 use alloy_rpc_types::{
     BlockOverrides,
@@ -8,9 +9,10 @@ use alloy_rpc_types::{
     simulate::{SimBlock, SimulatePayload},
     state::{AccountOverride, StateOverridesBuilder},
 };
-use anvil::{EthereumHardfork, NodeConfig, spawn};
+use anvil::{EthereumHardfork, NodeConfig, PrecompileFactory, spawn};
 use axum::{Json, Router, routing::post};
 use foundry_test_utils::rpc;
+use revm::precompile::{PrecompileOutput, PrecompileStatus};
 use serde_json::{Value, json};
 use std::time::Duration;
 
@@ -45,6 +47,227 @@ async fn test_fork_simulate_v1() {
         return_full_transactions: true,
     };
     let _res = api.simulate_v1(payload, None).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_v1_moves_precompiles_per_block_rpc() {
+    let (_, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let source = "0x0000000000000000000000000000000000000004";
+    let destination = "0x0000000000000000000000000000000000123456";
+    let return_42 = "0x000000000000000000000000000000000000000000000000000000000000002a";
+
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {
+                    "stateOverrides": {
+                        source: {
+                            "code": "0x602a60005260206000f3",
+                            "movePrecompileToAddress": destination
+                        }
+                    },
+                    "calls": [
+                        {"to": source, "input": "0x1234"},
+                        {"to": destination, "input": "0x1234"}
+                    ]
+                },
+                {
+                    "calls": [
+                        {"to": source, "input": "0x1234"},
+                        {"to": destination, "input": "0x1234"}
+                    ]
+                }
+            ]
+        }, "latest"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+
+    let blocks = response["result"].as_array().unwrap();
+    assert_eq!(blocks[0]["calls"][0]["returnData"], return_42);
+    assert_eq!(blocks[0]["calls"][1]["returnData"], "0x1234");
+    assert_eq!(blocks[1]["calls"][0]["returnData"], "0x1234");
+    assert_eq!(blocks[1]["calls"][1]["returnData"], "0x");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_v1_preserves_precompile_warming_rpc() {
+    let (_, handle) = spawn(NodeConfig::test()).await;
+    let source = "0x0000000000000000000000000000000000000004";
+    let destination = "0x0000000000000000000000000000000000123456";
+    let helper = "0x0000000000000000000000000000000000001000";
+    let helper_code = format!(
+        "0x5a73{}31505a035f525a73{}31505a036020525a73{}31505a0360405260605ff3",
+        &source[2..],
+        &destination[2..],
+        &destination[2..],
+    );
+
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{"blockStateCalls": [{
+            "stateOverrides": {
+                source: {"movePrecompileToAddress": destination},
+                helper: {"code": helper_code}
+            },
+            "calls": [{"to": helper}]
+        }]}, "latest"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+
+    let return_data = response["result"][0]["calls"][0]["returnData"].as_str().unwrap();
+    let return_data = alloy_primitives::hex::decode(&return_data[2..]).unwrap();
+    let access_costs = return_data.chunks_exact(32).map(U256::from_be_slice).collect::<Vec<_>>();
+
+    // The measured delta includes PUSH20, POP, and the second GAS opcode (7 gas total).
+    assert_eq!(access_costs, [U256::from(107), U256::from(2_607), U256::from(107)]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_v1_validates_precompile_moves_rpc() {
+    let (_, handle) = spawn(NodeConfig::test()).await;
+    let endpoint = handle.http_endpoint();
+    let precompile_one = "0x0000000000000000000000000000000000000001";
+    let precompile_two = "0x0000000000000000000000000000000000000002";
+    let not_precompile = "0xc100000000000000000000000000000000000000";
+    let destination = "0xc200000000000000000000000000000000000000";
+
+    let cases = [
+        (
+            json!([{"blockStateCalls": [{"stateOverrides": {
+                not_precompile: {"movePrecompileToAddress": not_precompile}
+            }}]}, "latest"]),
+            -32000,
+        ),
+        (
+            json!([{"blockStateCalls": [{"stateOverrides": {
+                precompile_one: {"movePrecompileToAddress": precompile_one}
+            }}]}, "latest"]),
+            -38022,
+        ),
+        (
+            json!([{"blockStateCalls": [{"stateOverrides": {
+                not_precompile: {"movePrecompileToAddress": destination},
+                "0xc300000000000000000000000000000000000000": {
+                    "movePrecompileToAddress": destination
+                }
+            }}]}, "latest"]),
+            -32000,
+        ),
+        (
+            json!([{"blockStateCalls": [{"stateOverrides": {
+                precompile_one: {"movePrecompileToAddress": destination},
+                precompile_two: {"movePrecompileToAddress": destination}
+            }}]}, "latest"]),
+            -38023,
+        ),
+    ];
+
+    for (params, expected_code) in cases {
+        let response = rpc_request(&endpoint, "eth_simulateV1", params).await;
+        assert_eq!(response["error"]["code"], expected_code, "{response}");
+    }
+
+    let (_, handle) =
+        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Homestead.into()))).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{"blockStateCalls": [{"stateOverrides": {
+            "0x0000000000000000000000000000000000000005": {
+                "movePrecompileToAddress": destination
+            }
+        }}]}, "latest"]),
+    )
+    .await;
+    assert_eq!(response["error"]["code"], -32000, "{response}");
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LookupOnlyPrecompileFactory(Address);
+
+impl PrecompileFactory for LookupOnlyPrecompileFactory {
+    fn precompiles(&self) -> Vec<(Address, DynPrecompile)> {
+        Vec::new()
+    }
+
+    fn install(&self, precompiles: &mut PrecompilesMap) {
+        let lookup_address = self.0;
+        precompiles.set_precompile_lookup(move |address| {
+            (*address == lookup_address).then(|| {
+                DynPrecompile::from(|input: PrecompileInput<'_>| {
+                    Ok(PrecompileOutput {
+                        status: PrecompileStatus::Success,
+                        bytes: Bytes::copy_from_slice(input.data),
+                        gas_used: 0,
+                        gas_refunded: 0,
+                        state_gas_used: 0,
+                        reservoir: input.reservoir,
+                    })
+                })
+            })
+        });
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_v1_rejects_lookup_only_precompile_move_rpc() {
+    let source = address!("0xdead000000000000000000000000000000000071");
+    let (_, handle) =
+        spawn(NodeConfig::test().with_precompile_factory(LookupOnlyPrecompileFactory(source)))
+            .await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{"blockStateCalls": [{"stateOverrides": {
+            (source): {
+                "movePrecompileToAddress": "0x0000000000000000000000000000000000123456"
+            }
+        }}]}, "latest"]),
+    )
+    .await;
+
+    assert_eq!(response["error"]["code"], -32000, "{response}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_v1_rejects_precompile_moves_on_tempo_rpc() {
+    let (_, handle) = spawn(NodeConfig::test_tempo()).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{"blockStateCalls": [{"stateOverrides": {
+            "0x0000000000000000000000000000000000000004": {
+                "movePrecompileToAddress": "0x0000000000000000000000000000000000123456"
+            }
+        }}]}, "latest"]),
+    )
+    .await;
+
+    assert_eq!(response["error"]["code"], -32000, "{response}");
+}
+
+#[cfg(feature = "optimism")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_v1_rejects_precompile_moves_on_optimism_rpc() {
+    let (_, handle) = spawn(NodeConfig::test().with_optimism()).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{"blockStateCalls": [{"stateOverrides": {
+            "0x0000000000000000000000000000000000000004": {
+                "movePrecompileToAddress": "0x0000000000000000000000000000000000123456"
+            }
+        }}]}, "latest"]),
+    )
+    .await;
+
+    assert_eq!(response["error"]["code"], -32000, "{response}");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -100,7 +100,7 @@ async fn test_simulate_v1_preserves_precompile_warming_rpc() {
     let destination = "0x0000000000000000000000000000000000123456";
     let helper = "0x0000000000000000000000000000000000001000";
     let helper_code = format!(
-        "0x5a73{}31505a035f525a73{}31505a036020525a73{}31505a0360405260605ff3",
+        "0x5a73{}31505a90035f525a73{}31505a90036020525a73{}31505a900360405260605ff3",
         &source[2..],
         &destination[2..],
         &destination[2..],
@@ -122,7 +122,13 @@ async fn test_simulate_v1_preserves_precompile_warming_rpc() {
 
     let return_data = response["result"][0]["calls"][0]["returnData"].as_str().unwrap();
     let return_data = alloy_primitives::hex::decode(&return_data[2..]).unwrap();
-    let access_costs = return_data.chunks_exact(32).map(U256::from_be_slice).collect::<Vec<_>>();
+    let access_costs = return_data
+        .as_chunks::<32>()
+        .0
+        .iter()
+        .copied()
+        .map(U256::from_be_bytes)
+        .collect::<Vec<_>>();
 
     // The measured delta includes PUSH20, POP, and the second GAS opcode (7 gas total).
     assert_eq!(access_costs, [U256::from(107), U256::from(2_607), U256::from(107)]);
@@ -198,7 +204,7 @@ impl PrecompileFactory for LookupOnlyPrecompileFactory {
 
     fn install(&self, precompiles: &mut PrecompilesMap) {
         let lookup_address = self.0;
-        precompiles.set_precompile_lookup(move |address| {
+        precompiles.set_precompile_lookup(move |address: &Address| {
             (*address == lookup_address).then(|| {
                 DynPrecompile::from(|input: PrecompileInput<'_>| {
                     Ok(PrecompileOutput {
@@ -225,7 +231,7 @@ async fn test_simulate_v1_rejects_lookup_only_precompile_move_rpc() {
         &handle.http_endpoint(),
         "eth_simulateV1",
         json!([{"blockStateCalls": [{"stateOverrides": {
-            (source): {
+            (source.to_string()): {
                 "movePrecompileToAddress": "0x0000000000000000000000000000000000123456"
             }
         }}]}, "latest"]),


### PR DESCRIPTION
## Motivation

Adds support for `movePrecompileToAddress` in `eth_simulateV1` state overrides. Each simulated block validates relocations against the active Ethereum precompile set, rejects self-relocations and duplicate destinations with the specified error codes, and applies valid moves only for that block.

Relocating a precompile frees its original address for a bytecode override while preserving protocol-address warming under EIP-2929. Optimism and Tempo retain their existing execution paths.

Closes OSS-560
