### PR TITLE
fix(anvil): disable pre-London simulation fees

### DIFF
--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -185,6 +185,9 @@ impl FeeManager {
         gas_limit: u64,
         last_fee_per_gas: u64,
     ) -> u64 {
+        if !self.is_eip1559() {
+            return 0;
+        }
         // Tempo replaces EIP-1559 with its own hardfork-specific base fee rules.
         if let Some(hardfork) = self.tempo_hardfork() {
             return tempo_next_block_base_fee(hardfork, gas_used, last_fee_per_gas);
@@ -509,5 +512,38 @@ impl fmt::Debug for FeeDetails {
         write!(fmt, "max_priority_fee_per_gas: {:?}, ", self.max_priority_fee_per_gas)?;
         write!(fmt, "}}")?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fee_manager(spec_id: SpecId) -> FeeManager {
+        FeeManager::new(
+            spec_id,
+            INITIAL_BASE_FEE,
+            true,
+            INITIAL_GAS_PRICE,
+            BlobExcessGasAndPrice::new_with_spec(0, SpecId::CANCUN),
+            BlobParams::cancun(),
+            BaseFeeParams::ethereum(),
+            None,
+        )
+    }
+
+    #[test]
+    fn raw_next_base_fee_respects_london_activation() {
+        let berlin = fee_manager(SpecId::BERLIN);
+        assert_eq!(
+            berlin.calculate_next_block_base_fee_per_gas(30_000_000, 30_000_000, INITIAL_BASE_FEE),
+            0
+        );
+
+        let london = fee_manager(SpecId::LONDON);
+        assert_ne!(
+            london.calculate_next_block_base_fee_per_gas(30_000_000, 30_000_000, INITIAL_BASE_FEE),
+            0
+        );
     }
 }

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -801,6 +801,26 @@ async fn test_simulate_scopes_block_overrides_and_derives_base_fee_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_simulate_pre_london_blocks_keep_base_fee_disabled_rpc() {
+    let (_api, handle) =
+        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Berlin.into()))).await;
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [{}, {}],
+            "validation": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    let blocks = response["result"].as_array().unwrap();
+    assert_eq!(blocks.len(), 2);
+    assert!(blocks.iter().all(|block| block["baseFeePerGas"] == "0x0"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_derives_from_historical_base_rpc() {
     let (api, handle) = spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
     api.mine_one().await;


### PR DESCRIPTION
The raw next-block fee calculator used by `eth_simulateV1` bypasses the normal zero-fee sentinel, but it also calculated EIP-1559 fees before London. This change gates that calculation on hardfork activation so Berlin simulations keep a zero base fee while London and network-specific fee behavior remain unchanged.

The regression simulates multiple pre-London blocks through the RPC and checks that each reported base fee remains zero. Closes #15895.

AI assistance was used for implementation and code review.
