### PR TITLE
fix(anvil): return sync timeout details

### DIFF
--- a/.changelog/anvil-sync-transaction-timeout-response.md
+++ b/.changelog/anvil-sync-transaction-timeout-response.md
@@ -1,0 +1,5 @@
+---
+anvil: patch
+---
+
+Return the EIP-7966 timeout code and transaction hash from `eth_sendRawTransactionSync`.

--- a/crates/anvil/src/eth/error/mod.rs
+++ b/crates/anvil/src/eth/error/mod.rs
@@ -451,9 +451,11 @@ impl<T: Serialize> ToRpcResponseResult for Result<T> {
                 BlockchainError::ChainIdNotAvailable => {
                     RpcError::invalid_params("Chain Id not available")
                 }
-                BlockchainError::TransactionConfirmationTimeout { .. } => {
-                    RpcError::internal_error_with("Transaction confirmation timeout")
-                }
+                BlockchainError::TransactionConfirmationTimeout { hash, .. } => RpcError {
+                    code: ErrorCode::ServerError(4),
+                    message: "Transaction confirmation timeout".into(),
+                    data: serde_json::to_value(hash).ok(),
+                },
                 BlockchainError::InvalidTransaction(err) => match err {
                     InvalidTransactionError::Revert(data) => {
                         // this mimics geth revert error

--- a/crates/anvil/tests/it/api.rs
+++ b/crates/anvil/tests/it/api.rs
@@ -758,6 +758,44 @@ async fn can_parse_raw_tx_sync_timeout() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn can_send_raw_tx_sync_timeout_error() {
+    let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()));
+    let (_api, handle) = spawn(node_config).await;
+    let provider = handle.http_provider();
+
+    let wallets = handle.dev_wallets().collect::<Vec<_>>();
+    let eip1559_est = provider.estimate_eip1559_fees().await.unwrap();
+
+    let mut tx = TxEip1559 {
+        max_fee_per_gas: eip1559_est.max_fee_per_gas,
+        max_priority_fee_per_gas: eip1559_est.max_priority_fee_per_gas,
+        gas_limit: 21_000,
+        chain_id: 31337,
+        nonce: 1,
+        to: alloy_primitives::TxKind::Call(wallets[0].address()),
+        ..Default::default()
+    };
+    let signature = wallets[1].sign_transaction_sync(&mut tx).unwrap();
+    let tx = tx.into_signed(signature);
+    let tx_hash = *tx.hash();
+    let mut encoded = Vec::new();
+    tx.eip2718_encode(&mut encoded);
+
+    let result: Result<serde_json::Value, _> = provider
+        .client()
+        .request("eth_sendRawTransactionSync", (alloy_primitives::Bytes::from(encoded), 100u64))
+        .await;
+    let error = result.unwrap_err();
+    let response = error.as_error_resp().expect("should return a JSON-RPC error");
+
+    assert_eq!(response.code, 4);
+    assert_eq!(response.message, "Transaction confirmation timeout");
+    let data = response.data.as_ref().expect("data should contain transaction hash");
+    let response_hash: B256 = serde_json::from_str(data.get()).unwrap();
+    assert_eq!(response_hash, tx_hash);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn can_send_raw_transaction_conditional() {
     let node_config = NodeConfig::test().with_hardfork(Some(EthereumHardfork::Prague.into()));
     let (_api, handle) = spawn(node_config).await;


### PR DESCRIPTION
`eth_sendRawTransactionSync` already honored its optional timeout duration, but Anvil converted the resulting confirmation timeout into a generic internal JSON-RPC error and discarded the submitted transaction hash. This changes that conversion to return EIP-7966 error code `4` with the hash in `data`, and adds regression coverage using a nonce-gapped transaction and a 100 ms timeout.

Closes #16035.

This PR was written with Codex assistance for investigation, implementation, testing, and PR drafting.
