### PR TITLE
feat(cast): add CREATE2 init code hash

### DIFF
--- a/.changelog/cast-create2-init-code-hash.md
+++ b/.changelog/cast-create2-init-code-hash.md
@@ -1,0 +1,5 @@
+---
+cast: minor
+---
+
+Added `cast create2 init-code-hash` to compute the CREATE2 init code hash of a compiled contract with constructor arguments.

--- a/crates/cast/src/args.rs
+++ b/crates/cast/src/args.rs
@@ -935,7 +935,7 @@ pub async fn run_command(args: CastArgs) -> Result<()> {
             }
         }
         CastSubcommand::Create2(cmd) => {
-            cmd.run()?;
+            cmd.execute()?;
         }
         CastSubcommand::Wallet { command } => command.run().await?,
         CastSubcommand::Completions { shell } => {

--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -3,6 +3,7 @@ use alloy_primitives::{Address, B256, U256, hex, keccak256};
 use clap::{Args, Parser, Subcommand};
 use eyre::{Result, WrapErr};
 use foundry_cli::{
+    json::print_scalar,
     opts::BuildOpts,
     utils::{LoadConfig, find_contract_artifacts, parse_constructor_args},
 };
@@ -30,7 +31,7 @@ struct InitCodeHashArgs {
     contract: ContractInfo,
 
     /// The constructor arguments.
-    #[arg(value_name = "ARGS", allow_hyphen_values = true)]
+    #[arg(value_name = "ARGS", allow_negative_numbers = true)]
     constructor_args: Vec<String>,
 
     #[command(flatten)]
@@ -60,6 +61,9 @@ impl InitCodeHashArgs {
         let Some(bytecode) = bin.object.into_bytes() else {
             eyre::bail!("contract contains unlinked libraries");
         };
+        if bytecode.is_empty() {
+            eyre::bail!("no bytecode found in bin object for {}", self.contract.name);
+        }
 
         let mut init_code = bytecode.to_vec();
         if let Some(constructor) = &abi.constructor {
@@ -69,7 +73,7 @@ impl InitCodeHashArgs {
             eyre::bail!("contract does not have a constructor");
         }
 
-        sh_println!("{}", keccak256(init_code))?;
+        print_scalar(keccak256(init_code))?;
         Ok(())
     }
 }

--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -58,7 +58,7 @@ impl InitCodeHashArgs {
         let output = compile::compile_target(&target_path, &project, true)?;
         let (abi, bin, _) = find_contract_artifacts(output, &target_path, &self.contract.name)?;
         let Some(bytecode) = bin.object.into_bytes() else {
-            eyre::bail!("contract contains unlinked libraries")
+            eyre::bail!("contract contains unlinked libraries");
         };
 
         let mut init_code = bytecode.to_vec();
@@ -66,7 +66,7 @@ impl InitCodeHashArgs {
             let params = parse_constructor_args(constructor, &self.constructor_args)?;
             init_code.extend(constructor.abi_encode_input(&params)?);
         } else if !self.constructor_args.is_empty() {
-            eyre::bail!("contract does not have a constructor")
+            eyre::bail!("contract does not have a constructor");
         }
 
         sh_println!("{}", keccak256(init_code))?;

--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -1,6 +1,13 @@
+use alloy_dyn_abi::JsonAbiExt;
 use alloy_primitives::{Address, B256, U256, hex, keccak256};
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use eyre::{Result, WrapErr};
+use foundry_cli::{
+    opts::BuildOpts,
+    utils::{LoadConfig, find_contract_artifacts, parse_constructor_args},
+};
+use foundry_common::compile;
+use foundry_compilers::{info::ContractInfo, utils::canonicalize};
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use regex::RegexSetBuilder;
 use std::time::Instant;
@@ -8,9 +15,72 @@ use std::time::Instant;
 // https://etherscan.io/address/0x4e59b44847b379578588920ca78fbf26c0b4956c#code
 const DEPLOYER: &str = "0x4e59b44847b379578588920ca78fbf26c0b4956c";
 
+#[derive(Clone, Debug, Subcommand)]
+enum Create2Subcommand {
+    /// Compute a contract's CREATE2 init code hash.
+    #[command(visible_alias = "initcodehash")]
+    InitCodeHash(InitCodeHashArgs),
+}
+
+foundry_config::impl_figment_convert!(InitCodeHashArgs, build);
+
+#[derive(Clone, Debug, Args)]
+struct InitCodeHashArgs {
+    /// The contract identifier in the form `<path>:<contractname>`.
+    contract: ContractInfo,
+
+    /// The constructor arguments.
+    #[arg(value_name = "ARGS", allow_hyphen_values = true)]
+    constructor_args: Vec<String>,
+
+    #[command(flatten)]
+    build: BuildOpts,
+}
+
+impl Create2Subcommand {
+    fn run(&self) -> Result<()> {
+        match self {
+            Self::InitCodeHash(args) => args.run(),
+        }
+    }
+}
+
+impl InitCodeHashArgs {
+    fn run(&self) -> Result<()> {
+        let config = self.load_config()?;
+        let project = config.project()?;
+        let target_path = if let Some(path) = &self.contract.path {
+            canonicalize(project.root().join(path))?
+        } else {
+            project.find_contract_path(&self.contract.name)?
+        };
+
+        let output = compile::compile_target(&target_path, &project, true)?;
+        let (abi, bin, _) = find_contract_artifacts(output, &target_path, &self.contract.name)?;
+        let Some(bytecode) = bin.object.into_bytes() else {
+            eyre::bail!("contract contains unlinked libraries")
+        };
+
+        let mut init_code = bytecode.to_vec();
+        if let Some(constructor) = &abi.constructor {
+            let params = parse_constructor_args(constructor, &self.constructor_args)?;
+            init_code.extend(constructor.abi_encode_input(&params)?);
+        } else if !self.constructor_args.is_empty() {
+            eyre::bail!("contract does not have a constructor")
+        }
+
+        sh_println!("{}", keccak256(init_code))?;
+        Ok(())
+    }
+}
+
 /// CLI arguments for `cast create2`.
 #[derive(Clone, Debug, Parser)]
+#[command(subcommand_negates_reqs = true, args_conflicts_with_subcommands = true)]
 pub struct Create2Args {
+    #[command(subcommand)]
+    command: Option<Create2Subcommand>,
+
     /// Prefix for the contract address.
     #[arg(
         long,
@@ -89,8 +159,16 @@ pub struct Create2Output {
 }
 
 impl Create2Args {
+    pub fn execute(self) -> Result<()> {
+        if let Some(command) = &self.command {
+            return command.run();
+        }
+        self.run().map(drop)
+    }
+
     pub fn run(self) -> Result<Create2Output> {
         let Self {
+            command: _,
             starts_with,
             ends_with,
             matching,

--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -170,7 +170,7 @@ impl Create2Args {
         self.run().map(drop)
     }
 
-    pub fn run(self) -> Result<Create2Output> {
+    fn run(self) -> Result<Create2Output> {
         let Self {
             command: _,
             starts_with,
@@ -313,6 +313,12 @@ mod tests {
     use super::*;
     use alloy_primitives::{address, b256};
     use std::str::FromStr;
+
+    #[test]
+    fn create2_subcommand_uses_execute() {
+        let args = Create2Args::parse_from(["foundry-cli", "init-code-hash", "MissingContract"]);
+        assert!(args.execute().is_err());
+    }
 
     #[test]
     fn basic_create2() {

--- a/crates/cast/src/cmd/create2.rs
+++ b/crates/cast/src/cmd/create2.rs
@@ -170,7 +170,13 @@ impl Create2Args {
         self.run().map(drop)
     }
 
-    fn run(self) -> Result<Create2Output> {
+    pub fn run(self) -> Result<Create2Output> {
+        if self.command.is_some() {
+            eyre::bail!(
+                "`Create2Args::run` does not support subcommands; use `Create2Args::execute` instead"
+            );
+        }
+
         let Self {
             command: _,
             starts_with,
@@ -315,9 +321,13 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn create2_subcommand_uses_execute() {
+    fn create2_subcommand_is_rejected_by_legacy_runner() {
         let args = Create2Args::parse_from(["foundry-cli", "init-code-hash", "MissingContract"]);
-        assert!(args.execute().is_err());
+        let err = args.run().err().unwrap();
+        assert_eq!(
+            err.to_string(),
+            "`Create2Args::run` does not support subcommands; use `Create2Args::execute` instead"
+        );
     }
 
     #[test]

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -2280,6 +2280,46 @@ casttest!(create2_fixed_salt_output_channels, |_prj, cmd| {
 "#]]);
 });
 
+casttest!(create2_init_code_hash, |prj, cmd| {
+    prj.add_source(
+        "InitCodeHash",
+        r#"
+contract InitCodeHash {
+    uint256 public immutable value;
+    address public immutable owner;
+
+    constructor(uint256 value_, address owner_) {
+        value = value_;
+        owner = owner_;
+    }
+}
+"#,
+    );
+
+    let owner = address!("0x0000000000000000000000000000000000000001");
+    let bytecode = cmd
+        .forge_fuse()
+        .args(["inspect", "InitCodeHash", "bytecode"])
+        .assert_success()
+        .get_output()
+        .stdout_lossy();
+    let mut expected_init_code = hex::decode(bytecode.trim()).unwrap();
+    expected_init_code.extend((U256::from(42), owner).abi_encode());
+    let expected = keccak256(expected_init_code);
+
+    cmd.cast_fuse()
+        .current_dir(prj.root())
+        .args([
+            "create2",
+            "init-code-hash",
+            "src/InitCodeHash.sol:InitCodeHash",
+            "42",
+            &owner.to_string(),
+        ])
+        .assert_success()
+        .stdout_eq(format!("{expected}\n"));
+});
+
 casttest!(mktx, |_prj, cmd| {
     cmd.args([
         "mktx",

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -4,7 +4,7 @@ use alloy_chains::NamedChain;
 use alloy_eips::Decodable2718;
 use alloy_hardforks::EthereumHardfork;
 use alloy_network::{ReceiptResponse, TransactionBuilder, TransactionResponse};
-use alloy_primitives::{Address, B256, Bytes, U256, address, b256, hex, keccak256};
+use alloy_primitives::{Address, B256, Bytes, I256, U256, address, b256, hex, keccak256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::{
     Authorization, BlockNumberOrTag, Index, TransactionRequest, engine::JwtSecret,
@@ -2285,10 +2285,10 @@ casttest!(create2_init_code_hash, |prj, cmd| {
         "InitCodeHash",
         r#"
 contract InitCodeHash {
-    uint256 public immutable value;
+    int256 public immutable value;
     address public immutable owner;
 
-    constructor(uint256 value_, address owner_) {
+    constructor(int256 value_, address owner_) {
         value = value_;
         owner = owner_;
     }
@@ -2304,7 +2304,7 @@ contract InitCodeHash {
         .get_output()
         .stdout_lossy();
     let mut expected_init_code = hex::decode(bytecode.trim()).unwrap();
-    expected_init_code.extend((U256::from(42), owner).abi_encode());
+    expected_init_code.extend((I256::unchecked_from(42), owner).abi_encode());
     let expected = keccak256(expected_init_code);
 
     cmd.cast_fuse()
@@ -2318,6 +2318,59 @@ contract InitCodeHash {
         ])
         .assert_success()
         .stdout_eq(format!("{expected}\n"));
+
+    let mut expected_init_code = hex::decode(bytecode.trim()).unwrap();
+    expected_init_code.extend((I256::unchecked_from(-5), owner).abi_encode());
+    let expected = keccak256(expected_init_code);
+    let root = prj.root().to_str().unwrap();
+
+    cmd.cast_fuse()
+        .current_dir(prj.root())
+        .args([
+            "create2",
+            "init-code-hash",
+            "src/InitCodeHash.sol:InitCodeHash",
+            "-5",
+            &owner.to_string(),
+            "--root",
+            root,
+        ])
+        .assert_success()
+        .stdout_eq(format!("{expected}\n"));
+
+    cmd.cast_fuse()
+        .current_dir(prj.root())
+        .args([
+            "--json",
+            "create2",
+            "init-code-hash",
+            "src/InitCodeHash.sol:InitCodeHash",
+            "-5",
+            &owner.to_string(),
+        ])
+        .assert_json_stdout(format!(
+            r#"{{"schema_version":1,"success":true,"data":"{expected}","errors":[],"warnings":[]}}"#
+        ));
+});
+
+casttest!(create2_init_code_hash_rejects_abstract_contract, |prj, cmd| {
+    prj.add_source(
+        "AbstractInitCodeHash",
+        r#"
+abstract contract AbstractInitCodeHash {
+    function value() public pure virtual returns (uint256);
+}
+"#,
+    );
+
+    cmd.cast_fuse()
+        .current_dir(prj.root())
+        .args(["create2", "init-code-hash", "src/AbstractInitCodeHash.sol:AbstractInitCodeHash"])
+        .assert_failure()
+        .stderr_eq(str![[r#"
+Error: no bytecode found in bin object for AbstractInitCodeHash
+
+"#]]);
 });
 
 casttest!(mktx, |_prj, cmd| {

--- a/crates/cli/src/utils/cmd.rs
+++ b/crates/cli/src/utils/cmd.rs
@@ -1,6 +1,9 @@
-use alloy_json_abi::JsonAbi;
+use alloy_dyn_abi::{DynSolValue, Specifier};
+use alloy_json_abi::{Constructor, JsonAbi};
 use eyre::{Result, WrapErr};
-use foundry_common::{TestFunctionExt, fs, fs::json_files, selectors::SelectorKind, shell};
+use foundry_common::{
+    TestFunctionExt, fmt::parse_tokens, fs, fs::json_files, selectors::SelectorKind, shell,
+};
 use foundry_compilers::{
     Artifact, ArtifactId, ProjectCompileOutput, artifacts::CompactBytecode, utils::read_json_file,
 };
@@ -250,6 +253,30 @@ pub fn read_constructor_args_file(constructor_args_path: PathBuf) -> Result<Vec<
         fs::read_to_string(constructor_args_path)?.split_whitespace().map(str::to_string).collect()
     };
     Ok(args)
+}
+
+/// Parses constructor arguments by matching them against the constructor's input parameters.
+pub fn parse_constructor_args(
+    constructor: &Constructor,
+    constructor_args: &[String],
+) -> Result<Vec<DynSolValue>> {
+    if constructor.inputs.len() != constructor_args.len() {
+        eyre::bail!(
+            "Constructor argument count mismatch: expected {} but got {}",
+            constructor.inputs.len(),
+            constructor_args.len()
+        );
+    }
+
+    let mut params = Vec::with_capacity(constructor.inputs.len());
+    for (input, arg) in constructor.inputs.iter().zip(constructor_args) {
+        let ty = input
+            .resolve()
+            .wrap_err_with(|| format!("Could not resolve constructor arg: input={input}"))?;
+        params.push((ty, arg));
+    }
+    let params = params.iter().map(|(ty, arg)| (ty, arg.as_str()));
+    parse_tokens(params).map_err(Into::into)
 }
 
 /// A slimmed down return from the executor used for returning minimal trace + gas metering info

--- a/crates/forge/src/cmd/create.rs
+++ b/crates/forge/src/cmd/create.rs
@@ -1,8 +1,8 @@
 use crate::cmd::install;
 use alloy_chains::Chain;
 use alloy_consensus::{SignableTransaction, Signed};
-use alloy_dyn_abi::{DynSolValue, JsonAbiExt, Specifier};
-use alloy_json_abi::{Constructor, JsonAbi};
+use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
+use alloy_json_abi::JsonAbi;
 use alloy_network::{Ethereum, EthereumWallet, Network, ReceiptResponse, TransactionBuilder};
 use alloy_primitives::{Address, Bytes, U256, hex};
 use alloy_provider::{PendingTransactionError, Provider, ProviderBuilder as AlloyProviderBuilder};
@@ -15,13 +15,12 @@ use foundry_cli::{
     opts::{BuildOpts, EthereumOpts, EtherscanOpts, TransactionOpts},
     utils::{
         LoadConfig, ResolvedLane, find_contract_artifacts, maybe_print_resolved_lane,
-        read_constructor_args_file, resolve_lane,
+        parse_constructor_args, read_constructor_args_file, resolve_lane,
     },
 };
 use foundry_common::{
     FoundryTransactionBuilder,
     compile::{self},
-    fmt::parse_tokens,
     provider::{
         ProviderBuilder,
         fee::{estimate_eip1559_fees, resolve_broadcast_eip1559_fees},
@@ -222,7 +221,7 @@ impl CreateArgs {
         let params = if let Some(constructor) = &abi.constructor {
             let constructor_args =
                 self.constructor_args_path.clone().map(read_constructor_args_file).transpose()?;
-            self.parse_constructor_args(
+            parse_constructor_args(
                 constructor,
                 constructor_args.as_deref().unwrap_or(&self.constructor_args),
             )?
@@ -736,35 +735,6 @@ impl CreateArgs {
         sh_status!("Waiting for {resolved_verifier} to detect contract deployment...")?;
         verify.run().await
     }
-
-    /// Parses the given constructor arguments into a vector of `DynSolValue`s, by matching them
-    /// against the constructor's input params.
-    ///
-    /// Returns a list of parsed values that match the constructor's input params.
-    fn parse_constructor_args(
-        &self,
-        constructor: &Constructor,
-        constructor_args: &[String],
-    ) -> Result<Vec<DynSolValue>> {
-        if constructor.inputs.len() != constructor_args.len() {
-            eyre::bail!(
-                "Constructor argument count mismatch: expected {} but got {}",
-                constructor.inputs.len(),
-                constructor_args.len()
-            );
-        }
-
-        let mut params = Vec::with_capacity(constructor.inputs.len());
-        for (input, arg) in constructor.inputs.iter().zip(constructor_args) {
-            // resolve the input type directly
-            let ty = input
-                .resolve()
-                .wrap_err_with(|| format!("Could not resolve constructor arg: input={input}"))?;
-            params.push((ty, arg));
-        }
-        let params = params.iter().map(|(ty, arg)| (ty, arg.as_str()));
-        parse_tokens(params).map_err(Into::into)
-    }
 }
 
 impl figment::Provider for CreateArgs {
@@ -927,6 +897,7 @@ impl From<PendingTransactionError> for ContractDeploymentError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_json_abi::Constructor;
     use alloy_primitives::I256;
 
     #[test]
@@ -997,7 +968,7 @@ mod tests {
             "Hello",
         ]);
         let constructor: Constructor = serde_json::from_str(r#"{"type":"constructor","inputs":[{"name":"_name","type":"string","internalType":"string"}],"stateMutability":"nonpayable"}"#).unwrap();
-        let params = args.parse_constructor_args(&constructor, &args.constructor_args).unwrap();
+        let params = parse_constructor_args(&constructor, &args.constructor_args).unwrap();
         assert_eq!(params, vec![DynSolValue::String("Hello".to_string())]);
     }
 
@@ -1010,7 +981,7 @@ mod tests {
             "[(1,2), (2,3), (3,4)]",
         ]);
         let constructor: Constructor = serde_json::from_str(r#"{"type":"constructor","inputs":[{"name":"_points","type":"tuple[]","internalType":"struct Point[]","components":[{"name":"x","type":"uint256","internalType":"uint256"},{"name":"y","type":"uint256","internalType":"uint256"}]}],"stateMutability":"nonpayable"}"#).unwrap();
-        let _params = args.parse_constructor_args(&constructor, &args.constructor_args).unwrap();
+        let _params = parse_constructor_args(&constructor, &args.constructor_args).unwrap();
     }
 
     #[test]
@@ -1022,7 +993,7 @@ mod tests {
             "-5",
         ]);
         let constructor: Constructor = serde_json::from_str(r#"{"type":"constructor","inputs":[{"name":"_name","type":"int256","internalType":"int256"}],"stateMutability":"nonpayable"}"#).unwrap();
-        let params = args.parse_constructor_args(&constructor, &args.constructor_args).unwrap();
+        let params = parse_constructor_args(&constructor, &args.constructor_args).unwrap();
         assert_eq!(params, vec![DynSolValue::Int(I256::unchecked_from(-5), 256)]);
     }
 }


### PR DESCRIPTION
## Motivation

`cast create2` accepts raw init code or an existing hash, but computing that hash from a local contract and constructor arguments currently requires a multi-command shell pipeline. This addresses #7076.

## Solution

This adds `cast create2 init-code-hash <contract> [args]...`, which compiles the target using the project configuration, parses constructor arguments against its ABI, appends their canonical encoding to the creation bytecode, and prints the resulting Keccak-256 hash. Constructor parsing is shared with `forge create` so both commands retain identical validation and encoding behavior. The existing `cast create2` interface remains unchanged, and `initcodehash` is available as an alias.

This PR was written with Codex, which assisted with issue investigation, implementation, tests, live validation, and PR text.
