### PR TITLE
fix(anvil): reject unsupported zkSync forks

### DIFF
--- a/.changelog/reject-zksync-era-forks.md
+++ b/.changelog/reject-zksync-era-forks.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Reject zkSync Era forks with an actionable error instead of executing native EraVM bytecode as EVM bytecode and returning incorrect results.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -1386,6 +1386,7 @@ impl NodeConfig {
         fees: &FeeManager,
     ) -> Result<(ForkedDatabase<AnyNetwork>, ClientForkConfig, Option<ForkTransactionReplay>)> {
         debug!(target: "node", ?eth_rpc_url, "setting up fork db");
+        let override_chain_id = self.chain_id;
 
         // Always bootstrap with the primary URL only to avoid race conditions
         // where discovery calls (get_chain_id, find_latest_fork_block, get_block)
@@ -1402,9 +1403,42 @@ impl NodeConfig {
         );
 
         let source_chain_id = if let Some(chain_id) = self.fork_chain_id {
+            eyre::ensure!(
+                self.fork_urls.len() == 1,
+                "multiple fork URLs cannot be validated with --fork-chain-id; remove \
+                 --fork-chain-id to validate every endpoint"
+            );
             chain_id.to()
         } else {
-            provider.get_chain_id().await.wrap_err("failed to fetch network chain ID")?
+            let chain_id = provider
+                .get_chain_id()
+                .await
+                .wrap_err_with(|| format!("failed to fetch network chain ID from {eth_rpc_url}"))?;
+            ensure_fork_network_supported(chain_id)?;
+
+            for url in self.fork_urls.iter().skip(1) {
+                let endpoint_provider = ProviderBuilder::<AnyNetwork>::new(url)
+                    .timeout(self.fork_request_timeout)
+                    .initial_backoff(self.fork_retry_backoff.as_millis() as u64)
+                    .compute_units_per_second(self.compute_units_per_second)
+                    .max_retry(self.fork_request_retries)
+                    .headers(self.fork_headers.clone())
+                    .build()
+                    .wrap_err_with(|| format!("failed to establish provider to fork url {url}"))?;
+                let endpoint_chain_id = endpoint_provider
+                    .get_chain_id()
+                    .await
+                    .wrap_err_with(|| format!("failed to fetch network chain ID from {url}"))?;
+                ensure_fork_network_supported(endpoint_chain_id)?;
+                if endpoint_chain_id != chain_id {
+                    eyre::bail!(
+                        "fork endpoints must use the same chain ID: expected {chain_id}, got \
+                         {endpoint_chain_id} from {url}"
+                    );
+                }
+            }
+
+            chain_id
         };
         ensure_fork_network_supported(source_chain_id)?;
 
@@ -1558,7 +1592,6 @@ latest block number: {latest_block}"
 
         let block_hash = block.header.hash;
 
-        let override_chain_id = self.chain_id;
         // apply changes such as difficulty -> prevrandao and chain specifics for current chain id
         apply_chain_and_block_specific_env_changes::<AnyNetwork, _, _>(
             evm_env,

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -3,7 +3,7 @@ use crate::{
     eth::{
         backend::{
             db::{Db, SerializableState},
-            fork::{ClientFork, ClientForkConfig},
+            fork::{ClientFork, ClientForkConfig, ensure_fork_network_supported},
             genesis::GenesisConfig,
             mem::fork_db::ForkedDatabase,
             time::duration_since_unix_epoch,
@@ -1401,31 +1401,27 @@ impl NodeConfig {
                 .wrap_err("failed to establish provider to fork url")?,
         );
 
-        let (fork_block_number, fork_chain_id, fork_transaction_replay) = if let Some(fork_choice) =
-            &self.fork_choice
-        {
-            let (fork_block_number, fork_transaction_replay) =
-                derive_block_and_replay(fork_choice, &provider).await.wrap_err(
-                    "failed to derive fork block and transaction replay from fork choice",
-                )?;
-            let chain_id = if let Some(chain_id) = self.fork_chain_id {
-                Some(chain_id)
-            } else if self.hardfork.is_none() {
-                let chain_id =
-                    provider.get_chain_id().await.wrap_err("failed to fetch network chain ID")?;
-                Some(U256::from(chain_id))
-            } else {
-                None
-            };
-
-            (fork_block_number, chain_id, fork_transaction_replay)
+        let source_chain_id = if let Some(chain_id) = self.fork_chain_id {
+            chain_id.to()
         } else {
-            // pick the last block number but also ensure it's not pending anymore
-            let bn = find_latest_fork_block(&provider)
-                .await
-                .wrap_err("failed to get fork block number")?;
-            (bn, None, None)
+            provider.get_chain_id().await.wrap_err("failed to fetch network chain ID")?
         };
+        ensure_fork_network_supported(source_chain_id)?;
+
+        let (fork_block_number, fork_transaction_replay) =
+            if let Some(fork_choice) = &self.fork_choice {
+                let (fork_block_number, fork_transaction_replay) =
+                    derive_block_and_replay(fork_choice, &provider).await.wrap_err(
+                        "failed to derive fork block and transaction replay from fork choice",
+                    )?;
+                (fork_block_number, fork_transaction_replay)
+            } else {
+                // pick the last block number but also ensure it's not pending anymore
+                let bn = find_latest_fork_block(&provider)
+                    .await
+                    .wrap_err("failed to get fork block number")?;
+                (bn, None)
+            };
 
         let block = provider
             .get_block(BlockNumberOrTag::Number(fork_block_number).into())
@@ -1492,16 +1488,10 @@ latest block number: {latest_block}"
         let chain_id = if let Some(chain_id) = self.chain_id {
             chain_id
         } else {
-            let chain_id = if let Some(fork_chain_id) = fork_chain_id {
-                fork_chain_id.to()
-            } else {
-                provider.get_chain_id().await.wrap_err("failed to fetch network chain ID")?
-            };
-
             // need to update the dev signers and env with the chain id
-            self.set_chain_id(Some(chain_id));
-            evm_env.cfg_env.chain_id = chain_id;
-            chain_id
+            self.set_chain_id(Some(source_chain_id));
+            evm_env.cfg_env.chain_id = source_chain_id;
+            source_chain_id
         };
 
         // Auto-detect hardfork from chain activation data if not explicitly set.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -47,6 +47,7 @@ use alloy_primitives::{
     Address, B64, B256, Bytes, TxHash, TxKind, U64, U256,
     map::{HashMap, HashSet},
 };
+use alloy_provider::Provider;
 use alloy_rpc_types::{
     AccessListResult, BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions,
     EIP1186AccountProofResponse, FeeHistory, Filter, FilteredParams, Index, Log, Work,
@@ -72,7 +73,6 @@ use alloy_rpc_types_eth::{AccountInfo, Bundle, EthCallResponse, FillTransaction,
 use alloy_rpc_types_mev::{EthCallBundle, EthCallBundleResponse};
 use alloy_serde::WithOtherFields;
 use alloy_sol_types::{SolCall, SolValue, sol};
-use alloy_transport::TransportErrorKind;
 use anvil_core::{
     eth::{
         EthRequest,
@@ -86,7 +86,6 @@ use anvil_rpc::{
     response::ResponseResult,
 };
 use foundry_common::{
-    provider::ProviderBuilder,
     tempo::{PaymentLaneClassification, PaymentLaneReason, classify_payment_lane},
     version::{COMMIT_SHA, SEMVER_VERSION},
 };
@@ -565,21 +564,15 @@ impl<N: Network> EthApi<N> {
     pub async fn anvil_set_rpc_url(&self, url: String) -> Result<()> {
         node_info!("anvil_setRpcUrl");
         if let Some(fork) = self.backend.get_fork() {
+            let urls = vec![url.clone()];
+            let new_provider = fork.config.read().provider_for_urls(&urls)?;
+            let source_chain_id = new_provider.get_chain_id().await?;
+            backend::fork::ensure_fork_network_supported(source_chain_id)?;
+
             let mut config = fork.config.write();
-            // let interval = config.provider.get_interval();
-            let new_provider = Arc::new(
-                ProviderBuilder::new(&url).max_retry(10).initial_backoff(1000).build().map_err(
-                    |_| {
-                        TransportErrorKind::custom_str(
-                            format!("Failed to parse invalid url {url}").as_str(),
-                        )
-                    },
-                    // TODO: Add interval
-                )?, // .interval(interval),
-            );
             config.provider = new_provider;
             trace!(target: "backend", "Updated fork rpc from \"{}\" to \"{}\"", config.eth_rpc_url().unwrap_or("none"), url);
-            config.fork_urls = vec![url.clone()];
+            config.fork_urls = urls;
         }
         // Keep node_config in sync so anvil_reset(None) uses the updated URL
         self.backend.node_config.write().await.fork_urls = vec![url];
@@ -705,15 +698,14 @@ impl<N: Network> EthApi<N> {
     ///
     /// Handler for RPC call: `anvil_reset`
     pub async fn anvil_reset(&self, forking: Option<Forking>) -> Result<()> {
-        self.reset_instance_id();
         node_info!("anvil_reset");
         if let Some(forking) = forking {
-            // if we're resetting the fork we need to reset the instance id
             self.backend.reset_fork(forking).await?;
         } else {
             // Reset to a fresh in-memory state
             self.backend.reset_to_in_mem().await?;
         }
+        self.reset_instance_id();
         // Clear pending transactions since they reference the old chain state.
         self.pool.clear();
         Ok(())

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -47,7 +47,6 @@ use alloy_primitives::{
     Address, B64, B256, Bytes, TxHash, TxKind, U64, U256,
     map::{HashMap, HashSet},
 };
-use alloy_provider::Provider;
 use alloy_rpc_types::{
     AccessListResult, BlockId, BlockNumberOrTag as BlockNumber, BlockTransactions,
     EIP1186AccountProofResponse, FeeHistory, Filter, FilteredParams, Index, Log, Work,
@@ -565,9 +564,8 @@ impl<N: Network> EthApi<N> {
         node_info!("anvil_setRpcUrl");
         if let Some(fork) = self.backend.get_fork() {
             let urls = vec![url.clone()];
-            let new_provider = fork.config.read().provider_for_urls(&urls)?;
-            let source_chain_id = new_provider.get_chain_id().await?;
-            backend::fork::ensure_fork_network_supported(source_chain_id)?;
+            let config = fork.config.read().clone();
+            let (new_provider, _) = config.validated_provider_for_urls(&urls).await?;
 
             let mut config = fork.config.write();
             config.provider = new_provider;
@@ -575,7 +573,9 @@ impl<N: Network> EthApi<N> {
             config.fork_urls = urls;
         }
         // Keep node_config in sync so anvil_reset(None) uses the updated URL
-        self.backend.node_config.write().await.fork_urls = vec![url];
+        let mut node_config = self.backend.node_config.write().await;
+        node_config.fork_urls = vec![url];
+        node_config.fork_chain_id = None;
         Ok(())
     }
 

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -1,6 +1,7 @@
 //! Support for forking off another client
 
 use crate::eth::{backend::db::Db, error::BlockchainError};
+use alloy_chains::NamedChain;
 use alloy_consensus::{BlockHeader, TrieAccount};
 use alloy_eips::eip2930::AccessListResult;
 use alloy_network::{
@@ -44,6 +45,18 @@ use parking_lot::{
 use revm::context_interface::block::BlobExcessGasAndPrice;
 use std::{sync::Arc, time::Duration};
 use tokio::sync::RwLock as AsyncRwLock;
+
+/// Ensures the fork network can be executed by Anvil's EVM backend.
+pub(crate) fn ensure_fork_network_supported(chain_id: u64) -> Result<(), BlockchainError> {
+    if matches!(NamedChain::try_from(chain_id), Ok(NamedChain::ZkSync | NamedChain::ZkSyncTestnet))
+    {
+        return Err(BlockchainError::UnsupportedForkNetwork {
+            chain_id,
+            reason: "Anvil's EVM backend cannot execute native EraVM bytecode; use `anvil-zksync` for zkSync Era forks",
+        });
+    }
+    Ok(())
+}
 
 /// Represents a fork of a remote client
 ///
@@ -427,6 +440,7 @@ impl<N: Network> ClientFork<N> {
         block_number: impl Into<BlockId>,
     ) -> Result<(), BlockchainError> {
         let block_number = block_number.into();
+        self.prepare_reset(urls.clone(), block_number).await?;
         {
             self.database
                 .write()
@@ -434,8 +448,6 @@ impl<N: Network> ClientFork<N> {
                 .maybe_reset(urls.clone(), block_number)
                 .map_err(BlockchainError::Internal)?;
         }
-
-        self.prepare_reset(urls, block_number).await?;
 
         let number = self.block_number();
         let block_hash = self.block_hash();
@@ -450,18 +462,14 @@ impl<N: Network> ClientFork<N> {
         urls: Vec<String>,
         block_number: BlockId,
     ) -> Result<(), BlockchainError> {
-        if !urls.is_empty() {
-            self.config.write().update_urls(urls)?;
-            let override_chain_id = self.config.read().override_chain_id;
-            let chain_id = if let Some(chain_id) = override_chain_id {
-                chain_id
-            } else {
-                self.provider().get_chain_id().await?
-            };
-            self.config.write().chain_id = chain_id;
-        }
-
-        let provider = self.provider();
+        let (provider, source_chain_id) = if urls.is_empty() {
+            (self.provider(), None)
+        } else {
+            let provider = self.config.read().provider_for_urls(&urls)?;
+            let source_chain_id = provider.get_chain_id().await?;
+            ensure_fork_network_supported(source_chain_id)?;
+            (provider, Some(source_chain_id))
+        };
         let block =
             provider.get_block(block_number).await?.ok_or(BlockchainError::BlockNotFound)?;
         let block_hash = block.header().hash();
@@ -470,7 +478,15 @@ impl<N: Network> ClientFork<N> {
         let total_difficulty = block.header().difficulty();
 
         let number = block.header().number();
-        self.config.write().update_block(
+        let mut config = self.config.write();
+        if let Some(source_chain_id) = source_chain_id {
+            if config.override_chain_id.is_none() {
+                config.chain_id = source_chain_id;
+            }
+            config.provider = provider;
+            config.fork_urls = urls;
+        }
+        config.update_block(
             number,
             block_hash,
             timestamp,
@@ -895,12 +911,15 @@ impl<N: Network> ClientForkConfig<N> {
         self.fork_urls.first().map(|s| s.as_str())
     }
 
-    /// Updates the provider URLs
+    /// Builds a provider for the given URLs without changing the active fork configuration.
     ///
     /// # Errors
     ///
     /// This will fail if no new provider could be established (erroneous URL)
-    fn update_urls(&mut self, urls: Vec<String>) -> Result<(), BlockchainError> {
+    pub(crate) fn provider_for_urls(
+        &self,
+        urls: &[String],
+    ) -> Result<Arc<RetryProvider<N>>, BlockchainError> {
         let primary = urls.first().ok_or_else(|| {
             BlockchainError::InvalidUrl("at least one fork URL required".to_string())
         })?;
@@ -912,16 +931,14 @@ impl<N: Network> ClientForkConfig<N> {
             .compute_units_per_second(self.compute_units_per_second)
             .headers(self.headers.clone());
 
-        self.provider = Arc::new(if urls.len() > 1 {
+        let provider = if urls.len() > 1 {
             builder
-                .build_fallback(urls.clone())
+                .build_fallback(urls.to_vec())
                 .map_err(|e| BlockchainError::InvalidUrl(format!("{primary}: {e}")))?
         } else {
             builder.build().map_err(|e| BlockchainError::InvalidUrl(format!("{primary}: {e}")))?
-        });
-        trace!(target: "fork", "Updated fork urls: {:?}", urls);
-        self.fork_urls = urls;
-        Ok(())
+        };
+        Ok(Arc::new(provider))
     }
 
     /// Updates the block forked off `(block number, block hash, timestamp)`

--- a/crates/anvil/src/eth/backend/fork.rs
+++ b/crates/anvil/src/eth/backend/fork.rs
@@ -465,9 +465,8 @@ impl<N: Network> ClientFork<N> {
         let (provider, source_chain_id) = if urls.is_empty() {
             (self.provider(), None)
         } else {
-            let provider = self.config.read().provider_for_urls(&urls)?;
-            let source_chain_id = provider.get_chain_id().await?;
-            ensure_fork_network_supported(source_chain_id)?;
+            let config = self.config.read().clone();
+            let (provider, source_chain_id) = config.validated_provider_for_urls(&urls).await?;
             (provider, Some(source_chain_id))
         };
         let block =
@@ -939,6 +938,33 @@ impl<N: Network> ClientForkConfig<N> {
             builder.build().map_err(|e| BlockchainError::InvalidUrl(format!("{primary}: {e}")))?
         };
         Ok(Arc::new(provider))
+    }
+
+    /// Builds a provider after validating that every URL belongs to the same supported network.
+    pub(crate) async fn validated_provider_for_urls(
+        &self,
+        urls: &[String],
+    ) -> Result<(Arc<RetryProvider<N>>, u64), BlockchainError> {
+        let mut source_chain_id = None;
+        for url in urls {
+            let provider = self.provider_for_urls(std::slice::from_ref(url))?;
+            let chain_id = provider.get_chain_id().await?;
+            ensure_fork_network_supported(chain_id)?;
+            if let Some(source_chain_id) = source_chain_id
+                && chain_id != source_chain_id
+            {
+                return Err(BlockchainError::UnsupportedForkNetwork {
+                    chain_id,
+                    reason: "fork endpoints must use the same chain ID",
+                });
+            }
+            source_chain_id = Some(chain_id);
+        }
+
+        let source_chain_id = source_chain_id.ok_or_else(|| {
+            BlockchainError::InvalidUrl("at least one fork URL required".to_string())
+        })?;
+        Ok((self.provider_for_urls(urls)?, source_chain_id))
     }
 
     /// Updates the block forked off `(block number, block hash, timestamp)`

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3274,23 +3274,22 @@ impl<N: Network> Backend<N> {
         if !self.is_fork() {
             if let Some(eth_rpc_url) = forking.json_rpc_url.clone() {
                 let mut evm_env = self.evm_env.read().clone();
+                let mut node_config = self.node_config.read().await.clone();
 
-                let (db, config) = {
-                    let mut node_config = self.node_config.write().await;
+                // we want to force the correct base fee for the next block during
+                // `setup_fork_db_config`
+                node_config.base_fee.take();
+                node_config.fork_urls = vec![eth_rpc_url.clone()];
+                node_config.apply_tempo_fork_beneficiary_default(&mut evm_env);
 
-                    // we want to force the correct base fee for the next block during
-                    // `setup_fork_db_config`
-                    node_config.base_fee.take();
-                    node_config.fork_urls = vec![eth_rpc_url.clone()];
-                    node_config.apply_tempo_fork_beneficiary_default(&mut evm_env);
-
-                    node_config.setup_fork_db_config(eth_rpc_url, &mut evm_env, &self.fees).await?
-                };
+                let (db, config) =
+                    node_config.setup_fork_db_config(eth_rpc_url, &mut evm_env, &self.fees).await?;
 
                 *self.db.write().await = Box::new(db);
 
                 let fork = ClientFork::new(config, Arc::clone(&self.db));
 
+                *self.node_config.write().await = node_config;
                 *self.evm_env.write() = evm_env;
                 *self.fork.write() = Some(fork);
             } else {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -3343,12 +3343,12 @@ impl<N: Network> Backend<N> {
             // update all settings related to the forked block
             {
                 if let Some(fork_url) = forking.json_rpc_url {
-                    self.reset_block_number(fork_url, fork_block_number).await?;
+                    self.reset_block_number(fork_url, fork_block_number, true).await?;
                 } else {
                     // If rpc url is unspecified, then update the fork with the new block number and
                     // existing rpc url, this updates the cache path
                     if let Some(fork_url) = target_rpc_url.clone() {
-                        self.reset_block_number(fork_url, fork_block_number).await?;
+                        self.reset_block_number(fork_url, fork_block_number, false).await?;
                     }
 
                     let gas_limit = self.node_config.read().await.fork_gas_limit(&fork_block);
@@ -3478,9 +3478,16 @@ impl<N: Network> Backend<N> {
         &self,
         fork_url: String,
         fork_block_number: u64,
+        validated_url: bool,
     ) -> Result<(), BlockchainError> {
-        let mut node_config = self.node_config.write().await;
+        let mut node_config = self.node_config.read().await.clone();
         node_config.fork_choice = Some(ForkChoice::Block(fork_block_number as i128));
+        let override_chain_id =
+            self.get_fork().and_then(|fork| fork.config.read().override_chain_id);
+        node_config.set_chain_id(override_chain_id);
+        if validated_url {
+            node_config.fork_chain_id = None;
+        }
         // Update fork_urls so setup_fork_db_config uses the correct URL set
         node_config.fork_urls = vec![fork_url.clone()];
 
@@ -3490,6 +3497,7 @@ impl<N: Network> Backend<N> {
 
         *self.db.write().await = Box::new(forked_db);
         let fork = ClientFork::new(client_fork_config, Arc::clone(&self.db));
+        *self.node_config.write().await = node_config;
         *self.fork.write() = Some(fork);
         *self.evm_env.write() = evm_env;
 

--- a/crates/anvil/src/eth/error/mod.rs
+++ b/crates/anvil/src/eth/error/mod.rs
@@ -69,6 +69,8 @@ pub enum BlockchainError {
     EvmOverrideError(String),
     #[error("Invalid url {0:?}")]
     InvalidUrl(String),
+    #[error("unsupported fork network for chain {chain_id}: {reason}")]
+    UnsupportedForkNetwork { chain_id: u64, reason: &'static str },
     #[error("Internal error: {0:?}")]
     Internal(String),
     #[error("BlockOutOfRangeError: block height is {0} but requested was {1}")]
@@ -535,6 +537,9 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                     RpcError::invalid_params(err.to_string())
                 }
                 err @ BlockchainError::InvalidUrl(_) => RpcError::invalid_params(err.to_string()),
+                err @ BlockchainError::UnsupportedForkNetwork { .. } => {
+                    RpcError::invalid_params(err.to_string())
+                }
                 BlockchainError::Internal(err) => RpcError::internal_error_with(err),
                 err @ BlockchainError::BlockOutOfRange(_, _) => {
                     RpcError::invalid_params(err.to_string())

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -677,6 +677,41 @@ async fn validates_fork_source_chain_instead_of_local_chain_id() {
     assert_eq!(handle.http_provider().get_chain_id().await.unwrap(), NamedChain::ZkSync as u64);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn validates_every_fork_url_uses_the_same_supported_network() {
+    let (_mainnet_api, mainnet_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
+    let (_zksync_api, zksync_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::ZkSync as u64))).await;
+
+    let result = try_spawn(
+        NodeConfig::test()
+            .with_fork_urls(vec![mainnet_handle.http_endpoint(), zksync_handle.http_endpoint()]),
+    )
+    .await;
+    let Err(error) = result else { panic!("expected zkSync fallback URL to be rejected") };
+    assert!(format!("{error:?}").contains("cannot execute native EraVM bytecode"));
+
+    let (_sepolia_api, sepolia_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Sepolia as u64))).await;
+    let result = try_spawn(
+        NodeConfig::test()
+            .with_fork_urls(vec![mainnet_handle.http_endpoint(), sepolia_handle.http_endpoint()]),
+    )
+    .await;
+    let Err(error) = result else { panic!("expected mixed fork networks to be rejected") };
+    assert!(format!("{error:?}").contains("fork endpoints must use the same chain ID"));
+
+    let result = try_spawn(
+        NodeConfig::test()
+            .with_fork_urls(vec![mainnet_handle.http_endpoint(), sepolia_handle.http_endpoint()])
+            .with_fork_chain_id(Some(U256::from(NamedChain::Mainnet as u64))),
+    )
+    .await;
+    let Err(error) = result else { panic!("expected unverifiable offline fallbacks to fail") };
+    assert!(format!("{error:?}").contains("multiple fork URLs cannot be validated"));
+}
+
 // <https://github.com/foundry-rs/foundry/issues/9743>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_set_storage_visible_to_call() {
@@ -2952,6 +2987,50 @@ async fn test_anvil_reset_with_url_updates_fork_urls() {
         vec![new_url.clone()],
         "ClientForkConfig.fork_urls should reflect the new URL after anvil_reset"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_reset_updates_inferred_chain_id() {
+    let (_mainnet_api, mainnet_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
+    let (api, handle) =
+        spawn(NodeConfig::test().with_eth_rpc_url(Some(mainnet_handle.http_endpoint()))).await;
+    assert_eq!(handle.http_provider().get_chain_id().await.unwrap(), NamedChain::Mainnet as u64);
+
+    let (_sepolia_api, sepolia_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Sepolia as u64))).await;
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(sepolia_handle.http_endpoint()),
+        block_number: None,
+    }))
+    .await
+    .unwrap();
+
+    assert_eq!(handle.http_provider().get_chain_id().await.unwrap(), NamedChain::Sepolia as u64);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_reset_replaces_offline_fork_chain_id() {
+    let (_mainnet_api, mainnet_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
+    let (api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(mainnet_handle.http_endpoint()))
+            .with_fork_block_number(Some(0u64))
+            .with_fork_chain_id(Some(U256::from(NamedChain::Mainnet as u64))),
+    )
+    .await;
+
+    let (_sepolia_api, sepolia_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Sepolia as u64))).await;
+    api.anvil_reset(Some(Forking {
+        json_rpc_url: Some(sepolia_handle.http_endpoint()),
+        block_number: None,
+    }))
+    .await
+    .unwrap();
+
+    assert_eq!(handle.http_provider().get_chain_id().await.unwrap(), NamedChain::Sepolia as u64);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -646,6 +646,37 @@ async fn test_spawn_fork() {
     assert_eq!(head, U256::from(BLOCK_NUMBER))
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn validates_fork_source_chain_instead_of_local_chain_id() {
+    for chain_id in [NamedChain::ZkSyncTestnet, NamedChain::ZkSync] {
+        let (_origin_api, origin_handle) =
+            spawn(NodeConfig::test().with_chain_id(Some(chain_id as u64))).await;
+
+        let result = try_spawn(
+            NodeConfig::test()
+                .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+                .with_chain_id(Some(31_337u64)),
+        )
+        .await;
+        let Err(error) = result else { panic!("expected zkSync fork startup to fail") };
+        let message = format!("{error:?}");
+        assert!(message.contains("cannot execute native EraVM bytecode"), "{message}");
+        assert!(message.contains("anvil-zksync"), "{message}");
+    }
+
+    let (_origin_api, origin_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
+
+    let (_api, handle) = spawn(
+        NodeConfig::test()
+            .with_eth_rpc_url(Some(origin_handle.http_endpoint()))
+            .with_chain_id(Some(NamedChain::ZkSync as u64)),
+    )
+    .await;
+
+    assert_eq!(handle.http_provider().get_chain_id().await.unwrap(), NamedChain::ZkSync as u64);
+}
+
 // <https://github.com/foundry-rs/foundry/issues/9743>
 #[tokio::test(flavor = "multi_thread")]
 async fn test_fork_set_storage_visible_to_call() {
@@ -2883,6 +2914,21 @@ async fn test_anvil_set_rpc_url_syncs_fork_config() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_set_rpc_url_rejects_zksync_source_atomically() {
+    let (_origin_api, origin_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
+    let origin_url = origin_handle.http_endpoint();
+    let (api, _handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(origin_url.clone()))).await;
+
+    let (_zksync_api, zksync_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::ZkSync as u64))).await;
+    let error = api.anvil_set_rpc_url(zksync_handle.http_endpoint()).await.unwrap_err();
+
+    assert!(error.to_string().contains("cannot execute native EraVM bytecode"));
+    assert_eq!(api.backend.get_fork().unwrap().eth_rpc_url().as_deref(), Some(origin_url.as_str()));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_anvil_reset_with_url_updates_fork_urls() {
     // Spawn an origin node and fork off it
     let (_origin_api, origin_handle) = spawn(NodeConfig::test()).await;
@@ -2906,4 +2952,55 @@ async fn test_anvil_reset_with_url_updates_fork_urls() {
         vec![new_url.clone()],
         "ClientForkConfig.fork_urls should reflect the new URL after anvil_reset"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_reset_rejects_zksync_source_atomically() {
+    let (_origin_api, origin_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Mainnet as u64))).await;
+    let origin_url = origin_handle.http_endpoint();
+    let (api, handle) = spawn(NodeConfig::test().with_eth_rpc_url(Some(origin_url.clone()))).await;
+    let original_block = handle.http_provider().get_block_number().await.unwrap();
+    let original_instance_id = api.instance_id();
+
+    let (_zksync_api, zksync_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::ZkSync as u64))).await;
+    let error = api
+        .anvil_reset(Some(Forking {
+            json_rpc_url: Some(zksync_handle.http_endpoint()),
+            block_number: None,
+        }))
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("cannot execute native EraVM bytecode"));
+    let fork = api.backend.get_fork().unwrap();
+    assert_eq!(fork.eth_rpc_url().as_deref(), Some(origin_url.as_str()));
+    assert_eq!(handle.http_provider().get_block_number().await.unwrap(), original_block);
+    assert_eq!(api.instance_id(), original_instance_id);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_anvil_reset_from_local_node_rejects_zksync_source_atomically() {
+    let (api, handle) = spawn(NodeConfig::test()).await;
+    api.mine_one().await;
+    let original_block = handle.http_provider().get_block_number().await.unwrap();
+    let original_chain_id = handle.http_provider().get_chain_id().await.unwrap();
+    let original_instance_id = api.instance_id();
+
+    let (_zksync_api, zksync_handle) =
+        spawn(NodeConfig::test().with_chain_id(Some(NamedChain::ZkSync as u64))).await;
+    let error = api
+        .anvil_reset(Some(Forking {
+            json_rpc_url: Some(zksync_handle.http_endpoint()),
+            block_number: None,
+        }))
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("cannot execute native EraVM bytecode"));
+    assert!(!api.is_fork());
+    assert_eq!(handle.http_provider().get_block_number().await.unwrap(), original_block);
+    assert_eq!(handle.http_provider().get_chain_id().await.unwrap(), original_chain_id);
+    assert_eq!(api.instance_id(), original_instance_id);
 }

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -3062,7 +3062,7 @@ async fn test_anvil_reset_rejects_zksync_source_atomically() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_anvil_reset_from_local_node_rejects_zksync_source_atomically() {
     let (api, handle) = spawn(NodeConfig::test()).await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let original_block = handle.http_provider().get_block_number().await.unwrap();
     let original_chain_id = handle.http_provider().get_chain_id().await.unwrap();
     let original_instance_id = api.instance_id();


### PR DESCRIPTION
Standard Anvil cannot execute the native EraVM bytecode returned by zkSync Era RPCs. This change rejects zkSync Era source forks with guidance to use `anvil-zksync`, preventing silently incorrect execution results while preserving local chain-ID overrides.

Closes #9860.