### PR TITLE
test: cover dump state ordering

### DIFF
--- a/testdata/default/cheats/ExecuteTransaction.t.sol
+++ b/testdata/default/cheats/ExecuteTransaction.t.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.18;
 
 import "utils/Test.sol";
 
+contract ExecuteTransactionDeployment {}
+
 contract ExecuteTransactionTest is Test {
     function test_revert_not_a_tx() public {
         vm._expectCheatcodeRevert("failed to decode RLP-encoded transaction: unexpected string");
@@ -60,6 +62,34 @@ contract ExecuteTransactionTest is Test {
         // Gas price is set to 0 in isolated execution, so no gas cost deducted.
         assertEq(from.balance, balance - amountSent);
         assertEq(to.balance, amountSent);
+    }
+
+    function test_execute_create_preserves_dump_state_order() public {
+        string memory path =
+            string.concat(vm.projectRoot(), "/fixtures/Json/test_execute_transaction_deployment_order.json");
+        address sender = 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf;
+        address transactionDeployment = vm.computeCreateAddress(sender, 0);
+
+        vm.chainId(1);
+        vm.deal(sender, 1 ether);
+
+        // Legacy signed contract-creation transaction from `sender` at nonce 0. The initcode
+        // deploys a contract with a single STOP opcode as its runtime code.
+        vm.executeTransaction(
+            hex"f8598001830186a080808d6001600c60003960016000f30026a057de88a4ac083e50d0c51c31cb45549ef390e5a0892fbd86583f4597a2307b66a06390a6a450e856491037610ec440d234503d19379b20c202c74be55de9ff3518"
+        );
+        ExecuteTransactionDeployment later = new ExecuteTransactionDeployment();
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 transactionIndex =
+            vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(transactionDeployment)), '"'));
+        uint256 laterIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(later))), '"'));
+        assertTrue(transactionIndex != type(uint256).max);
+        assertTrue(laterIndex != type(uint256).max);
+        assertLt(transactionIndex, laterIndex);
+
+        vm.removeFile(path);
     }
 
     function test_execute_erc20_transfer() public {

--- a/testdata/default/cheats/dumpState.t.sol
+++ b/testdata/default/cheats/dumpState.t.sol
@@ -3,6 +3,16 @@ pragma solidity ^0.8.18;
 
 import "utils/Test.sol";
 
+contract ConstructorDeploymentChild {}
+
+contract ConstructorDeploymentParent {
+    ConstructorDeploymentChild public child;
+
+    constructor() {
+        child = new ConstructorDeploymentChild();
+    }
+}
+
 contract SimpleContract {
     constructor() {
         assembly {
@@ -117,6 +127,40 @@ contract DumpStateTest is Test {
         assertEq(0, vm.parseJsonUint(json, string.concat(".", vm.toString(address(0x400)), ".balance")));
         assertEq(hex"af", vm.parseJsonBytes(json, string.concat(".", vm.toString(address(0x400)), ".code")));
         assertEq(0, vm.parseJsonKeys(json, string.concat(".", vm.toString(address(0x400)), ".storage")).length);
+
+        vm.removeFile(path);
+    }
+
+    function testDumpStateOrderingContract() public {
+        string memory path = string.concat(vm.projectRoot(), "/fixtures/Json/test_dump_state_ordering_contract.json");
+
+        vm.setNonce(address(0x300), 1);
+        ConstructorDeploymentParent parent = new ConstructorDeploymentParent();
+        vm.setNonce(address(0x100), 1);
+        SimpleContract later = new SimpleContract();
+        vm.setNonce(address(0x200), 1);
+        vm.dumpState(path);
+
+        string memory json = vm.readFile(path);
+        uint256 parentIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(parent))), '"'));
+        uint256 childIndex =
+            vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(parent.child()))), '"'));
+        uint256 laterIndex = vm.indexOf(json, string.concat('"', vm.toLowercase(vm.toString(address(later))), '"'));
+        uint256 lowIndex = vm.indexOf(json, '"0x0000000000000000000000000000000000000100"');
+        uint256 middleIndex = vm.indexOf(json, '"0x0000000000000000000000000000000000000200"');
+        uint256 highIndex = vm.indexOf(json, '"0x0000000000000000000000000000000000000300"');
+
+        assertTrue(parentIndex != type(uint256).max);
+        assertTrue(childIndex != type(uint256).max);
+        assertTrue(laterIndex != type(uint256).max);
+        assertTrue(lowIndex != type(uint256).max);
+        assertTrue(middleIndex != type(uint256).max);
+        assertTrue(highIndex != type(uint256).max);
+        assertLt(parentIndex, childIndex);
+        assertLt(childIndex, laterIndex);
+        assertLt(laterIndex, lowIndex);
+        assertLt(lowIndex, middleIndex);
+        assertLt(middleIndex, highIndex);
 
         vm.removeFile(path);
     }


### PR DESCRIPTION
Adds regression coverage for dumpState’s complete ordering contract and contract creation through executeTransaction. This verifies that created accounts remain in deployment order while non-created accounts stay address-sorted.