### PR TITLE
fix(cast): accept 0x-prefixed vanity patterns

### DIFF
--- a/.changelog/accept-prefixed-vanity-patterns.md
+++ b/.changelog/accept-prefixed-vanity-patterns.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Accepted `0x`-prefixed patterns in `cast wallet vanity`.

--- a/crates/cast/src/cmd/wallet/vanity.rs
+++ b/crates/cast/src/cmd/wallet/vanity.rs
@@ -343,6 +343,12 @@ impl VanityMatcher for RegexMatcher {
 }
 
 fn parse_pattern(pattern: &str, is_start: bool) -> Result<Either<Vec<u8>, Regex>> {
+    let pattern =
+        pattern.strip_prefix("0x").or_else(|| pattern.strip_prefix("0X")).unwrap_or(pattern);
+    if pattern.is_empty() {
+        return Err(eyre::eyre!("Vanity pattern cannot be empty"));
+    }
+
     let is_hex = pattern.bytes().all(|byte| byte.is_ascii_hexdigit());
     if is_hex && pattern.len() > 40 {
         return Err(eyre::eyre!("Hex pattern must be less than 20 bytes"));
@@ -441,5 +447,34 @@ mod tests {
     fn reject_overlong_odd_length_hex_pattern() {
         let err = parse_pattern(&"1".repeat(41), true).unwrap_err();
         assert_eq!(err.to_string(), "Hex pattern must be less than 20 bytes");
+    }
+
+    #[test]
+    fn parse_prefixed_vanity_patterns() {
+        let Either::Left(lowercase) = parse_pattern("0xdead", true).unwrap() else {
+            panic!("expected an exact hex pattern");
+        };
+        assert_eq!(lowercase, hex::decode("dead").unwrap());
+        let mut matching = [0; 20];
+        matching[..2].copy_from_slice(&lowercase);
+        assert!(LeftHexMatcher { left: lowercase }.is_match(&Address::from(matching)));
+
+        let Either::Left(uppercase) = parse_pattern("0Xdead", true).unwrap() else {
+            panic!("expected an exact hex pattern");
+        };
+        assert_eq!(uppercase, hex::decode("dead").unwrap());
+
+        let Either::Right(odd_nibble) = parse_pattern("0x9", true).unwrap() else {
+            panic!("expected a regex pattern");
+        };
+        let mut matching = [0; 20];
+        matching[0] = 0x90;
+        assert!(SingleRegexMatcher { re: odd_nibble }.is_match(&Address::from(matching)));
+    }
+
+    #[test]
+    fn reject_empty_prefixed_vanity_pattern() {
+        let err = parse_pattern("0x", true).unwrap_err();
+        assert_eq!(err.to_string(), "Vanity pattern cannot be empty");
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`cast wallet vanity` treats patterns as exact hex when decoding succeeds and otherwise falls back to regex matching against an unprefixed hexadecimal address. As a result, a value such as `--starts-with 0xdead` became the impossible regex `^0xdead`, causing the infinite wallet generator to keep consuming CPU without ever finding a match.



## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Strip an optional `0x` or `0X` prefix before parsing, and reject patterns that are empty after stripping. This preserves odd-nibble patterns such as `0x9` through the existing regex path and applies equally to `--starts-with` and `--ends-with`. Unit tests cover prefixed exact hex, uppercase prefixes, odd-nibble matching, and empty-pattern rejection.



## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
