### PR TITLE
fix(cast): reject malformed vanity wallet files

### DIFF
--- a/.changelog/reject-malformed-vanity-wallet-files.md
+++ b/.changelog/reject-malformed-vanity-wallet-files.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Prevented `cast wallet vanity --save-path` from overwriting malformed wallet files.

--- a/crates/cast/src/cmd/wallet/vanity.rs
+++ b/crates/cast/src/cmd/wallet/vanity.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{Address, hex};
 use alloy_signer::{k256::ecdsa::SigningKey, utils::secret_key_to_address};
 use alloy_signer_local::PrivateKeySigner;
 use clap::Parser;
-use eyre::Result;
+use eyre::{Result, WrapErr};
 use foundry_cli::json::print_json_success;
 use foundry_common::{sh_println, shell};
 use itertools::Either;
@@ -178,7 +178,12 @@ impl VanityArgs {
 fn save_wallet_to_file(wallet: &PrivateKeySigner, path: &Path) -> Result<()> {
     let mut wallets = if path.exists() {
         let data = fs::read_to_string(path)?;
-        serde_json::from_str::<Wallets>(&data).unwrap_or_default()
+        if data.trim().is_empty() {
+            Wallets::default()
+        } else {
+            serde_json::from_str::<Wallets>(&data)
+                .wrap_err_with(|| format!("failed to parse wallet file {}", path.display()))?
+        }
     } else {
         Wallets::default()
     };
@@ -395,5 +400,17 @@ mod tests {
         let s = fs::read_to_string(tmp.path()).unwrap();
         let wallets: Wallets = serde_json::from_str(&s).unwrap();
         assert!(!wallets.wallets.is_empty());
+    }
+
+    #[test]
+    fn malformed_wallet_file_is_not_overwritten() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let original = "{\"wallets\":[";
+        fs::write(tmp.path(), original).unwrap();
+
+        let err = save_wallet_to_file(&PrivateKeySigner::random(), tmp.path()).unwrap_err();
+
+        assert!(err.to_string().contains("failed to parse wallet file"));
+        assert_eq!(fs::read_to_string(tmp.path()).unwrap(), original);
     }
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Existing non-empty files passed via `cast wallet vanity --save-path` were treated as empty whenever deserialization failed because `unwrap_or_default()` discarded the parse error. The subsequent write could therefore replace previously saved wallets, including their private keys, with only the newly generated wallet.

This change keeps the existing empty-file initialization behavior, but returns a path-aware error for malformed non-empty files before any write occurs. The regression test also verifies that the original file contents remain unchanged.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
