### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/.changelog/bump-version-1.8.0.md
+++ b/.changelog/bump-version-1.8.0.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Prepared the workspace for the Foundry 1.8.0 release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,7 +1224,7 @@ dependencies = [
 
 [[package]]
 name = "anvil"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-core"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -1325,7 +1325,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-rpc"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "anvil-server"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "anvil-rpc",
  "async-trait",
@@ -2907,7 +2907,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cast"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "chisel"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -5030,7 +5030,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "forge"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "forge-doc"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -5135,7 +5135,7 @@ dependencies = [
 
 [[package]]
 name = "forge-fmt"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "foundry-common",
  "foundry-config",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "forge-lint"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "forge-script-sequence"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "forge-sol-macro-gen"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "forge-verify"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-bench"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "chrono",
  "clap",
@@ -5328,7 +5328,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5386,7 +5386,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cheatcodes-spec"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-cli-markdown"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "clap",
  "pretty_assertions",
@@ -5457,7 +5457,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5528,7 +5528,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-common-fmt"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -5647,7 +5647,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-config"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -5689,7 +5689,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-debugger"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -5710,7 +5710,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-eips",
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-abi"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5762,7 +5762,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-core"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -5819,7 +5819,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-coverage"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-primitives",
  "eyre",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-fuzz"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-hardforks"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -5875,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-networks"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-eips",
@@ -5892,11 +5892,11 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-sancov"
-version = "1.7.2"
+version = "1.8.0"
 
 [[package]]
 name = "foundry-evm-symbolic"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-evm-traces"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-linking"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-primitives",
  "foundry-compilers",
@@ -5991,7 +5991,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-macros"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-primitives"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-test-utils"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6056,7 +6056,7 @@ dependencies = [
 
 [[package]]
 name = "foundry-tui"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "crossterm",
  "ratatui",
@@ -11449,7 +11449,7 @@ dependencies = [
 
 [[package]]
 name = "solar"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "solar-cli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.7.2"
+version = "1.8.0"
 edition = "2024"
 rust-version = "1.89"
 authors = ["Foundry Contributors"]


### PR DESCRIPTION
Bumps the workspace and lockfile package versions from 1.7.2 to 1.8.0. This aligns the stable release candidate with the minor release required by the pending `jsonc-cheatcodes` changelog fragment and unblocks the Stable Version PR workflow.

Includes a changelog fragment for the 1.8.0 release preparation.

This PR was written primarily by Codex.

Prompted by: @grandizzy
