### PR TITLE
fix: replay Arbitrum transactions

### DIFF
--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1657,7 +1657,9 @@ async fn derive_block_and_transactions(
             // Convert the transactions to PoolTransactions
             let force_transactions = filtered_transactions
                 .iter()
-                .map(|&transaction| PoolTransaction::try_from(transaction.clone()))
+                .map(|&transaction| {
+                    PoolTransaction::try_from(transaction.clone()).map(PoolTransaction::with_replay)
+                })
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(|e| eyre::eyre!("Err converting to pool transactions {e}"))?;
             Ok((transaction_block_number.saturating_sub(1), Some(force_transactions)))

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -2737,7 +2737,7 @@ impl EthApi<FoundryNetwork> {
         };
 
         let pool_transaction =
-            PoolTransaction { requires, provides, pending_transaction, priority };
+            PoolTransaction { requires, provides, pending_transaction, priority, is_replay: false };
 
         let tx = self.pool.add_transaction(pool_transaction)?;
         trace!(target: "node", "Added transaction: [{:?}] sender={:?}", tx.hash(), from);
@@ -3875,7 +3875,7 @@ impl EthApi<FoundryNetwork> {
                     }
                 };
 
-                let pooled = PoolTransaction::new(pending);
+                let pooled = PoolTransaction::new(pending).with_replay();
                 txs.entry(block_index).or_default().push(Arc::new(pooled));
             }
 
@@ -4482,7 +4482,7 @@ impl EthApi<FoundryNetwork> {
         let from = *pending_transaction.sender();
         let priority = self.transaction_priority(&pending_transaction.transaction);
         let pool_transaction =
-            PoolTransaction { requires, provides, pending_transaction, priority };
+            PoolTransaction { requires, provides, pending_transaction, priority, is_replay: false };
         let tx = self.pool.add_transaction(pool_transaction)?;
         trace!(target: "node", "Added transaction: [{:?}] sender={:?}", tx.hash(), from);
         Ok(*tx.hash())

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -332,7 +332,7 @@ pub fn execute_pool_transactions<B>(
     inspector_config: &InspectorTxConfig,
     cheats: &CheatsManager,
     validator: &dyn Fn(
-        &PendingTransaction<B::Transaction>,
+        &PoolTransaction<B::Transaction>,
         &AccountInfo,
     ) -> Result<(), InvalidTransactionError>,
 ) -> ExecutedPoolTransactions<B::Transaction>
@@ -405,7 +405,7 @@ where
         }
 
         // Validate
-        if let Err(err) = validator(pending, &account) {
+        if let Err(err) = validator(pool_tx, &account) {
             warn!(target: "backend", "Skipping invalid tx execution [{:?}] {}", pool_tx.hash(), err);
             invalid.push(pool_tx.clone());
             continue;

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -117,8 +117,9 @@ use foundry_evm::{
         TracingInspectorConfig,
     },
     utils::{
-        block_env_from_header, get_blob_base_fee_update_fraction,
-        get_blob_base_fee_update_fraction_by_spec_id, get_blob_params_by_spec_id,
+        apply_chain_specific_tx_replay_env_changes, block_env_from_header,
+        get_blob_base_fee_update_fraction, get_blob_base_fee_update_fraction_by_spec_id,
+        get_blob_params_by_spec_id,
     },
 };
 use foundry_evm_networks::{NetworkConfigs, arbitrum};
@@ -3188,21 +3189,26 @@ where
                 // to ensure the timestamp is as close as possible to the actual execution.
                 evm_env.block_env.timestamp = U256::from(self.time.next_timestamp());
 
-                let spec_id = *evm_env.spec_id();
+                // Forced historical transactions bypass pool admission and are replayed while
+                // mining. Keep this exception local to the disposable mining environment.
+                let mut mining_evm_env = evm_env.clone();
+                apply_chain_specific_tx_replay_env_changes(&mut mining_evm_env);
+
+                let spec_id = *mining_evm_env.spec_id();
 
                 let inspector_tx_config = self.inspector_tx_config();
-                let gas_config = self.pool_tx_gas_config(&evm_env);
+                let gas_config = self.pool_tx_gas_config(&mining_evm_env);
 
                 let (pool_result, block_result) = self.execute_with_block_executor(
                     &mut **db,
-                    &evm_env,
+                    &mining_evm_env,
                     best_hash,
                     spec_id,
                     &pool_transactions,
                     &gas_config,
                     &inspector_tx_config,
                     &|pending, account| {
-                        self.validate_pool_transaction_for(pending, account, &evm_env)
+                        self.validate_pool_transaction_for(pending, account, &mining_evm_env)
                     },
                 );
 
@@ -3212,7 +3218,7 @@ where
 
                 let state_root = db.maybe_state_root().unwrap_or_default();
                 let block_info = self.build_block_info(
-                    &evm_env,
+                    &mining_evm_env,
                     best_hash,
                     block_number,
                     state_root,
@@ -5953,8 +5959,9 @@ where
                     return Err(InvalidTransactionError::FeeCapTooLow);
                 }
 
-                if let (Some(max_priority_fee_per_gas), max_fee_per_gas) =
-                    (tx.as_ref().max_priority_fee_per_gas(), tx.as_ref().max_fee_per_gas())
+                if !evm_env.cfg_env.disable_priority_fee_check
+                    && let (Some(max_priority_fee_per_gas), max_fee_per_gas) =
+                        (tx.as_ref().max_priority_fee_per_gas(), tx.as_ref().max_fee_per_gas())
                     && max_priority_fee_per_gas > max_fee_per_gas
                 {
                     debug!(target: "backend", "max priority fee per gas={}, too high, max fee per gas={}", max_priority_fee_per_gas, max_fee_per_gas);

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -821,6 +821,14 @@ impl<N: Network> Backend<N> {
         evm_env
     }
 
+    /// Returns the environment for replaying transactions from a historical block.
+    fn tx_replay_evm_env(&self, header: &impl BlockHeader) -> EvmEnv {
+        let mut evm_env = self.evm_env.read().clone();
+        evm_env.block_env = block_env_from_header(header);
+        apply_chain_specific_tx_replay_env_changes(&mut evm_env);
+        evm_env
+    }
+
     /// Builds [`Inspector`] with the configured options.
     fn build_inspector(&self) -> AnvilInspector {
         let mut inspector = AnvilInspector::default();
@@ -1564,7 +1572,7 @@ impl<N: Network> Backend<N> {
         gas_config: &PoolTxGasConfig,
         inspector_tx_config: &InspectorTxConfig,
         validator: &dyn Fn(
-            &PendingTransaction<FoundryTxEnvelope>,
+            &PoolTransaction<FoundryTxEnvelope>,
             &AccountInfo,
         ) -> Result<(), InvalidTransactionError>,
     ) -> (ExecutedPoolTransactions<FoundryTxEnvelope>, BlockExecutionResult<FoundryReceiptEnvelope>)
@@ -2251,9 +2259,7 @@ impl<N: Network> Backend<N> {
         let mut cache_db = CacheDB::new(Box::new(parent_state));
         let mut results = Vec::new();
 
-        // Configure the block environment
-        let mut evm_env = self.evm_env.read().clone();
-        evm_env.block_env = block_env_from_header(&block.header);
+        let evm_env = self.tx_replay_evm_env(&block.header);
 
         // Execute each transaction in the block with tracing
         for tx_envelope in &block.body.transactions {
@@ -3192,7 +3198,9 @@ where
                 // Forced historical transactions bypass pool admission and are replayed while
                 // mining. Keep this exception local to the disposable mining environment.
                 let mut mining_evm_env = evm_env.clone();
-                apply_chain_specific_tx_replay_env_changes(&mut mining_evm_env);
+                if pool_transactions.iter().any(|tx| tx.is_replay) {
+                    apply_chain_specific_tx_replay_env_changes(&mut mining_evm_env);
+                }
 
                 let spec_id = *mining_evm_env.spec_id();
 
@@ -3207,8 +3215,14 @@ where
                     &pool_transactions,
                     &gas_config,
                     &inspector_tx_config,
-                    &|pending, account| {
-                        self.validate_pool_transaction_for(pending, account, &mining_evm_env)
+                    &|pool_tx, account| {
+                        let validation_env =
+                            if pool_tx.is_replay { &mining_evm_env } else { &evm_env };
+                        self.validate_pool_transaction_for(
+                            &pool_tx.pending_transaction,
+                            account,
+                            validation_env,
+                        )
                     },
                 );
 
@@ -3405,7 +3419,9 @@ where
             &pool_transactions,
             &gas_config,
             &inspector_tx_config,
-            &|pending, account| self.validate_pool_transaction_for(pending, account, &evm_env),
+            &|pool_tx, account| {
+                self.validate_pool_transaction_for(&pool_tx.pending_transaction, account, &evm_env)
+            },
         );
 
         // Extract inner CacheDB (which implements MaybeFullDatabase)
@@ -3619,6 +3635,7 @@ where
                     requires: vec![],
                     provides: vec![],
                     priority: crate::eth::pool::transactions::TransactionPriority(0),
+                    is_replay: true,
                 })
             })
             .collect();
@@ -3627,8 +3644,7 @@ where
             let mut cache_db =
                 AnvilCacheDB::new(Box::new(parent_state) as Box<dyn MaybeFullDatabase + '_>);
 
-            let mut evm_env = self.evm_env.read().clone();
-            evm_env.block_env = block_env_from_header(&block.header);
+            let evm_env = self.tx_replay_evm_env(&block.header);
 
             let spec_id = *evm_env.spec_id();
             let inspector_tx_config = self.inspector_tx_config();
@@ -3642,7 +3658,13 @@ where
                 &pool_txs,
                 &gas_config,
                 &inspector_tx_config,
-                &|pending, account| self.validate_pool_transaction_for(pending, account, &evm_env),
+                &|pool_tx, account| {
+                    self.validate_pool_transaction_for(
+                        &pool_tx.pending_transaction,
+                        account,
+                        &evm_env,
+                    )
+                },
             );
 
             let cache_db = cache_db.0;
@@ -4012,6 +4034,7 @@ where
                     requires: vec![],
                     provides: vec![],
                     priority: crate::eth::pool::transactions::TransactionPriority(0),
+                    is_replay: true,
                 })
             })
             .collect();
@@ -4019,10 +4042,7 @@ where
         let trace = |parent_state: &StateDb| -> Result<T, BlockchainError> {
             let mut cache_db = AnvilCacheDB::new(Box::new(parent_state));
 
-            // configure the blockenv for the block of the transaction
-            let mut evm_env = self.evm_env.read().clone();
-
-            evm_env.block_env = block_env_from_header(&block.header);
+            let evm_env = self.tx_replay_evm_env(&block.header);
 
             let spec_id = *evm_env.spec_id();
 
@@ -4037,7 +4057,13 @@ where
                 &pool_txs,
                 &gas_config,
                 &inspector_tx_config,
-                &|pending, account| self.validate_pool_transaction_for(pending, account, &evm_env),
+                &|pool_tx, account| {
+                    self.validate_pool_transaction_for(
+                        &pool_tx.pending_transaction,
+                        account,
+                        &evm_env,
+                    )
+                },
             );
 
             // Extract inner CacheDB to match the expected types for the target tx execution
@@ -4221,8 +4247,7 @@ where
             let mut cache_db = CacheDB::new(Box::new(parent_state));
             let mut transactions = Vec::with_capacity(block.body.transactions.len());
 
-            let mut evm_env = self.evm_env.read().clone();
-            evm_env.block_env = block_env_from_header(&block.header);
+            let evm_env = self.tx_replay_evm_env(&block.header);
 
             for tx_envelope in &block.body.transactions {
                 let mut inspector = OpcodeGasInspector::default();
@@ -4313,14 +4338,14 @@ where
                     requires: vec![],
                     provides: vec![],
                     priority: crate::eth::pool::transactions::TransactionPriority(0),
+                    is_replay: true,
                 })
             })
             .collect();
 
         let trace = |parent_state: &StateDb| -> Result<RpcAccountInfo, BlockchainError> {
             let mut cache_db = AnvilCacheDB::new(Box::new(parent_state));
-            let mut evm_env = self.evm_env.read().clone();
-            evm_env.block_env = block_env_from_header(&block.header);
+            let evm_env = self.tx_replay_evm_env(&block.header);
 
             let spec_id = *evm_env.spec_id();
             let inspector_tx_config = self.inspector_tx_config();
@@ -4334,7 +4359,13 @@ where
                 &pool_txs,
                 &gas_config,
                 &inspector_tx_config,
-                &|pending, account| self.validate_pool_transaction_for(pending, account, &evm_env),
+                &|pool_tx, account| {
+                    self.validate_pool_transaction_for(
+                        &pool_tx.pending_transaction,
+                        account,
+                        &evm_env,
+                    )
+                },
             );
 
             let cache_db = cache_db.0;

--- a/crates/anvil/src/eth/pool/transactions.rs
+++ b/crates/anvil/src/eth/pool/transactions.rs
@@ -86,6 +86,8 @@ pub struct PoolTransaction<T> {
     pub provides: Vec<TxMarker>,
     /// priority of the transaction
     pub priority: TransactionPriority,
+    /// Whether this transaction is being replayed from chain history.
+    pub is_replay: bool,
 }
 
 // == impl PoolTransaction ==
@@ -97,7 +99,14 @@ impl<T> PoolTransaction<T> {
             requires: vec![],
             provides: vec![],
             priority: TransactionPriority(0),
+            is_replay: false,
         }
+    }
+
+    /// Marks this transaction as a historical replay.
+    pub const fn with_replay(mut self) -> Self {
+        self.is_replay = true;
+        self
     }
 
     /// Returns the hash of this transaction
@@ -147,6 +156,7 @@ where
             requires: vec![],
             provides: vec![],
             priority: TransactionPriority(0),
+            is_replay: false,
         })
     }
 }

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -5,6 +5,7 @@ use crate::{
     fork::fork_config,
     utils::http_provider_with_signer,
 };
+use alloy_chains::NamedChain;
 use alloy_consensus::{SignableTransaction, TxEip1559};
 use alloy_network::{EthereumWallet, TransactionBuilder, TxSignerSync};
 use alloy_primitives::{Address, Bytes, TxKind, U256, address, b256, fixed_bytes};
@@ -875,6 +876,59 @@ async fn flaky_test_reorg() {
         })
         .await;
     assert!(res.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn can_replay_arbitrum_transaction_with_priority_fee_above_max_fee() {
+    let (api, handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Arbitrum as u64))).await;
+    let provider = handle.http_provider();
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    api.mine_one().await;
+
+    let recipient = accounts[1].address();
+    let value = U256::from(100);
+    let mut tx = TxEip1559 {
+        chain_id: api.chain_id(),
+        to: TxKind::Call(recipient),
+        value,
+        max_priority_fee_per_gas: 3_000_000_000,
+        max_fee_per_gas: 2_000_000_000,
+        gas_limit: 21_000,
+        ..Default::default()
+    };
+    let signature = accounts[0].sign_transaction_sync(&mut tx).unwrap();
+    let tx = tx.into_signed(signature);
+    let mut encoded = vec![];
+    tx.eip2718_encode(&mut encoded);
+
+    let balance_before = provider.get_balance(recipient).await.unwrap();
+    api.anvil_reorg(ReorgOptions {
+        depth: 1,
+        tx_block_pairs: vec![(TransactionData::Raw(encoded.into()), 0)],
+    })
+    .await
+    .unwrap();
+    let balance_after = provider.get_balance(recipient).await.unwrap();
+
+    assert_eq!(balance_after, balance_before + value);
+
+    let mut tx = TxEip1559 {
+        chain_id: api.chain_id(),
+        nonce: 1,
+        to: TxKind::Call(recipient),
+        max_priority_fee_per_gas: 3_000_000_000,
+        max_fee_per_gas: 2_000_000_000,
+        gas_limit: 21_000,
+        ..Default::default()
+    };
+    let signature = accounts[0].sign_transaction_sync(&mut tx).unwrap();
+    let tx = tx.into_signed(signature);
+    let mut encoded = vec![];
+    tx.eip2718_encode(&mut encoded);
+
+    let err = provider.send_raw_transaction(&encoded).await.unwrap_err();
+    assert!(err.to_string().contains("max priority fee per gas higher than max fee per gas"));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use alloy_chains::NamedChain;
 use alloy_consensus::{SignableTransaction, TxEip1559};
+use alloy_eips::eip2718::Decodable2718;
 use alloy_network::{EthereumWallet, TransactionBuilder, TxSignerSync};
 use alloy_primitives::{Address, Bytes, TxKind, U256, address, b256, fixed_bytes};
 use alloy_provider::{Provider, ext::TxPoolApi};
@@ -15,19 +16,26 @@ use alloy_rpc_types::{
     anvil::{
         ForkedNetwork, Forking, Metadata, MineOptions, NodeEnvironment, NodeForkConfig, NodeInfo,
     },
+    trace::parity::TraceType,
 };
 use alloy_serde::WithOtherFields;
-use anvil::{NodeConfig, eth::api::CLIENT_VERSION, spawn};
+use anvil::{
+    NodeConfig,
+    eth::{api::CLIENT_VERSION, pool::transactions::PoolTransaction},
+    spawn,
+};
 use anvil_core::{
-    eth::EthRequest,
+    eth::{EthRequest, transaction::PendingTransaction},
     types::{ReorgOptions, TransactionData},
 };
 use foundry_common::version::{COMMIT_SHA, SEMVER_VERSION};
 use foundry_evm::hardfork::EthereumHardfork;
+use foundry_primitives::FoundryTxEnvelope;
 use tempo_hardfork::TempoHardfork;
 
 use std::{
     str::FromStr,
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -899,6 +907,7 @@ async fn can_replay_arbitrum_transaction_with_priority_fee_above_max_fee() {
     };
     let signature = accounts[0].sign_transaction_sync(&mut tx).unwrap();
     let tx = tx.into_signed(signature);
+    let tx_hash = *tx.hash();
     let mut encoded = vec![];
     tx.eip2718_encode(&mut encoded);
 
@@ -912,6 +921,12 @@ async fn can_replay_arbitrum_transaction_with_priority_fee_above_max_fee() {
     let balance_after = provider.get_balance(recipient).await.unwrap();
 
     assert_eq!(balance_after, balance_before + value);
+
+    let trace = api
+        .trace_replay_transaction(tx_hash, [TraceType::Trace].into_iter().collect())
+        .await
+        .unwrap();
+    assert!(!trace.trace.is_empty());
 
     let mut tx = TxEip1559 {
         chain_id: api.chain_id(),
@@ -929,6 +944,37 @@ async fn can_replay_arbitrum_transaction_with_priority_fee_above_max_fee() {
 
     let err = provider.send_raw_transaction(&encoded).await.unwrap_err();
     assert!(err.to_string().contains("max priority fee per gas higher than max fee per gas"));
+
+    let pending =
+        PendingTransaction::new(FoundryTxEnvelope::decode_2718(&mut encoded.as_slice()).unwrap())
+            .unwrap();
+    let ordinary_hash = *pending.hash();
+    let ordinary = Arc::new(PoolTransaction::new(pending));
+
+    let mut tx = TxEip1559 {
+        chain_id: api.chain_id(),
+        to: TxKind::Call(accounts[2].address()),
+        value: U256::from(1),
+        max_priority_fee_per_gas: 3_000_000_000,
+        max_fee_per_gas: 2_000_000_000,
+        gas_limit: 21_000,
+        ..Default::default()
+    };
+    let signature = accounts[1].sign_transaction_sync(&mut tx).unwrap();
+    let tx = tx.into_signed(signature);
+    let replay_hash = *tx.hash();
+    let mut encoded = vec![];
+    tx.eip2718_encode(&mut encoded);
+    let pending =
+        PendingTransaction::new(FoundryTxEnvelope::decode_2718(&mut encoded.as_slice()).unwrap())
+            .unwrap();
+
+    let replay = Arc::new(PoolTransaction::new(pending).with_replay());
+    let outcome = api.backend.mine_block(vec![replay, ordinary]).await;
+    assert_eq!(outcome.included.len(), 1);
+    assert_eq!(outcome.included[0].hash(), replay_hash);
+    assert_eq!(outcome.invalid.len(), 1);
+    assert_eq!(outcome.invalid[0].hash(), ordinary_hash);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -4,7 +4,10 @@ use crate::{
         call_frame_to_arena_with_root_address, is_method_not_found_error, is_missing_state_error,
     },
     traces::TraceKind,
-    utils::{apply_chain_and_block_specific_env_changes, block_env_from_header},
+    utils::{
+        apply_chain_and_block_specific_env_changes, apply_chain_specific_tx_replay_env_changes,
+        block_env_from_header,
+    },
 };
 use alloy_consensus::{BlockHeader, Transaction, transaction::SignerRecoverable};
 
@@ -365,6 +368,7 @@ impl RunArgs {
                 config.networks,
             );
         }
+        apply_chain_specific_tx_replay_env_changes(&mut evm_env);
 
         let trace_requirements = TraceRequirements::none()
             .with_calls(true)

--- a/crates/evm/core/Cargo.toml
+++ b/crates/evm/core/Cargo.toml
@@ -50,6 +50,7 @@ revm = { workspace = true, features = [
     "optional_eip3607",
     "optional_block_gas_limit",
     "optional_no_base_fee",
+    "optional_priority_fee_check",
     "arbitrary",
     "c-kzg",
     "blst",

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     fork::{CreateFork, ForkId, MultiFork},
     state_snapshot::StateSnapshots,
-    utils::get_blob_base_fee_update_fraction,
+    utils::{apply_chain_specific_tx_replay_env_changes, get_blob_base_fee_update_fraction},
 };
 use alloy_consensus::{BlockHeader, Typed2718};
 use alloy_evm::{Evm, EvmEnv, EvmFactory};
@@ -935,7 +935,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
     pub fn replay_until(
         &mut self,
         id: LocalForkId,
-        evm_env: EvmEnvFor<FEN>,
+        mut evm_env: EvmEnvFor<FEN>,
         tx_hash: B256,
         journaled_state: &mut JournaledState,
     ) -> eyre::Result<Option<AnyRpcTransaction>> {
@@ -969,6 +969,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
 
             // Clone the fork's CacheDB once. The underlying SharedBackend is Arc-backed,
             // so only the local cache layer is actually duplicated.
+            apply_chain_specific_tx_replay_env_changes(&mut evm_env);
             let chain_id = evm_env.cfg_env.chain_id;
             let timestamp = evm_env.block_env.timestamp().saturating_to();
             let replay_db = fork.db.clone();
@@ -1390,6 +1391,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         let (_fork_block, block) =
             self.get_block_number_and_block_for_transaction(id, transaction)?;
         update_env_block(&mut evm_env, block.header());
+        apply_chain_specific_tx_replay_env_changes(&mut evm_env);
 
         let fork = self.inner.get_fork_by_id_mut(id)?;
         commit_transaction::<FEN>(

--- a/crates/evm/core/src/backend/mod.rs
+++ b/crates/evm/core/src/backend/mod.rs
@@ -929,6 +929,22 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         }
     }
 
+    /// Applies replay changes using the targeted fork's chain rather than the active environment.
+    fn apply_fork_tx_replay_env_changes(
+        &self,
+        id: LocalForkId,
+        evm_env: &mut EvmEnvFor<FEN>,
+    ) -> eyre::Result<()> {
+        let fork_id = self.inner.ensure_fork_id(id).cloned()?;
+        let fork_evm_env = self
+            .forks
+            .get_evm_env(fork_id)?
+            .ok_or_else(|| eyre::eyre!("Requested fork `{id}` does not exist"))?;
+        evm_env.cfg_env.chain_id = fork_evm_env.cfg_env.chain_id;
+        apply_chain_specific_tx_replay_env_changes(evm_env);
+        Ok(())
+    }
+
     /// Replays all the transactions at the forks current block that were mined before the `tx`
     ///
     /// Returns the _unmined_ transaction that corresponds to the given `tx_hash`
@@ -942,6 +958,7 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
         trace!(?id, ?tx_hash, "replay until transaction");
 
         let persistent_accounts = self.inner.persistent_accounts.clone();
+        self.apply_fork_tx_replay_env_changes(id, &mut evm_env)?;
 
         let fork = self.inner.get_fork_by_id_mut(id)?;
         let full_block =
@@ -969,7 +986,6 @@ impl<FEN: FoundryEvmNetwork> Backend<FEN> {
 
             // Clone the fork's CacheDB once. The underlying SharedBackend is Arc-backed,
             // so only the local cache layer is actually duplicated.
-            apply_chain_specific_tx_replay_env_changes(&mut evm_env);
             let chain_id = evm_env.cfg_env.chain_id;
             let timestamp = evm_env.block_env.timestamp().saturating_to();
             let replay_db = fork.db.clone();
@@ -1391,7 +1407,7 @@ impl<FEN: FoundryEvmNetwork> DatabaseExt<FEN::EvmFactory> for Backend<FEN> {
         let (_fork_block, block) =
             self.get_block_number_and_block_for_transaction(id, transaction)?;
         update_env_block(&mut evm_env, block.header());
-        apply_chain_specific_tx_replay_env_changes(&mut evm_env);
+        self.apply_fork_tx_replay_env_changes(id, &mut evm_env)?;
 
         let fork = self.inner.get_fork_by_id_mut(id)?;
         commit_transaction::<FEN>(

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -30,6 +30,14 @@ pub fn block_env_from_header<BLOCK: FoundryBlock + Default>(header: &impl BlockH
     block
 }
 
+/// Applies chain-specific changes required to replay transactions accepted on-chain.
+pub fn apply_chain_specific_tx_replay_env_changes<SPEC, BLOCK>(evm_env: &mut EvmEnv<SPEC, BLOCK>) {
+    if NamedChain::try_from(evm_env.cfg_env.chain_id).is_ok_and(|chain| chain.is_arbitrum()) {
+        // Arbitrum does not enforce the EIP-1559 priority fee ordering constraint.
+        evm_env.cfg_env.disable_priority_fee_check = true;
+    }
+}
+
 /// Depending on the configured chain id and block number this should apply any specific changes
 ///
 /// - checks for prevrandao mixhash after merge

--- a/crates/evm/core/src/utils.rs
+++ b/crates/evm/core/src/utils.rs
@@ -175,6 +175,24 @@ mod tests {
     use super::*;
 
     #[test]
+    fn tx_replay_env_changes_disable_priority_fee_check_only_for_arbitrum() {
+        let mut evm_env = EvmEnv::new(
+            revm::context::CfgEnv::<SpecId>::default(),
+            revm::context::BlockEnv::default(),
+        );
+        evm_env.cfg_env.chain_id = NamedChain::Arbitrum as u64;
+
+        apply_chain_specific_tx_replay_env_changes(&mut evm_env);
+        assert!(evm_env.cfg_env.disable_priority_fee_check);
+
+        evm_env.cfg_env.chain_id = NamedChain::Mainnet as u64;
+        evm_env.cfg_env.disable_priority_fee_check = false;
+
+        apply_chain_specific_tx_replay_env_changes(&mut evm_env);
+        assert!(!evm_env.cfg_env.disable_priority_fee_check);
+    }
+
+    #[test]
     fn blob_params_by_spec_id_tracks_latest_known_blob_schedule() {
         assert_eq!(get_blob_params_by_spec_id(SpecId::CANCUN), BlobParams::cancun());
         assert_eq!(get_blob_params_by_spec_id(SpecId::PRAGUE), BlobParams::prague());

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -977,6 +977,29 @@ contract BlobForkTest is Test {
     cmd.args(["test", "-vvvv"]).assert_success();
 });
 
+// https://github.com/foundry-rs/foundry/issues/10689
+forgetest_init!(flaky_roll_fork_arbitrum_priority_fee_above_max_fee, |prj, cmd| {
+    let endpoint = "https://arb-mainnet.g.alchemy.com/public";
+
+    prj.add_test(
+        "ArbitrumFork.t.sol",
+        &r#"
+import {Test} from "forge-std/Test.sol";
+
+contract ArbitrumForkTest is Test {
+    function test_rollFork() public {
+        vm.createSelectFork("<url>");
+        bytes32 txHash = 0x2e43e9ececcbb9cd08ce061edc3b4d39ca2b0ba480034e5f4650ba0065bf6b62;
+        vm.rollFork(txHash);
+    }
+}
+    "#
+        .replace("<url>", endpoint),
+    );
+
+    cmd.arg("test").assert_success();
+});
+
 // https://github.com/foundry-rs/foundry/issues/6579
 forgetest_init!(include_custom_types_in_traces, |prj, cmd| {
     prj.add_test(

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -988,9 +988,9 @@ import {Test} from "forge-std/Test.sol";
 
 contract ArbitrumForkTest is Test {
     function test_rollFork() public {
-        vm.createSelectFork("<url>");
+        uint256 forkId = vm.createFork("<url>");
         bytes32 txHash = 0x2e43e9ececcbb9cd08ce061edc3b4d39ca2b0ba480034e5f4650ba0065bf6b62;
-        vm.rollFork(txHash);
+        vm.rollFork(forkId, txHash);
     }
 }
     "#

--- a/crates/verify/src/bytecode.rs
+++ b/crates/verify/src/bytecode.rs
@@ -42,6 +42,7 @@ use foundry_evm::{
         evm::{EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor},
     },
     executors::EvmError,
+    utils::apply_chain_specific_tx_replay_env_changes,
 };
 use foundry_evm_networks::NetworkVariant;
 use revm::{context::Block as _, state::AccountInfo};
@@ -660,6 +661,7 @@ impl VerifyBytecodeArgs {
             let prev_block_nonce =
                 provider.get_transaction_count(transaction.from()).block_id(prev_block_id).await?;
 
+            apply_chain_specific_tx_replay_env_changes(&mut evm_env);
             if let Some(ref block) = block {
                 configure_env_block::<FEN>(&mut evm_env, block, config.networks);
 


### PR DESCRIPTION
Allows Foundry to replay historical Arbitrum transactions where the priority fee exceeds the maximum fee, matching transactions accepted on-chain. The relaxed validation is limited to historical replay environments and does not affect ordinary local execution.

Closes #10689.