### PR TITLE
fix(traces): bound external identification

### DIFF
--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -258,7 +258,8 @@ impl CallArgs {
         let mut config = load_config_from_provider(figment)?;
         let state_overrides = self.get_state_overrides()?;
         let block_overrides = self.get_block_overrides()?;
-        let tracing = self.resolve_tracing(&config.tracing, shell::verbosity());
+        config.tracing = self.resolve_tracing(&config.tracing, shell::verbosity());
+        let tracing = config.tracing.clone();
 
         let Self {
             to,

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -170,7 +170,8 @@ impl RunArgs {
         let evm_opts = figment.extract::<EvmOpts>()?;
         let mut config = load_config_from_provider(figment)?;
         self.tracing.labels.append(&mut self.legacy_labels);
-        let tracing = self.resolve_tracing(&config.tracing, shell::verbosity());
+        config.tracing = self.resolve_tracing(&config.tracing, shell::verbosity());
+        let tracing = config.tracing.clone();
 
         let with_local_artifacts = self.with_local_artifacts;
         let debug = self.debug;

--- a/crates/cli/src/opts/tracing.rs
+++ b/crates/cli/src/opts/tracing.rs
@@ -48,6 +48,11 @@ pub struct TracingArgs {
     )]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub labels: Vec<String>,
+
+    /// Disable external trace identification using Sourcify, Etherscan, or OpenChain.
+    #[arg(long, help_heading = "Trace options")]
+    #[serde(skip)]
+    pub disable_external_identification: bool,
 }
 
 impl TracingArgs {
@@ -60,6 +65,9 @@ impl TracingArgs {
         tracing.compact_labels |= self.compact_labels;
         tracing.trace_depth = self.trace_depth.or(tracing.trace_depth);
         tracing.decode_internal |= self.decode_internal;
+        if self.disable_external_identification {
+            tracing.external_identification_timeout = 0;
+        }
         tracing
     }
 
@@ -97,6 +105,7 @@ mod tests {
             compact_labels: false,
             trace_depth: Some(1),
             decode_internal: false,
+            external_identification_timeout: 10,
         };
         let args = TracingArgs {
             decode_internal: true,
@@ -104,6 +113,7 @@ mod tests {
             disable_labels: true,
             compact_labels: true,
             labels: vec![format!("{address}:cli")],
+            disable_external_identification: true,
         };
 
         let tracing = args.resolve(&config, 3);
@@ -113,6 +123,16 @@ mod tests {
         assert!(tracing.compact_labels);
         assert_eq!(tracing.trace_depth, Some(2));
         assert!(tracing.decode_internal);
+        assert_eq!(tracing.external_identification_timeout, 0);
+    }
+
+    #[test]
+    fn resolve_preserves_external_identification_timeout() {
+        let config = TracingConfig { external_identification_timeout: 17, ..Default::default() };
+
+        let tracing = TracingArgs::default().resolve(&config, 0);
+
+        assert_eq!(tracing.external_identification_timeout, 17);
     }
 
     #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -5931,6 +5931,7 @@ mod tests {
                 compact_labels = true
                 trace_depth = 3
                 decode_internal = true
+                external_identification_timeout = 9
 
                 [tracing.labels]
                 0x0000000000000000000000000000000000000002 = "Bob"
@@ -5944,6 +5945,7 @@ mod tests {
             assert_eq!(config.tracing.trace_depth, Some(3));
             assert!(config.tracing.decode_internal);
             assert!(config.tracing.compact_labels);
+            assert_eq!(config.tracing.external_identification_timeout, 9);
             let labels = AddressHashMap::from_iter(vec![(
                 address!("0x0000000000000000000000000000000000000002"),
                 "Bob".to_string(),
@@ -5962,6 +5964,18 @@ mod tests {
             assert_eq!(reloaded.tracing.labels, labels);
             assert!(reloaded.warnings.is_empty());
 
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn test_external_identification_timeout_env() {
+        figment::Jail::expect_with(|jail| {
+            jail.set_env("FOUNDRY_TRACING_EXTERNAL_IDENTIFICATION_TIMEOUT", "0");
+
+            let config = Config::load().unwrap();
+
+            assert_eq!(config.tracing.external_identification_timeout, 0);
             Ok(())
         });
     }

--- a/crates/config/src/providers/warnings.rs
+++ b/crates/config/src/providers/warnings.rs
@@ -86,8 +86,15 @@ const SYMBOLIC_KEYS: &[&str] = &[
 /// Allowed keys for TracingConfig.
 /// Required because empty labels and optional trace depth are skipped by default serialization,
 /// but they are still valid user-facing config keys.
-const TRACING_KEYS: &[&str] =
-    &["verbosity", "labels", "disable_labels", "compact_labels", "trace_depth", "decode_internal"];
+const TRACING_KEYS: &[&str] = &[
+    "verbosity",
+    "labels",
+    "disable_labels",
+    "compact_labels",
+    "trace_depth",
+    "decode_internal",
+    "external_identification_timeout",
+];
 
 /// Reserved keys that should not trigger unknown key warnings.
 const RESERVED_KEYS: &[&str] = &["extends"];

--- a/crates/config/src/trace.rs
+++ b/crates/config/src/trace.rs
@@ -4,7 +4,8 @@ use alloy_primitives::map::AddressHashMap;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for trace rendering.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct TracingConfig {
     /// Verbosity to use for trace rendering.
     pub verbosity: u8,
@@ -20,4 +21,21 @@ pub struct TracingConfig {
     pub trace_depth: Option<usize>,
     /// Whether to identify internal functions in traces.
     pub decode_internal: bool,
+    /// Cumulative Sourcify/Etherscan metadata lookup budget, in seconds.
+    /// Zero disables all external trace identification, including OpenChain.
+    pub external_identification_timeout: u64,
+}
+
+impl Default for TracingConfig {
+    fn default() -> Self {
+        Self {
+            verbosity: 0,
+            labels: Default::default(),
+            disable_labels: false,
+            compact_labels: false,
+            trace_depth: None,
+            decode_internal: false,
+            external_identification_timeout: 5,
+        }
+    }
 }

--- a/crates/evm/traces/Cargo.toml
+++ b/crates/evm/traces/Cargo.toml
@@ -55,6 +55,7 @@ yansi.workspace = true
 [dev-dependencies]
 ron.workspace = true
 snapbox.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 default = ["optimism"]

--- a/crates/evm/traces/src/identifier/external.rs
+++ b/crates/evm/traces/src/identifier/external.rs
@@ -30,12 +30,15 @@ pub struct ExternalIdentifier {
     fetchers: Vec<Arc<dyn ExternalFetcherT>>,
     /// Cached contracts.
     contracts: HashMap<Address, (FetcherKind, Option<Metadata>)>,
+    /// Remaining time external identification may block trace rendering.
+    remaining_budget: Duration,
 }
 
 impl ExternalIdentifier {
     /// Creates a new external identifier with the given client
     pub fn new(config: &Config, mut chain: Option<Chain>) -> eyre::Result<Option<Self>> {
-        if config.offline {
+        let timeout = config.tracing.external_identification_timeout;
+        if config.offline || timeout == 0 {
             return Ok(None);
         }
 
@@ -76,7 +79,11 @@ impl ExternalIdentifier {
             return Ok(None);
         }
 
-        Ok(Some(Self { fetchers, contracts: Default::default() }))
+        Ok(Some(Self {
+            fetchers,
+            contracts: Default::default(),
+            remaining_budget: Duration::from_secs(timeout),
+        }))
     }
 
     /// Goes over the list of contracts we have pulled from the traces, clones their source from
@@ -149,6 +156,62 @@ impl ExternalIdentifier {
             artifact_id: None,
         }
     }
+
+    fn cache_fetched(&mut self, address: Address, value: (FetcherKind, Option<Metadata>)) {
+        match self.contracts.entry(address) {
+            Entry::Occupied(mut occupied_entry) => {
+                let old = occupied_entry.get();
+                // Only override when the new result is strictly better:
+                // - new has metadata and old doesn't, OR
+                // - both have metadata but new is from Etherscan and old is not.
+                // Never downgrade a successful lookup to None.
+                let should_replace = match (&old.1, &value.1) {
+                    (None, Some(_)) => true,
+                    (Some(_), None) => false,
+                    _ => {
+                        matches!(value.0, FetcherKind::Etherscan)
+                            && !matches!(old.0, FetcherKind::Etherscan)
+                    }
+                };
+                if should_replace {
+                    occupied_entry.insert(value);
+                }
+            }
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(value);
+            }
+        }
+    }
+
+    fn fetch_addresses(&mut self, addresses: &[Address]) {
+        foundry_common::block_on(self.fetch_addresses_async(addresses));
+    }
+
+    async fn fetch_addresses_async(&mut self, addresses: &[Address]) {
+        if addresses.is_empty() || self.remaining_budget.is_zero() {
+            return;
+        }
+
+        let fetchers = self
+            .fetchers
+            .clone()
+            .into_iter()
+            .map(|fetcher| ExternalFetcher::new(fetcher, addresses));
+        let started = tokio::time::Instant::now();
+        let timed_out = tokio::time::timeout(self.remaining_budget, async {
+            let mut fetched = futures::stream::select_all(fetchers);
+            while let Some((address, value)) = fetched.next().await {
+                self.cache_fetched(address, value);
+            }
+        })
+        .await
+        .is_err();
+        self.remaining_budget = self.remaining_budget.saturating_sub(started.elapsed());
+        if timed_out {
+            self.remaining_budget = Duration::ZERO;
+            warn!(target: "evm::traces::external", "external identification timed out; disabling it for the remainder of this session");
+        }
+    }
 }
 
 impl TraceIdentifier for ExternalIdentifier {
@@ -179,48 +242,20 @@ impl TraceIdentifier for ExternalIdentifier {
         if to_fetch.is_empty() {
             return identities;
         }
+        if self.remaining_budget.is_zero() {
+            return identities;
+        }
         trace!(target: "evm::traces::external", "fetching {} addresses", to_fetch.len());
 
         let to_fetch = to_fetch.into_iter().collect::<Vec<_>>();
-        let fetchers =
-            self.fetchers.iter().map(|fetcher| ExternalFetcher::new(fetcher.clone(), &to_fetch));
-        let fetched_identities = foundry_common::block_on(
-            futures::stream::select_all(fetchers)
-                .filter_map(|(address, value)| {
-                    let addr = value
-                        .1
-                        .as_ref()
-                        .map(|metadata| self.identify_from_metadata(address, metadata));
-                    match self.contracts.entry(address) {
-                        Entry::Occupied(mut occupied_entry) => {
-                            let old = occupied_entry.get();
-                            // Only override when the new result is strictly better:
-                            // - new has metadata and old doesn't, OR
-                            // - both have metadata but new is from Etherscan and old is not.
-                            // Never downgrade a successful lookup to None.
-                            let should_replace = match (&old.1, &value.1) {
-                                (None, Some(_)) => true,
-                                (Some(_), None) => false,
-                                _ => {
-                                    matches!(value.0, FetcherKind::Etherscan)
-                                        && !matches!(old.0, FetcherKind::Etherscan)
-                                }
-                            };
-                            if should_replace {
-                                occupied_entry.insert(value);
-                            }
-                        }
-                        Entry::Vacant(vacant_entry) => {
-                            vacant_entry.insert(value);
-                        }
-                    }
-                    async move { addr }
-                })
-                .collect::<Vec<IdentifiedAddress<'_>>>(),
-        );
-        trace!(target: "evm::traces::external", "fetched {} addresses: {fetched_identities:#?}", fetched_identities.len());
+        self.fetch_addresses(&to_fetch);
 
-        identities.extend(fetched_identities);
+        for address in to_fetch {
+            if let Some((_, Some(metadata))) = self.contracts.get(&address) {
+                identities.push(self.identify_from_metadata(address, metadata));
+            }
+        }
+        trace!(target: "evm::traces::external", "identified {} addresses", identities.len());
         identities
     }
 }
@@ -231,6 +266,10 @@ type FetchFuture =
 /// Maximum number of times a single address is retried through a transient Cloudflare
 /// block before we give up on it. Bounded so a persistent block can't loop forever.
 const MAX_CLOUDFLARE_RETRIES: u32 = 5;
+
+fn backoff_interval(period: Duration) -> Interval {
+    tokio::time::interval_at(tokio::time::Instant::now() + period, period)
+}
 
 /// A rate limit aware fetcher.
 ///
@@ -317,7 +356,7 @@ impl Stream for ExternalFetcher {
                         }
                         Err(EtherscanError::RateLimitExceeded) => {
                             warn!(target: "evm::traces::external", "rate limit exceeded on attempt");
-                            pin.backoff = Some(tokio::time::interval(pin.timeout));
+                            pin.backoff = Some(backoff_interval(pin.timeout));
                             pin.queue.push(addr);
                         }
                         Err(EtherscanError::InvalidApiKey) => {
@@ -339,7 +378,7 @@ impl Stream for ExternalFetcher {
                             };
                             if attempts <= MAX_CLOUDFLARE_RETRIES {
                                 warn!(target: "evm::traces::external", attempts, "blocked by cloudflare, backing off");
-                                pin.backoff = Some(tokio::time::interval(pin.timeout));
+                                pin.backoff = Some(backoff_interval(pin.timeout));
                                 pin.queue.push(addr);
                             } else {
                                 warn!(target: "evm::traces::external", "blocked by cloudflare, giving up on address");
@@ -536,7 +575,105 @@ impl From<SourcifyMetadata> for Metadata {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{collections::HashSet as StdHashSet, sync::Mutex};
+    use std::{
+        collections::HashSet as StdHashSet,
+        future::pending,
+        sync::{
+            Mutex,
+            atomic::{AtomicUsize, Ordering as AtomicOrdering},
+        },
+    };
+
+    struct TestFetcher {
+        kind: FetcherKind,
+        delay: Option<Duration>,
+        contract_name: Option<&'static str>,
+        calls: Arc<AtomicUsize>,
+        invalid: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl ExternalFetcherT for TestFetcher {
+        fn kind(&self) -> FetcherKind {
+            self.kind
+        }
+
+        fn timeout(&self) -> Duration {
+            Duration::from_millis(1)
+        }
+
+        fn concurrency(&self) -> usize {
+            1
+        }
+
+        fn invalid_api_key(&self) -> &AtomicBool {
+            &self.invalid
+        }
+
+        async fn fetch(&self, _address: Address) -> Result<Option<Metadata>, EtherscanError> {
+            self.calls.fetch_add(1, AtomicOrdering::Relaxed);
+            let Some(delay) = self.delay else { return pending().await };
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+            Ok(self.contract_name.map(metadata))
+        }
+    }
+
+    struct RateLimitedFetcher {
+        calls: Arc<AtomicUsize>,
+        invalid: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl ExternalFetcherT for RateLimitedFetcher {
+        fn kind(&self) -> FetcherKind {
+            FetcherKind::Sourcify
+        }
+
+        fn timeout(&self) -> Duration {
+            Duration::from_millis(5)
+        }
+
+        fn concurrency(&self) -> usize {
+            1
+        }
+
+        fn invalid_api_key(&self) -> &AtomicBool {
+            &self.invalid
+        }
+
+        async fn fetch(&self, _address: Address) -> Result<Option<Metadata>, EtherscanError> {
+            self.calls.fetch_add(1, AtomicOrdering::Relaxed);
+            Err(EtherscanError::RateLimitExceeded)
+        }
+    }
+
+    fn metadata(contract_name: &str) -> Metadata {
+        SourcifyMetadata {
+            abi: None,
+            compilation: Some(Compilation {
+                compiler_version: String::new(),
+                name: contract_name.to_string(),
+            }),
+        }
+        .into()
+    }
+
+    fn test_identifier(
+        fetchers: Vec<Arc<dyn ExternalFetcherT>>,
+        remaining_budget: Duration,
+    ) -> ExternalIdentifier {
+        ExternalIdentifier { fetchers, contracts: Default::default(), remaining_budget }
+    }
+
+    #[test]
+    fn zero_timeout_disables_external_identification() {
+        let mut config = Config::default();
+        config.tracing.external_identification_timeout = 0;
+
+        assert!(ExternalIdentifier::new(&config, Some(Chain::mainnet())).unwrap().is_none());
+    }
 
     /// Fetcher that returns a transient Cloudflare block the first time it sees an address, then
     /// succeeds. Mirrors Etherscan/Cloudflare throttling a burst of concurrent requests.
@@ -581,5 +718,131 @@ mod tests {
         let got: StdHashSet<Address> = collected.into_iter().map(|(addr, _)| addr).collect();
         let want: StdHashSet<Address> = addrs.into_iter().collect();
         assert_eq!(got, want, "every address must be yielded despite a transient cloudflare block");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_keeps_partial_results_and_opens_circuit() {
+        let successful_calls = Arc::new(AtomicUsize::new(0));
+        let stalled_calls = Arc::new(AtomicUsize::new(0));
+        let fetchers: Vec<Arc<dyn ExternalFetcherT>> = vec![
+            Arc::new(TestFetcher {
+                kind: FetcherKind::Sourcify,
+                delay: Some(Duration::ZERO),
+                contract_name: Some("PartialResult"),
+                calls: Arc::clone(&successful_calls),
+                invalid: AtomicBool::new(false),
+            }),
+            Arc::new(TestFetcher {
+                kind: FetcherKind::Etherscan,
+                delay: None,
+                contract_name: None,
+                calls: Arc::clone(&stalled_calls),
+                invalid: AtomicBool::new(false),
+            }),
+        ];
+        let mut identifier = test_identifier(fetchers, Duration::from_millis(20));
+        let address = Address::with_last_byte(1);
+
+        identifier.fetch_addresses_async(&[address]).await;
+
+        assert!(identifier.remaining_budget.is_zero());
+        assert_eq!(
+            identifier.contracts[&address].1.as_ref().unwrap().contract_name,
+            "PartialResult"
+        );
+        assert_eq!(successful_calls.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(stalled_calls.load(AtomicOrdering::Relaxed), 1);
+
+        identifier.fetch_addresses_async(&[Address::with_last_byte(2)]).await;
+        assert_eq!(successful_calls.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(stalled_calls.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn timeout_returns_partial_identity() {
+        let fetchers: Vec<Arc<dyn ExternalFetcherT>> = vec![
+            Arc::new(TestFetcher {
+                kind: FetcherKind::Sourcify,
+                delay: Some(Duration::ZERO),
+                contract_name: Some("PartialResult"),
+                calls: Arc::new(AtomicUsize::new(0)),
+                invalid: AtomicBool::new(false),
+            }),
+            Arc::new(TestFetcher {
+                kind: FetcherKind::Etherscan,
+                delay: None,
+                contract_name: None,
+                calls: Arc::new(AtomicUsize::new(0)),
+                invalid: AtomicBool::new(false),
+            }),
+        ];
+        let mut identifier = test_identifier(fetchers, Duration::from_millis(20));
+        let mut node = CallTraceNode::default();
+        node.trace.address = Address::with_last_byte(1);
+
+        let identities = identifier.identify_addresses(&[&node]);
+
+        assert_eq!(identities.len(), 1);
+        assert_eq!(identities[0].label.as_deref(), Some("PartialResult"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_budget_is_cumulative_across_fetches() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let fetcher: Arc<dyn ExternalFetcherT> = Arc::new(TestFetcher {
+            kind: FetcherKind::Sourcify,
+            delay: Some(Duration::from_millis(20)),
+            contract_name: Some("FirstResult"),
+            calls: Arc::clone(&calls),
+            invalid: AtomicBool::new(false),
+        });
+        let mut identifier = test_identifier(vec![fetcher], Duration::from_millis(30));
+        let first = Address::with_last_byte(1);
+        let second = Address::with_last_byte(2);
+
+        identifier.fetch_addresses_async(&[first]).await;
+        assert!(identifier.contracts[&first].1.is_some());
+        assert!(identifier.remaining_budget < Duration::from_millis(15));
+
+        identifier.fetch_addresses_async(&[second]).await;
+        assert!(identifier.remaining_budget.is_zero());
+        assert!(!identifier.contracts.contains_key(&second));
+        assert_eq!(calls.load(AtomicOrdering::Relaxed), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rate_limit_retries_cannot_escape_timeout_budget() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let fetcher: Arc<dyn ExternalFetcherT> = Arc::new(RateLimitedFetcher {
+            calls: Arc::clone(&calls),
+            invalid: AtomicBool::new(false),
+        });
+        let mut identifier = test_identifier(vec![fetcher], Duration::from_millis(20));
+
+        identifier.fetch_addresses_async(&[Address::with_last_byte(1)]).await;
+
+        assert!(identifier.remaining_budget.is_zero());
+        assert!(calls.load(AtomicOrdering::Relaxed) > 1);
+    }
+
+    #[test]
+    fn etherscan_metadata_takes_precedence() {
+        let address = Address::with_last_byte(1);
+        let mut identifier = test_identifier(Vec::new(), Duration::ZERO);
+
+        identifier
+            .cache_fetched(address, (FetcherKind::Sourcify, Some(metadata("SourcifyResult"))));
+        identifier.cache_fetched(address, (FetcherKind::Etherscan, None));
+        assert_eq!(
+            identifier.contracts[&address].1.as_ref().unwrap().contract_name,
+            "SourcifyResult"
+        );
+
+        identifier
+            .cache_fetched(address, (FetcherKind::Etherscan, Some(metadata("EtherscanResult"))));
+        assert_eq!(
+            identifier.contracts[&address].1.as_ref().unwrap().contract_name,
+            "EtherscanResult"
+        );
     }
 }

--- a/crates/evm/traces/src/identifier/signatures.rs
+++ b/crates/evm/traces/src/identifier/signatures.rs
@@ -199,7 +199,7 @@ impl SignaturesIdentifier {
 
     /// Creates a new `SignaturesIdentifier` from the global configuration.
     pub fn from_config(config: &Config) -> Result<Self> {
-        Self::new(config.offline)
+        Self::new(config.offline || config.tracing.external_identification_timeout == 0)
     }
 
     /// Creates an offline `SignaturesIdentifier` with the default cache directory and local ABIs.
@@ -392,6 +392,16 @@ impl Drop for SignaturesIdentifierInner {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn zero_external_identification_timeout_disables_client() {
+        let mut config = Config::default();
+        config.tracing.external_identification_timeout = 0;
+
+        let identifier = SignaturesIdentifier::from_config(&config).unwrap();
+
+        assert!(identifier.0.client.is_none());
+    }
 
     #[test]
     fn unknown_signatures_not_persisted_to_disk() {

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -292,6 +292,7 @@ verbosity = 0
 disable_labels = false
 compact_labels = false
 decode_internal = false
+external_identification_timeout = 5
 
 [vyper]
 
@@ -1727,7 +1728,8 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "verbosity": 0,
     "disable_labels": false,
     "compact_labels": false,
-    "decode_internal": false
+    "decode_internal": false,
+    "external_identification_timeout": 5
   },
   "ffi": false,
   "live_logs": false,


### PR DESCRIPTION
Bounds external trace identification with a cumulative timeout so stalled Sourcify or Etherscan requests cannot indefinitely block trace rendering. Setting the timeout to zero or passing `--disable-external-identification` disables external lookups without preventing compiler downloads.

Fixes #12714.