### PR TITLE
test: pin Fuji fork block

### DIFF
--- a/testdata/default/repros/Issue3674.t.sol
+++ b/testdata/default/repros/Issue3674.t.sol
@@ -9,7 +9,7 @@ contract Issue3674Test is Test {
     function testNonceCreateSelect() public {
         vm.createSelectFork("sepolia");
 
-        vm.createSelectFork("avaxTestnet");
+        vm.createSelectFork("avaxTestnet", 57578054);
         assertTrue(vm.getNonce(msg.sender) > 0x17);
     }
 }


### PR DESCRIPTION
The Issue3674 testdata fixture currently forks Avalanche Fuji at the latest block. Fuji's public RPC can expose an unaccepted head, causing `createSelectFork` and the nonce assertion to fail across CI platforms.

This pins the fixture to accepted block 57578054, where the regression sender has nonce 227, while preserving the existing cross-fork assertion. This CI-only test fixture change should receive `L-ignore`.

AI assistance disclosure: This PR was written with Codex.

Prompted by: @grandizzy