### PR TITLE
perf(cast): speed up trace artifact matching

### DIFF
--- a/.changelog/cast-concurrent-trace-code.md
+++ b/.changelog/cast-concurrent-trace-code.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fetched contract bytecode concurrently to speed up local artifact matching for RPC traces.

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -51,8 +51,11 @@ use foundry_evm::{
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements, Traces},
 };
-use futures::TryFutureExt;
+use futures::{StreamExt, TryFutureExt};
 use revm::{DatabaseRef, context::Block, primitives::hardfork::SpecId};
+
+/// Matches Cast's bounded concurrency for chunked RPC log fetching.
+const MAX_CONCURRENT_CODE_FETCHES: usize = 5;
 
 /// CLI arguments for `cast run`.
 #[derive(Clone, Debug, Parser)]
@@ -587,14 +590,20 @@ pub async fn fetch_contracts_bytecode_via_rpc<N: Network, P: Provider<N>>(
 ) -> Result<AddressHashMap<Bytes>> {
     let mut contracts_bytecode = AddressHashMap::default();
     if let Some(ref traces) = result.traces {
-        for addr in gather_trace_addresses(traces) {
-            match provider.get_code_at(addr).block_id(block).await {
+        let mut requests =
+            futures::stream::iter(gather_trace_addresses(traces))
+                .map(|address| async move {
+                    (address, provider.get_code_at(address).block_id(block).await)
+                })
+                .buffer_unordered(MAX_CONCURRENT_CODE_FETCHES);
+        while let Some((address, code)) = requests.next().await {
+            match code {
                 Ok(code) if !code.is_empty() => {
-                    contracts_bytecode.insert(addr, code);
+                    contracts_bytecode.insert(address, code);
                 }
                 Ok(_) => {}
                 Err(err) => {
-                    let _ = sh_warn!("Failed to fetch code for {addr}: {err}");
+                    let _ = sh_warn!("Failed to fetch code for {address}: {err}");
                 }
             }
         }
@@ -638,11 +647,17 @@ async fn fetch_transaction_contracts_bytecode_via_rpc<N: Network, P: Provider<N>
     }
 
     if let Some(ref traces) = result.traces {
-        for address in gather_trace_addresses(traces) {
-            if contracts_bytecode.contains_key(&address) {
-                continue;
-            }
-            match provider.get_code_at(address).block_id(block).await {
+        let missing_addresses = gather_trace_addresses(traces)
+            .filter(|address| !contracts_bytecode.contains_key(address))
+            .collect::<Vec<_>>();
+        let mut requests =
+            futures::stream::iter(missing_addresses)
+                .map(|address| async move {
+                    (address, provider.get_code_at(address).block_id(block).await)
+                })
+                .buffer_unordered(MAX_CONCURRENT_CODE_FETCHES);
+        while let Some((address, code)) = requests.next().await {
+            match code {
                 Ok(code) if !code.is_empty() => {
                     contracts_bytecode.insert(address, code);
                 }
@@ -694,7 +709,15 @@ impl figment::Provider for RunArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloy_network::Ethereum;
     use alloy_primitives::address;
+    use alloy_provider::{ProviderBuilder as AlloyProviderBuilder, mock::Asserter};
+    use alloy_rpc_client::RpcClient;
+    use alloy_transport::{TransportFut, mock::MockTransport};
+    use foundry_evm::traces::CallTraceArena;
+    use std::{sync::Arc, time::Duration};
+    use tokio::{sync::Barrier, time::timeout};
+    use tower::Service;
 
     #[test]
     fn parses_legacy_short_label_alias() {
@@ -765,5 +788,51 @@ mod tests {
         let config = TracingConfig { decode_internal: true, ..Default::default() };
 
         assert!(!args.resolve_tracing(&config, 0).decode_internal);
+    }
+
+    #[tokio::test]
+    async fn fetches_trace_bytecode_concurrently() {
+        let addresses = [Address::repeat_byte(1), Address::repeat_byte(2)];
+        let mut arena = CallTraceArena::default();
+        arena.nodes_mut()[0].trace.address = addresses[0];
+        arena.nodes_mut()[0].trace.caller = addresses[1];
+        let result = TraceResult {
+            success: true,
+            traces: Some(vec![(
+                TraceKind::Execution,
+                SparsedTraceArena {
+                    arena,
+                    ignored: Default::default(),
+                    diagnostics: Default::default(),
+                },
+            )]),
+            gas_used: 0,
+        };
+
+        let asserter = Asserter::new();
+        for _ in &addresses {
+            asserter.push_success(&Bytes::from_static(&[1]));
+        }
+        let inner = MockTransport::new(asserter);
+        let barrier = Arc::new(Barrier::new(addresses.len()));
+        let transport = tower::service_fn(move |request| {
+            let mut inner = inner.clone();
+            let barrier = barrier.clone();
+            Box::pin(async move {
+                barrier.wait().await;
+                inner.call(request).await
+            }) as TransportFut<'static>
+        });
+        let provider = AlloyProviderBuilder::new_with_network::<Ethereum>()
+            .connect_client(RpcClient::new(transport, true));
+
+        let bytecode = timeout(
+            Duration::from_secs(1),
+            fetch_contracts_bytecode_via_rpc(&provider, &result, BlockId::latest()),
+        )
+        .await
+        .expect("code requests were not in flight together")
+        .unwrap();
+        assert_eq!(bytecode.len(), addresses.len());
     }
 }

--- a/crates/cast/src/cmd/run.rs
+++ b/crates/cast/src/cmd/run.rs
@@ -1,4 +1,5 @@
 use crate::{
+    MAX_CONCURRENT_RPC_REQUESTS,
     debug::handle_traces,
     rpc_trace::{
         call_frame_to_arena_with_root_address, is_method_not_found_error, is_missing_state_error,
@@ -53,9 +54,6 @@ use foundry_evm::{
 };
 use futures::{StreamExt, TryFutureExt};
 use revm::{DatabaseRef, context::Block, primitives::hardfork::SpecId};
-
-/// Matches Cast's bounded concurrency for chunked RPC log fetching.
-const MAX_CONCURRENT_CODE_FETCHES: usize = 5;
 
 /// CLI arguments for `cast run`.
 #[derive(Clone, Debug, Parser)]
@@ -595,7 +593,7 @@ pub async fn fetch_contracts_bytecode_via_rpc<N: Network, P: Provider<N>>(
                 .map(|address| async move {
                     (address, provider.get_code_at(address).block_id(block).await)
                 })
-                .buffer_unordered(MAX_CONCURRENT_CODE_FETCHES);
+                .buffer_unordered(MAX_CONCURRENT_RPC_REQUESTS);
         while let Some((address, code)) = requests.next().await {
             match code {
                 Ok(code) if !code.is_empty() => {
@@ -655,7 +653,7 @@ async fn fetch_transaction_contracts_bytecode_via_rpc<N: Network, P: Provider<N>
                 .map(|address| async move {
                     (address, provider.get_code_at(address).block_id(block).await)
                 })
-                .buffer_unordered(MAX_CONCURRENT_CODE_FETCHES);
+                .buffer_unordered(MAX_CONCURRENT_RPC_REQUESTS);
         while let Some((address, code)) = requests.next().await {
             match code {
                 Ok(code) if !code.is_empty() => {
@@ -709,15 +707,7 @@ impl figment::Provider for RunArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_network::Ethereum;
     use alloy_primitives::address;
-    use alloy_provider::{ProviderBuilder as AlloyProviderBuilder, mock::Asserter};
-    use alloy_rpc_client::RpcClient;
-    use alloy_transport::{TransportFut, mock::MockTransport};
-    use foundry_evm::traces::CallTraceArena;
-    use std::{sync::Arc, time::Duration};
-    use tokio::{sync::Barrier, time::timeout};
-    use tower::Service;
 
     #[test]
     fn parses_legacy_short_label_alias() {
@@ -788,51 +778,5 @@ mod tests {
         let config = TracingConfig { decode_internal: true, ..Default::default() };
 
         assert!(!args.resolve_tracing(&config, 0).decode_internal);
-    }
-
-    #[tokio::test]
-    async fn fetches_trace_bytecode_concurrently() {
-        let addresses = [Address::repeat_byte(1), Address::repeat_byte(2)];
-        let mut arena = CallTraceArena::default();
-        arena.nodes_mut()[0].trace.address = addresses[0];
-        arena.nodes_mut()[0].trace.caller = addresses[1];
-        let result = TraceResult {
-            success: true,
-            traces: Some(vec![(
-                TraceKind::Execution,
-                SparsedTraceArena {
-                    arena,
-                    ignored: Default::default(),
-                    diagnostics: Default::default(),
-                },
-            )]),
-            gas_used: 0,
-        };
-
-        let asserter = Asserter::new();
-        for _ in &addresses {
-            asserter.push_success(&Bytes::from_static(&[1]));
-        }
-        let inner = MockTransport::new(asserter);
-        let barrier = Arc::new(Barrier::new(addresses.len()));
-        let transport = tower::service_fn(move |request| {
-            let mut inner = inner.clone();
-            let barrier = barrier.clone();
-            Box::pin(async move {
-                barrier.wait().await;
-                inner.call(request).await
-            }) as TransportFut<'static>
-        });
-        let provider = AlloyProviderBuilder::new_with_network::<Ethereum>()
-            .connect_client(RpcClient::new(transport, true));
-
-        let bytecode = timeout(
-            Duration::from_secs(1),
-            fetch_contracts_bytecode_via_rpc(&provider, &result, BlockId::latest()),
-        )
-        .await
-        .expect("code requests were not in flight together")
-        .unwrap();
-        assert_eq!(bytecode.len(), addresses.len());
     }
 }

--- a/crates/cast/src/lib.rs
+++ b/crates/cast/src/lib.rs
@@ -78,6 +78,8 @@ pub mod tx;
 
 use rlp_converter::Item;
 
+const MAX_CONCURRENT_RPC_REQUESTS: usize = 5;
+
 // TODO: CastContract with common contract initializers? Same for CastProviders?
 
 pub struct Cast<P, N = AnyNetwork> {
@@ -757,7 +759,7 @@ impl<P: Provider<N> + Clone + Unpin, N: Network> Cast<P, N> {
                         Self::get_logs_bisecting(&provider, &filter, start_block, end_block).await
                     }
                 })
-                .buffered(5)
+                .buffered(MAX_CONCURRENT_RPC_REQUESTS)
                 .try_collect()
                 .await?;
 


### PR DESCRIPTION
## Summary

Fetches runtime bytecode from up to five trace addresses concurrently for RPC-backed local artifact matching. This speeds both `cast call --debug-trace-call --with-local-artifacts` and `cast run --debug-trace-transaction --with-local-artifacts`; the transaction path still uses the prestate tracer first and only queries missing addresses, and individual RPC failures remain nonfatal. The implementation and review were AI-assisted.

## Benchmarks

Profiling builds of `master` (`23c445849`) and this branch, using local Anvil behind a proxy that added 200 ms of latency only to `eth_getCode`, with six unique trace addresses, 5 warmups, and 20 measured `hyperfine` runs.

| Metric | `master` | This PR | Change |
| --- | ---: | ---: | ---: |
| Wall time | 1.441 s ± 61 ms | 620.0 ms ± 39.8 ms | 2.32× faster |
| `eth_getCode` requests | 6 | 6 | Unchanged |
| RPC latency waves | 6 | 2 | Five-request bounded fanout |
