### PR TITLE
feat(ci): add explicit RC transitions

### DIFF
--- a/.changelog/README.md
+++ b/.changelog/README.md
@@ -25,6 +25,16 @@ the check action's built-in AI installer, which does not pin the installed CLI.
 - Generated `CHANGELOG.md` history starts at adoption. Historical releases are not
   backfilled.
 
+Release automation accepts only canonical `X.Y.Z` versions and `vX.Y.Z` tags, plus
+strict release candidates in the form `X.Y.Z-rcN` and `vX.Y.Z-rcN` where `N >= 1`.
+Legacy prerelease forms are excluded from transition state. Manual dispatches must
+confirm their exact source and target tags: `start` turns the checked-in stable candidate
+into `rc1`, `advance` moves the latest same-core RC to the next RC, and `promote` removes
+the RC suffix. Starting and advancing require and consume changelog fragments; promotion
+requires zero fragments and leaves `CHANGELOG.md` unchanged. Source RC tags must exist,
+be the latest same-core RC, form a contiguous sequence from `rc1`, and be ancestors of
+the release commit.
+
 Root changelog format gives every discovered package one unified version. A read-only dry
 run at the pinned revision discovers 37 release-planned packages;
 `forge-sol-macro-gen` and `foundry-test-utils` are excluded because they set

--- a/.changelog/explicit-rc-release-transitions.md
+++ b/.changelog/explicit-rc-release-transitions.md
@@ -1,0 +1,8 @@
+---
+forge: patch
+cast: patch
+anvil: patch
+chisel: patch
+---
+
+Added explicit operations to start, advance, and promote release candidates.

--- a/.github/scripts/prepare-stable-release.py
+++ b/.github/scripts/prepare-stable-release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prepare a stable Foundry version pull request from pending changelog fragments."""
+"""Prepare or validate an exact Foundry release transition."""
 
 import argparse
 import json
@@ -11,8 +11,9 @@ import sys
 import tomllib
 
 
-STABLE_TAG = re.compile(r"v(\d+)\.(\d+)\.(\d+)")
-VERSION = re.compile(r"\d+\.\d+\.\d+")
+VERSION = re.compile(r"(\d+)\.(\d+)\.(\d+)(?:-rc([1-9]\d*))?")
+TAG = re.compile(r"v(\d+)\.(\d+)\.(\d+)(?:-rc([1-9]\d*))?")
+OPERATIONS = {"stable", "start", "advance", "promote"}
 WORKSPACE_VERSION = re.compile(
     r'(?ms)(^\[workspace\.package\]\s*$.*?^version\s*=\s*")([^"\n]+)(")'
 )
@@ -48,27 +49,43 @@ def run_preserving_lockfile(
         lockfile.write_bytes(original)
 
 
-def parse_version(value: str) -> tuple[int, int, int]:
-    if not VERSION.fullmatch(value):
-        raise ReleaseError(f"expected a stable X.Y.Z version, got {value!r}")
-    version = tuple(int(part) for part in value.split("."))
-    if ".".join(map(str, version)) != value:
-        raise ReleaseError(f"expected a canonical stable X.Y.Z version, got {value!r}")
+def parse_version(value: str) -> tuple[int, int, int, int | None]:
+    match = VERSION.fullmatch(value)
+    if not match:
+        raise ReleaseError(f"expected a strict X.Y.Z or X.Y.Z-rcN version, got {value!r}")
+    version = tuple(int(part) if part is not None else None for part in match.groups())
+    core = ".".join(map(str, version[:3]))
+    canonical = core if version[3] is None else f"{core}-rc{version[3]}"
+    if canonical != value:
+        raise ReleaseError(f"expected a canonical release version, got {value!r}")
     return version
 
 
 def latest_stable_tag(tags: str) -> tuple[str, tuple[int, int, int]]:
-    stable = []
-    for tag in tags.splitlines():
-        match = STABLE_TAG.fullmatch(tag.strip())
-        if match:
-            version = tuple(int(part) for part in match.groups())
-            if f"v{'.'.join(map(str, version))}" == tag.strip():
-                stable.append((version, tag.strip()))
+    stable = [
+        (version[:3], tag)
+        for tag, version in strict_tags(tags).items()
+        if version[3] is None
+    ]
     if not stable:
         raise ReleaseError("no stable vX.Y.Z tag found")
     version, tag = max(stable)
     return tag, version
+
+
+def strict_tags(tags: str) -> dict[str, tuple[int, int, int, int | None]]:
+    result = {}
+    for value in tags.splitlines():
+        tag = value.strip()
+        match = TAG.fullmatch(tag)
+        if not match:
+            continue
+        version = tuple(int(part) if part is not None else None for part in match.groups())
+        core = ".".join(map(str, version[:3]))
+        canonical = f"v{core}" if version[3] is None else f"v{core}-rc{version[3]}"
+        if canonical == tag:
+            result[tag] = version
+    return result
 
 
 def workspace_version(manifest: Path) -> str:
@@ -165,7 +182,23 @@ def publishable_packages(metadata: dict) -> set[str]:
     }
 
 
-def repair_solar_alias(manifest: Path, original_content: str, candidate: str) -> None:
+def desired_manifest(original: str, target: str) -> str:
+    updated, count = WORKSPACE_VERSION.subn(rf"\g<1>{target}\g<3>", original, count=1)
+    if count != 1:
+        raise ReleaseError("could not update source [workspace.package].version")
+    return updated
+
+
+def verify_manifest_change(source: bytes, target: bytes, version: str) -> None:
+    try:
+        expected = desired_manifest(source.decode(), version).encode()
+    except UnicodeDecodeError as error:
+        raise ReleaseError("source Cargo.toml is not UTF-8") from error
+    if target != expected:
+        raise ReleaseError("release changed Cargo.toml beyond the workspace version")
+
+
+def repair_solar_alias(manifest: Path, original_content: str, target: str) -> None:
     original = tomllib.loads(original_content)
     current_content = manifest.read_text()
     current = tomllib.loads(current_content)
@@ -173,24 +206,79 @@ def repair_solar_alias(manifest: Path, original_content: str, candidate: str) ->
     current_solar = current["workspace"]["dependencies"]["solar"]
     if original_solar.get("package") != "solar-compiler" or original_solar.get("version") != "=0.2.0":
         raise ReleaseError("reviewed solar-compiler dependency alias changed")
-    if current_solar.get("version") != candidate:
+    if current_solar.get("version") != target:
         raise ReleaseError("pinned changelogs CLI did not produce the expected solar alias collision")
 
     original_lines = re.findall(r"(?m)^solar\s*=\s*\{[^\n]+\}$", original_content)
     if len(original_lines) != 1:
         raise ReleaseError("could not repair the solar-compiler dependency alias")
-    candidate_line, replacements = re.subn(
+    target_line, replacements = re.subn(
         r'version\s*=\s*"=0\.2\.0"',
-        f'version = "{candidate}"',
+        f'version = "{target}"',
         original_lines[0],
         count=1,
     )
     if replacements != 1:
         raise ReleaseError("could not identify the reviewed solar-compiler version constraint")
-    expected_content = original_content.replace(original_lines[0], candidate_line, 1)
-    if current_content != expected_content:
+    expected = desired_manifest(original_content, target)
+    expected_cli = expected.replace(original_lines[0], target_line, 1)
+    if current_content != expected_cli:
         raise ReleaseError("pinned changelogs CLI made an unexpected Cargo.toml change")
-    manifest.write_text(original_content)
+    manifest.write_text(expected)
+
+
+def lock_packages(path: Path) -> list[dict]:
+    with path.open("rb") as file:
+        return tomllib.load(file)["package"]
+
+
+def lock_packages_bytes(content: bytes) -> list[dict]:
+    return tomllib.loads(content.decode())["package"]
+
+
+def normalize_workspace_dependency(
+    dependency: str, workspace_names: set[str], source: str, target: str
+) -> str:
+    name, separator, remainder = dependency.partition(" ")
+    if separator and name in workspace_names and remainder == source:
+        return f"{name} {target}"
+    return dependency
+
+
+def verify_lock_change(
+    before: list[dict],
+    after: list[dict],
+    workspace_names: set[str],
+    source: str,
+    target: str,
+) -> None:
+    def key(package: dict) -> tuple[str, str | None, str | None]:
+        if package.get("source") is None and package["name"] in workspace_names:
+            return package["name"], None, None
+        return package["name"], package["version"], package.get("source")
+
+    before_by_key = {key(package): package for package in before}
+    after_by_key = {key(package): package for package in after}
+    if len(before_by_key) != len(before) or len(after_by_key) != len(after):
+        raise ReleaseError("Cargo.lock contains duplicate package identities")
+    if set(before_by_key) != set(after_by_key):
+        raise ReleaseError("Cargo.lock changed package resolution")
+
+    for identity, original in before_by_key.items():
+        expected = dict(original)
+        if original.get("source") is None and original["name"] in workspace_names:
+            if original["version"] != source:
+                raise ReleaseError(
+                    f"workspace lock package {original['name']} does not use source version {source}"
+                )
+            expected["version"] = target
+        if "dependencies" in expected:
+            expected["dependencies"] = [
+                normalize_workspace_dependency(dependency, workspace_names, source, target)
+                for dependency in expected["dependencies"]
+            ]
+        if after_by_key[identity] != expected:
+            raise ReleaseError(f"Cargo.lock changed unexpectedly for {original['name']}")
 
 
 def set_output(name: str, value: str) -> None:
@@ -211,24 +299,33 @@ def name_status(command: list[str], root: Path) -> dict[str, str]:
     return statuses
 
 
-def verify_stable_diff(statuses: dict[str, str], fragment_count: int) -> None:
+def verify_release_diff_statuses(
+    statuses: dict[str, str], operation: str, fragment_count: int
+) -> None:
     fragments = {
         path: status
         for path, status in statuses.items()
         if re.fullmatch(r"\.changelog/[^/]+\.md", path)
         and path != ".changelog/README.md"
     }
+    regular = {path: status for path, status in statuses.items() if path not in fragments}
+    expected = {
+        "stable": {"CHANGELOG.md": {"A", "M"}},
+        "start": {"Cargo.toml": {"M"}, "Cargo.lock": {"M"}, "CHANGELOG.md": {"A", "M"}},
+        "advance": {"Cargo.toml": {"M"}, "Cargo.lock": {"M"}, "CHANGELOG.md": {"M"}},
+        "promote": {"Cargo.toml": {"M"}, "Cargo.lock": {"M"}},
+    }[operation]
     if (
-        statuses.get("CHANGELOG.md") != "M"
+        set(regular) != set(expected)
+        or any(status not in expected[path] for path, status in regular.items())
         or len(fragments) != fragment_count
-        or fragment_count < 1
         or any(status != "D" for status in fragments.values())
-        or set(statuses) != {"CHANGELOG.md", *fragments}
+        or (operation == "promote") != (fragment_count == 0)
     ):
-        raise ReleaseError("stable release diff must modify CHANGELOG.md and delete every fragment")
+        raise ReleaseError(f"invalid {operation} release diff statuses or paths")
 
 
-def verify_changed_paths(root: Path, fragments: list[Path]) -> None:
+def verify_changed_paths(root: Path, fragments: list[Path], operation: str) -> None:
     statuses = name_status(["git", "diff", "--name-status", "--no-renames"], root)
     untracked = run(
         ["git", "ls-files", "--others", "--exclude-standard"],
@@ -236,7 +333,7 @@ def verify_changed_paths(root: Path, fragments: list[Path]) -> None:
         capture_output=True,
     ).stdout.splitlines()
     statuses.update({path: "A" for path in untracked})
-    verify_stable_diff(statuses, len(fragments))
+    verify_release_diff_statuses(statuses, operation, len(fragments))
 
 
 def git_bytes(root: Path, revision: str, path: str) -> bytes:
@@ -246,6 +343,10 @@ def git_bytes(root: Path, revision: str, path: str) -> bytes:
         check=True,
         stdout=subprocess.PIPE,
     ).stdout
+
+
+def manifest_version(content: bytes) -> str:
+    return tomllib.loads(content.decode())["workspace"]["package"]["version"]
 
 
 def verify_ancestor(root: Path, ancestor: str, descendant: str) -> None:
@@ -274,10 +375,72 @@ def verify_target_tag(root: Path, target_tag: str, expected_sha: str) -> None:
         )
 
 
+def tag_state(
+    root: Path, *, exclude: str | None = None
+) -> tuple[tuple[int, int, int], dict[str, tuple[int, int, int, int | None]]]:
+    output = run(["git", "tag", "--list", "v*"], root, capture_output=True).stdout
+    tags = strict_tags(output)
+    transition_tags = {tag: version for tag, version in tags.items() if tag != exclude}
+    _, stable_version = latest_stable_tag("\n".join(transition_tags))
+    return stable_version, transition_tags
+
+
+def transition(
+    operation: str,
+    checked: str,
+    stable: tuple[int, int, int],
+    tags: dict[str, tuple[int, int, int, int | None]],
+    source_tag: str | None,
+    target_tag: str | None,
+    *,
+    allow_target: bool = False,
+) -> tuple[str, str]:
+    version = parse_version(checked)
+    core, rc = version[:3], version[3]
+    if operation in ("stable", "start"):
+        if rc is not None or core <= stable:
+            raise ReleaseError("checked-in stable candidate must be newer than the latest stable")
+        same_core = [tag for tag, item in tags.items() if item[:3] == core and item[3] is not None]
+        if same_core:
+            raise ReleaseError("same-core release candidate train already exists")
+        target = checked if operation == "stable" else f"{checked}-rc1"
+        source = f"v{'.'.join(map(str, stable))}"
+    else:
+        if rc is None:
+            raise ReleaseError(f"{operation} requires a checked-in strict release candidate")
+        if core <= stable:
+            raise ReleaseError("release candidate core must be newer than the latest stable")
+        source = f"v{checked}"
+        target = (
+            ".".join(map(str, core))
+            if operation == "promote"
+            else f"{'.'.join(map(str, core))}-rc{rc + 1}"
+        )
+        same_core = [
+            (item[3], tag)
+            for tag, item in tags.items()
+            if item[:3] == core and item[3] is not None
+        ]
+        if source not in tags or not same_core or max(same_core)[1] != source:
+            raise ReleaseError("source tag is not the latest same-core strict RC")
+        if sorted(item for item, _ in same_core) != list(range(1, rc + 1)):
+            raise ReleaseError("same-core release candidate history is not contiguous from rc1")
+    expected_target = f"v{target}"
+    if expected_target in tags and not allow_target:
+        raise ReleaseError(f"target tag {expected_target} already exists")
+    if operation != "stable" and (source_tag != source or target_tag != expected_target):
+        raise ReleaseError(
+            f"manual confirmation mismatch: expected source {source} and target {expected_target}"
+        )
+    return source, target
+
+
 def validate_merged(
     root: Path,
+    operation: str,
     expected_sha: str,
     source_sha: str,
+    source_tag: str,
     expected_version: str,
     expected_tag: str,
     expected_fragment_count: int,
@@ -287,42 +450,69 @@ def validate_merged(
     if head != expected_sha:
         raise ReleaseError(f"checked out commit {head} does not match merged commit {expected_sha}")
     verify_target_tag(root, expected_tag, expected_sha)
+    stable, tags = tag_state(root, exclude=expected_tag)
+    source_manifest = git_bytes(root, source_sha, "Cargo.toml")
+    source_lock = git_bytes(root, source_sha, "Cargo.lock")
+    baseline = manifest_version(source_manifest)
+    derived_source, derived_version = transition(
+        operation,
+        baseline,
+        stable,
+        tags,
+        source_tag if operation != "stable" else None,
+        expected_tag if operation != "stable" else None,
+        allow_target=True,
+    )
+    candidate = workspace_version(root / "Cargo.toml")
+    if (
+        derived_source != source_tag
+        or derived_version != expected_version
+        or expected_tag != f"v{derived_version}"
+        or candidate != derived_version
+    ):
+        raise ReleaseError("release metadata, tag, transition, and workspace version are inconsistent")
+    if operation in ("advance", "promote"):
+        verify_ancestor(root, source_tag, expected_sha)
     verify_ancestor(root, source_sha, expected_sha)
     statuses = name_status(
         ["git", "diff", "--name-status", "--no-renames", source_sha, expected_sha], root
     )
-    verify_stable_diff(statuses, expected_fragment_count)
-    if (root / "Cargo.toml").read_bytes() != git_bytes(root, source_sha, "Cargo.toml"):
-        raise ReleaseError("stable release changed Cargo.toml")
-    if (root / "Cargo.lock").read_bytes() != git_bytes(root, source_sha, "Cargo.lock"):
-        raise ReleaseError("stable release changed Cargo.lock")
-
-    candidate = workspace_version(root / "Cargo.toml")
-    parse_version(candidate)
-    if candidate != expected_version:
-        raise ReleaseError(
-            f"workspace version {candidate} does not match pull request metadata {expected_version}"
-        )
-    derived_tag = f"v{candidate}"
-    if derived_tag != expected_tag:
-        raise ReleaseError(
-            f"derived tag {derived_tag} does not match pull request metadata {expected_tag}"
-        )
+    verify_release_diff_statuses(statuses, operation, expected_fragment_count)
+    verify_manifest_change(source_manifest, (root / "Cargo.toml").read_bytes(), expected_version)
 
     fragments = pending_fragments(root)
     if fragments:
         names = ", ".join(str(path.relative_to(root)) for path in fragments)
         raise ReleaseError(f"merged release still contains pending changelog fragments: {names}")
-    verify_release_heading_count(root / "CHANGELOG.md", candidate, 1)
+    verify_release_heading_count(
+        root / "CHANGELOG.md", candidate, 0 if operation == "promote" else 1
+    )
 
-    metadata = json.loads(
+    target_metadata = json.loads(
         run(
             ["cargo", "metadata", "--locked", "--no-deps", "--format-version", "1"],
             root,
             capture_output=True,
         ).stdout
     )
-    package_count = verify_workspace_versions(metadata, candidate)
+    if operation == "stable":
+        if (root / "Cargo.lock").read_bytes() != source_lock:
+            raise ReleaseError("stable release changed Cargo.lock")
+    else:
+        members = set(target_metadata["workspace_members"])
+        workspace_names = {
+            package["name"]
+            for package in target_metadata["packages"]
+            if package["id"] in members
+        }
+        verify_lock_change(
+            lock_packages_bytes(source_lock),
+            lock_packages(root / "Cargo.lock"),
+            workspace_names,
+            baseline,
+            derived_version,
+        )
+    package_count = verify_workspace_versions(target_metadata, candidate)
     if package_count != expected_package_count:
         raise ReleaseError(
             f"verified {package_count} workspace packages, pull request metadata records "
@@ -331,98 +521,119 @@ def validate_merged(
     print(f"Validated {expected_tag} at merged commit {expected_sha}.")
 
 
-def prepare(root: Path, changelogs: Path) -> None:
+def metadata(root: Path, *, locked: bool = True) -> dict:
+    command = ["cargo", "metadata"]
+    if locked:
+        command.append("--locked")
+    command.extend(["--no-deps", "--format-version", "1"])
+    return json.loads(run(command, root, capture_output=True).stdout)
+
+
+def prepare(
+    root: Path,
+    changelogs: Path,
+    operation: str = "stable",
+    source_tag: str | None = None,
+    target_tag: str | None = None,
+) -> None:
     manifest = root / "Cargo.toml"
     lockfile = root / "Cargo.lock"
     changelog = root / "CHANGELOG.md"
     original_manifest = manifest.read_text()
-    candidate = workspace_version(manifest)
-    candidate_version = parse_version(candidate)
+    checked = workspace_version(manifest)
+    checked_version = parse_version(checked)
     fragments = pending_fragments(root)
     set_output("base_branch", "master")
-    if not fragments:
+    set_output("operation", operation)
+    if operation == "stable" and checked_version[3] is not None:
+        set_output("changed", "false")
+        print("An RC train is active; automatic stable reconciliation is skipped.")
+        return
+    if operation == "stable" and not fragments:
         set_output("changed", "false")
         print("No pending changelog fragments.")
         return
+    if operation == "promote" and fragments:
+        raise ReleaseError("promotion requires zero pending changelog fragments")
+    if operation != "promote" and not fragments:
+        raise ReleaseError(f"{operation} requires pending changelog fragments")
 
-    verify_release_heading_count(changelog, candidate, 0)
-
-    tags = run(["git", "tag", "--list", "v*"], root, capture_output=True).stdout
-    stable_tag, stable_version = latest_stable_tag(tags)
+    stable_version, tags = tag_state(root)
     stable = ".".join(str(part) for part in stable_version)
-    if candidate_version <= stable_version:
-        raise ReleaseError(
-            f"workspace candidate {candidate} must be newer than latest stable {stable_tag}"
-        )
+    source, target = transition(operation, checked, stable_version, tags, source_tag, target_tag)
+    if operation in ("advance", "promote"):
+        verify_ancestor(root, source, "HEAD")
+    verify_release_heading_count(changelog, target, 0)
 
-    initial_metadata = json.loads(
-        run(
-            ["cargo", "metadata", "--locked", "--no-deps", "--format-version", "1"],
-            root,
-            capture_output=True,
-        ).stdout
-    )
+    initial_metadata = metadata(root)
     expected_packages = publishable_packages(initial_metadata)
+    members = set(initial_metadata["workspace_members"])
+    workspace_names = {
+        package["name"]
+        for package in initial_metadata["packages"]
+        if package["id"] in members
+    }
+    before_lock = lock_packages(lockfile)
+    original_changelog = changelog.read_bytes() if changelog.exists() else None
 
-    # The manifest already names the next candidate. Give the pinned CLI the latest stable
-    # version as its baseline, then require its release plan to land exactly on that candidate.
-    set_workspace_version(manifest, stable)
+    baseline = stable if operation in ("stable", "start") else checked
+    command = [str(changelogs), "version"]
+    if operation in ("start", "advance"):
+        command.extend(["--prerelease", "rc"])
+
+    set_workspace_version(manifest, baseline)
     try:
         dry_run = run_preserving_lockfile(
-            [str(changelogs), "version", "--dry-run"],
-            root,
-            lockfile,
-            capture_output=True,
+            command + ["--dry-run"], root, lockfile, capture_output=True
         ).stdout
     finally:
-        set_workspace_version(manifest, candidate)
+        set_workspace_version(manifest, checked)
 
-    plan = release_plan(dry_run)
-    verify_release_plan(plan, expected_packages, candidate)
+    verify_release_plan(release_plan(dry_run), expected_packages, target)
 
-    set_workspace_version(manifest, stable)
+    set_workspace_version(manifest, baseline)
     try:
-        run_preserving_lockfile([str(changelogs), "version"], root, lockfile)
+        run_preserving_lockfile(command, root, lockfile)
         cli_version = workspace_version(manifest)
-    finally:
-        try:
-            if manifest.exists() and workspace_version(manifest) == candidate:
-                # The pinned CLI confuses Foundry's local `solar` package with the external
-                # `solar-compiler` dependency alias. Repair only that reviewed collision.
-                repair_solar_alias(manifest, original_manifest, candidate)
-            else:
-                manifest.write_text(original_manifest)
-        except Exception:
-            manifest.write_text(original_manifest)
-            raise
-    if cli_version != candidate:
-        raise ReleaseError("changelogs CLI did not write the expected workspace candidate")
+        # The pinned CLI confuses Foundry's local `solar` package with the external
+        # `solar-compiler` dependency alias. Repair only that reviewed collision.
+        repair_solar_alias(manifest, original_manifest, target)
+    except Exception:
+        manifest.write_text(original_manifest)
+        raise
+    if cli_version != target:
+        raise ReleaseError("changelogs CLI did not write the expected workspace target")
     if any(path.exists() for path in fragments):
-        raise ReleaseError("changelogs CLI did not consume every pending fragment")
+        raise ReleaseError("release operation did not consume every pending fragment")
+    if operation == "promote" and changelog.read_bytes() != original_changelog:
+        raise ReleaseError("promotion changed CHANGELOG.md")
 
-    verify_release_heading_count(changelog, candidate, 1)
+    verify_release_heading_count(changelog, target, 0 if operation == "promote" else 1)
 
-    metadata = json.loads(
-        run(
-            ["cargo", "metadata", "--locked", "--no-deps", "--format-version", "1"],
-            root,
-            capture_output=True,
-        ).stdout
-    )
-    package_count = verify_workspace_versions(metadata, candidate)
+    if operation != "stable":
+        run(["cargo", "update", "--workspace"], root)
+        verify_lock_change(
+            before_lock,
+            lock_packages(lockfile),
+            workspace_names,
+            checked,
+            target,
+        )
+    package_count = verify_workspace_versions(metadata(root), target)
 
-    verify_changed_paths(root, fragments)
+    verify_changed_paths(root, fragments, operation)
 
-    expected_tag = f"v{candidate}"
+    expected_tag = f"v{target}"
     source_sha = run(["git", "rev-parse", "HEAD"], root, capture_output=True).stdout.strip()
     set_output("changed", "true")
+    set_output("source_tag", source)
     set_output("source_sha", source_sha)
-    set_output("expected_version", candidate)
+    set_output("expected_version", target)
     set_output("expected_tag", expected_tag)
     set_output("fragment_count", str(len(fragments)))
     set_output("package_count", str(package_count))
     print(
-        f"Prepared {expected_tag} from {len(fragments)} fragment(s); "
+        f"Prepared {operation} transition to {expected_tag} from {len(fragments)} fragment(s); "
         f"verified {package_count} workspace packages."
     )
 
@@ -430,9 +641,13 @@ def prepare(root: Path, changelogs: Path) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--changelogs", type=Path, help="Pinned changelogs binary")
+    parser.add_argument("--operation", choices=sorted(OPERATIONS), default="stable")
+    parser.add_argument("--source-tag")
+    parser.add_argument("--target-tag")
     parser.add_argument("--validate-merged", action="store_true")
     parser.add_argument("--expected-sha")
     parser.add_argument("--expected-source-sha")
+    parser.add_argument("--expected-source-tag")
     parser.add_argument("--expected-version")
     parser.add_argument("--expected-tag")
     parser.add_argument("--expected-fragment-count", type=int)
@@ -446,6 +661,7 @@ def main() -> int:
             expected = {
                 "--expected-sha": args.expected_sha,
                 "--expected-source-sha": args.expected_source_sha,
+                "--expected-source-tag": args.expected_source_tag,
                 "--expected-version": args.expected_version,
                 "--expected-tag": args.expected_tag,
                 "--expected-fragment-count": args.expected_fragment_count,
@@ -456,8 +672,10 @@ def main() -> int:
                 parser.error(f"--validate-merged requires {', '.join(missing)}")
             validate_merged(
                 root,
+                args.operation,
                 args.expected_sha,
                 args.expected_source_sha,
+                args.expected_source_tag,
                 args.expected_version,
                 args.expected_tag,
                 args.expected_fragment_count,
@@ -466,7 +684,15 @@ def main() -> int:
         else:
             if args.changelogs is None:
                 parser.error("--changelogs is required unless --validate-merged is used")
-            prepare(root, args.changelogs.resolve())
+            if args.operation != "stable" and (args.source_tag is None or args.target_tag is None):
+                parser.error("manual operations require --source-tag and --target-tag")
+            prepare(
+                root,
+                args.changelogs.resolve(),
+                args.operation,
+                args.source_tag,
+                args.target_tag,
+            )
     except subprocess.CalledProcessError as error:
         output = error.stdout
         if isinstance(output, bytes):

--- a/.github/scripts/tests/test_prepare_stable_release.py
+++ b/.github/scripts/tests/test_prepare_stable_release.py
@@ -64,11 +64,15 @@ class VersionTests(unittest.TestCase):
             self.assertEqual(lockfile.read_bytes(), b"reviewed lockfile\n")
 
     def test_accepts_stable_version(self) -> None:
-        self.assertEqual(prepare_stable_release.parse_version("1.7.2"), (1, 7, 2))
+        self.assertEqual(prepare_stable_release.parse_version("1.7.2"), (1, 7, 2, None))
 
-    def test_rejects_prerelease_version(self) -> None:
-        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "stable X.Y.Z"):
-            prepare_stable_release.parse_version("1.7.2-rc1")
+    def test_accepts_only_strict_rc_versions(self) -> None:
+        self.assertEqual(prepare_stable_release.parse_version("1.7.2-rc1"), (1, 7, 2, 1))
+        for version in ["1.7.2-rc", "1.7.2-rc0", "1.7.2-rc01", "1.7.2-rc.1"]:
+            with self.subTest(version=version), self.assertRaisesRegex(
+                prepare_stable_release.ReleaseError, "strict|canonical"
+            ):
+                prepare_stable_release.parse_version(version)
 
     def test_rejects_noncanonical_stable_version(self) -> None:
         with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "canonical"):
@@ -80,6 +84,53 @@ class VersionTests(unittest.TestCase):
         )
         self.assertEqual(tag, "v1.7.1")
         self.assertEqual(version, (1, 7, 1))
+
+    def test_all_release_transitions(self) -> None:
+        stable = (1, 7, 1)
+        self.assertEqual(
+            prepare_stable_release.transition("stable", "1.7.2", stable, {}, None, None),
+            ("v1.7.1", "1.7.2"),
+        )
+        self.assertEqual(
+            prepare_stable_release.transition(
+                "start", "1.7.2", stable, {}, "v1.7.1", "v1.7.2-rc1"
+            ),
+            ("v1.7.1", "1.7.2-rc1"),
+        )
+        tags = {"v1.7.2-rc1": (1, 7, 2, 1)}
+        self.assertEqual(
+            prepare_stable_release.transition(
+                "advance", "1.7.2-rc1", stable, tags, "v1.7.2-rc1", "v1.7.2-rc2"
+            ),
+            ("v1.7.2-rc1", "1.7.2-rc2"),
+        )
+        self.assertEqual(
+            prepare_stable_release.transition(
+                "promote", "1.7.2-rc1", stable, tags, "v1.7.2-rc1", "v1.7.2"
+            ),
+            ("v1.7.2-rc1", "1.7.2"),
+        )
+
+    def test_rejects_stale_confirmation_existing_target_and_rc_gaps(self) -> None:
+        stable = (1, 7, 1)
+        tags = {"v1.7.2-rc1": (1, 7, 2, 1), "v1.7.2-rc3": (1, 7, 2, 3)}
+        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "latest same-core"):
+            prepare_stable_release.transition(
+                "advance", "1.7.2-rc1", stable, tags, "v1.7.2-rc1", "v1.7.2-rc2"
+            )
+        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "not contiguous"):
+            prepare_stable_release.transition(
+                "advance", "1.7.2-rc3", stable, tags, "v1.7.2-rc3", "v1.7.2-rc4"
+            )
+        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "already exists"):
+            prepare_stable_release.transition(
+                "start",
+                "1.7.2",
+                stable,
+                {"v1.7.2-rc1": (1, 7, 2, 1)},
+                "v1.7.1",
+                "v1.7.2-rc1",
+            )
 
     def test_extracts_full_release_plan(self) -> None:
         output = "✓ forge 1.7.1 → 1.7.2\n✓ cast 1.7.1 → 1.7.2\n"
@@ -230,14 +281,37 @@ class WorkspaceTests(unittest.TestCase):
         with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "omitted.*cast"):
             prepare_stable_release.verify_workspace_versions(metadata, "1.7.2")
 
-    def test_accepts_exact_stable_diff(self) -> None:
-        prepare_stable_release.verify_stable_diff(
-            {"CHANGELOG.md": "M", ".changelog/release.md": "D"}, 1
-        )
+    def test_accepts_exact_release_diff_for_every_operation(self) -> None:
+        cases = {
+            "stable": ({"CHANGELOG.md": "M", ".changelog/release.md": "D"}, 1),
+            "start": (
+                {
+                    "Cargo.toml": "M",
+                    "Cargo.lock": "M",
+                    "CHANGELOG.md": "M",
+                    ".changelog/release.md": "D",
+                },
+                1,
+            ),
+            "advance": (
+                {
+                    "Cargo.toml": "M",
+                    "Cargo.lock": "M",
+                    "CHANGELOG.md": "M",
+                    ".changelog/release.md": "D",
+                },
+                1,
+            ),
+            "promote": ({"Cargo.toml": "M", "Cargo.lock": "M"}, 0),
+        }
+        for operation, (statuses, count) in cases.items():
+            with self.subTest(operation=operation):
+                prepare_stable_release.verify_release_diff_statuses(
+                    statuses, operation, count
+                )
 
-    def test_rejects_wrong_stable_diff_status_path_and_count(self) -> None:
+    def test_rejects_wrong_release_diff_status_path_and_count(self) -> None:
         cases = [
-            ({"CHANGELOG.md": "A", ".changelog/release.md": "D"}, 1),
             ({"CHANGELOG.md": "M", ".changelog/release.md": "M"}, 1),
             ({"CHANGELOG.md": "M", "Cargo.lock": "M", ".changelog/release.md": "D"}, 1),
             ({"CHANGELOG.md": "M", ".changelog/release.md": "D"}, 2),
@@ -247,7 +321,22 @@ class WorkspaceTests(unittest.TestCase):
             with self.subTest(statuses=statuses, count=count), self.assertRaisesRegex(
                 prepare_stable_release.ReleaseError, "stable release diff"
             ):
-                prepare_stable_release.verify_stable_diff(statuses, count)
+                prepare_stable_release.verify_release_diff_statuses(statuses, "stable", count)
+
+    def test_fragment_requirements_for_manual_operations(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / ".changelog").mkdir()
+            (root / "Cargo.toml").write_text('[workspace.package]\nversion = "1.7.2"\n')
+            with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "requires pending"):
+                prepare_stable_release.prepare(
+                    root, root / "changelogs", "start", "v1.7.1", "v1.7.2-rc1"
+                )
+            (root / ".changelog" / "pending.md").write_text("pending\n")
+            with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "zero pending"):
+                prepare_stable_release.prepare(
+                    root, root / "changelogs", "promote", "v1.7.2-rc1", "v1.7.2"
+                )
 
     def test_rejects_rename_copy_and_malformed_diff_status(self) -> None:
         for output in ["R100\told\tnew\n", "C100\told\tnew\n", "malformed\n"]:
@@ -275,7 +364,44 @@ class WorkspaceTests(unittest.TestCase):
             output = root / "output"
             with patch.dict(os.environ, {"GITHUB_OUTPUT": str(output)}):
                 prepare_stable_release.prepare(root, root / "changelogs")
-            self.assertEqual(output.read_text(), "base_branch=master\nchanged=false\n")
+            self.assertEqual(
+                output.read_text(), "base_branch=master\noperation=stable\nchanged=false\n"
+            )
+
+    def test_stable_skips_active_rc(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / ".changelog").mkdir()
+            (root / ".changelog" / "pending.md").write_text("pending\n")
+            (root / "Cargo.toml").write_text(
+                '[workspace.package]\nversion = "1.7.2-rc1"\n'
+            )
+            output = root / "output"
+            with patch.dict(os.environ, {"GITHUB_OUTPUT": str(output)}):
+                prepare_stable_release.prepare(root, root / "changelogs")
+            self.assertEqual(
+                output.read_text(), "base_branch=master\noperation=stable\nchanged=false\n"
+            )
+
+    def test_lock_change_accepts_only_workspace_versions(self) -> None:
+        before = [
+            {"name": "forge", "version": "1.7.2", "dependencies": ["cast 1.7.2"]},
+            {"name": "cast", "version": "1.7.2"},
+            {"name": "external", "version": "1.0.0", "source": "registry", "checksum": "a"},
+        ]
+        after = [
+            {"name": "forge", "version": "1.7.2-rc1", "dependencies": ["cast 1.7.2-rc1"]},
+            {"name": "cast", "version": "1.7.2-rc1"},
+            {"name": "external", "version": "1.0.0", "source": "registry", "checksum": "a"},
+        ]
+        prepare_stable_release.verify_lock_change(
+            before, after, {"forge", "cast"}, "1.7.2", "1.7.2-rc1"
+        )
+        after[2]["checksum"] = "changed"
+        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "external"):
+            prepare_stable_release.verify_lock_change(
+                before, after, {"forge", "cast"}, "1.7.2", "1.7.2-rc1"
+            )
 
     def test_release_plan_warning_stops_before_mutation(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -285,6 +411,10 @@ class WorkspaceTests(unittest.TestCase):
             fragment.write_text("pending changelog\n")
             manifest = root / "Cargo.toml"
             manifest.write_text('[workspace.package]\nversion = "1.7.2"\n')
+            (root / "Cargo.lock").write_text(
+                'version = 4\n\n[[package]]\nname = "forge"\nversion = "1.7.2"\n'
+                '\n[[package]]\nname = "cast"\nversion = "1.7.2"\n'
+            )
             metadata = {
                 "workspace_members": ["forge", "cast"],
                 "packages": [
@@ -351,8 +481,10 @@ class MergedReleaseTests(unittest.TestCase):
     def validate(self, **overrides) -> None:
         arguments = {
             "root": self.root,
+            "operation": "stable",
             "expected_sha": "merged-sha",
             "source_sha": "source-sha",
+            "source_tag": "v1.7.1",
             "expected_version": "1.7.2",
             "expected_tag": "v1.7.2",
             "expected_fragment_count": 1,
@@ -365,6 +497,10 @@ class MergedReleaseTests(unittest.TestCase):
             prepare_stable_release, "verify_target_tag"
         ), patch.object(
             prepare_stable_release, "verify_ancestor"
+        ), patch.object(
+            prepare_stable_release,
+            "tag_state",
+            return_value=((1, 7, 1), {"v1.7.1": (1, 7, 1, None)}),
         ), patch.object(
             prepare_stable_release,
             "name_status",
@@ -386,11 +522,19 @@ class MergedReleaseTests(unittest.TestCase):
             return_value=subprocess.CompletedProcess([], returncode=0, stdout="later-sha\n"),
         ), self.assertRaisesRegex(prepare_stable_release.ReleaseError, "does not match merged"):
             prepare_stable_release.validate_merged(
-                self.root, "merged-sha", "source-sha", "1.7.2", "v1.7.2", 1, 2
+                self.root,
+                "stable",
+                "merged-sha",
+                "source-sha",
+                "v1.7.1",
+                "1.7.2",
+                "v1.7.2",
+                1,
+                2,
             )
 
     def test_rejects_metadata_mismatch(self) -> None:
-        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "pull request metadata"):
+        with self.assertRaisesRegex(prepare_stable_release.ReleaseError, "release metadata"):
             self.validate(expected_version="1.7.3", expected_tag="v1.7.3")
 
     def test_rejects_pending_fragment(self) -> None:
@@ -406,7 +550,7 @@ class MergedReleaseTests(unittest.TestCase):
         for path, message in [("Cargo.toml", "Cargo.toml"), ("Cargo.lock", "Cargo.lock")]:
             with self.subTest(path=path):
                 original = (self.root / path).read_bytes()
-                (self.root / path).write_bytes(original + b"changed\n")
+                (self.root / path).write_bytes(original + b"# changed\n")
                 try:
                     with self.assertRaisesRegex(prepare_stable_release.ReleaseError, message):
                         self.validate()

--- a/.github/workflows/stable-version-pr.yml
+++ b/.github/workflows/stable-version-pr.yml
@@ -1,5 +1,5 @@
 ---
-name: Stable Version PR
+name: Release Version PR
 
 permissions: {}
 
@@ -16,9 +16,21 @@ permissions: {}
       - '.github/scripts/prepare-stable-release.py'
       - '.github/workflows/stable-version-pr.yml'
   workflow_dispatch:
+    inputs:
+      operation:
+        description: RC operation
+        required: true
+        type: choice
+        options: [start, advance, promote]
+      source_tag:
+        description: Exact source tag confirmation
+        required: true
+      target_tag:
+        description: Exact target tag confirmation
+        required: true
 
 concurrency:
-  group: stable-version-pr
+  group: release-version-pr
   cancel-in-progress: false
 
 env:
@@ -31,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - name: Checkout master
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -38,7 +51,49 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Inspect existing release pull requests
+        id: inspect
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REQUESTED_OPERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.operation || 'stable' }}
+          REQUESTED_TARGET: ${{ inputs.target_tag || '' }}
+        with:
+          script: |
+            const prs = await github.paginate(github.rest.pulls.list, {
+              ...context.repo,
+              state: 'open',
+              base: 'master',
+              per_page: 100,
+            });
+            const repository = context.payload.repository.full_name;
+            const internal = prs.filter(pr => pr.head.repo.full_name === repository);
+            if (internal.some(pr => pr.head.ref === 'release/stable')) {
+              throw new Error('Close the legacy release/stable pull request first');
+            }
+            const release = internal.find(pr => pr.head.ref === 'release/version');
+            if (!release) return;
+            const operation = /- Operation: `([^`]+)`/.exec(release.body || '')?.[1];
+            const target = /- Target tag: `([^`]+)`/.exec(release.body || '')?.[1];
+            if (!['stable', 'start', 'advance', 'promote'].includes(operation) || !target) {
+              throw new Error('release/version contains malformed release metadata');
+            }
+            if (context.eventName === 'push') {
+              if (operation !== 'stable') {
+                core.setOutput('skip', 'true');
+              } else {
+                core.setOutput('cleanup', 'true');
+              }
+              return;
+            }
+            if (
+              operation !== process.env.REQUESTED_OPERATION ||
+              target !== process.env.REQUESTED_TARGET
+            ) {
+              throw new Error(`release/version already contains ${operation} ${target}`);
+            }
+
       - name: Detect pending changelog fragments
+        if: steps.inspect.outputs.skip != 'true'
         id: fragments
         run: |
           if [[ -n "$(find .changelog -maxdepth 1 -type f -name '*.md' ! -name README.md -print -quit)" ]]; then
@@ -48,7 +103,7 @@ jobs:
           fi
 
       - name: Install pinned changelogs CLI
-        if: steps.fragments.outputs.found == 'true'
+        if: steps.inspect.outputs.skip != 'true' && (steps.fragments.outputs.found == 'true' || inputs.operation == 'promote')
         run: |
           cargo install \
             --git https://github.com/tempoxyz/changelogs \
@@ -56,22 +111,33 @@ jobs:
             --locked \
             --root "$RUNNER_TEMP/changelogs"
 
-      - name: Prepare stable release
+      - name: Prepare release
+        if: steps.inspect.outputs.skip != 'true'
         id: prepare
+        env:
+          OPERATION: ${{ github.event_name == 'workflow_dispatch' && inputs.operation || 'stable' }}
+          SOURCE_TAG: ${{ inputs.source_tag || '' }}
+          TARGET_TAG: ${{ inputs.target_tag || '' }}
         run: |
-          python3 ./.github/scripts/prepare-stable-release.py \
+          args=(
             --changelogs "$RUNNER_TEMP/changelogs/bin/changelogs"
+            --operation "$OPERATION"
+          )
+          if [[ "$OPERATION" != stable ]]; then
+            args+=(--source-tag "$SOURCE_TAG" --target-tag "$TARGET_TAG")
+          fi
+          python3 ./.github/scripts/prepare-stable-release.py "${args[@]}"
 
       - name: Show disabled production changes
         if: steps.prepare.outputs.changed == 'true' && env.STABLE_VERSION_PRS_ENABLED != 'true'
         run: |
-          echo "Stable version PR writes remain disabled until changelog validation is required."
+          echo "Release version PR writes are disabled."
           git status --short
           git diff --stat
 
       - name: Create repository-scoped App token
         id: app-token
-        if: env.STABLE_VERSION_PRS_ENABLED == 'true'
+        if: (steps.prepare.outputs.changed == 'true' || steps.inspect.outputs.cleanup == 'true') && env.STABLE_VERSION_PRS_ENABLED == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.FOUNDRY_RELEASE_APP_ID }}
@@ -82,7 +148,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Verify checked-out master is current
-        if: env.STABLE_VERSION_PRS_ENABLED == 'true'
+        if: (steps.prepare.outputs.changed == 'true' || steps.inspect.outputs.cleanup == 'true') && env.STABLE_VERSION_PRS_ENABLED == 'true'
         run: |
           git fetch --no-tags origin +master:refs/remotes/origin/master
           checked_out=$(git rev-parse HEAD)
@@ -92,14 +158,14 @@ jobs:
             exit 1
           fi
 
-      - name: Reconcile stable version PR
-        if: env.STABLE_VERSION_PRS_ENABLED == 'true'
+      - name: Reconcile release version PR
+        if: (steps.prepare.outputs.changed == 'true' || steps.inspect.outputs.cleanup == 'true') && env.STABLE_VERSION_PRS_ENABLED == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch-token: ${{ steps.app-token.outputs.token }}
           base: ${{ steps.prepare.outputs.base_branch }}
-          branch: release/stable
+          branch: release/version
           delete-branch: true
           add-paths: |
             .changelog
@@ -110,14 +176,14 @@ jobs:
           title: "chore: prepare ${{ steps.prepare.outputs.expected_tag }}"
           labels: L-ignore
           body: |
-            <!-- foundry-stable-version-pr -->
-            Prepares Foundry ${{ steps.prepare.outputs.expected_version }} from pending changelog entries.
+            <!-- foundry-release-version-pr -->
+            Prepares an exact Foundry release transition.
 
+            - Operation: `${{ steps.prepare.outputs.operation }}`
             - Base branch: `${{ steps.prepare.outputs.base_branch }}`
             - Source master SHA: `${{ steps.prepare.outputs.source_sha }}`
-            - Expected version: `${{ steps.prepare.outputs.expected_version }}`
-            - Expected tag: `${{ steps.prepare.outputs.expected_tag }}`
+            - Source tag: `${{ steps.prepare.outputs.source_tag }}`
+            - Target version: `${{ steps.prepare.outputs.expected_version }}`
+            - Target tag: `${{ steps.prepare.outputs.expected_tag }}`
             - Changelog fragments: ${{ steps.prepare.outputs.fragment_count }}
-            - Verified workspace packages: ${{ steps.prepare.outputs.package_count }}
-
-            This pull request does not create a tag, GitHub release, or registry publication.
+            - Workspace packages: ${{ steps.prepare.outputs.package_count }}

--- a/.github/workflows/tag-stable-release.yml
+++ b/.github/workflows/tag-stable-release.yml
@@ -1,5 +1,5 @@
 ---
-name: Validate and Tag Stable Release
+name: Validate and Tag Release
 
 permissions: {}
 
@@ -12,16 +12,16 @@ permissions: {}
     types: [closed]
 
 concurrency:
-  group: tag-stable-release-${{ github.event.pull_request.number }}
+  group: tag-release-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
   validate:
-    name: Validate stable release
+    name: Validate release
     if: >-
       (github.event_name == 'pull_request' || github.event.pull_request.merged == true) &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.head.ref == 'release/stable'
+      github.event.pull_request.head.ref == 'release/version'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -39,7 +39,7 @@ jobs:
             .github/scripts/prepare-stable-release.py
           sparse-checkout-cone-mode: false
 
-      - name: Recognize stable version pull request
+      - name: Recognize release version pull request
         id: release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -52,51 +52,55 @@ jobs:
               throw new Error('FOUNDRY_RELEASE_APP_BOT_ID is not configured');
             }
             if (pr.user?.type !== 'Bot' || String(pr.user.id) !== process.env.RELEASE_APP_BOT_ID) {
-              throw new Error('Stable version pull request was not created by the release App');
+              throw new Error('Release version pull request was not created by the release App');
             }
             if (pr.base.ref !== 'master' || pr.base.repo.full_name !== repository) {
-              throw new Error('Stable version pull request does not target this repository master');
+              throw new Error('Release version pull request does not target this repository master');
             }
-            if (pr.head.ref !== 'release/stable' || pr.head.repo.full_name !== repository) {
-              throw new Error('Stable version pull request did not use the release/stable branch');
+            if (pr.head.ref !== 'release/version' || pr.head.repo.full_name !== repository) {
+              throw new Error('Release version pull request did not use the release/version branch');
             }
 
-            const marker = '<!-- foundry-stable-version-pr -->';
+            const marker = '<!-- foundry-release-version-pr -->';
             const metadata = new RegExp(
-              `${marker}\\nPrepares Foundry (\\d+\\.\\d+\\.\\d+) from pending changelog entries\\.\\n\\n` +
+              `${marker}\\nPrepares an exact Foundry release transition\\.\\n\\n` +
+              '- Operation: `(stable|start|advance|promote)`\\n' +
               '- Base branch: `master`\\n' +
               '- Source master SHA: `([0-9a-f]{40})`\\n' +
-              '- Expected version: `([^`]+)`\\n' +
-              '- Expected tag: `([^`]+)`\\n' +
+              '- Source tag: `(v[^`]+)`\\n' +
+              '- Target version: `([^`]+)`\\n' +
+              '- Target tag: `(v[^`]+)`\\n' +
               '- Changelog fragments: (\\d+)\\n' +
-              '- Verified workspace packages: (\\d+)\\n',
+              '- Workspace packages: (\\d+)\\n?$',
             ).exec(pr.body || '');
-            if (!metadata) throw new Error('Stable version pull request metadata is malformed');
-            if (metadata[1] !== metadata[3]) {
-              throw new Error('Stable version pull request versions do not match');
+            if (!metadata) throw new Error('Release version pull request metadata is malformed');
+            if (metadata[5] !== `v${metadata[4]}`) {
+              throw new Error('Release version pull request tag does not match its version');
             }
-            if (metadata[4] !== `v${metadata[1]}`) {
-              throw new Error('Stable version pull request tag does not match its version');
+            if (pr.title !== `chore: prepare ${metadata[5]}`) {
+              throw new Error('Release version pull request title does not match its tag');
             }
-            if (pr.title !== `chore: prepare ${metadata[4]}`) {
-              throw new Error('Stable version pull request title does not match its tag');
+            if ((metadata[1] === 'promote') !== (Number(metadata[6]) === 0)) {
+              throw new Error('Release version pull request has invalid fragment semantics');
             }
             if (context.eventName === 'pull_request') {
               const master = await github.rest.repos.getCommit({ ...context.repo, ref: 'master' });
               if (metadata[2] !== pr.base.sha || metadata[2] !== master.data.sha) {
-                throw new Error('Stable version pull request was prepared from a stale master commit');
+                throw new Error('Release version pull request was prepared from a stale master commit');
               }
             }
             const sha = context.eventName === 'pull_request' ? context.sha : pr.merge_commit_sha;
             if (!/^[0-9a-f]{40}$/i.test(sha || '')) {
-              throw new Error('Stable version pull request has no exact validation commit');
+              throw new Error('Release version pull request has no exact validation commit');
             }
 
-            core.setOutput('version', metadata[1]);
+            core.setOutput('operation', metadata[1]);
             core.setOutput('source_sha', metadata[2]);
-            core.setOutput('tag', metadata[4]);
-            core.setOutput('fragment_count', metadata[5]);
-            core.setOutput('package_count', metadata[6]);
+            core.setOutput('source_tag', metadata[3]);
+            core.setOutput('version', metadata[4]);
+            core.setOutput('tag', metadata[5]);
+            core.setOutput('fragment_count', metadata[6]);
+            core.setOutput('package_count', metadata[7]);
             core.setOutput('sha', sha);
 
       - name: Checkout exact release tree
@@ -125,15 +129,19 @@ jobs:
           python3 trusted/.github/scripts/prepare-stable-release.py \
             --validate-merged \
             --root release \
+            --operation "$OPERATION" \
             --expected-sha "$MERGE_SHA" \
             --expected-source-sha "$SOURCE_SHA" \
+            --expected-source-tag "$SOURCE_TAG" \
             --expected-version "$EXPECTED_VERSION" \
             --expected-tag "$EXPECTED_TAG" \
             --expected-fragment-count "$EXPECTED_FRAGMENT_COUNT" \
             --expected-package-count "$EXPECTED_PACKAGE_COUNT"
         env:
+          OPERATION: ${{ steps.release.outputs.operation }}
           MERGE_SHA: ${{ steps.release.outputs.sha }}
           SOURCE_SHA: ${{ steps.release.outputs.source_sha }}
+          SOURCE_TAG: ${{ steps.release.outputs.source_tag }}
           EXPECTED_VERSION: ${{ steps.release.outputs.version }}
           EXPECTED_TAG: ${{ steps.release.outputs.tag }}
           EXPECTED_FRAGMENT_COUNT: ${{ steps.release.outputs.fragment_count }}


### PR DESCRIPTION
Adds explicit operations to start, advance, and promote release candidates through the existing version PR and exact-tag pipeline. Stacked on #15981. 

Closes OSS-591