### PR TITLE
fix: preserve dumpState deployment order

### DIFF
--- a/crates/cheatcodes/assets/cheatcodes.json
+++ b/crates/cheatcodes/assets/cheatcodes.json
@@ -4387,7 +4387,7 @@
     {
       "func": {
         "id": "dumpState",
-        "description": "Dump a genesis JSON file's `allocs` to disk.",
+        "description": "Dumps a genesis JSON file's `allocs` to disk. Accounts created in the current transaction\nare ordered by deployment, followed by the remaining accounts in ascending address order.",
         "declaration": "function dumpState(string calldata pathToStateJson) external;",
         "visibility": "external",
         "mutability": "",

--- a/crates/cheatcodes/spec/src/vm.rs
+++ b/crates/cheatcodes/spec/src/vm.rs
@@ -365,7 +365,8 @@ interface Vm {
     #[cheatcode(group = Evm, safety = Safe)]
     function addr(uint256 privateKey) external pure returns (address keyAddr);
 
-    /// Dump a genesis JSON file's `allocs` to disk.
+    /// Dumps a genesis JSON file's `allocs` to disk. Accounts created in the current transaction
+    /// are ordered by deployment, followed by the remaining accounts in ascending address order.
     #[cheatcode(group = Evm, safety = Unsafe)]
     function dumpState(string calldata pathToStateJson) external;
 

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -57,7 +57,7 @@ mod record_debug_step;
 use foundry_common::fmt::format_token_raw;
 use foundry_config::{ExecutionSpec, evm_spec_id_from_str};
 use record_debug_step::{convert_call_trace_ctx_to_debug_step, flatten_call_trace};
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeMap};
 
 mod fork;
 pub(crate) mod mapping;
@@ -74,6 +74,21 @@ struct LogJson {
     data: String,
     /// The address of the log's emitter.
     emitter: String,
+}
+
+struct StateDump<'a>(&'a [(Address, GenesisAccount)]);
+
+impl Serialize for StateDump<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for (address, account) in self.0 {
+            map.serialize_entry(address, account)?;
+        }
+        map.end()
+    }
 }
 
 /// Records storage slots reads and writes.
@@ -361,6 +376,9 @@ impl Cheatcode for dumpStateCall {
         let Self { pathToStateJson } = self;
         let path = Path::new(pathToStateJson);
 
+        let fork_id = ccx.ecx.db().active_fork_id();
+        let created_accounts = ccx.state.created_accounts(fork_id).copied().collect::<Vec<_>>();
+
         // Do not include system account or empty accounts in the dump.
         let skip = |key: &Address, val: &Account| {
             key == &CHEATCODE_ADDRESS
@@ -372,16 +390,24 @@ impl Cheatcode for dumpStateCall {
                 || val.is_empty()
         };
 
-        let alloc = ccx
+        let mut alloc = ccx
             .ecx
             .journal_mut()
             .evm_state_mut()
             .iter_mut()
             .filter(|(key, val)| !skip(key, val))
-            .map(|(key, val)| (key, genesis_account(val)))
+            .map(|(key, val)| (*key, genesis_account(val)))
             .collect::<BTreeMap<_, _>>();
 
-        write_json_file(path, &alloc)?;
+        let mut ordered_alloc = Vec::with_capacity(alloc.len());
+        for address in created_accounts {
+            if let Some(account) = alloc.remove(&address) {
+                ordered_alloc.push((address, account));
+            }
+        }
+        ordered_alloc.extend(alloc);
+
+        write_json_file(path, &StateDump(&ordered_alloc))?;
         Ok(Default::default())
     }
 }
@@ -1016,6 +1042,7 @@ impl Cheatcode for deleteSnapshotCall {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
         ccx.state.env_overrides_snapshots.remove(snapshotId);
+        ccx.state.delete_created_accounts_snapshot(*snapshotId);
         Ok(result.abi_encode())
     }
 }
@@ -1025,6 +1052,7 @@ impl Cheatcode for deleteStateSnapshotCall {
         let Self { snapshotId } = self;
         let result = ccx.ecx.db_mut().delete_state_snapshot(*snapshotId);
         ccx.state.env_overrides_snapshots.remove(snapshotId);
+        ccx.state.delete_created_accounts_snapshot(*snapshotId);
         Ok(result.abi_encode())
     }
 }
@@ -1035,6 +1063,7 @@ impl Cheatcode for deleteSnapshotsCall {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
         ccx.state.env_overrides_snapshots.clear();
+        ccx.state.clear_created_accounts_snapshots();
         Ok(Default::default())
     }
 }
@@ -1044,6 +1073,7 @@ impl Cheatcode for deleteStateSnapshotsCall {
         let Self {} = self;
         ccx.ecx.db_mut().delete_state_snapshots();
         ccx.state.env_overrides_snapshots.clear();
+        ccx.state.clear_created_accounts_snapshots();
         Ok(Default::default())
     }
 }
@@ -1251,6 +1281,7 @@ impl Cheatcode for executeTransactionCall {
         let sender =
             tx.recover_signer().map_err(|err| fmt_err!("failed to recover signer: {err}"))?;
         let tx_env = TxEnvFor::<FEN>::from_recovered_tx(&tx, sender);
+        let created_address = tx_env.kind().is_create().then(|| sender.create(tx_env.nonce()));
 
         // Save current env for restoration after execution.
         let cached_evm_env = ccx.ecx.evm_clone();
@@ -1281,6 +1312,10 @@ impl Cheatcode for executeTransactionCall {
         // Mark as inner context so isolation mode doesn't trigger a nested transact_inner
         // when the inner EVM executes calls at depth == 1.
         executor.set_in_inner_context(true, Some(sender));
+        if let Some(address) = created_address {
+            let fork_id = ccx.ecx.db().active_fork_id();
+            ccx.state.record_created_account(fork_id, address);
+        }
 
         // Clone journaled state and mark all accounts/slots cold.
         let cold_state = {
@@ -1494,6 +1529,7 @@ fn inner_snapshot_state<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCtxt<'_, '_, FEN
     // snapshot so they can be rolled back in lockstep with `EvmEnv`. See
     // `Cheatcodes::env_overrides_snapshots`.
     ccx.state.env_overrides_snapshots.insert(id, all_env_overrides);
+    ccx.state.snapshot_created_accounts(id);
     Ok(id.abi_encode())
 }
 
@@ -1558,6 +1594,7 @@ fn inner_revert_to_state<FEN: FoundryEvmNetwork>(
         if let Some(snap) = ccx.state.env_overrides_snapshots.get(&snapshot_id) {
             ccx.state.env_overrides = snap.clone();
         }
+        ccx.state.revert_created_accounts(snapshot_id, false);
         sync_tx_after_env_override_restore(ccx);
         Ok(true.abi_encode())
     } else {
@@ -1584,6 +1621,7 @@ fn inner_revert_to_state_and_delete<FEN: FoundryEvmNetwork>(
         if let Some(snap) = ccx.state.env_overrides_snapshots.remove(&snapshot_id) {
             ccx.state.env_overrides = snap;
         }
+        ccx.state.revert_created_accounts(snapshot_id, true);
         sync_tx_after_env_override_restore(ccx);
         Ok(true.abi_encode())
     } else {

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -377,7 +377,14 @@ impl Cheatcode for dumpStateCall {
         let path = Path::new(pathToStateJson);
 
         let fork_id = ccx.ecx.db().active_fork_id();
-        let created_accounts = ccx.state.created_accounts(fork_id).copied().collect::<Vec<_>>();
+        let created_accounts = ccx
+            .state
+            .created_accounts()
+            .filter_map(|(created_fork_id, address)| {
+                (*created_fork_id == fork_id || ccx.ecx.db().is_persistent(address))
+                    .then_some(*address)
+            })
+            .collect::<Vec<_>>();
 
         // Do not include system account or empty accounts in the dump.
         let skip = |key: &Address, val: &Account| {

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -379,10 +379,10 @@ impl Cheatcode for dumpStateCall {
         let fork_id = ccx.ecx.db().active_fork_id();
         let created_accounts = ccx
             .state
-            .created_accounts()
-            .filter_map(|(created_fork_id, address)| {
-                (*created_fork_id == fork_id || ccx.ecx.db().is_persistent(address))
-                    .then_some(*address)
+            .created_accounts(fork_id)
+            .into_iter()
+            .filter(|address| {
+                ccx.ecx.journal().evm_state().get(address).is_some_and(Account::is_created)
             })
             .collect::<Vec<_>>();
 
@@ -1530,13 +1530,14 @@ fn inner_snapshot_state<FEN: FoundryEvmNetwork>(ccx: &mut CheatsCtxt<'_, '_, FEN
             active.pre_override_blob_hashes = Some(ccx.ecx.tx().blob_versioned_hashes().to_vec());
         }
     }
+    let fork_id = ccx.ecx.db().active_fork_id();
     let (db, inner) = ccx.ecx.db_journal_inner_mut();
     let id = db.snapshot_state(inner, &evm_env);
     // Capture the cheatcode-side env overrides alongside the backend
     // snapshot so they can be rolled back in lockstep with `EvmEnv`. See
     // `Cheatcodes::env_overrides_snapshots`.
     ccx.state.env_overrides_snapshots.insert(id, all_env_overrides);
-    ccx.state.snapshot_created_accounts(id);
+    ccx.state.snapshot_created_accounts(id, fork_id);
     Ok(id.abi_encode())
 }
 

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -5,13 +5,16 @@ use crate::{
 use alloy_dyn_abi::DynSolValue;
 use alloy_evm::EvmEnv;
 use alloy_network::AnyNetwork;
-use alloy_primitives::{Address, B256, U256};
+use alloy_primitives::{Address, B256, U256, map::AddressHashMap};
 use alloy_provider::Provider;
 use alloy_rpc_types::Filter;
 use alloy_sol_types::SolValue;
 use foundry_common::provider::ProviderBuilder;
 use foundry_evm_core::{
-    FoundryContextExt, backend::JournaledState, evm::FoundryEvmNetwork, fork::CreateFork,
+    FoundryContextExt,
+    backend::{JournaledState, LocalForkId},
+    evm::FoundryEvmNetwork,
+    fork::CreateFork,
 };
 use revm::context::ContextTr;
 
@@ -113,9 +116,14 @@ impl Cheatcode for selectForkCall {
         let Self { forkId } = self;
         persist_caller(ccx);
         check_broadcast(ccx.state)?;
-        fork_env_op(ccx.ecx, |db, evm_env, tx_env, inner| {
+        let source_fork_id = ccx.ecx.db().active_fork_id();
+        let initial = ccx.state.created_account_bindings(None);
+        let propagated = persistent_created_accounts(ccx);
+        let result = fork_env_op(ccx.ecx, |db, evm_env, tx_env, inner| {
             db.select_fork(*forkId, evm_env, tx_env, inner)
-        })
+        })?;
+        record_fork_switch(ccx, source_fork_id, initial, propagated);
+        Ok(result)
     }
 }
 
@@ -322,9 +330,14 @@ fn create_select_fork<FEN: FoundryEvmNetwork>(
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, block)?;
-    fork_env_op(ccx.ecx, |db, evm_env, tx_env, inner| {
+    let source_fork_id = ccx.ecx.db().active_fork_id();
+    let initial = ccx.state.created_account_bindings(None);
+    let propagated = persistent_created_accounts(ccx);
+    let result = fork_env_op(ccx.ecx, |db, evm_env, tx_env, inner| {
         db.create_select_fork(fork, evm_env, tx_env, inner)
-    })
+    })?;
+    record_fork_switch(ccx, source_fork_id, initial, propagated);
+    Ok(result)
 }
 
 /// Creates a new fork
@@ -347,9 +360,14 @@ fn create_select_fork_at_transaction<FEN: FoundryEvmNetwork>(
     check_broadcast(ccx.state)?;
 
     let fork = create_fork_request(ccx, url_or_alias, None)?;
-    fork_env_op(ccx.ecx, |db, evm_env, tx_env, inner| {
+    let source_fork_id = ccx.ecx.db().active_fork_id();
+    let initial = ccx.state.created_account_bindings(None);
+    let propagated = persistent_created_accounts(ccx);
+    let result = fork_env_op(ccx.ecx, |db, evm_env, tx_env, inner| {
         db.create_select_fork_at_transaction(fork, evm_env, tx_env, inner, *transaction)
-    })
+    })?;
+    record_fork_switch(ccx, source_fork_id, initial, propagated);
+    Ok(result)
 }
 
 /// Creates a new fork at the given transaction
@@ -408,6 +426,31 @@ fn fork_env_op<CTX: FoundryContextExt, T: SolValue>(
     ecx.set_evm(evm_env);
     ecx.set_tx(tx_env);
     Ok(result.abi_encode())
+}
+
+fn persistent_created_accounts<FEN: FoundryEvmNetwork>(
+    ccx: &CheatsCtxt<'_, '_, FEN>,
+) -> Vec<(Address, usize)> {
+    let fork_id = ccx.ecx.db().active_fork_id();
+    ccx.state
+        .created_account_bindings(fork_id)
+        .into_iter()
+        .filter(|(address, _)| ccx.ecx.db().is_persistent(address))
+        .collect()
+}
+
+fn record_fork_switch<FEN: FoundryEvmNetwork>(
+    ccx: &mut CheatsCtxt<'_, '_, FEN>,
+    source_fork_id: Option<LocalForkId>,
+    initial: AddressHashMap<usize>,
+    propagated: Vec<(Address, usize)>,
+) {
+    let target_fork_id = ccx.ecx.db().active_fork_id();
+    if source_fork_id != target_fork_id {
+        ccx.state.commit_created_account_changes(source_fork_id);
+    }
+    ccx.state.record_initial_created_accounts(target_fork_id, initial);
+    ccx.state.record_propagated_accounts(target_fork_id, propagated);
 }
 
 fn check_broadcast<FEN: FoundryEvmNetwork>(state: &Cheatcodes<FEN>) -> Result<()> {

--- a/crates/cheatcodes/src/evm/fork.rs
+++ b/crates/cheatcodes/src/evm/fork.rs
@@ -75,9 +75,11 @@ impl Cheatcode for rollFork_0Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { blockNumber } = self;
         persist_caller(ccx);
-        fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
+        let result = fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
             db.roll_fork(None, (*blockNumber).to(), evm_env, inner)
-        })
+        })?;
+        record_fork_roll(ccx, None);
+        Ok(result)
     }
 }
 
@@ -85,9 +87,11 @@ impl Cheatcode for rollFork_1Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { txHash } = self;
         persist_caller(ccx);
-        fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
+        let result = fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
             db.roll_fork_to_transaction(None, *txHash, evm_env, inner)
-        })
+        })?;
+        record_fork_roll(ccx, None);
+        Ok(result)
     }
 }
 
@@ -95,9 +99,11 @@ impl Cheatcode for rollFork_2Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { forkId, blockNumber } = self;
         persist_caller(ccx);
-        fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
+        let result = fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
             db.roll_fork(Some(*forkId), (*blockNumber).to(), evm_env, inner)
-        })
+        })?;
+        record_fork_roll(ccx, Some(*forkId));
+        Ok(result)
     }
 }
 
@@ -105,9 +111,11 @@ impl Cheatcode for rollFork_3Call {
     fn apply_stateful<FEN: FoundryEvmNetwork>(&self, ccx: &mut CheatsCtxt<'_, '_, FEN>) -> Result {
         let Self { forkId, txHash } = self;
         persist_caller(ccx);
-        fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
+        let result = fork_env_op(ccx.ecx, |db, evm_env, _, inner| {
             db.roll_fork_to_transaction(Some(*forkId), *txHash, evm_env, inner)
-        })
+        })?;
+        record_fork_roll(ccx, Some(*forkId));
+        Ok(result)
     }
 }
 
@@ -451,6 +459,16 @@ fn record_fork_switch<FEN: FoundryEvmNetwork>(
     }
     ccx.state.record_initial_created_accounts(target_fork_id, initial);
     ccx.state.record_propagated_accounts(target_fork_id, propagated);
+}
+
+fn record_fork_roll<FEN: FoundryEvmNetwork>(
+    ccx: &mut CheatsCtxt<'_, '_, FEN>,
+    target_fork_id: Option<LocalForkId>,
+) {
+    let active_fork_id = ccx.ecx.db().active_fork_id();
+    if target_fork_id.is_none() || target_fork_id == active_fork_id {
+        ccx.state.commit_created_account_changes(active_fork_id);
+    }
 }
 
 fn check_broadcast<FEN: FoundryEvmNetwork>(state: &Cheatcodes<FEN>) -> Result<()> {

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -601,6 +601,15 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// Completed account accesses prepended to the active user recording session.
     recorded_account_diffs_prefix: Option<Arc<[AccountAccess]>>,
 
+    /// Successfully created accounts in execution order, tagged by fork.
+    created_accounts: Vec<(Option<LocalForkId>, Address)>,
+
+    /// Creation-list lengths at the start of each active call or create frame.
+    created_accounts_checkpoints: Vec<usize>,
+
+    /// Creation lists captured by state snapshots.
+    created_accounts_snapshots: HashMap<U256, Vec<(Option<LocalForkId>, Address)>>,
+
     /// The information of the debug step recording.
     pub record_debug_steps_info: Option<RecordDebugStepInfo>,
 
@@ -756,6 +765,9 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             recorded_account_diffs_stack: Default::default(),
             pending_account_diffs: Default::default(),
             recorded_account_diffs_prefix: Default::default(),
+            created_accounts: Default::default(),
+            created_accounts_checkpoints: Default::default(),
+            created_accounts_snapshots: Default::default(),
             recorded_logs: Default::default(),
             record_debug_steps_info: Default::default(),
             mocked_calls: Default::default(),
@@ -837,6 +849,74 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             .take()
             .map(|prefix| prefix.as_ref().to_vec())
             .unwrap_or_default()
+    }
+
+    /// Returns successfully created accounts for the active fork in execution order.
+    pub(crate) fn created_accounts(
+        &self,
+        fork_id: Option<LocalForkId>,
+    ) -> impl Iterator<Item = &Address> {
+        self.created_accounts.iter().filter_map(move |(created_fork_id, address)| {
+            (*created_fork_id == fork_id).then_some(address)
+        })
+    }
+
+    /// Records a successfully created account.
+    pub(crate) fn record_created_account(
+        &mut self,
+        fork_id: Option<LocalForkId>,
+        address: Address,
+    ) {
+        self.created_accounts.push((fork_id, address));
+    }
+
+    /// Captures creation ordering alongside a state snapshot.
+    pub(crate) fn snapshot_created_accounts(&mut self, snapshot_id: U256) {
+        self.created_accounts_snapshots.insert(snapshot_id, self.created_accounts.clone());
+    }
+
+    /// Restores creation ordering from a state snapshot.
+    pub(crate) fn revert_created_accounts(&mut self, snapshot_id: U256, remove: bool) {
+        let snapshot = if remove {
+            self.created_accounts_snapshots.remove(&snapshot_id)
+        } else {
+            self.created_accounts_snapshots.get(&snapshot_id).cloned()
+        };
+        if let Some(snapshot) = snapshot {
+            self.created_accounts = snapshot;
+        }
+    }
+
+    /// Deletes one captured creation-order snapshot.
+    pub(crate) fn delete_created_accounts_snapshot(&mut self, snapshot_id: U256) {
+        self.created_accounts_snapshots.remove(&snapshot_id);
+    }
+
+    /// Deletes all captured creation-order snapshots.
+    pub(crate) fn clear_created_accounts_snapshots(&mut self) {
+        self.created_accounts_snapshots.clear();
+    }
+
+    fn start_created_accounts_frame(&mut self, reset: bool) {
+        if reset {
+            self.created_accounts.clear();
+            self.created_accounts_checkpoints.clear();
+            // Earlier snapshots contain no creations from the new root transaction.
+            for snapshot in self.created_accounts_snapshots.values_mut() {
+                snapshot.clear();
+            }
+        }
+        self.created_accounts_checkpoints.push(self.created_accounts.len());
+    }
+
+    fn finish_created_accounts_frame(&mut self, success: bool) {
+        let checkpoint = self
+            .created_accounts_checkpoints
+            .pop()
+            .expect("creation frame checkpoint is initialized");
+        if !success {
+            self.created_accounts.truncate(checkpoint);
+        }
     }
 
     /// Returns the env overrides for the given fork (`None` = no-fork / local).
@@ -991,6 +1071,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
 
         let gas = Gas::new(call.gas_limit);
         let curr_depth = ecx.journal().depth();
+        self.start_created_accounts_frame(curr_depth == 0);
 
         // At the root call to test function or script `run()`/`setUp()` functions, we are
         // decreasing sender nonce to ensure that it matches on-chain nonce once we start
@@ -1724,6 +1805,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         let cheatcode_call = call.target_address == CHEATCODE_ADDRESS
             || call.target_address == HARDHAT_CONSOLE_ADDRESS;
 
+        self.finish_created_accounts_frame(outcome.result.is_ok());
+
         // Clean up pranks/broadcasts if it's not a cheatcode call end. We shouldn't do
         // it for cheatcode calls because they are not applied for cheatcodes in the `call` hook.
         // This should be placed before the revert handling, because we might exit early there
@@ -2176,6 +2259,9 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         }
 
         let gas = Gas::new(input.gas_limit());
+        let curr_depth = ecx.journal().depth();
+        self.start_created_accounts_frame(curr_depth == 0);
+
         // Check if we should intercept this create
         if self.intercept_next_create_call {
             // Reset the flag
@@ -2190,8 +2276,6 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                 address: None,
             });
         }
-
-        let curr_depth = ecx.journal().depth();
 
         // Apply our prank
         if let Some(prank) = &self.get_prank(curr_depth)
@@ -2272,6 +2356,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         // Allow cheatcodes from the address of the new contract
         let address = input.allow_cheatcodes(self, ecx);
 
+        self.record_created_account(ecx.db().active_fork_id(), address);
+
         // If `recordAccountAccesses` has been called, record the create
         if let Some(recorded_account_diffs_stack) = &mut self.recorded_account_diffs_stack {
             recorded_account_diffs_stack.push(vec![AccountAccess {
@@ -2307,6 +2393,8 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
     ) {
         let call = Some(call);
         let curr_depth = ecx.journal().depth();
+
+        self.finish_created_accounts_frame(outcome.result.is_ok());
 
         // Clean up pranks
         if let Some(prank) = &self.get_prank(curr_depth)

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -525,6 +525,19 @@ impl ArbitraryStorage {
 /// List of transactions that can be broadcasted.
 pub type BroadcastableTransactions<N> = VecDeque<BroadcastableTransaction<N>>;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CreatedAccountsFrameKind {
+    Call,
+    Create,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CreatedAccountsFrame {
+    kind: CreatedAccountsFrameKind,
+    depth: usize,
+    checkpoint: usize,
+}
+
 /// An EVM inspector that handles calls to various cheatcodes, each with their own behavior.
 ///
 /// Cheatcodes can be called by contracts during execution to modify the VM environment, such as
@@ -604,8 +617,8 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// Successfully created accounts in execution order, tagged by fork.
     created_accounts: Vec<(Option<LocalForkId>, Address)>,
 
-    /// Creation-list lengths at the start of each active call or create frame.
-    created_accounts_checkpoints: Vec<usize>,
+    /// Creation-list checkpoints for frames observed by this inspector.
+    created_accounts_frames: Vec<CreatedAccountsFrame>,
 
     /// Creation lists captured by state snapshots.
     created_accounts_snapshots: HashMap<U256, Vec<(Option<LocalForkId>, Address)>>,
@@ -766,7 +779,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             pending_account_diffs: Default::default(),
             recorded_account_diffs_prefix: Default::default(),
             created_accounts: Default::default(),
-            created_accounts_checkpoints: Default::default(),
+            created_accounts_frames: Default::default(),
             created_accounts_snapshots: Default::default(),
             recorded_logs: Default::default(),
             record_debug_steps_info: Default::default(),
@@ -897,23 +910,43 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         self.created_accounts_snapshots.clear();
     }
 
-    fn start_created_accounts_frame(&mut self, reset: bool) {
+    fn start_created_accounts_frame(
+        &mut self,
+        reset: bool,
+        kind: CreatedAccountsFrameKind,
+        depth: usize,
+    ) {
         if reset {
             self.created_accounts.clear();
-            self.created_accounts_checkpoints.clear();
+            self.created_accounts_frames.clear();
             // Earlier snapshots contain no creations from the new root transaction.
             for snapshot in self.created_accounts_snapshots.values_mut() {
                 snapshot.clear();
             }
         }
-        self.created_accounts_checkpoints.push(self.created_accounts.len());
+        self.created_accounts_frames.push(CreatedAccountsFrame {
+            kind,
+            depth,
+            checkpoint: self.created_accounts.len(),
+        });
     }
 
-    fn finish_created_accounts_frame(&mut self, success: bool) {
-        let checkpoint = self
-            .created_accounts_checkpoints
-            .pop()
-            .expect("creation frame checkpoint is initialized");
+    fn finish_created_accounts_frame(
+        &mut self,
+        success: bool,
+        kind: CreatedAccountsFrameKind,
+        depth: usize,
+    ) {
+        let Some(frame) = self
+            .created_accounts_frames
+            .last()
+            .copied()
+            .filter(|frame| frame.kind == kind && frame.depth == depth)
+        else {
+            return;
+        };
+        let checkpoint = frame.checkpoint;
+        self.created_accounts_frames.pop();
         if !success {
             self.created_accounts.truncate(checkpoint);
         }
@@ -1071,7 +1104,11 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
 
         let gas = Gas::new(call.gas_limit);
         let curr_depth = ecx.journal().depth();
-        self.start_created_accounts_frame(curr_depth == 0);
+        self.start_created_accounts_frame(
+            curr_depth == 0,
+            CreatedAccountsFrameKind::Call,
+            curr_depth,
+        );
 
         // At the root call to test function or script `run()`/`setUp()` functions, we are
         // decreasing sender nonce to ensure that it matches on-chain nonce once we start
@@ -1804,15 +1841,19 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
     ) {
         let cheatcode_call = call.target_address == CHEATCODE_ADDRESS
             || call.target_address == HARDHAT_CONSOLE_ADDRESS;
+        let curr_depth = ecx.journal().depth();
 
-        self.finish_created_accounts_frame(outcome.result.is_ok());
+        self.finish_created_accounts_frame(
+            outcome.result.is_ok(),
+            CreatedAccountsFrameKind::Call,
+            curr_depth,
+        );
 
         // Clean up pranks/broadcasts if it's not a cheatcode call end. We shouldn't do
         // it for cheatcode calls because they are not applied for cheatcodes in the `call` hook.
         // This should be placed before the revert handling, because we might exit early there
         if !cheatcode_call {
             // Clean up pranks
-            let curr_depth = ecx.journal().depth();
             if let Some(prank) = &self.get_prank(curr_depth)
                 && curr_depth == prank.depth
             {
@@ -2260,7 +2301,11 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
 
         let gas = Gas::new(input.gas_limit());
         let curr_depth = ecx.journal().depth();
-        self.start_created_accounts_frame(curr_depth == 0);
+        self.start_created_accounts_frame(
+            curr_depth == 0,
+            CreatedAccountsFrameKind::Create,
+            curr_depth,
+        );
 
         // Check if we should intercept this create
         if self.intercept_next_create_call {
@@ -2394,7 +2439,11 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
         let call = Some(call);
         let curr_depth = ecx.journal().depth();
 
-        self.finish_created_accounts_frame(outcome.result.is_ok());
+        self.finish_created_accounts_frame(
+            outcome.result.is_ok(),
+            CreatedAccountsFrameKind::Create,
+            curr_depth,
+        );
 
         // Clean up pranks
         if let Some(prank) = &self.get_prank(curr_depth)

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -538,6 +538,21 @@ struct CreatedAccountsFrame {
     checkpoint: usize,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct CreatedAccountChange {
+    fork_id: Option<LocalForkId>,
+    address: Address,
+    creation: usize,
+    previous: Option<usize>,
+    committed: bool,
+}
+
+#[derive(Clone, Debug)]
+struct CreatedAccountsSnapshot {
+    fork_id: Option<LocalForkId>,
+    bindings: AddressHashMap<usize>,
+}
+
 /// An EVM inspector that handles calls to various cheatcodes, each with their own behavior.
 ///
 /// Cheatcodes can be called by contracts during execution to modify the VM environment, such as
@@ -614,14 +629,20 @@ pub struct Cheatcodes<FEN: FoundryEvmNetwork = EthEvmNetwork> {
     /// Completed account accesses prepended to the active user recording session.
     recorded_account_diffs_prefix: Option<Arc<[AccountAccess]>>,
 
-    /// Successfully created accounts in execution order, tagged by fork.
-    created_accounts: Vec<(Option<LocalForkId>, Address)>,
+    /// Successfully created accounts in execution order.
+    created_accounts: Vec<Address>,
+
+    /// The creation currently represented by each address on each fork.
+    created_account_bindings: HashMap<(Option<LocalForkId>, Address), usize>,
+
+    /// Revertible changes to creation bindings made by EVM create frames.
+    created_account_changes: Vec<CreatedAccountChange>,
 
     /// Creation-list checkpoints for frames observed by this inspector.
     created_accounts_frames: Vec<CreatedAccountsFrame>,
 
     /// Creation lists captured by state snapshots.
-    created_accounts_snapshots: HashMap<U256, Vec<(Option<LocalForkId>, Address)>>,
+    created_accounts_snapshots: HashMap<U256, CreatedAccountsSnapshot>,
 
     /// The information of the debug step recording.
     pub record_debug_steps_info: Option<RecordDebugStepInfo>,
@@ -779,6 +800,8 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             pending_account_diffs: Default::default(),
             recorded_account_diffs_prefix: Default::default(),
             created_accounts: Default::default(),
+            created_account_bindings: Default::default(),
+            created_account_changes: Default::default(),
             created_accounts_frames: Default::default(),
             created_accounts_snapshots: Default::default(),
             recorded_logs: Default::default(),
@@ -864,9 +887,29 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             .unwrap_or_default()
     }
 
-    /// Returns successfully created accounts and their originating forks in execution order.
-    pub(crate) fn created_accounts(&self) -> impl Iterator<Item = &(Option<LocalForkId>, Address)> {
-        self.created_accounts.iter()
+    /// Returns the current creation bound to each address on the given fork.
+    pub(crate) fn created_account_bindings(
+        &self,
+        fork_id: Option<LocalForkId>,
+    ) -> AddressHashMap<usize> {
+        self.created_account_bindings
+            .iter()
+            .filter_map(|(&(event_fork_id, address), &creation)| {
+                (event_fork_id == fork_id).then_some((address, creation))
+            })
+            .collect()
+    }
+
+    /// Returns successfully created accounts bound to the given fork in creation order.
+    pub(crate) fn created_accounts(&self, fork_id: Option<LocalForkId>) -> Vec<Address> {
+        let bindings = self.created_account_bindings(fork_id);
+        self.created_accounts
+            .iter()
+            .enumerate()
+            .filter_map(|(index, &address)| {
+                (bindings.get(&address) == Some(&index)).then_some(address)
+            })
+            .collect()
     }
 
     /// Records a successfully created account.
@@ -875,12 +918,57 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         fork_id: Option<LocalForkId>,
         address: Address,
     ) {
-        self.created_accounts.push((fork_id, address));
+        let creation = self.created_accounts.len();
+        self.created_accounts.push(address);
+        let previous = self.created_account_bindings.insert((fork_id, address), creation);
+        self.created_account_changes.push(CreatedAccountChange {
+            fork_id,
+            address,
+            creation,
+            previous,
+            committed: false,
+        });
+    }
+
+    /// Keeps creation bindings saved with an outgoing fork across later frame reverts.
+    pub(crate) fn commit_created_account_changes(&mut self, fork_id: Option<LocalForkId>) {
+        for change in &mut self.created_account_changes {
+            if change.fork_id == fork_id {
+                change.committed = true;
+            }
+        }
+    }
+
+    /// Records shared pre-fork creations on a newly selected fork without replacing local ones.
+    pub(crate) fn record_initial_created_accounts(
+        &mut self,
+        fork_id: Option<LocalForkId>,
+        accounts: impl IntoIterator<Item = (Address, usize)>,
+    ) {
+        for (address, creation) in accounts {
+            self.created_account_bindings.entry((fork_id, address)).or_insert(creation);
+        }
+    }
+
+    /// Records creations propagated to a fork with persistent account state.
+    pub(crate) fn record_propagated_accounts(
+        &mut self,
+        fork_id: Option<LocalForkId>,
+        accounts: impl IntoIterator<Item = (Address, usize)>,
+    ) {
+        self.created_account_bindings
+            .extend(accounts.into_iter().map(|(address, creation)| ((fork_id, address), creation)));
     }
 
     /// Captures creation ordering alongside a state snapshot.
-    pub(crate) fn snapshot_created_accounts(&mut self, snapshot_id: U256) {
-        self.created_accounts_snapshots.insert(snapshot_id, self.created_accounts.clone());
+    pub(crate) fn snapshot_created_accounts(
+        &mut self,
+        snapshot_id: U256,
+        fork_id: Option<LocalForkId>,
+    ) {
+        let bindings = self.created_account_bindings(fork_id);
+        self.created_accounts_snapshots
+            .insert(snapshot_id, CreatedAccountsSnapshot { fork_id, bindings });
     }
 
     /// Restores creation ordering from a state snapshot.
@@ -891,7 +979,13 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             self.created_accounts_snapshots.get(&snapshot_id).cloned()
         };
         if let Some(snapshot) = snapshot {
-            self.created_accounts = snapshot;
+            self.created_account_bindings.retain(|(fork_id, _), _| *fork_id != snapshot.fork_id);
+            self.created_account_bindings.extend(
+                snapshot
+                    .bindings
+                    .into_iter()
+                    .map(|(address, creation)| ((snapshot.fork_id, address), creation)),
+            );
         }
     }
 
@@ -913,16 +1007,18 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
     ) {
         if reset {
             self.created_accounts.clear();
+            self.created_account_bindings.clear();
+            self.created_account_changes.clear();
             self.created_accounts_frames.clear();
             // Earlier snapshots contain no creations from the new root transaction.
             for snapshot in self.created_accounts_snapshots.values_mut() {
-                snapshot.clear();
+                snapshot.bindings.clear();
             }
         }
         self.created_accounts_frames.push(CreatedAccountsFrame {
             kind,
             depth,
-            checkpoint: self.created_accounts.len(),
+            checkpoint: self.created_account_changes.len(),
         });
     }
 
@@ -943,7 +1039,21 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         let checkpoint = frame.checkpoint;
         self.created_accounts_frames.pop();
         if !success {
-            self.created_accounts.truncate(checkpoint);
+            while self.created_account_changes.len() > checkpoint {
+                let change = self.created_account_changes.pop().expect("length checked");
+                if change.committed {
+                    continue;
+                }
+                let key = (change.fork_id, change.address);
+                if self.created_account_bindings.get(&key) != Some(&change.creation) {
+                    continue;
+                }
+                if let Some(previous) = change.previous {
+                    self.created_account_bindings.insert(key, previous);
+                } else {
+                    self.created_account_bindings.remove(&key);
+                }
+            }
         }
     }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -864,14 +864,9 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
             .unwrap_or_default()
     }
 
-    /// Returns successfully created accounts for the active fork in execution order.
-    pub(crate) fn created_accounts(
-        &self,
-        fork_id: Option<LocalForkId>,
-    ) -> impl Iterator<Item = &Address> {
-        self.created_accounts.iter().filter_map(move |(created_fork_id, address)| {
-            (*created_fork_id == fork_id).then_some(address)
-        })
+    /// Returns successfully created accounts and their originating forks in execution order.
+    pub(crate) fn created_accounts(&self) -> impl Iterator<Item = &(Option<LocalForkId>, Address)> {
+        self.created_accounts.iter()
     }
 
     /// Records a successfully created account.

--- a/testdata/default/cheats/Fork2.t.sol
+++ b/testdata/default/cheats/Fork2.t.sol
@@ -28,6 +28,7 @@ contract MyContract {
 contract ForkTest is Test {
     uint256 mainnetFork;
     uint256 optimismFork;
+    address createdBeforeSwitch;
 
     // this will create two _different_ forks during setup
     function setUp() public {
@@ -166,6 +167,125 @@ contract ForkTest is Test {
         assertLt(firstIndex, secondIndex);
 
         vm.removeFile(path);
+    }
+
+    function testForkDumpStatePreservesRevokedPersistentDeploymentOrder() public {
+        string memory path =
+            string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_revoked_persistent_deployment_order.json");
+
+        vm.selectFork(mainnetFork);
+        DummyContract first = new DummyContract();
+        vm.makePersistent(address(first));
+
+        vm.selectFork(optimismFork);
+        vm.revokePersistent(address(first));
+        assert(!vm.isPersistent(address(first)));
+        DummyContract second = new DummyContract();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(first))), '"'));
+        uint256 secondIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(second))), '"'));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+
+        vm.removeFile(path);
+    }
+
+    function testForkDumpStateUsesActiveForkCreationForSameAddress() public {
+        string memory path =
+            string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_same_address_creation.json");
+
+        vm.selectFork(mainnetFork);
+        DummyContract first = new DummyContract{salt: bytes32(uint256(1))}();
+
+        vm.selectFork(optimismFork);
+        DummyContract second = new DummyContract();
+        DummyContract recreated = new DummyContract{salt: bytes32(uint256(1))}();
+        assertEq(address(first), address(recreated));
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 secondIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(second))), '"'));
+        uint256 recreatedIndex =
+            vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(recreated))), '"'));
+        assertTrue(secondIndex != type(uint256).max);
+        assertTrue(recreatedIndex != type(uint256).max);
+        assertLt(secondIndex, recreatedIndex);
+
+        vm.removeFile(path);
+    }
+
+    function testForkDumpStatePreservesPropagationAfterSnapshotRevert() public {
+        string memory path = string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_snapshot_propagation.json");
+
+        vm.selectFork(mainnetFork);
+        DummyContract first = new DummyContract();
+        vm.makePersistent(address(first));
+        uint256 snapshot = vm.snapshotState();
+
+        vm.selectFork(optimismFork);
+        vm.revokePersistent(address(first));
+        assert(vm.revertToState(snapshot));
+        vm.selectFork(optimismFork);
+        DummyContract second = new DummyContract();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(first))), '"'));
+        uint256 secondIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(second))), '"'));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+
+        vm.removeFile(path);
+    }
+
+    function testForkDumpStatePreservesInitialDeploymentOrder() public {
+        string memory path = string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_initial_order.json");
+
+        DummyContract first = new DummyContract();
+        vm.selectFork(mainnetFork);
+        DummyContract second = new DummyContract();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(first))), '"'));
+        uint256 secondIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(second))), '"'));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+
+        vm.removeFile(path);
+    }
+
+    function testForkDumpStatePreservesSourceOrderAfterRevertedSwitch() public {
+        string memory path = string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_reverted_switch.json");
+
+        vm.selectFork(mainnetFork);
+        try this.createSwitchAndRevert(optimismFork) {} catch {}
+
+        vm.selectFork(mainnetFork);
+        address first = createdBeforeSwitch;
+        assertTrue(first != address(0));
+        DummyContract second = new DummyContract();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(first)), '"'));
+        uint256 secondIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(second))), '"'));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+
+        vm.removeFile(path);
+    }
+
+    function createSwitchAndRevert(uint256 forkId) external {
+        createdBeforeSwitch = address(new DummyContract());
+        vm.selectFork(forkId);
+        revert();
     }
 
     /// forge-config: default.allow_internal_expect_revert = true

--- a/testdata/default/cheats/Fork2.t.sol
+++ b/testdata/default/cheats/Fork2.t.sol
@@ -146,6 +146,28 @@ contract ForkTest is Test {
         assertEq(dummy.val(), expectedValue);
     }
 
+    function testForkDumpStatePreservesPersistentDeploymentOrder() public {
+        string memory path =
+            string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_persistent_deployment_order.json");
+
+        vm.selectFork(mainnetFork);
+        DummyContract first = new DummyContract();
+        vm.makePersistent(address(first));
+
+        vm.selectFork(optimismFork);
+        DummyContract second = new DummyContract();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(first))), '"'));
+        uint256 secondIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(second))), '"'));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+
+        vm.removeFile(path);
+    }
+
     /// forge-config: default.allow_internal_expect_revert = true
     function testNonExistingContractRevert() public {
         vm.selectFork(mainnetFork);

--- a/testdata/default/cheats/Fork2.t.sol
+++ b/testdata/default/cheats/Fork2.t.sol
@@ -282,9 +282,36 @@ contract ForkTest is Test {
         vm.removeFile(path);
     }
 
+    function testForkDumpStatePreservesOrderAfterRevertedRoll() public {
+        string memory path = string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_reverted_roll.json");
+
+        vm.selectFork(mainnetFork);
+        address first =
+            vm.computeCreate2Address(bytes32(uint256(1)), keccak256(type(DummyContract).creationCode), address(this));
+        try this.createRollAndRevert(block.number) {} catch {}
+
+        DummyContract second = new DummyContract();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(first)), '"'));
+        uint256 secondIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(second))), '"'));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+
+        vm.removeFile(path);
+    }
+
     function createSwitchAndRevert(uint256 forkId) external {
         createdBeforeSwitch = address(new DummyContract());
         vm.selectFork(forkId);
+        revert();
+    }
+
+    function createRollAndRevert(uint256 blockNumber) external {
+        new DummyContract{salt: bytes32(uint256(1))}();
+        vm.rollFork(blockNumber);
         revert();
     }
 

--- a/testdata/default/cheats/dumpState.t.sol
+++ b/testdata/default/cheats/dumpState.t.sol
@@ -11,6 +11,21 @@ contract SimpleContract {
     }
 }
 
+contract DeploymentOrderHelper {
+    function deploy() public returns (SimpleContract) {
+        return new SimpleContract();
+    }
+
+    function deploy(bytes32 salt) public returns (SimpleContract) {
+        return new SimpleContract{salt: salt}();
+    }
+
+    function deployAndRevert() public {
+        new SimpleContract();
+        revert();
+    }
+}
+
 contract DumpStateTest is Test {
     function testDumpStateCheatAccount() public {
         // Path to temporary file that is deleted after the test
@@ -69,6 +84,9 @@ contract DumpStateTest is Test {
         string memory json = vm.readFile(path);
         string[] memory keys = vm.parseJsonKeys(json, "");
         assertEq(keys.length, 4);
+        assertLt(indexOfAddress(json, address(0x100)), indexOfAddress(json, address(0x200)));
+        assertLt(indexOfAddress(json, address(0x200)), indexOfAddress(json, address(0x300)));
+        assertLt(indexOfAddress(json, address(0x300)), indexOfAddress(json, address(0x400)));
 
         assertEq(4, vm.parseJsonKeys(json, string.concat(".", vm.toString(address(0x100)))).length);
         assertEq(1, vm.parseJsonUint(json, string.concat(".", vm.toString(address(0x100)), ".nonce")));
@@ -119,6 +137,100 @@ contract DumpStateTest is Test {
         vm.removeFile(path);
     }
 
+    function testDumpStateDeploymentOrder() public {
+        string memory path = string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_deployment_order.json");
+
+        SimpleContract first = new SimpleContract();
+        SimpleContract second = new SimpleContract();
+        SimpleContract third = new SimpleContract();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = indexOfAddress(json, address(first));
+        uint256 secondIndex = indexOfAddress(json, address(second));
+        uint256 thirdIndex = indexOfAddress(json, address(third));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertTrue(thirdIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+        assertLt(secondIndex, thirdIndex);
+
+        vm.removeFile(path);
+    }
+
+    function testDumpStateDeploymentOrderAfterRevert() public {
+        string memory path =
+            string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_deployment_order_revert.json");
+
+        DeploymentOrderHelper helper = new DeploymentOrderHelper();
+        SimpleContract first = new SimpleContract();
+        try helper.deployAndRevert() {} catch {}
+        SimpleContract second = new SimpleContract();
+        SimpleContract third = helper.deploy();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = indexOfAddress(json, address(first));
+        uint256 secondIndex = indexOfAddress(json, address(second));
+        uint256 thirdIndex = indexOfAddress(json, address(third));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertTrue(thirdIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+        assertLt(secondIndex, thirdIndex);
+
+        vm.removeFile(path);
+    }
+
+    function testDumpStateDeploymentOrderAfterSnapshotRevert() public {
+        string memory path =
+            string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_deployment_order_snapshot.json");
+
+        DeploymentOrderHelper helper = new DeploymentOrderHelper();
+        uint256 snapshot = vm.snapshotState();
+        bytes32 salt = bytes32(uint256(1));
+        helper.deploy(salt);
+        assertTrue(vm.revertToState(snapshot));
+        SimpleContract first = new SimpleContract();
+        SimpleContract second = helper.deploy(salt);
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = indexOfAddress(json, address(first));
+        uint256 secondIndex = indexOfAddress(json, address(second));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+
+        vm.removeFile(path);
+    }
+
+    function testDumpStateDeploymentOrderAfterNonlinearSnapshotRevert() public {
+        string memory path =
+            string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_deployment_order_nonlinear_snapshot.json");
+
+        SimpleContract first = new SimpleContract();
+        uint256 firstSnapshot = vm.snapshotState();
+        SimpleContract second = new SimpleContract();
+        uint256 secondSnapshot = vm.snapshotState();
+        assertTrue(vm.revertToState(firstSnapshot));
+        assertTrue(vm.revertToState(secondSnapshot));
+        SimpleContract third = new SimpleContract();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 firstIndex = indexOfAddress(json, address(first));
+        uint256 secondIndex = indexOfAddress(json, address(second));
+        uint256 thirdIndex = indexOfAddress(json, address(third));
+        assertTrue(firstIndex != type(uint256).max);
+        assertTrue(secondIndex != type(uint256).max);
+        assertTrue(thirdIndex != type(uint256).max);
+        assertLt(firstIndex, secondIndex);
+        assertLt(secondIndex, thirdIndex);
+
+        vm.removeFile(path);
+    }
+
     function testDumpStateEmptyAccount() public {
         string memory path = string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_empty_account.json");
 
@@ -132,5 +244,9 @@ contract DumpStateTest is Test {
         assertEq(keys.length, 0);
 
         vm.removeFile(path);
+    }
+
+    function indexOfAddress(string memory json, address account) private view returns (uint256) {
+        return vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(account)), '"'));
     }
 }


### PR DESCRIPTION
Preserves deployment order for accounts created in the current transaction when `vm.dumpState` writes genesis allocations, while retaining deterministic address ordering for all remaining accounts. Creation tracking follows reverts, snapshots, and active forks so the output reflects the surviving state.

Closes #8503.