### PR TITLE
fix(deps): unify Tempo git revisions

### DIFF
--- a/.changelog/bump-tempo-dependencies.md
+++ b/.changelog/bump-tempo-dependencies.md
@@ -1,0 +1,7 @@
+---
+cast: patch
+anvil: patch
+forge: patch
+---
+
+Updated Tempo dependencies to the latest main revision.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http 1.4.2",
+ "http 1.5.0",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -1052,7 +1052,7 @@ dependencies = [
  "alloy-transport",
  "alloy-transport-ws",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "mpp",
  "reqwest 0.13.4",
  "rustls",
@@ -1076,7 +1076,7 @@ dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "rustls",
  "serde_json",
  "tokio",
@@ -1195,7 +1195,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1219,7 +1219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1286,11 +1286,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-evm",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -1774,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1887,9 +1887,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701418aa459dac33e50a0f8e818e5662a16bc018a6ac7423659b70f3799d67a8"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1907,7 +1907,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "sha1",
  "time",
  "tokio",
@@ -1954,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6b50a43f3ccdf331521c6d6c68b7cc9668b6e09d439ebda9569df5722324d76"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -1969,7 +1969,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
@@ -1979,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.113.0"
+version = "1.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63e9270baf4f303322da2da92c36db3d9bb28d5a31c3ad28c8818b20f4b9814"
+checksum = "c0b7d906608ee41e7ddea9983577ba82200435644d567d63dc34e822e088b453"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -1998,16 +1998,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.104.0"
+version = "1.105.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53416d16c278234845392e38d93bd4481d2f09daa0f005a2277f0aa91f59c22"
+checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -2024,16 +2024,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.106.0"
+version = "1.107.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc9b706c3305ed0285d5b1b696c747aa34950f830fb03e3e6c76890f99b9f188"
+checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -2050,16 +2050,16 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.109.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d214cdfa5bbe17f117e76a7643fadf32a5234fb597322ef8b1fb4b2f17dbbd"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -2077,7 +2077,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "regex-lite",
  "tracing",
 ]
@@ -2097,7 +2097,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "percent-encoding",
  "sha2 0.11.0",
  "time",
@@ -2127,7 +2127,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "percent-encoding",
@@ -2146,7 +2146,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -2209,7 +2209,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -2230,7 +2230,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -2256,7 +2256,7 @@ checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -2269,7 +2269,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 0.4.6",
  "http-body 1.1.0",
  "http-body-util",
@@ -2320,7 +2320,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -2353,7 +2353,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "mime",
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
 dependencies = [
  "cc",
  "glob",
@@ -2730,7 +2730,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2870,9 +2870,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -2970,10 +2970,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-contracts",
- "tempo-hardfork",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tokio",
  "tower",
  "tracing",
@@ -2993,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -3137,9 +3137,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -3157,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3172,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]
@@ -3217,7 +3217,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.19",
  "which",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3376,7 +3376,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4451,7 +4451,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4479,13 +4479,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4597,9 +4597,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -4661,22 +4661,22 @@ checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4723,7 +4723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4854,12 +4854,6 @@ name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
-
-[[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -5103,7 +5097,7 @@ dependencies = [
  "soldeer-core",
  "svm-rs",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "toml_edit",
@@ -5145,7 +5139,7 @@ dependencies = [
  "similar",
  "snapbox",
  "solar-compiler",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -5205,8 +5199,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5375,12 +5369,12 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts",
- "tempo-hardfork",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "walkdir",
 ]
@@ -5391,7 +5385,7 @@ version = "1.8.0"
 dependencies = [
  "alloy-sol-types",
  "foundry-macros",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
 ]
@@ -5438,10 +5432,10 @@ dependencies = [
  "solar-compiler",
  "strsim",
  "tempfile",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tikv-jemallocator",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber 0.3.23",
  "tracing-tracy",
@@ -5515,8 +5509,8 @@ dependencies = [
  "sha2 0.11.0",
  "solar-compiler",
  "tempfile",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "tower",
@@ -5548,7 +5542,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "yansi",
 ]
 
@@ -5680,7 +5674,7 @@ dependencies = [
  "strum 0.28.0",
  "tempfile",
  "thiserror 2.0.19",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "toml_edit",
  "tracing",
  "unit-prefix",
@@ -5742,7 +5736,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5805,12 +5799,12 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-contracts",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-evm",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -5871,7 +5865,7 @@ dependencies = [
  "op-revm",
  "revm",
  "serde",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
@@ -5888,7 +5882,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-contracts",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
@@ -5950,7 +5944,7 @@ dependencies = [
  "snapbox",
  "solar-compiler",
  "tempfile",
- "tempo-contracts",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -6022,8 +6016,8 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
 ]
 
@@ -6094,7 +6088,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -6311,8 +6305,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -6437,7 +6431,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -6587,9 +6581,9 @@ dependencies = [
 
 [[package]]
 name = "html-escape"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
+checksum = "c9356095b4b41197bba32173600e1582792cda618f65d12f68e2e77d273413c5"
 
 [[package]]
 name = "http"
@@ -6604,9 +6598,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -6630,7 +6624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -6641,7 +6635,7 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "pin-project-lite",
 ]
@@ -6660,9 +6654,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -6678,7 +6672,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "httparse",
  "httpdate",
@@ -6695,7 +6689,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -6729,7 +6723,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "hyper",
  "ipnet",
@@ -6756,7 +6750,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7067,9 +7061,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.2"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+checksum = "798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -7104,9 +7098,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-terminal"
@@ -7116,7 +7110,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7178,9 +7172,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
  "defmt",
  "jiff-core",
@@ -7202,9 +7196,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
  "jiff-core",
  "proc-macro2",
@@ -7436,9 +7430,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -7760,7 +7754,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hmac 0.13.0",
- "http 1.4.2",
+ "http 1.5.0",
  "p256",
  "rand 0.10.2",
  "reqwest 0.13.4",
@@ -7770,7 +7764,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2 0.11.0",
  "subtle",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -7786,9 +7780,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "newtype-uuid"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c012d14ef788ab066a347d19e3dda699916c92293b05b85ba2c76b8c82d2830"
+checksum = "0fa56da58097c7ae893c4097bb6d91bb5f7fa330053e07e033349db4d5f83ba8"
 dependencies = [
  "uuid 1.24.0",
 ]
@@ -7927,7 +7921,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8085,12 +8079,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
+ "dispatch2",
+ "objc2",
 ]
 
 [[package]]
@@ -8107,6 +8114,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -8151,7 +8159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b685c8311c9171d1bd2895222965d25616b2de2cb5819dd3504ed9250df9fecd"
 dependencies = [
  "ahash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "parking_lot",
  "stable_deref_trait",
 ]
@@ -8324,7 +8332,7 @@ checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "opentelemetry",
  "reqwest 0.12.28",
 ]
@@ -8335,7 +8343,7 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -8418,26 +8426,35 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
 dependencies = [
  "approx",
- "fast-srgb8",
  "libm",
  "palette_derive",
+ "palette_math",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
 dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -9228,7 +9245,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9621,7 +9638,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -9663,7 +9680,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -10653,14 +10670,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -10712,7 +10729,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10843,9 +10860,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -10856,14 +10873,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -11061,13 +11078,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -11149,7 +11166,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -11445,7 +11462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11845,34 +11862,35 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sval"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb9efbae90f97301f4d25f3be63dfd99d6b7af9d088228a52ec960d649b2e7d"
+checksum = "ba3a370f3cd0422964fd9a19b6516f048527738e6ec50b1b0ff79b460b468390"
 
 [[package]]
 name = "sval_buffer"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5c0280ea0af40b3a1fd0b532680b5067482ffb81412ee66ec04b1d9952b49a"
+checksum = "111e6e2dab25782acb41b281263f5f60d6f56a2ba0b3b076187ad23a1552544d"
 dependencies = [
  "sval",
  "sval_ref",
+ "zerocopy",
 ]
 
 [[package]]
 name = "sval_dynamic"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b9067f2e68f58e110cf8019a268057e3791cf74b0fdb1b3c7c6e49104f44e6"
+checksum = "590ac4ebd299740eac453162302a494e6d5b3be243feab8bf07d0d4331b6b2b3"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_fmt"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ebdbf0e4b175884aa587fcf551c16dabe245ea04235abdd8cbbd160b27ed5a"
+checksum = "4b964d6d917267355d7f343c515b908586e5b4aeeada328738f703452f9412d6"
 dependencies = [
  "itoa",
  "ryu",
@@ -11881,9 +11899,9 @@ dependencies = [
 
 [[package]]
 name = "sval_json"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e448d9fa216a6c16670b28d624fbbcf5c04e41eb187bd7c52e01222ffa72a12"
+checksum = "dea35e4d6b997acc7dc4786ab782f6a6c5000efe4ae93a2db89cf350775fe5fe"
 dependencies = [
  "itoa",
  "ryu",
@@ -11892,9 +11910,9 @@ dependencies = [
 
 [[package]]
 name = "sval_nested"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021de5b5c26efd544c694cef9b8a9abe8633481bf3be1ea145a18a740818b291"
+checksum = "a73195ebd4b3e5866db2e1b75f3f383657ad5abc600c646d69b4f064fee89154"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -11903,18 +11921,18 @@ dependencies = [
 
 [[package]]
 name = "sval_ref"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ef5ffec8bc52ded04ee424ab8d959e25e64fd40a48a16d21f8991ce824c1bb"
+checksum = "c0ef28df9d586bfd15115286651337cb5645f8c203160d22d2d1a20cf13c428c"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_serde"
-version = "2.20.0"
+version = "2.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b983833a8a2390f89ebcf9b9acd06883017014b4ffd72ee28e0c9de6852039f5"
+checksum = "d72fbe6537e88878f10237bde71ae4a1b65b2bf54bdf274abc566fc696334c92"
 dependencies = [
  "serde_core",
  "sval",
@@ -12074,13 +12092,13 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12103,15 +12121,15 @@ dependencies = [
  "derive_more",
  "dirs-next",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "p256",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-chainspec",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tower",
  "tracing",
@@ -12120,7 +12138,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12136,26 +12154,26 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-dkg-onchain-artifacts",
- "tempo-hardfork",
- "tempo-primitives",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-sol-types",
  "serde",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12167,7 +12185,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12185,11 +12203,11 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-primitives-traits 0.5.2",
  "reth-revm",
- "tempo-chainspec",
- "tempo-contracts",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-dkg-onchain-artifacts",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tracing",
@@ -12198,7 +12216,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12210,7 +12228,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12222,10 +12240,10 @@ dependencies = [
  "paste",
  "revm",
  "scoped-tls",
- "tempo-chainspec",
- "tempo-contracts",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles-macros",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -12233,7 +12251,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12244,7 +12262,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12265,13 +12283,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12282,10 +12300,10 @@ dependencies = [
  "reth-evm",
  "reth-storage-api",
  "revm",
- "tempo-chainspec",
- "tempo-contracts",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -12297,7 +12315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12331,9 +12349,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
 
 [[package]]
 name = "thiserror"
@@ -12501,13 +12519,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -12591,9 +12609,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -12639,9 +12657,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.4",
 ]
@@ -12663,7 +12681,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "hyper",
@@ -12724,7 +12742,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
  "pin-project-lite",
@@ -12744,7 +12762,7 @@ checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body 1.1.0",
  "percent-encoding",
  "pin-project-lite",
@@ -12936,7 +12954,7 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.5",
@@ -12955,7 +12973,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.5",
@@ -13255,9 +13273,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef73bfbaf3216cb59c205d7176bee1194e0d84348979da31f4a71fefe3c2054e"
+checksum = "068e763e8279de7ab94b6afebded2cb701678af094feb1c12ccb061b4783c1be"
 dependencies = [
  "value-bag-serde1",
  "value-bag-sval2",
@@ -13265,9 +13283,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-serde1"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b92170db3db8a6354f12a5b7f13a5453928433e08fc46aee51eedfa8f7a28a1"
+checksum = "417d6197dd0ee696783d6be4276ac6ea74b985e00024c85ccfb37aff4f2bed82"
 dependencies = [
  "erased-serde",
  "serde_core",
@@ -13276,9 +13294,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag-sval2"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9832097ca044466ae3f1aa43a943d4e450b7c3b8cdf65363875df07da79a0"
+checksum = "c61f7251ecde2c9ed431bbe0659853e7991753447447bbf1ae59d8b31c578d4e"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -13499,7 +13517,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13559,15 +13577,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
 dependencies = [
- "core-foundation 0.10.1",
  "jni",
  "log",
  "ndk-context",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "url",
  "web-sys",
@@ -13647,7 +13665,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,11 +1286,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-evm",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -2970,10 +2970,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tokio",
  "tower",
  "tracing",
@@ -5097,7 +5097,7 @@ dependencies = [
  "soldeer-core",
  "svm-rs",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "toml_edit",
@@ -5199,8 +5199,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5369,10 +5369,10 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
@@ -5432,7 +5432,7 @@ dependencies = [
  "solar-compiler",
  "strsim",
  "tempfile",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tikv-jemallocator",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
@@ -5509,8 +5509,8 @@ dependencies = [
  "sha2 0.11.0",
  "solar-compiler",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "tower",
@@ -5542,7 +5542,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "yansi",
 ]
 
@@ -5736,7 +5736,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5799,12 +5799,12 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-evm",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -5865,7 +5865,7 @@ dependencies = [
  "op-revm",
  "revm",
  "serde",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
@@ -5882,7 +5882,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
@@ -5944,7 +5944,7 @@ dependencies = [
  "snapbox",
  "solar-compiler",
  "tempfile",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -6016,8 +6016,8 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
 ]
 
@@ -6088,7 +6088,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -7764,7 +7764,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2 0.11.0",
  "subtle",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -12098,7 +12098,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12127,9 +12127,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tower",
  "tracing",
@@ -12138,7 +12138,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12154,26 +12154,26 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-dkg-onchain-artifacts",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-sol-types",
  "serde",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12185,7 +12185,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12203,11 +12203,11 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-primitives-traits 0.5.2",
  "reth-revm",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-dkg-onchain-artifacts",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tracing",
@@ -12216,7 +12216,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12228,7 +12228,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12240,10 +12240,10 @@ dependencies = [
  "paste",
  "revm",
  "scoped-tls",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles-macros",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -12251,7 +12251,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12262,7 +12262,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12283,13 +12283,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12300,10 +12300,10 @@ dependencies = [
  "reth-evm",
  "reth-storage-api",
  "revm",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,7 +1045,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=6b05c45fd08e1331434d4fb42dd4039bb5ba06bd#6b05c45fd08e1331434d4fb42dd4039bb5ba06bd"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=54c00386713797bd10f021c33cd4d73fc62bd083#54c00386713797bd10f021c33cd4d73fc62bd083"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1286,11 +1286,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-evm",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -2970,10 +2970,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tokio",
  "tower",
  "tracing",
@@ -5097,7 +5097,7 @@ dependencies = [
  "soldeer-core",
  "svm-rs",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "toml_edit",
@@ -5199,8 +5199,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5369,10 +5369,10 @@ dependencies = [
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
@@ -5432,7 +5432,7 @@ dependencies = [
  "solar-compiler",
  "strsim",
  "tempfile",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tikv-jemallocator",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
@@ -5509,8 +5509,8 @@ dependencies = [
  "sha2 0.11.0",
  "solar-compiler",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "tower",
@@ -5542,7 +5542,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "yansi",
 ]
 
@@ -5736,7 +5736,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5799,12 +5799,12 @@ dependencies = [
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-evm",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -5865,7 +5865,7 @@ dependencies = [
  "op-revm",
  "revm",
  "serde",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
@@ -5882,7 +5882,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
@@ -5944,7 +5944,7 @@ dependencies = [
  "snapbox",
  "solar-compiler",
  "tempfile",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -6016,8 +6016,8 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
 ]
 
@@ -6060,7 +6060,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=fc6094a327729aad6d7c8668746cad6a7118c328#fc6094a327729aad6d7c8668746cad6a7118c328"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -6088,7 +6088,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -7743,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=6b05c45fd08e1331434d4fb42dd4039bb5ba06bd#6b05c45fd08e1331434d4fb42dd4039bb5ba06bd"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=54c00386713797bd10f021c33cd4d73fc62bd083#54c00386713797bd10f021c33cd4d73fc62bd083"
 dependencies = [
  "alloy",
  "async-stream",
@@ -7764,7 +7764,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2 0.11.0",
  "subtle",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -12098,7 +12098,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12127,9 +12127,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tower",
  "tracing",
@@ -12138,7 +12138,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12154,26 +12154,26 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-dkg-onchain-artifacts",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-sol-types",
  "serde",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12185,7 +12185,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12203,11 +12203,11 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-primitives-traits 0.5.2",
  "reth-revm",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-dkg-onchain-artifacts",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tracing",
@@ -12216,7 +12216,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12228,7 +12228,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12240,10 +12240,10 @@ dependencies = [
  "paste",
  "revm",
  "scoped-tls",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles-macros",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -12251,7 +12251,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12262,7 +12262,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12283,13 +12283,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
 ]
 
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12300,10 +12300,10 @@ dependencies = [
  "reth-evm",
  "reth-storage-api",
  "revm",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo.git?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c)",
  "thiserror 2.0.19",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "fb7922c0e92cf52b5cbca73826fb05ca7e32a50f", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "fc6094a327729aad6d7c8668746cad6a7118c328", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -512,30 +512,30 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6b05c45fd08e1331434d4fb42dd4039bb5ba06bd", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "54c00386713797bd10f021c33cd4d73fc62bd083", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6b05c45fd08e1331434d4fb42dd4039bb5ba06bd", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "54c00386713797bd10f021c33cd4d73fc62bd083", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -629,16 +629,9 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = 
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-
-[patch."https://github.com/tempoxyz/tempo"]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -522,20 +522,20 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6b05c45fd08e1331434d4
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -629,9 +629,16 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = 
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+
+[patch."https://github.com/tempoxyz/tempo"]
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -522,20 +522,20 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "6b05c45fd08e1331434d4
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -629,16 +629,16 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = 
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
 
 [patch."https://github.com/tempoxyz/tempo"]
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-chainspec = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-chainspec = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo.git", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]


### PR DESCRIPTION
Coordinate the Tempo revision across Foundry, foundry-core, and mpp-rs so the workspace resolves one compatible git revision.

Depends on [foundry-core#141](https://github.com/foundry-rs/foundry-core/pull/141) and [mpp-rs#372](https://github.com/tempoxyz/mpp-rs/pull/372). The lockfile and required dependency changelog are included.

Prompted by: @grandizzy

This PR was written primarily by Codex.