### PR TITLE
perf(forge): speed up forked scripts

### DIFF
--- a/.changelog/forge-script-chain-id-reuse.md
+++ b/.changelog/forge-script-chain-id-reuse.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Reduced redundant chain ID requests when running scripts against a fork.

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -29,11 +29,6 @@ pub struct EvmOpts {
     #[serde(rename = "eth_rpc_url")]
     pub fork_url: Option<String>,
 
-    /// Chain ID fetched from the fork URL during network inference.
-    #[doc(hidden)]
-    #[serde(skip)]
-    pub cached_fork_chain_id: Option<(String, ChainId)>,
-
     /// Pins the block number for the state fork.
     pub fork_block_number: Option<u64>,
 
@@ -98,7 +93,6 @@ impl Default for EvmOpts {
         Self {
             env: Env::default(),
             fork_url: None,
-            cached_fork_chain_id: None,
             fork_block_number: None,
             fork_retries: None,
             fork_retry_backoff: None,
@@ -186,7 +180,6 @@ impl EvmOpts {
             && let Ok(chain_id) = provider.get_chain_id().await
         {
             self.env.chain_id.get_or_insert(chain_id);
-            self.cached_fork_chain_id = Some((fork_url.clone(), chain_id));
 
             // If Anvil's chain, request anvil_nodeInfo to determine if the network is Tempo.
             if chain_id == NamedChain::AnvilHardhat as u64 {
@@ -418,16 +411,9 @@ impl EvmOpts {
 
     /// Returns the chain ID from the RPC, if any.
     pub async fn get_remote_chain_id(&self) -> Option<Chain> {
-        if let Some(url) = &self.fork_url {
-            if let Some((cached_url, chain_id)) = &self.cached_fork_chain_id
-                && cached_url == url
-            {
-                return Some(Chain::from(*chain_id));
-            }
-
-            let Ok(provider) = self.fork_provider_with_url::<AnyNetwork>(url) else {
-                return None;
-            };
+        if let Some(url) = &self.fork_url
+            && let Ok(provider) = self.fork_provider_with_url::<AnyNetwork>(url)
+        {
             trace!(?url, "retrieving chain via eth_chainId");
 
             if let Ok(id) = provider.get_chain_id().await {
@@ -519,16 +505,13 @@ mod tests {
 
         let config = Config::figment();
         let mut evm_opts = config.extract::<EvmOpts>().unwrap();
-        let fork_url = handle.http_endpoint();
-        evm_opts.fork_url = Some(fork_url.clone());
+        evm_opts.fork_url = Some(handle.http_endpoint());
         assert_eq!(evm_opts.networks, NetworkConfigs::default());
 
         evm_opts.infer_network_from_fork().await;
 
         // Plain anvil (chain id 31337) without tempo flag -> Ethereum (no network flags set).
         assert_eq!(evm_opts.env.chain_id, Some(31337));
-        assert_eq!(evm_opts.cached_fork_chain_id, Some((fork_url, 31337)));
-        assert_eq!(evm_opts.get_remote_chain_id().await, Some(Chain::from(31337)));
         assert!(!evm_opts.networks.is_tempo());
         #[cfg(feature = "optimism")]
         assert!(!evm_opts.networks.is_optimism());
@@ -552,22 +535,6 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn infer_network_keeps_remote_chain_separate_from_explicit_chain() {
-        let (_api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
-        let fork_url = handle.http_endpoint();
-        let mut evm_opts = EvmOpts {
-            env: Env { chain_id: Some(1), ..Default::default() },
-            fork_url: Some(fork_url.clone()),
-            ..Default::default()
-        };
-
-        evm_opts.infer_network_from_fork().await;
-
-        assert_eq!(evm_opts.env.chain_id, Some(1));
-        assert_eq!(evm_opts.cached_fork_chain_id, Some((fork_url, 31337)));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
     async fn infer_network_tempo_anvil_skips_rpc_when_already_set() {
         // Use a URL that would fail if any RPC call were attempted (connection refused).
         // This proves the early-return guard prevents all network requests.
@@ -581,21 +548,6 @@ mod tests {
 
         // Should still be tempo, the early-return guard skips the RPC call.
         assert!(evm_opts.networks.is_tempo());
-    }
-
-    #[tokio::test]
-    async fn cached_fork_chain_id_is_url_scoped() {
-        let cached_url = "http://cached.invalid".to_string();
-        let mut evm_opts = EvmOpts {
-            fork_url: Some(cached_url.clone()),
-            cached_fork_chain_id: Some((cached_url, 1)),
-            ..Default::default()
-        };
-
-        assert_eq!(evm_opts.get_remote_chain_id().await, Some(Chain::mainnet()));
-
-        evm_opts.fork_url = Some("not a valid URL".to_string());
-        assert_eq!(evm_opts.get_remote_chain_id().await, None);
     }
 
     #[tokio::test]

--- a/crates/evm/core/src/opts.rs
+++ b/crates/evm/core/src/opts.rs
@@ -29,6 +29,11 @@ pub struct EvmOpts {
     #[serde(rename = "eth_rpc_url")]
     pub fork_url: Option<String>,
 
+    /// Chain ID fetched from the fork URL during network inference.
+    #[doc(hidden)]
+    #[serde(skip)]
+    pub cached_fork_chain_id: Option<(String, ChainId)>,
+
     /// Pins the block number for the state fork.
     pub fork_block_number: Option<u64>,
 
@@ -93,6 +98,7 @@ impl Default for EvmOpts {
         Self {
             env: Env::default(),
             fork_url: None,
+            cached_fork_chain_id: None,
             fork_block_number: None,
             fork_retries: None,
             fork_retry_backoff: None,
@@ -180,6 +186,7 @@ impl EvmOpts {
             && let Ok(chain_id) = provider.get_chain_id().await
         {
             self.env.chain_id.get_or_insert(chain_id);
+            self.cached_fork_chain_id = Some((fork_url.clone(), chain_id));
 
             // If Anvil's chain, request anvil_nodeInfo to determine if the network is Tempo.
             if chain_id == NamedChain::AnvilHardhat as u64 {
@@ -411,9 +418,16 @@ impl EvmOpts {
 
     /// Returns the chain ID from the RPC, if any.
     pub async fn get_remote_chain_id(&self) -> Option<Chain> {
-        if let Some(url) = &self.fork_url
-            && let Ok(provider) = self.fork_provider_with_url::<AnyNetwork>(url)
-        {
+        if let Some(url) = &self.fork_url {
+            if let Some((cached_url, chain_id)) = &self.cached_fork_chain_id
+                && cached_url == url
+            {
+                return Some(Chain::from(*chain_id));
+            }
+
+            let Ok(provider) = self.fork_provider_with_url::<AnyNetwork>(url) else {
+                return None;
+            };
             trace!(?url, "retrieving chain via eth_chainId");
 
             if let Ok(id) = provider.get_chain_id().await {
@@ -505,13 +519,16 @@ mod tests {
 
         let config = Config::figment();
         let mut evm_opts = config.extract::<EvmOpts>().unwrap();
-        evm_opts.fork_url = Some(handle.http_endpoint());
+        let fork_url = handle.http_endpoint();
+        evm_opts.fork_url = Some(fork_url.clone());
         assert_eq!(evm_opts.networks, NetworkConfigs::default());
 
         evm_opts.infer_network_from_fork().await;
 
         // Plain anvil (chain id 31337) without tempo flag -> Ethereum (no network flags set).
         assert_eq!(evm_opts.env.chain_id, Some(31337));
+        assert_eq!(evm_opts.cached_fork_chain_id, Some((fork_url, 31337)));
+        assert_eq!(evm_opts.get_remote_chain_id().await, Some(Chain::from(31337)));
         assert!(!evm_opts.networks.is_tempo());
         #[cfg(feature = "optimism")]
         assert!(!evm_opts.networks.is_optimism());
@@ -535,6 +552,22 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn infer_network_keeps_remote_chain_separate_from_explicit_chain() {
+        let (_api, handle) = anvil::spawn(anvil::NodeConfig::test()).await;
+        let fork_url = handle.http_endpoint();
+        let mut evm_opts = EvmOpts {
+            env: Env { chain_id: Some(1), ..Default::default() },
+            fork_url: Some(fork_url.clone()),
+            ..Default::default()
+        };
+
+        evm_opts.infer_network_from_fork().await;
+
+        assert_eq!(evm_opts.env.chain_id, Some(1));
+        assert_eq!(evm_opts.cached_fork_chain_id, Some((fork_url, 31337)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn infer_network_tempo_anvil_skips_rpc_when_already_set() {
         // Use a URL that would fail if any RPC call were attempted (connection refused).
         // This proves the early-return guard prevents all network requests.
@@ -548,6 +581,21 @@ mod tests {
 
         // Should still be tempo, the early-return guard skips the RPC call.
         assert!(evm_opts.networks.is_tempo());
+    }
+
+    #[tokio::test]
+    async fn cached_fork_chain_id_is_url_scoped() {
+        let cached_url = "http://cached.invalid".to_string();
+        let mut evm_opts = EvmOpts {
+            fork_url: Some(cached_url.clone()),
+            cached_fork_chain_id: Some((cached_url, 1)),
+            ..Default::default()
+        };
+
+        assert_eq!(evm_opts.get_remote_chain_id().await, Some(Chain::mainnet()));
+
+        evm_opts.fork_url = Some("not a valid URL".to_string());
+        assert_eq!(evm_opts.get_remote_chain_id().await, None);
     }
 
     #[tokio::test]

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -8,6 +8,7 @@ use alloy_hardforks::EthereumHardfork;
 use alloy_network::Ethereum;
 use alloy_primitives::{Address, Bytes, U256, address, hex};
 use anvil::{NodeConfig, spawn};
+use axum::{Router, body::Bytes as BodyBytes};
 use forge_script_sequence::ScriptSequence;
 use foundry_test_utils::{
     ScriptOutcome, ScriptTester,
@@ -20,6 +21,10 @@ use serde_json::Value;
 use std::{
     env, fs,
     path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 fn latest_dry_run_sequence(root: &Path) -> ScriptSequence<Ethereum> {
@@ -1164,6 +1169,50 @@ forgetest_async!(can_deploy_and_simulate_25_txes_concurrently, |prj, cmd| {
         .broadcast(ScriptOutcome::OkBroadcast)
         .assert_nonce_increment(&[(0, 25)])
         .await;
+});
+
+forgetest_async!(fork_script_reuses_inferred_chain_id, |prj, cmd| {
+    let (_api, handle) = spawn(NodeConfig::test()).await;
+    let upstream = handle.http_endpoint();
+    let chain_id_requests = Arc::new(AtomicUsize::new(0));
+    let client = reqwest::Client::new();
+    let app = Router::new().fallback({
+        let chain_id_requests = Arc::clone(&chain_id_requests);
+        move |body: BodyBytes| {
+            let upstream = upstream.clone();
+            let client = client.clone();
+            let chain_id_requests = Arc::clone(&chain_id_requests);
+            async move {
+                let request: Value = serde_json::from_slice(&body).unwrap();
+                if request.get("method").and_then(Value::as_str) == Some("eth_chainId") {
+                    chain_id_requests.fetch_add(1, Ordering::Relaxed);
+                }
+                let response = client
+                    .post(upstream)
+                    .header("content-type", "application/json")
+                    .body(body)
+                    .send()
+                    .await
+                    .unwrap();
+                let status = response.status();
+                let body = response.bytes().await.unwrap();
+                (status, [("content-type", "application/json")], body)
+            }
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let _proxy = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let mut tester = ScriptTester::new_broadcast(cmd, &endpoint, prj.root());
+    tester
+        .add_deployer(0)
+        .add_sig("ScriptAdditionalContracts", "run()")
+        .args(&["--chain", "1"])
+        .simulate(ScriptOutcome::OkSimulation);
+
+    assert_eq!(chain_id_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(latest_dry_run_sequence(prj.root()).chain, 31337);
 });
 
 forgetest_async!(can_deploy_and_simulate_mixed_broadcast_modes, |prj, cmd| {

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -21,10 +21,7 @@ use serde_json::Value;
 use std::{
     env, fs,
     path::{Path, PathBuf},
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 fn latest_dry_run_sequence(root: &Path) -> ScriptSequence<Ethereum> {
@@ -1171,47 +1168,44 @@ forgetest_async!(can_deploy_and_simulate_25_txes_concurrently, |prj, cmd| {
         .await;
 });
 
-forgetest_async!(fork_script_reuses_inferred_chain_id, |prj, cmd| {
+forgetest_async!(fork_script_reuses_chain_ids, |prj, cmd| {
+    static CHAIN_ID_REQUESTS: AtomicUsize = AtomicUsize::new(0);
+    CHAIN_ID_REQUESTS.store(0, Ordering::Relaxed);
+
     let (_api, handle) = spawn(NodeConfig::test()).await;
     let upstream = handle.http_endpoint();
-    let chain_id_requests = Arc::new(AtomicUsize::new(0));
     let client = reqwest::Client::new();
-    let app = Router::new().fallback({
-        let chain_id_requests = Arc::clone(&chain_id_requests);
-        move |body: BodyBytes| {
-            let upstream = upstream.clone();
-            let client = client.clone();
-            let chain_id_requests = Arc::clone(&chain_id_requests);
-            async move {
-                let request: Value = serde_json::from_slice(&body).unwrap();
-                if request.get("method").and_then(Value::as_str) == Some("eth_chainId") {
-                    chain_id_requests.fetch_add(1, Ordering::Relaxed);
-                }
-                let response = client
-                    .post(upstream)
-                    .header("content-type", "application/json")
-                    .body(body)
-                    .send()
-                    .await
-                    .unwrap();
-                let status = response.status();
-                let body = response.bytes().await.unwrap();
-                (status, [("content-type", "application/json")], body)
+    let app = Router::new().fallback(move |body: BodyBytes| {
+        let upstream = upstream.clone();
+        let client = client.clone();
+        async move {
+            let request: Value = serde_json::from_slice(&body).unwrap();
+            if request.get("method").and_then(Value::as_str) == Some("eth_chainId") {
+                CHAIN_ID_REQUESTS.fetch_add(1, Ordering::Relaxed);
             }
+            client
+                .post(upstream)
+                .header("content-type", "application/json")
+                .body(body)
+                .send()
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
         }
     });
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let endpoint = format!("http://{}", listener.local_addr().unwrap());
     let _proxy = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-    let mut tester = ScriptTester::new_broadcast(cmd, &endpoint, prj.root());
-    tester
+    ScriptTester::new_broadcast(cmd, &endpoint, prj.root())
         .add_deployer(0)
         .add_sig("ScriptAdditionalContracts", "run()")
         .args(&["--chain", "1"])
         .simulate(ScriptOutcome::OkSimulation);
 
-    assert_eq!(chain_id_requests.load(Ordering::Relaxed), 1);
+    assert_eq!(CHAIN_ID_REQUESTS.load(Ordering::Relaxed), 2);
     assert_eq!(latest_dry_run_sequence(prj.root()).chain, 31337);
 });
 

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -28,7 +28,6 @@ use foundry_evm::{
     decode::decode_console_logs,
     hardforks::TempoHardfork,
     inspectors::cheatcodes::BroadcastableTransactions,
-    opts::EvmOpts,
     traces::{
         CallTraceDecoder, CallTraceDecoderBuilder, DebugTraceIdentifier, TraceKind,
         decode_trace_arena,
@@ -250,20 +249,11 @@ pub struct RpcData {
 
 impl RpcData {
     /// Iterates over script transactions and collects RPC urls.
-    fn from_transactions<N: Network>(
-        txs: &BroadcastableTransactions<N>,
-        evm_opts: &EvmOpts,
-    ) -> Self {
+    fn from_transactions<N: Network>(txs: &BroadcastableTransactions<N>) -> Self {
         let missing_rpc = txs.iter().any(|tx| tx.rpc.is_none());
         let total_rpcs = txs.iter().filter_map(|tx| tx.rpc.clone()).collect::<HashSet<_>>();
-        let mut chain_ids = HashMap::default();
-        if let Some((url, chain_id)) = &evm_opts.cached_fork_chain_id
-            && total_rpcs.contains(url)
-        {
-            chain_ids.insert(url.clone(), *chain_id);
-        }
 
-        Self { total_rpcs, missing_rpc, chain_ids }
+        Self { total_rpcs, missing_rpc, chain_ids: HashMap::default() }
     }
 
     /// Returns true if script might be multi-chain.
@@ -274,20 +264,12 @@ impl RpcData {
 
     /// Checks if all RPCs support EIP-3855. Prints a warning if not.
     async fn check_shanghai_support(&mut self) -> Result<()> {
-        let missing_rpcs = self
-            .total_rpcs
-            .iter()
-            .filter(|rpc| !self.chain_ids.contains_key(*rpc))
-            .cloned()
-            .collect::<Vec<_>>();
-        let chain_ids = missing_rpcs.iter().map(|rpc| async move {
+        let chain_ids = self.total_rpcs.iter().map(|rpc| async move {
             let provider = ProviderBuilder::<AnyNetwork>::new(rpc).build().ok()?;
-            provider.get_chain_id().await.ok()
+            Some((rpc.clone(), provider.get_chain_id().await.ok()?))
         });
 
-        let chains = join_all(chain_ids).await;
-        self.chain_ids
-            .extend(missing_rpcs.into_iter().zip(chains).filter_map(|(rpc, id)| Some((rpc, id?))));
+        self.chain_ids.extend(join_all(chain_ids).await.into_iter().flatten());
         let iter = self
             .chain_ids
             .values()
@@ -346,8 +328,6 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
     async fn prepare_simulation_inner(self, silent: bool) -> Result<PreSimulationState<FEN>> {
         let returns = self.get_returns()?;
 
-        let decoder = self.build_trace_decoder(&self.build_data.known_contracts).await?;
-
         let mut txs: BroadcastableTransactions<FEN::Network> =
             self.execution_result.transactions.clone().unwrap_or_default();
 
@@ -360,7 +340,7 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
                 *req = req.clone().with_input_kind(input, TransactionInputKind::Both);
             }
         }
-        let mut rpc_data = RpcData::from_transactions(&txs, &self.script_config.evm_opts);
+        let mut rpc_data = RpcData::from_transactions(&txs);
 
         if rpc_data.is_multi_chain() && !silent {
             sh_warn!("Multi chain deployment is still under development. Use with caution.")?;
@@ -373,6 +353,8 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
         if !silent {
             rpc_data.check_shanghai_support().await?;
         }
+
+        let decoder = self.build_trace_decoder(&self.build_data.known_contracts, &rpc_data).await?;
 
         Ok(PreSimulationState {
             args: self.args,
@@ -390,8 +372,18 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
     async fn build_trace_decoder(
         &self,
         known_contracts: &ContractsByArtifact,
+        rpc_data: &RpcData,
     ) -> Result<CallTraceDecoder> {
-        let chain_id = self.script_config.evm_opts.get_remote_chain_id().await;
+        let chain_id = match self
+            .script_config
+            .evm_opts
+            .fork_url
+            .as_ref()
+            .and_then(|url| rpc_data.chain_ids.get(url))
+        {
+            Some(chain_id) => Some((*chain_id).into()),
+            None => self.script_config.evm_opts.get_remote_chain_id().await,
+        };
         let is_tempo = self.script_config.evm_opts.networks.is_tempo()
             || chain_id.as_ref().is_some_and(|chain| chain.is_tempo());
         let mut tracing = self.script_config.config.tracing.clone();

--- a/crates/script/src/execute.rs
+++ b/crates/script/src/execute.rs
@@ -28,6 +28,7 @@ use foundry_evm::{
     decode::decode_console_logs,
     hardforks::TempoHardfork,
     inspectors::cheatcodes::BroadcastableTransactions,
+    opts::EvmOpts,
     traces::{
         CallTraceDecoder, CallTraceDecoderBuilder, DebugTraceIdentifier, TraceKind,
         decode_trace_arena,
@@ -243,15 +244,26 @@ pub struct RpcData {
     pub total_rpcs: HashSet<String>,
     /// If true, one of the transactions did not have a rpc.
     pub missing_rpc: bool,
+    /// Chain IDs already fetched for each RPC URL.
+    pub(crate) chain_ids: HashMap<String, u64>,
 }
 
 impl RpcData {
     /// Iterates over script transactions and collects RPC urls.
-    fn from_transactions<N: Network>(txs: &BroadcastableTransactions<N>) -> Self {
+    fn from_transactions<N: Network>(
+        txs: &BroadcastableTransactions<N>,
+        evm_opts: &EvmOpts,
+    ) -> Self {
         let missing_rpc = txs.iter().any(|tx| tx.rpc.is_none());
         let total_rpcs = txs.iter().filter_map(|tx| tx.rpc.clone()).collect::<HashSet<_>>();
+        let mut chain_ids = HashMap::default();
+        if let Some((url, chain_id)) = &evm_opts.cached_fork_chain_id
+            && total_rpcs.contains(url)
+        {
+            chain_ids.insert(url.clone(), *chain_id);
+        }
 
-        Self { total_rpcs, missing_rpc }
+        Self { total_rpcs, missing_rpc, chain_ids }
     }
 
     /// Returns true if script might be multi-chain.
@@ -261,15 +273,26 @@ impl RpcData {
     }
 
     /// Checks if all RPCs support EIP-3855. Prints a warning if not.
-    async fn check_shanghai_support(&self) -> Result<()> {
-        let chain_ids = self.total_rpcs.iter().map(|rpc| async move {
+    async fn check_shanghai_support(&mut self) -> Result<()> {
+        let missing_rpcs = self
+            .total_rpcs
+            .iter()
+            .filter(|rpc| !self.chain_ids.contains_key(*rpc))
+            .cloned()
+            .collect::<Vec<_>>();
+        let chain_ids = missing_rpcs.iter().map(|rpc| async move {
             let provider = ProviderBuilder::<AnyNetwork>::new(rpc).build().ok()?;
-            let id = provider.get_chain_id().await.ok()?;
-            NamedChain::try_from(id).ok()
+            provider.get_chain_id().await.ok()
         });
 
         let chains = join_all(chain_ids).await;
-        let iter = chains.iter().flatten().map(|c| (c.supports_shanghai(), c));
+        self.chain_ids
+            .extend(missing_rpcs.into_iter().zip(chains).filter_map(|(rpc, id)| Some((rpc, id?))));
+        let iter = self
+            .chain_ids
+            .values()
+            .filter_map(|id| NamedChain::try_from(*id).ok())
+            .map(|chain| (chain.supports_shanghai(), chain));
         if iter.clone().any(|(s, _)| !s) {
             let msg = format!(
                 "\
@@ -278,7 +301,7 @@ Unsupported Chain IDs: {}.
 Contracts deployed with a Solidity version equal or higher than 0.8.20 might not work properly.
 For more information, please see https://eips.ethereum.org/EIPS/eip-3855",
                 iter.filter(|(supported, _)| !supported)
-                    .map(|(_, chain)| *chain as u64)
+                    .map(|(_, chain)| chain as u64)
                     .format(", ")
             );
             sh_warn!("{msg}")?;
@@ -337,7 +360,7 @@ impl<FEN: FoundryEvmNetwork> ExecutedState<FEN> {
                 *req = req.clone().with_input_kind(input, TransactionInputKind::Both);
             }
         }
-        let rpc_data = RpcData::from_transactions(&txs);
+        let mut rpc_data = RpcData::from_transactions(&txs, &self.script_config.evm_opts);
 
         if rpc_data.is_multi_chain() && !silent {
             sh_warn!("Multi chain deployment is still under development. Use with caution.")?;

--- a/crates/script/src/providers.rs
+++ b/crates/script/src/providers.rs
@@ -25,13 +25,14 @@ impl<N: Network> ProvidersManager<N> {
     pub async fn get_or_init_provider(
         &mut self,
         rpc: &str,
+        chain: Option<u64>,
         is_legacy: bool,
         fee_estimate: Eip1559FeeEstimatePreset,
     ) -> Result<&ProviderInfo<N>> {
         Ok(match self.inner.entry(rpc.to_string()) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let info = ProviderInfo::new(rpc, is_legacy, fee_estimate).await?;
+                let info = ProviderInfo::new(rpc, chain, is_legacy, fee_estimate).await?;
                 entry.insert(info)
             }
         })
@@ -64,11 +65,15 @@ pub enum GasPrice {
 impl<N: Network> ProviderInfo<N> {
     pub async fn new(
         rpc: &str,
+        chain: Option<u64>,
         mut is_legacy: bool,
         fee_estimate: Eip1559FeeEstimatePreset,
     ) -> Result<Self> {
         let provider = Arc::new(ProviderBuilder::new(rpc).build()?);
-        let chain = provider.get_chain_id().await?;
+        let chain = match chain {
+            Some(chain) => chain,
+            None => provider.get_chain_id().await?,
+        };
 
         if let Some(chain) = Chain::from(chain).named() {
             is_legacy |= chain.is_legacy();

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -307,6 +307,7 @@ impl<FEN: FoundryEvmNetwork> FilledTransactionsState<FEN> {
             let provider_info = manager
                 .get_or_init_provider(
                     &tx.rpc,
+                    self.execution_artifacts.rpc_data.chain_ids.get(&tx.rpc).copied(),
                     self.args.legacy,
                     self.script_config.config.eip1559_fee_estimate,
                 )


### PR DESCRIPTION
Forked `forge script` runs now retain successful chain IDs fetched by the existing post-execution Shanghai compatibility check and reuse them for trace decoding and simulation provider setup, instead of sending two more `eth_chainId` requests per RPC URL. The cache is scoped to exact URLs and does not cross script execution, preserving explicit `--chain`, failed-lookup fallbacks, silent optimization candidates, and scripts that mutate RPC state while running. Developed with OpenAI Codex assistance.

### Results

Local debug builds from exact master `0c6ed5d09`, using `ScriptAdditionalContracts` through a deterministic proxy that delays only `eth_chainId` by 200ms. Hyperfine used 5 warmups and 20 measured runs, removing generated `out`, `cache`, and `broadcast` output before each sample:

| Version | `eth_chainId` requests | Time (mean ± σ) | Range | Speedup |
| --- | ---: | ---: | ---: | ---: |
| master | 4 | 1.264s ± 0.042s | 1.237–1.439s | — |
| this PR | 2 | 841.6ms ± 9.1ms | 826.1–866.5ms | 1.50× |
