### PR TITLE
fix(tempo): use canonical Accounts store locking

### DIFF
--- a/.changelog/tempo-canonical-accounts-store-lock.md
+++ b/.changelog/tempo-canonical-accounts-store-lock.md
@@ -1,0 +1,6 @@
+---
+cast: patch
+foundry-common: patch
+---
+
+Delegated Tempo Accounts store mutations to the SDK's canonical cross-process lock, preventing nested lock deadlocks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=db89c09221b82e906d9ad697e4bad92423b59643#db89c09221b82e906d9ad697e4bad92423b59643"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=249ee928a0f90dc7e56fa097401644ad7d9bd361#249ee928a0f90dc7e56fa097401644ad7d9bd361"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -5497,7 +5497,6 @@ dependencies = [
  "foundry-config",
  "foundry-evm-hardforks",
  "foundry-wallets",
- "fs2",
  "itertools 0.15.0",
  "jiff",
  "k256",
@@ -6066,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=7c633b142b1d5f4bd75a34d6c12cf13ea49ba468#7c633b142b1d5f4bd75a34d6c12cf13ea49ba468"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=50bce74973f82db24de2bc77016fe0d0e446b9fa#50bce74973f82db24de2bc77016fe0d0e446b9fa"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -6103,6 +6102,7 @@ dependencies = [
  "tracing",
  "uuid 1.24.0",
  "webbrowser",
+ "zeroize",
 ]
 
 [[package]]
@@ -7748,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=db89c09221b82e906d9ad697e4bad92423b59643#db89c09221b82e906d9ad697e4bad92423b59643"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=249ee928a0f90dc7e56fa097401644ad7d9bd361#249ee928a0f90dc7e56fa097401644ad7d9bd361"
 dependencies = [
  "alloy",
  "async-stream",
@@ -9698,7 +9698,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9778,7 +9778,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.5",
@@ -9792,7 +9792,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9818,7 +9818,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9834,7 +9834,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9847,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9861,7 +9861,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.5",
@@ -9870,6 +9870,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "derive_more",
+ "fixed-cache",
  "futures-util",
  "rayon",
  "reth-execution-errors",
@@ -9884,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9904,7 +9905,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9917,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9936,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10001,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10015,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10043,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10055,7 +10056,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10069,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928 0.4.5",
@@ -10094,7 +10095,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10111,7 +10112,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10121,7 +10122,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12078,7 +12079,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12118,7 +12119,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12141,7 +12142,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12153,7 +12154,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12165,7 +12166,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12196,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12208,7 +12209,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12231,7 +12232,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12242,7 +12243,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12269,7 +12270,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1#ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1"
+source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=249ee928a0f90dc7e56fa097401644ad7d9bd361#249ee928a0f90dc7e56fa097401644ad7d9bd361"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=66ed774556d1ef59c2703aef5cfddfd87f846846#66ed774556d1ef59c2703aef5cfddfd87f846846"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -6065,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=50bce74973f82db24de2bc77016fe0d0e446b9fa#50bce74973f82db24de2bc77016fe0d0e446b9fa"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7748,7 +7748,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=249ee928a0f90dc7e56fa097401644ad7d9bd361#249ee928a0f90dc7e56fa097401644ad7d9bd361"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=66ed774556d1ef59c2703aef5cfddfd87f846846#66ed774556d1ef59c2703aef5cfddfd87f846846"
 dependencies = [
  "alloy",
  "async-stream",
@@ -12079,7 +12079,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12119,7 +12119,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12142,7 +12142,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12154,7 +12154,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12166,7 +12166,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12197,7 +12197,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12209,7 +12209,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12232,7 +12232,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12243,7 +12243,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12270,7 +12270,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=c72b8e98efeef1246a9b5f47f1f7b948259768af#c72b8e98efeef1246a9b5f47f1f7b948259768af"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "50bce74973f82db24de2bc77016fe0d0e446b9fa", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "fb7922c0e92cf52b5cbca73826fb05ca7e32a50f", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -512,30 +512,30 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "249ee928a0f90dc7e56fa097401644ad7d9bd361", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "66ed774556d1ef59c2703aef5cfddfd87f846846", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "249ee928a0f90dc7e56fa097401644ad7d9bd361", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "66ed774556d1ef59c2703aef5cfddfd87f846846", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -629,9 +629,9 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = 
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "7c633b142b1d5f4bd75a34d6c12cf13ea49ba468", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "50bce74973f82db24de2bc77016fe0d0e446b9fa", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -510,33 +510,32 @@ heck = "0.5"
 uuid = "1.19.0"
 flate2 = "1.1"
 ethereum_ssz = "0.10"
-fs2 = "0.4"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "db89c09221b82e906d9ad697e4bad92423b59643", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "249ee928a0f90dc7e56fa097401644ad7d9bd361", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "db89c09221b82e906d9ad697e4bad92423b59643", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "249ee928a0f90dc7e56fa097401644ad7d9bd361", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -630,9 +629,9 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = 
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "ddbe8350c5b449a6bb98660e21bb6e9107f3cbe1" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c72b8e98efeef1246a9b5f47f1f7b948259768af" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/crates/cast/src/cmd/tempo.rs
+++ b/crates/cast/src/cmd/tempo.rs
@@ -2,10 +2,8 @@ use alloy_primitives::Address;
 use alloy_signer_local::PrivateKeySigner;
 use clap::Parser;
 use eyre::Result;
-use foundry_common::tempo::{
-    EnsureAccessKeyConfig, decode_key_authorization, ensure_access_key,
-    with_tempo_accounts_store_lock,
-};
+use foundry_common::tempo::{EnsureAccessKeyConfig, decode_key_authorization, ensure_access_key};
+use tempo_alloy::accounts::TempoAccountsStore;
 use tempo_primitives::transaction::SignedKeyAuthorization;
 
 /// Tempo wallet integration commands.
@@ -74,16 +72,14 @@ impl TempoSubcommand {
                     decode_key_authorization::<SignedKeyAuthorization>(&authorization)?;
                 let chain_id = authorization.chain_id;
                 let key_address = access_key.address();
-                let store_path = with_tempo_accounts_store_lock(|store| {
-                    store.upsert_secp256k1_access_key(account, &access_key, &authorization)?;
-                    Ok(store.path().to_path_buf())
-                })?;
+                let store = TempoAccountsStore::default_path()?;
+                store.upsert_secp256k1_access_key(account, &access_key, &authorization)?;
                 let _ = foundry_common::sh_status!(
                     "Imported access key {} for wallet {} on chain {} into {}",
                     key_address,
                     account,
                     chain_id,
-                    store_path.display(),
+                    store.path().display(),
                 );
                 Ok(())
             }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -81,7 +81,6 @@ flate2.workspace = true
 tempo-alloy.workspace = true
 tempo-primitives.workspace = true
 mpp.workspace = true
-fs2.workspace = true
 foundry-wallets = { workspace = true, features = ["browser", "tempo"] }
 alloy-signer-local = { workspace = true, features = ["mnemonic-all-languages"] }
 base64.workspace = true

--- a/crates/common/src/tempo/auth.rs
+++ b/crates/common/src/tempo/auth.rs
@@ -20,7 +20,7 @@ use std::{
     sync::LazyLock,
     time::{Duration, Instant},
 };
-use tempo_alloy::accounts::TempoAccountsKeyAuthorization;
+use tempo_alloy::accounts::{TempoAccountsKeyAuthorization, TempoAccountsStore};
 use tempo_primitives::transaction::{SignatureType, SignedKeyAuthorization};
 use tokio::sync::Mutex;
 
@@ -212,10 +212,11 @@ pub async fn ensure_access_key(cfg: EnsureAccessKeyConfig) -> Result<AccessKeyOu
                     );
                 }
                 let chain_id = signed.authorization.chain_id;
-                super::with_tempo_accounts_store_lock(|store| {
-                    store.upsert_secp256k1_access_key(account_address, &signer, &signed)?;
-                    Ok(())
-                })?;
+                TempoAccountsStore::default_path()?.upsert_secp256k1_access_key(
+                    account_address,
+                    &signer,
+                    &signed,
+                )?;
                 return Ok(AccessKeyOutcome {
                     wallet_address: account_address,
                     key_address,

--- a/crates/common/src/tempo/keystore.rs
+++ b/crates/common/src/tempo/keystore.rs
@@ -2,14 +2,8 @@
 
 use alloy_primitives::{Address, hex};
 use alloy_rlp::Decodable;
-use eyre::{Context, ContextCompat};
-use fs2::FileExt;
 use serde::{Deserialize, Serialize};
-use std::{
-    fs::{self, OpenOptions},
-    path::PathBuf,
-    sync::Mutex,
-};
+use std::path::PathBuf;
 use tempo_alloy::accounts::{TempoAccountsStore, default_accounts_store_path};
 use tempo_primitives::{
     SignatureType,
@@ -18,8 +12,6 @@ use tempo_primitives::{
 
 /// Environment variable to override the Tempo home directory.
 pub const TEMPO_HOME_ENV: &str = "TEMPO_HOME";
-
-static ACCOUNTS_STORE_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Cryptographic key type used by Tempo Accounts access keys.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
@@ -134,34 +126,6 @@ pub fn tempo_accounts_store_path() -> Option<PathBuf> {
     default_accounts_store_path().ok()
 }
 
-/// Run an Accounts store mutation while holding the common process and cross-process lock.
-pub fn with_tempo_accounts_store_lock<T>(
-    mutate: impl FnOnce(&TempoAccountsStore) -> eyre::Result<T>,
-) -> eyre::Result<T> {
-    let _process_guard = ACCOUNTS_STORE_MUTEX
-        .lock()
-        .map_err(|_| eyre::eyre!("Tempo Accounts store lock was poisoned"))?;
-    let store = TempoAccountsStore::default_path()?;
-    let store_dir = store.path().parent().context("Tempo Accounts store path has no parent")?;
-    fs::create_dir_all(store_dir).wrap_err_with(|| {
-        format!("failed to create Tempo Accounts store directory {}", store_dir.display())
-    })?;
-    let lock_path = store.path().with_extension("json.lock");
-    let lock_file = OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(&lock_path)
-        .wrap_err_with(|| {
-            format!("failed to open Tempo Accounts store lock {}", lock_path.display())
-        })?;
-    lock_file.lock_exclusive().wrap_err_with(|| {
-        format!("failed to lock Tempo Accounts store at {}", lock_path.display())
-    })?;
-    mutate(&store)
-}
-
 /// Read non-secret metadata from the canonical Tempo Accounts store.
 pub fn read_tempo_accounts_store() -> Option<AccountsStoreView> {
     let store = match TempoAccountsStore::try_open_default() {
@@ -205,53 +169,4 @@ pub fn decode_key_authorization<T: Decodable>(encoded: &str) -> eyre::Result<T> 
         eyre::bail!("key authorization has trailing bytes");
     }
     Ok(authorization)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::{
-        env,
-        process::{Command, Stdio},
-        thread,
-        time::Duration,
-    };
-
-    const LOCK_TEST_COUNTER_ENV: &str = "FOUNDRY_TEMPO_LOCK_TEST_COUNTER";
-
-    #[test]
-    fn accounts_store_lock_helper() {
-        let Ok(counter_path) = env::var(LOCK_TEST_COUNTER_ENV) else { return };
-        with_tempo_accounts_store_lock(|_| {
-            let count = fs::read_to_string(&counter_path)?.parse::<u64>()?;
-            thread::sleep(Duration::from_millis(100));
-            fs::write(&counter_path, (count + 1).to_string())?;
-            Ok(())
-        })
-        .unwrap();
-    }
-
-    #[test]
-    fn accounts_store_lock_serializes_processes() {
-        let temp = tempfile::tempdir().unwrap();
-        let counter_path = temp.path().join("counter");
-        fs::write(&counter_path, "0").unwrap();
-        let test_exe = env::current_exe().unwrap();
-        let mut children = (0..2)
-            .map(|_| {
-                Command::new(&test_exe)
-                    .args(["--exact", "tempo::keystore::tests::accounts_store_lock_helper"])
-                    .env(TEMPO_HOME_ENV, temp.path())
-                    .env(LOCK_TEST_COUNTER_ENV, &counter_path)
-                    .stdout(Stdio::null())
-                    .spawn()
-                    .unwrap()
-            })
-            .collect::<Vec<_>>();
-
-        for child in &mut children {
-            assert!(child.wait().unwrap().success());
-        }
-        assert_eq!(fs::read_to_string(counter_path).unwrap(), "2");
-    }
 }

--- a/crates/common/src/tempo/session.rs
+++ b/crates/common/src/tempo/session.rs
@@ -332,10 +332,12 @@ pub fn upsert_session_entry(entry: SessionEntry) -> eyre::Result<()> {
         .ok_or_else(|| eyre::eyre!("managed access key has no signed authorization"))?;
     let authorization = super::decode_key_authorization::<SignedKeyAuthorization>(encoded)?;
     validate_signed_session_authorization(&entry, SignatureType::Secp256k1, &authorization)?;
-    super::with_tempo_accounts_store_lock(|store| {
-        store.upsert_secp256k1_access_key(entry.root_account, &signer, &authorization)?;
-        Ok(())
-    })
+    TempoAccountsStore::default_path()?.upsert_secp256k1_access_key(
+        entry.root_account,
+        &signer,
+        &authorization,
+    )?;
+    Ok(())
 }
 
 /// Retire local signing material in `store.json` for the selected managed key.
@@ -343,32 +345,29 @@ pub fn upsert_session_entry(entry: SessionEntry) -> eyre::Result<()> {
 /// The non-secret account, chain, policy, and authorization witness remain available for
 /// on-chain revoke retries.
 pub fn retire_session_entry(session_id: B256) -> eyre::Result<bool> {
-    super::with_tempo_accounts_store_lock(|store| {
-        let Some(entry) = read_session_entry(session_id)? else {
-            return Ok(false);
-        };
-        store
-            .retire_access_key(entry.root_account, entry.chain_id, entry.key_address)
-            .map_err(Into::into)
-    })
+    let Some(entry) = read_session_entry(session_id)? else {
+        return Ok(false);
+    };
+    TempoAccountsStore::default_path()?
+        .retire_access_key(entry.root_account, entry.chain_id, entry.key_address)
+        .map_err(Into::into)
 }
 
 /// Retire expired managed access keys and return the number changed.
 pub fn mark_expired_session_entries(now: u64) -> eyre::Result<usize> {
-    super::with_tempo_accounts_store_lock(|store| {
-        let Some(entries) = read_session_entries(now)? else {
-            return Ok(0);
-        };
-        let mut retired = 0;
-        for entry in entries {
-            if entry.status == SessionStatus::Expired
-                && store.retire_access_key(entry.root_account, entry.chain_id, entry.key_address)?
-            {
-                retired += 1;
-            }
+    let Some(entries) = read_session_entries(now)? else {
+        return Ok(0);
+    };
+    let store = TempoAccountsStore::default_path()?;
+    let mut retired = 0;
+    for entry in entries {
+        if entry.status == SessionStatus::Expired
+            && store.retire_access_key(entry.root_account, entry.chain_id, entry.key_address)?
+        {
+            retired += 1;
         }
-        Ok(retired)
-    })
+    }
+    Ok(retired)
 }
 
 fn read_session_entries(now: u64) -> eyre::Result<Option<Vec<SessionEntry>>> {

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -484,11 +484,11 @@ mod tests {
     fn test_tempo_hardfork_from_chain_and_timestamp() {
         assert_eq!(
             FoundryHardfork::from_chain_and_timestamp(4217, u64::MAX),
-            Some(FoundryHardfork::Tempo(TempoHardfork::T8))
+            Some(FoundryHardfork::Tempo(TempoHardfork::T9))
         );
         assert_eq!(
             FoundryHardfork::from_chain_and_timestamp(42431, u64::MAX),
-            Some(FoundryHardfork::Tempo(TempoHardfork::T8))
+            Some(FoundryHardfork::Tempo(TempoHardfork::T9))
         );
 
         assert_eq!(
@@ -516,6 +516,14 @@ mod tests {
             Some(FoundryHardfork::Tempo(TempoHardfork::T8))
         );
         assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(MAINNET_CHAIN_ID, MAINNET_T9_TIMESTAMP - 1),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T8))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(MAINNET_CHAIN_ID, MAINNET_T9_TIMESTAMP),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T9))
+        );
+        assert_eq!(
             FoundryHardfork::from_chain_and_timestamp(MODERATO_CHAIN_ID, MODERATO_T6_TIMESTAMP - 1),
             Some(FoundryHardfork::Tempo(TempoHardfork::T5))
         );
@@ -538,6 +546,14 @@ mod tests {
         assert_eq!(
             FoundryHardfork::from_chain_and_timestamp(MODERATO_CHAIN_ID, MODERATO_T8_TIMESTAMP),
             Some(FoundryHardfork::Tempo(TempoHardfork::T8))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(MODERATO_CHAIN_ID, MODERATO_T9_TIMESTAMP - 1),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T8))
+        );
+        assert_eq!(
+            FoundryHardfork::from_chain_and_timestamp(MODERATO_CHAIN_ID, MODERATO_T9_TIMESTAMP),
+            Some(FoundryHardfork::Tempo(TempoHardfork::T9))
         );
     }
 


### PR DESCRIPTION
## Summary

- pin Tempo to merged commit `bdc5c78c155d746d4e7f16d64b41ce791ba24580`, mpp-rs to merged commit `66ed774556d1ef59c2703aef5cfddfd87f846846`, and foundry-wallets to foundry-core merged commit `fb7922c0e92cf52b5cbca73826fb05ca7e32a50f`
- delegate every canonical Accounts-store mutation to tempo-alloy's internally locked upsert/retire APIs
- remove Foundry's duplicate process/file lock and direct `fs2` dependency

## Why

Tempo now owns the full cross-process lock/read/modify/atomic-write transaction for `store.json`. Keeping Foundry's outer lock would acquire the same exclusive sidecar lock twice through separate descriptors and can self-deadlock on Unix. Using tempo-alloy as the sole lock owner also ensures Foundry writers participate in the same protocol as other participating SDK consumers.

## Upstream rollout

- tempoxyz/tempo#6965 — merged
- tempoxyz/mpp-rs#365 — merged
- foundry-rs/foundry-core#138 — merged

## Testing

- `cargo +1.96.0 check -p foundry-common -p cast@1.7.2 --all-features --locked`
- `cargo +1.96.0 test -p foundry-common tempo --lib --locked` (46 passed)
- `cargo +1.96.0 test -p foundry-evm-hardforks@1.7.2 --locked` (12 passed against the final merged revisions)
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

Co-Authored-By: grandizzy <38490174+grandizzy@users.noreply.github.com>

Prompted by: George
