### PR TITLE
fix(ci): limit forge fmt cache size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,10 @@ jobs:
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          cache-targets: false
+          cache-bin: false
+          prefix-key: v1-rust-forge-fmt-no-target
       - name: forge fmt
         shell: bash
         run: ./.github/scripts/format.sh --check


### PR DESCRIPTION
The `forge-fmt` job restores the full Rust target cache even though it already uses `sccache` for compilation. The restored artifacts exhausted the Depot runner filesystem before the job could finish, so this changes the job to cache only Cargo registry data and rotates the cache prefix to avoid restoring the existing large cache.

This is a CI-only maintenance change;

This PR was written with AI assistance to inspect the failed workflow and author the CI change.

Prompted by: @grandizzy
