### PR TITLE
fix(anvil): ignore empty state diffs

### DIFF
--- a/.changelog/anvil-empty-state-diff.md
+++ b/.changelog/anvil-empty-state-diff.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Fixed empty `stateDiff` overrides changing `eth_simulateV1` state roots.

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5984,7 +5984,10 @@ impl Backend<FoundryNetwork> {
                             || account.nonce.is_some()
                             || account.code.is_some()
                             || account.state.is_some()
-                            || account.state_diff.is_some()
+                            || account
+                                .state_diff
+                                .as_ref()
+                                .is_some_and(|state_diff| !state_diff.is_empty())
                     });
                     let previously_deleted = previously_deleted_accounts(
                         &cache_db.cache.accounts,

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -865,15 +865,26 @@ async fn test_simulate_empty_state_override_preserves_root_rpc() {
     let with_empty_override = rpc_request(
         &endpoint,
         "eth_simulateV1",
-        json!([{"blockStateCalls": [{"stateOverrides": {(account): {}}}]}]),
+        json!([{"blockStateCalls": [{"stateOverrides": {(account.clone()): {}}}]}]),
+    )
+    .await;
+    let with_empty_state_diff = rpc_request(
+        &endpoint,
+        "eth_simulateV1",
+        json!([{"blockStateCalls": [{"stateOverrides": {(account): {"stateDiff": {}}}}]}]),
     )
     .await;
 
     assert!(without_override.get("error").is_none(), "{without_override}");
     assert!(with_empty_override.get("error").is_none(), "{with_empty_override}");
+    assert!(with_empty_state_diff.get("error").is_none(), "{with_empty_state_diff}");
     assert_eq!(
         without_override["result"][0]["stateRoot"],
         with_empty_override["result"][0]["stateRoot"]
+    );
+    assert_eq!(
+        without_override["result"][0]["stateRoot"],
+        with_empty_state_diff["result"][0]["stateRoot"]
     );
 }
 


### PR DESCRIPTION
An empty `stateDiff` override performs no storage writes, but `eth_simulateV1` currently materializes an absent account and changes the simulated state root and derived block hash. Ignore otherwise-empty state diffs while preserving full storage replacements, non-empty diffs, and override conflict validation, and extend the existing root-parity regression.