### PR TITLE
ci: consolidate workflow validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,11 +203,14 @@ jobs:
         with:
           category: "/language:${{matrix.language}}"
 
-  scan-github-actions:
-    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648 # main
+  workflow-validation:
+    name: Workflow Validation
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@483bda4a2a4b5e04a51edff03768c1590d271f80 # main
     permissions:
       actions: read
       contents: read
+    with:
+      pinact: true
 
   ci-success:
     runs-on: ubuntu-latest
@@ -225,10 +228,10 @@ jobs:
       - forge-fmt
       - deny
       - codeql
-      - scan-github-actions
+      - workflow-validation
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,10 @@
+version: 3
+
+rules:
+  # Tempo's shared workflows are SHA-pinned but do not publish releases that
+  # pinact can use for version-comment or minimum-age verification.
+  - ignore: true
+    conditions:
+      - expr: |
+          ActionRepoFullName in ["tempoxyz/ci", "tempoxyz/gh-actions"]
+      - expr: ActionVersion matches "^[0-9a-f]{40}$"


### PR DESCRIPTION
Replaces the standalone scanner gate with the shared Tempo validation job, combining zizmor, actionlint, and immutable action-pin policy under one required CI dependency. Existing Foundry runner and actionlint policy remains repository-owned, while unreleased Tempo workflows receive only SHA-constrained exceptions.

This repository-maintenance-only change should receive the `L-ignore` label. The change was prepared with AI assistance and reviewed locally.

Part of [OSS-545](https://linear.app/tempoxyz/issue/OSS-545).
