### PR TITLE
fix(config): handle Windows remapping separators

### DIFF
--- a/.changelog/windows-remapping-paths.md
+++ b/.changelog/windows-remapping-paths.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed duplicate contextual remappings and lost context directory boundaries on Windows.

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -277,7 +277,8 @@ impl RemappingsProvider<'_> {
                     && auto_detected_remappings.iter().any(|auto| {
                         auto.context == r.context
                             && auto.name == r.name
-                            && is_strict_descendant(Path::new(&r.path), Path::new(&auto.path))
+                            && Path::new(&r.path) != Path::new(&auto.path)
+                            && Path::new(&r.path).starts_with(&auto.path)
                     })
                 {
                     let mut contextual = r.clone();
@@ -409,10 +410,6 @@ impl RemappingsProvider<'_> {
     }
 }
 
-fn is_strict_descendant(path: &Path, parent: &Path) -> bool {
-    path != parent && path.starts_with(parent)
-}
-
 fn remapping_name_is_prefix(prefix: &str, name: &str) -> bool {
     let prefix = prefix.trim_end_matches('/');
     let name = name.trim_end_matches('/');
@@ -508,19 +505,6 @@ impl Provider for RemappingsProvider<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn equivalent_paths_are_not_strict_descendants() {
-        let parent = Path::new("lib/pkg/src");
-        assert!(!is_strict_descendant(Path::new("lib/pkg/src/"), parent));
-        assert!(is_strict_descendant(Path::new("lib/pkg/src/contracts"), parent));
-
-        #[cfg(windows)]
-        {
-            let parent = Path::new("lib/pkg/src/");
-            assert!(!is_strict_descendant(Path::new(r"lib\pkg\src"), parent));
-        }
-    }
 
     #[test]
     fn relative_remapping_preserves_context_directory_boundary() {

--- a/crates/config/src/providers/remappings.rs
+++ b/crates/config/src/providers/remappings.rs
@@ -277,8 +277,7 @@ impl RemappingsProvider<'_> {
                     && auto_detected_remappings.iter().any(|auto| {
                         auto.context == r.context
                             && auto.name == r.name
-                            && auto.path != r.path
-                            && Path::new(&r.path).starts_with(&auto.path)
+                            && is_strict_descendant(Path::new(&r.path), Path::new(&auto.path))
                     })
                 {
                     let mut contextual = r.clone();
@@ -410,6 +409,10 @@ impl RemappingsProvider<'_> {
     }
 }
 
+fn is_strict_descendant(path: &Path, parent: &Path) -> bool {
+    path != parent && path.starts_with(parent)
+}
+
 fn remapping_name_is_prefix(prefix: &str, name: &str) -> bool {
     let prefix = prefix.trim_end_matches('/');
     let name = name.trim_end_matches('/');
@@ -443,10 +446,14 @@ pub fn relative_remapping_preserving_context_boundary(
     let has_boundary =
         remapping.context.as_deref().is_some_and(|context| context.ends_with(['/', '\\']));
     let mut remapping = RelativeRemapping::new(remapping, root);
+    // Slash conversion on Windows only preserves a trailing native separator.
     if has_boundary
         && let Some(context) = &mut remapping.context
-        && !context.ends_with(['/', '\\'])
+        && !context.ends_with(MAIN_SEPARATOR)
     {
+        if context.ends_with(['/', '\\']) {
+            context.pop();
+        }
         context.push(MAIN_SEPARATOR);
     }
     remapping
@@ -503,15 +510,29 @@ mod tests {
     use super::*;
 
     #[test]
+    fn equivalent_paths_are_not_strict_descendants() {
+        let parent = Path::new("lib/pkg/src");
+        assert!(!is_strict_descendant(Path::new("lib/pkg/src/"), parent));
+        assert!(is_strict_descendant(Path::new("lib/pkg/src/contracts"), parent));
+
+        #[cfg(windows)]
+        {
+            let parent = Path::new("lib/pkg/src/");
+            assert!(!is_strict_descendant(Path::new(r"lib\pkg\src"), parent));
+        }
+    }
+
+    #[test]
     fn relative_remapping_preserves_context_directory_boundary() {
         let remapping = Remapping {
-            context: Some(format!("lib{MAIN_SEPARATOR}outer{MAIN_SEPARATOR}")),
+            context: Some("lib/outer/".to_string()),
             name: "inner/".to_string(),
             path: format!("lib{MAIN_SEPARATOR}outer{MAIN_SEPARATOR}lib{MAIN_SEPARATOR}inner"),
         };
 
         let remapping = relative_remapping_preserving_context_boundary(remapping, Path::new("."));
-        assert!(remapping.context.unwrap().ends_with(MAIN_SEPARATOR));
+        assert!(remapping.context.as_ref().unwrap().ends_with(MAIN_SEPARATOR));
+        assert_eq!(remapping.to_string(), "lib/outer/:inner/=lib/outer/lib/inner/");
     }
 
     #[test]


### PR DESCRIPTION
#15929 compared nested remapping paths as raw strings for inequality but used `Path` semantics for ancestry. On Windows, nested-config sanitization changes backslashes to forward slashes while auto-detected paths retain native separators, so the same directory was misclassified as a refinement and emitted as a duplicate contextual remapping.

This change compares both paths semantically and canonicalizes preserved context boundaries to the platform separator before slash-normalized rendering. The focused config and Forge regressions retain coverage for the serialized remapping behavior. Together, these changes fix the 20 failures in the [Windows test job](https://github.com/foundry-rs/foundry/actions/runs/30529082800/job/90826907468).

> This PR's implementation, tests, description, and review follow-up were written primarily with Codex.
