### PR TITLE
fix(debugger): search split call segments

### DIFF
--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -552,18 +552,23 @@ impl TUIContext<'_> {
     }
 
     fn search_opcode(&mut self, query: &str, direction: SearchDirection) {
-        let Some(step_index) =
-            find_opcode_match(&self.opcode_list, self.current_step, query, direction)
-        else {
+        let Some((node_index, step_index)) = find_opcode_match(
+            self.debug_arena(),
+            self.draw_memory.inner_call_index,
+            self.current_step,
+            query,
+            direction,
+        ) else {
             self.set_error(format!("No opcode matching `{query}` in current call"));
             return;
         };
 
+        self.draw_memory.inner_call_index = node_index;
         self.current_step = step_index;
         self.update_scroll_positions();
 
         let pc = self.current_step().pc;
-        let opcode = self.opcode_list.get(step_index).map(String::as_str).unwrap_or_default();
+        let opcode = pretty_opcode(self.current_step());
         self.set_info(format!("Found `{query}` at PC 0x{pc:x} ({pc}): {opcode}"));
     }
 
@@ -1613,31 +1618,47 @@ fn pc_exists_outside_code_context(arena: &[DebugNode], current: &DebugNode, pc: 
 }
 
 fn find_opcode_match(
-    opcodes: &[String],
+    arena: &[DebugNode],
+    current_node_index: usize,
     current_step: usize,
     query: &str,
     direction: SearchDirection,
-) -> Option<usize> {
-    if opcodes.is_empty() {
-        return None;
-    }
-
+) -> Option<(usize, usize)> {
     let needle = query.trim().to_ascii_lowercase();
     if needle.is_empty() {
         return None;
     }
 
-    let current = current_step.min(opcodes.len() - 1);
-    let matches = |i: usize| opcodes[i].to_ascii_lowercase().contains(&needle);
-
-    match direction {
-        SearchDirection::Forward => {
-            ((current + 1)..opcodes.len()).chain(0..=current).find(|&i| matches(i))
-        }
-        SearchDirection::Backward => {
-            (0..current).rev().chain((current..opcodes.len()).rev()).find(|&i| matches(i))
-        }
-    }
+    let current_node = arena.get(current_node_index)?;
+    let trace_node_idx = current_node.trace_node_idx;
+    let current_absolute_step = current_node.step_offset.saturating_add(current_step);
+    let steps = || {
+        arena.iter().enumerate().filter(|(_, node)| node.trace_node_idx == trace_node_idx).flat_map(
+            |(node_index, node)| {
+                node.steps.iter().enumerate().map(move |(step_index, step)| {
+                    (node_index, step_index, node.step_offset.saturating_add(step_index), step)
+                })
+            },
+        )
+    };
+    let target = match direction {
+        SearchDirection::Forward => steps()
+            .filter(|(_, _, absolute_step, _)| *absolute_step > current_absolute_step)
+            .chain(
+                steps().filter(|(_, _, absolute_step, _)| *absolute_step <= current_absolute_step),
+            )
+            .find(|(_, _, _, step)| pretty_opcode(step).to_ascii_lowercase().contains(&needle)),
+        SearchDirection::Backward => steps()
+            .rev()
+            .filter(|(_, _, absolute_step, _)| *absolute_step < current_absolute_step)
+            .chain(
+                steps()
+                    .rev()
+                    .filter(|(_, _, absolute_step, _)| *absolute_step >= current_absolute_step),
+            )
+            .find(|(_, _, _, step)| pretty_opcode(step).to_ascii_lowercase().contains(&needle)),
+    };
+    target.map(|(node_index, step_index, _, _)| (node_index, step_index))
 }
 
 fn pretty_opcode(step: &CallTraceStep) -> String {
@@ -2790,13 +2811,32 @@ mod tests {
 
     #[test]
     fn opcode_search_wraps_and_is_case_insensitive() {
-        let opcodes =
-            vec!["STOP".to_string(), "PUSH4(0x95d89b41)".to_string(), "MSTORE".to_string()];
+        let arena = vec![DebugNode::new(
+            Address::repeat_byte(1),
+            CallKind::Call,
+            vec![
+                step(1),
+                step_with_immediate(2, OpCode::PUSH4, &[0x95, 0xd8, 0x9b, 0x41]),
+                step_with_stack(3, OpCode::MSTORE, &[]),
+            ],
+            Bytes::new(),
+            0,
+            None,
+        )];
 
-        assert_eq!(find_opcode_match(&opcodes, 0, "push4", SearchDirection::Forward), Some(1));
-        assert_eq!(find_opcode_match(&opcodes, 0, "95D89B41", SearchDirection::Forward), Some(1));
-        assert_eq!(find_opcode_match(&opcodes, 0, "mstore", SearchDirection::Backward), Some(2));
-        assert_eq!(find_opcode_match(&opcodes, 0, "sload", SearchDirection::Forward), None);
+        assert_eq!(
+            find_opcode_match(&arena, 0, 0, "push4", SearchDirection::Forward),
+            Some((0, 1))
+        );
+        assert_eq!(
+            find_opcode_match(&arena, 0, 0, "95D89B41", SearchDirection::Forward),
+            Some((0, 1))
+        );
+        assert_eq!(
+            find_opcode_match(&arena, 0, 0, "mstore", SearchDirection::Backward),
+            Some((0, 2))
+        );
+        assert_eq!(find_opcode_match(&arena, 0, 0, "sload", SearchDirection::Forward), None);
     }
 
     #[test]
@@ -2865,6 +2905,35 @@ mod tests {
 
         let _ = tui.handle_key_event(key(KeyCode::Char('N')));
         assert_eq!(tui.current_step, 2);
+    }
+
+    #[test]
+    fn opcode_search_crosses_split_call_segments() {
+        let address = Address::repeat_byte(1);
+        let node = |address, trace_node_idx, step_offset, steps| {
+            let mut node = DebugNode::new(address, CallKind::Call, steps, Bytes::new(), 0, None);
+            node.trace_node_idx = trace_node_idx;
+            node.step_offset = step_offset;
+            node
+        };
+        let arena = vec![
+            node(address, 0, 0, vec![step_with_stack(1, OpCode::MSTORE, &[]), step(2)]),
+            node(Address::repeat_byte(2), 1, 0, vec![step_with_stack(3, OpCode::MSTORE, &[])]),
+            node(address, 0, 2, vec![step(4), step_with_stack(5, OpCode::MSTORE, &[])]),
+        ];
+
+        assert_eq!(
+            find_opcode_match(&arena, 0, 0, "mstore", SearchDirection::Forward),
+            Some((2, 1))
+        );
+        assert_eq!(
+            find_opcode_match(&arena, 2, 1, "mstore", SearchDirection::Forward),
+            Some((0, 0))
+        );
+        assert_eq!(
+            find_opcode_match(&arena, 0, 0, "mstore", SearchDirection::Backward),
+            Some((2, 1))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Opcode search currently inspects only the active flattened trace segment even though its scope is presented as the current call. Parent calls are split around nested calls, so opcodes before or after a child can be invisible to `/`, `n`, and `N`.

Search now follows the stable trace node ID and absolute step offsets across every segment of the logical call. Forward and backward searches retain their wraparound behavior while skipping opcodes that belong to child calls.

Progresses #927.

This PR was written primarily by Codex under my direction.
