### PR TITLE
fix(test-utils): use official BSC testnet RPC

### DIFF
--- a/.changelog/replace-bsc-testnet-rpc.md
+++ b/.changelog/replace-bsc-testnet-rpc.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Use the official BNB Chain RPC endpoint for BSC testnet integration tests.

--- a/crates/test-utils/src/rpc.rs
+++ b/crates/test-utils/src/rpc.rs
@@ -182,7 +182,7 @@ fn next_url_inner(is_ws: bool, chain: NamedChain) -> String {
     }
 
     if matches!(chain, BinanceSmartChainTestnet) {
-        return "https://bsc-testnet-rpc.publicnode.com".to_string();
+        return "https://bsc-testnet.bnbchain.org".to_string();
     }
 
     if matches!(chain, Celo) {


### PR DESCRIPTION
Use the official BNB Chain BSC testnet RPC endpoint for Cast integration tests, replacing the unavailable PublicNode endpoint that caused repeated HTTP 503 failures in CI.\n\nThis PR was written primarily with Codex.\n\nPrompted by: @grandizzy