### PR TITLE
fix(forge): preserve fuzz replay runs

### DIFF
--- a/.changelog/fuzz-stale-replay-run-accounting.md
+++ b/.changelog/fuzz-stale-replay-run-accounting.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed stale fuzz failure replay consuming a generated run and recording incorrect reproduction metadata.

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -700,7 +700,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
         // 2. Worker hasn't reached its specific run limit
         'stop: while shared_state.should_continue() && worker.runs < worker_runs {
             // If counterexample recorded, replay it first, without incrementing runs.
-            let (input, fuzz_run) = if worker_id == 0
+            let (input, fuzz_run, is_persisted_replay) = if worker_id == 0
                 && let Some(failure) = persisted_failure.take()
                 && failure.calldata.get(..4).is_some_and(|selector| func.selector() == selector)
             {
@@ -729,6 +729,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                         failure.fuzz.run,
                         Some(failure.fuzz.worker.unwrap_or(worker_id as u32)),
                     )),
+                    true,
                 )
             } else {
                 runs_since_sync += 1;
@@ -770,6 +771,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                         Some(fuzz_run),
                         Some(worker_id as u32),
                     )),
+                    false,
                 )
             };
 
@@ -799,6 +801,9 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             ) {
                 Ok(fuzz_outcome) => match fuzz_outcome {
                     FuzzOutcome::Case(case) => {
+                        if is_persisted_replay {
+                            continue 'stop;
+                        }
                         let total_runs = inc_runs();
 
                         if worker_id == 0 && self.config.corpus.collect_edge_coverage() {
@@ -855,7 +860,9 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                         counterexample: outcome,
                         ..
                     }) => {
-                        inc_runs();
+                        if !is_persisted_replay {
+                            inc_runs();
+                        }
                         worker.failure_run = fuzz_run;
 
                         // Only classify magic skip payloads when the revert originates from the

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -4326,6 +4326,68 @@ Encountered 1 failing test in test/Counter.t.sol:CounterTest
 "#]]);
 });
 
+forgetest_init!(test_fuzz_stale_success_does_not_consume_run, |prj, cmd| {
+    prj.update_config(|config| {
+        config.fuzz.runs = 1;
+        config.fuzz.seed = Some(U256::from(1));
+        config.fuzz.dictionary.dictionary_weight = 0;
+    });
+    prj.add_test(
+        "StaleFailure.t.sol",
+        r#"
+contract StaleFailureTest {
+    error Nonzero(uint256 value);
+
+    function testFuzz_slot(uint256 value) public pure {
+        if (value != 0) revert Nonzero(value);
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mc", "StaleFailureTest", "-j1"]).assert_failure();
+
+    let failure_file = prj.root().join("cache/fuzz/failures/StaleFailureTest/testFuzz_slot");
+    let mut failure: BaseCounterExample =
+        serde_json::from_slice(&std::fs::read(&failure_file).unwrap()).unwrap();
+    let generated_calldata = failure.calldata.clone();
+    assert_ne!(U256::from_be_slice(&generated_calldata[4..]), U256::ZERO);
+
+    let selector = generated_calldata[..4].to_vec();
+    failure.calldata = [selector.as_slice(), &[0; 32]].concat().into();
+    failure.args = Some("0".to_string());
+    failure.raw_args = Some("0".to_string());
+    std::fs::write(&failure_file, serde_json::to_vec(&failure).unwrap()).unwrap();
+
+    cmd.forge_fuse().args(["test", "--mc", "StaleFailureTest", "-j1"]).assert_failure();
+
+    let failure: BaseCounterExample =
+        serde_json::from_slice(&std::fs::read(&failure_file).unwrap()).unwrap();
+    assert_eq!(failure.calldata, generated_calldata);
+    assert_eq!(failure.fuzz.seed, Some(U256::from(1)));
+    assert_eq!(failure.fuzz.run, Some(1));
+    assert_eq!(failure.fuzz.worker, Some(0));
+
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--mc",
+            "StaleFailureTest",
+            "--fuzz-seed",
+            "1",
+            "--fuzz-run",
+            "1",
+            "--fuzz-worker",
+            "0",
+            "-j1",
+        ])
+        .assert_failure();
+
+    let failure: BaseCounterExample =
+        serde_json::from_slice(&std::fs::read(&failure_file).unwrap()).unwrap();
+    assert_eq!(failure.calldata, generated_calldata);
+});
+
 forgetest_init!(fuzz_basic, |prj, cmd| {
     prj.add_test(
         "Fuzz.t.sol",


### PR DESCRIPTION
Prevent persisted failure replays from consuming generated fuzz runs, preserving campaign coverage and reproduction metadata.