### PR TITLE
fix(fuzz): preserve enum bounds in mutations

### DIFF
--- a/.changelog/fuzz-enum-mutation-bounds.md
+++ b/.changelog/fuzz-enum-mutation-bounds.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-evm: patch
+foundry-evm-fuzz: patch
+---
+
+Fixed corpus mutations generating values outside Solidity enum bounds.

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -625,9 +625,10 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
             self.config.corpus.payable_value_weight,
         );
         let fuzz_state = fuzz_seed.stateless_worker();
-        let generator = foundry_evm_fuzz::sequence::SequenceGenerator::stateless(
+        let generator = foundry_evm_fuzz::sequence::SequenceGenerator::stateless_with_fixtures(
             generator,
             fuzz_state.clone(),
+            fuzz_fixtures.clone(),
             func.clone(),
             &self.config.corpus,
         )?;

--- a/crates/evm/evm/src/executors/invariant/mod.rs
+++ b/crates/evm/evm/src/executors/invariant/mod.rs
@@ -1802,9 +1802,10 @@ impl<'a, FEN: FoundryEvmNetwork> InvariantExecutor<'a, FEN> {
             fuzz_state.collect_fuzzer_values(fuzzer);
             let _ = fuzzer.take_observed_calls();
         }
-        let generator = foundry_evm_fuzz::sequence::SequenceGenerator::invariant(
+        let generator = foundry_evm_fuzz::sequence::SequenceGenerator::invariant_with_fixtures(
             generator,
             fuzz_state.clone(),
+            fuzz_fixtures.clone(),
             targeted_contracts.clone(),
             &config.corpus,
         )?;

--- a/crates/evm/fuzz/src/sequence.rs
+++ b/crates/evm/fuzz/src/sequence.rs
@@ -1,9 +1,11 @@
 //! Pure transaction-sequence generation and mutation primitives.
 
 use crate::{
-    BasicTxDetails,
+    BasicTxDetails, FuzzFixtures,
     invariant::FuzzRunIdentifiedContracts,
-    strategies::{FuzzState, TxGenerator, generate_msg_value, mutate_param_value},
+    strategies::{
+        FuzzState, TxGenerator, constrain_enum_value, generate_msg_value, mutate_param_value,
+    },
 };
 use alloy_dyn_abi::JsonAbiExt;
 use alloy_json_abi::Function;
@@ -49,6 +51,7 @@ enum SequenceMode {
 pub struct SequenceGenerator {
     tx: TxGenerator,
     state: FuzzState,
+    fixtures: FuzzFixtures,
     mode: SequenceMode,
     weights: FuzzCorpusMutationWeights,
     mutations: WeightedIndex<u32>,
@@ -138,7 +141,16 @@ impl SequenceGenerator {
         function: Function,
         config: &FuzzCorpusConfig,
     ) -> Result<Self> {
-        Self::new(tx, state, SequenceMode::Stateless(function), config)
+        Self::stateless_with_fixtures(tx, state, FuzzFixtures::default(), function, config)
+    }
+    pub fn stateless_with_fixtures(
+        tx: TxGenerator,
+        state: FuzzState,
+        fixtures: FuzzFixtures,
+        function: Function,
+        config: &FuzzCorpusConfig,
+    ) -> Result<Self> {
+        Self::new(tx, state, fixtures, SequenceMode::Stateless(function), config)
     }
     pub fn invariant(
         tx: TxGenerator,
@@ -146,11 +158,21 @@ impl SequenceGenerator {
         targets: FuzzRunIdentifiedContracts,
         config: &FuzzCorpusConfig,
     ) -> Result<Self> {
-        Self::new(tx, state, SequenceMode::Invariant(targets), config)
+        Self::invariant_with_fixtures(tx, state, FuzzFixtures::default(), targets, config)
+    }
+    pub fn invariant_with_fixtures(
+        tx: TxGenerator,
+        state: FuzzState,
+        fixtures: FuzzFixtures,
+        targets: FuzzRunIdentifiedContracts,
+        config: &FuzzCorpusConfig,
+    ) -> Result<Self> {
+        Self::new(tx, state, fixtures, SequenceMode::Invariant(targets), config)
     }
     fn new(
         tx: TxGenerator,
         state: FuzzState,
+        fixtures: FuzzFixtures,
         mode: SequenceMode,
         config: &FuzzCorpusConfig,
     ) -> Result<Self> {
@@ -185,6 +207,7 @@ impl SequenceGenerator {
         Ok(Self {
             tx,
             state,
+            fixtures,
             mode,
             weights,
             mutations,
@@ -243,8 +266,13 @@ impl SequenceGenerator {
         let hints = entry.comparisons.first().map_or(&[][..], Vec::as_slice);
         match self.arg_mutations.as_ref().map(|d| d.sample(runner.rng()) == 1) {
             Some(true)
-                if !SequenceMutator::cmp_mutate(&mut tx, function, hints, runner)?
-                    && self.weights.mutation_weight_abi > 0
+                if !SequenceMutator::cmp_mutate(
+                    &mut tx,
+                    function,
+                    hints,
+                    runner,
+                    &self.fixtures,
+                )? && self.weights.mutation_weight_abi > 0
                     && !function.inputs.is_empty() =>
             {
                 SequenceMutator::abi_mutate(
@@ -252,6 +280,7 @@ impl SequenceGenerator {
                     function,
                     runner,
                     &self.state,
+                    &self.fixtures,
                     self.payable_weight,
                 )?
             }
@@ -262,11 +291,13 @@ impl SequenceGenerator {
                     function,
                     runner,
                     &self.state,
+                    &self.fixtures,
                     self.payable_weight,
                 )?
             }
             Some(false) if self.weights.mutation_weight_cmp > 0 => {
-                let _ = SequenceMutator::cmp_mutate(&mut tx, function, hints, runner)?;
+                let _ =
+                    SequenceMutator::cmp_mutate(&mut tx, function, hints, runner, &self.fixtures)?;
             }
             None => return Ok((InitialSequence::Single(self.tx.next_tx(runner)?), None)),
             _ => {}
@@ -347,6 +378,7 @@ impl SequenceGenerator {
                             f,
                             runner,
                             &self.state,
+                            &self.fixtures,
                             self.payable_weight,
                         )?;
                     }
@@ -360,7 +392,8 @@ impl SequenceGenerator {
                         for (idx, h) in candidates.cycle().skip(start).take(count) {
                             let tx = &mut seq[idx];
                             if let (_, Some(f)) = targets.targets().fuzzed_artifacts(tx) {
-                                mutated = SequenceMutator::cmp_mutate(tx, f, h, runner)?;
+                                mutated =
+                                    SequenceMutator::cmp_mutate(tx, f, h, runner, &self.fixtures)?;
                                 if mutated {
                                     break;
                                 }
@@ -377,6 +410,7 @@ impl SequenceGenerator {
                                 f,
                                 runner,
                                 &self.state,
+                                &self.fixtures,
                                 self.payable_weight,
                             )?
                         }
@@ -471,6 +505,7 @@ impl SequenceMutator {
         function: &Function,
         runner: &mut TestRunner,
         state: &FuzzState,
+        fixtures: &FuzzFixtures,
         payable_value_weight: u32,
     ) -> Result<()> {
         if function.inputs.is_empty() || tx.call_details.calldata.len() < 4 {
@@ -500,6 +535,11 @@ impl SequenceMutator {
             );
             rounds -= 1;
         }
+        let inputs = inputs
+            .into_iter()
+            .zip(&function.inputs)
+            .map(|(value, input)| constrain_enum_value(value, input, fixtures))
+            .collect::<Vec<_>>();
         tx.call_details.calldata =
             function.abi_encode_input(&inputs).map_err(|err| eyre!(err.to_string()))?.into();
         Ok(())
@@ -510,6 +550,7 @@ impl SequenceMutator {
         function: &Function,
         hints: &[ComparisonHint],
         runner: &mut TestRunner,
+        fixtures: &FuzzFixtures,
     ) -> Result<bool> {
         if hints.is_empty() || tx.call_details.calldata.len() <= 4 {
             return Ok(false);
@@ -520,7 +561,14 @@ impl SequenceMutator {
                 tx.call_details.calldata.as_ref(),
                 hints[(start + offset) % hints.len()],
                 runner,
-            ) && function.abi_decode_input(&calldata[4..]).is_ok()
+            ) && let Ok(inputs) = function.abi_decode_input(&calldata[4..])
+                && inputs
+                    .iter()
+                    .cloned()
+                    .zip(&function.inputs)
+                    .map(|(value, input)| constrain_enum_value(value, input, fixtures))
+                    .zip(&inputs)
+                    .all(|(constrained, input)| constrained == *input)
             {
                 tx.call_details.calldata = calldata.into();
                 return Ok(true);
@@ -684,6 +732,7 @@ mod tests {
                 &function,
                 &[ComparisonHint { lhs: U256::from(7), rhs: U256::from(42) }],
                 &mut runner,
+                &FuzzFixtures::default(),
             )
             .unwrap()
         );

--- a/crates/evm/fuzz/src/strategies/calldata.rs
+++ b/crates/evm/fuzz/src/strategies/calldata.rs
@@ -114,6 +114,18 @@ impl EnumClamp {
     }
 }
 
+/// Constrains enum leaves in a decoded value to the range declared by its Solidity type.
+pub(crate) fn constrain_enum_value(
+    value: DynSolValue,
+    input: &Param,
+    fuzz_fixtures: &FuzzFixtures,
+) -> DynSolValue {
+    match EnumClamp::for_param(input, fuzz_fixtures) {
+        Some(plan) => plan.apply(value),
+        None => value,
+    }
+}
+
 /// Wraps `strat` to constrain any enum leaves in `input` to their valid range; a no-op otherwise.
 fn bound_enum(
     strat: BoxedStrategy<DynSolValue>,

--- a/crates/evm/fuzz/src/strategies/mod.rs
+++ b/crates/evm/fuzz/src/strategies/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use param::{fuzz_param_from_state, mutate_param_value};
 
 mod calldata;
 pub use calldata::fuzz_calldata;
-pub(crate) use calldata::fuzz_calldata_from_state;
+pub(crate) use calldata::{constrain_enum_value, fuzz_calldata_from_state};
 
 mod state;
 pub(crate) use state::DictionaryRead;

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -5061,6 +5061,80 @@ Ran 1 test suite [ELAPSED]: 4 tests passed, 0 failed, 0 skipped (4 total tests)
     ]);
 });
 
+forgetest_init!(fuzz_mutations_preserve_enum_bounds, |prj, cmd| {
+    let corpus_dir = prj.root().join("enum-corpus");
+    prj.update_config(|config| {
+        config.fuzz.runs = 256;
+        config.fuzz.seed = Some(U256::from(1));
+        config.fuzz.corpus.corpus_dir = Some(corpus_dir.clone());
+        config.fuzz.corpus.corpus_random_sequence_weight = 0;
+        let weights = &mut config.fuzz.corpus.mutation_weights;
+        weights.mutation_weight_splice = 0;
+        weights.mutation_weight_repeat = 0;
+        weights.mutation_weight_interleave = 0;
+        weights.mutation_weight_prefix = 0;
+        weights.mutation_weight_suffix = 0;
+        weights.mutation_weight_abi = 1;
+        weights.mutation_weight_cmp = 0;
+    });
+    prj.add_test(
+        "FuzzEnumMutation.t.sol",
+        r#"
+contract FuzzEnumMutation {
+    enum Choice { A, B, C }
+
+    function testEnum(Choice) public pure {}
+}
+   "#,
+    );
+
+    cmd.args(["test", "--mc", "FuzzEnumMutation", "-j1"]).assert_success().stdout_eq(str![[r#"
+...
+Ran 1 test for test/FuzzEnumMutation.t.sol:FuzzEnumMutation
+[PASS] testEnum(uint8) (runs: 256, [AVG_GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]]);
+
+    std::fs::remove_dir_all(&corpus_dir).unwrap();
+    prj.clear_cache_dir();
+    prj.update_config(|config| {
+        let weights = &mut config.fuzz.corpus.mutation_weights;
+        weights.mutation_weight_abi = 0;
+        weights.mutation_weight_cmp = 1;
+    });
+    prj.add_test(
+        "FuzzEnumMutation.t.sol",
+        r#"
+contract FuzzEnumMutation {
+    enum Choice { A, B, C }
+
+    function testEnum(Choice) public pure {
+        uint256 raw;
+        assembly {
+            raw := calldataload(4)
+        }
+        require(raw != 255, "unreachable for a valid enum");
+    }
+}
+   "#,
+    );
+
+    cmd.forge_fuse().args(["test", "--mc", "FuzzEnumMutation", "-j1"]).assert_success().stdout_eq(
+        str![[r#"
+...
+Ran 1 test for test/FuzzEnumMutation.t.sol:FuzzEnumMutation
+[PASS] testEnum(uint8) (runs: 256, [AVG_GAS])
+Suite result: ok. 1 passed; 0 failed; 0 skipped; [ELAPSED]
+
+Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
+
+"#]],
+    );
+});
+
 fn random_failure_reason(stdout: &str) -> String {
     Regex::new(r"\[FAIL: (Random\([^)]+\))")
         .unwrap()


### PR DESCRIPTION
Preserve Solidity enum bounds during ABI and comparison-guided corpus mutations. This prevents invalid enum values from reverting in the ABI decoder before the fuzz test body executes.