### PR TITLE
fix(fuzz): keep persistent values across revert

### DIFF
--- a/.changelog/persistent-value-revert.md
+++ b/.changelog/persistent-value-revert.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed persistent trace-cmp values in the fuzz dictionary being dropped when state values are reverted between invariant runs.

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -622,8 +622,24 @@ impl FuzzDictionary {
         if self.persistent_values.len() >= MAX_PERSISTENT_VALUES {
             return;
         }
-        if self.persistent_values.insert(value) && self.state_values.insert(value) {
-            self.db_state_values += 1;
+        if !self.persistent_values.insert(value) {
+            return;
+        }
+        // `revert()` truncates `state_values` down to the first `db_state_values` entries, so the
+        // value must be placed inside that prefix; a plain `insert` appends past it and would be
+        // truncated at the end of the run.
+        match self.state_values.get_index_of(&value) {
+            // Already inside the persisted prefix.
+            Some(index) if index < self.db_state_values => {}
+            // Collected as an ephemeral value earlier in this run: move it into the prefix.
+            Some(index) => {
+                self.state_values.move_index(index, self.db_state_values);
+                self.db_state_values += 1;
+            }
+            None => {
+                self.state_values.shift_insert(self.db_state_values, value);
+                self.db_state_values += 1;
+            }
         }
     }
 
@@ -928,6 +944,48 @@ mod tests {
         dictionary.insert_push_bytes_values(&Address::repeat_byte(0x22), &account);
         assert_eq!(dictionary.push_bytecode_hashes.len(), 1);
         assert!(dictionary.state_values.contains(&B256::from(U256::from(1))));
+    }
+
+    #[test]
+    fn persistent_value_survives_revert() {
+        let mut dictionary = FuzzDictionary::default();
+        dictionary.db_state_values = dictionary.state_values.len();
+
+        let ephemeral = B256::from(U256::from(0xbeef_u64));
+        let persistent = B256::from(U256::from(0xcafe_u64));
+        dictionary.insert_value(ephemeral);
+        dictionary.insert_persistent_value(persistent);
+
+        dictionary.revert();
+
+        assert!(dictionary.state_values.contains(&persistent));
+        assert!(!dictionary.state_values.contains(&ephemeral));
+        assert!(dictionary.db_state_values <= dictionary.state_values.len());
+
+        // Values already inside the persisted prefix are left untouched.
+        let watermark = dictionary.db_state_values;
+        let len = dictionary.state_values.len();
+        dictionary.insert_persistent_value(B256::ZERO);
+        assert_eq!(dictionary.db_state_values, watermark);
+        assert_eq!(dictionary.state_values.len(), len);
+    }
+
+    #[test]
+    fn persistent_value_promotes_existing_ephemeral() {
+        let mut dictionary = FuzzDictionary::default();
+        dictionary.db_state_values = dictionary.state_values.len();
+
+        let ephemeral = B256::from(U256::from(0xbeef_u64));
+        let value = B256::from(U256::from(0xdead_u64));
+        dictionary.insert_value(ephemeral);
+        dictionary.insert_value(value);
+        dictionary.insert_persistent_value(value);
+
+        dictionary.revert();
+
+        assert!(dictionary.state_values.contains(&value));
+        assert!(!dictionary.state_values.contains(&ephemeral));
+        assert!(dictionary.db_state_values <= dictionary.state_values.len());
     }
 
     #[test]


### PR DESCRIPTION
`FuzzDictionary::insert_persistent_value` appended the trace-cmp value to `state_values` and bumped the `db_state_values` watermark. Since `IndexSet::insert` appends past the watermark, the bump extended the prefix preserved by `revert()` over the oldest ephemeral value collected earlier in the run rather than over the appended value. Whenever any ephemeral value existed, the persistent value was truncated away at the end of the run and could never be re-added because `persistent_values` already contained it, while one arbitrary ephemeral value was retained forever in its place.

The value is now placed directly at the watermark index with `shift_insert`, and a value that was already collected as an ephemeral earlier in the same run is moved into the persisted prefix with `move_index`; that second case previously lost the value the same way. Values already inside the prefix are left untouched, which also avoids `shift_insert`'s move semantics ejecting an already-protected value from the prefix. The shifting cost is proportional to the ephemeral tail and bounded overall by the `MAX_PERSISTENT_VALUES` cap, since only never-seen values reach it.

This PR was written by Claude Code.