### PR TITLE
fix(forge): honor fuzz input file

### DIFF
--- a/.changelog/replay-explicit-fuzz-input.md
+++ b/.changelog/replay-explicit-fuzz-input.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Fixed `--fuzz-input-file` to replay the specified stateless fuzz failure.

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -197,7 +197,7 @@ pub struct FuzzRunArgs {
     pub(crate) showmap_corpus_dir: Option<PathBuf>,
 
     /// File to rerun fuzz failures from.
-    #[arg(long, value_name = "PATH", value_hint = ValueHint::FilePath)]
+    #[arg(long, value_name = "PATH", value_hint = ValueHint::FilePath, conflicts_with = "list")]
     pub(crate) fuzz_input_file: Option<PathBuf>,
 }
 

--- a/crates/forge/src/cmd/fuzz.rs
+++ b/crates/forge/src/cmd/fuzz.rs
@@ -197,8 +197,8 @@ pub struct FuzzRunArgs {
     pub(crate) showmap_corpus_dir: Option<PathBuf>,
 
     /// File to rerun fuzz failures from.
-    #[arg(long)]
-    pub(crate) fuzz_input_file: Option<String>,
+    #[arg(long, value_name = "PATH", value_hint = ValueHint::FilePath)]
+    pub(crate) fuzz_input_file: Option<PathBuf>,
 }
 
 /// Replay persisted fuzz failures, or corpus entries with `--corpus-dir`.
@@ -211,6 +211,9 @@ pub struct FuzzReplayArgs {
 impl FuzzReplayArgs {
     async fn run(self) -> Result<TestOutcome> {
         let corpus_dir = self.run.campaign.corpus_dir.clone();
+        if corpus_dir.is_some() && self.run.fuzz_input_file.is_some() {
+            bail!("`--fuzz-input-file` cannot be combined with `--corpus-dir`");
+        }
         let mut test = TestArgs::from_fuzz_run(self.run);
         if corpus_dir.is_none() {
             test.enable_fuzz_failure_replay();

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -4,9 +4,9 @@ use crate::{
     decode::decode_console_logs,
     gas_report::GasReport,
     multi_runner::{
-        FuzzMinimizeConfig, FuzzMinimizeEdgeIndices, FuzzMinimizeMode, FuzzMinimizeObservation,
-        MultiNetworkConfig, ShowmapConfig, SymbolicArtifactReplayConfig, TestFunctionMatcher,
-        is_generated_symbolic_regression_contract,
+        FuzzFailureReplayConfig, FuzzMinimizeConfig, FuzzMinimizeEdgeIndices, FuzzMinimizeMode,
+        FuzzMinimizeObservation, MultiNetworkConfig, ShowmapConfig, SymbolicArtifactReplayConfig,
+        TestFunctionMatcher, is_generated_symbolic_regression_contract,
     },
     mutation::{MutationRunConfig, run_mutation_testing},
     result::{
@@ -41,8 +41,8 @@ use foundry_common::{
     fs, sh_status, sh_warn, shell,
 };
 use foundry_compilers::{
-    ProjectCompileOutput,
-    artifacts::Libraries,
+    Artifact, ProjectCompileOutput,
+    artifacts::{BytecodeObject, Libraries},
     compilers::{
         Language,
         multi::{MultiCompiler, MultiCompilerLanguage},
@@ -66,7 +66,7 @@ use foundry_evm::{
         BlockEnvFor, EthEvmNetwork, FoundryEvmNetwork, SpecFor, TempoEvmNetwork, TxEnvFor,
     },
     executors::ShowmapDomain,
-    fuzz::{BasicTxDetails, CounterExample},
+    fuzz::{BaseCounterExample, BasicTxDetails, CounterExample},
     hardforks::TempoHardfork,
     opts::EvmOpts,
     traces::{
@@ -93,7 +93,10 @@ mod filter;
 mod summary;
 use crate::{
     result::TestKind,
-    runner::{count_runnable_invariant_campaign_anchors, function_matches_network_pass},
+    runner::{
+        count_runnable_invariant_campaign_anchors, effective_test_function_kind,
+        function_matches_network_pass, inline_config_for,
+    },
     traces::render_trace_arena_inner,
 };
 use filter::RerunFailures;
@@ -338,6 +341,7 @@ pub(crate) struct TestExecutionOptions {
     pub(crate) should_debug: bool,
     pub(crate) decode_internal: InternalTraceMode,
     pub(crate) multi_network: MultiNetworkConfig,
+    pub(crate) fuzz_input: Option<FuzzFailureReplayConfig>,
     pub(crate) replay_symbolic_artifact: Option<SymbolicArtifactReplayConfig>,
     pub(crate) inline_config: Arc<InlineConfig>,
     pub(crate) selected_sources: BTreeSet<PathBuf>,
@@ -350,6 +354,7 @@ impl TestExecutionOptions {
             should_debug: false,
             decode_internal: InternalTraceMode::None,
             multi_network: MultiNetworkConfig::default(),
+            fuzz_input: None,
             replay_symbolic_artifact: None,
             inline_config,
             selected_sources: BTreeSet::new(),
@@ -759,7 +764,7 @@ pub struct TestArgs {
         long,
         value_name = "PATH",
         value_hint = ValueHint::FilePath,
-        conflicts_with = "fuzz_run"
+        conflicts_with_all = ["fuzz_run", "list"]
     )]
     pub fuzz_input_file: Option<PathBuf>,
 
@@ -1365,11 +1370,6 @@ impl TestArgs {
                     "`--fuzz-run` only applies to fuzz tests; no matched fuzz tests were found."
                 )?;
             }
-            if self.fuzz_input_file.is_some() {
-                sh_warn!(
-                    "`--fuzz-input-file` only applies to fuzz tests; no matched fuzz tests were found."
-                )?;
-            }
         }
 
         if counts.invariant == 0 && counts.fuzz > 0 {
@@ -1546,6 +1546,45 @@ impl TestArgs {
         }
 
         Ok(Some(SymbolicArtifactReplayConfig { artifact, path: path.clone() }))
+    }
+
+    fn load_fuzz_input(
+        &self,
+        output: &ProjectCompileOutput,
+        config: &Config,
+        inline_config: &InlineConfig,
+        filter: &ProjectPathsAwareFilter,
+    ) -> Result<Option<FuzzFailureReplayConfig>> {
+        let Some(path) = &self.fuzz_input_file else {
+            return Ok(None);
+        };
+        let failure = fs::read_json_file::<BaseCounterExample>(path)?;
+        let Some(selector) = failure.calldata.get(..4) else {
+            bail!(
+                "fuzz input file {} contains calldata shorter than a 4-byte selector",
+                path.display()
+            );
+        };
+        let targets =
+            matching_fuzz_replay_targets(output, config, inline_config, filter, selector)?;
+        let [(contract, test)] = targets.as_slice() else {
+            if targets.is_empty() {
+                bail!(
+                    "fuzz input file {} does not match any selected stateless fuzz test",
+                    path.display()
+                );
+            }
+            bail!(
+                "fuzz input file {} matches {} selected stateless fuzz tests; replay requires exactly one target",
+                path.display(),
+                targets.len()
+            );
+        };
+        Ok(Some(FuzzFailureReplayConfig {
+            failure: Arc::new(failure),
+            contract: contract.clone(),
+            test: test.clone(),
+        }))
     }
 
     /// Returns a list of files that need to be compiled in order to run all the tests that match
@@ -1921,14 +1960,6 @@ impl TestArgs {
             bail!("`fuzz.run` must be greater than 0");
         }
 
-        self.warn_unsupported_engine_flags(
-            output,
-            &config,
-            &execution.inline_config,
-            filter,
-            &execution.multi_network,
-        )?;
-
         if self.list {
             return list_from_output(
                 output,
@@ -1939,6 +1970,17 @@ impl TestArgs {
                 execution.replay_symbolic_artifact.as_ref(),
             );
         }
+
+        execution.fuzz_input =
+            self.load_fuzz_input(output, &config, &execution.inline_config, filter)?;
+
+        self.warn_unsupported_engine_flags(
+            output,
+            &config,
+            &execution.inline_config,
+            filter,
+            &execution.multi_network,
+        )?;
 
         let mut filter = filter.clone();
 
@@ -2540,7 +2582,7 @@ impl TestArgs {
             .with_showmap(showmap)
             .with_fuzz_only(self.fuzz_only.is_enabled())
             .with_fuzz_failure_replay(self.fuzz_failure_replay)
-            .with_fuzz_input_file(self.fuzz_input_file.clone())
+            .with_fuzz_input(execution.fuzz_input)
             .with_symbolic_artifact_replay(execution.replay_symbolic_artifact)
             .with_create2_deployer_available(create2_deployer_available)
             .build::<FEN, MultiCompiler>(output, evm_env, tx_env, evm_opts)?;
@@ -3785,6 +3827,58 @@ fn matched_engine_counts(
             acc.invariant += counts.invariant;
             acc
         })
+}
+
+fn matching_fuzz_replay_targets(
+    output: &ProjectCompileOutput,
+    config: &Config,
+    inline_config: &InlineConfig,
+    filter: &ProjectPathsAwareFilter,
+    selector: &[u8],
+) -> Result<Vec<(String, String)>> {
+    let matcher = TestFunctionMatcher::new(config, inline_config, None);
+    let mut targets = Vec::new();
+    for (id, artifact) in output.artifact_ids() {
+        let Some(abi) = artifact.abi.as_ref() else { continue };
+        let has_creation_code =
+            artifact.get_bytecode_object().is_some_and(|object| match object.as_ref() {
+                BytecodeObject::Bytecode(bytecode) => !bytecode.is_empty(),
+                BytecodeObject::Unlinked(_) => true,
+            });
+        let deployable = has_creation_code
+            && abi
+                .constructor
+                .as_ref()
+                .map(|constructor| constructor.inputs.is_empty())
+                .unwrap_or(true);
+        if !deployable {
+            continue;
+        }
+
+        let id = id.with_stripped_file_prefixes(&config.root);
+        if !matcher.matches_contract(filter, &id, abi) {
+            continue;
+        }
+        let contract = id.identifier();
+        let generated_symbolic_regression = is_generated_symbolic_regression_contract(abi);
+        for func in abi.functions() {
+            let kind = matcher.test_function_kind(&contract, func, generated_symbolic_regression);
+            if !matches!(kind, TestFunctionKind::FuzzTest { .. })
+                || !filter.matches_test_function_kind_in_contract(&contract, func, kind)
+            {
+                continue;
+            }
+            let function_config = inline_config_for(config, inline_config, &contract, Some(func))?;
+            if matches!(
+                effective_test_function_kind(kind, &function_config, func),
+                TestFunctionKind::FuzzTest { .. }
+            ) && func.selector() == selector
+            {
+                targets.push((contract.clone(), func.signature()));
+            }
+        }
+    }
+    Ok(targets)
 }
 
 fn print_list_results(results: &BTreeMap<String, BTreeMap<String, Vec<String>>>) -> Result<()> {

--- a/crates/forge/src/cmd/test/mod.rs
+++ b/crates/forge/src/cmd/test/mod.rs
@@ -755,8 +755,13 @@ pub struct TestArgs {
     pub fuzz_mutation_weight_cmp: Option<u32>,
 
     /// File to rerun fuzz failures from.
-    #[arg(long)]
-    pub fuzz_input_file: Option<String>,
+    #[arg(
+        long,
+        value_name = "PATH",
+        value_hint = ValueHint::FilePath,
+        conflicts_with = "fuzz_run"
+    )]
+    pub fuzz_input_file: Option<PathBuf>,
 
     /// Number of calls executed to try to break invariants in one run.
     #[arg(long, env = "FOUNDRY_INVARIANT_DEPTH", value_name = "DEPTH")]
@@ -2535,6 +2540,7 @@ impl TestArgs {
             .with_showmap(showmap)
             .with_fuzz_only(self.fuzz_only.is_enabled())
             .with_fuzz_failure_replay(self.fuzz_failure_replay)
+            .with_fuzz_input_file(self.fuzz_input_file.clone())
             .with_symbolic_artifact_replay(execution.replay_symbolic_artifact)
             .with_create2_deployer_available(create2_deployer_available)
             .build::<FEN, MultiCompiler>(output, evm_env, tx_env, evm_opts)?;
@@ -3423,9 +3429,6 @@ impl Provider for TestArgs {
         }
         if let Some(weight) = self.fuzz_mutation_weight_cmp {
             fuzz_dict.insert("mutation_weight_cmp".to_string(), weight.into());
-        }
-        if let Some(fuzz_input_file) = self.fuzz_input_file.clone() {
-            fuzz_dict.insert("failure_persist_file".to_string(), fuzz_input_file.into());
         }
         dict.insert("fuzz".to_string(), fuzz_dict.into());
 

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -519,6 +519,8 @@ pub struct TestRunnerConfig<FEN: FoundryEvmNetwork> {
     pub fuzz_only: bool,
     /// Replay persisted fuzz failures without running a new fuzz campaign.
     pub fuzz_failure_replay: bool,
+    /// Explicit stateless fuzz failure file to replay.
+    pub fuzz_input_file: Option<PathBuf>,
 
     /// When set, run only the matching test and replay this artifact's concrete payload.
     pub symbolic_artifact_replay: Option<SymbolicArtifactReplayConfig>,
@@ -654,6 +656,8 @@ pub struct MultiContractRunnerBuilder {
     pub fuzz_only: bool,
     /// Replay persisted fuzz failures without running a new fuzz campaign.
     pub fuzz_failure_replay: bool,
+    /// Explicit stateless fuzz failure file to replay.
+    pub fuzz_input_file: Option<PathBuf>,
     /// Symbolic artifact replay mode (CLI-only, off by default).
     pub symbolic_artifact_replay: Option<SymbolicArtifactReplayConfig>,
     /// Whether the configured CREATE2 deployer is available in the execution environment.
@@ -687,6 +691,7 @@ impl MultiContractRunnerBuilder {
             fuzz_minimize: None,
             fuzz_only: false,
             fuzz_failure_replay: false,
+            fuzz_input_file: None,
             symbolic_artifact_replay: None,
             create2_deployer_available: None,
         }
@@ -714,6 +719,11 @@ impl MultiContractRunnerBuilder {
 
     pub const fn with_fuzz_failure_replay(mut self, fuzz_failure_replay: bool) -> Self {
         self.fuzz_failure_replay = fuzz_failure_replay;
+        self
+    }
+
+    pub fn with_fuzz_input_file(mut self, fuzz_input_file: Option<PathBuf>) -> Self {
+        self.fuzz_input_file = fuzz_input_file;
         self
     }
 
@@ -963,6 +973,7 @@ impl MultiContractRunnerBuilder {
                 fuzz_minimize: self.fuzz_minimize,
                 fuzz_only: self.fuzz_only,
                 fuzz_failure_replay: self.fuzz_failure_replay,
+                fuzz_input_file: self.fuzz_input_file,
                 symbolic_artifact_replay: self.symbolic_artifact_replay,
                 config: self.config,
             },

--- a/crates/forge/src/multi_runner.rs
+++ b/crates/forge/src/multi_runner.rs
@@ -29,7 +29,7 @@ use foundry_evm::{
     executors::{EarlyExit, Executor, ExecutorBuilder, ReplayObservation, ShowmapDomain},
     fork::CreateFork,
     fuzz::{
-        BasicTxDetails,
+        BaseCounterExample, BasicTxDetails,
         strategies::{EnumBounds, LiteralsDictionary},
     },
     inspectors::{CheatsConfig, EdgeIndexMap},
@@ -473,6 +473,17 @@ pub struct SymbolicArtifactReplayConfig {
     pub path: PathBuf,
 }
 
+/// A validated stateless fuzz failure and its unique replay target.
+#[derive(Clone, Debug)]
+pub struct FuzzFailureReplayConfig {
+    /// Artifact payload to replay.
+    pub failure: Arc<BaseCounterExample>,
+    /// Fully qualified contract identifier selected for replay.
+    pub contract: String,
+    /// Function signature selected for replay.
+    pub test: String,
+}
+
 /// Configuration for the test runner.
 ///
 /// This is modified after instantiation through inline config.
@@ -519,8 +530,8 @@ pub struct TestRunnerConfig<FEN: FoundryEvmNetwork> {
     pub fuzz_only: bool,
     /// Replay persisted fuzz failures without running a new fuzz campaign.
     pub fuzz_failure_replay: bool,
-    /// Explicit stateless fuzz failure file to replay.
-    pub fuzz_input_file: Option<PathBuf>,
+    /// Validated explicit stateless fuzz failure to replay.
+    pub fuzz_input: Option<FuzzFailureReplayConfig>,
 
     /// When set, run only the matching test and replay this artifact's concrete payload.
     pub symbolic_artifact_replay: Option<SymbolicArtifactReplayConfig>,
@@ -656,8 +667,8 @@ pub struct MultiContractRunnerBuilder {
     pub fuzz_only: bool,
     /// Replay persisted fuzz failures without running a new fuzz campaign.
     pub fuzz_failure_replay: bool,
-    /// Explicit stateless fuzz failure file to replay.
-    pub fuzz_input_file: Option<PathBuf>,
+    /// Validated explicit stateless fuzz failure to replay.
+    pub fuzz_input: Option<FuzzFailureReplayConfig>,
     /// Symbolic artifact replay mode (CLI-only, off by default).
     pub symbolic_artifact_replay: Option<SymbolicArtifactReplayConfig>,
     /// Whether the configured CREATE2 deployer is available in the execution environment.
@@ -691,7 +702,7 @@ impl MultiContractRunnerBuilder {
             fuzz_minimize: None,
             fuzz_only: false,
             fuzz_failure_replay: false,
-            fuzz_input_file: None,
+            fuzz_input: None,
             symbolic_artifact_replay: None,
             create2_deployer_available: None,
         }
@@ -722,8 +733,8 @@ impl MultiContractRunnerBuilder {
         self
     }
 
-    pub fn with_fuzz_input_file(mut self, fuzz_input_file: Option<PathBuf>) -> Self {
-        self.fuzz_input_file = fuzz_input_file;
+    pub fn with_fuzz_input(mut self, fuzz_input: Option<FuzzFailureReplayConfig>) -> Self {
+        self.fuzz_input = fuzz_input;
         self
     }
 
@@ -973,7 +984,7 @@ impl MultiContractRunnerBuilder {
                 fuzz_minimize: self.fuzz_minimize,
                 fuzz_only: self.fuzz_only,
                 fuzz_failure_replay: self.fuzz_failure_replay,
-                fuzz_input_file: self.fuzz_input_file,
+                fuzz_input: self.fuzz_input,
                 symbolic_artifact_replay: self.symbolic_artifact_replay,
                 config: self.config,
             },

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -97,6 +97,18 @@ fn should_symbolically_import_fuzz_corpus(config: &Config, func: &Function) -> b
     config.symbolic.use_fuzz_corpus && func.test_function_kind().is_fuzz_test()
 }
 
+pub(crate) fn effective_test_function_kind(
+    kind: TestFunctionKind,
+    config: &Config,
+    func: &Function,
+) -> TestFunctionKind {
+    if should_symbolically_import_fuzz_corpus(config, func) {
+        TestFunctionKind::SymbolicTest
+    } else {
+        kind
+    }
+}
+
 fn should_symbolically_use_fuzz_frontiers(config: &Config, func: &Function) -> bool {
     config.symbolic.use_fuzz_frontiers && func.test_function_kind().is_fuzz_test()
 }
@@ -326,7 +338,7 @@ pub(crate) fn function_matches_network_pass(
     }
 }
 
-fn inline_config_for(
+pub(crate) fn inline_config_for(
     config: &Config,
     inline_config: &InlineConfig,
     contract_name: &str,
@@ -2113,11 +2125,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             self.result.single_fail(Some(e.to_string()));
             return self.result;
         }
-        let kind = if should_symbolically_import_fuzz_corpus(&self.config, func) {
-            TestFunctionKind::SymbolicTest
-        } else {
-            kind
-        };
+        let kind = effective_test_function_kind(kind, &self.config, func);
 
         // In showmap replay mode and `forge fuzz`, only fuzz/invariant tests are runnable.
         if (self.cr.mcr.tcfg.showmap.is_some() || self.cr.mcr.tcfg.fuzz_only)
@@ -4842,7 +4850,10 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             self.cr.name,
             &func.name,
         );
-        if self.cr.mcr.tcfg.fuzz_input_file.is_some() && fuzz_config.run.is_some() {
+        let fuzz_input = self.cr.mcr.tcfg.fuzz_input.as_ref();
+        let is_explicit_target = fuzz_input
+            .is_some_and(|input| input.contract == self.cr.name && input.test == func.signature());
+        if is_explicit_target && fuzz_config.run.is_some() {
             self.result.fuzz_setup_fail(eyre::eyre!(
                 "`--fuzz-input-file` cannot be combined with `fuzz.run`"
             ));
@@ -4931,20 +4942,12 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             return self.result;
         }
 
-        // Load persisted counterexample, if any. An explicit input is required to be readable;
-        // the canonical cache remains optional.
-        let replay_file =
-            self.cr.mcr.tcfg.fuzz_input_file.as_deref().unwrap_or(failure_file.as_path());
-        let persisted_failure = if self.cr.mcr.tcfg.fuzz_input_file.is_some() {
-            match foundry_common::fs::read_json_file::<BaseCounterExample>(replay_file) {
-                Ok(failure) => Some(failure),
-                Err(err) => {
-                    self.result.fuzz_setup_fail(err.into());
-                    return self.result;
-                }
-            }
+        // Load the validated explicit input for its unique target, or fall back to this test's
+        // canonical cache.
+        let persisted_failure = if is_explicit_target {
+            fuzz_input.map(|input| input.failure.as_ref().clone())
         } else {
-            foundry_common::fs::read_json_file::<BaseCounterExample>(replay_file).ok()
+            foundry_common::fs::read_json_file::<BaseCounterExample>(failure_file.as_path()).ok()
         };
         if self.cr.mcr.tcfg.fuzz_failure_replay {
             let Some(failure) = persisted_failure.as_ref() else {
@@ -4952,7 +4955,7 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
                     skipped: true,
                     reason: Some(format!(
                         "no persisted fuzz failure found at {}",
-                        replay_file.display()
+                        failure_file.display()
                     )),
                     ..Default::default()
                 };

--- a/crates/forge/src/runner.rs
+++ b/crates/forge/src/runner.rs
@@ -4842,6 +4842,12 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             self.cr.name,
             &func.name,
         );
+        if self.cr.mcr.tcfg.fuzz_input_file.is_some() && fuzz_config.run.is_some() {
+            self.result.fuzz_setup_fail(eyre::eyre!(
+                "`--fuzz-input-file` cannot be combined with `fuzz.run`"
+            ));
+            return self.result;
+        }
 
         // Showmap replay mode: replay the persisted corpus and emit coverage
         // files instead of running the fuzz campaign.
@@ -4925,16 +4931,28 @@ impl<'a, FEN: FoundryEvmNetwork> FunctionRunner<'a, FEN> {
             return self.result;
         }
 
-        // Load persisted counterexample, if any.
-        let persisted_failure =
-            foundry_common::fs::read_json_file::<BaseCounterExample>(failure_file.as_path()).ok();
+        // Load persisted counterexample, if any. An explicit input is required to be readable;
+        // the canonical cache remains optional.
+        let replay_file =
+            self.cr.mcr.tcfg.fuzz_input_file.as_deref().unwrap_or(failure_file.as_path());
+        let persisted_failure = if self.cr.mcr.tcfg.fuzz_input_file.is_some() {
+            match foundry_common::fs::read_json_file::<BaseCounterExample>(replay_file) {
+                Ok(failure) => Some(failure),
+                Err(err) => {
+                    self.result.fuzz_setup_fail(err.into());
+                    return self.result;
+                }
+            }
+        } else {
+            foundry_common::fs::read_json_file::<BaseCounterExample>(replay_file).ok()
+        };
         if self.cr.mcr.tcfg.fuzz_failure_replay {
             let Some(failure) = persisted_failure.as_ref() else {
                 let result = FuzzTestResult {
                     skipped: true,
                     reason: Some(format!(
                         "no persisted fuzz failure found at {}",
-                        failure_file.display()
+                        replay_file.display()
                     )),
                     ..Default::default()
                 };

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -316,6 +316,192 @@ Ran 1 test suite [ELAPSED]: 0 tests passed, 0 failed, 2 skipped (2 total tests)
     ]]);
 });
 
+forgetest_init!(forge_fuzz_replays_explicit_failure_file, |prj, cmd| {
+    prj.add_test(
+        "ForgeExplicitFuzzReplay.t.sol",
+        r#"
+contract ForgeExplicitFuzzReplayTest {
+    function testFuzz_failure(uint256) public pure {
+        revert("boom");
+    }
+
+    function testFuzz_other(uint256 value) public pure {
+        value;
+    }
+}
+   "#,
+    );
+
+    cmd.args([
+        "test",
+        "--match-contract",
+        "ForgeExplicitFuzzReplayTest",
+        "--match-test",
+        "testFuzz_failure",
+        "--fuzz-runs",
+        "1",
+        "--fuzz-seed",
+        "1",
+    ])
+    .assert_failure();
+
+    let canonical =
+        prj.root().join("cache/fuzz/failures/ForgeExplicitFuzzReplayTest/testFuzz_failure");
+    let explicit = prj.root().join("explicit-fuzz-failure.json");
+    std::fs::rename(&canonical, &explicit).unwrap();
+    let original = std::fs::read(&explicit).unwrap();
+    let persisted: BaseCounterExample = serde_json::from_slice(&original).unwrap();
+    let failing_value = U256::from_be_slice(&persisted.calldata[4..36]);
+
+    let missing = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "replay",
+            "--match-contract",
+            "ForgeExplicitFuzzReplayTest",
+            "--match-test",
+            "testFuzz_failure",
+        ])
+        .assert_success();
+    let stdout = String::from_utf8_lossy(&missing.get_output().stdout);
+    assert!(stdout.contains("no persisted fuzz failure found"), "{stdout}");
+
+    let replay = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "replay",
+            "--match-contract",
+            "ForgeExplicitFuzzReplayTest",
+            "--match-test",
+            "testFuzz_failure",
+            "--fuzz-input-file",
+            "explicit-fuzz-failure.json",
+        ])
+        .assert_failure();
+    let stdout = String::from_utf8_lossy(&replay.get_output().stdout);
+    assert!(stdout.contains("[FAIL: boom; counterexample:"), "{stdout}");
+
+    let mismatch = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "replay",
+            "--match-contract",
+            "ForgeExplicitFuzzReplayTest",
+            "--match-test",
+            "testFuzz_other",
+            "--fuzz-input-file",
+        ])
+        .arg(&explicit)
+        .assert_success();
+    let stdout = String::from_utf8_lossy(&mismatch.get_output().stdout);
+    assert!(stdout.contains("persisted fuzz failure selector does not match"), "{stdout}");
+
+    prj.add_test(
+        "ForgeExplicitFuzzReplay.t.sol",
+        &format!(
+            r#"
+contract ForgeExplicitFuzzReplayTest {{
+    function testFuzz_failure(uint256 value) public pure {{
+        require(value != {failing_value}, "boom");
+    }}
+
+    function testFuzz_other(uint256 value) public pure {{
+        value;
+    }}
+}}
+   "#
+        ),
+    );
+
+    cmd.forge_fuse()
+        .args([
+            "test",
+            "--match-contract",
+            "ForgeExplicitFuzzReplayTest",
+            "--match-test",
+            "testFuzz_failure",
+            "--fuzz-runs",
+            "1",
+            "--fuzz-seed",
+            "2",
+            "--fuzz-input-file",
+        ])
+        .arg(&explicit)
+        .assert_failure();
+    assert_eq!(std::fs::read(&explicit).unwrap(), original);
+    assert!(canonical.is_file());
+
+    let missing_explicit = prj.root().join("missing-fuzz-failure.json");
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "replay",
+            "--match-contract",
+            "ForgeExplicitFuzzReplayTest",
+            "--match-test",
+            "testFuzz_failure",
+            "--fuzz-input-file",
+        ])
+        .arg(&missing_explicit)
+        .assert_failure();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    assert!(stdout.contains(&missing_explicit.display().to_string()), "{stdout}");
+
+    let malformed = prj.root().join("malformed-fuzz-failure.json");
+    std::fs::write(&malformed, "not json").unwrap();
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "replay",
+            "--match-contract",
+            "ForgeExplicitFuzzReplayTest",
+            "--match-test",
+            "testFuzz_failure",
+            "--fuzz-input-file",
+        ])
+        .arg(&malformed)
+        .assert_failure();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    assert!(stdout.contains(&malformed.display().to_string()), "{stdout}");
+
+    let output = cmd
+        .forge_fuse()
+        .args(["test", "--fuzz-run", "1", "--fuzz-input-file"])
+        .arg(&explicit)
+        .assert_failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("cannot be used with '--fuzz-input-file"), "{stderr}");
+
+    prj.update_config(|config| config.fuzz.run = Some(1));
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "test",
+            "--match-contract",
+            "ForgeExplicitFuzzReplayTest",
+            "--match-test",
+            "testFuzz_failure",
+            "--fuzz-input-file",
+        ])
+        .arg(&explicit)
+        .assert_failure();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    assert!(stdout.contains("cannot be combined with `fuzz.run`"), "{stdout}");
+});
+
+forgetest_init!(forge_fuzz_replay_rejects_multiple_input_sources, |_prj, cmd| {
+    let output = cmd
+        .args(["fuzz", "replay", "--corpus-dir", "corpus", "--fuzz-input-file", "failure.json"])
+        .assert_failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("cannot be combined with `--corpus-dir`"), "{stderr}");
+});
+
 forgetest_init!(forge_fuzz_replay_rejects_watch, |_prj, cmd| {
     let output = cmd.args(["fuzz", "replay", "--watch"]).assert_failure();
     let stderr = String::from_utf8(output.get_output().stderr.clone()).unwrap();

--- a/crates/forge/tests/cli/test_cmd/fuzz.rs
+++ b/crates/forge/tests/cli/test_cmd/fuzz.rs
@@ -1,6 +1,6 @@
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt};
 use alloy_json_abi::JsonAbi;
-use alloy_primitives::{U256, hex};
+use alloy_primitives::{U256, hex, keccak256};
 use foundry_config::fs_permissions::PathPermission;
 use foundry_evm::fuzz::BaseCounterExample;
 use foundry_test_utils::{TestCommand, forgetest_init, str};
@@ -320,13 +320,19 @@ forgetest_init!(forge_fuzz_replays_explicit_failure_file, |prj, cmd| {
     prj.add_test(
         "ForgeExplicitFuzzReplay.t.sol",
         r#"
-contract ForgeExplicitFuzzReplayTest {
-    function testFuzz_failure(uint256) public pure {
+library ForgeExplicitFuzzReplayLibrary {
+    function fail() external pure {
         revert("boom");
     }
+}
 
-    function testFuzz_other(uint256 value) public pure {
-        value;
+contract ForgeExplicitFuzzReplayTest {
+    function testFuzz_failure(uint256) public pure {
+        ForgeExplicitFuzzReplayLibrary.fail();
+    }
+
+    function testFuzz_other(uint256) public pure {
+        revert("other boom");
     }
 }
    "#,
@@ -352,6 +358,15 @@ contract ForgeExplicitFuzzReplayTest {
     let original = std::fs::read(&explicit).unwrap();
     let persisted: BaseCounterExample = serde_json::from_slice(&original).unwrap();
     let failing_value = U256::from_be_slice(&persisted.calldata[4..36]);
+    let mut other_failure = persisted.clone();
+    let mut other_calldata = other_failure.calldata.to_vec();
+    other_calldata[..4].copy_from_slice(&keccak256("testFuzz_other(uint256)").as_slice()[..4]);
+    other_failure.calldata = other_calldata.into();
+    std::fs::write(
+        prj.root().join("cache/fuzz/failures/ForgeExplicitFuzzReplayTest/testFuzz_other"),
+        serde_json::to_vec(&other_failure).unwrap(),
+    )
+    .unwrap();
 
     let missing = cmd
         .forge_fuse()
@@ -395,9 +410,79 @@ contract ForgeExplicitFuzzReplayTest {
             "--fuzz-input-file",
         ])
         .arg(&explicit)
-        .assert_success();
-    let stdout = String::from_utf8_lossy(&mismatch.get_output().stdout);
-    assert!(stdout.contains("persisted fuzz failure selector does not match"), "{stdout}");
+        .assert_failure();
+    let stderr = String::from_utf8_lossy(&mismatch.get_output().stderr);
+    assert!(stderr.contains("does not match any selected stateless fuzz test"), "{stderr}");
+
+    let short = prj.root().join("short-fuzz-failure.json");
+    let mut short_failure = persisted;
+    short_failure.calldata = hex!("12").into();
+    std::fs::write(&short, serde_json::to_vec(&short_failure).unwrap()).unwrap();
+    let output = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "replay",
+            "--match-contract",
+            "ForgeExplicitFuzzReplayTest",
+            "--match-test",
+            "testFuzz_failure",
+            "--fuzz-input-file",
+        ])
+        .arg(&short)
+        .assert_failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("calldata shorter than a 4-byte selector"), "{stderr}");
+
+    for args in [
+        &["test", "--list", "--fuzz-input-file"][..],
+        &["fuzz", "replay", "--list", "--fuzz-input-file"][..],
+    ] {
+        let output = cmd.forge_fuse().args(args).arg(&explicit).assert_failure();
+        let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+        assert!(
+            stderr.contains("cannot be used with")
+                && stderr.contains("--list")
+                && stderr.contains("--fuzz-input-file"),
+            "{stderr}"
+        );
+    }
+
+    prj.add_test(
+        "ForgeExplicitFuzzReplayDuplicate.t.sol",
+        r#"
+contract ForgeExplicitFuzzReplayDuplicateTest {
+    function testFuzz_failure(uint256 value) public pure {
+        value;
+    }
+}
+   "#,
+    );
+    let output = cmd
+        .forge_fuse()
+        .args(["fuzz", "replay", "--match-test", "testFuzz_failure", "--fuzz-input-file"])
+        .arg(&explicit)
+        .assert_failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(
+        stderr.contains("matches 2 selected stateless fuzz tests; replay requires exactly one"),
+        "{stderr}"
+    );
+
+    let broad = cmd
+        .forge_fuse()
+        .args([
+            "fuzz",
+            "replay",
+            "--match-contract",
+            "ForgeExplicitFuzzReplayTest",
+            "--fuzz-input-file",
+        ])
+        .arg(&explicit)
+        .assert_failure();
+    let stdout = String::from_utf8_lossy(&broad.get_output().stdout);
+    assert!(stdout.contains("[FAIL: boom; counterexample:"), "{stdout}");
+    assert!(stdout.contains("[FAIL: other boom; counterexample:"), "{stdout}");
 
     prj.add_test(
         "ForgeExplicitFuzzReplay.t.sol",
@@ -448,8 +533,8 @@ contract ForgeExplicitFuzzReplayTest {{
         ])
         .arg(&missing_explicit)
         .assert_failure();
-    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
-    assert!(stdout.contains(&missing_explicit.display().to_string()), "{stdout}");
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains(&missing_explicit.display().to_string()), "{stderr}");
 
     let malformed = prj.root().join("malformed-fuzz-failure.json");
     std::fs::write(&malformed, "not json").unwrap();
@@ -466,8 +551,8 @@ contract ForgeExplicitFuzzReplayTest {{
         ])
         .arg(&malformed)
         .assert_failure();
-    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
-    assert!(stdout.contains(&malformed.display().to_string()), "{stdout}");
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains(&malformed.display().to_string()), "{stderr}");
 
     let output = cmd
         .forge_fuse()
@@ -492,6 +577,20 @@ contract ForgeExplicitFuzzReplayTest {{
         .assert_failure();
     let stdout = String::from_utf8_lossy(&output.get_output().stdout);
     assert!(stdout.contains("cannot be combined with `fuzz.run`"), "{stdout}");
+
+    prj.update_config(|config| config.fuzz.run = None);
+    std::fs::write(
+        prj.root().join("cache/test-failures"),
+        r#"{"version":1,"failures":[{"contract":"test/ForgeExplicitFuzzReplay.t.sol:ForgeExplicitFuzzReplayTest","test":"testFuzz_other(uint256)"}]}"#,
+    )
+    .unwrap();
+    let output = cmd
+        .forge_fuse()
+        .args(["test", "--rerun", "--fuzz-input-file"])
+        .arg(&explicit)
+        .assert_failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("does not match any selected stateless fuzz test"), "{stderr}");
 });
 
 forgetest_init!(forge_fuzz_replay_rejects_multiple_input_sources, |_prj, cmd| {
@@ -1017,20 +1116,12 @@ contract ForgeFuzzRunInvariantWarningsTest is Test {
             "1",
             "--frontier-dir",
             "frontier",
-            "--fuzz-input-file",
-            "failure",
         ])
         .assert_success();
     let stderr = String::from_utf8(output.get_output().stderr.clone()).unwrap();
     assert!(
         stderr.contains(
             "`--frontier-dir` only applies to fuzz tests; no matched fuzz tests were found."
-        ),
-        "{stderr}"
-    );
-    assert!(
-        stderr.contains(
-            "`--fuzz-input-file` only applies to fuzz tests; no matched fuzz tests were found."
         ),
         "{stderr}"
     );

--- a/docs/dev/showmap.md
+++ b/docs/dev/showmap.md
@@ -84,7 +84,9 @@ differential-coverage relscore coverage_data
 - `forge fuzz replay --corpus-dir <PATH>` replays corpus entries as seeds and
   reports whether they execute successfully for the selected targets. It is not
   the persisted-failure replay path. To reproduce the last saved fuzz failure,
-  run `forge fuzz replay` without `--corpus-dir`.
+  run `forge fuzz replay` without `--corpus-dir`, or replay a specific failure
+  with `forge fuzz replay --fuzz-input-file <PATH>`. `--corpus-dir` and
+  `--fuzz-input-file` cannot be combined.
 - Unit and table tests are not runnable in showmap mode and are skipped.
 - A test with no `corpus_dir` configured is `SKIP`ped with reason
   `"no corpus_dir configured for this test"`.

--- a/docs/dev/showmap.md
+++ b/docs/dev/showmap.md
@@ -86,7 +86,8 @@ differential-coverage relscore coverage_data
   the persisted-failure replay path. To reproduce the last saved fuzz failure,
   run `forge fuzz replay` without `--corpus-dir`, or replay a specific failure
   with `forge fuzz replay --fuzz-input-file <PATH>`. `--corpus-dir` and
-  `--fuzz-input-file` cannot be combined.
+  `--fuzz-input-file` cannot be combined. The selected tests must contain exactly
+  one stateless fuzz function matching the artifact's selector.
 - Unit and table tests are not runnable in showmap mode and are skipped.
 - A test with no `corpus_dir` configured is `SKIP`ped with reason
   `"no corpus_dir configured for this test"`.


### PR DESCRIPTION
`--fuzz-input-file` was accepted but silently ignored, potentially reporting success without replaying the requested failure. This change replays the specified stateless fuzz artifact, reports invalid input files, and rejects combinations that would suppress replay.