### PR TITLE
fix(forge): link multi-profile libraries

### DIFF
--- a/.changelog/multi-profile-library-linking.md
+++ b/.changelog/multi-profile-library-linking.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed test linking when multiple compiler profiles produce different artifacts for the same library.

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -38,7 +38,7 @@ use foundry_evm::{
 };
 use foundry_evm_networks::NetworkVariant;
 
-use foundry_linking::{LinkOutput, Linker, LinkerError};
+use foundry_linking::{DetailedLinkOutput, LinkOutput, Linker, LinkerError};
 use rayon::prelude::*;
 use std::{
     borrow::Borrow,
@@ -801,7 +801,7 @@ impl MultiContractRunnerBuilder {
         let configured_libraries = self.config.libraries_with_remappings()?;
         let create2_deployer_available = self.create2_deployer_available(&evm_opts);
         let create2 = if create2_deployer_available {
-            match linker.link_with_create2(
+            match linker.link_with_create2_detailed(
                 configured_libraries.clone(),
                 evm_opts.create2_deployer,
                 self.config.create2_library_salt,
@@ -814,30 +814,37 @@ impl MultiContractRunnerBuilder {
         } else {
             None
         };
-        let (LinkOutput { libraries, library_addresses, libs_to_deploy }, library_deployment) =
-            if let Some(output) = create2 {
-                let deployment = if output.libs_to_deploy.is_empty() {
-                    LibraryDeployment::Nonce
-                } else {
-                    LibraryDeployment::Create2 {
-                        deployer: evm_opts.create2_deployer,
-                        salt: self.config.create2_library_salt,
-                    }
-                };
-                (output, deployment)
+        let (
+            DetailedLinkOutput {
+                output: LinkOutput { libraries, library_addresses, libs_to_deploy },
+                artifact_libraries,
+                ..
+            },
+            library_deployment,
+        ) = if let Some(output) = create2 {
+            let deployment = if output.output.libs_to_deploy.is_empty() {
+                LibraryDeployment::Nonce
             } else {
-                (
-                    linker.link_with_nonce_or_address(
-                        configured_libraries,
-                        LIBRARY_DEPLOYER,
-                        0,
-                        linker.contracts.keys(),
-                    )?,
-                    LibraryDeployment::Nonce,
-                )
+                LibraryDeployment::Create2 {
+                    deployer: evm_opts.create2_deployer,
+                    salt: self.config.create2_library_salt,
+                }
             };
+            (output, deployment)
+        } else {
+            (
+                linker.link_with_nonce_or_address_detailed(
+                    configured_libraries,
+                    LIBRARY_DEPLOYER,
+                    0,
+                    linker.contracts.keys(),
+                )?,
+                LibraryDeployment::Nonce,
+            )
+        };
 
-        let linked_contracts = linker.get_linked_artifacts_cow(&libraries)?;
+        let linked_contracts = linker
+            .get_linked_artifacts_cow_with_artifact_libraries(&libraries, &artifact_libraries)?;
         let inline_config = self.inline_config;
 
         // Create a mapping of name => (abi, deployment code, Vec<library deployment code>)
@@ -864,7 +871,8 @@ impl MultiContractRunnerBuilder {
                     continue;
                 };
 
-                let library_addresses = linker.linked_library_addresses(id, &libraries)?;
+                let artifact_libraries = artifact_libraries.get(id).unwrap_or(&libraries);
+                let library_addresses = linker.linked_library_addresses(id, artifact_libraries)?;
 
                 deployable_contracts.insert(
                     id.clone(),

--- a/crates/forge/tests/cli/test_cmd/mod.rs
+++ b/crates/forge/tests/cli/test_cmd/mod.rs
@@ -3,6 +3,7 @@
 use crate::utils::assert_debug_dump_identifies_contract;
 use alloy_primitives::{Address, U256};
 use anvil::{NodeConfig, spawn};
+use foundry_config::{CompilationRestrictions, SettingsOverrides, filter::GlobMatcher};
 use foundry_test_utils::{
     TestCommand,
     rpc::{self, rpc_endpoints},
@@ -593,7 +594,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
 "#]]);
 });
 
-forgetest_init!(rejects_library_key_collisions_across_versions, |prj, cmd| {
+forgetest_init!(links_library_artifacts_across_versions, |prj, cmd| {
     prj.wipe_contracts();
     prj.update_config(|config| config.solc = None);
 
@@ -642,16 +643,85 @@ contract OldTest {{
         ),
     );
 
-    cmd.arg("test").assert_failure().stderr_eq(str![[r#"
-Error: multiple library artifacts resolve to the same key src/Lib.sol:Lib
-
-"#]]);
+    cmd.arg("test").assert_success();
 
     prj.update_config(|config| config.create2_deployer = Address::ZERO);
-    cmd.forge_fuse().arg("test").assert_failure().stderr_eq(str![[r#"
-Error: multiple library artifacts resolve to the same key src/Lib.sol:Lib
+    cmd.forge_fuse().arg("test").assert_success();
+});
 
-"#]]);
+forgetest_init!(links_library_artifacts_across_compiler_profiles, |prj, cmd| {
+    prj.wipe_contracts();
+    prj.add_source(
+        "Lib.sol",
+        r#"
+pragma solidity >=0.8.0;
+
+library Lib {
+    function identity(uint256 value) external pure returns (uint256) {
+        return value;
+    }
+}
+"#,
+    );
+    prj.add_source(
+        "Prod.sol",
+        r#"
+pragma solidity >=0.8.0;
+
+import "src/Lib.sol";
+
+contract Prod {
+    function identity(uint256 value) external view returns (uint256) {
+        return Lib.identity(value);
+    }
+}
+"#,
+    );
+    prj.add_test(
+        "Profiles.t.sol",
+        r#"
+pragma solidity >=0.8.0;
+
+import "src/Lib.sol";
+import "src/Prod.sol";
+
+contract ProfilesTest {
+    function testProfiles() public {
+        require(Lib.identity(1) == 1);
+        require(new Prod().identity(2) == 2);
+    }
+}
+"#,
+    );
+    prj.update_config(|config| {
+        config.additional_compiler_profiles = vec![SettingsOverrides {
+            name: "prod".to_string(),
+            via_ir: Some(true),
+            evm_version: None,
+            optimizer: Some(true),
+            optimizer_runs: Some(1),
+            bytecode_hash: None,
+        }];
+        config.compilation_restrictions = vec![CompilationRestrictions {
+            paths: GlobMatcher::from_str("src/Prod.sol").unwrap(),
+            version: None,
+            via_ir: Some(true),
+            bytecode_hash: None,
+            min_optimizer_runs: None,
+            optimizer_runs: Some(1),
+            max_optimizer_runs: None,
+            min_evm_version: None,
+            evm_version: None,
+            max_evm_version: None,
+        }];
+    });
+
+    cmd.arg("test").assert_success();
+    assert!(prj.artifacts().join("Lib.sol/Lib.json").exists());
+    assert!(prj.artifacts().join("Lib.sol/Lib.prod.json").exists());
+
+    prj.update_config(|config| config.create2_deployer = Address::ZERO);
+    cmd.forge_fuse().arg("test").assert_success();
 });
 
 #[cfg(unix)]

--- a/crates/linking/src/lib.rs
+++ b/crates/linking/src/lib.rs
@@ -44,8 +44,10 @@ pub struct Linker<'a> {
 
 /// Output of the `link_with_nonce_or_address`
 pub struct LinkOutput {
-    /// Resolved library addresses. Contains both user-provided and newly deployed libraries.
-    /// It will always contain library paths with stripped path prefixes.
+    /// Flattened resolved library addresses. Contains both user-provided and newly deployed
+    /// libraries, with stripped path prefixes. Auto-linked keys that resolve to different
+    /// addresses for different artifacts are omitted; use
+    /// [`DetailedLinkOutput::artifact_libraries`] for complete per-artifact mappings.
     pub libraries: Libraries,
     /// Addresses of libraries required by the linked targets.
     pub library_addresses: Vec<Address>,
@@ -58,7 +60,15 @@ pub struct LinkOutput {
 pub struct DetailedLinkOutput {
     /// The backwards-compatible linker output.
     pub output: LinkOutput,
-    /// Auto-linked libraries, preserving their artifact identity and linked creation bytecode.
+    /// Complete transitive library address mapping selected for each linked artifact.
+    pub artifact_libraries: BTreeMap<ArtifactId, Libraries>,
+    /// Address selected for every resolved library artifact, including byte-identical variants.
+    pub artifact_addresses: BTreeMap<ArtifactId, Address>,
+    /// Unique physical library deployments and their linked creation bytecode.
+    ///
+    /// Multiple byte-identical artifacts can share one CREATE2 deployment. In that case, this
+    /// contains one representative artifact while [`Self::artifact_addresses`] preserves every
+    /// artifact identity.
     pub linked_libraries: Vec<LinkedLibrary>,
 }
 
@@ -244,13 +254,11 @@ impl<'a> Linker<'a> {
         Ok(candidates.into_iter().next())
     }
 
-    /// Performs DFS on the graph of link references, and populates `deps` with all found libraries.
-    fn collect_dependencies(
+    fn direct_dependencies(
         &'a self,
         target: &'a ArtifactId,
-        deps: &mut BTreeSet<&'a ArtifactId>,
         references: &mut BTreeMap<&'a ArtifactId, BTreeSet<PathBuf>>,
-    ) -> Result<(), LinkerError> {
+    ) -> Result<BTreeSet<&'a ArtifactId>, LinkerError> {
         let contract = self.contracts.get(target).ok_or(LinkerError::MissingTargetArtifact)?;
 
         let mut link_references: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
@@ -268,15 +276,30 @@ impl<'a> Linker<'a> {
             extend(bytecode);
         }
 
+        let mut dependencies = BTreeSet::new();
         for (file, libs) in link_references {
             for name in libs {
                 let id = self.find_artifact_id_by_library_path(&file, &name, target)?.ok_or_else(
                     || LinkerError::MissingLibraryArtifact { file: file.clone(), name },
                 )?;
                 references.entry(id).or_default().insert(file.clone().into());
-                if deps.insert(id) {
-                    self.collect_dependencies(id, deps, references)?;
-                }
+                dependencies.insert(id);
+            }
+        }
+
+        Ok(dependencies)
+    }
+
+    /// Performs DFS on the graph of link references, and populates `deps` with all found libraries.
+    fn collect_dependencies(
+        &'a self,
+        target: &'a ArtifactId,
+        deps: &mut BTreeSet<&'a ArtifactId>,
+        references: &mut BTreeMap<&'a ArtifactId, BTreeSet<PathBuf>>,
+    ) -> Result<(), LinkerError> {
+        for id in self.direct_dependencies(target, references)? {
+            if deps.insert(id) {
+                self.collect_dependencies(id, deps, references)?;
             }
         }
 
@@ -348,6 +371,136 @@ impl<'a> Linker<'a> {
             }
         }
         Ok(library_keys)
+    }
+
+    fn configured_library_address(
+        &self,
+        id: &ArtifactId,
+        libraries: &Libraries,
+    ) -> Result<Option<Address>, LinkerError> {
+        let (file, name) = self.convert_artifact_id_to_lib_path(id);
+        libraries
+            .libs
+            .get(&file)
+            .and_then(|libraries| libraries.get(&name))
+            .map(|address| Address::from_str(address).map_err(LinkerError::InvalidAddress))
+            .transpose()
+    }
+
+    fn libraries_for_artifact(
+        &'a self,
+        target: &'a ArtifactId,
+        configured: &Libraries,
+        addresses: &BTreeMap<&'a ArtifactId, Address>,
+    ) -> Result<Libraries, LinkerError> {
+        let mut libraries = configured.clone();
+        let mut dependencies = BTreeSet::new();
+        self.collect_dependencies(target, &mut dependencies, &mut BTreeMap::new())?;
+        for id in dependencies {
+            let Some(&address) = addresses.get(id) else { continue };
+            let (file, name) = self.convert_artifact_id_to_lib_path(id);
+            let entry = libraries.libs.entry(file.clone()).or_default().entry(name.clone());
+            if let std::collections::btree_map::Entry::Occupied(entry) = &entry
+                && Address::from_str(entry.get()).map_err(LinkerError::InvalidAddress)? != address
+            {
+                return Err(LinkerError::ConflictingLibraryArtifacts {
+                    file: file.display().to_string(),
+                    name,
+                });
+            }
+            entry.or_insert_with(|| address.to_checksum(None));
+        }
+        Ok(libraries)
+    }
+
+    fn artifact_libraries(
+        &'a self,
+        artifacts: impl IntoIterator<Item = &'a ArtifactId>,
+        configured: &Libraries,
+        addresses: &BTreeMap<&'a ArtifactId, Address>,
+    ) -> Result<BTreeMap<ArtifactId, Libraries>, LinkerError> {
+        artifacts
+            .into_iter()
+            .map(|id| Ok((id.clone(), self.libraries_for_artifact(id, configured, addresses)?)))
+            .collect()
+    }
+
+    fn output_libraries(
+        &self,
+        mut libraries: Libraries,
+        addresses: &BTreeMap<&ArtifactId, Address>,
+    ) -> Libraries {
+        let mut by_key = BTreeMap::<(PathBuf, String), BTreeSet<Address>>::new();
+        for (&id, &address) in addresses {
+            by_key.entry(self.convert_artifact_id_to_lib_path(id)).or_default().insert(address);
+        }
+        for ((file, name), addresses) in by_key {
+            if let Some(address) = addresses.first().filter(|_| addresses.len() == 1) {
+                libraries
+                    .libs
+                    .entry(file)
+                    .or_default()
+                    .entry(name)
+                    .or_insert_with(|| address.to_checksum(None));
+            }
+        }
+        libraries
+    }
+
+    fn assigned_library_addresses(
+        &self,
+        addresses: &BTreeMap<&ArtifactId, Address>,
+    ) -> Vec<Address> {
+        addresses.values().copied().collect::<BTreeSet<_>>().into_iter().collect()
+    }
+
+    fn artifact_addresses(
+        &self,
+        addresses: &BTreeMap<&ArtifactId, Address>,
+    ) -> BTreeMap<ArtifactId, Address> {
+        addresses.iter().map(|(&id, &address)| (id.clone(), address)).collect()
+    }
+
+    fn artifact_addresses_from_libraries(
+        &self,
+        artifacts: impl IntoIterator<Item = &'a ArtifactId>,
+        libraries: &Libraries,
+    ) -> Result<BTreeMap<ArtifactId, Address>, LinkerError> {
+        artifacts
+            .into_iter()
+            .map(|id| {
+                let address = self
+                    .configured_library_address(id, libraries)?
+                    .ok_or_else(|| LinkerError::LinkingFailed { artifact: id.identifier() })?;
+                Ok((id.clone(), address))
+            })
+            .collect()
+    }
+
+    fn ensure_flattened_libraries(
+        &self,
+        artifact_libraries: &BTreeMap<ArtifactId, Libraries>,
+    ) -> Result<(), LinkerError> {
+        let mut addresses = BTreeMap::<(PathBuf, String), BTreeSet<Address>>::new();
+        for libraries in artifact_libraries.values() {
+            for (file, libraries) in &libraries.libs {
+                for (name, address) in libraries {
+                    addresses
+                        .entry((file.clone(), name.clone()))
+                        .or_default()
+                        .insert(Address::from_str(address).map_err(LinkerError::InvalidAddress)?);
+                }
+            }
+        }
+        if let Some(((file, name), _)) =
+            addresses.into_iter().find(|(_, addresses)| addresses.len() > 1)
+        {
+            return Err(LinkerError::ConflictingLibraryArtifacts {
+                file: file.display().to_string(),
+                name,
+            });
+        }
+        Ok(())
     }
 
     fn library_addresses(
@@ -435,7 +588,9 @@ impl<'a> Linker<'a> {
         nonce: u64,
         targets: impl IntoIterator<Item = &'a ArtifactId>,
     ) -> Result<LinkOutput, LinkerError> {
-        Ok(self.link_with_nonce_or_address_detailed(libraries, sender, nonce, targets)?.output)
+        let output = self.link_with_nonce_or_address_detailed(libraries, sender, nonce, targets)?;
+        self.ensure_flattened_libraries(&output.artifact_libraries)?;
+        Ok(output.output)
     }
 
     /// Links like [`Self::link_with_nonce_or_address`] and includes auto-linked library metadata.
@@ -450,44 +605,53 @@ impl<'a> Linker<'a> {
         // user-provided paths to be able to match them correctly.
         let mut libraries = libraries.with_stripped_file_prefixes(self.root.as_path());
 
+        let targets = targets.into_iter().collect::<Vec<_>>();
         let mut needed_libraries = BTreeSet::new();
         let mut references = BTreeMap::new();
-        for target in targets {
+        for &target in &targets {
             self.collect_dependencies(target, &mut needed_libraries, &mut references)?;
         }
         self.apply_configured_references(&references, &mut libraries)?;
-        let library_keys = self.collect_library_keys(&needed_libraries, &libraries)?;
 
+        let mut addresses = BTreeMap::new();
         let mut libs_to_deploy = Vec::new();
-
-        // If `libraries` does not contain needed dependency, compute its address and add to
-        // `libs_to_deploy`.
-        for id in needed_libraries {
-            let (lib_path, lib_name) = self.convert_artifact_id_to_lib_path(id);
-
-            libraries.libs.entry(lib_path).or_default().entry(lib_name).or_insert_with(|| {
+        for &id in &needed_libraries {
+            let address = if let Some(address) = self.configured_library_address(id, &libraries)? {
+                address
+            } else {
                 let address = sender.create(nonce);
-                libs_to_deploy.push((id, address));
                 nonce += 1;
-
-                address.to_checksum(None)
-            });
+                libs_to_deploy.push((id, address));
+                address
+            };
+            addresses.insert(id, address);
         }
+
+        let artifact_libraries = self.artifact_libraries(
+            targets.iter().copied().chain(needed_libraries.iter().copied()),
+            &libraries,
+            &addresses,
+        )?;
 
         // Link and collect bytecodes for `libs_to_deploy`.
         let linked_libraries = libs_to_deploy
             .into_par_iter()
             .map(|(id, address)| {
+                let artifact_libraries = artifact_libraries.get(id).unwrap();
                 let bytecode =
-                    self.link(id, &libraries)?.get_bytecode_bytes().unwrap().into_owned();
+                    self.link(id, artifact_libraries)?.get_bytecode_bytes().unwrap().into_owned();
                 Ok(LinkedLibrary { id: id.clone(), address, bytecode })
             })
             .collect::<Result<Vec<_>, LinkerError>>()?;
         let libs_to_deploy = linked_libraries.iter().map(|lib| lib.bytecode.clone()).collect();
 
-        let library_addresses = self.library_addresses(&library_keys, &libraries)?;
+        let library_addresses = self.assigned_library_addresses(&addresses);
+        let artifact_addresses = self.artifact_addresses(&addresses);
+        let libraries = self.output_libraries(libraries, &addresses);
         Ok(DetailedLinkOutput {
             output: LinkOutput { libraries, library_addresses, libs_to_deploy },
+            artifact_libraries,
+            artifact_addresses,
             linked_libraries,
         })
     }
@@ -499,7 +663,9 @@ impl<'a> Linker<'a> {
         salt: B256,
         targets: impl IntoIterator<Item = &'a ArtifactId>,
     ) -> Result<LinkOutput, LinkerError> {
-        Ok(self.link_with_create2_detailed(libraries, sender, salt, targets)?.output)
+        let output = self.link_with_create2_detailed(libraries, sender, salt, targets)?;
+        self.ensure_flattened_libraries(&output.artifact_libraries)?;
+        Ok(output.output)
     }
 
     /// Links like [`Self::link_with_create2`] and includes auto-linked library metadata.
@@ -514,70 +680,70 @@ impl<'a> Linker<'a> {
         // user-provided paths to be able to match them correctly.
         let mut libraries = libraries.with_stripped_file_prefixes(self.root.as_path());
 
+        let targets = targets.into_iter().collect::<Vec<_>>();
         let mut needed_libraries = BTreeSet::new();
         let mut references = BTreeMap::new();
-        for target in targets {
+        for &target in &targets {
             self.collect_dependencies(target, &mut needed_libraries, &mut references)?;
         }
         self.apply_configured_references(&references, &mut libraries)?;
 
-        let library_keys = self.collect_library_keys(&needed_libraries, &libraries)?;
-
-        let mut needed_libraries = needed_libraries
-            .into_par_iter()
-            .filter(|id| {
-                // Filter out already provided libraries.
-                let (file, name) = self.convert_artifact_id_to_lib_path(id);
-                libraries.libs.get(&file).is_none_or(|lib| !lib.contains_key(&name))
-            })
-            .map(|id| -> Result<_, LinkerError> {
-                // Link library with provided libs and extract bytecode object (possibly unlinked).
-                let bytecode = self.link(id, &libraries)?.bytecode.ok_or_else(|| {
-                    LinkerError::LinkingFailed { artifact: id.source.to_string_lossy().into() }
-                })?;
-                Ok((id, bytecode))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let mut linked_libraries = Vec::new();
+        let mut addresses = BTreeMap::new();
+        let mut pending = Vec::new();
+        for &id in &needed_libraries {
+            if let Some(address) = self.configured_library_address(id, &libraries)? {
+                addresses.insert(id, address);
+            } else {
+                pending.push(id);
+            }
+        }
+        let mut linked_libraries = Vec::<LinkedLibrary>::new();
 
         // Iteratively compute addresses and link libraries until we have no unlinked libraries
         // left.
-        while !needed_libraries.is_empty() {
-            // Find any library which is fully linked.
-            let deployable = needed_libraries
-                .iter()
-                .enumerate()
-                .find(|(_, (_, bytecode))| !bytecode.object.is_unlinked());
-
-            // If we haven't found any deployable library, it means we have a cyclic dependency.
-            let Some((index, &(id, _))) = deployable else {
+        while !pending.is_empty() {
+            let mut deployable = None;
+            for (index, &id) in pending.iter().enumerate() {
+                let artifact_libraries = self.libraries_for_artifact(id, &libraries, &addresses)?;
+                let bytecode = self.link(id, &artifact_libraries)?.bytecode.ok_or_else(|| {
+                    LinkerError::LinkingFailed { artifact: id.source.to_string_lossy().into() }
+                })?;
+                if !bytecode.object.is_unlinked() {
+                    deployable = Some((index, id, bytecode));
+                    break;
+                }
+            }
+            let Some((index, id, bytecode)) = deployable else {
                 return Err(LinkerError::CyclicDependency);
             };
-            let (_, bytecode) = needed_libraries.swap_remove(index);
+            pending.swap_remove(index);
             let code = bytecode.bytes().ok_or_else(|| LinkerError::LinkingFailed {
                 artifact: id.source.to_string_lossy().into(),
             })?;
             let address = sender.create2_from_code(salt, code);
-            linked_libraries.push(LinkedLibrary {
-                id: id.clone(),
-                address,
-                bytecode: code.clone(),
-            });
-
-            let (file, name) = self.convert_artifact_id_to_lib_path(id);
-
-            needed_libraries.par_iter_mut().try_for_each(|(target, bytecode)| {
-                self.link_bytecode(bytecode.to_mut(), target, &file, &name, address)
-            })?;
-
-            libraries.libs.entry(file).or_default().insert(name, address.to_checksum(None));
+            if linked_libraries.iter().all(|library| library.address != address) {
+                linked_libraries.push(LinkedLibrary {
+                    id: id.clone(),
+                    address,
+                    bytecode: code.clone(),
+                });
+            }
+            addresses.insert(id, address);
         }
 
+        let artifact_libraries = self.artifact_libraries(
+            targets.iter().copied().chain(needed_libraries.iter().copied()),
+            &libraries,
+            &addresses,
+        )?;
         let libs_to_deploy = linked_libraries.iter().map(|lib| lib.bytecode.clone()).collect();
-        let library_addresses = self.library_addresses(&library_keys, &libraries)?;
+        let library_addresses = self.assigned_library_addresses(&addresses);
+        let artifact_addresses = self.artifact_addresses(&addresses);
+        let libraries = self.output_libraries(libraries, &addresses);
         Ok(DetailedLinkOutput {
             output: LinkOutput { libraries, library_addresses, libs_to_deploy },
+            artifact_libraries,
+            artifact_addresses,
             linked_libraries,
         })
     }
@@ -604,7 +770,7 @@ impl<'a> Linker<'a> {
         }
         let mut local_nonce = 0;
         let mut assigned = Vec::new();
-        for id in needed {
+        for &id in &needed {
             let (file, name) = self.convert_artifact_id_to_lib_path(id);
             libraries.libs.entry(file).or_default().entry(name).or_insert_with(|| {
                 let onchain = required_with_dependencies.contains(id);
@@ -637,9 +803,14 @@ impl<'a> Linker<'a> {
             linked.iter().filter(|(_, onchain)| !*onchain).map(|(lib, _)| lib.clone()).collect();
         let linked_libraries = linked.into_iter().map(|(lib, _)| lib).collect();
         let library_addresses = self.library_addresses(&library_keys, &libraries)?;
+        let artifact_addresses =
+            self.artifact_addresses_from_libraries(needed.iter().copied(), &libraries)?;
+        let artifact_libraries = BTreeMap::from([(target.clone(), libraries.clone())]);
         Ok((
             DetailedLinkOutput {
                 output: LinkOutput { libraries, library_addresses, libs_to_deploy },
+                artifact_libraries,
+                artifact_addresses,
                 linked_libraries,
             },
             local,
@@ -668,7 +839,7 @@ impl<'a> Linker<'a> {
         }
         let mut local_ids = Vec::new();
         let mut required_ids = Vec::new();
-        for id in needed {
+        for &id in &needed {
             let (file, name) = self.convert_artifact_id_to_lib_path(id);
             if libraries.libs.get(&file).is_some_and(|libs| libs.contains_key(&name)) {
                 continue;
@@ -728,9 +899,14 @@ impl<'a> Linker<'a> {
         linked_libraries.extend(local.iter().cloned());
         let libs_to_deploy = onchain.into_iter().map(|lib| lib.bytecode).collect();
         let library_addresses = self.library_addresses(&library_keys, &libraries)?;
+        let artifact_addresses =
+            self.artifact_addresses_from_libraries(needed.iter().copied(), &libraries)?;
+        let artifact_libraries = BTreeMap::from([(target.clone(), libraries.clone())]);
         Ok((
             DetailedLinkOutput {
                 output: LinkOutput { libraries, library_addresses, libs_to_deploy },
+                artifact_libraries,
+                artifact_addresses,
                 linked_libraries,
             },
             local,
@@ -812,9 +988,20 @@ impl<'a> Linker<'a> {
         &self,
         libraries: &Libraries,
     ) -> Result<ArtifactContracts<CompactContractBytecodeCow<'a>>, LinkerError> {
+        self.get_linked_artifacts_cow_with_artifact_libraries(libraries, &BTreeMap::new())
+    }
+
+    pub fn get_linked_artifacts_cow_with_artifact_libraries(
+        &self,
+        libraries: &Libraries,
+        artifact_libraries: &BTreeMap<ArtifactId, Libraries>,
+    ) -> Result<ArtifactContracts<CompactContractBytecodeCow<'a>>, LinkerError> {
         self.contracts
             .par_iter()
-            .map(|(id, _)| Ok((id.clone(), self.link(id, libraries)?)))
+            .map(|(id, _)| {
+                let libraries = artifact_libraries.get(id).unwrap_or(libraries);
+                Ok((id.clone(), self.link(id, libraries)?))
+            })
             .collect::<Result<_, _>>()
             .map(ArtifactContracts)
     }
@@ -826,6 +1013,7 @@ mod tests {
     use alloy_primitives::{address, fixed_bytes, map::HashMap};
     use foundry_compilers::{
         Project, ProjectCompileOutput, ProjectPathsConfig,
+        artifacts::BytecodeObject,
         multi::MultiCompiler,
         solc::{Solc, SolcCompiler},
     };
@@ -1324,7 +1512,156 @@ mod tests {
     }
 
     #[test]
-    fn linking_handles_library_key_collisions_across_versions() {
+    fn detailed_linking_includes_transitive_library_addresses() {
+        let test = LinkerTest::new(&testdata().join("default/linking/nested"), true);
+        let linker = Linker::new(test.project.root(), test.output.artifact_ids().collect());
+        let consumer = linker.contracts.keys().find(|id| id.name == "LibraryConsumer").unwrap();
+
+        let create2 = linker
+            .link_with_create2_detailed(Libraries::default(), Address::ZERO, B256::ZERO, [consumer])
+            .unwrap();
+        let libraries = create2.artifact_libraries.get(consumer).unwrap();
+        assert_eq!(linker.linked_library_addresses(consumer, libraries).unwrap().len(), 2);
+
+        let nonce = linker
+            .link_with_nonce_or_address_detailed(Libraries::default(), Address::ZERO, 0, [consumer])
+            .unwrap();
+        let libraries = nonce.artifact_libraries.get(consumer).unwrap();
+        assert_eq!(linker.linked_library_addresses(consumer, libraries).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn linking_preserves_transitive_profile_identity() {
+        let test = LinkerTest::new(&testdata().join("default/linking/profile_nested"), true);
+        let linker = Linker::new(test.project.root(), test.output.artifact_ids().collect());
+        let find = |name| {
+            linker
+                .contracts
+                .iter()
+                .find(|(id, _)| id.name == name)
+                .map(|(id, contract)| (id.clone(), contract.clone()))
+                .unwrap()
+        };
+        let (inner_id, inner) = find("Inner");
+        let (outer_id, outer) = find("Outer");
+        let (consumer_id, consumer) = find("Consumer");
+
+        let mut contracts = linker.contracts.clone();
+        let mut other_inner_id = inner_id.clone();
+        other_inner_id.build_id = "other".to_string();
+        other_inner_id.profile = "other".to_string();
+        contracts.insert(other_inner_id.clone(), inner);
+        let mut other_outer_id = outer_id.clone();
+        other_outer_id.build_id = "other".to_string();
+        other_outer_id.profile = "other".to_string();
+        contracts.insert(other_outer_id.clone(), outer);
+        let mut other_consumer_id = consumer_id.clone();
+        other_consumer_id.build_id = "other".to_string();
+        other_consumer_id.profile = "other".to_string();
+        contracts.insert(other_consumer_id.clone(), consumer);
+
+        for id in [&other_inner_id, &other_outer_id] {
+            let bytecode = contracts.get_mut(id).unwrap().bytecode.as_mut().unwrap().to_mut();
+            match &mut bytecode.object {
+                BytecodeObject::Bytecode(bytes) => {
+                    let mut distinct = bytes.to_vec();
+                    distinct.push(0);
+                    *bytes = distinct.into();
+                }
+                BytecodeObject::Unlinked(code) => code.push_str("00"),
+            }
+        }
+
+        let linker = Linker::new(test.project.root(), contracts);
+        let consumers = [&consumer_id, &other_consumer_id];
+        let profiles = [
+            (&consumer_id, &outer_id, &inner_id),
+            (&other_consumer_id, &other_outer_id, &other_inner_id),
+        ];
+        let assert_identity = |output: &DetailedLinkOutput| {
+            assert_eq!(output.artifact_addresses.len(), 4);
+            assert_eq!(
+                output.output.libs_to_deploy,
+                output
+                    .linked_libraries
+                    .iter()
+                    .map(|library| library.bytecode.clone())
+                    .collect::<Vec<_>>()
+            );
+
+            for linked in &output.linked_libraries {
+                assert_eq!(output.artifact_addresses[&linked.id], linked.address);
+                assert_eq!(
+                    linker
+                        .linked_creation_bytecode(
+                            &linked.id,
+                            &output.artifact_libraries[&linked.id],
+                        )
+                        .unwrap(),
+                    linked.bytecode
+                );
+            }
+
+            for (index, &(consumer, outer, inner)) in profiles.iter().enumerate() {
+                let sibling_outer = profiles[1 - index].1;
+                let sibling_inner = profiles[1 - index].2;
+                let outer_address = output.artifact_addresses[outer];
+                let inner_address = output.artifact_addresses[inner];
+
+                let consumer_bytecode = linker
+                    .link(consumer, &output.artifact_libraries[consumer])
+                    .unwrap()
+                    .get_bytecode_bytes()
+                    .unwrap()
+                    .into_owned();
+                assert!(
+                    consumer_bytecode
+                        .windows(Address::len_bytes())
+                        .any(|window| { window == outer_address.as_slice() })
+                );
+                assert!(!consumer_bytecode.windows(Address::len_bytes()).any(|window| {
+                    window == output.artifact_addresses[sibling_outer].as_slice()
+                }));
+
+                let outer_bytecode = &output
+                    .linked_libraries
+                    .iter()
+                    .find(|library| library.id == *outer)
+                    .unwrap()
+                    .bytecode;
+                assert!(
+                    outer_bytecode
+                        .windows(Address::len_bytes())
+                        .any(|window| window == inner_address.as_slice())
+                );
+                assert!(!outer_bytecode.windows(Address::len_bytes()).any(|window| {
+                    window == output.artifact_addresses[sibling_inner].as_slice()
+                }));
+            }
+        };
+
+        let sender = address!("1000000000000000000000000000000000000000");
+        let nonce = 7;
+        let output = linker
+            .link_with_nonce_or_address_detailed(Libraries::default(), sender, nonce, consumers)
+            .unwrap();
+        assert_identity(&output);
+        for (index, library) in output.linked_libraries.iter().enumerate() {
+            assert_eq!(library.address, sender.create(nonce + index as u64));
+        }
+
+        let salt = B256::with_last_byte(1);
+        let output = linker
+            .link_with_create2_detailed(Libraries::default(), sender, salt, consumers)
+            .unwrap();
+        assert_identity(&output);
+        for library in &output.linked_libraries {
+            assert_eq!(library.address, sender.create2_from_code(salt, &library.bytecode));
+        }
+    }
+
+    #[test]
+    fn linking_handles_library_key_collisions_across_profiles() {
         let test = LinkerTest::new(&testdata().join("default/linking/simple"), true);
         let linker = Linker::new(test.project.root(), test.output.artifact_ids().collect());
         let (library_id, library) = linker
@@ -1342,25 +1679,40 @@ mod tests {
 
         let mut contracts = linker.contracts.clone();
         let mut other_library_id = library_id.clone();
-        other_library_id.version = Version::new(0, 8, 19);
         other_library_id.build_id = "other".to_string();
-        contracts.insert(other_library_id, library);
+        other_library_id.profile = "other".to_string();
+        contracts.insert(other_library_id.clone(), library);
         let mut other_consumer_id = consumer_id.clone();
-        other_consumer_id.version = Version::new(0, 8, 19);
         other_consumer_id.build_id = "other".to_string();
+        other_consumer_id.profile = "other".to_string();
         contracts.insert(other_consumer_id.clone(), consumer);
 
-        let linker = Linker::new(test.project.root(), contracts);
-        let Err(err) = linker.link_with_create2(
-            Libraries::default(),
-            Address::ZERO,
-            B256::ZERO,
-            [&consumer_id, &other_consumer_id],
-        ) else {
-            panic!("expected conflicting library artifacts");
-        };
+        let linker = Linker::new(test.project.root(), contracts.clone());
+        let detailed = linker
+            .link_with_create2_detailed(
+                Libraries::default(),
+                Address::ZERO,
+                B256::ZERO,
+                [&consumer_id, &other_consumer_id],
+            )
+            .unwrap();
+        assert_eq!(detailed.linked_libraries.len(), 1);
+        assert_eq!(detailed.artifact_addresses.len(), 2);
+        assert_eq!(detailed.artifact_addresses[&library_id], detailed.linked_libraries[0].address);
+        assert_eq!(
+            detailed.artifact_addresses[&other_library_id],
+            detailed.linked_libraries[0].address
+        );
 
-        assert!(matches!(err, LinkerError::ConflictingLibraryArtifacts { .. }));
+        let output = linker
+            .link_with_create2(
+                Libraries::default(),
+                Address::ZERO,
+                B256::ZERO,
+                [&consumer_id, &other_consumer_id],
+            )
+            .unwrap();
+        assert_eq!(output.libs_to_deploy.len(), 1);
 
         let Err(err) = linker.link_with_nonce_or_address(
             Libraries::default(),
@@ -1370,7 +1722,83 @@ mod tests {
         ) else {
             panic!("expected conflicting library artifacts");
         };
+        assert!(matches!(err, LinkerError::ConflictingLibraryArtifacts { .. }));
 
+        let other_library = contracts.get_mut(&other_library_id).unwrap();
+        let bytecode = other_library.bytecode.as_mut().unwrap().to_mut();
+        let mut bytes = bytecode.object.as_bytes().unwrap().to_vec();
+        bytes.push(0);
+        bytecode.object = BytecodeObject::Bytecode(bytes.into());
+
+        let linker = Linker::new(test.project.root(), contracts);
+        let output = linker
+            .link_with_create2_detailed(
+                Libraries::default(),
+                Address::ZERO,
+                B256::ZERO,
+                [&consumer_id, &other_consumer_id],
+            )
+            .unwrap();
+        assert_eq!(output.linked_libraries.len(), 2);
+        assert_ne!(output.linked_libraries[0].address, output.linked_libraries[1].address);
+        for (target, library) in
+            [(&consumer_id, &library_id), (&other_consumer_id, &other_library_id)]
+        {
+            let expected = output
+                .linked_libraries
+                .iter()
+                .find(|linked| linked.id == *library)
+                .unwrap()
+                .address;
+            let (file, name) = linker.convert_artifact_id_to_lib_path(library);
+            let actual =
+                output.artifact_libraries[target].libs[&file][&name].parse::<Address>().unwrap();
+            assert_eq!(actual, expected);
+        }
+
+        let Err(err) = linker.link_with_create2(
+            Libraries::default(),
+            Address::ZERO,
+            B256::ZERO,
+            [&consumer_id, &other_consumer_id],
+        ) else {
+            panic!("expected conflicting library artifacts");
+        };
+        assert!(matches!(err, LinkerError::ConflictingLibraryArtifacts { .. }));
+
+        let output = linker
+            .link_with_nonce_or_address_detailed(
+                Libraries::default(),
+                Address::ZERO,
+                0,
+                [&consumer_id, &other_consumer_id],
+            )
+            .unwrap();
+        assert_eq!(output.linked_libraries.len(), 2);
+        assert_ne!(output.linked_libraries[0].address, output.linked_libraries[1].address);
+        for (target, library) in
+            [(&consumer_id, &library_id), (&other_consumer_id, &other_library_id)]
+        {
+            let expected = output
+                .linked_libraries
+                .iter()
+                .find(|linked| linked.id == *library)
+                .unwrap()
+                .address;
+            let (file, name) = linker.convert_artifact_id_to_lib_path(library);
+            let actual =
+                output.artifact_libraries[target].libs[&file][&name].parse::<Address>().unwrap();
+            assert_eq!(actual, expected);
+        }
+
+        let Err(err) = linker.link_with_nonce_or_address(
+            Libraries::default(),
+            Address::ZERO,
+            0,
+            [&consumer_id, &other_consumer_id],
+        ) else {
+            panic!("expected conflicting library artifacts");
+        };
         assert!(matches!(err, LinkerError::ConflictingLibraryArtifacts { .. }));
 
         let configured_address = address!("0000000000000000000000000000000000000001");

--- a/testdata/default/linking/profile_nested/Nested.sol
+++ b/testdata/default/linking/profile_nested/Nested.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.18;
+
+library Inner {
+    function addOne(uint256 value) public pure returns (uint256) {
+        return value + 1;
+    }
+}
+
+library Outer {
+    function addTwo(uint256 value) public pure returns (uint256) {
+        return Inner.addOne(value) + 1;
+    }
+}
+
+contract Consumer {
+    function consume(uint256 value) external pure returns (uint256) {
+        return Outer.addTwo(value);
+    }
+}


### PR DESCRIPTION
## Description

#15839 correctly stopped silently choosing between conflicting library artifacts, but it also exposed that Forge flattened libraries to `(path, name)` before linking. When the same library is compiled under multiple compiler profiles, as in Aave v4’s `LiquidationLogic` tests, those distinct artifacts collide even though their build and profile identities are available.

This change preserves artifact identity throughout nonce and CREATE2 linking and gives each consumer the complete transitive address map for its selected variants. Detailed output exposes both per-consumer library mappings and every `ArtifactId -> Address` association, while CREATE2 may still deduplicate byte-identical variants into one physical deployment. The legacy flattened APIs continue rejecting genuinely lossy mappings instead of silently selecting an artifact.

Tested against aave/aave-v4 @ af1f0f2b, now forge test works correctly.