### PR TITLE
fix(anvil): reduce state load memory

### DIFF
--- a/.changelog/reduce-anvil-state-load-memory.md
+++ b/.changelog/reduce-anvil-state-load-memory.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Reduced peak memory usage when Anvil loads state files.

--- a/crates/anvil/src/config.rs
+++ b/crates/anvil/src/config.rs
@@ -201,7 +201,7 @@ pub struct NodeConfig {
     pub prune_history: PruneStateHistoryConfig,
     /// Max number of states cached on disk.
     pub max_persisted_states: Option<usize>,
-    /// The file where to load the state from
+    /// The initial state to apply and consume during startup.
     pub init_state: Option<SerializableState>,
     /// max number of blocks with transactions in memory
     pub transaction_block_keeper: Option<usize>,

--- a/crates/anvil/src/eth/backend/db.rs
+++ b/crates/anvil/src/eth/backend/db.rs
@@ -3,6 +3,8 @@
 use std::{
     collections::BTreeMap,
     fmt::{self, Debug},
+    fs::File,
+    io::BufReader,
     path::Path,
 };
 
@@ -295,7 +297,7 @@ pub trait Db:
         historical_states: Option<SerializableHistoricalStates>,
     ) -> DatabaseResult<Option<SerializableState>>;
 
-    /// Deserialize and add all chain data to the backend storage
+    /// Deserialize and add all accounts to the backend storage.
     fn load_state(&mut self, state: SerializableState) -> DatabaseResult<bool> {
         for (addr, account) in state.accounts {
             let old_account_nonce = DatabaseRef::basic_ref(self, addr)
@@ -714,12 +716,19 @@ pub struct SerializableState {
 impl SerializableState {
     /// Loads the `Genesis` object from the given json file path
     pub fn load(path: impl AsRef<Path>) -> Result<Self, FsPathError> {
-        let path = path.as_ref();
+        let mut path = path.as_ref().to_path_buf();
         if path.is_dir() {
-            foundry_common::fs::read_json_file(&path.join("state.json"))
-        } else {
-            foundry_common::fs::read_json_file(path)
+            path = path.join("state.json");
         }
+
+        let file = File::open(&path).map_err(|err| FsPathError::read(err, &path))?;
+        serde_json::from_reader(BufReader::new(file)).map_err(|err| {
+            if err.is_io() {
+                FsPathError::read(err.into(), &path)
+            } else {
+                FsPathError::ReadJson { source: err, path }
+            }
+        })
     }
 
     /// This is used as the clap `value_parser` implementation
@@ -881,6 +890,29 @@ impl IntoIterator for SerializableHistoricalStates {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::fs;
+
+    #[test]
+    fn loads_state_from_file_or_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state_path = tmp.path().join("state.json");
+        fs::write(&state_path, serde_json::to_vec(&SerializableState::default()).unwrap()).unwrap();
+
+        assert!(SerializableState::load(&state_path).unwrap().accounts.is_empty());
+        assert!(SerializableState::load(tmp.path()).unwrap().accounts.is_empty());
+
+        fs::write(&state_path, b"not json").unwrap();
+        let Err(FsPathError::ReadJson { path, .. }) = SerializableState::load(tmp.path()) else {
+            panic!("expected invalid JSON error")
+        };
+        assert_eq!(path, state_path);
+
+        let missing_path = tmp.path().join("missing.json");
+        let Err(FsPathError::Read { path, .. }) = SerializableState::load(&missing_path) else {
+            panic!("expected file read error")
+        };
+        assert_eq!(path, missing_path);
+    }
 
     #[test]
     fn cache_db_full_state_merges_base_and_overlay() {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -5803,8 +5803,8 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
     }
 
     /// Apply [SerializableState] data to the backend storage.
-    pub async fn load_state(&self, state: SerializableState) -> Result<bool, BlockchainError> {
-        let mut block_env = state.block.clone();
+    pub async fn load_state(&self, mut state: SerializableState) -> Result<bool, BlockchainError> {
+        let mut block_env = state.block.take();
         let mut selected_head = None;
         let mut selected_header = None;
         let mut checkpoint = None;
@@ -5902,8 +5902,8 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         // without their transactions or a partially updated head.
         {
             let mut storage = self.blockchain.storage.write();
-            storage.load_blocks(state.blocks.clone());
-            storage.load_transactions(state.transactions.clone());
+            storage.load_blocks(std::mem::take(&mut state.blocks));
+            storage.load_transactions(std::mem::take(&mut state.transactions));
             if let Some(checkpoint) = checkpoint {
                 storage.insert_block(checkpoint);
             }
@@ -5950,7 +5950,8 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
             ));
         }
 
-        if !self.db.write().await.load_state(state.clone())? {
+        let historical_states = state.historical_states.take();
+        if !self.db.write().await.load_state(state)? {
             return Err(RpcError::invalid_params(
                 "Loading state not supported with the current configuration",
             )
@@ -5973,7 +5974,7 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> Backend<N> {
         };
         self.db.write().await.set_block_hashes(block_hashes);
 
-        if let Some(historical_states) = state.historical_states {
+        if let Some(historical_states) = historical_states {
             self.states.write().load_states(historical_states);
         }
 

--- a/crates/anvil/src/eth/backend/mem/storage.rs
+++ b/crates/anvil/src/eth/backend/mem/storage.rs
@@ -464,8 +464,8 @@ impl<N: Network> BlockchainStorage<N> {
 
     /// Deserialize and add all blocks data to the backend storage
     pub fn load_blocks(&mut self, serializable_blocks: Vec<SerializableBlock>) {
-        for serializable_block in &serializable_blocks {
-            let block: Block = serializable_block.clone().into();
+        for serializable_block in serializable_blocks {
+            let block: Block = serializable_block.into();
             self.insert_block(block);
         }
     }
@@ -502,8 +502,8 @@ impl<N: Network<ReceiptEnvelope = FoundryReceiptEnvelope>> BlockchainStorage<N> 
 
     /// Deserialize and add all transactions data to the backend storage
     pub fn load_transactions(&mut self, serializable_transactions: Vec<SerializableTransaction>) {
-        for serializable_transaction in &serializable_transactions {
-            let transaction: MinedTransaction<N> = serializable_transaction.clone().into();
+        for serializable_transaction in serializable_transactions {
+            let transaction: MinedTransaction<N> = serializable_transaction.into();
             self.transactions.insert(transaction.info.transaction_hash, transaction);
         }
     }

--- a/crates/anvil/src/lib.rs
+++ b/crates/anvil/src/lib.rs
@@ -141,9 +141,10 @@ pub async fn try_spawn(mut config: NodeConfig) -> Result<(EthApi<FoundryNetwork>
     let logger = if config.enable_tracing { init_tracing() } else { Default::default() };
     logger.set_enabled(!config.silent);
 
+    let init_state = config.init_state.take();
     let (backend, fork_transaction_replay) = config.setup::<FoundryNetwork>().await?;
 
-    if let Some(state) = config.init_state.clone() {
+    if let Some(state) = init_state {
         backend.load_state(state).await.wrap_err("failed to load init state")?;
     }
 


### PR DESCRIPTION
Anvil currently reads the complete state file into memory and retains or clones the deserialized state several times during startup. This switches state-file loading to buffered deserialization and moves each state component into its final backend destination, reducing avoidable peak memory while preserving the state format and loading order.

Closes #9562.