### PR TITLE
fix(tempo): harden CLI sponsorship integrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=1d3c2590fff578f0e5feca3c7724c82bcd91caa7#1d3c2590fff578f0e5feca3c7724c82bcd91caa7"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b937e7ea997e07937ab340e0d8e9c700c641a330#b937e7ea997e07937ab340e0d8e9c700c641a330"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7674,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=5caad442edeab796821b7f3bb009ab6945106e35#5caad442edeab796821b7f3bb009ab6945106e35"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=e7a8c495b9c9cb56a318368caee55dc2a237f961#e7a8c495b9c9cb56a318368caee55dc2a237f961"
 dependencies = [
  "alloy",
  "async-stream",
@@ -11955,7 +11955,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -11996,7 +11996,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12019,7 +12019,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12031,7 +12031,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12043,7 +12043,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12074,7 +12074,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12086,7 +12086,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12109,7 +12109,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12120,7 +12120,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12147,7 +12147,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=cf4e08013c0d6c537364f053462807ec42d4056a#cf4e08013c0d6c537364f053462807ec42d4056a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7674,7 +7674,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=e7a8c495b9c9cb56a318368caee55dc2a237f961#e7a8c495b9c9cb56a318368caee55dc2a237f961"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=3ea54e5eca3d93069f1e282733b84ee6aa425944#3ea54e5eca3d93069f1e282733b84ee6aa425944"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "1d3c2590fff578f0e5feca3c7724c82bcd91caa7", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "b937e7ea997e07937ab340e0d8e9c700c641a330", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -510,26 +510,26 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "5caad442edeab796821b7f3bb009ab6945106e35", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "e7a8c495b9c9cb56a318368caee55dc2a237f961", default-features = false, features = [
     "tempo",
     "client",
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -619,9 +619,9 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = 
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "cf4e08013c0d6c537364f053462807ec42d4056a" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -510,7 +510,7 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "e7a8c495b9c9cb56a318368caee55dc2a237f961", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "3ea54e5eca3d93069f1e282733b84ee6aa425944", default-features = false, features = [
     "tempo",
     "client",
     "reqwest-rustls-tls",

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -4813,6 +4813,15 @@ where
                 _ => info.from,
             };
             inner = inner.with_fee_payer(fee_payer);
+
+            // Match Tempo's receipt conversion: the final log of every non-free
+            // transaction is the fee token transfer to TIPFeeManager.
+            if inner.effective_gas_price() > 0
+                && inner.gas_used() > 0
+                && let Some(fee_token) = inner.0.inner.logs().last().map(|log| log.address())
+            {
+                inner = inner.with_fee_token(fee_token);
+            }
         }
         Some(MinedTransactionReceipt { inner, out: info.out })
     }

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -3470,12 +3470,32 @@ async fn test_tempo_aa_transaction_receipt_fields() {
     let provider = handle.http_provider();
 
     let accounts: Vec<Address> = handle.dev_accounts().collect();
+    let sender = accounts[0];
     let recipient = accounts[1];
     let signer = dev_key(0);
 
     let token = IERC20::new(PATH_USD, &provider);
     let chain_id = provider.get_chain_id().await.unwrap();
     let base_fee = provider.get_gas_price().await.unwrap();
+
+    let ordinary_call = token.transfer(recipient, U256::from(50_000));
+    let ordinary_tx = TransactionRequest::default()
+        .from(sender)
+        .to(PATH_USD)
+        .with_input(ordinary_call.calldata().clone())
+        .with_gas_limit(TIP20_TRANSFER_GAS)
+        .max_fee_per_gas(base_fee * 2)
+        .max_priority_fee_per_gas(base_fee / 10);
+    let ordinary_receipt = provider
+        .send_transaction(WithOtherFields::new(ordinary_tx))
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    let ordinary_receipt = serde_json::to_value(ordinary_receipt).unwrap();
+    assert_eq!(ordinary_receipt["feePayer"], format!("{sender:#x}"));
+    assert_eq!(ordinary_receipt["feeToken"], format!("{ALPHA_USD:#x}"));
 
     let transfer_call = token.transfer(recipient, U256::from(50_000));
     let calldata: Bytes = transfer_call.calldata().clone();
@@ -3512,6 +3532,9 @@ async fn test_tempo_aa_transaction_receipt_fields() {
     assert!(receipt.status(), "Transaction should succeed");
     assert!(receipt.gas_used > 0, "Gas used should be non-zero");
     assert!(!receipt.inner.logs().is_empty(), "Should have Transfer event logs");
+    let receipt = serde_json::to_value(receipt).unwrap();
+    assert_eq!(receipt["feePayer"], format!("{sender:#x}"));
+    assert_eq!(receipt["feeToken"], format!("{ALPHA_USD:#x}"));
 }
 
 // ============================================================================

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -3,7 +3,7 @@ use std::{str::FromStr, time::Duration};
 use crate::{
     cmd::{
         call_overrides::CallOverrideOpts,
-        send::{cast_send, cast_send_with_tempo_wallet},
+        send::{cast_send, cast_send_with_tempo_wallet, validate_sponsor_url},
     },
     format_uint_exp, tempo,
     tx::{CastTxSender, SendTxOpts, TxParams, fill_transaction_gas_fees},
@@ -13,7 +13,9 @@ use alloy_eips::BlockId;
 use alloy_ens::NameOrAddress;
 use alloy_network::{Ethereum, EthereumWallet, Network, TransactionBuilder};
 use alloy_primitives::{Address, U256};
-use alloy_provider::{Provider, fillers::RecommendedFillers};
+use alloy_provider::{
+    Provider, ProviderBuilder as AlloyProviderBuilder, fillers::RecommendedFillers,
+};
 use alloy_signer::{Signature, Signer};
 use alloy_sol_types::sol;
 use clap::Parser;
@@ -33,6 +35,7 @@ use foundry_common::{
 pub use foundry_config::{Chain, Eip1559FeeEstimatePreset, utils::*};
 use foundry_wallets::{TempoAccountsWallet, WalletSigner};
 use tempo_alloy::TempoNetwork;
+use tempo_primitives::transaction::FEE_PAYER_SIGNATURE_MARKER;
 
 sol! {
     #[sol(rpc)]
@@ -395,11 +398,25 @@ impl Erc20Subcommand {
                         (pre_resolved_signer, tempo_keychain)
                     };
                 let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
+                let sponsor_url = tx_opts.tempo.sponsor_url.clone();
                 let sponsor_fee_payer = tx_opts.tempo.sponsor;
                 let expires_at = tx_opts.tempo.resolve_expires();
-                let tempo_sponsor =
-                    if print_sponsor_hash { None } else { tx_opts.tempo.sponsor_config().await? };
-                let needs_sponsor_payload = print_sponsor_hash || tempo_sponsor.is_some();
+                let tempo_sponsor = if print_sponsor_hash || sponsor_url.is_some() {
+                    None
+                } else {
+                    tx_opts.tempo.sponsor_config().await?
+                };
+                let needs_sponsor_payload =
+                    print_sponsor_hash || tempo_sponsor.is_some() || sponsor_url.is_some();
+                if let Some(ref url) = sponsor_url {
+                    validate_sponsor_url(url)?;
+                    if $send_tx.browser.browser {
+                        eyre::bail!("--sponsor-url cannot be combined with --browser");
+                    }
+                    if tempo_keychain.is_some() {
+                        eyre::bail!("--sponsor-url cannot be combined with a Tempo access key");
+                    }
+                }
                 if let Some(ts) = expires_at {
                     sh_status!("Transaction expires at unix timestamp {ts}")?;
                 }
@@ -538,7 +555,12 @@ impl Erc20Subcommand {
                 } else {
                     let signer = pre_resolved_signer.unwrap_or($send_tx.eth.wallet.signer().await?);
                     let from = signer.address();
-                    let $provider = build_provider_with_signer::<N>(&$send_tx, signer)?;
+                    let wallet = EthereumWallet::from(signer);
+                    let $provider = ProviderBuilder::<N>::from_config(&config)?
+                        .build_with_wallet(wallet.clone())?;
+                    if let Some(interval) = $send_tx.poll_interval {
+                        $provider.client().set_poll_interval(Duration::from_secs(interval));
+                    }
                     let $erc20 = IERC20::new($token.resolve(&$provider).await?, &$provider);
                     let mut tx = { $build_tx }.into_transaction_request();
                     let chain = get_chain(config.chain, &$provider).await?;
@@ -590,18 +612,39 @@ impl Erc20Subcommand {
                         )
                         .await?;
                     }
-                    cast_send(
-                        $provider,
-                        tx,
-                        tempo_sponsor.is_none().then_some(chain),
-                        None,
-                        $send_tx.cast_async,
-                        $send_tx.sync,
-                        $send_tx.confirmations,
-                        timeout,
-                        tempo_sponsor.is_none() && !config.eth_rpc_curl,
-                    )
-                    .await?;
+                    if let Some(sponsor_url) = sponsor_url {
+                        tx.set_fee_payer_signature(FEE_PAYER_SIGNATURE_MARKER);
+                        let connector = tempo::sponsor_relay_connector(&$provider, &sponsor_url)?;
+                        let provider = AlloyProviderBuilder::<_, _, N>::default()
+                            .wallet(wallet)
+                            .connect_with(&connector)
+                            .await?;
+                        cast_send(
+                            provider,
+                            tx,
+                            None,
+                            None,
+                            $send_tx.cast_async,
+                            $send_tx.sync,
+                            $send_tx.confirmations,
+                            timeout,
+                            false,
+                        )
+                        .await?;
+                    } else {
+                        cast_send(
+                            $provider,
+                            tx,
+                            tempo_sponsor.is_none().then_some(chain),
+                            None,
+                            $send_tx.cast_async,
+                            $send_tx.sync,
+                            $send_tx.confirmations,
+                            timeout,
+                            tempo_sponsor.is_none() && !config.eth_rpc_curl,
+                        )
+                        .await?;
+                    }
                 }
             }};
         }

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -3559,6 +3559,13 @@ pub(crate) async fn send_keychain_tx_with_root_signer(
     root_signer: KeychainRootSigner,
     before_submit: impl FnOnce() -> Result<()>,
 ) -> Result<KeychainTxOutcome> {
+    if tx_opts.tempo.sponsor_url.is_some() {
+        eyre::bail!(
+            "--sponsor-url is not supported by cast keychain; use --tempo.sponsor with \
+             --tempo.sponsor-signer or --tempo.sponsor-sig"
+        );
+    }
+
     let print_sponsor_hash = tx_opts.tempo.print_sponsor_hash;
     let sponsor_fee_payer = tx_opts.tempo.sponsor;
     let expires_at = tx_opts.tempo.resolve_expires();

--- a/crates/cast/src/cmd/mktx.rs
+++ b/crates/cast/src/cmd/mktx.rs
@@ -101,6 +101,13 @@ pub enum MakeTxSubcommands {
 
 impl MakeTxArgs {
     pub async fn run(self) -> Result<()> {
+        if self.tx.tempo.sponsor_url.is_some() {
+            eyre::bail!(
+                "--sponsor-url is not supported by cast mktx; use --tempo.sponsor with \
+                 --tempo.sponsor-signer or --tempo.sponsor-sig"
+            );
+        }
+
         if self.tx.tempo.session_id()?.is_some() {
             return self.run_generic::<TempoNetwork>(None, None).await;
         }

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -250,6 +250,30 @@ casttest!(keychain_authorize_sponsor_hash_json_is_object, async |_prj, cmd| {
     assert_eq!(hash.len(), 66, "sponsor_hash should be 32-byte hex (66 chars), got: {hash}");
 });
 
+casttest!(keychain_rejects_remote_sponsor_instead_of_ignoring_it, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
+    let rpc = handle.http_endpoint();
+
+    let stderr = cmd
+        .cast_fuse()
+        .args([
+            "keychain",
+            "authorize",
+            accounts::ADDR2,
+            "--private-key",
+            accounts::PK1,
+            "--rpc-url",
+            &rpc,
+            "--sponsor-url",
+            "http://localhost:1",
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("--sponsor-url is not supported by cast keychain"), "{stderr}");
+});
+
 // TODO: remove this check once browser supports T5/T6 KeyAuthorization fields
 casttest!(key_authorization_sign_rejects_browser_witness_before_browser_run, |_prj, cmd| {
     let stderr = cmd
@@ -541,6 +565,13 @@ casttest!(send_with_local_sponsor_reports_sponsor_as_fee_payer, async |_prj, cmd
     assert_eq!(
         fee_payer,
         accounts::ADDR2.parse::<alloy_primitives::Address>().unwrap(),
+        "unexpected receipt: {output}"
+    );
+    let fee_token: alloy_primitives::Address =
+        receipt["feeToken"].as_str().expect("feeToken").parse().expect("valid feeToken");
+    assert_eq!(
+        fee_token,
+        path_usd.parse::<alloy_primitives::Address>().unwrap(),
         "unexpected receipt: {output}"
     );
 });

--- a/crates/cast/tests/cli/tempo.rs
+++ b/crates/cast/tests/cli/tempo.rs
@@ -760,6 +760,24 @@ casttest!(tip20_logo_commands_expose_browser_and_remote_sponsor_options, |_prj, 
     }
 });
 
+casttest!(mktx_rejects_remote_sponsor_instead_of_ignoring_it, |_prj, cmd| {
+    let stderr = cmd
+        .cast_fuse()
+        .args([
+            "mktx",
+            "0x0000000000000000000000000000000000000001",
+            "--private-key",
+            "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+            "--sponsor-url",
+            "http://localhost:1",
+        ])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(stderr.contains("--sponsor-url is not supported by cast mktx"), "{stderr}");
+});
+
 casttest!(tip20_logo_check_accepts_valid_values, |_prj, cmd| {
     for uri in ["", "https://example.com/logo.png", "HTTP://example.com/logo.png", "ipfs://token"] {
         cmd.cast_fuse().args(["tip20", "logo-check", uri]).assert_success();

--- a/crates/cli/src/opts/tempo.rs
+++ b/crates/cli/src/opts/tempo.rs
@@ -125,7 +125,7 @@ pub struct TempoOpts {
     /// This option is supported by `cast send` and `cast erc20`. Forge commands currently support
     /// local sponsorship through `--tempo.sponsor` and `--tempo.sponsor-signer` instead.
     ///
-    /// Example: `cast send 0x... --sponsor-url https://sponsor.tempo.xyz/tp_abc123`
+    /// Example: `cast send 0x... --sponsor-url https://sponsor.moderato.tempo.xyz`
     #[arg(
         long = "sponsor-url",
         alias = "tempo.sponsor-url",

--- a/crates/common/src/tempo/mod.rs
+++ b/crates/common/src/tempo/mod.rs
@@ -227,7 +227,7 @@ fn decode_stablecoin_dex_fee_token(input: &[u8]) -> Option<Address> {
 }
 
 /// Returns the known symbol for a Tempo fee token without making an RPC call.
-const fn known_fee_token_symbol(fee_token: Address) -> Option<&'static str> {
+pub const fn known_fee_token_symbol(fee_token: Address) -> Option<&'static str> {
     match fee_token {
         PATH_USD_ADDRESS => Some("PathUSD"),
         ALPHA_USD_ADDRESS => Some("AlphaUSD"),

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -4688,6 +4688,11 @@ contract DeploySponsoredTempoAA is Script {
         .assert_success();
     let output = assert.get_output();
 
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Estimated amount required:"), "{stdout}");
+    assert!(stdout.contains(" PathUSD"), "{stdout}");
+    assert!(!stdout.contains(" ETH"), "{stdout}");
+
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(stderr.to_ascii_lowercase().contains(&format!("tempo sponsor: {sponsor}")), "{stderr}");
 });

--- a/crates/primitives/src/network/receipt.rs
+++ b/crates/primitives/src/network/receipt.rs
@@ -37,6 +37,12 @@ impl FoundryTxReceipt {
         self
     }
 
+    /// Adds a `feeToken` field to the receipt.
+    pub fn with_fee_token(mut self, fee_token: Address) -> Self {
+        self.0.other.insert("feeToken".to_string(), serde_json::to_value(fee_token).unwrap());
+        self
+    }
+
     /// Get block timestamp from other fields if present.
     pub fn block_timestamp(&self) -> Option<u64> {
         self.0.other.get_deserialized::<u64>("blockTimestamp").transpose().ok().flatten()

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -19,7 +19,10 @@ use eyre::{Context, Result};
 use forge_script_sequence::{ScriptSequence, TransactionWithMetadata};
 use foundry_cheatcodes::Wallets;
 use foundry_cli::utils::{has_different_gas_calc, now};
-use foundry_common::{ContractData, provider::fee::resolve_broadcast_eip1559_fees, shell};
+use foundry_common::{
+    ContractData, provider::fee::resolve_broadcast_eip1559_fees, shell,
+    tempo::known_fee_token_symbol,
+};
 use foundry_evm::{
     core::{FoundryBlock, evm::FoundryEvmNetwork},
     traces::{decode_trace_arena, prune_trace_depth, render_trace_arena_inner},
@@ -375,11 +378,22 @@ impl<FEN: FoundryEvmNetwork> FilledTransactionsState<FEN> {
             for (rpc, total_gas) in total_gas_per_rpc {
                 let provider_info = manager.get(&rpc).expect("provider is set.");
 
-                // Get the native token symbol for the chain using NamedChain
-                let token_symbol = NamedChain::try_from(provider_info.chain)
-                    .unwrap_or_default()
-                    .native_currency_symbol()
-                    .unwrap_or("ETH");
+                let token_symbol = if self.script_config.evm_opts.networks.is_tempo() {
+                    self.args.tempo.fee_token.map_or_else(
+                        || "TIP-20".to_string(),
+                        |fee_token| {
+                            known_fee_token_symbol(fee_token)
+                                .map(str::to_string)
+                                .unwrap_or_else(|| fee_token.to_string())
+                        },
+                    )
+                } else {
+                    NamedChain::try_from(provider_info.chain)
+                        .unwrap_or_default()
+                        .native_currency_symbol()
+                        .unwrap_or("ETH")
+                        .to_string()
+                };
 
                 // We don't store it in the transactions, since we want the most updated value.
                 // Right before broadcasting.


### PR DESCRIPTION
## Summary

Follow-up from black-box testing the first merged Tempo nightly as a CLI user.

- Make Anvil Tempo receipts report the actual fee payer and fee token for ordinary and AA transactions.
- Label Forge Tempo gas estimates in the TIP-20 fee token rather than ETH.
- Route cast erc20 --sponsor-url through the tempo-alloy relay connector while preserving the existing RPC transport, including MPP.
- Reject --sponsor-url explicitly in cast mktx and keychain mutation paths instead of silently ignoring it.
- Update the public sponsor example to https://sponsor.moderato.tempo.xyz.
- Align Tempo, foundry-core, and mpp-rs pins so Foundry builds one Tempo dependency graph.

Depends on tempoxyz/tempo#6965, foundry-rs/foundry-core#130, and tempoxyz/mpp-rs#356.

## Validation

- cargo fmt --all -- --check
- warnings-denied Clippy for foundry-primitives, anvil, cast, and forge-script, all targets/features
- focused Anvil ordinary + AA receipt test
- focused Cast local sponsor receipt test
- focused Forge locally sponsored broadcast/fee-label test
- focused tests proving unsupported mktx and keychain relay flags fail closed
- package checks for Cast, Anvil, and Forge Script
- dependency-tree audit: no stale/duplicate Tempo revision remains

## Live CLI coverage

Tested the official merged nightly first, then the patched binary against Moderato: public relay direct and through an MPP-challenged RPC; cast send and cast erc20 transfer; local sponsorship direct and through MPP; Accounts store.json access-key signing; session create/use/revoke/fail-closed reuse; Forge create and script broadcast; and ordinary Ethereum RPC isolation with valid unrelated and corrupt Tempo stores.

Final public sponsor-over-MPP smoke transaction: 0x13e0b20c5e0b575b94fde9e414f4d6b80b9541c1127bf38fc5a277a152d23bdf (zero-value PathUSD transfer). The receipt reports public fee payer 0x58aa7ce42e1d13b2919e2ac7e006c4fbc171442c and PathUSD as fee token.