### PR TITLE
fix(cast): preserve named keystores

### DIFF
--- a/.changelog/cast-wallet-list-keystore-names.md
+++ b/.changelog/cast-wallet-list-keystore-names.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Fixed `cast wallet list` prepending `0x` to custom keystore names.

--- a/crates/cast/src/cmd/wallet/list.rs
+++ b/crates/cast/src/cmd/wallet/list.rs
@@ -5,7 +5,7 @@ use foundry_common::{fs, sh_err, sh_println, shell};
 use foundry_config::Config;
 use foundry_wallets::wallet_multi::MultiWalletOptsBuilder;
 use serde::Serialize;
-use std::env;
+use std::{borrow::Cow, env};
 
 /// CLI arguments for `cast wallet list`.
 #[derive(Clone, Debug, Parser)]
@@ -145,21 +145,30 @@ impl ListArgs {
                 && let Some(file_name) = path.file_name()
                 && let Some(name) = file_name.to_str()
             {
-                // Extract address from keystore filename format: UTC--{timestamp}--{address}
-                if let Some(address) = name.split("--").last() {
-                    if format_json {
-                        accounts.push(WalletAccount {
-                            address: format!("0x{address}"),
-                            source: "Local",
-                        });
-                    } else {
-                        sh_println!("0x{} (Local)", address)?;
-                    }
+                let account = local_account_name(name);
+                if format_json {
+                    accounts.push(WalletAccount { address: account.into_owned(), source: "Local" });
+                } else {
+                    sh_println!("{} (Local)", account)?;
                 }
             }
         }
 
         Ok(accounts)
+    }
+}
+
+/// Extracts the address from a Geth-style keystore filename, preserving custom names.
+fn local_account_name(name: &str) -> Cow<'_, str> {
+    if let Some((timestamp, address)) =
+        name.strip_prefix("UTC--").and_then(|suffix| suffix.rsplit_once("--"))
+        && !timestamp.is_empty()
+        && address.len() == 40
+        && address.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        Cow::Owned(format!("0x{address}"))
+    } else {
+        Cow::Borrowed(name)
     }
 }
 

--- a/crates/cast/tests/cli/main.rs
+++ b/crates/cast/tests/cli/main.rs
@@ -1130,6 +1130,43 @@ casttest!(wallet_list_local_accounts_json, |prj, cmd| {
         );
 });
 
+// tests that `cast wallet list` preserves custom keystore names
+casttest!(wallet_list_named_local_account, |prj, cmd| {
+    let keystore_path = prj.root().join("keystore");
+    fs::create_dir_all(&keystore_path).unwrap();
+    fs::write(keystore_path.join("my_account"), "{}").unwrap();
+    cmd.set_current_dir(prj.root());
+
+    cmd.cast_fuse().args(["wallet", "list", "--dir", "keystore"]).assert_success().stdout_eq(str![
+        [r#"
+my_account (Local)
+
+"#]
+    ]);
+
+    cmd.cast_fuse()
+        .args(["wallet", "list", "--json", "--dir", "keystore"])
+        .assert_success()
+        .stdout_eq(
+            str![[r#"
+{
+  "schema_version": 1,
+  "success": true,
+  "data": [
+    {
+      "address": "my_account",
+      "source": "Local"
+    }
+  ],
+  "errors": [],
+  "warnings": []
+}
+
+"#]]
+            .is_json(),
+        );
+});
+
 // tests that `cast wallet vanity --json --nonce` wraps wallet and contract address output
 casttest!(wallet_vanity_json_nonce_contract_address, |_prj, cmd| {
     cmd.args(["wallet", "vanity", "--starts-with", ".", "--nonce", "1", "--json"])


### PR DESCRIPTION
`cast wallet list` treated every local keystore filename as a Geth-style `UTC--<timestamp>--<address>` name, causing custom account names to be incorrectly prefixed with `0x`.

This change only extracts an address from structurally valid Geth-style filenames and otherwise preserves the custom keystore name. It adds regression coverage for both text and JSON output.

Fixes #16014.

This PR was implemented with Codex assistance, including code generation and test coverage.
