### PR TITLE
fix(tempo): lock Accounts store mutations

### DIFF
--- a/.changelog/tempo-accounts-store-lock.md
+++ b/.changelog/tempo-accounts-store-lock.md
@@ -1,0 +1,6 @@
+---
+cast: patch
+foundry-common: patch
+---
+
+Serialized Tempo Accounts store mutations across Foundry processes to prevent concurrent session and login updates from overwriting each other.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5497,6 +5497,7 @@ dependencies = [
  "foundry-config",
  "foundry-evm-hardforks",
  "foundry-wallets",
+ "fs2",
  "itertools 0.15.0",
  "jiff",
  "k256",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -510,6 +510,7 @@ heck = "0.5"
 uuid = "1.19.0"
 flate2 = "1.1"
 ethereum_ssz = "0.10"
+fs2 = "0.4"
 
 # Tempo
 alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "db89c09221b82e906d9ad697e4bad92423b59643", default-features = false, features = [

--- a/crates/cast/src/cmd/tempo.rs
+++ b/crates/cast/src/cmd/tempo.rs
@@ -2,8 +2,10 @@ use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use clap::Parser;
 use eyre::Result;
-use foundry_common::tempo::{EnsureAccessKeyConfig, decode_key_authorization, ensure_access_key};
-use tempo_alloy::accounts::TempoAccountsStore;
+use foundry_common::tempo::{
+    EnsureAccessKeyConfig, decode_key_authorization, ensure_access_key,
+    with_tempo_accounts_store_lock,
+};
 use tempo_primitives::transaction::SignedKeyAuthorization;
 
 /// Tempo wallet integration commands.
@@ -72,14 +74,16 @@ impl TempoSubcommand {
                     decode_key_authorization::<SignedKeyAuthorization>(&authorization)?;
                 let chain_id = authorization.chain_id;
                 let key_address = access_key.address();
-                let store = TempoAccountsStore::default_path()?;
-                store.upsert_secp256k1_access_key(account, &access_key, &authorization)?;
+                let store_path = with_tempo_accounts_store_lock(|store| {
+                    store.upsert_secp256k1_access_key(account, &access_key, &authorization)?;
+                    Ok(store.path().to_path_buf())
+                })?;
                 let _ = foundry_common::sh_status!(
                     "Imported access key {} for wallet {} on chain {} into {}",
                     key_address,
                     account,
                     chain_id,
-                    store.path().display(),
+                    store_path.display(),
                 );
                 Ok(())
             }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -81,6 +81,7 @@ flate2.workspace = true
 tempo-alloy.workspace = true
 tempo-primitives.workspace = true
 mpp.workspace = true
+fs2.workspace = true
 foundry-wallets = { workspace = true, features = ["browser", "tempo"] }
 alloy-signer-local = { workspace = true, features = ["mnemonic-all-languages"] }
 base64.workspace = true

--- a/crates/common/src/tempo/auth.rs
+++ b/crates/common/src/tempo/auth.rs
@@ -20,7 +20,7 @@ use std::{
     sync::LazyLock,
     time::{Duration, Instant},
 };
-use tempo_alloy::accounts::{TempoAccountsKeyAuthorization, TempoAccountsStore};
+use tempo_alloy::accounts::TempoAccountsKeyAuthorization;
 use tempo_primitives::transaction::{SignatureType, SignedKeyAuthorization};
 use tokio::sync::Mutex;
 
@@ -212,11 +212,10 @@ pub async fn ensure_access_key(cfg: EnsureAccessKeyConfig) -> Result<AccessKeyOu
                     );
                 }
                 let chain_id = signed.authorization.chain_id;
-                TempoAccountsStore::default_path()?.upsert_secp256k1_access_key(
-                    account_address,
-                    &signer,
-                    &signed,
-                )?;
+                super::with_tempo_accounts_store_lock(|store| {
+                    store.upsert_secp256k1_access_key(account_address, &signer, &signed)?;
+                    Ok(())
+                })?;
                 return Ok(AccessKeyOutcome {
                     wallet_address: account_address,
                     key_address,

--- a/crates/common/src/tempo/keystore.rs
+++ b/crates/common/src/tempo/keystore.rs
@@ -2,8 +2,14 @@
 
 use alloy_primitives::{Address, hex};
 use alloy_rlp::Decodable;
+use eyre::{Context, ContextCompat};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{
+    fs::{self, OpenOptions},
+    path::PathBuf,
+    sync::Mutex,
+};
 use tempo_alloy::accounts::{TempoAccountsStore, default_accounts_store_path};
 use tempo_primitives::{
     SignatureType,
@@ -12,6 +18,8 @@ use tempo_primitives::{
 
 /// Environment variable to override the Tempo home directory.
 pub const TEMPO_HOME_ENV: &str = "TEMPO_HOME";
+
+static ACCOUNTS_STORE_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Cryptographic key type used by Tempo Accounts access keys.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
@@ -126,6 +134,34 @@ pub fn tempo_accounts_store_path() -> Option<PathBuf> {
     default_accounts_store_path().ok()
 }
 
+/// Run an Accounts store mutation while holding the common process and cross-process lock.
+pub fn with_tempo_accounts_store_lock<T>(
+    mutate: impl FnOnce(&TempoAccountsStore) -> eyre::Result<T>,
+) -> eyre::Result<T> {
+    let _process_guard = ACCOUNTS_STORE_MUTEX
+        .lock()
+        .map_err(|_| eyre::eyre!("Tempo Accounts store lock was poisoned"))?;
+    let store = TempoAccountsStore::default_path()?;
+    let store_dir = store.path().parent().context("Tempo Accounts store path has no parent")?;
+    fs::create_dir_all(store_dir).wrap_err_with(|| {
+        format!("failed to create Tempo Accounts store directory {}", store_dir.display())
+    })?;
+    let lock_path = store.path().with_extension("json.lock");
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .wrap_err_with(|| {
+            format!("failed to open Tempo Accounts store lock {}", lock_path.display())
+        })?;
+    lock_file.lock_exclusive().wrap_err_with(|| {
+        format!("failed to lock Tempo Accounts store at {}", lock_path.display())
+    })?;
+    mutate(&store)
+}
+
 /// Read non-secret metadata from the canonical Tempo Accounts store.
 pub fn read_tempo_accounts_store() -> Option<AccountsStoreView> {
     let store = match TempoAccountsStore::try_open_default() {
@@ -169,4 +205,53 @@ pub fn decode_key_authorization<T: Decodable>(encoded: &str) -> eyre::Result<T> 
         eyre::bail!("key authorization has trailing bytes");
     }
     Ok(authorization)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        env,
+        process::{Command, Stdio},
+        thread,
+        time::Duration,
+    };
+
+    const LOCK_TEST_COUNTER_ENV: &str = "FOUNDRY_TEMPO_LOCK_TEST_COUNTER";
+
+    #[test]
+    fn accounts_store_lock_helper() {
+        let Ok(counter_path) = env::var(LOCK_TEST_COUNTER_ENV) else { return };
+        with_tempo_accounts_store_lock(|_| {
+            let count = fs::read_to_string(&counter_path)?.parse::<u64>()?;
+            thread::sleep(Duration::from_millis(100));
+            fs::write(&counter_path, (count + 1).to_string())?;
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn accounts_store_lock_serializes_processes() {
+        let temp = tempfile::tempdir().unwrap();
+        let counter_path = temp.path().join("counter");
+        fs::write(&counter_path, "0").unwrap();
+        let test_exe = env::current_exe().unwrap();
+        let mut children = (0..2)
+            .map(|_| {
+                Command::new(&test_exe)
+                    .args(["--exact", "tempo::keystore::tests::accounts_store_lock_helper"])
+                    .env(TEMPO_HOME_ENV, temp.path())
+                    .env(LOCK_TEST_COUNTER_ENV, &counter_path)
+                    .stdout(Stdio::null())
+                    .spawn()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        for child in &mut children {
+            assert!(child.wait().unwrap().success());
+        }
+        assert_eq!(fs::read_to_string(counter_path).unwrap(), "2");
+    }
 }

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -330,12 +330,10 @@ pub fn upsert_session_entry(entry: SessionEntry) -> eyre::Result<()> {
         .ok_or_else(|| eyre::eyre!("managed access key has no signed authorization"))?;
     let authorization = super::decode_key_authorization::<SignedKeyAuthorization>(encoded)?;
     validate_signed_session_authorization(&entry, SignatureType::Secp256k1, &authorization)?;
-    TempoAccountsStore::default_path()?.upsert_secp256k1_access_key(
-        entry.root_account,
-        &signer,
-        &authorization,
-    )?;
-    Ok(())
+    super::with_tempo_accounts_store_lock(|store| {
+        store.upsert_secp256k1_access_key(entry.root_account, &signer, &authorization)?;
+        Ok(())
+    })
 }
 
 /// Retire local signing material in `store.json` for the selected managed key.
@@ -343,29 +341,32 @@ pub fn upsert_session_entry(entry: SessionEntry) -> eyre::Result<()> {
 /// The non-secret account, chain, policy, and authorization witness remain available for
 /// on-chain revoke retries.
 pub fn retire_session_entry(session_id: B256) -> eyre::Result<bool> {
-    let Some(entry) = read_session_entry(session_id)? else {
-        return Ok(false);
-    };
-    TempoAccountsStore::open_default()?
-        .retire_access_key(entry.root_account, entry.chain_id, entry.key_address)
-        .map_err(Into::into)
+    super::with_tempo_accounts_store_lock(|store| {
+        let Some(entry) = read_session_entry(session_id)? else {
+            return Ok(false);
+        };
+        store
+            .retire_access_key(entry.root_account, entry.chain_id, entry.key_address)
+            .map_err(Into::into)
+    })
 }
 
 /// Retire expired managed access keys and return the number changed.
 pub fn mark_expired_session_entries(now: u64) -> eyre::Result<usize> {
-    let Some(entries) = read_session_entries(now)? else {
-        return Ok(0);
-    };
-    let store = TempoAccountsStore::open_default()?;
-    let mut retired = 0;
-    for entry in entries {
-        if entry.status == SessionStatus::Expired
-            && store.retire_access_key(entry.root_account, entry.chain_id, entry.key_address)?
-        {
-            retired += 1;
+    super::with_tempo_accounts_store_lock(|store| {
+        let Some(entries) = read_session_entries(now)? else {
+            return Ok(0);
+        };
+        let mut retired = 0;
+        for entry in entries {
+            if entry.status == SessionStatus::Expired
+                && store.retire_access_key(entry.root_account, entry.chain_id, entry.key_address)?
+            {
+                retired += 1;
+            }
         }
-    }
-    Ok(retired)
+        Ok(retired)
+    })
 }
 
 fn read_session_entries(now: u64) -> eyre::Result<Option<Vec<SessionEntry>>> {


### PR DESCRIPTION
This serializes Foundry's whole-file Tempo Accounts store mutations behind a shared in-process mutex and cross-process file lock. Session creation, retirement, expiry cleanup, interactive login, and access-key imports now use the same critical section, preventing concurrent operations from dropping persistent keys or restoring retired key material. A subprocess regression test exercises the lost-update boundary.

Follow-up to https://github.com/foundry-rs/foundry/pull/15924#discussion_r3665734691.

> This PR was written with Codex, including code generation and test implementation. Reviewed manually.
