### PR TITLE
refactor(anvil): use tx conversion methods

### DIFF
--- a/crates/anvil/core/src/eth/block.rs
+++ b/crates/anvil/core/src/eth/block.rs
@@ -2,8 +2,8 @@ use super::transaction::TransactionInfo;
 #[cfg(test)]
 use alloy_consensus::Header;
 use alloy_consensus::{
-    BlockBody, EMPTY_OMMER_ROOT_HASH, TxEip4844Variant, Typed2718,
-    proofs::ordered_trie_root_with_encoder, transaction::RlpEcdsaEncodableTx,
+    BlockBody, EMPTY_OMMER_ROOT_HASH, Typed2718, proofs::ordered_trie_root_with_encoder,
+    transaction::RlpEcdsaEncodableTx,
 };
 use alloy_eips::eip2718::Encodable2718;
 use alloy_network::Network;
@@ -40,20 +40,14 @@ impl EncodableBlockTransaction for FoundryTxEnvelope {
     }
 }
 
-/// Drops pooled sidecars so a transaction uses its canonical block-body representation.
-pub fn canonical_block_transaction(tx: FoundryTxEnvelope) -> FoundryTxEnvelope {
-    match tx {
-        FoundryTxEnvelope::Eip4844(tx) => {
-            FoundryTxEnvelope::Eip4844(tx.map(TxEip4844Variant::drop_sidecar))
-        }
-        tx => tx,
-    }
-}
-
 /// Returns a block whose transactions use canonical block-body representations.
 pub fn canonical_block(mut block: Block) -> Block {
-    block.body.transactions =
-        block.body.transactions.into_iter().map(|tx| tx.map(canonical_block_transaction)).collect();
+    block.body.transactions = block
+        .body
+        .transactions
+        .into_iter()
+        .map(|tx| tx.map(FoundryTxEnvelope::into_canonical))
+        .collect();
     block
 }
 
@@ -86,7 +80,7 @@ where
 mod tests {
     use alloy_consensus::{
         BlobTransactionSidecar, BlobTransactionSidecarVariant, BlockHeader, SignableTransaction,
-        TxEip4844, proofs::calculate_transaction_root,
+        TxEip4844, TxEip4844Variant, proofs::calculate_transaction_root,
     };
     use alloy_primitives::{
         Address, B64, B256, Bloom, Signature, U256, b256,

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -1,7 +1,4 @@
-use super::{
-    backend::mem::{BlockRequest, DatabaseRef, State, sanitize_simulation_blocks},
-    sign::build_impersonated,
-};
+use super::backend::mem::{BlockRequest, DatabaseRef, State, sanitize_simulation_blocks};
 use crate::{
     ClientFork, LoggingManager, Miner, MiningMode, StorageInfo,
     eth::{
@@ -24,7 +21,7 @@ use crate::{
                 PoolTransaction, TransactionOrder, TransactionPriority, TxMarker, to_marker,
             },
         },
-        sign::{self, Signer},
+        sign::Signer,
     },
     filter::{EthFilter, Filters, LogsFilter},
     mem::transaction_build,
@@ -76,7 +73,7 @@ use alloy_transport::TransportErrorKind;
 use anvil_core::{
     eth::{
         EthRequest,
-        block::{BlockInfo, canonical_block, canonical_block_transaction},
+        block::{BlockInfo, canonical_block},
         transaction::{MaybeImpersonatedTransaction, PendingTransaction},
     },
     types::{ReorgOptions, TransactionData},
@@ -2163,7 +2160,7 @@ impl EthApi<FoundryNetwork> {
     fn sign_request(&self, from: &Address, typed_tx: FoundryTypedTx) -> Result<FoundryTxEnvelope> {
         match typed_tx {
             #[cfg(feature = "optimism")]
-            FoundryTypedTx::Deposit(_) => return Ok(build_impersonated(typed_tx)),
+            FoundryTypedTx::Deposit(_) => return Ok(typed_tx.into_impersonated()),
             _ => {
                 for signer in self.signers.iter() {
                     if signer.accounts().contains(from) {
@@ -2566,7 +2563,7 @@ impl EthApi<FoundryNetwork> {
 
         // if the sender is currently impersonated we need to "bypass" signing
         let pending_transaction = if self.is_impersonated(from) {
-            let transaction = sign::build_impersonated(typed_tx);
+            let transaction = typed_tx.into_impersonated();
             self.ensure_typed_transaction_supported(&transaction)?;
             trace!(target : "node", ?from, "eth_sendTransaction: impersonating");
             PendingTransaction::with_impersonated(transaction, from)
@@ -2618,7 +2615,7 @@ impl EthApi<FoundryNetwork> {
         let typed_tx = self.build_tx_request(request, nonce).await?;
 
         let pending_transaction = if self.is_impersonated(from) {
-            let transaction = sign::build_impersonated(typed_tx);
+            let transaction = typed_tx.into_impersonated();
             self.ensure_typed_transaction_supported(&transaction)?;
             trace!(target : "node", ?from, "eth_resend: impersonating");
             PendingTransaction::with_impersonated(transaction, from)
@@ -3119,7 +3116,7 @@ impl EthApi<FoundryNetwork> {
         }
 
         let typed_tx = self.build_tx_request(request, nonce).await?;
-        let tx = build_impersonated(typed_tx);
+        let tx = typed_tx.into_impersonated();
 
         let raw = tx.encoded_2718().into();
 
@@ -3411,7 +3408,7 @@ impl EthApi<FoundryNetwork> {
                 .body
                 .transactions
                 .into_iter()
-                .map(|tx| canonical_block_transaction(tx.into_inner()).encoded_2718().into())
+                .map(|tx| tx.into_inner().into_canonical().encoded_2718().into())
                 .collect());
         }
 
@@ -3864,7 +3861,7 @@ impl EthApi<FoundryNetwork> {
 
                         // Handle signer and convert to pending transaction
                         if self.is_impersonated(from) {
-                            let transaction = sign::build_impersonated(typed_tx);
+                            let transaction = typed_tx.into_impersonated();
                             self.ensure_typed_transaction_supported(&transaction)?;
                             PendingTransaction::with_impersonated(transaction, from)
                         } else {
@@ -3968,7 +3965,7 @@ impl EthApi<FoundryNetwork> {
 
         let typed_tx = self.build_tx_request(request, nonce).await?;
 
-        let transaction = sign::build_impersonated(typed_tx);
+        let transaction = typed_tx.into_impersonated();
 
         self.ensure_typed_transaction_supported(&transaction)?;
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -27,7 +27,6 @@ use crate::{
         fees::{FeeDetails, FeeManager, MIN_SUGGESTED_PRIORITY_FEE},
         macros::node_info,
         pool::transactions::PoolTransaction,
-        sign::build_impersonated,
     },
     mem::{
         inspector::{AnvilInspector, InspectorTxConfig},
@@ -5435,7 +5434,7 @@ impl Backend<FoundryNetwork> {
                         .build_unsigned()
                         .map_err(|e| BlockchainError::InvalidTransactionRequest(e.to_string()))?;
 
-                    let tx = build_impersonated(typed_tx);
+                    let tx = typed_tx.into_impersonated();
                     let tx_hash = tx.hash();
                     let rpc_tx = transaction_build(
                         None,

--- a/crates/anvil/src/eth/sign.rs
+++ b/crates/anvil/src/eth/sign.rs
@@ -1,6 +1,4 @@
 use crate::eth::error::BlockchainError;
-#[cfg(feature = "optimism")]
-use alloy_consensus::Sealed;
 use alloy_consensus::SignableTransaction;
 use alloy_dyn_abi::TypedData;
 use alloy_network::{Network, TxSignerSync};
@@ -8,7 +6,6 @@ use alloy_primitives::{Address, B256, Signature, map::AddressHashMap};
 use alloy_signer::Signer as AlloySigner;
 use alloy_signer_local::PrivateKeySigner;
 use foundry_primitives::{FoundryTxEnvelope, FoundryTypedTx};
-use tempo_primitives::TempoSignature;
 
 /// Network-agnostic signing: messages, typed data, and hashes.
 #[async_trait::async_trait]
@@ -146,32 +143,5 @@ impl Signer<foundry_primitives::FoundryNetwork> for DevSigner {
             }
         };
         Ok(envelope)
-    }
-}
-
-/// Builds a TxEnvelope from UnsignedTx with r=1, s=1 dummy signature.
-///
-/// Used for impersonated accounts, where transactions are accepted without a valid signature.
-/// The signature uses r=1, s=1 (not zero) because go-ethereum and other clients reject transactions
-/// where r or s are zero with "invalid transaction v, r, s values".
-pub fn build_impersonated(typed_tx: FoundryTypedTx) -> FoundryTxEnvelope {
-    let signature =
-        Signature::from_scalars_and_parity(B256::with_last_byte(1), B256::with_last_byte(1), false);
-    match typed_tx {
-        FoundryTypedTx::Legacy(tx) => FoundryTxEnvelope::Legacy(tx.into_signed(signature)),
-        FoundryTypedTx::Eip2930(tx) => FoundryTxEnvelope::Eip2930(tx.into_signed(signature)),
-        FoundryTypedTx::Eip1559(tx) => FoundryTxEnvelope::Eip1559(tx.into_signed(signature)),
-        FoundryTypedTx::Eip7702(tx) => FoundryTxEnvelope::Eip7702(tx.into_signed(signature)),
-        FoundryTypedTx::Eip4844(tx) => FoundryTxEnvelope::Eip4844(tx.into_signed(signature)),
-        #[cfg(feature = "optimism")]
-        FoundryTypedTx::Deposit(tx) => FoundryTxEnvelope::Deposit(Sealed::new(tx)),
-        #[cfg(feature = "optimism")]
-        FoundryTypedTx::PostExec(_) => {
-            unreachable!("op post-exec txs should not be impersonated")
-        }
-        FoundryTypedTx::Tempo(tx) => {
-            let tempo_sig: TempoSignature = signature.into();
-            FoundryTxEnvelope::Tempo(tx.into_signed(tempo_sig))
-        }
     }
 }

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "optimism")]
 use alloy_consensus::{Sealed, Transaction as _};
 use alloy_consensus::{
-    Signed, TransactionEnvelope, TxEip1559, TxEip2930, TxEnvelope, TxLegacy, TxType, Typed2718,
+    SignableTransaction, Signed, TransactionEnvelope, TxEip1559, TxEip2930, TxEnvelope, TxLegacy,
+    TxType, Typed2718,
     crypto::RecoveryError,
     transaction::{
         SignerRecoverable, TxEip7702, TxHashRef,
@@ -10,12 +11,12 @@ use alloy_consensus::{
 };
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded};
 use alloy_network::{AnyRpcTransaction, AnyTxEnvelope, TransactionResponse};
-use alloy_primitives::{Address, B256, Bytes, TxHash};
+use alloy_primitives::{Address, B256, Bytes, Signature, TxHash};
 use alloy_rpc_types::ConversionError;
 #[cfg(feature = "optimism")]
 use op_alloy_consensus::{DEPOSIT_TX_TYPE_ID, POST_EXEC_TX_TYPE_ID, TxDeposit, TxPostExec};
 use revm::context::TxEnv;
-use tempo_primitives::{AASigned, TempoTransaction};
+use tempo_primitives::{AASigned, TempoSignature, TempoTransaction};
 use tempo_revm::TempoTxEnv;
 
 //
@@ -141,6 +142,14 @@ impl FoundryTxEnvelope {
         }
     }
 
+    /// Drops pooled sidecars so the transaction uses its canonical block-body representation.
+    pub fn into_canonical(self) -> Self {
+        match self {
+            Self::Eip4844(tx) => Self::Eip4844(tx.map(TxEip4844Variant::drop_sidecar)),
+            tx => tx,
+        }
+    }
+
     /// Returns the hash of the transaction.
     ///
     /// # Note
@@ -209,6 +218,34 @@ impl FoundryTxType {
 }
 
 impl FoundryTypedTx {
+    /// Builds an envelope with a dummy signature for an impersonated account.
+    ///
+    /// The signature uses `r = 1` and `s = 1` because clients reject zero scalar values.
+    pub fn into_impersonated(self) -> FoundryTxEnvelope {
+        let signature = Signature::from_scalars_and_parity(
+            B256::with_last_byte(1),
+            B256::with_last_byte(1),
+            false,
+        );
+        match self {
+            Self::Legacy(tx) => FoundryTxEnvelope::Legacy(tx.into_signed(signature)),
+            Self::Eip2930(tx) => FoundryTxEnvelope::Eip2930(tx.into_signed(signature)),
+            Self::Eip1559(tx) => FoundryTxEnvelope::Eip1559(tx.into_signed(signature)),
+            Self::Eip7702(tx) => FoundryTxEnvelope::Eip7702(tx.into_signed(signature)),
+            Self::Eip4844(tx) => FoundryTxEnvelope::Eip4844(tx.into_signed(signature)),
+            #[cfg(feature = "optimism")]
+            Self::Deposit(tx) => FoundryTxEnvelope::Deposit(Sealed::new(tx)),
+            #[cfg(feature = "optimism")]
+            Self::PostExec(_) => {
+                unreachable!("op post-exec txs should not be impersonated")
+            }
+            Self::Tempo(tx) => {
+                let tempo_sig: TempoSignature = signature.into();
+                FoundryTxEnvelope::Tempo(tx.into_signed(tempo_sig))
+            }
+        }
+    }
+
     /// Returns `true` if this is an OP stack deposit transaction.
     #[cfg(feature = "optimism")]
     pub const fn is_deposit(&self) -> bool {
@@ -477,7 +514,6 @@ mod tests {
 
     use alloy_primitives::{TxKind, U256, b256, hex};
     use alloy_rlp::Decodable;
-    use alloy_signer::Signature;
 
     use super::*;
 
@@ -537,6 +573,19 @@ mod tests {
             assert!(FoundryTxEnvelope::Deposit(Sealed::new(TxDeposit::default())).is_deposit());
             assert!(FoundryTxEnvelope::PostExec(Sealed::new(TxPostExec::default())).is_post_exec());
         }
+    }
+
+    #[test]
+    fn impersonated_tx_uses_nonzero_dummy_signature() {
+        let FoundryTxEnvelope::Legacy(tx) =
+            FoundryTypedTx::Legacy(TxLegacy::default()).into_impersonated()
+        else {
+            panic!("expected legacy transaction");
+        };
+
+        assert_eq!(tx.signature().r(), U256::from(1));
+        assert_eq!(tx.signature().s(), U256::from(1));
+        assert!(!tx.signature().v());
     }
 
     #[test]


### PR DESCRIPTION
Moves block-body canonicalization onto `FoundryTxEnvelope::into_canonical` and dummy-signature construction onto `FoundryTypedTx::into_impersonated`, updating Anvil call sites and preserving behavior with a focused signature test. A repository-wide audit found no other standalone functions whose sole argument is a direct Foundry primitive type; `canonical_block` remains free because its `Block` alias resolves to an Alloy type and cannot host an inherent implementation.

This PR was written primarily by OpenAI Codex.
