### PR TITLE
fix(common): normalize browser estimate hints

### DIFF
--- a/.changelog/tempo-browser-estimation-hints.md
+++ b/.changelog/tempo-browser-estimation-hints.md
@@ -1,0 +1,5 @@
+---
+foundry-common: patch
+---
+
+Handled incomplete Tempo browser-wallet estimation hints conservatively.

--- a/crates/common/src/tempo/tests.rs
+++ b/crates/common/src/tempo/tests.rs
@@ -52,15 +52,40 @@ fn browser_gas_estimation_uses_conservative_webauthn_hint() {
     assert_eq!(request.key_type, None);
     assert_eq!(request.key_data, None);
     assert_eq!(request.inner.to, Some(TxKind::Create));
+}
 
+#[test]
+fn browser_gas_estimation_preserves_complete_signer_hints() {
+    for key_type in [SignatureType::Secp256k1, SignatureType::P256, SignatureType::WebAuthn] {
+        let request = TempoTransactionRequest {
+            key_type: Some(key_type),
+            key_data: Some(Bytes::from_static(&[0x01])),
+            ..Default::default()
+        };
+        let estimate_request = request.browser_wallet_gas_estimation_request();
+        assert_eq!(estimate_request.key_type, request.key_type);
+        assert_eq!(estimate_request.key_data, request.key_data);
+    }
+}
+
+#[test]
+fn browser_gas_estimation_fills_missing_webauthn_key_data() {
+    let request =
+        TempoTransactionRequest { key_type: Some(SignatureType::WebAuthn), ..Default::default() };
+    let estimate_request = request.browser_wallet_gas_estimation_request();
+    assert_eq!(estimate_request.key_type, request.key_type);
+    assert_eq!(estimate_request.key_data, Some(Bytes::from_static(&[0x05, 0x78])));
+}
+
+#[test]
+fn browser_gas_estimation_replaces_key_data_without_key_type() {
     let request = TempoTransactionRequest {
-        key_type: Some(SignatureType::P256),
         key_data: Some(Bytes::from_static(&[0x01])),
         ..Default::default()
     };
     let estimate_request = request.browser_wallet_gas_estimation_request();
-    assert_eq!(estimate_request.key_type, request.key_type);
-    assert_eq!(estimate_request.key_data, request.key_data);
+    assert_eq!(estimate_request.key_type, Some(SignatureType::WebAuthn));
+    assert_eq!(estimate_request.key_data, Some(Bytes::from_static(&[0x05, 0x78])));
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/common/src/transactions/builder.rs
+++ b/crates/common/src/transactions/builder.rs
@@ -185,6 +185,9 @@ pub trait FoundryTransactionBuilder<N: Network>: NetworkTransactionBuilder<N> {
     }
 
     /// Clone this request and prepare it for browser-wallet gas estimation.
+    ///
+    /// Complete signer hints are preserved. Missing or incomplete hints default to a conservative
+    /// WebAuthn signature size.
     fn browser_wallet_gas_estimation_request(&self) -> Self
     where
         Self: Clone,
@@ -450,8 +453,11 @@ impl FoundryTransactionBuilder<TempoNetwork> for <TempoNetwork as Network>::Tran
         let mut request = self.clone();
         if request.key_type.is_none() {
             request.key_type = Some(SignatureType::WebAuthn);
-        }
-        if matches!(request.key_type, Some(SignatureType::WebAuthn)) && request.key_data.is_none() {
+            request.key_data =
+                Some(Bytes::copy_from_slice(&TEMPO_BROWSER_WEBAUTHN_DATA_SIZE.to_be_bytes()));
+        } else if matches!(request.key_type, Some(SignatureType::WebAuthn))
+            && request.key_data.is_none()
+        {
             request.key_data =
                 Some(Bytes::copy_from_slice(&TEMPO_BROWSER_WEBAUTHN_DATA_SIZE.to_be_bytes()));
         }


### PR DESCRIPTION
Stacked on #15935.

Browser-wallet gas estimation now preserves complete signer hints while treating partial metadata conservatively. A request with `keyData` but no `keyType` is normalized to WebAuthn with the 1,400-byte size hint, while known secp256k1, P256, and WebAuthn metadata remains unchanged. This leaves room for future provider-specific callers to supply signer knowledge without allowing incomplete hints to underestimate gas.

Amp was used to explore the browser-wallet infrastructure and prepare the implementation.
