### PR TITLE
fix(ci): harden stable release validation

### DIFF
--- a/.github/scripts/prepare-stable-release.py
+++ b/.github/scripts/prepare-stable-release.py
@@ -51,7 +51,10 @@ def run_preserving_lockfile(
 def parse_version(value: str) -> tuple[int, int, int]:
     if not VERSION.fullmatch(value):
         raise ReleaseError(f"expected a stable X.Y.Z version, got {value!r}")
-    return tuple(int(part) for part in value.split("."))
+    version = tuple(int(part) for part in value.split("."))
+    if ".".join(map(str, version)) != value:
+        raise ReleaseError(f"expected a canonical stable X.Y.Z version, got {value!r}")
+    return version
 
 
 def latest_stable_tag(tags: str) -> tuple[str, tuple[int, int, int]]:
@@ -59,7 +62,9 @@ def latest_stable_tag(tags: str) -> tuple[str, tuple[int, int, int]]:
     for tag in tags.splitlines():
         match = STABLE_TAG.fullmatch(tag.strip())
         if match:
-            stable.append((tuple(int(part) for part in match.groups()), tag.strip()))
+            version = tuple(int(part) for part in match.groups())
+            if f"v{'.'.join(map(str, version))}" == tag.strip():
+                stable.append((version, tag.strip()))
     if not stable:
         raise ReleaseError("no stable vX.Y.Z tag found")
     version, tag = max(stable)
@@ -195,48 +200,102 @@ def set_output(name: str, value: str) -> None:
             file.write(f"{name}={value}\n")
 
 
-def require_changes(root: Path) -> None:
-    result = subprocess.run(["git", "diff", "--quiet", "--exit-code"], cwd=root)
-    if result.returncode == 0:
-        raise ReleaseError("release preparation did not change any tracked files")
-    if result.returncode != 1:
-        raise ReleaseError(f"git diff failed with exit code {result.returncode}")
+def name_status(command: list[str], root: Path) -> dict[str, str]:
+    output = run(command, root, capture_output=True).stdout
+    entries = [line.split("\t") for line in output.splitlines()]
+    if any(len(entry) != 2 or entry[0] not in {"A", "M", "D"} for entry in entries):
+        raise ReleaseError("release diff contains a rename, copy, or malformed status")
+    statuses = {path: status for status, path in entries}
+    if len(statuses) != len(entries):
+        raise ReleaseError("release diff contains duplicate paths")
+    return statuses
 
 
-def changed_paths(root: Path) -> set[str]:
-    tracked = subprocess.run(
-        ["git", "diff", "--name-only", "-z"],
-        cwd=root,
-        check=True,
-        stdout=subprocess.PIPE,
-    ).stdout.decode().split("\0")
-    untracked = subprocess.run(
-        ["git", "ls-files", "--others", "--exclude-standard", "-z"],
-        cwd=root,
-        check=True,
-        stdout=subprocess.PIPE,
-    ).stdout.decode().split("\0")
-    return {path for path in tracked + untracked if path}
+def verify_stable_diff(statuses: dict[str, str], fragment_count: int) -> None:
+    fragments = {
+        path: status
+        for path, status in statuses.items()
+        if re.fullmatch(r"\.changelog/[^/]+\.md", path)
+        and path != ".changelog/README.md"
+    }
+    if (
+        statuses.get("CHANGELOG.md") != "M"
+        or len(fragments) != fragment_count
+        or fragment_count < 1
+        or any(status != "D" for status in fragments.values())
+        or set(statuses) != {"CHANGELOG.md", *fragments}
+    ):
+        raise ReleaseError("stable release diff must modify CHANGELOG.md and delete every fragment")
 
 
 def verify_changed_paths(root: Path, fragments: list[Path]) -> None:
-    allowed = {"Cargo.toml", "CHANGELOG.md"}
-    allowed.update(str(path.relative_to(root)) for path in fragments)
-    unexpected = sorted(changed_paths(root) - allowed)
-    if unexpected:
-        raise ReleaseError(f"release preparation changed unexpected paths: {', '.join(unexpected)}")
+    statuses = name_status(["git", "diff", "--name-status", "--no-renames"], root)
+    untracked = run(
+        ["git", "ls-files", "--others", "--exclude-standard"],
+        root,
+        capture_output=True,
+    ).stdout.splitlines()
+    statuses.update({path: "A" for path in untracked})
+    verify_stable_diff(statuses, len(fragments))
+
+
+def git_bytes(root: Path, revision: str, path: str) -> bytes:
+    return subprocess.run(
+        ["git", "show", f"{revision}:{path}"],
+        cwd=root,
+        check=True,
+        stdout=subprocess.PIPE,
+    ).stdout
+
+
+def verify_ancestor(root: Path, ancestor: str, descendant: str) -> None:
+    try:
+        run(["git", "merge-base", "--is-ancestor", ancestor, descendant], root)
+    except subprocess.CalledProcessError as error:
+        raise ReleaseError(f"{ancestor} is not an ancestor of {descendant}") from error
+
+
+def verify_target_tag(root: Path, target_tag: str, expected_sha: str) -> None:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{target_tag}^{{commit}}"],
+        cwd=root,
+        check=False,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode == 1:
+        return
+    if result.returncode != 0:
+        raise ReleaseError(f"could not resolve target tag {target_tag}")
+    actual_sha = result.stdout.strip()
+    if actual_sha != expected_sha:
+        raise ReleaseError(
+            f"target tag {target_tag} resolves to {actual_sha}, expected {expected_sha}"
+        )
 
 
 def validate_merged(
     root: Path,
     expected_sha: str,
+    source_sha: str,
     expected_version: str,
     expected_tag: str,
+    expected_fragment_count: int,
     expected_package_count: int,
 ) -> None:
     head = run(["git", "rev-parse", "HEAD"], root, capture_output=True).stdout.strip()
     if head != expected_sha:
         raise ReleaseError(f"checked out commit {head} does not match merged commit {expected_sha}")
+    verify_target_tag(root, expected_tag, expected_sha)
+    verify_ancestor(root, source_sha, expected_sha)
+    statuses = name_status(
+        ["git", "diff", "--name-status", "--no-renames", source_sha, expected_sha], root
+    )
+    verify_stable_diff(statuses, expected_fragment_count)
+    if (root / "Cargo.toml").read_bytes() != git_bytes(root, source_sha, "Cargo.toml"):
+        raise ReleaseError("stable release changed Cargo.toml")
+    if (root / "Cargo.lock").read_bytes() != git_bytes(root, source_sha, "Cargo.lock"):
+        raise ReleaseError("stable release changed Cargo.lock")
 
     candidate = workspace_version(root / "Cargo.toml")
     parse_version(candidate)
@@ -353,12 +412,14 @@ def prepare(root: Path, changelogs: Path) -> None:
     package_count = verify_workspace_versions(metadata, candidate)
 
     verify_changed_paths(root, fragments)
-    require_changes(root)
 
     expected_tag = f"v{candidate}"
+    source_sha = run(["git", "rev-parse", "HEAD"], root, capture_output=True).stdout.strip()
     set_output("changed", "true")
+    set_output("source_sha", source_sha)
     set_output("expected_version", candidate)
     set_output("expected_tag", expected_tag)
+    set_output("fragment_count", str(len(fragments)))
     set_output("package_count", str(package_count))
     print(
         f"Prepared {expected_tag} from {len(fragments)} fragment(s); "
@@ -371,8 +432,10 @@ def main() -> int:
     parser.add_argument("--changelogs", type=Path, help="Pinned changelogs binary")
     parser.add_argument("--validate-merged", action="store_true")
     parser.add_argument("--expected-sha")
+    parser.add_argument("--expected-source-sha")
     parser.add_argument("--expected-version")
     parser.add_argument("--expected-tag")
+    parser.add_argument("--expected-fragment-count", type=int)
     parser.add_argument("--expected-package-count", type=int)
     parser.add_argument("--root", type=Path, default=Path.cwd())
     args = parser.parse_args()
@@ -382,8 +445,10 @@ def main() -> int:
         if args.validate_merged:
             expected = {
                 "--expected-sha": args.expected_sha,
+                "--expected-source-sha": args.expected_source_sha,
                 "--expected-version": args.expected_version,
                 "--expected-tag": args.expected_tag,
+                "--expected-fragment-count": args.expected_fragment_count,
                 "--expected-package-count": args.expected_package_count,
             }
             missing = [name for name, value in expected.items() if value is None]
@@ -392,8 +457,10 @@ def main() -> int:
             validate_merged(
                 root,
                 args.expected_sha,
+                args.expected_source_sha,
                 args.expected_version,
                 args.expected_tag,
+                args.expected_fragment_count,
                 args.expected_package_count,
             )
         else:

--- a/.github/scripts/tests/test_prepare_stable_release.py
+++ b/.github/scripts/tests/test_prepare_stable_release.py
@@ -70,9 +70,13 @@ class VersionTests(unittest.TestCase):
         with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "stable X.Y.Z"):
             prepare_stable_release.parse_version("1.7.2-rc1")
 
+    def test_rejects_noncanonical_stable_version(self) -> None:
+        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "canonical"):
+            prepare_stable_release.parse_version("01.7.2")
+
     def test_selects_latest_strict_stable_tag_and_ignores_prereleases(self) -> None:
         tag, version = prepare_stable_release.latest_stable_tag(
-            "v1.7.0\nv1.7.2-rc1\nv1.7.1\nnightly\nv2.0.0-rc1\n"
+            "v1.7.0\nv1.7.2-rc1\nv1.7.1\nv01.8.0\nnightly\nv2.0.0-rc1\n"
         )
         self.assertEqual(tag, "v1.7.1")
         self.assertEqual(version, (1, 7, 1))
@@ -226,31 +230,42 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "omitted.*cast"):
             prepare_stable_release.verify_workspace_versions(metadata, "1.7.2")
 
-    def test_rejects_unexpected_changed_path(self) -> None:
+    def test_accepts_exact_stable_diff(self) -> None:
+        prepare_stable_release.verify_stable_diff(
+            {"CHANGELOG.md": "M", ".changelog/release.md": "D"}, 1
+        )
+
+    def test_rejects_wrong_stable_diff_status_path_and_count(self) -> None:
+        cases = [
+            ({"CHANGELOG.md": "A", ".changelog/release.md": "D"}, 1),
+            ({"CHANGELOG.md": "M", ".changelog/release.md": "M"}, 1),
+            ({"CHANGELOG.md": "M", "Cargo.lock": "M", ".changelog/release.md": "D"}, 1),
+            ({"CHANGELOG.md": "M", ".changelog/release.md": "D"}, 2),
+            ({"CHANGELOG.md": "M"}, 0),
+        ]
+        for statuses, count in cases:
+            with self.subTest(statuses=statuses, count=count), self.assertRaisesRegex(
+                prepare_stable_release.ReleaseError, "stable release diff"
+            ):
+                prepare_stable_release.verify_stable_diff(statuses, count)
+
+    def test_rejects_rename_copy_and_malformed_diff_status(self) -> None:
+        for output in ["R100\told\tnew\n", "C100\told\tnew\n", "malformed\n"]:
+            with self.subTest(output=output), patch.object(
+                prepare_stable_release,
+                "run",
+                return_value=subprocess.CompletedProcess([], returncode=0, stdout=output),
+            ), self.assertRaisesRegex(prepare_stable_release.ReleaseError, "rename, copy"):
+                prepare_stable_release.name_status(["git", "diff"], Path("."))
+
+    def test_rejects_duplicate_diff_path(self) -> None:
+        output = "M\tCHANGELOG.md\nM\tCHANGELOG.md\n"
         with patch.object(
             prepare_stable_release,
-            "changed_paths",
-            return_value={"Cargo.lock", "crates/forge/Cargo.toml"},
-        ), self.assertRaisesRegex(
-            prepare_stable_release.ReleaseError, "Cargo.lock, crates/forge/Cargo.toml"
-        ):
-            prepare_stable_release.verify_changed_paths(Path("."), [])
-
-    def test_requires_a_tracked_change(self) -> None:
-        with patch.object(
-            prepare_stable_release.subprocess,
             "run",
-            return_value=subprocess.CompletedProcess([], returncode=1),
-        ):
-            prepare_stable_release.require_changes(Path("."))
-
-    def test_rejects_no_tracked_changes(self) -> None:
-        with patch.object(
-            prepare_stable_release.subprocess,
-            "run",
-            return_value=subprocess.CompletedProcess([], returncode=0),
-        ), self.assertRaisesRegex(prepare_stable_release.ReleaseError, "did not change"):
-            prepare_stable_release.require_changes(Path("."))
+            return_value=subprocess.CompletedProcess([], returncode=0, stdout=output),
+        ), self.assertRaisesRegex(prepare_stable_release.ReleaseError, "duplicate"):
+            prepare_stable_release.name_status(["git", "diff"], Path("."))
 
     def test_no_fragments_outputs_cleanup_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -308,7 +323,12 @@ class MergedReleaseTests(unittest.TestCase):
         (self.root / "Cargo.toml").write_text(
             '[workspace.package]\nversion = "1.7.2"\n'
         )
+        (self.root / "Cargo.lock").write_text("reviewed lockfile\n")
         (self.root / "CHANGELOG.md").write_text("## 1.7.2 (2026-07-29)\n")
+        self.source = {
+            "Cargo.toml": (self.root / "Cargo.toml").read_bytes(),
+            "Cargo.lock": (self.root / "Cargo.lock").read_bytes(),
+        }
         self.metadata = {
             "workspace_members": ["forge", "cast"],
             "packages": [
@@ -328,11 +348,36 @@ class MergedReleaseTests(unittest.TestCase):
         )
         return subprocess.CompletedProcess(command, returncode=0, stdout=output)
 
+    def validate(self, **overrides) -> None:
+        arguments = {
+            "root": self.root,
+            "expected_sha": "merged-sha",
+            "source_sha": "source-sha",
+            "expected_version": "1.7.2",
+            "expected_tag": "v1.7.2",
+            "expected_fragment_count": 1,
+            "expected_package_count": 2,
+        }
+        arguments.update(overrides)
+        with patch.object(
+            prepare_stable_release, "run", side_effect=self.completed
+        ), patch.object(
+            prepare_stable_release, "verify_target_tag"
+        ), patch.object(
+            prepare_stable_release, "verify_ancestor"
+        ), patch.object(
+            prepare_stable_release,
+            "name_status",
+            return_value={"CHANGELOG.md": "M", ".changelog/release.md": "D"},
+        ), patch.object(
+            prepare_stable_release,
+            "git_bytes",
+            side_effect=lambda root, sha, path: self.source[path],
+        ):
+            prepare_stable_release.validate_merged(**arguments)
+
     def test_validates_merged_release(self) -> None:
-        with patch.object(prepare_stable_release, "run", side_effect=self.completed):
-            prepare_stable_release.validate_merged(
-                self.root, "merged-sha", "1.7.2", "v1.7.2", 2
-            )
+        self.validate()
 
     def test_rejects_wrong_checkout(self) -> None:
         with patch.object(
@@ -341,30 +386,60 @@ class MergedReleaseTests(unittest.TestCase):
             return_value=subprocess.CompletedProcess([], returncode=0, stdout="later-sha\n"),
         ), self.assertRaisesRegex(prepare_stable_release.ReleaseError, "does not match merged"):
             prepare_stable_release.validate_merged(
-                self.root, "merged-sha", "1.7.2", "v1.7.2", 2
+                self.root, "merged-sha", "source-sha", "1.7.2", "v1.7.2", 1, 2
             )
 
     def test_rejects_metadata_mismatch(self) -> None:
-        with patch.object(prepare_stable_release, "run", side_effect=self.completed), \
-            self.assertRaisesRegex(prepare_stable_release.ReleaseError, "pull request metadata"):
-            prepare_stable_release.validate_merged(
-                self.root, "merged-sha", "1.7.3", "v1.7.3", 2
-            )
+        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "pull request metadata"):
+            self.validate(expected_version="1.7.3", expected_tag="v1.7.3")
 
     def test_rejects_pending_fragment(self) -> None:
         (self.root / ".changelog" / "pending.md").write_text("pending\n")
-        with patch.object(prepare_stable_release, "run", side_effect=self.completed), \
-            self.assertRaisesRegex(prepare_stable_release.ReleaseError, "pending changelog"):
-            prepare_stable_release.validate_merged(
-                self.root, "merged-sha", "1.7.2", "v1.7.2", 2
-            )
+        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "pending changelog"):
+            self.validate()
 
     def test_rejects_package_count_mismatch(self) -> None:
-        with patch.object(prepare_stable_release, "run", side_effect=self.completed), \
-            self.assertRaisesRegex(prepare_stable_release.ReleaseError, "metadata records 3"):
-            prepare_stable_release.validate_merged(
-                self.root, "merged-sha", "1.7.2", "v1.7.2", 3
-            )
+        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "metadata records 3"):
+            self.validate(expected_package_count=3)
+
+    def test_rejects_changed_source_manifest_or_lockfile(self) -> None:
+        for path, message in [("Cargo.toml", "Cargo.toml"), ("Cargo.lock", "Cargo.lock")]:
+            with self.subTest(path=path):
+                original = (self.root / path).read_bytes()
+                (self.root / path).write_bytes(original + b"changed\n")
+                try:
+                    with self.assertRaisesRegex(prepare_stable_release.ReleaseError, message):
+                        self.validate()
+                finally:
+                    (self.root / path).write_bytes(original)
+
+    def test_source_sha_must_be_ancestor(self) -> None:
+        error = subprocess.CalledProcessError(1, ["git", "merge-base"])
+        with patch.object(prepare_stable_release, "run", side_effect=error), \
+            self.assertRaisesRegex(prepare_stable_release.ReleaseError, "not an ancestor"):
+            prepare_stable_release.verify_ancestor(self.root, "source", "merged")
+
+    def test_target_tag_is_idempotent_only_at_expected_commit(self) -> None:
+        cases = [
+            (1, "", None),
+            (0, "merged-sha\n", None),
+            (0, "other-sha\n", "resolves to other-sha"),
+            (2, "", "could not resolve"),
+        ]
+        for returncode, stdout, error in cases:
+            result = subprocess.CompletedProcess([], returncode=returncode, stdout=stdout)
+            with self.subTest(returncode=returncode, stdout=stdout), patch.object(
+                prepare_stable_release.subprocess, "run", return_value=result
+            ):
+                if error:
+                    with self.assertRaisesRegex(prepare_stable_release.ReleaseError, error):
+                        prepare_stable_release.verify_target_tag(
+                            self.root, "v1.7.2", "merged-sha"
+                        )
+                else:
+                    prepare_stable_release.verify_target_tag(
+                        self.root, "v1.7.2", "merged-sha"
+                    )
 
 
 class CommandTests(unittest.TestCase):

--- a/.github/workflows/stable-version-pr.yml
+++ b/.github/workflows/stable-version-pr.yml
@@ -114,8 +114,10 @@ jobs:
             Prepares Foundry ${{ steps.prepare.outputs.expected_version }} from pending changelog entries.
 
             - Base branch: `${{ steps.prepare.outputs.base_branch }}`
+            - Source master SHA: `${{ steps.prepare.outputs.source_sha }}`
             - Expected version: `${{ steps.prepare.outputs.expected_version }}`
             - Expected tag: `${{ steps.prepare.outputs.expected_tag }}`
+            - Changelog fragments: ${{ steps.prepare.outputs.fragment_count }}
             - Verified workspace packages: ${{ steps.prepare.outputs.package_count }}
 
             This pull request does not create a tag, GitHub release, or registry publication.

--- a/.github/workflows/tag-stable-release.yml
+++ b/.github/workflows/tag-stable-release.yml
@@ -65,48 +65,28 @@ jobs:
             const metadata = new RegExp(
               `${marker}\\nPrepares Foundry (\\d+\\.\\d+\\.\\d+) from pending changelog entries\\.\\n\\n` +
               '- Base branch: `master`\\n' +
+              '- Source master SHA: `([0-9a-f]{40})`\\n' +
               '- Expected version: `([^`]+)`\\n' +
               '- Expected tag: `([^`]+)`\\n' +
+              '- Changelog fragments: (\\d+)\\n' +
               '- Verified workspace packages: (\\d+)\\n',
             ).exec(pr.body || '');
             if (!metadata) throw new Error('Stable version pull request metadata is malformed');
-            if (metadata[1] !== metadata[2]) {
+            if (metadata[1] !== metadata[3]) {
               throw new Error('Stable version pull request versions do not match');
             }
-            if (metadata[3] !== `v${metadata[1]}`) {
+            if (metadata[4] !== `v${metadata[1]}`) {
               throw new Error('Stable version pull request tag does not match its version');
             }
-            if (pr.title !== `chore: prepare ${metadata[3]}`) {
+            if (pr.title !== `chore: prepare ${metadata[4]}`) {
               throw new Error('Stable version pull request title does not match its tag');
             }
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-              per_page: 100,
-            });
-            if (files.length !== pr.changed_files) {
-              throw new Error('Could not inspect the complete stable version pull request diff');
-            }
-            const isChangelog = file =>
-              file.filename === 'CHANGELOG.md' && file.status === 'modified' && !file.previous_filename;
-            const isRemovedFragment = file =>
-              file.status === 'removed' &&
-              !file.previous_filename &&
-              /^\.changelog\/[^/]+\.md$/.test(file.filename) &&
-              file.filename !== '.changelog/README.md';
-            const unexpected = files.filter(file => !isChangelog(file) && !isRemovedFragment(file));
-            if (unexpected.length) {
-              throw new Error(`Stable version pull request changed unexpected paths: ${unexpected.map(file => file.filename).join(', ')}`);
-            }
-            if (!files.some(isChangelog) || !files.some(isRemovedFragment)) {
-              throw new Error('Stable version pull request is missing expected release changes');
-            }
-
             core.setOutput('version', metadata[1]);
-            core.setOutput('tag', metadata[3]);
-            core.setOutput('package_count', metadata[4]);
+            core.setOutput('source_sha', metadata[2]);
+            core.setOutput('tag', metadata[4]);
+            core.setOutput('fragment_count', metadata[5]);
+            core.setOutput('package_count', metadata[6]);
             core.setOutput('merge_sha', pr.merge_commit_sha);
 
       - name: Checkout merged release
@@ -114,6 +94,7 @@ jobs:
         with:
           ref: ${{ steps.release.outputs.merge_sha }}
           path: release
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Revalidate merged release
@@ -122,13 +103,17 @@ jobs:
             --validate-merged \
             --root release \
             --expected-sha "$MERGE_SHA" \
+            --expected-source-sha "$SOURCE_SHA" \
             --expected-version "$EXPECTED_VERSION" \
             --expected-tag "$EXPECTED_TAG" \
+            --expected-fragment-count "$EXPECTED_FRAGMENT_COUNT" \
             --expected-package-count "$EXPECTED_PACKAGE_COUNT"
         env:
           MERGE_SHA: ${{ steps.release.outputs.merge_sha }}
+          SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
           EXPECTED_VERSION: ${{ steps.release.outputs.version }}
           EXPECTED_TAG: ${{ steps.release.outputs.tag }}
+          EXPECTED_FRAGMENT_COUNT: ${{ steps.release.outputs.fragment_count }}
           EXPECTED_PACKAGE_COUNT: ${{ steps.release.outputs.package_count }}
 
       - name: Create repository-scoped App token


### PR DESCRIPTION
Records the source commit and validates the exact stable release diff before creating a tag. This prevents unexpected manifest, lockfile, fragment, or tag changes from reaching the release pipeline.

Part of OSS-591