### PR TITLE
fix(inspect): support exact input paths

### DIFF
--- a/.changelog/inspect-exact-input-paths.md
+++ b/.changelog/inspect-exact-input-paths.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `forge inspect` contract resolution for exact paths outside the source directory.

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -577,23 +577,14 @@ pub fn find_target_path(project: &Project, identifier: &PathOrContractInfo) -> R
         PathOrContractInfo::ContractInfo(info) => {
             if let Some(path) = info.path.as_ref() {
                 let path = canonicalized(project.root().join(path));
-                let sources = project.sources()?;
-                let contract_path = sources
-                    .iter()
-                    .find_map(|(src_path, _)| {
-                        if **src_path == path {
-                            return Some(src_path.clone());
-                        }
-                        None
-                    })
-                    .ok_or_else(|| {
-                        eyre::eyre!(
-                            "Could not find source file for contract `{}` at {}",
-                            info.name,
-                            path.strip_prefix(project.root()).unwrap().display()
-                        )
-                    })?;
-                return Ok(contract_path);
+                if !path.is_file() {
+                    eyre::bail!(
+                        "Could not find source file for contract `{}` at {}",
+                        info.name,
+                        path.strip_prefix(project.root()).unwrap_or(&path).display()
+                    );
+                }
+                return Ok(path);
             }
             // If ContractInfo.path hasn't been provided we try to find the contract using the name.
             // This will fail if projects have multiple contracts with the same name. In that case,

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -4105,6 +4105,47 @@ forgetest!(inspect_multiple_contracts_with_different_paths, |prj, cmd| {
 "#]]);
 });
 
+// <https://github.com/foundry-rs/foundry/issues/11146>
+forgetest!(inspect_contracts_by_exact_input_path, |prj, cmd| {
+    prj.add_test(
+        "InspectTarget.t.sol",
+        r#"
+contract InspectTarget {
+    function testValue() external pure returns (uint256) {
+        return 1;
+    }
+}
+"#,
+    );
+    prj.create_file(
+        "node_modules/example/Dependency.sol",
+        r#"
+pragma solidity ^0.8.0;
+
+contract Dependency {
+    function dependencyValue() external pure returns (uint256) {
+        return 2;
+    }
+}
+"#,
+    );
+    prj.update_config(|config| config.libs.push("node_modules".into()));
+
+    for (target, function) in [
+        ("test/InspectTarget.t.sol:InspectTarget", "testValue"),
+        ("node_modules/example/Dependency.sol:Dependency", "dependencyValue"),
+    ] {
+        let stdout = cmd
+            .forge_fuse()
+            .args(["inspect", target, "abi", "--json"])
+            .assert_success()
+            .get_output()
+            .stdout_lossy();
+        let abi: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        assert!(abi.as_array().unwrap().iter().any(|item| item["name"] == function));
+    }
+});
+
 forgetest!(inspect_custom_counter_method_identifiers, |prj, cmd| {
     prj.add_source("Counter.sol", CUSTOM_COUNTER);
 


### PR DESCRIPTION
## Motivation

`forge inspect` rejects path-qualified contracts outside the configured source directory, even when the caller provides the exact existing path. This prevents inspecting contracts under `test/` or dependency directories such as `node_modules/`.

Closes #11146.

## Solution

Accept an explicitly provided contract path when it resolves to an existing file, instead of requiring it to be present in `Project::sources()`. Bare contract-name lookup remains unchanged.

Add CLI regression coverage for exact paths in both `test/` and a configured `node_modules` library.