### PR TITLE
fix(cast): restore browser wallet signing

### DIFF
--- a/.changelog/restore-cast-browser-wallet-signing.md
+++ b/.changelog/restore-cast-browser-wallet-signing.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Restored browser wallet personal-message and EIP-712 signing for `cast wallet sign`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=8b2c49e0baf93bb603bc80487cbe94d59a25a1ba#8b2c49e0baf93bb603bc80487cbe94d59a25a1ba"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=886503a096f15c26e13dfddf2b6330508c97b3bd#886503a096f15c26e13dfddf2b6330508c97b3bd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=0634600a803ec16553010f6d7bc36c14f40f4525#0634600a803ec16553010f6d7bc36c14f40f4525"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=8b2c49e0baf93bb603bc80487cbe94d59a25a1ba#8b2c49e0baf93bb603bc80487cbe94d59a25a1ba"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "0634600a803ec16553010f6d7bc36c14f40f4525", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b2c49e0baf93bb603bc80487cbe94d59a25a1ba", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "8b2c49e0baf93bb603bc80487cbe94d59a25a1ba", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "886503a096f15c26e13dfddf2b6330508c97b3bd", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -18,7 +18,7 @@ use foundry_cli::{
 };
 use foundry_common::{fs, sh_println, shell};
 use foundry_config::Config;
-use foundry_wallets::{RawWalletOpts, WalletOpts, WalletSigner};
+use foundry_wallets::{BrowserWalletOpts, RawWalletOpts, WalletOpts, WalletSigner};
 use rand_08::thread_rng;
 use serde_json::json;
 use std::path::Path;
@@ -162,6 +162,9 @@ pub enum WalletSubcommands {
 
         #[command(flatten)]
         wallet: WalletOpts,
+
+        #[command(flatten)]
+        browser: BrowserWalletOpts,
     },
 
     /// EIP-7702 sign authorization.
@@ -649,9 +652,12 @@ impl WalletSubcommands {
 
                 print_scalar(format!("0x{}", hex::encode(public_key)))?;
             }
-            Self::Sign { message, data, from_file, no_hash, wallet } => {
-                let wallet = wallet.signer().await?;
-                let sig = if data {
+            Self::Sign { message, data, from_file, no_hash, wallet, browser } => {
+                if browser.browser && no_hash {
+                    eyre::bail!("Raw hash signing is not supported with a browser wallet");
+                }
+
+                let typed_data = if data {
                     let typed_data: TypedData = if from_file {
                         // data is a file name, read json from file
                         foundry_common::fs::read_json_file(message.as_ref())?
@@ -659,24 +665,42 @@ impl WalletSubcommands {
                         // data is a json string
                         serde_json::from_str(&message)?
                     };
-                    wallet.sign_dynamic_typed_data(&typed_data).await?
-                } else if no_hash {
-                    wallet.sign_hash(&hex::decode(&message)?[..].try_into()?).await?
+                    Some(typed_data)
                 } else {
-                    wallet.sign_message(&Self::hex_str_to_bytes(&message)?).await?
+                    None
                 };
+
+                let (sig, address) =
+                    if let Some(browser) = browser.run::<alloy_network::Ethereum>().await? {
+                        let sig = if let Some(typed_data) = &typed_data {
+                            browser.sign_dynamic_typed_data(typed_data).await?
+                        } else {
+                            browser.sign_message(&Self::hex_str_to_bytes(&message)?).await?
+                        };
+                        (sig, browser.address())
+                    } else {
+                        let wallet = wallet.signer().await?;
+                        let sig = if let Some(typed_data) = &typed_data {
+                            wallet.sign_dynamic_typed_data(typed_data).await?
+                        } else if no_hash {
+                            wallet.sign_hash(&hex::decode(&message)?[..].try_into()?).await?
+                        } else {
+                            wallet.sign_message(&Self::hex_str_to_bytes(&message)?).await?
+                        };
+                        (sig, wallet.address())
+                    };
 
                 if shell::verbosity() > 0 {
                     if shell::is_json() {
                         print_json_success(json!({
                             "message": message,
-                            "address": wallet.address(),
+                            "address": address,
                             "signature": hex::encode(sig.as_bytes()),
                         }))?;
                     } else {
                         sh_status!("Successfully signed!")?;
                         sh_status!("   Message: {message}")?;
-                        sh_status!("   Address: {}", wallet.address())?;
+                        sh_status!("   Address: {address}")?;
                         sh_println!("0x{}", hex::encode(sig.as_bytes()))?;
                     }
                 } else {


### PR DESCRIPTION

## Motivation
Restore `cast wallet sign --browser` for personal messages and dynamic EIP-712 typed data. Browser message signing was removed with the unused generic signer implementations in #13613 + #13657.

## Solution

This uses the new explicit `BrowserSigner` APIs instead of restoring the generic `Signer`, `SignerSync`, or `TxSigner` implementations. Raw hash signing remains unsupported for browser wallets and is rejected before starting the browser server. Existing quiet, verbose, and JSON output modes use the connected browser-wallet address.

## Examples

Personal-message signing:

```sh
cast wallet sign "hello from cast" --browser
```

EIP-712 signing:

```sh
cast wallet sign --browser --data \
  '{"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"}],"Message":[{"name":"contents","type":"string"}]},"primaryType":"Message","domain":{"name":"Cast browser test","version":"1","chainId":1},"message":{"contents":"hello from EIP-712"}}'
```