### PR TITLE
fix(fuzz): reliably synchronize worker corpus

### DIFF
--- a/.changelog/fuzz-corpus-worker-sync.md
+++ b/.changelog/fuzz-corpus-worker-sync.md
@@ -1,0 +1,6 @@
+---
+forge: patch
+foundry-evm: patch
+---
+
+Fixed coverage-guided fuzz workers permanently skipping delayed corpus findings during synchronization.

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -224,6 +224,41 @@ fn same_tx_sequence(left: &[BasicTxDetails], right: &[BasicTxDetails]) -> bool {
         })
 }
 
+fn accept_synced_corpus_file(
+    entry: &CorpusDirEntry,
+    tx_seq: &[BasicTxDetails],
+    corpus_path: &Path,
+) -> bool {
+    if corpus_path.is_file() {
+        let existing = CorpusDirEntry {
+            path: corpus_path.to_path_buf(),
+            uuid: entry.uuid,
+            timestamp: entry.timestamp,
+        };
+        if existing.read_tx_seq().is_ok_and(|existing| same_tx_sequence(&existing, tx_seq)) {
+            if let Err(err) = std::fs::remove_file(&entry.path) {
+                debug!(target: "corpus", %err, "failed to remove synced corpus link {}", entry.path.display());
+                return false;
+            }
+            return true;
+        }
+
+        warn!(target: "corpus", "not overwriting conflicting corpus file {}", corpus_path.display());
+        let quarantine_path =
+            entry.path.with_file_name(format!("{}.{}.invalid", entry.name(), Uuid::new_v4()));
+        if let Err(err) = std::fs::rename(&entry.path, &quarantine_path) {
+            debug!(target: "corpus", %err, "failed to quarantine conflicting corpus file {}", entry.path.display());
+        }
+        return false;
+    }
+
+    if let Err(err) = std::fs::rename(&entry.path, corpus_path) {
+        debug!(target: "corpus", %err, "failed to move synced corpus from {:?} to {corpus_path:?} dir", entry.path);
+        return false;
+    }
+    true
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CorpusInsertionMode {
     Live,
@@ -283,6 +318,7 @@ pub(crate) struct WorkerCorpusSeed {
     edge_indices: EdgeIndexMap,
     sancov_history_map: Vec<u8>,
     metrics: CorpusMetrics,
+    replay_dirs: Option<Vec<PathBuf>>,
     failed_replays: usize,
     optimization_best_value: Option<I256>,
     optimization_best_sequence: Vec<BasicTxDetails>,
@@ -343,6 +379,7 @@ impl WorkerCorpusSeed {
             edge_indices: self.edge_indices.clone(),
             sancov_history_map: self.sancov_history_map.clone(),
             metrics,
+            replay_dirs: self.replay_dirs.clone(),
             failed_replays: self.failed_replays,
             optimization_best_value: self.optimization_best_value,
             optimization_best_sequence: self.optimization_best_sequence.clone(),
@@ -375,6 +412,8 @@ impl WorkerCorpusSeed {
         let Some(corpus_dir) = &config.corpus_dir else {
             return Ok(seed);
         };
+        let replay_dirs = canonical_replay_dirs(corpus_dir);
+        seed.replay_dirs = Some(replay_dirs.clone());
 
         // Seed in-memory corpus with the persisted optimization best sequence so the mutation
         // engine can build on it in future runs.
@@ -395,7 +434,7 @@ impl WorkerCorpusSeed {
         };
         let mut seen_entries =
             seed.in_memory_corpus.iter().map(|entry| entry.uuid).collect::<HashSet<_>>();
-        for entry in unique_corpus_entries(&canonical_replay_dirs(corpus_dir), &mut seen_entries) {
+        for entry in unique_corpus_entries(&replay_dirs, &mut seen_entries) {
             // A corrupt or truncated corpus file (e.g. a process killed mid-write, since entries
             // are persisted non-atomically) must not abort the whole campaign startup: skip it
             // and keep loading the rest of the corpus.
@@ -584,8 +623,8 @@ pub struct WorkerCorpus {
     config: Arc<FuzzCorpusConfig>,
     /// Indices of new entries added to [`WorkerCorpus::in_memory_corpus`] since last sync.
     new_entry_indices: Vec<usize>,
-    /// Whether the master still needs to distribute corpus entries loaded at startup.
-    initial_export_pending: bool,
+    /// Corpus directories the master loaded at startup and still needs to distribute.
+    initial_export_dirs: Option<Vec<PathBuf>>,
     /// Worker Dir
     /// corpus_dir/worker1/
     worker_dir: Option<PathBuf>,
@@ -812,8 +851,9 @@ impl WorkerCorpus {
         id: usize,
         config: FuzzCorpusConfig,
         sequence_generator: SequenceGenerator,
-        seed: WorkerCorpusSeed,
+        mut seed: WorkerCorpusSeed,
     ) -> Result<Self> {
+        let initial_export_dirs = if id == 0 { seed.replay_dirs.take() } else { None };
         let worker_dir = config.corpus_dir.as_ref().map(|corpus_dir| {
             let worker_dir = corpus_dir.join(format!("{WORKER}{id}"));
             let worker_corpus = worker_dir.join(CORPUS_DIR);
@@ -838,7 +878,7 @@ impl WorkerCorpus {
             current_mutated_index: None,
             config: config.into(),
             new_entry_indices: Default::default(),
-            initial_export_pending: id == 0,
+            initial_export_dirs,
             worker_dir,
             last_sync_metrics: Default::default(),
             optimization_best_value: seed.optimization_best_value,
@@ -1213,6 +1253,14 @@ impl WorkerCorpus {
                 Ok(tx_seq) => tx_seq,
                 Err(err) => {
                     warn!(target: "corpus", "skipping unreadable corpus file {}: {err}", entry.path.display());
+                    let quarantine_path = entry.path.with_file_name(format!(
+                        "{}.{}.invalid",
+                        entry.name(),
+                        Uuid::new_v4()
+                    ));
+                    if let Err(err) = std::fs::rename(&entry.path, &quarantine_path) {
+                        debug!(target: "corpus", %err, "failed to quarantine unreadable corpus file {}", entry.path.display());
+                    }
                     continue;
                 }
             };
@@ -1288,8 +1336,7 @@ impl WorkerCorpus {
             if keep_entry && new_coverage {
                 // Move file from sync/ to corpus/ directory.
                 let corpus_path = corpus_dir.join(sync_path.components().next_back().unwrap());
-                if let Err(err) = std::fs::rename(sync_path, &corpus_path) {
-                    debug!(target: "corpus", %err, "failed to move synced corpus from {sync_path:?} to {corpus_path:?} dir");
+                if !accept_synced_corpus_file(&entry, &tx_seq, &corpus_path) {
                     continue;
                 }
 
@@ -1369,8 +1416,11 @@ impl WorkerCorpus {
 
         let worker_dir = self.worker_dir.as_ref().unwrap();
         let master_corpus_dir = worker_dir.join(CORPUS_DIR);
-        let entries = if self.initial_export_pending {
-            read_corpus_dir(&master_corpus_dir).map(|entry| entry.path).collect::<Vec<_>>()
+        let entries = if let Some(replay_dirs) = &self.initial_export_dirs {
+            let mut seen_entries = HashSet::new();
+            unique_corpus_entries(replay_dirs, &mut seen_entries)
+                .map(|entry| entry.path)
+                .collect::<Vec<_>>()
         } else {
             self.new_entry_indices
                 .iter()
@@ -1404,7 +1454,7 @@ impl WorkerCorpus {
             }
         }
 
-        self.initial_export_pending = false;
+        self.initial_export_dirs = None;
         debug!(target: "corpus", %any_distributed, "distributed master corpus to all workers");
 
         Ok(())
@@ -1791,12 +1841,18 @@ mod tests {
         let mut empty = CorpusEntry::new(vec![]);
         empty.timestamp = 0;
         let empty_path = empty.write_to_disk_in(&sync_dir, false).unwrap();
+        let corrupt_path = sync_dir.join(format!("{}-0.json", Uuid::new_v4()));
+        fs::write(&corrupt_path, b"{ not valid json").unwrap();
 
         let imports = manager.load_sync_corpus().unwrap();
 
         assert_eq!(imports.len(), 1);
         assert_eq!(imports[0].0.timestamp, 0);
         assert!(!empty_path.exists());
+        assert!(!corrupt_path.exists());
+        assert!(fs::read_dir(&sync_dir).unwrap().flatten().any(|entry| {
+            entry.file_name().to_string_lossy().ends_with(".invalid") && entry.path().is_file()
+        }));
     }
 
     #[test]
@@ -1822,7 +1878,7 @@ mod tests {
     fn master_distributes_old_synced_entries() {
         let corpus_root = temp_corpus_dir();
         let mut master = empty_worker_corpus(0, corpus_root.clone());
-        master.initial_export_pending = false;
+        master.initial_export_dirs = None;
         let mut corpus =
             CorpusEntry::new(vec![basic_tx_with_calldata(vec![0; GZIP_THRESHOLD * 2])]);
         corpus.timestamp = 0;
@@ -1841,25 +1897,62 @@ mod tests {
     #[test]
     fn master_distributes_startup_corpus_only_once() {
         let corpus_root = temp_corpus_dir();
-        let mut master = empty_worker_corpus(0, corpus_root.clone());
         let corpus = CorpusEntry::new(vec![basic_tx()]);
         let name = corpus.file_name(false);
-        corpus.write_to_disk_in(&corpus_root.join("worker0").join(CORPUS_DIR), false).unwrap();
+        let non_master_corpus = corpus_root.join("worker1").join(CORPUS_DIR);
+        fs::create_dir_all(&non_master_corpus).unwrap();
+        corpus.write_to_disk_in(&non_master_corpus, false).unwrap();
+        let seed = WorkerCorpusSeed {
+            replay_dirs: Some(canonical_replay_dirs(&corpus_root)),
+            ..Default::default()
+        };
+        let mut master = worker_corpus(0, corpus_root.clone(), seed);
 
-        master.export_to_workers(2).unwrap();
-        let worker_sync = corpus_root.join("worker1").join(SYNC_DIR).join(name);
-        assert!(worker_sync.is_file());
+        master.export_to_workers(3).unwrap();
+        let source_worker_sync = corpus_root.join("worker1").join(SYNC_DIR).join(&name);
+        let other_worker_sync = corpus_root.join("worker2").join(SYNC_DIR).join(&name);
+        assert!(source_worker_sync.is_file());
+        assert!(other_worker_sync.is_file());
 
-        fs::remove_file(&worker_sync).unwrap();
-        master.export_to_workers(2).unwrap();
-        assert!(!worker_sync.exists());
+        let source_entry = read_corpus_dir(source_worker_sync.parent().unwrap()).next().unwrap();
+        assert!(accept_synced_corpus_file(
+            &source_entry,
+            &source_entry.read_tx_seq().unwrap(),
+            &non_master_corpus.join(&name),
+        ));
+        assert!(!source_worker_sync.exists());
+        assert!(non_master_corpus.join(&name).is_file());
+
+        fs::remove_file(&other_worker_sync).unwrap();
+        master.export_to_workers(3).unwrap();
+        assert!(!other_worker_sync.exists());
+
+        let flat_root = temp_corpus_dir();
+        let flat_corpus = CorpusEntry::new(vec![basic_tx()]);
+        let flat_name = flat_corpus.file_name(false);
+        flat_corpus.write_to_disk_in(&flat_root, false).unwrap();
+        let config = corpus_config(flat_root.clone());
+        let seed = WorkerCorpusSeed::load_from_disk::<foundry_evm_core::evm::EthEvmNetwork>(
+            &config,
+            None,
+            ReplayTarget { stateless: None, fuzzed_contracts: None, dynamic: None },
+        )
+        .unwrap();
+        fs::create_dir_all(flat_root.join("worker1").join(CORPUS_DIR)).unwrap();
+        let generator =
+            test_sequence(&config, TxGenerator::from_strategy(Just(basic_tx()).boxed()));
+        let mut flat_master = WorkerCorpus::from_seed(0, config, generator, seed).unwrap();
+
+        flat_master.export_to_workers(2).unwrap();
+
+        assert!(flat_root.join("worker1").join(SYNC_DIR).join(flat_name).is_file());
     }
 
     #[test]
     fn master_fanout_indices_remain_valid_after_eviction() {
         let corpus_root = temp_corpus_dir();
         let mut master = empty_worker_corpus(0, corpus_root.clone());
-        master.initial_export_pending = false;
+        master.initial_export_dirs = None;
         let mut evicted = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
         evicted.total_mutations = 1;
         let retained = CorpusEntry::new(vec![basic_tx_with_calldata([2])]);
@@ -2109,6 +2202,7 @@ mod tests {
                 corpus_count: 1,
                 favored_items: 0,
             },
+            replay_dirs: None,
             failed_replays: 13,
             optimization_best_value: Some(I256::try_from(17).unwrap()),
             optimization_best_sequence: tx_seq,
@@ -2153,6 +2247,7 @@ mod tests {
                 corpus_count: 10,
                 favored_items: 5,
             },
+            replay_dirs: None,
             failed_replays: 13,
             optimization_best_value: Some(I256::try_from(17).unwrap()),
             optimization_best_sequence: vec![basic_tx()],

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -224,6 +224,32 @@ fn same_tx_sequence(left: &[BasicTxDetails], right: &[BasicTxDetails]) -> bool {
         })
 }
 
+fn link_corpus_file(from: &Path, to: &Path) -> bool {
+    match std::fs::hard_link(from, to) {
+        Ok(()) => true,
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            let entry = |path: &Path| CorpusDirEntry {
+                path: path.to_path_buf(),
+                uuid: Uuid::nil(),
+                timestamp: 0,
+            };
+            let matches = entry(from)
+                .read_tx_seq()
+                .ok()
+                .zip(entry(to).read_tx_seq().ok())
+                .is_some_and(|(from, to)| same_tx_sequence(&from, &to));
+            if !matches {
+                debug!(target: "corpus", from=?from, to=?to, "conflicting corpus file already exists");
+            }
+            matches
+        }
+        Err(err) => {
+            debug!(target: "corpus", %err, from=?from, to=?to, "failed to link corpus file");
+            false
+        }
+    }
+}
+
 fn accept_synced_corpus_file(
     entry: &CorpusDirEntry,
     tx_seq: &[BasicTxDetails],
@@ -1309,28 +1335,27 @@ impl WorkerCorpus {
         };
         let corpus_dir = worker_dir.join(CORPUS_DIR);
 
-        let mut executor = executor.clone();
         for (entry, tx_seq) in self.load_sync_corpus()? {
+            let mut history_map = self.history_map.clone();
+            let mut edge_indices = self.edge_indices.clone();
+            let mut sancov_history_map = self.sancov_history_map.clone();
+            let mut metrics = self.metrics.clone();
             let coverage = ReplayCoverage {
-                history_map: &mut self.history_map,
-                edge_indices: &mut self.edge_indices,
-                sancov_history_map: &mut self.sancov_history_map,
-                metrics: Some(&mut self.metrics),
+                history_map: &mut history_map,
+                edge_indices: &mut edge_indices,
+                sancov_history_map: &mut sancov_history_map,
+                metrics: Some(&mut metrics),
             };
+            let mut replay_executor = executor.clone();
             let ReplayOutcome { keep_entry, new_coverage, new_edge, cmp_seq, .. } =
                 replay_corpus_sequence_with_executor(
                     &tx_seq,
-                    &mut executor,
+                    &mut replay_executor,
                     target,
                     coverage,
                     true,
                     false,
                 )?;
-
-            // A synced edge is new to this worker's local map, so it advances the timer.
-            if new_edge {
-                self.last_new_edge_at = Some(Instant::now());
-            }
 
             let sync_path = &entry.path;
             if keep_entry && new_coverage {
@@ -1338,6 +1363,15 @@ impl WorkerCorpus {
                 let corpus_path = corpus_dir.join(sync_path.components().next_back().unwrap());
                 if !accept_synced_corpus_file(&entry, &tx_seq, &corpus_path) {
                     continue;
+                }
+
+                self.history_map = history_map;
+                self.edge_indices = edge_indices;
+                self.sancov_history_map = sancov_history_map;
+                self.metrics = metrics;
+                // A synced edge is new to this worker's local map, so it advances the timer.
+                if new_edge {
+                    self.last_new_edge_at = Some(Instant::now());
                 }
 
                 debug!(
@@ -1367,7 +1401,7 @@ impl WorkerCorpus {
 
     /// Exports the new corpus entries to the master worker's sync dir.
     #[instrument(skip_all)]
-    fn export_to_master(&self) -> Result<()> {
+    fn export_to_master(&mut self) -> Result<()> {
         // Master doesn't export (it only receives from others).
         assert_ne!(self.id, 0, "non-master only");
 
@@ -1388,18 +1422,29 @@ impl WorkerCorpus {
 
         let mut exported = 0;
         let corpus_dir = worker_dir.join(CORPUS_DIR);
+        let mut delivered = HashSet::new();
 
         for &index in &self.new_entry_indices {
-            let Some(corpus) = self.in_memory_corpus.get(index) else { continue };
+            let Some(corpus) = self.in_memory_corpus.get(index) else {
+                delivered.insert(index);
+                continue;
+            };
             let file_name = corpus.file_name(self.config.corpus_gzip);
             let file_path = corpus_dir.join(&file_name);
+            if !file_path.is_file()
+                && let Err(err) = corpus.write_to_disk_in(&corpus_dir, self.config.corpus_gzip)
+            {
+                debug!(target: "corpus", %err, "failed to persist corpus {} for export", corpus.uuid);
+                continue;
+            }
             let sync_path = master_sync_dir.join(&file_name);
-            if let Err(err) = std::fs::hard_link(&file_path, &sync_path) {
-                debug!(target: "corpus", %err, "failed to export corpus {}", corpus.uuid);
+            if !link_corpus_file(&file_path, &sync_path) {
                 continue;
             }
             exported += 1;
+            delivered.insert(index);
         }
+        self.new_entry_indices.retain(|index| !delivered.contains(index));
 
         debug!(target: "corpus", "exported {exported} new corpus entries");
 
@@ -1416,19 +1461,33 @@ impl WorkerCorpus {
 
         let worker_dir = self.worker_dir.as_ref().unwrap();
         let master_corpus_dir = worker_dir.join(CORPUS_DIR);
-        let entries = if let Some(replay_dirs) = &self.initial_export_dirs {
+        let startup_entries = if let Some(replay_dirs) = &self.initial_export_dirs {
             let mut seen_entries = HashSet::new();
             unique_corpus_entries(replay_dirs, &mut seen_entries)
                 .map(|entry| entry.path)
                 .collect::<Vec<_>>()
         } else {
-            self.new_entry_indices
-                .iter()
-                .filter_map(|&index| self.in_memory_corpus.get(index))
-                .map(|corpus| master_corpus_dir.join(corpus.file_name(self.config.corpus_gzip)))
-                .collect()
+            Vec::new()
         };
-        let mut any_distributed = false;
+        let mut pending_entries = Vec::new();
+        let mut delivered = HashSet::new();
+        for &index in &self.new_entry_indices {
+            let Some(corpus) = self.in_memory_corpus.get(index) else {
+                delivered.insert(index);
+                continue;
+            };
+            let path = master_corpus_dir.join(corpus.file_name(self.config.corpus_gzip));
+            if !path.is_file()
+                && let Err(err) =
+                    corpus.write_to_disk_in(&master_corpus_dir, self.config.corpus_gzip)
+            {
+                debug!(target: "corpus", %err, "failed to persist corpus {} for fan-out", corpus.uuid);
+                continue;
+            }
+            pending_entries.push((index, path));
+        }
+
+        let mut target_dirs = Vec::new();
         for target_worker in 1..num_workers {
             let target_dir = self
                 .config
@@ -1437,24 +1496,53 @@ impl WorkerCorpus {
                 .unwrap()
                 .join(format!("{WORKER}{target_worker}"))
                 .join(SYNC_DIR);
-
             if !target_dir.is_dir() {
                 foundry_common::fs::create_dir_all(&target_dir)?;
             }
+            target_dirs.push(target_dir);
+        }
 
-            for path in &entries {
-                let Some(name) = path.file_name() else { continue };
+        let mut any_distributed = false;
+        let mut startup_delivered = true;
+        for path in &startup_entries {
+            let Some(name) = path.file_name() else {
+                startup_delivered = false;
+                continue;
+            };
+            let mut delivered_to_all = true;
+            for target_dir in &target_dirs {
                 let sync_path = target_dir.join(name);
-                if let Err(err) = std::fs::hard_link(path, &sync_path) {
-                    debug!(target: "corpus", %err, from=?path, to=?sync_path, "failed to distribute corpus");
-                    continue;
+                if link_corpus_file(path, &sync_path) {
+                    any_distributed = true;
+                    trace!(target: "corpus", name=%name.to_string_lossy(), ?target_dir, "distributed corpus");
+                } else {
+                    delivered_to_all = false;
                 }
-                any_distributed = true;
-                trace!(target: "corpus", name=%name.to_string_lossy(), ?target_dir, "distributed corpus");
+            }
+            startup_delivered &= delivered_to_all;
+        }
+
+        for (index, path) in pending_entries {
+            let Some(name) = path.file_name() else { continue };
+            let mut delivered_to_all = true;
+            for target_dir in &target_dirs {
+                let sync_path = target_dir.join(name);
+                if link_corpus_file(&path, &sync_path) {
+                    any_distributed = true;
+                    trace!(target: "corpus", name=%name.to_string_lossy(), ?target_dir, "distributed corpus");
+                } else {
+                    delivered_to_all = false;
+                }
+            }
+            if delivered_to_all {
+                delivered.insert(index);
             }
         }
 
-        self.initial_export_dirs = None;
+        self.new_entry_indices.retain(|index| !delivered.contains(index));
+        if startup_delivered {
+            self.initial_export_dirs = None;
+        }
         debug!(target: "corpus", %any_distributed, "distributed master corpus to all workers");
 
         Ok(())
@@ -1532,8 +1620,6 @@ impl WorkerCorpus {
         } else {
             self.export_to_master()?;
         }
-
-        self.new_entry_indices.clear();
 
         debug!(target: "corpus", "synced");
 
@@ -1892,6 +1978,63 @@ mod tests {
 
         assert!(corpus_root.join("worker1").join(SYNC_DIR).join(&name).is_file());
         assert!(corpus_root.join("worker2").join(SYNC_DIR).join(name).is_file());
+        assert!(master.new_entry_indices.is_empty());
+    }
+
+    #[test]
+    fn worker_retries_failed_export() {
+        let corpus_root = temp_corpus_dir();
+        let mut worker = empty_worker_corpus(1, corpus_root.clone());
+        let corpus = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
+        let name = corpus.file_name(false);
+        worker.push_corpus_entry(corpus);
+
+        let master_sync = corpus_root.join("worker0").join(SYNC_DIR);
+        fs::create_dir_all(&master_sync).unwrap();
+        let destination = master_sync.join(&name);
+        foundry_common::fs::write_json_file(&destination, &vec![basic_tx_with_calldata([2])])
+            .unwrap();
+
+        worker.export_to_master().unwrap();
+        assert_eq!(worker.new_entry_indices, [0]);
+        assert!(corpus_root.join("worker1").join(CORPUS_DIR).join(&name).is_file());
+
+        fs::remove_file(&destination).unwrap();
+        worker.export_to_master().unwrap();
+
+        assert!(worker.new_entry_indices.is_empty());
+        let exported = read_corpus_dir(&master_sync).next().unwrap().read_tx_seq().unwrap();
+        assert!(same_tx_sequence(&exported, &[basic_tx_with_calldata([1])]));
+    }
+
+    #[test]
+    fn master_retries_partial_fanout() {
+        let corpus_root = temp_corpus_dir();
+        let mut master = empty_worker_corpus(0, corpus_root.clone());
+        master.initial_export_dirs = None;
+        let corpus = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
+        let name = corpus.file_name(false);
+        corpus.write_to_disk_in(&corpus_root.join("worker0").join(CORPUS_DIR), false).unwrap();
+        master.push_corpus_entry(corpus);
+
+        let worker2_sync = corpus_root.join("worker2").join(SYNC_DIR);
+        fs::create_dir_all(&worker2_sync).unwrap();
+        let worker2_destination = worker2_sync.join(&name);
+        foundry_common::fs::write_json_file(
+            &worker2_destination,
+            &vec![basic_tx_with_calldata([2])],
+        )
+        .unwrap();
+
+        master.export_to_workers(3).unwrap();
+        assert_eq!(master.new_entry_indices, [0]);
+        assert!(corpus_root.join("worker1").join(SYNC_DIR).join(&name).is_file());
+
+        fs::remove_file(&worker2_destination).unwrap();
+        master.export_to_workers(3).unwrap();
+
+        assert!(master.new_entry_indices.is_empty());
+        assert!(worker2_destination.is_file());
     }
 
     #[test]
@@ -1908,11 +2051,22 @@ mod tests {
         };
         let mut master = worker_corpus(0, corpus_root.clone(), seed);
 
+        let other_worker_sync_dir = corpus_root.join("worker2").join(SYNC_DIR);
+        fs::create_dir_all(&other_worker_sync_dir).unwrap();
+        let other_worker_sync = other_worker_sync_dir.join(&name);
+        foundry_common::fs::write_json_file(&other_worker_sync, &vec![basic_tx_with_calldata([1])])
+            .unwrap();
+
         master.export_to_workers(3).unwrap();
         let source_worker_sync = corpus_root.join("worker1").join(SYNC_DIR).join(&name);
-        let other_worker_sync = corpus_root.join("worker2").join(SYNC_DIR).join(&name);
         assert!(source_worker_sync.is_file());
         assert!(other_worker_sync.is_file());
+        assert!(master.initial_export_dirs.is_some());
+
+        fs::remove_file(&other_worker_sync).unwrap();
+        master.export_to_workers(3).unwrap();
+        assert!(other_worker_sync.is_file());
+        assert!(master.initial_export_dirs.is_none());
 
         let source_entry = read_corpus_dir(source_worker_sync.parent().unwrap()).next().unwrap();
         assert!(accept_synced_corpus_file(
@@ -1942,10 +2096,16 @@ mod tests {
         let generator =
             test_sequence(&config, TxGenerator::from_strategy(Just(basic_tx()).boxed()));
         let mut flat_master = WorkerCorpus::from_seed(0, config, generator, seed).unwrap();
+        let pending = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
+        let pending_name = pending.file_name(false);
+        pending.write_to_disk_in(&flat_root.join("worker0").join(CORPUS_DIR), false).unwrap();
+        flat_master.push_corpus_entry(pending);
 
         flat_master.export_to_workers(2).unwrap();
 
         assert!(flat_root.join("worker1").join(SYNC_DIR).join(flat_name).is_file());
+        assert!(flat_root.join("worker1").join(SYNC_DIR).join(pending_name).is_file());
+        assert!(flat_master.new_entry_indices.is_empty());
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/corpus.rs
+++ b/crates/evm/evm/src/executors/corpus.rs
@@ -113,6 +113,9 @@ struct CorpusEntry {
     /// Timestamp of when this entry was written to disk in seconds.
     #[serde(skip_serializing)]
     timestamp: u64,
+    /// Original filename for an entry imported from another worker.
+    #[serde(skip_serializing)]
+    persisted_file_name: Option<String>,
 }
 
 impl CorpusEntry {
@@ -138,6 +141,7 @@ impl CorpusEntry {
                 .duration_since(UNIX_EPOCH)
                 .expect("time went backwards")
                 .as_secs(),
+            persisted_file_name: None,
         }
     }
 
@@ -161,6 +165,9 @@ impl CorpusEntry {
     }
 
     fn file_name(&self, can_gzip: bool) -> String {
+        if let Some(name) = &self.persisted_file_name {
+            return name.clone();
+        }
         let ext = if self.should_gzip(can_gzip) { ".json.gz" } else { ".json" };
         format!("{}-{}{ext}", self.uuid, self.timestamp)
     }
@@ -577,8 +584,8 @@ pub struct WorkerCorpus {
     config: Arc<FuzzCorpusConfig>,
     /// Indices of new entries added to [`WorkerCorpus::in_memory_corpus`] since last sync.
     new_entry_indices: Vec<usize>,
-    /// Last sync timestamp in seconds.
-    last_sync_timestamp: u64,
+    /// Whether the master still needs to distribute corpus entries loaded at startup.
+    initial_export_pending: bool,
     /// Worker Dir
     /// corpus_dir/worker1/
     worker_dir: Option<PathBuf>,
@@ -831,7 +838,7 @@ impl WorkerCorpus {
             current_mutated_index: None,
             config: config.into(),
             new_entry_indices: Default::default(),
-            last_sync_timestamp: 0,
+            initial_export_pending: id == 0,
             worker_dir,
             last_sync_metrics: Default::default(),
             optimization_best_value: seed.optimization_best_value,
@@ -1201,9 +1208,6 @@ impl WorkerCorpus {
 
         let mut imports = vec![];
         for entry in read_corpus_dir(&sync_dir) {
-            if entry.timestamp <= self.last_sync_timestamp {
-                continue;
-            }
             // A corrupt or truncated sync file must not abort the whole sync pass: skip it.
             let tx_seq = match entry.read_tx_seq() {
                 Ok(tx_seq) => tx_seq,
@@ -1214,6 +1218,9 @@ impl WorkerCorpus {
             };
             if tx_seq.is_empty() {
                 warn!(target: "corpus", "skipping empty corpus entry: {}", entry.path.display());
+                if let Err(err) = std::fs::remove_file(&entry.path) {
+                    debug!(target: "corpus", %err, "failed to remove empty corpus file {}", entry.path.display());
+                }
                 continue;
             }
             imports.push((entry, tx_seq));
@@ -1224,6 +1231,21 @@ impl WorkerCorpus {
         }
 
         Ok(imports)
+    }
+
+    /// Adds a calibrated sync entry to the local corpus and queues it for fan-out on the master.
+    fn push_synced_corpus_entry(
+        &mut self,
+        mut corpus: CorpusEntry,
+        timestamp: u64,
+        file_name: String,
+    ) {
+        corpus.timestamp = timestamp;
+        corpus.persisted_file_name = Some(file_name);
+        if self.id == 0 {
+            self.new_entry_indices.push(self.in_memory_corpus.len());
+        }
+        self.in_memory_corpus.push(corpus);
     }
 
     /// Syncs and calibrates the in memory corpus and updates the history_map if new coverage is
@@ -1278,7 +1300,11 @@ impl WorkerCorpus {
                 );
 
                 let corpus_entry = CorpusEntry::new_with_cmp(tx_seq.clone(), cmp_seq, entry.uuid);
-                self.in_memory_corpus.push(corpus_entry);
+                self.push_synced_corpus_entry(
+                    corpus_entry,
+                    entry.timestamp,
+                    entry.name().to_owned(),
+                );
             } else {
                 // Remove the file as it did not generate new coverage.
                 if let Err(err) = std::fs::remove_file(&entry.path) {
@@ -1343,9 +1369,15 @@ impl WorkerCorpus {
 
         let worker_dir = self.worker_dir.as_ref().unwrap();
         let master_corpus_dir = worker_dir.join(CORPUS_DIR);
-        let filtered_master_corpus = read_corpus_dir(&master_corpus_dir)
-            .filter(|entry| entry.timestamp > self.last_sync_timestamp)
-            .collect::<Vec<_>>();
+        let entries = if self.initial_export_pending {
+            read_corpus_dir(&master_corpus_dir).map(|entry| entry.path).collect::<Vec<_>>()
+        } else {
+            self.new_entry_indices
+                .iter()
+                .filter_map(|&index| self.in_memory_corpus.get(index))
+                .map(|corpus| master_corpus_dir.join(corpus.file_name(self.config.corpus_gzip)))
+                .collect()
+        };
         let mut any_distributed = false;
         for target_worker in 1..num_workers {
             let target_dir = self
@@ -1360,18 +1392,19 @@ impl WorkerCorpus {
                 foundry_common::fs::create_dir_all(&target_dir)?;
             }
 
-            for entry in &filtered_master_corpus {
-                let name = entry.name();
+            for path in &entries {
+                let Some(name) = path.file_name() else { continue };
                 let sync_path = target_dir.join(name);
-                if let Err(err) = std::fs::hard_link(&entry.path, &sync_path) {
-                    debug!(target: "corpus", %err, from=?entry.path, to=?sync_path, "failed to distribute corpus");
+                if let Err(err) = std::fs::hard_link(path, &sync_path) {
+                    debug!(target: "corpus", %err, from=?path, to=?sync_path, "failed to distribute corpus");
                     continue;
                 }
                 any_distributed = true;
-                trace!(target: "corpus", %name, ?target_dir, "distributed corpus");
+                trace!(target: "corpus", name=%name.to_string_lossy(), ?target_dir, "distributed corpus");
             }
         }
 
+        self.initial_export_pending = false;
         debug!(target: "corpus", %any_distributed, "distributed master corpus to all workers");
 
         Ok(())
@@ -1450,12 +1483,9 @@ impl WorkerCorpus {
             self.export_to_master()?;
         }
 
-        let last_sync = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
-        self.last_sync_timestamp = last_sync;
-
         self.new_entry_indices.clear();
 
-        debug!(target: "corpus", last_sync, "synced");
+        debug!(target: "corpus", "synced");
 
         Ok(())
     }
@@ -1748,6 +1778,107 @@ mod tests {
             }
         }
         assert_eq!((ok, err), (1, 1), "the corrupt file must read as Err, the valid one as Ok");
+    }
+
+    #[test]
+    fn sync_inbox_loads_entries_regardless_of_timestamp() {
+        let corpus_root = temp_corpus_dir();
+        let manager = empty_worker_corpus(0, corpus_root.clone());
+        let sync_dir = corpus_root.join("worker0").join(SYNC_DIR);
+        let mut corpus = CorpusEntry::new(vec![basic_tx()]);
+        corpus.timestamp = 0;
+        corpus.write_to_disk_in(&sync_dir, false).unwrap();
+        let mut empty = CorpusEntry::new(vec![]);
+        empty.timestamp = 0;
+        let empty_path = empty.write_to_disk_in(&sync_dir, false).unwrap();
+
+        let imports = manager.load_sync_corpus().unwrap();
+
+        assert_eq!(imports.len(), 1);
+        assert_eq!(imports[0].0.timestamp, 0);
+        assert!(!empty_path.exists());
+    }
+
+    #[test]
+    fn synced_entries_are_queued_for_fanout_only_on_master() {
+        let corpus_root = temp_corpus_dir();
+        let mut master = empty_worker_corpus(0, corpus_root.clone());
+        let mut worker = empty_worker_corpus(1, corpus_root);
+        let master_entry = CorpusEntry::new(vec![basic_tx()]);
+        let worker_entry = CorpusEntry::new(vec![basic_tx()]);
+
+        master.push_synced_corpus_entry(master_entry, 1, "master-1.json".to_string());
+        worker.push_synced_corpus_entry(worker_entry, 2, "worker-2.json".to_string());
+
+        assert_eq!(master.new_entry_indices, [0]);
+        assert!(worker.new_entry_indices.is_empty());
+        assert_eq!(master.in_memory_corpus[0].timestamp, 1);
+        assert_eq!(worker.in_memory_corpus[0].timestamp, 2);
+        assert_eq!(master.metrics.corpus_count, 0);
+        assert_eq!(worker.metrics.corpus_count, 0);
+    }
+
+    #[test]
+    fn master_distributes_old_synced_entries() {
+        let corpus_root = temp_corpus_dir();
+        let mut master = empty_worker_corpus(0, corpus_root.clone());
+        master.initial_export_pending = false;
+        let mut corpus =
+            CorpusEntry::new(vec![basic_tx_with_calldata(vec![0; GZIP_THRESHOLD * 2])]);
+        corpus.timestamp = 0;
+        let path =
+            corpus.write_to_disk_in(&corpus_root.join("worker0").join(CORPUS_DIR), true).unwrap();
+        let name = path.file_name().unwrap().to_str().unwrap().to_owned();
+        assert!(name.ends_with(".json.gz"));
+        master.push_synced_corpus_entry(corpus, 0, name.clone());
+
+        master.export_to_workers(3).unwrap();
+
+        assert!(corpus_root.join("worker1").join(SYNC_DIR).join(&name).is_file());
+        assert!(corpus_root.join("worker2").join(SYNC_DIR).join(name).is_file());
+    }
+
+    #[test]
+    fn master_distributes_startup_corpus_only_once() {
+        let corpus_root = temp_corpus_dir();
+        let mut master = empty_worker_corpus(0, corpus_root.clone());
+        let corpus = CorpusEntry::new(vec![basic_tx()]);
+        let name = corpus.file_name(false);
+        corpus.write_to_disk_in(&corpus_root.join("worker0").join(CORPUS_DIR), false).unwrap();
+
+        master.export_to_workers(2).unwrap();
+        let worker_sync = corpus_root.join("worker1").join(SYNC_DIR).join(name);
+        assert!(worker_sync.is_file());
+
+        fs::remove_file(&worker_sync).unwrap();
+        master.export_to_workers(2).unwrap();
+        assert!(!worker_sync.exists());
+    }
+
+    #[test]
+    fn master_fanout_indices_remain_valid_after_eviction() {
+        let corpus_root = temp_corpus_dir();
+        let mut master = empty_worker_corpus(0, corpus_root.clone());
+        master.initial_export_pending = false;
+        let mut evicted = CorpusEntry::new(vec![basic_tx_with_calldata([1])]);
+        evicted.total_mutations = 1;
+        let retained = CorpusEntry::new(vec![basic_tx_with_calldata([2])]);
+        let evicted_name = evicted.file_name(false);
+        let retained_name = retained.file_name(false);
+        let evicted_timestamp = evicted.timestamp;
+        let retained_timestamp = retained.timestamp;
+        let master_corpus = corpus_root.join("worker0").join(CORPUS_DIR);
+        evicted.write_to_disk_in(&master_corpus, false).unwrap();
+        retained.write_to_disk_in(&master_corpus, false).unwrap();
+        master.push_synced_corpus_entry(evicted, evicted_timestamp, evicted_name.clone());
+        master.push_synced_corpus_entry(retained, retained_timestamp, retained_name.clone());
+
+        master.evict_oldest_corpus().unwrap();
+        master.export_to_workers(2).unwrap();
+
+        let worker_sync = corpus_root.join("worker1").join(SYNC_DIR);
+        assert!(!worker_sync.join(evicted_name).exists());
+        assert!(worker_sync.join(retained_name).is_file());
     }
 
     #[test]


### PR DESCRIPTION
Removes timestamp-based corpus synchronization so delayed worker findings are not permanently skipped. Uses inbox presence and explicit pending-entry tracking while preserving startup distribution and corpus file compatibility.