### PR TITLE
fix(anvil): return sync timeout data

### DIFF
--- a/.changelog/anvil-sync-timeout-error.md
+++ b/.changelog/anvil-sync-timeout-error.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Return error code 4 and the transaction hash when synchronous transaction confirmation times out.

--- a/crates/anvil/src/eth/error/mod.rs
+++ b/crates/anvil/src/eth/error/mod.rs
@@ -451,9 +451,11 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 BlockchainError::ChainIdNotAvailable => {
                     RpcError::invalid_params("Chain Id not available")
                 }
-                BlockchainError::TransactionConfirmationTimeout { .. } => {
-                    RpcError::internal_error_with("Transaction confirmation timeout")
-                }
+                BlockchainError::TransactionConfirmationTimeout { hash, .. } => RpcError {
+                    code: ErrorCode::ServerError(4),
+                    message: "Transaction confirmation timeout".into(),
+                    data: Some(serde_json::Value::String(hash.to_string())),
+                },
                 BlockchainError::InvalidTransaction(err) => match err {
                     InvalidTransactionError::Revert(data) => {
                         // this mimics geth revert error

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -758,6 +758,38 @@ async fn can_parse_raw_tx_sync_timeout() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn raw_tx_sync_timeout_returns_transaction_hash() {
+    let (_api, handle) = spawn(NodeConfig::test().with_no_mining(true)).await;
+    let provider = http_provider(&handle.http_endpoint());
+
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let eip1559_est = provider.estimate_eip1559_fees().await.unwrap();
+    let mut tx = TxEip1559 {
+        max_fee_per_gas: eip1559_est.max_fee_per_gas,
+        max_priority_fee_per_gas: eip1559_est.max_priority_fee_per_gas,
+        gas_limit: 100000,
+        chain_id: 31337,
+        to: alloy_primitives::TxKind::Call(wallets[0].address()),
+        ..Default::default()
+    };
+    let signature = wallets[1].sign_transaction_sync(&mut tx).unwrap();
+    let tx = tx.into_signed(signature);
+    let expected_hash = *tx.hash();
+    let mut encoded = Vec::new();
+    tx.eip2718_encode(&mut encoded);
+
+    let response: Result<serde_json::Value, _> = provider
+        .client()
+        .request("eth_sendRawTransactionSync", (alloy_primitives::Bytes::from(encoded), 1u64))
+        .await;
+    let error = response.unwrap_err();
+    assert_eq!(error.tx_hash_data(), Some(expected_hash));
+    let error = error.as_error_resp().unwrap();
+    assert_eq!(error.code, 4);
+    assert_eq!(error.message, "Transaction confirmation timeout");
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_send_raw_transaction_conditional() {
     let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()));
     let (_api, handle) = spawn(node_config).await;


### PR DESCRIPTION
Fixes #16035 by returning EIP-7966 error code `4` and the transaction hash when synchronous transaction confirmation times out. Adds regression coverage for the JSON-RPC response.