### PR TITLE
fix(fuzz): disable zero invariant delays

### DIFF
--- a/.changelog/disable-zero-invariant-delay.md
+++ b/.changelog/disable-zero-invariant-delay.md
@@ -1,0 +1,7 @@
+---
+forge: patch
+foundry-config: patch
+foundry-evm-fuzz: patch
+---
+
+Treat zero invariant time and block delay limits as disabled instead of panicking.

--- a/crates/config/src/invariant.rs
+++ b/crates/config/src/invariant.rs
@@ -218,7 +218,8 @@ impl InvariantConfig {
 
     /// Returns true if generated invariant calls may advance block time or height.
     pub const fn has_delay(&self) -> bool {
-        self.max_block_delay.is_some() || self.max_time_delay.is_some()
+        matches!(self.max_block_delay, Some(delay) if delay > 0)
+            || matches!(self.max_time_delay, Some(delay) if delay > 0)
     }
 }
 
@@ -253,6 +254,19 @@ mod tests {
     fn invariant_workers_reject_zero() {
         let err = serde_json::from_str::<InvariantWorkers>(r#"0"#).unwrap_err();
         assert!(err.to_string().contains("greater than 0"));
+    }
+
+    #[test]
+    fn invariant_config_zero_delays_are_disabled() {
+        let mut config = InvariantConfig { max_block_delay: Some(0), ..Default::default() };
+        assert!(!config.has_delay());
+
+        config.max_block_delay = None;
+        config.max_time_delay = Some(0);
+        assert!(!config.has_delay());
+
+        config.max_time_delay = Some(1);
+        assert!(config.has_delay());
     }
 
     #[test]

--- a/crates/evm/fuzz/src/strategies/tx.rs
+++ b/crates/evm/fuzz/src/strategies/tx.rs
@@ -98,15 +98,13 @@ impl TxGenerator {
                     }
                     selector.select(planned.calls.iter()).clone()
                 };
-                let warp = optional_delay(config.max_time_delay.is_some());
-                let roll = optional_delay(config.max_block_delay.is_some());
+                let warp = optional_delay(config.max_time_delay);
+                let roll = optional_delay(config.max_block_delay);
                 (warp, roll, sender, call)
             })
             .prop_map(move |(warp, roll, sender, call_details)| BasicTxDetails {
-                warp: warp
-                    .map(|value| value % U256::from(config.max_time_delay.unwrap_or_default())),
-                roll: roll
-                    .map(|value| value % U256::from(config.max_block_delay.unwrap_or_default())),
+                warp,
+                roll,
                 sender,
                 call_details,
             })
@@ -142,8 +140,12 @@ impl TxGenerator {
     }
 }
 
-fn optional_delay(enabled: bool) -> BoxedStrategy<Option<U256>> {
-    if enabled { any::<U256>().prop_map(Some).boxed() } else { Just(None).boxed() }
+fn optional_delay(max: Option<u32>) -> BoxedStrategy<Option<U256>> {
+    if let Some(max) = max.filter(|max| *max > 0) {
+        any::<U256>().prop_map(move |value| Some(value % U256::from(max))).boxed()
+    } else {
+        Just(None).boxed()
+    }
 }
 
 fn select_sender(
@@ -177,6 +179,17 @@ mod tests {
     use alloy_json_abi::JsonAbi;
     use foundry_config::FuzzDictionaryConfig;
     use revm::database::{CacheDB, EmptyDB};
+
+    #[test]
+    fn zero_delay_is_disabled() {
+        let mut runner = TestRunner::deterministic();
+        assert_eq!(optional_delay(Some(0)).new_tree(&mut runner).unwrap().current(), None);
+        assert_eq!(
+            optional_delay(Some(1)).new_tree(&mut runner).unwrap().current(),
+            Some(U256::ZERO)
+        );
+    }
+
     #[test]
     fn stateless_generator_has_fixed_metadata() {
         let target = Address::with_last_byte(1);

--- a/crates/forge/tests/cli/test_cmd/invariant/common.rs
+++ b/crates/forge/tests/cli/test_cmd/invariant/common.rs
@@ -2608,6 +2608,38 @@ contract InvariantOptimizeTest is Test {
 "#]]);
 });
 
+forgetest_init!(invariant_zero_delays_are_disabled, |prj, cmd| {
+    prj.add_test(
+        "InvariantZeroDelay.t.sol",
+        r#"
+contract InvariantZeroDelay {
+    Target target;
+
+    function setUp() public {
+        target = new Target();
+    }
+
+    /// forge-config: default.invariant.runs = 1
+    /// forge-config: default.invariant.depth = 1
+    /// forge-config: default.invariant.max_time_delay = 0
+    function invariant_zeroTimeDelay() public pure {}
+
+    /// forge-config: default.invariant.runs = 1
+    /// forge-config: default.invariant.depth = 1
+    /// forge-config: default.invariant.max_block_delay = 0
+    function invariant_zeroBlockDelay() public pure {}
+}
+
+contract Target {
+    function touch() public {}
+}
+"#,
+    );
+
+    cmd.args(["test", "--mt", "invariant_zeroTimeDelay"]).assert_success();
+    cmd.forge_fuse().args(["test", "--mt", "invariant_zeroBlockDelay"]).assert_success();
+});
+
 // Test optimization mode with time-dependent logic using warp and fixed seed for reproducibility.
 // This test ensures warp values are correctly accumulated during shrinking.
 forgetest_init!(invariant_optimization_with_warp, |prj, cmd| {


### PR DESCRIPTION
Treat zero invariant time and block delay limits as disabled. This prevents modulo-by-zero panics and keeps delay detection consistent with transaction generation.