### PR TITLE
fix(symbolic): debit pranked call value

### DIFF
--- a/crates/evm/symbolic/src/executor/calls.rs
+++ b/crates/evm/symbolic/src/executor/calls.rs
@@ -857,11 +857,16 @@ impl SymbolicExecutor {
             }
         }
 
+        if matches!(kind, CallKind::DelegateCall) && state.prank.has_active() {
+            return Err(SymbolicError::Unsupported("symbolic prank delegatecall"));
+        }
+        let (call_caller, call_caller_word, pranked_origin) = state.prank_for_next_call();
         if matches!(kind, CallKind::Call)
             && !self.prepare_value_transfer(
                 executor,
                 state,
                 worklist,
+                call_caller,
                 value.clone(),
                 out_offset.clone(),
                 &out_size,
@@ -882,6 +887,7 @@ impl SymbolicExecutor {
                     worklist,
                     kind,
                     to,
+                    call_caller,
                     value,
                     out_offset,
                     &out_size,
@@ -899,7 +905,7 @@ impl SymbolicExecutor {
                 Some(return_data) => {
                     state.return_data = return_data;
                     if matches!(kind, CallKind::Call) {
-                        state.world.transfer(&mut self.cx, executor, state.address, to, value);
+                        state.world.transfer(&mut self.cx, executor, call_caller, to, value);
                     }
                     state.copy_call_output_offset(&mut self.cx, out_offset, &out_size)?;
                     state.stack.push(SymExpr::one(&mut self.cx))?;
@@ -916,7 +922,7 @@ impl SymbolicExecutor {
         let child_code = state.world.extcode(&mut self.cx, executor, code_address)?;
         if child_code.is_empty() {
             if matches!(kind, CallKind::Call) {
-                state.world.transfer(&mut self.cx, executor, state.address, to, value);
+                state.world.transfer(&mut self.cx, executor, call_caller, to, value);
             }
             state.return_data = SymReturnData::empty(&mut self.cx);
             state.copy_call_output_offset(&mut self.cx, out_offset, &out_size)?;
@@ -935,10 +941,6 @@ impl SymbolicExecutor {
                     .cloned()
             })
             .unwrap_or_else(|| SymExpr::constant(&mut self.cx, address_word(to)));
-        if matches!(kind, CallKind::DelegateCall) && state.prank.has_active() {
-            return Err(SymbolicError::Unsupported("symbolic prank delegatecall"));
-        }
-        let (pranked_caller, pranked_caller_word, pranked_origin) = state.prank_for_next_call();
         let frame = match kind {
             CallKind::Call => {
                 let mut frame = CallFrame::new(
@@ -946,13 +948,13 @@ impl SymbolicExecutor {
                     to,
                     code_address,
                     to,
-                    pranked_caller,
+                    call_caller,
                     value.clone(),
                     state.is_static,
                     calldata,
                 );
                 frame.address_word = callee_address_word;
-                frame.caller_word = pranked_caller_word;
+                frame.caller_word = call_caller_word;
                 frame
             }
             CallKind::StaticCall => {
@@ -962,13 +964,13 @@ impl SymbolicExecutor {
                     to,
                     code_address,
                     to,
-                    pranked_caller,
+                    call_caller,
                     value,
                     true,
                     calldata,
                 );
                 frame.address_word = callee_address_word;
-                frame.caller_word = pranked_caller_word;
+                frame.caller_word = call_caller_word;
                 frame
             }
             CallKind::DelegateCall => {
@@ -992,13 +994,13 @@ impl SymbolicExecutor {
                     state.address,
                     code_address,
                     state.storage_address,
-                    pranked_caller,
+                    call_caller,
                     value.clone(),
                     state.is_static,
                     calldata,
                 );
                 frame.address_word = state.address_word.clone();
-                frame.caller_word = pranked_caller_word;
+                frame.caller_word = call_caller_word;
                 frame
             }
         };
@@ -1010,7 +1012,7 @@ impl SymbolicExecutor {
             child.origin_word = origin_word;
         }
         if matches!(kind, CallKind::Call) {
-            child.world.transfer(&mut self.cx, executor, state.address, to, value);
+            child.world.transfer(&mut self.cx, executor, call_caller, to, value);
         }
         child.expected_revert = None;
         child.assume_no_revert_next_call = None;
@@ -1126,6 +1128,7 @@ impl SymbolicExecutor {
         worklist: &mut VecDeque<PathState>,
         kind: CallKind,
         to: Address,
+        call_caller: Address,
         value: SymExpr,
         out_offset: SymExpr,
         out_size: &BoundedCopySize,
@@ -1134,7 +1137,15 @@ impl SymbolicExecutor {
     ) -> Result<StepOutcome, SymbolicError> {
         if let Some(outcome) = kzg_constrained_outcome(&mut self.cx, state, &input, &input_len)? {
             self.apply_precompile_outcome(
-                executor, state, kind, to, value, out_offset, out_size, outcome,
+                executor,
+                state,
+                kind,
+                to,
+                call_caller,
+                value,
+                out_offset,
+                out_size,
+                outcome,
             )?;
             return Ok(StepOutcome::Continue);
         }
@@ -1167,6 +1178,7 @@ impl SymbolicExecutor {
                     &mut failure,
                     kind,
                     to,
+                    call_caller,
                     value.clone(),
                     out_offset.clone(),
                     out_size,
@@ -1181,6 +1193,7 @@ impl SymbolicExecutor {
                     state,
                     kind,
                     to,
+                    call_caller,
                     value,
                     out_offset,
                     out_size,
@@ -1196,6 +1209,7 @@ impl SymbolicExecutor {
                     state,
                     kind,
                     to,
+                    call_caller,
                     value,
                     out_offset,
                     out_size,
@@ -1206,7 +1220,15 @@ impl SymbolicExecutor {
             (false, true) => {
                 state.constraints = failure_constraints;
                 self.apply_precompile_outcome(
-                    executor, state, kind, to, value, out_offset, out_size, None,
+                    executor,
+                    state,
+                    kind,
+                    to,
+                    call_caller,
+                    value,
+                    out_offset,
+                    out_size,
+                    None,
                 )?;
                 Ok(StepOutcome::Continue)
             }
@@ -1222,6 +1244,7 @@ impl SymbolicExecutor {
         state: &mut PathState,
         kind: CallKind,
         to: Address,
+        call_caller: Address,
         value: SymExpr,
         out_offset: SymExpr,
         out_size: &BoundedCopySize,
@@ -1231,7 +1254,7 @@ impl SymbolicExecutor {
             Some(return_data) => {
                 state.return_data = return_data;
                 if matches!(kind, CallKind::Call) {
-                    state.world.transfer(&mut self.cx, executor, state.address, to, value);
+                    state.world.transfer(&mut self.cx, executor, call_caller, to, value);
                 }
                 state.copy_call_output_offset(&mut self.cx, out_offset, out_size)?;
                 state.stack.push(SymExpr::one(&mut self.cx))?;
@@ -1245,11 +1268,13 @@ impl SymbolicExecutor {
         Ok(())
     }
 
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn prepare_value_transfer<FEN: FoundryEvmNetwork>(
         &mut self,
         executor: &Executor<FEN>,
         state: &mut PathState,
         worklist: &mut VecDeque<PathState>,
+        from: Address,
         value: SymExpr,
         out_offset: SymExpr,
         out_size: &BoundedCopySize,
@@ -1258,7 +1283,7 @@ impl SymbolicExecutor {
             return Ok(true);
         }
 
-        let balance = state.world.balance_word_for_address(&mut self.cx, executor, state.address);
+        let balance = state.world.balance_word_for_address(&mut self.cx, executor, from);
         let can_pay = SymBoolExpr::cmp(&mut self.cx, SymCmpOp::Uge, balance, value);
         match can_pay.as_const() {
             Some(true) => Ok(true),
@@ -1410,24 +1435,23 @@ impl SymbolicExecutor {
             let mut branch = state.clone();
             branch.constraints = outside_constraints;
 
+            if matches!(kind, CallKind::DelegateCall) && branch.prank.has_active() {
+                return Err(SymbolicError::Unsupported("symbolic prank delegatecall"));
+            }
+            let (call_caller, _, _) = branch.prank_for_next_call();
             if matches!(kind, CallKind::Call) {
                 if self.prepare_value_transfer(
                     executor,
                     &mut branch,
                     &mut parents,
+                    call_caller,
                     value.clone(),
                     out_offset.clone(),
                     &out_size,
                 )? {
                     let symbolic_target = target;
                     let to = branch.world.symbolic_address_slot(symbolic_target);
-                    branch.world.transfer(
-                        &mut self.cx,
-                        executor,
-                        branch.address,
-                        to,
-                        value.clone(),
-                    );
+                    branch.world.transfer(&mut self.cx, executor, call_caller, to, value.clone());
                     branch.return_data = SymReturnData::empty(&mut self.cx);
                     branch.copy_call_output_offset(&mut self.cx, out_offset.clone(), &out_size)?;
                     branch.stack.push(SymExpr::one(&mut self.cx))?;

--- a/crates/evm/symbolic/src/runtime/state.rs
+++ b/crates/evm/symbolic/src/runtime/state.rs
@@ -1932,7 +1932,7 @@ impl SymbolicWorld {
         to: Address,
         value: SymExpr,
     ) {
-        if value.as_const().is_some_and(|value| value.is_zero()) {
+        if from == to || value.as_const().is_some_and(|value| value.is_zero()) {
             return;
         }
         let from_balance = self.balance_word_for_address(cx, executor, from);

--- a/crates/forge/tests/cli/test_cmd/symbolic_engine_capabilities.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_engine_capabilities.rs
@@ -611,3 +611,42 @@ Ran 1 test for test/PrankedValueTransfer.t.sol:PrankedValueTransfer
 ...
 "#]]);
 });
+
+forgetest_init!(pranked_self_value_transfer, |prj, cmd| {
+    skip_unless_z3!("pranked_self_value_transfer");
+
+    prj.add_test(
+        "PrankedSelfValueTransfer.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract PrankedSelfValueTransfer is Test {
+    address constant ALICE = address(0xA11CE);
+
+    function checkSelfTransferPreservesBalance(uint96 amount) public {
+        vm.deal(ALICE, amount);
+
+        vm.prank(ALICE);
+        (bool ok,) = ALICE.call{value: amount}("");
+
+        assertTrue(ok);
+        assertEq(ALICE.balance, amount);
+    }
+}
+"#,
+    );
+
+    assert_symbolic(cmd.args([
+        "test",
+        "--symbolic",
+        "--match-test",
+        "checkSelfTransferPreservesBalance",
+    ]))
+    .success()
+    .stdout_eq(str![[r#"
+...
+Ran 1 test for test/PrankedSelfValueTransfer.t.sol:PrankedSelfValueTransfer
+[PASS] checkSelfTransferPreservesBalance(uint96) ([METRICS])
+...
+"#]]);
+});

--- a/crates/forge/tests/cli/test_cmd/symbolic_engine_capabilities.rs
+++ b/crates/forge/tests/cli/test_cmd/symbolic_engine_capabilities.rs
@@ -548,3 +548,66 @@ Ran 1 test for test/ExpSmallBounded.t.sol:ExpSmallBounded
 ...
 "#]]);
 });
+
+// ---------------------------------------------------------------------------
+// Pranked CALL value transfers debit the effective caller.
+// ---------------------------------------------------------------------------
+forgetest_init!(pranked_value_transfer_roundtrip, |prj, cmd| {
+    skip_unless_z3!("pranked_value_transfer_roundtrip");
+
+    prj.add_test(
+        "PrankedValueTransfer.t.sol",
+        r#"
+import "forge-std/Test.sol";
+
+contract WrappedEther {
+    mapping(address => uint256) public balanceOf;
+
+    function deposit() external payable {
+        balanceOf[msg.sender] += msg.value;
+    }
+
+    function withdraw(uint256 amount) external {
+        balanceOf[msg.sender] -= amount;
+        payable(msg.sender).transfer(amount);
+    }
+}
+
+contract PrankedValueTransfer is Test {
+    address constant ALICE = address(0xA11CE);
+    WrappedEther weth;
+
+    function setUp() public {
+        weth = new WrappedEther();
+    }
+
+    function checkDepositWithdrawRoundtrip(uint96 amount) public {
+        vm.deal(ALICE, amount);
+        uint256 preEthBalance = ALICE.balance;
+
+        vm.prank(ALICE);
+        weth.deposit{value: amount}();
+
+        vm.prank(ALICE);
+        weth.withdraw(amount);
+
+        assertEq(ALICE.balance, preEthBalance);
+    }
+}
+"#,
+    );
+
+    assert_symbolic(cmd.args([
+        "test",
+        "--symbolic",
+        "--match-test",
+        "checkDepositWithdrawRoundtrip",
+    ]))
+    .success()
+    .stdout_eq(str![[r#"
+...
+Ran 1 test for test/PrankedValueTransfer.t.sol:PrankedValueTransfer
+[PASS] checkDepositWithdrawRoundtrip(uint96) ([METRICS])
+...
+"#]]);
+});


### PR DESCRIPTION
## Description

Symbolic execution previously applied `vm.prank` when constructing the callee frame, after checking and transferring call value from the executing contract. Resolve the effective caller before those operations and use it consistently across deployed contracts, empty accounts, precompiles, and symbolic call targets. This aligns symbolic value transfers with concrete Forge execution and prevents replay-rejected counterexamples.

Adds regression coverage for a pranked WETH deposit and withdrawal round trip.

Fixes #15903.