### PR TITLE
fix(fuzz): replay runs after rejected inputs

### DIFF
--- a/.changelog/fix-fuzz-run-replay-rejects.md
+++ b/.changelog/fix-fuzz-run-replay-rejects.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `--fuzz-run` replay coordinates when earlier generated inputs are rejected by assumptions.

--- a/crates/evm/evm/src/executors/fuzz/mod.rs
+++ b/crates/evm/evm/src/executors/fuzz/mod.rs
@@ -688,6 +688,7 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                 }
             }
         }
+        let mut generated_inputs = 0;
 
         let mut persisted_failure =
             self.persisted_failure.as_ref().filter(|_| worker_id == 0 && self.config.run.is_none());
@@ -748,7 +749,10 @@ impl<FEN: FoundryEvmNetwork> FuzzedExecutor<FEN> {
                     runs_since_sync = 0;
                 }
 
-                let fuzz_run = self.config.run.unwrap_or(worker.runs + 1);
+                let fuzz_run = self.config.run.unwrap_or_else(|| {
+                    generated_inputs += 1;
+                    generated_inputs
+                });
                 if let Some(cheats) = executor.inspector_mut().cheatcodes.as_mut()
                     && let Some(seed) = self.config.seed
                 {

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -4980,6 +4980,59 @@ Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
     cmd.forge_fuse().args(["test", "--rerun", "-j1"]).assert_failure().stdout_eq(expected_output);
 });
 
+forgetest_init!(test_fuzz_run_replays_calldata_failure_after_rejects, |prj, cmd| {
+    prj.add_test(
+        "FuzzReplayTest.t.sol",
+        r#"
+pragma solidity >=0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+
+contract FuzzReplayTest is Test {
+    function testFuzz_replayAfterReject(uint256 x) public pure {
+        vm.assume(x != 0);
+        assert(x != 1);
+    }
+}
+   "#,
+    );
+
+    cmd.args(["test", "--fuzz-seed", "1", "--mt", "testFuzz_replayAfterReject", "-j1"])
+        .assert_failure();
+
+    let failure_file =
+        prj.root().join("cache/fuzz/failures/FuzzReplayTest/testFuzz_replayAfterReject");
+    let persisted_failure: BaseCounterExample =
+        serde_json::from_slice(&std::fs::read(&failure_file).unwrap()).unwrap();
+    assert_eq!(persisted_failure.fuzz.run, Some(4));
+
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--fuzz-seed",
+            "1",
+            "--fuzz-run",
+            "2",
+            "--mt",
+            "testFuzz_replayAfterReject",
+            "-j1",
+        ])
+        .assert_success();
+
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--fuzz-seed",
+            "1",
+            "--fuzz-run",
+            "4",
+            "--mt",
+            "testFuzz_replayAfterReject",
+            "-j1",
+        ])
+        .assert_failure();
+});
+
 forgetest_init!(test_fuzz_rerun_replays_random_uint_failure_without_seed, |prj, cmd| {
     prj.add_test(
         "RandomFuzzTest.t.sol",


### PR DESCRIPTION
Track generated fuzz inputs separately from accepted executions so persisted `fuzz_run` coordinates remain aligned with the deterministic input stream after `vm.assume` rejections. This allows `--fuzz-run` to reproduce the original failing calldata.