### PR TITLE
perf(forge): speed up selector commands

### DIFF
--- a/.changelog/forge-selectors-cache.md
+++ b/.changelog/forge-selectors-cache.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Reused the preprocessed compiler cache for ABI-based `forge selectors` commands.

--- a/crates/forge/src/cmd/selectors.rs
+++ b/crates/forge/src/cmd/selectors.rs
@@ -98,13 +98,12 @@ impl SelectorsSubcommands {
                 }
 
                 sh_status!("Caching selectors for contracts in the project...")?;
-                let mut project = project_from_paths(project_paths)?;
-                let outcome =
-                    compile_abi_project(&mut project, ProjectCompiler::new().quiet(true))?;
+                let (mut project, compiler) = project_from_paths(project_paths)?;
+                let outcome = compile_abi_project(&mut project, compiler.quiet(true))?;
                 cache_local_signatures(&outcome)?;
             }
             Self::Upload { contract, all, project_paths } => {
-                let mut project = project_from_paths(project_paths)?;
+                let (mut project, compiler) = project_from_paths(project_paths)?;
                 let output = if let Some(contract_info) = &contract {
                     let Some(contract_name) = contract_info.name() else {
                         eyre::bail!("No contract name provided.");
@@ -114,9 +113,9 @@ impl SelectorsSubcommands {
                         .path()
                         .map(Ok)
                         .unwrap_or_else(|| project.find_contract_path(contract_name))?;
-                    compile_abi_project(&mut project, ProjectCompiler::new().files([target_path]))?
+                    compile_abi_project(&mut project, compiler.files([target_path]))?
                 } else {
-                    compile_abi_project(&mut project, ProjectCompiler::new())?
+                    compile_abi_project(&mut project, compiler)?
                 };
                 let artifacts = if all {
                     output
@@ -241,9 +240,8 @@ impl SelectorsSubcommands {
             }
             Self::List { contract, project_paths, no_group } => {
                 sh_status!("Listing selectors for contracts in the project...")?;
-                let mut project = project_from_paths(project_paths)?;
-                let outcome =
-                    compile_abi_project(&mut project, ProjectCompiler::new().quiet(true))?;
+                let (mut project, compiler) = project_from_paths(project_paths)?;
+                let outcome = compile_abi_project(&mut project, compiler.quiet(true))?;
                 let artifacts = if let Some(contract) = contract {
                     let found_artifact = outcome.find_first(&contract);
                     let artifact = found_artifact
@@ -377,9 +375,8 @@ impl SelectorsSubcommands {
             Self::Find { selector, project_paths } => {
                 sh_status!("Searching for selector {selector:?} in the project...")?;
 
-                let mut project = project_from_paths(project_paths)?;
-                let outcome =
-                    compile_abi_project(&mut project, ProjectCompiler::new().quiet(true))?;
+                let (mut project, compiler) = project_from_paths(project_paths)?;
+                let outcome = compile_abi_project(&mut project, compiler.quiet(true))?;
                 let artifacts = outcome
                     .into_artifacts_with_files()
                     .filter(|(file, _, _)| {
@@ -450,11 +447,14 @@ impl SelectorsSubcommands {
     }
 }
 
-fn project_from_paths(project_paths: ProjectPathOpts) -> Result<Project<MultiCompiler>> {
+fn project_from_paths(
+    project_paths: ProjectPathOpts,
+) -> Result<(Project<MultiCompiler>, ProjectCompiler)> {
     let config = BuildOpts { project_paths, ..Default::default() }.load_config()?;
+    let compiler = ProjectCompiler::new().dynamic_test_linking(config.dynamic_test_linking);
     let mut project = config.project()?;
     if !project.build_info {
         project.no_artifacts = true;
     }
-    Ok(project)
+    Ok((project, compiler))
 }

--- a/crates/forge/tests/cli/test_optimizer.rs
+++ b/crates/forge/tests/cli/test_optimizer.rs
@@ -1,7 +1,7 @@
-//! Tests for the `forge test` with preprocessed cache.
+//! Tests for commands using the preprocessed cache.
 
 #[cfg(unix)]
-forgetest_init!(filtered_tests_reuse_preprocessed_cache, |prj, cmd| {
+forgetest_init!(abi_commands_reuse_preprocessed_cache, |prj, cmd| {
     use foundry_test_utils::util::OutputExt;
     use std::{fs, os::unix::fs::PermissionsExt};
 
@@ -39,6 +39,9 @@ exit 1
         "cached ABI did not select CounterTest: {stdout}"
     );
     assert!(!invoked.exists(), "filtered test compilation did not reuse the preprocessed cache");
+
+    cmd.forge_fuse().args(["selectors", "list"]).assert_success();
+    assert!(!invoked.exists(), "selector compilation did not reuse the preprocessed cache");
 });
 
 // <https://github.com/foundry-rs/foundry/issues/8842>


### PR DESCRIPTION
## Summary

Reuses the project's dynamic test-linking mode for ABI-based `forge selectors` commands. This lets a warm normal build satisfy the narrower ABI request from its existing artifacts instead of invoking a fresh compiler job. `selectors collision` is intentionally unchanged because it requests method identifiers rather than ABI-only output.

AI assistance: Codex was used to investigate, benchmark, and implement this change.

## Benchmarks

Aave v4, warm normal cache, profiling builds, 10 runs:

| Command | master | PR | Speedup |
| --- | ---: | ---: | ---: |
| `forge selectors list` | `2.034s ± 0.161s` | `74.0ms ± 0.8ms` | `27.49x` |

Peak RSS averaged over three runs decreased from `1350.4 MiB` to `211.0 MiB` (`6.40x` lower).
