### PR TITLE
fix(anvil): isolate transaction hash replay

### DIFF
--- a/.changelog/anvil-transaction-hash-replay.md
+++ b/.changelog/anvil-transaction-hash-replay.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Replayed transaction-hash fork prefixes atomically during startup before local mining begins.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -9,7 +9,7 @@ use crate::{
             time::duration_since_unix_epoch,
         },
         fees::{INITIAL_BASE_FEE, INITIAL_GAS_PRICE},
-        pool::transactions::{PoolTransaction, TransactionOrder},
+        pool::transactions::TransactionOrder,
     },
     mem::{self, in_memory_db::StateRootDb},
 };
@@ -18,7 +18,7 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1559::BaseFeeParams, eip7840::BlobParams};
 use alloy_evm::EvmEnv;
 use alloy_genesis::Genesis;
-use alloy_network::{AnyNetwork, BlockResponse, TransactionResponse};
+use alloy_network::{AnyNetwork, AnyRpcBlock, BlockResponse, TransactionResponse};
 use alloy_primitives::{
     Address, BlockNumber, TxHash, U256, hex, keccak256, map::HashMap, utils::Unit,
 };
@@ -47,8 +47,6 @@ use foundry_evm::{
         get_blob_base_fee_update_fraction,
     },
 };
-use foundry_primitives::FoundryTxEnvelope;
-use itertools::Itertools;
 use parking_lot::RwLock;
 use rand_08::thread_rng;
 use revm::{
@@ -89,6 +87,13 @@ pub const DEFAULT_GAS_LIMIT: u64 = 30_000_000;
 pub const DEFAULT_SLOTS_IN_AN_EPOCH: u64 = 32;
 /// Default mnemonic for dev accounts
 pub const DEFAULT_MNEMONIC: &str = "test test test test test test test test test test test junk";
+
+/// One-shot source data for a transaction-hash fork replay.
+#[derive(Clone, Debug)]
+pub(crate) struct ForkTransactionReplay {
+    pub(crate) source_block: AnyRpcBlock,
+    pub(crate) target_index: usize,
+}
 
 /// The default IPC endpoint
 pub const DEFAULT_IPC_ENDPOINT: &str =
@@ -1165,7 +1170,9 @@ impl NodeConfig {
     /// [Backend](mem::Backend)
     ///
     /// *Note*: only memory based backend for now
-    pub(crate) async fn setup<N>(&mut self) -> Result<mem::Backend<N>>
+    pub(crate) async fn setup<N>(
+        &mut self,
+    ) -> Result<(mem::Backend<N>, Option<ForkTransactionReplay>)>
     where
         N: alloy_network::Network<
                 TxEnvelope = foundry_primitives::FoundryTxEnvelope,
@@ -1223,12 +1230,14 @@ impl NodeConfig {
             tempo_hardfork,
         );
 
-        let (db, fork): (Arc<TokioRwLock<Box<dyn Db>>>, Option<ClientFork>) =
+        let (db, fork, fork_transaction_replay) =
             if let Some(eth_rpc_url) = self.fork_urls.first().cloned() {
-                self.setup_fork_db(eth_rpc_url, &mut evm_env, &fees).await?
+                self.setup_fork_db_with_replay(eth_rpc_url, &mut evm_env, &fees).await?
             } else {
                 let track_history = self.prune_history.is_state_history_supported();
-                (Arc::new(TokioRwLock::new(Box::new(StateRootDb::new(track_history)))), None)
+                let db: Arc<TokioRwLock<Box<dyn Db>>> =
+                    Arc::new(TokioRwLock::new(Box::new(StateRootDb::new(track_history))));
+                (db, None, None)
             };
 
         // if provided use all settings of `genesis.json`
@@ -1319,7 +1328,7 @@ impl NodeConfig {
             }
         }
 
-        Ok(backend)
+        Ok((backend, fork_transaction_replay))
     }
 
     /// Configures everything related to forking based on the passed `eth_rpc_url`:
@@ -1334,10 +1343,23 @@ impl NodeConfig {
         evm_env: &mut EvmEnv,
         fees: &FeeManager,
     ) -> Result<(Arc<TokioRwLock<Box<dyn Db>>>, Option<ClientFork>)> {
-        let (db, config) = self.setup_fork_db_config(eth_rpc_url, evm_env, fees).await?;
+        let (db, fork, replay) = self.setup_fork_db_with_replay(eth_rpc_url, evm_env, fees).await?;
+        eyre::ensure!(replay.is_none(), "transaction-hash fork replay requires full node startup");
+        Ok((db, fork))
+    }
+
+    async fn setup_fork_db_with_replay(
+        &mut self,
+        eth_rpc_url: String,
+        evm_env: &mut EvmEnv,
+        fees: &FeeManager,
+    ) -> Result<(Arc<TokioRwLock<Box<dyn Db>>>, Option<ClientFork>, Option<ForkTransactionReplay>)>
+    {
+        let (db, config, replay) =
+            self.setup_fork_db_config_with_replay(eth_rpc_url, evm_env, fees).await?;
         let db: Arc<TokioRwLock<Box<dyn Db>>> = Arc::new(TokioRwLock::new(Box::new(db)));
         let fork = ClientFork::new(config, Arc::clone(&db));
-        Ok((db, Some(fork)))
+        Ok((db, Some(fork), replay))
     }
 
     /// Configures everything related to forking based on the passed `eth_rpc_url`:
@@ -1351,6 +1373,18 @@ impl NodeConfig {
         evm_env: &mut EvmEnv,
         fees: &FeeManager,
     ) -> Result<(ForkedDatabase<AnyNetwork>, ClientForkConfig)> {
+        let (db, config, replay) =
+            self.setup_fork_db_config_with_replay(eth_rpc_url, evm_env, fees).await?;
+        eyre::ensure!(replay.is_none(), "transaction-hash fork replay requires full node startup");
+        Ok((db, config))
+    }
+
+    pub(crate) async fn setup_fork_db_config_with_replay(
+        &mut self,
+        eth_rpc_url: String,
+        evm_env: &mut EvmEnv,
+        fees: &FeeManager,
+    ) -> Result<(ForkedDatabase<AnyNetwork>, ClientForkConfig, Option<ForkTransactionReplay>)> {
         debug!(target: "node", ?eth_rpc_url, "setting up fork db");
 
         // Always bootstrap with the primary URL only to avoid race conditions
@@ -1367,12 +1401,12 @@ impl NodeConfig {
                 .wrap_err("failed to establish provider to fork url")?,
         );
 
-        let (fork_block_number, fork_chain_id, force_transactions) = if let Some(fork_choice) =
+        let (fork_block_number, fork_chain_id, fork_transaction_replay) = if let Some(fork_choice) =
             &self.fork_choice
         {
-            let (fork_block_number, force_transactions) =
-                derive_block_and_transactions(fork_choice, &provider).await.wrap_err(
-                    "failed to derive fork block number and force transactions from fork choice",
+            let (fork_block_number, fork_transaction_replay) =
+                derive_block_and_replay(fork_choice, &provider).await.wrap_err(
+                    "failed to derive fork block and transaction replay from fork choice",
                 )?;
             let chain_id = if let Some(chain_id) = self.fork_chain_id {
                 Some(chain_id)
@@ -1384,7 +1418,7 @@ impl NodeConfig {
                 None
             };
 
-            (fork_block_number, chain_id, force_transactions)
+            (fork_block_number, chain_id, fork_transaction_replay)
         } else {
             // pick the last block number but also ensure it's not pending anymore
             let bn = find_latest_fork_block(&provider)
@@ -1416,6 +1450,28 @@ latest block number: {latest_block}"
             }
             eyre::bail!("failed to get block for block number: {fork_block_number}");
         };
+
+        if let Some(replay) = &fork_transaction_replay {
+            let source_header = replay.source_block.header();
+            eyre::ensure!(
+                block.header.hash == source_header.parent_hash,
+                "fork transaction block {} at {} has parent {}, but fetched fork block at {} has \
+                 hash {}",
+                source_header.hash,
+                source_header.number,
+                source_header.parent_hash,
+                block.header.number,
+                block.header.hash
+            );
+            eyre::ensure!(
+                block.header.number.checked_add(1) == Some(source_header.number),
+                "fork transaction block {} has number {}, but fetched parent {} has number {}",
+                source_header.hash,
+                source_header.number,
+                block.header.hash,
+                block.header.number
+            );
+        }
 
         let gas_limit = self.fork_gas_limit(&block);
         self.gas_limit = Some(gas_limit);
@@ -1577,7 +1633,6 @@ latest block number: {latest_block}"
             total_difficulty: block.header.total_difficulty.unwrap_or_default(),
             blob_gas_used: block.header.blob_gas_used().map(|g| g as u128),
             blob_excess_gas_and_price: evm_env.block_env.blob_excess_gas_and_price,
-            force_transactions,
         };
 
         debug!(target: "node", fork_number=config.block_number, fork_hash=%config.block_hash, "set up fork db");
@@ -1587,7 +1642,7 @@ latest block number: {latest_block}"
         // need to insert the forked block's hash
         db.insert_block_hash(U256::from(config.block_number), config.block_hash);
 
-        Ok((db, config))
+        Ok((db, config, fork_transaction_replay))
     }
 
     /// we only use the gas limit value of the block if it is non-zero and the block gas
@@ -1625,10 +1680,10 @@ pub(crate) const fn tempo_default_base_fee(hardfork: TempoHardfork) -> u64 {
 /// If the fork choice is a transaction hash, determine the block that the transaction was mined in,
 /// and return the block number before the fork block along with all transactions in the fork block
 /// that are before (and including) the fork transaction.
-async fn derive_block_and_transactions(
+async fn derive_block_and_replay(
     fork_choice: &ForkChoice,
     provider: &Arc<RetryProvider>,
-) -> eyre::Result<(BlockNumber, Option<Vec<PoolTransaction<FoundryTxEnvelope>>>)> {
+) -> eyre::Result<(BlockNumber, Option<ForkTransactionReplay>)> {
     match fork_choice {
         ForkChoice::Block(block_number) => {
             let block_number = *block_number;
@@ -1645,38 +1700,88 @@ async fn derive_block_and_transactions(
             let transaction = provider
                 .get_transaction_by_hash(transaction_hash.0.into())
                 .await?
-                .ok_or_else(|| eyre::eyre!("failed to get fork transaction by hash"))?;
+                .ok_or_else(|| eyre::eyre!("fork transaction {transaction_hash} was not found"))?;
             let transaction_block_number = transaction.block_number().ok_or_else(|| {
-                eyre::eyre!("fork transaction is not mined yet (no block number)")
+                eyre::eyre!("fork transaction {transaction_hash} is not mined (no block number)")
+            })?;
+            let transaction_block_hash = transaction.block_hash().ok_or_else(|| {
+                eyre::eyre!("fork transaction {transaction_hash} is not mined (no block hash)")
             })?;
 
             // Get the block pertaining to the fork transaction
-            let transaction_block = provider
-                .get_block_by_number(transaction_block_number.into())
-                .full()
-                .await?
-                .ok_or_else(|| eyre::eyre!("failed to get fork block by number"))?;
-
-            // Filter out transactions that are after the fork transaction
-            let filtered_transactions = transaction_block
-                .transactions
-                .as_transactions()
-                .ok_or_else(|| eyre::eyre!("failed to get transactions from full fork block"))?
-                .iter()
-                .take_while_inclusive(|&transaction| transaction.tx_hash() != transaction_hash.0)
-                .collect::<Vec<_>>();
-
-            // Convert the transactions to PoolTransactions
-            let force_transactions = filtered_transactions
-                .iter()
-                .map(|&transaction| {
-                    PoolTransaction::try_from(transaction.clone()).map(PoolTransaction::with_replay)
-                })
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| eyre::eyre!("Err converting to pool transactions {e}"))?;
-            Ok((transaction_block_number.saturating_sub(1), Some(force_transactions)))
+            let transaction_block =
+                provider.get_block_by_hash(transaction_block_hash).full().await?.ok_or_else(
+                    || {
+                        eyre::eyre!(
+                            "failed to get fork block {transaction_block_hash} for transaction \
+                         {transaction_hash}"
+                        )
+                    },
+                )?;
+            let replay = validate_fork_transaction_replay(
+                *transaction_hash,
+                &transaction,
+                transaction_block,
+            )?;
+            Ok((transaction_block_number.saturating_sub(1), Some(replay)))
         }
     }
+}
+
+fn validate_fork_transaction_replay(
+    transaction_hash: TxHash,
+    transaction: &alloy_network::AnyRpcTransaction,
+    source_block: AnyRpcBlock,
+) -> eyre::Result<ForkTransactionReplay> {
+    let source_hash = source_block.header.hash;
+    let source_number = source_block.header.number;
+    let transaction_block_hash = transaction.block_hash().ok_or_else(|| {
+        eyre::eyre!("fork transaction {transaction_hash} is not mined (no block hash)")
+    })?;
+    let transaction_block_number = transaction.block_number().ok_or_else(|| {
+        eyre::eyre!("fork transaction {transaction_hash} is not mined (no block number)")
+    })?;
+
+    eyre::ensure!(
+        source_hash == transaction_block_hash,
+        "fork transaction {transaction_hash} reports block {transaction_block_hash}, but fetched \
+         block hash is {source_hash}"
+    );
+    eyre::ensure!(
+        source_number == transaction_block_number,
+        "fork transaction {transaction_hash} reports block number {transaction_block_number}, but \
+         fetched block {source_hash} has number {source_number}"
+    );
+    eyre::ensure!(
+        source_number > 0,
+        "fork transaction {transaction_hash} is in genesis block {source_hash}, which has no parent"
+    );
+
+    let transactions = source_block.transactions.as_transactions().ok_or_else(|| {
+        eyre::eyre!("fork block {source_hash} at {source_number} did not include full transactions")
+    })?;
+    let mut matches =
+        transactions.iter().enumerate().filter(|(_, tx)| tx.tx_hash() == transaction_hash);
+    let target_index = matches.next().map(|(index, _)| index).ok_or_else(|| {
+        eyre::eyre!(
+            "fork transaction {transaction_hash} is absent from block {source_hash} at \
+             {source_number}"
+        )
+    })?;
+    eyre::ensure!(
+        matches.next().is_none(),
+        "fork transaction {transaction_hash} occurs more than once in block {source_hash} at \
+         {source_number}"
+    );
+    if let Some(reported_index) = transaction.transaction_index() {
+        eyre::ensure!(
+            reported_index == target_index as u64,
+            "fork transaction {transaction_hash} reports index {reported_index}, but occurs at \
+             index {target_index} in block {source_hash}"
+        );
+    }
+
+    Ok(ForkTransactionReplay { source_block, target_index })
 }
 
 /// Fork delimiter used to specify which block or transaction to fork from.

--- a/crates/anvil/src/eth/backend/executor.rs
+++ b/crates/anvil/src/eth/backend/executor.rs
@@ -36,7 +36,7 @@ use revm::{
     context_interface::result::{ExecutionResult, Output, ResultAndState},
     interpreter::InstructionResult,
     primitives::hardfork::SpecId,
-    state::AccountInfo,
+    state::{AccountInfo, EvmState},
 };
 use std::{fmt, fmt::Debug, mem::take, sync::Arc};
 
@@ -156,6 +156,8 @@ pub struct AnvilBlockExecutor<E> {
     gas_used: u64,
     /// Blob gas used by the block.
     blob_gas_used: u64,
+    /// State changes captured for deferred publication.
+    state_changes: Option<Vec<EvmState>>,
 }
 
 impl<E: fmt::Debug> fmt::Debug for AnvilBlockExecutor<E> {
@@ -182,7 +184,19 @@ impl<E> AnvilBlockExecutor<E> {
             receipts: Vec::new(),
             gas_used: 0,
             blob_gas_used: 0,
+            state_changes: None,
         }
+    }
+
+    /// Captures every committed changeset so callers can publish them after block execution.
+    pub(crate) fn with_state_changes(mut self) -> Self {
+        self.state_changes = Some(Vec::new());
+        self
+    }
+
+    /// Takes the captured changesets.
+    pub(crate) fn take_state_changes(&mut self) -> Vec<EvmState> {
+        self.state_changes.take().unwrap_or_default()
     }
 }
 
@@ -210,6 +224,9 @@ where
                 )
                 .map_err(BlockExecutionError::other)?;
 
+            if let Some(state_changes) = &mut self.state_changes {
+                state_changes.push(result.state.clone());
+            }
             self.evm.db_mut().commit(result.state);
         }
         Ok(())
@@ -296,6 +313,9 @@ where
             cumulative_gas_used: self.gas_used,
         });
 
+        if let Some(state_changes) = &mut self.state_changes {
+            state_changes.push(state.clone());
+        }
         self.receipts.push(receipt);
         self.evm.db_mut().commit(state);
 

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -1,6 +1,6 @@
 //! Support for forking off another client
 
-use crate::eth::{backend::db::Db, error::BlockchainError, pool::transactions::PoolTransaction};
+use crate::eth::{backend::db::Db, error::BlockchainError};
 use alloy_consensus::{BlockHeader, TrieAccount};
 use alloy_eips::eip2930::AccessListResult;
 use alloy_network::{
@@ -36,7 +36,7 @@ use alloy_serde::WithOtherFields;
 use alloy_transport::TransportError;
 use foundry_common::provider::{ProviderBuilder, RetryProvider};
 use foundry_evm::hardfork::FoundryHardfork;
-use foundry_primitives::{FoundryTxEnvelope, FoundryTxReceipt};
+use foundry_primitives::FoundryTxReceipt;
 use parking_lot::{
     RawRwLock, RwLock,
     lock_api::{RwLockReadGuard, RwLockWriteGuard},
@@ -887,8 +887,6 @@ pub struct ClientForkConfig<N: Network = AnyNetwork> {
     pub headers: Vec<String>,
     /// total difficulty of the chain until this block
     pub total_difficulty: U256,
-    /// Transactions to force include in the forked chain
-    pub force_transactions: Option<Vec<PoolTransaction<FoundryTxEnvelope>>>,
 }
 
 impl<N: Network> ClientForkConfig<N> {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3,7 +3,7 @@ use self::state::trie_storage;
 
 use crate::{
     ForkChoice, NodeConfig, PrecompileFactory,
-    config::PruneStateHistoryConfig,
+    config::{ForkTransactionReplay, PruneStateHistoryConfig},
     eth::{
         backend::{
             cheats::{CheatEcrecover, CheatsManager},
@@ -19,6 +19,10 @@ use crate::{
                 storage::MinedTransactionReceipt,
             },
             notifications::{ChainNotification, ChainNotifications, NewBlockNotification},
+            replay::{
+                ExecutedHistoricalReplay, HistoricalReplayTransaction, execute_historical_replay,
+                prepare_fork_transaction_replay,
+            },
             tempo::AnvilStorageProvider,
             time::{TimeManager, utc_from_secs},
             validate::TransactionValidator,
@@ -3446,6 +3450,197 @@ where
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
     ) -> MinedBlockOutcome<FoundryTxEnvelope> {
         self.do_mine_block(pool_transactions).await
+    }
+
+    /// Replays a transaction-hash fork prefix before the live pool and miner are created.
+    pub(crate) async fn apply_fork_transaction_replay(
+        &self,
+        replay: ForkTransactionReplay,
+    ) -> Result<()> {
+        let transactions = prepare_fork_transaction_replay(replay)?;
+        eyre::ensure!(!transactions.is_empty(), "fork transaction replay prefix is empty");
+
+        let _mining_guard = self.mining.lock().await;
+        let current_base_fee = self.base_fee();
+        let current_excess_blob_gas_and_price = self.excess_blob_gas_and_price();
+        let mut evm_env = self.evm_env.read().clone();
+        if evm_env.block_env.basefee == 0 {
+            evm_env.cfg_env.disable_base_fee = true;
+        }
+
+        let block_number = self.blockchain.storage.read().best_number.saturating_add(1);
+        if is_arbitrum(evm_env.cfg_env.chain_id) {
+            evm_env.block_env.number = U256::from(block_number);
+        } else {
+            evm_env.block_env.number = evm_env.block_env.number.saturating_add(U256::from(1));
+        }
+        evm_env.block_env.basefee = current_base_fee;
+        evm_env.block_env.blob_excess_gas_and_price = current_excess_blob_gas_and_price;
+        evm_env.block_env.timestamp = U256::from(self.time.next_timestamp());
+
+        let best_hash = self.blockchain.storage.read().best_hash;
+        let mut prevrandao_input = [0u8; 40];
+        prevrandao_input[..32].copy_from_slice(best_hash.as_slice());
+        prevrandao_input[32..].copy_from_slice(&block_number.to_le_bytes());
+        evm_env.block_env.prevrandao = Some(
+            self.cheats.take_next_block_prevrandao().unwrap_or_else(|| keccak256(prevrandao_input)),
+        );
+
+        let mut replay_env = evm_env.clone();
+        apply_chain_specific_tx_replay_env_changes(&mut replay_env);
+        let spec_id = *replay_env.spec_id();
+        let inspector_tx_config = self.inspector_tx_config();
+
+        let (block_info, state_changes, block_hash) = {
+            let db = self.db.read().await;
+            let mut overlay = AnvilCacheDB::new(&**db);
+            let ExecutedHistoricalReplay {
+                block_result,
+                transactions,
+                transaction_infos,
+                state_changes,
+            } = self.execute_with_replay_block_executor(
+                &mut overlay,
+                &replay_env,
+                best_hash,
+                spec_id,
+                &transactions,
+                &inspector_tx_config,
+            )?;
+            let state_root = overlay.maybe_state_root().unwrap_or_default();
+            let block_info = self.build_block_info(
+                &replay_env,
+                best_hash,
+                block_number,
+                state_root,
+                block_result,
+                transactions,
+                transaction_infos,
+            );
+            let block_hash = block_info.block.header.hash_slow();
+            (block_info, state_changes, block_hash)
+        };
+
+        if self.prune_state_history_config.is_state_history_supported() {
+            let state = self.db.read().await.current_state();
+            self.states.write().insert(best_hash, state);
+        }
+
+        {
+            let mut db = self.db.write().await;
+            for state in state_changes {
+                db.commit(state);
+            }
+            db.insert_block_hash(U256::from(block_number), block_hash);
+        }
+
+        let BlockInfo { block, transactions, receipts } = block_info;
+        let header = block.header.clone();
+        {
+            let mut storage = self.blockchain.storage.write();
+            storage.best_number = block_number;
+            storage.best_hash = block_hash;
+            if !self.is_eip3675() {
+                storage.total_difficulty =
+                    storage.total_difficulty.saturating_add(header.difficulty);
+            }
+            storage.blocks.insert(block_hash, block);
+            storage.hashes.insert(block_number, block_hash);
+            for (info, receipt) in transactions.into_iter().zip(receipts) {
+                let mined_tx = MinedTransaction { info, receipt, block_hash, block_number };
+                storage.transactions.insert(mined_tx.info.transaction_hash, mined_tx);
+            }
+
+            if let Some(transaction_block_keeper) = self.transaction_block_keeper
+                && storage.blocks.len() > transaction_block_keeper
+            {
+                let to_clear = block_number
+                    .saturating_sub(transaction_block_keeper.try_into().unwrap_or(u64::MAX));
+                storage.remove_block_transactions_by_number(to_clear)
+            }
+        }
+
+        evm_env.block_env.difficulty = U256::ZERO;
+        *self.evm_env.write() = evm_env;
+
+        let next_block_base_fee = self.fees.get_next_block_base_fee_per_gas(
+            header.gas_used,
+            header.gas_limit,
+            header.base_fee_per_gas.unwrap_or_default(),
+        );
+        let next_block_excess_blob_gas = self.fees.get_next_block_blob_excess_gas(
+            header.excess_blob_gas.unwrap_or_default(),
+            header.blob_gas_used.unwrap_or_default(),
+        );
+        self.fees.set_base_fee(next_block_base_fee);
+        self.fees.set_blob_excess_gas_and_price(BlobExcessGasAndPrice::new(
+            next_block_excess_blob_gas,
+            get_blob_base_fee_update_fraction_by_spec_id(*self.evm_env.read().spec_id()),
+        ));
+        self.notify_on_new_block(header.into_inner(), block_hash);
+
+        Ok(())
+    }
+
+    fn execute_with_replay_block_executor<DB>(
+        &self,
+        db: DB,
+        evm_env: &EvmEnv,
+        parent_hash: B256,
+        spec_id: SpecId,
+        transactions: &[HistoricalReplayTransaction],
+        inspector_tx_config: &InspectorTxConfig,
+    ) -> Result<ExecutedHistoricalReplay>
+    where
+        DB: StateDB<Error = DatabaseError>,
+    {
+        let inspector = self.build_mining_inspector();
+
+        macro_rules! run {
+            ($evm:expr) => {{
+                self.inject_precompiles($evm.precompiles_mut(), evm_env);
+                self.inject_arbitrum_precompile($evm.precompiles_mut(), evm_env);
+                let mut executor =
+                    AnvilBlockExecutor::new($evm, parent_hash, spec_id).with_state_changes();
+                executor
+                    .apply_pre_execution_changes()
+                    .wrap_err("failed to apply replay block-start transitions")?;
+                let (stored_transactions, transaction_infos) =
+                    execute_historical_replay(&mut executor, transactions, inspector_tx_config)?;
+                let state_changes = executor.take_state_changes();
+                let (evm, block_result) =
+                    executor.finish().wrap_err("failed to finish replay block execution")?;
+                drop(evm);
+                Ok(ExecutedHistoricalReplay {
+                    block_result,
+                    transactions: stored_transactions,
+                    transaction_infos,
+                    state_changes,
+                })
+            }};
+        }
+
+        #[cfg(feature = "optimism")]
+        if self.is_optimism() {
+            let op_env = EvmEnv::new(
+                evm_env.cfg_env.clone().with_spec_and_mainnet_gas_params(self.hardfork.into()),
+                evm_env.block_env.clone(),
+            );
+            let mut evm =
+                OpEvmFactory::<OpTx>::default().create_evm_with_inspector(db, op_env, inspector);
+            return run!(evm);
+        }
+
+        if self.is_tempo() {
+            let tempo_env = self.build_tempo_evm_env(evm_env);
+            let mut evm =
+                TempoEvmFactory::default().create_evm_with_inspector(db, tempo_env, inspector);
+            run!(evm)
+        } else {
+            let mut evm =
+                EthEvmFactory::default().create_evm_with_inspector(db, evm_env.clone(), inspector);
+            run!(evm)
+        }
     }
 
     /// Builds a [`BlockInfo`] from the EVM environment, execution results, and transactions.

--- a/crates/anvil/src/eth/backend/mod.rs
+++ b/crates/anvil/src/eth/backend/mod.rs
@@ -13,5 +13,6 @@ pub mod fork;
 pub mod genesis;
 pub mod info;
 pub mod notifications;
+pub(crate) mod replay;
 pub mod tempo;
 pub mod validate;

--- a/crates/anvil/src/eth/backend/replay.rs
+++ b/crates/anvil/src/eth/backend/replay.rs
@@ -1,0 +1,159 @@
+//! Transaction-hash fork replay preparation and execution.
+
+use crate::{
+    config::ForkTransactionReplay,
+    eth::backend::executor::AnvilBlockExecutor,
+    mem::inspector::{AnvilInspector, InspectorTxConfig},
+};
+use alloy_consensus::{
+    Transaction,
+    transaction::{Recovered, SignerRecoverable, TxHashRef},
+};
+use alloy_evm::{
+    Evm, FromRecoveredTx, FromTxWithEncoded, RecoveredTx,
+    block::{BlockExecutionResult, BlockExecutor, StateDB, TxResult},
+};
+use alloy_network::{BlockResponse, TransactionResponse};
+use anvil_core::eth::transaction::{MaybeImpersonatedTransaction, TransactionInfo};
+use eyre::{Context, Result};
+use foundry_evm::core::evm::IntoInstructionResult;
+use foundry_primitives::{FoundryReceiptEnvelope, FoundryTxEnvelope};
+use revm::{
+    Database,
+    context_interface::result::{ExecutionResult, Output},
+    interpreter::InstructionResult,
+    state::EvmState,
+};
+
+/// A source transaction prepared for direct historical execution.
+#[derive(Clone, Debug)]
+pub(crate) struct HistoricalReplayTransaction {
+    pub(crate) transaction: Recovered<FoundryTxEnvelope>,
+    pub(crate) source_index: usize,
+}
+
+/// The complete result of executing a historical prefix against an overlay.
+pub(crate) struct ExecutedHistoricalReplay {
+    pub(crate) block_result: BlockExecutionResult<FoundryReceiptEnvelope>,
+    pub(crate) transactions: Vec<MaybeImpersonatedTransaction<FoundryTxEnvelope>>,
+    pub(crate) transaction_infos: Vec<TransactionInfo>,
+    pub(crate) state_changes: Vec<EvmState>,
+}
+
+/// Converts and validates every source-prefix transaction before database execution.
+pub(crate) fn prepare_fork_transaction_replay(
+    replay: ForkTransactionReplay,
+) -> Result<Vec<HistoricalReplayTransaction>> {
+    let source_hash = replay.source_block.header().hash;
+    let source_number = replay.source_block.header().number;
+    let source_transactions = replay
+        .source_block
+        .transactions()
+        .as_transactions()
+        .expect("full source block validated during resolution");
+
+    source_transactions
+        .iter()
+        .take(replay.target_index.saturating_add(1))
+        .enumerate()
+        .map(|(source_index, source_transaction)| {
+            let source_transaction_hash = source_transaction.tx_hash();
+            let transaction = FoundryTxEnvelope::try_from(source_transaction.clone())
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to convert source transaction {source_transaction_hash} at index \
+                         {source_index} in block {source_hash} ({source_number})"
+                    )
+                })?;
+            eyre::ensure!(
+                transaction.tx_hash() == &source_transaction_hash,
+                "converted source transaction at index {source_index} in block {source_hash} \
+                 ({source_number}) changed hash from {source_transaction_hash} to {}",
+                transaction.tx_hash()
+            );
+            let sender = transaction.recover_signer().wrap_err_with(|| {
+                format!(
+                    "failed to recover sender for source transaction {source_transaction_hash} at \
+                     index {source_index} in block {source_hash} ({source_number})"
+                )
+            })?;
+            Ok(HistoricalReplayTransaction {
+                transaction: Recovered::new_unchecked(transaction, sender),
+                source_index,
+            })
+        })
+        .collect()
+}
+
+/// Executes a prepared prefix strictly and captures changesets for deferred publication.
+pub(crate) fn execute_historical_replay<E>(
+    executor: &mut AnvilBlockExecutor<E>,
+    transactions: &[HistoricalReplayTransaction],
+    inspector_config: &InspectorTxConfig,
+) -> Result<(Vec<MaybeImpersonatedTransaction<FoundryTxEnvelope>>, Vec<TransactionInfo>)>
+where
+    E: Evm<
+            DB: StateDB,
+            Inspector = AnvilInspector,
+            Tx: FromRecoveredTx<FoundryTxEnvelope> + FromTxWithEncoded<FoundryTxEnvelope>,
+        >,
+    E::HaltReason: Clone + IntoInstructionResult,
+{
+    let mut stored_transactions = Vec::with_capacity(transactions.len());
+    let mut transaction_infos = Vec::with_capacity(transactions.len());
+
+    for replay in transactions {
+        let transaction = replay.transaction.tx();
+        let transaction_hash = *transaction.tx_hash();
+        let sender = replay.transaction.signer();
+        let nonce = executor
+            .evm_mut()
+            .db_mut()
+            .basic(sender)
+            .wrap_err_with(|| {
+                format!(
+                    "database error preparing source transaction {transaction_hash} at index {}",
+                    replay.source_index
+                )
+            })?
+            .unwrap_or_default()
+            .nonce;
+
+        let result = executor
+            .execute_transaction_without_commit(replay.transaction.clone().into_encoded())
+            .map_err(|err| {
+                eyre::eyre!(
+                    "failed to execute source transaction {transaction_hash} at index {}: {err}",
+                    replay.source_index
+                )
+            })?;
+        let execution_result = result.result().result.clone();
+        let gas_used = execution_result.tx_gas_used();
+        executor.commit_transaction(result);
+
+        let traces = executor.evm_mut().inspector_mut().finish_transaction(inspector_config);
+        let (exit_reason, out) = match execution_result {
+            ExecutionResult::Success { reason, output, .. } => (reason.into(), Some(output)),
+            ExecutionResult::Revert { output, .. } => {
+                (InstructionResult::Revert, Some(Output::Call(output)))
+            }
+            ExecutionResult::Halt { reason, .. } => (reason.into_instruction_result(), None),
+        };
+        let contract_address = transaction.to().is_none().then(|| sender.create(nonce));
+        transaction_infos.push(TransactionInfo {
+            transaction_hash,
+            transaction_index: replay.source_index as u64,
+            from: sender,
+            to: transaction.to(),
+            contract_address,
+            traces,
+            exit: exit_reason,
+            out: out.map(Output::into_data),
+            nonce,
+            gas_used,
+        });
+        stored_transactions.push(MaybeImpersonatedTransaction::new(transaction.clone()));
+    }
+
+    Ok((stored_transactions, transaction_infos))
+}

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -10,6 +10,7 @@ use futures::{
 use parking_lot::{RawRwLock, RwLock, lock_api::RwLockWriteGuard};
 use std::{
     fmt,
+    marker::PhantomData,
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
@@ -28,27 +29,19 @@ pub struct Miner<T> {
     ///
     /// This will register the task so we can manually wake it up if the mining mode was changed
     inner: Arc<MinerInner>,
-    /// Transactions included into the pool before any others are.
-    /// Done once on startup.
-    force_transactions: Option<Vec<Arc<PoolTransaction<T>>>>,
+    /// Transaction type handled by the associated pool.
+    transaction: PhantomData<fn() -> T>,
 }
 
 impl<T> Clone for Miner<T> {
     fn clone(&self) -> Self {
-        Self {
-            mode: self.mode.clone(),
-            inner: self.inner.clone(),
-            force_transactions: self.force_transactions.clone(),
-        }
+        Self { mode: self.mode.clone(), inner: self.inner.clone(), transaction: PhantomData }
     }
 }
 
 impl<T> fmt::Debug for Miner<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Miner")
-            .field("mode", &self.mode)
-            .field("force_transactions", &self.force_transactions.as_ref().map(|txs| txs.len()))
-            .finish_non_exhaustive()
+        f.debug_struct("Miner").field("mode", &self.mode).finish_non_exhaustive()
     }
 }
 
@@ -58,21 +51,8 @@ impl<T> Miner<T> {
         Self {
             mode: Arc::new(RwLock::new(mode)),
             inner: Default::default(),
-            force_transactions: None,
+            transaction: PhantomData,
         }
-    }
-
-    /// Provide transactions that will cause a block to be mined with transactions
-    /// as soon as the miner is polled.
-    /// Providing an empty list of transactions will cause the miner to mine an empty block assuming
-    /// there are not other transactions in the pool.
-    pub fn with_forced_transactions(
-        mut self,
-        force_transactions: Option<Vec<PoolTransaction<T>>>,
-    ) -> Self {
-        self.force_transactions =
-            force_transactions.map(|tx| tx.into_iter().map(Arc::new).collect());
-        self
     }
 
     /// Returns the write lock of the mining mode
@@ -123,12 +103,6 @@ impl<T> Miner<T> {
         cx: &mut Context<'_>,
     ) -> Poll<Vec<Arc<PoolTransaction<T>>>> {
         self.inner.register(cx);
-        if let Some(mut transactions) = self.force_transactions.take() {
-            if let Poll::Ready(next) = self.mode.write().poll(pool, cx) {
-                transactions.extend(next);
-            }
-            return Poll::Ready(transactions);
-        }
         self.mode.write().poll(pool, cx)
     }
 }
@@ -340,46 +314,5 @@ impl fmt::Debug for ReadyTransactionMiner {
         f.debug_struct("ReadyTransactionMiner")
             .field("max_transactions", &self.max_transactions)
             .finish_non_exhaustive()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use alloy_primitives::{Address, hex};
-    use alloy_rlp::Decodable;
-    use anvil_core::eth::transaction::PendingTransaction;
-    use foundry_primitives::FoundryTxEnvelope;
-    use futures::task::noop_waker;
-
-    fn forced_tx() -> PoolTransaction<FoundryTxEnvelope> {
-        let raw = hex::decode("f86b02843b9aca00830186a094d3e8763675e4c425df46cc3b5c0f6cbdac39604687038d7ea4c68000802ba00eb96ca19e8a77102767a41fc85a36afd5c61ccb09911cec5d3e86e193d9c5aea03a456401896b1b6055311536bf00a718568c744d8c1f9df59879e8350220ca18").unwrap();
-        let tx = FoundryTxEnvelope::decode(&mut &raw[..]).unwrap();
-        let sender: Address = "0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5".parse().unwrap();
-        let pending = PendingTransaction::with_impersonated(tx, sender);
-        PoolTransaction::new(pending)
-    }
-
-    #[test]
-    fn poll_consumes_forced_transactions_before_mode_is_ready() {
-        let forced = forced_tx();
-        let forced_hash = forced.hash();
-
-        let pool = Arc::new(Pool::default());
-        let mut miner = Miner::new(MiningMode::None).with_forced_transactions(Some(vec![forced]));
-
-        let waker = noop_waker();
-        let mut cx = Context::from_waker(&waker);
-
-        let polled = miner.poll(&pool, &mut cx);
-        let txs = match polled {
-            Poll::Ready(txs) => txs,
-            Poll::Pending => panic!("expected forced transactions to be returned immediately"),
-        };
-        assert_eq!(txs.len(), 1);
-        assert_eq!(txs[0].hash(), forced_hash);
-
-        // Forced transactions are consumed exactly once.
-        assert!(miner.poll(&pool, &mut cx).is_pending());
     }
 }

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -141,10 +141,17 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
     let logger = if config.enable_tracing { init_tracing() } else { Default::default() };
     logger.set_enabled(!config.silent);
 
-    let backend = config.setup::<FoundryNetwork>().await?;
+    let (backend, fork_transaction_replay) = config.setup::<FoundryNetwork>().await?;
 
     if let Some(state) = config.init_state.clone() {
         backend.load_state(state).await.wrap_err("failed to load init state")?;
+    }
+
+    if let Some(replay) = fork_transaction_replay {
+        backend
+            .apply_fork_transaction_replay(replay)
+            .await
+            .wrap_err("failed to replay fork transaction prefix")?;
     }
 
     let backend = Arc::new(backend);
@@ -185,12 +192,7 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
         MiningMode::instant(max_transactions, listener)
     };
 
-    let miner = match &fork {
-        Some(fork) => {
-            Miner::new(mode).with_forced_transactions(fork.config.read().force_transactions.clone())
-        }
-        _ => Miner::new(mode),
-    };
+    let miner = Miner::new(mode);
 
     let dev_signer: Box<dyn EthSigner<foundry_primitives::FoundryNetwork>> =
         Box::new(DevSigner::new(signer_accounts));

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -11,8 +11,10 @@ use alloy_eips::{
     eip7910::{EthConfig, SystemContract},
 };
 use alloy_network::{EthereumWallet, ReceiptResponse, TransactionBuilder, TransactionResponse};
-use alloy_primitives::{Address, Bytes, TxHash, TxKind, U64, U256, address, b256, bytes, uint};
-use alloy_provider::Provider;
+use alloy_primitives::{
+    Address, Bytes, TxHash, TxKind, U64, U256, address, b256, bytes, hex, uint,
+};
+use alloy_provider::{Provider, ext::TxPoolApi};
 use alloy_rpc_types::{
     AccountInfo, BlockId, BlockNumberOrTag, Index,
     anvil::Forking,
@@ -22,7 +24,9 @@ use alloy_rpc_types::{
 };
 use alloy_serde::WithOtherFields;
 use alloy_signer_local::PrivateKeySigner;
-use anvil::{EthereumHardfork, NodeConfig, NodeHandle, PrecompileFactory, eth::EthApi, spawn};
+use anvil::{
+    EthereumHardfork, NodeConfig, NodeHandle, PrecompileFactory, eth::EthApi, spawn, try_spawn,
+};
 use foundry_common::provider::get_http_provider;
 use foundry_config::Config;
 use foundry_evm_networks::NetworkConfigs;
@@ -33,7 +37,6 @@ use revm::precompile::PrecompileStatus;
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::Arc,
-    thread::sleep,
     time::Duration,
 };
 
@@ -72,6 +75,176 @@ pub fn fork_config() -> NodeConfig {
     NodeConfig::test()
         .with_eth_rpc_url(Some(rpc::next_http_archive_rpc_url()))
         .with_fork_block_number(Some(BLOCK_NUMBER))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_transaction_hash_replays_before_startup() {
+    let (origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    origin_api.anvil_set_auto_mine(false).await.unwrap();
+    let origin_provider = origin_handle.http_provider();
+    let sender = origin_handle.dev_wallets().next().unwrap().address();
+
+    let first = origin_provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .from(sender)
+                .to(Address::random())
+                .value(U256::from(1))
+                .nonce(0),
+        ))
+        .await
+        .unwrap();
+    let second = origin_provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .from(sender)
+                .to(Address::random())
+                .value(U256::from(2))
+                .nonce(1),
+        ))
+        .await
+        .unwrap();
+    let reverted = origin_provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .from(sender)
+                .with_input(hex!("60006000fd").to_vec())
+                .gas_limit(100_000)
+                .nonce(2),
+        ))
+        .await
+        .unwrap();
+    let expected_hashes = [*first.tx_hash(), *second.tx_hash(), *reverted.tx_hash()];
+    origin_api.mine_one().await;
+    assert!(
+        !origin_provider
+            .get_transaction_receipt(expected_hashes[2])
+            .await
+            .unwrap()
+            .unwrap()
+            .status()
+    );
+
+    let (fork_api, fork_handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+            .with_fork_transaction_hash(Some(expected_hashes[2]))
+            .with_no_mining(true),
+    )
+    .await;
+    let fork_provider = fork_handle.http_provider();
+
+    assert_eq!(fork_api.block_number().unwrap(), U256::from(1));
+    let replayed =
+        fork_api.block_by_number_full(BlockNumberOrTag::Number(1)).await.unwrap().unwrap();
+    let replayed_hashes = replayed
+        .transactions
+        .as_transactions()
+        .unwrap()
+        .iter()
+        .map(|tx| tx.tx_hash())
+        .collect::<Vec<_>>();
+    assert_eq!(replayed_hashes, expected_hashes);
+    assert_eq!(fork_provider.txpool_status().await.unwrap().pending, 0);
+    assert_eq!(fork_provider.txpool_status().await.unwrap().queued, 0);
+    let content = fork_provider.txpool_content().await.unwrap();
+    assert!(content.pending.is_empty());
+    assert!(content.queued.is_empty());
+    assert_eq!(fork_provider.get_transaction_count(sender).await.unwrap(), 3);
+    assert!(
+        !fork_provider.get_transaction_receipt(expected_hashes[2]).await.unwrap().unwrap().status()
+    );
+
+    let (prefix_api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+            .with_fork_transaction_hash(Some(expected_hashes[1]))
+            .with_no_mining(true),
+    )
+    .await;
+    let prefix =
+        prefix_api.block_by_number_full(BlockNumberOrTag::Number(1)).await.unwrap().unwrap();
+    assert_eq!(
+        prefix
+            .transactions
+            .as_transactions()
+            .unwrap()
+            .iter()
+            .map(|tx| tx.tx_hash())
+            .collect::<Vec<_>>(),
+        expected_hashes[..2]
+    );
+    assert!(prefix_api.backend.mined_transaction_by_hash(expected_hashes[2]).is_none());
+
+    let (pruned_api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+            .with_fork_transaction_hash(Some(expected_hashes[0]))
+            .with_transaction_block_keeper(Some(0usize))
+            .with_no_mining(true),
+    )
+    .await;
+    assert!(pruned_api.backend.mined_transaction_by_hash(expected_hashes[0]).is_none());
+
+    let _pending = fork_provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .from(sender)
+                .to(Address::random())
+                .value(U256::from(3))
+                .nonce(3),
+        ))
+        .await
+        .unwrap();
+    let pool = fork_provider.txpool_status().await.unwrap();
+    assert_eq!(pool.pending, 1);
+    assert_eq!(pool.queued, 0);
+
+    let (auto_mining_api, _) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+            .with_fork_transaction_hash(Some(expected_hashes[2])),
+    )
+    .await;
+    let replayed =
+        auto_mining_api.block_by_number_full(BlockNumberOrTag::Number(1)).await.unwrap().unwrap();
+    assert_eq!(
+        replayed
+            .transactions
+            .as_transactions()
+            .unwrap()
+            .iter()
+            .map(|tx| tx.tx_hash())
+            .collect::<Vec<_>>(),
+        expected_hashes
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fork_transaction_hash_replay_error_fails_startup() {
+    let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
+    let origin_provider = origin_handle.http_provider();
+    let sender = origin_handle.dev_wallets().next().unwrap().address();
+    let pending = origin_provider
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default().from(sender).to(Address::random()).value(U256::from(1)),
+        ))
+        .await
+        .unwrap();
+    let transaction_hash = *pending.tx_hash();
+    pending.get_receipt().await.unwrap();
+
+    let result = try_spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+            .with_fork_transaction_hash(Some(transaction_hash))
+            .with_gas_limit(Some(20_000)),
+    )
+    .await;
+    let Err(error) = result else { panic!("expected fork transaction replay to fail") };
+    let message = error.to_string();
+    assert!(message.contains("failed to replay fork transaction prefix"));
+    assert!(format!("{error:?}").contains(&transaction_hash.to_string()));
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -431,16 +604,26 @@ async fn test_fork_optimism_with_transaction_hash() {
     let fork_tx_hash =
         TxHash::from_str("fcb864b5a50f0f0b111dbbf9e9167b2cb6179dfd6270e1ad53aac6049c0ec038")
             .unwrap();
-    let (api, _handle) = spawn(
+    let (api, handle) = spawn(
         NodeConfig::test()
             .with_eth_rpc_url(Some(rpc::next_rpc_endpoint(NamedChain::Optimism)))
             .with_fork_transaction_hash(Some(fork_tx_hash)),
     )
     .await;
 
-    // Make sure the fork starts from previous block
+    // The prefix is replayed synchronously as the next local block.
     let block_number = api.block_number().unwrap().to::<u64>();
-    assert_eq!(block_number, 125777954 - 1);
+    assert_eq!(block_number, 125777954);
+    assert!(api.backend.mined_transaction_by_hash(fork_tx_hash).is_some());
+    assert!(
+        handle
+            .http_provider()
+            .get_transaction_receipt(fork_tx_hash)
+            .await
+            .unwrap()
+            .unwrap()
+            .status()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1620,15 +1803,9 @@ async fn test_immutable_fork_transaction_hash() {
 
     let fork_block_number = 21824325;
 
-    // Make sure the fork starts from previous block
-    let mut block_number = api.block_number().unwrap().to::<u64>();
-    assert_eq!(block_number, fork_block_number - 1);
-
-    // Wait for fork to pass the target block
-    while block_number < fork_block_number {
-        sleep(Duration::from_millis(250));
-        block_number = api.block_number().unwrap().to::<u64>();
-    }
+    // The prefix is installed before startup returns.
+    let block_number = api.block_number().unwrap().to::<u64>();
+    assert_eq!(block_number, fork_block_number);
 
     let block = api
         .block_by_number(BlockNumberOrTag::Number(fork_block_number - 1))


### PR DESCRIPTION
Transaction-hash forks currently convert the selected source prefix into forced pool transactions. This lets historical replay share miner control flow with live transactions and makes completion depend on the configured mining mode.

This resolves the target and its parent against hash-consistent source blocks, prepares the complete inclusive prefix, and executes it against an isolated backend overlay during startup. The prefix is published as one local Anvil block only after the full batch succeeds; reverted transactions remain included, while fatal failures publish nothing. The live pool and miner are constructed afterward, removing forced replay state from `ClientForkConfig` and `Miner`.

This establishes the network-neutral replay boundary needed by #15878 for #15343. Source-chain-specific protocol replay semantics remain follow-up work.

AI assistance disclosure: Codex was used for codebase analysis and an initial implementation; the final implementation was largely reworked and completed by the author.
