### PR TITLE
test(tempo): drain Pong in MPP WS test

### DIFF
--- a/crates/common/src/provider/mpp/ws.rs
+++ b/crates/common/src/provider/mpp/ws.rs
@@ -442,7 +442,8 @@ mod tests {
             let credential = socket.next().await.unwrap().unwrap();
             assert!(matches!(credential, Message::Text(_)));
             socket.send(Message::Ping(Vec::new().into())).await.unwrap();
-            tokio::time::sleep(Duration::from_millis(25)).await;
+            let pong = socket.next().await.unwrap().unwrap();
+            assert!(matches!(pong, Message::Pong(_)));
             server_receipt_sent.store(true, Ordering::SeqCst);
             let receipt = WsServerMessage::Receipt { receipt: serde_json::json!({}) };
             socket


### PR DESCRIPTION
The Windows test server dropped its WebSocket while the client’s automatic Pong remained unread, which caused Winsock to reset the connection before the receipt was observed. Wait for and consume the Pong instead of sleeping for an arbitrary duration, making the test deterministic across platforms.

re CI failure https://github.com/foundry-rs/foundry/actions/runs/30228296208/job/89884006426

This PR was authored with Codex.

Prompted by: @grandizzy