### PR TITLE
fix(anvil): load legacy state dumps

### DIFF
--- a/.changelog/fix-anvil-legacy-state-load.md
+++ b/.changelog/fix-anvil-legacy-state-load.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed loading legacy Anvil state dumps with missing block history or large blob gas prices.

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -500,7 +500,7 @@ pub struct LegacyBlockEnv {
 #[derive(Debug, Deserialize)]
 pub struct LegacyBlobExcessGasAndPrice {
     pub excess_blob_gas: u64,
-    pub blob_gasprice: u64,
+    pub blob_gasprice: u128,
 }
 
 /// Legacy string or u64 type from before v1.3.
@@ -543,7 +543,10 @@ impl TryFrom<LegacyBlockEnv> for BlockEnv {
             slot_num: 0,
             blob_excess_gas_and_price: legacy
                 .blob_excess_gas_and_price
-                .map(|v| BlobExcessGasAndPrice::new(v.excess_blob_gas, v.blob_gasprice))
+                .map(|v| BlobExcessGasAndPrice {
+                    excess_blob_gas: v.excess_blob_gas,
+                    blob_gasprice: v.blob_gasprice,
+                })
                 .or_else(|| {
                     Some(BlobExcessGasAndPrice::new(0, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE))
                 }),

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5255,6 +5255,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
             storage.load_blocks(state.blocks.clone());
             storage.load_transactions(state.transactions.clone());
         }
+        let mut checkpoint_header = None;
         // reset the block env
         if let Some(block) = state.block.clone() {
             {
@@ -5270,50 +5271,83 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
             let fork_num_and_hash = self.get_fork().map(|f| (f.block_number(), f.block_hash()));
 
             let best_number = state.best_block_number.unwrap_or(block.number.saturating_to());
-            let selected_best_number = if let Some((number, hash)) = fork_num_and_hash {
+            let (selected_best_number, selected_best_hash) = if let Some((number, hash)) =
+                fork_num_and_hash
+            {
                 trace!(target: "backend", state_block_number=?best_number, fork_block_number=?number);
                 // If the state.block_number is greater than the fork block number, set best number
                 // to the state block number.
                 // Ref: https://github.com/foundry-rs/foundry/issues/9539
                 if best_number > number {
-                    self.blockchain.storage.write().best_number = best_number;
-                    let best_hash = self
-                        .blockchain
-                        .storage
-                        .read()
-                        .hash(best_number.into(), self.slots_in_an_epoch)
-                        .ok_or_else(|| {
-                            BlockchainError::RpcError(RpcError::internal_error_with(format!(
-                                "Best hash not found for best number {best_number}",
-                            )))
-                        })?;
-                    self.blockchain.storage.write().best_hash = best_hash;
-                    best_number
+                    (best_number, None)
                 } else {
                     // If loading state file on a fork, set best number to the fork block number.
                     // Ref: https://github.com/foundry-rs/foundry/pull/9215#issue-2618681838
-                    self.blockchain.storage.write().best_number = number;
-                    self.blockchain.storage.write().best_hash = hash;
-                    number
+                    (number, Some(hash))
                 }
             } else {
-                self.blockchain.storage.write().best_number = best_number;
+                (best_number, None)
+            };
 
-                // Set the current best block hash;
-                let best_hash = self
+            let best_hash = if let Some(hash) = selected_best_hash {
+                hash
+            } else if let Some(hash) = self
+                .blockchain
+                .storage
+                .read()
+                .hash(selected_best_number.into(), self.slots_in_an_epoch)
+            {
+                hash
+            } else if state.blocks.is_empty() {
+                let spec_id = self.spec_id();
+                let is_cancun = spec_id >= SpecId::CANCUN;
+                let parent_hash = self
                     .blockchain
                     .storage
                     .read()
-                    .hash(best_number.into(), self.slots_in_an_epoch)
-                    .ok_or_else(|| {
-                        BlockchainError::RpcError(RpcError::internal_error_with(format!(
-                            "Best hash not found for best number {best_number}",
-                        )))
-                    })?;
-
-                self.blockchain.storage.write().best_hash = best_hash;
-                best_number
+                    .hashes
+                    .get(&selected_best_number.saturating_sub(1))
+                    .copied()
+                    .unwrap_or_default();
+                let header = Header {
+                    parent_hash,
+                    beneficiary: block.beneficiary,
+                    difficulty: block.difficulty,
+                    number: selected_best_number,
+                    gas_limit: block.gas_limit,
+                    timestamp: block.timestamp.saturating_to(),
+                    mix_hash: block.prevrandao.unwrap_or_default(),
+                    base_fee_per_gas: (spec_id >= SpecId::LONDON).then_some(block.basefee),
+                    parent_beacon_block_root: is_cancun.then_some(Default::default()),
+                    blob_gas_used: is_cancun.then_some(0),
+                    excess_blob_gas: if is_cancun { block.blob_excess_gas() } else { None },
+                    withdrawals_root: (spec_id >= SpecId::SHANGHAI).then_some(EMPTY_WITHDRAWALS),
+                    requests_hash: (spec_id >= SpecId::PRAGUE).then_some(EMPTY_REQUESTS_HASH),
+                    ..Default::default()
+                };
+                let header = FoundryHeader::new(header, self.is_tempo());
+                checkpoint_header = Some(header.clone());
+                let checkpoint = create_block(
+                    header,
+                    Vec::<MaybeImpersonatedTransaction<FoundryTxEnvelope>>::new(),
+                );
+                warn!(
+                    target: "backend",
+                    block_number = selected_best_number,
+                    "state dump has no block history; created a synthetic checkpoint block"
+                );
+                self.blockchain.storage.write().insert_block(checkpoint)
+            } else {
+                return Err(BlockchainError::RpcError(RpcError::internal_error_with(format!(
+                    "Best hash not found for best number {selected_best_number}",
+                ))));
             };
+
+            {
+                let mut storage = self.blockchain.storage.write();
+                storage.best_number = selected_best_number;
+                storage.best_hash = best_hash;
+            }
 
             // Keep NUMBER aligned with the canonical local head chosen above. Arbitrum state dumps
             // can intentionally keep BlockEnv.number distinct from the best L2 block number.
@@ -5322,17 +5356,24 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
             }
         }
 
-        if let Some(latest) = state.blocks.iter().max_by_key(|b| b.header.number()) {
-            let header = &latest.header;
+        let latest_header = state
+            .blocks
+            .iter()
+            .max_by_key(|block| block.header.number())
+            .map(|block| &block.header)
+            .or(checkpoint_header.as_ref());
+        if let Some(header) = latest_header {
             let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
                 header.gas_used(),
                 header.gas_limit(),
                 header.base_fee_per_gas().unwrap_or_default(),
             );
-            let next_block_excess_blob_gas = self.fees.get_next_block_blob_excess_gas(
-                header.excess_blob_gas().unwrap_or_default(),
-                header.blob_gas_used().unwrap_or_default(),
-            );
+            let next_block_excess_blob_gas =
+                self.fees.blob_params().next_block_excess_blob_gas_osaka(
+                    header.excess_blob_gas().unwrap_or_default(),
+                    header.blob_gas_used().unwrap_or_default(),
+                    header.base_fee_per_gas().unwrap_or_default(),
+                );
 
             // update next base fee
             self.fees.set_base_fee(next_block_base_fee);

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5248,24 +5248,14 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
 
     /// Apply [SerializableState] data to the backend storage.
     pub async fn load_state(&self, state: SerializableState) -> Result<bool, BlockchainError> {
-        // load the blocks and transactions into the storage atomically so concurrent readers
-        // never observe blocks without their transactions
-        {
-            let mut storage = self.blockchain.storage.write();
-            storage.load_blocks(state.blocks.clone());
-            storage.load_transactions(state.transactions.clone());
-        }
-        let mut checkpoint_header = None;
-        // reset the block env
-        if let Some(block) = state.block.clone() {
-            {
-                let mut env = self.evm_env.write();
-                env.block_env = block.clone();
-                if self.is_tempo() && self.is_fork() && env.block_env.beneficiary.is_zero() {
-                    env.block_env.beneficiary = TIP_FEE_MANAGER_ADDRESS;
-                }
+        let mut block_env = state.block.clone();
+        let mut selected_head = None;
+        let mut selected_header = None;
+        let mut checkpoint = None;
+        if let Some(block) = &mut block_env {
+            if self.is_tempo() && self.is_fork() && block.beneficiary.is_zero() {
+                block.beneficiary = TIP_FEE_MANAGER_ADDRESS;
             }
-
             // Set the current best block number.
             // Defaults to block number for compatibility with existing state files.
             let fork_num_and_hash = self.get_fork().map(|f| (f.block_number(), f.block_hash()));
@@ -5290,24 +5280,19 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
             };
 
             let best_hash = if let Some(hash) = selected_best_hash {
-                hash
-            } else if let Some(hash) = self
-                .blockchain
-                .storage
-                .read()
-                .hash(selected_best_number.into(), self.slots_in_an_epoch)
-            {
+                selected_header = state
+                    .blocks
+                    .iter()
+                    .rev()
+                    .find(|block| block.header.hash_slow() == hash)
+                    .map(|block| block.header.clone());
                 hash
             } else if state.blocks.is_empty() {
                 let spec_id = self.spec_id();
                 let is_cancun = spec_id >= SpecId::CANCUN;
-                let parent_hash = self
-                    .blockchain
-                    .storage
-                    .read()
-                    .hashes
-                    .get(&selected_best_number.saturating_sub(1))
-                    .copied()
+                let parent_hash = selected_best_number
+                    .checked_sub(1)
+                    .and_then(|number| self.blockchain.storage.read().hashes.get(&number).copied())
                     .unwrap_or_default();
                 let header = Header {
                     parent_hash,
@@ -5326,43 +5311,65 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
                     ..Default::default()
                 };
                 let header = FoundryHeader::new(header, self.is_tempo());
-                checkpoint_header = Some(header.clone());
-                let checkpoint = create_block(
+                let best_hash = header.hash_slow();
+                selected_header = Some(header.clone());
+                checkpoint = Some(create_block(
                     header,
                     Vec::<MaybeImpersonatedTransaction<FoundryTxEnvelope>>::new(),
-                );
+                ));
                 warn!(
                     target: "backend",
                     block_number = selected_best_number,
                     "state dump has no block history; created a synthetic checkpoint block"
                 );
-                self.blockchain.storage.write().insert_block(checkpoint)
+                best_hash
+            } else if let Some(header) = state
+                .blocks
+                .iter()
+                .rev()
+                .find(|block| block.header.number() == selected_best_number)
+                .map(|block| block.header.clone())
+            {
+                let best_hash = header.hash_slow();
+                selected_header = Some(header);
+                best_hash
             } else {
                 return Err(BlockchainError::RpcError(RpcError::internal_error_with(format!(
                     "Best hash not found for best number {selected_best_number}",
                 ))));
             };
 
-            {
-                let mut storage = self.blockchain.storage.write();
-                storage.best_number = selected_best_number;
-                storage.best_hash = best_hash;
-            }
+            selected_head = Some((selected_best_number, best_hash));
+        }
 
-            // Keep NUMBER aligned with the canonical local head chosen above. Arbitrum state dumps
-            // can intentionally keep BlockEnv.number distinct from the best L2 block number.
-            if !is_arbitrum(self.chain_id().to()) {
-                self.set_block_number(selected_best_number);
+        // Apply the prepared chain data atomically so concurrent readers never observe blocks
+        // without their transactions or a partially updated head.
+        {
+            let mut storage = self.blockchain.storage.write();
+            storage.load_blocks(state.blocks.clone());
+            storage.load_transactions(state.transactions.clone());
+            if let Some(checkpoint) = checkpoint {
+                storage.insert_block(checkpoint);
+            }
+            if let Some((number, hash)) = selected_head {
+                storage.hashes.insert(number, hash);
+                storage.best_number = number;
+                storage.best_hash = hash;
             }
         }
 
-        let latest_header = state
-            .blocks
-            .iter()
-            .max_by_key(|block| block.header.number())
-            .map(|block| &block.header)
-            .or(checkpoint_header.as_ref());
-        if let Some(header) = latest_header {
+        if let Some(mut block) = block_env {
+            // Keep NUMBER aligned with the canonical local head chosen above. Arbitrum state dumps
+            // can intentionally keep BlockEnv.number distinct from the best L2 block number.
+            if !is_arbitrum(self.chain_id().to())
+                && let Some((number, _)) = selected_head
+            {
+                block.number = U256::from(number);
+            }
+            self.evm_env.write().block_env = block;
+        }
+
+        if let Some(header) = selected_header.as_ref() {
             let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
                 header.gas_used(),
                 header.gas_limit(),

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -444,22 +444,29 @@ impl<N: Network> BlockchainStorage<N> {
         self.blocks.values().map(|block| block.clone().into()).collect()
     }
 
+    /// Adds a block to storage and returns its hash.
+    pub fn insert_block(&mut self, block: Block) -> B256 {
+        let block_hash = block.header.hash_slow();
+        let block_number = block.header.number();
+        self.blocks.insert(block_hash, block);
+        self.hashes.insert(block_number, block_hash);
+
+        // Update genesis_hash if we are loading the genesis block, so that
+        // Finalized/Safe/Earliest block tag lookups return the correct hash. The genesis
+        // number can be non-zero when configured via `--block-number`.
+        // See: https://github.com/foundry-rs/foundry/issues/12645
+        if block_number == self.genesis_number {
+            self.genesis_hash = block_hash;
+        }
+
+        block_hash
+    }
+
     /// Deserialize and add all blocks data to the backend storage
     pub fn load_blocks(&mut self, serializable_blocks: Vec<SerializableBlock>) {
         for serializable_block in &serializable_blocks {
             let block: Block = serializable_block.clone().into();
-            let block_hash = block.header.hash_slow();
-            let block_number = block.header.number();
-            self.blocks.insert(block_hash, block);
-            self.hashes.insert(block_number, block_hash);
-
-            // Update genesis_hash if we are loading the genesis block, so that
-            // Finalized/Safe/Earliest block tag lookups return the correct hash. The genesis
-            // number can be non-zero when configured via `--block-number`.
-            // See: https://github.com/foundry-rs/foundry/issues/12645
-            if block_number == self.genesis_number {
-                self.genesis_hash = block_hash;
-            }
+            self.insert_block(block);
         }
     }
 

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -181,11 +181,18 @@ async fn can_load_state_without_block_history() {
 // <https://github.com/foundry-rs/foundry/issues/10363>
 #[tokio::test(flavor = "multi_thread")]
 async fn can_load_state_without_block_history_at_runtime() {
-    let (state, _, _, _) = state_without_block_history().await;
+    let (mut state, _, _, _) = state_without_block_history().await;
+    let loaded_beneficiary = address!("0000000000000000000000000000000000010363");
+    state["block"]["coinbase"] = json!(loaded_beneficiary);
+
     let (api, _handle) = spawn(NodeConfig::test()).await;
+    api.backend.set_coinbase(address!("0000000000000000000000000000000000000001"));
     api.mine_one().await;
     let parent =
         api.block_by_number(alloy_eips::BlockNumberOrTag::Number(1)).await.unwrap().unwrap();
+    api.mine_one().await;
+    let previous =
+        api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
 
     api.anvil_load_state(Bytes::from(serde_json::to_vec(&state).unwrap())).await.unwrap();
 
@@ -193,6 +200,9 @@ async fn can_load_state_without_block_history_at_runtime() {
         api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(checkpoint.header.number, 2);
     assert_eq!(checkpoint.header.parent_hash, parent.header.hash);
+    assert_eq!(checkpoint.header.beneficiary, loaded_beneficiary);
+    assert_ne!(checkpoint.header.hash, previous.header.hash);
+    assert_eq!(checkpoint.header.hash, api.backend.best_hash());
 
     api.mine_one().await;
     let latest = api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
@@ -224,16 +234,63 @@ async fn state_without_block_history_restores_osaka_blob_excess_gas() {
 #[tokio::test(flavor = "multi_thread")]
 async fn rejects_nonempty_block_history_without_best_block() {
     let (source, _handle) = spawn(NodeConfig::test()).await;
+    source.backend.set_coinbase(address!("0000000000000000000000000000000000000002"));
+    source.mine_one().await;
     source.mine_one().await;
     source.mine_one().await;
     let mut state = source.serialized_state(false).await.unwrap();
-    state.blocks.retain(|block| block.header.number != 2);
+    state.blocks.retain(|block| block.header.number != 3);
     assert!(!state.blocks.is_empty());
+    let incoming_hash =
+        state.blocks.iter().find(|block| block.header.number == 2).unwrap().header.hash_slow();
 
     let (api, _handle) = spawn(NodeConfig::test()).await;
+    let original_coinbase = address!("0000000000000000000000000000000000000001");
+    api.backend.set_coinbase(original_coinbase);
+    api.mine_one().await;
+    let original =
+        api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert!(api.block_by_hash(incoming_hash).await.unwrap().is_none());
+
     let err =
         api.anvil_load_state(Bytes::from(serde_json::to_vec(&state).unwrap())).await.unwrap_err();
-    assert!(err.to_string().contains("Best hash not found for best number 2"));
+    assert!(err.to_string().contains("Best hash not found for best number 3"));
+    assert_eq!(api.backend.best_number(), original.header.number);
+    assert_eq!(api.backend.best_hash(), original.header.hash);
+    assert_eq!(api.backend.coinbase(), original_coinbase);
+    assert!(api.block_by_hash(incoming_hash).await.unwrap().is_none());
+
+    api.mine_one().await;
+    let latest = api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(latest.header.number, original.header.number + 1);
+    assert_eq!(latest.header.parent_hash, original.header.hash);
+    assert_eq!(latest.header.beneficiary, original_coinbase);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn loaded_state_fees_use_selected_head() {
+    let (source, _handle) = spawn(NodeConfig::test()).await;
+    source.mine_one().await;
+    let mut state = source.serialized_state(false).await.unwrap();
+    let selected_hash = source.backend.best_hash();
+    let selected_next_base_fee = source.backend.fees().base_fee();
+
+    source.mine_one().await;
+    let newer_state = source.serialized_state(false).await.unwrap();
+    let newer_block =
+        newer_state.blocks.into_iter().find(|block| block.header.number == 2).unwrap();
+    assert_ne!(source.backend.fees().base_fee(), selected_next_base_fee);
+    state.blocks.push(newer_block);
+
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    api.anvil_load_state(Bytes::from(serde_json::to_vec(&state).unwrap())).await.unwrap();
+    assert_eq!(api.backend.best_hash(), selected_hash);
+    assert_eq!(api.backend.fees().base_fee(), selected_next_base_fee);
+
+    api.mine_one().await;
+    let latest = api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(latest.header.parent_hash, selected_hash);
+    assert_eq!(latest.header.base_fee_per_gas, Some(selected_next_base_fee));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -2,7 +2,7 @@
 
 use crate::abi::Greeter;
 use alloy_network::{ReceiptResponse, TransactionBuilder};
-use alloy_primitives::{B256, Bytes, U256, Uint, address, b256, bytes, utils::Unit};
+use alloy_primitives::{Address, B256, Bytes, U256, Uint, address, b256, bytes, utils::Unit};
 use alloy_provider::Provider;
 use alloy_rpc_types::{
     BlockId, TransactionRequest,
@@ -10,13 +10,35 @@ use alloy_rpc_types::{
 };
 use alloy_serde::WithOtherFields;
 use anvil::{NodeConfig, eth::backend::db::SerializableState, spawn};
+use foundry_evm::hardfork::EthereumHardfork;
 use foundry_test_utils::rpc::next_http_archive_rpc_url;
 use revm::{
     context_interface::block::BlobExcessGasAndPrice,
     primitives::eip4844::BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
 };
-use serde_json::json;
+use serde_json::{Value, json};
 use std::str::FromStr;
+
+async fn state_without_block_history() -> (Value, Address, U256, u64) {
+    let account = address!("0000000000000000000000000000000000010363");
+    let balance = U256::from(10363);
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    api.anvil_set_balance(account, balance).await.unwrap();
+    api.mine_one().await;
+    api.mine_one().await;
+
+    let mut state = serde_json::to_value(api.serialized_state(false).await.unwrap()).unwrap();
+    let state = state.as_object_mut().unwrap();
+    state.remove("blocks");
+    state.remove("transactions");
+    state.remove("historical_states");
+
+    let block = state.get_mut("block").unwrap().as_object_mut().unwrap();
+    let beneficiary = block.remove("beneficiary").unwrap();
+    block.insert("coinbase".to_string(), beneficiary);
+
+    (Value::Object(state.clone()), account, balance, api.backend.fees().base_fee())
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_load_state() {
@@ -118,6 +140,100 @@ async fn can_load_existing_state_legacy() {
 
     let block_number = api.block_number().unwrap();
     assert_eq!(block_number, Uint::from(2));
+}
+
+// <https://github.com/foundry-rs/foundry/issues/10363>
+#[tokio::test(flavor = "multi_thread")]
+async fn can_load_state_without_block_history() {
+    let (state, account, balance, next_base_fee) = state_without_block_history().await;
+    let tmp = tempfile::tempdir().unwrap();
+    let state_file = tmp.path().join("state.json");
+    foundry_common::fs::write_json_file(&state_file, &state).unwrap();
+
+    let (api, handle) = spawn(NodeConfig::test().with_init_state_path(state_file)).await;
+    let provider = handle.http_provider();
+
+    assert_eq!(provider.get_balance(account).await.unwrap(), balance);
+    assert_eq!(api.block_number().unwrap(), U256::from(2));
+
+    let checkpoint =
+        api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(checkpoint.header.number, 2);
+    assert_eq!(checkpoint.header.hash, api.backend.best_hash());
+    assert_eq!(api.backend.fees().base_fee(), next_base_fee);
+
+    api.mine_one().await;
+    let latest = api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(latest.header.number, 3);
+    assert_eq!(latest.header.parent_hash, checkpoint.header.hash);
+    assert_eq!(latest.header.base_fee_per_gas, Some(next_base_fee));
+
+    let dumped = api.serialized_state(false).await.unwrap();
+    assert!(dumped.blocks.iter().any(|block| block.header.number == 2));
+
+    let (reloaded, _handle) = spawn(NodeConfig::test().with_init_state(Some(dumped))).await;
+    let reloaded_latest =
+        reloaded.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(reloaded_latest.header.number, 3);
+    assert_eq!(reloaded_latest.header.hash, latest.header.hash);
+}
+
+// <https://github.com/foundry-rs/foundry/issues/10363>
+#[tokio::test(flavor = "multi_thread")]
+async fn can_load_state_without_block_history_at_runtime() {
+    let (state, _, _, _) = state_without_block_history().await;
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    api.mine_one().await;
+    let parent =
+        api.block_by_number(alloy_eips::BlockNumberOrTag::Number(1)).await.unwrap().unwrap();
+
+    api.anvil_load_state(Bytes::from(serde_json::to_vec(&state).unwrap())).await.unwrap();
+
+    let checkpoint =
+        api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(checkpoint.header.number, 2);
+    assert_eq!(checkpoint.header.parent_hash, parent.header.hash);
+
+    api.mine_one().await;
+    let latest = api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(latest.header.number, 3);
+    assert_eq!(latest.header.parent_hash, checkpoint.header.hash);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn state_without_block_history_restores_osaka_blob_excess_gas() {
+    let (mut state, _, _, _) = state_without_block_history().await;
+    let blob_params = alloy_eips::eip7840::BlobParams::osaka();
+    let target_blob_gas = blob_params.target_blob_gas_per_block();
+    state["block"]["basefee"] = json!(1);
+    state["block"]["blob_excess_gas_and_price"]["excess_blob_gas"] = json!(target_blob_gas);
+    state["block"]["blob_excess_gas_and_price"]["blob_gasprice"] =
+        json!(blob_params.calc_blob_fee(target_blob_gas));
+
+    let state = serde_json::from_value(state).unwrap();
+    let (api, _handle) = spawn(
+        NodeConfig::test()
+            .with_hardfork(Some(EthereumHardfork::Osaka.into()))
+            .with_init_state(Some(state)),
+    )
+    .await;
+
+    assert_eq!(api.backend.fees().excess_blob_gas_and_price().unwrap().excess_blob_gas, 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rejects_nonempty_block_history_without_best_block() {
+    let (source, _handle) = spawn(NodeConfig::test()).await;
+    source.mine_one().await;
+    source.mine_one().await;
+    let mut state = source.serialized_state(false).await.unwrap();
+    state.blocks.retain(|block| block.header.number != 2);
+    assert!(!state.blocks.is_empty());
+
+    let (api, _handle) = spawn(NodeConfig::test()).await;
+    let err =
+        api.anvil_load_state(Bytes::from(serde_json::to_vec(&state).unwrap())).await.unwrap_err();
+    assert!(err.to_string().contains("Best hash not found for best number 2"));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -437,8 +553,8 @@ async fn test_backward_compatibility_deserialization_v1_2() {
             "difficulty": "0x0",
             "prevrandao": "0xecc5f0af8ff6b65c14bfdac55ba9db870d89482eb2b87200c6d7e7cd3a3a5ad5",
             "blob_excess_gas_and_price": {
-                "excess_blob_gas": 0,
-                "blob_gasprice": 1
+                "excess_blob_gas": 173990704,
+                "blob_gasprice": 43056053164891617135028
             }
         },
         "accounts": {},
@@ -453,6 +569,9 @@ async fn test_backward_compatibility_deserialization_v1_2() {
     assert_eq!(block_env.number, U256::from(5));
     // Verify coinbase was converted to beneficiary
     assert_eq!(block_env.beneficiary, address!("0x1234567890123456789012345678901234567890"));
+    let blob = block_env.blob_excess_gas_and_price.unwrap();
+    assert_eq!(blob.excess_blob_gas, 173990704);
+    assert_eq!(blob.blob_gasprice, 43056053164891617135028);
 
     // New format with beneficiary and numeric values
     let new_format = r#"{


### PR DESCRIPTION
Restores legacy Anvil state dumps with missing block history by creating a consistent checkpoint. It also supports historical blob gas prices larger than `u64`, allowing affected dumps to load offline and continue mining.

Closes #10363 