### PR TITLE
fix(forge): preserve arbitrary storage writes

### DIFF
--- a/.changelog/arbitrary-storage-explicit-store.md
+++ b/.changelog/arbitrary-storage-explicit-store.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed zero values written with `vm.store` being replaced by arbitrary storage values in subsequent test transactions.

--- a/crates/cheatcodes/src/evm.rs
+++ b/crates/cheatcodes/src/evm.rs
@@ -299,7 +299,10 @@ impl Cheatcode for loadCall {
             .sload(target, slot.into())
             .map_err(|e| fmt_err!("failed to load storage slot: {:?}", e))?;
 
-        if val.is_cold && val.data.is_zero() {
+        if val.is_cold
+            && val.data.is_zero()
+            && !ccx.state.is_arbitrary_storage_slot_explicit(target, slot.into())
+        {
             if ccx.state.has_arbitrary_storage(&target) {
                 // If storage slot is untouched and load from a target with arbitrary storage,
                 // then set random value for current slot.
@@ -814,6 +817,7 @@ impl Cheatcode for storeCall {
             .journal_mut()
             .sstore(target, slot.into(), value.into())
             .map_err(|e| fmt_err!("failed to store storage slot: {:?}", e))?;
+        ccx.state.mark_arbitrary_storage_slot_explicit(target, slot.into());
         Ok(Default::default())
     }
 }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -408,12 +408,15 @@ pub struct ArbitraryStorage {
     copies: HashMap<Address, Address>,
     /// Address with storage slots that should be overwritten even if previously set.
     overwrites: HashSet<Address>,
+    /// Storage slots explicitly written with `vm.store`, grouped by address.
+    explicit_slots: HashMap<Address, HashSet<U256>>,
 }
 
 impl ArbitraryStorage {
     /// Marks an address with arbitrary storage.
     pub fn mark_arbitrary(&mut self, address: &Address, overwrite: bool) {
         self.values.insert(*address, HashMap::default());
+        self.explicit_slots.remove(address);
         if overwrite {
             self.overwrites.insert(*address);
         } else {
@@ -425,7 +428,24 @@ impl ArbitraryStorage {
     pub fn mark_copy(&mut self, from: &Address, to: &Address) {
         if self.values.contains_key(from) {
             self.copies.insert(*to, *from);
+            if let Some(slots) = self.explicit_slots.get(from).cloned() {
+                self.explicit_slots.insert(*to, slots);
+            } else {
+                self.explicit_slots.remove(to);
+            }
         }
+    }
+
+    /// Marks a slot as explicitly written if the address has arbitrary or copied storage.
+    fn mark_explicit(&mut self, address: Address, slot: U256) {
+        if self.values.contains_key(&address) || self.copies.contains_key(&address) {
+            self.explicit_slots.entry(address).or_default().insert(slot);
+        }
+    }
+
+    /// Returns whether a slot was explicitly written for the given address.
+    fn is_explicit(&self, address: Address, slot: U256) -> bool {
+        self.explicit_slots.get(&address).is_some_and(|slots| slots.contains(&slot))
     }
 
     /// Returns addresses explicitly marked with arbitrary storage.
@@ -1649,6 +1669,18 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         if let Some(storage) = &mut self.arbitrary_storage {
             storage.cache_value(address, slot, value);
         }
+    }
+
+    /// Marks a slot as explicitly written with `vm.store`.
+    pub fn mark_arbitrary_storage_slot_explicit(&mut self, address: Address, slot: U256) {
+        if let Some(storage) = &mut self.arbitrary_storage {
+            storage.mark_explicit(address, slot);
+        }
+    }
+
+    /// Returns whether a slot was explicitly written with `vm.store`.
+    pub fn is_arbitrary_storage_slot_explicit(&self, address: Address, slot: U256) -> bool {
+        self.arbitrary_storage.as_ref().is_some_and(|storage| storage.is_explicit(address, slot))
     }
 
     /// Returns a cached arbitrary-storage replay value for a slot.
@@ -2891,6 +2923,10 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
         } else {
             return;
         };
+
+        if self.is_arbitrary_storage_slot_explicit(target_address, key) {
+            return;
+        }
 
         let Some(value) = ecx.sload(target_address, key) else {
             return;

--- a/testdata/default/cheats/ArbitraryStorage.t.sol
+++ b/testdata/default/cheats/ArbitraryStorage.t.sol
@@ -68,6 +68,38 @@ contract CounterArbitraryStorageWithSeedTest is Test {
     }
 }
 
+// <https://github.com/foundry-rs/forge-std/issues/667>
+/// forge-config: default.fuzz.seed = "100"
+contract ArbitraryStorageStoreWithSeedTest is Test {
+    Counter source;
+    Counter copy;
+    Counter overwrite;
+
+    function setUp() public {
+        source = new Counter();
+        copy = new Counter();
+        overwrite = new Counter();
+
+        vm.setArbitraryStorage(address(source));
+        vm.store(address(source), bytes32(uint256(0)), bytes32(uint256(0)));
+        vm.copyStorage(address(source), address(copy));
+
+        vm.setArbitraryStorage(address(overwrite), true);
+        vm.store(address(overwrite), bytes32(uint256(0)), bytes32(uint256(0)));
+
+        assertEq(source.a(), 0);
+        assertEq(copy.a(), 0);
+        assertEq(overwrite.a(), 0);
+    }
+
+    function test_storeZeroPersistsAcrossSetup() public {
+        assertEq(vm.load(address(source), bytes32(uint256(0))), bytes32(uint256(0)));
+        assertEq(source.a(), 0);
+        assertEq(copy.a(), 0);
+        assertEq(overwrite.a(), 0);
+    }
+}
+
 contract AContract {
     uint256[] public a;
     address[] public b;


### PR DESCRIPTION
Preserves values explicitly written with `vm.store` on arbitrary-storage accounts. This prevents zero values from being replaced during cold reads across the `setUp` and test boundary while retaining `copyStorage`, overwrite mode, and `vm.load` semantics.

Fixes foundry-rs/forge-std#667.