### PR TITLE
fix(ci): validate changelogs on stale forks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Checkout trusted validator
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.ref }}
           path: trusted
           persist-credentials: false
           sparse-checkout: .github/scripts/validate_changelog.py
@@ -43,17 +44,11 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           EXEMPT: ${{ contains(github.event.pull_request.labels.*.name, 'L-ignore') }}
-          SAME_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
           validator=trusted/.github/scripts/validate_changelog.py
           if [[ ! -f "$validator" ]]; then
-            if [[ "$SAME_REPOSITORY" != "true" || ! "$AUTHOR_ASSOCIATION" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
-              echo "The trusted changelog validator is not available on the base branch." >&2
-              exit 1
-            fi
-            # Bootstrap the validator only for its initial trusted same-repository PR.
-            validator=pull-request/.github/scripts/validate_changelog.py
+            echo "The trusted changelog validator is not available on the current base branch." >&2
+            exit 1
           fi
           args=(--root pull-request --base "$BASE_SHA" --head "$HEAD_SHA")
           if [[ "$EXEMPT" == "true" ]]; then


### PR DESCRIPTION
Pull requests opened before #15882 retain a base SHA from before the trusted changelog validator existed. The changelog job checked the validator out at that historical SHA and then correctly refused to execute the external contributor's copy, causing valid changelog entries to fail without being inspected.

This loads the validator from the current trusted target branch while continuing to validate the recorded base and head SHAs. It also removes the bootstrap path entirely, so contributor-controlled validator code is never executed. The check remains blocking and the existing `L-ignore` exemption is unchanged.

This PR was written with Codex assistance.
