### PR TITLE
fix(anvil): use Tempo reth feature

### DIFF
--- a/.changelog/anvil-tempo-reth-feature.md
+++ b/.changelog/anvil-tempo-reth-feature.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Use Tempo's `reth` compatibility feature in Anvil tests.

--- a/crates/anvil/Cargo.toml
+++ b/crates/anvil/Cargo.toml
@@ -123,7 +123,7 @@ reqwest.workspace = true
 foundry-test-utils.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
-tempo-alloy.workspace = true
+tempo-alloy = { workspace = true, features = ["reth"] }
 
 [features]
 default = ["cli", "jemalloc", "asm-keccak", "optimism", "js-tracer"]


### PR DESCRIPTION
Uses Tempo’s `reth` feature for Anvil’s `tempo-alloy` dev-dependency. This keeps tests compatible with Tempo `main` while the focused lightweight `revm` feature is reviewed separately.

This supersedes tempoxyz/tempo#6969.

This PR was authored with Codex assistance.

Prompted by: @grandizzy