### PR TITLE
feat(cheatcodes): parse JSON comments

### DIFF
--- a/.changelog/jsonc-cheatcodes.md
+++ b/.changelog/jsonc-cheatcodes.md
@@ -1,0 +1,5 @@
+---
+forge: minor
+---
+
+Added support for line and block comments in JSON parsing cheatcodes.

--- a/crates/cheatcodes/src/json.rs
+++ b/crates/cheatcodes/src/json.rs
@@ -489,7 +489,73 @@ pub(super) fn parse_json_array_length(json: &str, key: &str) -> Result {
 }
 
 fn parse_json_str(json: &str) -> Result<Value> {
-    serde_json::from_str(json).map_err(|e| fmt_err!("failed parsing JSON: {e}"))
+    let json = strip_json_comments(json)?;
+    serde_json::from_str(&json).map_err(|e| fmt_err!("failed parsing JSON: {e}"))
+}
+
+fn strip_json_comments(json: &str) -> Result<Cow<'_, str>> {
+    let bytes = json.as_bytes();
+    let mut stripped = None;
+    let mut index = 0;
+    let mut in_string = false;
+
+    while index < bytes.len() {
+        if in_string {
+            match bytes[index] {
+                b'\\' => index += 2,
+                b'"' => {
+                    in_string = false;
+                    index += 1;
+                }
+                _ => index += 1,
+            }
+            continue;
+        }
+
+        match (bytes[index], bytes.get(index + 1)) {
+            (b'"', _) => {
+                in_string = true;
+                index += 1;
+            }
+            (b'/', Some(b'/')) => {
+                let stripped = stripped.get_or_insert_with(|| bytes.to_vec());
+                while index < bytes.len() && !matches!(bytes[index], b'\r' | b'\n') {
+                    stripped[index] = b' ';
+                    index += 1;
+                }
+            }
+            (b'/', Some(b'*')) => {
+                let stripped = stripped.get_or_insert_with(|| bytes.to_vec());
+                stripped[index] = b' ';
+                stripped[index + 1] = b' ';
+                index += 2;
+
+                let mut closed = false;
+                while index < bytes.len() {
+                    if bytes[index] == b'*' && bytes.get(index + 1) == Some(&b'/') {
+                        stripped[index] = b' ';
+                        stripped[index + 1] = b' ';
+                        index += 2;
+                        closed = true;
+                        break;
+                    }
+                    if !matches!(bytes[index], b'\r' | b'\n') {
+                        stripped[index] = b' ';
+                    }
+                    index += 1;
+                }
+                ensure!(closed, "failed parsing JSON: unterminated block comment");
+            }
+            _ => index += 1,
+        }
+    }
+
+    Ok(match stripped {
+        Some(stripped) => {
+            String::from_utf8(stripped).expect("comment stripping preserves valid UTF-8").into()
+        }
+        None => json.into(),
+    })
 }
 
 fn json_to_sol(defs: Option<&StructDefinitions>, json: &[&Value]) -> Result<Vec<DynSolValue>> {
@@ -896,6 +962,25 @@ mod tests {
     use foundry_common::fmt::{TypeDefMap, serialize_value_as_json};
     use proptest::{arbitrary::any, prop_oneof, strategy::Strategy};
     use std::collections::HashSet;
+
+    #[test]
+    fn test_parse_json_comments() {
+        let value = parse_json_str(
+            r#"{
+                // A line comment.
+                "value": 42,
+                /* A block comment. */
+                "url": "https://example.com/path/*literal*/"
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(value["value"], 42);
+        assert_eq!(value["url"], "https://example.com/path/*literal*/");
+
+        let error = parse_json_str(r#"{"value": 42} /* unterminated"#).unwrap_err();
+        assert!(error.to_string().contains("unterminated block comment"));
+    }
 
     fn valid_value(value: &DynSolValue) -> bool {
         (match value {

--- a/testdata/default/cheats/Json.t.sol
+++ b/testdata/default/cheats/Json.t.sol
@@ -141,6 +141,14 @@ contract ParseJsonTest is Test {
         assertEq("hai", decodedData);
     }
 
+    function test_parseJsonComments() public {
+        string memory jsonc = vm.readFile("fixtures/Json/comments.jsonc");
+
+        assertEq(vm.parseJsonUint(jsonc, ".value"), 42);
+        assertTrue(vm.parseJsonBool(jsonc, ".enabled"));
+        assertEq(vm.parseJsonString(jsonc, ".url"), "https://example.com/path/*literal*/");
+    }
+
     function test_null() public {
         bytes memory data = vm.parseJson(json, ".null");
         bytes memory decodedData = abi.decode(data, (bytes));

--- a/testdata/fixtures/Json/comments.jsonc
+++ b/testdata/fixtures/Json/comments.jsonc
@@ -1,0 +1,9 @@
+{
+  // Line comments are allowed in JSONC.
+  "value": 42,
+  /*
+   * Block comments are also allowed.
+   */
+  "enabled": true,
+  "url": "https://example.com/path/*literal*/"
+}


### PR DESCRIPTION
`vm.parseJson*` currently passes input directly to `serde_json`, so JSONC line and block comments fail before key selection. This adds a lightweight comment preprocessor at the shared parse boundary. It replaces comment contents with spaces while preserving line endings, only allocates when a comment is present, and leaves comment-like sequences inside JSON strings untouched.

The regression uses an actual `.jsonc` fixture containing both comment forms and a URL containing comment markers. The behavior applies consistently to the read-side JSON cheatcodes without changing strict JSON behavior such as trailing-comma rejection.

Closes #8135

This PR was written with Codex assistance for issue triage, implementation, tests, and PR text.
