### PR TITLE
test(forge): fix Issue6636 fuzz bound

### DIFF
--- a/testdata/default/repros/Issue6636.t.sol
+++ b/testdata/default/repros/Issue6636.t.sol
@@ -97,7 +97,7 @@ contract Issue6636Test is Issue6636Assertions {
 
     /// forge-config: default.fuzz.runs = 2
     function testFuzzLibraryDeploymentRecordedPerInput(uint256 value) public {
-        value = vm.bound(value, 0, type(uint256).max - 1);
+        value = bound(value, 0, type(uint256).max - 1);
         assertLibraryDeployment(recordLibraryCall(value));
     }
 }

--- a/testdata/default/repros/Issue6636.t.sol
+++ b/testdata/default/repros/Issue6636.t.sol
@@ -97,7 +97,7 @@ contract Issue6636Test is Issue6636Assertions {
 
     /// forge-config: default.fuzz.runs = 2
     function testFuzzLibraryDeploymentRecordedPerInput(uint256 value) public {
-        value = bound(value, 0, type(uint256).max - 1);
+        value %= type(uint256).max;
         assertLibraryDeployment(recordLibraryCall(value));
     }
 }


### PR DESCRIPTION
The Issue6636 fuzz regression used the mutation-oriented `vm.bound`, which rejects `uint256::MAX` because it falls outside the requested range. The fixture’s minimal `Test` contract does not provide `StdUtils.bound`, so this directly maps the fuzz input with modulo: every value below `uint256::MAX` remains unchanged, while `uint256::MAX` maps to zero without discarding the input.

ref https://github.com/foundry-rs/foundry/actions/runs/30249356080/job/89923620799

Prompted by: @grandizzy

AI assistance: Centaur investigated the CI failure and authored this one-line test correction.