### PR TITLE
chore(deps): bump revm to v42

### DIFF
--- a/.changelog/bump-revm-42.md
+++ b/.changelog/bump-revm-42.md
@@ -1,0 +1,7 @@
+---
+cast: patch
+anvil: patch
+forge: patch
+---
+
+Updated Foundry's Tempo integration to revm 42.

--- a/.changelog/bump-revm-42.md
+++ b/.changelog/bump-revm-42.md
@@ -4,4 +4,4 @@ anvil: patch
 forge: patch
 ---
 
-Updated Foundry's Tempo integration to revm 42.
+Updated Foundry's Ethereum, Optimism, and Tempo EVM integrations to revm 42, including Amsterdam state-gas accounting and the latest hardfork mappings.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -77,9 +77,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdf7932042b511ad4ad67f7eeac896df62439ac91a8c516d678b79cbe3f9c27"
+checksum = "6c8d8a7d7e896331d13d94cd50779a843d3fb3d8b0389826e43638f6276bc4b3"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
+checksum = "51b9eb70841f76b69b1205bb57b551b7d7afd8407ad57cbda02e833877507c16"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
+checksum = "f89486e1bd2c5c56522cf18e73460c3fe7b54d50f5e80131466e62b7632edfcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69937abc65310c6eb739e540b107688943b61f38e7dcf9fde769367d3608d657"
+checksum = "b4c0dadb2468adc8aaaaad4c9a6cfa6bd055fe6596c40017067b37671f2c45f5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -236,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip5792"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac64bba0a9cd7653a893912dc8a2bd3e0d9954a17f279fb4bf316ef8e39d9025"
+checksum = "521961e45f3198ece43ab862b5096352a29713779e30cb44a6e0e06d0c001b99"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -262,20 +262,6 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "borsh",
- "once_cell",
- "serde",
- "thiserror 2.0.19",
-]
-
-[[package]]
-name = "alloy-eip7928"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
@@ -290,14 +276,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
+checksum = "fddc9c1868d6331b56926de8ab4c4a80d8dcb7bc4f8f7bebc6a89d0548f79af2"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
@@ -315,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
+checksum = "3fe3f812d024acd2a612aea20629130cd59595064f1420953e6e20c84165def9"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -329,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acde665074b478c97047dc2a461b4916cac77922d690e5b7415d1941ae7ff7bf"
+checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -342,16 +328,16 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "revm",
+ "revm 42.0.1",
  "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
+checksum = "921b3dccecc4e9dd571c9f9a728d913c2fc7a8ecdfce6005ed99751817523d0d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -390,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
+checksum = "989d701ece9bccec3294991ce4b4a39dd1cecd0979ea58e86b9878679591b4f5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -405,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ff1439d901b44f6ff840545f82d65e66830ee33fb33cae495a566d66e0ccc8"
+checksum = "acfca49fbbe3b30de8114b9cfd89029f87cb33ca7e8a5f5f48a809caaf085126"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -431,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
+checksum = "2af7b76520abc91b9e0f1aa987d42df55a66494f94a1881cdadd9b8f67e0b924"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -445,17 +431,17 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
+source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.5.0",
  "alloy-primitives",
  "auto_impl",
  "op-alloy",
- "op-revm",
- "revm",
+ "op-revm 20.0.0 (git+https://github.com/foundry-rs/optimism?branch=develop)",
+ "revm 42.0.1",
  "thiserror 2.0.19",
 ]
 
@@ -472,6 +458,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-op-hardforks"
+version = "0.5.0"
+source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+dependencies = [
+ "alloy-chains",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "auto_impl",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,7 +481,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "fixed-cache",
- "foldhash",
+ "foldhash 0.2.0",
  "getrandom 0.4.3",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -505,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329375f50202cc6b2dcc8c6b1e53b716cbbebbeea54e931befc4f3b628dfc469"
+checksum = "3a3fb53b31526b0f97cdbfaf9d8bb72b3e4a9ac7965148d79ecec4c733c8558e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -550,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71044e076a7c243454619e36279fc4654bc1ff846fbf666663ef574388859c84"
+checksum = "197325ef17fcdf5dfa21999a2a33877b82bb5009d5cc9b5c7f5ddb840fa3b6bb"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -594,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bffef2c5714f578f267bb959b47908b95728f1f3e2073a96d928f4441c148d"
+checksum = "f5274f9ada7f558d2feaba16fadcb96022512566cf424147f9cfa2000bc2e458"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -620,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64449cae1cf37c4907b10ccca1613b71809f9a1f3ad6e2b4cc14d08e2e4947f"
+checksum = "12a456d697d4f639d20ac242981de13b94f911c99199e4175e85eaf52b8f785c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -636,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261411a259d346a69078237e2997a7ce0faba006baf5b1937023316d5ef07bf4"
+checksum = "7d7e911c628067c406effef5137d0e253d98e117cdb81d47aacfe2816199297e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -648,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe7fa70c3af4b2de7f670b50d680700e0f979ce3a0ab7725958b51ffc3b16c2"
+checksum = "5493c88bfdd02271de47f28d69481191a2af6b2907901a3a8c7aff79a6b574eb"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -663,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22759d1d0e79082a5a06f75dc45bf55dfedbb4ac9890da1f179d85a5d2f32f7"
+checksum = "b8573342cde98a4d40120b7bc0063fbda42cfd87fb305ab834704177b60d8691"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -679,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b918cbaadbdcffa4ed64840a5ecbde80a6476ab23adc8c5c8ae6feec081058c"
+checksum = "bddf06191e2b12eaaeb3a50ef29a8f3416fb74c61421b80f9d7554c4c1d59a56"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -692,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30ff2e8f7d05433c1d36cf0f1ba045bf071a3d139f63923742fbdfb171dfe44"
+checksum = "866fa880cfd95681c979bf3f8385964c2317ef7423c31c0de53159f01112fedf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -712,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
+checksum = "9d3b805bb9cafaf1362c28b377e2035e49fc5ae0a5ee3ea61bafd9a5d33959e1"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -733,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04a8f30a439c995d71ab999d56a828dcbe4d90b4f012419832779e60acf86af"
+checksum = "2b973745b97a364c0215f681b2fb3cb6f0bbeda4dcdba5f56c50f999719ec96f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -748,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12cafc0ee2290122ec4e069bb0f2389a356f4b5414f2e82de8288049c2bc98a"
+checksum = "2a6fae28f1bda2586b117a5754b49366160770e63e09ac93fc3d872015a5a993"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -762,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157eec8f8661e6e70e3749c0a4d918a8831f0b0fc152aed60c0de457faca420b"
+checksum = "4962825b8819e54028cbdaadeba128a613afa55c91b9a88e0b0dc257772a14d7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -774,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
+checksum = "3ad7efdd5e8fe92f5bab87956d6d3f717d1614c4ab6ad0d1f869b16e83b0dff9"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -785,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc43a73bc1bf7044898e1b0dcefaba45d0cfac3e379bb5ca29cc3e3a04c61451"
+checksum = "afa150cd076471ef21aa7b181d8186cb86c3239518859a2e5d80fbec74f0ec38"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives",
@@ -802,9 +799,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1a457df25c6f8cec9cf3fd15db7864780c19c24e372cd4fff66e2bf1cff1c8"
+checksum = "c621822c9971a3d895bbd5620dca425ca78ce3345b60ae8268a89f1faa35cd8a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -821,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d9d231dc021653db081a6ec8f2c84f06d7b61c9585a437ab3febe9b7f33f35"
+checksum = "e774bb2e422fb7a1d07618273fe62ea3665c6cba800979cffa7a5a162f2cd69e"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -839,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32c516c9f3153b83cb6b006b5ff26a651dc2868fef970b62b70f61b63c6701c"
+checksum = "61301531ee6aacbb242b9f7daca4bc6cf6529f21498e9f6aeecae7ea15afca4b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -859,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372ff9be2b61c2cd6d33cfcef9bd5865962c0628c932767f5154443aba2c9746"
+checksum = "f125bb730d4772538835d4a31e8e5ed5068e2a991619ba32711fd53ad8c93032"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -879,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-trezor"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f109f645c0ee244e76e4470c1eeedbca39dc082d17b4950d9c4b1735dee44142"
+checksum = "b4c5f7e7e14e6d22ba836739c0dd2573d1aea1512275e0caf597ba03e8d62e43"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -896,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-turnkey"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a2b89298ef96b1682c8698cc11269549c1e125163b35140ebca7b124edb772"
+checksum = "ab3fb2b858a66b4ea0df01976b8c5da6b220bf15ad02775d65e9aabf8161724a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -985,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
+checksum = "3cd5dbd32cae5d1bc3afaf455064ebd9bcce70b57de220468908717c225225dd"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -1008,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ecd298fb0e6a31bd90c72efba2728e3d7569f1c89a3719576fb0e4e40b0fc8"
+checksum = "f0b7b1f0e528ae788d05937f5b351afae3b4c1e08f17a061d868bd28e56aa9e3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1024,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b51470da19d0ed256bb3cf31042cceca3ce01714a9ca76624fc71a999f6a27"
+checksum = "b964b4c048eea647a701a6af07307c64995c4abd42d46ba0b3be9593ae3c333c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1069,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67177a75a6e8a44f39ccbbc64a3e3a70186ef401d7313285b56735d4285aa34"
+checksum = "efecf9efc5d56276e115b13b36ff27311b8cd6f72affc9788a10ff46b55b2616"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1080,7 +1077,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite 0.29.0",
  "tracing",
  "url",
  "ws_stream_wasm",
@@ -1104,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
+checksum = "b3e2386593cef5b12c7d439dbcf62d7d51c3a50dc943909b42ae34b48f1b69dc"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1276,21 +1273,21 @@ dependencies = [
  "itertools 0.15.0",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
- "op-revm",
+ "op-revm 20.0.0 (git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab)",
  "parking_lot",
  "rand 0.8.7",
  "rand 0.9.5",
  "reqwest 0.13.4",
- "revm",
+ "revm 42.0.1",
  "revm-inspectors",
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-evm",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -1318,7 +1315,7 @@ dependencies = [
  "foundry-evm",
  "foundry-primitives",
  "rand 0.9.5",
- "revm",
+ "revm 42.0.1",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -1398,10 +1395,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -1410,10 +1419,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
- "ark-r1cs-std",
+ "ark-r1cs-std 0.5.0",
  "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-r1cs-std 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -1424,13 +1445,34 @@ checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
- "ark-poly",
+ "ark-poly 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1619,16 +1661,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "ark-r1cs-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
- "ark-relations",
+ "ark-relations 0.5.1",
  "ark-std 0.5.0",
  "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-relations 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1645,6 +1720,22 @@ dependencies = [
  "ark-std 0.5.0",
  "tracing",
  "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
+dependencies = [
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "foldhash 0.1.5",
+ "indexmap 2.14.0",
+ "tracing",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -2399,9 +2490,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64-simd"
@@ -2970,16 +3061,16 @@ dependencies = [
  "rand 0.9.5",
  "rayon",
  "regex",
- "revm",
+ "revm 42.0.1",
  "rpassword",
  "semver 1.0.28",
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-contracts",
- "tempo-hardfork",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tokio",
  "tower",
  "tracing",
@@ -3314,7 +3405,7 @@ dependencies = [
  "const-hex",
  "digest 0.10.7",
  "generic-array",
- "ripemd",
+ "ripemd 0.1.3",
  "serde",
  "sha2 0.10.9",
  "sha3 0.10.9",
@@ -4170,6 +4261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,6 +4299,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4220,6 +4334,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,9 +4361,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "defmt"
@@ -5025,6 +5150,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -5091,7 +5222,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest 0.13.4",
- "revm",
+ "revm 42.0.1",
  "rexpect",
  "semver 1.0.28",
  "serde",
@@ -5103,7 +5234,7 @@ dependencies = [
  "soldeer-core",
  "svm-rs",
  "tempfile",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "thiserror 2.0.19",
  "tokio",
  "toml_edit",
@@ -5205,8 +5336,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5270,7 +5401,7 @@ dependencies = [
  "itertools 0.15.0",
  "regex",
  "reqwest 0.13.4",
- "revm",
+ "revm 42.0.1",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -5346,7 +5477,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
- "base64 0.23.0",
+ "base64 0.23.1",
  "dialoguer",
  "ecdsa",
  "ed25519-consensus",
@@ -5368,17 +5499,17 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.5",
- "revm",
+ "revm 42.0.1",
  "revm-inspectors",
  "semver 1.0.28",
  "serde",
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts",
- "tempo-hardfork",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "thiserror 2.0.19",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
@@ -5438,7 +5569,7 @@ dependencies = [
  "solar-compiler",
  "strsim",
  "tempfile",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tikv-jemallocator",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
@@ -5484,7 +5615,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "axum",
- "base64 0.23.0",
+ "base64 0.23.1",
  "chrono",
  "ciborium",
  "clap",
@@ -5508,15 +5639,15 @@ dependencies = [
  "path-slash",
  "regex",
  "reqwest 0.13.4",
- "revm",
+ "revm 42.0.1",
  "semver 1.0.28",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "solar-compiler",
  "tempfile",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "thiserror 2.0.19",
  "tokio",
  "tower",
@@ -5544,11 +5675,11 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "proptest",
- "revm",
+ "revm 42.0.1",
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "yansi",
 ]
 
@@ -5703,7 +5834,7 @@ dependencies = [
  "foundry-evm-traces",
  "foundry-tui",
  "ratatui",
- "revm",
+ "revm 42.0.1",
  "revm-inspectors",
  "serde",
  "tracing",
@@ -5737,12 +5868,12 @@ dependencies = [
  "proptest",
  "rand 0.9.5",
  "rayon",
- "revm",
+ "revm 42.0.1",
  "revm-inspectors",
  "serde",
  "serde_json",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5799,18 +5930,18 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types",
- "op-revm",
+ "op-revm 20.0.0 (git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab)",
  "parking_lot",
- "revm",
+ "revm 42.0.1",
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-contracts",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-evm",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -5828,7 +5959,7 @@ dependencies = [
  "foundry-compilers",
  "foundry-evm-core",
  "rayon",
- "revm",
+ "revm 42.0.1",
  "semver 1.0.28",
  "solar-compiler",
  "tracing",
@@ -5852,7 +5983,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.5",
- "revm",
+ "revm 42.0.1",
  "serde",
  "solar-compiler",
  "thiserror 2.0.19",
@@ -5865,13 +5996,13 @@ version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.4.7",
  "alloy-rpc-types",
  "foundry-compilers",
- "op-revm",
- "revm",
+ "op-revm 20.0.0 (git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab)",
+ "revm 42.0.1",
  "serde",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
 ]
 
 [[package]]
@@ -5881,14 +6012,14 @@ dependencies = [
  "alloy-chains",
  "alloy-eips",
  "alloy-evm",
- "alloy-op-hardforks",
+ "alloy-op-hardforks 0.4.7",
  "alloy-primitives",
  "clap",
  "foundry-evm-hardforks",
- "revm",
+ "revm 42.0.1",
  "serde",
  "serde_json",
- "tempo-contracts",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
 ]
 
 [[package]]
@@ -5905,7 +6036,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "alloy-sol-types",
- "base64 0.23.0",
+ "base64 0.23.1",
  "foundry-cheatcodes-spec",
  "foundry-common",
  "foundry-config",
@@ -5942,7 +6073,7 @@ dependencies = [
  "memchr",
  "rayon",
  "reqwest 0.13.4",
- "revm",
+ "revm 42.0.1",
  "revm-inspectors",
  "ron",
  "serde",
@@ -5950,7 +6081,7 @@ dependencies = [
  "snapbox",
  "solar-compiler",
  "tempfile",
- "tempo-contracts",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -5969,7 +6100,7 @@ dependencies = [
  "eyre",
  "futures",
  "parking_lot",
- "revm",
+ "revm 41.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -6018,12 +6149,12 @@ dependencies = [
  "derive_more",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
- "op-revm",
- "revm",
+ "op-revm 20.0.0 (git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab)",
+ "revm 42.0.1",
  "serde",
  "serde_json",
- "tempo-alloy",
- "tempo-primitives",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-revm",
 ]
 
@@ -6094,7 +6225,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -6381,9 +6512,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "globset"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -6485,7 +6616,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -6496,7 +6627,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
@@ -6896,9 +7027,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -7054,15 +7185,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7383,9 +7514,9 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -7468,9 +7599,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -7535,9 +7666,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -7770,7 +7901,7 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2 0.11.0",
  "subtle",
- "tempo-alloy",
+ "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -8178,8 +8309,8 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "op-alloy"
-version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
+version = "2.0.0"
+source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -8190,8 +8321,8 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
+version = "2.0.0"
+source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8202,8 +8333,8 @@ dependencies = [
  "alloy-serde",
  "bytes",
  "derive_more",
- "reth-codecs 0.2.0",
- "reth-zstd-compressors 0.2.0",
+ "reth-codecs 0.5.2",
+ "reth-zstd-compressors 0.5.2",
  "serde",
  "serde_with",
  "thiserror 2.0.19",
@@ -8217,8 +8348,8 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-alloy-network"
-version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
+version = "2.0.0"
+source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8230,8 +8361,8 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-provider"
-version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
+version = "2.0.0"
+source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8244,8 +8375,8 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
+version = "2.0.0"
+source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8264,8 +8395,8 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.24.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
+version = "2.0.0"
+source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8273,7 +8404,6 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-serde",
- "derive_more",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "op-alloy-consensus",
@@ -8286,11 +8416,21 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "20.0.0"
-source = "git+https://github.com/foundry-rs/op-revm?rev=c10fd76e66fd46cebc08ba370aa58bde72b94140#c10fd76e66fd46cebc08ba370aa58bde72b94140"
+source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "auto_impl",
- "revm",
+ "op-alloy-consensus",
+ "revm 42.0.1",
  "serde",
+]
+
+[[package]]
+name = "op-revm"
+version = "20.0.0"
+source = "git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab#dca56351469222d8eae9185b6c19ac14f6c0d0ab"
+dependencies = [
+ "auto_impl",
+ "revm 42.0.1",
 ]
 
 [[package]]
@@ -8644,7 +8784,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -8655,7 +8795,9 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
+ "phf_macros 0.14.0",
  "phf_shared 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -8689,6 +8831,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.14.0",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8696,6 +8848,19 @@ checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator 0.13.1",
  "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9441,7 +9606,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.1",
+ "lru 0.18.2",
  "palette",
  "serde",
  "strum 0.28.0",
@@ -9601,9 +9766,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -9722,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9735,27 +9900,8 @@ dependencies = [
  "derive_more",
  "reth-ethereum-forks",
  "reth-network-peers",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
  "serde_json",
-]
-
-[[package]]
-name = "reth-codecs"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29541038ab108b2e9d527c66b565e717e252e4eef6675377fc21f9ba587f792"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "parity-scale-codec",
- "reth-codecs-derive 0.2.0",
- "reth-zstd-compressors 0.2.0",
- "serde",
 ]
 
 [[package]]
@@ -9778,14 +9924,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-codecs-derive"
-version = "0.2.0"
+name = "reth-codecs"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5646d4aff98bd51050fc920bc3ffdff209f2343def9ed31b56eea13c4245c4da"
+checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-trie",
+ "bytes",
+ "modular-bitfield",
+ "parity-scale-codec",
+ "reth-codecs-derive 0.6.0",
+ "reth-zstd-compressors 0.6.0",
+ "serde",
 ]
 
 [[package]]
@@ -9800,49 +9954,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-codecs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928",
  "alloy-primitives",
  "auto_impl",
  "reth-execution-types",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "reth-chainspec",
  "reth-consensus",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
 ]
 
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "bytes",
- "reth-codecs 0.5.2",
- "reth-primitives-traits 0.5.2",
+ "reth-codecs 0.6.0",
+ "reth-primitives-traits 0.6.0",
  "serde",
 ]
 
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9851,14 +10016,14 @@ dependencies = [
  "reth-consensus",
  "reth-consensus-common",
  "reth-execution-types",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
  "tracing",
 ]
 
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9871,24 +10036,24 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "reth-codecs 0.5.2",
- "reth-primitives-traits 0.5.2",
+ "reth-codecs 0.6.0",
+ "reth-primitives-traits 0.6.0",
  "serde",
 ]
 
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-evm",
  "alloy-primitives",
@@ -9899,17 +10064,17 @@ dependencies = [
  "rayon",
  "reth-execution-errors",
  "reth-execution-types",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm",
+ "revm 42.0.1",
 ]
 
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9921,15 +10086,15 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-evm",
  "reth-execution-types",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
  "reth-storage-errors",
- "revm",
+ "revm 42.0.1",
 ]
 
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9942,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9951,9 +10116,9 @@ dependencies = [
  "alloy-rlp",
  "derive_more",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
  "reth-trie-common",
- "revm",
+ "revm 42.0.1",
  "serde",
  "serde_with",
 ]
@@ -9961,7 +10126,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9969,31 +10134,6 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.19",
  "url",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96ffdb2ce0cdcd814d39428dc1e9b660c85d85e0b75eb465a1ed0943a48c7bd"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "bytes",
- "derive_more",
- "once_cell",
- "quanta",
- "revm-bytecode 9.0.0",
- "revm-primitives 22.1.0",
- "revm-state 10.0.0",
- "secp256k1 0.30.0",
- "serde",
- "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -10010,11 +10150,8 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-trie",
  "bytes",
- "dashmap",
  "derive_more",
  "once_cell",
- "quanta",
- "reth-codecs 0.5.2",
  "revm-bytecode 41.0.0",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
@@ -10024,13 +10161,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-primitives-traits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-rpc-types-eth",
+ "alloy-trie",
+ "bytes",
+ "dashmap",
+ "derive_more",
+ "once_cell",
+ "quanta",
+ "reth-codecs 0.6.0",
+ "revm-bytecode 42.0.0",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
+ "secp256k1 0.30.0",
+ "serde",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-primitives",
  "derive_more",
- "reth-codecs 0.5.2",
+ "reth-codecs 0.6.0",
  "serde",
  "strum 0.27.2",
  "thiserror 2.0.19",
@@ -10040,39 +10204,39 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
  "reth-storage-api",
  "reth-storage-errors",
- "revm",
+ "revm 42.0.1",
 ]
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.2.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c870f120b2e179e44906b7b288b0dea6577573010272adda8fff536e86fedd05"
+checksum = "ace77dbcdd59c014fda4565ebfec76cd1fe6f5d98584b4655e8d22a947b9eee3"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-signer",
- "reth-primitives-traits 0.2.0",
+ "reth-primitives-traits 0.5.2",
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-primitives",
  "bytes",
- "reth-codecs 0.5.2",
+ "reth-codecs 0.6.0",
  "reth-trie-common",
  "serde",
 ]
@@ -10080,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -10094,10 +10258,10 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-consensus",
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -10106,37 +10270,37 @@ dependencies = [
  "reth-db-models",
  "reth-ethereum-primitives",
  "reth-execution-types",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
  "reth-prune-types",
  "reth-stages-types",
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm",
+ "revm 42.0.1",
  "serde_json",
 ]
 
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "derive_more",
- "reth-codecs 0.5.2",
- "reth-primitives-traits 0.5.2",
+ "reth-codecs 0.6.0",
+ "reth-primitives-traits 0.6.0",
  "reth-prune-types",
  "reth-static-file-types",
- "revm",
+ "revm 42.0.1",
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -10146,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10159,20 +10323,11 @@ dependencies = [
  "derive_more",
  "itertools 0.14.0",
  "nybbles",
- "reth-codecs 0.5.2",
- "reth-primitives-traits 0.5.2",
- "revm",
+ "reth-codecs 0.6.0",
+ "reth-primitives-traits 0.6.0",
+ "revm 42.0.1",
  "serde",
  "serde_with",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3882441cf1d51fe24dfc6df9919e6f17edfdb6b121050bd34348e925e61c7af1"
-dependencies = [
- "zstd",
 ]
 
 [[package]]
@@ -10185,34 +10340,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-zstd-compressors"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
+dependencies = [
+ "zstd",
+]
+
+[[package]]
 name = "revm"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
 dependencies = [
  "revm-bytecode 41.0.0",
- "revm-context",
- "revm-context-interface",
- "revm-database",
- "revm-database-interface",
- "revm-handler",
- "revm-inspector",
- "revm-interpreter",
- "revm-precompile",
+ "revm-context 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-database 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-handler 41.0.0",
+ "revm-inspector 41.0.0",
+ "revm-interpreter 41.0.0",
+ "revm-precompile 41.0.0",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
 ]
 
 [[package]]
-name = "revm-bytecode"
-version = "9.0.0"
+name = "revm"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86e468df3cf5cf59fa7ef71a3e9ccabb76bb336401ea2c0674f563104cf3c5e"
+checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
- "bitvec",
- "phf 0.13.1",
- "revm-primitives 22.1.0",
- "serde",
+ "revm-bytecode 42.0.0",
+ "revm-context 42.0.0",
+ "revm-context-interface 42.0.0",
+ "revm-database 42.0.0",
+ "revm-database-interface 42.0.0",
+ "revm-handler 42.0.1",
+ "revm-inspector 42.0.1",
+ "revm-interpreter 42.0.0",
+ "revm-precompile 42.0.1",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
 ]
 
 [[package]]
@@ -10222,9 +10393,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
 dependencies = [
  "bitvec",
- "paste",
  "phf 0.13.1",
  "revm-primitives 41.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
+dependencies = [
+ "bitvec",
+ "paste",
+ "phf 0.14.0",
+ "revm-primitives 42.0.0",
  "serde",
 ]
 
@@ -10238,10 +10421,27 @@ dependencies = [
  "cfg-if",
  "derive-where",
  "revm-bytecode 41.0.0",
- "revm-context-interface",
- "revm-database-interface",
+ "revm-context-interface 41.0.0",
+ "revm-database-interface 41.0.0",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode 42.0.0",
+ "revm-context-interface 42.0.0",
+ "revm-database-interface 42.0.0",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
  "serde",
 ]
 
@@ -10255,9 +10455,25 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface",
+ "revm-database-interface 41.0.0",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface 42.0.0",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
  "serde",
 ]
 
@@ -10271,9 +10487,25 @@ dependencies = [
  "derive_more",
  "either",
  "revm-bytecode 41.0.0",
- "revm-database-interface",
+ "revm-database-interface 41.0.0",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
+dependencies = [
+ "alloy-eips",
+ "derive_more",
+ "either",
+ "revm-bytecode 42.0.0",
+ "revm-database-interface 42.0.0",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
  "serde",
 ]
 
@@ -10292,6 +10524,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-database-interface"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
+ "serde",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "revm-handler"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10300,13 +10546,32 @@ dependencies = [
  "auto_impl",
  "derive-where",
  "revm-bytecode 41.0.0",
- "revm-context",
- "revm-context-interface",
- "revm-database-interface",
- "revm-interpreter",
- "revm-precompile",
+ "revm-context 41.0.0",
+ "revm-context-interface 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-interpreter 41.0.0",
+ "revm-precompile 41.0.0",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-handler"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode 42.0.0",
+ "revm-context 42.0.0",
+ "revm-context-interface 42.0.0",
+ "revm-database-interface 42.0.0",
+ "revm-interpreter 42.0.0",
+ "revm-precompile 42.0.1",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
  "serde",
 ]
 
@@ -10318,10 +10583,10 @@ checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context",
- "revm-database-interface",
- "revm-handler",
- "revm-interpreter",
+ "revm-context 41.0.0",
+ "revm-database-interface 41.0.0",
+ "revm-handler 41.0.0",
+ "revm-interpreter 41.0.0",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
  "serde",
@@ -10329,10 +10594,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-inspectors"
-version = "0.41.2"
+name = "revm-inspector"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e22e1aa328f78e8c3dea6a3a860a3a3c3a77c4a7e775e3fdd3dcbb24a152ac"
+checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context 42.0.0",
+ "revm-database-interface 42.0.0",
+ "revm-handler 42.0.1",
+ "revm-interpreter 42.0.0",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-inspectors"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3958b5de5c2c08c6a49b8d94f6ead3e9cd7980c43d6ed240aa3d6485d53269b5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -10342,7 +10625,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm",
+ "revm 42.0.1",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -10355,9 +10638,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
 dependencies = [
  "revm-bytecode 41.0.0",
- "revm-context-interface",
+ "revm-context-interface 41.0.0",
  "revm-primitives 41.0.0",
  "revm-state 41.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
+dependencies = [
+ "revm-bytecode 42.0.0",
+ "revm-context-interface 42.0.0",
+ "revm-primitives 42.0.0",
+ "revm-state 42.0.0",
  "serde",
 ]
 
@@ -10367,9 +10663,9 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
 dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
+ "ark-bls12-381 0.5.0",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "arrayref",
@@ -10379,23 +10675,36 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface",
+ "revm-context-interface 41.0.0",
  "revm-primitives 41.0.0",
- "ripemd",
+ "ripemd 0.1.3",
  "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
 
 [[package]]
-name = "revm-primitives"
-version = "22.1.0"
+name = "revm-precompile"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfb5ce6cf18b118932bcdb7da05cd9c250f2cb9f64131396b55f3fe3537c35"
+checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
 dependencies = [
- "alloy-primitives",
- "num_enum",
- "once_cell",
- "serde",
+ "ark-bls12-381 0.6.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-context-interface 42.0.0",
+ "revm-primitives 42.0.0",
+ "ripemd 0.2.0",
+ "secp256k1 0.31.1",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -10410,15 +10719,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "revm-state"
-version = "10.0.0"
+name = "revm-primitives"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29404707763da607e5d6e4771cb203998c28159279c2f64cc32de08d2814651"
+checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
 dependencies = [
- "alloy-eip7928 0.3.7",
- "bitflags 2.13.1",
- "revm-bytecode 9.0.0",
- "revm-primitives 22.1.0",
+ "alloy-primitives",
+ "once_cell",
  "serde",
 ]
 
@@ -10428,7 +10735,7 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
 dependencies = [
- "alloy-eip7928 0.4.5",
+ "alloy-eip7928",
  "bitflags 2.13.1",
  "nonmax",
  "revm-bytecode 41.0.0",
@@ -10437,9 +10744,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-state"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags 2.13.1",
+ "nonmax",
+ "revm-bytecode 42.0.0",
+ "revm-primitives 42.0.0",
+ "serde",
+]
+
+[[package]]
 name = "rexpect"
 version = "0.6.2"
-source = "git+https://github.com/rust-cli/rexpect?rev=2ed0b1898d7edaf6a85bedbae71a01cc578958fc#2ed0b1898d7edaf6a85bedbae71a01cc578958fc"
+source = "git+https://github.com/rust-cli/rexpect?rev=2de4faa2a4421f15bbdce3bf196ccda4dac0228e#2de4faa2a4421f15bbdce3bf196ccda4dac0228e"
 dependencies = [
  "comma",
  "nix 0.30.1",
@@ -10488,6 +10809,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -11363,9 +11693,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6505efef05804732ed8a3f2d4f279429eb485bd69d5b0cc6b19cc02005cda16"
+checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
 dependencies = [
  "bstr",
  "unicode-segmentation",
@@ -11868,15 +12198,15 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "sval"
-version = "2.21.0"
+version = "2.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a370f3cd0422964fd9a19b6516f048527738e6ec50b1b0ff79b460b468390"
+checksum = "ec4a2a7d92fa86fcc6222e4c3845f8486cff899d9db32480b26c91a5dbf2e22d"
 
 [[package]]
 name = "sval_buffer"
-version = "2.21.0"
+version = "2.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111e6e2dab25782acb41b281263f5f60d6f56a2ba0b3b076187ad23a1552544d"
+checksum = "f4324db9ac500c609d659b752edf9c8abbf2233f8afd61a503fd6f88ed625032"
 dependencies = [
  "sval",
  "sval_ref",
@@ -11885,18 +12215,18 @@ dependencies = [
 
 [[package]]
 name = "sval_dynamic"
-version = "2.21.0"
+version = "2.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590ac4ebd299740eac453162302a494e6d5b3be243feab8bf07d0d4331b6b2b3"
+checksum = "4046add0eecf55e680b9e207edf5fc7737b18a1d950db363d97e7f1b2d7c629c"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_fmt"
-version = "2.21.0"
+version = "2.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b964d6d917267355d7f343c515b908586e5b4aeeada328738f703452f9412d6"
+checksum = "911a3486b5984a0a4f25edefcf2c2dba23654c29f63e75493b671d338bf24243"
 dependencies = [
  "itoa",
  "ryu",
@@ -11905,9 +12235,9 @@ dependencies = [
 
 [[package]]
 name = "sval_json"
-version = "2.21.0"
+version = "2.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea35e4d6b997acc7dc4786ab782f6a6c5000efe4ae93a2db89cf350775fe5fe"
+checksum = "da53aae7c737b5b5f1be4bcb0ff20e057bf6b2ee4e9d025560075c5830d09f95"
 dependencies = [
  "itoa",
  "ryu",
@@ -11916,9 +12246,9 @@ dependencies = [
 
 [[package]]
 name = "sval_nested"
-version = "2.21.0"
+version = "2.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73195ebd4b3e5866db2e1b75f3f383657ad5abc600c646d69b4f064fee89154"
+checksum = "df24df43cbdc4bb8c9f5ed19d0d57dc8f60a1a4259cdce52d597fe774ad3a71f"
 dependencies = [
  "sval",
  "sval_buffer",
@@ -11927,18 +12257,18 @@ dependencies = [
 
 [[package]]
 name = "sval_ref"
-version = "2.21.0"
+version = "2.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ef28df9d586bfd15115286651337cb5645f8c203160d22d2d1a20cf13c428c"
+checksum = "2bebc17f0f1fad060e57b778728d41ef87627e9111a6365d7463472cb58fc1b3"
 dependencies = [
  "sval",
 ]
 
 [[package]]
 name = "sval_serde"
-version = "2.21.0"
+version = "2.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d72fbe6537e88878f10237bde71ae4a1b65b2bf54bdf274abc566fc696334c92"
+checksum = "9f26fe3f6a68b40e6c8d654ea48c00e4316272fddf68c80493714c1b034ae70b"
 dependencies = [
  "serde_core",
  "sval",
@@ -12104,7 +12434,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12133,9 +12463,89 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-chainspec",
- "tempo-contracts",
- "tempo-primitives",
+ "tempo-chainspec 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
+ "tempo-contracts 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
+ "tempo-primitives 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
+ "thiserror 2.0.19",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "tempo-alloy"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rlp",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "alloy-transport",
+ "async-trait",
+ "base64 0.22.1",
+ "dashmap",
+ "derive_more",
+ "dirs-next",
+ "futures",
+ "http 1.5.0",
+ "p256",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "thiserror 2.0.19",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "tempo-alloy"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rlp",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "alloy-transport",
+ "async-trait",
+ "base64 0.22.1",
+ "dashmap",
+ "derive_more",
+ "dirs-next",
+ "futures",
+ "http 1.5.0",
+ "p256",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
  "thiserror 2.0.19",
  "tower",
  "tracing",
@@ -12144,7 +12554,23 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+dependencies = [
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "once_cell",
+ "paste",
+ "serde",
+ "serde_json",
+ "tempo-hardfork 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
+ "tempo-primitives 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
+]
+
+[[package]]
+name = "tempo-chainspec"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12160,26 +12586,66 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-dkg-onchain-artifacts",
- "tempo-hardfork",
- "tempo-primitives",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+]
+
+[[package]]
+name = "tempo-chainspec"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
+dependencies = [
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "once_cell",
+ "paste",
+ "serde",
+ "serde_json",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
 ]
 
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-sol-types",
  "serde",
- "tempo-hardfork",
+ "tempo-hardfork 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
+]
+
+[[package]]
+name = "tempo-contracts"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+]
+
+[[package]]
+name = "tempo-contracts"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
 ]
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12191,7 +12657,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12207,13 +12673,13 @@ dependencies = [
  "reth-ethereum-consensus",
  "reth-evm",
  "reth-evm-ethereum",
- "reth-primitives-traits 0.5.2",
+ "reth-primitives-traits 0.6.0",
  "reth-revm",
- "tempo-chainspec",
- "tempo-contracts",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-dkg-onchain-artifacts",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-revm",
  "thiserror 2.0.19",
  "tracing",
@@ -12222,7 +12688,18 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+dependencies = [
+ "alloy-eips",
+ "alloy-hardforks",
+ "paste",
+ "serde",
+]
+
+[[package]]
+name = "tempo-hardfork"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12232,9 +12709,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-hardfork"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
+dependencies = [
+ "alloy-eips",
+ "alloy-hardforks",
+ "paste",
+ "serde",
+]
+
+[[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12244,12 +12732,12 @@ dependencies = [
  "commonware-cryptography",
  "derive_more",
  "paste",
- "revm",
+ "revm 42.0.1",
  "scoped-tls",
- "tempo-chainspec",
- "tempo-contracts",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-precompiles-macros",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -12257,7 +12745,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12268,7 +12756,32 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "base64 0.22.1",
+ "derive_more",
+ "ed25519-consensus",
+ "once_cell",
+ "p256",
+ "reth-codecs 0.6.0",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits 0.6.0",
+ "revm 42.0.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-contracts 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
+]
+
+[[package]]
+name = "tempo-primitives"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12282,20 +12795,45 @@ dependencies = [
  "ed25519-consensus",
  "once_cell",
  "p256",
- "reth-codecs 0.5.2",
+ "reth-codecs 0.6.0",
  "reth-ethereum-primitives",
- "reth-primitives-traits 0.5.2",
- "revm",
+ "reth-primitives-traits 0.6.0",
+ "revm 42.0.1",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+]
+
+[[package]]
+name = "tempo-primitives"
+version = "1.10.1"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "base64 0.22.1",
+ "derive_more",
+ "ed25519-consensus",
+ "once_cell",
+ "p256",
+ "reth-codecs 0.6.0",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits 0.6.0",
+ "revm 42.0.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
 ]
 
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=76908150fc56bc6dcb91ecbb8a424939f8acef4c#76908150fc56bc6dcb91ecbb8a424939f8acef4c"
+source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12305,11 +12843,11 @@ dependencies = [
  "derive_more",
  "reth-evm",
  "reth-storage-api",
- "revm",
- "tempo-chainspec",
- "tempo-contracts",
+ "revm 42.0.1",
+ "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "tempo-precompiles",
- "tempo-primitives",
+ "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -12564,12 +13102,8 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
- "rustls-pki-types",
  "tokio",
- "tokio-rustls",
  "tungstenite 0.28.0",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -12580,8 +13114,12 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite 0.29.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -12964,8 +13502,6 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
- "rustls",
- "rustls-pki-types",
  "sha1",
  "thiserror 2.0.19",
  "utf-8",
@@ -12983,6 +13519,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.19",
 ]
@@ -13348,9 +13886,9 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "10.0.1"
+version = "10.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd42fd155c2c2971f6d00face12ec245fbb604fce011ccaf2306d014c2e97ca"
+checksum = "7d6a4e23de0fd3f8a940650a4d83eca980e9ef8f108fe6ddeb5313b0313523d3"
 dependencies = [
  "anyhow",
  "bon",
@@ -13583,9 +14121,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
+checksum = "3d6eb50cc7b133f0c7720a64661fbd8e520b882f8ab9015deea5e00d5cd809c4"
 dependencies = [
  "jni",
  "log",
@@ -14315,9 +14853,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ dependencies = [
  "alloy-serde",
  "alloy-trie",
  "alloy-tx-macros",
+ "arbitrary",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -150,6 +151,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "arbitrary",
  "serde",
 ]
 
@@ -217,7 +219,9 @@ checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
  "crc",
+ "rand 0.8.7",
  "serde",
  "thiserror 2.0.19",
 ]
@@ -230,7 +234,9 @@ checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
  "borsh",
+ "rand 0.8.7",
  "serde",
 ]
 
@@ -254,8 +260,10 @@ checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
  "borsh",
  "k256",
+ "rand 0.8.7",
  "serde",
  "thiserror 2.0.19",
 ]
@@ -268,6 +276,7 @@ checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
  "borsh",
  "once_cell",
  "serde",
@@ -287,6 +296,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "arbitrary",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -479,7 +489,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.8.0",
  "rand 0.9.5",
  "rapidhash",
  "ruint",
@@ -710,6 +720,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
+ "arbitrary",
  "itertools 0.14.0",
  "serde",
  "serde_json",
@@ -765,6 +776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad7efdd5e8fe92f5bab87956d6d3f717d1614c4ab6ad0d1f869b16e83b0dff9"
 dependencies = [
  "alloy-primitives",
+ "arbitrary",
  "serde",
  "serde_json",
 ]
@@ -781,7 +793,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "k256",
  "thiserror 2.0.19",
 ]
@@ -800,7 +812,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-kms",
  "k256",
- "spki",
+ "spki 0.7.3",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -818,7 +830,7 @@ dependencies = [
  "async-trait",
  "gcloud-sdk",
  "k256",
- "spki",
+ "spki 0.7.3",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -1031,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=cc95fb153e1848f844f6d5110a8a62ac7dc34b9b#cc95fb153e1848f844f6d5110a8a62ac7dc34b9b"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=0d7660f0b33e7899f79a1df6671a44d0155f8761#0d7660f0b33e7899f79a1df6671a44d0155f8761"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1080,8 +1092,12 @@ checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "arbitrary",
+ "derive_arbitrary",
  "derive_more",
  "nybbles",
+ "proptest",
+ "proptest-derive 0.7.0",
  "serde",
  "smallvec",
  "thiserror 2.0.19",
@@ -2365,6 +2381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +2866,7 @@ version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
 dependencies = [
+ "arbitrary",
  "blst",
  "cc",
  "glob",
@@ -3392,39 +3415,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
-name = "commonware-broadcast"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+name = "commonware-actor"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beac6262223b45c6843ab70b245b526b28836a8257b1759a509ba5fab24fa4a6"
 dependencies = [
+ "cfg-if",
+ "commonware-macros",
+ "commonware-runtime",
+ "crossbeam-queue",
+ "futures-util",
+ "parking_lot",
+]
+
+[[package]]
+name = "commonware-broadcast"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a2d7e56dc894ad3f55dbe5726468915492ae8e4650ad2a45c1bcfd138c2037f"
+dependencies = [
+ "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
  "commonware-p2p",
  "commonware-runtime",
  "commonware-utils",
- "prometheus-client",
  "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "commonware-codec"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8eb7efe071cea13e8b23a0a7f584398870c401d2b2aabfb6b9ab3634ebcba3a"
 dependencies = [
  "bytes",
  "cfg-if",
+ "commonware-codec-macros",
  "commonware-macros",
  "paste",
- "rand 0.8.7",
- "rand_chacha 0.3.1",
+ "rand_chacha 0.10.0",
  "thiserror 2.0.19",
 ]
 
 [[package]]
+name = "commonware-codec-macros"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a876bec347344381948901d0f5ec2e9443ebc8dbab99a63bc2db78c2fc2efbdd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "commonware-coding"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409e9997c1bb3273b9570c26ddef4f252327c9bf18968d4439a83cfd1d3e5661"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3435,24 +3487,24 @@ dependencies = [
  "commonware-storage",
  "commonware-utils",
  "num-rational",
- "rand 0.8.7",
- "rand_core 0.6.4",
  "rayon",
- "reed-solomon-simd",
  "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "commonware-consensus"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf15e3402e26f062695d4dd5e4b5967f601dc7303d06b9fafdb20a6485a3a0a"
 dependencies = [
  "bytes",
  "cfg-if",
+ "commonware-actor",
  "commonware-broadcast",
  "commonware-codec",
  "commonware-coding",
  "commonware-cryptography",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-math",
  "commonware-p2p",
@@ -3463,10 +3515,8 @@ dependencies = [
  "commonware-utils",
  "futures",
  "pin-project",
- "prometheus-client",
- "rand 0.8.7",
- "rand_core 0.6.4",
- "rand_distr",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rayon",
  "thiserror 2.0.19",
  "tracing",
@@ -3474,9 +3524,11 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b842f31e1aaa1af284a1f9dc4f1234761f72d07e70d53cf3f1521b0870ade094"
 dependencies = [
+ "ahash",
  "anyhow",
  "aws-lc-rs",
  "blake3",
@@ -3485,31 +3537,48 @@ dependencies = [
  "cfg-if",
  "chacha20poly1305",
  "commonware-codec",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-math",
  "commonware-parallel",
  "commonware-utils",
+ "cpufeatures 0.2.17",
  "crc-fast",
  "ctutils 0.3.1",
- "ecdsa",
- "ed25519-consensus",
+ "curve25519-dalek",
+ "ecdsa 0.17.0",
+ "fixedbitset",
  "getrandom 0.2.17",
+ "getrandom 0.4.3",
+ "hashbrown 0.16.1",
  "num-rational",
  "num-traits",
- "p256",
- "rand 0.8.7",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "sha2 0.10.9",
+ "once_cell",
+ "p256 0.14.0",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
  "thiserror 2.0.19",
  "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
+name = "commonware-formatting"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab01b7f2798e29b0a4f7b47da5b7f3c106881578af3e69e8d2ee9d89d7c1d4fd"
+dependencies = [
+ "commonware-macros",
+ "const-hex",
+]
+
+[[package]]
 name = "commonware-macros"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e37a17d5c99ec6711098c6614af1023fd32926aa0414ec0f0613f6bb940278"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3517,8 +3586,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d44bceee874226efca172f0e9ec9ec4eb486788ba6be1d98710f3f159b807af"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3529,22 +3599,25 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "593fa0c5aa8bd8d350724b9b1ad4e85072845aa85a06b39ca4598998bbec1e00"
 dependencies = [
  "bytes",
  "commonware-codec",
  "commonware-macros",
  "commonware-parallel",
  "commonware-utils",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "commonware-p2p"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f974fcd27c0dad7ae73caeaf00c8330fd29c60f5ff1f679ccc1a51c8ed95bc"
 dependencies = [
+ "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
@@ -3558,9 +3631,8 @@ dependencies = [
  "num-integer",
  "num-rational",
  "num-traits",
- "prometheus-client",
- "rand 0.8.7",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rand_distr",
  "thiserror 2.0.19",
  "tracing",
@@ -3568,20 +3640,25 @@ dependencies = [
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7109817274c671f1fb0ba17cf8aecfbb70672d29379284feeac43fa1b1dc0201"
 dependencies = [
  "cfg-if",
  "commonware-macros",
+ "dashmap",
+ "futures",
  "rayon",
 ]
 
 [[package]]
 name = "commonware-resolver"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a497cc9e9a2cd205d96474d0d40c7731f29085cd467adbe9ff0f94719659582"
 dependencies = [
  "bytes",
+ "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
@@ -3590,39 +3667,44 @@ dependencies = [
  "commonware-stream",
  "commonware-utils",
  "futures",
- "prometheus-client",
- "rand 0.8.7",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "thiserror 2.0.19",
  "tracing",
 ]
 
 [[package]]
 name = "commonware-runtime"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a84bc6cefb099b1ffce3e04705a1e61e91d895b9f09b9e1be14c8ec5823c181"
 dependencies = [
+ "ahash",
  "axum",
  "bytes",
  "cfg-if",
  "commonware-codec",
  "commonware-cryptography",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-parallel",
+ "commonware-runtime-macros",
  "commonware-utils",
  "criterion",
- "crossbeam-queue",
+ "crossbeam-utils",
  "futures",
  "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "governor",
  "libc",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "prometheus-client",
- "rand 0.8.7",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rayon",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sysinfo",
  "thiserror 2.0.19",
  "tokio",
@@ -3632,9 +3714,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "commonware-runtime-macros"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f7b39ef9fd9f1df4fe4445c9a5ec5ba012d90d1602b12a8b8626a8563ab02c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "commonware-storage"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac18e2b696ab7bbecf1059bc3b8d39fc0af002180906d65c7df3112fd9385de"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3642,14 +3737,14 @@ dependencies = [
  "cfg-if",
  "commonware-codec",
  "commonware-cryptography",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-parallel",
  "commonware-runtime",
  "commonware-utils",
  "futures",
  "futures-util",
- "prometheus-client",
- "rayon",
+ "hashbrown 0.16.1",
  "thiserror 2.0.19",
  "tracing",
  "zstd",
@@ -3657,18 +3752,19 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8890b69e3fa209bc9e87d199ff60ca5a21c88322d32914847511887e6dc5364b"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
  "commonware-cryptography",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-runtime",
  "commonware-utils",
  "futures",
- "rand 0.8.7",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "thiserror 2.0.19",
  "x25519-dalek",
  "zeroize",
@@ -3676,15 +3772,20 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a484dd46b738d9b5ba892312425e71e6afaf4320e388d74449bd9ca0ea14cd76"
 dependencies = [
+ "ahash",
  "bytes",
  "cfg-if",
  "commonware-codec",
+ "commonware-formatting",
  "commonware-macros",
  "futures",
  "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hashbrown 0.16.1",
  "num-bigint",
  "num-integer",
@@ -3692,9 +3793,10 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "pin-project",
- "rand 0.8.7",
+ "rand 0.10.2",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
  "zeroize",
 ]
 
@@ -3851,6 +3953,12 @@ name = "cow-utils"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -4032,6 +4140,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils 0.4.2",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,7 +4172,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4087,17 +4213,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov 0.5.4",
+ "subtle",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
+ "digest 0.11.3",
  "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
@@ -4238,6 +4366,7 @@ version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
+ "arbitrary",
  "cfg-if",
  "crossbeam-utils",
  "hashbrown 0.14.5",
@@ -4292,6 +4421,16 @@ checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -4578,13 +4717,28 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "serdect",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "serdect 0.2.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -4629,17 +4783,37 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
- "serdect",
+ "sec1 0.7.3",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -4934,10 +5108,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
+name = "ff"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "figment2"
@@ -5332,7 +5516,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5367,7 +5551,7 @@ dependencies = [
  "alloy-sol-types",
  "base64 0.23.1",
  "dialoguer",
- "ecdsa",
+ "ecdsa 0.16.9",
  "ed25519-consensus",
  "eyre",
  "forge-script-sequence",
@@ -5383,7 +5567,7 @@ dependencies = [
  "jsonpath_lib",
  "k256",
  "memchr",
- "p256",
+ "p256 0.13.2",
  "parking_lot",
  "proptest",
  "rand 0.9.5",
@@ -5574,7 +5758,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5605,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5614,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5634,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5647,7 +5831,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -5979,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6085,7 +6269,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -6440,8 +6624,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -6474,6 +6669,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hash-db"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
 name = "hashbrown"
@@ -6674,7 +6875,9 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -7316,7 +7519,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
@@ -7328,12 +7531,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
- "serdect",
+ "serdect 0.2.0",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -7629,6 +7832,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7759,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=cc95fb153e1848f844f6d5110a8a62ac7dc34b9b#cc95fb153e1848f844f6d5110a8a62ac7dc34b9b"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=0d7660f0b33e7899f79a1df6671a44d0155f8761#0d7660f0b33e7899f79a1df6671a44d0155f8761"
 dependencies = [
  "alloy",
  "async-stream",
@@ -7771,7 +7984,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 1.5.0",
- "p256",
+ "p256 0.13.2",
  "rand 0.10.2",
  "reqwest 0.13.4",
  "rusqlite",
@@ -8078,6 +8291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
  "alloy-rlp",
+ "arbitrary",
  "cfg-if",
  "proptest",
  "ruint",
@@ -8328,9 +8542,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -8342,22 +8556,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.5.0",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http 1.5.0",
  "opentelemetry",
@@ -8365,35 +8579,33 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.4",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "thiserror 2.0.19",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.14.4",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.5",
  "thiserror 2.0.19",
  "tokio",
@@ -8433,11 +8645,24 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "serdect",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "serdect 0.2.0",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -8801,8 +9026,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -8810,6 +9045,15 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain_hasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "plotters"
@@ -8945,13 +9189,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
- "serdect",
+ "elliptic-curve 0.13.8",
+ "serdect 0.2.0",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect 0.4.3",
+ "wnaf",
 ]
 
 [[package]]
@@ -9081,6 +9352,27 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "proptest-arbitrary-interop"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1981e49bd2432249da8b0e11e5557099a8e74690d6b94e721f7dc0bb7f3555f"
+dependencies = [
+ "arbitrary",
+ "proptest",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9381,6 +9673,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9407,12 +9709,12 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.8.7",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -9548,12 +9850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "readme-rustdocifier"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
-
-[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9588,18 +9884,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.19",
-]
-
-[[package]]
-name = "reed-solomon-simd"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffef0520d30fbd4151fb20e262947ae47fb0ab276a744a19b6398438105a072"
-dependencies = [
- "cpufeatures 0.2.17",
- "fixedbitset",
- "once_cell",
- "readme-rustdocifier",
 ]
 
 [[package]]
@@ -9675,9 +9959,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http 1.5.0",
  "http-body 1.1.0",
@@ -9804,12 +10086,14 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
+ "arbitrary",
  "bytes",
  "modular-bitfield",
  "parity-scale-codec",
  "reth-codecs-derive 0.6.0",
  "reth-zstd-compressors 0.6.0",
  "serde",
+ "visibility",
 ]
 
 [[package]]
@@ -9862,13 +10146,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-db-api"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+dependencies = [
+ "alloy-consensus",
+ "alloy-primitives",
+ "arbitrary",
+ "arrayvec",
+ "bytes",
+ "derive_more",
+ "metrics",
+ "modular-bitfield",
+ "proptest",
+ "reth-codecs 0.6.0",
+ "reth-db-models",
+ "reth-ethereum-primitives",
+ "reth-primitives-traits 0.6.0",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-errors",
+ "reth-trie-common",
+ "roaring",
+ "serde",
+]
+
+[[package]]
 name = "reth-db-models"
 version = "2.4.1"
 source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
+ "arbitrary",
  "bytes",
+ "modular-bitfield",
  "reth-codecs 0.6.0",
  "reth-primitives-traits 0.6.0",
  "serde",
@@ -10043,10 +10355,15 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-trie",
+ "arbitrary",
+ "byteorder",
  "bytes",
  "dashmap",
  "derive_more",
+ "modular-bitfield",
  "once_cell",
+ "proptest",
+ "proptest-arbitrary-interop",
  "quanta",
  "reth-codecs 0.6.0",
  "revm-bytecode 42.0.0",
@@ -10063,7 +10380,9 @@ version = "2.4.1"
 source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-primitives",
+ "arbitrary",
  "derive_more",
+ "modular-bitfield",
  "reth-codecs 0.6.0",
  "serde",
  "strum 0.27.2",
@@ -10105,7 +10424,9 @@ version = "2.4.1"
 source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
 dependencies = [
  "alloy-primitives",
+ "arbitrary",
  "bytes",
+ "modular-bitfield",
  "reth-codecs 0.6.0",
  "reth-trie-common",
  "serde",
@@ -10188,11 +10509,14 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-trie",
+ "arbitrary",
  "arrayvec",
  "bytes",
  "derive_more",
+ "hash-db",
  "itertools 0.14.0",
  "nybbles",
+ "plain_hasher",
  "reth-codecs 0.6.0",
  "reth-primitives-traits 0.6.0",
  "revm",
@@ -10412,7 +10736,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "k256",
- "p256",
+ "p256 0.13.2",
  "revm-context-interface",
  "revm-primitives 42.0.0",
  "ripemd 0.2.0",
@@ -10493,6 +10817,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10541,6 +10875,16 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
 ]
 
 [[package]]
@@ -10962,11 +11306,25 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
- "serdect",
+ "pkcs8 0.10.2",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils 0.4.2",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -11240,7 +11598,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -11383,6 +11751,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11463,6 +11841,7 @@ version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
+ "arbitrary",
  "serde",
 ]
 
@@ -11649,7 +12028,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11807,7 +12186,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -12002,7 +12391,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "url",
  "zip 8.6.0",
 ]
@@ -12147,7 +12536,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12171,7 +12560,7 @@ dependencies = [
  "dirs-next",
  "futures",
  "http 1.5.0",
- "p256",
+ "p256 0.13.2",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -12187,7 +12576,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12210,7 +12599,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12222,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12234,7 +12623,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12265,7 +12654,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12277,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12300,7 +12689,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12311,7 +12700,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12321,11 +12710,12 @@ dependencies = [
  "alloy-serde",
  "aws-lc-rs",
  "base64 0.22.1",
+ "commonware-cryptography",
  "derive_more",
- "ed25519-consensus",
  "once_cell",
- "p256",
+ "p256 0.13.2",
  "reth-codecs 0.6.0",
+ "reth-db-api",
  "reth-ethereum-primitives",
  "reth-primitives-traits 0.6.0",
  "revm",
@@ -12338,7 +12728,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
+source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12876,9 +13266,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -13001,7 +13391,7 @@ dependencies = [
  "base64 0.22.1",
  "hex",
  "k256",
- "p256",
+ "p256 0.13.2",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -13362,6 +13752,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "vsimd"
@@ -14076,6 +14477,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14117,13 +14529,12 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
- "serde",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,7 +431,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-evm"
 version = "0.32.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -448,7 +448,7 @@ dependencies = [
 [[package]]
 name = "alloy-op-hardforks"
 version = "0.5.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
@@ -1181,7 +1181,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1205,7 +1205,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2715,7 +2715,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -3202,7 +3202,7 @@ dependencies = [
  "terminfo",
  "thiserror 2.0.19",
  "which",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3361,7 +3361,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4470,7 +4470,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4742,7 +4742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6330,8 +6330,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -6766,7 +6766,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -7126,7 +7126,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7937,7 +7937,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8189,7 +8189,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 [[package]]
 name = "op-alloy"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
@@ -8201,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-consensus"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8228,7 +8228,7 @@ checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 [[package]]
 name = "op-alloy-network"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -8241,7 +8241,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-provider"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -8255,7 +8255,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8275,7 +8275,7 @@ dependencies = [
 [[package]]
 name = "op-alloy-rpc-types-engine"
 version = "2.0.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8295,7 +8295,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "20.0.0"
-source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
+source = "git+https://github.com/foundry-rs/optimism?rev=4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2#4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2"
 dependencies = [
  "auto_impl",
  "op-alloy-consensus",
@@ -9134,7 +9134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -9286,7 +9286,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10719,7 +10719,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10778,7 +10778,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11511,7 +11511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11637,7 +11637,7 @@ dependencies = [
  "derive_more",
  "dunce",
  "inturn",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "itoa",
  "normalize-path",
  "once_map",
@@ -11649,7 +11649,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 2.0.19",
+ "thiserror 1.0.69",
  "tracing",
  "unicode-width 0.2.2",
 ]
@@ -11683,7 +11683,7 @@ dependencies = [
  "alloy-primitives",
  "bitflags 2.13.1",
  "bumpalo",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "memchr",
  "num-bigint",
  "num-rational",
@@ -12002,7 +12002,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 1.0.69",
  "url",
  "zip 8.6.0",
 ]
@@ -12141,7 +12141,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12364,7 +12364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13522,7 +13522,7 @@ dependencies = [
  "watchexec-events",
  "watchexec-signals",
  "watchexec-supervisor",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13670,7 +13670,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=0d7660f0b33e7899f79a1df6671a44d0155f8761#0d7660f0b33e7899f79a1df6671a44d0155f8761"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=1241b29975eedcfd82bfb85fac186b92cc6dac16#1241b29975eedcfd82bfb85fac186b92cc6dac16"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -5516,7 +5516,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5758,7 +5758,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5768,7 +5768,7 @@ dependencies = [
  "foundry-compilers-artifacts",
  "foundry-compilers-core",
  "fs_extra",
- "itertools 0.15.0",
+ "itertools 0.13.0",
  "path-slash",
  "rand 0.10.2",
  "rayon",
@@ -5789,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5818,7 +5818,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5831,7 +5831,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -6163,7 +6163,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6269,7 +6269,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=b69e1fddb37aecbb048cd8de9d2b6c19990d9a47#b69e1fddb37aecbb048cd8de9d2b6c19990d9a47"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=2a5b28096bb94c048e79f0a76748e59d89444d00#2a5b28096bb94c048e79f0a76748e59d89444d00"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -7972,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=0d7660f0b33e7899f79a1df6671a44d0155f8761#0d7660f0b33e7899f79a1df6671a44d0155f8761"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=1241b29975eedcfd82bfb85fac186b92cc6dac16#1241b29975eedcfd82bfb85fac186b92cc6dac16"
 dependencies = [
  "alloy",
  "async-stream",
@@ -12536,7 +12536,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -12576,7 +12576,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12599,7 +12599,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -12623,7 +12623,7 @@ dependencies = [
 [[package]]
 name = "tempo-evm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12654,7 +12654,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -12666,7 +12666,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -12689,7 +12689,7 @@ dependencies = [
 [[package]]
 name = "tempo-precompiles-macros"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -12700,7 +12700,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12728,7 +12728,7 @@ dependencies = [
 [[package]]
 name = "tempo-revm"
 version = "1.11.0"
-source = "git+https://github.com/tempoxyz/tempo?rev=0cffd71de70874ec3fc2814caeee12ad528a6127#0cffd71de70874ec3fc2814caeee12ad528a6127"
+source = "git+https://github.com/tempoxyz/tempo?rev=c93d08a9b6b26baa3026a4f280e5d82aa2d65643#c93d08a9b6b26baa3026a4f280e5d82aa2d65643"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "derive_more",
- "revm 42.0.1",
+ "revm",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -436,25 +436,13 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-op-hardforks 0.5.0",
+ "alloy-op-hardforks",
  "alloy-primitives",
  "auto_impl",
  "op-alloy",
- "op-revm 20.0.0 (git+https://github.com/foundry-rs/optimism?branch=develop)",
- "revm 42.0.1",
+ "op-revm",
+ "revm",
  "thiserror 2.0.19",
-]
-
-[[package]]
-name = "alloy-op-hardforks"
-version = "0.4.7"
-source = "git+https://github.com/foundry-rs/optimism?branch=bump-alloy-evm-0-36-tempo#a305f5a34d20699d2301bdb57e379e62bc04937f"
-dependencies = [
- "alloy-chains",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "serde",
 ]
 
 [[package]]
@@ -466,6 +454,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-primitives",
  "auto_impl",
+ "serde",
 ]
 
 [[package]]
@@ -1042,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=cc95fb153e1848f844f6d5110a8a62ac7dc34b9b#cc95fb153e1848f844f6d5110a8a62ac7dc34b9b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1058,7 +1047,7 @@ dependencies = [
  "thiserror 2.0.19",
  "time",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tower-service",
  "tracing",
  "url",
@@ -1077,7 +1066,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tracing",
  "url",
  "ws_stream_wasm",
@@ -1273,26 +1262,26 @@ dependencies = [
  "itertools 0.15.0",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
- "op-revm 20.0.0 (git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab)",
+ "op-revm",
  "parking_lot",
  "rand 0.8.7",
  "rand 0.9.5",
  "reqwest 0.13.4",
- "revm 42.0.1",
+ "revm",
  "revm-inspectors",
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-alloy",
  "tempo-evm",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-hardfork",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "yansi",
 ]
 
@@ -1315,7 +1304,7 @@ dependencies = [
  "foundry-evm",
  "foundry-primitives",
  "rand 0.9.5",
- "revm 42.0.1",
+ "revm",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -1391,38 +1380,14 @@ checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
-dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
-]
-
-[[package]]
-name = "ark-bls12-381"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-serialize 0.6.0",
  "ark-std 0.6.0",
-]
-
-[[package]]
-name = "ark-bn254"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
-dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-r1cs-std 0.5.0",
- "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -1431,31 +1396,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
- "ark-r1cs-std 0.6.0",
+ "ark-r1cs-std",
  "ark-std 0.6.0",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-poly 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
- "num-bigint",
- "num-integer",
- "num-traits",
- "zeroize",
 ]
 
 [[package]]
@@ -1466,7 +1410,7 @@ checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
  "ark-ff 0.6.0",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-serialize 0.6.0",
  "ark-std 0.6.0",
  "educe",
@@ -1647,21 +1591,6 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
-dependencies = [
- "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
- "educe",
- "fnv",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "ark-poly"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
@@ -1677,30 +1606,13 @@ dependencies = [
 
 [[package]]
 name = "ark-r1cs-std"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
-dependencies = [
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-relations 0.5.1",
- "ark-std 0.5.0",
- "educe",
- "num-bigint",
- "num-integer",
- "num-traits",
- "tracing",
-]
-
-[[package]]
-name = "ark-r1cs-std"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
 dependencies = [
- "ark-ec 0.6.0",
+ "ark-ec",
  "ark-ff 0.6.0",
- "ark-relations 0.6.0",
+ "ark-relations",
  "ark-std 0.6.0",
  "educe",
  "itertools 0.14.0",
@@ -1712,30 +1624,18 @@ dependencies = [
 
 [[package]]
 name = "ark-relations"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
-dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
- "tracing",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "ark-relations"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
 dependencies = [
  "ark-ff 0.6.0",
- "ark-poly 0.6.0",
+ "ark-poly",
  "ark-serialize 0.6.0",
  "ark-std 0.6.0",
  "foldhash 0.1.5",
  "indexmap 2.14.0",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1765,7 +1665,6 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -1778,22 +1677,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
- "ark-serialize-derive 0.6.0",
+ "ark-serialize-derive",
  "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint",
  "serde_with",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -2429,7 +2317,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3061,16 +2949,16 @@ dependencies = [
  "rand 0.9.5",
  "rayon",
  "regex",
- "revm 42.0.1",
+ "revm",
  "rpassword",
  "semver 1.0.28",
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-alloy",
+ "tempo-contracts",
+ "tempo-hardfork",
+ "tempo-primitives",
  "tokio",
  "tower",
  "tracing",
@@ -3175,7 +3063,7 @@ dependencies = [
  "tempfile",
  "time",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "walkdir",
  "yansi",
 ]
@@ -3740,7 +3628,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -5222,7 +5110,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest 0.13.4",
- "revm 42.0.1",
+ "revm",
  "rexpect",
  "semver 1.0.28",
  "serde",
@@ -5234,7 +5122,7 @@ dependencies = [
  "soldeer-core",
  "svm-rs",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-alloy",
  "thiserror 2.0.19",
  "tokio",
  "toml_edit",
@@ -5336,8 +5224,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-alloy",
+ "tempo-primitives",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5401,7 +5289,7 @@ dependencies = [
  "itertools 0.15.0",
  "regex",
  "reqwest 0.13.4",
- "revm 42.0.1",
+ "revm",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -5444,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "foundry-block-explorers"
 version = "0.24.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
 dependencies = [
  "alloy-chains",
  "alloy-json-abi",
@@ -5499,17 +5387,17 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.5",
- "revm 42.0.1",
+ "revm",
  "revm-inspectors",
  "semver 1.0.28",
  "serde",
  "serde_json",
  "solar-compiler",
  "tempfile",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-contracts",
+ "tempo-hardfork",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives",
  "thiserror 2.0.19",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
@@ -5569,12 +5457,12 @@ dependencies = [
  "solar-compiler",
  "strsim",
  "tempfile",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives",
  "tikv-jemallocator",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "tracing-tracy",
  "yansi",
 ]
@@ -5639,15 +5527,15 @@ dependencies = [
  "path-slash",
  "regex",
  "reqwest 0.13.4",
- "revm 42.0.1",
+ "revm",
  "semver 1.0.28",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "solar-compiler",
  "tempfile",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-alloy",
+ "tempo-primitives",
  "thiserror 2.0.19",
  "tokio",
  "tower",
@@ -5675,18 +5563,18 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-rpc-types",
  "proptest",
- "revm 42.0.1",
+ "revm",
  "serde",
  "serde_json",
  "similar-asserts",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-alloy",
  "yansi",
 ]
 
 [[package]]
 name = "foundry-compilers"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5717,7 +5605,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -5726,7 +5614,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-solc"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5746,7 +5634,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -5759,7 +5647,7 @@ dependencies = [
 [[package]]
 name = "foundry-compilers-core"
 version = "0.21.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
 dependencies = [
  "alloy-primitives",
  "dunce",
@@ -5834,7 +5722,7 @@ dependencies = [
  "foundry-evm-traces",
  "foundry-tui",
  "ratatui",
- "revm 42.0.1",
+ "revm",
  "revm-inspectors",
  "serde",
  "tracing",
@@ -5868,12 +5756,12 @@ dependencies = [
  "proptest",
  "rand 0.9.5",
  "rayon",
- "revm 42.0.1",
+ "revm",
  "revm-inspectors",
  "serde",
  "serde_json",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5930,18 +5818,18 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types",
- "op-revm 20.0.0 (git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab)",
+ "op-revm",
  "parking_lot",
- "revm 42.0.1",
+ "revm",
  "revm-inspectors",
  "serde",
  "serde_json",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-alloy",
+ "tempo-contracts",
  "tempo-evm",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-hardfork",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.19",
  "tokio",
@@ -5959,7 +5847,7 @@ dependencies = [
  "foundry-compilers",
  "foundry-evm-core",
  "rayon",
- "revm 42.0.1",
+ "revm",
  "semver 1.0.28",
  "solar-compiler",
  "tracing",
@@ -5983,7 +5871,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "rand 0.9.5",
- "revm 42.0.1",
+ "revm",
  "serde",
  "solar-compiler",
  "thiserror 2.0.19",
@@ -5996,13 +5884,13 @@ version = "1.8.0"
 dependencies = [
  "alloy-chains",
  "alloy-hardforks",
- "alloy-op-hardforks 0.4.7",
+ "alloy-op-hardforks",
  "alloy-rpc-types",
  "foundry-compilers",
- "op-revm 20.0.0 (git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab)",
- "revm 42.0.1",
+ "op-revm",
+ "revm",
  "serde",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-hardfork",
 ]
 
 [[package]]
@@ -6012,14 +5900,14 @@ dependencies = [
  "alloy-chains",
  "alloy-eips",
  "alloy-evm",
- "alloy-op-hardforks 0.4.7",
+ "alloy-op-hardforks",
  "alloy-primitives",
  "clap",
  "foundry-evm-hardforks",
- "revm 42.0.1",
+ "revm",
  "serde",
  "serde_json",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-contracts",
 ]
 
 [[package]]
@@ -6073,7 +5961,7 @@ dependencies = [
  "memchr",
  "rayon",
  "reqwest 0.13.4",
- "revm 42.0.1",
+ "revm",
  "revm-inspectors",
  "ron",
  "serde",
@@ -6081,7 +5969,7 @@ dependencies = [
  "snapbox",
  "solar-compiler",
  "tempfile",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-contracts",
  "tempo-precompiles",
  "tokio",
  "tracing",
@@ -6091,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "foundry-fork-db"
 version = "0.27.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -6100,7 +5988,7 @@ dependencies = [
  "eyre",
  "futures",
  "parking_lot",
- "revm 41.0.0",
+ "revm",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -6149,12 +6037,12 @@ dependencies = [
  "derive_more",
  "op-alloy-consensus",
  "op-alloy-rpc-types",
- "op-revm 20.0.0 (git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab)",
- "revm 42.0.1",
+ "op-revm",
+ "revm",
  "serde",
  "serde_json",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-alloy",
+ "tempo-primitives",
  "tempo-revm",
 ]
 
@@ -6182,7 +6070,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "ui_test",
 ]
 
@@ -6197,7 +6085,7 @@ dependencies = [
 [[package]]
 name = "foundry-wallets"
 version = "0.1.0"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=d80a95d94aecafcf38647dfee9f4804552576c35#d80a95d94aecafcf38647dfee9f4804552576c35"
+source = "git+https://github.com/foundry-rs/foundry-core?rev=d48ea2f276d52b43c32914bcea03ce67cf8c75f1#d48ea2f276d52b43c32914bcea03ce67cf8c75f1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -6225,7 +6113,7 @@ dependencies = [
  "rusb",
  "serde",
  "serde_json",
- "tempo-alloy 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
+ "tempo-alloy",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -6598,15 +6486,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -7652,7 +7531,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7880,7 +7759,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=cc95fb153e1848f844f6d5110a8a62ac7dc34b9b#cc95fb153e1848f844f6d5110a8a62ac7dc34b9b"
 dependencies = [
  "alloy",
  "async-stream",
@@ -7901,11 +7780,11 @@ dependencies = [
  "serde_json_canonicalizer",
  "sha2 0.11.0",
  "subtle",
- "tempo-alloy 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
+ "tempo-alloy",
  "thiserror 2.0.19",
  "time",
  "tokio",
- "tokio-tungstenite 0.29.0",
+ "tokio-tungstenite",
  "uuid 1.24.0",
 ]
 
@@ -8420,17 +8299,8 @@ source = "git+https://github.com/foundry-rs/optimism?branch=develop#4ce11c64258b
 dependencies = [
  "auto_impl",
  "op-alloy-consensus",
- "revm 42.0.1",
+ "revm",
  "serde",
-]
-
-[[package]]
-name = "op-revm"
-version = "20.0.0"
-source = "git+https://github.com/foundry-rs/op-revm?rev=dca56351469222d8eae9185b6c19ac14f6c0d0ab#dca56351469222d8eae9185b6c19ac14f6c0d0ab"
-dependencies = [
- "auto_impl",
- "revm 42.0.1",
 ]
 
 [[package]]
@@ -10068,7 +9938,7 @@ dependencies = [
  "reth-storage-api",
  "reth-storage-errors",
  "reth-trie-common",
- "revm 42.0.1",
+ "revm",
 ]
 
 [[package]]
@@ -10088,7 +9958,7 @@ dependencies = [
  "reth-execution-types",
  "reth-primitives-traits 0.6.0",
  "reth-storage-errors",
- "revm 42.0.1",
+ "revm",
 ]
 
 [[package]]
@@ -10118,7 +9988,7 @@ dependencies = [
  "reth-ethereum-primitives",
  "reth-primitives-traits 0.6.0",
  "reth-trie-common",
- "revm 42.0.1",
+ "revm",
  "serde",
  "serde_with",
 ]
@@ -10211,7 +10081,7 @@ dependencies = [
  "reth-primitives-traits 0.6.0",
  "reth-storage-api",
  "reth-storage-errors",
- "revm 42.0.1",
+ "revm",
 ]
 
 [[package]]
@@ -10276,7 +10146,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-tokio-util",
  "reth-trie-common",
- "revm 42.0.1",
+ "revm",
  "serde_json",
 ]
 
@@ -10293,7 +10163,7 @@ dependencies = [
  "reth-primitives-traits 0.6.0",
  "reth-prune-types",
  "reth-static-file-types",
- "revm 42.0.1",
+ "revm",
  "thiserror 2.0.19",
 ]
 
@@ -10325,7 +10195,7 @@ dependencies = [
  "nybbles",
  "reth-codecs 0.6.0",
  "reth-primitives-traits 0.6.0",
- "revm 42.0.1",
+ "revm",
  "serde",
  "serde_with",
 ]
@@ -10350,38 +10220,19 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
-dependencies = [
- "revm-bytecode 41.0.0",
- "revm-context 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-database 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-handler 41.0.0",
- "revm-inspector 41.0.0",
- "revm-interpreter 41.0.0",
- "revm-precompile 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
-]
-
-[[package]]
-name = "revm"
 version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
  "revm-bytecode 42.0.0",
- "revm-context 42.0.0",
- "revm-context-interface 42.0.0",
- "revm-database 42.0.0",
- "revm-database-interface 42.0.0",
- "revm-handler 42.0.1",
- "revm-inspector 42.0.1",
- "revm-interpreter 42.0.0",
- "revm-precompile 42.0.1",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
  "revm-primitives 42.0.0",
  "revm-state 42.0.0",
 ]
@@ -10413,23 +10264,6 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
-dependencies = [
- "bitvec",
- "cfg-if",
- "derive-where",
- "revm-bytecode 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-context"
 version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
@@ -10438,26 +10272,10 @@ dependencies = [
  "cfg-if",
  "derive-where",
  "revm-bytecode 42.0.0",
- "revm-context-interface 42.0.0",
- "revm-database-interface 42.0.0",
+ "revm-context-interface",
+ "revm-database-interface",
  "revm-primitives 42.0.0",
  "revm-state 42.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-context-interface"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702",
- "auto_impl",
- "either",
- "revm-database-interface 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10471,25 +10289,9 @@ dependencies = [
  "alloy-eip7702",
  "auto_impl",
  "either",
- "revm-database-interface 42.0.0",
+ "revm-database-interface",
  "revm-primitives 42.0.0",
  "revm-state 42.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-database"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
-dependencies = [
- "alloy-eips",
- "derive_more",
- "either",
- "revm-bytecode 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
  "serde",
 ]
 
@@ -10503,24 +10305,10 @@ dependencies = [
  "derive_more",
  "either",
  "revm-bytecode 42.0.0",
- "revm-database-interface 42.0.0",
+ "revm-database-interface",
  "revm-primitives 42.0.0",
  "revm-state 42.0.0",
  "serde",
-]
-
-[[package]]
-name = "revm-database-interface"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
-dependencies = [
- "auto_impl",
- "either",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
- "serde",
- "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -10539,25 +10327,6 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
-dependencies = [
- "auto_impl",
- "derive-where",
- "revm-bytecode 41.0.0",
- "revm-context 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-interpreter 41.0.0",
- "revm-precompile 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
- "serde",
-]
-
-[[package]]
-name = "revm-handler"
 version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
@@ -10565,32 +10334,14 @@ dependencies = [
  "auto_impl",
  "derive-where",
  "revm-bytecode 42.0.0",
- "revm-context 42.0.0",
- "revm-context-interface 42.0.0",
- "revm-database-interface 42.0.0",
- "revm-interpreter 42.0.0",
- "revm-precompile 42.0.1",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
  "revm-primitives 42.0.0",
  "revm-state 42.0.0",
  "serde",
-]
-
-[[package]]
-name = "revm-inspector"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
-dependencies = [
- "auto_impl",
- "either",
- "revm-context 41.0.0",
- "revm-database-interface 41.0.0",
- "revm-handler 41.0.0",
- "revm-interpreter 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -10601,10 +10352,10 @@ checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
 dependencies = [
  "auto_impl",
  "either",
- "revm-context 42.0.0",
- "revm-database-interface 42.0.0",
- "revm-handler 42.0.1",
- "revm-interpreter 42.0.0",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
  "revm-primitives 42.0.0",
  "revm-state 42.0.0",
  "serde",
@@ -10625,23 +10376,10 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "colorchoice",
- "revm 42.0.1",
+ "revm",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
-]
-
-[[package]]
-name = "revm-interpreter"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
-dependencies = [
- "revm-bytecode 41.0.0",
- "revm-context-interface 41.0.0",
- "revm-primitives 41.0.0",
- "revm-state 41.0.0",
- "serde",
 ]
 
 [[package]]
@@ -10651,35 +10389,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
 dependencies = [
  "revm-bytecode 42.0.0",
- "revm-context-interface 42.0.0",
+ "revm-context-interface",
  "revm-primitives 42.0.0",
  "revm-state 42.0.0",
  "serde",
-]
-
-[[package]]
-name = "revm-precompile"
-version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
-dependencies = [
- "ark-bls12-381 0.5.0",
- "ark-bn254 0.5.0",
- "ark-ec 0.5.0",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "arrayref",
- "aurora-engine-modexp",
- "blst",
- "c-kzg",
- "cfg-if",
- "k256",
- "p256",
- "revm-context-interface 41.0.0",
- "revm-primitives 41.0.0",
- "ripemd 0.1.3",
- "secp256k1 0.31.1",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10688,9 +10401,9 @@ version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
 dependencies = [
- "ark-bls12-381 0.6.0",
- "ark-bn254 0.6.0",
- "ark-ec 0.6.0",
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
  "ark-ff 0.6.0",
  "ark-serialize 0.6.0",
  "arrayref",
@@ -10700,7 +10413,7 @@ dependencies = [
  "cfg-if",
  "k256",
  "p256",
- "revm-context-interface 42.0.0",
+ "revm-context-interface",
  "revm-primitives 42.0.0",
  "ripemd 0.2.0",
  "secp256k1 0.31.1",
@@ -10760,7 +10473,7 @@ dependencies = [
 [[package]]
 name = "rexpect"
 version = "0.6.2"
-source = "git+https://github.com/rust-cli/rexpect?rev=2de4faa2a4421f15bbdce3bf196ccda4dac0228e#2de4faa2a4421f15bbdce3bf196ccda4dac0228e"
+source = "git+https://github.com/rust-cli/rexpect?rev=2ed0b1898d7edaf6a85bedbae71a01cc578958fc#2ed0b1898d7edaf6a85bedbae71a01cc578958fc"
 dependencies = [
  "comma",
  "nix 0.30.1",
@@ -11846,7 +11559,7 @@ dependencies = [
  "solar-sema",
  "tikv-jemallocator",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "tracing-tracy",
 ]
 
@@ -12434,46 +12147,6 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
-dependencies = [
- "alloy-consensus",
- "alloy-contract",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rlp",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer",
- "alloy-signer-local",
- "alloy-sol-types",
- "alloy-transport",
- "async-trait",
- "base64 0.22.1",
- "dashmap",
- "derive_more",
- "dirs-next",
- "futures",
- "http 1.5.0",
- "p256",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tempo-chainspec 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
- "tempo-contracts 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
- "tempo-primitives 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
- "thiserror 2.0.19",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "tempo-alloy"
-version = "1.10.1"
 source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd#72974b5b400c340273551152a366870dc5f92bbd"
 dependencies = [
  "alloy-consensus",
@@ -12503,68 +12176,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-chainspec",
+ "tempo-contracts",
+ "tempo-primitives",
  "thiserror 2.0.19",
  "tower",
  "tracing",
-]
-
-[[package]]
-name = "tempo-alloy"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
-dependencies = [
- "alloy-consensus",
- "alloy-contract",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-primitives",
- "alloy-provider",
- "alloy-rlp",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer",
- "alloy-signer-local",
- "alloy-sol-types",
- "alloy-transport",
- "async-trait",
- "base64 0.22.1",
- "dashmap",
- "derive_more",
- "dirs-next",
- "futures",
- "http 1.5.0",
- "p256",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
- "thiserror 2.0.19",
- "tower",
- "tracing",
-]
-
-[[package]]
-name = "tempo-chainspec"
-version = "1.10.1"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
-dependencies = [
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "once_cell",
- "paste",
- "serde",
- "serde_json",
- "tempo-hardfork 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
- "tempo-primitives 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
 ]
 
 [[package]]
@@ -12586,36 +12203,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempo-dkg-onchain-artifacts",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
-]
-
-[[package]]
-name = "tempo-chainspec"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
-dependencies = [
- "alloy-eips",
- "alloy-genesis",
- "alloy-primitives",
- "once_cell",
- "paste",
- "serde",
- "serde_json",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
-]
-
-[[package]]
-name = "tempo-contracts"
-version = "1.10.1"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
-dependencies = [
- "alloy-contract",
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
- "tempo-hardfork 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
+ "tempo-hardfork",
+ "tempo-primitives",
 ]
 
 [[package]]
@@ -12627,19 +12216,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "serde",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
-]
-
-[[package]]
-name = "tempo-contracts"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
-dependencies = [
- "alloy-contract",
- "alloy-primitives",
- "alloy-sol-types",
- "serde",
- "tempo-hardfork 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
+ "tempo-hardfork",
 ]
 
 [[package]]
@@ -12675,25 +12252,14 @@ dependencies = [
  "reth-evm-ethereum",
  "reth-primitives-traits 0.6.0",
  "reth-revm",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-chainspec",
+ "tempo-contracts",
  "tempo-dkg-onchain-artifacts",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.19",
  "tracing",
-]
-
-[[package]]
-name = "tempo-hardfork"
-version = "1.10.1"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
-dependencies = [
- "alloy-eips",
- "alloy-hardforks",
- "paste",
- "serde",
 ]
 
 [[package]]
@@ -12703,17 +12269,6 @@ source = "git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366
 dependencies = [
  "alloy-eips",
  "alloy-evm",
- "alloy-hardforks",
- "paste",
- "serde",
-]
-
-[[package]]
-name = "tempo-hardfork"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
-dependencies = [
- "alloy-eips",
  "alloy-hardforks",
  "paste",
  "serde",
@@ -12732,12 +12287,12 @@ dependencies = [
  "commonware-cryptography",
  "derive_more",
  "paste",
- "revm 42.0.1",
+ "revm",
  "scoped-tls",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-chainspec",
+ "tempo-contracts",
  "tempo-precompiles-macros",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -12751,31 +12306,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "tempo-primitives"
-version = "1.10.1"
-source = "git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f#fb7922c0e92cf52b5cbca73826fb05ca7e32a50f"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "base64 0.22.1",
- "derive_more",
- "ed25519-consensus",
- "once_cell",
- "p256",
- "reth-codecs 0.6.0",
- "reth-ethereum-primitives",
- "reth-primitives-traits 0.6.0",
- "revm 42.0.1",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tempo-contracts 1.10.1 (git+https://github.com/foundry-rs/foundry-core?rev=fb7922c0e92cf52b5cbca73826fb05ca7e32a50f)",
 ]
 
 [[package]]
@@ -12798,36 +12328,11 @@ dependencies = [
  "reth-codecs 0.6.0",
  "reth-ethereum-primitives",
  "reth-primitives-traits 0.6.0",
- "revm 42.0.1",
+ "revm",
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
-]
-
-[[package]]
-name = "tempo-primitives"
-version = "1.10.1"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8#9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "base64 0.22.1",
- "derive_more",
- "ed25519-consensus",
- "once_cell",
- "p256",
- "reth-codecs 0.6.0",
- "reth-ethereum-primitives",
- "reth-primitives-traits 0.6.0",
- "revm 42.0.1",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/mpp-rs?rev=9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8)",
+ "tempo-contracts",
 ]
 
 [[package]]
@@ -12843,11 +12348,11 @@ dependencies = [
  "derive_more",
  "reth-evm",
  "reth-storage-api",
- "revm 42.0.1",
- "tempo-chainspec 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
- "tempo-contracts 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "revm",
+ "tempo-chainspec",
+ "tempo-contracts",
  "tempo-precompiles",
- "tempo-primitives 1.10.1 (git+https://github.com/tempoxyz/tempo?rev=72974b5b400c340273551152a366870dc5f92bbd)",
+ "tempo-primitives",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -13096,18 +12601,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.28.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -13118,7 +12611,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.29.0",
+ "tungstenite",
  "webpki-roots 0.26.11",
 ]
 
@@ -13367,7 +12860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -13393,7 +12886,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "web-time",
 ]
 
@@ -13404,15 +12897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
  "tracing-core",
 ]
 
@@ -13444,7 +12928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
 dependencies = [
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "tracy-client",
 ]
 
@@ -13489,23 +12973,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http 1.5.0",
- "httparse",
- "log",
- "rand 0.9.5",
- "sha1",
- "thiserror 2.0.19",
- "utf-8",
-]
 
 [[package]]
 name = "tungstenite"
@@ -13762,12 +13229,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "d48ea2f276d52b43c32914bcea03ce67cf8c75f1", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "b69e1fddb37aecbb048cd8de9d2b6c19990d9a47", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -512,30 +512,30 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "cc95fb153e1848f844f6d5110a8a62ac7dc34b9b", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "0d7660f0b33e7899f79a1df6671a44d0155f8761", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "cc95fb153e1848f844f6d5110a8a62ac7dc34b9b", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "0d7660f0b33e7899f79a1df6671a44d0155f8761", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -553,9 +553,9 @@ solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e22
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e2267c549555a980aef6b0b1f249eb" }
 
 ## foundry-core
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "d48ea2f276d52b43c32914bcea03ce67cf8c75f1" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "d48ea2f276d52b43c32914bcea03ce67cf8c75f1" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "d48ea2f276d52b43c32914bcea03ce67cf8c75f1" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b69e1fddb37aecbb048cd8de9d2b6c19990d9a47" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b69e1fddb37aecbb048cd8de9d2b6c19990d9a47" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "b69e1fddb37aecbb048cd8de9d2b6c19990d9a47" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
@@ -613,24 +613,10 @@ op-alloy-network = { git = "https://github.com/foundry-rs/optimism", rev = "4ce1
 op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
 alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
 
-## commonware — match the rev patched by the current Tempo workspace
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
-
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "b69e1fddb37aecbb048cd8de9d2b6c19990d9a47", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "2a5b28096bb94c048e79f0a76748e59d89444d00", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -512,30 +512,30 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "0d7660f0b33e7899f79a1df6671a44d0155f8761", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "1241b29975eedcfd82bfb85fac186b92cc6dac16", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "0d7660f0b33e7899f79a1df6671a44d0155f8761", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "1241b29975eedcfd82bfb85fac186b92cc6dac16", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -553,9 +553,9 @@ solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e22
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e2267c549555a980aef6b0b1f249eb" }
 
 ## foundry-core
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b69e1fddb37aecbb048cd8de9d2b6c19990d9a47" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "b69e1fddb37aecbb048cd8de9d2b6c19990d9a47" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "b69e1fddb37aecbb048cd8de9d2b6c19990d9a47" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "2a5b28096bb94c048e79f0a76748e59d89444d00" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "2a5b28096bb94c048e79f0a76748e59d89444d00" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "2a5b28096bb94c048e79f0a76748e59d89444d00" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
@@ -614,9 +614,9 @@ op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "4c
 alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "0cffd71de70874ec3fc2814caeee12ad528a6127" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "c93d08a9b6b26baa3026a4f280e5d82aa2d65643" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,7 +329,7 @@ foundry-evm-symbolic = { path = "crates/evm/symbolic", default-features = false 
 foundry-evm-traces = { path = "crates/evm/traces", default-features = false }
 foundry-macros = { path = "crates/macros" }
 foundry-test-utils = { path = "crates/test-utils", default-features = false }
-foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "d80a95d94aecafcf38647dfee9f4804552576c35", default-features = false }
+foundry-wallets = { git = "https://github.com/foundry-rs/foundry-core", rev = "d48ea2f276d52b43c32914bcea03ce67cf8c75f1", default-features = false }
 foundry-linking = { path = "crates/linking" }
 foundry-primitives = { path = "crates/primitives", default-features = false }
 foundry-tui = { path = "crates/tui", default-features = false }
@@ -379,7 +379,7 @@ alloy-transport-http = { version = "2.2.0", default-features = false }
 alloy-transport-ipc = { version = "2.2.0", default-features = false }
 alloy-transport-ws = { version = "2.2.0", default-features = false }
 alloy-hardforks = { version = "0.4.7", default-features = false }
-alloy-op-hardforks = { version = "0.4.7", default-features = false }
+alloy-op-hardforks = { version = "0.5.0", default-features = false }
 
 ## alloy-core
 alloy-dyn-abi = "1.6.1"
@@ -411,7 +411,7 @@ alloy-op-evm = "0.32.0"
 # revm
 revm = { version = "42.0.1", default-features = false }
 revm-inspectors = { version = "0.42.0", features = ["serde"] }
-op-revm = { version = "20.0.0", default-features = false }
+op-revm = { git = "https://github.com/foundry-rs/optimism", branch = "develop", default-features = false }
 
 ## cli
 anstream = "1.0"
@@ -553,9 +553,9 @@ solar-cli = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e22
 solar-lint = { git = "https://github.com/paradigmxyz/solar", rev = "a38f69e4f2e2267c549555a980aef6b0b1f249eb" }
 
 ## foundry-core
-foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "fb7922c0e92cf52b5cbca73826fb05ca7e32a50f" }
-foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "fb7922c0e92cf52b5cbca73826fb05ca7e32a50f" }
-foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "fb7922c0e92cf52b5cbca73826fb05ca7e32a50f" }
+foundry-compilers = { git = "https://github.com/foundry-rs/foundry-core", rev = "d48ea2f276d52b43c32914bcea03ce67cf8c75f1" }
+foundry-block-explorers = { git = "https://github.com/foundry-rs/foundry-core", rev = "d48ea2f276d52b43c32914bcea03ce67cf8c75f1" }
+foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "d48ea2f276d52b43c32914bcea03ce67cf8c75f1" }
 
 ## alloy-core
 # alloy-dyn-abi = { path = "../../alloy-rs/core/crates/dyn-abi" }
@@ -607,12 +607,11 @@ foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "f
 
 ## op-revm / op-alloy / alloy-op-evm
 ## Pinned to foundry-rs forks for the revm 42 stack.
-op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "dca56351469222d8eae9185b6c19ac14f6c0d0ab" }
 alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
 op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
 op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
 op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
-alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
+alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
 
 ## commonware — match the rev patched by the current Tempo workspace
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -512,10 +512,10 @@ flate2 = "1.1"
 ethereum_ssz = "0.10"
 
 # Tempo
-alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8", default-features = false, features = [
+alloy-transport-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "cc95fb153e1848f844f6d5110a8a62ac7dc34b9b", default-features = false, features = [
     "aws-lc-rs",
 ] }
-mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8", default-features = false, features = [
+mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "cc95fb153e1848f844f6d5110a8a62ac7dc34b9b", default-features = false, features = [
     "tempo",
     "client",
     "sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -399,9 +399,9 @@ alloy-rlp = "0.3"
 alloy-trie = "0.9"
 
 ## op-alloy
-op-alloy-consensus = "0.24.0"
-op-alloy-network = "0.24.0"
-op-alloy-rpc-types = "0.24.0"
+op-alloy-consensus = "2.0.0"
+op-alloy-network = "2.0.0"
+op-alloy-rpc-types = "2.0.0"
 op-alloy-flz = "0.13.1"
 
 ## alloy-evm
@@ -606,13 +606,13 @@ foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "f
 # alloy-evm = { git = "https://github.com/paradigmxyz/evm.git", rev = "04d8e4a" }
 
 ## op-revm / op-alloy / alloy-op-evm
-## Pinned to foundry-rs forks until upstream optimism bumps to revm 40.
+## Pinned to foundry-rs forks for the revm 42 stack.
 op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "dca56351469222d8eae9185b6c19ac14f6c0d0ab" }
 alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
 op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
 op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
 op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
-alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
+alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
 
 ## commonware — match the rev patched by the current Tempo workspace
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -405,12 +405,12 @@ op-alloy-rpc-types = "0.24.0"
 op-alloy-flz = "0.13.1"
 
 ## alloy-evm
-alloy-evm = "0.37.0"
+alloy-evm = "0.38.0"
 alloy-op-evm = "0.32.0"
 
 # revm
-revm = { version = "41.0.0", default-features = false }
-revm-inspectors = { version = "0.41.1", features = ["serde"] }
+revm = { version = "42.0.1", default-features = false }
+revm-inspectors = { version = "0.42.0", features = ["serde"] }
 op-revm = { version = "20.0.0", default-features = false }
 
 ## cli
@@ -522,20 +522,20 @@ mpp = { git = "https://github.com/tempoxyz/mpp-rs", rev = "9808dede7ad8d388d519f
     "reqwest-rustls-tls",
     "ws",
 ] }
-tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
+tempo-hardfork = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false, features = [
     "serde",
     "std",
 ] }
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false, features = [
     "serde",
 ] }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
-tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false }
-tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c", default-features = false, features = [
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false }
+tempo-evm = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false }
+tempo-revm = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd", default-features = false, features = [
     "serde",
 ] }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
+tempo-precompiles = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
 
 ## Pinned dependencies. Enabled for the workspace in crates/test-utils.
 
@@ -607,12 +607,12 @@ foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "f
 
 ## op-revm / op-alloy / alloy-op-evm
 ## Pinned to foundry-rs forks until upstream optimism bumps to revm 40.
-op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "c10fd76e66fd46cebc08ba370aa58bde72b94140" }
-alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
-op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
-op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
-op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
-alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "bump-alloy-evm-0-36-tempo" }
+op-revm = { git = "https://github.com/foundry-rs/op-revm", rev = "dca56351469222d8eae9185b6c19ac14f6c0d0ab" }
+alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
+op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
+op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
+op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
+alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
 
 ## commonware — match the rev patched by the current Tempo workspace
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
@@ -629,9 +629,9 @@ commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = 
 commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }
 
 ## tempo — unify crates.io versions (pulled by mpp/foundry-wallets) with git rev
-tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
-tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "76908150fc56bc6dcb91ecbb8a424939f8acef4c" }
+tempo-primitives = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
+tempo-alloy = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
+tempo-contracts = { git = "https://github.com/tempoxyz/tempo", rev = "72974b5b400c340273551152a366870dc5f92bbd" }
 
 [workspace.metadata.cargo-shear]
 ignored = ["idna_adapter", "cast", "chisel", "forge", "alloy-contract"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,7 +411,7 @@ alloy-op-evm = "0.32.0"
 # revm
 revm = { version = "42.0.1", default-features = false }
 revm-inspectors = { version = "0.42.0", features = ["serde"] }
-op-revm = { git = "https://github.com/foundry-rs/optimism", branch = "develop", default-features = false }
+op-revm = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2", default-features = false }
 
 ## cli
 anstream = "1.0"
@@ -607,11 +607,11 @@ foundry-fork-db = { git = "https://github.com/foundry-rs/foundry-core", rev = "d
 
 ## op-revm / op-alloy / alloy-op-evm
 ## Pinned to foundry-rs forks for the revm 42 stack.
-alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
-op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
-op-alloy-network = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
-op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
-alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", branch = "develop" }
+alloy-op-evm = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
+op-alloy-consensus = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
+op-alloy-network = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
+op-alloy-rpc-types = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
+alloy-op-hardforks = { git = "https://github.com/foundry-rs/optimism", rev = "4ce11c64258bc5d0bcad64ed49e1ea54b41a72c2" }
 
 ## commonware — match the rev patched by the current Tempo workspace
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }

--- a/crates/anvil/src/eth/backend/tempo.rs
+++ b/crates/anvil/src/eth/backend/tempo.rs
@@ -190,6 +190,10 @@ impl PrecompileStorageProvider for AnvilStorageProvider<'_> {
         0
     }
 
+    fn state_gas_spilled(&self) -> u64 {
+        0
+    }
+
     fn gas_limit(&self) -> u64 {
         u64::MAX
     }

--- a/crates/anvil/src/evm/mod.rs
+++ b/crates/anvil/src/evm/mod.rs
@@ -63,6 +63,7 @@ mod tests {
                 gas_used: 0,
                 gas_refunded: 0,
                 state_gas_used: 0,
+                state_gas_spilled: 0,
                 reservoir: input.reservoir,
             })
         })

--- a/crates/anvil/tests/it/eip2935.rs
+++ b/crates/anvil/tests/it/eip2935.rs
@@ -47,6 +47,7 @@ impl PrecompileFactory for FailingHistoryPrecompile {
                 gas_used: 0,
                 gas_refunded: 0,
                 state_gas_used: 0,
+                state_gas_spilled: 0,
                 reservoir: input.reservoir,
             })
         });
@@ -70,6 +71,7 @@ impl PrecompileFactory for OrderedBlockStartPrecompiles {
                 gas_used: 0,
                 gas_refunded: 0,
                 state_gas_used: 0,
+                state_gas_spilled: 0,
                 reservoir: input.reservoir,
             })
         });
@@ -87,6 +89,7 @@ impl PrecompileFactory for OrderedBlockStartPrecompiles {
                 gas_used: 0,
                 gas_refunded: 0,
                 state_gas_used: 0,
+                state_gas_spilled: 0,
                 reservoir: input.reservoir,
             })
         });
@@ -168,8 +171,9 @@ impl PrecompileFactory for CountingPostBlockPrecompiles {
                         bytes: Bytes::new(),
                         gas_used: 0,
                         gas_refunded: 0,
-                        state_gas_used: 0,
-                        reservoir: input.reservoir,
+                    state_gas_used: 0,
+                    state_gas_spilled: 0,
+                    reservoir: input.reservoir,
                     })
                 });
                 (address, precompile)

--- a/crates/anvil/tests/it/eip2935.rs
+++ b/crates/anvil/tests/it/eip2935.rs
@@ -171,9 +171,9 @@ impl PrecompileFactory for CountingPostBlockPrecompiles {
                         bytes: Bytes::new(),
                         gas_used: 0,
                         gas_refunded: 0,
-                    state_gas_used: 0,
-                    state_gas_spilled: 0,
-                    reservoir: input.reservoir,
+                        state_gas_used: 0,
+                        state_gas_spilled: 0,
+                        reservoir: input.reservoir,
                     })
                 });
                 (address, precompile)

--- a/crates/anvil/tests/it/fork.rs
+++ b/crates/anvil/tests/it/fork.rs
@@ -2780,6 +2780,7 @@ async fn test_config_with_osaka_hardfork_with_precompile_factory() {
                             gas_refunded: 0,
                             status: PrecompileStatus::Success,
                             state_gas_used: 0,
+                            state_gas_spilled: 0,
                             reservoir: input.reservoir,
                         })
                     },

--- a/crates/anvil/tests/it/simulate.rs
+++ b/crates/anvil/tests/it/simulate.rs
@@ -257,6 +257,7 @@ impl PrecompileFactory for LookupOnlyPrecompileFactory {
                         gas_used: 0,
                         gas_refunded: 0,
                         state_gas_used: 0,
+                        state_gas_spilled: 0,
                         reservoir: input.reservoir,
                     })
                 })
@@ -1001,6 +1002,7 @@ impl PrecompileFactory for RequestOutputPrecompileFactory {
                         gas_used: 0,
                         gas_refunded: 0,
                         state_gas_used: 0,
+                        state_gas_spilled: 0,
                         reservoir: input.reservoir,
                     })
                 }),
@@ -1014,6 +1016,7 @@ impl PrecompileFactory for RequestOutputPrecompileFactory {
                         gas_used: 0,
                         gas_refunded: 0,
                         state_gas_used: 0,
+                        state_gas_spilled: 0,
                         reservoir: input.reservoir,
                     })
                 }),
@@ -1038,6 +1041,7 @@ impl PrecompileFactory for PerBlockRequestPrecompileFactory {
                     gas_used: 0,
                     gas_refunded: 0,
                     state_gas_used: 0,
+                    state_gas_spilled: 0,
                     reservoir: input.reservoir,
                 })
             }),

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -1333,7 +1333,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                         memory_offset: call.return_memory_offset.clone(),
                         was_precompile_called: false,
                         precompile_call_logs: vec![],
-                        charged_new_account_state_gas: false,
+                        charged_new_account_state_gas: call.charged_new_account_state_gas,
                     });
                 }
             };
@@ -1354,7 +1354,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                     memory_offset: call.return_memory_offset.clone(),
                     was_precompile_called: true,
                     precompile_call_logs: vec![],
-                    charged_new_account_state_gas: false,
+                    charged_new_account_state_gas: call.charged_new_account_state_gas,
                 }),
                 Err(err) => Some(CallOutcome {
                     result: InterpreterResult {
@@ -1365,7 +1365,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                     memory_offset: call.return_memory_offset.clone(),
                     was_precompile_called: false,
                     precompile_call_logs: vec![],
-                    charged_new_account_state_gas: false,
+                    charged_new_account_state_gas: call.charged_new_account_state_gas,
                 }),
             };
         }
@@ -1490,7 +1490,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                                 memory_offset: call.return_memory_offset.clone(),
                                 was_precompile_called: false,
                                 precompile_call_logs: vec![],
-                                charged_new_account_state_gas: false,
+                                charged_new_account_state_gas: call.charged_new_account_state_gas,
                             });
                         }
                     }
@@ -1510,7 +1510,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                     memory_offset: call.return_memory_offset.clone(),
                     was_precompile_called: true,
                     precompile_call_logs: vec![],
-                    charged_new_account_state_gas: false,
+                    charged_new_account_state_gas: call.charged_new_account_state_gas,
                 });
             }
         }
@@ -1551,7 +1551,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                             memory_offset: call.return_memory_offset.clone(),
                             was_precompile_called: false,
                             precompile_call_logs: vec![],
-                            charged_new_account_state_gas: false,
+                            charged_new_account_state_gas: call.charged_new_account_state_gas,
                         });
                     }
 
@@ -1587,7 +1587,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                                 memory_offset: call.return_memory_offset.clone(),
                                 was_precompile_called: false,
                                 precompile_call_logs: vec![],
-                                charged_new_account_state_gas: false,
+                                charged_new_account_state_gas: call.charged_new_account_state_gas,
                             });
                         }
                         tx_req.set_blob_sidecar(blob_sidecar);
@@ -1633,7 +1633,7 @@ impl<FEN: FoundryEvmNetwork> Cheatcodes<FEN> {
                         memory_offset: call.return_memory_offset.clone(),
                         was_precompile_called: false,
                         precompile_call_logs: vec![],
-                        charged_new_account_state_gas: false,
+                        charged_new_account_state_gas: call.charged_new_account_state_gas,
                     });
                 }
             }

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2715,7 +2715,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             return Some(CreateOutcome {
                 result: InterpreterResult { result: InstructionResult::Revert, output, gas },
                 address: None,
-                charged_create_state_gas: false,
+                charged_create_state_gas: input.charged_create_state_gas(),
             });
         }
 
@@ -2764,7 +2764,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         gas,
                     },
                     address: None,
-                    charged_create_state_gas: false,
+                    charged_create_state_gas: input.charged_create_state_gas(),
                 });
             }
 

--- a/crates/cheatcodes/src/inspector.rs
+++ b/crates/cheatcodes/src/inspector.rs
@@ -2614,6 +2614,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
             return Some(CreateOutcome {
                 result: InterpreterResult { result: InstructionResult::Revert, output, gas },
                 address: None,
+                charged_create_state_gas: false,
             });
         }
 
@@ -2662,6 +2663,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>> for Cheatcode
                         gas,
                     },
                     address: None,
+                    charged_create_state_gas: false,
                 });
             }
 

--- a/crates/evm/core/src/evm/eth.rs
+++ b/crates/evm/core/src/evm/eth.rs
@@ -12,7 +12,8 @@ use revm::{
     },
     inspector::InspectorHandler,
     interpreter::{
-        FrameInput, SharedMemory, interpreter::EthInterpreter, interpreter_action::FrameInit,
+        FrameInput, GasTracker, SharedMemory, interpreter::EthInterpreter,
+        interpreter_action::FrameInit,
     },
     primitives::hardfork::SpecId,
 };
@@ -78,8 +79,6 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
         let mut handler = EthEvmHandler::<I>::default();
-        let reservoir = frame.reservoir();
-
         // Create first frame
         let memory =
             SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
@@ -89,7 +88,12 @@ impl<'db, I: FoundryInspectorExt<EthEvmContext<&'db mut dyn DatabaseExt<EthEvmFa
         let mut frame_result = handler.inspect_run_exec_loop(self, first_frame_input)?;
 
         // Handle last frame result
-        handler.last_frame_result(self, reservoir, &mut frame_result)?;
+        let mut parent_gas = GasTracker::new(
+            frame_result.gas().limit(),
+            frame_result.gas().remaining(),
+            frame_result.gas().reservoir(),
+        );
+        handler.last_frame_result(self, &mut frame_result, &mut parent_gas)?;
 
         Ok(frame_result)
     }

--- a/crates/evm/core/src/evm/op.rs
+++ b/crates/evm/core/src/evm/op.rs
@@ -11,7 +11,7 @@ use revm::{
     handler::{EthFrame, EvmTr, FrameResult, Handler, instructions::EthInstructions},
     inspector::InspectorHandler,
     interpreter::{
-        FrameInput, InstructionResult, SharedMemory, interpreter::EthInterpreter,
+        FrameInput, GasTracker, InstructionResult, SharedMemory, interpreter::EthInterpreter,
         interpreter_action::FrameInit,
     },
 };
@@ -100,8 +100,6 @@ impl<'db, I: FoundryInspectorExt<OpEvmContext<&'db mut dyn DatabaseExt<OpEvmFact
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
         let mut handler = OpEvmHandler::<I>::new();
-        let reservoir = frame.reservoir();
-
         let memory =
             SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
         let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
@@ -109,7 +107,14 @@ impl<'db, I: FoundryInspectorExt<OpEvmContext<&'db mut dyn DatabaseExt<OpEvmFact
         let mut frame_result =
             handler.inspect_run_exec_loop(self, first_frame_input).map_err(map_op_error)?;
 
-        handler.last_frame_result(self, reservoir, &mut frame_result).map_err(map_op_error)?;
+        let mut parent_gas = GasTracker::new(
+            frame_result.gas().limit(),
+            frame_result.gas().remaining(),
+            frame_result.gas().reservoir(),
+        );
+        handler
+            .last_frame_result(self, &mut frame_result, &mut parent_gas)
+            .map_err(map_op_error)?;
 
         Ok(frame_result)
     }

--- a/crates/evm/core/src/evm/tempo.rs
+++ b/crates/evm/core/src/evm/tempo.rs
@@ -9,7 +9,7 @@ use revm::{
     },
     handler::{EvmTr, FrameResult, Handler},
     inspector::InspectorHandler,
-    interpreter::{FrameInput, SharedMemory, interpreter_action::FrameInit},
+    interpreter::{FrameInput, GasTracker, SharedMemory, interpreter_action::FrameInit},
     state::Bytecode,
 };
 use tempo_evm::{TempoBlockEnv, TempoEvmFactory, TempoHaltReason, evm::TempoEvm};
@@ -157,8 +157,6 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
 
     fn run_execution(&mut self, frame: FrameInput) -> Result<FrameResult, EVMError<DatabaseError>> {
         let mut handler = TempoEvmHandler::new();
-        let reservoir = frame.reservoir();
-
         let memory =
             SharedMemory::new_with_buffer(self.ctx_ref().local().shared_memory_buffer().clone());
         let first_frame_input = FrameInit { depth: 0, memory, frame_input: frame };
@@ -166,7 +164,14 @@ impl<'db, I: FoundryInspectorExt<TempoContext<&'db mut dyn DatabaseExt<TempoEvmF
         let mut frame_result =
             handler.inspect_run_exec_loop(self, first_frame_input).map_err(map_tempo_error)?;
 
-        handler.last_frame_result(self, reservoir, &mut frame_result).map_err(map_tempo_error)?;
+        let mut parent_gas = GasTracker::new(
+            frame_result.gas().limit(),
+            frame_result.gas().remaining(),
+            frame_result.gas().reservoir(),
+        );
+        handler
+            .last_frame_result(self, &mut frame_result, &mut parent_gas)
+            .map_err(map_tempo_error)?;
 
         Ok(frame_result)
     }

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1374,6 +1374,7 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
     let gas = revm::interpreter::gas::calculate_initial_tx_gas_for_tx(
         &tx_env,
         evm_env.cfg_env.spec.into(),
+        None,
     );
 
     let result = match &out {

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1736,6 +1736,44 @@ mod tests {
     }
 
     #[test]
+    fn amsterdam_intercepted_create_refunds_state_gas() {
+        let cheats_config = Arc::new(CheatsConfig::new(
+            &Config::default(),
+            EvmOpts::default(),
+            None,
+            None,
+            None,
+            false,
+        ));
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default()
+            .inspectors(|stack| stack.cheatcodes(cheats_config))
+            .spec_id(SpecId::AMSTERDAM)
+            .gas_limit(1_000_000)
+            .build(EvmEnv::default(), TxEnv::default(), backend);
+
+        let target = Address::repeat_byte(0x11);
+        // PUSH0; PUSH0; PUSH0; CREATE; POP; STOP.
+        executor
+            .set_code(
+                target,
+                Bytecode::new_raw(Bytes::from_static(&[0x5f, 0x5f, 0x5f, 0xf0, 0x50, 0x00])),
+            )
+            .unwrap();
+        executor.inspector_mut().cheatcodes.as_mut().unwrap().intercept_next_create_call = true;
+
+        let result = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO).unwrap();
+
+        assert!(!result.reverted);
+        assert!(
+            result.gas_used
+                < revm::context_interface::cfg::GasParams::new_spec(SpecId::AMSTERDAM)
+                    .create_state_gas(),
+            "failed CREATE retained its conditional state-gas charge"
+        );
+    }
+
+    #[test]
     fn early_exit_interrupts_active_evm_execution() {
         const GAS_LIMIT: u64 = 1 << 24;
         let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -45,8 +45,9 @@ use foundry_evm_fuzz::ObservedCall;
 use foundry_evm_traces::{SparsedTraceArena, TraceRequirements};
 use revm::{
     bytecode::Bytecode,
-    context::{Block, Transaction},
+    context::{Block, Cfg, Transaction},
     context_interface::{
+        cfg::gas_params::Eip2780TxInfo,
         result::{ExecutionResult, Output, ResultAndState},
         transaction::SignedAuthorization,
     },
@@ -1350,7 +1351,16 @@ impl<T, FEN: FoundryEvmNetwork> std::ops::DerefMut for CallResult<T, FEN> {
     }
 }
 
-/// Converts the data aggregated in the `inspector` and `call` to a `RawCallResult`
+fn calculate_stipend(tx_env: &impl Transaction, spec: SpecId, eip2780_enabled: bool) -> u64 {
+    let eip2780 = eip2780_enabled.then(|| Eip2780TxInfo {
+        value: tx_env.value(),
+        is_self_transfer: matches!(tx_env.kind(), TxKind::Call(to) if to == tx_env.caller()),
+    });
+    revm::interpreter::gas::calculate_initial_tx_gas_for_tx(tx_env, spec, eip2780)
+        .initial_total_gas()
+}
+
+/// Converts the data aggregated in the `inspector` and `call` to a `RawCallResult`.
 fn convert_executed_result<FEN: FoundryEvmNetwork>(
     evm_env: EvmEnvFor<FEN>,
     tx_env: TxEnvFor<FEN>,
@@ -1371,10 +1381,10 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
             (reason.into_instruction_result(), 0_u64, gas.tx_gas_used(), None, logs)
         }
     };
-    let gas = revm::interpreter::gas::calculate_initial_tx_gas_for_tx(
+    let stipend = calculate_stipend(
         &tx_env,
         evm_env.cfg_env.spec.into(),
-        None,
+        evm_env.cfg_env.is_amsterdam_eip2780_enabled(),
     );
 
     let result = match &out {
@@ -1418,7 +1428,7 @@ fn convert_executed_result<FEN: FoundryEvmNetwork>(
         result,
         gas_used,
         gas_refunded,
-        stipend: gas.initial_total_gas(),
+        stipend,
         logs,
         labels,
         traces,
@@ -1584,7 +1594,7 @@ mod tests {
     };
     use foundry_config::Config;
     use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
-    use revm::context::{Cfg, TxEnv};
+    use revm::context::TxEnv;
     use std::{sync::mpsc, thread};
 
     fn dense_call(edge: EdgeKey) -> RawCallResult {
@@ -1700,6 +1710,29 @@ mod tests {
             &revm::context_interface::cfg::GasParams::new_spec(SpecId::AMSTERDAM),
         );
         assert!(executor.evm_env().cfg_env.is_amsterdam_eip8037_enabled());
+    }
+
+    #[test]
+    fn calculate_stipend_uses_eip2780_transaction_context() {
+        let caller = Address::repeat_byte(0x11);
+        let recipient = Address::repeat_byte(0x22);
+        let mut tx = TxEnv { caller, kind: TxKind::Call(recipient), ..Default::default() };
+
+        assert_eq!(
+            calculate_stipend(&tx, SpecId::AMSTERDAM, true),
+            revm::primitives::eip2780::TX_BASE_COST
+                + revm::primitives::eip8038::COLD_ACCOUNT_ACCESS
+        );
+        assert_eq!(
+            calculate_stipend(&tx, SpecId::AMSTERDAM, false),
+            revm::context_interface::cfg::GasParams::new_spec(SpecId::AMSTERDAM).tx_base_stipend()
+        );
+
+        tx.kind = TxKind::Call(caller);
+        assert_eq!(
+            calculate_stipend(&tx, SpecId::AMSTERDAM, true),
+            revm::primitives::eip2780::TX_BASE_COST
+        );
     }
 
     #[test]

--- a/crates/evm/evm/src/executors/mod.rs
+++ b/crates/evm/evm/src/executors/mod.rs
@@ -1590,7 +1590,7 @@ mod tests {
     use alloy_primitives::B256;
     use foundry_cheatcodes::{
         CheatsConfig,
-        Vm::{blobhashesCall, revertToStateCall, snapshotStateCall},
+        Vm::{blobhashesCall, mockCallRevert_1Call, revertToStateCall, snapshotStateCall},
     };
     use foundry_config::Config;
     use foundry_evm_core::{constants::MAGIC_SKIP, opts::EvmOpts};
@@ -1770,6 +1770,60 @@ mod tests {
                 < revm::context_interface::cfg::GasParams::new_spec(SpecId::AMSTERDAM)
                     .create_state_gas(),
             "failed CREATE retained its conditional state-gas charge"
+        );
+    }
+
+    #[test]
+    fn amsterdam_mocked_call_revert_refunds_state_gas() {
+        let cheats_config = Arc::new(CheatsConfig::new(
+            &Config::default(),
+            EvmOpts::default(),
+            None,
+            None,
+            None,
+            false,
+        ));
+        let backend = Backend::<EthEvmNetwork>::spawn(None).unwrap();
+        let mut executor = ExecutorBuilder::default()
+            .inspectors(|stack| stack.cheatcodes(cheats_config))
+            .spec_id(SpecId::AMSTERDAM)
+            .gas_limit(1_000_000)
+            .build(EvmEnv::default(), TxEnv::default(), backend);
+
+        let target = Address::repeat_byte(0x11);
+        let mocked = Address::repeat_byte(0x22);
+        executor
+            .transact_raw(
+                CALLER,
+                CHEATCODE_ADDRESS,
+                mockCallRevert_1Call {
+                    callee: mocked,
+                    msgValue: U256::from(1),
+                    data: Bytes::new(),
+                    revertData: Bytes::new(),
+                }
+                .abi_encode()
+                .into(),
+                U256::ZERO,
+            )
+            .unwrap();
+        executor.set_code(mocked, Bytecode::default()).unwrap();
+        executor.set_balance(target, U256::from(1)).unwrap();
+
+        // PUSH0 x4; PUSH1 1; PUSH20 <mocked>; GAS; CALL; POP; STOP.
+        let mut code = vec![0x5f, 0x5f, 0x5f, 0x5f, 0x60, 0x01, 0x73];
+        code.extend_from_slice(mocked.as_slice());
+        code.extend_from_slice(&[0x5a, 0xf1, 0x50, 0x00]);
+        executor.set_code(target, Bytecode::new_raw(code.into())).unwrap();
+
+        let result = executor.transact_raw(CALLER, target, Bytes::new(), U256::ZERO).unwrap();
+
+        assert!(!result.reverted);
+        assert!(
+            result.gas_used
+                < revm::context_interface::cfg::GasParams::new_spec(SpecId::AMSTERDAM)
+                    .new_account_state_gas(),
+            "reverted mocked CALL retained its conditional state-gas charge"
         );
     }
 

--- a/crates/evm/evm/src/inspectors/logs.rs
+++ b/crates/evm/evm/src/inspectors/logs.rs
@@ -43,7 +43,7 @@ impl LogCollector {
                 memory_offset: inputs.return_memory_offset.clone(),
                 was_precompile_called: true,
                 precompile_call_logs: vec![],
-                charged_new_account_state_gas: false,
+                charged_new_account_state_gas: inputs.charged_new_account_state_gas,
             });
         }
         None

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1581,7 +1581,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                         memory_offset: call.return_memory_offset.clone(),
                         was_precompile_called: true,
                         precompile_call_logs: vec![],
-                        charged_new_account_state_gas: false,
+                        charged_new_account_state_gas: call.charged_new_account_state_gas,
                     });
                 }
                 // Mark accounts and storage cold before STATICCALLs

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -371,6 +371,12 @@ struct EarlyExitTestGate {
     notified: Arc<std::sync::atomic::AtomicBool>,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct PendingCreate2Redirect {
+    depth: usize,
+    charged_create_state_gas: bool,
+}
+
 /// All used inspectors besides [Cheatcodes].
 ///
 /// See [`InspectorStack`].
@@ -410,8 +416,7 @@ pub struct InspectorStackInner {
     /// Address that reverted the call, if any.
     pub reverter: Option<Address>,
     /// LIFO stack tracking CREATE2 frames that were redirected to the CREATE2 factory.
-    /// Each entry records the journal depth at which the redirect occurred.
-    pub pending_create2_redirects: Vec<usize>,
+    pending_create2_redirects: Vec<PendingCreate2Redirect>,
     /// Pending CREATE2 deployer validation error, deferred from `frame_start` to `create` so
     /// it goes through the normal inspector lifecycle (tracing, etc.).
     pub pending_create2_error: Option<CreateOutcome>,
@@ -1362,7 +1367,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                         gas: Gas::new(gas_limit),
                     },
                     address: None,
-                    charged_create_state_gas: false,
+                    charged_create_state_gas: inputs.charged_create_state_gas(),
                 });
                 return None;
             } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
@@ -1373,7 +1378,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                         gas: Gas::new(gas_limit),
                     },
                     address: None,
-                    charged_create_state_gas: false,
+                    charged_create_state_gas: inputs.charged_create_state_gas(),
                 });
                 return None;
             }
@@ -1383,7 +1388,10 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                     .ok()?;
 
             // Record the redirect depth *after* validation succeeds.
-            self.inner.pending_create2_redirects.push(ecx.journal().depth());
+            self.inner.pending_create2_redirects.push(PendingCreate2Redirect {
+                depth: ecx.journal().depth(),
+                charged_create_state_gas: inputs.charged_create_state_gas(),
+            });
 
             // Rewrite the frame input from Create to Call.
             *frame_input = FrameInput::Call(Box::new(call_inputs));
@@ -1399,10 +1407,15 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
         frame_result: &mut FrameResult,
     ) {
         let depth = ecx.journal().depth();
-        if self.inner.pending_create2_redirects.last().copied() != Some(depth) {
+        let Some(redirect) = self
+            .inner
+            .pending_create2_redirects
+            .last()
+            .copied()
+            .filter(|redirect| redirect.depth == depth)
+        else {
             return;
-        }
-
+        };
         self.inner.pending_create2_redirects.pop();
 
         let FrameResult::Call(call) = frame_result else {
@@ -1426,7 +1439,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
         *frame_result = FrameResult::Create(CreateOutcome {
             result: call.result.clone(),
             address,
-            charged_create_state_gas: false,
+            charged_create_state_gas: redirect.charged_create_state_gas,
         });
     }
 
@@ -1710,7 +1723,11 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             );
             let address =
                 address.or_else(|| if result.is_revert() { precomputed_address } else { None });
-            return Some(CreateOutcome { result, address, charged_create_state_gas: false });
+            return Some(CreateOutcome {
+                result,
+                address,
+                charged_create_state_gas: create.charged_create_state_gas(),
+            });
         }
 
         None

--- a/crates/evm/evm/src/inspectors/stack.rs
+++ b/crates/evm/evm/src/inspectors/stack.rs
@@ -1350,6 +1350,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                         gas: Gas::new(gas_limit),
                     },
                     address: None,
+                    charged_create_state_gas: false,
                 });
                 return None;
             } else if code_hash != DEFAULT_CREATE2_DEPLOYER_CODEHASH {
@@ -1360,6 +1361,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
                         gas: Gas::new(gas_limit),
                     },
                     address: None,
+                    charged_create_state_gas: false,
                 });
                 return None;
             }
@@ -1409,7 +1411,11 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             _ => None,
         };
 
-        *frame_result = FrameResult::Create(CreateOutcome { result: call.result.clone(), address });
+        *frame_result = FrameResult::Create(CreateOutcome {
+            result: call.result.clone(),
+            address,
+            charged_create_state_gas: false,
+        });
     }
 
     fn call(
@@ -1692,7 +1698,7 @@ impl<FEN: FoundryEvmNetwork> Inspector<FoundryContextFor<'_, FEN>>
             );
             let address =
                 address.or_else(|| if result.is_revert() { precomputed_address } else { None });
-            return Some(CreateOutcome { result, address });
+            return Some(CreateOutcome { result, address, charged_create_state_gas: false });
         }
 
         None

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -251,7 +251,7 @@ pub fn spec_id_from_optimism_hardfork(hardfork: OpHardfork) -> OpSpecId {
         OpHardfork::Isthmus => OpSpecId::ISTHMUS,
         OpHardfork::Jovian => OpSpecId::JOVIAN,
         OpHardfork::Karst => OpSpecId::KARST,
-        OpHardfork::Interop => OpSpecId::INTEROP,
+        OpHardfork::Lagoon => OpSpecId::LAGOON,
         f => unreachable!("unimplemented {}", f),
     }
 }
@@ -265,7 +265,7 @@ pub fn eth_spec_id_from_optimism_hardfork(hardfork: OpHardfork) -> SpecId {
         OpHardfork::Ecotone | OpHardfork::Fjord | OpHardfork::Granite | OpHardfork::Holocene => {
             SpecId::CANCUN
         }
-        OpHardfork::Isthmus | OpHardfork::Jovian | OpHardfork::Interop => SpecId::PRAGUE,
+        OpHardfork::Isthmus | OpHardfork::Jovian | OpHardfork::Lagoon => SpecId::PRAGUE,
         OpHardfork::Karst => SpecId::OSAKA,
         f => unreachable!("unimplemented {}", f),
     }
@@ -614,7 +614,7 @@ mod tests {
             // Test latest hardforks
             assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Holocene), OpSpecId::HOLOCENE);
             assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Karst), OpSpecId::KARST);
-            assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Interop), OpSpecId::INTEROP);
+            assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Lagoon), OpSpecId::LAGOON);
             assert_eq!(evm_spec_id::<OpSpecId>(EvmVersion::Osaka), OpSpecId::KARST);
         }
 

--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -265,8 +265,8 @@ pub fn eth_spec_id_from_optimism_hardfork(hardfork: OpHardfork) -> SpecId {
         OpHardfork::Ecotone | OpHardfork::Fjord | OpHardfork::Granite | OpHardfork::Holocene => {
             SpecId::CANCUN
         }
-        OpHardfork::Isthmus | OpHardfork::Jovian | OpHardfork::Lagoon => SpecId::PRAGUE,
-        OpHardfork::Karst => SpecId::OSAKA,
+        OpHardfork::Isthmus | OpHardfork::Jovian => SpecId::PRAGUE,
+        OpHardfork::Karst | OpHardfork::Lagoon => SpecId::OSAKA,
         f => unreachable!("unimplemented {}", f),
     }
 }
@@ -615,6 +615,9 @@ mod tests {
             assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Holocene), OpSpecId::HOLOCENE);
             assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Karst), OpSpecId::KARST);
             assert_eq!(spec_id_from_optimism_hardfork(OpHardfork::Lagoon), OpSpecId::LAGOON);
+            assert_eq!(eth_spec_id_from_optimism_hardfork(OpHardfork::Jovian), SpecId::PRAGUE);
+            assert_eq!(eth_spec_id_from_optimism_hardfork(OpHardfork::Karst), SpecId::OSAKA);
+            assert_eq!(eth_spec_id_from_optimism_hardfork(OpHardfork::Lagoon), SpecId::OSAKA);
             assert_eq!(evm_spec_id::<OpSpecId>(EvmVersion::Osaka), OpSpecId::KARST);
         }
 


### PR DESCRIPTION
Updates Foundry to the revm 42 dependency stack required by the Tempo revm bump:

- bump `revm`, `revm-inspectors`, and `alloy-evm`
- align Tempo pins with the revm 42 integration
- update direct `op-alloy` crates to 2.0.0
- pin the revm 42 Optimism dependency family to one immutable revision

The lockfile is regenerated, and the Foundry, MPP, and Tempo checks pass with the unified revm 42 dependency graph.

Depends on:
- https://github.com/tempoxyz/tempo/pull/6946

Prompted by: @klkvr

This PR was prepared with AI assistance.
