### PR TITLE
fix(anvil): report per-transaction gas

### DIFF
--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3282,7 +3282,7 @@ where
                 if let Some(contract) = &info.contract_address {
                     node_info!("    Contract created: {contract}");
                 }
-                node_info!("    Gas used: {}", receipt.cumulative_gas_used());
+                node_info!("    Gas used: {}", info.gas_used);
                 if !info.exit.is_ok() {
                     let r = RevertDecoder::new().decode(
                         info.out.as_ref().map(|b| &b[..]).unwrap_or_default(),
@@ -4631,10 +4631,7 @@ where
                                     |_, _, inspector, _, _| {
                                         inspector
                                             .geth_builder()
-                                            .geth_call_traces(
-                                                call_config,
-                                                tx.receipt.cumulative_gas_used(),
-                                            )
+                                            .geth_call_traces(call_config, tx.info.gas_used)
                                             .into()
                                     },
                                 )?;
@@ -4680,11 +4677,7 @@ where
 
         // default structlog tracer
         Ok(GethTraceBuilder::new(tx.info.traces.clone())
-            .geth_traces(
-                tx.receipt.cumulative_gas_used(),
-                tx.info.out.clone().unwrap_or_default(),
-                config,
-            )
+            .geth_traces(tx.info.gas_used, tx.info.out.clone().unwrap_or_default(), config)
             .into())
     }
 

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -783,6 +783,60 @@ async fn test_debug_trace_call_tx_index() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_debug_trace_transaction_reports_transaction_gas() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    let provider = handle.http_provider();
+
+    api.anvil_set_auto_mine(false).await.unwrap();
+
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let from = accounts[0].address();
+    let to = accounts[1].address();
+    let nonce = provider.get_transaction_count(from).await.unwrap();
+
+    let first = provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default().from(from).to(to).value(U256::from(1)).nonce(nonce),
+        ))
+        .await
+        .unwrap();
+    let second = provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default().from(from).to(to).value(U256::from(2)).nonce(nonce + 1),
+        ))
+        .await
+        .unwrap();
+
+    api.mine_one().await;
+    let first_receipt = first.get_receipt().await.unwrap();
+    let second_receipt = second.get_receipt().await.unwrap();
+    assert_eq!(first_receipt.block_hash, second_receipt.block_hash);
+
+    let default_trace = api
+        .debug_trace_transaction(
+            second_receipt.transaction_hash,
+            GethDebugTracingOptions::default(),
+        )
+        .await
+        .unwrap();
+    let GethTrace::Default(default_frame) = default_trace else {
+        unreachable!("expected default trace")
+    };
+    assert_eq!(default_frame.gas, second_receipt.gas_used);
+
+    let call_trace = api
+        .debug_trace_transaction(
+            second_receipt.transaction_hash,
+            GethDebugTracingOptions::default()
+                .with_tracer(GethDebugTracerType::from(GethDebugBuiltInTracerType::CallTracer)),
+        )
+        .await
+        .unwrap();
+    let GethTrace::CallTracer(call_frame) = call_trace else { unreachable!("expected call trace") };
+    assert_eq!(call_frame.gas_used, U256::from(second_receipt.gas_used));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_debug_trace_call_tx_index_fork_lazy_state() {
     let (_api, handle) = spawn(fork_config()).await;
     let provider = handle.http_provider();


### PR DESCRIPTION
Anvil receipts correctly contain cumulative gas, but transaction-local mining output and debug trace frames were reading that cumulative value. Transactions after index zero therefore reported gas consumed by earlier transactions in the same block. This change uses the transaction's own `TransactionInfo::gas_used` for those outputs while leaving receipt accounting unchanged.

The regression mines two transactions together and compares the second transaction's default and call-tracer gas with its receipt `gasUsed`. Closes #15893.

AI assistance was used for implementation and code review.
