### PR TITLE
fix(anvil): sync auto-detected fee spec

### DIFF
--- a/.changelog/pr-15908.md
+++ b/.changelog/pr-15908.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fix fork resets to refresh auto-detected hardfork and fee settings from the target fork.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -120,7 +120,7 @@ pub struct NodeConfig {
     pub disable_min_priority_fee: bool,
     /// Default blob excess gas and price
     pub blob_excess_gas_and_price: Option<BlobExcessGasAndPrice>,
-    /// The hardfork to use
+    /// The hardfork to force, or `None` to infer it from chain activation data.
     pub hardfork: Option<FoundryHardfork>,
     /// Signer accounts that will be initialised with `genesis_balance` in the genesis block
     pub genesis_accounts: Vec<PrivateKeySigner>,
@@ -310,7 +310,14 @@ Chain ID
             );
         }
 
-        if (SpecId::from(self.get_hardfork()) as u8) < (SpecId::LONDON as u8) {
+        let active_hardfork = fork
+            .and_then(|fork| fork.config.read().hardfork)
+            .unwrap_or_else(|| self.get_hardfork());
+        let active_base_fee =
+            fork.and_then(ClientFork::base_fee).unwrap_or_else(|| self.get_base_fee() as u128);
+        let active_gas_price =
+            fork.map(ClientFork::gas_price).unwrap_or_else(|| self.get_gas_price());
+        if (SpecId::from(active_hardfork) as u8) < (SpecId::LONDON as u8) {
             let _ = write!(
                 s,
                 r#"
@@ -319,7 +326,7 @@ Gas Price
 
 {}
 "#,
-                self.get_gas_price().green()
+                active_gas_price.green()
             );
         } else {
             let _ = write!(
@@ -330,7 +337,7 @@ Base Fee
 
 {}
 "#,
-                self.get_base_fee().green()
+                active_base_fee.green()
             );
         }
 
@@ -345,6 +352,8 @@ Gas Limit
             {
                 if self.disable_block_gas_limit {
                     "Disabled".to_string()
+                } else if let Some(fork) = fork {
+                    fork.gas_limit().to_string()
                 } else {
                     self.gas_limit.map(|l| l.to_string()).unwrap_or_else(|| {
                         if self.fork_choice.is_some() {
@@ -417,9 +426,9 @@ Genesis Number
               "block_hash": fork.block_hash(),
               "chain_id": fork.chain_id(),
               "wallet": wallet_description,
-              "base_fee": format!("{}", self.get_base_fee()),
-              "gas_price": format!("{}", self.get_gas_price()),
-              "gas_limit": gas_limit,
+              "base_fee": format!("{}", fork.base_fee().unwrap_or_else(|| self.get_base_fee() as u128)),
+              "gas_price": format!("{}", fork.gas_price()),
+              "gas_limit": Some(fork.gas_limit().to_string()),
             })
         } else {
             json!({
@@ -1260,8 +1269,12 @@ impl NodeConfig {
             genesis_init: self.genesis.clone(),
         };
 
+        let active_hardfork = fork
+            .as_ref()
+            .and_then(|fork| fork.config.read().hardfork)
+            .unwrap_or_else(|| self.get_hardfork());
         let mut decoder_builder = CallTraceDecoderBuilder::new().with_tempo_hardfork(
-            self.networks.is_tempo().then(|| TempoHardfork::from(self.get_hardfork())),
+            self.networks.is_tempo().then(|| TempoHardfork::from(active_hardfork)),
         );
         if self.print_traces {
             // if traces should get printed we configure the decoder with the signatures cache
@@ -1327,7 +1340,8 @@ impl NodeConfig {
     ) -> Result<(Arc<TokioRwLock<Box<dyn Db>>>, Option<ClientFork>)> {
         let (db, config) = self.setup_fork_db_config(eth_rpc_url, evm_env, fees).await?;
         let db: Arc<TokioRwLock<Box<dyn Db>>> = Arc::new(TokioRwLock::new(Box::new(db)));
-        let fork = ClientFork::new(config, Arc::clone(&db));
+        let fork = ClientFork::new(config, Arc::clone(&db))
+            .with_runtime_info(fees.raw_gas_price(), evm_env.block_env.gas_limit);
         Ok((db, Some(fork)))
     }
 
@@ -1409,7 +1423,6 @@ latest block number: {latest_block}"
         };
 
         let gas_limit = self.fork_gas_limit(&block);
-        self.gas_limit = Some(gas_limit);
 
         // Cache identity must describe the remote fork block, not local execution overrides that
         // can change after mining (for example, the locally advanced base fee).
@@ -1444,37 +1457,39 @@ latest block number: {latest_block}"
             chain_id
         };
 
-        // Auto-detect hardfork from chain activation data if not explicitly set.
-        if self.hardfork.is_none()
-            && let Some(hardfork) =
-                FoundryHardfork::from_chain_and_timestamp(chain_id, block.header.timestamp())
-        {
-            evm_env.cfg_env.spec = SpecId::from(hardfork);
-            self.hardfork = Some(hardfork);
-        }
+        // Resolve the fork block's hardfork without materializing it into `self.hardfork`.
+        // That field represents the user's explicit override; keeping inference on the fork
+        // config lets a later reset re-resolve timestamp-based activations.
+        let fork_hardfork = self.hardfork.or_else(|| {
+            FoundryHardfork::from_chain_and_timestamp(chain_id, block.header.timestamp())
+        });
+        let active_hardfork = fork_hardfork.unwrap_or_else(|| self.get_hardfork());
+        let spec_id = SpecId::from(active_hardfork);
+        evm_env.cfg_env.set_spec_and_mainnet_gas_params(spec_id);
+        fees.set_hardfork(
+            spec_id,
+            self.networks.is_tempo().then(|| TempoHardfork::from(active_hardfork)),
+        );
 
-        // The fee manager was built before the fork hardfork was known, so refresh the Tempo
-        // hardfork it uses for base fee calculations.
-        if self.networks.is_tempo() {
-            fees.set_tempo_hardfork(Some(TempoHardfork::from(self.get_hardfork())));
-        }
-
-        // if not set explicitly we use the base fee of the latest block
-        if self.base_fee.is_none()
-            && let Some(base_fee) = block.header.base_fee_per_gas()
-        {
-            self.base_fee = Some(base_fee);
-            evm_env.block_env.basefee = base_fee;
+        let fork_base_fee = self.base_fee.or_else(|| block.header.base_fee_per_gas());
+        evm_env.block_env.basefee = fork_base_fee.unwrap_or_default();
+        if let Some(base_fee) = self.base_fee {
+            fees.set_base_fee(base_fee);
+        } else if let Some(base_fee) = block.header.base_fee_per_gas() {
             // this is the base fee of the current block, but we need the base fee of
             // the next block
-            let next_block_base_fee = fees.get_next_block_base_fee_per_gas(
+            let next_block_base_fee = fees.calculate_next_block_base_fee_per_gas(
                 block.header.gas_used(),
                 gas_limit,
-                block.header.base_fee_per_gas().unwrap_or_default(),
+                base_fee,
             );
 
             // update next base fee
             fees.set_base_fee(next_block_base_fee);
+        } else {
+            // Keep the configured/default local seed behind a pre-London spec so clearing the fork
+            // can restore the non-fork fallback without reviving a previous fork's fee.
+            fees.set_base_fee(self.get_base_fee());
         }
 
         if let (Some(blob_excess_gas), Some(blob_gas_used)) =
@@ -1498,13 +1513,13 @@ latest block number: {latest_block}"
             ));
         }
 
-        // use remote gas price
-        if self.gas_price.is_none()
-            && let Ok(gas_price) = provider.get_gas_price().await
-        {
-            self.gas_price = Some(gas_price);
-            fees.set_gas_price(gas_price);
-        }
+        // Use the configured override or refresh the remote gas price for every target fork.
+        let gas_price = if let Some(gas_price) = self.gas_price {
+            gas_price
+        } else {
+            provider.get_gas_price().await.unwrap_or_else(|_| self.get_gas_price())
+        };
+        fees.set_gas_price(gas_price);
 
         let block_hash = block.header.hash;
 
@@ -1558,9 +1573,9 @@ latest block number: {latest_block}"
             provider,
             chain_id,
             override_chain_id,
-            hardfork: self.hardfork,
+            hardfork: fork_hardfork,
             timestamp: block.header.timestamp(),
-            base_fee: block.header.base_fee_per_gas().map(|g| g as u128),
+            base_fee: fork_base_fee.map(|g| g as u128),
             timeout: self.fork_request_timeout,
             retries: self.fork_request_retries,
             backoff: self.fork_retry_backoff,
@@ -1893,5 +1908,30 @@ mod tests {
         let config = NodeConfig::test_tempo();
 
         assert_eq!(config.get_hardfork(), FoundryHardfork::Tempo(latest_active_tempo_hardfork()));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fork_banner_uses_resolved_hardfork() {
+        let (source_api, source_handle) = crate::spawn(
+            NodeConfig::test()
+                .with_chain_id(Some(1u64))
+                .with_hardfork(Some(EthereumHardfork::Berlin.into()))
+                .with_genesis_timestamp(Some(1_618_481_223u64)),
+        )
+        .await;
+        source_api.evm_set_next_block_timestamp(1_618_481_224u64).unwrap();
+        source_api.mine_one().await;
+
+        let (api, handle) = crate::spawn(
+            NodeConfig::test()
+                .with_eth_rpc_url(Some(source_handle.http_endpoint()))
+                .with_fork_block_number(Some(1u64)),
+        )
+        .await;
+        let fork = api.get_fork().unwrap();
+        let banner = handle.config().as_string(Some(&fork));
+
+        assert!(banner.contains("\nGas Price\n"));
+        assert!(!banner.contains("\nBase Fee\n"));
     }
 }

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -59,12 +59,30 @@ pub struct ClientFork<N: Network = AnyNetwork> {
     pub config: Arc<RwLock<ClientForkConfig<N>>>,
     /// This also holds a handle to the underlying database
     pub database: Arc<AsyncRwLock<Box<dyn Db>>>,
+    /// Resolved runtime values that are not configuration overrides.
+    runtime: Arc<RwLock<ForkRuntimeInfo>>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct ForkRuntimeInfo {
+    gas_price: u128,
+    gas_limit: u64,
 }
 
 impl<N: Network> ClientFork<N> {
     /// Creates a new instance of the fork
     pub fn new(config: ClientForkConfig<N>, database: Arc<AsyncRwLock<Box<dyn Db>>>) -> Self {
-        Self { storage: Default::default(), config: Arc::new(RwLock::new(config)), database }
+        Self {
+            storage: Default::default(),
+            config: Arc::new(RwLock::new(config)),
+            database,
+            runtime: Default::default(),
+        }
+    }
+
+    pub(crate) fn with_runtime_info(self, gas_price: u128, gas_limit: u64) -> Self {
+        *self.runtime.write() = ForkRuntimeInfo { gas_price, gas_limit };
+        self
     }
 
     /// Removes all data cached from previous responses
@@ -101,6 +119,14 @@ impl<N: Network> ClientFork<N> {
 
     pub fn base_fee(&self) -> Option<u128> {
         self.config.read().base_fee
+    }
+
+    pub fn gas_price(&self) -> u128 {
+        self.runtime.read().gas_price
+    }
+
+    pub fn gas_limit(&self) -> u64 {
+        self.runtime.read().gas_limit
     }
 
     pub fn block_hash(&self) -> B256 {
@@ -456,6 +482,7 @@ impl<N: Network> ClientFork<N> {
         let block_hash = block.header().hash();
         let timestamp = block.header().timestamp();
         let base_fee = block.header().base_fee_per_gas();
+        let gas_limit = block.header().gas_limit();
         let total_difficulty = block.header().difficulty();
 
         let number = block.header().number();
@@ -466,6 +493,9 @@ impl<N: Network> ClientFork<N> {
             base_fee.map(|g| g as u128),
             total_difficulty,
         );
+        let gas_price =
+            provider.get_gas_price().await.unwrap_or_else(|_| self.runtime.read().gas_price);
+        *self.runtime.write() = ForkRuntimeInfo { gas_price, gas_limit };
 
         self.clear_cached_storage();
 

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -1635,7 +1635,7 @@ impl<N: Network> Backend<N> {
         #[cfg(feature = "optimism")]
         if self.is_optimism() {
             let op_env = EvmEnv::new(
-                evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(self.hardfork.into()),
+                evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(self.hardfork().into()),
                 evm_env.block_env.clone(),
             );
             let mut evm =
@@ -2567,9 +2567,8 @@ impl<N: Network> Backend<N> {
             }
         }
 
-        let db = self.db.write().await;
         // apply the genesis.json alloc
-        self.genesis.apply_genesis_json_alloc(db)?;
+        self.genesis.apply_genesis_json_alloc(self.db.write().await)?;
 
         // Initialize Tempo precompiles and fee tokens when in Tempo mode (not in fork mode).
         // In fork mode, precompiles are inherited from the forked origin.
@@ -2641,7 +2640,8 @@ impl<N: Network> Backend<N> {
             node_config.setup_fork_db_config(target_rpc_url, &mut evm_env, &candidate_fees).await?;
         self.apply_fork_genesis(&mut db)?;
         let candidate_fee_state = candidate_fees.snapshot();
-        let fork = ClientFork::new(config, Arc::clone(&self.db));
+        let fork = ClientFork::new(config, Arc::clone(&self.db))
+            .with_runtime_info(candidate_fees.raw_gas_price(), evm_env.block_env.gas_limit);
 
         let _mining_guard = self.mining.lock().await;
 
@@ -2677,33 +2677,60 @@ impl<N: Network> Backend<N> {
     /// Resets the backend to a fresh in-memory state, clearing all existing data
     pub async fn reset_to_in_mem(&self) -> Result<(), BlockchainError> {
         let _mining_guard = self.mining.lock().await;
-        let fallback_chain_id = {
-            let current_fork = self.get_fork();
+        let current_fork = self.get_fork();
+        let (
+            fallback_chain_id,
+            fallback_hardfork,
+            fallback_base_fee,
+            fallback_gas_price,
+            fallback_gas_limit,
+            fallback_blob_excess_gas_and_price,
+            fallback_blob_params,
+        ) = {
             let mut config = self.node_config.write().await;
             if let Some(fork) = &current_fork {
                 config.set_chain_id(fork.override_chain_id());
             }
-            config.get_chain_id()
+            (
+                config.get_chain_id(),
+                config.get_hardfork(),
+                config.get_base_fee(),
+                config.get_gas_price(),
+                config.gas_limit(),
+                config.get_blob_excess_gas_and_price(),
+                config.get_blob_params(),
+            )
         };
+        let fallback_spec_id = SpecId::from(fallback_hardfork);
 
         // Clear the fork if any exists
         *self.fork.write() = None;
 
+        // Restore the configured non-fork hardfork after clearing an inferred fork. Explicit
+        // hardfork overrides remain pinned, while auto-detected fork hardforks fall back to the
+        // local node default.
+        self.fees.set_hardfork(
+            fallback_spec_id,
+            self.is_tempo().then(|| TempoHardfork::from(fallback_hardfork)),
+        );
+        self.fees.set_base_fee(fallback_base_fee);
+        self.fees.set_gas_price(fallback_gas_price);
+        self.fees.set_blob_excess_gas_and_price(fallback_blob_excess_gas_and_price);
+        self.fees.set_blob_params(fallback_blob_params);
+
         let genesis_timestamp = self.genesis.timestamp;
         let genesis_number = self.genesis.number;
 
-        // Tempo chains seed the hardfork's own fixed base fee on reset; other chains keep the
-        // pre-reset base fee for the genesis block, as before. Computed up front so the env,
-        // storage, and fee manager all agree.
-        let reset_base_fee = self.fees.tempo_hardfork().map(crate::config::tempo_default_base_fee);
-        let genesis_base_fee = reset_base_fee.unwrap_or_else(|| self.fees.base_fee());
+        let genesis_base_fee = fallback_base_fee;
 
         // Reset environment to genesis state
         {
             let mut env = self.evm_env.write();
             env.cfg_env.chain_id = fallback_chain_id;
+            env.cfg_env.set_spec_and_mainnet_gas_params(fallback_spec_id);
             env.block_env.number = U256::from(genesis_number);
             env.block_env.timestamp = U256::from(genesis_timestamp);
+            env.block_env.gas_limit = fallback_gas_limit;
             // Reset other block env fields to their defaults
             env.block_env.basefee = genesis_base_fee;
             env.block_env.prevrandao = Some(B256::ZERO);
@@ -2728,24 +2755,14 @@ impl<N: Network> Backend<N> {
         // drop any pending next-block prevrandao override so it does not leak into a block
         self.cheats.clear_next_block_prevrandao();
 
-        // Seed the next block's base fee. On Tempo the genesis keeps its fixed default while the
-        // next block already follows the hardfork's rule (e.g. T7 clamps to the cap); other chains
-        // use Anvil's Ethereum default.
-        if self.fees.is_eip1559() {
-            let next_base_fee = match reset_base_fee {
-                Some(genesis_base_fee) => {
-                    // Seed the fixed genesis fee first so the next-block computation is not
-                    // affected by any manually zeroed base fee, then advance one block per Tempo.
-                    self.fees.set_base_fee(genesis_base_fee);
-                    let gas_limit = self.evm_env.read().block_env.gas_limit;
-                    self.fees.get_next_block_base_fee_per_gas(0, gas_limit, genesis_base_fee)
-                }
-                None => crate::eth::fees::INITIAL_BASE_FEE,
-            };
+        // Tempo advances its configured genesis seed according to the active hardfork. Other
+        // networks retain the configured local base fee for the first block after reset.
+        if self.fees.tempo_hardfork().is_some() {
+            let gas_limit = self.evm_env.read().block_env.gas_limit;
+            let next_base_fee =
+                self.fees.get_next_block_base_fee_per_gas(0, gas_limit, genesis_base_fee);
             self.fees.set_base_fee(next_base_fee);
         }
-
-        self.fees.set_gas_price(crate::eth::fees::INITIAL_GAS_PRICE);
 
         // Reapply genesis configuration
         self.apply_genesis().await?;

--- a/crates/anvil/src/eth/fees.rs
+++ b/crates/anvil/src/eth/fees.rs
@@ -124,9 +124,11 @@ impl FeeManager {
         self.state.read().tempo_hardfork
     }
 
-    /// Sets the active Tempo hardfork after fork auto-detection.
-    pub fn set_tempo_hardfork(&self, hardfork: Option<TempoHardfork>) {
-        self.state.write().tempo_hardfork = hardfork;
+    /// Sets the EVM and Tempo hardfork identifiers atomically.
+    pub fn set_hardfork(&self, spec_id: SpecId, tempo_hardfork: Option<TempoHardfork>) {
+        let mut state = self.state.write();
+        state.spec_id = spec_id;
+        state.tempo_hardfork = tempo_hardfork;
     }
 
     pub fn elasticity(&self) -> f64 {

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -1403,6 +1403,88 @@ async fn test_anvil_reset_fork_to_non_fork() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_reset_fork_to_non_fork_restores_configured_hardfork() {
+    let (source_api, source_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::Berlin.into()))
+            .with_genesis_timestamp(Some(1_618_481_223u64)),
+    )
+    .await;
+    source_api.evm_set_next_block_timestamp(1_618_481_224u64).unwrap();
+    source_api.mine_one().await;
+
+    let (api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(source_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64)),
+    )
+    .await;
+    assert_eq!(api.backend.hardfork(), EthereumHardfork::Berlin.into());
+    assert!(!api.backend.is_eip1559());
+    assert_eq!(api.backend.base_fee(), 0);
+
+    api.anvil_reset(None).await.unwrap();
+
+    assert_eq!(api.backend.hardfork(), NodeConfig::test().get_hardfork());
+    assert!(api.backend.is_eip1559());
+    assert_ne!(api.backend.base_fee(), 0);
+
+    let (api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(source_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::Berlin.into())),
+    )
+    .await;
+
+    api.anvil_reset(None).await.unwrap();
+
+    assert_eq!(api.backend.hardfork(), EthereumHardfork::Berlin.into());
+    assert!(!api.backend.is_eip1559());
+    assert_eq!(api.backend.base_fee(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_reset_fork_to_non_fork_restores_configured_fees() {
+    let (source_api, source_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::London.into()))
+            .with_base_fee(Some(1_000u64)),
+    )
+    .await;
+    source_api.mine_one().await;
+
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(source_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64))
+            .with_base_fee(Some(5_000u64))
+            .with_gas_limit(Some(25_000_000u64)),
+    )
+    .await;
+
+    api.anvil_reset(None).await.unwrap();
+
+    assert_eq!(api.backend.base_fee(), 5_000);
+    assert_eq!(api.backend.gas_limit(), 25_000_000);
+    let genesis = handle.http_provider().get_block(BlockId::latest()).await.unwrap().unwrap();
+    assert_eq!(genesis.header.base_fee_per_gas, Some(5_000));
+
+    let (api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(source_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::Berlin.into()))
+            .with_gas_price(Some(6_000u128)),
+    )
+    .await;
+    api.anvil_reset(None).await.unwrap();
+    assert_eq!(api.gas_price(), 6_000);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_anvil_reset_fork_refreshes_inferred_chain_id() {
     let (source_a_api, source_a_handle) = spawn(NodeConfig::test().with_chain_id(Some(1u64))).await;
     source_a_api.mine_one().await;
@@ -1470,6 +1552,130 @@ async fn test_anvil_reset_fork_refreshes_inferred_chain_id() {
     .await
     .unwrap();
     assert_eq!(api.chain_id(), 31337);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_reset_fork_refreshes_inferred_fees() {
+    let (london_a_api, london_a_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::London.into()))
+            .with_base_fee(Some(1_000u64))
+            .with_gas_limit(Some(10_000_000u64))
+            .with_genesis_timestamp(Some(1_628_166_823u64)),
+    )
+    .await;
+    london_a_api.evm_set_next_block_timestamp(1_628_166_824u64).unwrap();
+    london_a_api.mine_one().await;
+
+    let (london_b_api, london_b_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::London.into()))
+            .with_base_fee(Some(2_000u64))
+            .with_gas_limit(Some(20_000_000u64))
+            .with_genesis_timestamp(Some(1_628_166_823u64)),
+    )
+    .await;
+    london_b_api.evm_set_next_block_timestamp(1_628_166_824u64).unwrap();
+    london_b_api.mine_one().await;
+
+    let (berlin_a_api, berlin_a_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::Berlin.into()))
+            .with_gas_price(Some(3_000u128))
+            .with_genesis_timestamp(Some(1_618_481_223u64)),
+    )
+    .await;
+    berlin_a_api.evm_set_next_block_timestamp(1_618_481_224u64).unwrap();
+    berlin_a_api.mine_one().await;
+
+    let (berlin_b_api, berlin_b_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::Berlin.into()))
+            .with_gas_price(Some(4_000u128))
+            .with_genesis_timestamp(Some(1_618_481_223u64)),
+    )
+    .await;
+    berlin_b_api.evm_set_next_block_timestamp(1_618_481_224u64).unwrap();
+    berlin_b_api.mine_one().await;
+
+    let (api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(london_a_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64)),
+    )
+    .await;
+    let london_a_base_fee = api.backend.base_fee();
+    assert_eq!(api.backend.gas_limit(), 10_000_000);
+
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(london_b_handle.http_endpoint()),
+        block_number: Some(1u64),
+    }))
+    .await
+    .unwrap();
+    let london_b_base_fee = api.backend.base_fee();
+    assert_ne!(london_b_base_fee, london_a_base_fee);
+    assert_eq!(api.backend.gas_limit(), 20_000_000);
+
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(berlin_a_handle.http_endpoint()),
+        block_number: Some(1u64),
+    }))
+    .await
+    .unwrap();
+    assert_eq!(api.gas_price(), 3_000);
+
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(berlin_b_handle.http_endpoint()),
+        block_number: Some(1u64),
+    }))
+    .await
+    .unwrap();
+    assert_eq!(api.gas_price(), 4_000);
+
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(london_b_handle.http_endpoint()),
+        block_number: Some(1u64),
+    }))
+    .await
+    .unwrap();
+    assert_eq!(api.backend.base_fee(), london_b_base_fee);
+
+    let (api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(london_a_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64))
+            .with_base_fee(Some(5_000u64))
+            .with_gas_limit(Some(25_000_000u64)),
+    )
+    .await;
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(london_b_handle.http_endpoint()),
+        block_number: Some(1u64),
+    }))
+    .await
+    .unwrap();
+    assert_eq!(api.backend.base_fee(), 5_000);
+    assert_eq!(api.backend.gas_limit(), 25_000_000);
+
+    let (api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(berlin_a_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64))
+            .with_gas_price(Some(6_000u128)),
+    )
+    .await;
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(berlin_b_handle.http_endpoint()),
+        block_number: Some(1u64),
+    }))
+    .await
+    .unwrap();
+    assert_eq!(api.gas_price(), 6_000);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -5,6 +5,7 @@ use alloy_primitives::{Address, Bytes, TxKind, U256, address};
 use alloy_provider::Provider;
 use alloy_rpc_types::{
     BlockOverrides,
+    anvil::Forking,
     request::TransactionRequest,
     simulate::{SimBlock, SimulatePayload},
     state::{AccountOverride, StateOverridesBuilder},
@@ -801,14 +802,32 @@ async fn test_simulate_scopes_block_overrides_and_derives_base_fee_rpc() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_simulate_pre_london_blocks_keep_base_fee_disabled_rpc() {
-    let (_api, handle) =
-        spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Berlin.into()))).await;
+async fn test_fork_simulate_auto_detects_pre_london_base_fee_rpc() {
+    let (berlin_api, berlin_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::Berlin.into()))
+            .with_genesis_timestamp(Some(1_618_481_223u64)),
+    )
+    .await;
+    berlin_api.evm_set_next_block_timestamp(1_618_481_224u64).unwrap();
+    berlin_api.mine_one().await;
+
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(berlin_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64)),
+    )
+    .await;
+    let endpoint = handle.http_endpoint();
     let response = rpc_request(
-        &handle.http_endpoint(),
+        &endpoint,
         "eth_simulateV1",
         json!([{
-            "blockStateCalls": [{}, {}],
+            "blockStateCalls": [
+                {"blockOverrides": {"baseFeePerGas": "0x3e8"}},
+                {}
+            ],
             "validation": true
         }, "latest"]),
     )
@@ -817,7 +836,101 @@ async fn test_simulate_pre_london_blocks_keep_base_fee_disabled_rpc() {
     assert!(response.get("error").is_none(), "{response}");
     let blocks = response["result"].as_array().unwrap();
     assert_eq!(blocks.len(), 2);
-    assert!(blocks.iter().all(|block| block["baseFeePerGas"] == "0x0"));
+    assert_eq!(blocks[0]["baseFeePerGas"], "0x3e8");
+    assert_eq!(blocks[1]["baseFeePerGas"], "0x0");
+
+    let (london_api, london_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::London.into()))
+            .with_genesis_timestamp(Some(1_628_166_823u64)),
+    )
+    .await;
+    london_api.evm_set_next_block_timestamp(1_628_166_824u64).unwrap();
+    london_api.mine_one().await;
+
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(london_handle.http_endpoint()),
+        block_number: Some(1u64),
+    }))
+    .await
+    .unwrap();
+
+    let response = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {"blockOverrides": {"baseFeePerGas": "0x3e8"}},
+                {}
+            ],
+            "validation": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    let blocks = response["result"].as_array().unwrap();
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks[0]["baseFeePerGas"], "0x3e8");
+    assert_eq!(blocks[1]["baseFeePerGas"], "0x36b");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_simulate_preserves_explicit_fee_spec_on_reset_rpc() {
+    let (berlin_api, berlin_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::Berlin.into()))
+            .with_genesis_timestamp(Some(1_618_481_223u64)),
+    )
+    .await;
+    berlin_api.evm_set_next_block_timestamp(1_618_481_224u64).unwrap();
+    berlin_api.mine_one().await;
+
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(berlin_handle.http_endpoint()))
+            .with_fork_block_number(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::Berlin.into())),
+    )
+    .await;
+
+    let (london_api, london_handle) = spawn(
+        NodeConfig::test()
+            .with_chain_id(Some(1u64))
+            .with_hardfork(Some(EthereumHardfork::London.into()))
+            .with_genesis_timestamp(Some(1_628_166_823u64)),
+    )
+    .await;
+    london_api.evm_set_next_block_timestamp(1_628_166_824u64).unwrap();
+    london_api.mine_one().await;
+
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(london_handle.http_endpoint()),
+        block_number: Some(1u64),
+    }))
+    .await
+    .unwrap();
+
+    let response = rpc_request(
+        &handle.http_endpoint(),
+        "eth_simulateV1",
+        json!([{
+            "blockStateCalls": [
+                {"blockOverrides": {"baseFeePerGas": "0x3e8"}},
+                {}
+            ],
+            "validation": true
+        }, "latest"]),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    let blocks = response["result"].as_array().unwrap();
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks[0]["baseFeePerGas"], "0x3e8");
+    assert_eq!(blocks[1]["baseFeePerGas"], "0x0");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Motivation

#15898 gates raw base-fee calculation on the fee manager’s active spec, but historical fork auto-detection happens after the fee manager is constructed. Forks without an explicit hardfork could therefore retain the default post-London spec and continue deriving EIP-1559 base fees. Fork-derived values could also become persistent configuration overrides, preventing later resets from refreshing them from the target fork.

Built on #15919, this keeps configured overrides separate from resolved fork state. Fork setup synchronizes the EVM and fee-manager hardfork with the target block and refreshes inferred base fee, gas price, and gas limit on every reset, while explicit overrides remain pinned. Clearing a fork restores the configured non-fork fallback, and fork reporting uses the active resolved values.
