### PR TITLE
fix(anvil): make mining finalization atomic

### DIFF
--- a/.changelog/anvil-atomic-mining-finalization.md
+++ b/.changelog/anvil-atomic-mining-finalization.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Made block mining atomic when finalization fails and return errors from manual mining RPCs.

--- a/crates/anvil/src/eth/api.rs
+++ b/crates/anvil/src/eth/api.rs
@@ -3617,10 +3617,14 @@ impl EthApi<FoundryNetwork> {
             // mine all the blocks
             for _ in 0..blocks.saturating_to::<u64>() {
                 // If we have an interval, jump forwards in time to the "next" timestamp
-                if let Some(interval) = interval {
-                    this.backend.time().increase_time(interval);
+                let pending_increase =
+                    interval.map(|interval| this.backend.time().apply_time_increase(interval));
+                if let Err(error) = this.mine_one().await {
+                    if let Some(pending) = pending_increase {
+                        this.backend.time().revert_time_increase(pending);
+                    }
+                    return Err(error);
                 }
-                this.mine_one().await;
             }
             Ok(())
         })
@@ -4145,7 +4149,7 @@ impl EthApi<FoundryNetwork> {
         self.on_blocking_task(|this| async move {
             // mine all the blocks
             for _ in 0..blocks_to_mine {
-                this.mine_one().await;
+                this.mine_one().await?;
             }
             Ok(())
         })
@@ -4320,12 +4324,13 @@ impl EthApi<FoundryNetwork> {
     }
 
     /// Mines exactly one block
-    pub async fn mine_one(&self) {
+    pub async fn mine_one(&self) -> Result<()> {
         let transactions = self.pool.ready_transactions().collect::<Vec<_>>();
-        let outcome = self.backend.mine_block(transactions).await;
+        let outcome = self.backend.mine_block(transactions).await?;
 
         trace!(target: "node", blocknumber = ?outcome.block_number, "mined block");
         self.pool.on_mined_block(outcome);
+        Ok(())
     }
 
     /// Returns the pending block with tx hashes

--- a/crates/anvil/src/eth/backend/cheats.rs
+++ b/crates/anvil/src/eth/backend/cheats.rs
@@ -90,14 +90,32 @@ impl CheatsManager {
     /// only.
     pub fn set_next_block_prevrandao(&self, prevrandao: B256) {
         trace!(target: "cheats", %prevrandao, "set next block prevrandao");
-        self.state.write().next_block_prevrandao.replace(prevrandao);
+        let mut state = self.state.write();
+        state.prevrandao_generation = state.prevrandao_generation.wrapping_add(1);
+        state.next_block_prevrandao = Some(prevrandao);
     }
 
-    /// Takes the manually set `prevrandao` value for the next block, if any.
-    ///
-    /// This consumes the override so it only applies to a single block.
+    /// Prepares the manually set `prevrandao` without consuming it.
+    pub(crate) fn prepare_next_block_prevrandao(&self) -> Option<PendingPrevrandao> {
+        let state = self.state.read();
+        state
+            .next_block_prevrandao
+            .map(|value| PendingPrevrandao { value, generation: state.prevrandao_generation })
+    }
+
+    /// Takes the manually set `prevrandao` value for forced replay mining.
     pub fn take_next_block_prevrandao(&self) -> Option<B256> {
-        self.state.write().next_block_prevrandao.take()
+        let mut state = self.state.write();
+        state.prevrandao_generation = state.prevrandao_generation.wrapping_add(1);
+        state.next_block_prevrandao.take()
+    }
+
+    /// Consumes a `prevrandao` override after the candidate using it was committed.
+    pub(crate) fn consume_next_block_prevrandao(&self, pending: PendingPrevrandao) {
+        let mut state = self.state.write();
+        if state.prevrandao_generation == pending.generation {
+            state.next_block_prevrandao.take();
+        }
     }
 
     /// Clears any manually set `prevrandao` value for the next block.
@@ -105,7 +123,9 @@ impl CheatsManager {
     /// Used on reset/revert so a set-but-unmined override does not leak into a later block,
     /// mirroring how the next-block timestamp override is cleared by `TimeManager::reset`.
     pub fn clear_next_block_prevrandao(&self) {
-        self.state.write().next_block_prevrandao.take();
+        let mut state = self.state.write();
+        state.prevrandao_generation = state.prevrandao_generation.wrapping_add(1);
+        state.next_block_prevrandao.take();
     }
 }
 
@@ -121,6 +141,15 @@ pub struct CheatsState {
     /// The `prevrandao` value to use for the next mined block, if manually set via
     /// `anvil_setNextBlockPrevRandao`.
     pub next_block_prevrandao: Option<B256>,
+    /// Generation of the most recently installed `prevrandao` override.
+    prevrandao_generation: u64,
+}
+
+/// A `prevrandao` override reserved by a candidate block.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PendingPrevrandao {
+    pub(crate) value: B256,
+    generation: u64,
 }
 
 impl CheatEcrecover {
@@ -175,6 +204,19 @@ pub struct CheatEcrecover {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn candidate_consumes_only_its_prevrandao_override() {
+        let cheats = CheatsManager::default();
+        let value = B256::with_last_byte(1);
+        cheats.set_next_block_prevrandao(value);
+        let pending = cheats.prepare_next_block_prevrandao().unwrap();
+
+        cheats.set_next_block_prevrandao(value);
+        cheats.consume_next_block_prevrandao(pending);
+
+        assert_eq!(cheats.prepare_next_block_prevrandao().unwrap().value, value);
+    }
 
     #[test]
     fn impersonate_returns_false_then_true() {

--- a/crates/anvil/src/eth/backend/mem/mod.rs
+++ b/crates/anvil/src/eth/backend/mem/mod.rs
@@ -353,7 +353,7 @@ use revm::{
     interpreter::{InstructionResult, interpreter::EthInterpreter, interpreter_action::FrameInit},
     precompile::{PrecompileSpecId, Precompiles},
     primitives::{KECCAK_EMPTY, hardfork::SpecId},
-    state::{AccountInfo, EvmState},
+    state::{Account, AccountInfo, EvmState, EvmStorageSlot, TransactionId},
 };
 use revm_inspectors::opcode::OpcodeGasInspector;
 use std::{
@@ -3751,7 +3751,7 @@ where
     pub async fn mine_block(
         &self,
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
-    ) -> MinedBlockOutcome<FoundryTxEnvelope> {
+    ) -> Result<MinedBlockOutcome<FoundryTxEnvelope>, BlockchainError> {
         self.do_mine_block(pool_transactions).await
     }
 
@@ -4042,7 +4042,7 @@ where
     async fn do_mine_block(
         &self,
         pool_transactions: Vec<Arc<PoolTransaction<FoundryTxEnvelope>>>,
-    ) -> MinedBlockOutcome<FoundryTxEnvelope> {
+    ) -> Result<MinedBlockOutcome<FoundryTxEnvelope>, BlockchainError> {
         let _mining_guard = self.mining.lock().await;
         trace!(target: "backend", "creating new block with {} transactions", pool_transactions.len());
 
@@ -4079,22 +4079,18 @@ where
             // Use the `prevrandao` value set via `anvil_setNextBlockPrevRandao` for this block if
             // one was provided, otherwise derive it from the parent hash and block number. The
             // manual override is consumed here so it only applies to this single block.
+            let next_prevrandao = self.cheats.prepare_next_block_prevrandao();
             evm_env.block_env.prevrandao =
-                Some(self.cheats.take_next_block_prevrandao().unwrap_or_else(|| keccak256(input)));
+                Some(next_prevrandao.map_or_else(|| keccak256(input), |pending| pending.value));
 
-            if self.prune_state_history_config.is_state_history_supported() {
-                let db = self.db.read().await.current_state();
-                // store current state before executing all transactions
-                self.states.write().insert(best_hash, db);
-            }
-
-            let (block_info, included, invalid, not_yet_valid, block_hash) = {
+            let (block_info, included, invalid, not_yet_valid, block_hash, parent_state) = {
                 let mut db = self.db.write().await;
 
                 // finally set the next block timestamp, this is done just before execution, because
                 // there can be concurrent requests that can delay acquiring the db lock and we want
                 // to ensure the timestamp is as close as possible to the actual execution.
-                evm_env.block_env.timestamp = U256::from(self.time.next_timestamp());
+                let pending_timestamp = self.time.prepare_next_timestamp();
+                evm_env.block_env.timestamp = U256::from(pending_timestamp.timestamp);
 
                 // Forced historical transactions bypass pool admission and are replayed while
                 // mining. Keep this exception local to the disposable mining environment.
@@ -4108,33 +4104,38 @@ where
                 let inspector_tx_config = self.inspector_tx_config();
                 let gas_config = self.pool_tx_gas_config(&mining_evm_env);
 
-                let (pool_result, block_result) = self
-                    .execute_with_block_executor(
-                        &mut **db,
-                        &mining_evm_env,
-                        best_hash,
-                        spec_id,
-                        Some(B256::ZERO),
-                        BlockExecutionKind::Complete,
-                        &pool_transactions,
-                        &gas_config,
-                        &inspector_tx_config,
-                        &|pool_tx, account| {
-                            let validation_env =
-                                if pool_tx.is_replay { &mining_evm_env } else { &evm_env };
-                            self.validate_pool_transaction_for(
-                                &pool_tx.pending_transaction,
-                                account,
-                                validation_env,
-                            )
-                        },
-                    )
-                    .expect("block execution failed");
+                let mut candidate_db = AnvilCacheDB::new(&**db);
+                let (pool_result, block_result) = self.execute_with_block_executor(
+                    &mut candidate_db,
+                    &mining_evm_env,
+                    best_hash,
+                    spec_id,
+                    Some(B256::ZERO),
+                    BlockExecutionKind::Complete,
+                    &pool_transactions,
+                    &gas_config,
+                    &inspector_tx_config,
+                    &|pool_tx, account| {
+                        let validation_env =
+                            if pool_tx.is_replay { &mining_evm_env } else { &evm_env };
+                        self.validate_pool_transaction_for(
+                            &pool_tx.pending_transaction,
+                            account,
+                            validation_env,
+                        )
+                    },
+                )?;
 
                 let included = pool_result.included;
                 let invalid = pool_result.invalid;
                 let not_yet_valid = pool_result.not_yet_valid;
 
+                let CacheDB { cache, db: _ } = candidate_db.0;
+                let parent_state = self
+                    .prune_state_history_config
+                    .is_state_history_supported()
+                    .then(|| db.current_state());
+                commit_cache(&mut **db, cache)?;
                 let state_root = db.maybe_state_root().unwrap_or_default();
                 let block_info = self.build_block_info(
                     &mining_evm_env,
@@ -4150,14 +4151,22 @@ where
                 // Update the new blockhash in the db itself.
                 let block_hash = block_info.block.header.hash_slow();
                 db.insert_block_hash(U256::from(block_info.block.header.number()), block_hash);
+                self.time.commit_next_timestamp(pending_timestamp);
+                if let Some(pending) = next_prevrandao {
+                    self.cheats.consume_next_block_prevrandao(pending);
+                }
 
-                (block_info, included, invalid, not_yet_valid, block_hash)
+                (block_info, included, invalid, not_yet_valid, block_hash, parent_state)
             };
 
             // create the new block with the current timestamp
             let BlockInfo { block, transactions, receipts } = block_info;
 
             let header = block.header.clone();
+
+            if let Some(parent_state) = parent_state {
+                self.states.write().insert(best_hash, parent_state);
+            }
 
             trace!(
                 target: "backend",
@@ -4253,7 +4262,7 @@ where
         // notify all listeners
         self.notify_on_new_block(header.into_inner(), block_hash);
 
-        outcome
+        Ok(outcome)
     }
 
     /// Reorg the chain to a common height and execute blocks to build new chain.
@@ -4272,7 +4281,7 @@ where
         // Create the new reorged chain, filling the blocks with transactions if supplied
         for i in 0..depth {
             let to_be_mined = tx_pairs.get(&i).cloned().unwrap_or_else(Vec::new);
-            let outcome = self.do_mine_block(to_be_mined).await;
+            let outcome = self.do_mine_block(to_be_mined).await?;
             node_info!(
                 "    Mined reorg block number {}. With {} valid txs and with invalid {} txs",
                 outcome.block_number,
@@ -7468,6 +7477,48 @@ pub fn is_arbitrum(chain_id: u64) -> bool {
     false
 }
 
+/// Commits a fully executed candidate cache to the live database.
+fn commit_cache(db: &mut dyn Db, cache: revm::database::Cache) -> Result<(), BlockchainError> {
+    let revm::database::Cache { accounts, contracts, .. } = cache;
+    let mut changes = EvmState::default();
+    for (address, db_account) in accounts {
+        if db_account.account_state == AccountState::None {
+            continue;
+        }
+
+        let DbAccount { mut info, account_state, storage } = db_account;
+        // `CacheDB` also records absent-account reads as `NotExisting`. They are not state changes
+        // and must not become synthetic selfdestructs in the live database.
+        if account_state == AccountState::NotExisting && db.basic(address)?.is_none() {
+            continue;
+        }
+        if info.code.is_none() {
+            info.code = contracts.get(&info.code_hash).cloned();
+        }
+        let mut account = Account::from(info);
+        account.mark_touch();
+        match account_state {
+            AccountState::NotExisting => account.mark_selfdestruct(),
+            AccountState::StorageCleared => account.mark_created(),
+            AccountState::Touched => {}
+            AccountState::None => unreachable!(),
+        }
+        for (slot, value) in storage {
+            let original = if account_state == AccountState::StorageCleared {
+                U256::ZERO
+            } else {
+                db.storage(address, slot)?
+            };
+            account
+                .storage
+                .insert(slot, EvmStorageSlot::new_changed(original, value, TransactionId::ZERO));
+        }
+        changes.insert(address, account);
+    }
+    db.commit(changes);
+    Ok(())
+}
+
 fn simulate_rpc_error(code: i64, message: impl Into<String>) -> BlockchainError {
     BlockchainError::RpcError(RpcError {
         code: ErrorCode::from(code),
@@ -7630,8 +7681,8 @@ mod tests {
         let (api_b, _handle_b) = spawn(config_b).await;
 
         // Mine empty blocks (no transactions) on both backends
-        let outcome_a_1 = api_a.backend.mine_block(vec![]).await;
-        let outcome_b_1 = api_b.backend.mine_block(vec![]).await;
+        let outcome_a_1 = api_a.backend.mine_block(vec![]).await.unwrap();
+        let outcome_b_1 = api_b.backend.mine_block(vec![]).await.unwrap();
 
         // Both should mine the same block number
         assert_eq!(outcome_a_1.block_number, outcome_b_1.block_number);
@@ -7650,8 +7701,8 @@ mod tests {
         );
 
         // Mine another block to ensure it remains deterministic
-        let outcome_a_2 = api_a.backend.mine_block(vec![]).await;
-        let outcome_b_2 = api_b.backend.mine_block(vec![]).await;
+        let outcome_a_2 = api_a.backend.mine_block(vec![]).await.unwrap();
+        let outcome_b_2 = api_b.backend.mine_block(vec![]).await.unwrap();
 
         let block_a_2 =
             api_a.block_by_number(outcome_a_2.block_number.into()).await.unwrap().unwrap();

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -13,26 +13,46 @@ pub fn utc_from_secs(secs: u64) -> DateTime<Utc> {
 /// Manages block time
 #[derive(Clone, Debug)]
 pub struct TimeManager {
-    /// tracks the overall applied timestamp offset
-    offset: Arc<RwLock<i128>>,
-    /// The timestamp of the last block header
-    last_timestamp: Arc<RwLock<u64>>,
-    /// Contains the next timestamp to use
-    /// if this is set then the next time `[TimeManager::current_timestamp()]` is called this value
-    /// will be taken and returned. After which the `offset` will be updated accordingly
-    next_exact_timestamp: Arc<RwLock<Option<u64>>>,
-    /// The interval to use when determining the next block's timestamp
-    interval: Arc<RwLock<Option<u64>>>,
+    state: Arc<RwLock<TimeState>>,
+}
+
+/// Timestamp controls that must be read and committed atomically.
+#[derive(Debug, Default)]
+struct TimeState {
+    offset: i128,
+    offset_reset_generation: u64,
+    last_timestamp: u64,
+    next_exact_timestamp: Option<TimestampOverride>,
+    interval: Option<u64>,
+    next_override_generation: u64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TimestampOverride {
+    timestamp: u64,
+    generation: u64,
+}
+
+/// A timestamp prepared for a candidate block but not yet committed.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PendingBlockTimestamp {
+    pub(crate) timestamp: u64,
+    exact_generation: Option<u64>,
+    prepared_offset: i128,
+    offset_reset_generation: u64,
+    next_offset: Option<i128>,
+}
+
+/// A temporary additive time increase that can be rolled back after failed manual mining.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct PendingTimeIncrease {
+    seconds: u64,
+    offset_reset_generation: u64,
 }
 
 impl TimeManager {
     pub fn new(start_timestamp: u64) -> Self {
-        let time_manager = Self {
-            last_timestamp: Default::default(),
-            offset: Default::default(),
-            next_exact_timestamp: Default::default(),
-            interval: Default::default(),
-        };
+        let time_manager = Self { state: Default::default() };
         time_manager.reset(start_timestamp);
         time_manager
     }
@@ -41,21 +61,24 @@ impl TimeManager {
     /// next block timestamp option
     pub fn reset(&self, start_timestamp: u64) {
         let current = duration_since_unix_epoch().as_secs() as i128;
-        *self.last_timestamp.write() = start_timestamp;
-        *self.offset.write() = (start_timestamp as i128) - current;
-        self.next_exact_timestamp.write().take();
+        let mut state = self.state.write();
+        state.last_timestamp = start_timestamp;
+        state.offset = (start_timestamp as i128) - current;
+        state.offset_reset_generation = state.offset_reset_generation.wrapping_add(1);
+        state.next_exact_timestamp = None;
+        state.next_override_generation = state.next_override_generation.wrapping_add(1);
     }
 
     pub fn offset(&self) -> i128 {
-        *self.offset.read()
+        self.state.read().offset
     }
 
     /// Adds the given `offset` to the already tracked offset and returns the result
     fn add_offset(&self, offset: i128) -> i128 {
-        let mut current = self.offset.write();
-        let next = current.saturating_add(offset);
+        let mut state = self.state.write();
+        let next = state.offset.saturating_add(offset);
         trace!(target: "time", "adding timestamp offset={}, total={}", offset, next);
-        *current = next;
+        state.offset = next;
         next
     }
 
@@ -66,16 +89,34 @@ impl TimeManager {
         self.add_offset(seconds as i128)
     }
 
+    /// Applies a temporary increase that can be rolled back if mining fails.
+    pub(crate) fn apply_time_increase(&self, seconds: u64) -> PendingTimeIncrease {
+        let mut state = self.state.write();
+        state.offset = state.offset.saturating_add(seconds as i128);
+        PendingTimeIncrease { seconds, offset_reset_generation: state.offset_reset_generation }
+    }
+
+    /// Reverts a temporary increase unless an absolute time reset superseded it.
+    pub(crate) fn revert_time_increase(&self, pending: PendingTimeIncrease) {
+        let mut state = self.state.write();
+        if state.offset_reset_generation == pending.offset_reset_generation {
+            state.offset = state.offset.saturating_sub(pending.seconds as i128);
+        }
+    }
+
     /// Sets the exact timestamp to use in the next block
     /// Fails if it's before (or at the same time) the last timestamp
     pub fn set_next_block_timestamp(&self, timestamp: u64) -> Result<(), BlockchainError> {
         trace!(target: "time", "override next timestamp {}", timestamp);
-        if timestamp < *self.last_timestamp.read() {
+        let mut state = self.state.write();
+        if timestamp < state.last_timestamp {
             return Err(BlockchainError::TimestampError(format!(
                 "{timestamp} is lower than previous block's timestamp"
             )));
         }
-        self.next_exact_timestamp.write().replace(timestamp);
+        state.next_override_generation = state.next_override_generation.wrapping_add(1);
+        state.next_exact_timestamp =
+            Some(TimestampOverride { timestamp, generation: state.next_override_generation });
         Ok(())
     }
 
@@ -85,17 +126,17 @@ impl TimeManager {
     /// be set starting with the current timestamp.
     pub fn set_block_timestamp_interval(&self, interval: u64) {
         trace!(target: "time", "set interval {}", interval);
-        self.interval.write().replace(interval);
+        self.state.write().interval = Some(interval);
     }
 
     /// Returns the configured block timestamp interval.
     pub(crate) fn block_timestamp_interval(&self) -> Option<u64> {
-        *self.interval.read()
+        self.state.read().interval
     }
 
     /// Removes the interval if it exists
     pub fn remove_block_timestamp_interval(&self) -> bool {
-        if self.interval.write().take().is_some() {
+        if self.state.write().interval.take().is_some() {
             trace!(target: "time", "removed interval");
             true
         } else {
@@ -104,42 +145,70 @@ impl TimeManager {
     }
 
     /// Computes the next timestamp without updating internals
-    fn compute_next_timestamp(&self) -> (u64, Option<i128>) {
-        let current = duration_since_unix_epoch().as_secs() as i128;
-        let last_timestamp = *self.last_timestamp.read();
+    fn compute_next_timestamp(
+        state: &TimeState,
+        current: i128,
+    ) -> (u64, Option<u64>, Option<i128>) {
+        let exact_timestamp = state.next_exact_timestamp;
+        let last_timestamp = state.last_timestamp;
 
-        let (mut next_timestamp, update_offset) =
-            if let Some(next) = *self.next_exact_timestamp.read() {
-                (next, true)
-            } else if let Some(interval) = *self.interval.read() {
-                (last_timestamp.saturating_add(interval), false)
-            } else {
-                (current.saturating_add(self.offset()) as u64, false)
-            };
+        let (mut next_timestamp, update_offset) = if let Some(next) = exact_timestamp {
+            (next.timestamp, true)
+        } else if let Some(interval) = state.interval {
+            (last_timestamp.saturating_add(interval), false)
+        } else {
+            (current.saturating_add(state.offset) as u64, false)
+        };
         // Ensures that the timestamp is always increasing
         if next_timestamp < last_timestamp {
             next_timestamp = last_timestamp + 1;
         }
         let next_offset = update_offset.then_some((next_timestamp as i128) - current);
-        (next_timestamp, next_offset)
+        (next_timestamp, exact_timestamp.map(|exact| exact.generation), next_offset)
+    }
+
+    /// Prepares the next timestamp without consuming a one-shot override.
+    pub(crate) fn prepare_next_timestamp(&self) -> PendingBlockTimestamp {
+        let current = duration_since_unix_epoch().as_secs() as i128;
+        let state = self.state.read();
+        let (timestamp, exact_generation, next_offset) =
+            Self::compute_next_timestamp(&state, current);
+        PendingBlockTimestamp {
+            timestamp,
+            exact_generation,
+            prepared_offset: state.offset,
+            offset_reset_generation: state.offset_reset_generation,
+            next_offset,
+        }
+    }
+
+    /// Commits a timestamp after its candidate block finalized successfully.
+    pub(crate) fn commit_next_timestamp(&self, pending: PendingBlockTimestamp) {
+        let mut state = self.state.write();
+        if pending.exact_generation.is_some_and(|generation| {
+            state.next_exact_timestamp.is_some_and(|exact| exact.generation == generation)
+        }) {
+            state.next_exact_timestamp = None;
+        }
+        if let Some(next_offset) = pending.next_offset {
+            if state.offset_reset_generation == pending.offset_reset_generation {
+                let concurrent_offset = state.offset.saturating_sub(pending.prepared_offset);
+                state.offset = next_offset.saturating_add(concurrent_offset);
+            }
+        }
+        state.last_timestamp = pending.timestamp;
     }
 
     /// Returns the current timestamp and updates the underlying offset and interval accordingly
     pub fn next_timestamp(&self) -> u64 {
-        let (next_timestamp, next_offset) = self.compute_next_timestamp();
-        // Make sure we reset the `next_exact_timestamp`
-        self.next_exact_timestamp.write().take();
-        if let Some(next_offset) = next_offset {
-            *self.offset.write() = next_offset;
-        }
-        *self.last_timestamp.write() = next_timestamp;
-        next_timestamp
+        let pending = self.prepare_next_timestamp();
+        self.commit_next_timestamp(pending);
+        pending.timestamp
     }
 
     /// Returns the current timestamp for a call that does _not_ update the value
     pub fn current_call_timestamp(&self) -> u64 {
-        let (next_timestamp, _) = self.compute_next_timestamp();
-        next_timestamp
+        self.prepare_next_timestamp().timestamp
     }
 }
 
@@ -149,4 +218,64 @@ pub fn duration_since_unix_epoch() -> Duration {
     let now = SystemTime::now();
     now.duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_else(|err| panic!("Current time {now:?} is invalid: {err:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn candidate_consumes_only_its_timestamp_override() {
+        let time = TimeManager::new(1);
+        time.set_next_block_timestamp(100).unwrap();
+        let pending = time.prepare_next_timestamp();
+
+        time.set_next_block_timestamp(100).unwrap();
+        time.commit_next_timestamp(pending);
+
+        let state = time.state.read();
+        assert_eq!(state.last_timestamp, 100);
+        assert_eq!(state.next_exact_timestamp.unwrap().timestamp, 100);
+    }
+
+    #[test]
+    fn candidate_commit_preserves_concurrent_time_increase() {
+        let time = TimeManager::new(1);
+        time.set_next_block_timestamp(100).unwrap();
+        let pending = time.prepare_next_timestamp();
+
+        time.increase_time(10);
+        time.commit_next_timestamp(pending);
+
+        let state = time.state.read();
+        assert_eq!(state.last_timestamp, 100);
+        assert_eq!(state.offset, pending.next_offset.unwrap() + 10);
+    }
+
+    #[test]
+    fn candidate_commit_preserves_concurrent_time_reset() {
+        let time = TimeManager::new(1);
+        time.set_next_block_timestamp(100).unwrap();
+        let pending = time.prepare_next_timestamp();
+
+        time.reset(1_000);
+        let reset_offset = time.offset();
+        time.commit_next_timestamp(pending);
+
+        let state = time.state.read();
+        assert_eq!(state.last_timestamp, 100);
+        assert_eq!(state.offset, reset_offset);
+    }
+
+    #[test]
+    fn failed_temporary_increase_preserves_concurrent_time_reset() {
+        let time = TimeManager::new(1);
+        let pending = time.apply_time_increase(60);
+
+        time.reset(1_000);
+        let reset_offset = time.offset();
+        time.revert_time_increase(pending);
+
+        assert_eq!(time.offset(), reset_offset);
+    }
 }

--- a/crates/anvil/src/eth/backend/time.rs
+++ b/crates/anvil/src/eth/backend/time.rs
@@ -190,11 +190,11 @@ impl TimeManager {
         }) {
             state.next_exact_timestamp = None;
         }
-        if let Some(next_offset) = pending.next_offset {
-            if state.offset_reset_generation == pending.offset_reset_generation {
-                let concurrent_offset = state.offset.saturating_sub(pending.prepared_offset);
-                state.offset = next_offset.saturating_add(concurrent_offset);
-            }
+        if let Some(next_offset) = pending.next_offset
+            && state.offset_reset_generation == pending.offset_reset_generation
+        {
+            let concurrent_offset = state.offset.saturating_sub(pending.prepared_offset);
+            state.offset = next_offset.saturating_add(concurrent_offset);
         }
         state.last_timestamp = pending.timestamp;
     }

--- a/crates/anvil/src/eth/miner.rs
+++ b/crates/anvil/src/eth/miner.rs
@@ -12,7 +12,10 @@ use std::{
     fmt,
     marker::PhantomData,
     pin::Pin,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     task::{Context, Poll},
     time::Duration,
 };
@@ -25,6 +28,8 @@ const INSTANT_COALESCE_WINDOW: Duration = Duration::from_millis(5);
 pub struct Miner<T> {
     /// The mode this miner currently operates in
     mode: Arc<RwLock<MiningMode>>,
+    /// Identifies the current mode so stale candidate failures cannot modify its replacement.
+    generation: Arc<AtomicU64>,
     /// used for task wake up when the mining mode was forcefully changed
     ///
     /// This will register the task so we can manually wake it up if the mining mode was changed
@@ -35,7 +40,12 @@ pub struct Miner<T> {
 
 impl<T> Clone for Miner<T> {
     fn clone(&self) -> Self {
-        Self { mode: self.mode.clone(), inner: self.inner.clone(), transaction: PhantomData }
+        Self {
+            mode: self.mode.clone(),
+            generation: self.generation.clone(),
+            inner: self.inner.clone(),
+            transaction: PhantomData,
+        }
     }
 }
 
@@ -50,6 +60,7 @@ impl<T> Miner<T> {
     pub fn new(mode: MiningMode) -> Self {
         Self {
             mode: Arc::new(RwLock::new(mode)),
+            generation: Default::default(),
             inner: Default::default(),
             transaction: PhantomData,
         }
@@ -88,23 +99,60 @@ impl<T> Miner<T> {
     /// Sets the mining mode to operate in
     pub fn set_mining_mode(&self, mode: MiningMode) {
         let new_mode = format!("{mode:?}");
-        let mode = std::mem::replace(&mut *self.mode_write(), mode);
+        let mut current = self.mode_write();
+        let mode = std::mem::replace(&mut *current, mode);
+        self.generation.fetch_add(1, Ordering::Relaxed);
+        drop(current);
         trace!(target: "miner", "updated mining mode from {:?} to {}", mode, new_mode);
         self.inner.wake();
+    }
+
+    /// Resets the mode that launched a failed candidate.
+    pub(crate) fn handle_failed_candidate(&self, generation: u64) {
+        let mut mode = self.mode.write();
+        if self.generation.load(Ordering::Relaxed) != generation {
+            if let MiningMode::Auto(miner) | MiningMode::Mixed(miner, _) = &mut *mode {
+                miner.has_pending_txs = Some(true);
+                miner.coalesce = None;
+            }
+            return;
+        }
+        match &mut *mode {
+            MiningMode::Auto(miner) | MiningMode::Mixed(miner, _) => {
+                miner.has_pending_txs = Some(false);
+                miner.coalesce = None;
+            }
+            MiningMode::None | MiningMode::FixedBlockTime(_) => {}
+        }
+        match &mut *mode {
+            MiningMode::FixedBlockTime(miner) | MiningMode::Mixed(_, miner) => {
+                let period = miner.interval.period();
+                *miner = FixedBlockTimeMiner::new(period);
+            }
+            MiningMode::None | MiningMode::Auto(_) => {}
+        }
     }
 
     /// polls the [Pool] and returns those transactions that should be put in a block according to
     /// the current mode.
     ///
     /// May return an empty list, if no transactions are ready.
-    pub fn poll(
+    pub(crate) fn poll(
         &mut self,
         pool: &Arc<Pool<T>>,
         cx: &mut Context<'_>,
-    ) -> Poll<Vec<Arc<PoolTransaction<T>>>> {
+    ) -> Poll<MiningWork<T>> {
         self.inner.register(cx);
-        self.mode.write().poll(pool, cx)
+        let mut mode = self.mode.write();
+        let generation = self.generation.load(Ordering::Relaxed);
+        mode.poll(pool, cx).map(|transactions| MiningWork { transactions, generation })
     }
+}
+
+/// Transactions selected by a specific mining mode generation.
+pub(crate) struct MiningWork<T> {
+    pub(crate) transactions: Vec<Arc<PoolTransaction<T>>>,
+    pub(crate) generation: u64,
 }
 
 /// A Mining mode that does nothing
@@ -314,5 +362,39 @@ impl fmt::Debug for ReadyTransactionMiner {
         f.debug_struct("ReadyTransactionMiner")
             .field("max_transactions", &self.max_transactions)
             .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{channel::mpsc, future::poll_fn};
+
+    #[test]
+    fn stale_failure_resumes_replacement_autominer() {
+        let (_tx, rx) = mpsc::channel(1);
+        let miner = Miner::<()>::new(MiningMode::None);
+        miner.set_mining_mode(MiningMode::instant(1, rx));
+
+        miner.handle_failed_candidate(0);
+
+        let mode = miner.mode.read();
+        let MiningMode::Auto(auto) = &*mode else { panic!("expected auto mining") };
+        assert_eq!(auto.has_pending_txs, Some(true));
+    }
+
+    #[tokio::test]
+    async fn failed_fixed_candidate_rearms_interval() {
+        let mut miner = Miner::<()>::new(MiningMode::interval(Duration::from_millis(10)));
+        let pool = Arc::new(Pool::default());
+        tokio::time::timeout(Duration::from_secs(1), poll_fn(|cx| miner.poll(&pool, cx)))
+            .await
+            .unwrap();
+
+        miner.handle_failed_candidate(0);
+
+        tokio::time::timeout(Duration::from_secs(1), poll_fn(|cx| miner.poll(&pool, cx)))
+            .await
+            .unwrap();
     }
 }

--- a/crates/anvil/src/service.rs
+++ b/crates/anvil/src/service.rs
@@ -3,10 +3,8 @@
 use crate::{
     NodeResult,
     eth::{
-        backend::validate::TransactionValidator,
-        fees::FeeHistoryService,
-        miner::Miner,
-        pool::{Pool, transactions::PoolTransaction},
+        backend::validate::TransactionValidator, error::BlockchainError, fees::FeeHistoryService,
+        miner::Miner, pool::Pool,
     },
     filter::Filters,
     mem::{Backend, storage::MinedBlockOutcome},
@@ -86,15 +84,26 @@ where
         // producer
         loop {
             // advance block production until pending
-            while let Poll::Ready(Some(outcome)) = pin.block_producer.poll_next_unpin(cx) {
-                trace!(target: "node", "mined block {}", outcome.block_number);
-                // prune the transactions from the pool
-                pin.pool.on_mined_block(outcome);
+            while let Poll::Ready(Some(result)) = pin.block_producer.poll_next_unpin(cx) {
+                match result {
+                    BlockProduction::Mined(outcome) => {
+                        trace!(target: "node", "mined block {}", outcome.block_number);
+                        pin.pool.on_mined_block(outcome);
+                    }
+                    BlockProduction::Failed(generation) => {
+                        pin.miner.handle_failed_candidate(generation);
+                        break;
+                    }
+                }
             }
 
-            if let Poll::Ready(transactions) = pin.miner.poll(&pin.pool, cx) {
+            // Do not select snapshots while another candidate is in flight. This leaves newer
+            // ready notifications in the miner so a failed candidate cannot discard their work.
+            if pin.block_producer.is_idle()
+                && let Poll::Ready(work) = pin.miner.poll(&pin.pool, cx)
+            {
                 // miner returned a set of transaction that we feed to the producer
-                pin.block_producer.queued.push_back(transactions);
+                pin.block_producer.queued.push_back(work);
             } else {
                 // no progress made
                 break;
@@ -115,7 +124,13 @@ where
     }
 }
 
-type MiningResult<N> = (MinedBlockOutcome<<N as Network>::TxEnvelope>, Arc<Backend<N>>);
+type MiningResult<N> =
+    (Result<MinedBlockOutcome<<N as Network>::TxEnvelope>, BlockchainError>, Arc<Backend<N>>, u64);
+
+enum BlockProduction<T> {
+    Mined(MinedBlockOutcome<T>),
+    Failed(u64),
+}
 
 /// A type that exclusively mines one block at a time
 #[must_use = "streams do nothing unless polled"]
@@ -125,7 +140,7 @@ struct BlockProducer<N: Network> {
     /// Single active future that mines a new block
     block_mining: Option<JoinHandle<MiningResult<N>>>,
     /// backlog of sets of transactions ready to be mined
-    queued: VecDeque<Vec<Arc<PoolTransaction<N::TxEnvelope>>>>,
+    queued: VecDeque<crate::eth::miner::MiningWork<N::TxEnvelope>>,
 }
 
 impl<N: Network> BlockProducer<N>
@@ -136,6 +151,10 @@ where
     fn new(backend: Arc<Backend<N>>) -> Self {
         Self { idle_backend: Some(backend), block_mining: None, queued: Default::default() }
     }
+
+    fn is_idle(&self) -> bool {
+        self.idle_backend.is_some() && self.block_mining.is_none() && self.queued.is_empty()
+    }
 }
 
 impl<N: Network> Stream for BlockProducer<N>
@@ -143,7 +162,7 @@ where
     Backend<N>: TransactionValidator<N::TxEnvelope> + Send + Sync + 'static,
     N: Network<TxEnvelope = FoundryTxEnvelope, ReceiptEnvelope = FoundryReceiptEnvelope> + 'static,
 {
-    type Item = MinedBlockOutcome<N::TxEnvelope>;
+    type Item = BlockProduction<N::TxEnvelope>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let pin = self.get_mut();
@@ -151,7 +170,8 @@ where
         if !pin.queued.is_empty() {
             // only spawn a building task if there's none in progress already
             if let Some(backend) = pin.idle_backend.take() {
-                let transactions = pin.queued.pop_front().expect("not empty; qed");
+                let work = pin.queued.pop_front().expect("not empty; qed");
+                let generation = work.generation;
 
                 // we spawn this on as blocking task because this can be blocking for a while in
                 // forking mode, because of all the rpc calls to fetch the required state
@@ -159,9 +179,11 @@ where
                 let mining = tokio::task::spawn_blocking(move || {
                     handle.block_on(async move {
                         trace!(target: "miner", "creating new block");
-                        let block = backend.mine_block(transactions).await;
-                        trace!(target: "miner", "created new block: {}", block.block_number);
-                        (block, backend)
+                        let block = backend.mine_block(work.transactions).await;
+                        if let Ok(block) = &block {
+                            trace!(target: "miner", "created new block: {}", block.block_number);
+                        }
+                        (block, backend, generation)
                     })
                 });
                 pin.block_mining = Some(mining);
@@ -171,9 +193,15 @@ where
         if let Some(mut mining) = pin.block_mining.take() {
             if let Poll::Ready(res) = mining.poll_unpin(cx) {
                 return match res {
-                    Ok((outcome, backend)) => {
+                    Ok((Ok(outcome), backend, _)) => {
                         pin.idle_backend = Some(backend);
-                        Poll::Ready(Some(outcome))
+                        Poll::Ready(Some(BlockProduction::Mined(outcome)))
+                    }
+                    Ok((Err(error), backend, generation)) => {
+                        pin.idle_backend = Some(backend);
+                        pin.queued.clear();
+                        warn!(target: "miner", %error, "failed to finalize block");
+                        Poll::Ready(Some(BlockProduction::Failed(generation)))
                     }
                     Err(err) => {
                         panic!("miner task failed: {err}");

--- a/crates/anvil/tests/it/anvil.rs
+++ b/crates/anvil/tests/it/anvil.rs
@@ -208,7 +208,7 @@ async fn test_can_handle_large_timestamp() {
     let (api, _handle) = spawn(NodeConfig::test()).await;
     let num = 317071597274;
     api.evm_set_next_block_timestamp(num).unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(block.header.timestamp, num);
@@ -218,7 +218,7 @@ async fn test_can_handle_large_timestamp() {
 async fn test_shanghai_fields() {
     let (api, _handle) =
         spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Shanghai.into()))).await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(block.header.withdrawals_root, Some(EMPTY_ROOT_HASH));
@@ -231,7 +231,7 @@ async fn test_shanghai_fields() {
 async fn test_cancun_fields() {
     let (api, _handle) =
         spawn(NodeConfig::test().with_hardfork(Some(EthereumHardfork::Cancun.into()))).await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(block.header.withdrawals_root, Some(EMPTY_ROOT_HASH));

--- a/crates/anvil/tests/it/anvil_api.rs
+++ b/crates/anvil/tests/it/anvil_api.rs
@@ -9,7 +9,7 @@ use alloy_chains::NamedChain;
 use alloy_consensus::{SignableTransaction, TxEip1559};
 use alloy_eips::eip2718::Decodable2718;
 use alloy_network::{EthereumWallet, TransactionBuilder, TxSignerSync};
-use alloy_primitives::{Address, Bytes, TxKind, U256, address, b256, fixed_bytes};
+use alloy_primitives::{Address, Bytes, TxKind, U256, address, b256, fixed_bytes, keccak256};
 use alloy_provider::{Provider, ext::TxPoolApi};
 use alloy_rpc_types::{
     BlockId, BlockNumberOrTag, TransactionRequest,
@@ -31,6 +31,7 @@ use anvil_core::{
 use foundry_common::version::{COMMIT_SHA, SEMVER_VERSION};
 use foundry_evm::hardfork::EthereumHardfork;
 use foundry_primitives::FoundryTxEnvelope;
+use futures::{FutureExt, StreamExt};
 use tempo_hardfork::TempoHardfork;
 
 use std::{
@@ -58,7 +59,7 @@ async fn can_set_block_gas_limit() {
     let block_gas_limit = U256::from(1337);
     assert!(api.evm_set_block_gas_limit(block_gas_limit).unwrap());
     // Mine a new block, and check the new block gas limit
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(block_gas_limit.to::<u64>(), latest_block.header.gas_limit);
 }
@@ -599,16 +600,16 @@ async fn test_fork_revert_next_block_timestamp() {
     let (api, _handle) = spawn(fork_config()).await;
 
     // Mine a new block, and check the new block gas limit
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
 
     let state_snapshot = api.evm_snapshot().await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     api.evm_revert(state_snapshot).await.unwrap();
     let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(block, latest_block);
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert!(block.header.timestamp >= latest_block.header.timestamp);
 }
@@ -623,13 +624,13 @@ async fn test_set_next_block_prevrandao() {
     let prevrandao = b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
 
     api.anvil_set_next_block_prevrandao(prevrandao).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(block.header.mix_hash, Some(prevrandao));
 
     // the override only applies to a single block: the next block uses the default derivation
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let next = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_ne!(next.header.mix_hash, Some(prevrandao));
 }
@@ -647,7 +648,7 @@ async fn test_set_next_block_prevrandao_evm() {
 
     let prevrandao = b256!("0x00000000000000000000000000000000000000000000000000000000deadbeef");
     api.anvil_set_next_block_prevrandao(prevrandao).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     // post-merge the `PREVRANDAO` opcode (0x44) returns the current block's `prevrandao`
     let difficulty = multicall.getCurrentBlockDifficulty().call().await.unwrap();
@@ -668,7 +669,7 @@ async fn test_set_next_block_prevrandao_cleared_on_reset() {
     api.anvil_set_next_block_prevrandao(prevrandao).await.unwrap();
     // resetting must drop the pending override before it is consumed by a block
     api.anvil_reset(None).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_ne!(block.header.mix_hash, Some(prevrandao));
@@ -686,7 +687,7 @@ async fn test_set_next_block_prevrandao_cleared_on_revert() {
     api.anvil_set_next_block_prevrandao(prevrandao).await.unwrap();
     // reverting must drop the pending override before it is consumed by a block
     api.evm_revert(state_snapshot).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_ne!(block.header.mix_hash, Some(prevrandao));
@@ -700,11 +701,11 @@ async fn test_fork_revert_call_latest_block_timestamp() {
     let provider = handle.http_provider();
 
     // Mine a new block, and check the new block gas limit
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
 
     let state_snapshot = api.evm_snapshot().await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     api.evm_revert(state_snapshot).await.unwrap();
 
     let multicall_contract =
@@ -844,8 +845,8 @@ async fn flaky_test_reorg() {
     let value = storage.getValue().call().await.unwrap();
     assert_eq!("initial value".to_string(), value);
 
-    api.mine_one().await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
 
     // Test raw transaction data
     let mut tx = TxEip1559 {
@@ -892,7 +893,7 @@ async fn can_replay_arbitrum_transaction_with_priority_fee_above_max_fee() {
         spawn(NodeConfig::test().with_chain_id(Some(NamedChain::Arbitrum as u64))).await;
     let provider = handle.http_provider();
     let accounts = handle.dev_wallets().collect::<Vec<_>>();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let recipient = accounts[1].address();
     let value = U256::from(100);
@@ -970,11 +971,268 @@ async fn can_replay_arbitrum_transaction_with_priority_fee_above_max_fee() {
             .unwrap();
 
     let replay = Arc::new(PoolTransaction::new(pending).with_replay());
-    let outcome = api.backend.mine_block(vec![replay, ordinary]).await;
+    let outcome = api.backend.mine_block(vec![replay, ordinary]).await.unwrap();
     assert_eq!(outcome.included.len(), 1);
     assert_eq!(outcome.included[0].hash(), replay_hash);
     assert_eq!(outcome.invalid.len(), 1);
     assert_eq!(outcome.invalid[0].hash(), ordinary_hash);
+}
+
+#[derive(Clone, Copy)]
+enum FinalizationFailure {
+    RevertingSystemCall,
+    MalformedDeposit,
+}
+
+async fn assert_failed_mining_is_atomic(failure: FinalizationFailure) {
+    let config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Prague.into()))
+        .with_base_fee(Some(0));
+    let clean_config = config.clone();
+    let (api, handle) = spawn(config).await;
+    let provider = handle.http_provider();
+    let accounts = handle.dev_wallets().collect::<Vec<_>>();
+    let sender = accounts[0].address();
+    let contract = match failure {
+        FinalizationFailure::RevertingSystemCall => {
+            address!("0x1000000000000000000000000000000000000000")
+        }
+        FinalizationFailure::MalformedDeposit => {
+            address!("0x00000000219ab540356cbb839cbe05303d7705fa")
+        }
+    };
+    api.anvil_set_auto_mine(false).await.unwrap();
+    api.anvil_set_code(contract, Bytes::from_static(&[0x60, 0x01, 0x5f, 0x55, 0x00]))
+        .await
+        .unwrap();
+
+    match failure {
+        FinalizationFailure::RevertingSystemCall => {
+            api.anvil_set_code(
+                address!("0x00000961ef480eb55e80d19ad83579a64c007002"),
+                Bytes::from_static(&[0x5f, 0x5f, 0xfd]),
+            )
+            .await
+            .unwrap();
+        }
+        FinalizationFailure::MalformedDeposit => {
+            let mut code = vec![0x60, 0x01, 0x5f, 0x55, 0x7f];
+            code.extend_from_slice(
+                keccak256(b"DepositEvent(bytes,bytes,bytes,bytes,bytes)").as_slice(),
+            );
+            code.extend_from_slice(&[0x5f, 0x5f, 0xa1, 0x00]);
+            api.anvil_set_code(contract, code.into()).await.unwrap();
+        }
+    }
+
+    let genesis = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    let best_hash = api.backend.best_hash();
+    let base_fee = api.base_fee().unwrap();
+    let blob_fee = api.excess_blob_gas_and_price().unwrap();
+    let balance = provider.get_balance(sender).await.unwrap();
+    let nonce = provider.get_transaction_count(sender).await.unwrap();
+    let storage = provider.get_storage_at(contract, U256::ZERO).await.unwrap();
+    let mut notifications = api.new_block_notifications();
+    let request =
+        TransactionRequest::default().from(sender).to(contract).gas_price(0).gas_limit(100_000);
+    api.send_transaction(WithOtherFields::new(request.clone())).await.unwrap();
+
+    let error = api.mine_one().await.unwrap_err();
+    let message = error.to_string();
+    match failure {
+        FinalizationFailure::RevertingSystemCall => {
+            assert!(message.contains("execution reverted"), "{message}");
+        }
+        FinalizationFailure::MalformedDeposit => {
+            assert!(message.contains("deposit") || message.contains("decode"), "{message}");
+        }
+    }
+
+    let latest = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(api.backend.best_number(), 0);
+    assert_eq!(api.backend.best_hash(), best_hash);
+    assert_eq!(latest.header.hash, genesis.header.hash);
+    assert_eq!(latest.header.state_root, genesis.header.state_root);
+    assert_eq!(api.base_fee().unwrap(), base_fee);
+    assert_eq!(api.excess_blob_gas_and_price().unwrap(), blob_fee);
+    assert_eq!(provider.get_balance(sender).await.unwrap(), balance);
+    assert_eq!(provider.get_transaction_count(sender).await.unwrap(), nonce);
+    assert_eq!(provider.get_storage_at(contract, U256::ZERO).await.unwrap(), storage);
+    assert_eq!(api.txpool_status().await.unwrap().pending, 1);
+    assert!(notifications.next().now_or_never().is_none());
+
+    // A successful retry must produce the same root as a node that never executed the failed
+    // candidate, proving recovery publication matches a clean execution.
+    let valid_code = Bytes::from_static(&[0x60, 0x01, 0x5f, 0x55, 0x00]);
+    api.anvil_set_code(contract, valid_code.clone()).await.unwrap();
+    if matches!(failure, FinalizationFailure::RevertingSystemCall) {
+        api.anvil_set_code(address!("0x00000961ef480eb55e80d19ad83579a64c007002"), Bytes::new())
+            .await
+            .unwrap();
+    }
+
+    let (clean_api, _clean_handle) = spawn(clean_config).await;
+    clean_api.anvil_set_auto_mine(false).await.unwrap();
+    clean_api.anvil_set_code(contract, valid_code).await.unwrap();
+    if matches!(failure, FinalizationFailure::RevertingSystemCall) {
+        let withdrawals = address!("0x00000961ef480eb55e80d19ad83579a64c007002");
+        clean_api
+            .anvil_set_code(withdrawals, Bytes::from_static(&[0x5f, 0x5f, 0xfd]))
+            .await
+            .unwrap();
+        clean_api.anvil_set_code(withdrawals, Bytes::new()).await.unwrap();
+    }
+    clean_api.send_transaction(WithOtherFields::new(request)).await.unwrap();
+
+    api.mine_one().await.unwrap();
+    clean_api.mine_one().await.unwrap();
+    let recovered = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    let clean = clean_api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(recovered.header.state_root, clean.header.state_root);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reverting_prague_transition_rolls_back_mining() {
+    assert_failed_mining_is_atomic(FinalizationFailure::RevertingSystemCall).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn malformed_deposit_request_rolls_back_mining() {
+    assert_failed_mining_is_atomic(FinalizationFailure::MalformedDeposit).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn manual_mining_rpcs_preserve_controls_on_failure() {
+    let prevrandao = b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+    for method in ["anvil_mine", "evm_mine", "evm_mine_detailed"] {
+        let config = NodeConfig::test()
+            .with_hardfork(Some(EthereumHardfork::Prague.into()))
+            .with_base_fee(Some(0));
+        let (api, handle) = spawn(config).await;
+        let provider = handle.http_provider();
+        let withdrawals = address!("0x00000961ef480eb55e80d19ad83579a64c007002");
+        api.anvil_set_code(withdrawals, Bytes::from_static(&[0x5f, 0x5f, 0xfd])).await.unwrap();
+        let genesis = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+        let next_timestamp = genesis.header.timestamp + 100;
+        api.evm_set_next_block_timestamp(next_timestamp).unwrap();
+        api.anvil_set_next_block_prevrandao(prevrandao).await.unwrap();
+
+        let result: std::result::Result<serde_json::Value, _> = if method == "anvil_mine" {
+            provider.raw_request(method.into(), (U256::from(1),)).await
+        } else {
+            provider
+                .raw_request(
+                    method.into(),
+                    (MineOptions::Options { timestamp: None, blocks: Some(1) },),
+                )
+                .await
+        };
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("execution reverted"), "{method}: {error}");
+        assert_eq!(api.backend.best_number(), 0, "{method}");
+
+        api.anvil_set_code(withdrawals, Bytes::new()).await.unwrap();
+        api.mine_one().await.unwrap();
+        let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+        assert_eq!(block.header.timestamp, next_timestamp, "{method}");
+        assert_eq!(block.header.mix_hash, Some(prevrandao), "{method}");
+
+        api.evm_increase_time(U256::from(1)).await.unwrap();
+        api.mine_one().await.unwrap();
+        let following = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+        assert_ne!(following.header.mix_hash, Some(prevrandao), "{method}");
+        assert_eq!(following.header.timestamp, next_timestamp + 1, "{method}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn failed_anvil_mine_preserves_interval_adjustment() {
+    let config = NodeConfig::test()
+        .with_hardfork(Some(EthereumHardfork::Prague.into()))
+        .with_base_fee(Some(0));
+    let (api, _) = spawn(config).await;
+    let withdrawals = address!("0x00000961ef480eb55e80d19ad83579a64c007002");
+    api.anvil_set_code(withdrawals, Bytes::from_static(&[0x5f, 0x5f, 0xfd])).await.unwrap();
+    let genesis = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    api.evm_set_block_timestamp_interval(17).unwrap();
+
+    api.anvil_mine(Some(U256::from(2)), Some(U256::from(60))).await.unwrap_err();
+    api.anvil_set_code(withdrawals, Bytes::new()).await.unwrap();
+    api.mine_one().await.unwrap();
+    let block = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
+    assert_eq!(block.header.timestamp, genesis.header.timestamp + 17);
+    assert!(api.evm_remove_block_timestamp_interval().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn instant_mining_reselects_from_live_pool_after_failure() {
+    for drop_failed_transaction in [false, true] {
+        let config = NodeConfig::test()
+            .with_hardfork(Some(EthereumHardfork::Prague.into()))
+            .with_base_fee(Some(0));
+        let (api, handle) = spawn(config).await;
+        let provider = handle.http_provider();
+        let accounts = handle.dev_wallets().collect::<Vec<_>>();
+        let withdrawals = address!("0x00000961ef480eb55e80d19ad83579a64c007002");
+        api.anvil_set_code(withdrawals, Bytes::from_static(&[0x5f, 0x5f, 0xfd])).await.unwrap();
+
+        let first = TransactionRequest::default()
+            .from(accounts[0].address())
+            .to(accounts[1].address())
+            .value(U256::from(1));
+        let first_hash = api.send_transaction(WithOtherFields::new(first)).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(api.backend.best_number(), 0);
+        assert!(provider.get_transaction_receipt(first_hash).await.unwrap().is_none());
+
+        if drop_failed_transaction {
+            assert_eq!(api.anvil_drop_transaction(first_hash).await.unwrap(), Some(first_hash));
+        }
+        api.anvil_set_code(withdrawals, Bytes::new()).await.unwrap();
+        let second = TransactionRequest::default()
+            .from(accounts[1].address())
+            .to(accounts[2].address())
+            .value(U256::from(1));
+        let second_hash = api.send_transaction(WithOtherFields::new(second)).await.unwrap();
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if provider.get_transaction_receipt(second_hash).await.unwrap().is_some() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        let first_receipt = provider.get_transaction_receipt(first_hash).await.unwrap();
+        assert_eq!(first_receipt.is_some(), !drop_failed_transaction);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fixed_and_mixed_mining_failures_remain_bounded() {
+    for mixed in [false, true] {
+        let config = NodeConfig::test()
+            .with_hardfork(Some(EthereumHardfork::Prague.into()))
+            .with_base_fee(Some(0))
+            .with_mixed_mining(mixed, Some(Duration::from_millis(100)));
+        let (api, _handle) = spawn(config).await;
+        let withdrawals = address!("0x00000961ef480eb55e80d19ad83579a64c007002");
+        api.anvil_set_code(withdrawals, Bytes::from_static(&[0x5f, 0x5f, 0xfd])).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(250)).await;
+        assert_eq!(api.backend.best_number(), 0, "mixed={mixed}");
+
+        api.anvil_set_code(withdrawals, Bytes::new()).await.unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while api.backend.best_number() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("scheduler did not recover, mixed={mixed}"));
+        assert_eq!(api.backend.best_number(), 1, "mixed={mixed}");
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1006,7 +1264,7 @@ async fn test_reorg_blockhash_opcode_consistency() {
     .await
     .unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     for (block_num, rpc_before, opcode_before) in &cached_hashes {
         let rpc_after =
@@ -1062,7 +1320,7 @@ async fn test_reorg_deep_blockhash_consistency() {
     .await
     .unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let tip_after_reorg = api.block_number().unwrap().to::<u64>();
 
@@ -1104,7 +1362,7 @@ async fn test_rollback() {
 
     // Mine 5 blocks
     for _ in 0..5 {
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
     }
 
     // Get block 4 for later comparison
@@ -1134,8 +1392,8 @@ async fn test_arb_get_block() {
     let (api, _handle) = spawn(NodeConfig::test().with_chain_id(Some(421611u64))).await;
 
     // Mine two blocks
-    api.mine_one().await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
 
     let best_number = api.block_number().unwrap().to::<u64>();
 
@@ -1161,7 +1419,7 @@ async fn test_mine_blk_with_prev_timestamp() {
     // mock timestamp
     api.evm_set_next_block_timestamp(init_timestamp).unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
 
@@ -1175,7 +1433,7 @@ async fn test_mine_blk_with_prev_timestamp() {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     // Subsequent block should have a greater timestamp than previous block
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
 
@@ -1200,7 +1458,7 @@ async fn test_increase_time_by_zero() {
 
     api.evm_set_next_block_timestamp(init_timestamp).unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
 
@@ -1325,7 +1583,7 @@ async fn test_anvil_reset_non_fork() {
 
     // Mine some blocks and make transactions
     for _ in 0..5 {
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
     }
 
     // Send a transaction
@@ -1366,7 +1624,7 @@ async fn test_anvil_reset_non_fork() {
     assert_eq!(to_balance_after_reset, U256::ZERO);
 
     // Test we can continue mining after reset
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let new_block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
     assert_eq!(new_block.header.number, 1);
 }
@@ -1382,7 +1640,7 @@ async fn test_anvil_reset_fork_to_non_fork() {
 
     // Mine some blocks
     for _ in 0..3 {
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
     }
 
     // Reset to non-fork mode
@@ -1397,7 +1655,7 @@ async fn test_anvil_reset_fork_to_non_fork() {
     assert_eq!(block.header.number, 0);
 
     // Verify we can still mine blocks
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let new_block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
     assert_eq!(new_block.header.number, 1);
 }
@@ -1491,7 +1749,7 @@ async fn can_get_default_base_fee_tempo_t0() {
     let (api, handle) = spawn(config).await;
     let provider = handle.http_provider();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(BlockNumberOrTag::Latest.into()).await.unwrap().unwrap();
     assert_eq!(

--- a/crates/anvil/tests/it/eip2935.rs
+++ b/crates/anvil/tests/it/eip2935.rs
@@ -103,7 +103,7 @@ async fn ethereum_block_start_transitions_use_consensus_order() {
         .with_precompile_factory(OrderedBlockStartPrecompiles(Arc::clone(&order)));
     let (api, _) = spawn(node_config).await;
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     assert_eq!(order.load(Ordering::SeqCst), 2);
 }
@@ -124,7 +124,7 @@ async fn tempo_spec_id_does_not_enable_ethereum_block_transitions() {
     .await
     .unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     assert_eq!(order.load(Ordering::SeqCst), 0);
 }
@@ -147,7 +147,7 @@ async fn optimism_spec_id_does_not_enable_ethereum_block_transitions() {
     .await
     .unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     assert_eq!(order.load(Ordering::SeqCst), 0);
 }
@@ -197,7 +197,7 @@ async fn complete_block_paths_run_post_transitions_once() {
     .unwrap();
     assert_eq!(calls.load(Ordering::SeqCst), 4);
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     assert_eq!(calls.load(Ordering::SeqCst), 6);
 }
 
@@ -251,9 +251,9 @@ async fn eip2935_stores_parent_block_hash() {
     let provider = http_provider(&handle.http_endpoint());
 
     // Mine a few blocks so there are parent hashes to store
-    api.mine_one().await;
-    api.mine_one().await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
 
     // Block 1's hash should be stored when block 2 was mined
     let block1 = provider
@@ -313,7 +313,7 @@ async fn eip2935_local_block_replay_applies_pre_execution_changes() {
     )
     .await
     .unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let parent = provider
         .get_block_by_number(BlockNumberOrTag::Latest)
@@ -334,7 +334,7 @@ async fn eip2935_local_block_replay_applies_pre_execution_changes() {
         ))
         .await
         .unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let receipt = pending.get_receipt().await.unwrap();
     let block_number = receipt.block_number.unwrap();
 
@@ -384,7 +384,7 @@ async fn eip2935_local_block_replay_propagates_pre_execution_errors() {
         .await
         .unwrap();
     let block_number = receipt.block_number.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let empty_block_number = provider.get_block_number().await.unwrap();
     assert_eq!(empty_block_number, block_number + 1);
 

--- a/crates/anvil/tests/it/eip4844.rs
+++ b/crates/anvil/tests/it/eip4844.rs
@@ -292,11 +292,11 @@ async fn can_mine_blobs_when_exceeds_max_blobs() {
     tx.set_nonce(1);
     let second_tx = provider.send_transaction(tx).await.unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let first_receipt = first_tx.get_receipt().await.unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let second_receipt = second_tx.get_receipt().await.unwrap();
 
     let (first_block, second_block) = tokio::join!(

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -115,7 +115,7 @@ async fn test_fork_transaction_hash_replays_before_startup() {
         .await
         .unwrap();
     let expected_hashes = [*first.tx_hash(), *second.tx_hash(), *reverted.tx_hash()];
-    origin_api.mine_one().await;
+    origin_api.mine_one().await.unwrap();
     assert!(
         !origin_provider
             .get_transaction_receipt(expected_hashes[2])
@@ -252,7 +252,7 @@ async fn test_fork_transaction_hash_replay_preserves_cancun_header_inputs() {
         ))
         .await
         .unwrap();
-    origin_api.mine_one().await;
+    origin_api.mine_one().await.unwrap();
     let source =
         origin_api.block_by_number_full(BlockNumberOrTag::Number(1)).await.unwrap().unwrap();
     assert_eq!(source.header.timestamp, source_timestamp);
@@ -281,7 +281,7 @@ async fn test_fork_transaction_hash_replay_preserves_cancun_header_inputs() {
     assert_eq!(replayed.header.timestamp, source.header.timestamp);
     assert_eq!(replayed.header.parent_beacon_block_root, source.header.parent_beacon_block_root);
 
-    fork_api.mine_one().await;
+    fork_api.mine_one().await.unwrap();
     let next = fork_api.block_by_number_full(BlockNumberOrTag::Number(2)).await.unwrap().unwrap();
     assert!(next.header.timestamp > source.header.timestamp);
 }
@@ -312,7 +312,7 @@ async fn test_fork_transaction_hash_replay_resolves_source_hardfork() {
         .await
         .unwrap();
     let target_hash = *target.tx_hash();
-    origin_api.mine_one().await;
+    origin_api.mine_one().await.unwrap();
     let source =
         origin_api.block_by_number_full(BlockNumberOrTag::Number(1)).await.unwrap().unwrap();
     assert_eq!(source.header.timestamp, SHANGHAI_ERA_TIMESTAMP);
@@ -371,7 +371,7 @@ async fn test_fork_transaction_hash_replay_applies_source_beacon_root() {
         .await
         .unwrap();
     let target_hash = *target.tx_hash();
-    origin_api.mine_one().await;
+    origin_api.mine_one().await.unwrap();
     let source =
         origin_api.block_by_number_full(BlockNumberOrTag::Number(1)).await.unwrap().unwrap();
     assert_eq!(source.header.timestamp, CANCUN_ERA_TIMESTAMP);
@@ -1414,7 +1414,7 @@ async fn test_fork_init_base_fee() {
     let init_base_fee = block.header.base_fee_per_gas.unwrap();
     assert_eq!(init_base_fee, 63739886069);
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
 
@@ -1682,8 +1682,8 @@ async fn test_total_difficulty_fork() {
     assert_eq!(block.header.total_difficulty, Some(total_difficulty));
     assert_eq!(block.header.difficulty, difficulty);
 
-    api.mine_one().await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
 
     let next_total_difficulty = total_difficulty + difficulty;
 
@@ -1810,7 +1810,7 @@ async fn test_fork_reset_basefee() {
     // <https://etherscan.io/block/18835000>
     let (api, _handle) = spawn(fork_config().with_fork_block_number(Some(18835000u64))).await;
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
 
     // basefee of +1 block: <https://etherscan.io/block/18835001>
@@ -1821,7 +1821,7 @@ async fn test_fork_reset_basefee() {
         .await
         .unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest = api.block_by_number(BlockNumberOrTag::Latest).await.unwrap().unwrap();
 
     // basefee of the forked block: <https://etherscan.io/block/18835000>
@@ -1860,7 +1860,7 @@ async fn flaky_test_arb_fork_mining() {
     let init_blk_num = api.block_number().unwrap().to::<u64>();
 
     // Mine one
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let mined_blk_num = api.block_number().unwrap().to::<u64>();
 
     assert_eq!(mined_blk_num, init_blk_num + 1);
@@ -1895,7 +1895,7 @@ async fn flaky_test_arbitrum_fork_block_number() {
     let snapshot_state = api.evm_snapshot().await.unwrap();
 
     // mine new block and check block number returned by `eth_blockNumber`
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let block_number = api.block_number().unwrap().to::<u64>();
     assert_eq!(block_number, initial_block_number + 1);
 
@@ -2250,7 +2250,7 @@ async fn test_fork_reset_reuses_cached_remote_state() {
     let fork_block_number = api.anvil_node_info().await.unwrap().fork_config.fork_block_number;
 
     assert_eq!(provider.get_balance(address).await.unwrap(), balance);
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     for _ in 0..2 {
         api.anvil_reset(Some(Forking { json_rpc_url: None, block_number: fork_block_number }))
@@ -2340,10 +2340,10 @@ async fn test_fork_reset_does_not_reuse_cache_for_new_rpc_url() {
             .with_genesis_timestamp(Some(timestamp))
             .with_funded_accounts([(address, second_balance)].into_iter().collect());
         let (second_origin_api, second_origin_handle) = spawn(second_origin).await;
-        first_origin_api.mine_one().await;
-        first_origin_api.mine_one().await;
-        second_origin_api.mine_one().await;
-        second_origin_api.mine_one().await;
+        first_origin_api.mine_one().await.unwrap();
+        first_origin_api.mine_one().await.unwrap();
+        second_origin_api.mine_one().await.unwrap();
+        second_origin_api.mine_one().await.unwrap();
         let fork_config = NodeConfig::test()
             .with_chain_id(Some(chain_id))
             .with_eth_rpc_url(Some(first_origin_handle.http_endpoint()))

--- a/crates/anvil/tests/it/gas.rs
+++ b/crates/anvil/tests/it/gas.rs
@@ -129,7 +129,7 @@ async fn test_basefee_empty_block() {
         .unwrap();
 
     // mine empty block
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let next_base_fee = provider
         .get_block(BlockId::latest())

--- a/crates/anvil/tests/it/logs.rs
+++ b/crates/anvil/tests/it/logs.rs
@@ -104,7 +104,7 @@ async fn get_all_events() {
     let tx = contract.setValue("hi".to_string()).from(account);
     for _ in 0..num_tx {
         let tx = tx.send().await.unwrap();
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
         tx.get_receipt().await.unwrap();
     }
 

--- a/crates/anvil/tests/it/otterscan.rs
+++ b/crates/anvil/tests/it/otterscan.rs
@@ -17,7 +17,7 @@ use std::collections::VecDeque;
 #[tokio::test(flavor = "multi_thread")]
 async fn erigon_get_header_by_number() {
     let (api, _handle) = spawn(NodeConfig::test()).await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let res0 = api.erigon_get_header_by_number(0.into()).await.unwrap().unwrap();
     assert_eq!(res0.header.number, 0);
@@ -167,7 +167,7 @@ async fn ots_has_code() {
     let provider = handle.http_provider();
     let sender = handle.dev_accounts().next().unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let contract_address = sender.create(0);
 
@@ -364,7 +364,7 @@ async fn ots_get_block_transactions() {
         hashes.push_back(*pending_receipt.tx_hash());
     }
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let page_size = 3;
     for page in 0..4 {

--- a/crates/anvil/tests/it/pubsub.rs
+++ b/crates/anvil/tests/it/pubsub.rs
@@ -377,7 +377,7 @@ async fn test_sub_transaction_receipts() {
         ws_provider.get_subscription(filtered_id).await.unwrap();
     let mut filtered_stream = filtered_stream.into_stream();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let all_receipts = tokio::time::timeout(Duration::from_secs(5), all_stream.next())
         .await
@@ -414,8 +414,8 @@ async fn test_sub_transaction_receipts_cleanup_on_unsubscribe() {
 
     // Let the task observe the closed channel, then mine to trigger listener pruning.
     tokio::time::sleep(Duration::from_millis(200)).await;
-    api.mine_one().await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
 
     assert_eq!(
         api.backend.new_block_listeners_count(),
@@ -438,7 +438,7 @@ async fn test_sub_new_heads_fast() {
 
     let mut block_numbers = Vec::new();
     for _ in 0..num {
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
         let block_number = blocks.next().await.unwrap().number;
         block_numbers.push(block_number);
     }

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -324,8 +324,8 @@ async fn test_simulate_v1_rejects_precompile_moves_on_optimism_rpc() {
 async fn test_fork_simulate_normalizes_delegated_block_sequence_rpc() {
     let (origin_api, origin_handle) =
         spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
-    origin_api.mine_one().await;
-    origin_api.mine_one().await;
+    origin_api.mine_one().await.unwrap();
+    origin_api.mine_one().await.unwrap();
 
     let (api, handle) = spawn(
         NodeConfig::test()
@@ -390,8 +390,8 @@ async fn test_fork_simulate_preserves_delegated_base_selector_rpc() {
     let (hash_api, hash_handle) =
         spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
     hash_api.evm_set_block_timestamp_interval(1).unwrap();
-    hash_api.mine_one().await;
-    hash_api.mine_one().await;
+    hash_api.mine_one().await.unwrap();
+    hash_api.mine_one().await.unwrap();
     let hash_endpoint = hash_handle.http_endpoint();
     let hash_base =
         rpc_request(&hash_endpoint, "eth_getBlockByNumber", json!(["0x1", false])).await;
@@ -400,8 +400,8 @@ async fn test_fork_simulate_preserves_delegated_base_selector_rpc() {
     let (canonical_api, canonical_handle) =
         spawn(NodeConfig::test().with_genesis_timestamp(Some(2_000u64))).await;
     canonical_api.evm_set_block_timestamp_interval(1).unwrap();
-    canonical_api.mine_one().await;
-    canonical_api.mine_one().await;
+    canonical_api.mine_one().await.unwrap();
+    canonical_api.mine_one().await.unwrap();
     let canonical_endpoint = canonical_handle.http_endpoint();
     let canonical_base =
         rpc_request(&canonical_endpoint, "eth_getBlockByNumber", json!(["0x1", false])).await;
@@ -867,7 +867,7 @@ async fn test_simulate_pre_london_blocks_keep_base_fee_disabled_rpc() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_simulate_derives_from_historical_base_rpc() {
     let (api, handle) = spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000u64))).await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let endpoint = handle.http_endpoint();
     let genesis = rpc_request(&endpoint, "eth_getBlockByNumber", json!(["0x0", false])).await;
     let response =
@@ -924,7 +924,7 @@ async fn test_simulated_and_mined_ethereum_transitions_match_rpc() {
             .remove(0);
 
         api.evm_set_next_block_timestamp(next_timestamp).unwrap();
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
         let mined = provider
             .get_block_by_number(BlockNumberOrTag::Number(1))
             .await
@@ -1123,7 +1123,7 @@ async fn test_simulated_and_mined_prague_request_hashes_match_rpc() {
         .remove(0);
 
     api.evm_set_next_block_timestamp(genesis.header.timestamp + 12).unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let mined = provider
         .get_block_by_number(BlockNumberOrTag::Number(1))
         .await
@@ -1202,7 +1202,7 @@ async fn test_prague_requests_use_genesis_deposit_contract_and_consensus_order_r
 
     let _pending =
         handle.http_provider().send_transaction(WithOtherFields::new(request)).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let mined = handle
         .http_provider()
         .get_block_by_number(BlockNumberOrTag::Number(1))
@@ -1303,7 +1303,7 @@ async fn test_simulate_selfdestruct_state_root_matches_mined_rpc() {
     api.anvil_set_code(contract, code.into()).await.unwrap();
     api.anvil_set_balance(contract, U256::from(1)).await.unwrap();
     api.anvil_set_storage_at(contract, U256::ZERO, B256::from(U256::from(42))).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let selfdestruct = json!({
         "from": sender,
@@ -1399,7 +1399,7 @@ async fn test_simulate_state_override_preserves_selfdestructed_storage_rpc() {
     api.anvil_set_code(contract, selfdestruct_code.into()).await.unwrap();
     api.anvil_set_balance(contract, U256::from(1)).await.unwrap();
     api.anvil_set_storage_at(contract, U256::ZERO, B256::from(U256::from(42))).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let selfdestruct = json!({
         "from": sender,
@@ -1474,7 +1474,7 @@ async fn test_simulate_historical_tombstone_matches_latest_rpc() {
 
     api.anvil_set_code(contract, code.into()).await.unwrap();
     api.anvil_set_balance(contract, U256::from(1)).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     handle
         .http_provider()
         .send_transaction(WithOtherFields::new(TransactionRequest {
@@ -1491,7 +1491,7 @@ async fn test_simulate_historical_tombstone_matches_latest_rpc() {
         .unwrap();
     let historical_base =
         rpc_request(&endpoint, "eth_getBlockByNumber", json!(["latest", false])).await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_base =
         rpc_request(&endpoint, "eth_getBlockByNumber", json!(["latest", false])).await;
     assert_eq!(historical_base["result"]["stateRoot"], latest_base["result"]["stateRoot"]);

--- a/crates/anvil/tests/it/state.rs
+++ b/crates/anvil/tests/it/state.rs
@@ -24,8 +24,8 @@ async fn state_without_block_history() -> (Value, Address, U256, u64) {
     let balance = U256::from(10363);
     let (api, _handle) = spawn(NodeConfig::test()).await;
     api.anvil_set_balance(account, balance).await.unwrap();
-    api.mine_one().await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
 
     let mut state = serde_json::to_value(api.serialized_state(false).await.unwrap()).unwrap();
     let state = state.as_object_mut().unwrap();
@@ -47,8 +47,8 @@ async fn can_load_state() {
 
     let (api, _handle) = spawn(NodeConfig::test()).await;
 
-    api.mine_one().await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
 
     let num = api.block_number().unwrap();
 
@@ -83,7 +83,7 @@ async fn finalized_block_hash_consistent_after_load_state() {
 
     let (api, _handle) = spawn(NodeConfig::test()).await;
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     // Get the original genesis block hash
     let original_genesis = api.block_by_number(BlockNumberOrTag::Number(0)).await.unwrap().unwrap();
@@ -162,7 +162,7 @@ async fn can_load_state_without_block_history() {
     assert_eq!(checkpoint.header.hash, api.backend.best_hash());
     assert_eq!(api.backend.fees().base_fee(), next_base_fee);
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest = api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(latest.header.number, 3);
     assert_eq!(latest.header.parent_hash, checkpoint.header.hash);
@@ -187,10 +187,10 @@ async fn can_load_state_without_block_history_at_runtime() {
 
     let (api, _handle) = spawn(NodeConfig::test()).await;
     api.backend.set_coinbase(address!("0000000000000000000000000000000000000001"));
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let parent =
         api.block_by_number(alloy_eips::BlockNumberOrTag::Number(1)).await.unwrap().unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let previous =
         api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
 
@@ -204,7 +204,7 @@ async fn can_load_state_without_block_history_at_runtime() {
     assert_ne!(checkpoint.header.hash, previous.header.hash);
     assert_eq!(checkpoint.header.hash, api.backend.best_hash());
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest = api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(latest.header.number, 3);
     assert_eq!(latest.header.parent_hash, checkpoint.header.hash);
@@ -235,9 +235,9 @@ async fn state_without_block_history_restores_osaka_blob_excess_gas() {
 async fn rejects_nonempty_block_history_without_best_block() {
     let (source, _handle) = spawn(NodeConfig::test()).await;
     source.backend.set_coinbase(address!("0000000000000000000000000000000000000002"));
-    source.mine_one().await;
-    source.mine_one().await;
-    source.mine_one().await;
+    source.mine_one().await.unwrap();
+    source.mine_one().await.unwrap();
+    source.mine_one().await.unwrap();
     let mut state = source.serialized_state(false).await.unwrap();
     state.blocks.retain(|block| block.header.number != 3);
     assert!(!state.blocks.is_empty());
@@ -247,7 +247,7 @@ async fn rejects_nonempty_block_history_without_best_block() {
     let (api, _handle) = spawn(NodeConfig::test()).await;
     let original_coinbase = address!("0000000000000000000000000000000000000001");
     api.backend.set_coinbase(original_coinbase);
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let original =
         api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert!(api.block_by_hash(incoming_hash).await.unwrap().is_none());
@@ -260,7 +260,7 @@ async fn rejects_nonempty_block_history_without_best_block() {
     assert_eq!(api.backend.coinbase(), original_coinbase);
     assert!(api.block_by_hash(incoming_hash).await.unwrap().is_none());
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest = api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(latest.header.number, original.header.number + 1);
     assert_eq!(latest.header.parent_hash, original.header.hash);
@@ -270,12 +270,12 @@ async fn rejects_nonempty_block_history_without_best_block() {
 #[tokio::test(flavor = "multi_thread")]
 async fn loaded_state_fees_use_selected_head() {
     let (source, _handle) = spawn(NodeConfig::test()).await;
-    source.mine_one().await;
+    source.mine_one().await.unwrap();
     let mut state = source.serialized_state(false).await.unwrap();
     let selected_hash = source.backend.best_hash();
     let selected_next_base_fee = source.backend.fees().base_fee();
 
-    source.mine_one().await;
+    source.mine_one().await.unwrap();
     let newer_state = source.serialized_state(false).await.unwrap();
     let newer_block =
         newer_state.blocks.into_iter().find(|block| block.header.number == 2).unwrap();
@@ -287,7 +287,7 @@ async fn loaded_state_fees_use_selected_head() {
     assert_eq!(api.backend.best_hash(), selected_hash);
     assert_eq!(api.backend.fees().base_fee(), selected_next_base_fee);
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest = api.block_by_number(alloy_eips::BlockNumberOrTag::Latest).await.unwrap().unwrap();
     assert_eq!(latest.header.parent_hash, selected_hash);
     assert_eq!(latest.header.base_fee_per_gas, Some(selected_next_base_fee));
@@ -335,7 +335,7 @@ async fn test_make_sure_historical_state_is_not_cleared_on_dump() {
         .await
         .unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let ser_state = api.serialized_state(true).await.unwrap();
     foundry_common::fs::write_json_file(&state_file, &ser_state).unwrap();
@@ -375,7 +375,7 @@ async fn can_preserve_historical_states_between_dump_and_load() {
 
     let change_greeting_blk_num = tx.block_number.unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let ser_state = api.serialized_state(true).await.unwrap();
     foundry_common::fs::write_json_file(&state_file, &ser_state).unwrap();
@@ -502,7 +502,7 @@ async fn test_fork_load_state_keeps_number_opcode_in_sync() {
 
     // Runtime code: NUMBER, PUSH0, SSTORE, STOP.
     api.anvil_set_code(target, bytes!("435f5500")).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let serialized_state = api.serialized_state(false).await.unwrap();
 
@@ -543,7 +543,7 @@ async fn test_fork_load_state_with_greater_state_block() {
     )
     .await;
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block_number = api.block_number().unwrap();
 
@@ -1042,8 +1042,8 @@ async fn blockhash_opcode_consistent_after_load_state() {
     let state_file = tmp.path().join("state.json");
 
     let (api, _handle) = spawn(NodeConfig::test()).await;
-    api.mine_one().await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
 
     let block1_hash = api
         .block_by_number(alloy_eips::BlockNumberOrTag::Number(1))
@@ -1079,8 +1079,8 @@ async fn blockhash_opcode_consistent_after_load_state() {
 async fn blockhash_opcode_consistent_after_loading_older_state() {
     let (source_api, _source_handle) =
         spawn(NodeConfig::test().with_genesis_timestamp(Some(1_000_000_u64))).await;
-    source_api.mine_one().await;
-    source_api.mine_one().await;
+    source_api.mine_one().await.unwrap();
+    source_api.mine_one().await.unwrap();
 
     let block1_hash = source_api
         .block_by_number(alloy_eips::BlockNumberOrTag::Number(1))

--- a/crates/anvil/tests/it/tempo.rs
+++ b/crates/anvil/tests/it/tempo.rs
@@ -175,7 +175,7 @@ fn anvil_binary() -> PathBuf {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_get_tempo_header_by_number() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let provider = handle.http_provider();
     for number in ["0x1", "pending"] {
@@ -195,7 +195,7 @@ async fn tempo_new_heads_subscription_returns_full_header() {
     let subscription = provider.subscribe_blocks().await.unwrap();
     let mut blocks = subscription.into_stream();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let header = blocks.next().await.unwrap();
     assert_tempo_header_fields(&header);
 
@@ -207,8 +207,8 @@ async fn tempo_new_heads_subscription_returns_full_header() {
 #[tokio::test(flavor = "multi_thread")]
 async fn tempo_rpc_block_hashes_match_canonical_headers() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
-    api.mine_one().await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
+    api.mine_one().await.unwrap();
 
     let provider = handle.http_provider();
     let mut parent_hash = None;
@@ -243,7 +243,7 @@ async fn tempo_rpc_block_hashes_match_canonical_headers() {
 #[tokio::test(flavor = "multi_thread")]
 async fn tempo_rpc_projects_legacy_ethereum_headers() {
     let (source_api, _source_handle) = spawn(NodeConfig::test()).await;
-    source_api.mine_one().await;
+    source_api.mine_one().await.unwrap();
     let state = source_api.serialized_state(false).await.unwrap();
 
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
@@ -260,7 +260,7 @@ async fn tempo_rpc_projects_legacy_ethereum_headers() {
     assert_eq!(header.hash, legacy_hash);
     assert_ne!(header.as_ref().hash_slow(), legacy_hash);
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let child: TempoHeaderResponse =
         provider.client().request("eth_getHeaderByNumber", ("0x2",)).await.unwrap();
     assert_eq!(child.parent_hash(), legacy_hash);
@@ -270,7 +270,7 @@ async fn tempo_rpc_projects_legacy_ethereum_headers() {
 #[tokio::test(flavor = "multi_thread")]
 async fn tempo_raw_header_and_block_use_tempo_rlp() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let provider = handle.http_provider();
     let header: TempoHeaderResponse =
@@ -313,7 +313,7 @@ async fn test_tempo_fork_detects_hardfork_from_fork_timestamp() {
     let node_info = api.anvil_node_info().await.unwrap();
     assert_eq!(node_info.hard_fork, "T3");
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_block = handle
         .http_provider()
         .get_block_by_number(BlockNumberOrTag::Latest)
@@ -335,7 +335,7 @@ async fn test_tempo_reset_to_fork_uses_fee_manager_beneficiary() {
     .await
     .unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_block = handle
         .http_provider()
         .get_block_by_number(BlockNumberOrTag::Latest)
@@ -359,7 +359,7 @@ async fn test_tempo_reset_to_fork_preserves_explicit_coinbase() {
     .await
     .unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_block = handle
         .http_provider()
         .get_block_by_number(BlockNumberOrTag::Latest)
@@ -380,7 +380,7 @@ async fn test_tempo_fork_with_default_genesis_uses_fee_manager_beneficiary() {
     )
     .await;
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_block = handle
         .http_provider()
         .get_block_by_number(BlockNumberOrTag::Latest)
@@ -403,7 +403,7 @@ async fn test_tempo_fork_with_loaded_zero_beneficiary_state_uses_fee_manager_ben
     )
     .await;
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_block = handle
         .http_provider()
         .get_block_by_number(BlockNumberOrTag::Latest)
@@ -424,7 +424,7 @@ async fn test_tempo_fork_runtime_load_state_uses_fee_manager_beneficiary() {
 
     api.anvil_load_state(Bytes::from(serde_json::to_vec(&state).unwrap())).await.unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let latest_block = handle
         .http_provider()
         .get_block_by_number(BlockNumberOrTag::Latest)
@@ -437,7 +437,7 @@ async fn test_tempo_fork_runtime_load_state_uses_fee_manager_beneficiary() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tempo_fork_forwards_request_extensions() {
     let (source_api, source_handle) = spawn(NodeConfig::test_tempo()).await;
-    source_api.mine_one().await;
+    source_api.mine_one().await.unwrap();
     let source_provider = source_handle.http_provider();
     let from = source_handle.dev_accounts().next().unwrap();
     let recipient = Address::random();
@@ -491,7 +491,7 @@ async fn test_tempo_fork_forwards_request_extensions() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tempo_fork_executes_request_extensions_locally() {
     let (source_api, source_handle) = spawn(NodeConfig::test_tempo()).await;
-    source_api.mine_one().await;
+    source_api.mine_one().await.unwrap();
     let source_provider = source_handle.http_provider();
     let from = source_handle.dev_accounts().next().unwrap();
     let recipient = Address::random();
@@ -508,7 +508,7 @@ async fn test_tempo_fork_executes_request_extensions_locally() {
     let provider = fork_handle.http_provider();
 
     fork_api.anvil_deal_tip20(from, PATH_USD, balance + U256::from(1)).await.unwrap();
-    fork_api.mine_one().await;
+    fork_api.mine_one().await.unwrap();
     assert_eq!(
         IERC20::new(PATH_USD, &source_provider).balanceOf(from).call().await.unwrap(),
         balance
@@ -3118,7 +3118,7 @@ async fn test_tempo_estimate_gas_with_provisioned_key() {
         .raw_request::<_, B256>("eth_sendTransaction".into(), (authorization_request,))
         .await
         .unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let receipt = provider.get_transaction_receipt(tx_hash).await.unwrap().unwrap();
     assert!(receipt.status());
 
@@ -3640,7 +3640,7 @@ async fn test_tempo_aa_valid_after_future() {
     let pending = provider.send_raw_transaction(&encoded).await.unwrap();
     let tx_hash = *pending.tx_hash();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let receipt = provider.get_transaction_receipt(tx_hash).await.unwrap();
     assert!(receipt.is_none(), "Transaction should not be mined before valid_after");
     let recipient_balance = token.balanceOf(recipient).call().await.unwrap();
@@ -3648,7 +3648,7 @@ async fn test_tempo_aa_valid_after_future() {
 
     // Advance time past valid_after
     api.evm_set_next_block_timestamp(valid_after + 1).unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let receipt = pending.get_receipt().await.unwrap();
     assert!(receipt.status(), "Transaction should succeed after valid_after time");
@@ -3887,7 +3887,7 @@ async fn test_base_fee() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
     let provider = handle.http_provider();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(BlockNumberOrTag::Latest.into()).await.unwrap().unwrap();
 
@@ -4008,7 +4008,7 @@ async fn test_manual_mining() {
 
     let block_before = provider.get_block_number().await.unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block_after = provider.get_block_number().await.unwrap();
     assert_eq!(block_after, block_before + 1);
@@ -4130,7 +4130,7 @@ async fn test_block_has_timestamp() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
     let provider = handle.http_provider();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(1.into()).await.unwrap().unwrap();
     assert!(block.header.timestamp > 0, "Block should have a timestamp");
@@ -4145,13 +4145,13 @@ async fn test_block_timestamp_increases() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
     let provider = handle.http_provider();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let block1 = provider.get_block(1.into()).await.unwrap().unwrap();
 
     let future_timestamp = block1.header.timestamp + 100;
     api.evm_set_next_block_timestamp(future_timestamp).unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let block2 = provider.get_block(2.into()).await.unwrap().unwrap();
 
     assert_eq!(block2.header.timestamp, future_timestamp);
@@ -4167,14 +4167,14 @@ async fn test_block_timestamps_are_monotonic() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
     let provider = handle.http_provider();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let block1 = provider.get_block(BlockNumberOrTag::Latest.into()).await.unwrap().unwrap();
     let timestamp1 = block1.header.timestamp;
 
     let future_timestamp = timestamp1 + 10;
     api.evm_set_next_block_timestamp(future_timestamp).unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let block2 = provider.get_block(BlockNumberOrTag::Latest.into()).await.unwrap().unwrap();
     let timestamp2 = block2.header.timestamp;
 
@@ -4194,7 +4194,7 @@ async fn test_block_gas_limit() {
     let (api, handle) = spawn(NodeConfig::test_tempo()).await;
     let provider = handle.http_provider();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(BlockNumberOrTag::Latest.into()).await.unwrap().unwrap();
 
@@ -4266,7 +4266,7 @@ async fn test_multiple_transactions_in_block() {
     let pending1 = provider.send_transaction(tx1).await.unwrap();
     let pending2 = provider.send_transaction(tx2).await.unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let receipt1 = pending1.get_receipt().await.unwrap();
     let receipt2 = pending2.get_receipt().await.unwrap();
@@ -5658,7 +5658,7 @@ async fn test_tempo_pre_t7_base_fee_stays_fixed() {
     let provider = handle.http_provider();
 
     for _ in 0..5 {
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
     }
 
     let latest = provider.get_block(BlockId::latest()).await.unwrap().unwrap().header.number;
@@ -5680,11 +5680,11 @@ async fn test_tempo_base_fee_survives_reset() {
     let provider = handle.http_provider();
 
     for _ in 0..3 {
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
     }
 
     api.anvil_reset(None).await.unwrap();
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(BlockId::latest()).await.unwrap().unwrap();
     assert_eq!(
@@ -5702,7 +5702,7 @@ async fn test_tempo_t7_base_fee_is_dynamic() {
     let provider = handle.http_provider();
 
     for _ in 0..8 {
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
     }
 
     // The genesis block keeps the 20B seed (matching Tempo's T7 genesis).

--- a/crates/anvil/tests/it/traces.rs
+++ b/crates/anvil/tests/it/traces.rs
@@ -752,7 +752,7 @@ async fn test_debug_trace_call_tx_index() {
         let _ = provider.send_transaction(WithOtherFields::new(tx)).await.unwrap();
     }
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let block_number = provider.get_block_number().await.unwrap();
 
     let get_value = simple_storage_contract.getValue();
@@ -807,7 +807,7 @@ async fn test_debug_trace_transaction_reports_transaction_gas() {
         .await
         .unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let first_receipt = first.get_receipt().await.unwrap();
     let second_receipt = second.get_receipt().await.unwrap();
     assert_eq!(first_receipt.block_hash, second_receipt.block_hash);
@@ -1863,7 +1863,7 @@ async fn test_trace_replay_block_transactions_local() {
     let tx2 = WithOtherFields::new(tx2);
     let pending_tx2 = provider.send_transaction(tx2).await.unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let receipt1 = pending_tx1.get_receipt().await.unwrap();
     let receipt2 = pending_tx2.get_receipt().await.unwrap();
 

--- a/crates/anvil/tests/it/transaction.rs
+++ b/crates/anvil/tests/it/transaction.rs
@@ -139,7 +139,7 @@ async fn can_order_transactions() {
     let tx_higher = provider.send_transaction(tx).await.unwrap();
 
     // manually mine the block with the transactions
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let higher_price = tx_higher.get_receipt().await.unwrap().transaction_hash;
     let lower_price = tx_lower.get_receipt().await.unwrap().transaction_hash;
@@ -223,7 +223,7 @@ async fn can_replace_transaction() {
 
     let higher_tx_hash = *higher_priced_pending_tx.tx_hash();
     // mine exactly one block
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(1.into()).await.unwrap().unwrap();
 
@@ -281,7 +281,7 @@ async fn can_resend_transaction() {
 
     assert_ne!(*original_pending_tx.tx_hash(), replacement_hash);
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let block = provider.get_block(1.into()).await.unwrap().unwrap();
     assert_eq!(BlockTransactions::Hashes(vec![replacement_hash]), block.transactions);
@@ -342,7 +342,7 @@ async fn can_reject_invalid_resend_transaction() {
         underpriced_resend.unwrap_err().to_string().contains("replacement transaction underpriced")
     );
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     pending_tx.get_receipt().await.unwrap();
 }
 
@@ -440,7 +440,7 @@ async fn can_reject_underpriced_replacement() {
     assert!(replacement_err.to_string().contains("replacement transaction underpriced"));
 
     // mine exactly one block
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let higher_priced_receipt = higher_priced_pending_tx.get_receipt().await.unwrap();
 
     // ensure that only the higher priced tx was mined
@@ -585,7 +585,7 @@ async fn can_call_greeter_historic() {
     assert_eq!("Another Message", greeting);
 
     // min
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     // returns previous state
     let greeting =
@@ -857,7 +857,7 @@ async fn can_get_pending_transaction() {
     let pending = provider.get_transaction_by_hash(*tx.tx_hash()).await;
     assert!(pending.is_ok());
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let mined = provider.get_transaction_by_hash(*tx.tx_hash()).await.unwrap().unwrap();
 
     assert_eq!(mined.tx_hash(), pending.unwrap().unwrap().tx_hash());
@@ -908,7 +908,7 @@ async fn can_get_raw_transaction() {
     let res1 = api.raw_transaction(*tx.tx_hash()).await;
     assert!(res1.is_ok());
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let res2 = api.raw_transaction(*tx.tx_hash()).await;
 
     assert_eq!(res1.unwrap(), res2.unwrap());
@@ -933,7 +933,7 @@ async fn can_get_raw_receipts() {
     let first = provider.send_transaction(WithOtherFields::new(first)).await.unwrap();
     let second = provider.send_transaction(WithOtherFields::new(second)).await.unwrap();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let first_receipt = first.get_receipt().await.unwrap();
     let second_receipt = second.get_receipt().await.unwrap();
     assert_eq!(first_receipt.block_number, Some(1));
@@ -986,7 +986,7 @@ async fn can_get_raw_transactions() {
     let first_hash = *first.tx_hash();
     let second_hash = *second.tx_hash();
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let first_receipt = first.get_receipt().await.unwrap();
     let second_receipt = second.get_receipt().await.unwrap();
     assert_eq!(first_receipt.block_number, Some(1));
@@ -1142,7 +1142,7 @@ async fn includes_pending_tx_for_transaction_count() {
         assert_eq!(nonce, idx);
     }
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
     let nonce = provider.get_transaction_count(from).block_id(BlockId::pending()).await.unwrap();
     assert_eq!(nonce, tx_count);
 }
@@ -1824,7 +1824,7 @@ async fn can_get_tx_by_sender_and_nonce() {
     }
 
     // mine all transactions
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     for nonce in 0..4 {
         let result: Option<alloy_network::AnyRpcTransaction> = provider
@@ -1877,7 +1877,7 @@ async fn can_get_tx_by_sender_and_nonce() {
     assert_eq!(found_tx.inner.nonce(), 4);
     assert_eq!(found_tx.inner.tx_hash(), *pending_tx.tx_hash());
 
-    api.mine_one().await;
+    api.mine_one().await.unwrap();
 
     let result: Option<alloy_network::AnyRpcTransaction> = provider
         .client()

--- a/crates/script/src/receipts.rs
+++ b/crates/script/src/receipts.rs
@@ -475,7 +475,7 @@ mod tests {
 
         let pending = signer_provider.send_transaction(tx).await.unwrap();
         let tx_hash = *pending.tx_hash();
-        api.mine_one().await;
+        api.mine_one().await.unwrap();
 
         let provider = signer_provider.root().clone();
         let mut watcher =


### PR DESCRIPTION
## Description

Closes OSS-601

Anvil previously executed ordinary mining directly against live state and assumed block finalization could not fail. A failing Prague system transition or malformed deposit request could therefore partially apply state while producing no valid block, consume one-shot timestamp or prevrandao controls, and cause manual mining RPCs to report success.

This executes complete candidates against an isolated database overlay and publishes state, block metadata, history, fees, notifications, pool changes, and time controls only after finalization succeeds. Mining errors now propagate through the manual RPC paths. Background mining retains the live pool while discarding stale candidate selections, and generation checks prevent a failed candidate from modifying newer miner modes, timestamp overrides, prevrandao overrides, or concurrent time resets.

The regression coverage exercises both post-block failure modes, verifies state and metadata rollback against a clean node, checks all manual mining RPCs and one-shot controls, and covers fresh pool reselection plus fixed and mixed mining recovery.