### PR TITLE
feat(cast): add ERC-20 amount units

### DIFF
--- a/.changelog/cast-erc20-decimal-units.md
+++ b/.changelog/cast-erc20-decimal-units.md
@@ -1,0 +1,5 @@
+---
+cast: minor
+---
+
+Added opt-in decimal-aware amounts to `cast erc20` with explicit and automatic unit modes.

--- a/crates/cast/src/cmd/erc20.rs
+++ b/crates/cast/src/cmd/erc20.rs
@@ -1,6 +1,7 @@
 use std::{str::FromStr, time::Duration};
 
 use crate::{
+    SimpleCast,
     cmd::{
         call_overrides::CallOverrideOpts,
         send::{
@@ -21,7 +22,8 @@ use alloy_provider::{
 };
 use alloy_signer::{Signature, Signer};
 use alloy_sol_types::sol;
-use clap::Parser;
+use clap::{Args, Parser};
+use eyre::WrapErr;
 use foundry_cli::{
     json::{print_json_success, print_scalar},
     opts::RpcOpts,
@@ -46,7 +48,7 @@ sol! {
         #[derive(Debug)]
         function name() external view returns (string);
         function symbol() external view returns (string);
-        function decimals() external view returns (uint8);
+        function decimals() external view returns (uint256);
         function totalSupply() external view returns (uint256);
         function balanceOf(address owner) external view returns (uint256);
         function transfer(address to, uint256 amount) external returns (bool);
@@ -55,6 +57,102 @@ sol! {
         function mint(address to, uint256 amount) external;
         function burn(uint256 amount) external;
     }
+}
+
+const AUTO_UNITS_ERROR: &str = "failed to query ERC-20 `decimals()`; use an explicit decimal \
+                                count with `--units` for tokens with missing or nonstandard \
+                                metadata";
+
+/// How ERC-20 amounts are interpreted.
+#[derive(Clone, Copy, Debug, Default)]
+enum Erc20Units {
+    /// Base-unit integers.
+    #[default]
+    Raw,
+    /// The value returned by the token's `decimals()` function.
+    Auto,
+    /// An explicit decimal count.
+    Decimals(u8),
+}
+
+impl FromStr for Erc20Units {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "raw" => Ok(Self::Raw),
+            "auto" => Ok(Self::Auto),
+            _ => value.parse().map(Self::Decimals).map_err(|_| {
+                format!("invalid units `{value}`: expected `raw`, `auto`, or a decimal count")
+            }),
+        }
+    }
+}
+
+/// ERC-20 amount unit options.
+#[derive(Args, Clone, Copy, Debug, Default)]
+pub struct Erc20UnitsOpts {
+    /// Interpret amounts as raw base units, with a decimal count, or by querying `decimals()`.
+    ///
+    /// `auto` accepts an ABI integer from 0 to 255, including an ABI-compatible `uint256`,
+    /// and fails if `decimals()` is missing, reverts, or returns invalid data. Pass a decimal
+    /// count to bypass token metadata.
+    #[arg(long, default_value = "raw", value_name = "DECIMALS|auto|raw")]
+    units: Erc20Units,
+}
+
+macro_rules! resolve_erc20_decimals {
+    ($erc20:expr, $units:expr, $block:expr) => {{
+        match $units.units {
+            Erc20Units::Raw => None,
+            Erc20Units::Decimals(decimals) => Some(decimals),
+            Erc20Units::Auto => {
+                let decimals =
+                    $erc20.decimals().block($block).call().await.wrap_err(AUTO_UNITS_ERROR)?;
+                Some(parse_erc20_decimals(decimals).wrap_err(AUTO_UNITS_ERROR)?)
+            }
+        }
+    }};
+}
+
+fn parse_erc20_decimals(decimals: U256) -> eyre::Result<u8> {
+    eyre::ensure!(
+        decimals <= U256::from(u8::MAX),
+        "expected a value between 0 and 255, got {decimals}"
+    );
+    Ok(decimals.to::<u8>())
+}
+
+fn validate_erc20_amount_precision(amount: &str, decimals: u8) -> eyre::Result<()> {
+    if let Some((_, fractional)) = amount.split_once('.') {
+        let precision = usize::from(decimals);
+        let fractional = fractional.as_bytes();
+        eyre::ensure!(
+            fractional.len() <= precision
+                || fractional[precision..].iter().all(|&digit| digit == b'0'),
+            "amount has more than {decimals} decimal places"
+        );
+    }
+    Ok(())
+}
+
+fn parse_erc20_amount(amount: &str, decimals: Option<u8>) -> eyre::Result<U256> {
+    let Some(decimals) = decimals else {
+        return Ok(U256::from_str(amount)?);
+    };
+
+    validate_erc20_amount_precision(amount, decimals).wrap_err_with(|| {
+        format!("failed to parse ERC-20 amount `{amount}` with {decimals} decimals")
+    })?;
+    let amount = SimpleCast::parse_units(amount, decimals).wrap_err_with(|| {
+        format!("failed to parse ERC-20 amount `{amount}` with {decimals} decimals")
+    })?;
+    Ok(U256::from_str(&amount)?)
+}
+
+fn format_erc20_amount(amount: U256, decimals: u8) -> eyre::Result<String> {
+    SimpleCast::format_units(&amount.to_string(), decimals)
+        .wrap_err_with(|| format!("failed to format ERC-20 amount with {decimals} decimals"))
 }
 
 /// Creates a provider with a pre-resolved signer.
@@ -98,6 +196,9 @@ pub enum Erc20Subcommand {
 
         #[command(flatten)]
         overrides: CallOverrideOpts,
+
+        #[command(flatten)]
+        units: Erc20UnitsOpts,
     },
 
     /// Transfer ERC20 tokens.
@@ -113,6 +214,9 @@ pub enum Erc20Subcommand {
 
         /// The amount to transfer.
         amount: String,
+
+        #[command(flatten)]
+        units: Erc20UnitsOpts,
 
         #[command(flatten)]
         send_tx: SendTxOpts,
@@ -134,6 +238,9 @@ pub enum Erc20Subcommand {
 
         /// The amount to approve.
         amount: String,
+
+        #[command(flatten)]
+        units: Erc20UnitsOpts,
 
         #[command(flatten)]
         send_tx: SendTxOpts,
@@ -163,6 +270,9 @@ pub enum Erc20Subcommand {
 
         #[command(flatten)]
         rpc: RpcOpts,
+
+        #[command(flatten)]
+        units: Erc20UnitsOpts,
     },
 
     /// Query ERC20 token name.
@@ -223,6 +333,9 @@ pub enum Erc20Subcommand {
 
         #[command(flatten)]
         rpc: RpcOpts,
+
+        #[command(flatten)]
+        units: Erc20UnitsOpts,
     },
 
     /// Mint ERC20 tokens (if the token supports minting).
@@ -240,6 +353,9 @@ pub enum Erc20Subcommand {
         amount: String,
 
         #[command(flatten)]
+        units: Erc20UnitsOpts,
+
+        #[command(flatten)]
         send_tx: SendTxOpts,
 
         #[command(flatten)]
@@ -255,6 +371,9 @@ pub enum Erc20Subcommand {
 
         /// The amount to burn.
         amount: String,
+
+        #[command(flatten)]
+        units: Erc20UnitsOpts,
 
         #[command(flatten)]
         send_tx: SendTxOpts,
@@ -666,35 +785,61 @@ impl Erc20Subcommand {
 
         match self {
             // Read-only
-            Self::Allowance { token, owner, spender, block, .. } => {
+            Self::Allowance { token, owner, spender, block, units, .. } => {
                 let provider = get_provider(&config)?;
                 let token = token.resolve(&provider).await?;
                 let owner = owner.resolve(&provider).await?;
                 let spender = spender.resolve(&provider).await?;
+                let block = block.unwrap_or_default();
+                let erc20 = IERC20::new(token, &provider);
+                let decimals = resolve_erc20_decimals!(erc20, units, block);
 
-                let allowance = IERC20::new(token, &provider)
-                    .allowance(owner, spender)
-                    .block(block.unwrap_or_default())
-                    .call()
-                    .await?;
+                let allowance = erc20.allowance(owner, spender).block(block).call().await?;
 
-                if shell::is_json() {
+                if let Some(decimals) = decimals {
+                    let allowance = format_erc20_amount(allowance, decimals)?;
+                    if shell::is_json() {
+                        print_json_success(allowance)?;
+                    } else {
+                        sh_println!("{allowance}")?;
+                    }
+                } else if shell::is_json() {
                     print_json_success(allowance.to_string())?;
                 } else {
                     sh_println!("{}", format_uint_exp(allowance))?;
                 }
             }
-            Self::Balance { token, owner, block, overrides, .. } => {
+            Self::Balance { token, owner, block, overrides, units, .. } => {
                 let provider = get_provider(&config)?;
                 let token = token.resolve(&provider).await?;
                 let owner = owner.resolve(&provider).await?;
+                let block = block.unwrap_or_default();
 
-                let token = IERC20::new(token, &provider);
-                let balance_call = token.balanceOf(owner).block(block.unwrap_or_default());
+                let erc20 = IERC20::new(token, &provider);
+                let decimals = match units.units {
+                    Erc20Units::Raw => None,
+                    Erc20Units::Decimals(decimals) => Some(decimals),
+                    Erc20Units::Auto => {
+                        let decimals_call = erc20.decimals().block(block);
+                        let decimals = overrides
+                            .apply(decimals_call.call())?
+                            .await
+                            .wrap_err(AUTO_UNITS_ERROR)?;
+                        Some(parse_erc20_decimals(decimals).wrap_err(AUTO_UNITS_ERROR)?)
+                    }
+                };
+                let balance_call = erc20.balanceOf(owner).block(block);
                 let call = balance_call.call();
                 let balance = overrides.apply(call)?.await?;
 
-                if shell::is_json() {
+                if let Some(decimals) = decimals {
+                    let balance = format_erc20_amount(balance, decimals)?;
+                    if shell::is_json() {
+                        print_json_success(balance)?;
+                    } else {
+                        sh_println!("{balance}")?;
+                    }
+                } else if shell::is_json() {
                     print_json_success(balance.to_string())?;
                 } else {
                     sh_println!("{balance}")?;
@@ -733,43 +878,61 @@ impl Erc20Subcommand {
                     .block(block.unwrap_or_default())
                     .call()
                     .await?;
+                let decimals =
+                    parse_erc20_decimals(decimals).wrap_err("invalid ERC-20 `decimals()` value")?;
                 print_scalar(decimals)?;
             }
-            Self::TotalSupply { token, block, .. } => {
+            Self::TotalSupply { token, block, units, .. } => {
                 let provider = get_provider(&config)?;
                 let token = token.resolve(&provider).await?;
+                let block = block.unwrap_or_default();
+                let erc20 = IERC20::new(token, &provider);
+                let decimals = resolve_erc20_decimals!(erc20, units, block);
 
-                let total_supply = IERC20::new(token, &provider)
-                    .totalSupply()
-                    .block(block.unwrap_or_default())
-                    .call()
-                    .await?;
+                let total_supply = erc20.totalSupply().block(block).call().await?;
 
-                if shell::is_json() {
+                if let Some(decimals) = decimals {
+                    let total_supply = format_erc20_amount(total_supply, decimals)?;
+                    if shell::is_json() {
+                        print_json_success(total_supply)?;
+                    } else {
+                        sh_println!("{total_supply}")?;
+                    }
+                } else if shell::is_json() {
                     print_json_success(total_supply.to_string())?;
                 } else {
                     sh_println!("{}", format_uint_exp(total_supply))?
                 }
             }
             // State-changing
-            Self::Transfer { token, to, amount, send_tx, tx: tx_opts, .. } => {
+            Self::Transfer { token, to, amount, units, send_tx, tx: tx_opts, .. } => {
                 erc20_send!(token, send_tx, tx_opts, |erc20, provider| {
-                    erc20.transfer(to.resolve(&provider).await?, U256::from_str(&amount)?)
+                    let decimals = resolve_erc20_decimals!(erc20, units, BlockId::default());
+                    erc20.transfer(
+                        to.resolve(&provider).await?,
+                        parse_erc20_amount(&amount, decimals)?,
+                    )
                 })
             }
-            Self::Approve { token, spender, amount, send_tx, tx: tx_opts, .. } => {
+            Self::Approve { token, spender, amount, units, send_tx, tx: tx_opts, .. } => {
                 erc20_send!(token, send_tx, tx_opts, |erc20, provider| {
-                    erc20.approve(spender.resolve(&provider).await?, U256::from_str(&amount)?)
+                    let decimals = resolve_erc20_decimals!(erc20, units, BlockId::default());
+                    erc20.approve(
+                        spender.resolve(&provider).await?,
+                        parse_erc20_amount(&amount, decimals)?,
+                    )
                 })
             }
-            Self::Mint { token, to, amount, send_tx, tx: tx_opts, .. } => {
+            Self::Mint { token, to, amount, units, send_tx, tx: tx_opts, .. } => {
                 erc20_send!(token, send_tx, tx_opts, |erc20, provider| {
-                    erc20.mint(to.resolve(&provider).await?, U256::from_str(&amount)?)
+                    let decimals = resolve_erc20_decimals!(erc20, units, BlockId::default());
+                    erc20.mint(to.resolve(&provider).await?, parse_erc20_amount(&amount, decimals)?)
                 })
             }
-            Self::Burn { token, amount, send_tx, tx: tx_opts, .. } => {
+            Self::Burn { token, amount, units, send_tx, tx: tx_opts, .. } => {
                 erc20_send!(token, send_tx, tx_opts, |erc20, provider| {
-                    erc20.burn(U256::from_str(&amount)?)
+                    let decimals = resolve_erc20_decimals!(erc20, units, BlockId::default());
+                    erc20.burn(parse_erc20_amount(&amount, decimals)?)
                 })
             }
         };

--- a/crates/cast/tests/cli/erc20.rs
+++ b/crates/cast/tests/cli/erc20.rs
@@ -48,17 +48,10 @@ fn deploy_test_token(
     cmd: &mut foundry_test_utils::TestCommand,
     rpc: &str,
     private_key: &str,
+    contract: &str,
 ) -> String {
-    cmd.args([
-        "create",
-        "--private-key",
-        private_key,
-        "--rpc-url",
-        rpc,
-        "--broadcast",
-        "src/TestToken.sol:TestToken",
-    ])
-    .assert_success();
+    cmd.args(["create", "--private-key", private_key, "--rpc-url", rpc, "--broadcast", contract])
+        .assert_success();
 
     // Return the standard deployment address (nonce 0 from first account)
     anvil_const::TOKEN.to_string()
@@ -75,7 +68,22 @@ async fn setup_token_test(
     // Deploy TestToken contract
     foundry_test_utils::util::initialize(prj.root());
     prj.add_source("TestToken.sol", include_str!("../fixtures/TestToken.sol"));
-    let token = deploy_test_token(cmd, &rpc, anvil_const::PK1);
+    let token = deploy_test_token(cmd, &rpc, anvil_const::PK1, "src/TestToken.sol:TestToken");
+
+    (rpc, token, handle)
+}
+
+/// Helper to setup anvil node and deploy a six-decimal test token.
+async fn setup_six_decimal_token_test(
+    prj: &foundry_test_utils::TestProject,
+    cmd: &mut foundry_test_utils::TestCommand,
+) -> (String, String, NodeHandle) {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+
+    foundry_test_utils::util::initialize(prj.root());
+    prj.add_source("TestToken6.sol", include_str!("../fixtures/TestToken6.sol"));
+    let token = deploy_test_token(cmd, &rpc, anvil_const::PK1, "src/TestToken6.sol:TestToken6");
 
     (rpc, token, handle)
 }
@@ -212,6 +220,292 @@ forgetest_async!(erc20_approval_allowance, |prj, cmd| {
     // Verify allowance was set
     let allowance = get_allowance(&mut cmd, &token, anvil_const::ADDR1, anvil_const::ADDR2, &rpc);
     assert_eq!(allowance, approve_amount);
+});
+
+forgetest_async!(erc20_units_raw_default_and_explicit, |prj, cmd| {
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
+
+    for units in [None, Some("raw")] {
+        let mut args = vec![
+            "erc20",
+            "transfer",
+            &token,
+            anvil_const::ADDR2,
+            "1",
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ];
+        if let Some(units) = units {
+            args.extend(["--units", units]);
+        }
+        cmd.cast_fuse().args(args).assert_success();
+    }
+
+    let balance = get_u256_from_cmd(
+        &mut cmd,
+        &["erc20", "balance", &token, anvil_const::ADDR2, "--units", "raw", "--rpc-url", &rpc],
+    );
+    assert_eq!(balance, U256::from(2));
+});
+
+forgetest_async!(erc20_units_auto_18_decimals, |prj, cmd| {
+    let (rpc, token, _handle) = setup_token_test(&prj, &mut cmd).await;
+
+    cmd.cast_fuse()
+        .args([
+            "erc20",
+            "transfer",
+            &token,
+            anvil_const::ADDR2,
+            "1.5",
+            "--units",
+            "auto",
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_success();
+
+    cmd.cast_fuse()
+        .args([
+            "erc20",
+            "balance",
+            &token,
+            anvil_const::ADDR2,
+            "--units",
+            "auto",
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+1.500000000000000000
+
+"#]]);
+
+    cmd.cast_fuse()
+        .args([
+            "erc20",
+            "approve",
+            &token,
+            anvil_const::ADDR2,
+            "2.25",
+            "--units",
+            "18",
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_success();
+
+    cmd.cast_fuse()
+        .args([
+            "erc20",
+            "allowance",
+            &token,
+            anvil_const::ADDR1,
+            anvil_const::ADDR2,
+            "--units",
+            "auto",
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+2.250000000000000000
+
+"#]]);
+
+    cmd.cast_fuse()
+        .args([
+            "erc20",
+            "mint",
+            &token,
+            anvil_const::ADDR2,
+            "0.5",
+            "--units",
+            "auto",
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_success();
+
+    cmd.cast_fuse()
+        .args([
+            "erc20",
+            "burn",
+            &token,
+            "1.25",
+            "--units",
+            "18",
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_success();
+
+    cmd.cast_fuse()
+        .args(["erc20", "total-supply", &token, "--units", "auto", "--rpc-url", &rpc])
+        .assert_success()
+        .stdout_eq(str![[r#"
+999.250000000000000000
+
+"#]]);
+});
+
+forgetest_async!(erc20_units_explicit_and_auto_6_decimals, |prj, cmd| {
+    let (rpc, token, _handle) = setup_six_decimal_token_test(&prj, &mut cmd).await;
+
+    for (amount, units) in [("1.25", "6"), ("0.5", "auto")] {
+        cmd.cast_fuse()
+            .args([
+                "erc20",
+                "transfer",
+                &token,
+                anvil_const::ADDR2,
+                amount,
+                "--units",
+                units,
+                "--rpc-url",
+                &rpc,
+                "--private-key",
+                anvil_const::PK1,
+            ])
+            .assert_success();
+    }
+
+    assert_eq!(get_balance(&mut cmd, &token, anvil_const::ADDR2, &rpc), U256::from(1_750_000),);
+
+    cmd.cast_fuse()
+        .args([
+            "--json",
+            "erc20",
+            "balance",
+            &token,
+            anvil_const::ADDR2,
+            "--units",
+            "auto",
+            "--rpc-url",
+            &rpc,
+        ])
+        .assert_json_stdout(str![[r#"
+{
+  "schema_version": 1,
+  "success": true,
+  "data": "1.750000",
+  "errors": [],
+  "warnings": []
+}
+
+"#]]);
+});
+
+casttest!(erc20_units_auto_metadata_failures, async |_prj, cmd| {
+    let (_, handle) = anvil::spawn(NodeConfig::test()).await;
+    let rpc = handle.http_endpoint();
+    let token = "0x00000000000000000000000000000000000000aa";
+
+    for override_code in [None, Some("0x60006000fd"), Some("0x61010060005260206000f3")] {
+        let mut args = vec![
+            "erc20",
+            "balance",
+            token,
+            anvil_const::ADDR1,
+            "--units",
+            "auto",
+            "--rpc-url",
+            &rpc,
+        ];
+        let override_arg;
+        if let Some(code) = override_code {
+            override_arg = format!("{token}:{code}");
+            args.extend(["--override-code", &override_arg]);
+        }
+
+        let assert = cmd.cast_fuse().args(args).assert_failure();
+        let output = assert.get_output();
+        assert!(output.stdout.is_empty());
+        assert!(
+            output.stderr_lossy().starts_with("Error: failed to query ERC-20 `decimals()`"),
+            "unexpected metadata error: {}",
+            output.stderr_lossy(),
+        );
+    }
+
+    let override_arg = format!("{token}:0x61010060005260206000f3");
+    cmd.cast_fuse()
+        .args([
+            "erc20",
+            "balance",
+            token,
+            anvil_const::ADDR1,
+            "--units",
+            "6",
+            "--rpc-url",
+            &rpc,
+            "--override-code",
+            &override_arg,
+        ])
+        .assert_success()
+        .stdout_eq(str![[r#"
+0.000256
+
+"#]]);
+});
+
+forgetest_async!(erc20_units_reject_malformed_amounts, |prj, cmd| {
+    let (rpc, token, _handle) = setup_six_decimal_token_test(&prj, &mut cmd).await;
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "erc20",
+            "transfer",
+            &token,
+            anvil_const::ADDR2,
+            "0.0000001",
+            "--units",
+            "6",
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_failure();
+    let output = assert.get_output();
+    assert!(output.stdout.is_empty());
+    assert!(
+        output
+            .stderr_lossy()
+            .starts_with("Error: failed to parse ERC-20 amount `0.0000001` with 6 decimals"),
+        "unexpected amount error: {}",
+        output.stderr_lossy(),
+    );
+
+    let assert = cmd
+        .cast_fuse()
+        .args([
+            "erc20",
+            "transfer",
+            &token,
+            anvil_const::ADDR2,
+            "1.5",
+            "--rpc-url",
+            &rpc,
+            "--private-key",
+            anvil_const::PK1,
+        ])
+        .assert_failure();
+    let output = assert.get_output();
+    assert!(output.stdout.is_empty());
+    assert!(!output.stderr.is_empty(), "fractional amounts must fail in raw mode",);
 });
 
 // tests that `name`, `symbol`, `decimals`, and `totalSupply` commands work correctly
@@ -583,6 +877,23 @@ casttest!(erc20_transfer_help_includes_tempo_expires, |_prj, cmd| {
         output.contains("--tempo.expires <SECONDS>"),
         "expected erc20 transfer help to expose --tempo.expires, got:\n{output}",
     );
+});
+
+casttest!(erc20_units_help, |_prj, cmd| {
+    for subcommand in ["balance", "transfer"] {
+        let output = cmd
+            .cast_fuse()
+            .args(["erc20", subcommand, "--help"])
+            .assert_success()
+            .get_output()
+            .stdout_lossy();
+
+        assert!(output.contains("--units <DECIMALS|auto|raw>"), "{output}");
+        assert!(output.contains("[default: raw]"), "{output}");
+        assert!(output.contains("fails if `decimals()` is missing"), "{output}");
+        assert!(output.contains("Pass a decimal count"), "{output}");
+        assert!(output.contains("to bypass token metadata"), "{output}");
+    }
 });
 
 forgetest_async!(erc20_transfer_prints_tempo_sponsor_hash, |_prj, cmd| {

--- a/crates/cast/tests/fixtures/TestToken6.sol
+++ b/crates/cast/tests/fixtures/TestToken6.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract TestToken6 {
+    string public name = "Six Decimal Token";
+    string public symbol = "SIX";
+    // Deliberately uses uint256 instead of the standard uint8. The return data is still
+    // ABI-compatible with uint8 and should be accepted by automatic unit detection.
+    uint256 public decimals = 6;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor() {
+        totalSupply = 1000 * 10**decimals;
+        balanceOf[msg.sender] = totalSupply;
+        emit Transfer(address(0), msg.sender, totalSupply);
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        require(balanceOf[msg.sender] >= amount, "Insufficient balance");
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        emit Transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function mint(address to, uint256 amount) external {
+        totalSupply += amount;
+        balanceOf[to] += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function burn(uint256 amount) external {
+        require(balanceOf[msg.sender] >= amount, "Insufficient balance");
+        totalSupply -= amount;
+        balanceOf[msg.sender] -= amount;
+        emit Transfer(msg.sender, address(0), amount);
+    }
+}

--- a/docs/dev/output-channels.md
+++ b/docs/dev/output-channels.md
@@ -106,7 +106,7 @@ Each row's status is one of:
 | `cast wallet new`      | One record per wallet: `address` (keystore) or `address\tprivate_key` (no keystore) | JSON array of `{ address, public_key, path }` (keystore) or `{ address, public_key, private_key }` (no keystore) | migrated |
 | `cast wallet sign`     | Signature                                            | JSON                                                           | migrated |
 | `cast wallet sign-auth`| Signed authorization RLP                             | JSON                                                           | migrated |
-| `cast erc20 balance`   | Balance (decimal)                                    | JSON string                                                    | migrated |
+| `cast erc20 balance`   | Raw balance, or unit-formatted balance with `--units` | JSON string                                                    | migrated |
 | `cast create2`         | `address\tsalt` (tab-separated)                      | n/a                                                            | migrated |
 | `cast access-list`     | Access list                                          | JSON                                                           | migrated |
 | `cast interface`       | Solidity interface source                            | JSON ABI array                                                 | migrated |


### PR DESCRIPTION
`cast erc20` currently treats every token amount as a raw integer, which makes human-scale input and output awkward across tokens with different decimals. This adds opt-in `--units raw|auto|<DECIMALS>` handling to balance, allowance, total-supply, transfer, approve, mint, and burn while preserving raw behavior by default. Automatic mode queries `decimals()` at the selected block, accepts ABI-compatible integer metadata in the ERC-20 range, and fails clearly for missing, reverting, malformed, or out-of-range metadata; explicit counts bypass metadata. Amounts that would lose nonzero precision are rejected, and JSON output remains a clean string payload.

This PR was implemented with Codex, including code, tests, and documentation.
