### PR TITLE
fix(deps): update ruint to 1.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10522,9 +10522,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "arbitrary",


### PR DESCRIPTION
Updates `ruint` to `1.20.0` to address RUSTSEC-2026-0220, which affects shift overflow reporting and can cause incorrect checked or saturating operations.
