### PR TITLE
fix(mutation): filter non-lvalue increments

### DIFF
--- a/.changelog/mutation-unary-non-lvalues.md
+++ b/.changelog/mutation-unary-non-lvalues.md
@@ -1,0 +1,5 @@
+---
+forge: patch
+---
+
+Stopped mutation testing from generating increment and decrement operators for expressions that cannot be assigned to.

--- a/crates/forge/src/mutation/mod.rs
+++ b/crates/forge/src/mutation/mod.rs
@@ -430,7 +430,7 @@ impl MutationHandler {
         let mut mutant_cfg_hasher = DefaultHasher::new();
         // Version salt for this mutant-set cache schema. Bump this if the
         // inputs that define generated mutants change.
-        "mutant-set-v6".hash(&mut mutant_cfg_hasher);
+        "mutant-set-v7".hash(&mut mutant_cfg_hasher);
         for op in self.config.mutation.enabled_operators() {
             op.to_string().hash(&mut mutant_cfg_hasher);
         }

--- a/crates/forge/src/mutation/mutators/tests/unary_op_mutator_test.rs
+++ b/crates/forge/src/mutation/mutators/tests/unary_op_mutator_test.rs
@@ -30,5 +30,37 @@ mutator_tests!(UnaryOpMutator;
         "foo().bar--",
     ]);
     not_parenthesized_binary: "!(a == b)" => Some(vec!["(a == b)"]);
+    negated_call: "-foo()" => Some(vec!["~foo()"]);
+    negated_storage_push: "-values.push()" => Some(vec![
+        "++values.push()",
+        "--values.push()",
+        "~values.push()",
+        "values.push()++",
+        "values.push()--",
+    ]);
+    parenthesized_storage_push: "-(values.push())" => Some(vec![
+        "++(values.push())",
+        "--(values.push())",
+        "~(values.push())",
+        "(values.push())++",
+        "(values.push())--",
+    ]);
+    indexed_call: "-getStorageArray()[i]" => Some(vec![
+        "++getStorageArray()[i]",
+        "--getStorageArray()[i]",
+        "~getStorageArray()[i]",
+        "getStorageArray()[i]++",
+        "getStorageArray()[i]--",
+    ]);
+    bit_not_binary: "~(a + b)" => Some(vec!["-(a + b)"]);
+    negated_cast: "-uint256(x)" => Some(vec!["~uint256(x)"]);
+    negated_literal: "-1" => Some(vec!["~1"]);
+    parenthesized_identifier: "-(x)" => Some(vec![
+        "++(x)",
+        "--(x)",
+        "~(x)",
+        "(x)++",
+        "(x)--",
+    ]);
     non_unary:  "a = b + c" => None;
 );

--- a/crates/forge/src/mutation/mutators/tests/unary_op_mutator_test.rs
+++ b/crates/forge/src/mutation/mutators/tests/unary_op_mutator_test.rs
@@ -38,6 +38,7 @@ mutator_tests!(UnaryOpMutator;
         "values.push()++",
         "values.push()--",
     ]);
+    negated_method_named_push: "-producer.push(1)" => Some(vec!["~producer.push(1)"]);
     parenthesized_storage_push: "-(values.push())" => Some(vec![
         "++(values.push())",
         "--(values.push())",

--- a/crates/forge/src/mutation/mutators/unary_op_mutator.rs
+++ b/crates/forge/src/mutation/mutators/unary_op_mutator.rs
@@ -112,11 +112,12 @@ impl Mutator for UnaryOpMutator {
 }
 
 fn is_definitely_non_lvalue(expr: &solar::ast::Expr<'_>) -> bool {
-    if let ExprKind::Call(callee, _) = &expr.peel_parens().kind {
-        return !matches!(
-            &callee.peel_parens().kind,
-            ExprKind::Member(_, member) if member.as_str() == "push"
-        );
+    if let ExprKind::Call(callee, args) = &expr.peel_parens().kind {
+        return !(args.is_empty()
+            && matches!(
+                &callee.peel_parens().kind,
+                ExprKind::Member(_, member) if member.as_str() == "push"
+            ));
     }
 
     matches!(

--- a/crates/forge/src/mutation/mutators/unary_op_mutator.rs
+++ b/crates/forge/src/mutation/mutators/unary_op_mutator.rs
@@ -19,12 +19,12 @@ impl Mutator for UnaryOpMutator {
 
         let expr = context.expr.unwrap();
 
-        let (op, target_span) = match &expr.kind {
-            ExprKind::Unary(un_op, target) => (un_op.kind, target.span),
+        let (op, target) = match &expr.kind {
+            ExprKind::Unary(un_op, target) => (un_op.kind, &**target),
             _ => unreachable!(),
         };
 
-        let target_content = extract_span_text(context.source.unwrap_or(""), target_span);
+        let target_content = extract_span_text(context.source.unwrap_or(""), target.span);
         if target_content.is_empty() {
             return Ok(vec![]);
         }
@@ -55,6 +55,10 @@ impl Mutator for UnaryOpMutator {
         mutations = operations
             .into_iter()
             .filter(|&kind| kind != op)
+            .filter(|&kind| {
+                !matches!(kind, UnOpKind::PreInc | UnOpKind::PreDec)
+                    || !is_definitely_non_lvalue(target)
+            })
             .map(|kind| {
                 let new_expression = format!("{}{}", kind.to_str(), target_content);
 
@@ -72,23 +76,26 @@ impl Mutator for UnaryOpMutator {
             })
             .collect();
 
-        mutations.extend(post_fixed_operations.into_iter().filter(|&kind| kind != op).map(
-            |kind| {
-                let new_expression = format!("{}{}", target_content, kind.to_str());
+        mutations.extend(
+            post_fixed_operations
+                .into_iter()
+                .filter(|&kind| kind != op && !is_definitely_non_lvalue(target))
+                .map(|kind| {
+                    let new_expression = format!("{}{}", target_content, kind.to_str());
 
-                let mutated = UnaryOpMutated::new(new_expression, kind);
+                    let mutated = UnaryOpMutated::new(new_expression, kind);
 
-                Mutant {
-                    span: expr.span,
-                    mutation: MutationType::UnaryOperator(mutated),
-                    path: context.path.clone(),
-                    original: original.clone(),
-                    source_line: source_line.clone(),
-                    line_number,
-                    column_number,
-                }
-            },
-        ));
+                    Mutant {
+                        span: expr.span,
+                        mutation: MutationType::UnaryOperator(mutated),
+                        path: context.path.clone(),
+                        original: original.clone(),
+                        source_line: source_line.clone(),
+                        line_number,
+                        column_number,
+                    }
+                }),
+        );
 
         Ok(mutations)
     }
@@ -102,6 +109,32 @@ impl Mutator for UnaryOpMutator {
 
         false
     }
+}
+
+fn is_definitely_non_lvalue(expr: &solar::ast::Expr<'_>) -> bool {
+    if let ExprKind::Call(callee, _) = &expr.peel_parens().kind {
+        return !matches!(
+            &callee.peel_parens().kind,
+            ExprKind::Member(_, member) if member.as_str() == "push"
+        );
+    }
+
+    matches!(
+        &expr.peel_parens().kind,
+        ExprKind::Array(_)
+            | ExprKind::Assign(..)
+            | ExprKind::Binary(..)
+            | ExprKind::CallOptions(..)
+            | ExprKind::Delete(_)
+            | ExprKind::Lit(..)
+            | ExprKind::New(_)
+            | ExprKind::Payable(_)
+            | ExprKind::Ternary(..)
+            | ExprKind::Tuple(_)
+            | ExprKind::TypeCall(_)
+            | ExprKind::Type(_)
+            | ExprKind::Unary(..)
+    )
 }
 
 fn extract_span_text(source: &str, span: Span) -> String {

--- a/crates/forge/src/mutation/type_analysis.rs
+++ b/crates/forge/src/mutation/type_analysis.rs
@@ -146,6 +146,14 @@ impl<'hir> Visit<'hir> for MutationExclusionCollector<'hir> {
         {
             self.mutations.insert(MutationExclusion::unary(span, UnOpKind::Neg));
         }
+        if let ExprKind::Unary(_, operand) = &expr.kind
+            && is_non_storage_push_call(self.gcx, operand)
+            && let Some(span) = self.local_span(expr.span)
+        {
+            for op in [UnOpKind::PreInc, UnOpKind::PreDec, UnOpKind::PostInc, UnOpKind::PostDec] {
+                self.mutations.insert(MutationExclusion::unary(span, op));
+            }
+        }
         self.walk_expr(expr)
     }
 
@@ -289,6 +297,26 @@ fn comparison_operand_kind(
 fn is_unsigned(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> bool {
     gcx.type_of_expr(expr.peel_parens().id).is_some_and(|ty| {
         matches!(ty.peel_refs().kind, TyKind::Elementary(ElementaryType::UInt(_)))
+    })
+}
+
+fn is_non_storage_push_call(gcx: Gcx<'_>, expr: &hir::Expr<'_>) -> bool {
+    let ExprKind::Call(callee, args, _) = &expr.peel_parens().kind else { return false };
+    let ExprKind::Member(receiver, member) = &callee.peel_parens().kind else { return false };
+    if member.as_str() != "push" || !args.is_empty() {
+        return false;
+    }
+
+    !gcx.type_of_expr(receiver.id).is_some_and(|ty| {
+        matches!(
+            ty.kind,
+            TyKind::Ref(inner, location)
+                if location.is_storage()
+                    && matches!(
+                        inner.kind,
+                        TyKind::DynArray(_) | TyKind::Elementary(ElementaryType::Bytes)
+                    )
+        )
     })
 }
 
@@ -495,6 +523,44 @@ contract Test {
         assert!(mutations.contains(&unary_mutation(source, "unsigned++", UnOpKind::Neg)));
         assert!(mutations.contains(&unary_mutation(source, "++unsigned", UnOpKind::Neg)));
         assert!(!mutations.contains(&unary_mutation(source, "signed++", UnOpKind::Neg)));
+    }
+
+    #[test]
+    fn excludes_lvalue_mutations_for_user_defined_push() {
+        let source = r#"
+contract Test {
+    function push() external pure returns (int256) {
+        return 1;
+    }
+
+    function check() external view returns (int256) {
+        return -this.push();
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        for op in [UnOpKind::PreInc, UnOpKind::PreDec, UnOpKind::PostInc, UnOpKind::PostDec] {
+            assert!(mutations.contains(&unary_mutation(source, "-this.push()", op)));
+        }
+    }
+
+    #[test]
+    fn preserves_lvalue_mutations_for_storage_push() {
+        let source = r#"
+contract Test {
+    int256[] values;
+
+    function check() external returns (int256) {
+        return -values.push();
+    }
+}
+"#;
+        let mutations = collect(source);
+
+        for op in [UnOpKind::PreInc, UnOpKind::PreDec, UnOpKind::PostInc, UnOpKind::PostDec] {
+            assert!(!mutations.contains(&unary_mutation(source, "-values.push()", op)));
+        }
     }
 
     #[test]

--- a/crates/forge/tests/cli/test_cmd/mutation.rs
+++ b/crates/forge/tests/cli/test_cmd/mutation.rs
@@ -171,6 +171,70 @@ exclude_operators = [
 "#]]);
 });
 
+forgetest_init!(mutation_testing_retains_storage_push_lvalue_mutants, |prj, cmd| {
+    prj.add_source(
+        "StoragePush.sol",
+        r#"
+pragma solidity ^0.8.13;
+
+contract StoragePush {
+    int256[] private values;
+
+    function mutate() public returns (int256) {
+        return -values.push();
+    }
+
+    function value() public view returns (int256) {
+        return values[0];
+    }
+}
+"#,
+    );
+
+    prj.add_test(
+        "StoragePush.t.sol",
+        r#"
+pragma solidity ^0.8.13;
+
+import "../src/StoragePush.sol";
+
+contract StoragePushTest {
+    function testMutate() public {
+        StoragePush target = new StoragePush();
+        assert(target.mutate() == 0);
+        assert(target.value() == 0);
+    }
+}
+"#,
+    );
+
+    fs::write(
+        prj.root().join("foundry.toml"),
+        r#"
+[mutation]
+exclude_operators = [
+    "assembly",
+    "assignment",
+    "binary-op",
+    "delete-expression",
+    "elim-delegate",
+    "require",
+]
+"#,
+    )
+    .unwrap();
+
+    let output = cmd
+        .args(["test", "--mutate", "src/StoragePush.sol", "--mutation-jobs", "1", "--json"])
+        .assert_success();
+    let summary = mutation_summary(&output.get_output().stdout_lossy());
+
+    assert_eq!(summary["total"], 5);
+    assert_eq!(summary["killed"], 5);
+    assert_eq!(summary["invalid"], 0);
+    assert_eq!(summary["skipped"], 0);
+});
+
 forgetest_init!(mutation_testing_comparison_type_matrix, |prj, cmd| {
     prj.add_source(
         "Comparisons.sol",


### PR DESCRIPTION
This PR is stacked on #16050.

Unary mutation currently generates prefix and postfix increment or decrement operators for operands that cannot be assigned to, such as literals, binary expressions, casts, and ordinary function results. Those mutants are guaranteed to fail compilation and add noise to mutation runs.

This change filters increment and decrement replacements only when the operand is structurally known not to be an lvalue. The classification fails open for unknown or erroneous expression forms and preserves Solidity’s assignable zero-argument dynamic storage-array `push()` result, including parenthesized and indexed call expressions. This keeps valid mutants while avoiding compilation work for definitively invalid replacements.

AI assistance disclosure: Amp was used to review the implementation, identify edge cases, and assist with code and test generation.