### PR TITLE
fix(mutation): filter invalid assignments

### DIFF
--- a/.changelog/mutation-assignment-destination-types.md
+++ b/.changelog/mutation-assignment-destination-types.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Stopped mutation testing from generating assignment replacements that are invalid for the destination type.

--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -430,7 +430,7 @@ impl MutationHandler {
         let mut mutant_cfg_hasher = DefaultHasher::new();
         // Version salt for this mutant-set cache schema. Bump this if the
         // inputs that define generated mutants change.
-        "mutant-set-v5".hash(&mut mutant_cfg_hasher);
+        "mutant-set-v6".hash(&mut mutant_cfg_hasher);
         for op in self.config.mutation.enabled_operators() {
             op.to_string().hash(&mut mutant_cfg_hasher);
         }

--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -441,6 +441,21 @@ impl MutationHandler {
             }
             None => "nofilter".hash(&mut mutant_cfg_hasher),
         }
+        let mut exclusion_hashes = self
+            .mutation_exclusions
+            .iter()
+            .map(|exclusion| {
+                let mut hasher = DefaultHasher::new();
+                exclusion.hash(&mut hasher);
+                hasher.finish()
+            })
+            .collect::<Vec<_>>();
+        exclusion_hashes.sort_unstable();
+        "exclusions:".hash(&mut mutant_cfg_hasher);
+        exclusion_hashes.len().hash(&mut mutant_cfg_hasher);
+        for exclusion_hash in exclusion_hashes {
+            exclusion_hash.hash(&mut mutant_cfg_hasher);
+        }
         let mutant_cfg_hash = mutant_cfg_hasher.finish();
 
         let (ext, execution_suffix) = match kind {
@@ -597,6 +612,7 @@ impl MutationHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mutation::type_analysis::{AssignmentReplacement, MutationExclusion};
     use foundry_config::Config;
     use solar::ast::interface::BytePos;
     use tempfile::TempDir;
@@ -669,6 +685,31 @@ mod tests {
         let second = test_handler(second_config).cache_file_path("build", CacheKind::Mutants);
 
         assert_eq!(first, second);
+    }
+
+    #[test]
+    fn mutation_cache_paths_include_type_analysis_exclusions() {
+        let (_temp, config) = test_config();
+        let without_exclusions = test_handler(config.clone());
+        let exclusion = MutationExclusion::assignment(
+            Span::new(BytePos(10), BytePos(20)),
+            AssignmentReplacement::Zero,
+        );
+        let with_exclusions = test_handler(config).with_mutation_exclusions([exclusion].into());
+        without_exclusions.persist_cached_mutants("build", &[mutant(10, 20, "account")]).unwrap();
+
+        assert!(with_exclusions.retrieve_cached_mutants("build").is_none());
+
+        for kind in [
+            CacheKind::Mutants,
+            CacheKind::Results { execution_key: "exec" },
+            CacheKind::Survived { execution_key: "exec" },
+        ] {
+            assert_ne!(
+                without_exclusions.cache_file_path("build", kind),
+                with_exclusions.cache_file_path("build", kind),
+            );
+        }
     }
 
     #[test]

--- a/crates/forge/src/mutation/mutant.rs
+++ b/crates/forge/src/mutation/mutant.rs
@@ -250,6 +250,7 @@ impl Display for MutationType {
             Self::Assignment(kind) => match kind {
                 AssignVarTypes::Literal(lit) => write!(f, "{lit}"),
                 AssignVarTypes::Identifier(ident) => write!(f, "{ident}"),
+                AssignVarTypes::NegatedIdentifier(ident) => write!(f, "-{ident}"),
             },
             Self::BinaryOp(kind) => write!(f, "{}", kind.to_str()),
             Self::BinaryOpExpr { mutated_expr, .. } => write!(f, "{mutated_expr}"),

--- a/crates/forge/src/mutation/mutators/assignment_mutator.rs
+++ b/crates/forge/src/mutation/mutators/assignment_mutator.rs
@@ -87,9 +87,9 @@ impl Mutator for AssignmentMutator {
                 },
                 Mutant {
                     span: replacement_span,
-                    mutation: MutationType::Assignment(AssignVarTypes::Identifier(format!(
-                        "-{ident}"
-                    ))),
+                    mutation: MutationType::Assignment(AssignVarTypes::NegatedIdentifier(
+                        ident.clone(),
+                    )),
                     path: context.path.clone(),
                     original,
                     source_line,
@@ -97,6 +97,7 @@ impl Mutator for AssignmentMutator {
                     column_number,
                 },
             ]),
+            AssignVarTypes::NegatedIdentifier(_) => Ok(vec![]),
         }
     }
 

--- a/crates/forge/src/mutation/type_analysis.rs
+++ b/crates/forge/src/mutation/type_analysis.rs
@@ -18,7 +18,7 @@ use solar::{
     ast::{BinOpKind, UnOpKind},
     interface::{Session, source_map::FileName},
     sema::{
-        Compiler, Gcx,
+        Compiler, CompilerRef, Gcx,
         hir::{self, ElementaryType, ExprKind, Visit},
         ty::TyKind,
     },
@@ -26,8 +26,15 @@ use solar::{
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 enum ReplacementOperator {
+    Assignment(AssignmentReplacement),
     Binary(BinOpKind),
     Unary(UnOpKind),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum AssignmentReplacement {
+    Zero,
+    Negate,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -38,6 +45,14 @@ pub struct MutationExclusion {
 }
 
 impl MutationExclusion {
+    pub fn assignment(span: solar::ast::Span, replacement: AssignmentReplacement) -> Self {
+        Self {
+            lo: span.lo().0,
+            hi: span.hi().0,
+            new_op: ReplacementOperator::Assignment(replacement),
+        }
+    }
+
     pub fn binary(span: solar::ast::Span, new_op: BinOpKind) -> Self {
         Self { lo: span.lo().0, hi: span.hi().0, new_op: ReplacementOperator::Binary(new_op) }
     }
@@ -63,9 +78,18 @@ pub fn collect_mutation_exclusions(
         let Ok(ControlFlow::Continue(())) = compiler.lower_asts() else {
             return Ok(MutationExclusionsByPath::new());
         };
-        let _ = compiler.analysis();
-        Ok(collect_from_gcx(compiler.gcx()))
+        Ok(analyze_and_collect(compiler))
     })
+}
+
+fn analyze_and_collect(compiler: &CompilerRef<'_>) -> MutationExclusionsByPath {
+    let Ok(ControlFlow::Continue(())) = compiler.analysis() else {
+        return MutationExclusionsByPath::new();
+    };
+    if compiler.dcx().has_errors().is_err() {
+        return MutationExclusionsByPath::new();
+    }
+    collect_from_gcx(compiler.gcx())
 }
 
 fn collect_from_gcx<'gcx>(gcx: Gcx<'gcx>) -> MutationExclusionsByPath {
@@ -106,6 +130,11 @@ impl<'hir> Visit<'hir> for MutationExclusionCollector<'hir> {
     }
 
     fn visit_expr(&mut self, expr: &'hir hir::Expr<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let ExprKind::Assign(destination, None, value) = &expr.kind
+            && let Some(ty) = self.gcx.type_of_expr(destination.id)
+        {
+            self.collect_assignment(value, ty);
+        }
         if let ExprKind::Binary(left, op, right) = &expr.kind
             && (op.kind.is_cmp() || matches!(op.kind, BinOpKind::And | BinOpKind::Or))
         {
@@ -119,9 +148,29 @@ impl<'hir> Visit<'hir> for MutationExclusionCollector<'hir> {
         }
         self.walk_expr(expr)
     }
+
+    fn visit_var(&mut self, var: &'hir hir::Variable<'hir>) -> ControlFlow<Self::BreakValue> {
+        if let Some(value) = var.initializer {
+            self.collect_assignment(value, self.gcx.type_of_hir_ty(&var.ty));
+        }
+        self.walk_var(var)
+    }
 }
 
 impl MutationExclusionCollector<'_> {
+    fn collect_assignment(&mut self, value: &hir::Expr<'_>, destination: solar::sema::ty::Ty<'_>) {
+        let Some(span) = self.local_span(value.span) else { return };
+        let Some(kind) = assignment_destination_kind(destination) else { return };
+
+        if !kind.accepts_zero() {
+            self.mutations.insert(MutationExclusion::assignment(span, AssignmentReplacement::Zero));
+        }
+        if !kind.accepts_negation() {
+            self.mutations
+                .insert(MutationExclusion::assignment(span, AssignmentReplacement::Negate));
+        }
+    }
+
     fn collect_comparison(
         &mut self,
         expr: &hir::Expr<'_>,
@@ -153,6 +202,40 @@ impl MutationExclusionCollector<'_> {
         let lo = span.lo().0.checked_sub(self.source_start)?;
         let hi = span.hi().0.checked_sub(self.source_start)?;
         Some(solar::ast::Span::new(solar::interface::BytePos(lo), solar::interface::BytePos(hi)))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum AssignmentDestinationKind {
+    SignedNumber,
+    UnsignedNumber,
+    FixedBytes,
+    Other,
+}
+
+impl AssignmentDestinationKind {
+    const fn accepts_zero(self) -> bool {
+        !matches!(self, Self::Other)
+    }
+
+    const fn accepts_negation(self) -> bool {
+        matches!(self, Self::SignedNumber)
+    }
+}
+
+fn assignment_destination_kind(ty: solar::sema::ty::Ty<'_>) -> Option<AssignmentDestinationKind> {
+    match ty.peel_refs().kind {
+        TyKind::Elementary(ElementaryType::Int(_) | ElementaryType::Fixed(..)) => {
+            Some(AssignmentDestinationKind::SignedNumber)
+        }
+        TyKind::Elementary(ElementaryType::UInt(_) | ElementaryType::UFixed(..)) => {
+            Some(AssignmentDestinationKind::UnsignedNumber)
+        }
+        TyKind::Elementary(ElementaryType::FixedBytes(_)) => {
+            Some(AssignmentDestinationKind::FixedBytes)
+        }
+        TyKind::Udvt(..) | TyKind::Err(_) => None,
+        _ => Some(AssignmentDestinationKind::Other),
     }
 }
 
@@ -224,8 +307,7 @@ mod tests {
             pcx.add_file(file);
             pcx.parse();
             assert!(matches!(compiler.lower_asts(), Ok(ControlFlow::Continue(()))));
-            let _ = compiler.analysis();
-            collect_from_gcx(compiler.gcx()).remove(&path).unwrap_or_default()
+            analyze_and_collect(compiler).remove(&path).unwrap_or_default()
         })
     }
 
@@ -243,6 +325,143 @@ mod tests {
             solar::ast::Span::new(BytePos(lo), BytePos(lo + expression.len() as u32)),
             new_op,
         )
+    }
+
+    fn assignment_mutation(
+        source: &str,
+        value: &str,
+        replacement: AssignmentReplacement,
+    ) -> MutationExclusion {
+        let lo = source.rfind(value).expect("value") as u32;
+        MutationExclusion::assignment(
+            solar::ast::Span::new(BytePos(lo), BytePos(lo + value.len() as u32)),
+            replacement,
+        )
+    }
+
+    #[test]
+    fn excludes_assignments_invalid_for_destination_type() {
+        let source = r#"
+enum Choice { A, B }
+
+contract Test {
+    function check(address account, bool flag, uint256 unsigned, Choice choice) external pure {
+        address accountCopy = account;
+        bool flagCopy = flag;
+        uint256 unsignedCopy = unsigned;
+        Choice choiceCopy = choice;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        for value in ["account", "flag", "choice"] {
+            assert!(mutations.contains(&assignment_mutation(
+                source,
+                value,
+                AssignmentReplacement::Zero,
+            )));
+            assert!(mutations.contains(&assignment_mutation(
+                source,
+                value,
+                AssignmentReplacement::Negate,
+            )));
+        }
+        assert!(!mutations.contains(&assignment_mutation(
+            source,
+            "unsigned",
+            AssignmentReplacement::Zero,
+        )));
+        assert!(mutations.contains(&assignment_mutation(
+            source,
+            "unsigned",
+            AssignmentReplacement::Negate,
+        )));
+    }
+
+    #[test]
+    fn uses_lhs_type_for_assignments() {
+        let source = r#"
+contract Test {
+    function check(address account, bool flag) external pure {
+        account = account;
+        flag = flag;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        for value in ["account", "flag"] {
+            assert!(mutations.contains(&assignment_mutation(
+                source,
+                value,
+                AssignmentReplacement::Zero,
+            )));
+            assert!(mutations.contains(&assignment_mutation(
+                source,
+                value,
+                AssignmentReplacement::Negate,
+            )));
+        }
+    }
+
+    #[test]
+    fn preserves_valid_signed_and_fixed_bytes_assignments() {
+        let source = r#"
+contract Test {
+    function check(int256 signed, bytes32 word) external pure {
+        int256 signedCopy = signed;
+        bytes32 wordCopy = word;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        for replacement in [AssignmentReplacement::Zero, AssignmentReplacement::Negate] {
+            assert!(!mutations.contains(&assignment_mutation(source, "signed", replacement)));
+        }
+        assert!(!mutations.contains(&assignment_mutation(
+            source,
+            "word",
+            AssignmentReplacement::Zero,
+        )));
+        assert!(mutations.contains(&assignment_mutation(
+            source,
+            "word",
+            AssignmentReplacement::Negate,
+        )));
+    }
+
+    #[test]
+    fn preserves_udvt_assignments() {
+        let source = r#"
+type Amount is uint256;
+
+contract Test {
+    function check(Amount amount) external pure {
+        Amount copy = amount;
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        for replacement in [AssignmentReplacement::Zero, AssignmentReplacement::Negate] {
+            assert!(!mutations.contains(&assignment_mutation(source, "amount", replacement)));
+        }
+    }
+
+    #[test]
+    fn preserves_all_mutations_when_analysis_has_errors() {
+        let source = r#"
+contract Test {
+    function check(address account) external pure {
+        address copy = account;
+        unresolved = unresolved;
+    }
+}
+"#;
+
+        assert!(collect(source).is_empty());
     }
 
     #[test]

--- a/crates/forge/src/mutation/visitor.rs
+++ b/crates/forge/src/mutation/visitor.rs
@@ -8,7 +8,7 @@ use crate::mutation::mutators::Mutator;
 use crate::mutation::{
     mutant::{Mutant, OwnedLiteral},
     mutators::{MutationContext, mutator_registry::MutatorRegistry},
-    type_analysis::{MutationExclusion, MutationExclusionSet},
+    type_analysis::{AssignmentReplacement, MutationExclusion, MutationExclusionSet},
 };
 use foundry_config::MutatorType;
 
@@ -16,6 +16,7 @@ use foundry_config::MutatorType;
 pub enum AssignVarTypes {
     Literal(OwnedLiteral),
     Identifier(String),
+    NegatedIdentifier(String),
 }
 
 /// A visitor which collect all expression to mutate as well as the mutation types
@@ -112,6 +113,17 @@ impl<'src> MutantVisitor<'src> {
         let result = self.mutator_registry.generate_mutations(context);
         self.mutation_to_conduct.extend(result.mutations.into_iter().filter(|mutant| {
             let exclusion = match &mutant.mutation {
+                crate::mutation::mutant::MutationType::Assignment(kind) => {
+                    let replacement = match kind {
+                        AssignVarTypes::Literal(OwnedLiteral::Number(value)) if value.is_zero() => {
+                            AssignmentReplacement::Zero
+                        }
+                        AssignVarTypes::Literal(OwnedLiteral::NegatedNumber(_))
+                        | AssignVarTypes::NegatedIdentifier(_) => AssignmentReplacement::Negate,
+                        _ => return true,
+                    };
+                    MutationExclusion::assignment(mutant.span, replacement)
+                }
                 crate::mutation::mutant::MutationType::BinaryOpExpr { new_op, .. } => {
                     MutationExclusion::binary(mutant.span, *new_op)
                 }
@@ -355,6 +367,100 @@ contract Test {
 
             assert!(!comparison_mutations.contains(&solar::ast::BinOpKind::Le));
             assert!(comparison_mutations.contains(&solar::ast::BinOpKind::Lt));
+        });
+    }
+
+    #[test]
+    fn visitor_excludes_assignment_mutations_rejected_by_type_analysis() {
+        let source = "\
+pragma solidity ^0.8.0;
+contract Test {
+    function check(address account) public pure {
+        address copy = account;
+    }
+}
+";
+        let path = PathBuf::from("test.sol");
+        let lo = source.rfind("account").unwrap() as u32;
+        let span = solar::ast::Span::new(
+            solar::interface::BytePos(lo),
+            solar::interface::BytePos(lo + "account".len() as u32),
+        );
+        let mutation_exclusions = [
+            MutationExclusion::assignment(span, AssignmentReplacement::Zero),
+            MutationExclusion::assignment(span, AssignmentReplacement::Negate),
+        ]
+        .into_iter()
+        .collect();
+        let sess = Session::builder().with_silent_emitter(None).build();
+
+        sess.enter(|| {
+            let arena = Arena::new();
+            let mut parser =
+                Parser::from_lazy_source_code(&sess, &arena, FileName::Real(path.clone()), || {
+                    Ok(source.to_string())
+                })
+                .unwrap();
+            let ast = parser.parse_file().map_err(|e| e.emit()).unwrap();
+            drop(parser);
+            let mut visitor = MutantVisitor::new_with_mutators(
+                path,
+                vec![Box::new(crate::mutation::mutators::assignment_mutator::AssignmentMutator)],
+            )
+            .with_source(source)
+            .with_mutation_exclusions(mutation_exclusions);
+
+            let _ = visitor.visit_source_unit(&ast);
+
+            assert!(visitor.mutation_to_conduct.iter().all(|mutant| mutant.span != span));
+        });
+    }
+
+    #[test]
+    fn visitor_excludes_negated_number_but_retains_zero_assignment() {
+        let source = "\
+pragma solidity ^0.8.0;
+contract Test {
+    function check() public pure {
+        uint8 copy = 1;
+    }
+}
+";
+        let path = PathBuf::from("test.sol");
+        let lo = source.rfind('1').unwrap() as u32;
+        let span =
+            solar::ast::Span::new(solar::interface::BytePos(lo), solar::interface::BytePos(lo + 1));
+        let mutation_exclusions =
+            [MutationExclusion::assignment(span, AssignmentReplacement::Negate)]
+                .into_iter()
+                .collect();
+        let sess = Session::builder().with_silent_emitter(None).build();
+
+        sess.enter(|| {
+            let arena = Arena::new();
+            let mut parser =
+                Parser::from_lazy_source_code(&sess, &arena, FileName::Real(path.clone()), || {
+                    Ok(source.to_string())
+                })
+                .unwrap();
+            let ast = parser.parse_file().map_err(|e| e.emit()).unwrap();
+            drop(parser);
+            let mut visitor = MutantVisitor::new_with_mutators(
+                path,
+                vec![Box::new(crate::mutation::mutators::assignment_mutator::AssignmentMutator)],
+            )
+            .with_source(source)
+            .with_mutation_exclusions(mutation_exclusions);
+
+            let _ = visitor.visit_source_unit(&ast);
+            let replacements = visitor
+                .mutation_to_conduct
+                .iter()
+                .filter(|mutant| mutant.span == span)
+                .map(|mutant| mutant.mutation.to_string())
+                .collect::<Vec<_>>();
+
+            assert_eq!(replacements, ["0"]);
         });
     }
 

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -70,11 +70,11 @@ MUTATION TESTING RESULTS
 ╭──────────┬───────────┬────────────╮
 │ Status   ┆ # Mutants ┆ % of Total │
 ╞══════════╪═══════════╪════════════╡
-│ Survived ┆ 1         ┆ 16.7%      │
+│ Survived ┆ 1         ┆ 20.0%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Killed   ┆ 4         ┆ 66.7%      │
+│ Killed   ┆ 4         ┆ 80.0%      │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
-│ Invalid  ┆ 1         ┆ 16.7%      │
+│ Invalid  ┆ 0         ┆ 0.0%       │
 ├╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┤
 │ Skipped  ┆ 0         ┆ 0.0%       │
 ╰──────────┴───────────┴────────────╯
@@ -101,16 +101,13 @@ Survived mutants
 ────────────────────────────────────────────────────────────
 4 mutants killed
 
-────────────────────────────────────────────────────────────
-1 mutants invalid
-
 ════════════════════════════════════════════════════════════
 
 "#]]);
 
     // Run mutation testing with --json - verify the output contains valid mutation JSON
     cmd.forge_fuse().args(["test", "--mutate", "src/Counter.sol", "--mutation-jobs", "1", "--json"]).assert_success().stdout_eq(str![[r#"
-{"summary":{"total":6,"killed":4,"survived":1,"invalid":1,"skipped":0,"timed_out":0,"mutation_score":80.0,"duration_secs":[..]},"survived_mutants":{"src/Counter.sol":[{"line":13,"column":9,"original":"number++","mutant":"++number"}]}}
+{"summary":{"total":5,"killed":4,"survived":1,"invalid":0,"skipped":0,"timed_out":0,"mutation_score":80.0,"duration_secs":[..]},"survived_mutants":{"src/Counter.sol":[{"line":13,"column":9,"original":"number++","mutant":"++number"}]}}
 
 "#]]);
 });


### PR DESCRIPTION
Assignment mutations currently replace values with `0` or their negation without considering the destination type. This produces mutants that cannot compile, such as assigning `0` or a negated value to an address, boolean, enum, array, or struct.

This change uses Solar’s resolved destination types to exclude replacements that are invalid under Solidity 0.8 semantics. It handles both variable initializers and plain assignments while preserving valid replacements for numeric and fixed-bytes destinations. User-defined value types, unresolved types, compound assignments, and incomplete semantic analysis fail open so mutation testing does not discard replacements unless their invalidity is established.

AI assistance disclosure: Amp was used to review the implementation, identify edge cases, and assist with code and test generation.