### PR TITLE
fix(mutation): filter unsigned negation

### DIFF
--- a/.changelog/filter-unsigned-unary-negation.md
+++ b/.changelog/filter-unsigned-unary-negation.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Skipped invalid unary-negation mutants for operands with resolved unsigned integer types.

--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -341,7 +341,7 @@ pub struct MutationHandler {
     /// Optional regex used to restrict mutation to specific contracts within
     /// the file (matches against contract name).
     contract_filter: Option<regex::Regex>,
-    equivalent_mutations: type_analysis::EquivalentMutationSet,
+    mutation_exclusions: type_analysis::MutationExclusionSet,
 }
 
 impl MutationHandler {
@@ -354,7 +354,7 @@ impl MutationHandler {
             report: MutationsSummary::new(),
             survived_spans: SurvivedSpans::new(),
             contract_filter: None,
-            equivalent_mutations: type_analysis::EquivalentMutationSet::new(),
+            mutation_exclusions: type_analysis::MutationExclusionSet::new(),
         }
     }
 
@@ -364,12 +364,12 @@ impl MutationHandler {
         self
     }
 
-    /// Exclude binary operator replacements proven equivalent by type analysis.
-    pub(crate) fn with_equivalent_mutations(
+    /// Exclude operator replacements rejected by type analysis.
+    pub(crate) fn with_mutation_exclusions(
         mut self,
-        mutations: type_analysis::EquivalentMutationSet,
+        mutations: type_analysis::MutationExclusionSet,
     ) -> Self {
-        self.equivalent_mutations = mutations;
+        self.mutation_exclusions = mutations;
         self
     }
 
@@ -430,7 +430,7 @@ impl MutationHandler {
         let mut mutant_cfg_hasher = DefaultHasher::new();
         // Version salt for this mutant-set cache schema. Bump this if the
         // inputs that define generated mutants change.
-        "mutant-set-v3".hash(&mut mutant_cfg_hasher);
+        "mutant-set-v4".hash(&mut mutant_cfg_hasher);
         for op in self.config.mutation.enabled_operators() {
             op.to_string().hash(&mut mutant_cfg_hasher);
         }
@@ -513,7 +513,7 @@ impl MutationHandler {
             let operators = self.config.mutation.enabled_operators();
             let mut mutant_visitor = MutantVisitor::with_operators(path.clone(), &operators)
                 .with_source(&target_content)
-                .with_equivalent_mutations(self.equivalent_mutations.clone());
+                .with_mutation_exclusions(self.mutation_exclusions.clone());
 
             if let Some(filter) = contract_filter {
                 mutant_visitor =

--- a/crates/forge/src/mutation/mutators/unary_op_mutator.rs
+++ b/crates/forge/src/mutation/mutators/unary_op_mutator.rs
@@ -11,7 +11,7 @@ impl Mutator for UnaryOpMutator {
         let operations = vec![
             UnOpKind::PreInc, // number
             UnOpKind::PreDec, // n
-            UnOpKind::Neg,    // n @todo filter this one only for int
+            UnOpKind::Neg,    // n
             UnOpKind::BitNot, // n
         ];
 

--- a/crates/forge/src/mutation/orchestrator.rs
+++ b/crates/forge/src/mutation/orchestrator.rs
@@ -34,7 +34,7 @@ use crate::{
         MutationHandler, MutationProgress, MutationReporter, MutationsSummary,
         mutant::{Mutant, MutationResult},
         runner::run_mutations_parallel_with_progress,
-        type_analysis::{collect_equivalent_mutations, normalize_path},
+        type_analysis::{collect_mutation_exclusions, normalize_path},
     },
 };
 
@@ -173,8 +173,7 @@ pub async fn run_mutation_testing(
         mutation_config.rerun_failures.as_deref(),
         num_workers,
     )?;
-    let mut equivalent_mutations =
-        collect_equivalent_mutations(&config, output).unwrap_or_default();
+    let mut mutation_exclusions = collect_mutation_exclusions(&config, output).unwrap_or_default();
 
     if !mutation_config.show_progress && !json_output {
         sh_println!("Running mutation tests with {} parallel workers...", num_workers)?;
@@ -206,8 +205,8 @@ pub async fn run_mutation_testing(
         // Create handler for this file, optionally restricting to a subset of
         // contracts by name when --mutate-contract is provided.
         let mut handler = MutationHandler::new(path.clone(), config.clone());
-        if let Some(mutations) = equivalent_mutations.remove(&normalize_path(&path)) {
-            handler = handler.with_equivalent_mutations(mutations);
+        if let Some(mutations) = mutation_exclusions.remove(&normalize_path(&path)) {
+            handler = handler.with_mutation_exclusions(mutations);
         }
         if let Some(filter) = &mutation_config.mutate_contract_pattern {
             handler = handler.with_contract_filter(filter.clone());

--- a/crates/forge/src/mutation/type_analysis.rs
+++ b/crates/forge/src/mutation/type_analysis.rs
@@ -1,9 +1,10 @@
-//! Type-aware filtering for binary operator mutations.
+//! Type-aware filtering for operator mutations.
 //!
-//! This module records replacements that have the same result as the original comparison for
-//! every value in an operand's type range. It deliberately does not filter replacements merely
-//! because they are tautological. For example, `uint256 x == 0` and `x <= 0` are equivalent, but
-//! `x < 0` is retained because changing the original condition to `false` can expose missing tests.
+//! This module records replacements that are invalid or have the same result as the original
+//! comparison for every value in an operand's type range. It deliberately does not filter
+//! replacements merely because they are tautological. For example, `uint256 x == 0` and `x <= 0`
+//! are equivalent, but `x < 0` is retained because changing the original condition to `false` can
+//! expose missing tests.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -27,25 +28,35 @@ use solar::{
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct EquivalentMutation {
-    lo: u32,
-    hi: u32,
-    new_op: BinOpKind,
+enum ReplacementOperator {
+    Binary(BinOpKind),
+    Unary(UnOpKind),
 }
 
-impl EquivalentMutation {
-    pub fn new(span: solar::ast::Span, new_op: BinOpKind) -> Self {
-        Self { lo: span.lo().0, hi: span.hi().0, new_op }
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MutationExclusion {
+    lo: u32,
+    hi: u32,
+    new_op: ReplacementOperator,
+}
+
+impl MutationExclusion {
+    pub fn binary(span: solar::ast::Span, new_op: BinOpKind) -> Self {
+        Self { lo: span.lo().0, hi: span.hi().0, new_op: ReplacementOperator::Binary(new_op) }
+    }
+
+    pub fn unary(span: solar::ast::Span, new_op: UnOpKind) -> Self {
+        Self { lo: span.lo().0, hi: span.hi().0, new_op: ReplacementOperator::Unary(new_op) }
     }
 }
 
-pub type EquivalentMutationSet = HashSet<EquivalentMutation>;
-pub type EquivalentMutationsByPath = HashMap<PathBuf, EquivalentMutationSet>;
+pub type MutationExclusionSet = HashSet<MutationExclusion>;
+pub type MutationExclusionsByPath = HashMap<PathBuf, MutationExclusionSet>;
 
-pub fn collect_equivalent_mutations(
+pub fn collect_mutation_exclusions(
     config: &Config,
     output: &ProjectCompileOutput<MultiCompiler>,
-) -> Result<EquivalentMutationsByPath> {
+) -> Result<MutationExclusionsByPath> {
     let mut compiler = Compiler::new(Session::builder().with_silent_emitter(None).build());
     compiler.enter_mut(|compiler| {
         let mut pcx = compiler.parse();
@@ -53,24 +64,24 @@ pub fn collect_equivalent_mutations(
         pcx.parse();
 
         let Ok(ControlFlow::Continue(())) = compiler.lower_asts() else {
-            return Ok(EquivalentMutationsByPath::new());
+            return Ok(MutationExclusionsByPath::new());
         };
         let _ = compiler.analysis();
         Ok(collect_from_gcx(compiler.gcx()))
     })
 }
 
-fn collect_from_gcx<'gcx>(gcx: Gcx<'gcx>) -> EquivalentMutationsByPath {
-    let mut by_path = EquivalentMutationsByPath::new();
+fn collect_from_gcx<'gcx>(gcx: Gcx<'gcx>) -> MutationExclusionsByPath {
+    let mut by_path = MutationExclusionsByPath::new();
     for source_id in gcx.hir.source_ids() {
         let source = gcx.hir.source(source_id);
         let FileName::Real(path) = &source.file.name else { continue };
-        let mut collector = EquivalentMutationCollector {
+        let mut collector = MutationExclusionCollector {
             gcx,
             // HIR uses offsets in the compiler-wide source map, while the mutation visitor parses
             // each target independently and uses offsets relative to that file.
             source_start: source.file.start_pos.0,
-            mutations: EquivalentMutationSet::new(),
+            mutations: MutationExclusionSet::new(),
         };
         let _ = collector.visit_nested_source(source_id);
         if !collector.mutations.is_empty() {
@@ -84,13 +95,13 @@ pub fn normalize_path(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
-struct EquivalentMutationCollector<'hir> {
+struct MutationExclusionCollector<'hir> {
     gcx: Gcx<'hir>,
     source_start: u32,
-    mutations: EquivalentMutationSet,
+    mutations: MutationExclusionSet,
 }
 
-impl<'hir> Visit<'hir> for EquivalentMutationCollector<'hir> {
+impl<'hir> Visit<'hir> for MutationExclusionCollector<'hir> {
     type BreakValue = ();
 
     fn hir(&self) -> &'hir hir::Hir<'hir> {
@@ -103,11 +114,17 @@ impl<'hir> Visit<'hir> for EquivalentMutationCollector<'hir> {
         {
             self.collect_comparison(expr, left, op.kind, right);
         }
+        if let ExprKind::Unary(_, operand) = &expr.kind
+            && is_unsigned(self.gcx, operand)
+            && let Some(span) = self.local_span(expr.span)
+        {
+            self.mutations.insert(MutationExclusion::unary(span, UnOpKind::Neg));
+        }
         self.walk_expr(expr)
     }
 }
 
-impl EquivalentMutationCollector<'_> {
+impl MutationExclusionCollector<'_> {
     fn collect_comparison(
         &mut self,
         expr: &hir::Expr<'_>,
@@ -142,16 +159,18 @@ impl EquivalentMutationCollector<'_> {
                 continue;
             }
             let normalized_candidate = if operands_reversed { flip(candidate) } else { candidate };
-            if equivalent_at_boundary(range, value, normalized_original, normalized_candidate) {
-                let Some(lo) = expr.span.lo().0.checked_sub(self.source_start) else { continue };
-                let Some(hi) = expr.span.hi().0.checked_sub(self.source_start) else { continue };
-                let span = solar::ast::Span::new(
-                    solar::interface::BytePos(lo),
-                    solar::interface::BytePos(hi),
-                );
-                self.mutations.insert(EquivalentMutation::new(span, candidate));
+            if equivalent_at_boundary(range, value, normalized_original, normalized_candidate)
+                && let Some(span) = self.local_span(expr.span)
+            {
+                self.mutations.insert(MutationExclusion::binary(span, candidate));
             }
         }
+    }
+
+    fn local_span(&self, span: solar::ast::Span) -> Option<solar::ast::Span> {
+        let lo = span.lo().0.checked_sub(self.source_start)?;
+        let hi = span.hi().0.checked_sub(self.source_start)?;
+        Some(solar::ast::Span::new(solar::interface::BytePos(lo), solar::interface::BytePos(hi)))
     }
 }
 
@@ -207,6 +226,12 @@ fn integer_range(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> Option<IntegerRange> {
         _ => return None,
     };
     integer_range_for_type(ty)
+}
+
+fn is_unsigned(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> bool {
+    gcx.type_of_expr(expr.peel_parens().id).is_some_and(|ty| {
+        matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::UInt(_)))
+    })
 }
 
 fn integer_range_for_type(ty: ElementaryType) -> Option<IntegerRange> {
@@ -322,7 +347,7 @@ mod tests {
     use super::*;
     use solar::interface::BytePos;
 
-    fn collect(source: &str) -> EquivalentMutationSet {
+    fn collect(source: &str) -> MutationExclusionSet {
         let path = PathBuf::from("Test.sol");
         let mut compiler = Compiler::new(Session::builder().with_silent_emitter(None).build());
         compiler.enter_mut(|compiler| {
@@ -337,9 +362,17 @@ mod tests {
         })
     }
 
-    fn mutation(source: &str, expression: &str, new_op: BinOpKind) -> EquivalentMutation {
+    fn mutation(source: &str, expression: &str, new_op: BinOpKind) -> MutationExclusion {
         let lo = source.find(expression).expect("expression") as u32;
-        EquivalentMutation::new(
+        MutationExclusion::binary(
+            solar::ast::Span::new(BytePos(lo), BytePos(lo + expression.len() as u32)),
+            new_op,
+        )
+    }
+
+    fn unary_mutation(source: &str, expression: &str, new_op: UnOpKind) -> MutationExclusion {
+        let lo = source.find(expression).expect("expression") as u32;
+        MutationExclusion::unary(
             solar::ast::Span::new(BytePos(lo), BytePos(lo + expression.len() as u32)),
             new_op,
         )
@@ -392,6 +425,64 @@ contract Test {
         let mutations = collect(source);
 
         assert!(!mutations.contains(&mutation(source, "x == 0", BinOpKind::Le)));
+    }
+
+    #[test]
+    fn excludes_negation_only_for_unsigned_unary_operands() {
+        let source = r#"
+contract Test {
+    function check(uint256 unsigned, int256 signed) external pure {
+        unsigned++;
+        ++unsigned;
+        signed++;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        assert!(mutations.contains(&unary_mutation(source, "unsigned++", UnOpKind::Neg)));
+        assert!(mutations.contains(&unary_mutation(source, "++unsigned", UnOpKind::Neg)));
+        assert!(!mutations.contains(&unary_mutation(source, "signed++", UnOpKind::Neg)));
+    }
+
+    #[test]
+    fn preserves_overloaded_negation_for_unsigned_udvt() {
+        let source = r#"
+type Amount is uint256;
+
+function negate(Amount amount) pure returns (Amount) {
+    return Amount.wrap(type(uint256).max - Amount.unwrap(amount));
+}
+
+function complement(Amount amount) pure returns (Amount) {
+    return Amount.wrap(~Amount.unwrap(amount));
+}
+
+using {negate as -, complement as ~} for Amount global;
+
+contract Test {
+    function check(Amount amount) external pure returns (Amount) {
+        return ~amount;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        assert!(!mutations.contains(&unary_mutation(source, "~amount", UnOpKind::Neg)));
+    }
+
+    #[test]
+    fn preserves_negation_for_unresolved_operand() {
+        let source = r#"
+contract Test {
+    function check() external pure {
+        unresolved++;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        assert!(!mutations.contains(&unary_mutation(source, "unresolved++", UnOpKind::Neg)));
     }
 
     #[test]

--- a/crates/forge/src/mutation/visitor.rs
+++ b/crates/forge/src/mutation/visitor.rs
@@ -8,7 +8,7 @@ use crate::mutation::mutators::Mutator;
 use crate::mutation::{
     mutant::{Mutant, OwnedLiteral},
     mutators::{MutationContext, mutator_registry::MutatorRegistry},
-    type_analysis::{EquivalentMutation, EquivalentMutationSet},
+    type_analysis::{MutationExclusion, MutationExclusionSet},
 };
 use foundry_config::MutatorType;
 
@@ -34,7 +34,7 @@ pub struct MutantVisitor<'src> {
     /// matched the filter. Top-level items (outside any contract) are always
     /// considered "allowed".
     in_allowed_contract: bool,
-    equivalent_mutations: EquivalentMutationSet,
+    mutation_exclusions: MutationExclusionSet,
 }
 
 impl<'src> MutantVisitor<'src> {
@@ -48,7 +48,7 @@ impl<'src> MutantVisitor<'src> {
             source: None,
             contract_filter: None,
             in_allowed_contract: true,
-            equivalent_mutations: EquivalentMutationSet::new(),
+            mutation_exclusions: MutationExclusionSet::new(),
         }
     }
 
@@ -63,7 +63,7 @@ impl<'src> MutantVisitor<'src> {
             source: None,
             contract_filter: None,
             in_allowed_contract: true,
-            equivalent_mutations: EquivalentMutationSet::new(),
+            mutation_exclusions: MutationExclusionSet::new(),
         }
     }
 
@@ -78,7 +78,7 @@ impl<'src> MutantVisitor<'src> {
             source: None,
             contract_filter: None,
             in_allowed_contract: true,
-            equivalent_mutations: EquivalentMutationSet::new(),
+            mutation_exclusions: MutationExclusionSet::new(),
         }
     }
 
@@ -98,9 +98,9 @@ impl<'src> MutantVisitor<'src> {
         self
     }
 
-    /// Exclude binary operator replacements proven equivalent by type analysis.
-    pub fn with_equivalent_mutations(mut self, mutations: EquivalentMutationSet) -> Self {
-        self.equivalent_mutations = mutations;
+    /// Exclude operator replacements rejected by type analysis.
+    pub fn with_mutation_exclusions(mut self, mutations: MutationExclusionSet) -> Self {
+        self.mutation_exclusions = mutations;
         self
     }
 
@@ -111,12 +111,16 @@ impl<'src> MutantVisitor<'src> {
     fn collect_mutations(&mut self, context: &MutationContext<'_>) {
         let result = self.mutator_registry.generate_mutations(context);
         self.mutation_to_conduct.extend(result.mutations.into_iter().filter(|mutant| {
-            let crate::mutation::mutant::MutationType::BinaryOpExpr { new_op, .. } =
-                mutant.mutation
-            else {
-                return true;
+            let exclusion = match &mutant.mutation {
+                crate::mutation::mutant::MutationType::BinaryOpExpr { new_op, .. } => {
+                    MutationExclusion::binary(mutant.span, *new_op)
+                }
+                crate::mutation::mutant::MutationType::UnaryOperator(unary) => {
+                    MutationExclusion::unary(mutant.span, unary.resulting_op_kind)
+                }
+                _ => return true,
             };
-            !self.equivalent_mutations.contains(&EquivalentMutation::new(mutant.span, new_op))
+            !self.mutation_exclusions.contains(&exclusion)
         }));
 
         for err in result.errors {
@@ -323,8 +327,8 @@ contract Test {
             solar::interface::BytePos(lo),
             solar::interface::BytePos(lo + "x == 0".len() as u32),
         );
-        let equivalent_mutations =
-            [EquivalentMutation::new(span, solar::ast::BinOpKind::Le)].into_iter().collect();
+        let mutation_exclusions =
+            [MutationExclusion::binary(span, solar::ast::BinOpKind::Le)].into_iter().collect();
         let sess = Session::builder().with_silent_emitter(None).build();
 
         sess.enter(|| {
@@ -338,7 +342,7 @@ contract Test {
             drop(parser);
             let mut visitor = MutantVisitor::default(path)
                 .with_source(source)
-                .with_equivalent_mutations(equivalent_mutations);
+                .with_mutation_exclusions(mutation_exclusions);
 
             let _ = visitor.visit_source_unit(&ast);
             let comparison_mutations = visitor.mutation_to_conduct.iter().filter_map(|mutant| {
@@ -351,6 +355,63 @@ contract Test {
 
             assert!(!comparison_mutations.contains(&solar::ast::BinOpKind::Le));
             assert!(comparison_mutations.contains(&solar::ast::BinOpKind::Lt));
+        });
+    }
+
+    #[test]
+    fn visitor_excludes_unsigned_negation_but_retains_unary_swaps() {
+        let source = "\
+pragma solidity ^0.8.0;
+contract Test {
+    function increment(uint256 x) public pure {
+        x++;
+    }
+}
+";
+        let path = PathBuf::from("test.sol");
+        let lo = source.find("x++").unwrap() as u32;
+        let span = solar::ast::Span::new(
+            solar::interface::BytePos(lo),
+            solar::interface::BytePos(lo + "x++".len() as u32),
+        );
+        let mutation_exclusions =
+            [MutationExclusion::unary(span, solar::ast::UnOpKind::Neg)].into_iter().collect();
+        let sess = Session::builder().with_silent_emitter(None).build();
+
+        sess.enter(|| {
+            let arena = Arena::new();
+            let mut parser =
+                Parser::from_lazy_source_code(&sess, &arena, FileName::Real(path.clone()), || {
+                    Ok(source.to_string())
+                })
+                .unwrap();
+            let ast = parser.parse_file().map_err(|e| e.emit()).unwrap();
+            drop(parser);
+            let mut visitor = MutantVisitor::new_with_mutators(
+                path,
+                vec![Box::new(crate::mutation::mutators::unary_op_mutator::UnaryOpMutator)],
+            )
+            .with_source(source)
+            .with_mutation_exclusions(mutation_exclusions);
+
+            let _ = visitor.visit_source_unit(&ast);
+            let unary_mutations = visitor
+                .mutation_to_conduct
+                .iter()
+                .filter_map(|mutant| {
+                    let MutationType::UnaryOperator(unary) = &mutant.mutation else {
+                        return None;
+                    };
+                    (mutant.span == span).then_some(unary.resulting_op_kind)
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(unary_mutations.len(), 4);
+            assert!(!unary_mutations.contains(&solar::ast::UnOpKind::Neg));
+            assert!(unary_mutations.contains(&solar::ast::UnOpKind::PreInc));
+            assert!(unary_mutations.contains(&solar::ast::UnOpKind::PreDec));
+            assert!(unary_mutations.contains(&solar::ast::UnOpKind::BitNot));
+            assert!(unary_mutations.contains(&solar::ast::UnOpKind::PostDec));
         });
     }
 }

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -70,11 +70,11 @@ MUTATION TESTING RESULTS
 ╭──────────┬───────────┬────────────╮
 │ Status   ┆ # Mutants ┆ % of Total │
 ╞══════════╪═══════════╪════════════╡
-│ Survived ┆ 1         ┆ 14.3%      │
+│ Survived ┆ 1         ┆ 16.7%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Killed   ┆ 4         ┆ 57.1%      │
+│ Killed   ┆ 4         ┆ 66.7%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Invalid  ┆ 2         ┆ 28.6%      │
+│ Invalid  ┆ 1         ┆ 16.7%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
 │ Skipped  ┆ 0         ┆ 0.0%       │
 ╰──────────┴───────────┴────────────╯
@@ -102,7 +102,7 @@ Survived mutants
 4 mutants killed
 
 ────────────────────────────────────────────────────────────
-2 mutants invalid
+1 mutants invalid
 
 ════════════════════════════════════════════════════════════
 
@@ -110,7 +110,7 @@ Survived mutants
 
     // Run mutation testing with --json - verify the output contains valid mutation JSON
     cmd.forge_fuse().args(["test", "--mutate", "src/Counter.sol", "--mutation-jobs", "1", "--json"]).assert_success().stdout_eq(str![[r#"
-{"summary":{"total":7,"killed":4,"survived":1,"invalid":2,"skipped":0,"timed_out":0,"mutation_score":80.0,"duration_secs":[..]},"survived_mutants":{"src/Counter.sol":[{"line":13,"column":9,"original":"number++","mutant":"++number"}]}}
+{"summary":{"total":6,"killed":4,"survived":1,"invalid":1,"skipped":0,"timed_out":0,"mutation_score":80.0,"duration_secs":[..]},"survived_mutants":{"src/Counter.sol":[{"line":13,"column":9,"original":"number++","mutant":"++number"}]}}
 
 "#]]);
 });


### PR DESCRIPTION
Mutation testing currently generates unary-negation replacements for unsigned operands even though Solidity rejects them during compilation. This uses resolved HIR operand types to omit those mutants while retaining negation for signed values, unresolved types, and user-defined value types that may overload the operator.

Amp was used to review the implementation and strengthen regression coverage for overloaded user-defined value types.