### PR TITLE
feat(forge): add Solar LSP command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5058,6 +5058,7 @@ dependencies = [
  "similar",
  "similar-asserts",
  "solar-compiler",
+ "solar-lsp",
  "soldeer-commands",
  "soldeer-core",
  "svm-rs",
@@ -5073,6 +5074,98 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "yansi",
+]
+
+[[package]]
+name = "async-lsp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8b8fd1e175c5ee3108095da452e816519de618beccea23aa053c00cf5e344b9"
+dependencies = [
+ "futures",
+ "lsp-types",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "waitpid-any",
+]
+
+[[package]]
+name = "crop"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fa28d21af9044d49bcfb1eceddeeb9fadc6a17207c6a1bf0d841ef0bd9ad36e"
+dependencies = [
+ "str_indices",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.95.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "solar-lsp"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a7094eaa1f53e6259aefd8c3b7af60ec1cdfda3e0184948acc54ea01b54eef"
+dependencies = [
+ "async-lsp",
+ "crop",
+ "lsp-types",
+ "normalize-path",
+ "serde",
+ "serde_json",
+ "solar-config",
+ "solar-interface",
+ "solar-sema",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "toml_edit",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
+
+[[package]]
+name = "waitpid-any"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18aa3ce681e189f125c4c1e1388c03285e2fd434ef52c7203084012ac29c5e4a"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -344,6 +344,7 @@ foundry-fork-db = { version = "0.27.0", features = ["zstd"] }
 imbl = "7"
 solar = { package = "solar-compiler", version = "=0.2.0", default-features = false }
 solar-cli = { version = "=0.2.0", default-features = false }
+solar-lsp = { version = "=0.2.0", default-features = false }
 svm = { package = "svm-rs", version = "0.5", default-features = false, features = [
     "rustls",
 ] }

--- a/crates/forge/Cargo.toml
+++ b/crates/forge/Cargo.toml
@@ -84,6 +84,7 @@ semver.workspace = true
 serde_json.workspace = true
 similar = { version = "3", features = ["inline"] }
 solar.workspace = true
+solar-lsp.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["time", "signal"] }
 toml_edit.workspace = true

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -147,6 +147,7 @@ pub fn run_command(args: Forge) -> Result<()> {
         ForgeSubcommand::Eip712(cmd) => cmd.run(),
         ForgeSubcommand::BindJson(cmd) => cmd.run(),
         ForgeSubcommand::Lint(cmd) => cmd.run(),
+        ForgeSubcommand::Lsp(cmd) => global.block_on(cmd.run()),
     }
 }
 

--- a/crates/forge/src/cmd/lsp.rs
+++ b/crates/forge/src/cmd/lsp.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+use eyre::Result;
+
+/// Start the Solar language server over standard input and output.
+#[derive(Clone, Debug, Parser)]
+pub struct LspArgs;
+
+impl LspArgs {
+    pub async fn run(self) -> Result<()> {
+        solar_lsp::run_server_stdio(Default::default()).await?;
+        Ok(())
+    }
+}

--- a/crates/forge/src/cmd/mod.rs
+++ b/crates/forge/src/cmd/mod.rs
@@ -25,6 +25,7 @@ pub mod init;
 pub mod inspect;
 pub mod install;
 pub mod lint;
+pub mod lsp;
 pub mod remappings;
 pub mod remove;
 pub mod selectors;

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -2,8 +2,8 @@ use crate::cmd::{
     bind::BindArgs, bind_json, build::BuildArgs, cache::CacheArgs, clone::CloneArgs,
     compiler::CompilerArgs, config, coverage, create::CreateArgs, doc::DocArgs, eip712, flatten,
     fmt::FmtArgs, fuzz::FuzzArgs, geiger, generate, init::InitArgs, inspect, install::InstallArgs,
-    lint::LintArgs, remappings::RemappingArgs, remove::RemoveArgs, selectors::SelectorsSubcommands,
-    snapshot, soldeer, test, tree, update,
+    lint::LintArgs, lsp::LspArgs, remappings::RemappingArgs, remove::RemoveArgs,
+    selectors::SelectorsSubcommands, snapshot, soldeer, test, tree, update,
 };
 use clap::{Parser, Subcommand, ValueHint};
 use forge_script::ScriptArgs;
@@ -134,6 +134,9 @@ pub enum ForgeSubcommand {
     /// Lint Solidity source files
     #[command(visible_alias = "l")]
     Lint(LintArgs),
+
+    /// Run the Solar language server.
+    Lsp(LspArgs),
 
     /// Get specialized information about a smart contract.
     #[command(visible_alias = "in")]


### PR DESCRIPTION
## Motivation

Expose Solar’s language server through `forge lsp`, so editors can use the same Solar version bundled with Foundry. This supersedes the earlier attempts in #11619, #11277, and #11187 now that `solar-lsp` is released on crates.io.

Closes #11448.

## Changes

- Add the `forge lsp` subcommand.
- Run Solar 0.2.0’s language server over stdin/stdout.
- Pin `solar-lsp` alongside Foundry’s existing Solar dependencies.

## Testing

- `cargo +nightly fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

A full `cargo check -p forge` was attempted, but the sandbox could not authenticate to the workspace’s patched `foundry-rs/optimism` Git dependency.

## AI assistance

This PR was implemented and drafted with Codex.

Prompted by: @DaniPopes