### PR TITLE
fix(cast): honor sync for Tempo access keys

### DIFF
--- a/.changelog/tempo-access-key-sync.md
+++ b/.changelog/tempo-access-key-sync.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Honor `--sync` when sending transactions with Tempo Accounts access keys.

--- a/crates/cast/src/cmd/batch_send.rs
+++ b/crates/cast/src/cmd/batch_send.rs
@@ -162,6 +162,7 @@ impl BatchSendArgs {
                     Some(chain),
                     None,
                     send_tx.cast_async,
+                    send_tx.sync,
                     send_tx.confirmations,
                     timeout,
                     !config.eth_rpc_curl,

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -481,6 +481,7 @@ impl Erc20Subcommand {
                             &prepared_access_key,
                             sponsor_url,
                             $send_tx.cast_async,
+                            $send_tx.sync,
                             $send_tx.confirmations,
                             timeout,
                         )
@@ -493,6 +494,7 @@ impl Erc20Subcommand {
                             tempo_sponsor.is_none().then_some(chain),
                             None,
                             $send_tx.cast_async,
+                            $send_tx.sync,
                             $send_tx.confirmations,
                             timeout,
                             tempo_sponsor.is_none() && !config.eth_rpc_curl,

--- a/crates/cast/src/cmd/send.rs
+++ b/crates/cast/src/cmd/send.rs
@@ -418,6 +418,7 @@ impl SendTxArgs {
                     &prepared,
                     sponsor_url,
                     send_tx.cast_async,
+                    send_tx.sync,
                     send_tx.confirmations,
                     timeout,
                 )
@@ -430,6 +431,7 @@ impl SendTxArgs {
                     tempo_sponsor.is_none().then_some(chain),
                     None,
                     send_tx.cast_async,
+                    send_tx.sync,
                     send_tx.confirmations,
                     timeout,
                     tempo_sponsor.is_none() && !config.eth_rpc_curl,
@@ -569,7 +571,26 @@ where
     }
 }
 
-/// Signs a prepared transaction with a Tempo wallet and sends it via `send_raw_transaction`.
+/// Sends a raw transaction using the RPC method selected by `sync`.
+pub(crate) async fn cast_send_raw<N: Network, P: Provider<N>>(
+    provider: &P,
+    raw_tx: &[u8],
+    sync: bool,
+) -> Result<(B256, Option<String>)>
+where
+    N::TransactionRequest: FoundryTransactionBuilder<N>,
+    N::ReceiptResponse: UIfmt + UIfmtReceiptExt,
+{
+    if sync {
+        let (tx_hash, receipt) = CastTxSender::new(provider).send_raw_sync(raw_tx).await?;
+        Ok((tx_hash, Some(receipt)))
+    } else {
+        let tx_hash = *provider.send_raw_transaction(raw_tx).await?.tx_hash();
+        Ok((tx_hash, None))
+    }
+}
+
+/// Signs a prepared transaction with a Tempo wallet and sends it as a raw transaction.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn cast_send_with_tempo_wallet<N: Network, P: Provider<N>>(
     provider: &P,
@@ -578,6 +599,7 @@ pub(crate) async fn cast_send_with_tempo_wallet<N: Network, P: Provider<N>>(
     chain: Option<Chain>,
     fee_payer: Option<Address>,
     cast_async: bool,
+    sync: bool,
     confirmations: u64,
     timeout: u64,
     resolve_unknown_fee_token_symbol: bool,
@@ -595,21 +617,27 @@ where
     .await?;
     maybe_print_fee_token(resolve_unknown_fee_token_symbol.then_some(provider), fee_token).await?;
     let raw_tx = tx.sign_with_tempo_wallet(wallet).await?;
-    let tx_hash = *provider.send_raw_transaction(&raw_tx).await?.tx_hash();
-    CastTxSender::new(provider)
-        .print_tx_result(tx_hash, cast_async, confirmations, timeout)
-        .await?;
+    let cast = CastTxSender::new(provider);
+    let (tx_hash, receipt) = cast_send_raw(provider, &raw_tx, sync).await?;
+
+    if let Some(receipt) = receipt {
+        sh_println!("{receipt}")?;
+    } else {
+        cast.print_tx_result(tx_hash, cast_async, confirmations, timeout).await?;
+    }
     Ok(tx_hash)
 }
 
 /// Signs a prepared transaction with a Tempo wallet, obtains a remote fee-payer signature, and
 /// broadcasts the sponsored transaction through the original provider transport.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn cast_send_with_tempo_wallet_via_sponsor<N: Network, P: Provider<N>>(
     provider: &P,
     mut tx: N::TransactionRequest,
     wallet: &TempoAccountsWallet,
     sponsor_url: &str,
     cast_async: bool,
+    sync: bool,
     confirmations: u64,
     timeout: u64,
 ) -> Result<B256>
@@ -628,6 +656,7 @@ where
         None,
         None,
         cast_async,
+        sync,
         confirmations,
         timeout,
         false,
@@ -664,6 +693,41 @@ pub(crate) fn validate_sponsor_url(raw: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_json_rpc::{RequestPacket, ResponsePacket};
+    use alloy_provider::mock::Asserter;
+    use alloy_rpc_client::RpcClient;
+    use alloy_rpc_types::TransactionRequest;
+    use alloy_transport::{TransportError, TransportFut, mock::MockTransport};
+    use foundry_wallets::utils::create_local_signer;
+    use std::{
+        sync::{Arc, Mutex},
+        task::{Context, Poll},
+    };
+    use tempo_alloy::rpc::TempoTransactionRequest;
+    use tower::Service;
+
+    #[derive(Clone)]
+    struct RecordingTransport {
+        inner: MockTransport,
+        methods: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl Service<RequestPacket> for RecordingTransport {
+        type Response = ResponsePacket;
+        type Error = TransportError;
+        type Future = TransportFut<'static>;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        fn call(&mut self, req: RequestPacket) -> Self::Future {
+            if let RequestPacket::Single(req) = &req {
+                self.methods.lock().unwrap().push(req.method().to_string());
+            }
+            self.inner.call(req)
+        }
+    }
 
     #[test]
     fn test_validate_sponsor_url() {
@@ -678,5 +742,62 @@ mod tests {
         // bypass attempts that fooled the old starts_with check
         assert!(validate_sponsor_url("http://localhost.evil.com").is_err());
         assert!(validate_sponsor_url("http://127.0.0.1.evil.com").is_err());
+    }
+
+    #[tokio::test]
+    async fn tempo_wallet_sync_send_uses_sync_rpc_method() {
+        let asserter = Asserter::new();
+        let tx_hash = B256::repeat_byte(0x11);
+        asserter.push_success(&serde_json::json!({
+            "type": "0x76",
+            "status": "0x1",
+            "cumulativeGasUsed": "0x5208",
+            "logs": [],
+            "logsBloom": format!("0x{}", "00".repeat(256)),
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x0",
+            "blockHash": B256::repeat_byte(0x22),
+            "blockNumber": "0x1",
+            "gasUsed": "0x5208",
+            "effectiveGasPrice": "0x1",
+            "from": Address::ZERO,
+            "to": Address::ZERO,
+            "contractAddress": null,
+            "feeToken": Address::repeat_byte(0x55),
+            "feePayer": Address::ZERO,
+        }));
+        let methods = Arc::new(Mutex::new(Vec::new()));
+        let transport =
+            RecordingTransport { inner: MockTransport::new(asserter), methods: methods.clone() };
+        let provider = AlloyProviderBuilder::new_with_network::<TempoNetwork>()
+            .connect_client(RpcClient::new(transport, true));
+        let root = Address::repeat_byte(0x33);
+        let access_key = create_local_signer(
+            "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+        )
+        .unwrap();
+        let wallet =
+            TempoAccountsWallet::from_secp256k1(root, access_key, None).with_chain_id(4217);
+        let tx = TempoTransactionRequest {
+            inner: TransactionRequest {
+                to: Some(Address::repeat_byte(0x44).into()),
+                nonce: Some(0),
+                gas: Some(100_000),
+                max_fee_per_gas: Some(1),
+                max_priority_fee_per_gas: Some(1),
+                chain_id: Some(4217),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let actual_hash = cast_send_with_tempo_wallet(
+            &provider, tx, &wallet, None, None, false, true, 1, 1, false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(actual_hash, tx_hash);
+        assert_eq!(methods.lock().unwrap().as_slice(), ["eth_sendRawTransactionSync"]);
     }
 }

--- a/crates/cast/src/cmd/tip20/mine.rs
+++ b/crates/cast/src/cmd/tip20/mine.rs
@@ -132,6 +132,7 @@ pub(super) async fn register(
             Some(chain),
             None,
             send_tx.cast_async,
+            send_tx.sync,
             send_tx.confirmations,
             timeout,
             !config.eth_rpc_curl,

--- a/crates/cast/src/cmd/tip20/mod.rs
+++ b/crates/cast/src/cmd/tip20/mod.rs
@@ -326,6 +326,7 @@ pub(crate) async fn send_tip20_transaction(
                 &prepared,
                 sponsor_url,
                 send_tx.cast_async,
+                send_tx.sync,
                 send_tx.confirmations,
                 timeout,
             )
@@ -338,6 +339,7 @@ pub(crate) async fn send_tip20_transaction(
                 tempo_sponsor.is_none().then_some(chain),
                 None,
                 send_tx.cast_async,
+                send_tx.sync,
                 send_tx.confirmations,
                 timeout,
                 tempo_sponsor.is_none() && !config.eth_rpc_curl,

--- a/crates/cast/src/cmd/vaddr/create.rs
+++ b/crates/cast/src/cmd/vaddr/create.rs
@@ -1,7 +1,7 @@
 use crate::{
     cmd::{
         erc20::build_provider_with_signer,
-        send::{cast_send, cast_send_with_tempo_wallet},
+        send::{cast_send, cast_send_raw, cast_send_with_tempo_wallet},
         tip20::mine,
     },
     tempo,
@@ -210,15 +210,17 @@ async fn register(
             .await?;
             maybe_print_fee_token((!config.eth_rpc_curl).then_some(&provider), fee_token).await?;
             let raw_tx = tx.sign_with_tempo_wallet(&prepared).await?;
-            let tx_hash = *provider.send_raw_transaction(&raw_tx).await?.tx_hash();
-            wait_for_receipt_if_needed(
-                &provider,
-                tx_hash,
-                send_tx.cast_async,
-                send_tx.confirmations,
-                timeout,
-            )
-            .await?;
+            let (tx_hash, _) = cast_send_raw(&provider, &raw_tx, send_tx.sync).await?;
+            if !send_tx.sync {
+                wait_for_receipt_if_needed(
+                    &provider,
+                    tx_hash,
+                    send_tx.cast_async,
+                    send_tx.confirmations,
+                    timeout,
+                )
+                .await?;
+            }
             Ok(tx_hash)
         } else {
             cast_send_with_tempo_wallet(
@@ -228,6 +230,7 @@ async fn register(
                 Some(chain),
                 None,
                 send_tx.cast_async,
+                send_tx.sync,
                 send_tx.confirmations,
                 timeout,
                 !config.eth_rpc_curl,

--- a/crates/cast/src/tx.rs
+++ b/crates/cast/src/tx.rs
@@ -35,7 +35,8 @@ pub struct SendTxOpts {
     pub cast_async: bool,
 
     /// Wait for transaction receipt synchronously instead of polling.
-    /// Note: uses `eth_sendTransactionSync` which may not be supported by all clients.
+    /// Note: uses `eth_sendTransactionSync` or `eth_sendRawTransactionSync`, which may not be
+    /// supported by all clients.
     #[arg(long, conflicts_with = "async")]
     pub sync: bool,
 
@@ -291,6 +292,19 @@ where
     pub async fn send_raw(&self, raw_tx: &[u8]) -> Result<PendingTransactionBuilder<N>> {
         let res = self.provider.send_raw_transaction(raw_tx).await?;
         Ok(res)
+    }
+
+    /// Sends a raw RLP-encoded transaction and waits for its receipt synchronously.
+    pub async fn send_raw_sync(&self, raw_tx: &[u8]) -> Result<(B256, String)> {
+        let mut receipt = TransactionReceiptWithRevertReason::<N> {
+            receipt: self.provider.send_raw_transaction_sync(raw_tx).await?,
+            revert_reason: None,
+        };
+        let tx_hash = receipt.receipt.transaction_hash();
+        // Allow this to fail silently.
+        let _ = receipt.update_revert_reason(&self.provider).await;
+
+        self.format_receipt(receipt, None).map(|formatted| (tx_hash, formatted))
     }
 
     /// Prints the transaction hash (if async) or waits for the receipt and prints it.

--- a/crates/cast/tests/cli/keychain.rs
+++ b/crates/cast/tests/cli/keychain.rs
@@ -738,7 +738,7 @@ casttest!(send_uses_access_key_from_accounts_store, async |_prj, cmd| {
     assert_eq!(receipt["status"], "0x1", "unexpected receipt: {output}");
 });
 
-casttest!(send_with_accounts_store_and_remote_sponsor_succeeds, async |_prj, cmd| {
+casttest!(send_with_accounts_store_and_remote_sponsor_sync_succeeds, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let path_usd = path_usd();
@@ -774,6 +774,7 @@ casttest!(send_with_accounts_store_and_remote_sponsor_succeeds, async |_prj, cmd
             &rpc,
             "--sponsor-url",
             &sponsor_url,
+            "--sync",
             "--json",
         ])
         .assert_success()
@@ -1717,7 +1718,7 @@ casttest!(batch_mktx_raw_unsigned_resolves_tempo_access_key_metadata, async |_pr
     );
 });
 
-casttest!(vaddr_create_uses_tempo_session_id_env, async |_prj, cmd| {
+casttest!(vaddr_create_sync_json_uses_tempo_session_id_env, async |_prj, cmd| {
     let (_, handle) = anvil::spawn(NodeConfig::test_tempo()).await;
     let rpc = handle.http_endpoint();
     let tempo_home = tempfile::tempdir().unwrap();
@@ -1738,7 +1739,7 @@ casttest!(vaddr_create_uses_tempo_session_id_env, async |_prj, cmd| {
             PRECOMPUTED_VADDR_SALT_FOR_ADDR1,
             "--rpc-url",
             &rpc,
-            "--async",
+            "--sync",
         ])
         .assert_success()
         .get_output()


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/foundry-rs/foundry/pull/15920#discussion_r3661811521, this ensures `--sync` is honored when Cast signs Tempo transactions with an Accounts access key. Sponsored and unsponsored access-key paths now forward the send mode and use `eth_sendRawTransactionSync` instead of silently falling back to `eth_sendRawTransaction` followed by receipt polling.

Raw transaction submission now shares one sync-aware path across cast send, ERC-20, TIP-20, batch sends, and virtual-address registration. This also fixes `cast vaddr create --sync --json`, which previously changed submission behavior in JSON mode while still preserving its single composite JSON response.
