### PR TITLE
feat(forge): add coverage policies

### DIFF
--- a/.changelog/forge-coverage-policies.md
+++ b/.changelog/forge-coverage-policies.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added Istanbul-compatible JSON coverage summaries and aggregate coverage failure thresholds.

--- a/crates/config/src/coverage.rs
+++ b/crates/config/src/coverage.rs
@@ -1,6 +1,6 @@
 //! Configuration for `forge coverage`.
 
-use clap::ValueEnum;
+use clap::{Args, ValueEnum, builder::RangedU64ValueParser};
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
@@ -10,15 +10,70 @@ use std::path::PathBuf;
 /// Used both as a CLI value (`--report <kind>`) and as a TOML configuration
 /// value under `[profile.<name>.coverage] report = ["..."]`.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum CoverageReportKind {
     #[default]
     Summary,
+    /// Istanbul-compatible JSON summary report.
+    JsonSummary,
     Lcov,
     Debug,
     Bytecode,
     /// JSON report mapping each test to the source items it covers.
     Attribution,
+}
+
+/// Aggregate coverage thresholds.
+///
+/// Configured under `[profile.<name>.coverage.thresholds]`. The corresponding
+/// CLI flags are named `--fail-under-<kind>`.
+#[derive(Args, Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoverageThresholds {
+    /// Fail if aggregate line coverage is below this percentage.
+    #[arg(
+        long = "fail-under-lines",
+        value_parser = RangedU64ValueParser::<u8>::new().range(0..=100),
+        value_name = "PERCENT"
+    )]
+    #[serde(default, deserialize_with = "deserialize_coverage_threshold")]
+    pub lines: Option<u8>,
+
+    /// Fail if aggregate statement coverage is below this percentage.
+    #[arg(
+        long = "fail-under-statements",
+        value_parser = RangedU64ValueParser::<u8>::new().range(0..=100),
+        value_name = "PERCENT"
+    )]
+    #[serde(default, deserialize_with = "deserialize_coverage_threshold")]
+    pub statements: Option<u8>,
+
+    /// Fail if aggregate branch coverage is below this percentage.
+    #[arg(
+        long = "fail-under-branches",
+        value_parser = RangedU64ValueParser::<u8>::new().range(0..=100),
+        value_name = "PERCENT"
+    )]
+    #[serde(default, deserialize_with = "deserialize_coverage_threshold")]
+    pub branches: Option<u8>,
+
+    /// Fail if aggregate function coverage is below this percentage.
+    #[arg(
+        long = "fail-under-functions",
+        value_parser = RangedU64ValueParser::<u8>::new().range(0..=100),
+        value_name = "PERCENT"
+    )]
+    #[serde(default, deserialize_with = "deserialize_coverage_threshold")]
+    pub functions: Option<u8>,
+}
+
+impl CoverageThresholds {
+    /// Resolves unset thresholds from configuration.
+    pub fn resolve_with(&mut self, config: &Self) {
+        self.lines = self.lines.or(config.lines);
+        self.statements = self.statements.or(config.statements);
+        self.branches = self.branches.or(config.branches);
+        self.functions = self.functions.or(config.functions);
+    }
 }
 
 /// Configuration for `forge coverage`, exposed under `[coverage]` and
@@ -71,6 +126,10 @@ pub struct CoverageConfig {
     /// ```
     #[serde(default)]
     pub skip_files: Vec<String>,
+
+    /// Aggregate coverage thresholds. Unset thresholds are not enforced.
+    #[serde(default)]
+    pub thresholds: CoverageThresholds,
 }
 
 impl Default for CoverageConfig {
@@ -83,6 +142,7 @@ impl Default for CoverageConfig {
             include_libs: false,
             exclude_tests: false,
             skip_files: Vec::new(),
+            thresholds: CoverageThresholds::default(),
         }
     }
 }
@@ -101,6 +161,17 @@ where
 {
     let version = String::deserialize(deserializer)?;
     parse_lcov_version(&version).map_err(serde::de::Error::custom)
+}
+
+fn deserialize_coverage_threshold<'de, D>(deserializer: D) -> Result<Option<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let threshold = Option::<u8>::deserialize(deserializer)?;
+    if threshold.is_some_and(|threshold| threshold > 100) {
+        return Err(serde::de::Error::custom("coverage threshold must be between 0 and 100"));
+    }
+    Ok(threshold)
 }
 
 pub fn parse_lcov_version(s: &str) -> Result<Version, String> {
@@ -131,27 +202,51 @@ mod tests {
         assert!(!cfg.include_libs);
         assert!(!cfg.exclude_tests);
         assert!(cfg.skip_files.is_empty());
+        assert_eq!(cfg.thresholds, CoverageThresholds::default());
     }
 
     #[test]
     fn deserialize_from_toml() {
         let toml = r#"
-            report = ["summary", "lcov"]
+            report = ["summary", "json-summary", "lcov"]
             lcov_version = "2.2.0"
             ir_minimum = true
             report_file = "out/lcov.info"
             include_libs = true
             exclude_tests = true
             skip_files = ["test/**", "src/mocks/**"]
+
+            [thresholds]
+            lines = 80
+            statements = 81
+            branches = 82
+            functions = 83
         "#;
         let cfg: CoverageConfig = toml::from_str(toml).unwrap();
-        assert_eq!(cfg.report, vec![CoverageReportKind::Summary, CoverageReportKind::Lcov]);
+        assert_eq!(
+            cfg.report,
+            vec![
+                CoverageReportKind::Summary,
+                CoverageReportKind::JsonSummary,
+                CoverageReportKind::Lcov,
+            ]
+        );
         assert_eq!(cfg.lcov_version, Version::new(2, 2, 0));
         assert!(cfg.ir_minimum);
         assert_eq!(cfg.report_file.as_deref(), Some(std::path::Path::new("out/lcov.info")));
         assert!(cfg.include_libs);
         assert!(cfg.exclude_tests);
         assert_eq!(cfg.skip_files, vec!["test/**".to_string(), "src/mocks/**".to_string()]);
+        assert_eq!(
+            cfg.thresholds,
+            CoverageThresholds {
+                lines: Some(80),
+                statements: Some(81),
+                branches: Some(82),
+                functions: Some(83),
+            }
+        );
+        assert_eq!(toml::from_str::<CoverageConfig>(&toml::to_string(&cfg).unwrap()).unwrap(), cfg);
     }
 
     #[test]
@@ -180,5 +275,12 @@ mod tests {
                 toml::from_str(&format!(r#"lcov_version = "{input}""#)).unwrap();
             assert_eq!(cfg.lcov_version, expected);
         }
+    }
+
+    #[test]
+    fn deserialize_threshold_rejects_percentage_above_100() {
+        let err =
+            toml::from_str::<CoverageConfig>("[thresholds]\nlines = 101").unwrap_err().to_string();
+        assert!(err.contains("coverage threshold must be between 0 and 100"), "{err}");
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -117,7 +117,7 @@ mod symbolic;
 pub use symbolic::{SymbolicConfig, SymbolicExplorationOrder, SymbolicStorageLayout};
 
 mod coverage;
-pub use coverage::{CoverageConfig, CoverageReportKind, parse_lcov_version};
+pub use coverage::{CoverageConfig, CoverageReportKind, CoverageThresholds, parse_lcov_version};
 
 mod trace;
 pub use trace::TracingConfig;
@@ -8571,6 +8571,12 @@ mod tests {
                 include_libs = true
                 exclude_tests = true
                 skip_files = ["test/**", "src/mocks/**"]
+
+                [profile.default.coverage.thresholds]
+                lines = 80
+                statements = 81
+                branches = 82
+                functions = 83
                 "#,
             )?;
             let config = Config::load_with_root(jail.directory()).unwrap();
@@ -8590,6 +8596,15 @@ mod tests {
                 config.coverage.skip_files,
                 vec!["test/**".to_string(), "src/mocks/**".to_string()]
             );
+            assert_eq!(
+                config.coverage.thresholds,
+                CoverageThresholds {
+                    lines: Some(80),
+                    statements: Some(81),
+                    branches: Some(82),
+                    functions: Some(83),
+                }
+            );
             Ok(())
         });
     }
@@ -8605,6 +8620,9 @@ mod tests {
                 [coverage]
                 skip_files = ["script/**"]
                 exclude_tests = true
+
+                [coverage.thresholds]
+                lines = 75
                 "#,
             )?;
             let config = Config::load_with_root(jail.directory()).unwrap();
@@ -8613,6 +8631,7 @@ mod tests {
             // Untouched fields keep their defaults.
             assert_eq!(config.coverage.report, vec![CoverageReportKind::Summary]);
             assert_eq!(config.coverage.lcov_version, semver::Version::new(1, 0, 0));
+            assert_eq!(config.coverage.thresholds.lines, Some(75));
             Ok(())
         });
     }
@@ -8626,9 +8645,16 @@ mod tests {
                 [profile.default.coverage]
                 skip_files = ["script/**"]
 
+                [profile.default.coverage.thresholds]
+                lines = 75
+
                 [profile.ci.coverage]
                 skip_files = ["test/**", "lib/**"]
                 exclude_tests = true
+
+                [profile.ci.coverage.thresholds]
+                lines = 90
+                branches = 80
                 "#,
             )?;
 
@@ -8636,6 +8662,8 @@ mod tests {
             let config = Config::load_with_root(jail.directory()).unwrap();
             assert_eq!(config.coverage.skip_files, vec!["script/**".to_string()]);
             assert!(!config.coverage.exclude_tests);
+            assert_eq!(config.coverage.thresholds.lines, Some(75));
+            assert!(config.coverage.thresholds.branches.is_none());
 
             // CI profile sees its own override.
             jail.set_env("FOUNDRY_PROFILE", "ci");
@@ -8645,6 +8673,8 @@ mod tests {
                 vec!["test/**".to_string(), "lib/**".to_string()]
             );
             assert!(config.coverage.exclude_tests);
+            assert_eq!(config.coverage.thresholds.lines, Some(90));
+            assert_eq!(config.coverage.thresholds.branches, Some(80));
             Ok(())
         });
     }

--- a/crates/evm/coverage/src/lib.rs
+++ b/crates/evm/coverage/src/lib.rs
@@ -93,6 +93,15 @@ impl CoverageReport {
         self.by_file(|summary: &mut CoverageSummary, item| summary.add_item(item))
     }
 
+    /// Returns the aggregate coverage summary across all reportable source files.
+    pub fn summary(&self) -> CoverageSummary {
+        let mut total = CoverageSummary::default();
+        for (_, summary) in self.summary_by_file() {
+            total.merge(&summary);
+        }
+        total
+    }
+
     /// Returns an iterator over coverage items by source file path.
     pub fn items_by_file(&self) -> impl Iterator<Item = (&Path, Vec<&CoverageItem>)> {
         self.by_file(|list: &mut Vec<_>, item| list.push(item))

--- a/crates/forge/src/cmd/coverage.rs
+++ b/crates/forge/src/cmd/coverage.rs
@@ -5,10 +5,11 @@ use super::{
 };
 use crate::coverage::{
     BytecodeReporter, ContractId, CoverageAttributionReporter, CoverageReport, CoverageReporter,
-    CoverageSummaryReporter, DebugReporter, ItemAnchor, LcovReporter, ResolvedHitMap,
-    ResolvedHitMaps,
+    CoverageSummaryReporter, DebugReporter, ItemAnchor, JsonSummaryReporter, LcovReporter,
+    ResolvedHitMap, ResolvedHitMaps,
     analysis::{SourceAnalysis, SourceFiles},
     anchors::find_anchors,
+    ensure_coverage_thresholds,
 };
 use alloy_primitives::{Address, Bytes, U256, map::HashMap};
 use clap::{Parser, ValueHint};
@@ -22,7 +23,8 @@ use foundry_compilers::{
     utils::source_files_iter,
 };
 use foundry_config::{
-    Config, CoverageConfig, CoverageReportKind, InlineConfig, parse_lcov_version,
+    Config, CoverageConfig, CoverageReportKind, CoverageThresholds, InlineConfig,
+    parse_lcov_version,
 };
 use foundry_evm::{core::ic::IcPcMap, opts::EvmOpts};
 use globset::{Glob, GlobSetBuilder};
@@ -52,8 +54,9 @@ Compatibility:
   `forge coverage` supports test filters and `--watch`, but not test-only output or
   execution modes such as `--json`, `--junit`, `--list`, `--debug`, flame profiles,
   symbolic artifact replay, showmap replay, brutalization, or mutation testing. Use
-  `--report lcov` for interoperable coverage data or `--report attribution` for
-  Foundry's per-test JSON attribution report."#)]
+  `--report json-summary` for Istanbul-compatible summary JSON, `--report lcov` for
+  interoperable source coverage, or `--report attribution` for Foundry's per-test
+  JSON attribution report."#)]
 pub struct CoverageArgs {
     /// The report type to use for coverage.
     ///
@@ -118,6 +121,9 @@ pub struct CoverageArgs {
     skip_files: Vec<String>,
 
     #[command(flatten)]
+    thresholds: CoverageThresholds,
+
+    #[command(flatten)]
     test: TestArgs,
 }
 
@@ -132,7 +138,9 @@ impl CoverageArgs {
         let has_lcov = self.report.iter().any(|kind| matches!(kind, CoverageReportKind::Lcov));
         let has_attribution =
             self.report.iter().any(|kind| matches!(kind, CoverageReportKind::Attribution));
-        usize::from(has_lcov) + usize::from(has_attribution)
+        let has_json_summary =
+            self.report.iter().any(|kind| matches!(kind, CoverageReportKind::JsonSummary));
+        usize::from(has_lcov) + usize::from(has_attribution) + usize::from(has_json_summary)
     }
 
     pub(crate) fn ensure_mode_compatible(&self) -> Result<()> {
@@ -212,6 +220,7 @@ impl CoverageArgs {
         // Glob filters are additive — there's no CLI flag for these, so always
         // take from config.
         self.skip_files.clone_from(&config.skip_files);
+        self.thresholds.resolve_with(&config.thresholds);
     }
 
     fn populate_reporters(&mut self, root: &Path) {
@@ -221,6 +230,10 @@ impl CoverageArgs {
             .filter_map(|report_kind| match report_kind {
                 CoverageReportKind::Summary => {
                     Some(Box::<CoverageSummaryReporter>::default() as Box<dyn CoverageReporter>)
+                }
+                CoverageReportKind::JsonSummary => {
+                    let path = self.report_path(root, "coverage-summary.json");
+                    Some(Box::new(JsonSummaryReporter::new(path)))
                 }
                 CoverageReportKind::Lcov => {
                     let path = self.report_path(root, "lcov.info");
@@ -464,6 +477,7 @@ impl CoverageArgs {
 
         // Output final reports.
         self.report(&report)?;
+        let threshold_result = ensure_coverage_thresholds(&report.summary(), &self.thresholds);
 
         if self.report.iter().any(|kind| matches!(kind, CoverageReportKind::Attribution)) {
             let reporter = CoverageAttributionReporter::new(
@@ -475,6 +489,7 @@ impl CoverageArgs {
         // Check for test failures after generating coverage report.
         // This ensures coverage data is written even when tests fail.
         outcome.ensure_ok(false)?;
+        threshold_result?;
 
         Ok(())
     }

--- a/crates/forge/src/coverage.rs
+++ b/crates/forge/src/coverage.rs
@@ -7,6 +7,7 @@ use comfy_table::{
 };
 use evm_disassembler::disassemble_bytes;
 use foundry_common::{fs, shell};
+use foundry_config::CoverageThresholds;
 use semver::Version;
 use serde::{Serialize, ser::SerializeSeq};
 use std::{
@@ -35,8 +36,6 @@ pub trait CoverageReporter {
 pub struct CoverageSummaryReporter {
     /// The summary table.
     table: Table,
-    /// The total coverage of the entire project.
-    total: CoverageSummary,
 }
 
 impl Default for CoverageSummaryReporter {
@@ -56,7 +55,7 @@ impl Default for CoverageSummaryReporter {
             Cell::new("% Funcs"),
         ]);
 
-        Self { table, total: CoverageSummary::default() }
+        Self { table }
     }
 }
 
@@ -79,11 +78,10 @@ impl CoverageReporter for CoverageSummaryReporter {
 
     fn report(&mut self, report: &CoverageReport) -> eyre::Result<()> {
         for (path, summary) in report.summary_by_file() {
-            self.total.merge(&summary);
             self.add_row(path.display(), summary);
         }
 
-        self.add_row("Total", self.total.clone());
+        self.add_row("Total", report.summary());
         sh_println!("\n{}", self.table)?;
         Ok(())
     }
@@ -114,6 +112,169 @@ mod tests {
             format_cell(0, 0),
             Cell::new("N/A (0/0)").fg(Color::Grey).add_attribute(Attribute::Dim)
         );
+    }
+
+    #[test]
+    fn json_summary_percentage_matches_istanbul() {
+        assert_eq!(json_summary_percentage(2, 3), 66.66);
+        assert_eq!(json_summary_percentage(0, 0), 100.0);
+    }
+
+    #[test]
+    fn aggregate_thresholds_report_all_misses() {
+        let summary = CoverageSummary {
+            line_count: 10,
+            line_hits: 8,
+            statement_count: 10,
+            statement_hits: 7,
+            branch_count: 4,
+            branch_hits: 3,
+            function_count: 4,
+            function_hits: 3,
+        };
+        let thresholds = CoverageThresholds {
+            lines: Some(80),
+            statements: Some(80),
+            branches: Some(100),
+            functions: Some(80),
+        };
+
+        let err = ensure_coverage_thresholds(&summary, &thresholds).unwrap_err().to_string();
+        assert!(!err.contains("lines"), "{err}");
+        assert!(err.contains("statements: 70.00% (7/10), required 80%"), "{err}");
+        assert!(err.contains("branches: 75.00% (3/4), required 100%"), "{err}");
+        assert!(err.contains("functions: 75.00% (3/4), required 80%"), "{err}");
+
+        assert!(
+            ensure_coverage_thresholds(
+                &CoverageSummary::default(),
+                &CoverageThresholds {
+                    lines: Some(100),
+                    statements: Some(100),
+                    branches: Some(100),
+                    functions: Some(100),
+                }
+            )
+            .is_ok()
+        );
+    }
+}
+
+/// Writes coverage summaries using Istanbul's `json-summary` schema.
+pub struct JsonSummaryReporter {
+    path: PathBuf,
+}
+
+impl JsonSummaryReporter {
+    /// Creates a new JSON summary reporter.
+    pub const fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl CoverageReporter for JsonSummaryReporter {
+    fn name(&self) -> &'static str {
+        "json-summary"
+    }
+
+    fn report(&mut self, report: &CoverageReport) -> eyre::Result<()> {
+        let summaries = report
+            .summary_by_file()
+            .map(|(path, summary)| {
+                (path.display().to_string(), JsonCoverageSummary::from(&summary))
+            })
+            .collect();
+        let payload =
+            JsonSummaryReport { total: JsonCoverageSummary::from(&report.summary()), summaries };
+        let mut out = std::io::BufWriter::new(fs::create_file(&self.path)?);
+        serde_json::to_writer(&mut out, &payload)?;
+        writeln!(out)?;
+        out.flush()?;
+
+        sh_status!("Wrote JSON summary report.")?;
+        Ok(())
+    }
+}
+
+/// Istanbul-compatible JSON summary payload.
+#[derive(Serialize)]
+struct JsonSummaryReport {
+    total: JsonCoverageSummary,
+    #[serde(flatten)]
+    summaries: BTreeMap<String, JsonCoverageSummary>,
+}
+
+/// Summary counters for one source or the aggregate report.
+#[derive(Serialize)]
+struct JsonCoverageSummary {
+    lines: JsonCoverageMetric,
+    statements: JsonCoverageMetric,
+    functions: JsonCoverageMetric,
+    branches: JsonCoverageMetric,
+}
+
+impl From<&CoverageSummary> for JsonCoverageSummary {
+    fn from(summary: &CoverageSummary) -> Self {
+        Self {
+            lines: JsonCoverageMetric::new(summary.line_hits, summary.line_count),
+            statements: JsonCoverageMetric::new(summary.statement_hits, summary.statement_count),
+            functions: JsonCoverageMetric::new(summary.function_hits, summary.function_count),
+            branches: JsonCoverageMetric::new(summary.branch_hits, summary.branch_count),
+        }
+    }
+}
+
+/// Counters for one Istanbul coverage metric.
+#[derive(Serialize)]
+struct JsonCoverageMetric {
+    total: usize,
+    covered: usize,
+    skipped: usize,
+    pct: f64,
+}
+
+impl JsonCoverageMetric {
+    fn new(covered: usize, total: usize) -> Self {
+        Self { total, covered, skipped: 0, pct: json_summary_percentage(covered, total) }
+    }
+}
+
+fn json_summary_percentage(covered: usize, total: usize) -> f64 {
+    if total == 0 {
+        return 100.0;
+    }
+    let basis_points = (covered as u128 * 10_000) / total as u128;
+    basis_points as f64 / 100.0
+}
+
+/// Ensures aggregate coverage satisfies all configured thresholds.
+pub fn ensure_coverage_thresholds(
+    summary: &CoverageSummary,
+    thresholds: &CoverageThresholds,
+) -> eyre::Result<()> {
+    let metrics = [
+        ("lines", summary.line_hits, summary.line_count, thresholds.lines),
+        ("statements", summary.statement_hits, summary.statement_count, thresholds.statements),
+        ("branches", summary.branch_hits, summary.branch_count, thresholds.branches),
+        ("functions", summary.function_hits, summary.function_count, thresholds.functions),
+    ];
+    let failures = metrics
+        .into_iter()
+        .filter_map(|(name, covered, total, threshold)| {
+            let threshold = threshold?;
+            (total > 0 && covered as u128 * 100 < threshold as u128 * total as u128).then(|| {
+                format!(
+                    "- {name}: {:.2}% ({covered}/{total}), required {threshold}%",
+                    covered as f64 / total as f64 * 100.0
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        eyre::bail!("coverage thresholds not met:\n{}", failures.join("\n"));
     }
 }
 

--- a/crates/forge/tests/cli/config.rs
+++ b/crates/forge/tests/cli/config.rs
@@ -283,6 +283,8 @@ include_libs = false
 exclude_tests = false
 skip_files = []
 
+[coverage.thresholds]
+
 [mutation]
 include_operators = []
 exclude_operators = []
@@ -1715,7 +1717,13 @@ forgetest_init!(test_default_config, |prj, cmd| {
     "report_file": null,
     "include_libs": false,
     "exclude_tests": false,
-    "skip_files": []
+    "skip_files": [],
+    "thresholds": {
+      "lines": null,
+      "statements": null,
+      "branches": null,
+      "functions": null
+    }
   },
   "mutation": {
     "include_operators": [],

--- a/crates/forge/tests/cli/coverage.rs
+++ b/crates/forge/tests/cli/coverage.rs
@@ -1,6 +1,7 @@
 use clap::CommandFactory;
 use forge::cmd::coverage::CoverageArgs;
 use foundry_common::fs::{self, files_with_ext};
+use foundry_config::CoverageThresholds;
 use foundry_test_utils::{
     TestCommand, TestProject,
     snapbox::{Data, IntoData},
@@ -178,6 +179,71 @@ end_of_record
 forgetest_init!(basic, |prj, cmd| {
     prj.initialize_default_contracts();
     basic_base(prj, cmd);
+});
+
+forgetest_init!(json_summary_and_thresholds, |prj, cmd| {
+    prj.initialize_default_contracts();
+    prj.update_config(|config| {
+        config.coverage.thresholds = CoverageThresholds {
+            lines: Some(45),
+            statements: Some(41),
+            branches: Some(100),
+            functions: Some(51),
+        };
+    });
+
+    let output =
+        cmd.args(["coverage", "--report=json-summary"]).assert_failure().get_output().clone();
+    let stdout = output.stdout_lossy();
+    let stderr = output.stderr_lossy();
+    assert!(!stdout.contains("Wrote JSON summary report."), "{stdout}");
+    assert!(stderr.contains("Wrote JSON summary report."), "{stderr}");
+    assert!(stderr.contains("coverage thresholds not met:"), "{stderr}");
+    assert!(stderr.contains("lines: 44.44% (4/9), required 45%"), "{stderr}");
+    assert!(stderr.contains("statements: 40.00% (2/5), required 41%"), "{stderr}");
+    assert!(!stderr.contains("branches:"), "{stderr}");
+    assert!(stderr.contains("functions: 50.00% (2/4), required 51%"), "{stderr}");
+
+    let summary_path = prj.root().join("coverage-summary.json");
+    let summary: Value =
+        serde_json::from_str(&std::fs::read_to_string(&summary_path).unwrap()).unwrap();
+    assert_eq!(
+        summary,
+        serde_json::json!({
+            "total": {
+                "lines": { "total": 9, "covered": 4, "skipped": 0, "pct": 44.44 },
+                "statements": { "total": 5, "covered": 2, "skipped": 0, "pct": 40.0 },
+                "functions": { "total": 4, "covered": 2, "skipped": 0, "pct": 50.0 },
+                "branches": { "total": 0, "covered": 0, "skipped": 0, "pct": 100.0 }
+            },
+            "script/Counter.s.sol": {
+                "lines": { "total": 5, "covered": 0, "skipped": 0, "pct": 0.0 },
+                "statements": { "total": 3, "covered": 0, "skipped": 0, "pct": 0.0 },
+                "functions": { "total": 2, "covered": 0, "skipped": 0, "pct": 0.0 },
+                "branches": { "total": 0, "covered": 0, "skipped": 0, "pct": 100.0 }
+            },
+            "src/Counter.sol": {
+                "lines": { "total": 4, "covered": 4, "skipped": 0, "pct": 100.0 },
+                "statements": { "total": 2, "covered": 2, "skipped": 0, "pct": 100.0 },
+                "functions": { "total": 2, "covered": 2, "skipped": 0, "pct": 100.0 },
+                "branches": { "total": 0, "covered": 0, "skipped": 0, "pct": 100.0 }
+            }
+        })
+    );
+
+    let custom_summary = prj.root().join("custom-summary.json");
+    cmd.forge_fuse()
+        .args([
+            "coverage",
+            "--report=json-summary",
+            "--report-file=custom-summary.json",
+            "--fail-under-lines=0",
+            "--fail-under-statements=0",
+            "--fail-under-branches=0",
+            "--fail-under-functions=0",
+        ])
+        .assert_success();
+    assert!(custom_summary.exists(), "custom JSON summary report was not created");
 });
 
 forgetest_init!(basic_crlf, |prj, cmd| {


### PR DESCRIPTION
Adds an explicit `json-summary` coverage report that writes deterministic, Istanbul-compatible aggregate and per-source counters to `coverage-summary.json`, providing a stable CI interface without changing the meaning of global `--json`. This builds on #9525 and #15786 and delivers the coverage-policy use case raised in #3644.

Adds independent integer thresholds for lines, statements, branches, and functions through `foundry.toml` and `--fail-under-*` flags. Forge compares exact aggregate ratios, treats metrics with no coverable items as not applicable, writes requested reports before returning a nonzero status, and keeps report status text on stderr.

[foundry-rs/book#2026](https://github.com/foundry-rs/book/pull/2026) documents the report schema, configuration, defaults, environment support, and CLI behavior. This PR was written with OpenAI Codex assistance, including investigation, implementation, tests, documentation, and the PR description.
