### PR TITLE
perf(forge): speed up coverage line analysis

### DIFF
--- a/.changelog/forge-coverage-line-analysis.md
+++ b/.changelog/forge-coverage-line-analysis.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Speed up `forge coverage` analysis for sources with many executable lines.

--- a/crates/evm/coverage/src/analysis.rs
+++ b/crates/evm/coverage/src/analysis.rs
@@ -120,11 +120,14 @@ impl<'gcx> SourceVisitor<'gcx> {
     fn push_lines(&mut self) {
         self.all_lines.sort_unstable();
         self.all_lines.dedup();
-        let mut lines = Vec::new();
+        let mut lines = Vec::with_capacity(self.all_lines.len());
+        // Items are already ordered by line, so advance through them only once.
+        let mut items = self.items.iter().peekable();
         for &line in &self.all_lines {
-            if let Some(reference_item) =
-                self.items.iter().find(|item| item.loc.lines.start == line)
-            {
+            while items.peek().is_some_and(|item| item.loc.lines.start < line) {
+                items.next();
+            }
+            if let Some(reference_item) = items.peek().filter(|item| item.loc.lines.start == line) {
                 lines.push(CoverageItem {
                     kind: CoverageItemKind::Line,
                     loc: reference_item.loc.clone(),


### PR DESCRIPTION
## Summary

Build coverage line entries by walking the already-sorted coverage items once instead of rescanning every item for every executable line. This changes line construction from quadratic to linear in the number of coverage items while preserving the first matching source location for each line.

The stress fixture's 2.3 MB LCOV report is byte-for-byte identical before and after the change. AI assistance: Amp was used to investigate, benchmark, and implement this change.

## Benchmarks

Release builds from the same `master` commit, measured with Hyperfine (one warmup and three runs) on a 1.9 MiB generated Solidity source containing 200,000 executable statements plus one smoke test:

```text
forge coverage --report summary --no-match-coverage test/
```

| | Mean | Range |
| --- | ---: | ---: |
| master | `12.491s ± 0.067s` | `12.447s–12.568s` |
| this PR | `752.9ms ± 4.2ms` | `749.3ms–757.6ms` |

This is **16.59x faster**.
