### PR TITLE
fix(cast): reject trailing call fields

### DIFF
--- a/.changelog/reject-trailing-batch-call-fields.md
+++ b/.changelog/reject-trailing-batch-call-fields.md
@@ -1,0 +1,5 @@
+---
+cast: patch
+---
+
+Rejected trailing fields after raw calldata in Cast batch call specifications.

--- a/crates/cast/src/call_spec.rs
+++ b/crates/cast/src/call_spec.rs
@@ -67,10 +67,14 @@ impl CallSpec {
         // Pattern: to:value:sig:args or to::sig:args (empty value) or to:value:0xdata
         let mut idx = 1;
 
-        // Check for value (non-empty, not starting with 0x unless it's a number)
+        // Check for value (non-empty and not a signature). A terminal lowercase hex field is
+        // treated as raw calldata, while one followed by another field is a value.
         if idx < parts.len() {
             let part = parts[idx];
-            if !part.is_empty() && !part.starts_with("0x") && !part.contains('(') {
+            if !part.is_empty()
+                && (!part.starts_with("0x") || idx + 1 < parts.len())
+                && !part.contains('(')
+            {
                 // This looks like a value
                 value = parse_ether_or_wei(part)?;
                 idx += 1;
@@ -189,6 +193,19 @@ mod tests {
     fn test_parse_hex_value() {
         assert_eq!(parse_ether_or_wei("0x10").unwrap(), U256::from(16));
         assert_eq!(parse_ether_or_wei("0X10").unwrap(), U256::from(16));
+    }
+
+    #[test]
+    fn test_parse_lowercase_hex_value() {
+        let address = "0x1234567890123456789012345678901234567890";
+
+        let spec = CallSpec::parse(&format!("{address}:0x10:deposit()")).unwrap();
+        assert_eq!(spec.value, U256::from(16));
+        assert_eq!(spec.sig.as_deref(), Some("deposit()"));
+
+        let spec = CallSpec::parse(&format!("{address}:0x10")).unwrap();
+        assert_eq!(spec.value, U256::ZERO);
+        assert_eq!(spec.data, Some(Bytes::from([0x10])));
     }
 
     #[test]

--- a/crates/cast/src/call_spec.rs
+++ b/crates/cast/src/call_spec.rs
@@ -85,9 +85,12 @@ impl CallSpec {
             let part = parts[idx];
             if part.starts_with("0x") {
                 // Raw calldata
-                data = Some(Bytes::from(
-                    hex::decode(part).map_err(|e| eyre!("Invalid hex data '{}': {}", part, e))?,
-                ));
+                let decoded =
+                    hex::decode(part).map_err(|e| eyre!("Invalid hex data '{}': {}", part, e))?;
+                if idx + 1 != parts.len() {
+                    return Err(eyre!("Unexpected trailing field(s) after raw calldata"));
+                }
+                data = Some(Bytes::from(decoded));
             } else if !part.is_empty() {
                 // Function signature
                 sig = Some(part.to_string());
@@ -215,5 +218,18 @@ mod tests {
         assert_eq!(spec.value, U256::ZERO);
         assert!(spec.sig.is_none());
         assert_eq!(spec.data, Some(Bytes::from(hex::decode("abcdef").unwrap())));
+    }
+
+    #[test]
+    fn test_parse_raw_data_rejects_trailing_fields() {
+        for spec in [
+            "0x1234567890123456789012345678901234567890::0xabcdef:typo",
+            "0x1234567890123456789012345678901234567890:1wei:0xabcdef:unexpected",
+        ] {
+            assert_eq!(
+                CallSpec::parse(spec).unwrap_err().to_string(),
+                "Unexpected trailing field(s) after raw calldata"
+            );
+        }
     }
 }


### PR DESCRIPTION
Rejects trailing fields after raw calldata in Cast batch call specifications instead of silently ignoring them. This prevents malformed inputs from being signed or broadcast as shortened calls.