### PR TITLE
perf(forge): speed up path-filtered coverage

### DIFF
--- a/.changelog/forge-path-filtered-coverage.md
+++ b/.changelog/forge-path-filtered-coverage.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Sped up path-filtered coverage by compiling only matching test roots.

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -1,6 +1,6 @@
 use super::{
     install,
-    test::{ProjectPathsAwareFilter, TestArgs, TestExecutionOptions, sources_for_test_filter},
+    test::{ProjectPathsAwareFilter, TestArgs, TestExecutionOptions},
     watch::WatchArgs,
 };
 use crate::coverage::{
@@ -13,8 +13,8 @@ use crate::coverage::{
 use alloy_primitives::{Address, Bytes, U256, map::HashMap};
 use clap::{Parser, ValueHint};
 use eyre::Result;
-use foundry_cli::utils::{LoadConfig, STATIC_FUZZ_SEED};
-use foundry_common::{compile::ProjectCompiler, errors::convert_solar_errors};
+use foundry_cli::utils::{FoundryPathExt, LoadConfig, STATIC_FUZZ_SEED};
+use foundry_common::{TestFilter, compile::ProjectCompiler, errors::convert_solar_errors};
 use foundry_compilers::{
     Artifact, ArtifactId, Project, ProjectCompileOutput, ProjectPathsConfig, VYPER_EXTENSIONS,
     artifacts::{CompactBytecode, CompactDeployedBytecode, sourcemap::SourceMap},
@@ -29,6 +29,7 @@ use globset::{Glob, GlobSetBuilder};
 use rayon::prelude::*;
 use semver::Version;
 use std::{
+    collections::BTreeSet,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -264,10 +265,16 @@ impl CoverageArgs {
 
         let mut compiler = ProjectCompiler::new().dynamic_test_linking(config.dynamic_test_linking);
         if filter.args().path_pattern.is_some() || filter.args().path_pattern_inverse.is_some() {
-            let mut sources = sources_for_test_filter(config, filter);
-            // Coverage reports include scripts even though they are not test targets.
-            sources
-                .extend(source_files_iter(&config.script, MultiCompilerLanguage::FILE_EXTENSIONS));
+            let sources = source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
+                .chain(
+                    source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS)
+                        // Preserve path-filter behavior for conventional test files while still
+                        // scanning non-test fixtures under the test root.
+                        .filter(|path| !path.is_sol_test() || filter.matches_path(path)),
+                )
+                // Coverage reports include scripts even though they are not test targets.
+                .chain(source_files_iter(&config.script, MultiCompilerLanguage::FILE_EXTENSIONS))
+                .collect::<BTreeSet<_>>();
             compiler = compiler.files(sources);
         }
         let output = compiler.compile(&project)?.with_stripped_file_prefixes(project.root());

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -1,6 +1,6 @@
 use super::{
     install,
-    test::{TestArgs, TestExecutionOptions},
+    test::{ProjectPathsAwareFilter, TestArgs, TestExecutionOptions, sources_for_test_filter},
     watch::WatchArgs,
 };
 use crate::coverage::{
@@ -18,6 +18,8 @@ use foundry_common::{compile::ProjectCompiler, errors::convert_solar_errors};
 use foundry_compilers::{
     Artifact, ArtifactId, Project, ProjectCompileOutput, ProjectPathsConfig, VYPER_EXTENSIONS,
     artifacts::{CompactBytecode, CompactDeployedBytecode, sourcemap::SourceMap},
+    compilers::{Language, multi::MultiCompilerLanguage},
+    utils::source_files_iter,
 };
 use foundry_config::{
     Config, CoverageConfig, CoverageReportKind, InlineConfig, parse_lcov_version,
@@ -157,9 +159,10 @@ impl CoverageArgs {
         // Merge CLI args with `[profile.<name>.coverage]` config values. CLI
         // flags take precedence; unset CLI flags fall back to the config.
         self.resolve_with(&config.coverage);
+        let filter = self.test.filter(&config)?;
 
         let (paths, mut output) = {
-            let (project, output) = self.build(&config)?;
+            let (project, output) = self.build(&config, &filter)?;
             (project.paths, output)
         };
 
@@ -176,7 +179,7 @@ impl CoverageArgs {
         let report = self.prepare(&paths, &mut output)?;
 
         sh_println!("Running tests...")?;
-        self.collect(&paths.root, &output, report, config, evm_opts).await
+        self.collect(&paths.root, &output, report, config, evm_opts, filter).await
     }
 
     /// Merge `[profile.<name>.coverage]` config values into this struct. CLI
@@ -233,7 +236,11 @@ impl CoverageArgs {
     }
 
     /// Builds the project.
-    fn build(&self, config: &Config) -> Result<(Project, ProjectCompileOutput)> {
+    fn build(
+        &self,
+        config: &Config,
+        filter: &ProjectPathsAwareFilter,
+    ) -> Result<(Project, ProjectCompileOutput)> {
         let mut project = config.ephemeral_project()?;
 
         if self.ir_minimum {
@@ -255,10 +262,15 @@ impl CoverageArgs {
 
         config.disable_optimizations(&mut project, self.ir_minimum);
 
-        let output = ProjectCompiler::new()
-            .dynamic_test_linking(config.dynamic_test_linking)
-            .compile(&project)?
-            .with_stripped_file_prefixes(project.root());
+        let mut compiler = ProjectCompiler::new().dynamic_test_linking(config.dynamic_test_linking);
+        if filter.args().path_pattern.is_some() || filter.args().path_pattern_inverse.is_some() {
+            let mut sources = sources_for_test_filter(config, filter);
+            // Coverage reports include scripts even though they are not test targets.
+            sources
+                .extend(source_files_iter(&config.script, MultiCompilerLanguage::FILE_EXTENSIONS));
+            compiler = compiler.files(sources);
+        }
+        let output = compiler.compile(&project)?.with_stripped_file_prefixes(project.root());
 
         Ok((project, output))
     }
@@ -353,8 +365,8 @@ impl CoverageArgs {
         mut report: CoverageReport,
         config: Config,
         evm_opts: EvmOpts,
+        filter: ProjectPathsAwareFilter,
     ) -> Result<()> {
-        let filter = self.test.filter(&config)?;
         let inline_config = Arc::new(InlineConfig::new_parsed(output, &config)?);
         let outcome = self
             .test

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -378,20 +378,6 @@ struct CompiledTestProject {
     selected_sources: BTreeSet<PathBuf>,
 }
 
-pub(super) fn sources_for_test_filter(
-    config: &Config,
-    test_filter: &ProjectPathsAwareFilter,
-) -> BTreeSet<PathBuf> {
-    source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
-        .chain(
-            source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS)
-                // Preserve path-filter behavior for conventional test files while still
-                // scanning non-test fixtures under the test root.
-                .filter(|path| !path.is_sol_test() || test_filter.matches_path(path)),
-        )
-        .collect()
-}
-
 fn sources_to_compile_from_artifacts(
     config: &Config,
     test_filter: &ProjectPathsAwareFilter,
@@ -1567,7 +1553,14 @@ impl TestArgs {
         }
 
         let mut project = config.create_project(true, true)?;
-        let sources = sources_for_test_filter(config, test_filter);
+        let sources = source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
+            .chain(
+                source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS)
+                    // Preserve path-filter behavior for conventional test files while still
+                    // scanning non-test fixtures under the test root.
+                    .filter(|path| !path.is_sol_test() || test_filter.matches_path(path)),
+            )
+            .collect::<BTreeSet<_>>();
         let output = compile_abi_project(
             &mut project,
             ProjectCompiler::new()

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -378,6 +378,20 @@ struct CompiledTestProject {
     selected_sources: BTreeSet<PathBuf>,
 }
 
+pub(super) fn sources_for_test_filter(
+    config: &Config,
+    test_filter: &ProjectPathsAwareFilter,
+) -> BTreeSet<PathBuf> {
+    source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
+        .chain(
+            source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS)
+                // Preserve path-filter behavior for conventional test files while still
+                // scanning non-test fixtures under the test root.
+                .filter(|path| !path.is_sol_test() || test_filter.matches_path(path)),
+        )
+        .collect()
+}
+
 fn sources_to_compile_from_artifacts(
     config: &Config,
     test_filter: &ProjectPathsAwareFilter,
@@ -1553,14 +1567,7 @@ impl TestArgs {
         }
 
         let mut project = config.create_project(true, true)?;
-        let sources = source_files_iter(&config.src, MultiCompilerLanguage::FILE_EXTENSIONS)
-            .chain(
-                source_files_iter(&config.test, MultiCompilerLanguage::FILE_EXTENSIONS)
-                    // Preserve path-filter behavior for conventional test files while still
-                    // scanning non-test fixtures under the test root.
-                    .filter(|path| !path.is_sol_test() || test_filter.matches_path(path)),
-            )
-            .collect::<BTreeSet<_>>();
+        let sources = sources_for_test_filter(config, test_filter);
         let output = compile_abi_project(
             &mut project,
             ProjectCompiler::new()

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -2909,6 +2909,72 @@ contract Broken {
     }
 });
 
+forgetest_init!(coverage_match_path_compiles_selected_tests, |prj, cmd| {
+    prj.add_test(
+        "Shared.t.sol",
+        r#"
+abstract contract SharedTest {
+    function sharedValue() internal pure returns (uint256) {
+        return 1;
+    }
+}
+"#,
+    );
+    prj.add_test(
+        "Selected.t.sol",
+        r#"
+import {SharedTest} from "./Shared.t.sol";
+
+contract SelectedTest is SharedTest {
+    function testSelected() public pure {
+        require(sharedValue() == 1);
+    }
+}
+"#,
+    );
+    prj.add_test(
+        "Broken.t.sol",
+        r#"
+contract BrokenTest {
+    function broken() public pure returns (uint256) {
+        return;
+    }
+}
+"#,
+    );
+    prj.add_test(
+        "Unselected.t.sol",
+        r#"
+contract UnselectedTest {
+    function testUnselected() public {}
+}
+"#,
+    );
+    prj.add_script(
+        "Report.s.sol",
+        r#"
+contract ReportScript {
+    function run() public {}
+}
+"#,
+    );
+
+    let output = cmd
+        .args(["coverage", "--match-path", "test/Selected.t.sol"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    assert!(output.contains("testSelected()"), "selected test did not run:\n{output}");
+    assert!(
+        output.contains("script/Report.s.sol"),
+        "scripts should remain in path-filtered coverage reports:\n{output}"
+    );
+    assert!(
+        !output.contains("test/Unselected.t.sol"),
+        "unselected tests should be omitted from coverage reports:\n{output}"
+    );
+});
+
 #[test]
 fn coverage_help_renders_notes() {
     let help = CoverageArgs::command().render_long_help().to_string();


### PR DESCRIPTION
Path-filtered `forge coverage` now compiles only conventional `.t.sol` roots selected by `--match-path` or `--no-match-path`, while retaining all project sources, scripts, non-test fixtures, and transitive imports. This avoids code generation for tests that cannot execute under the filter and intentionally omits unmatched test roots from the report; the regression covers an imported unmatched helper, an invalid unrelated test, omission of an unselected valid test, and script reporting. Developed with OpenAI Codex assistance.

### Results

Profiling builds from exact master `c3285d584` on Solady `5dc5fc8`, using an identical controlled 20-test source set, `forge clean` before every sample, and 10 runs after one warmup:

| Version | Time (mean ± σ) | Range | Speedup |
| --- | ---: | ---: | ---: |
| master | 1.833s ± 0.036s | 1.768–1.877s | — |
| this PR | 1.127s ± 0.014s | 1.096–1.141s | 1.63× |
