### PR TITLE
fix(ci): coordinate release finalization

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -10,3 +10,11 @@ self-hosted-runner:
     - depot-windows-latest-16
 
 config-variables: null
+
+paths:
+  .github/workflows/finalize-release.yml:
+    ignore:
+      - '^unexpected key "queue" for "concurrency" section\.'
+  .github/workflows/release.yml:
+    ignore:
+      - '^unexpected key "queue" for "concurrency" section\.'

--- a/.github/scripts/finalize-release.py
+++ b/.github/scripts/finalize-release.py
@@ -99,13 +99,16 @@ def require_release_run(commands, repo, tag, commit):
         "gh", "api", "--paginate", "--slurp",
         f"repos/{repo}/actions/workflows/release.yml/runs?event=push&head_sha={commit}&per_page=100",
     ]))
-    valid = [
+    matching = [
         run for page in pages for run in page.get("workflow_runs", [])
-        if run.get("conclusion") == "success" and run.get("head_sha") == commit and run.get("head_branch") == tag
+        if run.get("head_sha") == commit and run.get("head_branch") == tag
     ]
-    if not valid:
-        raise ReleaseError(f"no successful release.yml push run for {tag} at {commit}")
-    return max(valid, key=lambda run: run["id"])["id"]
+    if not matching:
+        raise ReleaseError(f"no release.yml push run found for {tag} at {commit}")
+    latest = max(matching, key=lambda run: run["id"])
+    if latest.get("conclusion") != "success":
+        raise ReleaseError(f"latest release.yml push run for {tag} at {commit} was not successful")
+    return latest["id"]
 
 
 def release_run_digest(commands, repo, run_id):

--- a/.github/scripts/finalize-release.py
+++ b/.github/scripts/finalize-release.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Safely publish a staged Foundry release and promote its moving image aliases."""
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+
+STABLE = re.compile(r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+RC = re.compile(r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-rc([1-9][0-9]*)$")
+NIGHTLY = re.compile(r"^nightly-([0-9a-f]{40})$")
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class ReleaseError(RuntimeError):
+    pass
+
+
+class Commands:
+    def run(self, args, check=True):
+        try:
+            return subprocess.run(args, text=True, capture_output=True, check=check)
+        except subprocess.CalledProcessError as error:
+            detail = (error.stderr or error.stdout or "").strip()
+            raise ReleaseError(f"command failed ({' '.join(args)}): {detail}") from error
+
+    def output(self, args):
+        return self.run(args).stdout.strip()
+
+
+def parse_tag(tag, mode):
+    patterns = {"stable": (STABLE, RC), "nightly": (NIGHTLY,)}[mode]
+    for pattern in patterns:
+        if match := pattern.fullmatch(tag):
+            return pattern, tuple(int(value) for value in match.groups()) if pattern != NIGHTLY else match.group(1)
+    expected = "vX.Y.Z or vX.Y.Z-rcN" if mode == "stable" else "nightly-<40 lowercase hex SHA>"
+    raise ReleaseError(f"tag must be canonical {expected}: {tag}")
+
+
+def image_digest(commands, reference):
+    raw = commands.output([
+        "docker", "buildx", "imagetools", "inspect", reference,
+        "--format", "{{json .Manifest.Digest}}",
+    ])
+    try:
+        digest = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ReleaseError(f"could not parse digest for {reference}: {raw}") from error
+    if not isinstance(digest, str) or not DIGEST.fullmatch(digest):
+        raise ReleaseError(f"invalid digest for {reference}: {digest}")
+    return digest
+
+
+def verify_exact(commands, image, tag, expected=None):
+    digest = image_digest(commands, f"{image}:{tag}")
+    if expected and digest != expected:
+        raise ReleaseError(f"staged tag {tag} resolves to {digest}, expected {expected}")
+    return digest
+
+
+def releases(commands, repo):
+    pages = json.loads(commands.output([
+        "gh", "api", "--paginate", "--slurp", f"repos/{repo}/releases?per_page=100",
+    ]))
+    return [release for page in pages for release in page]
+
+
+def exact_release(all_releases, tag):
+    matches = [release for release in all_releases if release.get("tag_name") == tag]
+    if len(matches) != 1:
+        raise ReleaseError(f"expected exactly one GitHub release for {tag}, found {len(matches)}")
+    return matches[0]
+
+
+def stable_aliases(candidate, all_releases):
+    version = tuple(int(value) for value in STABLE.fullmatch(candidate).groups())
+    versions = [version]
+    for release in all_releases:
+        match = STABLE.fullmatch(release.get("tag_name", ""))
+        if match and not release.get("draft") and not release.get("prerelease"):
+            versions.append(tuple(int(value) for value in match.groups()))
+    aliases = []
+    if version == max(value for value in versions if value[:2] == version[:2]):
+        aliases.append(f"v{version[0]}.{version[1]}")
+    if version == max(value for value in versions if value[0] == version[0]):
+        aliases.append(f"v{version[0]}")
+    if version == max(versions):
+        aliases.append("latest")
+    return aliases, version == max(versions)
+
+
+def require_release_run(commands, repo, tag, commit):
+    pages = json.loads(commands.output([
+        "gh", "api", "--paginate", "--slurp",
+        f"repos/{repo}/actions/workflows/release.yml/runs?event=push&head_sha={commit}&per_page=100",
+    ]))
+    valid = [
+        run for page in pages for run in page.get("workflow_runs", [])
+        if run.get("conclusion") == "success" and run.get("head_sha") == commit and run.get("head_branch") == tag
+    ]
+    if not valid:
+        raise ReleaseError(f"no successful release.yml push run for {tag} at {commit}")
+    return max(valid, key=lambda run: run["id"])["id"]
+
+
+def release_run_digest(commands, repo, run_id):
+    with tempfile.TemporaryDirectory() as directory:
+        commands.run([
+            "gh", "run", "download", str(run_id), "--repo", repo,
+            "--name", "release-docker-digest", "--dir", directory,
+        ])
+        path = pathlib.Path(directory) / "release-docker-digest.txt"
+        if not path.is_file():
+            raise ReleaseError(f"release workflow run {run_id} has no Docker digest artifact")
+        digest = path.read_text().strip()
+    if not DIGEST.fullmatch(digest):
+        raise ReleaseError(f"release workflow run {run_id} has invalid Docker digest {digest!r}")
+    return digest
+
+
+def publish(commands, tag, prerelease, latest):
+    commands.run([
+        "gh", "release", "edit", tag, "--draft=false",
+        f"--prerelease={'true' if prerelease else 'false'}",
+        f"--latest={'true' if latest else 'false'}",
+    ])
+
+
+def promote(commands, image, digest, alias):
+    commands.run(["docker", "buildx", "imagetools", "create", "--tag", f"{image}:{alias}", f"{image}@{digest}"])
+    actual = image_digest(commands, f"{image}:{alias}")
+    if actual != digest:
+        raise ReleaseError(f"alias {alias} resolves to {actual}, expected {digest}")
+
+
+def finalize_stable(commands, repo, image, tag):
+    pattern, _ = parse_tag(tag, "stable")
+    all_releases = releases(commands, repo)
+    state = exact_release(all_releases, tag)
+    commit = commands.output(["git", "rev-parse", f"{tag}^{{commit}}"])
+    if not re.fullmatch(r"[0-9a-f]{40}", commit):
+        raise ReleaseError(f"could not resolve {tag} to a full commit SHA")
+    run_id = require_release_run(commands, repo, tag, commit)
+    expected = release_run_digest(commands, repo, run_id)
+    digest = verify_exact(commands, image, tag, expected)
+    prerelease = pattern == RC
+    if state.get("tag_name") != tag or state.get("prerelease") != prerelease:
+        raise ReleaseError(f"release {tag} has unexpected state/classification")
+    aliases, latest = (stable_aliases(tag, all_releases) if pattern == STABLE else ([], False))
+    if state.get("draft"):
+        publish(commands, tag, prerelease, latest)
+    if pattern == STABLE:
+        aliases, _ = stable_aliases(tag, releases(commands, repo))
+        for alias in aliases:
+            promote(commands, image, digest, alias)
+
+
+def current_nightly_revision(commands, image):
+    result = commands.run([
+        "docker", "buildx", "imagetools", "inspect", f"{image}:nightly",
+        "--format", "{{json .Image}}",
+    ], check=False)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).lower()
+        if "manifest unknown" in detail or "not found" in detail:
+            return None
+        raise ReleaseError(f"could not inspect current nightly image: {detail.strip()}")
+    try:
+        images = json.loads(result.stdout)
+        revisions = {
+            data["config"]["Labels"]["org.opencontainers.image.revision"]
+            for data in images.values()
+        }
+    except (json.JSONDecodeError, AttributeError, KeyError, TypeError) as error:
+        raise ReleaseError("current nightly image has malformed revision metadata") from error
+    if len(revisions) != 1:
+        raise ReleaseError("current nightly image has inconsistent revision metadata")
+    revision = revisions.pop()
+    if not re.fullmatch(r"[0-9a-f]{40}", revision):
+        raise ReleaseError(f"current nightly image has invalid revision {revision!r}")
+    return revision
+
+
+def nightly_eligible(commands, image, candidate_sha):
+    current = current_nightly_revision(commands, image)
+    if current is None or current == candidate_sha:
+        return True
+    result = commands.run(["git", "merge-base", "--is-ancestor", current, candidate_sha], check=False)
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise ReleaseError(f"could not compare nightly history {current}..{candidate_sha}: {(result.stderr or result.stdout).strip()}")
+
+
+def finalize_nightly(commands, repo, image, tag, expected=None):
+    _, sha = parse_tag(tag, "nightly")
+    digest = verify_exact(commands, image, tag, expected)
+    state = exact_release(releases(commands, repo), tag)
+    commit = commands.output(["git", "rev-parse", f"{tag}^{{commit}}"])
+    if commit != sha or not state.get("prerelease"):
+        raise ReleaseError(f"release {tag} has unexpected state/classification")
+    if state.get("draft"):
+        publish(commands, tag, True, False)
+    if nightly_eligible(commands, image, sha):
+        promote(commands, image, digest, "nightly")
+    else:
+        print(f"Not moving nightly: {tag} is not a descendant of the current nightly image.")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("stable", "nightly"))
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--digest")
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"))
+    parser.add_argument("--image")
+    args = parser.parse_args()
+    if not args.repo:
+        parser.error("--repo or GITHUB_REPOSITORY is required")
+    image = args.image or f"ghcr.io/{args.repo}"
+    try:
+        if args.mode == "stable":
+            finalize_stable(Commands(), args.repo, image, args.tag)
+        else:
+            finalize_nightly(Commands(), args.repo, image, args.tag, args.digest)
+    except ReleaseError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tests/test_finalize_release.py
+++ b/.github/scripts/tests/test_finalize_release.py
@@ -1,0 +1,225 @@
+import importlib.util
+import json
+import pathlib
+import subprocess
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "finalize-release.py"
+SPEC = importlib.util.spec_from_file_location("finalize_release", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+DIGEST = "sha256:" + "a" * 64
+OTHER_DIGEST = "sha256:" + "b" * 64
+RELEASES_COMMAND = (
+    "gh", "api", "--paginate", "--slurp", "repos/r/releases?per_page=100",
+)
+
+
+class FakeCommands:
+    def __init__(self, results=None, artifact_digest=None):
+        self.results = results or {}
+        self.artifact_digest = artifact_digest
+        self.calls = []
+
+    def _result(self, args):
+        key = tuple(args)
+        if key not in self.results:
+            raise AssertionError(f"unexpected command: {args}")
+        value = self.results[key]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def output(self, args):
+        self.calls.append(tuple(args))
+        return self._result(args)
+
+    def run(self, args, check=True):
+        self.calls.append(tuple(args))
+        if args[:3] == ["gh", "run", "download"]:
+            if self.artifact_digest is None:
+                raise AssertionError(f"unexpected command: {args}")
+            directory = pathlib.Path(args[args.index("--dir") + 1])
+            (directory / "release-docker-digest.txt").write_text(self.artifact_digest)
+            return subprocess.CompletedProcess(args, 0, "", "")
+        value = self._result(args)
+        if isinstance(value, subprocess.CompletedProcess):
+            return value
+        return subprocess.CompletedProcess(args, value, "", "")
+
+
+def completed(args, code=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args, code, stdout, stderr)
+
+
+def release(tag, draft=False, prerelease=False):
+    return {"tag_name": tag, "draft": draft, "prerelease": prerelease}
+
+
+def release_pages(*values):
+    return json.dumps([list(values)])
+
+
+def digest_command(reference):
+    return (
+        "docker", "buildx", "imagetools", "inspect", reference,
+        "--format", "{{json .Manifest.Digest}}",
+    )
+
+
+class ParsingTests(unittest.TestCase):
+    def test_strict_tags(self):
+        for tag in ("v0.1.10", "v1.2.3", "v1.2.3-rc1", "nightly-" + "a" * 40):
+            MODULE.parse_tag(tag, "nightly" if tag.startswith("nightly") else "stable")
+        for tag in ("v01.2.3", "v1.02.3", "v1.2.3-rc0", "v1.2.3-rc01", "nightly-" + "A" * 40):
+            with self.assertRaises(MODULE.ReleaseError):
+                MODULE.parse_tag(tag, "nightly" if tag.startswith("nightly") else "stable")
+
+    def test_exact_release_rejects_missing_and_duplicates(self):
+        self.assertEqual(MODULE.exact_release([release("v1.0.0")], "v1.0.0")["tag_name"], "v1.0.0")
+        for values in ([], [release("v1.0.0"), release("v1.0.0", draft=True)]):
+            with self.assertRaisesRegex(MODULE.ReleaseError, "exactly one"):
+                MODULE.exact_release(values, "v1.0.0")
+
+
+class StableTests(unittest.TestCase):
+    def test_numeric_alias_scopes_and_ignored_releases(self):
+        aliases, latest = MODULE.stable_aliases("v1.10.2", [
+            release("v1.9.99"), release("v1.10.3", draft=True),
+            release("v2.0.0-rc1", prerelease=True), release("v2.0.0"),
+        ])
+        self.assertEqual(aliases, ["v1.10", "v1"])
+        self.assertFalse(latest)
+
+    def test_older_candidate_can_advance_own_minor_only(self):
+        aliases, _ = MODULE.stable_aliases("v1.9.5", [release("v1.10.0")])
+        self.assertEqual(aliases, ["v1.9"])
+
+    def test_exact_digest_same_and_conflicting(self):
+        command = digest_command("image:v1.2.3")
+        commands = FakeCommands({command: f'"{DIGEST}"'})
+        self.assertEqual(MODULE.verify_exact(commands, "image", "v1.2.3", DIGEST), DIGEST)
+        with self.assertRaisesRegex(MODULE.ReleaseError, "expected"):
+            MODULE.verify_exact(FakeCommands({command: f'"{DIGEST}"'}), "image", "v1.2.3", OTHER_DIGEST)
+
+    def test_release_run_requirement_selects_latest_matching_run(self):
+        command = (
+            "gh", "api", "--paginate", "--slurp",
+            "repos/r/actions/workflows/release.yml/runs?event=push&head_sha=abc&per_page=100",
+        )
+        runs = {"workflow_runs": [
+            {"id": 1, "conclusion": "success", "head_sha": "abc", "head_branch": "v1.0.0"},
+            {"id": 2, "conclusion": "success", "head_sha": "abc", "head_branch": "v1.0.0"},
+        ]}
+        self.assertEqual(MODULE.require_release_run(FakeCommands({command: json.dumps([runs])}), "r", "v1.0.0", "abc"), 2)
+
+    def test_rc_draft_is_published_without_aliases(self):
+        tag = "v1.2.3-rc1"
+        commit = "c" * 40
+        run_command = (
+            "gh", "api", "--paginate", "--slurp",
+            f"repos/r/actions/workflows/release.yml/runs?event=push&head_sha={commit}&per_page=100",
+        )
+        publish = ("gh", "release", "edit", tag, "--draft=false", "--prerelease=true", "--latest=false")
+        commands = FakeCommands({
+            RELEASES_COMMAND: release_pages(release(tag, draft=True, prerelease=True)),
+            ("git", "rev-parse", f"{tag}^{{commit}}"): commit,
+            run_command: json.dumps([{"workflow_runs": [
+                {"id": 7, "conclusion": "success", "head_sha": commit, "head_branch": tag},
+            ]}]),
+            digest_command(f"image:{tag}"): f'"{DIGEST}"',
+            publish: 0,
+        }, artifact_digest=DIGEST)
+        MODULE.finalize_stable(commands, "r", "image", tag)
+        self.assertIn(publish, commands.calls)
+
+    def test_published_retry_does_not_edit_immutable_release(self):
+        tag = "v1.2.3"
+        commit = "c" * 40
+        run_command = (
+            "gh", "api", "--paginate", "--slurp",
+            f"repos/r/actions/workflows/release.yml/runs?event=push&head_sha={commit}&per_page=100",
+        )
+        results = {
+            RELEASES_COMMAND: release_pages(release(tag)),
+            ("git", "rev-parse", f"{tag}^{{commit}}"): commit,
+            run_command: json.dumps([{"workflow_runs": [
+                {"id": 7, "conclusion": "success", "head_sha": commit, "head_branch": tag},
+            ]}]),
+            digest_command(f"image:{tag}"): f'"{DIGEST}"',
+        }
+        for alias in ("v1.2", "v1", "latest"):
+            results[("docker", "buildx", "imagetools", "create", "--tag", f"image:{alias}", f"image@{DIGEST}")] = 0
+            results[digest_command(f"image:{alias}")] = f'"{DIGEST}"'
+        commands = FakeCommands(results, artifact_digest=DIGEST)
+        MODULE.finalize_stable(commands, "r", "image", tag)
+        self.assertFalse(any(call[:3] == ("gh", "release", "edit") for call in commands.calls))
+
+
+class NightlyTests(unittest.TestCase):
+    def image_data(self, *revisions):
+        return json.dumps({
+            f"linux/platform{index}": {
+                "config": {"Labels": {"org.opencontainers.image.revision": revision}},
+            }
+            for index, revision in enumerate(revisions)
+        })
+
+    def inspect_command(self):
+        return (
+            "docker", "buildx", "imagetools", "inspect", "image:nightly",
+            "--format", "{{json .Image}}",
+        )
+
+    def test_current_alias_newer_same_stale_and_error(self):
+        candidate = "b" * 40
+        older = "a" * 40
+        inspect = self.inspect_command()
+        ancestry = ("git", "merge-base", "--is-ancestor", older, candidate)
+        self.assertTrue(MODULE.nightly_eligible(FakeCommands({
+            inspect: completed(inspect, stdout=self.image_data(older, older)), ancestry: 0,
+        }), "image", candidate))
+        self.assertTrue(MODULE.nightly_eligible(FakeCommands({
+            inspect: completed(inspect, stdout=self.image_data(candidate, candidate)),
+        }), "image", candidate))
+        self.assertFalse(MODULE.nightly_eligible(FakeCommands({
+            inspect: completed(inspect, stdout=self.image_data(older, older)), ancestry: 1,
+        }), "image", candidate))
+        with self.assertRaisesRegex(MODULE.ReleaseError, "inspect current nightly"):
+            MODULE.nightly_eligible(FakeCommands({
+                inspect: completed(inspect, code=1, stderr="unauthorized"),
+            }), "image", candidate)
+
+    def test_missing_alias_bootstraps_but_inconsistent_revisions_fail(self):
+        candidate = "b" * 40
+        inspect = self.inspect_command()
+        self.assertTrue(MODULE.nightly_eligible(FakeCommands({
+            inspect: completed(inspect, code=1, stderr="manifest unknown"),
+        }), "image", candidate))
+        with self.assertRaisesRegex(MODULE.ReleaseError, "inconsistent"):
+            MODULE.nightly_eligible(FakeCommands({
+                inspect: completed(inspect, stdout=self.image_data("a" * 40, "b" * 40)),
+            }), "image", candidate)
+
+    def test_draft_is_published_before_current_alias_is_promoted(self):
+        candidate = "b" * 40
+        tag = f"nightly-{candidate}"
+        publish = ("gh", "release", "edit", tag, "--draft=false", "--prerelease=true", "--latest=false")
+        promote = ("docker", "buildx", "imagetools", "create", "--tag", "image:nightly", f"image@{DIGEST}")
+        commands = FakeCommands({
+            digest_command(f"image:{tag}"): f'"{DIGEST}"',
+            RELEASES_COMMAND: release_pages(release(tag, draft=True, prerelease=True)),
+            ("git", "rev-parse", f"{tag}^{{commit}}"): candidate,
+            publish: 0,
+            self.inspect_command(): completed(self.inspect_command(), stdout=self.image_data(candidate, candidate)),
+            promote: 0,
+            digest_command("image:nightly"): f'"{DIGEST}"',
+        })
+        MODULE.finalize_nightly(commands, "r", "image", tag, DIGEST)
+        self.assertLess(commands.calls.index(publish), commands.calls.index(promote))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_finalize_release.py
+++ b/.github/scripts/tests/test_finalize_release.py
@@ -104,7 +104,7 @@ class StableTests(unittest.TestCase):
         with self.assertRaisesRegex(MODULE.ReleaseError, "expected"):
             MODULE.verify_exact(FakeCommands({command: f'"{DIGEST}"'}), "image", "v1.2.3", OTHER_DIGEST)
 
-    def test_release_run_requirement_selects_latest_matching_run(self):
+    def test_release_run_requirement_uses_latest_matching_run(self):
         command = (
             "gh", "api", "--paginate", "--slurp",
             "repos/r/actions/workflows/release.yml/runs?event=push&head_sha=abc&per_page=100",
@@ -114,6 +114,9 @@ class StableTests(unittest.TestCase):
             {"id": 2, "conclusion": "success", "head_sha": "abc", "head_branch": "v1.0.0"},
         ]}
         self.assertEqual(MODULE.require_release_run(FakeCommands({command: json.dumps([runs])}), "r", "v1.0.0", "abc"), 2)
+        runs["workflow_runs"][1]["conclusion"] = "failure"
+        with self.assertRaisesRegex(MODULE.ReleaseError, "latest .* was not successful"):
+            MODULE.require_release_run(FakeCommands({command: json.dumps([runs])}), "r", "v1.0.0", "abc")
 
     def test_rc_draft_is_published_without_aliases(self):
         tag = "v1.2.3-rc1"
@@ -219,6 +222,22 @@ class NightlyTests(unittest.TestCase):
         })
         MODULE.finalize_nightly(commands, "r", "image", tag, DIGEST)
         self.assertLess(commands.calls.index(publish), commands.calls.index(promote))
+
+    def test_published_nightly_retry_still_promotes_alias(self):
+        candidate = "b" * 40
+        tag = f"nightly-{candidate}"
+        promote = ("docker", "buildx", "imagetools", "create", "--tag", "image:nightly", f"image@{DIGEST}")
+        commands = FakeCommands({
+            digest_command(f"image:{tag}"): f'"{DIGEST}"',
+            RELEASES_COMMAND: release_pages(release(tag, prerelease=True)),
+            ("git", "rev-parse", f"{tag}^{{commit}}"): candidate,
+            self.inspect_command(): completed(self.inspect_command(), stdout=self.image_data(candidate, candidate)),
+            promote: 0,
+            digest_command("image:nightly"): f'"{DIGEST}"',
+        })
+        MODULE.finalize_nightly(commands, "r", "image", tag, DIGEST)
+        self.assertFalse(any(call[:3] == ("gh", "release", "edit") for call in commands.calls))
+        self.assertIn(promote, commands.calls)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,10 +14,14 @@ on:
       tag_name:
         required: true
         type: string
+    outputs:
+      digest:
+        description: Immutable multi-platform image digest
+        value: ${{ jobs.build.outputs.digest }}
 
 concurrency:
-  group: docker-${{ github.head_ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: docker-${{ github.repository }}-${{ inputs.tag_name }}
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -29,15 +33,18 @@ env:
 
 jobs:
   build:
-    name: build and push
+    name: build, sign, and stage
     runs-on: depot-ubuntu-latest
     permissions:
       attestations: write
       artifact-metadata: write
+      actions: read
       contents: read
       id-token: write
       packages: write
     timeout-minutes: 60
+    outputs:
+      digest: ${{ steps.select.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -60,44 +67,39 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      # Derive Docker tags from inputs.tag_name:
-      # - v{major}.{minor}.{patch}: tagged as :v1.2.3, :v1.2, :v1, and :latest
-      # - nightly-{SHA}: tagged as :nightly-{SHA} and :nightly
-      # - anything else: tagged as-is
-      - name: Finalize Docker Metadata
-        id: docker_tagging
+      - name: Check for an already staged exact image
+        id: existing
         env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           TAG: ${{ inputs.tag_name }}
-          REGISTRY: ${{ env.REGISTRY }}
-          IMAGE: ${{ env.IMAGE_NAME }}
+        shell: bash
         run: |
-          if [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            MAJOR="v${BASH_REMATCH[1]}"
-            MINOR="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-            printf "version tag release, assigning %s, %s, %s, and latest tags\n" "$TAG" "$MINOR" "$MAJOR"
-            printf "docker_tags=%s/%s:%s,%s/%s:%s,%s/%s:%s,%s/%s:latest\n" "$REGISTRY" "$IMAGE" "$TAG" "$REGISTRY" "$IMAGE" "$MINOR" "$REGISTRY" "$IMAGE" "$MAJOR" "$REGISTRY" "$IMAGE" >> "$GITHUB_OUTPUT"
-          elif [[ "$TAG" =~ ^nightly- ]]; then
-            printf "nightly release, assigning %s and nightly tags\n" "$TAG"
-            printf "docker_tags=%s/%s:%s,%s/%s:nightly\n" "$REGISTRY" "$IMAGE" "$TAG" "$REGISTRY" "$IMAGE" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          inspect_error="$(mktemp)"
+          if digest="$(docker buildx imagetools inspect "$IMAGE:$TAG" --format '{{json .Manifest.Digest}}' 2>"$inspect_error" | tr -d '"')"; then
+            if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::Exact tag $TAG has invalid digest $digest."
+              exit 1
+            fi
+            {
+              printf 'exists=true\n'
+              printf 'digest=%s\n' "$digest"
+            } >> "$GITHUB_OUTPUT"
+          elif grep -Eiq 'manifest unknown|not found' "$inspect_error"; then
+            printf 'exists=false\n' >> "$GITHUB_OUTPUT"
           else
-            printf "tagging as %s\n" "$TAG"
-            printf "docker_tags=%s/%s:%s\n" "$REGISTRY" "$IMAGE" "$TAG" >> "$GITHUB_OUTPUT"
+            cat "$inspect_error" >&2
+            echo "::error::Could not determine whether exact tag $TAG exists."
+            exit 1
           fi
 
-      # Log docker metadata to explicitly know what is being pushed
-      - name: Inspect Docker Metadata
-        env:
-          DOCKER_TAGS: ${{ steps.docker_tagging.outputs.docker_tags }}
-          DOCKER_LABELS: ${{ steps.meta.outputs.labels }}
-        run: |
-          printf "TAGS -> %s\n" "$DOCKER_TAGS"
-          printf "LABELS -> %s\n" "$DOCKER_LABELS"
-
       - name: Set up Depot CLI
+        if: steps.existing.outputs.exists != 'true'
         uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1.7.1
 
       - name: Build and push Foundry image
         id: build
+        if: steps.existing.outputs.exists != 'true'
         uses: depot/build-push-action@98e78adca7817480b8185f474a400b451d74e287 # v1.18.0
         with:
           build-args: |
@@ -107,35 +109,105 @@ jobs:
             VERGEN_GIT_SHA=${{ github.sha }}
           project: 8gkbxxjrpw
           context: .
-          tags: ${{ steps.docker_tagging.outputs.docker_tags }}
+          outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          push: true
           no-cache: true
           sbom: true
           provenance: mode=max
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign image with cosign (keyless)
+      - name: Select and inspect image digest
+        id: select
         env:
-          DOCKER_TAGS: ${{ steps.docker_tagging.outputs.docker_tags }}
-          DIGEST: ${{ steps.build.outputs.digest }}
+          BUILT_DIGEST: ${{ steps.build.outputs.digest }}
+          EXISTING_DIGEST: ${{ steps.existing.outputs.digest }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         shell: bash
         run: |
           set -euo pipefail
-          IFS=',' read -r -a tags <<< "$DOCKER_TAGS"
-          for tag in "${tags[@]}"; do
-            # Strip any tag suffix and pin to immutable digest, then sign.
-            ref="${tag%%:*}@${DIGEST}"
-            printf 'Signing %s\n' "$ref"
-            cosign sign --yes "$ref"
-          done
+          DIGEST="${EXISTING_DIGEST:-$BUILT_DIGEST}"
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Invalid image digest: $DIGEST"
+            exit 1
+          fi
+          docker buildx imagetools inspect "$IMAGE@$DIGEST"
+          printf 'digest=%s\n' "$DIGEST" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Verify already staged image
+        if: steps.existing.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DIGEST: ${{ steps.select.outputs.digest }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          EXPECTED_REVISION: ${{ github.sha }}
+          REPOSITORY: ${{ github.repository }}
+          SOURCE_REF: ${{ github.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_data="$(docker buildx imagetools inspect "$IMAGE@$DIGEST" --format '{{json .Image}}')"
+          revision="$(jq -er '
+            [to_entries[].value.config.Labels["org.opencontainers.image.revision"]] |
+            unique | if length == 1 then .[0] else empty end
+          ' <<< "$image_data")"
+          if [[ "$revision" != "$EXPECTED_REVISION" ]]; then
+            echo "::error::Staged image revision $revision does not match $EXPECTED_REVISION."
+            exit 1
+          fi
+          docker_identity="https://github.com/${REPOSITORY}/.github/workflows/docker-publish.yml@${SOURCE_REF}"
+          cosign verify \
+            --certificate-identity "$docker_identity" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "$IMAGE@$DIGEST"
+          gh attestation verify "oci://$IMAGE@$DIGEST" \
+            --repo "$REPOSITORY" \
+            --signer-workflow "$REPOSITORY/.github/workflows/docker-publish.yml" \
+            --source-ref "$SOURCE_REF" \
+            --source-digest "$EXPECTED_REVISION"
+
+      - name: Sign image with cosign (keyless)
+        if: steps.existing.outputs.exists != 'true'
+        env:
+          DIGEST: ${{ steps.select.outputs.digest }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cosign sign --yes "$IMAGE@$DIGEST"
 
       - name: Image build provenance attestation
+        if: steps.existing.outputs.exists != 'true'
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build.outputs.digest }}
+          subject-digest: ${{ steps.select.outputs.digest }}
           push-to-registry: true
+
+      - name: Stage exact Docker tag
+        if: steps.existing.outputs.exists != 'true'
+        env:
+          DIGEST: ${{ steps.select.outputs.digest }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          TAG: ${{ inputs.tag_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          inspect_error="$(mktemp)"
+          if existing="$(docker buildx imagetools inspect "$IMAGE:$TAG" --format '{{json .Manifest.Digest}}' 2>"$inspect_error" | tr -d '"')"; then
+            if [[ "$existing" != "$DIGEST" ]]; then
+              echo "::error::Exact tag $TAG already resolves to conflicting digest $existing."
+              exit 1
+            fi
+            echo "Exact tag $TAG already staged at $DIGEST."
+          elif grep -Eiq 'manifest unknown|not found' "$inspect_error"; then
+            docker buildx imagetools create --tag "$IMAGE:$TAG" "$IMAGE@$DIGEST"
+          else
+            cat "$inspect_error" >&2
+            echo "::error::Could not determine whether exact tag $TAG exists."
+            exit 1
+          fi
+          actual="$(docker buildx imagetools inspect "$IMAGE:$TAG" --format '{{json .Manifest.Digest}}' | tr -d '"')"
+          [[ "$actual" == "$DIGEST" ]] || { echo "::error::Exact tag verification failed: $actual"; exit 1; }

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -13,6 +13,7 @@ on:
 concurrency:
   group: release-stable-promotion
   cancel-in-progress: false
+  queue: max
 
 jobs:
   validate-ref:

--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -1,0 +1,54 @@
+name: finalize release
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Strict stable or RC tag to finalize
+        required: true
+        type: string
+
+concurrency:
+  group: release-stable-promotion
+  cancel-in-progress: false
+
+jobs:
+  validate-ref:
+    name: Validate trusted ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require master
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          if [[ "$REF" != "refs/heads/master" ]]; then
+            echo "::error::Release finalization must run from refs/heads/master, not $REF."
+            exit 1
+          fi
+
+  finalize:
+    needs: validate-ref
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      actions: read
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Finalize release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag_name }}
+        run: python3 .github/scripts/finalize-release.py stable --tag "$TAG_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       tag_name: ${{ steps.release_info.outputs.tag_name }}
       release_name: ${{ steps.release_info.outputs.release_name }}
       changelog: ${{ steps.build_changelog.outputs.changelog }}
-      skip_release: ${{ steps.existing_release.outputs.skip_release || 'false' }}
+      skip_assets: ${{ steps.existing_release.outputs.skip_assets || 'false' }}
     steps:
       - name: Validate manual release ref
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master' }}
@@ -139,23 +139,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          skip_release=false
+          skip_assets=false
           if is_draft="$(gh release view "$TAG_NAME" --json isDraft --jq .isDraft 2>/dev/null)"; then
             if [[ "$is_draft" == "true" ]]; then
               echo "Draft nightly release $TAG_NAME already exists; continuing so assets can be uploaded."
             else
-              echo "Published nightly release $TAG_NAME already exists; skipping duplicate nightly release."
-              skip_release=true
+              echo "Published nightly release $TAG_NAME already exists; skipping assets and retrying finalization."
+              skip_assets=true
             fi
           fi
-          printf 'skip_release=%s\n' "$skip_release" >> "$GITHUB_OUTPUT"
+          printf 'skip_assets=%s\n' "$skip_assets" >> "$GITHUB_OUTPUT"
 
       # Creates a `nightly-SHA` tag for this specific nightly
       # This tag is used for this specific nightly version's release
       # which allows users to roll back. It is also used to build
       # the changelog.
       - name: Create build-specific nightly tag
-        if: ${{ env.IS_NIGHTLY == 'true' && steps.existing_release.outputs.skip_release != 'true' }}
+        if: ${{ env.IS_NIGHTLY == 'true' && steps.existing_release.outputs.skip_assets != 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
@@ -166,7 +166,7 @@ jobs:
 
       - name: Build changelog
         id: build_changelog
-        if: ${{ steps.existing_release.outputs.skip_release != 'true' }}
+        if: ${{ steps.existing_release.outputs.skip_assets != 'true' }}
         uses: mikepenz/release-changelog-builder-action@c9bcd8238b6f41e05561348339429d360b1c0247 # v6.2.3
         with:
           configuration: "./.github/changelog.json"
@@ -182,7 +182,7 @@ jobs:
       # a draft for the protected `finalize release` workflow; nightlies are
       # published by the `publish-nightly` job at the end of this workflow.
       - name: Create draft release
-        if: ${{ steps.existing_release.outputs.skip_release != 'true' }}
+        if: ${{ steps.existing_release.outputs.skip_assets != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -217,7 +217,6 @@ jobs:
   release-docker:
     name: Release Docker
     needs: prepare
-    if: ${{ needs.prepare.outputs.skip_release != 'true' }}
     uses: ./.github/workflows/docker-publish.yml
     permissions:
       actions: read
@@ -233,7 +232,6 @@ jobs:
     name: Record Docker digest
     runs-on: ubuntu-latest
     needs: [prepare, release-docker]
-    if: ${{ needs.prepare.outputs.skip_release != 'true' }}
     permissions:
       contents: read
     steps:
@@ -268,7 +266,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 240
     needs: prepare
-    if: ${{ needs.prepare.outputs.skip_release != 'true' }}
+    if: ${{ needs.prepare.outputs.skip_assets != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -540,10 +538,11 @@ jobs:
     name: Publish nightly release
     runs-on: ubuntu-latest
     needs: [prepare, release-docker, release-docker-metadata, release]
-    if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.prepare.outputs.skip_release != 'true' }}
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.prepare.result == 'success' && needs.release-docker.result == 'success' && needs.release-docker-metadata.result == 'success' && (needs.release.result == 'success' || (needs.prepare.outputs.skip_assets == 'true' && needs.release.result == 'skipped')) }}
     concurrency:
       group: release-nightly-promotion
       cancel-in-progress: false
+      queue: max
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
 
+concurrency:
+  group: release-${{ github.repository }}-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   IS_NIGHTLY: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
@@ -32,6 +36,14 @@ jobs:
       changelog: ${{ steps.build_changelog.outputs.changelog }}
       skip_release: ${{ steps.existing_release.outputs.skip_release || 'false' }}
     steps:
+      - name: Validate manual release ref
+        if: ${{ github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/master' }}
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "::error::Manual nightly releases must run from refs/heads/master, not $REF."
+          exit 1
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
@@ -167,8 +179,8 @@ jobs:
       # only upload assets to an existing draft. With immutable releases
       # enabled, an immutable release is sealed when it is published, so all
       # assets must be attached before that. Tagged releases are then left as
-      # a draft for a maintainer to publish manually; nightlies are auto-
-      # published by the `publish-nightly` job at the end of the workflow.
+      # a draft for the protected `finalize release` workflow; nightlies are
+      # published by the `publish-nightly` job at the end of this workflow.
       - name: Create draft release
         if: ${{ steps.existing_release.outputs.skip_release != 'true' }}
         env:
@@ -177,15 +189,15 @@ jobs:
           TAG_NAME: ${{ steps.release_info.outputs.tag_name }}
           RELEASE_NAME: ${{ steps.release_info.outputs.release_name }}
           CHANGELOG: ${{ steps.build_changelog.outputs.changelog }}
-          IS_PRERELEASE: ${{ steps.release_info.outputs.is_prerelease }}
+          EXPECTED_PRERELEASE: ${{ steps.release_info.outputs.is_prerelease }}
         shell: bash
         run: |
           set -euo pipefail
           if release_state="$(gh release view "$TAG_NAME" --json isDraft,isPrerelease --jq '[.isDraft, .isPrerelease] | @tsv' 2>/dev/null)"; then
             read -r is_draft is_prerelease <<< "$release_state"
             if [[ "$is_draft" == "true" ]]; then
-              if [[ "$is_prerelease" != "$IS_PRERELEASE" ]]; then
-                echo "::error::Draft release $TAG_NAME has prerelease=$is_prerelease; expected $IS_PRERELEASE."
+              if [[ "$is_prerelease" != "$EXPECTED_PRERELEASE" ]]; then
+                echo "::error::Draft release $TAG_NAME has prerelease=$is_prerelease; expected $EXPECTED_PRERELEASE."
                 exit 1
               fi
               echo "Draft release $TAG_NAME already exists; reusing it."
@@ -197,7 +209,7 @@ jobs:
           notes_file="$(mktemp)"
           printf '%s' "$CHANGELOG" > "$notes_file"
           flags=(--draft --verify-tag --title "$RELEASE_NAME" --notes-file "$notes_file")
-          if [[ "$IS_PRERELEASE" == "true" ]]; then
+          if [[ "$EXPECTED_PRERELEASE" == "true" ]]; then
             flags+=(--prerelease)
           fi
           gh release create "$TAG_NAME" "${flags[@]}"
@@ -208,6 +220,7 @@ jobs:
     if: ${{ needs.prepare.outputs.skip_release != 'true' }}
     uses: ./.github/workflows/docker-publish.yml
     permissions:
+      actions: read
       attestations: write
       artifact-metadata: write
       contents: read
@@ -216,8 +229,33 @@ jobs:
     with:
       tag_name: ${{ needs.prepare.outputs.tag_name }}
 
+  release-docker-metadata:
+    name: Record Docker digest
+    runs-on: ubuntu-latest
+    needs: [prepare, release-docker]
+    if: ${{ needs.prepare.outputs.skip_release != 'true' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Record release Docker digest
+        env:
+          DIGEST: ${{ needs.release-docker.outputs.digest }}
+        run: |
+          if [[ ! "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Invalid Docker digest: $DIGEST"
+            exit 1
+          fi
+          printf '%s\n' "$DIGEST" > release-docker-digest.txt
+      - name: Upload release Docker digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-docker-digest
+          path: release-docker-digest.txt
+          retention-days: 90
+          if-no-files-found: error
+
   # This job uploads assets to the draft release created in `prepare`.
-  # Tagged releases stay as drafts for a maintainer to publish manually;
+  # Tagged releases stay as drafts for the protected finalization workflow;
   # nightlies are auto-published by the `publish-nightly` job below. Either
   # way, GitHub's immutable-releases setting seals the release at publish.
   release:
@@ -467,8 +505,8 @@ jobs:
           printf '%s\n' "$ATTESTATION_URL" > "$FOUNDRY_ATTESTATION"
 
       # Upload assets to the draft release created in `prepare`. Tagged releases
-      # stay as drafts after this workflow finishes; a maintainer
-      # publishes them manually. Nightlies are auto-published below.
+      # stay as drafts after this workflow finishes; a maintainer runs the
+      # protected finalization workflow. Nightlies are auto-published below.
       - name: Upload assets to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -497,28 +535,47 @@ jobs:
 
   # Auto-publish nightly releases once all assets have been uploaded so that
   # foundryup and other consumers see them immediately. Tagged releases are
-  # left as drafts for a maintainer to publish manually.
+  # left as drafts for the protected finalization workflow.
   publish-nightly:
     name: Publish nightly release
     runs-on: ubuntu-latest
-    needs: [prepare, release-docker, release]
+    needs: [prepare, release-docker, release-docker-metadata, release]
     if: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && needs.prepare.outputs.skip_release != 'true' }}
+    concurrency:
+      group: release-nightly-promotion
+      cancel-in-progress: false
     permissions:
       contents: write
+      packages: write
     steps:
-      - name: Publish release
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4.5.2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish release and promote nightly image
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
+          DIGEST: ${{ needs.release-docker.outputs.digest }}
         shell: bash
-        run: gh release edit "$TAG_NAME" --draft=false
+        run: python3 .github/scripts/finalize-release.py nightly --tag "$TAG_NAME" --digest "$DIGEST"
 
   # If any of the jobs fail, this will create a high-priority issue to signal so.
   issue:
     name: Open an issue
     runs-on: ubuntu-latest
-    needs: [prepare, release-docker, release, publish-nightly]
+    needs: [
+      prepare,
+      release-docker,
+      release-docker-metadata,
+      release,
+      publish-nightly,
+    ]
     if: failure()
     permissions:
       contents: read


### PR DESCRIPTION
This coordinates GitHub release publication with Docker alias promotion so moving tags are updated only after all binary and image artifacts complete successfully. Docker images are built, signed, and attested by digest, while stable and RC finalization verifies the successful tagged workflow and its recorded digest through a protected manual workflow.

The finalization flow supports safe retries, prevents stable and nightly aliases from moving backward, and ensures release candidates never update stable aliases. 

Closes OSS-603.