### PR TITLE
docs(cli): add usage examples to command help

### DIFF
--- a/crates/anvil/src/opts.rs
+++ b/crates/anvil/src/opts.rs
@@ -3,9 +3,15 @@ use clap::{Parser, Subcommand};
 use foundry_cli::opts::GlobalArgs;
 use foundry_common::version::{LONG_VERSION, SHORT_VERSION};
 
-/// A fast local Ethereum development node.
+/// A fast local Ethereum development node
+///
+/// Examples:
+/// - anvil (start a local node on 127.0.0.1:8545)
+/// - anvil --fork-url $RPC_URL (fork the latest state of a live network)
+/// - anvil --block-time 12 (mine a new block every 12 seconds)
+/// - anvil --state state.json (load state if it exists and dump it on exit)
 #[derive(Parser)]
-#[command(name = "anvil", version = SHORT_VERSION, long_version = LONG_VERSION, next_display_order = None)]
+#[command(verbatim_doc_comment, name = "anvil", version = SHORT_VERSION, long_version = LONG_VERSION, next_display_order = None)]
 pub struct Anvil {
     /// Include the global arguments.
     #[command(flatten)]

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -38,8 +38,12 @@ use session::SessionArgs;
 /// CLI arguments for `cast wallet`.
 #[derive(Debug, Parser)]
 pub enum WalletSubcommands {
-    /// Create a new random keypair.
-    #[command(visible_alias = "n")]
+    /// Create a new random keypair
+    ///
+    /// Examples:
+    /// - cast wallet new (print a new private key and address)
+    /// - cast wallet new ~/.foundry/keystores dev (save to an encrypted keystore)
+    #[command(verbatim_doc_comment, visible_alias = "n")]
     New {
         /// If provided, then keypair will be written to an encrypted JSON keystore.
         path: Option<String>,
@@ -102,7 +106,11 @@ pub enum WalletSubcommands {
     },
 
     /// Derive accounts from a mnemonic
-    #[command(visible_alias = "d")]
+    ///
+    /// Examples:
+    /// - cast wallet derive "test test test test test test test test test test test junk"
+    /// - cast wallet derive "$MNEMONIC" --accounts 5
+    #[command(verbatim_doc_comment, visible_alias = "d")]
     Derive {
         /// The accounts will be derived from the specified mnemonic phrase.
         #[arg(value_name = "MNEMONIC")]
@@ -117,8 +125,13 @@ pub enum WalletSubcommands {
         insecure: bool,
     },
 
-    /// Sign a message or typed data.
-    #[command(visible_alias = "s")]
+    /// Sign a message or typed data
+    ///
+    /// Examples:
+    /// - cast wallet sign "hello" --account dev
+    /// - cast wallet sign "hello" --private-key $PK
+    /// - cast wallet sign --data --from-file typed_data.json --ledger
+    #[command(verbatim_doc_comment, visible_alias = "s")]
     Sign {
         /// The message, typed data, or hash to sign.
         ///
@@ -176,8 +189,12 @@ pub enum WalletSubcommands {
         wallet: WalletOpts,
     },
 
-    /// Verify the signature of a message.
-    #[command(visible_alias = "v")]
+    /// Verify the signature of a message
+    ///
+    /// Examples:
+    /// - cast wallet verify --address $ADDRESS "hello" $SIGNATURE
+    /// - cast wallet verify --address $ADDRESS --no-hash $HASH $SIGNATURE
+    #[command(verbatim_doc_comment, visible_alias = "v")]
     Verify {
         /// The original message.
         ///
@@ -214,8 +231,13 @@ pub enum WalletSubcommands {
         no_hash: bool,
     },
 
-    /// Import a private key into an encrypted keystore.
-    #[command(visible_alias = "i")]
+    /// Import a private key into an encrypted keystore
+    ///
+    /// Examples:
+    /// - cast wallet import dev --interactive (prompt for the private key)
+    /// - cast wallet import dev --private-key $PK
+    /// - cast wallet import dev --mnemonic "$MNEMONIC" --mnemonic-index 1
+    #[command(verbatim_doc_comment, visible_alias = "i")]
     Import {
         /// The name for the account in the keystore.
         #[arg(value_name = "ACCOUNT_NAME")]
@@ -259,7 +281,12 @@ pub enum WalletSubcommands {
     },
 
     /// Derives private key from mnemonic
-    #[command(name = "private-key", visible_alias = "pk", aliases = &["derive-private-key", "--derive-private-key"])]
+    ///
+    /// Examples:
+    /// - cast wallet private-key "test test test test test test test test test test test junk"
+    /// - cast wallet private-key "$MNEMONIC" 1 (derive the key at index 1)
+    /// - cast wallet private-key "$MNEMONIC" "m/44'/60'/0'/0/1" (use a custom path)
+    #[command(verbatim_doc_comment, name = "private-key", visible_alias = "pk", aliases = &["derive-private-key", "--derive-private-key"])]
     PrivateKey {
         /// If provided, the private key will be derived from the specified mnemonic phrase.
         #[arg(value_name = "MNEMONIC")]

--- a/crates/cast/src/opts.rs
+++ b/crates/cast/src/opts.rs
@@ -259,7 +259,7 @@ pub enum CastSubcommand {
         base_out: String,
     },
 
-    /// Convert an ETH amount into another unit (ether, gwei or wei).
+    /// Convert an ETH amount into another unit (ether, gwei or wei)
     ///
     /// Examples:
     /// - 1ether wei
@@ -267,7 +267,7 @@ pub enum CastSubcommand {
     /// - 1ether
     /// - 1 gwei
     /// - 1gwei ether
-    #[command(visible_aliases = &["--to-unit", "tun", "2un"])]
+    #[command(verbatim_doc_comment, visible_aliases = &["--to-unit", "tun", "2un"])]
     ToUnit {
         /// The value to convert.
         value: Option<String>,
@@ -277,13 +277,13 @@ pub enum CastSubcommand {
         unit: String,
     },
 
-    /// Convert a number from decimal to smallest unit with arbitrary decimals.
+    /// Convert a number from decimal to smallest unit with arbitrary decimals
     ///
     /// Examples:
     /// - 1.0 6    (for USDC, result: 1000000)
     /// - 2.5 12   (for 12 decimals token, result: 2500000000000)
     /// - 1.23 3   (for 3 decimals token, result: 1230)
-    #[command(visible_aliases = &["--parse-units", "pun"])]
+    #[command(verbatim_doc_comment, visible_aliases = &["--parse-units", "pun"])]
     ParseUnits {
         /// The value to convert.
         value: Option<String>,
@@ -293,13 +293,13 @@ pub enum CastSubcommand {
         unit: u8,
     },
 
-    /// Format a number from smallest unit to decimal with arbitrary decimals.
+    /// Format a number from smallest unit to decimal with arbitrary decimals
     ///
     /// Examples:
     /// - 1000000 6       (for USDC, result: 1.0)
     /// - 2500000000000 12 (for 12 decimals, result: 2.5)
     /// - 1230 3          (for 3 decimals, result: 1.23)
-    #[command(visible_aliases = &["--format-units", "fun"])]
+    #[command(verbatim_doc_comment, visible_aliases = &["--format-units", "fun"])]
     FormatUnits {
         /// The value to format.
         value: Option<String>,
@@ -337,7 +337,7 @@ pub enum CastSubcommand {
         unit: String,
     },
 
-    /// RLP encodes hex data, or an array of hex data.
+    /// RLP encodes hex data, or an array of hex data
     ///
     /// Accepts a hex-encoded string, or an array of hex-encoded strings.
     /// Can be arbitrarily recursive.
@@ -347,7 +347,7 @@ pub enum CastSubcommand {
     /// - `cast to-rlp "0x22"` -> `0x22`
     /// - `cast to-rlp "[\"0x61\"]"` -> `0xc161`
     /// - `cast to-rlp "[\"0xf1\", \"f2\"]"` -> `0xc481f181f2`
-    #[command(visible_aliases = &["--to-rlp"])]
+    #[command(verbatim_doc_comment, visible_aliases = &["--to-rlp"])]
     ToRlp {
         /// The value to convert.
         ///
@@ -391,14 +391,27 @@ pub enum CastSubcommand {
         #[arg(value_name = "BASE")]
         base_out: Option<String>,
     },
-    /// Create an access list for a transaction.
-    #[command(visible_aliases = &["ac", "acl"])]
+    /// Create an access list for a transaction
+    ///
+    /// Examples:
+    /// - cast access-list vitalik.eth --value 0.1ether
+    /// - cast access-list $TOKEN "transfer(address,uint256)" vitalik.eth 100
+    #[command(verbatim_doc_comment, visible_aliases = &["ac", "acl"])]
     AccessList(AccessListArgs),
-    /// Get logs by signature or topic.
-    #[command(visible_alias = "l")]
+    /// Get logs by signature or topic
+    ///
+    /// Examples:
+    /// - cast logs "Transfer(address indexed from, address indexed to, uint256 value)"
+    /// - cast logs --address $TOKEN --from-block 21000000 --to-block latest $TOPIC_0
+    #[command(verbatim_doc_comment, visible_alias = "l")]
     Logs(LogsArgs),
-    /// Get information about a block.
-    #[command(visible_alias = "bl")]
+    /// Get information about a block
+    ///
+    /// Examples:
+    /// - cast block latest
+    /// - cast block 21000000 --field timestamp
+    /// - cast block latest --json
+    #[command(verbatim_doc_comment, visible_alias = "bl")]
     Block {
         /// The block height to query at.
         ///
@@ -433,8 +446,12 @@ pub enum CastSubcommand {
         rpc: RpcOpts,
     },
 
-    /// Perform a call on an account without publishing a transaction.
-    #[command(visible_alias = "c")]
+    /// Perform a call on an account without publishing a transaction
+    ///
+    /// Examples:
+    /// - cast call $TOKEN "balanceOf(address)(uint256)" vitalik.eth
+    /// - cast call $TOKEN "transfer(address,uint256)" vitalik.eth 100 --trace
+    #[command(verbatim_doc_comment, visible_alias = "c")]
     Call(CallArgs),
 
     /// ABI-encode a function with arguments.
@@ -515,8 +532,12 @@ pub enum CastSubcommand {
         bytecode: Option<String>,
     },
 
-    /// Build and sign a transaction.
-    #[command(name = "mktx", visible_alias = "m")]
+    /// Build and sign a transaction
+    ///
+    /// Examples:
+    /// - cast mktx vitalik.eth --value 0.1ether --private-key $PK
+    /// - cast mktx $TOKEN "transfer(address,uint256)" vitalik.eth 100 --account dev
+    #[command(verbatim_doc_comment, name = "mktx", visible_alias = "m")]
     MakeTx(MakeTxArgs),
 
     /// Classify a raw transaction as Tempo T5 payment/general lane.
@@ -529,8 +550,13 @@ pub enum CastSubcommand {
     #[command(visible_aliases = &["na", "nh"])]
     Namehash { name: Option<String> },
 
-    /// Get information about a transaction.
-    #[command(visible_alias = "t")]
+    /// Get information about a transaction
+    ///
+    /// Examples:
+    /// - cast tx $TX_HASH
+    /// - cast tx $TX_HASH blockNumber (only print the blockNumber field)
+    /// - cast tx $TX_HASH --raw
+    #[command(verbatim_doc_comment, visible_alias = "t")]
     Tx {
         /// The transaction hash.
         tx_hash: Option<String>,
@@ -567,8 +593,12 @@ pub enum CastSubcommand {
         network: Option<NetworkVariant>,
     },
 
-    /// Get the transaction receipt for a transaction.
-    #[command(visible_alias = "re")]
+    /// Get the transaction receipt for a transaction
+    ///
+    /// Examples:
+    /// - cast receipt $TX_HASH
+    /// - cast receipt $TX_HASH status (only print the status field)
+    #[command(verbatim_doc_comment, visible_alias = "re")]
     Receipt {
         /// The transaction hash.
         tx_hash: String,
@@ -588,8 +618,13 @@ pub enum CastSubcommand {
         rpc: RpcOpts,
     },
 
-    /// Sign and publish a transaction.
-    #[command(name = "send", visible_alias = "s")]
+    /// Sign and publish a transaction
+    ///
+    /// Examples:
+    /// - cast send vitalik.eth --value 0.1ether --private-key $PK (transfer ETH)
+    /// - cast send $TOKEN "transfer(address,uint256)" vitalik.eth 100 --account dev
+    /// - cast send --private-key $PK --create $BYTECODE (deploy a contract)
+    #[command(verbatim_doc_comment, name = "send", visible_alias = "s")]
     SendTx(SendTxArgs),
 
     /// Build and sign a batch transaction (Tempo).
@@ -614,15 +649,22 @@ pub enum CastSubcommand {
         rpc: RpcOpts,
     },
 
-    /// Estimate the gas cost of a transaction.
-    #[command(visible_alias = "e")]
+    /// Estimate the gas cost of a transaction
+    ///
+    /// Examples:
+    /// - cast estimate vitalik.eth --value 0.1ether
+    /// - cast estimate $CONTRACT "deposit()" --value 1ether
+    #[command(verbatim_doc_comment, visible_alias = "e")]
     Estimate(EstimateArgs),
 
-    /// Decode ABI-encoded input data.
+    /// Decode ABI-encoded input data
     ///
-    /// Similar to `abi-decode --input`, but function selector MUST be prefixed in `calldata`
-    /// string
-    #[command(visible_aliases = &["calldata-decode", "--calldata-decode", "cdd"])]
+    /// Similar to `abi-decode --input`, but function selector MUST be prefixed in `calldata`.
+    ///
+    /// Examples:
+    /// - cast decode-calldata "transfer(address,uint256)" $CALLDATA
+    /// - cast decode-calldata --json "transfer(address,uint256)" $CALLDATA
+    #[command(verbatim_doc_comment, visible_aliases = &["calldata-decode", "--calldata-decode", "cdd"])]
     DecodeCalldata {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -645,8 +687,12 @@ pub enum CastSubcommand {
         data: String,
     },
 
-    /// Decode event data.
-    #[command(visible_aliases = &["event-decode", "--event-decode", "ed"])]
+    /// Decode event data
+    ///
+    /// Examples:
+    /// - cast decode-event --sig "Transfer(address,address,uint256)" $DATA
+    /// - cast decode-event $DATA (topic0-prefixed data; looks up the signature)
+    #[command(verbatim_doc_comment, visible_aliases = &["event-decode", "--event-decode", "ed"])]
     DecodeEvent {
         /// The event signature. If none provided then tries to decode from local cache or <https://api.openchain.xyz>.
         #[arg(long, visible_alias = "event-sig")]
@@ -665,12 +711,16 @@ pub enum CastSubcommand {
         data: String,
     },
 
-    /// Decode ABI-encoded input or output data.
+    /// Decode ABI-encoded input or output data
     ///
     /// Defaults to decoding output data. To decode input data pass --input.
     ///
-    /// When passing `--input`, function selector must NOT be prefixed in `calldata` string
-    #[command(name = "decode-abi", visible_aliases = &["abi-decode", "--abi-decode", "ad"])]
+    /// When passing `--input`, function selector must NOT be prefixed in `calldata` string.
+    ///
+    /// Examples:
+    /// - cast decode-abi "balanceOf(address)(uint256)" $DATA
+    /// - cast decode-abi --input "transfer(address,uint256)" $CALLDATA
+    #[command(verbatim_doc_comment, name = "decode-abi", visible_aliases = &["abi-decode", "--abi-decode", "ad"])]
     DecodeAbi {
         /// The function signature in the format `<name>(<in-types>)(<out-types>)`.
         sig: String,
@@ -683,8 +733,12 @@ pub enum CastSubcommand {
         input: bool,
     },
 
-    /// ABI encode the given function argument, excluding the selector.
-    #[command(visible_alias = "ae")]
+    /// ABI encode the given function argument, excluding the selector
+    ///
+    /// Examples:
+    /// - cast abi-encode "transfer(address,uint256)" $ADDRESS 100
+    /// - cast abi-encode --packed "f(string,uint64)" hello 100
+    #[command(verbatim_doc_comment, visible_alias = "ae")]
     AbiEncode {
         /// The function signature.
         sig: String,
@@ -836,8 +890,12 @@ pub enum CastSubcommand {
         rpc: RpcOpts,
     },
 
-    /// Get the balance of an account in wei.
-    #[command(visible_alias = "b")]
+    /// Get the balance of an account in wei
+    ///
+    /// Examples:
+    /// - cast balance vitalik.eth --ether
+    /// - cast balance vitalik.eth --erc20 0x6B175474E89094C44Da98b954EedeAC495271d0F
+    #[command(verbatim_doc_comment, visible_alias = "b")]
     Balance {
         /// The block height to query at.
         ///
@@ -877,8 +935,12 @@ pub enum CastSubcommand {
         rpc: RpcOpts,
     },
 
-    /// Get the runtime bytecode of a contract.
-    #[command(visible_alias = "co")]
+    /// Get the runtime bytecode of a contract
+    ///
+    /// Examples:
+    /// - cast code 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+    /// - cast code 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 --disassemble
+    #[command(verbatim_doc_comment, visible_alias = "co")]
     Code {
         /// The block height to query at.
         ///
@@ -929,8 +991,13 @@ pub enum CastSubcommand {
         event_string: Option<String>,
     },
 
-    /// Hash arbitrary data using Keccak-256.
-    #[command(visible_aliases = &["k", "keccak256"])]
+    /// Hash arbitrary data using Keccak-256
+    ///
+    /// Examples:
+    /// - cast keccak "hello world"
+    /// - cast keccak 0xdeadbeef
+    /// - echo -n "some data" | cast keccak (hash data from stdin)
+    #[command(verbatim_doc_comment, visible_aliases = &["k", "keccak256"])]
     Keccak {
         /// The data to hash.
         data: Option<String>,
@@ -971,8 +1038,12 @@ pub enum CastSubcommand {
         rpc: RpcOpts,
     },
 
-    /// Get the raw value of a contract's storage slot.
-    #[command(visible_alias = "st")]
+    /// Get the raw value of a contract's storage slot
+    ///
+    /// Examples:
+    /// - cast storage 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 0
+    /// - cast storage $TOKEN --etherscan-api-key $KEY (decode the full storage layout)
+    #[command(verbatim_doc_comment, visible_alias = "st")]
     Storage(StorageArgs),
 
     /// Generate a storage proof for a given storage slot.
@@ -1145,10 +1216,14 @@ pub enum CastSubcommand {
     #[command(visible_alias = "cra")]
     ConstructorArgs(ConstructorArgsArgs),
 
-    /// Generate a Solidity interface from a given ABI.
+    /// Generate a Solidity interface from a given ABI
     ///
     /// Currently does not support ABI encoder v2.
-    #[command(visible_alias = "i")]
+    ///
+    /// Examples:
+    /// - cast interface $TOKEN --etherscan-api-key $KEY (fetch the ABI from Etherscan)
+    /// - cast interface ./out/Counter.sol/Counter.json (load a local ABI file)
+    #[command(verbatim_doc_comment, visible_alias = "i")]
     Interface(InterfaceArgs),
 
     /// Generate a rust binding from a given ABI.
@@ -1159,8 +1234,12 @@ pub enum CastSubcommand {
     #[command(visible_alias = "b2e")]
     B2EPayload(B2EPayloadArgs),
 
-    /// Get the selector for a function.
-    #[command(visible_alias = "si")]
+    /// Get the selector for a function
+    ///
+    /// Examples:
+    /// - cast sig "transfer(address,uint256)"
+    /// - cast sig "deposit(uint256)" 2 (optimize for 2 leading zero bytes)
+    #[command(verbatim_doc_comment, visible_alias = "si")]
     Sig {
         /// The function signature, e.g. transfer(address,uint256).
         sig: Option<String>,
@@ -1185,12 +1264,22 @@ pub enum CastSubcommand {
         shell: foundry_cli::clap::Shell,
     },
 
-    /// Runs a published transaction in a local environment and prints the trace.
-    #[command(visible_alias = "r")]
+    /// Runs a published transaction in a local environment and prints the trace
+    ///
+    /// Examples:
+    /// - cast run $TX_HASH
+    /// - cast run $TX_HASH --quick (only use the state from the previous block)
+    /// - cast run $TX_HASH --debug (open the transaction in the debugger)
+    #[command(verbatim_doc_comment, visible_alias = "r")]
     Run(RunArgs),
 
-    /// Perform a raw JSON-RPC request.
-    #[command(visible_alias = "rp")]
+    /// Perform a raw JSON-RPC request
+    ///
+    /// Examples:
+    /// - cast rpc eth_blockNumber
+    /// - cast rpc eth_getBlockByNumber 0x123 false
+    /// - cast rpc eth_getBlockByNumber '["0x123", false]' --raw
+    #[command(verbatim_doc_comment, visible_alias = "rp")]
     Rpc(RpcArgs),
 
     /// Formats a string into bytes32 encoding.

--- a/crates/forge/src/opts.rs
+++ b/crates/forge/src/opts.rs
@@ -32,28 +32,55 @@ pub struct Forge {
 
 #[derive(Subcommand)]
 pub enum ForgeSubcommand {
-    /// Run the project's tests.
-    #[command(visible_alias = "t")]
+    /// Run the project's tests
+    ///
+    /// Examples:
+    /// - forge test
+    /// - forge test --match-test test_Increment -vvvv (show traces for a matching test)
+    /// - forge test --match-contract CounterTest --fuzz-runs 1000
+    #[command(verbatim_doc_comment, visible_alias = "t")]
     Test(test::TestArgs),
 
     /// Run and manage Forge fuzzing corpora.
     Fuzz(FuzzArgs),
 
-    /// Run a smart contract as a script, building transactions that can be sent onchain.
+    /// Run a smart contract as a script, building transactions that can be sent onchain
+    ///
+    /// Examples:
+    /// - forge script script/Counter.s.sol (simulate the script locally)
+    /// - forge script script/Counter.s.sol --rpc-url $RPC_URL --broadcast --account dev
+    /// - forge script script/Counter.s.sol --rpc-url $RPC_URL --resume
+    #[command(verbatim_doc_comment)]
     Script(ScriptArgs),
 
-    /// Generate coverage reports.
+    /// Generate coverage reports
+    ///
+    /// Examples:
+    /// - forge coverage
+    /// - forge coverage --report lcov --report-file lcov.info
+    /// - forge coverage --match-contract CounterTest
+    #[command(verbatim_doc_comment)]
     Coverage(coverage::CoverageArgs),
 
     /// Generate Rust bindings for smart contracts.
     #[command(alias = "bi")]
     Bind(BindArgs),
 
-    /// Build the project's smart contracts.
-    #[command(visible_aliases = ["b", "compile"])]
+    /// Build the project's smart contracts
+    ///
+    /// Examples:
+    /// - forge build
+    /// - forge build --sizes (print a contract size report)
+    /// - forge build --watch (rebuild on file changes)
+    #[command(verbatim_doc_comment, visible_aliases = ["b", "compile"])]
     Build(BuildArgs),
 
-    /// Clone a contract from Etherscan.
+    /// Clone a contract from Etherscan
+    ///
+    /// Examples:
+    /// - forge clone $WETH weth --etherscan-api-key $KEY (clone WETH into ./weth)
+    /// - forge clone --chain sepolia --etherscan-api-key $KEY $ADDRESS my-contract
+    #[command(verbatim_doc_comment)]
     Clone(CloneArgs),
 
     /// Update one or multiple dependencies.
@@ -62,10 +89,15 @@ pub enum ForgeSubcommand {
     #[command(visible_alias = "u")]
     Update(update::UpdateArgs),
 
-    /// Install one or multiple dependencies.
+    /// Install one or multiple dependencies
     ///
     /// If no arguments are provided, then existing dependencies will be installed.
-    #[command(visible_aliases = ["i", "add"])]
+    ///
+    /// Examples:
+    /// - forge install (install all dependencies of the project)
+    /// - forge install openzeppelin/openzeppelin-contracts
+    /// - forge install openzeppelin/openzeppelin-contracts@v5.0.2 (pin a version)
+    #[command(verbatim_doc_comment, visible_aliases = ["i", "add"])]
     Install(InstallArgs),
 
     /// Remove one or multiple dependencies.
@@ -76,8 +108,12 @@ pub enum ForgeSubcommand {
     #[command(visible_alias = "re")]
     Remappings(RemappingArgs),
 
-    /// Verify smart contracts on Etherscan and Sourcify.
-    #[command(visible_alias = "v")]
+    /// Verify smart contracts on Etherscan and Sourcify
+    ///
+    /// Examples:
+    /// - forge verify-contract --chain sepolia $ADDRESS src/Counter.sol:Counter --watch
+    /// - forge verify-contract $ADDRESS src/Counter.sol:Counter --verifier sourcify
+    #[command(verbatim_doc_comment, visible_alias = "v")]
     VerifyContract(VerifyArgs),
 
     /// Check verification status on the selected verifier.
@@ -88,8 +124,12 @@ pub enum ForgeSubcommand {
     #[command(visible_alias = "vb")]
     VerifyBytecode(VerifyBytecodeArgs),
 
-    /// Deploy a smart contract.
-    #[command(visible_alias = "c")]
+    /// Deploy a smart contract
+    ///
+    /// Examples:
+    /// - forge create Counter --rpc-url $RPC_URL --account dev --broadcast
+    /// - forge create Token --private-key $PK --broadcast --constructor-args Token TKN
+    #[command(verbatim_doc_comment, visible_alias = "c")]
     Create(CreateArgs),
 
     /// Create a new Forge project.
@@ -116,8 +156,13 @@ pub enum ForgeSubcommand {
     /// Manage the Foundry cache.
     Cache(CacheArgs),
 
-    /// Create a gas snapshot of each test's gas usage.
-    #[command(visible_alias = "s")]
+    /// Create a gas snapshot of each test's gas usage
+    ///
+    /// Examples:
+    /// - forge snapshot
+    /// - forge snapshot --diff (compare against the existing .gas-snapshot file)
+    /// - forge snapshot --check (fail if gas usage does not match .gas-snapshot)
+    #[command(verbatim_doc_comment, visible_alias = "s")]
     Snapshot(snapshot::GasSnapshotArgs),
 
     /// Display the current config.
@@ -128,15 +173,26 @@ pub enum ForgeSubcommand {
     #[command(visible_alias = "f")]
     Flatten(flatten::FlattenArgs),
 
-    /// Format Solidity source files.
+    /// Format Solidity source files
+    ///
+    /// Examples:
+    /// - forge fmt
+    /// - forge fmt --check (report formatting issues without writing changes)
+    /// - forge fmt src/Counter.sol
+    #[command(verbatim_doc_comment)]
     Fmt(FmtArgs),
 
     /// Lint Solidity source files
     #[command(visible_alias = "l")]
     Lint(LintArgs),
 
-    /// Get specialized information about a smart contract.
-    #[command(visible_alias = "in")]
+    /// Get specialized information about a smart contract
+    ///
+    /// Examples:
+    /// - forge inspect Counter abi
+    /// - forge inspect Counter bytecode
+    /// - forge inspect src/Counter.sol:Counter storageLayout
+    #[command(verbatim_doc_comment, visible_alias = "in")]
     Inspect(inspect::InspectArgs),
 
     /// Display a tree visualization of the project's dependency graph.


### PR DESCRIPTION
Only a handful of commands carry usage examples in their help text, so both local --help output and the generated CLI reference on getfoundry.sh show flags without a single concrete invocation. For the long tail of cast commands that reference is the only documentation page, which makes the first working command line unnecessarily hard to find — for people and for coding agents alike.

This adds short Examples blocks to the doc comments of the highest-traffic commands: 27 cast commands (including the wallet family), 11 forge commands, and the anvil top level — 39 blocks total, 2-4 lines each, following the format the existing to-unit/to-rlp examples established. Since clap collapses doc-comment lines in help output (the pre-existing example lists rendered as a single run-on paragraph), the touched commands get verbatim_doc_comment, which also fixes the four existing lists to render line by line; their first-line summaries lose their source periods to keep the Commands lists uniformly period-free, since verbatim also disables clap's trailing-period stripping.

Every example was verified against the current argument definitions and nearly all were executed end-to-end (offline commands verbatim; chain commands against a local anvil; project commands in a scratch forge project). That process caught two orderings the examples must not teach: parent flags have to precede the --create subcommand of cast send, and --constructor-args has to come last in forge create.

The examples reach the book automatically through the weekly generated-reference update; no book changes are needed.

Written with Claude Code, including an adversarial review pass that executed the documented commands.