### PR TITLE
chore(ci): ignore Dependabot changelogs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
+    labels:
+      - dependencies
+      - github_actions
+      - L-ignore
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
GitHub Actions dependency updates do not produce user-facing release changes, so Dependabot should apply `L-ignore` to these pull requests automatically. This explicitly retains the existing `dependencies` and `github_actions` labels because configuring custom Dependabot labels replaces its defaults.

> This PR was prepared with Codex assistance.
