### PR TITLE
test: use mainnet archive for fork repros

### DIFF
--- a/testdata/default/repros/Issue2956.t.sol
+++ b/testdata/default/repros/Issue2956.t.sol
@@ -9,24 +9,24 @@ contract Issue2956Test is Test {
     uint256 fork2;
 
     function setUp() public {
-        fork1 = vm.createFork("sepolia", 5565573);
+        fork1 = vm.createFork("mainnet", 20000000);
         fork2 = vm.createFork("avaxTestnet", 12880747);
     }
 
     function testForkNonce() public {
-        address user = address(0xF0959944122fb1ed4CfaBA645eA06EED30427BAA);
+        address user = address(0xa0Ee7A142d267C1f36714E4a8F75612F20a79720);
 
         assertEq(vm.getNonce(user), 0);
         vm.prank(user);
         new Counter();
 
         vm.selectFork(fork2);
-        assertEq(vm.getNonce(user), 3);
+        assertEq(vm.getNonce(user), 13);
         vm.prank(user);
         new Counter();
 
         vm.selectFork(fork1);
-        assertEq(vm.getNonce(user), 1);
+        assertEq(vm.getNonce(user), 9);
         vm.prank(user);
         new Counter();
     }

--- a/testdata/default/repros/Issue3221.t.sol
+++ b/testdata/default/repros/Issue3221.t.sol
@@ -9,23 +9,23 @@ contract Issue3221Test is Test {
     uint256 fork2;
 
     function setUp() public {
-        fork1 = vm.createFork("sepolia", 5565573);
+        fork1 = vm.createFork("mainnet", 20000000);
         fork2 = vm.createFork("avaxTestnet", 12880747);
     }
 
     function testForkNonce() public {
-        address user = address(0xF0959944122fb1ed4CfaBA645eA06EED30427BAA);
+        address user = address(0xa0Ee7A142d267C1f36714E4a8F75612F20a79720);
 
         // Loads but doesn't touch
         assertEq(vm.getNonce(user), 0);
 
         vm.selectFork(fork2);
-        assertEq(vm.getNonce(user), 3);
+        assertEq(vm.getNonce(user), 13);
         vm.prank(user);
         new Counter();
 
         vm.selectFork(fork1);
-        assertEq(vm.getNonce(user), 1);
+        assertEq(vm.getNonce(user), 9);
         vm.prank(user);
         new Counter();
     }

--- a/testdata/default/repros/Issue3223.t.sol
+++ b/testdata/default/repros/Issue3223.t.sol
@@ -4,27 +4,27 @@ pragma solidity ^0.8.18;
 import "utils/Test.sol";
 
 // https://github.com/foundry-rs/foundry/issues/3223
-/// forge-config: default.sender = "0xF0959944122fb1ed4CfaBA645eA06EED30427BAA"
+/// forge-config: default.sender = "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720"
 contract Issue3223Test is Test {
     uint256 fork1;
     uint256 fork2;
 
     function setUp() public {
-        fork1 = vm.createFork("sepolia", 2362365);
+        fork1 = vm.createFork("mainnet", 20000000);
         fork2 = vm.createFork("avaxTestnet", 12880747);
     }
 
     function testForkNonce() public {
-        address user = address(0xF0959944122fb1ed4CfaBA645eA06EED30427BAA);
+        address user = address(0xa0Ee7A142d267C1f36714E4a8F75612F20a79720);
         assertEq(user, msg.sender);
 
         vm.selectFork(fork2);
-        assertEq(vm.getNonce(user), 3);
+        assertEq(vm.getNonce(user), 13);
         vm.prank(user);
         new Counter();
 
         vm.selectFork(fork1);
-        assertEq(vm.getNonce(user), 1);
+        assertEq(vm.getNonce(user), 9);
     }
 }
 


### PR DESCRIPTION
This replaces the Sepolia snapshots used by the fork nonce regression fixtures with Mainnet block 20,000,000 served by Foundry's own archive endpoint, while retaining Avalanche Fuji. The current Sepolia RPC no longer exposes the historical state needed by the fixtures, causing unrelated CI failures. The sender and expected nonces are updated to immutable values present on both networks, preserving cross-fork account isolation coverage.

This PR was written with Codex, including the fixture changes and local validation.
