### PR TITLE
fix(forge): install dependencies for lint

### DIFF
--- a/.changelog/forge-lint-dependencies.md
+++ b/.changelog/forge-lint-dependencies.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `forge lint` to install missing Git submodule dependencies before resolving project sources.

--- a/crates/forge/src/args.rs
+++ b/crates/forge/src/args.rs
@@ -130,7 +130,7 @@ pub fn run_command(args: Forge) -> Result<()> {
         ForgeSubcommand::Flatten(cmd) => cmd.run(),
         ForgeSubcommand::Inspect(cmd) => cmd.run(),
         ForgeSubcommand::Tree(cmd) => cmd.run(),
-        ForgeSubcommand::Geiger(cmd) => cmd.run(),
+        ForgeSubcommand::Geiger(cmd) => global.block_on(cmd.run()),
         ForgeSubcommand::Doc(cmd) => {
             if cmd.is_watch() {
                 global.block_on(watch::watch_doc(cmd))
@@ -146,7 +146,7 @@ pub fn run_command(args: Forge) -> Result<()> {
         ForgeSubcommand::Soldeer(cmd) => global.block_on(cmd.run()),
         ForgeSubcommand::Eip712(cmd) => cmd.run(),
         ForgeSubcommand::BindJson(cmd) => cmd.run(),
-        ForgeSubcommand::Lint(cmd) => cmd.run(),
+        ForgeSubcommand::Lint(cmd) => global.block_on(cmd.run()),
     }
 }
 

--- a/crates/forge/src/cmd/geiger.rs
+++ b/crates/forge/src/cmd/geiger.rs
@@ -31,7 +31,7 @@ pub struct GeigerArgs {
 impl_figment_convert!(GeigerArgs, build);
 
 impl GeigerArgs {
-    pub fn run(self) -> Result<()> {
+    pub async fn run(self) -> Result<()> {
         // Deprecated flags warnings
         if self.check {
             sh_warn!("`--check` is deprecated as it's now the default behavior\n")?;
@@ -54,6 +54,6 @@ impl GeigerArgs {
         lint_args.build.deny = Some(DenyLevel::Notes);
 
         // Run the lint command with the geiger-specific configuration
-        lint_args.run()
+        lint_args.run().await
     }
 }

--- a/crates/forge/src/cmd/lint.rs
+++ b/crates/forge/src/cmd/lint.rs
@@ -1,3 +1,4 @@
+use super::install;
 use clap::{Parser, ValueHint};
 use eyre::{Result, eyre};
 use forge_lint::{
@@ -38,9 +39,16 @@ pub struct LintArgs {
 foundry_config::impl_figment_convert!(LintArgs, build);
 
 impl LintArgs {
-    pub fn run(self) -> Result<()> {
+    pub async fn run(self) -> Result<()> {
         let format_json = shell::is_json();
-        let config = self.load_config()?;
+        let mut config = self.load_config()?;
+
+        if install::install_missing_dependencies(&mut config).await && config.auto_detect_remappings
+        {
+            // Need to re-configure here to also catch additional remappings.
+            config = self.load_config()?;
+        }
+
         let project = config.ephemeral_project()?;
         let path_config = config.project_paths();
 

--- a/crates/forge/tests/cli/install.rs
+++ b/crates/forge/tests/cli/install.rs
@@ -93,6 +93,26 @@ Missing dependencies found. Installing now...
     assert_eq!(forge_std.rev(), FORGE_STD_REVISION);
 });
 
+// Checks missing dependencies are auto installed.
+forgetest_init!(can_install_missing_deps_lint, |prj, cmd| {
+    prj.initialize_default_contracts();
+    prj.clear();
+
+    // Wipe forge-std.
+    let forge_std_dir = prj.root().join("lib/forge-std");
+    pretty_err(&forge_std_dir, fs::remove_dir_all(&forge_std_dir));
+
+    cmd.arg("lint").assert_success().stdout_eq(str![""]).stderr_eq(str![[r#"
+Missing dependencies found. Installing now...
+[UPDATING_DEPENDENCIES]
+...
+"#]]);
+
+    // Assert lockfile.
+    let forge_std = lockfile_get(prj.root(), &PathBuf::from("lib/forge-std")).unwrap();
+    assert_eq!(forge_std.rev(), FORGE_STD_REVISION);
+});
+
 // test to check that install/remove works properly
 forgetest!(can_install_and_remove, |prj, cmd| {
     cmd.git_init();


### PR DESCRIPTION
Installs missing Git-submodule dependencies before `forge lint` resolves project sources, matching existing Forge command behavior. Configuration is reloaded after installation so auto-detected remappings include restored dependencies, with the same behavior preserved for the `geiger` alias.

Follow-up to #15913.