### PR TITLE
fix(cast): complete browser wallet restoration

### DIFF
--- a/.changelog/restore-cast-browser-wallet-readonly-commands.md
+++ b/.changelog/restore-cast-browser-wallet-readonly-commands.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Restored browser wallet address resolution for `cast wallet address`, `cast call`, `cast access-list`, and `cast estimate`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=886503a096f15c26e13dfddf2b6330508c97b3bd#886503a096f15c26e13dfddf2b6330508c97b3bd"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=4a3ddf4f7780874120f9734f0d6dd28c39166007#4a3ddf4f7780874120f9734f0d6dd28c39166007"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=4a3ddf4f7780874120f9734f0d6dd28c39166007#4a3ddf4f7780874120f9734f0d6dd28c39166007"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d80a95d94aecafcf38647dfee9f4804552576c35#d80a95d94aecafcf38647dfee9f4804552576c35"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "4a3ddf4f7780874120f9734f0d6dd28c39166007", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "d80a95d94aecafcf38647dfee9f4804552576c35", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "886503a096f15c26e13dfddf2b6330508c97b3bd", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "4a3ddf4f7780874120f9734f0d6dd28c39166007", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }

--- a/crates/cast/src/cmd/access_list.rs
+++ b/crates/cast/src/cmd/access_list.rs
@@ -12,7 +12,7 @@ use foundry_cli::{
     utils::LoadConfig,
 };
 use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder};
-use foundry_wallets::WalletOpts;
+use foundry_wallets::{BrowserWalletOpts, WalletOpts};
 use std::str::FromStr;
 use tempo_alloy::TempoNetwork;
 
@@ -55,6 +55,9 @@ pub struct AccessListArgs {
 
     #[command(flatten)]
     wallet: WalletOpts,
+
+    #[command(flatten)]
+    browser: BrowserWalletOpts,
 }
 
 impl AccessListArgs {
@@ -70,7 +73,7 @@ impl AccessListArgs {
     where
         N::TransactionRequest: FoundryTransactionBuilder<N>,
     {
-        let Self { to, mut sig, args, data, tx, rpc, wallet, block } = self;
+        let Self { to, mut sig, args, data, tx, rpc, wallet, browser, block } = self;
 
         if let Some(data) = data {
             sig = Some(data);
@@ -78,7 +81,11 @@ impl AccessListArgs {
 
         let config = rpc.load_config()?;
         let provider = ProviderBuilder::<N>::from_config(&config)?.build()?;
-        let sender = SenderKind::from_wallet_opts(wallet).await?;
+        let sender = if let Some(browser) = browser.run::<N>().await? {
+            browser.address().into()
+        } else {
+            SenderKind::from_wallet_opts(wallet).await?
+        };
 
         let (tx, _) = CastTxBuilder::new(&provider, tx, &config)
             .await?

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -205,6 +205,9 @@ impl CallArgs {
 
         // Handle --curl mode early, before any provider interaction
         if self.rpc.curl {
+            if self.browser.browser {
+                eyre::bail!("--browser cannot be combined with --curl; use --from <ADDRESS>");
+            }
             return self.run_curl().await;
         }
 

--- a/crates/cast/src/cmd/call.rs
+++ b/crates/cast/src/cmd/call.rs
@@ -52,7 +52,7 @@ use foundry_evm::{
     opts::EvmOpts,
     traces::{InternalTraceMode, SparsedTraceArena, TraceRequirements},
 };
-use foundry_wallets::WalletOpts;
+use foundry_wallets::{BrowserWalletOpts, WalletOpts};
 use std::str::FromStr;
 
 /// CLI arguments for `cast call`.
@@ -145,6 +145,9 @@ pub struct CallArgs {
 
     #[command(flatten)]
     wallet: WalletOpts,
+
+    #[command(flatten)]
+    browser: BrowserWalletOpts,
 
     #[arg(
         short,
@@ -274,6 +277,7 @@ impl CallArgs {
             data,
             with_local_artifacts,
             wallet,
+            browser,
             ..
         } = self;
 
@@ -282,7 +286,11 @@ impl CallArgs {
         }
 
         let provider = ProviderBuilder::<FEN::Network>::from_config(&config)?.build()?;
-        let sender = SenderKind::from_wallet_opts(wallet).await?;
+        let sender = if let Some(browser) = browser.run::<FEN::Network>().await? {
+            browser.address().into()
+        } else {
+            SenderKind::from_wallet_opts(wallet).await?
+        };
         let from = sender.address();
 
         let code = if let Some(CallSubcommands::Create {

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -12,7 +12,7 @@ use foundry_cli::{
     utils::{LoadConfig, parse_ether_value},
 };
 use foundry_common::{FoundryTransactionBuilder, provider::ProviderBuilder};
-use foundry_wallets::WalletOpts;
+use foundry_wallets::{BrowserWalletOpts, WalletOpts};
 use std::str::FromStr;
 use tempo_alloy::TempoNetwork;
 
@@ -44,6 +44,9 @@ pub struct EstimateArgs {
 
     #[command(flatten)]
     wallet: WalletOpts,
+
+    #[command(flatten)]
+    browser: BrowserWalletOpts,
 
     #[command(subcommand)]
     command: Option<EstimateSubcommands>,
@@ -93,11 +96,16 @@ impl EstimateArgs {
     where
         N::TransactionRequest: FoundryTransactionBuilder<N>,
     {
-        let Self { to, mut sig, mut args, mut tx, block, cost, wallet, rpc, command } = self;
+        let Self { to, mut sig, mut args, mut tx, block, cost, wallet, browser, rpc, command } =
+            self;
 
         let config = rpc.load_config()?;
         let provider = ProviderBuilder::<N>::from_config(&config)?.build()?;
-        let sender = SenderKind::from_wallet_opts(wallet).await?;
+        let sender = if let Some(browser) = browser.run::<N>().await? {
+            browser.address().into()
+        } else {
+            SenderKind::from_wallet_opts(wallet).await?
+        };
 
         let code = if let Some(EstimateSubcommands::Create {
             code,

--- a/crates/cast/src/cmd/estimate.rs
+++ b/crates/cast/src/cmd/estimate.rs
@@ -101,7 +101,8 @@ impl EstimateArgs {
 
         let config = rpc.load_config()?;
         let provider = ProviderBuilder::<N>::from_config(&config)?.build()?;
-        let sender = if let Some(browser) = browser.run::<N>().await? {
+        let browser = browser.run::<N>().await?;
+        let sender = if let Some(browser) = &browser {
             browser.address().into()
         } else {
             SenderKind::from_wallet_opts(wallet).await?
@@ -134,6 +135,7 @@ impl EstimateArgs {
             .build(sender)
             .await?;
 
+        let tx = if browser.is_some() { tx.browser_wallet_gas_estimation_request() } else { tx };
         let gas = provider.estimate_gas(tx).block(block.unwrap_or_default()).await?;
         if cost {
             let gas_price_wei = provider.get_gas_price().await?;

--- a/crates/cast/src/cmd/wallet/mod.rs
+++ b/crates/cast/src/cmd/wallet/mod.rs
@@ -103,6 +103,9 @@ pub enum WalletSubcommands {
 
         #[command(flatten)]
         wallet: WalletOpts,
+
+        #[command(flatten)]
+        browser: BrowserWalletOpts,
     },
 
     /// Derive accounts from a mnemonic
@@ -571,16 +574,20 @@ impl WalletSubcommands {
             Self::Vanity(cmd) => {
                 cmd.run()?;
             }
-            Self::Address { wallet, private_key_override } => {
-                let wallet = private_key_override
-                    .map(|pk| WalletOpts {
+            Self::Address { wallet, browser, private_key_override } => {
+                let addr = if let Some(pk) = private_key_override {
+                    WalletOpts {
                         raw: RawWalletOpts { private_key: Some(pk), ..Default::default() },
                         ..Default::default()
-                    })
-                    .unwrap_or(wallet)
+                    }
                     .signer()
-                    .await?;
-                let addr = wallet.address();
+                    .await?
+                    .address()
+                } else if let Some(browser) = browser.run::<alloy_network::Ethereum>().await? {
+                    browser.address()
+                } else {
+                    wallet.signer().await?.address()
+                };
                 print_scalar(addr.to_checksum(None))?;
             }
             Self::Derive { mnemonic, accounts, insecure } => {

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -6737,6 +6737,19 @@ casttest!(curl_call_debug_trace_call_forwards_tx_fields, |_prj, cmd| {
     assert!(output.contains("nonce"), "expected the nonce in params:\n{output}");
 });
 
+casttest!(curl_call_rejects_browser_wallet, |_prj, cmd| {
+    let stderr = cmd
+        .args(["call", "0xdead000000000000000000000000000000000000", "--browser", "--curl"])
+        .assert_failure()
+        .get_output()
+        .stderr_lossy();
+
+    assert!(
+        stderr.contains("--browser cannot be combined with --curl; use --from <ADDRESS>"),
+        "unexpected stderr:\n{stderr}"
+    );
+});
+
 // tests that `--labels` / `--disable-labels` are accepted with `--debug-trace-call`, which
 // forwards them to the trace renderer like `--trace` does
 casttest!(call_labels_accepted_with_debug_trace_call, |_prj, cmd| {

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -119,6 +119,22 @@ Find more information in the book: https://getfoundry.sh/cast/overview
 "#]]);
 });
 
+casttest!(browser_wallet_commands_expose_browser_option, |_prj, cmd| {
+    for (name, args) in [
+        ("call", &["call", "--help"][..]),
+        ("estimate", &["estimate", "--help"]),
+        ("access-list", &["access-list", "--help"]),
+        ("wallet address", &["wallet", "address", "--help"]),
+        ("wallet sign", &["wallet", "sign", "--help"]),
+    ] {
+        let output = cmd.cast_fuse().args(args).assert_success().get_output().stdout_lossy();
+        assert!(
+            output.contains("--browser"),
+            "expected {name} help to expose --browser:\n{output}"
+        );
+    }
+});
+
 // tests that the `cast block` command works correctly
 casttest!(latest_block, |_prj, cmd| {
     let eth_rpc_url = next_http_rpc_endpoint();


### PR DESCRIPTION
Follow-up to #16012, completing the restoration of browser-wallet support across Cast. This restores browser-wallet address resolution for `cast wallet address`, `cast call`, `cast access-list`, and `cast estimate`.

These commands unintentionally lost `--browser` when #13613 extracted `BrowserSigner` from `WalletSigner` and moved browser options out of the shared `WalletOpts`. They do not require generic message or transaction signing; they only need the connected wallet address when constructing their RPC requests.

This also pins `foundry-wallets` to foundry-rs/foundry-core#146. That dependency update recovers the signer from personal-message and EIP-712 signatures returned by the browser and rejects signatures that do not match the connected wallet address, instead of accepting them based only on their encoding.

This PR was written with Codex assistance, including implementation, tests, and dependency integration.
