### PR TITLE
fix(ci): run MPP checks on Moderato

### DIFF
--- a/.github/scripts/tempo-mpp.sh
+++ b/.github/scripts/tempo-mpp.sh
@@ -113,8 +113,7 @@ if [ "$TEMPO_ROTATE_WALLET" = "1" ]; then
   fi
   AUTHORIZATION=$("$CAST" key-authorization sign "$ACCESS_ADDRESS" \
     --chain-id "$CHAIN_ID" \
-    --private-key "$ROOT_PRIVATE_KEY" \
-    --bind-account "$WALLET")
+    --private-key "$ROOT_PRIVATE_KEY")
   "$CAST" tempo import-access-key \
     --account "$WALLET" \
     --access-key "$ACCESS_PRIVATE_KEY" \

--- a/.github/scripts/tempo-mpp.sh
+++ b/.github/scripts/tempo-mpp.sh
@@ -16,8 +16,14 @@
 
 set -euo pipefail
 
-if [ -n "${MPP_API_KEY:-}" ]; then
-  echo "ERROR: MPP_API_KEY bypasses payment challenges and must be unset for the paid MPP e2e" >&2
+# Moderato requires gateway authentication before returning its paid challenge. Keep the opt-in
+# explicit; the channel assertions below still verify that payment was not bypassed.
+if [ -n "${MPP_API_KEY:-}" ] && [ "${MPP_ALLOW_API_KEY:-0}" != "1" ]; then
+  echo "ERROR: MPP_API_KEY requires MPP_ALLOW_API_KEY=1 for the paid MPP e2e" >&2
+  exit 1
+fi
+if [ "${MPP_ALLOW_API_KEY:-0}" = "1" ] && [ -z "${MPP_API_KEY:-}" ]; then
+  echo "ERROR: MPP_ALLOW_API_KEY=1 requires MPP_API_KEY for gateway authentication" >&2
   exit 1
 fi
 

--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -7,6 +7,16 @@ on:
     branches: [master]
   pull_request:
   workflow_dispatch:
+    inputs:
+      network:
+        description: "Tempo network to check"
+        required: true
+        type: choice
+        default: "moderato"
+        options:
+          - moderato
+          - mainnet
+          - all
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -44,9 +54,12 @@ jobs:
           echo "${{ github.workspace }}/target/debug" >> "$GITHUB_PATH"
 
       - name: Restore bounded NanoUSD wallet
+        if: |
+          github.event_name == 'workflow_dispatch' &&
+          (inputs.network == 'mainnet' || inputs.network == 'all')
         env:
           TEMPO_ACCOUNTS_STORE_JSON_B64: ${{ secrets.TEMPO_ACCOUNTS_STORE_JSON_B64 }}
-          TEMPO_HOME: ${{ runner.temp }}/tempo-mpp
+          TEMPO_HOME: ${{ runner.temp }}/tempo-mpp-mainnet
         run: |
           if [ -z "$TEMPO_ACCOUNTS_STORE_JSON_B64" ]; then
             echo "TEMPO_ACCOUNTS_STORE_JSON_B64 is not configured"
@@ -56,9 +69,26 @@ jobs:
           printf '%s' "$TEMPO_ACCOUNTS_STORE_JSON_B64" | base64 --decode > "$TEMPO_HOME/wallet/store.json"
           chmod 600 "$TEMPO_HOME/wallet/store.json"
 
-      - name: Run MPP e2e test
+      - name: Run Moderato MPP e2e test
+        if: |
+          github.event_name != 'workflow_dispatch' ||
+          inputs.network == 'moderato' ||
+          inputs.network == 'all'
         env:
-          TEMPO_HOME: ${{ runner.temp }}/tempo-mpp
+          TEMPO_HOME: ${{ runner.temp }}/tempo-mpp-moderato
+          TEMPO_AUTO_FUND: "1"
+          TEMPO_ROTATE_WALLET: "1"
+          MPP_RPC_URL: https://rpc.mpp.moderato.tempo.xyz
+          TEMPO_RPC_URL: https://rpc.moderato.tempo.xyz
+          MPP_TOKEN: "0x20c0000000000000000000000000000000000000"
+        run: ./.github/scripts/tempo-mpp.sh "$(which cast | xargs dirname)"
+
+      - name: Run mainnet MPP e2e test
+        if: |
+          github.event_name == 'workflow_dispatch' &&
+          (inputs.network == 'mainnet' || inputs.network == 'all')
+        env:
+          TEMPO_HOME: ${{ runner.temp }}/tempo-mpp-mainnet
           MPP_RPC_URL: https://rpc.mpp.tempo.xyz
           TEMPO_RPC_URL: https://rpc.tempo.xyz
           MPP_TOKEN: "0x20c0000000000000000000008b4c619d2eedec7a"

--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -75,6 +75,8 @@ jobs:
           inputs.network == 'moderato' ||
           inputs.network == 'all'
         env:
+          MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
+          MPP_ALLOW_API_KEY: "1"
           TEMPO_HOME: ${{ runner.temp }}/tempo-mpp-moderato
           TEMPO_AUTO_FUND: "1"
           TEMPO_ROTATE_WALLET: "1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=db89c09221b82e906d9ad697e4bad92423b59643#db89c09221b82e906d9ad697e4bad92423b59643"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=1d1f05d6a18337b2bd68c19767d8174121e4d62b#1d1f05d6a18337b2bd68c19767d8174121e4d62b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -7748,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=db89c09221b82e906d9ad697e4bad92423b59643#db89c09221b82e906d9ad697e4bad92423b59643"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=1d1f05d6a18337b2bd68c19767d8174121e4d62b#1d1f05d6a18337b2bd68c19767d8174121e4d62b"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=1d1f05d6a18337b2bd68c19767d8174121e4d62b#1d1f05d6a18337b2bd68c19767d8174121e4d62b"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=094406789deb1c196d5708449ebe32c6fe302023#094406789deb1c196d5708449ebe32c6fe302023"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -7748,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=1d1f05d6a18337b2bd68c19767d8174121e4d62b#1d1f05d6a18337b2bd68c19767d8174121e4d62b"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=094406789deb1c196d5708449ebe32c6fe302023#094406789deb1c196d5708449ebe32c6fe302023"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=094406789deb1c196d5708449ebe32c6fe302023#094406789deb1c196d5708449ebe32c6fe302023"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=6b05c45fd08e1331434d4fb42dd4039bb5ba06bd#6b05c45fd08e1331434d4fb42dd4039bb5ba06bd"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1285,11 +1285,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-evm",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -2969,10 +2969,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-contracts",
- "tempo-hardfork",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tokio",
  "tower",
  "tracing",
@@ -5102,7 +5102,7 @@ dependencies = [
  "soldeer-core",
  "svm-rs",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "thiserror 2.0.19",
  "tokio",
  "toml_edit",
@@ -5204,8 +5204,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5374,10 +5374,10 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts",
- "tempo-hardfork",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "thiserror 2.0.19",
  "toml 1.1.3+spec-1.1.0",
  "tracing",
@@ -5437,7 +5437,7 @@ dependencies = [
  "solar-compiler",
  "strsim",
  "tempfile",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tikv-jemallocator",
  "tokio",
  "toml 1.1.3+spec-1.1.0",
@@ -5515,8 +5515,8 @@ dependencies = [
  "sha2 0.11.0",
  "solar-compiler",
  "tempfile",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "thiserror 2.0.19",
  "tokio",
  "tower",
@@ -5548,7 +5548,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "yansi",
 ]
 
@@ -5742,7 +5742,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5805,12 +5805,12 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-contracts",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-evm",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -5871,7 +5871,7 @@ dependencies = [
  "op-revm",
  "revm",
  "serde",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
 ]
 
 [[package]]
@@ -5888,7 +5888,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-contracts",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
 ]
 
 [[package]]
@@ -5950,7 +5950,7 @@ dependencies = [
  "snapbox",
  "solar-compiler",
  "tempfile",
- "tempo-contracts",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -6022,8 +6022,8 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-revm",
 ]
 
@@ -6094,7 +6094,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -7748,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=094406789deb1c196d5708449ebe32c6fe302023#094406789deb1c196d5708449ebe32c6fe302023"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=6b05c45fd08e1331434d4fb42dd4039bb5ba06bd#6b05c45fd08e1331434d4fb42dd4039bb5ba06bd"
 dependencies = [
  "alloy",
  "async-stream",
@@ -7769,7 +7769,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2 0.11.0",
  "subtle",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -9859,6 +9859,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-ethereum-primitives"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "reth-codecs 0.5.2",
+ "reth-primitives-traits 0.5.2",
+ "serde",
+]
+
+[[package]]
 name = "reth-evm"
 version = "2.4.1"
 source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
@@ -9893,7 +9907,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "reth-chainspec",
  "reth-ethereum-forks",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 2.4.1 (git+https://github.com/paradigmxyz/reth?rev=01d3400)",
  "reth-evm",
  "reth-execution-types",
  "reth-primitives-traits 0.5.2",
@@ -9925,7 +9939,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 2.4.1 (git+https://github.com/paradigmxyz/reth?rev=01d3400)",
  "reth-primitives-traits 0.5.2",
  "reth-trie-common",
  "revm",
@@ -10079,7 +10093,7 @@ dependencies = [
  "auto_impl",
  "reth-chainspec",
  "reth-db-models",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 2.4.1 (git+https://github.com/paradigmxyz/reth?rev=01d3400)",
  "reth-execution-types",
  "reth-primitives-traits 0.5.2",
  "reth-prune-types",
@@ -12078,6 +12092,46 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rlp",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "alloy-transport",
+ "async-trait",
+ "base64 0.22.1",
+ "dashmap",
+ "derive_more",
+ "dirs-next",
+ "futures",
+ "http 1.4.2",
+ "p256",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580)",
+ "thiserror 2.0.19",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "tempo-alloy"
+version = "1.10.1"
 source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
 dependencies = [
  "alloy-consensus",
@@ -12107,12 +12161,28 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-chainspec",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "thiserror 2.0.19",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "tempo-chainspec"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+dependencies = [
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "once_cell",
+ "paste",
+ "serde",
+ "serde_json",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580)",
 ]
 
 [[package]]
@@ -12134,8 +12204,20 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-dkg-onchain-artifacts",
- "tempo-hardfork",
- "tempo-primitives",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+]
+
+[[package]]
+name = "tempo-contracts"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580)",
 ]
 
 [[package]]
@@ -12147,7 +12229,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "serde",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
 ]
 
 [[package]]
@@ -12183,14 +12265,25 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-primitives-traits 0.5.2",
  "reth-revm",
- "tempo-chainspec",
- "tempo-contracts",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-dkg-onchain-artifacts",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tracing",
+]
+
+[[package]]
+name = "tempo-hardfork"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+dependencies = [
+ "alloy-eips",
+ "alloy-hardforks",
+ "paste",
+ "serde",
 ]
 
 [[package]]
@@ -12220,10 +12313,10 @@ dependencies = [
  "paste",
  "revm",
  "scoped-tls",
- "tempo-chainspec",
- "tempo-contracts",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-precompiles-macros",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -12237,6 +12330,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tempo-primitives"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "base64 0.22.1",
+ "derive_more",
+ "ed25519-consensus",
+ "once_cell",
+ "p256",
+ "reth-codecs 0.5.2",
+ "reth-ethereum-primitives 2.4.1 (git+https://github.com/paradigmxyz/reth?rev=fc3f7da)",
+ "reth-primitives-traits 0.5.2",
+ "revm",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580)",
 ]
 
 [[package]]
@@ -12257,13 +12375,13 @@ dependencies = [
  "once_cell",
  "p256",
  "reth-codecs 0.5.2",
- "reth-ethereum-primitives",
+ "reth-ethereum-primitives 2.4.1 (git+https://github.com/paradigmxyz/reth?rev=01d3400)",
  "reth-primitives-traits 0.5.2",
  "revm",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
 ]
 
 [[package]]
@@ -12280,10 +12398,10 @@ dependencies = [
  "reth-evm",
  "reth-storage-api",
  "revm",
- "tempo-chainspec",
- "tempo-contracts",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1)",
  "thiserror 2.0.19",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -513,10 +513,10 @@ ethereum_ssz = "0.10"
 fs2 = "0.4"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "094406789deb1c196d5708449ebe32c6fe302023", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6b05c45fd08e1331434d4fb42dd4039bb5ba06bd", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "094406789deb1c196d5708449ebe32c6fe302023", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6b05c45fd08e1331434d4fb42dd4039bb5ba06bd", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -513,10 +513,10 @@ ethereum_ssz = "0.10"
 fs2 = "0.4"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "1d1f05d6a18337b2bd68c19767d8174121e4d62b", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "094406789deb1c196d5708449ebe32c6fe302023", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "1d1f05d6a18337b2bd68c19767d8174121e4d62b", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "094406789deb1c196d5708449ebe32c6fe302023", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -513,10 +513,10 @@ ethereum_ssz = "0.10"
 fs2 = "0.4"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "db89c09221b82e906d9ad697e4bad92423b59643", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "1d1f05d6a18337b2bd68c19767d8174121e4d62b", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "db89c09221b82e906d9ad697e4bad92423b59643", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "1d1f05d6a18337b2bd68c19767d8174121e4d62b", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",

--- a/crates/common/src/provider/mpp/transport.rs
+++ b/crates/common/src/provider/mpp/transport.rs
@@ -45,10 +45,11 @@ pub struct LazyMppHttpTransport(MppHttpTransport<LazyAccountsProvider>);
 
 impl LazyMppHttpTransport {
     /// Create a transport that opens Tempo Accounts only after a paid challenge.
-    pub fn lazy(client: reqwest::Client, url: Url) -> Self {
+    pub fn lazy(client: reqwest::Client, url: Url, headers: reqwest::header::HeaderMap) -> Self {
         let provider = LazyAccountsProvider::new(url.to_string());
         Self(
             MppHttpTransport::new(client, url, provider)
+                .with_headers(headers)
                 .with_max_concurrent_requests(MAX_CONCURRENT_MPP_HTTP_REQUESTS),
         )
     }

--- a/crates/common/src/provider/runtime_transport.rs
+++ b/crates/common/src/provider/runtime_transport.rs
@@ -191,19 +191,7 @@ impl RuntimeTransport {
         }
     }
 
-    /// Creates a new reqwest client from this transport.
-    pub fn reqwest_client(&self) -> Result<reqwest::Client, RuntimeTransportError> {
-        let mut client_builder = reqwest::Client::builder()
-            .timeout(self.timeout)
-            .danger_accept_invalid_certs(self.accept_invalid_certs);
-
-        // Disable automatic proxy detection if requested. This helps in sandboxed environments
-        // (e.g., Cursor IDE sandbox, macOS App Sandbox) where system proxy detection via
-        // SCDynamicStore causes crashes. See: https://github.com/foundry-rs/foundry/issues/12733
-        if self.no_proxy || guess_local_url(self.url.as_str()) {
-            client_builder = client_builder.no_proxy();
-        }
-
+    fn reqwest_headers(&self) -> Result<reqwest::header::HeaderMap, RuntimeTransportError> {
         let mut headers = reqwest::header::HeaderMap::new();
 
         // If there's a JWT, add it to the headers if we can decode it.
@@ -252,15 +240,39 @@ impl RuntimeTransport {
             }
         }
 
+        Ok(headers)
+    }
+
+    fn reqwest_client_with_headers(
+        &self,
+        headers: reqwest::header::HeaderMap,
+    ) -> Result<reqwest::Client, RuntimeTransportError> {
+        let mut client_builder = reqwest::Client::builder()
+            .timeout(self.timeout)
+            .danger_accept_invalid_certs(self.accept_invalid_certs);
+
+        // Disable automatic proxy detection if requested. This helps in sandboxed environments
+        // (e.g., Cursor IDE sandbox, macOS App Sandbox) where system proxy detection via
+        // SCDynamicStore causes crashes. See: https://github.com/foundry-rs/foundry/issues/12733
+        if self.no_proxy || guess_local_url(self.url.as_str()) {
+            client_builder = client_builder.no_proxy();
+        }
+
         client_builder = client_builder.default_headers(headers);
 
         Ok(client_builder.build()?)
     }
 
+    /// Creates a new reqwest client from this transport.
+    pub fn reqwest_client(&self) -> Result<reqwest::Client, RuntimeTransportError> {
+        self.reqwest_client_with_headers(self.reqwest_headers()?)
+    }
+
     /// Connects to an HTTP transport with lazy MPP 402 handling.
     fn connect_http(&self) -> Result<InnerTransport, RuntimeTransportError> {
-        let client = self.reqwest_client()?;
-        Ok(InnerTransport::Http(LazyMppHttpTransport::lazy(client, self.url.clone())))
+        let headers = self.reqwest_headers()?;
+        let client = self.reqwest_client_with_headers(headers.clone())?;
+        Ok(InnerTransport::Http(LazyMppHttpTransport::lazy(client, self.url.clone(), headers)))
     }
 
     /// Connects to a WS transport.


### PR DESCRIPTION
## Description

PR #15885 moved MPP CI to mainnet to exercise NanoUSD with the canonical Accounts wallet. PR #15924 retained mainnet while expanding coverage to reusable MPP sessions. The persistent mainnet key has since exhausted its spending allowance, blocking unrelated CI runs.

Automatic MPP CI now runs against Moderato with a fresh faucet-funded Accounts wallet instead of consuming the bounded mainnet NanoUSD wallet on every run. Manual dispatches can still select Moderato, mainnet, or both, preserving production smoke coverage without allowing exhausted mainnet spending limits to block routine CI.