### PR TITLE
docs(cast): remove markdown escaping from --data help text

### DIFF
--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -34,7 +34,7 @@ pub struct AccessListArgs {
     #[arg(value_name = "ARGS", allow_negative_numbers = true)]
     args: Vec<String>,
 
-    /// Raw hex-encoded data for the transaction. Used instead of \[SIG\] and \[ARGS\].
+    /// Raw hex-encoded data for the transaction. Used instead of `SIG` and `ARGS`.
     #[arg(
         long,
         conflicts_with_all = &["sig", "args"]

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -89,7 +89,7 @@ pub struct CallArgs {
     #[arg(allow_negative_numbers = true)]
     args: Vec<String>,
 
-    /// Raw hex-encoded data for the transaction. Used instead of \[SIG\] and \[ARGS\].
+    /// Raw hex-encoded data for the transaction. Used instead of `SIG` and `ARGS`.
     #[arg(
         long,
         conflicts_with_all = &["sig", "args"]

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -50,7 +50,7 @@ pub struct SendTxArgs {
     #[arg(allow_negative_numbers = true)]
     args: Vec<String>,
 
-    /// Raw hex-encoded data for the transaction. Used instead of \[SIG\] and \[ARGS\].
+    /// Raw hex-encoded data for the transaction. Used instead of `SIG` and `ARGS`.
     #[arg(
         long,
         conflicts_with_all = &["sig", "args"]


### PR DESCRIPTION
The --data help text for cast send, cast call, and cast access-list contains literal backslashes: "Used instead of \[SIG\] and \[ARGS\]". They show up verbatim in --help output and in the generated CLI reference on getfoundry.sh. The escaping predates the current docs pipeline and only ever mattered for rustdoc, where bare [SIG] would trip broken_intra_doc_links (denied in the docs CI job) — so this switches to code spans, which render cleanly in the terminal and keep rustdoc quiet.

Found while auditing the docs site; written with Claude Code.