### PR TITLE
fix(mutation): prune equivalent bounds

### DIFF
--- a/.changelog/forge-mutation-equivalent-bounds.md
+++ b/.changelog/forge-mutation-equivalent-bounds.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Stopped Forge mutation testing from generating provably equivalent integer and address boundary comparisons.

--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -72,6 +72,7 @@ pub mod orchestrator;
 pub mod progress;
 mod reporter;
 pub mod runner;
+mod type_analysis;
 mod visitor;
 
 pub struct MutationsSummary {
@@ -340,6 +341,7 @@ pub struct MutationHandler {
     /// Optional regex used to restrict mutation to specific contracts within
     /// the file (matches against contract name).
     contract_filter: Option<regex::Regex>,
+    equivalent_mutations: type_analysis::EquivalentMutationSet,
 }
 
 impl MutationHandler {
@@ -352,12 +354,22 @@ impl MutationHandler {
             report: MutationsSummary::new(),
             survived_spans: SurvivedSpans::new(),
             contract_filter: None,
+            equivalent_mutations: type_analysis::EquivalentMutationSet::new(),
         }
     }
 
     /// Restrict mutation to contracts whose name matches `filter`.
     pub fn with_contract_filter(mut self, filter: regex::Regex) -> Self {
         self.contract_filter = Some(filter);
+        self
+    }
+
+    /// Exclude binary operator replacements proven equivalent by type analysis.
+    pub(crate) fn with_equivalent_mutations(
+        mut self,
+        mutations: type_analysis::EquivalentMutationSet,
+    ) -> Self {
+        self.equivalent_mutations = mutations;
         self
     }
 
@@ -418,7 +430,7 @@ impl MutationHandler {
         let mut mutant_cfg_hasher = DefaultHasher::new();
         // Version salt for this mutant-set cache schema. Bump this if the
         // inputs that define generated mutants change.
-        "mutant-set-v2".hash(&mut mutant_cfg_hasher);
+        "mutant-set-v3".hash(&mut mutant_cfg_hasher);
         for op in self.config.mutation.enabled_operators() {
             op.to_string().hash(&mut mutant_cfg_hasher);
         }
@@ -500,7 +512,8 @@ impl MutationHandler {
 
             let operators = self.config.mutation.enabled_operators();
             let mut mutant_visitor = MutantVisitor::with_operators(path.clone(), &operators)
-                .with_source(&target_content);
+                .with_source(&target_content)
+                .with_equivalent_mutations(self.equivalent_mutations.clone());
 
             if let Some(filter) = contract_filter {
                 mutant_visitor =

--- a/crates/forge/src/mutation/orchestrator.rs
+++ b/crates/forge/src/mutation/orchestrator.rs
@@ -34,6 +34,7 @@ use crate::{
         MutationHandler, MutationProgress, MutationReporter, MutationsSummary,
         mutant::{Mutant, MutationResult},
         runner::run_mutations_parallel_with_progress,
+        type_analysis::{collect_equivalent_mutations, normalize_path},
     },
 };
 
@@ -172,6 +173,8 @@ pub async fn run_mutation_testing(
         mutation_config.rerun_failures.as_deref(),
         num_workers,
     )?;
+    let mut equivalent_mutations =
+        collect_equivalent_mutations(&config, output).unwrap_or_default();
 
     if !mutation_config.show_progress && !json_output {
         sh_println!("Running mutation tests with {} parallel workers...", num_workers)?;
@@ -203,6 +206,9 @@ pub async fn run_mutation_testing(
         // Create handler for this file, optionally restricting to a subset of
         // contracts by name when --mutate-contract is provided.
         let mut handler = MutationHandler::new(path.clone(), config.clone());
+        if let Some(mutations) = equivalent_mutations.remove(&normalize_path(&path)) {
+            handler = handler.with_equivalent_mutations(mutations);
+        }
         if let Some(filter) = &mutation_config.mutate_contract_pattern {
             handler = handler.with_contract_filter(filter.clone());
         }

--- a/crates/forge/src/mutation/type_analysis.rs
+++ b/crates/forge/src/mutation/type_analysis.rs
@@ -1,0 +1,435 @@
+//! Type-aware filtering for binary operator mutations.
+//!
+//! This module records replacements that have the same result as the original comparison for
+//! every value in an operand's type range. It deliberately does not filter replacements merely
+//! because they are tautological. For example, `uint256 x == 0` and `x <= 0` are equivalent, but
+//! `x < 0` is retained because changing the original condition to `false` can expose missing tests.
+
+use std::{
+    collections::{HashMap, HashSet},
+    ops::ControlFlow,
+    path::{Path, PathBuf},
+};
+
+use alloy_primitives::U256;
+use eyre::Result;
+use foundry_cli::opts::configure_pcx_from_compile_output;
+use foundry_compilers::{ProjectCompileOutput, compilers::multi::MultiCompiler};
+use foundry_config::Config;
+use solar::{
+    ast::{BinOpKind, LitKind, UnOpKind},
+    interface::{Session, source_map::FileName},
+    sema::{
+        Compiler, Gcx,
+        hir::{self, ElementaryType, ExprKind, TypeKind, Visit},
+        ty::TyKind,
+    },
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct EquivalentMutation {
+    lo: u32,
+    hi: u32,
+    new_op: BinOpKind,
+}
+
+impl EquivalentMutation {
+    pub fn new(span: solar::ast::Span, new_op: BinOpKind) -> Self {
+        Self { lo: span.lo().0, hi: span.hi().0, new_op }
+    }
+}
+
+pub type EquivalentMutationSet = HashSet<EquivalentMutation>;
+pub type EquivalentMutationsByPath = HashMap<PathBuf, EquivalentMutationSet>;
+
+pub fn collect_equivalent_mutations(
+    config: &Config,
+    output: &ProjectCompileOutput<MultiCompiler>,
+) -> Result<EquivalentMutationsByPath> {
+    let mut compiler = Compiler::new(Session::builder().with_silent_emitter(None).build());
+    compiler.enter_mut(|compiler| {
+        let mut pcx = compiler.parse();
+        configure_pcx_from_compile_output(&mut pcx, config, output, None)?;
+        pcx.parse();
+
+        let Ok(ControlFlow::Continue(())) = compiler.lower_asts() else {
+            return Ok(EquivalentMutationsByPath::new());
+        };
+        let _ = compiler.analysis();
+        Ok(collect_from_gcx(compiler.gcx()))
+    })
+}
+
+fn collect_from_gcx<'gcx>(gcx: Gcx<'gcx>) -> EquivalentMutationsByPath {
+    let mut by_path = EquivalentMutationsByPath::new();
+    for source_id in gcx.hir.source_ids() {
+        let source = gcx.hir.source(source_id);
+        let FileName::Real(path) = &source.file.name else { continue };
+        let mut collector = EquivalentMutationCollector {
+            gcx,
+            // HIR uses offsets in the compiler-wide source map, while the mutation visitor parses
+            // each target independently and uses offsets relative to that file.
+            source_start: source.file.start_pos.0,
+            mutations: EquivalentMutationSet::new(),
+        };
+        let _ = collector.visit_nested_source(source_id);
+        if !collector.mutations.is_empty() {
+            by_path.insert(normalize_path(path), collector.mutations);
+        }
+    }
+    by_path
+}
+
+pub fn normalize_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+struct EquivalentMutationCollector<'hir> {
+    gcx: Gcx<'hir>,
+    source_start: u32,
+    mutations: EquivalentMutationSet,
+}
+
+impl<'hir> Visit<'hir> for EquivalentMutationCollector<'hir> {
+    type BreakValue = ();
+
+    fn hir(&self) -> &'hir hir::Hir<'hir> {
+        &self.gcx.hir
+    }
+
+    fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let ExprKind::Binary(left, op, right) = &expr.kind
+            && op.kind.is_cmp()
+        {
+            self.collect_comparison(expr, left, op.kind, right);
+        }
+        self.walk_expr(expr)
+    }
+}
+
+impl EquivalentMutationCollector<'_> {
+    fn collect_comparison(
+        &mut self,
+        expr: &hir::Expr<'_>,
+        left: &hir::Expr<'_>,
+        original: BinOpKind,
+        right: &hir::Expr<'_>,
+    ) {
+        let comparison = if let (Some(range), Some(value)) =
+            (integer_range(self.gcx, left), constant_value(right))
+        {
+            Some((range, value, original, false))
+        } else if let (Some(value), Some(range)) =
+            (constant_value(left), integer_range(self.gcx, right))
+        {
+            Some((range, value, flip(original), true))
+        } else {
+            None
+        };
+        let Some((range, value, normalized_original, operands_reversed)) = comparison else {
+            return;
+        };
+
+        for candidate in [
+            BinOpKind::Lt,
+            BinOpKind::Le,
+            BinOpKind::Gt,
+            BinOpKind::Ge,
+            BinOpKind::Eq,
+            BinOpKind::Ne,
+        ] {
+            if candidate == original {
+                continue;
+            }
+            let normalized_candidate = if operands_reversed { flip(candidate) } else { candidate };
+            if equivalent_at_boundary(range, value, normalized_original, normalized_candidate) {
+                let Some(lo) = expr.span.lo().0.checked_sub(self.source_start) else { continue };
+                let Some(hi) = expr.span.hi().0.checked_sub(self.source_start) else { continue };
+                let span = solar::ast::Span::new(
+                    solar::interface::BytePos(lo),
+                    solar::interface::BytePos(hi),
+                );
+                self.mutations.insert(EquivalentMutation::new(span, candidate));
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct IntegerRange {
+    lower: SignedValue,
+    upper: SignedValue,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SignedValue {
+    negative: bool,
+    magnitude: U256,
+}
+
+impl SignedValue {
+    const ZERO: Self = Self { negative: false, magnitude: U256::ZERO };
+
+    fn new(negative: bool, magnitude: U256) -> Self {
+        if magnitude.is_zero() { Self::ZERO } else { Self { negative, magnitude } }
+    }
+}
+
+fn integer_range(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> Option<IntegerRange> {
+    if let Some(ty) = gcx.type_of_expr(expr.id)
+        && let TyKind::Elementary(ty) = ty.peel_refs().kind
+    {
+        return integer_range_for_type(ty);
+    }
+
+    // Fall back to types available during lowering when Solar could not infer this expression.
+    let ty = match &expr.peel_parens().kind {
+        ExprKind::Ident(_) => {
+            let variable = expr.as_variable()?;
+            match gcx.hir.variable(variable).ty.kind {
+                TypeKind::Elementary(ty) => ty,
+                _ => return None,
+            }
+        }
+        ExprKind::Call(callee, args, _) => {
+            let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(ty), .. }) =
+                &callee.peel_parens().kind
+            else {
+                return None;
+            };
+            let mut expressions = args.exprs();
+            expressions.next()?;
+            if expressions.next().is_some() {
+                return None;
+            }
+            *ty
+        }
+        _ => return None,
+    };
+    integer_range_for_type(ty)
+}
+
+fn integer_range_for_type(ty: ElementaryType) -> Option<IntegerRange> {
+    match ty {
+        ElementaryType::UInt(size) => {
+            let bits = size.bits();
+            let upper =
+                if bits == 256 { U256::MAX } else { (U256::from(1u8) << bits) - U256::from(1u8) };
+            Some(IntegerRange { lower: SignedValue::ZERO, upper: SignedValue::new(false, upper) })
+        }
+        ElementaryType::Int(size) => {
+            let half = U256::from(1u8) << (size.bits() - 1);
+            Some(IntegerRange {
+                lower: SignedValue::new(true, half),
+                upper: SignedValue::new(false, half - U256::from(1u8)),
+            })
+        }
+        ElementaryType::Address(_) => {
+            let upper = (U256::from(1u8) << 160) - U256::from(1u8);
+            Some(IntegerRange { lower: SignedValue::ZERO, upper: SignedValue::new(false, upper) })
+        }
+        _ => None,
+    }
+}
+
+fn constant_value(expr: &hir::Expr<'_>) -> Option<SignedValue> {
+    match &expr.peel_parens().kind {
+        ExprKind::Lit(lit) => match lit.kind {
+            LitKind::Number(value) => Some(SignedValue::new(false, value)),
+            LitKind::Address(value) => {
+                Some(SignedValue::new(false, U256::from_be_slice(value.as_slice())))
+            }
+            _ => None,
+        },
+        ExprKind::Unary(op, inner) if op.kind == UnOpKind::Neg => {
+            let ExprKind::Lit(lit) = &inner.peel_parens().kind else { return None };
+            let LitKind::Number(value) = lit.kind else { return None };
+            Some(SignedValue::new(true, value))
+        }
+        ExprKind::Member(type_call, member) => {
+            let ExprKind::TypeCall(hir::Type { kind: TypeKind::Elementary(ty), .. }) =
+                &type_call.peel_parens().kind
+            else {
+                return None;
+            };
+            let range = integer_range_for_type(*ty)?;
+            match member.as_str() {
+                "min" => Some(range.lower),
+                "max" => Some(range.upper),
+                _ => None,
+            }
+        }
+        ExprKind::Call(callee, args, _) => {
+            let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(ty), .. }) =
+                &callee.peel_parens().kind
+            else {
+                return None;
+            };
+            let mut expressions = args.exprs();
+            let inner = expressions.next()?;
+            if expressions.next().is_some() {
+                return None;
+            }
+            let range = integer_range_for_type(*ty)?;
+            let value = constant_value(inner)?;
+            (value == range.lower || value == range.upper).then_some(value)
+        }
+        _ => None,
+    }
+}
+
+fn equivalent_at_boundary(
+    range: IntegerRange,
+    value: SignedValue,
+    original: BinOpKind,
+    candidate: BinOpKind,
+) -> bool {
+    let pair = (original, candidate);
+    if value == range.lower {
+        matches!(
+            pair,
+            (BinOpKind::Eq, BinOpKind::Le)
+                | (BinOpKind::Le, BinOpKind::Eq)
+                | (BinOpKind::Ne, BinOpKind::Gt)
+                | (BinOpKind::Gt, BinOpKind::Ne)
+        )
+    } else if value == range.upper {
+        matches!(
+            pair,
+            (BinOpKind::Eq, BinOpKind::Ge)
+                | (BinOpKind::Ge, BinOpKind::Eq)
+                | (BinOpKind::Ne, BinOpKind::Lt)
+                | (BinOpKind::Lt, BinOpKind::Ne)
+        )
+    } else {
+        false
+    }
+}
+
+const fn flip(op: BinOpKind) -> BinOpKind {
+    match op {
+        BinOpKind::Lt => BinOpKind::Gt,
+        BinOpKind::Le => BinOpKind::Ge,
+        BinOpKind::Gt => BinOpKind::Lt,
+        BinOpKind::Ge => BinOpKind::Le,
+        BinOpKind::Eq | BinOpKind::Ne => op,
+        _ => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solar::interface::BytePos;
+
+    fn collect(source: &str) -> EquivalentMutationSet {
+        let path = PathBuf::from("Test.sol");
+        let mut compiler = Compiler::new(Session::builder().with_silent_emitter(None).build());
+        compiler.enter_mut(|compiler| {
+            let mut pcx = compiler.parse();
+            let file =
+                pcx.sess.source_map().new_source_file(path.clone(), source).expect("source file");
+            pcx.add_file(file);
+            pcx.parse();
+            assert!(matches!(compiler.lower_asts(), Ok(ControlFlow::Continue(()))));
+            let _ = compiler.analysis();
+            collect_from_gcx(compiler.gcx()).remove(&path).unwrap_or_default()
+        })
+    }
+
+    fn mutation(source: &str, expression: &str, new_op: BinOpKind) -> EquivalentMutation {
+        let lo = source.find(expression).expect("expression") as u32;
+        EquivalentMutation::new(
+            solar::ast::Span::new(BytePos(lo), BytePos(lo + expression.len() as u32)),
+            new_op,
+        )
+    }
+
+    #[test]
+    fn identifies_only_equivalent_unsigned_lower_bound_mutations() {
+        let range =
+            integer_range_for_type(ElementaryType::UInt(solar::ast::TypeSize::new_int_bits(256)))
+                .unwrap();
+
+        assert!(equivalent_at_boundary(range, SignedValue::ZERO, BinOpKind::Eq, BinOpKind::Le));
+        assert!(!equivalent_at_boundary(range, SignedValue::ZERO, BinOpKind::Eq, BinOpKind::Lt));
+        assert!(equivalent_at_boundary(range, SignedValue::ZERO, BinOpKind::Ne, BinOpKind::Gt));
+    }
+
+    #[test]
+    fn does_not_treat_zero_as_a_signed_boundary() {
+        let range =
+            integer_range_for_type(ElementaryType::Int(solar::ast::TypeSize::new_int_bits(256)))
+                .unwrap();
+
+        assert!(!equivalent_at_boundary(range, SignedValue::ZERO, BinOpKind::Eq, BinOpKind::Le));
+    }
+
+    #[test]
+    fn collects_typed_unsigned_boundary_equivalents() {
+        let source = r#"
+contract Test {
+    function check(uint256 x) external pure returns (bool) {
+        return x == 0;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        assert!(mutations.contains(&mutation(source, "x == 0", BinOpKind::Le)));
+        assert!(!mutations.contains(&mutation(source, "x == 0", BinOpKind::Lt)));
+    }
+
+    #[test]
+    fn preserves_signed_zero_mutations() {
+        let source = r#"
+contract Test {
+    function check(int256 x) external pure returns (bool) {
+        return x == 0;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        assert!(!mutations.contains(&mutation(source, "x == 0", BinOpKind::Le)));
+    }
+
+    #[test]
+    fn handles_reversed_operands_and_upper_bounds() {
+        let source = r#"
+contract Test {
+    function lower(uint256 x) external pure returns (bool) {
+        return 0 == x;
+    }
+
+    function upper(uint8 x) external pure returns (bool) {
+        return x == type(uint8).max;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        assert!(mutations.contains(&mutation(source, "0 == x", BinOpKind::Ge)));
+        assert!(!mutations.contains(&mutation(source, "0 == x", BinOpKind::Gt)));
+        assert!(mutations.contains(&mutation(source, "x == type(uint8).max", BinOpKind::Ge)));
+    }
+
+    #[test]
+    fn uses_inferred_member_types_and_typed_zero_constants() {
+        let source = r#"
+contract Test {
+    function empty(bytes memory value) external pure returns (bool) {
+        return value.length == 0;
+    }
+
+    function zero(address value) external pure returns (bool) {
+        return value == address(0);
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        assert!(mutations.contains(&mutation(source, "value.length == 0", BinOpKind::Le)));
+        assert!(mutations.contains(&mutation(source, "value == address(0)", BinOpKind::Le)));
+    }
+}

--- a/crates/forge/src/mutation/visitor.rs
+++ b/crates/forge/src/mutation/visitor.rs
@@ -8,6 +8,7 @@ use crate::mutation::mutators::Mutator;
 use crate::mutation::{
     mutant::{Mutant, OwnedLiteral},
     mutators::{MutationContext, mutator_registry::MutatorRegistry},
+    type_analysis::{EquivalentMutation, EquivalentMutationSet},
 };
 use foundry_config::MutatorType;
 
@@ -33,6 +34,7 @@ pub struct MutantVisitor<'src> {
     /// matched the filter. Top-level items (outside any contract) are always
     /// considered "allowed".
     in_allowed_contract: bool,
+    equivalent_mutations: EquivalentMutationSet,
 }
 
 impl<'src> MutantVisitor<'src> {
@@ -46,6 +48,7 @@ impl<'src> MutantVisitor<'src> {
             source: None,
             contract_filter: None,
             in_allowed_contract: true,
+            equivalent_mutations: EquivalentMutationSet::new(),
         }
     }
 
@@ -60,6 +63,7 @@ impl<'src> MutantVisitor<'src> {
             source: None,
             contract_filter: None,
             in_allowed_contract: true,
+            equivalent_mutations: EquivalentMutationSet::new(),
         }
     }
 
@@ -74,6 +78,7 @@ impl<'src> MutantVisitor<'src> {
             source: None,
             contract_filter: None,
             in_allowed_contract: true,
+            equivalent_mutations: EquivalentMutationSet::new(),
         }
     }
 
@@ -93,13 +98,26 @@ impl<'src> MutantVisitor<'src> {
         self
     }
 
+    /// Exclude binary operator replacements proven equivalent by type analysis.
+    pub fn with_equivalent_mutations(mut self, mutations: EquivalentMutationSet) -> Self {
+        self.equivalent_mutations = mutations;
+        self
+    }
+
     pub fn take_errors(&mut self) -> Vec<Report> {
         std::mem::take(&mut self.errors)
     }
 
     fn collect_mutations(&mut self, context: &MutationContext<'_>) {
         let result = self.mutator_registry.generate_mutations(context);
-        self.mutation_to_conduct.extend(result.mutations);
+        self.mutation_to_conduct.extend(result.mutations.into_iter().filter(|mutant| {
+            let crate::mutation::mutant::MutationType::BinaryOpExpr { new_op, .. } =
+                mutant.mutation
+            else {
+                return true;
+            };
+            !self.equivalent_mutations.contains(&EquivalentMutation::new(mutant.span, new_op))
+        }));
 
         for err in result.errors {
             self.errors.push(err.wrap_err(format!(
@@ -286,6 +304,53 @@ contract Test {
             let err = format!("{:?}", errors[0]);
             assert!(err.contains("failed to generate mutations for test.sol:"));
             assert!(err.contains("synthetic visitor failure"));
+        });
+    }
+
+    #[test]
+    fn visitor_excludes_proven_equivalent_binary_mutations() {
+        let source = "\
+pragma solidity ^0.8.0;
+contract Test {
+    function check(uint256 x) public pure returns (bool) {
+        return x == 0;
+    }
+}
+";
+        let path = PathBuf::from("test.sol");
+        let lo = source.find("x == 0").unwrap() as u32;
+        let span = solar::ast::Span::new(
+            solar::interface::BytePos(lo),
+            solar::interface::BytePos(lo + "x == 0".len() as u32),
+        );
+        let equivalent_mutations =
+            [EquivalentMutation::new(span, solar::ast::BinOpKind::Le)].into_iter().collect();
+        let sess = Session::builder().with_silent_emitter(None).build();
+
+        sess.enter(|| {
+            let arena = Arena::new();
+            let mut parser =
+                Parser::from_lazy_source_code(&sess, &arena, FileName::Real(path.clone()), || {
+                    Ok(source.to_string())
+                })
+                .unwrap();
+            let ast = parser.parse_file().map_err(|e| e.emit()).unwrap();
+            drop(parser);
+            let mut visitor = MutantVisitor::default(path)
+                .with_source(source)
+                .with_equivalent_mutations(equivalent_mutations);
+
+            let _ = visitor.visit_source_unit(&ast);
+            let comparison_mutations = visitor.mutation_to_conduct.iter().filter_map(|mutant| {
+                let MutationType::BinaryOpExpr { new_op, .. } = mutant.mutation else {
+                    return None;
+                };
+                (mutant.span == span).then_some(new_op)
+            });
+            let comparison_mutations = comparison_mutations.collect::<Vec<_>>();
+
+            assert!(!comparison_mutations.contains(&solar::ast::BinOpKind::Le));
+            assert!(comparison_mutations.contains(&solar::ast::BinOpKind::Lt));
         });
     }
 }

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -115,6 +115,69 @@ Survived mutants
 "#]]);
 });
 
+forgetest_init!(mutation_testing_prunes_typed_boundary_equivalents, |prj, cmd| {
+    prj.add_source(
+        "Boundary.sol",
+        r#"
+pragma solidity ^0.8.13;
+
+contract Boundary {
+    function isZero(uint256 value) public pure returns (bool) {
+        return value == 0;
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "Boundary.t.sol",
+        r#"
+pragma solidity ^0.8.13;
+
+import "../src/Boundary.sol";
+
+contract BoundaryTest {
+    Boundary private boundary = new Boundary();
+
+    function testZero() public view {
+        assert(boundary.isZero(0));
+    }
+
+    function testNonzero() public view {
+        assert(!boundary.isZero(1));
+    }
+}
+"#,
+    );
+
+    fs::write(
+        prj.root().join("foundry.toml"),
+        r#"
+[mutation]
+exclude_operators = [
+    "assembly",
+    "assignment",
+    "delete-expression",
+    "elim-delegate",
+    "require",
+    "unary-op",
+]
+"#,
+    )
+    .unwrap();
+
+    let output = cmd
+        .args(["test", "--mutate", "src/Boundary.sol", "--mutation-jobs", "1", "--json"])
+        .assert_success();
+    let summary = mutation_summary(&output.get_output().stdout_lossy());
+
+    assert_eq!(summary["total"], 6);
+    assert_eq!(summary["killed"], 4);
+    assert_eq!(summary["survived"], 0);
+    assert_eq!(summary["invalid"], 2);
+    assert_eq!(summary["mutation_score"], 100.0);
+});
+
 forgetest_init!(mutation_testing_rejects_list_mode, |prj, cmd| {
     prj.add_source(
         "Counter.sol",
@@ -1574,7 +1637,7 @@ contract VaultTest is Test {
 "#,
     );
 
-    // The surviving mutant (msg.value > 0 -> msg.value != 0) is equivalent for uint256
+    // Type analysis excludes the equivalent msg.value > 0 -> msg.value != 0 mutant.
     let mut cmd2 = prj.forge_command();
     cmd2.args(["test", "--mutate", "src/Vault.sol", "--mutation-jobs", "2"]);
     cmd2.assert_success().stdout_eq(str![[r#"
@@ -1588,16 +1651,16 @@ MUTATION TESTING RESULTS
 ╭──────────┬───────────┬────────────╮
 │ Status   ┆ # Mutants ┆ % of Total │
 ╞══════════╪═══════════╪════════════╡
-│ Survived ┆ 3         ┆ 5.0%       │
+│ Survived ┆ 2         ┆ 3.4%       │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Killed   ┆ 48        ┆ 80.0%      │
+│ Killed   ┆ 48        ┆ 81.4%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Invalid  ┆ 7         ┆ 11.7%      │
+│ Invalid  ┆ 7         ┆ 11.9%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Skipped  ┆ 2         ┆ 3.3%       │
+│ Skipped  ┆ 2         ┆ 3.4%       │
 ╰──────────┴───────────┴────────────╯
 ...
-Mutation Score: 94.1% (48/51 mutants killed); [ELAPSED]
+Mutation Score: 96.0% (48/50 mutants killed); [ELAPSED]
 ...
 "#]]);
 });


### PR DESCRIPTION
Mutation testing currently generates every comparison replacement from the untyped Solar AST. This leaves provably equivalent mutants such as `uint256 value == 0` to `value <= 0`, which survive even with complete tests and lower the reported mutation score.

This change runs Solar lowering and type analysis once for the compiled project, maps inferred integer and address ranges back to per-file AST spans, and removes only replacements whose predicates match the original for every value in the type range. Tautological but behavior-changing replacements remain. In particular, `value == 0` still mutates to `value < 0`.

The analysis covers signed and unsigned bounds, address bounds, reversed operands, explicit casts, `type(T).min` and `type(T).max`, and inferred member or expression types. If the analysis cannot prove equivalence, the mutant remains. The mutation cache salt is updated because the generated set changes. Unit and CLI coverage includes the retained false-boundary mutation and the adjusted existing mutation summary.

Codex was used to inspect the mutation pipeline, implement the change, and generate tests.