### PR TITLE
refactor: inline trivial single-use helpers

### DIFF
--- a/crates/anvil/server/src/pubsub.rs
+++ b/crates/anvil/server/src/pubsub.rs
@@ -133,13 +133,9 @@ impl<Handler: PubSubRpcHandler, Connection> PubSubConnection<Handler, Connection
         }
     }
 
-    /// Returns a compatibility `RpcHandler`
-    fn compat_helper(&self) -> ContextAwareHandler<Handler> {
-        ContextAwareHandler { handler: self.handler.clone(), context: self.context.clone() }
-    }
-
     fn process_request(&mut self, req: serde_json::Result<Request>) {
-        let handler = self.compat_helper();
+        let handler =
+            ContextAwareHandler { handler: self.handler.clone(), context: self.context.clone() };
         self.processing.push(Box::pin(async move {
             match req {
                 Ok(req) => handle_request(req, handler).await,

--- a/crates/anvil/src/cmd.rs
+++ b/crates/anvil/src/cmd.rs
@@ -386,16 +386,12 @@ impl NodeArgs {
         generator
     }
 
-    /// Returns the location where to dump the state to.
-    fn dump_state_path(&self) -> Option<PathBuf> {
-        self.dump_state.as_ref().or_else(|| self.state.as_ref().map(|s| &s.path)).cloned()
-    }
-
     /// Starts the node
     ///
     /// See also [crate::spawn()]
     pub async fn run(self) -> eyre::Result<()> {
-        let dump_state = self.dump_state_path();
+        let dump_state =
+            self.dump_state.as_ref().or_else(|| self.state.as_ref().map(|s| &s.path)).cloned();
         let dump_interval =
             self.state_interval.map(Duration::from_secs).unwrap_or(DEFAULT_DUMP_INTERVAL);
         let preserve_historical_states = self.preserve_historical_states;

--- a/crates/cast/src/cmd/keychain.rs
+++ b/crates/cast/src/cmd/keychain.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::BlockHeader;
 use alloy_ens::NameOrAddress;
 use foundry_wallets::BrowserWalletOpts;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use alloy_network::{EthereumWallet, TransactionBuilder};
 use alloy_primitives::{Address, B256, Bytes, U256, hex};
@@ -2624,10 +2624,6 @@ async fn check_sponsorship(tempo: &TempoOpts, sender: Address) -> SponsorshipDia
     }
 }
 
-fn unix_timestamp_now() -> u64 {
-    std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs()
-}
-
 const fn key_type_matches_authorization(key_type: &KeyType, auth_type: &AuthSignatureType) -> bool {
     matches!(
         (key_type, auth_type),
@@ -4083,7 +4079,8 @@ fn format_timestamp_iso(timestamp: u64) -> String {
 }
 
 fn format_relative_timestamp(timestamp: u64) -> String {
-    format_relative_timestamp_from(timestamp, unix_timestamp_now())
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    format_relative_timestamp_from(timestamp, now)
 }
 
 fn format_relative_timestamp_from(timestamp: u64, now: u64) -> String {

--- a/crates/cast/src/cmd/tip403.rs
+++ b/crates/cast/src/cmd/tip403.rs
@@ -175,9 +175,11 @@ async fn create(
     let (sig, args) = if members.is_empty() {
         ("createPolicy(address,uint8)", vec![admin.to_string(), type_arg])
     } else {
+        let members =
+            format!("[{}]", members.iter().map(Address::to_string).collect::<Vec<_>>().join(","));
         (
             "createPolicyWithAccounts(address,uint8,address[])",
-            vec![admin.to_string(), type_arg, address_array(&members)],
+            vec![admin.to_string(), type_arg, members],
         )
     };
     send_tip20_transaction(
@@ -300,10 +302,6 @@ fn warn_if_virtual(account: Address) -> Result<()> {
         )?;
     }
     Ok(())
-}
-
-fn address_array(accounts: &[Address]) -> String {
-    format!("[{}]", accounts.iter().map(Address::to_string).collect::<Vec<_>>().join(","))
 }
 
 impl PolicyKind {

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -1874,9 +1874,6 @@ fn restore_eip2935_cold_state<
 // crates/precompiles/tests/storage_tests/solidity/testdata/tip20.layout.json
 // fixture, where `logoUri` has slot "5".
 const TIP20_LOGO_URI_SLOT_INDEX: u64 = 5;
-fn tip20_logo_uri_slot() -> U256 {
-    U256::from(TIP20_LOGO_URI_SLOT_INDEX)
-}
 
 fn set_tip20_logo_uri<FEN: FoundryEvmNetwork>(
     ccx: &mut CheatsCtxt<'_, '_, FEN>,
@@ -1889,7 +1886,12 @@ fn set_tip20_logo_uri<FEN: FoundryEvmNetwork>(
     })?;
     ccx.ensure_not_precompile(token)?;
     ensure_loaded_account(ccx.ecx, *token)?;
-    store_solidity_string(ccx.ecx, *token, tip20_logo_uri_slot(), new_logo_uri.as_bytes())
+    store_solidity_string(
+        ccx.ecx,
+        *token,
+        U256::from(TIP20_LOGO_URI_SLOT_INDEX),
+        new_logo_uri.as_bytes(),
+    )
 }
 
 fn store_solidity_string<CTX>(

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -106,7 +106,9 @@ pub struct ResolvedSessionSigner {
 }
 
 pub fn read_session_entry(session_id: B256) -> eyre::Result<Option<SessionEntry>> {
-    Ok(read_session_entries(now_unix())?
+    let now =
+        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs();
+    Ok(read_session_entries(now)?
         .and_then(|entries| entries.into_iter().find(|entry| entry.session_id == session_id)))
 }
 
@@ -424,10 +426,6 @@ fn read_session_entries(now: u64) -> eyre::Result<Option<Vec<SessionEntry>>> {
         })
         .collect();
     Ok(Some(sessions))
-}
-
-fn now_unix() -> u64 {
-    SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap_or_default().as_secs()
 }
 
 #[cfg(test)]

--- a/crates/config/src/fix.rs
+++ b/crates/config/src/fix.rs
@@ -25,10 +25,6 @@ impl TomlFile {
         &self.doc
     }
 
-    const fn doc_mut(&mut self) -> &mut toml_edit::DocumentMut {
-        &mut self.doc
-    }
-
     fn path(&self) -> &Path {
         self.path.as_ref()
     }
@@ -47,7 +43,7 @@ impl Deref for TomlFile {
 
 impl DerefMut for TomlFile {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.doc_mut()
+        &mut self.doc
     }
 }
 

--- a/crates/config/src/inline/natspec.rs
+++ b/crates/config/src/inline/natspec.rs
@@ -240,11 +240,14 @@ fn emit_halmos_arg(values: &mut Vec<String>, arg: HalmosArg, value: &str) -> Res
         HalmosArgParser::ArrayLengths => push_halmos_array_lengths(values, value),
         HalmosArgParser::Lengths => push_halmos_lengths(values, arg.foundry_field, value, arg.flag),
         HalmosArgParser::U32 => {
-            push_halmos_u32(values, arg.foundry_field, parse_halmos_u32(value, arg.flag)?);
+            let value = value
+                .parse::<u32>()
+                .map_err(|_| format!("invalid value `{value}` for {}", arg.flag))?;
+            values.push(format!("default.symbolic.{} = {value}", arg.foundry_field));
             Ok(())
         }
         HalmosArgParser::String => {
-            push_halmos_string(values, arg.foundry_field, value);
+            values.push(format!("default.symbolic.{} = {}", arg.foundry_field, toml_string(value)));
             Ok(())
         }
     }
@@ -284,20 +287,8 @@ fn push_halmos_lengths(
     Ok(())
 }
 
-fn push_halmos_u32(values: &mut Vec<String>, field: &str, value: u32) {
-    values.push(format!("default.symbolic.{field} = {value}"));
-}
-
-fn push_halmos_string(values: &mut Vec<String>, field: &str, value: &str) {
-    values.push(format!("default.symbolic.{field} = {}", toml_string(value)));
-}
-
 fn toml_string(value: &str) -> String {
     format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
-}
-
-fn parse_halmos_u32(value: &str, flag: &str) -> Result<u32, String> {
-    value.parse::<u32>().map_err(|_| format!("invalid value `{value}` for {flag}"))
 }
 
 enum HalmosArrayLengths {

--- a/crates/debugger/src/tui/context.rs
+++ b/crates/debugger/src/tui/context.rs
@@ -483,9 +483,9 @@ impl TUIContext<'_> {
     }
 
     fn handle_pc_input_key_event(&mut self, event: KeyEvent) {
-        if let Some(input) =
-            handle_prompt_input_key_event(&mut self.pc_input, event, |_, c| is_pc_input_char(c))
-        {
+        if let Some(input) = handle_prompt_input_key_event(&mut self.pc_input, event, |_, c| {
+            c.is_ascii_hexdigit() || matches!(c, 'x' | 'X' | ':')
+        }) {
             self.goto_pc_from_input(&input);
         }
     }
@@ -574,10 +574,6 @@ impl TUIContext<'_> {
 
     fn goto_pc_from_input(&mut self, input: &str) {
         self.move_to_pc_from_input(input, find_pc_target);
-    }
-
-    fn continue_to_pc_from_input(&mut self, input: &str) {
-        self.move_to_pc_from_input(input, find_next_pc_target);
     }
 
     fn move_to_pc_from_input(
@@ -709,7 +705,7 @@ impl TUIContext<'_> {
                 return self.set_error(command_usage(command, "<pc>"));
             }
             if is_continue_command {
-                self.continue_to_pc_from_input(pc);
+                self.move_to_pc_from_input(pc, find_next_pc_target);
             } else {
                 self.goto_pc_from_input(pc);
             }
@@ -1204,10 +1200,6 @@ fn handle_prompt_input_key_event(
     }
 
     None
-}
-
-const fn is_pc_input_char(c: char) -> bool {
-    c.is_ascii_hexdigit() || matches!(c, 'x' | 'X' | ':')
 }
 
 fn is_buffer_offset_input_char(input: &str, c: char) -> bool {

--- a/crates/debugger/src/tui/draw.rs
+++ b/crates/debugger/src/tui/draw.rs
@@ -582,7 +582,7 @@ impl TUIContext<'_> {
     fn draw_variables(&mut self, f: &mut Frame<'_>, area: Rect) {
         let variables = self.scope_variables();
         let storage_access = self.current_storage_access_line();
-        let step_notice = self.current_step_notice_line();
+        let step_notice = self.current_step_notice_text().map(step_notice_line);
         let known = variables.iter().filter(|variable| variable.value.is_some()).count();
         let title = variables_title(
             variables.len(),
@@ -615,10 +615,6 @@ impl TUIContext<'_> {
         let block = Block::default().title(title).borders(Borders::ALL);
         let paragraph = Paragraph::new(text).block(block).wrap(Wrap { trim: true });
         f.render_widget(paragraph, area);
-    }
-
-    fn current_step_notice_line(&self) -> Option<Line<'static>> {
-        self.current_step_notice_text().map(step_notice_line)
     }
 
     fn current_storage_access_line(&self) -> Option<Line<'static>> {

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -303,7 +303,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                 value: failure.value,
             },
         };
-        self.resolve_stateless_tx(&mut tx)?;
+        self.resolve_stateless_tx_with_executor(&self.executor_f, &mut tx)?;
         let mut call = self.executor_f.call_raw(
             tx.sender,
             tx.call_details.target,
@@ -455,10 +455,6 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                 breakpoints,
             }))
         }
-    }
-
-    fn resolve_stateless_tx(&self, tx: &mut BasicTxDetails) -> Result<()> {
-        self.resolve_stateless_tx_with_executor(&self.executor_f, tx)
     }
 
     fn resolve_stateless_tx_with_executor(

--- a/crates/evm/evm/src/executors/invariant/result.rs
+++ b/crates/evm/evm/src/executors/invariant/result.rs
@@ -143,12 +143,10 @@ fn is_revert_assertion_failure(data: &[u8]) -> bool {
 }
 
 fn is_cheatcode_assert_revert<FEN: FoundryEvmNetwork>(call_result: &RawCallResult<FEN>) -> bool {
-    fn decoded_cheatcode_message(data: &[u8]) -> Option<String> {
-        Vm::VmErrors::abi_decode(data).ok().map(|error| error.to_string())
-    }
-
     call_result.reverter == Some(CHEATCODE_ADDRESS)
-        && decoded_cheatcode_message(call_result.result.as_ref())
+        && Vm::VmErrors::abi_decode(call_result.result.as_ref())
+            .ok()
+            .map(|error| error.to_string())
             .is_some_and(|message| message.starts_with(ASSERTION_FAILED_PREFIX))
 }
 

--- a/crates/evm/evm/src/inspectors/revert_diagnostic.rs
+++ b/crates/evm/evm/src/inspectors/revert_diagnostic.rs
@@ -48,12 +48,6 @@ pub struct RevertDiagnostic {
 }
 
 impl RevertDiagnostic {
-    /// Returns the effective target address whose code would be executed.
-    /// For delegate calls, this is the `bytecode_address`. Otherwise, it's the `target_address`.
-    const fn code_target_address(&self, inputs: &mut CallInputs) -> Address {
-        if is_delegatecall(inputs.scheme) { inputs.bytecode_address } else { inputs.target_address }
-    }
-
     /// Derives the revert reason based on the cached data. Should only be called after a revert.
     const fn reason(&self) -> Option<DetailedRevertReason> {
         if let Some((addr, scheme, _)) = self.non_contract_call {
@@ -176,7 +170,12 @@ impl<CTX: ContextTr> Inspector<CTX> for RevertDiagnostic {
             return None;
         }
 
-        let target = self.code_target_address(inputs);
+        // Delegate calls execute the callee's code in the caller's storage context.
+        let target = if is_delegatecall(inputs.scheme) {
+            inputs.bytecode_address
+        } else {
+            inputs.target_address
+        };
 
         if IGNORE.contains(&target) || ctx.journal_ref().precompile_addresses().contains(&target) {
             return None;

--- a/crates/evm/fuzz/src/invariant/mod.rs
+++ b/crates/evm/fuzz/src/invariant/mod.rs
@@ -20,9 +20,8 @@ pub use filters::{ArtifactFilters, SenderFilters};
 use foundry_common::{ContractsByAddress, ContractsByArtifact};
 use foundry_evm_core::utils::StateChangeset;
 
-type DynamicTargetCacheKey = (Address, B256);
 type DynamicTargetArtifactMatchCache =
-    Rc<RefCell<HashMap<DynamicTargetCacheKey, Option<CachedTargetContract>>>>;
+    Rc<RefCell<HashMap<(Address, B256), Option<CachedTargetContract>>>>;
 type FuzzedFunction = (Address, Function);
 type FunctionLookup = HashMap<Selector, Function>;
 
@@ -716,10 +715,6 @@ mod tests {
         }
     }
 
-    fn project_contracts_with_runtime_code(name: &str, code: Bytes) -> ContractsByArtifact {
-        project_contracts_with_runtime_code_and_abi(name, code, JsonAbi::new())
-    }
-
     fn project_contracts_with_runtime_code_and_abi(
         name: &str,
         code: Bytes,
@@ -832,8 +827,11 @@ mod tests {
         let setup = Address::from([0x44; 20]);
         let untouched = Address::from([0x45; 20]);
         let runtime_code = Bytes::from_static(&[0x60, 0x00, 0x56]);
-        let project_contracts =
-            project_contracts_with_runtime_code("DynamicTarget", runtime_code.clone());
+        let project_contracts = project_contracts_with_runtime_code_and_abi(
+            "DynamicTarget",
+            runtime_code.clone(),
+            JsonAbi::new(),
+        );
         let mut targets = TargetedContracts::new();
         for address in [existing, setup, untouched] {
             targets.inner.insert(

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -307,13 +307,9 @@ impl FuzzDictionary {
             misses: Default::default(),
             hits: Default::default(),
         };
-        dictionary.prefill();
+        // Zero is a useful default seed even before state or literals populate the dictionary.
+        dictionary.insert_value(B256::ZERO);
         dictionary
-    }
-
-    /// Insert common values into the dictionary at initialization.
-    fn prefill(&mut self) {
-        self.insert_value(B256::ZERO);
     }
 
     /// Seeds `sample_values` with all words from the [`LiteralsDictionary`].

--- a/crates/evm/traces/src/debug/mod.rs
+++ b/crates/evm/traces/src/debug/mod.rs
@@ -102,10 +102,6 @@ impl<'a> DebugStepsWalker<'a> {
         self.src_map(self.current_step - 1)
     }
 
-    fn current_src_map(&self) -> Option<(SourceElement, &SourceData)> {
-        self.src_map(self.current_step)
-    }
-
     fn is_same_loc(&self, step: usize, other: usize) -> bool {
         let Some((loc, _)) = self.src_map(step) else {
             return false;
@@ -128,7 +124,7 @@ impl<'a> DebugStepsWalker<'a> {
             return;
         }
 
-        let Some((source_element, source)) = self.current_src_map() else {
+        let Some((source_element, source)) = self.src_map(self.current_step) else {
             return;
         };
 

--- a/crates/evm/traces/src/identifier/external.rs
+++ b/crates/evm/traces/src/identifier/external.rs
@@ -183,10 +183,6 @@ impl ExternalIdentifier {
         }
     }
 
-    fn fetch_addresses(&mut self, addresses: &[Address]) {
-        foundry_common::block_on(self.fetch_addresses_async(addresses));
-    }
-
     async fn fetch_addresses_async(&mut self, addresses: &[Address]) {
         if addresses.is_empty() || self.remaining_budget.is_zero() {
             return;
@@ -248,7 +244,7 @@ impl TraceIdentifier for ExternalIdentifier {
         trace!(target: "evm::traces::external", "fetching {} addresses", to_fetch.len());
 
         let to_fetch = to_fetch.into_iter().collect::<Vec<_>>();
-        self.fetch_addresses(&to_fetch);
+        foundry_common::block_on(self.fetch_addresses_async(&to_fetch));
 
         for address in to_fetch {
             if let Some((_, Some(metadata))) = self.contracts.get(&address) {

--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -1077,10 +1077,6 @@ impl<'ast> State<'_, 'ast> {
         self.print_str_lit(ast::StrKind::Str, strlit.span.lo(), strlit.value.as_str());
     }
 
-    fn print_lit(&mut self, lit: &'ast ast::Lit<'ast>) {
-        self.print_lit_inner(lit, false);
-    }
-
     fn print_ty(&mut self, ty: &'ast ast::Type<'ast>) {
         if self.handle_span(ty.span, false) {
             return;
@@ -1394,7 +1390,7 @@ impl<'ast> State<'_, 'ast> {
             ast::ExprKind::Ident(ident) => self.print_ident(ident),
             ast::ExprKind::Index(expr, kind) => self.print_index_expr(span, expr, kind),
             ast::ExprKind::Lit(lit, unit) => {
-                self.print_lit(lit);
+                self.print_lit_inner(lit, false);
                 if let Some(unit) = unit {
                     self.nbsp();
                     self.word(unit.to_str());

--- a/crates/forge/src/cmd/cache.rs
+++ b/crates/forge/src/cmd/cache.rs
@@ -160,7 +160,8 @@ pub struct ChainOrAllValueParser {
 
 impl Default for ChainOrAllValueParser {
     fn default() -> Self {
-        Self { inner: possible_chains() }
+        let inner = Some(&"all").into_iter().chain(NamedChain::VARIANT_NAMES).into();
+        Self { inner }
     }
 }
 
@@ -180,10 +181,6 @@ impl TypedValueParser for ChainOrAllValueParser {
             )
         })
     }
-}
-
-fn possible_chains() -> PossibleValuesParser {
-    Some(&"all").into_iter().chain(NamedChain::VARIANT_NAMES).into()
 }
 
 #[cfg(test)]

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -540,7 +540,12 @@ impl FuzzTminArgs {
 
         let before_txs = sequence.len();
         let decoder_args = self.test.clone();
-        let session = self.test.prepare_session(input_corpus_root(&self.input)).await?;
+        let corpus_root = self
+            .input
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or(Path::new("."));
+        let session = self.test.prepare_session(corpus_root).await?;
         let decoder = decoder_args.decoder();
         let attempts =
             minimize_entry(&session, &decoder, &self.input, &mut sequence, self.max_attempts)?;
@@ -831,10 +836,6 @@ fn temporary_cmin_out(out: &Path) -> Result<TempDir> {
     TempDirBuilder::new().prefix(&prefix).tempdir_in(parent).with_context(|| {
         format!("failed to create temporary output directory for {}", out.display())
     })
-}
-
-fn input_corpus_root(input: &Path) -> &Path {
-    input.parent().filter(|parent| !parent.as_os_str().is_empty()).unwrap_or(Path::new("."))
 }
 
 fn read_single_sequence(path: &Path) -> Result<Vec<BasicTxDetails>> {

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -1514,11 +1514,6 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
         &self.cr.mcr.revert_decoder
     }
 
-    /// Returns whether verbose symbolic diagnostics should be rendered after progress clears.
-    fn should_defer_symbolic_diagnostics(&self) -> bool {
-        self.cr.progress.is_some() && self.config.symbolic.dump_smt
-    }
-
     fn fuzz_minimize_target_id(&self, test_name: &str) -> String {
         let network = self
             .cr
@@ -2559,7 +2554,8 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             }
         }
         let mut symbolic = SymbolicExecutor::new(self.config.symbolic.clone());
-        if self.should_defer_symbolic_diagnostics() {
+        // Progress rendering must finish before verbose SMT diagnostics are printed.
+        if self.cr.progress.is_some() && self.config.symbolic.dump_smt {
             symbolic.capture_diagnostics();
         }
         let result = symbolic.run(SymbolicRunInput {
@@ -5260,7 +5256,6 @@ struct InvariantPersistedFailure {
     failure_site: Option<SymbolicInvariantFailureSite>,
 }
 
-type CheckSequenceResult = eyre::Result<CheckSequenceOutcome>;
 type HandlerFailureKey = (Address, Selector);
 type HandlerFailureStorageKey = (Address, Selector, B256);
 type HandlerFailureMap = std::collections::HashMap<HandlerFailureKey, InvariantFuzzError>;
@@ -5331,11 +5326,6 @@ fn invariant_failure_file(failure_dir: &Path, invariant: &Function) -> PathBuf {
     canonicalized(failure_dir.join("invariants").join(&invariant.name))
 }
 
-/// Returns the legacy invariant failure cache path.
-fn legacy_invariant_failure_file(failure_dir: &Path, invariant: &Function) -> PathBuf {
-    canonicalized(failure_dir.join(&invariant.name))
-}
-
 /// Loads a persisted invariant failure from the new cache path, falling back to the legacy path.
 fn persisted_invariant_failure(
     failure_dir: &Path,
@@ -5344,7 +5334,8 @@ fn persisted_invariant_failure(
 ) -> Option<InvariantPersistedFailure> {
     persisted_call_sequence(invariant_failure_file(failure_dir, invariant).as_path(), current_settings)
         .or_else(|| {
-            let legacy_path = legacy_invariant_failure_file(failure_dir, invariant);
+            // Older Foundry versions stored invariant failures directly under the failure root.
+            let legacy_path = canonicalized(failure_dir.join(&invariant.name));
             let persisted = persisted_call_sequence(legacy_path.as_path(), current_settings)?;
             let _ = sh_warn!(
                 "Using legacy invariant failure cache at {}; new failures will be persisted under {}/invariants.",
@@ -5440,7 +5431,7 @@ fn replay_persisted_call_sequence<FEN: FoundryEvmNetwork>(
     call_sequence: &mut [BaseCounterExample],
     expect_assertion_failure: bool,
     storage: &[SymbolicStorageAssignment],
-) -> (Vec<BasicTxDetails>, CheckSequenceResult) {
+) -> (Vec<BasicTxDetails>, eyre::Result<CheckSequenceOutcome>) {
     let txes = base_counterexamples_to_txes(ctx, call_sequence);
     if let Err(err) = apply_symbolic_storage_assignments(&mut executor, storage) {
         return (txes, Err(err));

--- a/crates/lint/src/sol/info/inline_assembly.rs
+++ b/crates/lint/src/sol/info/inline_assembly.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use solar::{
     ast::{Stmt, StmtKind},
-    interface::{BytePos, Span},
+    interface::BytePos,
 };
 
 declare_forge_lint!(
@@ -22,7 +22,8 @@ impl<'ast> EarlyLintPass<'ast> for InlineAssembly {
     fn check_stmt(&mut self, ctx: &LintContext, stmt: &'ast Stmt<'ast>) {
         let StmtKind::Assembly(asm) = &stmt.kind else { return };
 
-        let kw_span = assembly_keyword_span(stmt.span);
+        // Keep the diagnostic highlight on the leading `assembly` keyword.
+        let kw_span = stmt.span.with_hi(stmt.span.lo() + BytePos(ASSEMBLY_KW_LEN));
 
         let memory_safe = asm.flags.iter().any(|f| f.value.as_str() == "memory-safe")
             || has_memory_safe_natspec(ctx, stmt.span.lo());
@@ -35,11 +36,6 @@ impl<'ast> EarlyLintPass<'ast> for InlineAssembly {
 
         ctx.emit_with_msg(&INLINE_ASSEMBLY, kw_span, msg);
     }
-}
-
-/// Narrows a span to the leading `assembly` keyword to keep diagnostics readable.
-fn assembly_keyword_span(span: Span) -> Span {
-    span.with_hi(span.lo() + BytePos(ASSEMBLY_KW_LEN))
 }
 
 /// Returns `true` when the lines immediately preceding `stmt_lo` form a `///` NatSpec block

--- a/crates/lint/src/sol/low/missing_events_arithmetic.rs
+++ b/crates/lint/src/sol/low/missing_events_arithmetic.rs
@@ -145,10 +145,6 @@ impl WriteState {
     fn record_write(&mut self, write: StateWrite) {
         self.pending_writes.push(write);
     }
-
-    fn record_event(&mut self) {
-        self.pending_writes.clear();
-    }
 }
 
 #[derive(Default)]
@@ -334,7 +330,7 @@ impl<'a, 'hir> WriteAnalyzer<'a, 'hir> {
             }
             StmtKind::Emit(expr) => {
                 self.analyze_expr(expr, &mut state);
-                state.record_event();
+                state.pending_writes.clear();
                 WriteFlow::fallthrough(state)
             }
             StmtKind::Return(expr) => {

--- a/crates/script/src/lib.rs
+++ b/crates/script/src/lib.rs
@@ -885,10 +885,6 @@ impl<FEN: FoundryEvmNetwork> ScriptConfig<FEN> {
         Ok(())
     }
 
-    async fn get_runner(&mut self) -> Result<ScriptRunner<FEN>> {
-        self._get_runner(None, false, false).await
-    }
-
     async fn get_runner_with_cheatcodes(
         &mut self,
         known_contracts: ContractsByArtifact,

--- a/crates/script/src/simulate.rs
+++ b/crates/script/src/simulate.rs
@@ -258,7 +258,7 @@ impl<FEN: FoundryEvmNetwork> PreSimulationState<FEN> {
         let futs = rpcs.into_iter().map(|rpc| async move {
             let mut script_config = self.script_config.clone();
             script_config.evm_opts.fork_url = Some(rpc.clone());
-            let runner = script_config.get_runner().await?;
+            let runner = script_config._get_runner(None, false, false).await?;
             Ok((rpc, runner))
         });
         try_join_all(futs).await


### PR DESCRIPTION
This removes trivial single-use helpers, forwarding methods, and type aliases across the workspace by placing their logic directly at the relevant call sites. Small comments preserve context where the behavior is not immediately obvious.

This change was implemented with AI assistance.
