### PR TITLE
fix(mutation): retain gas-distinct bounds

### DIFF
--- a/.changelog/retain-gas-distinct-bounds.md
+++ b/.changelog/retain-gas-distinct-bounds.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Retained comparison mutants that can compile to gas-distinct bytecode.

--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -430,7 +430,7 @@ impl MutationHandler {
         let mut mutant_cfg_hasher = DefaultHasher::new();
         // Version salt for this mutant-set cache schema. Bump this if the
         // inputs that define generated mutants change.
-        "mutant-set-v4".hash(&mut mutant_cfg_hasher);
+        "mutant-set-v5".hash(&mut mutant_cfg_hasher);
         for op in self.config.mutation.enabled_operators() {
             op.to_string().hash(&mut mutant_cfg_hasher);
         }

--- a/crates/forge/src/mutation/type_analysis.rs
+++ b/crates/forge/src/mutation/type_analysis.rs
@@ -1,10 +1,8 @@
 //! Type-aware filtering for operator mutations.
 //!
-//! This module records replacements that are either type-invalid or have the same result as the
-//! original comparison for every value in an operand's type range. It deliberately does not filter
-//! replacements merely because they are tautological. For example, `uint256 x == 0` and `x <= 0`
-//! are equivalent, but `x < 0` is retained because changing the original condition to `false` can
-//! expose missing tests.
+//! This module records replacements that are type-invalid. It deliberately does not filter
+//! replacements merely because they return the same value for every input: different operators can
+//! still compile to gas-distinct bytecode.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -12,17 +10,16 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use alloy_primitives::U256;
 use eyre::Result;
 use foundry_cli::opts::configure_pcx_from_compile_output;
 use foundry_compilers::{ProjectCompileOutput, compilers::multi::MultiCompiler};
 use foundry_config::Config;
 use solar::{
-    ast::{BinOpKind, LitKind, UnOpKind},
+    ast::{BinOpKind, UnOpKind},
     interface::{Session, source_map::FileName},
     sema::{
         Compiler, Gcx,
-        hir::{self, ElementaryType, ExprKind, TypeKind, Visit},
+        hir::{self, ElementaryType, ExprKind, Visit},
         ty::TyKind,
     },
 };
@@ -150,42 +147,6 @@ impl MutationExclusionCollector<'_> {
                 self.mutations.insert(MutationExclusion::binary(span, candidate));
             }
         }
-
-        if !original.is_cmp() {
-            return;
-        }
-
-        let comparison = if let (Some(range), Some(value)) =
-            (integer_range(self.gcx, left), constant_value(right))
-        {
-            Some((range, value, original, false))
-        } else if let (Some(value), Some(range)) =
-            (constant_value(left), integer_range(self.gcx, right))
-        {
-            Some((range, value, flip(original), true))
-        } else {
-            None
-        };
-        let Some((range, value, normalized_original, operands_reversed)) = comparison else {
-            return;
-        };
-
-        for candidate in [
-            BinOpKind::Lt,
-            BinOpKind::Le,
-            BinOpKind::Gt,
-            BinOpKind::Ge,
-            BinOpKind::Eq,
-            BinOpKind::Ne,
-        ] {
-            if candidate == original {
-                continue;
-            }
-            let normalized_candidate = if operands_reversed { flip(candidate) } else { candidate };
-            if equivalent_at_boundary(range, value, normalized_original, normalized_candidate) {
-                self.mutations.insert(MutationExclusion::binary(span, candidate));
-            }
-        }
     }
 
     fn local_span(&self, span: solar::ast::Span) -> Option<solar::ast::Span> {
@@ -242,172 +203,10 @@ fn comparison_operand_kind(
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct IntegerRange {
-    lower: SignedValue,
-    upper: SignedValue,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct SignedValue {
-    negative: bool,
-    magnitude: U256,
-}
-
-impl SignedValue {
-    const ZERO: Self = Self { negative: false, magnitude: U256::ZERO };
-
-    fn new(negative: bool, magnitude: U256) -> Self {
-        if magnitude.is_zero() { Self::ZERO } else { Self { negative, magnitude } }
-    }
-}
-
-fn integer_range(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> Option<IntegerRange> {
-    if let Some(ty) = gcx.type_of_expr(expr.id)
-        && let TyKind::Elementary(ty) = ty.peel_refs().kind
-    {
-        return integer_range_for_type(ty);
-    }
-
-    // Fall back to types available during lowering when Solar could not infer this expression.
-    let ty = match &expr.peel_parens().kind {
-        ExprKind::Ident(_) => {
-            let variable = expr.as_variable()?;
-            match gcx.hir.variable(variable).ty.kind {
-                TypeKind::Elementary(ty) => ty,
-                _ => return None,
-            }
-        }
-        ExprKind::Call(callee, args, _) => {
-            let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(ty), .. }) =
-                &callee.peel_parens().kind
-            else {
-                return None;
-            };
-            let mut expressions = args.exprs();
-            expressions.next()?;
-            if expressions.next().is_some() {
-                return None;
-            }
-            *ty
-        }
-        _ => return None,
-    };
-    integer_range_for_type(ty)
-}
-
 fn is_unsigned(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> bool {
     gcx.type_of_expr(expr.peel_parens().id).is_some_and(|ty| {
         matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::UInt(_)))
     })
-}
-
-fn integer_range_for_type(ty: ElementaryType) -> Option<IntegerRange> {
-    match ty {
-        ElementaryType::UInt(size) => {
-            let bits = size.bits();
-            let upper =
-                if bits == 256 { U256::MAX } else { (U256::from(1u8) << bits) - U256::from(1u8) };
-            Some(IntegerRange { lower: SignedValue::ZERO, upper: SignedValue::new(false, upper) })
-        }
-        ElementaryType::Int(size) => {
-            let half = U256::from(1u8) << (size.bits() - 1);
-            Some(IntegerRange {
-                lower: SignedValue::new(true, half),
-                upper: SignedValue::new(false, half - U256::from(1u8)),
-            })
-        }
-        ElementaryType::Address(_) => {
-            let upper = (U256::from(1u8) << 160) - U256::from(1u8);
-            Some(IntegerRange { lower: SignedValue::ZERO, upper: SignedValue::new(false, upper) })
-        }
-        _ => None,
-    }
-}
-
-fn constant_value(expr: &hir::Expr<'_>) -> Option<SignedValue> {
-    match &expr.peel_parens().kind {
-        ExprKind::Lit(lit) => match lit.kind {
-            LitKind::Number(value) => Some(SignedValue::new(false, value)),
-            LitKind::Address(value) => {
-                Some(SignedValue::new(false, U256::from_be_slice(value.as_slice())))
-            }
-            _ => None,
-        },
-        ExprKind::Unary(op, inner) if op.kind == UnOpKind::Neg => {
-            let ExprKind::Lit(lit) = &inner.peel_parens().kind else { return None };
-            let LitKind::Number(value) = lit.kind else { return None };
-            Some(SignedValue::new(true, value))
-        }
-        ExprKind::Member(type_call, member) => {
-            let ExprKind::TypeCall(hir::Type { kind: TypeKind::Elementary(ty), .. }) =
-                &type_call.peel_parens().kind
-            else {
-                return None;
-            };
-            let range = integer_range_for_type(*ty)?;
-            match member.as_str() {
-                "min" => Some(range.lower),
-                "max" => Some(range.upper),
-                _ => None,
-            }
-        }
-        ExprKind::Call(callee, args, _) => {
-            let ExprKind::Type(hir::Type { kind: TypeKind::Elementary(ty), .. }) =
-                &callee.peel_parens().kind
-            else {
-                return None;
-            };
-            let mut expressions = args.exprs();
-            let inner = expressions.next()?;
-            if expressions.next().is_some() {
-                return None;
-            }
-            let range = integer_range_for_type(*ty)?;
-            let value = constant_value(inner)?;
-            (value == range.lower || value == range.upper).then_some(value)
-        }
-        _ => None,
-    }
-}
-
-fn equivalent_at_boundary(
-    range: IntegerRange,
-    value: SignedValue,
-    original: BinOpKind,
-    candidate: BinOpKind,
-) -> bool {
-    let pair = (original, candidate);
-    if value == range.lower {
-        matches!(
-            pair,
-            (BinOpKind::Eq, BinOpKind::Le)
-                | (BinOpKind::Le, BinOpKind::Eq)
-                | (BinOpKind::Ne, BinOpKind::Gt)
-                | (BinOpKind::Gt, BinOpKind::Ne)
-        )
-    } else if value == range.upper {
-        matches!(
-            pair,
-            (BinOpKind::Eq, BinOpKind::Ge)
-                | (BinOpKind::Ge, BinOpKind::Eq)
-                | (BinOpKind::Ne, BinOpKind::Lt)
-                | (BinOpKind::Lt, BinOpKind::Ne)
-        )
-    } else {
-        false
-    }
-}
-
-const fn flip(op: BinOpKind) -> BinOpKind {
-    match op {
-        BinOpKind::Lt => BinOpKind::Gt,
-        BinOpKind::Le => BinOpKind::Ge,
-        BinOpKind::Gt => BinOpKind::Lt,
-        BinOpKind::Ge => BinOpKind::Le,
-        BinOpKind::Eq | BinOpKind::Ne => op,
-        _ => unreachable!(),
-    }
 }
 
 #[cfg(test)]
@@ -447,27 +246,7 @@ mod tests {
     }
 
     #[test]
-    fn identifies_only_equivalent_unsigned_lower_bound_mutations() {
-        let range =
-            integer_range_for_type(ElementaryType::UInt(solar::ast::TypeSize::new_int_bits(256)))
-                .unwrap();
-
-        assert!(equivalent_at_boundary(range, SignedValue::ZERO, BinOpKind::Eq, BinOpKind::Le));
-        assert!(!equivalent_at_boundary(range, SignedValue::ZERO, BinOpKind::Eq, BinOpKind::Lt));
-        assert!(equivalent_at_boundary(range, SignedValue::ZERO, BinOpKind::Ne, BinOpKind::Gt));
-    }
-
-    #[test]
-    fn does_not_treat_zero_as_a_signed_boundary() {
-        let range =
-            integer_range_for_type(ElementaryType::Int(solar::ast::TypeSize::new_int_bits(256)))
-                .unwrap();
-
-        assert!(!equivalent_at_boundary(range, SignedValue::ZERO, BinOpKind::Eq, BinOpKind::Le));
-    }
-
-    #[test]
-    fn collects_typed_unsigned_boundary_equivalents() {
+    fn preserves_gas_distinct_unsigned_boundary_mutations() {
         let source = r#"
 contract Test {
     function check(uint256 x) external pure returns (bool) {
@@ -477,22 +256,8 @@ contract Test {
 "#;
         let mutations = collect(source);
 
-        assert!(mutations.contains(&mutation(source, "x == 0", BinOpKind::Le)));
-        assert!(!mutations.contains(&mutation(source, "x == 0", BinOpKind::Lt)));
-    }
-
-    #[test]
-    fn preserves_signed_zero_mutations() {
-        let source = r#"
-contract Test {
-    function check(int256 x) external pure returns (bool) {
-        return x == 0;
-    }
-}
-"#;
-        let mutations = collect(source);
-
         assert!(!mutations.contains(&mutation(source, "x == 0", BinOpKind::Le)));
+        assert!(!mutations.contains(&mutation(source, "x == 0", BinOpKind::Lt)));
     }
 
     #[test]
@@ -636,7 +401,7 @@ contract Test {
     }
 
     #[test]
-    fn handles_reversed_operands_and_upper_bounds() {
+    fn preserves_reversed_and_upper_boundary_mutations() {
         let source = r#"
 contract Test {
     function lower(uint256 x) external pure returns (bool) {
@@ -650,13 +415,13 @@ contract Test {
 "#;
         let mutations = collect(source);
 
-        assert!(mutations.contains(&mutation(source, "0 == x", BinOpKind::Ge)));
+        assert!(!mutations.contains(&mutation(source, "0 == x", BinOpKind::Ge)));
         assert!(!mutations.contains(&mutation(source, "0 == x", BinOpKind::Gt)));
-        assert!(mutations.contains(&mutation(source, "x == type(uint8).max", BinOpKind::Ge)));
+        assert!(!mutations.contains(&mutation(source, "x == type(uint8).max", BinOpKind::Ge)));
     }
 
     #[test]
-    fn uses_inferred_member_types_and_typed_zero_constants() {
+    fn preserves_member_and_typed_constant_boundary_mutations() {
         let source = r#"
 contract Test {
     function empty(bytes memory value) external pure returns (bool) {
@@ -670,7 +435,7 @@ contract Test {
 "#;
         let mutations = collect(source);
 
-        assert!(mutations.contains(&mutation(source, "value.length == 0", BinOpKind::Le)));
-        assert!(mutations.contains(&mutation(source, "value == address(0)", BinOpKind::Le)));
+        assert!(!mutations.contains(&mutation(source, "value.length == 0", BinOpKind::Le)));
+        assert!(!mutations.contains(&mutation(source, "value == address(0)", BinOpKind::Le)));
     }
 }

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -115,7 +115,7 @@ Survived mutants
 "#]]);
 });
 
-forgetest_init!(mutation_testing_prunes_typed_boundary_equivalents, |prj, cmd| {
+forgetest_init!(mutation_testing_retains_gas_distinct_bounds, |prj, cmd| {
     prj.add_source(
         "Boundary.sol",
         r#"
@@ -166,16 +166,12 @@ exclude_operators = [
     )
     .unwrap();
 
-    let output = cmd
-        .args(["test", "--mutate", "src/Boundary.sol", "--mutation-jobs", "1", "--json"])
-        .assert_success();
-    let summary = mutation_summary(&output.get_output().stdout_lossy());
+    cmd.args(["test", "--mutate", "src/Boundary.sol", "--mutation-jobs", "1", "--json"])
+        .assert_success()
+        .stdout_eq(str![[r#"
+{"summary":{"total":5,"killed":4,"survived":1,"invalid":0,"skipped":0,"timed_out":0,"mutation_score":80.0,"duration_secs":[..]},"survived_mutants":{"src/Boundary.sol":[{"line":7,"column":16,"original":"value == 0","mutant":"value <= 0"}]}}
 
-    assert_eq!(summary["total"], 4);
-    assert_eq!(summary["killed"], 4);
-    assert_eq!(summary["survived"], 0);
-    assert_eq!(summary["invalid"], 0);
-    assert_eq!(summary["mutation_score"], 100.0);
+"#]]);
 });
 
 forgetest_init!(mutation_testing_comparison_type_matrix, |prj, cmd| {
@@ -1720,7 +1716,7 @@ contract VaultTest is Test {
 "#,
     );
 
-    // Type analysis excludes the equivalent msg.value > 0 -> msg.value != 0 mutant.
+    // The gas-distinct msg.value > 0 -> msg.value != 0 mutant remains.
     let mut cmd2 = prj.forge_command();
     cmd2.args(["test", "--mutate", "src/Vault.sol", "--mutation-jobs", "2"]);
     cmd2.assert_success().stdout_eq(str![[r#"
@@ -1734,16 +1730,16 @@ MUTATION TESTING RESULTS
 ╭──────────┬───────────┬────────────╮
 │ Status   ┆ # Mutants ┆ % of Total │
 ╞══════════╪═══════════╪════════════╡
-│ Survived ┆ 2         ┆ 3.8%       │
+│ Survived ┆ 3         ┆ 5.6%       │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Killed   ┆ 49        ┆ 92.5%      │
+│ Killed   ┆ 49        ┆ 90.7%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
 │ Invalid  ┆ 1         ┆ 1.9%       │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
 │ Skipped  ┆ 1         ┆ 1.9%       │
 ╰──────────┴───────────┴────────────╯
 ...
-Mutation Score: 96.1% (49/51 mutants killed); [ELAPSED]
+Mutation Score: 94.2% (49/52 mutants killed); [ELAPSED]
 ...
 "#]]);
 });


### PR DESCRIPTION
## Motivation

#15942 correctly identified comparison mutants that produce the same Boolean result across an operand’s valid type range. However, equal truth tables do not guarantee equivalent EVM behavior: with the optimizer disabled, `uint256 value == 0` compiles using `EQ`, while `value <= 0` uses `GT; ISZERO`.

### Results

| solc | `== 0` gas | `<= 0` gas |
|---|---:|---:|
| 0.8.13 | 592 | 595 |
| 0.8.20 | 583 | 586 |
| 0.8.36 | 582 | 585 |

The three-gas difference creates a supplied-gas boundary where the original succeeds and the mutant runs out of gas. Optimized builds currently compile both expressions identically, but pruning cannot rely on optimizer-dependent equivalence when mutation testing uses the project’s actual compiler configuration.

This removes the source-level boundary-equivalence pruning while preserving the unsigned-negation filtering from #15962 and type-invalid comparison filtering from #15971. It also advances the mutation cache version for the restored mutant set.
