### PR TITLE
fix(anvil): `eth_simulateV1` trace ETH transfers

### DIFF
--- a/crates/anvil/src/eth/backend/mem/inspector.rs
+++ b/crates/anvil/src/eth/backend/mem/inspector.rs
@@ -1,7 +1,8 @@
 //! Anvil specific [`revm::Inspector`] implementation
 
 use crate::eth::macros::node_info;
-use alloy_primitives::{Address, Log, U256};
+use alloy_primitives::{Address, B256, Log, LogData, U256};
+use alloy_sol_types::SolValue;
 use foundry_evm::{
     call_inspectors,
     decode::decode_console_logs,
@@ -13,14 +14,14 @@ use foundry_evm::{
 };
 use revm::{
     Inspector,
-    context::ContextTr,
+    context::{ContextTr, JournalTr},
     inspector::JournalExt,
     interpreter::{
-        CallInputs, CallOutcome, CreateInputs, CreateOutcome, Interpreter,
-        interpreter::EthInterpreter,
+        CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, CreateScheme,
+        Interpreter, interpreter::EthInterpreter,
     },
 };
-use revm_inspectors::transfer::TransferInspector;
+use revm_inspectors::transfer::{TRANSFER_EVENT_TOPIC, TRANSFER_LOG_EMITTER, TransferInspector};
 use std::sync::Arc;
 
 /// The [`revm::Inspector`] used when transacting in the evm
@@ -32,6 +33,89 @@ pub struct AnvilInspector {
     pub log_collector: Option<LogCollector>,
     /// Collects all internal ETH transfers as ERC20 transfer events.
     pub transfer: Option<TransferInspector>,
+    /// Collects canonical and synthetic transfer logs for an `eth_simulateV1` response.
+    simulation_logs: Option<SimulationLogCollector>,
+}
+
+#[derive(Clone, Debug)]
+struct SimulationLog {
+    log: Log,
+    index: u64,
+    canonical: bool,
+}
+
+/// Collects simulation response logs without inserting synthetic logs into EVM state.
+#[derive(Clone, Debug, Default)]
+struct SimulationLogCollector {
+    logs: Vec<SimulationLog>,
+    checkpoints: Vec<usize>,
+    next_index: u64,
+    trace_transfers: bool,
+    journal_log_count: usize,
+}
+
+impl SimulationLogCollector {
+    fn push_log(&mut self, log: Log, canonical: bool) {
+        self.logs.push(SimulationLog { log, index: self.next_index, canonical });
+        self.next_index += 1;
+    }
+
+    fn push_canonical_log(&mut self, log: Log, journal_log_count: usize) {
+        self.push_log(log, true);
+        self.journal_log_count = journal_log_count;
+    }
+
+    fn sync_journal_logs(&mut self, logs: &[Log]) {
+        self.journal_log_count = self.journal_log_count.min(logs.len());
+        for log in &logs[self.journal_log_count..] {
+            self.push_log(log.clone(), true);
+        }
+        self.journal_log_count = logs.len();
+    }
+
+    fn push_transfer(&mut self, from: Address, to: Address, value: U256) {
+        if !self.trace_transfers || value.is_zero() {
+            return;
+        }
+        self.push_log(
+            Log {
+                address: TRANSFER_LOG_EMITTER,
+                data: LogData::new_unchecked(
+                    vec![
+                        TRANSFER_EVENT_TOPIC,
+                        B256::from_slice(&from.abi_encode()),
+                        B256::from_slice(&to.abi_encode()),
+                    ],
+                    value.abi_encode().into(),
+                ),
+            },
+            false,
+        );
+    }
+
+    fn frame_start(&mut self) {
+        self.checkpoints.push(self.logs.len());
+    }
+
+    fn frame_end(&mut self, success: bool, journal_log_count: usize) {
+        let checkpoint = self.checkpoints.pop().expect("execution frame checkpoint exists");
+        if !success {
+            self.logs.truncate(checkpoint);
+        }
+        self.journal_log_count = journal_log_count;
+    }
+
+    fn append_remaining_canonical_logs(&mut self, canonical_logs: &[Log]) {
+        let mut canonical_logs = canonical_logs.iter();
+        for collected in self.logs.iter().filter(|log| log.canonical) {
+            let canonical =
+                canonical_logs.next().expect("collected canonical log exists in result");
+            assert_eq!(&collected.log, canonical, "collected canonical logs preserve ordering");
+        }
+        for log in canonical_logs {
+            self.push_log(log.clone(), true);
+        }
+    }
 }
 
 /// Configuration for per-transaction inspector lifecycle.
@@ -130,6 +214,27 @@ impl AnvilInspector {
         self
     }
 
+    /// Collects canonical and synthetic transfer logs for an `eth_simulateV1` response.
+    pub fn with_simulation_logs(mut self, trace_transfers: bool) -> Self {
+        self.simulation_logs =
+            Some(SimulationLogCollector { trace_transfers, ..Default::default() });
+        self
+    }
+
+    /// Takes the collected `eth_simulateV1` response logs and attempted log count.
+    pub fn take_simulation_logs(
+        &mut self,
+        canonical_logs: &[Log],
+    ) -> Option<(Vec<(u64, Log)>, u64)> {
+        self.simulation_logs.take().map(|mut collector| {
+            collector.append_remaining_canonical_logs(canonical_logs);
+            (
+                collector.logs.into_iter().map(|log| (log.index, log.log)).collect(),
+                collector.next_index,
+            )
+        })
+    }
+
     /// Configures the `Tracer` [`revm::Inspector`] with a trace printer
     pub fn with_trace_printer(mut self) -> Self {
         self.tracer = Some(TracingInspector::new(TracingInspectorConfig::all().with_state_diffs()));
@@ -164,12 +269,18 @@ where
     CTX: ContextTr<Journal: JournalExt>,
 {
     fn initialize_interp(&mut self, interp: &mut Interpreter, ecx: &mut CTX) {
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.sync_journal_logs(ecx.journal().logs());
+        }
         call_inspectors!([&mut self.tracer], |inspector| {
             inspector.initialize_interp(interp, ecx);
         });
     }
 
     fn step(&mut self, interp: &mut Interpreter, ecx: &mut CTX) {
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.sync_journal_logs(ecx.journal().logs());
+        }
         call_inspectors!([&mut self.tracer], |inspector| {
             inspector.step(interp, ecx);
         });
@@ -179,6 +290,9 @@ where
         call_inspectors!([&mut self.tracer], |inspector| {
             inspector.step_end(interp, ecx);
         });
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.sync_journal_logs(ecx.journal().logs());
+        }
     }
 
     #[allow(clippy::redundant_clone)]
@@ -186,6 +300,9 @@ where
         call_inspectors!([&mut self.tracer, &mut self.log_collector], |inspector| {
             inspector.log(ecx, log.clone());
         });
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.push_canonical_log(log, ecx.journal().logs().len());
+        }
     }
 
     #[allow(clippy::redundant_clone)]
@@ -193,9 +310,21 @@ where
         call_inspectors!([&mut self.tracer, &mut self.log_collector], |inspector| {
             inspector.log_full(interp, ecx, log.clone());
         });
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.push_canonical_log(log, ecx.journal().logs().len());
+        }
     }
 
     fn call(&mut self, ecx: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.sync_journal_logs(ecx.journal().logs());
+            collector.frame_start();
+            if matches!(inputs.scheme, CallScheme::Call)
+                && let Some(value) = inputs.transfer_value()
+            {
+                collector.push_transfer(inputs.transfer_from(), inputs.transfer_to(), value);
+            }
+        }
         call_inspectors!(
             #[ret]
             [&mut self.tracer, &mut self.log_collector, &mut self.transfer],
@@ -208,9 +337,23 @@ where
         if let Some(tracer) = &mut self.tracer {
             tracer.call_end(ecx, inputs, outcome);
         }
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.sync_journal_logs(ecx.journal().logs());
+            collector.frame_end(outcome.instruction_result().is_ok(), ecx.journal().logs().len());
+        }
     }
 
     fn create(&mut self, ecx: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.sync_journal_logs(ecx.journal().logs());
+            collector.frame_start();
+            if matches!(inputs.scheme(), CreateScheme::Create | CreateScheme::Create2 { .. })
+                && let Ok(account) = ecx.journal_mut().load_account(inputs.caller())
+            {
+                let address = inputs.created_address(account.data.info.nonce);
+                collector.push_transfer(inputs.caller(), address, inputs.value());
+            }
+        }
         call_inspectors!(
             #[ret]
             [&mut self.tracer, &mut self.transfer],
@@ -223,12 +366,22 @@ where
         if let Some(tracer) = &mut self.tracer {
             tracer.create_end(ecx, inputs, outcome);
         }
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.sync_journal_logs(ecx.journal().logs());
+            collector.frame_end(
+                outcome.instruction_result().is_ok() && outcome.address.is_some(),
+                ecx.journal().logs().len(),
+            );
+        }
     }
 
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
         call_inspectors!([&mut self.tracer, &mut self.transfer], |inspector| {
             Inspector::<CTX, EthInterpreter>::selfdestruct(inspector, contract, target, value)
         });
+        if let Some(collector) = &mut self.simulation_logs {
+            collector.push_transfer(contract, target, value);
+        }
     }
 }
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5203,9 +5203,7 @@ impl Backend<FoundryNetwork> {
                     let mut inspector = self.build_inspector();
 
                     // transact
-                    if trace_transfers {
-                        inspector = inspector.with_transfers();
-                    }
+                    inspector = inspector.with_simulation_logs(trace_transfers);
                     trace!(target: "backend", env=?evm_env, spec=?evm_env.spec_id(),"simulate evm env");
                     let execution_result = self.transact_with_inspector_ref(
                         &cache_db,
@@ -5229,6 +5227,10 @@ impl Backend<FoundryNetwork> {
                     }
                     trace!(target: "backend", ?result, ?request, "simulate call");
 
+                    let canonical_logs = result.clone().into_logs();
+                    let (response_logs, attempted_log_count) = inspector
+                        .take_simulation_logs(&canonical_logs)
+                        .expect("simulation log collector is installed");
                     inspector.print_logs();
                     if self.print_traces {
                         inspector.into_print_traces(self.call_trace_decoder.clone());
@@ -5304,17 +5306,14 @@ impl Backend<FoundryNetwork> {
                                 data: None,
                             }),
                         },
-                        logs: result
-                            .clone()
-                            .into_logs()
+                        logs: response_logs
                             .into_iter()
-                            .enumerate()
                             .map(|(idx, log)| Log {
                                 inner: log,
                                 block_number: Some(block_env.number.saturating_to()),
                                 block_timestamp: Some(block_env.timestamp.saturating_to()),
                                 transaction_index: Some(req_idx as u64),
-                                log_index: Some((idx + log_index) as u64),
+                                log_index: Some(idx + log_index),
                                 removed: false,
 
                                 block_hash: None,
@@ -5322,8 +5321,8 @@ impl Backend<FoundryNetwork> {
                             })
                             .collect(),
                     };
-                    logs.extend(sim_res.logs.iter().map(|log| log.inner.clone()));
-                    log_index += sim_res.logs.len();
+                    logs.extend(canonical_logs);
+                    log_index += attempted_log_count;
                     call_res.push(sim_res);
                 }
 

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -890,7 +890,7 @@ async fn test_simulate_preserves_amsterdam_transfer_logs_rpc() {
     assert_ne!(response["result"][0]["logsBloom"], format!("0x{}", "00".repeat(256)));
     let logs = response["result"][0]["calls"][0]["logs"].as_array().unwrap();
     assert_eq!(logs.len(), 1);
-    assert_eq!(logs[0]["address"], "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+    assert_eq!(logs[0]["address"], "0xfffffffffffffffffffffffffffffffffffffffe");
     assert_eq!(logs[0]["logIndex"], "0x0");
 }
 

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -797,6 +797,365 @@ async fn test_simulate_create_calls_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_trace_transfer_response_logs_rpc() {
+    let config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Cancun.into()))
+        .with_base_fee(Some(0));
+    let (_api, handle) = spawn(config).await;
+    let endpoint = handle.http_endpoint();
+    let payload = json!({
+        "blockStateCalls": [{
+            "stateOverrides": {
+                "0xc000000000000000000000000000000000000000": {"balance": "0x2"},
+                "0xc100000000000000000000000000000000000000": {
+                    "code": "0x5f5f5f5f600173c2000000000000000000000000000000000000005af15000"
+                }
+            },
+            "calls": [{
+                "from": "0xc000000000000000000000000000000000000000",
+                "to": "0xc100000000000000000000000000000000000000",
+                "value": "0x2"
+            }]
+        }],
+        "traceTransfers": true
+    });
+    let response =
+        rpc_request(&endpoint, "eth_simulateV1", json!([payload.clone(), "latest"])).await;
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"][0]["logsBloom"], format!("0x{}", "00".repeat(256)));
+    let logs = response["result"][0]["calls"][0]["logs"].as_array().unwrap();
+    assert_eq!(logs.len(), 2);
+    assert_eq!(
+        logs.iter()
+            .map(|log| {
+                json!({
+                    "address": log["address"],
+                    "from": log["topics"][1],
+                    "to": log["topics"][2],
+                    "value": log["data"],
+                    "logIndex": log["logIndex"],
+                })
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            json!({
+                "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                "from": "0x000000000000000000000000c000000000000000000000000000000000000000",
+                "to": "0x000000000000000000000000c100000000000000000000000000000000000000",
+                "value": "0x0000000000000000000000000000000000000000000000000000000000000002",
+                "logIndex": "0x0",
+            }),
+            json!({
+                "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                "from": "0x000000000000000000000000c100000000000000000000000000000000000000",
+                "to": "0x000000000000000000000000c200000000000000000000000000000000000000",
+                "value": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "logIndex": "0x1",
+            }),
+        ]
+    );
+
+    let mut payload = payload;
+    payload["traceTransfers"] = json!(false);
+    let response = rpc_request(&endpoint, "eth_simulateV1", json!([payload, "latest"])).await;
+    assert_eq!(response["result"][0]["calls"][0]["logs"], json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_preserves_amsterdam_transfer_logs_rpc() {
+    let config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Amsterdam.into()))
+        .with_base_fee(Some(0));
+    let (_api, handle) = spawn(config).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {
+                    "0xc000000000000000000000000000000000000000": {"balance": "0x1"}
+                },
+                "calls": [{
+                    "from": "0xc000000000000000000000000000000000000000",
+                    "to": "0xc100000000000000000000000000000000000000",
+                    "value": "0x1"
+                }]
+            }],
+            "traceTransfers": false
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert_ne!(response["result"][0]["logsBloom"], format!("0x{}", "00".repeat(256)));
+    let logs = response["result"][0]["calls"][0]["logs"].as_array().unwrap();
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0]["address"], "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+    assert_eq!(logs[0]["logIndex"], "0x0");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_trace_transfer_excludes_callcode_rpc() {
+    let config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Cancun.into()))
+        .with_base_fee(Some(0));
+    let (_api, handle) = spawn(config).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {
+                    "0xc100000000000000000000000000000000000000": {
+                        "balance": "0x1",
+                        "code": "0x5f5f5f5f600173c2000000000000000000000000000000000000005af200"
+                    }
+                },
+                "calls": [{"to": "0xc100000000000000000000000000000000000000"}]
+            }],
+            "traceTransfers": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"][0]["calls"][0]["status"], "0x1");
+    assert_eq!(response["result"][0]["calls"][0]["logs"], json!([]));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_trace_transfer_create_nonce_overflow_rpc() {
+    let config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Cancun.into()))
+        .with_base_fee(Some(0));
+    let (_api, handle) = spawn(config).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {
+                    "0xc100000000000000000000000000000000000000": {
+                        "balance": "0x1",
+                        "nonce": "0xffffffffffffffff",
+                        "code": "0x600060006001f0505f5fa000"
+                    }
+                },
+                "calls": [{"to": "0xc100000000000000000000000000000000000000"}]
+            }],
+            "traceTransfers": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"][0]["calls"][0]["status"], "0x1");
+    let logs = response["result"][0]["calls"][0]["logs"].as_array().unwrap();
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0]["address"], "0xc100000000000000000000000000000000000000");
+    assert_eq!(logs[0]["logIndex"], "0x1");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_trace_create_and_selfdestruct_transfers_rpc() {
+    let config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Cancun.into()))
+        .with_base_fee(Some(0));
+    let (_api, handle) = spawn(config).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {
+                    "0xc100000000000000000000000000000000000000": {
+                        "balance": "0x1",
+                        "code": "0x600060006001f000"
+                    },
+                    "0xc200000000000000000000000000000000000000": {
+                        "balance": "0x1",
+                        "code": "0x6000600060006001f500"
+                    },
+                    "0xc300000000000000000000000000000000000000": {
+                        "balance": "0x2",
+                        "code": "0x73c400000000000000000000000000000000000000ff"
+                    }
+                },
+                "calls": [
+                    {"to": "0xc100000000000000000000000000000000000000"},
+                    {"to": "0xc200000000000000000000000000000000000000"},
+                    {"to": "0xc300000000000000000000000000000000000000"}
+                ]
+            }],
+            "traceTransfers": true
+        }, "latest"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+    let calls = response["result"][0]["calls"].as_array().unwrap();
+    assert!(calls.iter().all(|call| call["status"] == "0x1"));
+    for (index, sender) in [
+        "0x000000000000000000000000c100000000000000000000000000000000000000",
+        "0x000000000000000000000000c200000000000000000000000000000000000000",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let logs = calls[index]["logs"].as_array().unwrap();
+        assert_eq!(logs.len(), 1);
+        assert_eq!(logs[0]["topics"][1], sender);
+        assert_ne!(
+            logs[0]["topics"][2],
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+        );
+        assert_eq!(
+            logs[0]["data"],
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+        );
+    }
+    let selfdestruct = &calls[2]["logs"][0];
+    assert_eq!(
+        json!({
+            "from": selfdestruct["topics"][1],
+            "to": selfdestruct["topics"][2],
+            "value": selfdestruct["data"],
+        }),
+        json!({
+            "from": "0x000000000000000000000000c300000000000000000000000000000000000000",
+            "to": "0x000000000000000000000000c400000000000000000000000000000000000000",
+            "value": "0x0000000000000000000000000000000000000000000000000000000000000002",
+        })
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_trace_transfer_reverts_and_log_order_rpc() {
+    let config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Cancun.into()))
+        .with_base_fee(Some(0));
+    let (_api, handle) = spawn(config).await;
+    let endpoint = handle.http_endpoint();
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {
+                    "0xc200000000000000000000000000000000000000": {
+                        "balance": "0x2",
+                        "code": "0x730000000000000000000000000000000000000000ff"
+                    },
+                    "0xc400000000000000000000000000000000000000": {
+                        "code": "0x5f5fa05f5f5f5f5f73c2000000000000000000000000000000000000005af1505f5fa000"
+                    }
+                },
+                "calls": [{"to": "0xc400000000000000000000000000000000000000"}]
+            }],
+            "traceTransfers": true
+        }, "latest"]),
+    )
+    .await;
+    assert!(response.get("error").is_none(), "{response}");
+    let logs = response["result"][0]["calls"][0]["logs"].as_array().unwrap();
+    assert_eq!(
+        logs.iter()
+            .map(|log| json!({"address": log["address"], "logIndex": log["logIndex"]}))
+            .collect::<Vec<_>>(),
+        vec![
+            json!({
+                "address": "0xc400000000000000000000000000000000000000",
+                "logIndex": "0x0"
+            }),
+            json!({
+                "address": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+                "logIndex": "0x1"
+            }),
+            json!({
+                "address": "0xc400000000000000000000000000000000000000",
+                "logIndex": "0x2"
+            }),
+        ]
+    );
+
+    let reverted_log_payload = json!({
+        "blockStateCalls": [{
+            "stateOverrides": {
+                "0xc300000000000000000000000000000000000000": {
+                    "code": "0x5f5fa05f5ffd"
+                },
+                "0xc400000000000000000000000000000000000000": {
+                    "code": "0x5f5fa05f5f5f5f5f73c3000000000000000000000000000000000000005af1505f5fa000"
+                }
+            },
+            "calls": [{"to": "0xc400000000000000000000000000000000000000"}]
+        }],
+        "traceTransfers": true
+    });
+    let response =
+        rpc_request(&endpoint, "eth_simulateV1", json!([reverted_log_payload.clone(), "latest"]))
+            .await;
+    assert!(response.get("error").is_none(), "{response}");
+    let logs = response["result"][0]["calls"][0]["logs"].as_array().unwrap();
+    assert_eq!(
+        logs.iter()
+            .map(|log| json!({"address": log["address"], "logIndex": log["logIndex"]}))
+            .collect::<Vec<_>>(),
+        vec![
+            json!({
+                "address": "0xc400000000000000000000000000000000000000",
+                "logIndex": "0x0"
+            }),
+            json!({
+                "address": "0xc400000000000000000000000000000000000000",
+                "logIndex": "0x2"
+            }),
+        ]
+    );
+
+    let mut reverted_log_payload = reverted_log_payload;
+    reverted_log_payload["traceTransfers"] = json!(false);
+    let response =
+        rpc_request(&endpoint, "eth_simulateV1", json!([reverted_log_payload, "latest"])).await;
+    let logs = response["result"][0]["calls"][0]["logs"].as_array().unwrap();
+    assert_eq!(
+        logs.iter().map(|log| log["logIndex"].clone()).collect::<Vec<_>>(),
+        vec![json!("0x0"), json!("0x2")]
+    );
+
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{
+                "stateOverrides": {
+                    "0xc000000000000000000000000000000000000000": {"balance": "0x2"},
+                    "0xc100000000000000000000000000000000000000": {"code": "0x6000"}
+                },
+                "calls": [
+                    {
+                        "from": "0xc000000000000000000000000000000000000000",
+                        "to": "0xc100000000000000000000000000000000000000",
+                        "value": "0x1",
+                        "gas": "0x5208"
+                    },
+                    {
+                        "from": "0xc000000000000000000000000000000000000000",
+                        "to": "0xc100000000000000000000000000000000000000",
+                        "value": "0x1"
+                    }
+                ]
+            }],
+            "traceTransfers": true
+        }, "latest"]),
+    )
+    .await;
+    let calls = response["result"][0]["calls"].as_array().unwrap();
+    assert_eq!(calls[0]["status"], "0x0");
+    assert_eq!(calls[0]["logs"], json!([]));
+    assert_eq!(calls[1]["logs"][0]["logIndex"], "0x1");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_validation_defaults_base_fee_to_zero() {
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let response = rpc_request(


### PR DESCRIPTION
## Motivation

Corrects `eth_simulateV1` transfer tracing by collecting synthetic ETH transfer logs separately from EVM state. Transfers from top-level and internal calls, `CREATE`, `CREATE2`, and `SELFDESTRUCT` are interleaved with canonical logs in execution order.

Logs from reverted frames are discarded while attempted log indices remain observable as gaps. Synthetic transfer logs are excluded from the block bloom, and simulations without `traceTransfers` retain their existing behavior.

Closes OSS-567