### PR TITLE
fix(fuzz): handle zero dictionary capacity

### DIFF
--- a/.changelog/zero-capacity-fuzz-dictionary.md
+++ b/.changelog/zero-capacity-fuzz-dictionary.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-config: patch
+foundry-evm-fuzz: patch
+---
+
+Fixed fuzz tests panicking when the maximum number of dictionary values is configured as zero.

--- a/crates/config/src/fuzz.rs
+++ b/crates/config/src/fuzz.rs
@@ -84,6 +84,7 @@ pub struct FuzzDictionaryConfig {
     pub max_fuzz_dictionary_addresses: usize,
     /// How many values to record at most.
     /// Once the fuzzer exceeds this limit, it will start evicting random entries
+    /// The dictionary always retains a zero seed, so the effective minimum is one.
     #[serde(
         deserialize_with = "crate::deserialize_usize_or_max",
         serialize_with = "crate::serialize_usize_or_max"

--- a/crates/evm/fuzz/src/strategies/param.rs
+++ b/crates/evm/fuzz/src/strategies/param.rs
@@ -542,9 +542,15 @@ mod tests {
         FuzzFixtures,
         strategies::{EvmFuzzState, fuzz_calldata, fuzz_calldata_from_state},
     };
-    use alloy_primitives::B256;
+    use alloy_dyn_abi::{DynSolType, DynSolValue};
+    use alloy_primitives::{B256, U256};
     use foundry_common::abi::get_func;
-    use proptest::strategy::{Strategy, ValueTree};
+    use foundry_config::FuzzDictionaryConfig;
+    use proptest::{
+        strategy::{Strategy, ValueTree},
+        test_runner::TestRunner,
+    };
+    use revm::database::{CacheDB, EmptyDB};
     use std::collections::HashSet;
 
     #[test]
@@ -573,6 +579,23 @@ mod tests {
         let cfg = proptest::test_runner::Config { failure_persistence: None, ..Default::default() };
         let mut runner = proptest::test_runner::TestRunner::new(cfg);
         let _ = runner.run(&strategy, |_| Ok(()));
+    }
+
+    #[test]
+    fn can_fuzz_from_zero_capacity_dictionary() {
+        let state = EvmFuzzState::new(
+            &[],
+            &CacheDB::<EmptyDB>::default(),
+            FuzzDictionaryConfig { max_fuzz_dictionary_values: 0, ..Default::default() },
+            None,
+        );
+        let strategy = super::fuzz_param_from_state(&DynSolType::Uint(256), &state);
+        let mut runner = TestRunner::default();
+
+        assert_eq!(
+            strategy.new_tree(&mut runner).unwrap().current(),
+            DynSolValue::Uint(U256::ZERO, 256)
+        );
     }
 
     #[test]

--- a/crates/evm/fuzz/src/strategies/state.rs
+++ b/crates/evm/fuzz/src/strategies/state.rs
@@ -322,7 +322,8 @@ impl Default for FuzzDictionary {
 }
 
 impl FuzzDictionary {
-    pub fn new(config: FuzzDictionaryConfig) -> Self {
+    pub fn new(mut config: FuzzDictionaryConfig) -> Self {
+        config.max_fuzz_dictionary_values = config.max_fuzz_dictionary_values.max(1);
         let mut dictionary = Self {
             config,
             samples_seeded: false,
@@ -896,6 +897,19 @@ mod tests {
         assert!(dictionary.state_values.contains(&B256::from(U256::from(1))));
         assert!(dictionary.state_values.contains(&B256::from(U256::from(2))));
         assert!(!dictionary.state_values.contains(&B256::from(U256::from(3))));
+    }
+
+    #[test]
+    fn zero_value_capacity_keeps_only_required_seed() {
+        let mut dictionary = FuzzDictionary::new(FuzzDictionaryConfig {
+            max_fuzz_dictionary_values: 0,
+            ..Default::default()
+        });
+
+        assert_eq!(dictionary.config.max_fuzz_dictionary_values, 1);
+        assert_eq!(dictionary.state_values.as_slice(), &[B256::ZERO]);
+        assert!(!dictionary.insert_value(B256::from(U256::from(1))));
+        assert_eq!(dictionary.state_values.as_slice(), &[B256::ZERO]);
     }
 
     #[test]


### PR DESCRIPTION
Ensures the fuzz dictionary retains its required zero seed when `max_fuzz_dictionary_values` is configured as zero, preventing dictionary-backed fuzz generation from panicking on an empty collection.